### PR TITLE
[ci][docker] Add TPU as a recognized platform for Ray Docker images

### DIFF
--- a/ci/ray_ci/automation/docker_tags_lib.py
+++ b/ci/ray_ci/automation/docker_tags_lib.py
@@ -64,6 +64,8 @@ def _get_python_version_tag(python_version: str) -> str:
 def _get_platform_tag(platform: str) -> str:
     if platform == "cpu":
         return "-cpu"
+    if platform == "tpu":
+        return "-tpu"
     versions = platform.split(".")
     return f"-{versions[0]}{versions[1]}"  # cu11.8.0-cudnn8 -> cu118
 

--- a/ci/ray_ci/automation/image_tags_lib.py
+++ b/ci/ray_ci/automation/image_tags_lib.py
@@ -22,15 +22,18 @@ class ImageTagsError(Exception):
 
 def format_platform_tag(platform: str) -> str:
     """
-    Format platform as -cpu or shortened CUDA version.
+    Format platform as -cpu, -tpu, or shortened CUDA version.
 
     Examples:
         cpu -> -cpu
+        tpu -> -tpu
         cu12.1.1-cudnn8 -> -cu121
         cu12.3.2-cudnn9 -> -cu123
     """
     if platform == "cpu":
         return "-cpu"
+    if platform == "tpu":
+        return "-tpu"
     # cu12.3.2-cudnn9 -> -cu123
     platform_base = platform.split("-", 1)[0]
     parts = platform_base.split(".")

--- a/ci/ray_ci/automation/test_image_tags_lib.py
+++ b/ci/ray_ci/automation/test_image_tags_lib.py
@@ -19,6 +19,7 @@ class TestFormatPlatformTag:
         ("platform", "expected"),
         [
             ("cpu", "-cpu"),
+            ("tpu", "-tpu"),
             ("cu11.7.1-cudnn8", "-cu117"),
             ("cu11.8.0-cudnn8", "-cu118"),
             ("cu12.1.1-cudnn8", "-cu121"),
@@ -98,6 +99,11 @@ class TestGetPlatformSuffixes:
         assert "-cu121" in suffixes
         assert "-gpu" in suffixes
         assert "" in suffixes
+
+    def test_tpu_no_aliases(self):
+        """TPU gets no aliases."""
+        assert get_platform_suffixes("tpu", "ray") == ["-tpu"]
+        assert get_platform_suffixes("tpu", "ray-extra") == ["-tpu"]
 
     def test_non_gpu_platform_cuda_no_aliases(self):
         """Non-GPU_PLATFORM CUDA versions get no aliases."""

--- a/ci/ray_ci/automation/test_push_ray_image.py
+++ b/ci/ray_ci/automation/test_push_ray_image.py
@@ -42,6 +42,8 @@ class TestWandaImageName:
                 DEFAULT_ARCHITECTURE,
                 "ray-extra-py3.10-cpu",
             ),
+            # TPU images
+            (RayType.RAY, "3.10", "tpu", DEFAULT_ARCHITECTURE, "ray-py3.10-tpu"),
             # CUDA images
             (
                 RayType.RAY,
@@ -133,6 +135,8 @@ class TestPlatformSuffixes:
             ("cpu", RayType.RAY, ["-cpu", ""]),
             ("cpu", RayType.RAY_EXTRA, ["-cpu", ""]),
             ("cpu", RayType.RAY_ML, ["-cpu"]),  # ray-ml doesn't get empty for cpu
+            # TPU images
+            ("tpu", RayType.RAY, ["-tpu"]),
             # CUDA images
             ("cu11.7.1-cudnn8", RayType.RAY, ["-cu117"]),
             ("cu11.8.0-cudnn8", RayType.RAY, ["-cu118"]),

--- a/ci/ray_ci/docker_container.py
+++ b/ci/ray_ci/docker_container.py
@@ -8,6 +8,7 @@ from ci.ray_ci.linux_container import LinuxContainer
 
 PLATFORMS_RAY = [
     "cpu",
+    "tpu",
     "cu11.7.1-cudnn8",
     "cu11.8.0-cudnn8",
     "cu12.1.1-cudnn8",
@@ -144,6 +145,8 @@ class DockerContainer(LinuxContainer):
     def _get_platform_tag(self) -> str:
         if self.platform == "cpu":
             return "-cpu"
+        if self.platform == "tpu":
+            return "-tpu"
         versions = self.platform.split(".")
         return f"-{versions[0]}{versions[1]}"  # cu11.8.0 -> cu118
 

--- a/ci/ray_ci/test_ray_docker_container.py
+++ b/ci/ray_ci/test_ray_docker_container.py
@@ -445,6 +445,9 @@ class TestRayDockerContainer(RayCITestBase):
         container = RayDockerContainer(v, "cpu", "ray")
         assert container._get_platform_tag() == "-cpu"
 
+        container = RayDockerContainer(v, "tpu", "ray")
+        assert container._get_platform_tag() == "-tpu"
+
         container = RayDockerContainer(v, "cu11.8.0-cudnn8", "ray")
         assert container._get_platform_tag() == "-cu118"
 

--- a/ci/ray_ci/test_ray_image.py
+++ b/ci/ray_ci/test_ray_image.py
@@ -60,6 +60,8 @@ class TestWandaImageName:
                 DEFAULT_ARCHITECTURE,
                 f"ray-llm-extra-py3.11-{DEFAULT_TEST_CUDA_PLATFORM}",
             ),
+            # TPU images
+            (RayType.RAY, "3.10", "tpu", DEFAULT_ARCHITECTURE, "ray-py3.10-tpu"),
             # ray-ml types
             (RayType.RAY_ML, "3.10", "cpu", DEFAULT_ARCHITECTURE, "ray-ml-py3.10-cpu"),
             (
@@ -125,6 +127,9 @@ class TestVariationSuffix:
 class TestValidateValid:
     def test_ray_cpu(self):
         RayImage("ray", "3.10", "cpu").validate()
+
+    def test_ray_tpu(self):
+        RayImage("ray", "3.10", "tpu").validate()
 
     def test_ray_cuda(self):
         RayImage("ray", "3.13", "cu12.8.1-cudnn").validate()


### PR DESCRIPTION
Add "tpu" to PLATFORMS_RAY and update tag formatting so that `--platform tpu` is accepted by the image push CLI and produces `-tpu` suffixed Docker tags (e.g. `nightly-py310-tpu`).

Topic: tpu-platform-support
Signed-off-by: andrew <andrew@anyscale.com>