### PR TITLE
[RLlib] Optimise `NormalizeAndClipActions` connector

### DIFF
--- a/rllib/connectors/module_to_env/normalize_and_clip_actions.py
+++ b/rllib/connectors/module_to_env/normalize_and_clip_actions.py
@@ -136,7 +136,7 @@ class NormalizeAndClipActions(ConnectorV2):
         # computed/sampled actions intact.
         if self.normalize_actions or self.clip_actions:
             # Copy actions into separate column, just to go to the env.
-            batch[Columns.ACTIONS_FOR_ENV] = copy.deepcopy(batch[Columns.ACTIONS])
+            batch[Columns.ACTIONS_FOR_ENV] = copy.copy(batch[Columns.ACTIONS])
             self.foreach_batch_item_change_in_place(
                 batch=batch,
                 column=Columns.ACTIONS_FOR_ENV,

--- a/rllib/utils/spaces/space_utils.py
+++ b/rllib/utils/spaces/space_utils.py
@@ -48,7 +48,7 @@ def get_original_space(space: gym.Space) -> gym.Space:
 def is_composite_space(space: gym.Space) -> bool:
     """Returns true, if the space is composite.
 
-    Note, we follow here the glossary of `gymnasium` by which any spoace
+    Note, we follow here the glossary of `gymnasium` by which any space
     that holds other spaces is defined as being 'composite'.
 
     Args:
@@ -57,15 +57,15 @@ def is_composite_space(space: gym.Space) -> bool:
     Returns:
         True, if the space is composed of other spaces, otherwise False.
     """
-    if type(space) in [
-        gym.spaces.Dict,
-        gym.spaces.Graph,
-        gym.spaces.Sequence,
-        gym.spaces.Tuple,
-    ]:
-        return True
-    else:
-        return False
+    return isinstance(
+        space,
+        (
+            gym.spaces.Dict,
+            gym.spaces.Graph,
+            gym.spaces.Sequence,
+            gym.spaces.Tuple,
+        ),
+    )
 
 
 @DeveloperAPI


### PR DESCRIPTION
## Description
The `NormalizeAndClipActions` connector allows a neural network to output values different from those accepted within an environment's action space, e.g., outside the valid bounds and to be normalized values that needs to be reverted. 
Previously, the actions were deepcopied to ensure that the modified and original values are different and don't intermingle. 

This PR notices that the `_unsquash_or_clip` and particularly `unsquash_action` and `clip_action` create new arrays as their output meaning that if you just copy the data, for the data is modified, it isn't done in place and rather a new array is created. 
Therefore, allowing the `deepcopy` to be optimised away.  