### PR TITLE
[Train] Add exclude_resources and worker_cpus options to training_ingest benchmark

### DIFF
--- a/release/train_tests/benchmark/config.py
+++ b/release/train_tests/benchmark/config.py
@@ -50,6 +50,7 @@ class RayDataConfig(DataLoaderConfig):
     enable_shard_locality: bool = True
     preserve_order: bool = False
     ray_data_pin_memory: bool = False
+    exclude_object_store_memory_gb: float = -1
 
 
 class TorchConfig(DataLoaderConfig):
@@ -68,6 +69,7 @@ class BenchmarkConfig(BaseModel):
     max_workers: int = 0
     # Run CPU training where train workers request a `MOCK_GPU` resource instead.
     mock_gpu: bool = False
+    worker_cpus: float = -1
 
     # FailureConfig
     max_failures: int = 0

--- a/release/train_tests/benchmark/ray_dataloader_factory.py
+++ b/release/train_tests/benchmark/ray_dataloader_factory.py
@@ -138,8 +138,18 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
         return None
 
     def get_ray_data_config(self) -> ray.train.DataConfig:
+        dataloader_config = self.get_dataloader_config()
+        execution_options = None
+        if dataloader_config.exclude_object_store_memory_gb > 0:
+            execution_options = ray.data.ExecutionOptions(
+                exclude_resources=ray.data.ExecutionResources(
+                    object_store_memory=dataloader_config.exclude_object_store_memory_gb
+                    * 1024**3
+                ),
+            )
         return ray.train.DataConfig(
-            enable_shard_locality=self.get_dataloader_config().enable_shard_locality,
+            enable_shard_locality=dataloader_config.enable_shard_locality,
+            execution_options=execution_options,
         )
 
     def get_train_dataloader(self):

--- a/release/train_tests/benchmark/train_benchmark.py
+++ b/release/train_tests/benchmark/train_benchmark.py
@@ -78,6 +78,12 @@ def main():
 
     dataset_creation_time = time.perf_counter() - start_time
 
+    resources_per_worker = {}
+    if benchmark_config.mock_gpu:
+        resources_per_worker["MOCK_GPU"] = 1
+    if benchmark_config.worker_cpus > 0:
+        resources_per_worker["CPU"] = benchmark_config.worker_cpus
+
     trainer = TorchTrainer(
         train_loop_per_worker=train_fn_per_worker,
         train_loop_config={
@@ -87,7 +93,7 @@ def main():
         scaling_config=ray.train.ScalingConfig(
             num_workers=benchmark_config.num_workers,
             use_gpu=not benchmark_config.mock_gpu,
-            resources_per_worker={"MOCK_GPU": 1} if benchmark_config.mock_gpu else None,
+            resources_per_worker=resources_per_worker or None,
         ),
         run_config=ray.train.RunConfig(
             storage_path=f"{os.environ['ANYSCALE_ARTIFACT_STORAGE']}/train_benchmark/",


### PR DESCRIPTION
## Description

todo: try out heterogeneous setup with training workers reserving CPUs
* is there extra spilling due to cross node transfers?
* does fixing the data obj store mem budget help?