### PR TITLE
[Data] Added metrics to track task scheduling time, output backpressure

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -450,7 +450,9 @@ class ArrowBlockAccessor(TableBlockAccessor):
             blocks = TableBlockAccessor.normalize_block_types(blocks, BlockType.ARROW)
             concat_and_sort = get_concat_and_sort_transform(DataContext.get_current())
             ret = concat_and_sort(blocks, sort_key, promote_types=True)
-        return ret, BlockMetadataWithSchema.from_block(ret, stats=stats.build())
+        return ret, BlockMetadataWithSchema.from_block(
+            ret, block_exec_stats=stats.build()
+        )
 
     def block_type(self) -> BlockType:
         return BlockType.ARROW

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -1049,7 +1049,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
 
         # NOTE: This metric tracks task's wall-clock time as measured by
         #       the workers executing the task
-        self.task_worker_completion_time_s += task_exec_stats.task_wall_time_s
+        if task_exec_stats is not None:
+            self.task_worker_completion_time_s += task_exec_stats.task_wall_time_s
 
         # NOTE: This is used for Issue Detection
         self._op_task_duration_stats.add_duration(task_wall_time_s)

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -678,7 +678,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         metrics_group=MetricsGroup.TASKS,
     )
     def average_task_block_gen_and_ser_time_s(self) -> Optional[float]:
-        """Average task's completion time in seconds (excluding throttling)"""
+        """Average task's block generation and serialization time in seconds."""
         if self.num_tasks_finished == 0:
             return None
 

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -966,8 +966,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         # Checkpoint time to first block
         is_first_block: bool = task_info.num_outputs == 0
         time_to_first_output_s = (
-            time.perf_counter() - task_info.start_time
-            if is_first_block else None
+            time.perf_counter() - task_info.start_time if is_first_block else None
         )
 
         task_info.num_outputs += num_outputs
@@ -1007,8 +1006,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         #       are reported (ie when task completes successfully)
         if is_first_block:
             self.task_scheduling_time_s += time_to_first_output_s - (
-                task_info.cum_block_gen_time_s +
-                task_info.cum_block_ser_time_s
+                task_info.cum_block_gen_time_s + task_info.cum_block_ser_time_s
             )
 
         # Update per node metrics

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -15,12 +15,13 @@ from ray.data._internal.execution.interfaces.common import (
 )
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.memory_tracing import trace_allocation
-from ray.data.block import BlockMetadata
+from ray.data.block import BlockMetadata, TaskExecStats
 from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces.physical_operator import (
         PhysicalOperator,
+        TaskExecDriverStats,
     )
 
 
@@ -392,17 +393,34 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
     )
     task_submission_backpressure_time: float = metric_field(
         default=0,
-        description="Time spent in task submission backpressure.",
+        description="Wall-clock time operator wasn't able to launch any new tasks.",
         metrics_group=MetricsGroup.TASKS,
     )
     task_output_backpressure_time: float = metric_field(
         default=0,
-        description="Time spent in task output backpressure.",
+        description="Wall-clock time operator wasn't able to read any outputs.",
         metrics_group=MetricsGroup.TASKS,
     )
-    task_completion_time_total_s: float = metric_field(
+    task_completion_time_s: float = metric_field(
         default=0,
         description="Time spent running tasks to completion. This is a sum of all tasks' completion times.",
+        metrics_group=MetricsGroup.TASKS,
+    )
+    task_scheduling_time_s: float = metric_field(
+        default=0,
+        description=(
+            "Time spent scheduling tasks: this tracks time from launching the task in the driver, "
+            "all the way until it starts running (which is including fetching its arguments "
+            "from remote Object Store, submitting to a worker, etc)"
+        ),
+        metrics_group=MetricsGroup.TASKS,
+    )
+    task_output_backpressure_time_s: float = metric_field(
+        default=0,
+        description=(
+            "Total time tasks spent in output back-pressure: when task had outputs available but "
+            "these weren't retrieved from it."
+        ),
         metrics_group=MetricsGroup.TASKS,
     )
     task_completion_time: RuntimeMetricsHistogram = metric_field(
@@ -419,9 +437,12 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         metrics_type=MetricsType.Histogram,
         metrics_args={"boundaries": histogram_buckets_s},
     )
-    task_completion_time_excl_backpressure_s: float = metric_field(
+    task_block_gen_and_ser_time_s: float = metric_field(
         default=0,
-        description="Time spent running tasks to completion without backpressure.",
+        description=(
+            "Time spent by tasks running UDF, generating blocks and serializing "
+            "this into Ray objects"
+        ),
         metrics_group=MetricsGroup.TASKS,
     )
     block_size_bytes: RuntimeMetricsHistogram = metric_field(
@@ -602,24 +623,61 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         metrics_group=MetricsGroup.TASKS,
     )
     def average_total_task_completion_time_s(self) -> Optional[float]:
-        """Average task's completion time in seconds (including throttling)"""
+        """Average task's completion time in seconds (inclusive of output back-pressure)"""
         if self.num_tasks_finished == 0:
             return None
-        else:
-            return self.task_completion_time_total_s / self.num_tasks_finished
+
+        return self.task_completion_time_s / self.num_tasks_finished
 
     @metric_property(
-        description="Average task's completion time in seconds (excluding throttling).",
+        description="Average task's scheduling time in seconds.",
         metrics_group=MetricsGroup.TASKS,
     )
-    def average_task_completion_excl_backpressure_time_s(self) -> Optional[float]:
+    def average_task_scheduling_time_s(self) -> Optional[float]:
+        """Average task's completion time in seconds (inclusive of output back-pressure)"""
+        if self.num_tasks_finished == 0:
+            return None
+
+        return self.task_scheduling_time_s / self.num_tasks_finished
+
+    @metric_property(
+        description="Average task's time spent in output back-pressure (in seconds).",
+        metrics_group=MetricsGroup.TASKS,
+    )
+    def average_task_output_backpressure_time_s(self) -> Optional[float]:
+        """Average task's output backpressure time in seconds"""
+        if self.num_tasks_finished == 0:
+            return None
+
+        return self.task_output_backpressure_time_s / self.num_tasks_finished
+
+    @metric_property(
+        description="Average task's completion time in seconds (excluding output back-pressure).",
+        metrics_group=MetricsGroup.TASKS,
+    )
+    def average_task_completion_time_excl_backpressure_s(self) -> Optional[float]:
         """Average task's completion time in seconds (excluding throttling)"""
         if self.num_tasks_finished == 0:
             return None
-        else:
-            return (
-                self.task_completion_time_excl_backpressure_s / self.num_tasks_finished
-            )
+
+        return (
+            self.task_completion_time_s - self.task_output_backpressure_time_s
+        ) / self.num_tasks_finished
+
+    @metric_property(
+        description=(
+            "Average task's cumulative block generation and serialization time. "
+            "This metric tracks primarily pure UDF generation time, plus overhead "
+            "to create Ray objects"
+        ),
+        metrics_group=MetricsGroup.TASKS,
+    )
+    def average_task_block_gen_and_ser_time_s(self) -> Optional[float]:
+        """Average task's completion time in seconds (excluding throttling)"""
+        if self.num_tasks_finished == 0:
+            return None
+
+        return self.task_block_gen_and_ser_time_s / self.num_tasks_finished
 
     @metric_property(
         description="Average size of task output in bytes.",
@@ -937,7 +995,13 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
                 node_metrics.bytes_outputs_of_finished_tasks += meta.size_bytes
                 node_metrics.blocks_outputs_of_finished_tasks += 1
 
-    def on_task_finished(self, task_index: int, exception: Optional[Exception]):
+    def on_task_finished(
+        self,
+        task_index: int,
+        exception: Optional[Exception],
+        task_exec_stats: Optional["TaskExecStats"],
+        task_exec_driver_stats: Optional["TaskExecDriverStats"],
+    ):
         """Callback when a task is finished."""
         self.num_tasks_running -= 1
         self.num_tasks_finished += 1
@@ -950,27 +1014,52 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         self.bytes_outputs_of_finished_tasks += task_info.bytes_outputs
         self.rows_outputs_of_finished_tasks += task_info.num_rows_produced
 
-        task_time_delta = time.perf_counter() - task_info.start_time
-        self.task_completion_time_total_s += task_time_delta
-        self.task_completion_time.observe(task_time_delta)
+        # NOTE: This metric tracks task's wall-clock time as measured by
+        #       the driver which starts upon scheduling of the task and runs
+        #       until this callback is invoked
+        task_wall_time_s = time.perf_counter() - task_info.start_time
+
+        # Task's scheduling time is calculated as:
+        #
+        #   Driver's task-wall-time - Workers's task-wall-time
+        #
+        # NOTE: We're only tracking task scheduling time when `TaskExecStats`
+        #       are reported (ie when task completes successfully)
+        task_scheduling_time_s = (
+            task_wall_time_s - task_exec_stats.task_wall_time_s
+            if task_exec_stats
+            else 0
+        )
+
+        self.task_scheduling_time_s += task_scheduling_time_s
+        self.task_completion_time_s += task_wall_time_s
+
+        self.task_completion_time.observe(task_wall_time_s)
+        # NOTE: This is used for Issue Detection
+        self._op_task_duration_stats.add_duration(task_wall_time_s)
+
+        self.task_output_backpressure_time_s += (
+            task_exec_driver_stats.task_output_backpressure_s
+            if task_exec_driver_stats
+            else 0
+        )
 
         assert task_info.cum_block_gen_time_s is not None
+
+        block_gen_and_ser_time_s = (
+            task_info.cum_block_gen_time_s + task_info.cum_block_ser_time_s
+        )
+
+        self.task_block_gen_and_ser_time_s += block_gen_and_ser_time_s
+
         if task_info.num_outputs > 0:
             # Calculate the average block generation time per block
-            block_time_delta = (
-                task_info.cum_block_gen_time_s + task_info.cum_block_ser_time_s
-            ) / task_info.num_outputs
+            block_time_delta = block_gen_and_ser_time_s / task_info.num_outputs
 
             self.block_completion_time.observe(
                 block_time_delta, num_observations=task_info.num_outputs
             )
 
-        # NOTE: This is used for Issue Detection
-        self._op_task_duration_stats.add_duration(task_time_delta)
-
-        self.task_completion_time_excl_backpressure_s += (
-            task_info.cum_block_gen_time_s + task_info.cum_block_ser_time_s
-        )
         inputs = self._running_tasks[task_index].inputs
         self.num_task_inputs_processed += len(inputs)
         total_input_size = inputs.size_bytes()

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -15,7 +15,7 @@ from ray.data._internal.execution.interfaces.common import (
 )
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.memory_tracing import trace_allocation
-from ray.data.block import BlockMetadata, TaskExecStats
+from ray.data.block import BlockMetadata, TaskExecWorkerStats
 from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR
 
 if TYPE_CHECKING:
@@ -1024,7 +1024,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         self,
         task_index: int,
         exception: Optional[Exception],
-        task_exec_stats: Optional["TaskExecStats"],
+        task_exec_stats: Optional["TaskExecWorkerStats"],
         task_exec_driver_stats: Optional["TaskExecDriverStats"],
     ):
         """Callback when a task is finished."""

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -103,7 +103,8 @@ class TaskExecDriverStats:
 
 
 TaskDoneCallbackType = Callable[
-    [Optional[Exception], Optional[TaskExecWorkerStats], Optional[TaskExecDriverStats]], None
+    [Optional[Exception], Optional[TaskExecWorkerStats], Optional[TaskExecDriverStats]],
+    None,
 ]
 
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -30,7 +30,7 @@ from ray.data._internal.execution.interfaces.op_runtime_metrics import OpRuntime
 from ray.data._internal.logical.interfaces import LogicalOperator, Operator
 from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.stats import StatsDict, Timer
-from ray.data.block import Block, BlockMetadata, TaskExecStats
+from ray.data.block import Block, BlockMetadata, TaskExecWorkerStats
 from ray.data.context import DataContext
 
 if TYPE_CHECKING:
@@ -103,7 +103,7 @@ class TaskExecDriverStats:
 
 
 TaskDoneCallbackType = Callable[
-    [Optional[Exception], Optional[TaskExecStats], Optional[TaskExecDriverStats]], None
+    [Optional[Exception], Optional[TaskExecWorkerStats], Optional[TaskExecDriverStats]], None
 ]
 
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -590,9 +590,7 @@ class ActorPoolMapOperator(MapOperator):
     def get_autoscaling_actor_pools(self) -> List[AutoscalingActorPool]:
         return [self._actor_pool]
 
-    def per_task_resource_allocation(
-        self: "PhysicalOperator",
-    ) -> ExecutionResources:
+    def per_task_resource_allocation(self) -> ExecutionResources:
         # For Actor tasks resource allocation is determined as:
         #   - Per actor resource allocation divided by
         #   - Actor's max task concurrency
@@ -600,9 +598,7 @@ class ActorPoolMapOperator(MapOperator):
         per_actor_resource_usage = self._actor_pool.per_actor_resource_usage()
         return per_actor_resource_usage.scale(1 / max_concurrency)
 
-    def min_scheduling_resources(
-        self: "PhysicalOperator",
-    ) -> ExecutionResources:
+    def min_scheduling_resources(self) -> ExecutionResources:
         return self._actor_pool.per_actor_resource_usage()
 
     def update_resource_usage(self) -> None:

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -67,7 +67,7 @@ from ray.data.block import (
     BlockMetadataWithSchema,
     BlockStats,
     BlockType,
-    TaskExecStats,
+    TaskExecWorkerStats,
     to_stats,
 )
 from ray.data.context import (
@@ -886,7 +886,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         def _on_aggregation_done(
             partition_id: int,
             exc: Optional[Exception],
-            task_exec_stats: Optional[TaskExecStats],
+            task_exec_stats: Optional[TaskExecWorkerStats],
             task_exec_driver_stats: Optional[TaskExecDriverStats],
         ):
             # NOTE: `TaskExecStats` could be null in case there's no blocks
@@ -1787,7 +1787,7 @@ class HashShuffleAggregator:
             yield BlockMetadataWithSchema.from_block(
                 block,
                 block_exec_stats=exec_stats,
-                task_exec_stats=TaskExecStats(
+                task_exec_stats=TaskExecWorkerStats(
                     task_wall_time_s=time.perf_counter() - start_time_s,
                 ),
             )

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -743,7 +743,6 @@ def _map_task(
         ctx.task_idx,
     )
 
-
     ctx.kwargs.update(kwargs)
 
     with DataContext.current(data_context), TaskContext.current(ctx):

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -737,6 +737,8 @@ def _map_task(
     """
     task_start_s = time.perf_counter()
 
+    blk_exec_stats_builder = BlockExecStats.builder()
+
     logger.debug(
         "Executing map task of operator %s with task index %d",
         ctx.op_name,
@@ -751,8 +753,6 @@ def _map_task(
         )
 
         blocks_iter = _iter_sliced_blocks(blocks, slices) if slices else iter(blocks)
-
-        blk_exec_stats_builder = BlockExecStats.builder()
 
         with MemoryProfiler(data_context.memory_usage_poll_interval_s) as profiler:
             for block in map_transformer.apply_transform(blocks_iter, ctx):

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -2,6 +2,7 @@ import copy
 import functools
 import itertools
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import replace
 from typing import (
@@ -45,6 +46,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     DataOpTask,
     MetadataOpTask,
     OpTask,
+    TaskExecDriverStats,
     estimate_total_num_of_blocks,
 )
 from ray.data._internal.execution.interfaces.ref_bundle import (
@@ -67,6 +69,7 @@ from ray.data.block import (
     BlockExecStats,
     BlockMetadataWithSchema,
     BlockStats,
+    TaskExecStats,
     _take_first_non_empty_schema,
     to_stats,
 )
@@ -569,8 +572,22 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
             self._output_queue.add(output, key=task_index)
             self._metrics.on_output_queued(output)
 
-        def _task_done_callback(task_index: int, exception: Optional[Exception]):
-            self._metrics.on_task_finished(task_index, exception)
+        def _task_done_callback(
+            task_index: int,
+            exception: Optional[Exception],
+            task_exec_stats: Optional[TaskExecStats],
+            task_exec_driver_stats: Optional[TaskExecDriverStats],
+        ):
+            # NOTE: `TaskExecStats` could be null in case there's no blocks
+            #       emitted (current limitation, since it's emitted along with
+            #       `BlockMetadata`)
+            assert exception or (
+                task_exec_driver_stats
+            ), "Driver's task execution stats must be provided on task's successful completion"
+
+            self._metrics.on_task_finished(
+                task_index, exception, task_exec_stats, task_exec_driver_stats
+            )
 
             # Estimate number of tasks and rows from inputs received and tasks
             # submitted so far
@@ -718,48 +735,59 @@ def _map_task(
         A generator of blocks, followed by the list of BlockMetadata for the blocks
         as the last generator return.
     """
+    task_start_s = time.perf_counter()
+
     logger.debug(
         "Executing map task of operator %s with task index %d",
         ctx.op_name,
         ctx.task_idx,
     )
 
+
     ctx.kwargs.update(kwargs)
 
-    with (DataContext.current(data_context), TaskContext.current(ctx)):
-        stats = BlockExecStats.builder()
+    with DataContext.current(data_context), TaskContext.current(ctx):
         map_transformer.override_target_max_block_size(
             ctx.target_max_block_size_override
         )
-        block_iter: Iterable[Block]
-        if slices:
-            block_iter = _iter_sliced_blocks(blocks, slices)
-        else:
-            block_iter = iter(blocks)
+
+        blocks_iter = _iter_sliced_blocks(blocks, slices) if slices else iter(blocks)
+
+        blk_exec_stats_builder = BlockExecStats.builder()
 
         with MemoryProfiler(data_context.memory_usage_poll_interval_s) as profiler:
-            for block in map_transformer.apply_transform(block_iter, ctx):
+            for block in map_transformer.apply_transform(blocks_iter, ctx):
                 block_meta = BlockAccessor.for_block(block).get_metadata()
                 block_schema = BlockAccessor.for_block(block).schema()
 
                 # Derive block execution stats
-                exec_stats = stats.build()
+                blk_exec_stats = blk_exec_stats_builder.build()
                 # Yield block and retrieve its Ray object serialization timing
-                stats: StreamingGeneratorStats = yield block
-                if stats:
-                    exec_stats.block_ser_time_s = stats.object_creation_dur_s
+                gen_stats: StreamingGeneratorStats = yield block
+                if gen_stats:
+                    blk_exec_stats.block_ser_time_s = gen_stats.object_creation_dur_s
 
-                exec_stats.udf_time_s = map_transformer.udf_time_s(reset=True)
-                exec_stats.task_idx = ctx.task_idx
-                exec_stats.max_uss_bytes = profiler.estimate_max_uss()
+                blk_exec_stats.udf_time_s = map_transformer.udf_time_s(reset=True)
+                blk_exec_stats.task_idx = ctx.task_idx
+                blk_exec_stats.max_uss_bytes = profiler.estimate_max_uss()
+
+                # NOTE: This tracks task duration up to this point, though we're primarily
+                #       interested in task total duration
+                # TODO figure out a better way to track task total duration
+                task_dur_s = time.perf_counter() - task_start_s
 
                 yield BlockMetadataWithSchema(
-                    metadata=replace(block_meta, exec_stats=exec_stats),
+                    metadata=replace(
+                        block_meta,
+                        exec_stats=blk_exec_stats,
+                        task_exec_stats=TaskExecStats(task_wall_time_s=task_dur_s),
+                    ),
+                    # TODO only pass schema w/ the first block
                     schema=block_schema,
                 )
 
                 # Reset trackers
-                stats = BlockExecStats.builder()
+                blk_exec_stats_builder = BlockExecStats.builder()
                 profiler.reset()
 
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -69,7 +69,7 @@ from ray.data.block import (
     BlockExecStats,
     BlockMetadataWithSchema,
     BlockStats,
-    TaskExecStats,
+    TaskExecWorkerStats,
     _take_first_non_empty_schema,
     to_stats,
 )
@@ -575,7 +575,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         def _task_done_callback(
             task_index: int,
             exception: Optional[Exception],
-            task_exec_stats: Optional[TaskExecStats],
+            task_exec_stats: Optional[TaskExecWorkerStats],
             task_exec_driver_stats: Optional[TaskExecDriverStats],
         ):
             # NOTE: `TaskExecStats` could be null in case there's no blocks
@@ -779,7 +779,7 @@ def _map_task(
                     metadata=replace(
                         block_meta,
                         exec_stats=blk_exec_stats,
-                        task_exec_stats=TaskExecStats(task_wall_time_s=task_dur_s),
+                        task_exec_stats=TaskExecWorkerStats(task_wall_time_s=task_dur_s),
                     ),
                     # TODO only pass schema w/ the first block
                     schema=block_schema,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -779,7 +779,9 @@ def _map_task(
                     metadata=replace(
                         block_meta,
                         exec_stats=blk_exec_stats,
-                        task_exec_stats=TaskExecWorkerStats(task_wall_time_s=task_dur_s),
+                        task_exec_stats=TaskExecWorkerStats(
+                            task_wall_time_s=task_dur_s
+                        ),
                     ),
                     # TODO only pass schema w/ the first block
                     schema=block_schema,

--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -320,7 +320,9 @@ def _zip_one_block(
     result = BlockAccessor.for_block(block).zip(other_block)
     from ray.data.block import BlockMetadataWithSchema
 
-    return result, BlockMetadataWithSchema.from_block(result, stats=stats.build())
+    return result, BlockMetadataWithSchema.from_block(
+        result, block_exec_stats=stats.build()
+    )
 
 
 def _get_num_rows_and_bytes(block: Block) -> Tuple[int, int]:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -445,9 +445,9 @@ def process_completed_tasks(
                 else:
                     max_bytes_to_read = min(max_bytes_to_read, policy_limit)
 
-        assert max_bytes_to_read is None or max_bytes_to_read >= 0, (
-            f"Max bytes to read must either be null or >= 0 (got {max_bytes_to_read})"
-        )
+        assert (
+            max_bytes_to_read is None or max_bytes_to_read >= 0
+        ), f"Max bytes to read must either be null or >= 0 (got {max_bytes_to_read})"
 
         # If no policy provides a limit, there's no limit
         op.notify_in_task_output_backpressure(max_bytes_to_read == 0, limiting_policy)
@@ -487,8 +487,7 @@ def process_completed_tasks(
                         if state in remaining_output_budget:
                             # Clamp remaining output budget at 0
                             remaining_output_budget[state] = max(
-                                remaining_output_budget[state] - bytes_read,
-                                0
+                                remaining_output_budget[state] - bytes_read, 0
                             )
                     except Exception as e:
                         num_errored_blocks += 1

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -428,7 +428,7 @@ def process_completed_tasks(
         for task in op.get_active_tasks():
             active_tasks[task.get_waitable()] = (state, task)
 
-    max_bytes_to_read_per_op: Dict[OpState, int] = {}
+    remaining_output_budget: Dict[OpState, int] = {}
     for op, state in topology.items():
         # Check all backpressure policies for max_task_output_bytes_to_read
         # Use the minimum limit from all policies (most restrictive)
@@ -445,10 +445,15 @@ def process_completed_tasks(
                 else:
                     max_bytes_to_read = min(max_bytes_to_read, policy_limit)
 
+        assert max_bytes_to_read is None or max_bytes_to_read >= 0, (
+            f"Max bytes to read must either be null or >= 0 (got {max_bytes_to_read})"
+        )
+
         # If no policy provides a limit, there's no limit
         op.notify_in_task_output_backpressure(max_bytes_to_read == 0, limiting_policy)
+
         if max_bytes_to_read is not None:
-            max_bytes_to_read_per_op[state] = max_bytes_to_read
+            remaining_output_budget[state] = max_bytes_to_read
 
     # Process completed Ray tasks and notify operators.
     num_errored_blocks = 0
@@ -477,10 +482,14 @@ def process_completed_tasks(
                 if isinstance(task, DataOpTask):
                     try:
                         bytes_read = task.on_data_ready(
-                            max_bytes_to_read_per_op.get(state, None)
+                            remaining_output_budget.get(state, None)
                         )
-                        if state in max_bytes_to_read_per_op:
-                            max_bytes_to_read_per_op[state] -= bytes_read
+                        if state in remaining_output_budget:
+                            # Clamp remaining output budget at 0
+                            remaining_output_budget[state] = max(
+                                remaining_output_budget[state] - bytes_read,
+                                0
+                            )
                     except Exception as e:
                         num_errored_blocks += 1
                         should_ignore = (

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -682,7 +682,9 @@ class PandasBlockAccessor(TableBlockAccessor):
             ret = ret.sort_values(by=columns, ascending=ascending)
         from ray.data.block import BlockMetadataWithSchema
 
-        return ret, BlockMetadataWithSchema.from_block(ret, stats=stats.build())
+        return ret, BlockMetadataWithSchema.from_block(
+            ret, block_exec_stats=stats.build()
+        )
 
     def block_type(self) -> BlockType:
         return BlockType.PANDAS

--- a/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/aggregate_task_spec.py
@@ -66,7 +66,7 @@ class SortAggregateTaskSpec(ExchangeTaskSpec):
         from ray.data.block import BlockMetadataWithSchema
 
         meta_with_schema = BlockMetadataWithSchema.from_block(
-            block, stats=stats.build()
+            block, block_exec_stats=stats.build()
         )
         return parts + [meta_with_schema]
 

--- a/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/shuffle_task_spec.py
@@ -114,7 +114,7 @@ class ShuffleTaskSpec(ExchangeTaskSpec):
         assert num_rows == block.num_rows(), (num_rows, block.num_rows())
         from ray.data.block import BlockMetadataWithSchema
 
-        meta = block.get_metadata(exec_stats=stats.build())
+        meta = block.get_metadata(block_exec_stats=stats.build())
         schema = block.schema()
         meta_with_schema = BlockMetadataWithSchema(metadata=meta, schema=schema)
         return slices + [meta_with_schema]

--- a/python/ray/data/_internal/planner/exchange/sort_task_spec.py
+++ b/python/ray/data/_internal/planner/exchange/sort_task_spec.py
@@ -140,7 +140,7 @@ class SortTaskSpec(ExchangeTaskSpec):
         from ray.data.block import BlockMetadataWithSchema
 
         meta_with_schema = BlockMetadataWithSchema.from_block(
-            block, stats=stats.build()
+            block, block_exec_stats=stats.build()
         )
         return out + [meta_with_schema]
 

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -487,7 +487,9 @@ class TableBlockAccessor(BlockAccessor):
                 break
 
         ret = builder.build()
-        return ret, BlockMetadataWithSchema.from_block(ret, stats=stats.build())
+        return ret, BlockMetadataWithSchema.from_block(
+            ret, block_exec_stats=stats.build()
+        )
 
     def _find_partitions_sorted(
         self,

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -722,7 +722,9 @@ def pandas_df_to_arrow_block(
 
     block = BlockAccessor.for_block(df).to_arrow()
     stats = BlockExecStats.builder()
-    return block, BlockMetadataWithSchema.from_block(block, stats=stats.build())
+    return block, BlockMetadataWithSchema.from_block(
+        block, block_exec_stats=stats.build()
+    )
 
 
 def ndarray_to_block(
@@ -734,7 +736,9 @@ def ndarray_to_block(
 
     stats = BlockExecStats.builder()
     block = BlockAccessor.batch_to_block({"data": ndarray})
-    return block, BlockMetadataWithSchema.from_block(block, stats=stats.build())
+    return block, BlockMetadataWithSchema.from_block(
+        block, block_exec_stats=stats.build()
+    )
 
 
 def get_table_block_metadata_schema(
@@ -743,7 +747,7 @@ def get_table_block_metadata_schema(
     from ray.data.block import BlockExecStats, BlockMetadataWithSchema
 
     stats = BlockExecStats.builder()
-    return BlockMetadataWithSchema.from_block(table, stats=stats.build())
+    return BlockMetadataWithSchema.from_block(table, block_exec_stats=stats.build())
 
 
 def unify_block_metadata_schema(

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -160,7 +160,7 @@ def to_stats(metas: List["BlockMetadata"]) -> List["BlockStats"]:
 
 @DeveloperAPI
 @dataclass(frozen=True)
-class TaskExecStats:
+class TaskExecWorkerStats:
     """Task's execution stats reported from the executing worker"""
 
     # Total task's wall-clock time from start to finish (measured on the worker)
@@ -265,7 +265,7 @@ class BlockMetadata(BlockStats):
     input_files: Optional[List[str]]
 
     # Task execution stats reported from the worker
-    task_exec_stats: Optional[TaskExecStats] = field(default=None)
+    task_exec_stats: Optional[TaskExecWorkerStats] = field(default=None)
 
     def to_stats(self):
         return BlockStats(
@@ -297,7 +297,7 @@ class BlockMetadataWithSchema(BlockMetadata):
     def from_block(
         block: Block,
         block_exec_stats: Optional["BlockExecStats"] = None,
-        task_exec_stats: Optional["TaskExecStats"] = None,
+        task_exec_stats: Optional["TaskExecWorkerStats"] = None,
     ) -> "BlockMetadataWithSchema":
         accessor = BlockAccessor.for_block(block)
 
@@ -458,7 +458,7 @@ class BlockAccessor:
         self,
         input_files: Optional[List[str]] = None,
         block_exec_stats: Optional[BlockExecStats] = None,
-        task_exec_stats: Optional[TaskExecStats] = None,
+        task_exec_stats: Optional[TaskExecWorkerStats] = None,
     ) -> BlockMetadata:
         """Create a metadata object from this block."""
         return BlockMetadata(

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -170,11 +170,7 @@ class TaskExecWorkerStats:
 @DeveloperAPI
 @dataclass
 class BlockExecStats:
-    """Execution stats for a single output block produced by a task.
-
-    Set by :class:`_BlockExecStatsBuilder` (via :meth:`builder`) and enriched
-    by the map worker before the block is yielded.
-    """
+    """Execution stats for a single output block produced by a task."""
 
     # Index of the task that produced this block, used to attribute rows
     # to individual tasks in per-task statistics.
@@ -185,15 +181,15 @@ class BlockExecStats:
         default_factory=lambda: ray.runtime_context.get_runtime_context().get_node_id()
     )
 
-    # Absolute wall-clock timestamp when the task started.
+    # Absolute wall-clock timestamp when block generation started.
     start_time_s: Optional[float] = None
-    # Absolute wall-clock timestamp when the task finished.
+    # Absolute wall-clock timestamp when block generation finished.
     end_time_s: Optional[float] = None
-    # Total wall-clock duration of the task (end_time_s - start_time_s).
+    # Total wall-clock duration of the block generation (computed as end_time_s - start_time_s).
     wall_time_s: Optional[float] = None
-    # Time spent inside user-defined functions for this block.
+    # Time spent inside UDF while generating block.
     udf_time_s: Optional[float] = 0
-    # Time spent serializing this block into a Ray object (object_creation_dur_s).
+    # Time spent serializing this block into a Ray object.
     block_ser_time_s: Optional[float] = None
     # Total CPU time consumed by the worker process during the task, across all threads.
     cpu_time_s: Optional[float] = None

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -259,7 +259,7 @@ class BlockMetadata(BlockStats):
     # The pyarrow schema or types of the block elements, or None.
     # The list of file paths used to generate this block, or
     # the empty list if indeterminate.
-    input_files: Optional[List[str]]
+    input_files: Optional[List[str]] = field(default=None)
 
     def to_stats(self):
         return BlockStats(

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -238,6 +238,9 @@ class BlockStats:
     # Execution stats for this block.
     exec_stats: Optional[BlockExecStats]
 
+    # Overall task execution stats (reported from the worker).
+    task_exec_stats: Optional[TaskExecWorkerStats] = field(default=None)
+
     def __post_init__(self):
         if self.size_bytes is not None:
             # Require size_bytes to be int, ray.util.metrics objects
@@ -257,9 +260,6 @@ class BlockMetadata(BlockStats):
     # The list of file paths used to generate this block, or
     # the empty list if indeterminate.
     input_files: Optional[List[str]]
-
-    # Task execution stats reported from the worker
-    task_exec_stats: Optional[TaskExecWorkerStats] = field(default=None)
 
     def to_stats(self):
         return BlockStats(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -244,7 +244,7 @@ def from_items(
         block = builder.build()
         blocks.append(ray.put(block))
         meta_with_schema.append(
-            BlockMetadataWithSchema.from_block(block, stats=stats.build())
+            BlockMetadataWithSchema.from_block(block, block_exec_stats=stats.build())
         )
 
     from_items_op = FromItems(blocks, meta_with_schema)

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -11,6 +11,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     OpTask,
     PhysicalOperator,
     RefBundle,
+    TaskExecDriverStats,
 )
 from ray.data._internal.execution.operators.input_data_buffer import (
     InputDataBuffer,
@@ -27,7 +28,7 @@ from ray.data._internal.issue_detection.detectors.hanging_detector import (
 from ray.data._internal.issue_detection.detectors.high_memory_detector import (
     HighMemoryIssueDetector,
 )
-from ray.data.block import BlockMetadata
+from ray.data.block import BlockMetadata, TaskExecStats
 from ray.data.context import DataContext
 from ray.tests.conftest import *  # noqa
 
@@ -168,8 +169,18 @@ class TestHangingExecutionIssueDetector:
         op.metrics.on_task_submitted(0, input_bundle)
         op.metrics.on_task_submitted(1, input_bundle)
         op.metrics.on_task_submitted(2, input_bundle)
-        op.metrics.on_task_finished(0, exception=None)
-        op.metrics.on_task_finished(1, exception=None)
+        op.metrics.on_task_finished(
+            0,
+            exception=None,
+            task_exec_stats=TaskExecStats(task_wall_time_s=0.0),
+            task_exec_driver_stats=TaskExecDriverStats(task_output_backpressure_s=0),
+        )
+        op.metrics.on_task_finished(
+            1,
+            exception=None,
+            task_exec_stats=TaskExecStats(task_wall_time_s=0.0),
+            task_exec_driver_stats=TaskExecDriverStats(task_output_backpressure_s=0),
+        )
 
         # Start detecting
         issues = detector.detect()

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -28,7 +28,7 @@ from ray.data._internal.issue_detection.detectors.hanging_detector import (
 from ray.data._internal.issue_detection.detectors.high_memory_detector import (
     HighMemoryIssueDetector,
 )
-from ray.data.block import BlockMetadata, TaskExecStats
+from ray.data.block import BlockMetadata, TaskExecWorkerStats
 from ray.data.context import DataContext
 from ray.tests.conftest import *  # noqa
 
@@ -172,13 +172,13 @@ class TestHangingExecutionIssueDetector:
         op.metrics.on_task_finished(
             0,
             exception=None,
-            task_exec_stats=TaskExecStats(task_wall_time_s=0.0),
+            task_exec_stats=TaskExecWorkerStats(task_wall_time_s=0.0),
             task_exec_driver_stats=TaskExecDriverStats(task_output_backpressure_s=0),
         )
         op.metrics.on_task_finished(
             1,
             exception=None,
-            task_exec_stats=TaskExecStats(task_wall_time_s=0.0),
+            task_exec_stats=TaskExecWorkerStats(task_wall_time_s=0.0),
             task_exec_driver_stats=TaskExecDriverStats(task_output_backpressure_s=0),
         )
 

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -232,9 +232,16 @@ def test_task_completion_time_excl_backpressure(mock_perf_counter):
     total_scheduling_time_s = sum(t[1] for t in test_cases)
     total_output_bp_time_s = sum(t[2] for t in test_cases)
 
+    total_worker_wall_time_s = sum(
+        t[0] - t[1] for t in test_cases  # driver_wall_time_s - scheduling_time_s
+    )
+
     # Raw counters
     assert metrics.task_block_gen_and_ser_time_s == pytest.approx(total_gen_ser)
     assert metrics.task_completion_time_s == pytest.approx(total_driver_wall_time_s)
+    assert metrics.task_worker_completion_time_s == pytest.approx(
+        total_worker_wall_time_s
+    )
     assert metrics.task_scheduling_time_s == pytest.approx(total_scheduling_time_s)
     assert metrics.task_output_backpressure_time_s == pytest.approx(
         total_output_bp_time_s

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -1,5 +1,5 @@
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
 import pytest
@@ -9,8 +9,11 @@ from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.execution.interfaces.op_runtime_metrics import (
     OpRuntimeMetrics,
 )
+from ray.data._internal.execution.interfaces.physical_operator import (
+    TaskExecDriverStats,
+)
 from ray.data._internal.util import KiB
-from ray.data.block import BlockExecStats, BlockMetadata
+from ray.data.block import BlockExecStats, BlockMetadata, TaskExecStats
 from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR, DataContext
 
 
@@ -75,7 +78,12 @@ def test_task_completion_time_histogram():
         metrics._running_tasks[i].start_time = time.perf_counter() - completion_time
 
         # Complete the task
-        metrics.on_task_finished(i, None)  # None means no exception
+        metrics.on_task_finished(
+            i,
+            None,
+            TaskExecStats(task_wall_time_s=completion_time),
+            TaskExecDriverStats(task_output_backpressure_s=0),
+        )
 
         # Check that the correct bucket was incremented
         assert metrics.task_completion_time._bucket_counts[expected_bucket] == 1
@@ -119,7 +127,12 @@ def test_block_completion_time_histogram():
         metrics._running_tasks[i].cum_block_ser_time_s = ser_time
 
         # Complete the task
-        metrics.on_task_finished(i, None)  # None means no exception
+        metrics.on_task_finished(
+            i,
+            None,
+            TaskExecStats(task_wall_time_s=gen_time + ser_time),
+            TaskExecDriverStats(task_output_backpressure_s=0),
+        )
 
         # Check that the correct bucket was incremented by the number of blocks
         assert (
@@ -130,9 +143,10 @@ def test_block_completion_time_histogram():
         metrics.block_completion_time._bucket_counts[expected_bucket] = 0
 
 
-def test_task_completion_time_excl_backpressure():
-    """Test that task_completion_time_excl_backpressure_s includes both
-    block generation time and serialization time.
+@patch("time.perf_counter")
+def test_task_completion_time_excl_backpressure(mock_perf_counter):
+    """Test that average_task_completion_time_excl_backpressure_s correctly
+    subtracts output backpressure from the driver's wall-clock task time.
 
     This metric is critical for productivity calculation in resource allocators
     as it represents the actual work time excluding output backpressure delays.
@@ -142,34 +156,76 @@ def test_task_completion_time_excl_backpressure():
 
     metrics = OpRuntimeMetrics(op)
 
-    # Submit and complete multiple tasks with different gen/ser times
     test_cases = [
-        # (gen_time, ser_time, num_outputs)
-        (0.5, 0.1, 2),  # Task 0: 0.5s gen + 0.1s ser = 0.6s
-        (0.3, 0.05, 1),  # Task 1: 0.3s gen + 0.05s ser = 0.35s
-        (0.8, 0.2, 3),  # Task 2: 0.8s gen + 0.2s ser = 1.0s
+        # (driver_wall_time_s, worker_wall_time_s, backpressure_time_s, gen_time_s, ser_time_s, num_outputs)
+        (2.0, 1.8, 0.5, 0.5, 0.1, 2),  # Task 0
+        (1.5, 1.3, 0.2, 0.3, 0.05, 1),  # Task 1
+        (3.0, 2.8, 1.0, 0.8, 0.2, 3),  # Task 2
     ]
 
-    expected_total = 0
-    for i, (gen_time, ser_time, num_outputs) in enumerate(test_cases):
+    total_gen_ser = 0
+    clock = 0.0
+    for i, tc in enumerate(test_cases):
+        (
+            driver_wall_time_s,
+            worker_wall_time_s,
+            output_bp_time_s,
+            gen_time_s,
+            ser_time_s,
+            num_outputs,
+        ) = tc
+
         input_bundle = RefBundle([], owns_blocks=False, schema=None)
+
+        # Freeze time at task submission
+        mock_perf_counter.return_value = clock
         metrics.on_task_submitted(i, input_bundle)
 
-        # Set task info
         metrics._running_tasks[i].num_outputs = num_outputs
-        metrics._running_tasks[i].cum_block_gen_time_s = gen_time
-        metrics._running_tasks[i].cum_block_ser_time_s = ser_time
+        metrics._running_tasks[i].cum_block_gen_time_s = gen_time_s
+        metrics._running_tasks[i].cum_block_ser_time_s = ser_time_s
 
-        metrics.on_task_finished(i, None)
-        expected_total += gen_time + ser_time
+        # Advance clock by driver_wall_time_s before finishing
+        clock += driver_wall_time_s
+        mock_perf_counter.return_value = clock
 
-    assert metrics.task_completion_time_excl_backpressure_s == pytest.approx(
-        expected_total
+        metrics.on_task_finished(
+            i,
+            None,
+            TaskExecStats(task_wall_time_s=worker_wall_time_s),
+            TaskExecDriverStats(task_output_backpressure_s=output_bp_time_s),
+        )
+
+        total_gen_ser += gen_time_s + ser_time_s
+
+    num_tasks = len(test_cases)
+
+    total_driver_wall_time_s = sum(t[0] for t in test_cases)
+    total_worker_wall_time_s = sum(t[1] for t in test_cases)
+    total_output_bp_time_s = sum(t[2] for t in test_cases)
+
+    total_scheduling_time_s = total_driver_wall_time_s - total_worker_wall_time_s
+
+    # Raw counters
+    assert metrics.task_block_gen_and_ser_time_s == pytest.approx(total_gen_ser)
+    assert metrics.task_completion_time_s == pytest.approx(total_driver_wall_time_s)
+    assert metrics.task_scheduling_time_s == pytest.approx(total_scheduling_time_s)
+    assert metrics.task_output_backpressure_time_s == pytest.approx(
+        total_output_bp_time_s
     )
 
-    expected_avg = expected_total / len(test_cases)
-    assert metrics.average_task_completion_excl_backpressure_time_s == pytest.approx(
-        expected_avg
+    # Derived averages
+    assert metrics.average_total_task_completion_time_s == pytest.approx(
+        total_driver_wall_time_s / num_tasks
+    )
+    assert metrics.average_task_scheduling_time_s == pytest.approx(
+        total_scheduling_time_s / num_tasks
+    )
+    assert metrics.average_task_output_backpressure_time_s == pytest.approx(
+        total_output_bp_time_s / num_tasks
+    )
+    assert metrics.average_task_completion_time_excl_backpressure_s == pytest.approx(
+        (total_driver_wall_time_s - total_output_bp_time_s) / num_tasks
     )
 
 

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -13,7 +13,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     TaskExecDriverStats,
 )
 from ray.data._internal.util import KiB
-from ray.data.block import BlockExecStats, BlockMetadata, TaskExecStats
+from ray.data.block import BlockExecStats, BlockMetadata, TaskExecWorkerStats
 from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR, DataContext
 
 
@@ -81,7 +81,7 @@ def test_task_completion_time_histogram():
         metrics.on_task_finished(
             i,
             None,
-            TaskExecStats(task_wall_time_s=completion_time),
+            TaskExecWorkerStats(task_wall_time_s=completion_time),
             TaskExecDriverStats(task_output_backpressure_s=0),
         )
 
@@ -130,7 +130,7 @@ def test_block_completion_time_histogram():
         metrics.on_task_finished(
             i,
             None,
-            TaskExecStats(task_wall_time_s=gen_time + ser_time),
+            TaskExecWorkerStats(task_wall_time_s=gen_time + ser_time),
             TaskExecDriverStats(task_output_backpressure_s=0),
         )
 
@@ -222,7 +222,7 @@ def test_task_completion_time_excl_backpressure(mock_perf_counter):
         metrics.on_task_finished(
             i,
             None,
-            TaskExecStats(task_wall_time_s=driver_wall_time_s - scheduling_time_s),
+            TaskExecWorkerStats(task_wall_time_s=driver_wall_time_s - scheduling_time_s),
             TaskExecDriverStats(task_output_backpressure_s=output_bp_time_s),
         )
 

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -222,7 +222,9 @@ def test_task_completion_time_excl_backpressure(mock_perf_counter):
         metrics.on_task_finished(
             i,
             None,
-            TaskExecWorkerStats(task_wall_time_s=driver_wall_time_s - scheduling_time_s),
+            TaskExecWorkerStats(
+                task_wall_time_s=driver_wall_time_s - scheduling_time_s
+            ),
             TaskExecDriverStats(task_output_backpressure_s=output_bp_time_s),
         )
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -34,7 +34,7 @@ from ray.data._internal.execution.streaming_executor_state import (
     build_streaming_topology,
 )
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data.block import TaskExecStats
+from ray.data.block import TaskExecWorkerStats
 from ray.data.context import MAX_SAFE_BLOCK_SIZE_FACTOR, DataContext
 from ray.data.tests.conftest import *  # noqa
 
@@ -361,7 +361,7 @@ class TestResourceManager:
         o2.metrics.on_task_finished(
             0,
             None,
-            TaskExecStats(task_wall_time_s=0.0),
+            TaskExecWorkerStats(task_wall_time_s=0.0),
             TaskExecDriverStats(task_output_backpressure_s=0),
         )
         resource_manager.update_usages()
@@ -401,7 +401,7 @@ class TestResourceManager:
         o3.metrics.on_task_finished(
             0,
             None,
-            TaskExecStats(task_wall_time_s=0.0),
+            TaskExecWorkerStats(task_wall_time_s=0.0),
             TaskExecDriverStats(task_output_backpressure_s=0),
         )
         resource_manager.update_usages()

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -86,7 +86,10 @@ def gen_expected_metrics(
             "'average_num_inputs_per_task': N",
             "'num_output_blocks_per_task_s': N",
             "'average_total_task_completion_time_s': N",
-            "'average_task_completion_excl_backpressure_time_s': N",
+            "'average_task_scheduling_time_s': N",
+            "'average_task_output_backpressure_time_s': Z",
+            "'average_task_completion_time_excl_backpressure_s': N",
+            "'average_task_block_gen_and_ser_time_s': N",
             "'average_bytes_per_output': N",
             "'obj_store_mem_internal_inqueue': Z",
             "'obj_store_mem_internal_outqueue': Z",
@@ -133,10 +136,12 @@ def gen_expected_metrics(
                 "'task_output_backpressure_time': "
                 f"{'N' if task_output_backpressure else 'Z'}"
             ),
-            "'task_completion_time_total_s': N",
+            "'task_completion_time_s': N",
+            "'task_scheduling_time_s': N",
+            "'task_output_backpressure_time_s': Z",
             "'task_completion_time': (samples: N, avg: N)",
             "'block_completion_time': (samples: N, avg: N)",
-            "'task_completion_time_excl_backpressure_s': N",
+            "'task_block_gen_and_ser_time_s': N",
             "'block_size_bytes': (samples: N, avg: N)",
             "'block_size_rows': (samples: N, avg: N)",
             "'num_alive_actors': Z",
@@ -156,7 +161,10 @@ def gen_expected_metrics(
             "'average_num_inputs_per_task': None",
             "'num_output_blocks_per_task_s': None",
             "'average_total_task_completion_time_s': None",
-            "'average_task_completion_excl_backpressure_time_s': None",
+            "'average_task_scheduling_time_s': None",
+            "'average_task_output_backpressure_time_s': None",
+            "'average_task_completion_time_excl_backpressure_s': None",
+            "'average_task_block_gen_and_ser_time_s': None",
             "'average_bytes_per_output': None",
             "'obj_store_mem_internal_inqueue': Z",
             "'obj_store_mem_internal_outqueue': Z",
@@ -203,13 +211,12 @@ def gen_expected_metrics(
                 "'task_output_backpressure_time': "
                 f"{'N' if task_output_backpressure else 'Z'}"
             ),
-            "'task_completion_time_total_s': Z",
+            "'task_completion_time_s': Z",
+            "'task_scheduling_time_s': Z",
+            "'task_output_backpressure_time_s': Z",
             "'task_completion_time': (samples: Z, avg: Z)",
             "'block_completion_time': (samples: Z, avg: Z)",
-            (
-                "'task_completion_time_excl_backpressure_s': "
-                f"{'N' if task_backpressure else 'Z'}"
-            ),
+            "'task_block_gen_and_ser_time_s': Z",
             "'block_size_bytes': (samples: Z, avg: Z)",
             "'block_size_rows': (samples: Z, avg: Z)",
             "'num_alive_actors': Z",
@@ -629,7 +636,10 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      average_num_inputs_per_task: N,\n"
         "      num_output_blocks_per_task_s: N,\n"
         "      average_total_task_completion_time_s: N,\n"
-        "      average_task_completion_excl_backpressure_time_s: N,\n"
+        "      average_task_scheduling_time_s: N,\n"
+        "      average_task_output_backpressure_time_s: Z,\n"
+        "      average_task_completion_time_excl_backpressure_s: N,\n"
+        "      average_task_block_gen_and_ser_time_s: N,\n"
         "      average_bytes_per_output: N,\n"
         "      obj_store_mem_internal_inqueue: Z,\n"
         "      obj_store_mem_internal_outqueue: Z,\n"
@@ -670,10 +680,12 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      block_serialization_time_s: N,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
-        "      task_completion_time_total_s: N,\n"
+        "      task_completion_time_s: N,\n"
+        "      task_scheduling_time_s: N,\n"
+        "      task_output_backpressure_time_s: Z,\n"
         "      task_completion_time: (samples: N, avg: N),\n"
         "      block_completion_time: (samples: N, avg: N),\n"
-        "      task_completion_time_excl_backpressure_s: N,\n"
+        "      task_block_gen_and_ser_time_s: N,\n"
         "      block_size_bytes: (samples: N, avg: N),\n"
         "      block_size_rows: (samples: N, avg: N),\n"
         "      num_alive_actors: Z,\n"
@@ -775,7 +787,10 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      average_num_inputs_per_task: N,\n"
         "      num_output_blocks_per_task_s: N,\n"
         "      average_total_task_completion_time_s: N,\n"
-        "      average_task_completion_excl_backpressure_time_s: N,\n"
+        "      average_task_scheduling_time_s: N,\n"
+        "      average_task_output_backpressure_time_s: Z,\n"
+        "      average_task_completion_time_excl_backpressure_s: N,\n"
+        "      average_task_block_gen_and_ser_time_s: N,\n"
         "      average_bytes_per_output: N,\n"
         "      obj_store_mem_internal_inqueue: Z,\n"
         "      obj_store_mem_internal_outqueue: Z,\n"
@@ -816,10 +831,12 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      block_serialization_time_s: N,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
-        "      task_completion_time_total_s: N,\n"
+        "      task_completion_time_s: N,\n"
+        "      task_scheduling_time_s: N,\n"
+        "      task_output_backpressure_time_s: Z,\n"
         "      task_completion_time: (samples: N, avg: N),\n"
         "      block_completion_time: (samples: N, avg: N),\n"
-        "      task_completion_time_excl_backpressure_s: N,\n"
+        "      task_block_gen_and_ser_time_s: N,\n"
         "      block_size_bytes: (samples: N, avg: N),\n"
         "      block_size_rows: (samples: N, avg: N),\n"
         "      num_alive_actors: Z,\n"
@@ -874,7 +891,10 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            average_num_inputs_per_task: N,\n"
         "            num_output_blocks_per_task_s: N,\n"
         "            average_total_task_completion_time_s: N,\n"
-        "            average_task_completion_excl_backpressure_time_s: N,\n"
+        "            average_task_scheduling_time_s: N,\n"
+        "            average_task_output_backpressure_time_s: Z,\n"
+        "            average_task_completion_time_excl_backpressure_s: N,\n"
+        "            average_task_block_gen_and_ser_time_s: N,\n"
         "            average_bytes_per_output: N,\n"
         "            obj_store_mem_internal_inqueue: Z,\n"
         "            obj_store_mem_internal_outqueue: Z,\n"
@@ -915,10 +935,12 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            block_serialization_time_s: N,\n"
         "            task_submission_backpressure_time: N,\n"
         "            task_output_backpressure_time: Z,\n"
-        "            task_completion_time_total_s: N,\n"
+        "            task_completion_time_s: N,\n"
+        "            task_scheduling_time_s: N,\n"
+        "            task_output_backpressure_time_s: Z,\n"
         "            task_completion_time: (samples: N, avg: N),\n"
         "            block_completion_time: (samples: N, avg: N),\n"
-        "            task_completion_time_excl_backpressure_s: N,\n"
+        "            task_block_gen_and_ser_time_s: N,\n"
         "            block_size_bytes: (samples: N, avg: N),\n"
         "            block_size_rows: (samples: N, avg: N),\n"
         "            num_alive_actors: Z,\n"

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -137,6 +137,7 @@ def gen_expected_metrics(
                 f"{'N' if task_output_backpressure else 'Z'}"
             ),
             "'task_completion_time_s': N",
+            "'task_worker_completion_time_s': N",
             "'task_scheduling_time_s': N",
             "'task_output_backpressure_time_s': Z",
             "'task_completion_time': (samples: N, avg: N)",
@@ -212,6 +213,7 @@ def gen_expected_metrics(
                 f"{'N' if task_output_backpressure else 'Z'}"
             ),
             "'task_completion_time_s': Z",
+            "'task_worker_completion_time_s': Z",
             "'task_scheduling_time_s': Z",
             "'task_output_backpressure_time_s': Z",
             "'task_completion_time': (samples: Z, avg: Z)",
@@ -681,6 +683,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_s: N,\n"
+        "      task_worker_completion_time_s: N,\n"
         "      task_scheduling_time_s: N,\n"
         "      task_output_backpressure_time_s: Z,\n"
         "      task_completion_time: (samples: N, avg: N),\n"
@@ -832,6 +835,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_s: N,\n"
+        "      task_worker_completion_time_s: N,\n"
         "      task_scheduling_time_s: N,\n"
         "      task_output_backpressure_time_s: Z,\n"
         "      task_completion_time: (samples: N, avg: N),\n"
@@ -936,6 +940,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            task_submission_backpressure_time: N,\n"
         "            task_output_backpressure_time: Z,\n"
         "            task_completion_time_s: N,\n"
+        "            task_worker_completion_time_s: N,\n"
         "            task_scheduling_time_s: N,\n"
         "            task_output_backpressure_time_s: Z,\n"
         "            task_completion_time: (samples: N, avg: N),\n"

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -59,7 +59,7 @@ from ray.data._internal.execution.streaming_executor_state import (
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.logical.operators import MapRows, Read, Write
 from ray.data._internal.util import MiB
-from ray.data.block import BlockAccessor, BlockMetadataWithSchema
+from ray.data.block import BlockAccessor, BlockMetadataWithSchema, TaskExecStats
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -59,7 +59,7 @@ from ray.data._internal.execution.streaming_executor_state import (
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.logical.operators import MapRows, Read, Write
 from ray.data._internal.util import MiB
-from ray.data.block import BlockAccessor, BlockMetadataWithSchema, TaskExecStats
+from ray.data.block import BlockAccessor, BlockMetadataWithSchema, TaskExecWorkerStats
 from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
 
@@ -1151,7 +1151,7 @@ def create_stub_streaming_gen(
 
             block_accessor = BlockAccessor.for_block(block)
             block_metadata = block_accessor.get_metadata(
-                task_exec_stats=TaskExecStats(
+                task_exec_stats=TaskExecWorkerStats(
                     task_wall_time_s=_time.perf_counter() - task_start_s,
                 )
             )


### PR DESCRIPTION
## Description

This change adds ability to track

 - *Cumulative tasks output back-pressure*: tracks how many time individual task had results ready to be consumed but there was no Object Store budget to consume it
 - *Cumulative tasks scheduling time*: tracks how much time it took for task to get scheduled with all of its arguments pulled into the worker (calculated as driver task's wall time - worker's wall time)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
