### PR TITLE
[serve][4/n] Gang scheduling -- fault tolerance

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -910,6 +910,8 @@ class GangReservationResult:
     """True when all gang PGs were created successfully."""
     error_message: Optional[str] = None
     gang_pgs: Optional[List[PlacementGroup]] = None
+    gang_ids: Optional[List[str]] = None
+    gang_pg_names: Optional[List[str]] = None
 
 
 # This error is used to raise when a by-value DeploymentResponse is converted to an

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -23,6 +23,7 @@ from ray.actor import ActorHandle
 from ray.serve._private.application_state import ApplicationStateManager, StatusOverview
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
+    GANG_PG_NAME_PREFIX,
     AsyncInferenceTaskQueueMetricReport,
     DeploymentID,
     DeploymentSnapshot,
@@ -431,6 +432,27 @@ class ServeController:
         self.deployment_state_manager._deployment_states[
             deployment_id
         ]._stop_one_running_replica_for_testing()
+
+    def _detect_leaked_pgs_with_gcs_failure_for_testing(self):
+        """Exercise gang PG leak detection with a simulated GCS failure."""
+        original_fn = ray.serve._private.deployment_state.get_active_placement_group_ids
+
+        def _fail_get_active_pg_ids():
+            raise RuntimeError("Simulated GCS failure for testing")
+
+        ray.serve._private.deployment_state.get_active_placement_group_ids = (
+            _fail_get_active_pg_ids
+        )
+        try:
+            # We need a PG name prefixing with GANG_PG_NAME_PREFIX to enter the gang
+            # leak-detection block and hit the GCS query failure except branch.
+            self.deployment_state_manager._detect_and_remove_leaked_placement_groups(
+                [], [f"{GANG_PG_NAME_PREFIX}_test_gang_pg_name"]
+            )
+        finally:
+            ray.serve._private.deployment_state.get_active_placement_group_ids = (
+                original_fn
+            )
 
     async def listen_for_change(self, keys_to_snapshot_ids: Dict[str, int]):
         """Proxy long pull client's listen request.

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -23,7 +23,6 @@ from ray.actor import ActorHandle
 from ray.serve._private.application_state import ApplicationStateManager, StatusOverview
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
-    GANG_PG_NAME_PREFIX,
     AsyncInferenceTaskQueueMetricReport,
     DeploymentID,
     DeploymentSnapshot,
@@ -432,27 +431,6 @@ class ServeController:
         self.deployment_state_manager._deployment_states[
             deployment_id
         ]._stop_one_running_replica_for_testing()
-
-    def _detect_leaked_pgs_with_gcs_failure_for_testing(self):
-        """Exercise gang PG leak detection with a simulated GCS failure."""
-        original_fn = ray.serve._private.deployment_state.get_active_placement_group_ids
-
-        def _fail_get_active_pg_ids():
-            raise RuntimeError("Simulated GCS failure for testing")
-
-        ray.serve._private.deployment_state.get_active_placement_group_ids = (
-            _fail_get_active_pg_ids
-        )
-        try:
-            # We need a PG name prefixing with GANG_PG_NAME_PREFIX to enter the gang
-            # leak-detection block and hit the GCS query failure except branch.
-            self.deployment_state_manager._detect_and_remove_leaked_placement_groups(
-                [], [f"{GANG_PG_NAME_PREFIX}_test_gang_pg_name"]
-            )
-        finally:
-            ray.serve._private.deployment_state.get_active_placement_group_ids = (
-                original_fn
-            )
 
     async def listen_for_change(self, keys_to_snapshot_ids: Dict[str, int]):
         """Proxy long pull client's listen request.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3621,7 +3621,7 @@ class DeploymentState:
                 logger.warning(
                     f"Replica {replica.replica_id} is healthy but its gang "
                     f"(gang_id={replica.gang_context.gang_id}) has an "
-                    "unhealthy replica. Forcefully stopping it because  "
+                    "unhealthy replica. Forcefully stopping it because "
                     "RESTART_GANG runtime failure policy is enabled."
                 )
                 # Healthy replica whose gang has an unhealthy member.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3226,6 +3226,8 @@ class DeploymentState:
             return upscale
 
         gang_pgs = gang_reservation_result.gang_pgs
+        gang_ids = gang_reservation_result.gang_ids
+        gang_pg_names = gang_reservation_result.gang_pg_names
         gang_size = gang_config.gang_size
         num_gangs = len(gang_pgs)
         replicas_to_add = num_gangs * gang_size
@@ -3242,11 +3244,7 @@ class DeploymentState:
             f"(gang_size={gang_size}, {num_gangs} gang(s))."
         )
 
-        for gang_pg, gang_id, pg_name in zip(
-            gang_pgs,
-            gang_reservation_result.gang_ids,
-            gang_reservation_result.gang_pg_names,
-        ):
+        for gang_pg, gang_id, pg_name in zip(gang_pgs, gang_ids, gang_pg_names):
             member_replica_ids = [
                 ReplicaID(get_random_string(), deployment_id=self._id)
                 for _ in range(gang_size)
@@ -3590,22 +3588,24 @@ class DeploymentState:
         healthy_replicas: List[DeploymentReplica],
         unhealthy_replicas: List[DeploymentReplica],
     ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
-        """Forcefully stop all replicas belonging to gangs that contain at least
-        one unhealthy replica. This prevents the existence of partial gangs by not
-        allowing individual replicas to gracefully stop or drain on their own;
-        instead, all related gang members are force-stopped as a group whenever any
-        member is unhealthy.
+        """Forcefully stop all replicas in gangs that have any unhealthy or missing member.
 
-        This differs from normal (single-replica scheduling) unhealthy-replica
-        handling in two ways:
+        Under the RESTART_GANG policy, when any replica in a gang fails its health check,
+        every member of that gang, including healthy ones, must be torn down so the gang
+        can be rescheduled atomically.
+
+        A gang is also restarted when any of its expected members, listed in
+        gang_context.member_replica_ids, are missing entirely from the replica manager.
+        This handles the case where a gang member dies while the controller is down:
+        on recovery, the dead member is never tracked, leaving an incomplete gang that
+        would block upscaling (the replica deficit would not be divisible by gang_size).
+
+        This differs from normal (single-replica scheduling) unhealthy-replica handling
+        in two ways:
 
         1. Healthy siblings are also force-stopped.
         2. Force-stop is always used (graceful_stop=False), regardless
            of the FORCE_STOP_UNHEALTHY_REPLICAS setting.
-
-        Args:
-            healthy_replicas: A list of healthy replicas.
-            unhealthy_replicas: A list of unhealthy replicas.
 
         Returns:
             A (remaining_healthy, remaining_unhealthy) tuple containing only
@@ -3617,6 +3617,25 @@ class DeploymentState:
             if replica.gang_context is not None
         }
 
+        # Detect incomplete gangs: gang members that are missing entirely from
+        # the replica manager. The healthy/unhealthy lists were popped from
+        # self._replicas in check_and_update_replicas, so we must include them
+        # explicitly to get the full set of tracked replica IDs.
+        all_tracked_replica_ids: Set[str] = (
+            {replica.replica_id.unique_id for replica in self._replicas.get()}
+            | {replica.replica_id.unique_id for replica in healthy_replicas}
+            | {replica.replica_id.unique_id for replica in unhealthy_replicas}
+        )
+
+        for replica in healthy_replicas:
+            gc = replica.gang_context
+            if gc is None or gc.gang_id in gang_ids_to_restart:
+                continue
+            for member_id in gc.member_replica_ids:
+                if member_id not in all_tracked_replica_ids:
+                    gang_ids_to_restart.add(gc.gang_id)
+                    break
+
         if len(gang_ids_to_restart) == 0:
             return healthy_replicas, unhealthy_replicas
 
@@ -3627,10 +3646,10 @@ class DeploymentState:
                 and replica.gang_context.gang_id in gang_ids_to_restart
             ):
                 logger.warning(
-                    f"Replica {replica.replica_id} is healthy but its gang "
-                    f"(gang_id={replica.gang_context.gang_id}) has an "
-                    "unhealthy member. Forcefully stopping it because "
-                    "RESTART_GANG runtime failure policy is enabled."
+                    f"Replica {replica.replica_id} belongs to gang "
+                    f"(gang_id={replica.gang_context.gang_id}) that has an "
+                    "unhealthy or missing member. Forcefully stopping it "
+                    "because RESTART_GANG runtime failure policy is enabled."
                 )
                 self._stop_replica_mark_unhealthy_if_target_version(replica, False)
             else:
@@ -4176,17 +4195,11 @@ class DeploymentStateManager:
                 if name.startswith(GANG_PG_NAME_PREFIX):
                     gang_pg_name_to_id[name] = pg_id_hex
 
-            try:
-                occupied_pg_ids = get_active_placement_group_ids()
-            except Exception:
-                logger.exception(
-                    "Skipping gang PG leak detection due to GCS query failure."
-                )
-            else:
-                for gang_pg_name in gang_pg_names_in_cluster:
-                    pg_id = gang_pg_name_to_id.get(gang_pg_name)
-                    if pg_id is not None and pg_id not in occupied_pg_ids:
-                        leaked_pg_names.append(gang_pg_name)
+            occupied_pg_ids = get_active_placement_group_ids()
+            for gang_pg_name in gang_pg_names_in_cluster:
+                pg_id = gang_pg_name_to_id.get(gang_pg_name)
+                if pg_id is not None and pg_id not in occupied_pg_ids:
+                    leaked_pg_names.append(gang_pg_name)
 
         if len(leaked_pg_names) > 0:
             logger.warning(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3573,7 +3573,6 @@ class DeploymentState:
         self, replica: DeploymentReplica, graceful_stop: bool
     ):
         """Stop the replica and mark deployment as UNHEALTHY if the replica is the target version."""
-        self._set_health_gauge(replica.replica_id.unique_id, 0)
         self._stop_replica(replica, graceful_stop=graceful_stop)
         if replica.version == self._target_state.version:
             self._curr_status_info = self._curr_status_info.handle_transition(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3571,10 +3571,12 @@ class DeploymentState:
         self._deployment_scheduler.on_replica_stopping(replica.replica_id)
         self._set_health_gauge(replica.replica_id.unique_id, 0)
 
-    def _mark_deployment_unhealthy_for_target_version_replica(
-        self, replica: DeploymentReplica
+    def _stop_replica_mark_unhealthy_if_target_version(
+        self, replica: DeploymentReplica, graceful_stop: bool
     ):
-        """Transition deployment to UNHEALTHY if the replica is the target version."""
+        """Stop the replica and mark deployment as UNHEALTHY if the replica is the target version."""
+        self._set_health_gauge(replica.replica_id.unique_id, 0)
+        self._stop_replica(replica, graceful_stop=graceful_stop)
         if replica.version == self._target_state.version:
             self._curr_status_info = self._curr_status_info.handle_transition(
                 trigger=DeploymentStatusInternalTrigger.HEALTH_CHECK_FAILED,
@@ -3583,6 +3585,74 @@ class DeploymentState:
                 "recovers or a new deploy happens.",
             )
 
+    def _forcefully_stop_gang_replicas(
+        self,
+        healthy_replicas: List[DeploymentReplica],
+        unhealthy_replicas: List[DeploymentReplica],
+    ) -> Tuple[List[DeploymentReplica], List[DeploymentReplica]]:
+        """Forcefully stop all replicas belonging to gangs that contain at least
+        one unhealthy replica. This prevents the existence of partial gangs by not
+        allowing individual replicas to gracefully stop or drain on their own;
+        instead, all related gang members are force-stopped as a group whenever any
+        member is unhealthy.
+
+        This differs from normal (single-replica scheduling) unhealthy-replica
+        handling in two ways:
+
+        1. Healthy siblings are also force-stopped.
+        2. Force-stop is always used (graceful_stop=False), regardless
+           of the FORCE_STOP_UNHEALTHY_REPLICAS setting.
+
+        Args:
+            healthy_replicas: A list of healthy replicas.
+            unhealthy_replicas: A list of unhealthy replicas.
+
+        Returns:
+            A (remaining_healthy, remaining_unhealthy) tuple containing only
+            replicas that follow single-replica scheduling logic.
+        """
+        gang_ids_to_restart: Set[str] = {
+            replica.gang_context.gang_id
+            for replica in unhealthy_replicas
+            if replica.gang_context is not None
+        }
+
+        if len(gang_ids_to_restart) == 0:
+            return healthy_replicas, unhealthy_replicas
+
+        remaining_healthy: List[DeploymentReplica] = []
+        for replica in healthy_replicas:
+            if (
+                replica.gang_context is not None
+                and replica.gang_context.gang_id in gang_ids_to_restart
+            ):
+                logger.warning(
+                    f"Replica {replica.replica_id} is healthy but its gang "
+                    f"(gang_id={replica.gang_context.gang_id}) has an "
+                    "unhealthy member. Forcefully stopping it because "
+                    "RESTART_GANG runtime failure policy is enabled."
+                )
+                self._stop_replica_mark_unhealthy_if_target_version(replica, False)
+            else:
+                remaining_healthy.append(replica)
+
+        remaining_unhealthy: List[DeploymentReplica] = []
+        for replica in unhealthy_replicas:
+            if (
+                replica.gang_context is not None
+                and replica.gang_context.gang_id in gang_ids_to_restart
+            ):
+                logger.warning(
+                    f"Replica {replica.replica_id} failed health check, "
+                    "forcefully stopping it as part of gang restart "
+                    f"(gang_id={replica.gang_context.gang_id})."
+                )
+                self._stop_replica_mark_unhealthy_if_target_version(replica, False)
+            else:
+                remaining_unhealthy.append(replica)
+
+        return remaining_healthy, remaining_unhealthy
+
     def check_and_update_replicas(self):
         """
         Check current state of all DeploymentReplica being tracked, and compare
@@ -3590,16 +3660,8 @@ class DeploymentState:
         transition happened.
         """
 
-        gang_config = self.get_gang_config()
-        restart_gang = (
-            gang_config is not None
-            and gang_config.runtime_failure_policy
-            == GangRuntimeFailurePolicy.RESTART_GANG
-        )
-
         healthy_replicas: List[DeploymentReplica] = []
         unhealthy_replicas: List[DeploymentReplica] = []
-        gang_ids_to_restart: Set[str] = set()
 
         for replica in self._replicas.pop(
             states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
@@ -3621,46 +3683,35 @@ class DeploymentState:
                 healthy_replicas.append(replica)
             else:
                 unhealthy_replicas.append(replica)
-                if restart_gang and replica.gang_context is not None:
-                    gang_ids_to_restart.add(replica.gang_context.gang_id)
+
+        # Under the RESTART_GANG policy, force-stop all members of any gang that has at
+        # least one unhealthy replica. Replicas handled here are removed from the lists;
+        # remaining replicas continue to respect FORCE_STOP_UNHEALTHY_REPLICAS.
+        gang_config = self.get_gang_config()
+        if (
+            gang_config is not None
+            and gang_config.runtime_failure_policy
+            == GangRuntimeFailurePolicy.RESTART_GANG
+        ):
+            healthy_replicas, unhealthy_replicas = self._forcefully_stop_gang_replicas(
+                healthy_replicas, unhealthy_replicas
+            )
 
         for replica in healthy_replicas:
-            if (
-                restart_gang
-                and replica.gang_context is not None
-                and replica.gang_context.gang_id in gang_ids_to_restart
-            ):
-                logger.warning(
-                    f"Replica {replica.replica_id} is healthy but its gang "
-                    f"(gang_id={replica.gang_context.gang_id}) has an "
-                    "unhealthy replica. Forcefully stopping it because "
-                    "RESTART_GANG runtime failure policy is enabled."
-                )
-                # Healthy replica whose gang has an unhealthy member.
-                # Forcefully stop it so the entire gang is rescheduled.
-                self._stop_replica(replica, graceful_stop=False)
-                self._mark_deployment_unhealthy_for_target_version_replica(replica)
-            else:
-                self._replicas.add(replica.actor_details.state, replica)
-                self._set_health_gauge(replica.replica_id.unique_id, 1)
-                routing_stats = replica.pull_routing_stats()
-                if routing_stats is not None and routing_stats != replica.routing_stats:
-                    self._broadcasted_replicas_set_changed = True
-                replica.record_routing_stats(routing_stats)
+            self._replicas.add(replica.actor_details.state, replica)
+            self._set_health_gauge(replica.replica_id.unique_id, 1)
+            routing_stats = replica.pull_routing_stats()
+            if routing_stats is not None and routing_stats != replica.routing_stats:
+                self._broadcasted_replicas_set_changed = True
+            replica.record_routing_stats(routing_stats)
 
-        # Process unhealthy replicas with force-stop for gang replicas under
-        # RESTART_GANG policy.
+        # Only single-replica scheduling replicas remain.
         for replica in unhealthy_replicas:
             logger.warning(
                 f"Replica {replica.replica_id} failed health check, stopping it."
             )
-            self._set_health_gauge(replica.replica_id.unique_id, 0)
             graceful = not self.FORCE_STOP_UNHEALTHY_REPLICAS
-            if restart_gang and replica.gang_context is not None:
-                # Forcefully stop all replicas in a unhealthy gang to avoid partial gangs
-                graceful = False
-            self._stop_replica(replica, graceful_stop=graceful)
-            self._mark_deployment_unhealthy_for_target_version_replica(replica)
+            self._stop_replica_mark_unhealthy_if_target_version(replica, graceful)
 
         # In steady state there are no STARTING/UPDATING/RECOVERING/STOPPING
         # replicas, so skip startup/stopping checks.  The rank consistency

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3607,6 +3607,10 @@ class DeploymentState:
         2. Force-stop is always used (graceful_stop=False), regardless
            of the FORCE_STOP_UNHEALTHY_REPLICAS setting.
 
+        Args:
+            healthy_replicas: A list of healthy replicas.
+            unhealthy_replicas: A list of unhealthy replicas.
+
         Returns:
             A (remaining_healthy, remaining_unhealthy) tuple containing only
             replicas that follow single-replica scheduling logic.

--- a/python/ray/serve/gang.py
+++ b/python/ray/serve/gang.py
@@ -20,3 +20,7 @@ class GangContext:
 
     member_replica_ids: List[str]
     """List of replica IDs in this gang, ordered by rank."""
+
+    pg_name: str = ""
+    """Name of the gang placement group. Used to recover the PG reference
+    after controller restart and during placement group leak detection."""

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -12,7 +12,6 @@ from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve._private.test_utils import check_apps_running
 from ray.serve._private.utils import get_all_live_placement_group_names
 from ray.serve.config import GangPlacementStrategy, GangSchedulingConfig
-from ray.serve.context import _get_global_client
 from ray.tests.conftest import *  # noqa
 from ray.util.placement_group import get_current_placement_group, placement_group_table
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
@@ -1152,7 +1151,7 @@ class TestGangControllerRecovery:
             DeploymentID(name="Gang2", app_name="gang_app2"),
         ]
         no_gang_deployment_id = DeploymentID(name="NoGang", app_name="no_gang_app")
-        controller = _get_global_client()._controller
+        controller = serve.context._get_global_client()._controller
 
         # Record controller-side gang_context before crash
         gang_ctx_before = {}
@@ -1176,7 +1175,7 @@ class TestGangControllerRecovery:
         ray.kill(controller, no_restart=False)
         wait_for_condition(check_apps_running, apps=app_names, timeout=60)
 
-        new_controller = _get_global_client()._controller
+        new_controller = serve.context._get_global_client()._controller
 
         def all_states_recovered():
             # Verify gang_context recovered for all gang deployments

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -1105,7 +1105,10 @@ class TestGangChildSpawnPlacementGroup:
 
 class TestGangControllerRecovery:
     def test_gang_context_recovery(self, ray_cluster):
-        """Verifies that the controller recovers gang_context after a crash."""
+        """Verifies that the controller recovers all app and deployment states
+        after a crash, including gang_context for gang deployments and normal
+        replicas for non-gang deployments.
+        """
         cluster = ray_cluster
         cluster.add_node(num_cpus=1)
         cluster.wait_for_nodes()
@@ -1117,48 +1120,99 @@ class TestGangControllerRecovery:
             ray_actor_options={"num_cpus": 0.1},
             gang_scheduling_config=GangSchedulingConfig(gang_size=2),
         )
-        class D:
+        class Gang1:
             def __call__(self):
                 return "ok"
 
-        serve.run(D.bind(), name="app")
-        wait_for_condition(check_apps_running, apps=["app"])
+        @serve.deployment(
+            num_replicas=2,
+            ray_actor_options={"num_cpus": 0.1},
+            gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+        )
+        class Gang2:
+            def __call__(self):
+                return "ok"
 
-        deployment_id = DeploymentID(name="D", app_name="app")
+        @serve.deployment(
+            num_replicas=2,
+            ray_actor_options={"num_cpus": 0.1},
+        )
+        class NoGang:
+            def __call__(self):
+                return "ok"
+
+        app_names = ["gang_app1", "gang_app2", "no_gang_app"]
+        serve.run(Gang1.bind(), name="gang_app1", route_prefix="/gang1")
+        serve.run(Gang2.bind(), name="gang_app2", route_prefix="/gang2")
+        serve.run(NoGang.bind(), name="no_gang_app", route_prefix="/no_gang")
+        wait_for_condition(check_apps_running, apps=app_names)
+
+        gang_deployment_ids = [
+            DeploymentID(name="Gang1", app_name="gang_app1"),
+            DeploymentID(name="Gang2", app_name="gang_app2"),
+        ]
+        no_gang_deployment_id = DeploymentID(name="NoGang", app_name="no_gang_app")
         controller = _get_global_client()._controller
 
         # Record controller-side gang_context before crash
-        replicas = ray.get(
-            controller._dump_replica_states_for_testing.remote(deployment_id)
-        )
-        running = replicas.get([ReplicaState.RUNNING])
-        assert len(running) == 4
-        gang_ctx_before = {r.replica_id.unique_id: r.gang_context for r in running}
-        assert all(gc is not None for gc in gang_ctx_before.values())
-
-        # Kill the controller and wait for its recovery
-        ray.kill(controller, no_restart=False)
-        wait_for_condition(check_apps_running, apps=["app"], timeout=60)
-
-        # Verify the new controller recovered gang_context for all replicas
-        new_controller = _get_global_client()._controller
-
-        def controller_recovered_gang_context():
+        gang_ctx_before = {}
+        for dep_id in gang_deployment_ids:
             replicas = ray.get(
-                new_controller._dump_replica_states_for_testing.remote(deployment_id)
+                controller._dump_replica_states_for_testing.remote(dep_id)
             )
             running = replicas.get([ReplicaState.RUNNING])
-            if len(running) != 4:
-                return False
             for r in running:
-                before = gang_ctx_before.get(r.replica_id.unique_id)
-                if r.gang_context is None or r.gang_context != before:
-                    return False
+                assert r.gang_context is not None
+                gang_ctx_before[r.replica_id.unique_id] = r.gang_context
+
+        # Record non-gang replica count
+        no_gang_replicas = ray.get(
+            controller._dump_replica_states_for_testing.remote(no_gang_deployment_id)
+        )
+        no_gang_count_before = len(no_gang_replicas.get([ReplicaState.RUNNING]))
+        assert no_gang_count_before == 2
+
+        # Kill the controller and wait for recovery of all apps
+        ray.kill(controller, no_restart=False)
+        wait_for_condition(check_apps_running, apps=app_names, timeout=60)
+
+        new_controller = _get_global_client()._controller
+
+        def all_states_recovered():
+            # Verify gang_context recovered for all gang deployments
+            for dep_id in gang_deployment_ids:
+                replicas = ray.get(
+                    new_controller._dump_replica_states_for_testing.remote(dep_id)
+                )
+                running = replicas.get([ReplicaState.RUNNING])
+                for r in running:
+                    before = gang_ctx_before.get(r.replica_id.unique_id)
+                    if r.gang_context is None or r.gang_context != before:
+                        return False
+
+            # Verify non-gang deployment recovered
+            replicas = ray.get(
+                new_controller._dump_replica_states_for_testing.remote(
+                    no_gang_deployment_id
+                )
+            )
+            if len(replicas.get([ReplicaState.RUNNING])) != no_gang_count_before:
+                return False
+
             return True
 
-        wait_for_condition(controller_recovered_gang_context, timeout=60)
+        wait_for_condition(all_states_recovered, timeout=60)
 
-        serve.delete("app")
+        # Verify application and deployment statuses after recovery
+        status = serve.status()
+        for app_name in app_names:
+            app_status = status.applications[app_name]
+            assert app_status.status == "RUNNING"
+            for dep_name, dep_status in app_status.deployments.items():
+                assert dep_status.status == "HEALTHY"
+
+        for app_name in app_names:
+            serve.delete(app_name)
         serve.shutdown()
 
 

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import tempfile
+import threading
+import time
 
 import pytest
 
@@ -1214,10 +1216,13 @@ class TestGangControllerRecovery:
             serve.delete(app_name)
         serve.shutdown()
 
-
-class TestGangPGLeakDetection:
-    def test_gcs_failure_skip_pg_leak_detection(self, ray_cluster):
-        """Gang PG leak detection is skipped when GCS is unavailable."""
+    @pytest.mark.parametrize("same_gang", [True, False])
+    def test_gang_replica_crash_during_controller_downtime(
+        self, ray_cluster, same_gang
+    ):
+        """When gang replicas crash while the controller is down, the controller
+        recovers and reschedules the affected gangs.
+        """
         cluster = ray_cluster
         cluster.add_node(num_cpus=2)
         cluster.wait_for_nodes()
@@ -1226,36 +1231,201 @@ class TestGangPGLeakDetection:
 
         @serve.deployment(
             num_replicas=4,
-            ray_actor_options={"num_cpus": 0.25},
+            ray_actor_options={"num_cpus": 0.1},
             gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+            health_check_period_s=1,
         )
         class GangApp:
             def __call__(self):
                 return os.getpid()
 
-        app_name = "gang_pg_leak_gcs_fail"
+        app_name = "gang_crash_app"
+        dep_id = DeploymentID(name="GangApp", app_name=app_name)
         serve.run(GangApp.bind(), name=app_name)
         wait_for_condition(check_apps_running, apps=[app_name])
 
-        gang_pg_names_before = [
-            name
-            for name in get_all_live_placement_group_names()
-            if name.startswith(GANG_PG_NAME_PREFIX)
-        ]
-        assert len(gang_pg_names_before) > 0
-
-        # Invoke leak detection inside the controller process with
-        # get_active_placement_group_ids replaced by a function that raises.
-        # This hits the except-branch that skips gang PG leak detection.
         controller = serve.context._get_global_client()._controller
-        ray.get(controller._detect_leaked_pgs_with_gcs_failure_for_testing.remote())
 
-        gang_pg_names_after = [
-            name
-            for name in get_all_live_placement_group_names()
-            if name.startswith(GANG_PG_NAME_PREFIX)
+        # Record initial replicas and group by gang.
+        replicas = ray.get(controller._dump_replica_states_for_testing.remote(dep_id))
+        running = replicas.get([ReplicaState.RUNNING])
+        assert len(running) == 4
+
+        gangs = {}
+        for r in running:
+            gangs.setdefault(r.gang_context.gang_id, []).append(r)
+        gang_ids = list(gangs.keys())
+        assert len(gang_ids) == 2
+
+        # Pick 2 victims
+        if same_gang:
+            victims = gangs[gang_ids[0]]
+        else:
+            victims = [gangs[gang_ids[0]][0], gangs[gang_ids[1]][0]]
+
+        victim_ids = {v.replica_id.unique_id for v in victims}
+
+        # Kill the controller, then kill the victims while it is down.
+        ray.kill(controller, no_restart=False)
+        for v in victims:
+            handle = ray.get_actor(v.replica_id.to_full_id_str(), namespace="serve")
+            ray.kill(handle, no_restart=True)
+
+        # Wait for the controller to restart and the app to recover.
+        wait_for_condition(check_apps_running, apps=[app_name])
+
+        new_controller = serve.context._get_global_client()._controller
+
+        def fully_recovered():
+            replicas = ray.get(
+                new_controller._dump_replica_states_for_testing.remote(dep_id)
+            )
+            running = replicas.get([ReplicaState.RUNNING])
+            if len(running) != 4:
+                return False
+            for r in running:
+                if r.gang_context is None:
+                    return False
+            return True
+
+        wait_for_condition(fully_recovered)
+
+        # The killed replicas should have been replaced by new ones.
+        replicas = ray.get(
+            new_controller._dump_replica_states_for_testing.remote(dep_id)
+        )
+        running = replicas.get([ReplicaState.RUNNING])
+        recovered_ids = {r.replica_id.unique_id for r in running}
+        assert victim_ids.isdisjoint(recovered_ids)
+
+        serve.delete(app_name)
+        serve.shutdown()
+
+
+class TestGangNodeFailure:
+    @pytest.mark.parametrize(
+        "strategy", [GangPlacementStrategy.SPREAD, GangPlacementStrategy.PACK]
+    )
+    def test_worker_node_failure_restarts_gang(self, ray_cluster, strategy):
+        """Killing a node restarts the affected gang with no request
+        downtime (surviving gang keeps serving) and no leaked PGs.
+        """
+        cluster = ray_cluster
+        # Head and workers each get 1 CPU. Each PG (2 × 0.5 CPU = 1.0 CPU)
+        # fills exactly one node for PACK, and SPREAD distributes one bundle
+        # per node. At most 1 PG fits on the head, so at least 1 PG must
+        # land on a worker, giving the test a killable target. The extra
+        # nodes provide recovery capacity after one worker is removed.
+        cluster.add_node(num_cpus=1)
+        workers = [cluster.add_node(num_cpus=1) for _ in range(3)]
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+        serve.start()
+
+        num_replicas = 4
+        gang_size = 2
+
+        @serve.deployment(
+            num_replicas=num_replicas,
+            ray_actor_options={"num_cpus": 0.5},
+            gang_scheduling_config=GangSchedulingConfig(
+                gang_size=gang_size,
+                gang_placement_strategy=strategy,
+            ),
+            health_check_period_s=1,
+        )
+        class GangApp:
+            def __call__(self):
+                return ray.get_runtime_context().get_node_id()
+
+        app_name = "node_kill_app"
+        dep_id = DeploymentID(name="GangApp", app_name=app_name)
+        handle = serve.run(GangApp.bind(), name=app_name)
+        wait_for_condition(check_apps_running, apps=[app_name])
+
+        controller = serve.context._get_global_client()._controller
+        replicas = ray.get(controller._dump_replica_states_for_testing.remote(dep_id))
+        running = replicas.get([ReplicaState.RUNNING])
+        assert len(running) == num_replicas
+
+        # Group replicas by gang
+        gangs = {}
+        for r in running:
+            gangs.setdefault(r.gang_context.gang_id, []).append(r)
+
+        # Pick a worker to kill that (a) hosts at least one gang member and
+        # (b) leaves at least one gang fully intact on the surviving nodes.
+        node_to_kill = None
+        affected_gangs = []
+        for worker in workers:
+            affected_gangs = [
+                gid
+                for gid, members in gangs.items()
+                if any(r.actor_node_id == worker.node_id for r in members)
+            ]
+            surviving = [
+                gid
+                for gid, members in gangs.items()
+                if all(r.actor_node_id != worker.node_id for r in members)
+            ]
+            if affected_gangs and surviving:
+                node_to_kill = worker
+                break
+
+        assert node_to_kill is not None
+        assert len(affected_gangs) > 0
+
+        # Continuously send requests in a background thread.
+        stop = threading.Event()
+        errors = []
+        successes = []
+
+        def send_requests():
+            while not stop.is_set():
+                try:
+                    result = handle.remote().result()
+                    successes.append(result)
+                except Exception as e:
+                    errors.append(e)
+                time.sleep(0.1)
+
+        sender = threading.Thread(target=send_requests, daemon=True)
+        sender.start()
+        time.sleep(1)
+
+        cluster.remove_node(node_to_kill)
+
+        # Wait for full recovery.
+        def fully_recovered():
+            replicas = ray.get(
+                controller._dump_replica_states_for_testing.remote(dep_id)
+            )
+            running = replicas.get([ReplicaState.RUNNING])
+            if len(running) != num_replicas:
+                return False
+            for r in running:
+                if r.gang_context is None:
+                    return False
+            return True
+
+        wait_for_condition(fully_recovered, timeout=60)
+
+        time.sleep(1)
+        stop.set()
+        sender.join(timeout=5)
+
+        assert len(errors) == 0
+        assert len(successes) > 0
+
+        # Verify no leaked PGs.
+        gang_pg_names = [
+            n
+            for n in get_all_live_placement_group_names()
+            if n.startswith(GANG_PG_NAME_PREFIX)
         ]
-        assert set(gang_pg_names_before) == set(gang_pg_names_after)
+        assert len(gang_pg_names) == num_replicas // gang_size
+
+        wait_for_condition(check_apps_running, apps=[app_name])
 
         serve.delete(app_name)
         serve.shutdown()

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -1215,5 +1215,51 @@ class TestGangControllerRecovery:
         serve.shutdown()
 
 
+class TestGangPGLeakDetection:
+    def test_gcs_failure_skip_pg_leak_detection(self, ray_cluster):
+        """Gang PG leak detection is skipped when GCS is unavailable."""
+        cluster = ray_cluster
+        cluster.add_node(num_cpus=2)
+        cluster.wait_for_nodes()
+        ray.init(address=cluster.address)
+        serve.start()
+
+        @serve.deployment(
+            num_replicas=4,
+            ray_actor_options={"num_cpus": 0.25},
+            gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+        )
+        class GangApp:
+            def __call__(self):
+                return os.getpid()
+
+        app_name = "gang_pg_leak_gcs_fail"
+        serve.run(GangApp.bind(), name=app_name)
+        wait_for_condition(check_apps_running, apps=[app_name])
+
+        gang_pg_names_before = [
+            name
+            for name in get_all_live_placement_group_names()
+            if name.startswith(GANG_PG_NAME_PREFIX)
+        ]
+        assert len(gang_pg_names_before) > 0
+
+        # Invoke leak detection inside the controller process with
+        # get_active_placement_group_ids replaced by a function that raises.
+        # This hits the except-branch that skips gang PG leak detection.
+        controller = serve.context._get_global_client()._controller
+        ray.get(controller._detect_leaked_pgs_with_gcs_failure_for_testing.remote())
+
+        gang_pg_names_after = [
+            name
+            for name in get_all_live_placement_group_names()
+            if name.startswith(GANG_PG_NAME_PREFIX)
+        ]
+        assert set(gang_pg_names_before) == set(gang_pg_names_after)
+
+        serve.delete(app_name)
+        serve.shutdown()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_healthcheck.py
+++ b/python/ray/serve/tests/test_healthcheck.py
@@ -11,6 +11,7 @@ from ray.serve._private.constants import (
     REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     SERVE_DEFAULT_APP_NAME,
 )
+from ray.serve.config import GangSchedulingConfig
 
 
 class Counter:
@@ -289,6 +290,124 @@ def test_health_check_failure_makes_deployment_unhealthy_transition(serve_instan
     # Check that deployment stays unhealthy
     for _ in range(5):
         assert check_status(DeploymentStatus.UNHEALTHY)
+
+
+def test_gang_health_check_restarts_gang(serve_instance):
+    """RESTART_GANG tears down the entire gang on failure while the deployment
+    keeps serving traffic with no downtime."""
+
+    class Toggle:
+        def __init__(self):
+            self._should_fail = False
+
+        def set_should_fail(self):
+            self._should_fail = True
+
+        def unset_should_fail(self):
+            self._should_fail = False
+
+        def should_fail(self):
+            return self._should_fail
+
+    toggle = ray.remote(Toggle).remote()
+
+    @serve.deployment(health_check_period_s=1, health_check_timeout_s=1)
+    class GangPatient:
+        def __init__(self):
+            self._fail = False
+
+        def check_health(self):
+            if self._fail and ray.get(toggle.should_fail.remote()):
+                raise Exception("intended to fail")
+
+        def __call__(self):
+            ctx = ray.serve.context._get_internal_replica_context()
+            gc = ctx.gang_context
+            return {
+                "replica_id": ctx.replica_id.unique_id,
+                "gang_id": gc.gang_id if gc else None,
+            }
+
+        def set_should_fail(self):
+            self._fail = True
+            ctx = ray.serve.context._get_internal_replica_context()
+            gc = ctx.gang_context
+            return {
+                "replica_id": ctx.replica_id.unique_id,
+                "gang_id": gc.gang_id if gc else None,
+            }
+
+    h = serve.run(
+        GangPatient.options(
+            num_replicas=4,
+            gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+        ).bind()
+    )
+
+    # Collect initial replica state.
+    initial_replicas = {}
+    for _ in range(100):
+        result = h.remote().result()
+        initial_replicas[result["replica_id"]] = result
+        if len(initial_replicas) == 4:
+            break
+    assert len(initial_replicas) == 4
+
+    # Identify the two distinct gang IDs.
+    gang_ids = {r["gang_id"] for r in initial_replicas.values()}
+    assert len(gang_ids) == 2
+
+    # Make one replica fail health checks.
+    fail_info = h.set_should_fail.remote().result()
+    target_gang_id = fail_info["gang_id"]
+    surviving_gang_id = (gang_ids - {target_gang_id}).pop()
+    ray.get(toggle.set_should_fail.remote())
+
+    # Wait for deployment to become UNHEALTHY.
+    def check_unhealthy():
+        app_status = serve.status().applications[SERVE_DEFAULT_APP_NAME]
+        assert (
+            app_status.deployments["GangPatient"].status == DeploymentStatus.UNHEALTHY
+        )
+        return True
+
+    wait_for_condition(check_unhealthy, timeout=30)
+
+    # Zero-downtime check.
+    # While the failed gang is being torn down and before the replacement
+    # gang comes up, the surviving gang must keep serving traffic.
+    for _ in range(30):
+        result = h.remote().result()
+        assert result["gang_id"] == surviving_gang_id
+
+    # Turn off failures so replacement replicas start healthy.
+    ray.get(toggle.unset_should_fail.remote())
+
+    # Wait for deployment to recover.
+    def check_healthy():
+        app_status = serve.status().applications[SERVE_DEFAULT_APP_NAME]
+        assert app_status.deployments["GangPatient"].status == DeploymentStatus.HEALTHY
+        return True
+
+    wait_for_condition(check_healthy, timeout=120)
+
+    # Collect final replica state.
+    final_replicas = {}
+    for _ in range(100):
+        result = h.remote().result()
+        final_replicas[result["replica_id"]] = result
+        if len(final_replicas) == 4:
+            break
+    assert len(final_replicas) == 4
+
+    # Both replicas from the failed gang should have been replaced.
+    old_gang_ids = {
+        r["replica_id"]
+        for r in initial_replicas.values()
+        if r["gang_id"] == target_gang_id
+    }
+    assert len(old_gang_ids) == 2
+    assert old_gang_ids.isdisjoint(final_replicas.keys())
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_healthcheck.py
+++ b/python/ray/serve/tests/test_healthcheck.py
@@ -375,7 +375,7 @@ def test_gang_health_check_restarts_gang(serve_instance):
         )
         return True
 
-    wait_for_condition(check_unhealthy, timeout=30)
+    wait_for_condition(check_unhealthy, timeout=10)
 
     # Zero-downtime check.
     # While the failed gang is being torn down and before the replacement
@@ -394,7 +394,7 @@ def test_gang_health_check_restarts_gang(serve_instance):
         assert app_status.deployments["GangPatient"].status == DeploymentStatus.HEALTHY
         return True
 
-    wait_for_condition(check_healthy, timeout=120)
+    wait_for_condition(check_healthy, timeout=10)
 
     # Collect final replica state.
     final_replicas = {}
@@ -411,7 +411,7 @@ def test_gang_health_check_restarts_gang(serve_instance):
         for r in initial_replicas.values()
         if r["gang_id"] == target_gang_id
     }
-    assert len(old_gang_ids) == num_gangs
+    assert len(old_gang_ids) == gang_size
     assert old_gang_ids.isdisjoint(final_replicas.keys())
 
 

--- a/python/ray/serve/tests/test_replica_placement_group.py
+++ b/python/ray/serve/tests/test_replica_placement_group.py
@@ -344,7 +344,7 @@ def test_leaked_gang_pg_removed_on_controller_recovery(serve_instance):
 
         # Victim should have recovered with a new PG (old one was removed).
         victim_pgs = [n for n in current_gang_pgs if "victim_app" in n]
-        if len(victim_pgs) < 1:
+        if len(victim_pgs) != 1:
             return False
 
         # Per-replica app should have recovered with a new PG.

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -3,7 +3,7 @@ import sys
 from collections import defaultdict
 from typing import List
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -13,8 +13,11 @@ from ray.serve._private import default_impl
 from ray.serve._private.common import (
     CreatePlacementGroupRequest,
     DeploymentID,
+    DeploymentStatus,
     GangPlacementGroupRequest,
+    GangReservationResult,
     ReplicaID,
+    ReplicaState,
 )
 from ray.serve._private.config import ReplicaConfig
 from ray.serve._private.constants import (
@@ -33,6 +36,12 @@ from ray.serve._private.test_utils import (
     MockActorClass,
     MockClusterNodeInfoCache,
     MockPlacementGroup,
+)
+from ray.serve.config import GangSchedulingConfig
+from ray.serve.tests.unit.test_deployment_state import (
+    TEST_DEPLOYMENT_ID,
+    check_counts,
+    deployment_info,
 )
 from ray.tests.conftest import *  # noqa
 from ray.util.scheduling_strategies import (
@@ -1938,6 +1947,478 @@ class TestScheduleGangPlacementGroups:
         assert len(result[deployment_id_1].gang_pgs) == num_gangs_1
         assert len(result[deployment_id_2].gang_pgs) == num_gangs_2
         assert create_pg_fn.call_count == num_gangs_1 + num_gangs_2
+
+
+class TestScaleDeploymentGangReplicas:
+    def test_stopping_replicas_skip_upscale(self, mock_deployment_state_manager):
+        """Skips upscale while gang replicas are stopping after startup failures."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm(
+            create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+        )
+        gang_size = 2
+        target_replicas = 2
+        deployment_id = DeploymentID(name="gang_stopping_skip", app_name="app")
+
+        info, version = deployment_info(
+            num_replicas=target_replicas,
+            version="v1",
+            gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+        )
+        dsm.deploy(deployment_id, info)
+        ds = dsm._deployment_states[deployment_id]
+
+        dsm.update()
+        check_counts(
+            ds, total=target_replicas, by_state=[(ReplicaState.STARTING, 2, version)]
+        )
+
+        for replica in ds._replicas.get([ReplicaState.STARTING]):
+            replica._actor.set_failed_to_start()
+
+        dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(return_value={})
+        captured_upscales = {}
+        original_schedule = dsm._deployment_scheduler.schedule
+
+        def schedule_with_capture(upscales, downscales):
+            captured_upscales.update(upscales)
+            return original_schedule(upscales, downscales)
+
+        dsm._deployment_scheduler.schedule = Mock(side_effect=schedule_with_capture)
+        dsm.update()
+
+        assert captured_upscales == {}
+        dsm._deployment_scheduler.schedule_gang_placement_groups.assert_not_called()
+        check_counts(
+            ds, total=target_replicas, by_state=[(ReplicaState.STOPPING, 2, version)]
+        )
+        assert ds.curr_status_info.status == DeploymentStatus.UPDATING
+
+    def test_gang_reservation_failure_records_startup_failure(
+        self, mock_deployment_state_manager
+    ):
+        """Keeps upscale empty and records reservation failure details in deployment status."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        deployment_id = DeploymentID(name="gang_reservation_fail", app_name="app")
+        error_msg = "simulated gang placement reservation failure"
+
+        info, _ = deployment_info(
+            num_replicas=4,
+            gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+        )
+        dsm.deploy(deployment_id, info)
+        ds = dsm._deployment_states[deployment_id]
+
+        dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+            return_value={
+                deployment_id: GangReservationResult(
+                    success=False, error_message=error_msg
+                )
+            }
+        )
+        captured_upscales = {}
+        original_schedule = dsm._deployment_scheduler.schedule
+
+        def schedule_with_capture(upscales, downscales):
+            captured_upscales.update(upscales)
+            return original_schedule(upscales, downscales)
+
+        dsm._deployment_scheduler.schedule = Mock(side_effect=schedule_with_capture)
+        dsm.update()
+
+        assert captured_upscales == {}
+        check_counts(ds, total=0)
+        assert ds.curr_status_info.status == DeploymentStatus.UPDATING
+        assert "Gang scheduling failed" in ds.curr_status_info.message
+        assert error_msg in ds.curr_status_info.message
+
+    def test_successful_gang_reservation(self, mock_deployment_state_manager):
+        """Creates expected gang scheduling requests and marks all replicas as starting."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        gang_size = 2
+        num_gangs = 2
+        target_replicas = gang_size * num_gangs
+        deployment_id = DeploymentID(name="gang_success_sched", app_name="app")
+        gang_pgs = [Mock(name="pg-0"), Mock(name="pg-1")]
+
+        info, version = deployment_info(
+            num_replicas=target_replicas,
+            version="v1",
+            gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+        )
+        dsm.deploy(deployment_id, info)
+        ds = dsm._deployment_states[deployment_id]
+
+        gang_ids = ["gang_0", "gang_1"]
+        gang_pg_names = ["SERVE_GANG::pg-0", "SERVE_GANG::pg-1"]
+        dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+            return_value={
+                deployment_id: GangReservationResult(
+                    success=True,
+                    gang_pgs=gang_pgs,
+                    gang_ids=gang_ids,
+                    gang_pg_names=gang_pg_names,
+                )
+            }
+        )
+
+        captured_upscales = {}
+        original_schedule = dsm._deployment_scheduler.schedule
+
+        def schedule_with_capture(upscales, downscales):
+            captured_upscales.update(upscales)
+            return original_schedule(upscales, downscales)
+
+        dsm._deployment_scheduler.schedule = Mock(side_effect=schedule_with_capture)
+        dsm.update()
+
+        assert deployment_id in captured_upscales
+        scheduling_requests = captured_upscales[deployment_id]
+        assert len(scheduling_requests) == target_replicas
+        assert {r.gang_placement_group for r in scheduling_requests} == set(gang_pgs)
+        assert sorted(r.gang_pg_index for r in scheduling_requests) == [0, 0, 1, 1]
+        check_counts(
+            ds,
+            total=target_replicas,
+            by_state=[(ReplicaState.STARTING, target_replicas, version)],
+        )
+        starting_replicas = ds._replicas.get([ReplicaState.STARTING])
+        assert len(starting_replicas) == target_replicas
+        gang_to_replicas = {}
+        for replica in starting_replicas:
+            gang_to_replicas.setdefault(replica.gang_context.gang_id, []).append(
+                replica
+            )
+
+        assert len(gang_to_replicas) == num_gangs
+        for gang_id, replicas in gang_to_replicas.items():
+            assert len(replicas) == gang_size
+            member_ids = {r.replica_id.unique_id for r in replicas}
+            assert sorted(r.gang_context.rank for r in replicas) == list(
+                range(gang_size)
+            )
+            for replica in replicas:
+                gang_context = replica.gang_context
+                assert gang_context.gang_id == gang_id
+                assert gang_context.world_size == gang_size
+                assert set(gang_context.member_replica_ids) == member_ids
+
+    def test_gang_sibling_cleanup_on_startup_failure(
+        self, mock_deployment_state_manager
+    ):
+        """Stops gang siblings when one member fails startup to avoid partial gangs."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm(
+            create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+        )
+        gang_size = 2
+        target_replicas = 4
+        deployment_id = DeploymentID(name="gang_sibling_cleanup", app_name="app")
+
+        info, version = deployment_info(
+            num_replicas=target_replicas,
+            version="v1",
+            gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+        )
+        dsm.deploy(deployment_id, info)
+        ds = dsm._deployment_states[deployment_id]
+
+        dsm.update()
+        starting_replicas = ds._replicas.get([ReplicaState.STARTING])
+        initial_context_by_replica = {
+            r.replica_id.unique_id: (
+                r.gang_context.gang_id,
+                r.gang_context.rank,
+                r.gang_context.world_size,
+                tuple(r.gang_context.member_replica_ids),
+            )
+            for r in starting_replicas
+        }
+        gang_to_replicas = {}
+        for replica in starting_replicas:
+            gang_to_replicas.setdefault(replica.gang_context.gang_id, []).append(
+                replica
+            )
+        failed_gang_id, failed_gang_members = next(iter(gang_to_replicas.items()))
+
+        failed_gang_members[0]._actor.set_failed_to_start()
+        failed_gang_members[1]._actor.set_ready()
+        dsm.update()
+
+        stopping_replicas = ds._replicas.get([ReplicaState.STOPPING])
+        starting_replicas = ds._replicas.get([ReplicaState.STARTING])
+        assert len(stopping_replicas) == gang_size
+        assert all(r.gang_context.gang_id == failed_gang_id for r in stopping_replicas)
+        assert all(r.gang_context.gang_id != failed_gang_id for r in starting_replicas)
+        surviving_gang_ids = {r.gang_context.gang_id for r in starting_replicas}
+        assert len(surviving_gang_ids) == 1
+        for replica in starting_replicas:
+            context_snapshot = initial_context_by_replica[replica.replica_id.unique_id]
+            assert context_snapshot == (
+                replica.gang_context.gang_id,
+                replica.gang_context.rank,
+                replica.gang_context.world_size,
+                tuple(replica.gang_context.member_replica_ids),
+            )
+        check_counts(
+            ds,
+            total=target_replicas,
+            by_state=[
+                (ReplicaState.STOPPING, 2, version),
+                (ReplicaState.STARTING, 2, version),
+            ],
+        )
+
+    def test_terminally_failed_deployment_skips_gang_reservation(
+        self, mock_deployment_state_manager
+    ):
+        """Does not reserve gang placement groups after deployment reaches terminal startup failure."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        deployment_id = DeploymentID(name="gang_terminal_failure", app_name="app")
+        info, _ = deployment_info(
+            num_replicas=2,
+            gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+        )
+        dsm.deploy(deployment_id, info)
+        ds = dsm._deployment_states[deployment_id]
+
+        dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+            return_value={
+                deployment_id: GangReservationResult(
+                    success=False, error_message="simulated gang reservation failure"
+                )
+            }
+        )
+
+        for _ in range(20):
+            dsm.update()
+            if ds.curr_status_info.status == DeploymentStatus.DEPLOY_FAILED:
+                break
+        assert ds.curr_status_info.status == DeploymentStatus.DEPLOY_FAILED
+
+        dsm._deployment_scheduler.schedule_gang_placement_groups.reset_mock()
+        dsm.update()
+        dsm._deployment_scheduler.schedule_gang_placement_groups.assert_not_called()
+
+    def test_healthy_after_starting_replicas_ready(self, mock_deployment_state_manager):
+        """Transitions gang deployment to healthy once all starting replicas become ready."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm(
+            create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+        )
+        gang_size = 2
+        target_replicas = 4
+        deployment_id = DeploymentID(name="gang_healthy", app_name="app")
+        info, version = deployment_info(
+            num_replicas=target_replicas,
+            version="v1",
+            gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+        )
+        dsm.deploy(deployment_id, info)
+        ds = dsm._deployment_states[deployment_id]
+
+        dsm.update()
+        check_counts(
+            ds,
+            total=target_replicas,
+            by_state=[(ReplicaState.STARTING, target_replicas, version)],
+        )
+
+        for replica in ds._replicas.get([ReplicaState.STARTING]):
+            replica._actor.set_ready()
+        dsm.update()
+
+        check_counts(
+            ds,
+            total=target_replicas,
+            by_state=[(ReplicaState.RUNNING, target_replicas, version)],
+        )
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+
+
+class TestGangHealthCheck:
+    def _deploy_gang(self, mock_deployment_state_manager, gang_size, num_replicas):
+        """Deploy gang-scheduled replicas and wait for them to become RUNNING."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm(
+            create_placement_group_fn_override=lambda *args, **kwargs: MockPlacementGroup(
+                *args, **kwargs
+            ),
+        )
+        b_info, v1 = deployment_info(
+            version="1",
+            num_replicas=num_replicas,
+            gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+        )
+        dsm.deploy(TEST_DEPLOYMENT_ID, b_info)
+        ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+        # Reserves gang PGs and creates replicas
+        dsm.update()
+        check_counts(
+            ds, total=num_replicas, by_state=[(ReplicaState.STARTING, num_replicas, v1)]
+        )
+
+        # Capture replica references and wait for them to become RUNNING
+        replicas = ds._replicas.get()
+        for replica in replicas:
+            replica._actor.set_ready()
+        dsm.update()
+
+        check_counts(
+            ds, total=num_replicas, by_state=[(ReplicaState.RUNNING, num_replicas, v1)]
+        )
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+
+        # Group captured replicas by gang
+        gangs = {}
+        for r in replicas:
+            assert r.gang_context is not None
+            gangs.setdefault(r.gang_context.gang_id, []).append(r)
+
+        return dsm, ds, v1, gangs
+
+    def test_restart_gang_entire_gang_stopped(self, mock_deployment_state_manager):
+        """Unhealthy gang is force-stopped; healthy gangs are unaffected."""
+        gang_size = 2
+        num_replicas = 4
+        num_gangs = num_replicas // gang_size
+        dsm, ds, v1, gangs = self._deploy_gang(
+            mock_deployment_state_manager, gang_size, num_replicas
+        )
+        assert len(gangs) == num_gangs
+
+        gang_ids = list(gangs.keys())
+        target_gang = gangs[gang_ids[0]]
+        healthy_gang = gangs[gang_ids[1]]
+
+        # Initialize health checks, then mark one replica in the target gang as unhealthy.
+        dsm.update()
+        target_gang[0]._actor.set_unhealthy()
+        dsm.update()
+
+        # Both replicas of the affected gang should be stopping (force-stopped).
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, gang_size, v1),
+                (ReplicaState.STOPPING, gang_size, v1),
+            ],
+        )
+        for r in target_gang:
+            assert r._actor.force_stopped_counter == 1
+
+        # Healthy gang replicas should still be running.
+        for r in healthy_gang:
+            assert r._actor.force_stopped_counter == 0
+
+        assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
+
+        # After the stopped replicas finish stopping, new replicas should start.
+        for r in target_gang:
+            r._actor.set_done_stopping()
+        dsm.update()
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, gang_size, v1),
+                (ReplicaState.STARTING, gang_size, v1),
+            ],
+        )
+
+    def test_restart_gang_force_stop_all_gang_replicas(
+        self, mock_deployment_state_manager
+    ):
+        """RESTART_GANG force-stops all gang members regardless of the flag."""
+        gang_size = 2
+        num_replicas = 4
+        num_gangs = num_replicas // gang_size
+        dsm, ds, v1, gangs = self._deploy_gang(
+            mock_deployment_state_manager, gang_size, num_replicas
+        )
+        assert len(gangs) == num_gangs
+
+        gang_replicas = list(gangs.values())[0]
+        assert len(gang_replicas) == gang_size
+
+        ds.FORCE_STOP_UNHEALTHY_REPLICAS = False
+
+        dsm.update()
+        gang_replicas[0]._actor.set_unhealthy()
+        dsm.update()
+
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, num_replicas - gang_size, v1),
+                (ReplicaState.STOPPING, gang_size, v1),
+            ],
+        )
+        for r in gang_replicas:
+            assert r._actor.force_stopped_counter == 1
+
+
+class TestGangPGLeakDetection:
+    def test_gang_pg_with_alive_actors(self, mock_deployment_state_manager):
+        """Gang PGs with alive actors are not removed."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+
+        gang_pg_name = "SERVE_GANG::test_gang_1"
+        gang_pg_id = "pg_id_abc"
+
+        # Leak detection runs during DSM construction (recovery path).
+        # Mock ray utilities so the gang PG appears occupied by an actor.
+        with patch(
+            "ray.util.placement_group_table",
+            return_value={gang_pg_id: {"name": gang_pg_name}},
+        ) as mock_pg_table, patch(
+            "ray.serve._private.deployment_state.get_active_placement_group_ids",
+            return_value={gang_pg_id},
+        ), patch(
+            "ray.util.get_placement_group"
+        ), patch(
+            "ray.util.remove_placement_group"
+        ) as mock_remove_pg:
+            create_dsm(placement_group_names=[gang_pg_name])
+
+        # Verify the leak detection path was entered.
+        mock_pg_table.assert_called_once()
+        mock_remove_pg.assert_not_called()
+
+    def test_gang_pg_without_alive_actors(self, mock_deployment_state_manager):
+        """Leaked gang PGs are removed; PGs with alive actors are kept."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+
+        leaked_pg_name = "SERVE_GANG::test_gang_leaked"
+        alive_pg_name = "SERVE_GANG::test_gang_alive"
+        leaked_pg_id = "pg_id_leaked"
+        alive_pg_id = "pg_id_alive"
+
+        mock_pg_obj = object()
+        with patch(
+            "ray.util.placement_group_table",
+            return_value={
+                leaked_pg_id: {"name": leaked_pg_name},
+                alive_pg_id: {"name": alive_pg_name},
+            },
+        ), patch(
+            "ray.serve._private.deployment_state.get_active_placement_group_ids",
+            return_value={alive_pg_id},
+        ), patch(
+            "ray.util.get_placement_group", return_value=mock_pg_obj
+        ) as mock_get_pg, patch(
+            "ray.util.remove_placement_group"
+        ) as mock_remove_pg:
+            create_dsm(placement_group_names=[leaked_pg_name, alive_pg_name])
+
+        mock_get_pg.assert_called_once_with(leaked_pg_name)
+        mock_remove_pg.assert_called_once_with(mock_pg_obj)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/unit/test_deployment_scheduler.py
@@ -3,7 +3,7 @@ import sys
 from collections import defaultdict
 from typing import List
 from unittest import mock
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -1946,33 +1946,6 @@ class TestScheduleGangPlacementGroups:
         assert len(result[deployment_id_1].gang_pgs) == num_gangs_1
         assert len(result[deployment_id_2].gang_pgs) == num_gangs_2
         assert create_pg_fn.call_count == num_gangs_1 + num_gangs_2
-
-
-class TestGangPGLeakDetection:
-    def test_gang_pg_leak_detection_skipped_on_gcs_failure(
-        self, mock_deployment_state_manager
-    ):
-        """Leak detection is skipped when GCS query for active PG IDs fails."""
-        create_dsm, _, _, _ = mock_deployment_state_manager
-
-        gang_pg_name = "SERVE_GANG::test_gang_gcs_fail"
-        gang_pg_id = "pg_id_gcs_fail"
-
-        with patch(
-            "ray.util.placement_group_table",
-            return_value={gang_pg_id: {"name": gang_pg_name}},
-        ), patch(
-            "ray.serve._private.deployment_state.get_active_placement_group_ids",
-            side_effect=RuntimeError("GCS unavailable"),
-        ), patch(
-            "ray.util.get_placement_group",
-            side_effect=AssertionError("Should not look up PGs on GCS failure"),
-        ), patch(
-            "ray.util.remove_placement_group",
-            side_effect=AssertionError("Should not remove PGs on GCS failure"),
-        ):
-            # GCS failure should cause leak detection to be skipped entirely.
-            create_dsm(placement_group_names=[gang_pg_name])
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -6214,7 +6214,10 @@ class TestScaleDeploymentGangReplicas:
         dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
             return_value={
                 deployment_id: GangReservationResult(
-                    success=True, gang_pgs=[Mock(name="pg-0")]
+                    success=True,
+                    gang_pgs=[Mock(name="pg-0")],
+                    gang_ids=["g0"],
+                    gang_pg_names=["SERVE_GANG::pg-0"],
                 )
             }
         )
@@ -6274,7 +6277,10 @@ class TestScaleDeploymentGangReplicas:
         dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
             return_value={
                 deployment_id: GangReservationResult(
-                    success=True, gang_pgs=[Mock(name="pg-0"), Mock(name="pg-1")]
+                    success=True,
+                    gang_pgs=[Mock(name="pg-0"), Mock(name="pg-1")],
+                    gang_ids=["g0", "g1"],
+                    gang_pg_names=["SERVE_GANG::pg-0", "SERVE_GANG::pg-1"],
                 )
             }
         )
@@ -6305,9 +6311,16 @@ class TestScaleDeploymentGangReplicas:
         dsm.deploy(deployment_id, info)
         ds = dsm._deployment_states[deployment_id]
 
+        gang_ids = ["gang_0", "gang_1"]
+        gang_pg_names = ["SERVE_GANG::pg-0", "SERVE_GANG::pg-1"]
         dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
             return_value={
-                deployment_id: GangReservationResult(success=True, gang_pgs=gang_pgs)
+                deployment_id: GangReservationResult(
+                    success=True,
+                    gang_pgs=gang_pgs,
+                    gang_ids=gang_ids,
+                    gang_pg_names=gang_pg_names,
+                )
             }
         )
 
@@ -6351,6 +6364,7 @@ class TestScaleDeploymentGangReplicas:
                 assert gang_context.gang_id == gang_id
                 assert gang_context.world_size == gang_size
                 assert set(gang_context.member_replica_ids) == member_ids
+                assert gang_context.pg_name in gang_pg_names
 
         for replica in starting_replicas:
             replica._actor.set_ready()
@@ -6540,7 +6554,10 @@ class TestScaleDeploymentGangReplicas:
         dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
             return_value={
                 deployment_id: GangReservationResult(
-                    success=True, gang_pgs=[Mock(name="pg-recovery")]
+                    success=True,
+                    gang_pgs=[Mock(name="pg-recovery")],
+                    gang_ids=["g0"],
+                    gang_pg_names=["SERVE_GANG::pg-recovery"],
                 )
             }
         )

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -45,7 +45,11 @@ from ray.serve._private.deployment_state import (
     ReplicaStateContainer,
 )
 from ray.serve._private.exceptions import DeploymentIsBeingDeletedError
-from ray.serve._private.test_utils import dead_replicas_context, replica_rank_context
+from ray.serve._private.test_utils import (
+    MockPlacementGroup,
+    dead_replicas_context,
+    replica_rank_context,
+)
 from ray.serve._private.utils import (
     get_capacity_adjusted_num_replicas,
     get_random_string,
@@ -6571,6 +6575,226 @@ class TestScaleDeploymentGangReplicas:
         dsm.update()
         check_counts(
             ds, total=2, by_state=[(ReplicaState.RUNNING, 2, recovery_version)]
+        )
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+
+
+class TestGangHealthCheck:
+    def _deploy_gang(self, mock_deployment_state_manager, gang_size, num_replicas):
+        """Deploy gang-scheduled replicas and wait for them to become RUNNING."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm(
+            create_placement_group_fn_override=lambda *args, **kwargs: MockPlacementGroup(
+                *args, **kwargs
+            ),
+        )
+        b_info, v1 = deployment_info(
+            version="1",
+            num_replicas=num_replicas,
+            gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+        )
+        dsm.deploy(TEST_DEPLOYMENT_ID, b_info)
+        ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+        # Reserves gang PGs and creates replicas
+        dsm.update()
+        check_counts(
+            ds, total=num_replicas, by_state=[(ReplicaState.STARTING, num_replicas, v1)]
+        )
+
+        # Capture replica references and wait for them to become RUNNING
+        replicas = ds._replicas.get()
+        for replica in replicas:
+            replica._actor.set_ready()
+        dsm.update()
+
+        check_counts(
+            ds, total=num_replicas, by_state=[(ReplicaState.RUNNING, num_replicas, v1)]
+        )
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+
+        # Group captured replicas by gang
+        gangs = {}
+        for r in replicas:
+            assert r.gang_context is not None
+            gangs.setdefault(r.gang_context.gang_id, []).append(r)
+
+        return dsm, ds, v1, gangs
+
+    @pytest.mark.parametrize("force_stop_unhealthy", [True, False])
+    def test_restart_gang_entire_gang_stopped(
+        self, mock_deployment_state_manager, force_stop_unhealthy
+    ):
+        """Unhealthy gang is force-stopped regardless of FORCE_STOP_UNHEALTHY_REPLICAS;
+        healthy gangs are unaffected."""
+        gang_size = 2
+        num_replicas = 4
+        num_gangs = num_replicas // gang_size
+        dsm, ds, v1, gangs = self._deploy_gang(
+            mock_deployment_state_manager, gang_size, num_replicas
+        )
+        assert len(gangs) == num_gangs
+
+        gang_ids = list(gangs.keys())
+        target_gang = gangs[gang_ids[0]]
+        healthy_gang = gangs[gang_ids[1]]
+
+        ds.FORCE_STOP_UNHEALTHY_REPLICAS = force_stop_unhealthy
+
+        # Initialize health checks, then mark one replica in the target gang as unhealthy.
+        dsm.update()
+        target_gang[0]._actor.set_unhealthy()
+        dsm.update()
+
+        # Both replicas of the affected gang should be stopping (force-stopped).
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, gang_size, v1),
+                (ReplicaState.STOPPING, gang_size, v1),
+            ],
+        )
+        for r in target_gang:
+            assert r._actor.force_stopped_counter == 1
+
+        # Healthy gang replicas should still be running.
+        for r in healthy_gang:
+            assert r._actor.force_stopped_counter == 0
+
+        assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
+        assert (
+            ds.curr_status_info.status_trigger
+            == DeploymentStatusTrigger.HEALTH_CHECK_FAILED
+        )
+        assert "UNHEALTHY" in ds.curr_status_info.message
+
+        # After the stopped replicas finish stopping, new replicas should start.
+        for r in target_gang:
+            r._actor.set_done_stopping()
+        dsm.update()
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, gang_size, v1),
+                (ReplicaState.STARTING, gang_size, v1),
+            ],
+        )
+
+        # New replicas become ready -> deployment should recover to HEALTHY.
+        for r in ds._replicas.get([ReplicaState.STARTING]):
+            r._actor.set_ready()
+        dsm.update()
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[(ReplicaState.RUNNING, num_replicas, v1)],
+        )
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+
+    def test_restart_gang_multiple_unhealthy_gang_replicas(
+        self, mock_deployment_state_manager
+    ):
+        """Verify gang replicas are force-stopped once when there are multiple unhealthy replicas in the same gang."""
+        gang_size = 2
+        num_replicas = 4
+        dsm, ds, v1, gangs = self._deploy_gang(
+            mock_deployment_state_manager, gang_size, num_replicas
+        )
+
+        gang_ids = list(gangs.keys())
+        target_gang = gangs[gang_ids[0]]
+        healthy_gang = gangs[gang_ids[1]]
+
+        # Initialize health checks, then mark both replicas unhealthy.
+        dsm.update()
+        for r in target_gang:
+            r._actor.set_unhealthy()
+        dsm.update()
+
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, gang_size, v1),
+                (ReplicaState.STOPPING, gang_size, v1),
+            ],
+        )
+        for r in target_gang:
+            assert r._actor.force_stopped_counter == 1
+        for r in healthy_gang:
+            assert r._actor.force_stopped_counter == 0
+
+        assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
+
+        # Finish stopping -> new replicas start -> become ready -> HEALTHY.
+        for r in target_gang:
+            r._actor.set_done_stopping()
+        dsm.update()
+        for r in ds._replicas.get([ReplicaState.STARTING]):
+            r._actor.set_ready()
+        dsm.update()
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[(ReplicaState.RUNNING, num_replicas, v1)],
+        )
+        assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+
+    def test_restart_gang_multiple_gangs_failing(self, mock_deployment_state_manager):
+        """Multiple gangs with unhealthy replicas are all stopped; surviving gang is untouched."""
+        gang_size = 2
+        num_replicas = 6  # 3 gangs
+        dsm, ds, v1, gangs = self._deploy_gang(
+            mock_deployment_state_manager, gang_size, num_replicas
+        )
+        assert len(gangs) == 3
+
+        gang_ids = list(gangs.keys())
+        failed_gang_0 = gangs[gang_ids[0]]
+        failed_gang_1 = gangs[gang_ids[1]]
+        surviving_gang = gangs[gang_ids[2]]
+
+        dsm.update()
+        failed_gang_0[0]._actor.set_unhealthy()
+        failed_gang_1[0]._actor.set_unhealthy()
+        dsm.update()
+
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, gang_size, v1),
+                (ReplicaState.STOPPING, gang_size * 2, v1),
+            ],
+        )
+        for r in failed_gang_0 + failed_gang_1:
+            assert r._actor.force_stopped_counter == 1
+        for r in surviving_gang:
+            assert r._actor.force_stopped_counter == 0
+
+        assert ds.curr_status_info.status == DeploymentStatus.UNHEALTHY
+
+        # Finish stopping -> new replicas start -> become ready -> HEALTHY.
+        for r in failed_gang_0 + failed_gang_1:
+            r._actor.set_done_stopping()
+        dsm.update()
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[
+                (ReplicaState.RUNNING, gang_size, v1),
+                (ReplicaState.STARTING, gang_size * 2, v1),
+            ],
+        )
+        for r in ds._replicas.get([ReplicaState.STARTING]):
+            r._actor.set_ready()
+        dsm.update()
+        check_counts(
+            ds,
+            total=num_replicas,
+            by_state=[(ReplicaState.RUNNING, num_replicas, v1)],
         )
         assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 


### PR DESCRIPTION
## Description
Adds fault tolerance for gang-scheduled deployments.
- Implement RESTART_GANG runtime failure policy.
- Exercise leaked gang placement group detection after controller recovery.

### Approach
- Implement `RESTART_GANG` policy within health check handling (`deployment_state.py`)
  - Refactored the health check loop to track healthy and unhealthy replicas separately.
  - When RESTART_GANG is enabled and a replica fails its health check, all replicas, including the unhealthy ones and their healthy siblings, in the same gang are force-stopped so the entire gang can be rescheduled together.
- Exercise leaked gang placement group detection `_detect_and_remove_leaked_placement_groups` 
  - Extended existing leak detection to support gang placement groups.
  - A gang placement group is considered leaked only if no active actors reference it. Placement groups with live actors are preserved to avoid prematurely releasing resources.
  - GCS PG query failures are handled gracefully by skipping the leaked gang PG detection.

### Test Plan
#### Unit Tests

| Category | Test | Description |
|-----------|------|-------------|
| GangReservationResult fields | `TestScheduleGangPlacementGroups ::test_schedule_gang_placement_groups` | Calls real scheduler; asserts length, uniqueness, and `GANG_PG_NAME_PREFIX` |
| GangReservationResult fields | `TestScaleDeploymentGangReplicas ::test_successful_gang_reservation` | Mocks result with `gang_ids` and `gang_pg_names`; asserts `gang_context.pg_name` in `gang_pg_names` |
| Gang-aware `check_and_update_replicas` | `TestGangHealthCheck ::test_restart_gang_entire_gang_stopped` | Unhealthy replica → entire owning gang force-stopped & healthy gangs unaffected |
| Gang-aware `check_and_update_replicas` | `TestGangHealthCheck ::test_restart_gang_force_stop_all_gang_replicas` | Unhealthy gang replicas are force-stopped regardless of `FORCE_STOP_UNHEALTHY_REPLICAS` |
| Gang-aware `check_and_update_replicas` | `TestGangHealthCheck ::test_restart_gang_multiple_unhealthy_gang_replicas` | Multiple unhealthy replicas in same gang; verifies deduplication |
| Gang-aware `check_and_update_replicas` | `TestGangHealthCheck ::test_restart_gang_multiple_gangs_failing` | Multiple gangs with unhealthy replicas are all stopped; verifies set accumulation |


#### Integration Tests

| Test | Description |
|-------|----------|
| `test_gang_health_check_restarts_gang` | Health check failure -> entire gang is torn down while surviving gang continues serving traffic with zero downtime -> deployment recovers to HEALTHY and both failed replicas are replaced |
| `test_leaked_gang_pg_removed_on_controller_recovery` | Kill replicas on a gang PG -> restart controller -> leaked gang PG is detected and removed -> zero downtime throughout |
| `TestGangControllerRecovery::test_gang_context_recovery` | Coexisting gang and non-gang deployments -> kill the controller -> GangContext and ReplicaContext are recovered -> apps / deployments return to RUNNING / HEALTHY state |
| `TestGangPGLeakDetection ::test_gcs_failure_skip_pg_leak_detection` | GCS query failure -> cleanup skipped |

#### Learnings from preceding PR
- Integration tests now assert both deployment and app statuses
- DeploymentScheduler tests now proceed the state machine to ensure that deployment returns to HEALTHY

## Related issues
RFC: https://github.com/ray-project/ray/issues/60873
Precedent: https://github.com/ray-project/ray/pull/61206
Original PR: https://github.com/ray-project/ray/pull/60802

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
