### PR TITLE
[Data] Cleaning up `SplitCoordinator`

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -202,9 +202,10 @@ class SplitCoordinator:
         with self._lock:
             # This check gates that we start epoch only once
             if self._cur_epoch == starting_epoch:
+                # Reset state
+                self._reset_state()
+                # Ratchet epoch
                 self._cur_epoch += 1
-                self._unfinished_clients_in_epoch = self._n
-                self._next_bundle.clear()
 
                 try:
                     # Force executor shutdown if present
@@ -232,6 +233,11 @@ class SplitCoordinator:
             # If there was an error when advancing to the next epoch,
             # re-raise it for all threads.
             raise self._gen_epoch_error
+
+    def _reset_state(self):
+        self._unfinished_clients_in_epoch = self._n
+        self._next_bundle.clear()
+        self._gen_epoch_error = None
 
     def get(
         self,

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -214,6 +214,13 @@ class SplitCoordinator:
                     plan = self._base_dataset._plan
                     # Re-execute dataset
                     self._current_executor = plan.create_executor()
+                    # NOTE: We pass dataset.context (the original, uncopied context)
+                    #       rather than self._data_context (the deep copy used for
+                    #       process isolation) because the planner adds callbacks
+                    #       (e.g. checkpoint) to the original context during
+                    #       _get_execution_dag. Using self._data_context would cause
+                    #       those callbacks to be silently missed.
+                    # TODO: Fix this by having Planner.plan() return callbacks explicitly
                     self._output_iterator = execute_to_legacy_bundle_iterator(
                         self._current_executor, plan, self._base_dataset.context
                     )

--- a/python/ray/train/v2/tests/test_data_resource_cleanup.py
+++ b/python/ray/train/v2/tests/test_data_resource_cleanup.py
@@ -125,7 +125,7 @@ def test_split_coordinator_shutdown_executor(ray_start_4_cpus):
     # Explicitly trigger autoscaling
     ray.get(
         coord.__ray_call__.remote(
-            lambda coord: coord._executor._cluster_autoscaler.try_trigger_scaling()
+            lambda coord: coord._current_executor._cluster_autoscaler.try_trigger_scaling()
         )
     )
 


### PR DESCRIPTION
## Description

1. This change abstracts starting new epoch inside `_try_start_new_epoch` (removing prior iterator semantic)
2. Shuts down the executor before starting a new one in the new epoch

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
