### PR TITLE
[Serve] increase timeout on test_cli test_status_package_unavailable_…

### DIFF
--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -640,7 +640,7 @@ def test_status_package_unavailable_in_controller(serve_instance):
         assert "some_wrong_url" in status["deployments"]["TestDeployment"]["message"]
         return True
 
-    wait_for_condition(check_for_failed_deployment, timeout=20)
+    wait_for_condition(check_for_failed_deployment, timeout=40)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")


### PR DESCRIPTION
The deployment needs 3 consecutive replica startup failures to transition to `DEPLOY_FAILED` status (`min(max_constructor_retry_count=20, num_replicas * MAX_PER_REPLICA_RETRY_COUNT=1*3) = 3`). The first failure is slow (~16s in CI) because the replica's `runtime_env` must pip-install `PyMySQL` and `sqlalchemy` before the constructor runs and fails. This leaves insufficient time for the remaining 2 retries within the 20s window.

Increases timeout from 20s to 40s to accommodate CI variability in pip install latency.

**Test plan:**
- no testing done, will see how it goes

https://buildkite.com/organizations/ray-project/pipelines/postmerge/builds/16138/jobs/019c79a9-b43d-4307-94f1-aa02314237e5/log#614-7894