### PR TITLE
[Data] Extract Unity Catalog credential resolution into dedicated function.

### DIFF
--- a/python/ray/data/_internal/datasource/databricks_credentials.py
+++ b/python/ray/data/_internal/datasource/databricks_credentials.py
@@ -203,7 +203,7 @@ class EnvironmentCredentialProvider(DatabricksCredentialProvider):
             self._token = token
 
 
-def resolve_credential_provider(
+def resolve_credential_provider_for_databricks_table(
     credential_provider: Optional[DatabricksCredentialProvider] = None,
 ) -> DatabricksCredentialProvider:
     """Resolve credential provider.
@@ -220,6 +220,38 @@ def resolve_credential_provider(
 
     # Fall back to environment variables
     return EnvironmentCredentialProvider()
+
+
+def resolve_credential_provider_for_unity_catalog(
+    credential_provider: Optional[DatabricksCredentialProvider] = None,
+    url: Optional[str] = None,
+    token: Optional[str] = None,
+) -> DatabricksCredentialProvider:
+    """Resolve credential provider for Unity Catalog.
+
+    Args:
+        credential_provider: An explicit credential provider instance.
+            If provided, this takes precedence over url/token.
+        url: The Databricks host URL. Must be provided together with token
+            if credential_provider is None.
+        token: The Databricks authentication token. Must be provided together
+            with url if credential_provider is None.
+
+    Returns:
+        A DatabricksCredentialProvider instance.
+
+    Raises:
+        ValueError: If neither credential_provider nor both url and token
+            are provided.
+    """
+    if credential_provider is not None:
+        return credential_provider
+    if url is not None and token is not None:
+        return StaticCredentialProvider(token=token, host=url)
+
+    raise ValueError(
+        "Either 'credential_provider' or both 'url' and 'token' must be provided."
+    )
 
 
 def build_headers(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2785,13 +2785,13 @@ def read_databricks_tables(
     """  # noqa: E501
     # Resolve credential provider (single source of truth for token and host)
     from ray.data._internal.datasource.databricks_credentials import (
-        resolve_credential_provider,
+        resolve_credential_provider_for_databricks_table,
     )
     from ray.data._internal.datasource.databricks_uc_datasource import (
         DatabricksUCDatasource,
     )
 
-    resolved_provider = resolve_credential_provider(
+    resolved_provider = resolve_credential_provider_for_databricks_table(
         credential_provider=credential_provider
     )
 
@@ -4221,20 +4221,12 @@ def read_unity_catalog(
         A :class:`~ray.data.Dataset` containing the data from Unity Catalog.
     """  # noqa: E501
     from ray.data._internal.datasource.databricks_credentials import (
-        StaticCredentialProvider,
-        resolve_credential_provider,
+        resolve_credential_provider_for_unity_catalog,
     )
 
-    # Resolve credentials: either from credential_provider or from url/token
-    if credential_provider is not None:
-        resolved_provider = resolve_credential_provider(credential_provider)
-    elif url is not None and token is not None:
-        # Backwards compatible: create provider from url/token
-        resolved_provider = StaticCredentialProvider(token=token, host=url)
-    else:
-        raise ValueError(
-            "Either 'credential_provider' or both 'url' and 'token' must be provided."
-        )
+    resolved_provider = resolve_credential_provider_for_unity_catalog(
+        credential_provider=credential_provider, url=url, token=token
+    )
 
     connector = UnityCatalogConnector(
         table_full_name=table,

--- a/python/ray/data/tests/datasource/test_databricks_credentials.py
+++ b/python/ray/data/tests/datasource/test_databricks_credentials.py
@@ -9,8 +9,15 @@ from ray.data._internal.datasource.databricks_credentials import (
     DatabricksCredentialProvider,
     EnvironmentCredentialProvider,
     StaticCredentialProvider,
-    resolve_credential_provider,
+    resolve_credential_provider_for_databricks_table,
+    resolve_credential_provider_for_unity_catalog,
 )
+
+SAMPLE_TOKEN = "dapi_test_token_abc123"
+SAMPLE_HOST = "https://my-workspace.cloud.databricks.com"
+SAMPLE_URL = "https://uc-workspace.databricks.com"
+ALT_TOKEN = "dapi_alt_token_xyz789"
+ALT_HOST = "https://alt-workspace.databricks.com"
 
 
 class TestDatabricksCredentialProvider:
@@ -34,19 +41,17 @@ class TestStaticCredentialProvider:
 
     def test_init_with_valid_token_and_host(self):
         """Test successful initialization with token and host."""
-        provider = StaticCredentialProvider(
-            token="test_token", host="https://my-workspace.cloud.databricks.com"
-        )
-        assert provider.get_token() == "test_token"
-        assert provider.get_host() == "https://my-workspace.cloud.databricks.com"
+        provider = StaticCredentialProvider(token=SAMPLE_TOKEN, host=SAMPLE_HOST)
+        assert provider.get_token() == SAMPLE_TOKEN
+        assert provider.get_host() == SAMPLE_HOST
 
     @pytest.mark.parametrize(
         "token,host,expected_error",
         [
-            ("", "host", "Token cannot be empty"),
-            (None, "host", "Token cannot be empty"),
-            ("valid_token", "", "Host cannot be empty"),
-            ("valid_token", None, "Host cannot be empty"),
+            ("", SAMPLE_HOST, "Token cannot be empty"),
+            (None, SAMPLE_HOST, "Token cannot be empty"),
+            (SAMPLE_TOKEN, "", "Host cannot be empty"),
+            (SAMPLE_TOKEN, None, "Host cannot be empty"),
         ],
     )
     def test_init_with_invalid_inputs_raises_error(self, token, host, expected_error):
@@ -56,16 +61,16 @@ class TestStaticCredentialProvider:
 
     def test_invalidate_is_noop(self):
         """Test that invalidate doesn't affect the static token."""
-        provider = StaticCredentialProvider(token="test_token", host="test_host")
+        provider = StaticCredentialProvider(token=SAMPLE_TOKEN, host=SAMPLE_HOST)
         provider.invalidate()
-        assert provider.get_token() == "test_token"
-        assert provider.get_host() == "test_host"
+        assert provider.get_token() == SAMPLE_TOKEN
+        assert provider.get_host() == SAMPLE_HOST
 
     def test_get_token_returns_same_value(self):
         """Test that get_token always returns the same value."""
-        provider = StaticCredentialProvider(token="consistent_token", host="host")
-        assert provider.get_token() == "consistent_token"
-        assert provider.get_token() == "consistent_token"
+        provider = StaticCredentialProvider(token=SAMPLE_TOKEN, host=SAMPLE_HOST)
+        assert provider.get_token() == SAMPLE_TOKEN
+        assert provider.get_token() == SAMPLE_TOKEN
 
 
 class TestEnvironmentCredentialProvider:
@@ -74,25 +79,27 @@ class TestEnvironmentCredentialProvider:
     def test_get_token_from_env(self):
         """Test get_token reads from environment variable."""
         with mock.patch.dict(
-            os.environ, {"DATABRICKS_TOKEN": "env_token", "DATABRICKS_HOST": "host"}
+            os.environ,
+            {"DATABRICKS_TOKEN": SAMPLE_TOKEN, "DATABRICKS_HOST": SAMPLE_HOST},
         ):
             provider = EnvironmentCredentialProvider()
-            assert provider.get_token() == "env_token"
+            assert provider.get_token() == SAMPLE_TOKEN
 
     def test_get_host_from_env(self):
         """Test get_host reads from environment variable."""
         with mock.patch.dict(
-            os.environ, {"DATABRICKS_TOKEN": "token", "DATABRICKS_HOST": "env_host"}
+            os.environ,
+            {"DATABRICKS_TOKEN": SAMPLE_TOKEN, "DATABRICKS_HOST": SAMPLE_HOST},
         ):
             provider = EnvironmentCredentialProvider()
-            assert provider.get_host() == "env_host"
+            assert provider.get_host() == SAMPLE_HOST
 
     @pytest.mark.parametrize(
         "env_vars,expected_error",
         [
-            ({"DATABRICKS_HOST": "host"}, "DATABRICKS_TOKEN.*not set"),
+            ({"DATABRICKS_HOST": SAMPLE_HOST}, "DATABRICKS_TOKEN.*not set"),
             (
-                {"DATABRICKS_TOKEN": "token"},
+                {"DATABRICKS_TOKEN": SAMPLE_TOKEN},
                 "set environment variable.*DATABRICKS_HOST",
             ),
         ],
@@ -105,45 +112,51 @@ class TestEnvironmentCredentialProvider:
 
     def test_host_detected_from_databricks_runtime(self):
         """Test host is detected from Databricks runtime when env var not set."""
+        detected_host = "detected-host.databricks.com"
         with (
-            mock.patch.dict(os.environ, {"DATABRICKS_TOKEN": "token"}, clear=True),
+            mock.patch.dict(
+                os.environ, {"DATABRICKS_TOKEN": SAMPLE_TOKEN}, clear=True
+            ),
             mock.patch.object(
                 EnvironmentCredentialProvider,
                 "_detect_databricks_host",
-                return_value="detected-host.databricks.com",
+                return_value=detected_host,
             ),
         ):
             provider = EnvironmentCredentialProvider()
-            assert provider.get_host() == "detected-host.databricks.com"
+            assert provider.get_host() == detected_host
 
     def test_custom_env_var_names(self):
         """Test using custom environment variable names."""
         with mock.patch.dict(
-            os.environ, {"MY_TOKEN": "custom_token", "MY_HOST": "custom_host"}
+            os.environ, {"MY_TOKEN": SAMPLE_TOKEN, "MY_HOST": SAMPLE_HOST}
         ):
             provider = EnvironmentCredentialProvider(
                 token_env_var="MY_TOKEN", host_env_var="MY_HOST"
             )
-            assert provider.get_token() == "custom_token"
-            assert provider.get_host() == "custom_host"
+            assert provider.get_token() == SAMPLE_TOKEN
+            assert provider.get_host() == SAMPLE_HOST
 
     def test_invalidate_refreshes_token_from_env(self):
         """Test that invalidate re-reads token from environment."""
+        refreshed_token = "dapi_refreshed_token_456"
         with mock.patch.dict(
-            os.environ, {"DATABRICKS_TOKEN": "initial_token", "DATABRICKS_HOST": "host"}
+            os.environ,
+            {"DATABRICKS_TOKEN": SAMPLE_TOKEN, "DATABRICKS_HOST": SAMPLE_HOST},
         ):
             provider = EnvironmentCredentialProvider()
-            assert provider.get_token() == "initial_token"
+            assert provider.get_token() == SAMPLE_TOKEN
 
             # Simulate external token refresh
-            os.environ["DATABRICKS_TOKEN"] = "refreshed_token"
+            os.environ["DATABRICKS_TOKEN"] = refreshed_token
             provider.invalidate()
-            assert provider.get_token() == "refreshed_token"
+            assert provider.get_token() == refreshed_token
 
     def test_invalidate_keeps_token_if_env_unset(self):
         """Test that invalidate keeps existing token if env var is unset."""
         with mock.patch.dict(
-            os.environ, {"DATABRICKS_TOKEN": "initial_token", "DATABRICKS_HOST": "host"}
+            os.environ,
+            {"DATABRICKS_TOKEN": SAMPLE_TOKEN, "DATABRICKS_HOST": SAMPLE_HOST},
         ):
             provider = EnvironmentCredentialProvider()
 
@@ -151,16 +164,18 @@ class TestEnvironmentCredentialProvider:
             del os.environ["DATABRICKS_TOKEN"]
             provider.invalidate()
             # Should keep the old token rather than failing
-            assert provider.get_token() == "initial_token"
+            assert provider.get_token() == SAMPLE_TOKEN
 
 
-class TestResolveCredentialProvider:
-    """Tests for resolve_credential_provider function."""
+class TestResolveCredentialProviderForDatabricksTable:
+    """Tests for resolve_credential_provider_for_databricks_table function."""
 
     def test_resolve_with_explicit_provider(self):
         """Test that explicit credential_provider is returned as-is."""
-        provider = StaticCredentialProvider(token="my_token", host="my_host")
-        result = resolve_credential_provider(credential_provider=provider)
+        provider = StaticCredentialProvider(token=SAMPLE_TOKEN, host=SAMPLE_HOST)
+        result = resolve_credential_provider_for_databricks_table(
+            credential_provider=provider
+        )
         assert result is provider
 
     @pytest.mark.parametrize("credential_provider_arg", [None, "no_arg"])
@@ -169,15 +184,72 @@ class TestResolveCredentialProvider:
     ):
         """Test that EnvironmentCredentialProvider is returned when none provided."""
         with mock.patch.dict(
-            os.environ, {"DATABRICKS_TOKEN": "token", "DATABRICKS_HOST": "host"}
+            os.environ,
+            {"DATABRICKS_TOKEN": SAMPLE_TOKEN, "DATABRICKS_HOST": SAMPLE_HOST},
         ):
             if credential_provider_arg == "no_arg":
-                result = resolve_credential_provider()
+                result = resolve_credential_provider_for_databricks_table()
             else:
-                result = resolve_credential_provider(
+                result = resolve_credential_provider_for_databricks_table(
                     credential_provider=credential_provider_arg
                 )
             assert isinstance(result, EnvironmentCredentialProvider)
+
+
+class TestResolveCredentialProviderForUnityCatalog:
+    """Tests for resolve_credential_provider_for_unity_catalog function."""
+
+    def test_resolve_with_explicit_provider(self):
+        """Test that explicit credential_provider is returned as-is."""
+        provider = StaticCredentialProvider(token=SAMPLE_TOKEN, host=SAMPLE_HOST)
+        result = resolve_credential_provider_for_unity_catalog(
+            credential_provider=provider
+        )
+        assert result is provider
+
+    def test_resolve_with_explicit_provider_ignores_url_and_token(self):
+        """Test that url/token are ignored when credential_provider is given."""
+        provider = StaticCredentialProvider(token=SAMPLE_TOKEN, host=SAMPLE_HOST)
+        result = resolve_credential_provider_for_unity_catalog(
+            credential_provider=provider, url=ALT_HOST, token=ALT_TOKEN
+        )
+        assert result is provider
+
+    def test_resolve_with_url_and_token(self):
+        """Test that url and token create a StaticCredentialProvider."""
+        result = resolve_credential_provider_for_unity_catalog(
+            url=SAMPLE_URL, token=SAMPLE_TOKEN
+        )
+        assert isinstance(result, StaticCredentialProvider)
+        assert result.get_token() == SAMPLE_TOKEN
+        assert result.get_host() == SAMPLE_URL
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"url": SAMPLE_URL},
+            {"token": SAMPLE_TOKEN},
+        ],
+        ids=["no_args", "only_url", "only_token"],
+    )
+    def test_resolve_raises_with_incomplete_args(self, kwargs):
+        """Test that ValueError is raised when args are missing or incomplete."""
+        with pytest.raises(ValueError, match="Either 'credential_provider' or both"):
+            resolve_credential_provider_for_unity_catalog(**kwargs)
+
+    @pytest.mark.parametrize(
+        "url,token",
+        [
+            ("", SAMPLE_TOKEN),
+            (SAMPLE_URL, ""),
+        ],
+        ids=["empty_url", "empty_token"],
+    )
+    def test_resolve_with_empty_string_raises(self, url, token):
+        """Test that empty strings for url or token raise ValueError."""
+        with pytest.raises(ValueError):
+            resolve_credential_provider_for_unity_catalog(url=url, token=token)
 
 
 class TestCredentialProviderSerialization:
@@ -186,8 +258,8 @@ class TestCredentialProviderSerialization:
     @pytest.mark.parametrize(
         "provider_type,expected_token,expected_host",
         [
-            ("static", "test_token", "test_host"),
-            ("environment", "env_token", "env_host"),
+            ("static", SAMPLE_TOKEN, SAMPLE_HOST),
+            ("environment", SAMPLE_TOKEN, SAMPLE_HOST),
         ],
     )
     def test_provider_is_picklable(self, provider_type, expected_token, expected_host):


### PR DESCRIPTION
Renames resolve_credential_provider to resolve_credential_provider_for_databricks_table and adds a new resolve_credential_provider_for_unity_catalog function that encapsulates the credential resolution logic previously inline in read_unity_catalog(). This moves the if/elif/else branching (credential_provider vs url/token pair) into the credentials module for better separation of concerns. Updates tests to cover the renamed function and all branches of the new resolver.
