### PR TITLE
[Data] TurbopufferDatasink: accept either region or base_url

### DIFF
--- a/python/ray/data/_internal/datasource/turbopuffer_datasink.py
+++ b/python/ray/data/_internal/datasource/turbopuffer_datasink.py
@@ -58,7 +58,12 @@ class TurbopufferDatasink(Datasink):
             column is removed from the data before writing.  Mutually
             exclusive with ``namespace``.
         region: Turbopuffer region identifier (for example,
-            ``"gcp-us-central1"``).
+            ``"gcp-us-central1"``).  Mutually exclusive with ``base_url``.
+            Exactly one of ``region`` or ``base_url`` must be supplied.
+        base_url: Base URL for the Turbopuffer API (for example,
+            ``"https://gcp-us-central1.turbopuffer.com"``).  Mutually
+            exclusive with ``region``.  Exactly one of ``region`` or
+            ``base_url`` must be supplied.
         api_key: Turbopuffer API key. If omitted, the value is read from the
             ``TURBOPUFFER_API_KEY`` environment variable.
         schema: Optional Turbopuffer schema definition to pass along with
@@ -79,7 +84,7 @@ class TurbopufferDatasink(Datasink):
             :meth:`~ray.data.Dataset.write_datasink` ``concurrency``.
 
     Examples:
-        Write to a single namespace:
+        Write to a single namespace using a region:
 
         .. testcode::
            :skipif: True
@@ -97,6 +102,19 @@ class TurbopufferDatasink(Datasink):
                    namespace="my-namespace",
                    api_key="<YOUR_API_KEY>",
                    region="gcp-us-central1",
+               )
+           )
+
+        Write using a base URL instead of a region:
+
+        .. testcode::
+           :skipif: True
+
+           ds.write_datasink(
+               TurbopufferDatasink(
+                   namespace="my-namespace",
+                   api_key="<YOUR_API_KEY>",
+                   base_url="https://gcp-us-central1.turbopuffer.com",
                )
            )
 
@@ -119,7 +137,8 @@ class TurbopufferDatasink(Datasink):
         namespace: Optional[str] = None,
         *,
         namespace_column: Optional[str] = None,
-        region: str,
+        region: Optional[str] = None,
+        base_url: Optional[str] = None,
         api_key: Optional[str] = None,
         schema: Optional[dict] = None,
         id_column: str = "id",
@@ -142,11 +161,22 @@ class TurbopufferDatasink(Datasink):
                 "Either 'namespace' or 'namespace_column' must be provided."
             )
 
+        # Validate region / base_url mutual exclusivity.
+        if region and base_url:
+            raise ValueError(
+                "Specify exactly one of 'region' or 'base_url', not both."
+            )
+        if not region and not base_url:
+            raise ValueError(
+                "Either 'region' or 'base_url' must be provided."
+            )
+
         # Store configuration
         self.namespace = namespace
         self.namespace_column = namespace_column
         self.api_key = api_key or os.getenv(TURBOPUFFER_API_KEY_ENV_VAR)
         self.region = region
+        self.base_url = base_url
         self.schema = schema
         self.id_column = id_column
         self.vector_column = vector_column
@@ -195,9 +225,12 @@ class TurbopufferDatasink(Datasink):
         if self._client is None:
             import turbopuffer
 
-            self._client = turbopuffer.Turbopuffer(
-                api_key=self.api_key, region=self.region
-            )
+            kwargs = {"api_key": self.api_key}
+            if self.region is not None:
+                kwargs["region"] = self.region
+            else:
+                kwargs["base_url"] = self.base_url
+            self._client = turbopuffer.Turbopuffer(**kwargs)
         return self._client
 
     def write(

--- a/python/ray/data/_internal/datasource/turbopuffer_datasink.py
+++ b/python/ray/data/_internal/datasource/turbopuffer_datasink.py
@@ -163,13 +163,9 @@ class TurbopufferDatasink(Datasink):
 
         # Validate region / base_url mutual exclusivity.
         if region is not None and base_url is not None:
-            raise ValueError(
-                "Specify exactly one of 'region' or 'base_url', not both."
-            )
+            raise ValueError("Specify exactly one of 'region' or 'base_url', not both.")
         if region is None and base_url is None:
-            raise ValueError(
-                "Either 'region' or 'base_url' must be provided."
-            )
+            raise ValueError("Either 'region' or 'base_url' must be provided.")
 
         # Store configuration
         self.namespace = namespace

--- a/python/ray/data/_internal/datasource/turbopuffer_datasink.py
+++ b/python/ray/data/_internal/datasource/turbopuffer_datasink.py
@@ -162,11 +162,11 @@ class TurbopufferDatasink(Datasink):
             )
 
         # Validate region / base_url mutual exclusivity.
-        if region and base_url:
+        if region is not None and base_url is not None:
             raise ValueError(
                 "Specify exactly one of 'region' or 'base_url', not both."
             )
-        if not region and not base_url:
+        if region is None and base_url is None:
             raise ValueError(
                 "Either 'region' or 'base_url' must be provided."
             )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -5309,7 +5309,8 @@ class Dataset:
         *,
         namespace: Optional[str] = None,
         namespace_column: Optional[str] = None,
-        region: str,
+        region: Optional[str] = None,
+        base_url: Optional[str] = None,
         api_key: Optional[str] = None,
         schema: Optional[Dict[str, Any]] = None,
         id_column: str = "id",
@@ -5377,7 +5378,13 @@ class Dataset:
                 namespace.  The column is removed from the data before
                 writing.  Mutually exclusive with ``namespace``.
             region: Turbopuffer region identifier (for example,
-                ``"gcp-us-central1"``).
+                ``"gcp-us-central1"``).  Mutually exclusive with
+                ``base_url``.  Exactly one of ``region`` or ``base_url``
+                must be supplied.
+            base_url: Base URL for the Turbopuffer API (for example,
+                ``"https://gcp-us-central1.turbopuffer.com"``).  Mutually
+                exclusive with ``region``.  Exactly one of ``region`` or
+                ``base_url`` must be supplied.
             api_key: Turbopuffer API key. If omitted, the value is read from
                 the ``TURBOPUFFER_API_KEY`` environment variable.
             schema: Optional Turbopuffer schema definition to pass along with
@@ -5406,6 +5413,7 @@ class Dataset:
             namespace=namespace,
             namespace_column=namespace_column,
             region=region,
+            base_url=base_url,
             api_key=api_key,
             schema=schema,
             id_column=id_column,


### PR DESCRIPTION
## Summary
- Make `TurbopufferDatasink` accept either `region` or `base_url` (mutually exclusive) for configuring the Turbopuffer client endpoint
- Update `Dataset.write_turbopuffer()` public API with the same `base_url` parameter
- Add comprehensive tests for the new validation, client initialization, and serialization behavior

## Changes
- `turbopuffer_datasink.py`: Changed `region` from required to optional, added `base_url` parameter, added mutual exclusivity validation using `is not None` semantics (consistent with `_get_client`), updated `_get_client()` to pass whichever one is set
- `dataset.py`: Mirrored the same parameter changes in `write_turbopuffer()`
- `test_turbopuffer_datasink.py`: Added 8 new tests covering constructor validation, client initialization with `base_url`, and pickle round-trip preservation

## Test plan
- [x] Constructor accepts `region` alone
- [x] Constructor accepts `base_url` alone
- [x] Constructor rejects both `region` and `base_url`
- [x] Constructor rejects neither `region` nor `base_url`
- [x] Client initialized with `region` only (no `base_url` kwarg leaked)
- [x] Client initialized with `base_url` only (no `region` kwarg leaked)
- [x] `base_url` survives pickle round-trip and client re-initialization
- [x] All existing tests continue to pass