### PR TITLE
[1/n] [Data][DatasourceV2] Add datasource_v2 file listing infrastructure

### DIFF
--- a/python/ray/data/_internal/datasource_v2/__init__.py
+++ b/python/ray/data/_internal/datasource_v2/__init__.py
@@ -1,0 +1,3 @@
+from typing import TypeVar
+
+InputBucket = TypeVar("InputBucket")

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -1,0 +1,179 @@
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List, Optional
+
+from pyarrow.fs import FileSystem
+
+from ray._common.utils import env_integer
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
+from ray.data._internal.datasource_v2.listing.indexing_utils import _get_file_infos
+from ray.data._internal.util import make_async_gen
+from ray.data.block import BlockColumn
+from ray.data.datasource.path_util import _resolve_paths_and_filesystem
+
+logger = logging.getLogger(__name__)
+
+
+class FileIndexer(ABC):
+    @abstractmethod
+    def list_files(
+        self,
+        paths: "BlockColumn",
+        *,
+        filesystem: "FileSystem",
+        pruners: Optional[List[FilePruner]] = None,
+        preserve_order: bool = False,
+    ) -> Iterable[FileManifest]:
+        """List files and their on-disk sizes for the given path.
+
+        Args:
+            paths: A column of paths pointing to files or directories.
+            filesystem: A PyArrow filesystem object.
+            pruners: A list of file pruners to apply.
+            preserve_order: Whether to preserve order in file listing.
+
+        Returns:
+            An iterator of `FileManifest` objects, each of which contains a file path
+            and the on-disk size of the file in bytes.
+        """
+        ...
+
+
+@dataclass
+class FileInfo:
+    """File information for file listing."""
+
+    path: str
+    size: Optional[int]
+
+
+class NonSamplingFileIndexer(FileIndexer):
+    """A file indexer that exhaustively lists files.
+
+    This implementation works with paths that point to files or directories,
+    although it's slow if you try to list lots of paths pointing to files
+    rather than a single directory.
+    """
+
+    _MAX_PATHS_PER_LIST_FILES_OUTPUT = env_integer(
+        "RAY_DATA_MAX_PATHS_PER_LIST_FILES_OUTPUT", 1000
+    )
+
+    _QUEUE_SIZE_PER_THREAD = env_integer(
+        "RAY_DATA_LIST_FILES_QUEUE_SIZE_PER_THREAD",
+        _MAX_PATHS_PER_LIST_FILES_OUTPUT * 4,
+    )
+
+    _THREADED_NUM_WORKERS = env_integer("RAY_DATA_LIST_FILES_THREADED_NUM_WORKERS", 4)
+
+    def __init__(self, *, ignore_missing_paths: bool):
+        self._ignore_missing_paths = ignore_missing_paths
+
+    def list_files(
+        self,
+        paths: "BlockColumn",
+        *,
+        filesystem: "FileSystem",
+        pruners: Optional[List[FilePruner]] = None,
+        preserve_order: bool = False,
+    ) -> Iterable[FileManifest]:
+        file_info_iterator = (
+            self._get_file_info_iterator_threaded(paths, filesystem, preserve_order)
+            if self._THREADED_NUM_WORKERS > 1
+            else self._get_file_info_iterator_sequential(paths, filesystem)
+        )
+
+        yield from self._process_file_infos_to_manifests(
+            file_info_iterator, pruners or []
+        )
+
+    def _get_file_info_iterator_sequential(
+        self,
+        paths: "BlockColumn",
+        filesystem: "FileSystem",
+    ) -> Iterable[FileInfo]:
+        for input_path in paths.to_pylist():
+            resolved_paths, _ = _resolve_paths_and_filesystem(input_path, filesystem)
+            assert len(resolved_paths) == 1
+
+            for path, file_size in _get_file_infos(
+                resolved_paths[0], filesystem, self._ignore_missing_paths
+            ):
+                yield FileInfo(path=path, size=file_size)
+
+    def _get_file_info_iterator_threaded(
+        self,
+        paths: "BlockColumn",
+        filesystem: "FileSystem",
+        preserve_order: bool = False,
+    ) -> Iterable[FileInfo]:
+        paths_list = paths.to_pylist()
+        if len(paths_list) == 0:
+            return
+
+        num_workers = min(self._THREADED_NUM_WORKERS, len(paths_list))
+
+        def process_paths(
+            path_iterator: Iterator[str],
+        ) -> Iterator[FileInfo]:
+            for input_path in path_iterator:
+                resolved_paths, _ = _resolve_paths_and_filesystem(
+                    input_path, filesystem
+                )
+                assert len(resolved_paths) == 1
+
+                for path, file_size in _get_file_infos(
+                    resolved_paths[0],
+                    filesystem,
+                    self._ignore_missing_paths,
+                ):
+                    yield FileInfo(path=path, size=file_size)
+
+        yield from make_async_gen(
+            base_iterator=iter(paths_list),
+            fn=process_paths,
+            preserve_ordering=preserve_order,
+            num_workers=num_workers,
+            buffer_size=self._QUEUE_SIZE_PER_THREAD,
+        )
+
+    def _process_file_infos_to_manifests(
+        self,
+        file_infos: Iterable[FileInfo],
+        pruners: List[FilePruner],
+    ) -> Iterable[FileManifest]:
+        running_paths: List[str] = []
+        running_file_sizes: List[int] = []
+        manifests_count = 0
+        files_count = 0
+
+        for file_info in file_infos:
+            path, file_size = file_info.path, file_info.size
+
+            if file_size == 0:
+                logger.warning(f"Skipping zero-size file: {path!r}")
+                continue
+
+            if not all(pruner.should_include(path) for pruner in pruners):
+                continue
+
+            running_paths.append(path)
+            running_file_sizes.append(file_size)
+            files_count += 1
+
+            if len(running_paths) >= self._MAX_PATHS_PER_LIST_FILES_OUTPUT:
+                manifests_count += 1
+                yield FileManifest.construct_manifest(running_paths, running_file_sizes)
+                running_paths = []
+                running_file_sizes = []
+
+        if running_paths:
+            manifests_count += 1
+            yield FileManifest.construct_manifest(running_paths, running_file_sizes)
+
+        logger.debug(
+            f"Listing files: constructed {manifests_count} manifests "
+            f"with {files_count} files"
+        )

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -57,19 +57,32 @@ class NonSamplingFileIndexer(FileIndexer):
     rather than a single directory.
     """
 
-    _MAX_PATHS_PER_LIST_FILES_OUTPUT = env_integer(
+    _DEFAULT_MAX_PATHS_PER_OUTPUT = env_integer(
         "RAY_DATA_MAX_PATHS_PER_LIST_FILES_OUTPUT", 1000
     )
 
-    _QUEUE_SIZE_PER_THREAD = env_integer(
-        "RAY_DATA_LIST_FILES_QUEUE_SIZE_PER_THREAD",
-        _MAX_PATHS_PER_LIST_FILES_OUTPUT * 4,
-    )
+    _DEFAULT_NUM_WORKERS = env_integer("RAY_DATA_LIST_FILES_THREADED_NUM_WORKERS", 4)
 
-    _THREADED_NUM_WORKERS = env_integer("RAY_DATA_LIST_FILES_THREADED_NUM_WORKERS", 4)
-
-    def __init__(self, *, ignore_missing_paths: bool):
+    def __init__(
+        self,
+        *,
+        ignore_missing_paths: bool,
+        num_workers: Optional[int] = None,
+        max_paths_per_output: Optional[int] = None,
+    ):
         self._ignore_missing_paths = ignore_missing_paths
+        self._max_paths_per_output = (
+            max_paths_per_output
+            if max_paths_per_output is not None
+            else self._DEFAULT_MAX_PATHS_PER_OUTPUT
+        )
+        self._num_workers = (
+            num_workers if num_workers is not None else self._DEFAULT_NUM_WORKERS
+        )
+        self._queue_size_per_thread = env_integer(
+            "RAY_DATA_LIST_FILES_QUEUE_SIZE_PER_THREAD",
+            self._max_paths_per_output * 4,
+        )
 
     def list_files(
         self,
@@ -81,7 +94,7 @@ class NonSamplingFileIndexer(FileIndexer):
     ) -> Iterable[FileManifest]:
         file_info_iterator = (
             self._get_file_info_iterator_threaded(paths, filesystem, preserve_order)
-            if self._THREADED_NUM_WORKERS > 1
+            if self._num_workers > 1
             else self._get_file_info_iterator_sequential(paths, filesystem)
         )
 
@@ -113,7 +126,7 @@ class NonSamplingFileIndexer(FileIndexer):
         if len(paths_list) == 0:
             return
 
-        num_workers = min(self._THREADED_NUM_WORKERS, len(paths_list))
+        num_workers = min(self._num_workers, len(paths_list))
 
         def process_paths(
             path_iterator: Iterator[str],
@@ -136,7 +149,7 @@ class NonSamplingFileIndexer(FileIndexer):
             fn=process_paths,
             preserve_ordering=preserve_order,
             num_workers=num_workers,
-            buffer_size=self._QUEUE_SIZE_PER_THREAD,
+            buffer_size=self._queue_size_per_thread,
         )
 
     def _process_file_infos_to_manifests(
@@ -163,7 +176,7 @@ class NonSamplingFileIndexer(FileIndexer):
             running_file_sizes.append(file_size)
             files_count += 1
 
-            if len(running_paths) >= self._MAX_PATHS_PER_LIST_FILES_OUTPUT:
+            if len(running_paths) >= self._max_paths_per_output:
                 manifests_count += 1
                 yield FileManifest.construct_manifest(running_paths, running_file_sizes)
                 running_paths = []

--- a/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
@@ -1,0 +1,76 @@
+from functools import cached_property
+from typing import List
+
+import numpy as np
+import pyarrow as pa
+
+from ray.data.block import Block, BlockAccessor, BlockColumnAccessor
+
+# File manifest column names
+PATH_COLUMN_NAME = "__path"
+FILE_SIZE_COLUMN_NAME = "__file_size"
+
+
+class FileManifest:
+    """Structured view over file paths and file sizes.
+
+    A thin wrapper over `ListFiles` outputs that provides structured access to file
+    paths and sizes. This avoids making implicit assumptions about block structure as
+    data moves between file listing, partitioning, and reading stages.
+
+    All extracted views (i.e., `paths`, `file_sizes`) share the same row order as the
+    underlying block. Any transformation must preserve this.
+    """
+
+    def __init__(self, block: Block):
+        """Create a new `FileManifest` from a block.
+
+        Args:
+            block: Block with `PATH_COLUMN_NAME`, `FILE_SIZE_COLUMN_NAME`
+                Any other columns are optional and treated as input data.
+        """
+        column_names = BlockAccessor.for_block(block).column_names()
+        assert FILE_SIZE_COLUMN_NAME in column_names
+        assert PATH_COLUMN_NAME in column_names
+
+        self._block = block
+
+        self._paths = block[PATH_COLUMN_NAME]
+        self._file_sizes = block[FILE_SIZE_COLUMN_NAME]
+
+    def __len__(self) -> int:
+        return len(self._block)
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__} length={len(self._block)}>"
+
+    @cached_property
+    def paths(self) -> np.ndarray:
+        return BlockColumnAccessor.for_column(self._paths).to_numpy()
+
+    @cached_property
+    def file_sizes(self) -> np.ndarray:
+        return BlockColumnAccessor.for_column(self._file_sizes).to_numpy()
+
+    def as_block(self) -> Block:
+        """Return the underlying block for the `FileManifest`.
+
+        This doesn't make a copy of the underlying data.
+        """
+        return self._block
+
+    @classmethod
+    def construct_manifest(
+        cls,
+        paths: List[str],
+        sizes: List[int],
+    ) -> "FileManifest":
+        assert len(paths) == len(sizes)
+
+        block = pa.table(
+            {
+                PATH_COLUMN_NAME: paths,
+                FILE_SIZE_COLUMN_NAME: sizes,
+            }
+        )
+        return cls(block)

--- a/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
@@ -14,8 +14,7 @@ FILE_SIZE_COLUMN_NAME = "__file_size"
 class FileManifest:
     """Structured view over file paths and file sizes.
 
-    A thin wrapper over `ListFiles` outputs that provides structured access to file
-    paths and sizes. This avoids making implicit assumptions about block structure as
+    Provides structured access to file paths and sizes. This avoids making implicit assumptions about block structure as
     data moves between file listing, partitioning, and reading stages.
 
     All extracted views (i.e., `paths`, `file_sizes`) share the same row order as the

--- a/python/ray/data/_internal/datasource_v2/listing/file_pruners.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_pruners.py
@@ -1,0 +1,34 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from ray.data.datasource import PathPartitionFilter
+from ray.data.datasource.path_util import _has_file_extension
+
+
+class FilePruner(ABC):
+    """Generic file-level filter applied during listing."""
+
+    @abstractmethod
+    def should_include(self, path: str) -> bool:
+        """Return True if this file should be included, False to skip it."""
+        ...
+
+
+class FileExtensionPruner(FilePruner):
+    """Skip files that don't match the expected extensions."""
+
+    def __init__(self, file_extensions: List[str]):
+        self._file_extensions = file_extensions
+
+    def should_include(self, path: str) -> bool:
+        return _has_file_extension(path, self._file_extensions)
+
+
+class PartitionPruner(FilePruner):
+    """Skip files based on partition column predicates (e.g., hive partitioning)."""
+
+    def __init__(self, partition_filter: PathPartitionFilter):
+        self._filter = partition_filter
+
+    def should_include(self, path: str) -> bool:
+        return self._filter.apply(path)

--- a/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
@@ -1,0 +1,59 @@
+import logging
+from typing import Iterable, Optional, Tuple
+
+import pyarrow as pa
+from pyarrow.fs import FileSelector, FileType
+
+from ray.data.datasource.file_meta_provider import _handle_read_os_error
+
+logger = logging.getLogger(__name__)
+
+
+def _get_file_infos(
+    path: str, filesystem: pa.fs.FileSystem, ignore_missing_path: bool
+) -> Iterable[Tuple[str, Optional[int]]]:
+    try:
+        file_info = filesystem.get_file_info(path)
+    except OSError as e:
+        _handle_read_os_error(e, path)
+
+    if file_info.type == FileType.Directory:
+        yield from _expand_directory(path, filesystem, ignore_missing_path)
+    elif file_info.type == FileType.File:
+        yield (path, file_info.size)
+    elif file_info.type == FileType.NotFound and ignore_missing_path:
+        pass
+    else:
+        raise FileNotFoundError(path)
+
+
+def _expand_directory(
+    base_path: str, filesystem: pa.fs.FileSystem, ignore_missing_path: bool
+) -> Iterable[Tuple[str, Optional[int]]]:
+    exclude_prefixes = [".", "_"]
+    selector = FileSelector(
+        base_path, recursive=False, allow_not_found=ignore_missing_path
+    )
+    files = filesystem.get_file_info(selector)
+
+    assert isinstance(files, list), type(files)
+    files.sort(key=lambda file_: file_.path)
+
+    for file_ in files:
+        if not file_.path.startswith(base_path):
+            continue
+
+        relative = file_.path[len(base_path) :].lstrip("/")
+        if any(relative.startswith(prefix) for prefix in exclude_prefixes):
+            continue
+
+        if file_.type == FileType.File:
+            yield (file_.path, file_.size)
+        elif file_.type == FileType.Directory:
+            yield from _expand_directory(file_.path, filesystem, ignore_missing_path)
+        elif file_.type == FileType.UNKNOWN:
+            logger.warning(f"Discovered file with unknown type: '{file_.path}'")
+            continue
+        else:
+            assert file_.type == FileType.NotFound
+            raise FileNotFoundError(file_.path)

--- a/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/indexing_utils.py
@@ -28,9 +28,17 @@ def _get_file_infos(
 
 
 def _expand_directory(
-    base_path: str, filesystem: pa.fs.FileSystem, ignore_missing_path: bool
+    base_path: str,
+    filesystem: pa.fs.FileSystem,
+    ignore_missing_path: bool,
+    *,
+    _root_path: Optional[str] = None,
 ) -> Iterable[Tuple[str, Optional[int]]]:
     exclude_prefixes = [".", "_"]
+
+    if _root_path is None:
+        _root_path = base_path
+
     selector = FileSelector(
         base_path, recursive=False, allow_not_found=ignore_missing_path
     )
@@ -40,17 +48,19 @@ def _expand_directory(
     files.sort(key=lambda file_: file_.path)
 
     for file_ in files:
-        if not file_.path.startswith(base_path):
+        if not file_.path.startswith(_root_path):
             continue
 
-        relative = file_.path[len(base_path) :].lstrip("/")
+        relative = file_.path[len(_root_path) :].lstrip("/")
         if any(relative.startswith(prefix) for prefix in exclude_prefixes):
             continue
 
         if file_.type == FileType.File:
             yield (file_.path, file_.size)
         elif file_.type == FileType.Directory:
-            yield from _expand_directory(file_.path, filesystem, ignore_missing_path)
+            yield from _expand_directory(
+                file_.path, filesystem, ignore_missing_path, _root_path=_root_path
+            )
         elif file_.type == FileType.UNKNOWN:
             logger.warning(f"Discovered file with unknown type: '{file_.path}'")
             continue

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -1,0 +1,198 @@
+import os
+
+import pyarrow as pa
+import pytest
+from pyarrow.fs import LocalFileSystem
+
+from ray.data._internal.datasource_v2.listing.file_indexer import (
+    NonSamplingFileIndexer,
+)
+from ray.data._internal.datasource_v2.listing.file_pruners import FileExtensionPruner
+
+
+@pytest.fixture
+def fs():
+    return LocalFileSystem()
+
+
+def _create_file(path, size=100):
+    """Write `size` bytes to `path`, creating parent dirs as needed."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(b"x" * size)
+
+
+def _list_all(indexer, paths, fs, **kwargs):
+    """Run list_files and flatten all manifests into (path, size) pairs."""
+    pa_paths = pa.array(paths)
+    manifests = list(indexer.list_files(pa_paths, filesystem=fs, **kwargs))
+    results = []
+    for m in manifests:
+        for p, s in zip(m.paths, m.file_sizes):
+            results.append((str(p), int(s)))
+    return sorted(results)
+
+
+@pytest.fixture(params=[1, 2], ids=["sequential", "threaded"])
+def indexer(request, monkeypatch):
+    """Yield a NonSamplingFileIndexer using sequential or threaded listing."""
+    monkeypatch.setattr(NonSamplingFileIndexer, "_THREADED_NUM_WORKERS", request.param)
+    return NonSamplingFileIndexer(ignore_missing_paths=False)
+
+
+class TestListFiles:
+    def test_single_file(self, tmp_path, fs, indexer):
+        f = str(tmp_path / "data.csv")
+        _create_file(f, size=42)
+
+        results = _list_all(indexer, [f], fs)
+        assert results == [(f, 42)]
+
+    def test_directory(self, tmp_path, fs, indexer):
+        for name in ["a.csv", "b.csv", "c.csv"]:
+            _create_file(str(tmp_path / name), size=10)
+
+        results = _list_all(indexer, [str(tmp_path)], fs)
+        assert len(results) == 3
+        assert all(size == 10 for _, size in results)
+
+    def test_nested_directories(self, tmp_path, fs, indexer):
+        _create_file(str(tmp_path / "top.csv"))
+        _create_file(str(tmp_path / "sub" / "nested.csv"))
+        _create_file(str(tmp_path / "sub" / "deep" / "leaf.csv"))
+
+        results = _list_all(indexer, [str(tmp_path)], fs)
+        assert len(results) == 3
+        basenames = sorted(os.path.basename(p) for p, _ in results)
+        assert basenames == ["leaf.csv", "nested.csv", "top.csv"]
+
+    def test_multiple_paths(self, tmp_path, fs, indexer):
+        f1 = str(tmp_path / "one.csv")
+        f2 = str(tmp_path / "two.csv")
+        _create_file(f1, size=10)
+        _create_file(f2, size=20)
+
+        results = _list_all(indexer, [f1, f2], fs)
+        assert sorted(results) == [(f1, 10), (f2, 20)]
+
+    @pytest.mark.parametrize(
+        "filename",
+        [".hidden", "_metadata", "_SUCCESS", ".gitignore"],
+        ids=["dot-prefix", "underscore-prefix", "underscore-upper", "dotfile"],
+    )
+    def test_excludes_hidden_and_metadata_files(self, tmp_path, fs, indexer, filename):
+        _create_file(str(tmp_path / filename))
+        _create_file(str(tmp_path / "visible.csv"))
+
+        results = _list_all(indexer, [str(tmp_path)], fs)
+        assert len(results) == 1
+        assert os.path.basename(results[0][0]) == "visible.csv"
+
+    def test_skips_zero_size_files(self, tmp_path, fs, indexer):
+        _create_file(str(tmp_path / "empty.csv"), size=0)
+        _create_file(str(tmp_path / "real.csv"), size=50)
+
+        results = _list_all(indexer, [str(tmp_path)], fs)
+        assert len(results) == 1
+        assert os.path.basename(results[0][0]) == "real.csv"
+
+    def test_empty_directory(self, tmp_path, fs, indexer):
+        os.makedirs(tmp_path / "empty_dir", exist_ok=True)
+        results = _list_all(indexer, [str(tmp_path / "empty_dir")], fs)
+        assert results == []
+
+
+class TestPruners:
+    @pytest.fixture
+    def indexer(self, monkeypatch):
+        monkeypatch.setattr(NonSamplingFileIndexer, "_THREADED_NUM_WORKERS", 1)
+        return NonSamplingFileIndexer(ignore_missing_paths=False)
+
+    @pytest.mark.parametrize(
+        "extensions, expected_basenames",
+        [
+            (["csv"], ["a.csv"]),
+            (["json"], ["b.json"]),
+            (["csv", "json"], ["a.csv", "b.json"]),
+            (["parquet"], []),
+        ],
+        ids=["csv-only", "json-only", "csv-and-json", "no-match"],
+    )
+    def test_extension_pruner(
+        self, tmp_path, fs, indexer, extensions, expected_basenames
+    ):
+        _create_file(str(tmp_path / "a.csv"))
+        _create_file(str(tmp_path / "b.json"))
+        _create_file(str(tmp_path / "c.txt"))
+
+        pruner = FileExtensionPruner(extensions)
+        results = _list_all(indexer, [str(tmp_path)], fs, pruners=[pruner])
+        basenames = sorted(os.path.basename(p) for p, _ in results)
+        assert basenames == sorted(expected_basenames)
+
+    def test_multiple_pruners_intersect(self, tmp_path, fs, indexer):
+        """Multiple pruners are AND'd — a file must pass all of them."""
+        _create_file(str(tmp_path / "a.csv"))
+        _create_file(str(tmp_path / "b.json"))
+
+        pruner_csv = FileExtensionPruner(["csv", "json"])
+        pruner_json = FileExtensionPruner(["json"])
+        results = _list_all(
+            indexer, [str(tmp_path)], fs, pruners=[pruner_csv, pruner_json]
+        )
+        basenames = [os.path.basename(p) for p, _ in results]
+        assert basenames == ["b.json"]
+
+
+class TestMissingPaths:
+    def test_raises_on_missing_path(self, tmp_path, fs):
+        indexer = NonSamplingFileIndexer(ignore_missing_paths=False)
+        missing = str(tmp_path / "nonexistent")
+
+        with pytest.raises(FileNotFoundError):
+            _list_all(indexer, [missing], fs)
+
+    def test_ignores_missing_path(self, tmp_path, fs):
+        indexer = NonSamplingFileIndexer(ignore_missing_paths=True)
+        missing = str(tmp_path / "nonexistent")
+
+        results = _list_all(indexer, [missing], fs)
+        assert results == []
+
+    def test_mixed_existing_and_missing(self, tmp_path, fs):
+        indexer = NonSamplingFileIndexer(ignore_missing_paths=True)
+        real = str(tmp_path / "real.csv")
+        _create_file(real, size=10)
+        missing = str(tmp_path / "gone")
+
+        results = _list_all(indexer, [real, missing], fs)
+        assert results == [(real, 10)]
+
+
+class TestManifestBatching:
+    def test_splits_into_multiple_manifests(self, tmp_path, fs, monkeypatch):
+        monkeypatch.setattr(NonSamplingFileIndexer, "_THREADED_NUM_WORKERS", 1)
+        monkeypatch.setattr(
+            NonSamplingFileIndexer, "_MAX_PATHS_PER_LIST_FILES_OUTPUT", 3
+        )
+        indexer = NonSamplingFileIndexer(ignore_missing_paths=False)
+
+        for i in range(7):
+            _create_file(str(tmp_path / f"file_{i}.csv"))
+
+        pa_paths = pa.array([str(tmp_path)])
+        manifests = list(indexer.list_files(pa_paths, filesystem=fs))
+
+        assert len(manifests) == 3  # ceil(7/3)
+        assert len(manifests[0]) == 3
+        assert len(manifests[1]) == 3
+        assert len(manifests[2]) == 1
+
+        total_files = sum(len(m) for m in manifests)
+        assert total_files == 7
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -78,6 +78,28 @@ class TestListFiles:
         assert len(results) == 1
         assert os.path.basename(results[0][0]) == "visible.csv"
 
+    @pytest.mark.parametrize(
+        "filename",
+        ["_metadata", "_my_file.csv", ".hidden_data"],
+        ids=["underscore-metadata", "underscore-csv", "dot-hidden"],
+    )
+    def test_includes_excluded_prefix_files_in_subdirectories(
+        self, tmp_path, indexer, filename
+    ):
+        """Files whose names start with _ or . should only be excluded when
+        they appear at the top level of the listed directory, not when they
+        appear inside a subdirectory. The relative path from the root is
+        e.g. "subdir/_metadata" which starts with "s", not "_"."""
+        sub = tmp_path / "subdir"
+        sub.mkdir()
+        (sub / filename).write_bytes(b"x" * 50)
+        (sub / "normal.csv").write_bytes(b"x" * 50)
+
+        results = _list_all(indexer, [str(tmp_path)])
+        basenames = sorted(os.path.basename(p) for p, _ in results)
+        assert filename in basenames
+        assert "normal.csv" in basenames
+
     def test_skips_zero_size_files(self, tmp_path, indexer):
         (tmp_path / "empty.csv").write_bytes(b"")
         (tmp_path / "real.csv").write_bytes(b"x" * 50)

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -10,21 +10,10 @@ from ray.data._internal.datasource_v2.listing.file_indexer import (
 from ray.data._internal.datasource_v2.listing.file_pruners import FileExtensionPruner
 
 
-@pytest.fixture
-def fs():
-    return LocalFileSystem()
-
-
-def _create_file(path, size=100):
-    """Write `size` bytes to `path`, creating parent dirs as needed."""
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "wb") as f:
-        f.write(b"x" * size)
-
-
-def _list_all(indexer, paths, fs, **kwargs):
+def _list_all(indexer, paths, **kwargs):
     """Run list_files and flatten all manifests into (path, size) pairs."""
     pa_paths = pa.array(paths)
+    fs = LocalFileSystem()
     manifests = list(indexer.list_files(pa_paths, filesystem=fs, **kwargs))
     results = []
     for m in manifests:
@@ -34,79 +23,79 @@ def _list_all(indexer, paths, fs, **kwargs):
 
 
 @pytest.fixture(params=[1, 2], ids=["sequential", "threaded"])
-def indexer(request, monkeypatch):
+def indexer(request):
     """Yield a NonSamplingFileIndexer using sequential or threaded listing."""
-    monkeypatch.setattr(NonSamplingFileIndexer, "_THREADED_NUM_WORKERS", request.param)
-    return NonSamplingFileIndexer(ignore_missing_paths=False)
+    return NonSamplingFileIndexer(ignore_missing_paths=False, num_workers=request.param)
 
 
 class TestListFiles:
-    def test_single_file(self, tmp_path, fs, indexer):
-        f = str(tmp_path / "data.csv")
-        _create_file(f, size=42)
+    def test_single_file(self, tmp_path, indexer):
+        f = tmp_path / "data.csv"
+        f.write_bytes(b"x" * 42)
 
-        results = _list_all(indexer, [f], fs)
-        assert results == [(f, 42)]
+        results = _list_all(indexer, [str(f)])
+        assert results == [(str(f), 42)]
 
-    def test_directory(self, tmp_path, fs, indexer):
+    def test_directory(self, tmp_path, indexer):
         for name in ["a.csv", "b.csv", "c.csv"]:
-            _create_file(str(tmp_path / name), size=10)
+            (tmp_path / name).write_bytes(b"x" * 10)
 
-        results = _list_all(indexer, [str(tmp_path)], fs)
+        results = _list_all(indexer, [str(tmp_path)])
         assert len(results) == 3
         assert all(size == 10 for _, size in results)
 
-    def test_nested_directories(self, tmp_path, fs, indexer):
-        _create_file(str(tmp_path / "top.csv"))
-        _create_file(str(tmp_path / "sub" / "nested.csv"))
-        _create_file(str(tmp_path / "sub" / "deep" / "leaf.csv"))
+    def test_nested_directories(self, tmp_path, indexer):
+        (tmp_path / "top.csv").write_bytes(b"x" * 100)
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "nested.csv").write_bytes(b"x" * 100)
+        (tmp_path / "sub" / "deep").mkdir()
+        (tmp_path / "sub" / "deep" / "leaf.csv").write_bytes(b"x" * 100)
 
-        results = _list_all(indexer, [str(tmp_path)], fs)
+        results = _list_all(indexer, [str(tmp_path)])
         assert len(results) == 3
         basenames = sorted(os.path.basename(p) for p, _ in results)
         assert basenames == ["leaf.csv", "nested.csv", "top.csv"]
 
-    def test_multiple_paths(self, tmp_path, fs, indexer):
-        f1 = str(tmp_path / "one.csv")
-        f2 = str(tmp_path / "two.csv")
-        _create_file(f1, size=10)
-        _create_file(f2, size=20)
+    def test_multiple_paths(self, tmp_path, indexer):
+        f1 = tmp_path / "one.csv"
+        f2 = tmp_path / "two.csv"
+        f1.write_bytes(b"x" * 10)
+        f2.write_bytes(b"x" * 20)
 
-        results = _list_all(indexer, [f1, f2], fs)
-        assert sorted(results) == [(f1, 10), (f2, 20)]
+        results = _list_all(indexer, [str(f1), str(f2)])
+        assert sorted(results) == [(str(f1), 10), (str(f2), 20)]
 
     @pytest.mark.parametrize(
         "filename",
         [".hidden", "_metadata", "_SUCCESS", ".gitignore"],
         ids=["dot-prefix", "underscore-prefix", "underscore-upper", "dotfile"],
     )
-    def test_excludes_hidden_and_metadata_files(self, tmp_path, fs, indexer, filename):
-        _create_file(str(tmp_path / filename))
-        _create_file(str(tmp_path / "visible.csv"))
+    def test_excludes_hidden_and_metadata_files(self, tmp_path, indexer, filename):
+        (tmp_path / filename).write_bytes(b"x" * 100)
+        (tmp_path / "visible.csv").write_bytes(b"x" * 100)
 
-        results = _list_all(indexer, [str(tmp_path)], fs)
+        results = _list_all(indexer, [str(tmp_path)])
         assert len(results) == 1
         assert os.path.basename(results[0][0]) == "visible.csv"
 
-    def test_skips_zero_size_files(self, tmp_path, fs, indexer):
-        _create_file(str(tmp_path / "empty.csv"), size=0)
-        _create_file(str(tmp_path / "real.csv"), size=50)
+    def test_skips_zero_size_files(self, tmp_path, indexer):
+        (tmp_path / "empty.csv").write_bytes(b"")
+        (tmp_path / "real.csv").write_bytes(b"x" * 50)
 
-        results = _list_all(indexer, [str(tmp_path)], fs)
+        results = _list_all(indexer, [str(tmp_path)])
         assert len(results) == 1
         assert os.path.basename(results[0][0]) == "real.csv"
 
-    def test_empty_directory(self, tmp_path, fs, indexer):
+    def test_empty_directory(self, tmp_path, indexer):
         os.makedirs(tmp_path / "empty_dir", exist_ok=True)
-        results = _list_all(indexer, [str(tmp_path / "empty_dir")], fs)
+        results = _list_all(indexer, [str(tmp_path / "empty_dir")])
         assert results == []
 
 
 class TestPruners:
     @pytest.fixture
-    def indexer(self, monkeypatch):
-        monkeypatch.setattr(NonSamplingFileIndexer, "_THREADED_NUM_WORKERS", 1)
-        return NonSamplingFileIndexer(ignore_missing_paths=False)
+    def indexer(self):
+        return NonSamplingFileIndexer(ignore_missing_paths=False, num_workers=1)
 
     @pytest.mark.parametrize(
         "extensions, expected_basenames",
@@ -118,69 +107,64 @@ class TestPruners:
         ],
         ids=["csv-only", "json-only", "csv-and-json", "no-match"],
     )
-    def test_extension_pruner(
-        self, tmp_path, fs, indexer, extensions, expected_basenames
-    ):
-        _create_file(str(tmp_path / "a.csv"))
-        _create_file(str(tmp_path / "b.json"))
-        _create_file(str(tmp_path / "c.txt"))
+    def test_extension_pruner(self, tmp_path, indexer, extensions, expected_basenames):
+        (tmp_path / "a.csv").write_bytes(b"x" * 100)
+        (tmp_path / "b.json").write_bytes(b"x" * 100)
+        (tmp_path / "c.txt").write_bytes(b"x" * 100)
 
         pruner = FileExtensionPruner(extensions)
-        results = _list_all(indexer, [str(tmp_path)], fs, pruners=[pruner])
+        results = _list_all(indexer, [str(tmp_path)], pruners=[pruner])
         basenames = sorted(os.path.basename(p) for p, _ in results)
         assert basenames == sorted(expected_basenames)
 
-    def test_multiple_pruners_intersect(self, tmp_path, fs, indexer):
+    def test_multiple_pruners_intersect(self, tmp_path, indexer):
         """Multiple pruners are AND'd — a file must pass all of them."""
-        _create_file(str(tmp_path / "a.csv"))
-        _create_file(str(tmp_path / "b.json"))
+        (tmp_path / "a.csv").write_bytes(b"x" * 100)
+        (tmp_path / "b.json").write_bytes(b"x" * 100)
 
         pruner_csv = FileExtensionPruner(["csv", "json"])
         pruner_json = FileExtensionPruner(["json"])
-        results = _list_all(
-            indexer, [str(tmp_path)], fs, pruners=[pruner_csv, pruner_json]
-        )
+        results = _list_all(indexer, [str(tmp_path)], pruners=[pruner_csv, pruner_json])
         basenames = [os.path.basename(p) for p, _ in results]
         assert basenames == ["b.json"]
 
 
 class TestMissingPaths:
-    def test_raises_on_missing_path(self, tmp_path, fs):
+    def test_raises_on_missing_path(self, tmp_path):
         indexer = NonSamplingFileIndexer(ignore_missing_paths=False)
         missing = str(tmp_path / "nonexistent")
 
         with pytest.raises(FileNotFoundError):
-            _list_all(indexer, [missing], fs)
+            _list_all(indexer, [missing])
 
-    def test_ignores_missing_path(self, tmp_path, fs):
+    def test_ignores_missing_path(self, tmp_path):
         indexer = NonSamplingFileIndexer(ignore_missing_paths=True)
         missing = str(tmp_path / "nonexistent")
 
-        results = _list_all(indexer, [missing], fs)
+        results = _list_all(indexer, [missing])
         assert results == []
 
-    def test_mixed_existing_and_missing(self, tmp_path, fs):
+    def test_mixed_existing_and_missing(self, tmp_path):
         indexer = NonSamplingFileIndexer(ignore_missing_paths=True)
-        real = str(tmp_path / "real.csv")
-        _create_file(real, size=10)
+        real = tmp_path / "real.csv"
+        real.write_bytes(b"x" * 10)
         missing = str(tmp_path / "gone")
 
-        results = _list_all(indexer, [real, missing], fs)
-        assert results == [(real, 10)]
+        results = _list_all(indexer, [str(real), missing])
+        assert results == [(str(real), 10)]
 
 
 class TestManifestBatching:
-    def test_splits_into_multiple_manifests(self, tmp_path, fs, monkeypatch):
-        monkeypatch.setattr(NonSamplingFileIndexer, "_THREADED_NUM_WORKERS", 1)
-        monkeypatch.setattr(
-            NonSamplingFileIndexer, "_MAX_PATHS_PER_LIST_FILES_OUTPUT", 3
+    def test_splits_into_multiple_manifests(self, tmp_path):
+        indexer = NonSamplingFileIndexer(
+            ignore_missing_paths=False, max_paths_per_output=3
         )
-        indexer = NonSamplingFileIndexer(ignore_missing_paths=False)
 
         for i in range(7):
-            _create_file(str(tmp_path / f"file_{i}.csv"))
+            (tmp_path / f"file_{i}.csv").write_bytes(b"x" * 100)
 
         pa_paths = pa.array([str(tmp_path)])
+        fs = LocalFileSystem()
         manifests = list(indexer.list_files(pa_paths, filesystem=fs))
 
         assert len(manifests) == 3  # ceil(7/3)


### PR DESCRIPTION
## Description
Introduce the foundational file discovery pipeline for DataSourceV2:
- FileManifest: structured view over file paths and sizes
- FileIndexer/NonSamplingFileIndexer: threaded file listing with batched manifests
- FilePruner: extensible file filtering (by extension, partition predicates)
- Indexing utilities for directory expansion and file info retrieval
- Unit tests for NonSamplingFileIndexer (29 tests)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
