### PR TITLE
[WIP][Data] Support Unbounded datasource

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1213,6 +1213,16 @@ py_test(
 )
 
 py_test(
+    name = "test_input_data_buffer_streaming",
+    size = "small",
+    srcs = ["tests/test_input_data_buffer_streaming.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+)
+
+py_test(
     name = "test_metadata_provider",
     size = "small",
     srcs = ["tests/test_metadata_provider.py"],

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -108,7 +108,7 @@ class Read(
     @functools.cached_property
     def _cached_output_metadata(self) -> "BlockMetadataWithSchema":
         # Legacy datasources might not implement `get_read_tasks`.
-        if self.datasource.should_create_reader:
+        if self.datasource.should_create_reader or self.datasource.is_streaming:
             empty_meta = BlockMetadata(None, None, None, None)
             return BlockMetadataWithSchema(metadata=empty_meta, schema=None)
 

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -101,7 +101,16 @@ def plan_read_op(
             ret.append(ref_bundle)
         return ret
 
-    inputs = InputDataBuffer(data_context, input_data_factory=get_input_data)
+    is_streaming = op.datasource.is_streaming
+    # Get metadata fetch interval from datasource property (returns None by default)
+    # This allows datasources to control their own fetch intervals
+    polling_new_tasks_interval_s = op.datasource.polling_new_tasks_interval_s
+    inputs = InputDataBuffer(
+        data_context,
+        input_data_factory=get_input_data,
+        streaming=is_streaming,
+        polling_new_tasks_interval_s=polling_new_tasks_interval_s,
+    )
 
     def do_read(blocks: Iterable[ReadTask], _: TaskContext) -> Iterable[Block]:
         for read_task in blocks:

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -303,6 +303,20 @@ class Datasource(_DatasourceProjectionPushdownMixin, _DatasourcePredicatePushdow
         """If ``False``, only launch read tasks on the driver's node."""
         return True
 
+    @property
+    def is_streaming(self) -> bool:
+        """Return True if this is a streaming datasource."""
+        return False
+
+    @property
+    def polling_new_tasks_interval_s(self) -> Optional[float]:
+        """Return the read tasks fetch interval in seconds for micro-batching.
+
+        Returns:
+            The interval in seconds, or None if not configured.
+        """
+        return self._polling_new_tasks_interval_s
+
 
 @Deprecated
 class Reader:

--- a/python/ray/data/datasource/datasource.py
+++ b/python/ray/data/datasource/datasource.py
@@ -315,7 +315,7 @@ class Datasource(_DatasourceProjectionPushdownMixin, _DatasourcePredicatePushdow
         Returns:
             The interval in seconds, or None if not configured.
         """
-        return self._polling_new_tasks_interval_s
+        return None
 
 
 @Deprecated

--- a/python/ray/data/tests/test_input_data_buffer_streaming.py
+++ b/python/ray/data/tests/test_input_data_buffer_streaming.py
@@ -1,0 +1,124 @@
+"""Tests for InputDataBuffer streaming and micro-batching functionality."""
+
+import time
+from typing import List, Optional
+
+import pyarrow as pa
+import pytest
+
+from ray.data._internal.execution.interfaces import ExecutionOptions
+from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.logical.operators import Read
+from ray.data._internal.planner.plan_read_op import plan_read_op
+from ray.data.block import Block, BlockMetadata
+from ray.data.context import DataContext
+from ray.data.datasource import Datasource, ReadTask
+
+
+class MockStreamingDatasource(Datasource):
+    """Mock streaming datasource that tracks get_read_tasks calls."""
+
+    def __init__(
+        self,
+        batches_per_fetch: int = 1,
+        polling_new_tasks_interval_s: Optional[float] = None,
+    ):
+        """Initialize mock streaming datasource.
+
+        Args:
+            batches_per_fetch: Number of RefBundles to return per get_read_tasks call.
+            polling_new_tasks_interval_s: Optional metadata fetch interval in seconds.
+        """
+        super().__init__()
+        self._call_count = 0
+        self._batches_per_fetch = batches_per_fetch
+        self._call_times = []
+        self._polling_new_tasks_interval_s = polling_new_tasks_interval_s
+
+    @property
+    def is_streaming(self) -> bool:
+        return True
+
+    @property
+    def polling_new_tasks_interval_s(self) -> Optional[float]:
+        """Return the metadata fetch interval configured for this datasource."""
+        return self._polling_new_tasks_interval_s
+
+    def get_read_tasks(
+        self,
+        parallelism: int,
+        per_task_row_limit: Optional[int] = None,
+        data_context: Optional[DataContext] = None,
+    ) -> List[ReadTask]:
+        """Return read tasks, tracking each call."""
+        self._call_count += 1
+        self._call_times.append(time.time())
+        read_tasks = []
+        batch_id = self._call_count
+        for i in range(self._batches_per_fetch):
+            # Create a read task that returns a simple block
+            def create_read_fn(batch_id=batch_id, task_id=i):
+                def read_fn() -> List[Block]:
+                    table = pa.table({"batch_id": [batch_id], "task_id": [task_id]})
+                    return [table]
+
+                return read_fn
+
+            metadata = BlockMetadata(
+                num_rows=1,
+                size_bytes=100,
+                input_files=None,
+                exec_stats=None,
+            )
+            read_task = ReadTask(create_read_fn(), metadata)
+            read_tasks.append(read_task)
+
+        return read_tasks
+
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        return None
+
+
+def test_streaming_input_data_buffer_from_datasource(ray_start_regular_shared):
+    """Test that metadata fetch interval can be set from datasource."""
+
+    # Create mock streaming datasource with interval configured
+    datasource_interval = 1  # 5 seconds interval
+    datasource = MockStreamingDatasource(
+        batches_per_fetch=1, polling_new_tasks_interval_s=datasource_interval
+    )
+
+    # Create a Read operator
+    read_op = Read(
+        datasource=datasource,
+        datasource_or_legacy_reader=datasource,
+        parallelism=1,
+    )
+    # Set detected parallelism (required before planning)
+    read_op.set_detected_parallelism(1)
+
+    # Plan the read operation
+    physical_op = plan_read_op(read_op, [], DataContext.get_current())
+    input_buffer = physical_op.input_dependencies[0]
+    assert isinstance(input_buffer, InputDataBuffer)
+
+    # Verify the interval was set from datasource
+    assert input_buffer._polling_new_tasks_interval_s == datasource_interval
+
+    # Start execution
+    input_buffer.start(ExecutionOptions())
+
+    # First access triggers fetch
+    assert input_buffer.has_next()
+    assert datasource._call_count == 1
+
+    # Wait for interval and verify second fetch
+    time.sleep(datasource_interval + 0.1)
+    assert input_buffer.has_next()
+    assert datasource._call_count == 2
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_input_data_buffer_streaming.py
+++ b/python/ray/data/tests/test_input_data_buffer_streaming.py
@@ -84,7 +84,7 @@ def test_streaming_input_data_buffer_from_datasource(ray_start_regular_shared):
     """Test that metadata fetch interval can be set from datasource."""
 
     # Create mock streaming datasource with interval configured
-    datasource_interval = 1  # 5 seconds interval
+    datasource_interval = 1  # 1 second interval
     datasource = MockStreamingDatasource(
         batches_per_fetch=1, polling_new_tasks_interval_s=datasource_interval
     )

--- a/python/ray/data/tests/test_input_data_buffer_streaming.py
+++ b/python/ray/data/tests/test_input_data_buffer_streaming.py
@@ -13,6 +13,7 @@ from ray.data._internal.planner.plan_read_op import plan_read_op
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import DataContext
 from ray.data.datasource import Datasource, ReadTask
+from ray.tests.conftest import *  # noqa
 
 
 class MockStreamingDatasource(Datasource):


### PR DESCRIPTION

This PR adds support for unbounded (continuous) streaming reads from Kafka topics in Ray Data. Users can now set `trigger="continuous"` on `read_kafka` to create a long-running pipeline that continuously polls Kafka for new messages.

### High-Level Design

The streaming implementation uses a **micro-batching** strategy: instead of a single long-running Ray task that polls Kafka indefinitely, the **driver** periodically queries Kafka for new data and creates bounded `ReadTask` objects for any new offset ranges. This approach reuses the existing bounded read infrastructure and avoids long-lived remote tasks.

**Offset tracking flow:**
1. On the first call to `get_read_tasks()`, the driver creates a `KafkaConsumer` to discover all topic-partitions and resolves the initial `start_offset` (e.g. `"earliest"` → concrete integer) via `_resolve_offsets`. These become the initial `_last_offsets`.
2. On each subsequent call (triggered by `InputDataBuffer` at configurable intervals), the driver queries Kafka for the current `end_offsets` of each partition, compares against `_last_offsets`, and creates bounded `ReadTask` objects only for partitions where `start < end` (i.e., new data exists).
3. After task creation, `_last_offsets` is updated to the new end offsets so the next poll picks up only fresh data.
4. Offset resolution (converting `datetime`, `"earliest"`, `"latest"` to integers) is done **on the driver** for both bounded and streaming modes, so workers receive pre-resolved integer offsets directly.

### Key Changes

**`Datasource` base class** — Added `is_streaming` and `polling_new_tasks_interval_s` properties (both default to `False`/`None`) so the framework can detect and configure streaming datasources generically.

**`InputDataBuffer`** — Core streaming enablement:
- `has_next()` periodically re-invokes the input data factory (i.e. `get_read_tasks()`) at the configured polling interval, appending new bundles to the buffer. Non-blocking — returns immediately if no new data.
- Overrides `has_execution_finished()` to return `False` for streaming, preventing premature pipeline termination. Only finishes when explicitly marked (e.g. `take(N)` via `LimitOperator`, or consumer stops pulling).
- `_initialize_metadata()` now accumulates stats incrementally rather than overwriting, since streaming adds bundles over time.

**`KafkaDatasource`** — Unified `get_read_tasks()` handles both modes:
- *Bounded*: one task per partition from `start_offset` to `end_offset` (same as before, but offsets now resolved on driver).
- *Streaming*: compares `_last_offsets` against current Kafka end offsets, creates tasks only for partitions with new data, then advances offsets.
- Refactored to a single `KafkaConsumer` for both partition discovery and offset queries.
- Warns if `end_offset` is set in streaming mode (it's ignored).

**`read_kafka` API** — `trigger` now accepts `"continuous"`; added `polling_new_tasks_interval_s` parameter (default 5s).

**Planning-phase bypass** — Streaming datasources skip all `get_read_tasks()` calls during planning (parallelism estimation in `set_read_parallelism.py`, schema detection in `read_operator.py`, stats collection in `read_api.py`) to avoid consuming offsets before execution starts.

**`plan_read_op`** — Passes `is_streaming` and `polling_new_tasks_interval_s` from datasource → `InputDataBuffer`.

### Limitations

- **Cannot use with `materialize()`**: `materialize()` waits for all data to be processed. Since a streaming dataset is unbounded, this would block indefinitely. Users must consume streaming datasets with **`take(N)`** or **`iter_batches()`**.
- **No checkpointing**: `_last_offsets` is tracked in-memory on the driver. If the job crashes, offsets are lost. A TODO is left for adding fault-tolerant offset checkpointing.

Closes #40513 