### PR TITLE
[Core] Add root logger handler so user loggers work in spawn'd subprocesses

### DIFF
--- a/python/ray/_private/log.py
+++ b/python/ray/_private/log.py
@@ -108,6 +108,11 @@ def generate_logging_config():
         ray_logger.addHandler(default_handler)
         ray_logger.propagate = False
 
+        root_logger = logging.getLogger()
+        if not root_logger.handlers:
+            root_logger.setLevel(logging.INFO)
+            root_logger.addHandler(PlainRayHandler())
+
         # Special handling for ray.rllib: only warning-level messages passed through
         # See https://github.com/ray-project/ray/pull/31858 for related PR
         rllib_logger = logging.getLogger("ray.rllib")

--- a/python/ray/_private/ray_logging/logging_config.py
+++ b/python/ray/_private/ray_logging/logging_config.py
@@ -44,6 +44,10 @@ class DefaultLoggingConfigurator(LoggingConfigurator):
 
         root_logger = logging.getLogger()
         root_logger.setLevel(logging_config.log_level)
+        # Remove existing handlers (e.g., PlainRayHandler added by
+        # generate_logging_config) to avoid duplicate log output.
+        for h in root_logger.handlers[:]:
+            root_logger.removeHandler(h)
         root_logger.addHandler(handler)
 
         ray_logger = logging.getLogger("ray")

--- a/python/ray/tests/test_logging_2.py
+++ b/python/ray/tests/test_logging_2.py
@@ -181,13 +181,15 @@ actor_instance = actor.remote()
 ray.get(actor_instance.print_message.remote())
 """
         stderr = run_string_as_driver(script)
+        # Without LoggingConfig the plain root-logger handler is active, so the
+        # message text appears but structured fields are absent.
+        assert "This is a Ray actor" in stderr
         should_not_exist = [
             "job_id",
             "worker_id",
             "node_id",
             "actor_id",
             "task_id",
-            "This is a Ray actor",
             "timestamp_ns",
         ]
         for s in should_not_exist:


### PR DESCRIPTION
## Why are these changes needed?

When a subprocess is created with `multiprocessing.get_context('spawn')` inside a Ray task/actor, `Logger.info()` calls in the subprocess are **silently dropped**. `print()` works fine because Ray's FD-level redirection (via `dup2()`) is inherited by child processes, but Python's `logging` module starts with zero handlers in a `spawn`'d process.

### Root cause

`generate_logging_config()` in `ray/_private/log.py` only configures the `"ray"` logger, not the root logger. User loggers (e.g. `logging.getLogger("my_dataloader")`) are not children of `"ray"`, so when they propagate up to the root logger, there's no handler to catch them. Python's built-in "last resort" handler only handles `WARNING+`, so `INFO` messages are lost entirely.

### Fix

Add a `PlainRayHandler` to the root logger (guarded by `if not root_logger.handlers` to avoid duplicates). This ensures user loggers work automatically in any process that `import ray`, including `spawn`'d subprocesses.

The handler chain becomes:
```
logger.info("msg")  # user logger, e.g. "my_dataloader"
  → propagates to root logger
    → PlainRayHandler.emit()
      → logging._StderrHandler → sys.stderr
        → FD 2 (inherited from parent via dup2)
          → Ray's worker-XXXX.err log file
```

### Verified on Anyscale

Submitted an [Anyscale job](https://console.anyscale.com/jobs/prodjob_wcs5cbz9vkiy112wmhudbg628u) demonstrating:
1. **Without fix**: `Logger.info()` in spawn'd subprocess → NOT FOUND in Ray logs
2. **With user-level workaround**: manually adding `StreamHandler(sys.stderr)` → appears in logs
3. **With this Ray-level fix** (runtime-patched): `Logger.info()` → appears in logs automatically

## Related issue(s)

None

## Checks

- [x] I've signed the [CLA](http://ray.io/cla)
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've updated the `test_logging_2.py::test_logger_not_set` test to match new behavior.
- [x] I've verified on a real Anyscale cluster that the fix works.