### PR TITLE
[serve LLM] Set download task num_cpus zero to mitigate resource contention on low cpu machine

### DIFF
--- a/python/ray/llm/_internal/serve/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/utils/node_initialization_utils.py
@@ -56,7 +56,7 @@ async def initialize_node(llm_config: LLMConfig):
         )
         download_tasks.append(
             ray.remote(initialize_remote_node).options(
-                num_cpus=1,
+                num_cpus=0,
                 scheduling_strategy=node_affinity_strategy,
                 runtime_env=ctx.runtime_env,
             )


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

## Description
Sets `num_cpus` to 0 for the download task within the `initialize_node` function. This prevents LLMServer from hanging when CPU resources are exhausted on GPU nodes, as the download task is primarily I/O-bound and does not require CPU resources, but still needs to be scheduled on the target node via `NodeAffinitySchedulingStrategy`.

## Related issues
<!-- No specific issue was provided for this change. -->

## Additional information
This change is made in `python/ray/llm/_internal/serve/utils/node_initialization_utils.py`.

---
[Slack Thread](https://anyscaleteam.slack.com/archives/C05N9KFPUR3/p1771541909813299?thread_ts=1771541909.813299&cid=C05N9KFPUR3)

<p><a href="https://cursor.com/agents?id=bc-a16b2d0a-9827-597b-b4fd-b4416dc765ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a16b2d0a-9827-597b-b4fd-b4416dc765ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

