### PR TITLE
[Serve] Add tracing support in Ray Serve

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -139,6 +139,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    :toctree: doc/
 
    serve.get_replica_context
+   serve.get_trace_context
    serve.context.ReplicaContext
    serve.context.GangContext
    serve.get_multiplexed_model_id

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -25,6 +25,7 @@ try:
     )
     from ray.serve.batching import batch
     from ray.serve.config import HTTPOptions
+    from ray.serve.utils import get_trace_context
 
 except ModuleNotFoundError as e:
     e.msg += (
@@ -47,6 +48,7 @@ __all__ = [
     "start",
     "HTTPOptions",
     "get_replica_context",
+    "get_trace_context",
     "shutdown",
     "shutdown_async",
     "ingress",

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -733,6 +733,18 @@ SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER = "x-request-timeout-seconds"
 # HTTP request disconnect disabled
 SERVE_HTTP_REQUEST_DISCONNECT_DISABLED_HEADER = "x-request-disconnect-disabled"
 
+# Path to tracing exporter function
+# If empty string (default), then tracing is disabled
+RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH = os.environ.get(
+    "RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH", ""
+)
+DEFAULT_TRACING_EXPORTER_IMPORT_PATH = (
+    "ray.serve._private.tracing_utils:default_tracing_exporter"
+)
+RAY_SERVE_TRACING_SAMPLING_RATIO = float(
+    os.environ.get("RAY_SERVE_TRACING_SAMPLING_RATIO", 0.01)
+)
+
 # If throughput optimized Ray Serve is enabled, set the following constants.
 # This should be at the end.
 RAY_SERVE_THROUGHPUT_OPTIMIZED = get_env_bool("RAY_SERVE_THROUGHPUT_OPTIMIZED", "0")

--- a/python/ray/serve/_private/proxy_request_response.py
+++ b/python/ray/serve/_private/proxy_request_response.py
@@ -10,6 +10,11 @@ from starlette.types import Receive, Scope, Send
 
 from ray.serve._private.common import StreamingHTTPRequest, gRPCRequest
 from ray.serve._private.constants import SERVE_LOGGER_NAME
+from ray.serve._private.tracing_utils import (
+    extract_propagated_context,
+    is_tracing_enabled,
+    set_trace_context,
+)
 from ray.serve._private.utils import DEFAULT
 from ray.serve.grpc_util import RayServegRPCContext
 
@@ -57,6 +62,12 @@ class ProxyRequest(ABC):
     @property
     @abstractmethod
     def is_health_request(self) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def populate_tracing_context(self):
+        """Implement this method to populate tracing context so the parent and
+        child spans will be connected into a single trace."""
         raise NotImplementedError
 
 
@@ -120,6 +131,22 @@ class ASGIProxyRequest(ProxyRequest):
                 proxy_actor_name=proxy_actor_name,
             )
         )
+
+    def populate_tracing_context(self):
+        """Populate tracing context for ASGI requests.
+
+        This method extracts the "traceparent" header from the request headers and sets
+        the tracing context from it.
+        """
+        if not is_tracing_enabled():
+            return
+
+        for key, value in self.headers:
+            if key.decode() == "traceparent":
+                trace_context = extract_propagated_context(
+                    {key.decode(): value.decode()}
+                )
+                set_trace_context(trace_context)
 
 
 class gRPCProxyRequest(ProxyRequest):
@@ -187,6 +214,20 @@ class gRPCProxyRequest(ProxyRequest):
         # NOTE(edoakes): it's important that the request is sent as raw bytes to
         # skip the Ray cloudpickle serialization codepath for performance.
         return pickle.dumps(gRPCRequest(user_request_proto=self._request_proto))
+
+    def populate_tracing_context(self):
+        """Populate tracing context for gRPC requests.
+
+        This method extracts the "traceparent" metadata from the request headers and
+        sets the tracing context from it.
+        """
+        if not is_tracing_enabled():
+            return
+
+        for key, value in self.context.invocation_metadata():
+            if key == "traceparent":
+                trace_context = extract_propagated_context({key: value})
+                set_trace_context(trace_context)
 
 
 @dataclass(frozen=True)

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -131,6 +131,17 @@ from ray.serve._private.thirdparty.get_asgi_route_name import (
     extract_route_patterns,
     get_asgi_route_name,
 )
+from ray.serve._private.tracing_utils import (
+    TraceContextManager,
+    extract_propagated_context,
+    is_span_recording,
+    is_tracing_enabled,
+    set_http_span_attributes,
+    set_rpc_span_attributes,
+    set_span_attributes,
+    set_span_exception,
+    setup_tracing,
+)
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import (
     Semaphore,
@@ -1328,7 +1339,14 @@ class ReplicaBase(ABC):
         # Design: We return it so it can be passed to _wrap_request() which
         # stores it in _RequestContext. Users can then access it via serve.context
         # if needed (advanced use case), while keeping it out of their method signatures.
+        #
+        # For gRPC requests (when using RAY_SERVE_USE_GRPC_BY_DEFAULT),
+        # the _ray_trace_ctx is not injected into kwargs since there's no Ray actor
+        # call. Instead, the tracing context is passed via request_metadata.tracing_context.
+        # We fall back to using that if _ray_trace_ctx is not in kwargs.
         ray_trace_ctx = request_kwargs.pop("_ray_trace_ctx", None)
+        if ray_trace_ctx is None:
+            ray_trace_ctx = request_metadata.tracing_context
 
         if request_metadata.is_http_request:
             assert len(request_args) == 1 and isinstance(
@@ -1707,6 +1725,20 @@ class Replica(ReplicaBase):
 
         super().__init__(**kwargs)
 
+        try:
+            is_tracing_setup_successful = setup_tracing(
+                component_type=ServeComponentType.REPLICA,
+                component_name=self._component_name,
+                component_id=self._component_id,
+            )
+            if is_tracing_setup_successful:
+                logger.info("Successfully set up tracing for replica")
+        except Exception as e:
+            logger.warning(
+                f"Failed to set up tracing: {e}. "
+                "The replica will continue running, but traces will not be exported."
+            )
+
         self._controller_handle = ray.get_actor(
             SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE
         )
@@ -1899,6 +1931,33 @@ class Replica(ReplicaBase):
             return super()._can_accept_request(request_metadata)
 
     @contextmanager
+    def _tracing_context(self, request_metadata: RequestMetadata):
+        if not is_tracing_enabled():
+            yield
+            return
+
+        call_method = request_metadata.call_method
+        trace_context = extract_propagated_context(request_metadata.tracing_context)
+        trace_manager = TraceContextManager(
+            trace_name=f"replica_handle_request {self._deployment_id.name} {call_method}",
+            trace_context=trace_context,
+        )
+        with trace_manager:
+            if is_span_recording():
+                trace_attributes = {
+                    "request_id": request_metadata.request_id,
+                    "replica_id": self._replica_id.unique_id,
+                    "deployment": self._deployment_id.name,
+                    "app": self._deployment_id.app_name,
+                    "call_method": request_metadata.call_method,
+                    "route": request_metadata.route,
+                    "multiplexed_model_id": request_metadata.multiplexed_model_id,
+                    "is_streaming": request_metadata.is_streaming,
+                }
+                set_span_attributes(trace_attributes)
+            yield
+
+    @contextmanager
     def _wrap_request(
         self, request_metadata: RequestMetadata, ray_trace_ctx: Optional[Any] = None
     ) -> Generator[StatusCodeCallback, None, None]:
@@ -1908,22 +1967,53 @@ class Replica(ReplicaBase):
         2) Records the access log message (if not disabled).
         3) Records per-request metrics via the metrics manager.
         """
-        ray.serve.context._serve_request_context.set(
-            ray.serve.context._RequestContext(
-                route=request_metadata.route,
-                request_id=request_metadata.request_id,
-                _internal_request_id=request_metadata.internal_request_id,
-                app_name=self._deployment_id.app_name,
-                multiplexed_model_id=request_metadata.multiplexed_model_id,
-                grpc_context=request_metadata.grpc_context,
-                cancel_on_parent_request_cancel=self._ingress
-                and RAY_SERVE_ENABLE_DIRECT_INGRESS,
-                _ray_trace_ctx=ray_trace_ctx,
+        with self._tracing_context(request_metadata):
+            ray.serve.context._serve_request_context.set(
+                ray.serve.context._RequestContext(
+                    route=request_metadata.route,
+                    request_id=request_metadata.request_id,
+                    _internal_request_id=request_metadata.internal_request_id,
+                    app_name=self._deployment_id.app_name,
+                    multiplexed_model_id=request_metadata.multiplexed_model_id,
+                    grpc_context=request_metadata.grpc_context,
+                    cancel_on_parent_request_cancel=self._ingress
+                    and RAY_SERVE_ENABLE_DIRECT_INGRESS,
+                    _ray_trace_ctx=ray_trace_ctx,
+                )
             )
+
+            with self._handle_errors_and_metrics(
+                request_metadata
+            ) as status_code_callback:
+                yield status_code_callback
+
+    def _record_errors_and_metrics(
+        self,
+        user_exception: Optional[BaseException],
+        status_code: Optional[str],
+        latency_ms: float,
+        request_metadata: RequestMetadata,
+    ):
+        super()._record_errors_and_metrics(
+            user_exception, status_code, latency_ms, request_metadata
         )
 
-        with self._handle_errors_and_metrics(request_metadata) as status_code_callback:
-            yield status_code_callback
+        if is_span_recording():
+            if request_metadata.is_http_request:
+                set_http_span_attributes(
+                    method=request_metadata._http_method,
+                    status_code=status_code,
+                    route=request_metadata.route,
+                )
+            else:
+                set_rpc_span_attributes(
+                    system=request_metadata._request_protocol,
+                    method=request_metadata.call_method,
+                    status_code=status_code,
+                    service=self._deployment_id.name,
+                )
+            if user_exception is not None:
+                set_span_exception(user_exception, escaped=False)
 
     @_wrap_grpc_call
     async def HandleRequest(

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -1,0 +1,501 @@
+import inspect
+import os
+import threading
+from contextvars import ContextVar, Token
+from functools import wraps
+from typing import Any, Callable, Dict, List, Optional
+
+from ray._common.utils import import_attr
+from ray.serve._private.constants import (
+    DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
+    RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+    RAY_SERVE_TRACING_SAMPLING_RATIO,
+)
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.context import attach, detach, get_current
+    from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+    from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+    from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
+    from opentelemetry.semconv.trace import SpanAttributes
+    from opentelemetry.trace import SpanKind
+    from opentelemetry.trace.propagation import set_span_in_context
+    from opentelemetry.trace.propagation.tracecontext import (
+        TraceContextTextMapPropagator,
+    )
+    from opentelemetry.trace.status import Status, StatusCode
+
+except ImportError:
+    SpanProcessor = None
+    ConsoleSpanExporter = None
+    SimpleSpanProcessor = None
+    trace = None
+    SpanKind = None
+    TracerProvider = None
+    TraceIdRatioBased = None
+    Status = None
+    StatusCode = None
+    set_span_in_context = None
+    TraceContextTextMapPropagator = None
+    get_current = None
+    attach = None
+    detach = None
+    SpanAttributes = None
+    ParentBasedTraceIdRatio = None
+
+
+TRACE_STACK: ContextVar[List[Any]] = ContextVar(
+    "trace_stack"
+)  # Create tracer once at module level
+
+_tracer = None
+_tracer_lock = threading.Lock()
+
+
+def get_tracer():
+    global _tracer
+    if _tracer is None:
+        with _tracer_lock:
+            if _tracer is None:
+                _tracer = trace.get_tracer(__name__)
+    return _tracer
+
+
+# Default tracing exporter needs to map to DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+# defined in "python/ray/serve/_private/constants.py"
+def default_tracing_exporter(tracing_file_name):
+    from ray.serve._private.logging_utils import get_serve_logs_dir
+
+    serve_logs_dir = get_serve_logs_dir()
+    spans_dir = os.path.join(serve_logs_dir, "spans")
+    os.makedirs(spans_dir, exist_ok=True)
+    spans_file = os.path.join(spans_dir, tracing_file_name)
+
+    return [SimpleSpanProcessor(ConsoleSpanExporter(out=open(spans_file, "a")))]
+
+
+class TraceContextManager:
+    def __init__(
+        self, trace_name, span_kind=None, trace_context: Optional[Dict[str, str]] = None
+    ):
+        self.span = None
+        self.trace_name = trace_name
+        self.span_kind = span_kind
+        self.trace_context = trace_context
+
+        self.is_tracing_enabled = is_tracing_enabled()
+
+    def __enter__(self):
+        if self.is_tracing_enabled:
+            self.span_kind = self.span_kind or SpanKind.SERVER
+
+            tracer = get_tracer()
+            ctx = self.trace_context if self.trace_context else get_trace_context()
+
+            self.span = tracer.start_span(
+                self.trace_name,
+                kind=self.span_kind,
+                context=ctx,
+            )
+            if not self.span.get_span_context().trace_flags.sampled:
+                return self
+            new_ctx = set_span_in_context(self.span)
+            set_trace_context(new_ctx)
+            _append_trace_stack(self.span)
+            set_span_name(self.trace_name)
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.is_tracing_enabled and self.span is not None:
+            # if exc_type is not None, we have made a explicit decision
+            # to not set the span status to error. This is because
+            # errors are spans internal to Ray Serve and should not
+            # be reported as errors in the trace. They cause noise
+            # in the trace and are not meaningful to the user.
+            self.span.end()
+            _pop_trace_stack()
+
+        return False
+
+
+class BatchTraceContextManager:
+    """Attach/detach a tracing context around a block to scope the span of a batch."""
+
+    def __init__(self, trace_context: Optional[object]):
+        self._enabled = is_tracing_enabled() and trace_context is not None
+        self._trace_context = trace_context
+        self._token: Optional[Token] = None
+
+    def __enter__(self):
+        if self._enabled:
+            self._token = set_trace_context(self._trace_context)
+
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._enabled and self._token is not None:
+            detach_trace_context(self._token)
+        return False
+
+
+def tracing_decorator_factory(
+    trace_name: str, span_kind: Optional[Any] = None
+) -> Callable:
+    """
+    Factory function to create a tracing decorator for instrumenting functions/methods
+    with distributed tracing.
+
+    Args:
+        trace_name: The name of the trace.
+        span_kind: The kind of span to create
+            (e.g., SERVER, CLIENT). Defaults to trace.SpanKind.SERVER.
+
+    Returns:
+        Callable: A decorator function that can be used to wrap
+            functions/methods with distributed tracing.
+
+    Example Usage:
+    ```python
+    @tracing_decorator_factory(
+        "my_trace",
+        span_kind=trace.SpanKind.CLIENT,
+    )
+    def my_function(obj):
+        # Function implementation
+    ```
+    """
+
+    def tracing_decorator(func):
+        if not is_tracing_enabled():
+            # if tracing is not enabled, we don't want to wrap the function
+            # with the tracing decorator.
+            return func
+
+        @wraps(func)
+        def synchronous_wrapper(*args, **kwargs):
+            with TraceContextManager(trace_name, span_kind):
+                result = func(*args, **kwargs)
+
+            return result
+
+        @wraps(func)
+        def generator_wrapper(*args, **kwargs):
+            with TraceContextManager(trace_name, span_kind):
+                for item in func(*args, **kwargs):
+                    yield item
+
+        @wraps(func)
+        async def asynchronous_wrapper(*args, **kwargs):
+            with TraceContextManager(trace_name, span_kind):
+                result = await func(*args, **kwargs)
+            return result
+
+        @wraps(func)
+        async def asyc_generator_wrapper(*args, **kwargs):
+            with TraceContextManager(trace_name, span_kind):
+                async for item in func(*args, **kwargs):
+                    yield item
+
+        is_generator = _is_generator_function(func)
+        is_async = _is_async_function(func)
+        if is_generator and is_async:
+            return asyc_generator_wrapper
+        elif is_async:
+            return asynchronous_wrapper
+        elif is_generator:
+            return generator_wrapper
+        else:
+            return synchronous_wrapper
+
+    return tracing_decorator
+
+
+def setup_tracing(
+    component_name: str,
+    component_id: str,
+    component_type: Optional["ServeComponentType"] = None,  # noqa: F821
+    tracing_exporter_import_path: Optional[
+        str
+    ] = RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+    tracing_sampling_ratio: Optional[float] = RAY_SERVE_TRACING_SAMPLING_RATIO,
+) -> bool:
+    """
+    Set up tracing for a specific Serve component.
+
+    Args:
+        component_name: The name of the component.
+        component_id: The unique identifier of the component.
+        component_type: The type of the component.
+        tracing_exporter_import_path: Path to tracing exporter function.
+        tracing_sampling_ratio: Sampling ratio for traces (0.0 to 1.0).
+
+    Returns:
+        bool: True if tracing setup is successful, False otherwise.
+    """
+    if tracing_exporter_import_path == "":
+        return False
+
+    # Check dependencies
+    if not trace:
+        raise ImportError(
+            "You must `pip install opentelemetry-api` and "
+            "`pip install opentelemetry-sdk` "
+            "to enable tracing on Ray Serve."
+        )
+
+    from ray.serve._private.utils import get_component_file_name
+
+    tracing_file_name = get_component_file_name(
+        component_name=component_name,
+        component_id=component_id,
+        component_type=component_type,
+        suffix="_tracing.json",
+    )
+
+    span_processors = _load_span_processors(
+        tracing_exporter_import_path, tracing_file_name
+    )
+
+    # Intialize tracing
+    # Sets the tracer_provider. This is only allowed once~ per execution
+    # context and will log a warning if attempted multiple times.
+    # use ParentBasedTraceIdRatio to respect the parent span's sampling decision
+    # and sample probabilistically based on the tracing_sampling_ratio
+    sampler = ParentBasedTraceIdRatio(tracing_sampling_ratio)
+
+    trace.set_tracer_provider(TracerProvider(sampler=sampler))
+
+    for span_processor in span_processors:
+        trace.get_tracer_provider().add_span_processor(span_processor)
+
+    return True
+
+
+def create_propagated_context() -> Dict[str, str]:
+    """Create context that can be used across services and processes.
+
+    This function retrieves the current context and converts it
+    into a dictionary that can be used across actors and tasks since
+    it is serializable.
+
+    Returns:
+    - Trace Context Propagator (dict or None): A dictionary containing the propagated
+    trace context if available, otherwise None.
+    """
+    trace_context = get_trace_context()
+    if trace_context and TraceContextTextMapPropagator:
+        ctx = {}
+        TraceContextTextMapPropagator().inject(ctx, trace_context)
+        return ctx
+
+    return None
+
+
+def extract_propagated_context(
+    propagated_context: Optional[Dict[str, str]] = None
+) -> Optional[Dict[str, str]]:
+    """Extract the trace context from a Trace Context Propagator."""
+    if is_tracing_enabled() and propagated_context and TraceContextTextMapPropagator:
+        return TraceContextTextMapPropagator().extract(carrier=propagated_context)
+
+    return None
+
+
+def set_trace_context(trace_context: Dict[str, str]) -> Optional[Token]:
+    """Set the current trace context."""
+    if attach is None:
+        return
+
+    return attach(trace_context)
+
+
+def detach_trace_context(token: Token):
+    """Detach the current trace context corresponding to the token."""
+    if detach is None:
+        return
+
+    detach(token)
+
+
+def get_trace_context() -> Optional[Dict[str, str]]:
+    """Retrieve the current trace context."""
+    if get_current is None:
+        return None
+
+    context = get_current()
+    return context if context else None
+
+
+def set_span_name(name: str):
+    """Set the name for the current span in context."""
+    if TRACE_STACK:
+        trace_stack = TRACE_STACK.get([])
+        if trace_stack:
+            trace_stack[-1].update_name(name)
+    # this is added specifically for Datadog tracing.
+    # See https://docs.datadoghq.com/tracing/guide/configuring-primary-operation/#opentracing
+    set_span_attributes({"resource.name": name})
+
+
+def set_rpc_span_attributes(
+    system: str = "grpc",
+    method: Optional[str] = None,
+    status_code: Optional[str] = None,
+    service: Optional[str] = None,
+):
+    """
+    Use this function to set attributes for RPC spans.
+    Only include attributes that are in the OpenTelemetry
+    RPC span attributes spec https://opentelemetry.io/docs/specs/semconv/attributes-registry/rpc/.
+    """
+    if not is_tracing_enabled():
+        return
+    attributes = {
+        SpanAttributes.RPC_SYSTEM: system,
+        SpanAttributes.RPC_METHOD: method,
+        SpanAttributes.RPC_GRPC_STATUS_CODE: status_code,
+        SpanAttributes.RPC_SERVICE: service,
+    }
+    set_span_attributes(attributes)
+
+
+def set_http_span_attributes(
+    method: Optional[str] = None,
+    status_code: Optional[str] = None,
+    route: Optional[str] = None,
+):
+    """
+    Use this function to set attributes for HTTP spans.
+    Only include attributes that are in the OpenTelemetry
+    HTTP span attributes spec https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/.
+    """
+    if not is_tracing_enabled():
+        return
+    attributes = {
+        SpanAttributes.HTTP_METHOD: method,
+        SpanAttributes.HTTP_STATUS_CODE: status_code,
+        SpanAttributes.HTTP_ROUTE: route,
+    }
+    set_span_attributes(attributes)
+
+
+def set_span_attributes(attributes: Dict[str, Any]):
+    """Set attributes for the current span in context."""
+    if TRACE_STACK:
+        trace_stack = TRACE_STACK.get([])
+        if trace_stack:
+            # filter attribute values that are None, otherwise they
+            # will show up as warning logs on the console.
+            attributes = {k: v for k, v in attributes.items() if v is not None}
+            trace_stack[-1].set_attributes(attributes)
+
+
+def set_trace_status(is_error: bool, description: str = ""):
+    """Set the status for the current span in context."""
+    trace_stack = TRACE_STACK.get([])
+    if trace_stack:
+        if is_error:
+            status_code = StatusCode.ERROR
+        else:
+            status_code = StatusCode.OK
+            description = None
+        trace_stack[-1].set_status(
+            Status(status_code=status_code, description=description)
+        )
+
+
+def set_span_exception(exc: Exception, escaped: bool = False):
+    """Set the exception for the current span in context."""
+    trace_stack = TRACE_STACK.get([])
+    if trace_stack:
+        trace_stack[-1].record_exception(exc, escaped=escaped)
+
+
+def is_tracing_enabled() -> bool:
+    return RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH != "" and trace is not None
+
+
+def is_span_recording() -> bool:
+    if TRACE_STACK:
+        trace_stack = TRACE_STACK.get([])
+        if trace_stack:
+            return True
+    return False
+
+
+def _append_trace_stack(span):
+    """Append span to global trace stack."""
+    trace_stack = TRACE_STACK.get([])
+    trace_stack.append(span)
+    TRACE_STACK.set(trace_stack)
+
+
+def _pop_trace_stack():
+    """Pop span to global trace stack."""
+    trace_stack = TRACE_STACK.get([])
+    if trace_stack:
+        trace_stack.pop()
+        TRACE_STACK.set(trace_stack)
+
+
+def _validate_tracing_exporter(func: Callable) -> None:
+    """Validate that the custom tracing exporter
+    is a function that takes no arguments.
+    """
+    if inspect.isfunction(func) is False:
+        raise TypeError("Tracing exporter must be a function.")
+
+    signature = inspect.signature(func)
+
+    if len(signature.parameters) != 0:
+        raise TypeError("Tracing exporter cannot take any arguments.")
+
+
+def _validate_tracing_exporter_processors(span_processors: List[Any]):
+    """Validate that the output of a custom tracing exporter
+    returns type List[SpanProcessor].
+    """
+    if not isinstance(span_processors, list):
+        raise TypeError(
+            "Output of tracing exporter needs to be of type "
+            f"List[SpanProcessor], but received type {type(span_processors)}."
+        )
+
+    for span_processor in span_processors:
+        if not isinstance(span_processor, SpanProcessor):
+            raise TypeError(
+                "Output of tracing exporter needs to be of "
+                "type List[SpanProcessor], "
+                f"but received type {type(span_processor)}."
+            )
+
+
+def _load_span_processors(
+    tracing_exporter_import_path: str,
+    tracing_file_name: str,
+):
+    """Load span processors from a custome tracing
+    exporter function.
+    """
+    tracing_exporter_def = import_attr(tracing_exporter_import_path)
+
+    if tracing_exporter_import_path == DEFAULT_TRACING_EXPORTER_IMPORT_PATH:
+        return tracing_exporter_def(tracing_file_name)
+    else:
+        # Validate tracing exporter function
+        _validate_tracing_exporter(tracing_exporter_def)
+        # Validate tracing exporter processors
+        span_processors = tracing_exporter_def()
+        _validate_tracing_exporter_processors(span_processors)
+
+    return span_processors
+
+
+def _is_generator_function(func):
+    return inspect.isgeneratorfunction(func) or inspect.isasyncgenfunction(func)
+
+
+def _is_async_function(func):
+    return inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -176,6 +176,28 @@ py_test_module_list(
     ],
 )
 
+# Tracing tests (require fixture data and tracing env var for subprocesses).
+py_test_module_list(
+    size = "medium",
+    data = glob(["fixtures/*.*"]),
+    env = {
+        "RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH": "ray.serve._private.tracing_utils:default_tracing_exporter",
+        "RAY_SERVE_TRACING_SAMPLING_RATIO": "1.0",
+    },
+    files = [
+        "test_tracing_utils.py",
+    ],
+    tags = [
+        "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
 # Large tests.
 py_test_module_list(
     size = "enormous",

--- a/python/ray/serve/tests/fixtures/basic_proxy_spans.json
+++ b/python/ray/serve/tests/fixtures/basic_proxy_spans.json
@@ -1,0 +1,46 @@
+[
+   {
+     "name": "route_to_replica BasicModel __call__",
+     "kind": "SpanKind.SERVER",
+     "status": {
+       "status_code": "UNSET"
+     },
+     "attributes": {
+       "request_id": "",
+       "deployment": "BasicModel",
+       "app": "default",
+       "call_method": "__call__",
+       "route": "/",
+       "multiplexed_model_id": "",
+       "is_streaming": true,
+       "is_http_request": true,
+       "is_grpc_request": false,
+       "resource.name": "route_to_replica BasicModel __call__",
+       "http.method": "__call__",
+       "http.route": "/"
+     },
+     "events": [],
+     "links": []
+   },
+   {
+     "name": "proxy_http_request BasicModel POST /",
+     "kind": "SpanKind.SERVER",
+     "status": {
+       "status_code": "OK"
+     },
+     "attributes": {
+       "request_id": "",
+       "deployment": "BasicModel",
+       "app": "default",
+       "request_type": "http",
+       "request_method": "POST",
+       "request_route_path": "/",
+       "resource.name": "proxy_http_request BasicModel POST /",
+       "http.method": "POST",
+       "http.status_code": 200,
+       "http.route": "/"
+     },
+     "events": [],
+     "links": []
+   }
+ ]

--- a/python/ray/serve/tests/fixtures/basic_replica_spans.json
+++ b/python/ray/serve/tests/fixtures/basic_replica_spans.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "application_span",
+    "kind": "SpanKind.INTERNAL",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {
+      "deployment": "BasicModel",
+      "replica_id": ""
+    },
+    "events": [],
+    "links": []
+  },
+  {
+    "name": "replica_handle_request BasicModel __call__",
+    "kind": "SpanKind.SERVER",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {
+      "request_id": "",
+      "replica_id": "",
+      "deployment": "BasicModel",
+      "app": "default",
+      "call_method": "__call__",
+      "route": "/",
+      "multiplexed_model_id": "",
+      "is_streaming": true,
+      "resource.name": "replica_handle_request BasicModel __call__",
+      "http.method": "POST",
+      "http.status_code": "200",
+      "http.route": "/"
+    },
+    "events": [],
+    "links": []
+  }
+]

--- a/python/ray/serve/tests/fixtures/basic_upstream_spans.json
+++ b/python/ray/serve/tests/fixtures/basic_upstream_spans.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "upstream_app",
+    "kind": "SpanKind.INTERNAL",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {},
+    "events": [],
+    "links": []
+  }
+]

--- a/python/ray/serve/tests/fixtures/grpc_proxy_spans.json
+++ b/python/ray/serve/tests/fixtures/grpc_proxy_spans.json
@@ -1,0 +1,45 @@
+[
+  {
+      "name": "route_to_replica grpc-deployment __call__",
+      "kind": "SpanKind.SERVER",
+      "status": {
+          "status_code": "UNSET"
+      },
+      "attributes": {
+          "request_id": "",
+          "deployment": "grpc-deployment",
+          "app": "default",
+          "call_method": "__call__",
+          "route": "default",
+          "multiplexed_model_id": "",
+          "is_streaming": false,
+          "is_http_request": false,
+          "is_grpc_request": true,
+          "resource.name": "route_to_replica grpc-deployment __call__",
+          "rpc.system": "gRPC",
+          "rpc.method": "__call__",
+          "rpc.service": "grpc-deployment"
+      },
+      "events": [],
+      "links": []
+  },
+  {
+      "name": "proxy_grpc_request grpc-deployment /ray.serve.UserDefinedService/__call__",
+      "kind": "SpanKind.SERVER",
+      "status": {
+          "status_code": "OK"
+      },
+      "attributes": {
+          "request_id": "",
+          "deployment": "grpc-deployment",
+          "app": "default",
+          "request_type": "grpc",
+          "resource.name": "proxy_grpc_request grpc-deployment /ray.serve.UserDefinedService/__call__",
+          "rpc.system": "grpc",
+          "rpc.method": "/ray.serve.UserDefinedService/__call__",
+          "rpc.grpc.status_code": "OK"
+      },
+      "events": [],
+      "links": []
+  }
+]

--- a/python/ray/serve/tests/fixtures/grpc_replica_spans.json
+++ b/python/ray/serve/tests/fixtures/grpc_replica_spans.json
@@ -1,0 +1,38 @@
+[
+  {
+      "name": "application_span",
+      "kind": "SpanKind.INTERNAL",
+      "status": {
+          "status_code": "UNSET"
+      },
+      "attributes": {
+          "deployment": "grpc-deployment",
+          "replica_id": ""
+      },
+      "events": [],
+      "links": []
+  },
+  {
+      "name": "replica_handle_request grpc-deployment __call__",
+      "kind": "SpanKind.SERVER",
+      "status": {
+          "status_code": "UNSET"
+      },
+      "attributes": {
+          "request_id": "",
+          "replica_id": "",
+          "deployment": "grpc-deployment",
+          "app": "default",
+          "call_method": "__call__",
+          "route": "default",
+          "multiplexed_model_id": "",
+          "is_streaming": false,
+          "resource.name": "replica_handle_request grpc-deployment __call__",
+          "rpc.system": "gRPC",
+          "rpc.method": "__call__",
+          "rpc.service": "grpc-deployment"
+      },
+      "events": [],
+      "links": []
+  }
+]

--- a/python/ray/serve/tests/fixtures/grpc_upstream_spans.json
+++ b/python/ray/serve/tests/fixtures/grpc_upstream_spans.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "upstream_app",
+    "kind": "SpanKind.INTERNAL",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {},
+    "events": [],
+    "links": []
+  }
+]

--- a/python/ray/serve/tests/fixtures/streaming_proxy_spans.json
+++ b/python/ray/serve/tests/fixtures/streaming_proxy_spans.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "route_to_replica StreamingModel __call__",
+    "kind": "SpanKind.SERVER",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {
+      "request_id": "",
+      "deployment": "StreamingModel",
+      "app": "default",
+      "call_method": "__call__",
+      "route": "/",
+      "multiplexed_model_id": "",
+      "is_streaming": true,
+      "is_http_request": true,
+      "is_grpc_request": false,
+      "resource.name": "route_to_replica StreamingModel __call__",
+      "http.method": "__call__",
+      "http.route": "/"
+    },
+    "events": [],
+    "links": []
+  },
+  {
+    "name": "proxy_http_request StreamingModel GET /",
+    "kind": "SpanKind.SERVER",
+    "status": {
+      "status_code": "OK"
+    },
+    "attributes": {
+      "request_id": "",
+      "deployment": "StreamingModel",
+      "app": "default",
+      "request_type": "http",
+      "request_method": "GET",
+      "request_route_path": "/",
+      "resource.name": "proxy_http_request StreamingModel GET /",
+      "http.method": "GET",
+      "http.status_code": 200,
+      "http.route": "/"
+    },
+    "events": [],
+    "links": []
+  }
+]

--- a/python/ray/serve/tests/fixtures/streaming_replica_spans.json
+++ b/python/ray/serve/tests/fixtures/streaming_replica_spans.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "application_span",
+    "kind": "SpanKind.INTERNAL",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {
+      "deployment": "StreamingModel",
+      "replica_id": ""
+    },
+    "events": [],
+    "links": []
+  },
+  {
+    "name": "replica_handle_request StreamingModel __call__",
+    "kind": "SpanKind.SERVER",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {
+      "request_id": "",
+      "replica_id": "",
+      "deployment": "StreamingModel",
+      "app": "default",
+      "call_method": "__call__",
+      "route": "/",
+      "multiplexed_model_id": "",
+      "is_streaming": true,
+      "resource.name": "replica_handle_request StreamingModel __call__",
+      "http.method": "GET",
+      "http.status_code": "200",
+      "http.route": "/"
+    },
+    "events": [],
+    "links": []
+  }
+]

--- a/python/ray/serve/tests/fixtures/streaming_upstream_spans.json
+++ b/python/ray/serve/tests/fixtures/streaming_upstream_spans.json
@@ -1,0 +1,12 @@
+[
+  {
+    "name": "upstream_app",
+    "kind": "SpanKind.INTERNAL",
+    "status": {
+      "status_code": "UNSET"
+    },
+    "attributes": {},
+    "events": [],
+    "links": []
+  }
+]

--- a/python/ray/serve/tests/test_tracing_utils.py
+++ b/python/ray/serve/tests/test_tracing_utils.py
@@ -1,0 +1,1031 @@
+import json
+import os
+import re
+import shutil
+import uuid
+from pathlib import Path
+from threading import Thread
+from typing import Set
+from unittest.mock import patch
+
+import grpc
+import httpx
+import pytest
+import starlette
+from starlette.requests import Request
+from starlette.responses import StreamingResponse
+
+import ray
+from ray import serve
+from ray._common.test_utils import SignalActor
+from ray.serve._private.common import ServeComponentType
+from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_DIRECT_INGRESS,
+    RAY_SERVE_ENABLE_HA_PROXY,
+)
+from ray.serve._private.logging_utils import get_serve_logs_dir
+from ray.serve._private.test_utils import get_application_url
+from ray.serve._private.tracing_utils import (
+    DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
+    TRACE_STACK,
+    _append_trace_stack,
+    _load_span_processors,
+    _validate_tracing_exporter,
+    _validate_tracing_exporter_processors,
+    set_trace_status,
+    setup_tracing,
+)
+from ray.serve.config import HTTPOptions, gRPCOptions
+from ray.serve.generated import serve_pb2, serve_pb2_grpc
+from ray.serve.tests.conftest import *  # noqa
+from ray.serve.utils import get_trace_context
+from ray.tests.conftest import *  # noqa
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+    from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
+    from opentelemetry.trace.propagation.tracecontext import (
+        TraceContextTextMapPropagator,
+    )
+    from opentelemetry.trace.status import StatusCode
+except ImportError:
+    raise ModuleNotFoundError(
+        "`opentelemetry` or `opentelemetry.sdk.trace.export` not found"
+    )
+
+CUSTOM_EXPORTER_OUTPUT_FILENAME = "spans.txt"
+
+
+@pytest.fixture
+def use_custom_tracing_exporter():
+    yield "ray.serve.tests.test_tracing_utils:custom_tracing_exporter"
+
+    # Clean up output file produced by custom exporter
+    if os.path.exists(CUSTOM_EXPORTER_OUTPUT_FILENAME):
+        os.remove(CUSTOM_EXPORTER_OUTPUT_FILENAME)
+
+
+@pytest.fixture
+def serve_and_ray_shutdown():
+    serve.shutdown()
+    ray.shutdown()
+    yield
+    serve.shutdown()
+
+
+class FakeSpan:
+    def __init__(self):
+        self.status = None
+
+    def set_status(self, status):
+        self.status = status
+
+
+def test_disable_tracing_exporter():
+    """Test that setting `tracing_exporter_import_path`
+    to an empty string disables tracing.
+    """
+    is_tracing_setup_successful = setup_tracing(
+        component_type=ServeComponentType.REPLICA,
+        component_name="component_name",
+        component_id="component_id",
+        tracing_exporter_import_path="",
+        tracing_sampling_ratio=1.0,
+    )
+
+    assert is_tracing_setup_successful is False
+
+
+def test_validate_tracing_exporter_with_string():
+    """Test exception message for invalid exporter type."""
+    invalid_exporters = [1, "string", []]
+    expected_exception = "Tracing exporter must be a function."
+
+    for invalid_exporter in invalid_exporters:
+        with pytest.raises(TypeError, match=expected_exception):
+            _validate_tracing_exporter(invalid_exporter)
+
+
+def test_validate_tracing_exporter_with_args():
+    """Test exception message for _validate_tracing_exporter.
+    if exporter contains an argument.
+    """
+
+    def test_exporter(arg):
+        return arg
+
+    expected_exception = "Tracing exporter cannot take any arguments."
+
+    with pytest.raises(TypeError, match=expected_exception):
+        _validate_tracing_exporter(test_exporter)
+
+
+def test_validate_tracing_exporter_processors_list():
+    """Test exception message for _validate_tracing_exporter.
+    if exporter returns invalid return type.
+    """
+    invalid_span_processors = [1, "string"]
+    for invalid_span_processor in invalid_span_processors:
+        expected_exception = re.escape(
+            "Output of tracing exporter needs to be of type "
+            "List[SpanProcessor], but received type "
+            f"{type(invalid_span_processor)}."
+        )
+        with pytest.raises(TypeError, match=expected_exception):
+            _validate_tracing_exporter_processors(invalid_span_processor)
+
+
+def test_validate_tracing_exporter_processors_full_output():
+    """Test exception message for _validate_tracing_exporter.
+    if exporter returns invalid return type.
+    """
+    invalid_span_processors = [[1, 2], ["1", "2"]]
+    for invalid_span_processor in invalid_span_processors:
+        expected_exception = re.escape(
+            "Output of tracing exporter needs to be of "
+            "type List[SpanProcessor], "
+            f"but received type {type(invalid_span_processor[0])}."
+        )
+        with pytest.raises(TypeError, match=expected_exception):
+            _validate_tracing_exporter_processors(invalid_span_processor)
+
+
+def test_missing_dependencies():
+    """Test that setup_tracing raises an exception if
+    tracing module is not installed.
+    """
+    expected_exception = (
+        "You must `pip install opentelemetry-api` and "
+        "`pip install opentelemetry-sdk` "
+        "to enable tracing on Ray Serve."
+    )
+    with patch("ray.serve._private.tracing_utils.trace", new=None):
+        with pytest.raises(ImportError, match=expected_exception):
+            setup_tracing(
+                component_type=ServeComponentType.REPLICA,
+                component_name="component_name",
+                component_id="component_id",
+                tracing_exporter_import_path=DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
+                tracing_sampling_ratio=1.0,
+            )
+
+
+def test_default_tracing_exporter(ray_start_cluster):
+    """Test that the default tracing exporter returns
+    List[SimpleSpanProcessor].
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    cluster.wait_for_nodes()
+
+    ray.init(address=cluster.address)
+
+    span_processors = _load_span_processors(
+        DEFAULT_TRACING_EXPORTER_IMPORT_PATH, "mock_file.json"
+    )
+
+    assert isinstance(span_processors, list)
+
+    for span_processor in span_processors:
+        assert isinstance(span_processor, SimpleSpanProcessor)
+
+
+def test_custom_tracing_exporter(use_custom_tracing_exporter):
+    """Test setup_tracing with a custom tracing exporter."""
+    custom_tracing_exporter_path = use_custom_tracing_exporter
+
+    span_processors = _load_span_processors(
+        custom_tracing_exporter_path, "mock_file.json"
+    )
+
+    assert isinstance(span_processors, list)
+
+    for span_processor in span_processors:
+        assert isinstance(span_processor, SimpleSpanProcessor)
+
+    is_tracing_setup_successful = setup_tracing(
+        "component_name",
+        "component_id",
+        ServeComponentType.REPLICA,
+        custom_tracing_exporter_path,
+        tracing_sampling_ratio=1.0,
+    )
+
+    # Validate that tracing is setup successfully
+    # and the tracing exporter created the output file
+    assert is_tracing_setup_successful
+    assert os.path.exists(CUSTOM_EXPORTER_OUTPUT_FILENAME)
+
+
+def test_tracing_sampler(use_custom_tracing_exporter):
+    """Test that tracing sampler is properly configured
+    through tracing_sampling_ratio argument.
+    """
+    custom_tracing_exporter_path = use_custom_tracing_exporter
+    tracing_sampling_ratio = 1
+
+    is_tracing_setup_successful = setup_tracing(
+        "component_name",
+        "component_id",
+        ServeComponentType.REPLICA,
+        custom_tracing_exporter_path,
+        tracing_sampling_ratio,
+    )
+
+    # Validate that tracing is setup successfully
+    # and the tracing exporter created the output file
+    assert is_tracing_setup_successful
+    assert os.path.exists(CUSTOM_EXPORTER_OUTPUT_FILENAME)
+
+    tracer = trace.get_tracer(__name__)
+    tracer_data = tracer.__dict__
+
+    assert "sampler" in tracer_data
+
+    sampler = tracer_data["sampler"]
+    sampler_data = sampler.__dict__
+
+    # ParentBasedTraceIdRatio sampler contains other samplers as attributes
+    # The sampling ratio is stored in the underlying samplers
+    # Check that we have the expected sampler structure
+    assert "_local_parent_not_sampled" in sampler_data
+    assert "_local_parent_sampled" in sampler_data
+    assert "_remote_parent_sampled" in sampler_data
+    assert "_remote_parent_not_sampled" in sampler_data
+
+    assert isinstance(sampler, ParentBasedTraceIdRatio)
+
+
+@pytest.mark.parametrize(
+    (
+        "serve_application",
+        "expected_proxy_spans_path",
+        "expected_replica_spans_path",
+        "expected_upstream_spans_path",
+    ),
+    [
+        (
+            "basic",
+            "fixtures/basic_proxy_spans.json",
+            "fixtures/basic_replica_spans.json",
+            "fixtures/basic_upstream_spans.json",
+        ),
+        (
+            "streaming",
+            "fixtures/streaming_proxy_spans.json",
+            "fixtures/streaming_replica_spans.json",
+            "fixtures/streaming_upstream_spans.json",
+        ),
+        (
+            "grpc",
+            "fixtures/grpc_proxy_spans.json",
+            "fixtures/grpc_replica_spans.json",
+            "fixtures/grpc_upstream_spans.json",
+        ),
+    ],
+)
+def test_tracing_e2e(
+    serve_and_ray_shutdown,
+    serve_application,
+    expected_proxy_spans_path,
+    expected_replica_spans_path,
+    expected_upstream_spans_path,
+):
+    """Test tracing e2e."""
+
+    signal_actor = SignalActor.remote()
+
+    @serve.deployment
+    class BasicModel:
+        def __call__(self, req: starlette.requests.Request):
+            replica_context = serve.get_replica_context()
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                "application_span", context=get_trace_context()
+            ) as span:
+                span.set_attribute("deployment", replica_context.deployment)
+                span.set_attribute("replica_id", replica_context.replica_id.unique_id)
+                return "hello"
+
+    def hi_gen_sync():
+        for i in range(10):
+            yield f"hello_{i}"
+            # to avoid coalescing chunks
+            ray.get(signal_actor.wait.remote())
+
+    @serve.deployment
+    class StreamingModel:
+        def __call__(self, request: Request) -> StreamingResponse:
+            gen = hi_gen_sync()
+            replica_context = serve.get_replica_context()
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                "application_span", context=get_trace_context()
+            ) as span:
+                span.set_attribute("deployment", replica_context.deployment)
+                span.set_attribute("replica_id", replica_context.replica_id.unique_id)
+                return StreamingResponse(gen, media_type="text/plain")
+
+    @serve.deployment
+    class GrpcDeployment:
+        def __call__(self, user_message):
+            replica_context = serve.get_replica_context()
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                "application_span", context=get_trace_context()
+            ) as span:
+                span.set_attribute("deployment", replica_context.deployment)
+                span.set_attribute("replica_id", replica_context.replica_id.unique_id)
+
+                greeting = f"Hello {user_message.name} from {user_message.foo}"
+                num_x2 = user_message.num * 2
+                user_response = serve_pb2.UserDefinedResponse(
+                    greeting=greeting,
+                    num_x2=num_x2,
+                )
+                return user_response
+
+    if serve_application == "basic":
+        serve.start(
+            http_options=HTTPOptions(
+                host="0.0.0.0",
+            )
+        )
+        serve.run(BasicModel.bind())
+
+        setup_tracing(
+            component_name="upstream_app",
+            component_id="345",
+            tracing_sampling_ratio=1.0,
+        )
+        tracer = trace.get_tracer("test_tracing")
+        with tracer.start_as_current_span("upstream_app"):
+            ctx = get_trace_context()
+            headers = {}
+            TraceContextTextMapPropagator().inject(headers, ctx)
+            url = get_application_url("HTTP")
+            r = httpx.post(f"{url}/", headers=headers)
+            assert r.text == "hello"
+
+    elif serve_application == "streaming":
+        serve.start(
+            http_options=HTTPOptions(
+                host="0.0.0.0",
+            )
+        )
+        serve.run(StreamingModel.bind())
+        setup_tracing(
+            component_name="upstream_app",
+            component_id="345",
+            tracing_sampling_ratio=1.0,
+        )
+        tracer = trace.get_tracer("test_tracing")
+        with tracer.start_as_current_span("upstream_app"):
+            ctx = get_trace_context()
+            headers = {}
+            TraceContextTextMapPropagator().inject(headers, ctx)
+            url = get_application_url("HTTP")
+
+            with httpx.stream("GET", f"{url}/", headers=headers) as r:
+                r.raise_for_status()
+                for i, chunk in enumerate(r.iter_text()):
+                    assert chunk == f"hello_{i}"
+                    ray.get(signal_actor.send.remote())
+
+    elif serve_application == "grpc":
+        # TODO: Remove this once HAProxy supports gRPC
+        if RAY_SERVE_ENABLE_HA_PROXY:
+            return
+
+        grpc_port = 9000
+        grpc_servicer_functions = [
+            "ray.serve.generated.serve_pb2_grpc"
+            ".add_UserDefinedServiceServicer_to_server",
+            "ray.serve.generated.serve_pb2_grpc.add_FruitServiceServicer_to_server",
+        ]
+
+        serve.start(
+            grpc_options=gRPCOptions(
+                port=grpc_port,
+                grpc_servicer_functions=grpc_servicer_functions,
+            ),
+        )
+        g = GrpcDeployment.options(name="grpc-deployment").bind()
+        serve.run(g)
+
+        setup_tracing(
+            component_name="upstream_app",
+            component_id="345",
+            tracing_sampling_ratio=1.0,
+        )
+        tracer = trace.get_tracer("test_tracing")
+        with tracer.start_as_current_span("upstream_app"):
+            ctx = get_trace_context()
+            headers = {}
+            TraceContextTextMapPropagator().inject(headers, ctx)
+            metadata = tuple(headers.items())
+
+            channel = grpc.insecure_channel(get_application_url("gRPC"))
+
+            stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
+            request = serve_pb2.UserDefinedMessage(name="foo", num=30, foo="bar")
+            response, call = stub.__call__.with_call(request=request, metadata=metadata)
+
+            assert call.code() == grpc.StatusCode.OK, call.code()
+            assert response.greeting == "Hello foo from bar", response.greeting
+
+    serve.shutdown()
+
+    serve_logs_dir = get_serve_logs_dir()
+    spans_dir = os.path.join(serve_logs_dir, "spans")
+
+    files = os.listdir(spans_dir)
+
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        # We don't currently trace HAProxy.
+        assert len(files) == 2
+    else:
+        assert len(files) == 3
+
+    replica_filename = None
+    proxy_filename = None or RAY_SERVE_ENABLE_HA_PROXY
+    upstream_filename = None
+    for file in files:
+        if "replica" in file:
+            replica_filename = file
+        elif "proxy" in file:
+            proxy_filename = file
+        elif "upstream" in file:
+            upstream_filename = file
+        else:
+            assert False, f"Did not expect tracing file with name {file}"
+
+    assert replica_filename and proxy_filename and upstream_filename
+
+    upstream_spans = load_spans(os.path.join(spans_dir, upstream_filename))
+    if not RAY_SERVE_ENABLE_DIRECT_INGRESS:
+        proxy_spans = load_spans(os.path.join(spans_dir, proxy_filename))
+    else:
+        proxy_spans = []
+    replica_spans = load_spans(os.path.join(spans_dir, replica_filename))
+
+    entire_trace = replica_spans + proxy_spans + upstream_spans
+    validate_span_associations_in_trace(entire_trace)
+
+    expected_upstream_spans = load_json_fixture(expected_upstream_spans_path)
+    if not RAY_SERVE_ENABLE_DIRECT_INGRESS:
+        expected_proxy_spans = load_json_fixture(expected_proxy_spans_path)
+    else:
+        expected_proxy_spans = []
+    expected_replica_spans = load_json_fixture(expected_replica_spans_path)
+
+    sanitize_spans(upstream_spans)
+    sanitize_spans(proxy_spans)
+    sanitize_spans(replica_spans)
+
+    assert upstream_spans == expected_upstream_spans
+    assert proxy_spans == expected_proxy_spans
+    assert replica_spans == expected_replica_spans
+
+    shutil.rmtree(spans_dir)
+
+
+@pytest.mark.parametrize(
+    "protocol,expected_status_code,expected_span_status",
+    [
+        ("http", 500, StatusCode.ERROR),
+        ("streaming", 500, StatusCode.ERROR),
+        ("grpc", grpc.StatusCode.INTERNAL.name, StatusCode.ERROR),
+    ],
+)
+def test_tracing_e2e_with_errors(
+    serve_and_ray_shutdown, protocol, expected_status_code, expected_span_status
+):
+    """Test tracing with error responses across HTTP, streaming, and gRPC protocols."""
+
+    @serve.deployment
+    class HttpErrorModel:
+        def __call__(self, request: starlette.requests.Request):
+            replica_context = serve.get_replica_context()
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                "application_span", context=get_trace_context()
+            ) as span:
+                span.set_attribute("deployment", replica_context.deployment)
+                span.set_attribute("replica_id", replica_context.replica_id.unique_id)
+
+                raise RuntimeError("Internal server error")
+
+    @serve.deployment
+    class StreamingErrorModel:
+        def __call__(self, request: Request) -> StreamingResponse:
+            replica_context = serve.get_replica_context()
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                "application_span", context=get_trace_context()
+            ) as span:
+                span.set_attribute("deployment", replica_context.deployment)
+                span.set_attribute("replica_id", replica_context.replica_id.unique_id)
+
+                def error_generator():
+                    raise RuntimeError("Streaming error occurred")
+
+                return StreamingResponse(error_generator(), media_type="text/plain")
+
+    @serve.deployment
+    class GrpcErrorModel:
+        def __call__(self, user_message):
+            replica_context = serve.get_replica_context()
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                "application_span", context=get_trace_context()
+            ) as span:
+                span.set_attribute("deployment", replica_context.deployment)
+                span.set_attribute("replica_id", replica_context.replica_id.unique_id)
+
+                # Raise error
+                raise RuntimeError("gRPC error occurred")
+
+    # Setup based on protocol
+    if protocol == "http":
+        serve.start(
+            http_options=HTTPOptions(
+                host="0.0.0.0",
+            )
+        )
+        serve.run(HttpErrorModel.bind())
+
+        setup_tracing(
+            component_name="upstream_app",
+            component_id="345",
+            tracing_sampling_ratio=1.0,
+        )
+        tracer = trace.get_tracer("test_tracing")
+        with tracer.start_as_current_span("upstream_app"):
+            ctx = get_trace_context()
+            headers = {}
+            TraceContextTextMapPropagator().inject(headers, ctx)
+
+            # Make HTTP request
+            url = get_application_url("HTTP")
+            response = httpx.post(f"{url}/", headers=headers)
+            assert response.status_code == expected_status_code
+
+    elif protocol == "streaming":
+        serve.start(
+            http_options=HTTPOptions(
+                host="0.0.0.0",
+            )
+        )
+        serve.run(StreamingErrorModel.bind())
+
+        setup_tracing(
+            component_name="upstream_app",
+            component_id="345",
+            tracing_sampling_ratio=1.0,
+        )
+        tracer = trace.get_tracer("test_tracing")
+        with tracer.start_as_current_span("upstream_app"):
+            ctx = get_trace_context()
+            headers = {}
+            TraceContextTextMapPropagator().inject(headers, ctx)
+
+            url = get_application_url("HTTP")
+            with httpx.stream("GET", f"{url}/", headers=headers) as r:
+                assert r.status_code == expected_status_code
+
+    elif protocol == "grpc":
+        # TODO: Remove this once HAProxy supports gRPC
+        if RAY_SERVE_ENABLE_HA_PROXY:
+            return
+
+        grpc_port = 9000
+        grpc_servicer_functions = [
+            "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",
+        ]
+
+        serve.start(
+            grpc_options=gRPCOptions(
+                port=grpc_port,
+                grpc_servicer_functions=grpc_servicer_functions,
+            ),
+        )
+        serve.run(GrpcErrorModel.options(name="grpc-error-model").bind())
+
+        setup_tracing(
+            component_name="upstream_app",
+            component_id="345",
+            tracing_sampling_ratio=1.0,
+        )
+        tracer = trace.get_tracer("test_tracing")
+        with tracer.start_as_current_span("upstream_app"):
+            ctx = get_trace_context()
+            headers = {}
+            TraceContextTextMapPropagator().inject(headers, ctx)
+            channel = grpc.insecure_channel("localhost:9000")
+            stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
+            request = serve_pb2.UserDefinedMessage(name="test", num=10, foo="bar")
+
+            with pytest.raises(grpc.RpcError) as exception_info:
+                _ = stub.__call__(request=request)
+            rpc_error = exception_info.value
+            print(rpc_error)
+            assert rpc_error.code().name == expected_status_code
+    else:
+        assert False, "Invalid protocol"
+
+    serve.shutdown()
+
+    # Verify the trace data
+    serve_logs_dir = get_serve_logs_dir()
+    spans_dir = os.path.join(serve_logs_dir, "spans")
+
+    files = os.listdir(spans_dir)
+
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        # We don't currently trace HAProxy.
+        assert len(files) == 2
+    else:
+        assert len(files) == 3  # proxy, replica, and upstream spans
+
+    replica_filename = None
+    proxy_filename = None or RAY_SERVE_ENABLE_HA_PROXY
+    upstream_filename = None
+    for file in files:
+        if "replica" in file:
+            replica_filename = file
+        elif "proxy" in file:
+            proxy_filename = file
+        elif "upstream" in file:
+            upstream_filename = file
+        else:
+            assert False, f"Did not expect tracing file with name {file}"
+
+    assert replica_filename and proxy_filename and upstream_filename
+
+    # Load and check spans
+    if not RAY_SERVE_ENABLE_DIRECT_INGRESS:
+        proxy_spans = load_spans(os.path.join(spans_dir, proxy_filename))
+    else:
+        proxy_spans = []
+    replica_spans = load_spans(os.path.join(spans_dir, replica_filename))
+
+    # Verify error status in spans
+    for span in replica_spans:
+        if "application_span" in span["name"]:
+            assert span["status"]["status_code"] == expected_span_status.name
+
+            # Check for error attributes based on protocol and error type
+            if protocol == "http":
+                assert "Internal server error" in str(span.get("events", []))
+            elif protocol == "streaming":
+                assert "Streaming error occurred" in str(span.get("events", []))
+            elif protocol == "grpc":
+                assert "gRPC error occurred" in str(span.get("events", []))
+            else:
+                assert False, "Invalid protocol"
+
+    # Verify status code in proxy spans
+    for span in proxy_spans:
+        if protocol == "http" or protocol == "streaming":
+            if "proxy_http_request" in span["name"]:
+                assert (
+                    span["attributes"].get("http.status_code") == expected_status_code
+                )
+                assert span["status"]["status_code"] == "ERROR"
+            elif "route_to_replica" in span["name"]:
+                pass
+            else:
+                raise Exception("Invalid proxy span")
+        elif protocol == "grpc":
+            if "proxy_grpc_request" in span["name"]:
+                assert (
+                    span["attributes"].get("rpc.grpc.status_code")
+                    == expected_status_code
+                )
+                assert span["status"]["status_code"] == "ERROR"
+            elif "route_to_replica" in span["name"]:
+                pass
+            else:
+                assert False, "Invalid proxy span"
+        else:
+            assert False, "Invalid protocol"
+    # Clean up
+    shutil.rmtree(spans_dir)
+
+
+def custom_tracing_exporter():
+    """Custom tracing exporter used for testing."""
+    return [
+        SimpleSpanProcessor(
+            ConsoleSpanExporter(out=open(CUSTOM_EXPORTER_OUTPUT_FILENAME, "a"))
+        )
+    ]
+
+
+def load_json_fixture(file_path):
+    """Load json from a fixture."""
+    with Path(__file__).parent.joinpath(file_path).open() as f:
+        return json.load(f)
+
+
+def load_spans(file_path):
+    """Load and parse spans from a `.span` file.
+    This requires special handling because ConsoleSpanExporter
+    does not write proper JSON since the data is streamed.
+    """
+    with open(file_path, "r") as file:
+        file_contents = file.read()
+
+    raw_spans = file_contents.split("}\n{")
+    spans = []
+    for i, raw_span in enumerate(raw_spans):
+        if len(raw_spans) > 1:
+            if i == 0:
+                raw_span = raw_span + "}"
+            elif i == (len(raw_spans) - 1):
+                raw_span = "{" + raw_span
+            elif i != 0:
+                raw_span = "{" + raw_span + "}"
+
+        span_dict = json.loads(raw_span)
+
+        spans.append(span_dict)
+
+    spans.sort(reverse=True, key=lambda x: x["start_time"])
+
+    return spans
+
+
+def sanitize_spans(spans):
+    """Remove span attributes with ephemeral data."""
+    for span in spans:
+        del span["context"]
+        del span["parent_id"]
+        del span["start_time"]
+        del span["end_time"]
+        del span["resource"]
+        for k, _ in span["attributes"].items():
+            if "_id" in k:
+                span["attributes"][k] = ""
+
+
+def validate_span_associations_in_trace(spans):
+    """Validate that all spans in a
+    trace are correctly associated with each
+    other through the parent_id relationship.
+    """
+    if len(spans) <= 1:
+        return
+
+    class Span:
+        def __init__(self, _span_id: str, _parent_id: str, _name: str):
+            self.span_id = _span_id
+            self.parent_id = _parent_id
+            self.name = _name
+
+        def __repr__(self):
+            return f"Span(span_id={self.span_id}, parent_id={self.parent_id}, name={self.name})"
+
+    span_nodes = {}
+    starting_span = None
+    for span in spans:
+        span_id = span["context"]["span_id"].lstrip("0x")
+        parent_id = span["parent_id"].lstrip("0x") if span["parent_id"] else None
+        name = span["name"]
+        new_span = Span(span_id, parent_id, name)
+        span_nodes[span_id] = new_span
+        # The starting span is always the application span.
+        if name == "application_span":
+            assert starting_span is None, "Multiple starting spans found in trace"
+            starting_span = new_span
+    current_span = starting_span
+    span_nodes.pop(current_span.span_id)
+    while current_span:
+        current_span = span_nodes.pop(current_span.parent_id, None)
+    # All spans should have been visited.
+    assert not span_nodes
+
+
+def test_set_trace_status_empty_stack():
+    """test calling set_trace_status with an empty trace stack.
+
+    When there is nothing in the trace stack, calling set_trace_status does nothing
+    and does not error.
+    """
+
+    set_trace_status(is_error=True, description="error")
+    trace_stack = TRACE_STACK.get([])
+    assert trace_stack == []
+
+
+def test_set_trace_status_error():
+    """test calling set_trace_status with error status.
+
+    When there is a trace stack, calling set_trace_status with error updates
+    the correct status.
+    """
+    error_message = "error"
+    TRACE_STACK.set([FakeSpan()])
+    set_trace_status(is_error=True, description=error_message)
+    trace_stack = TRACE_STACK.get([])
+    assert len(trace_stack) == 1
+    assert trace_stack[0].status.status_code == StatusCode.ERROR
+    assert trace_stack[0].status.description == error_message
+
+
+def test_set_trace_status_ok(caplog):
+    """test calling set_trace_status with ok status.
+
+    When there is a trace stack, calling set_trace_status with ok updates
+    the correct status.
+    """
+    ok_message = "ok"
+    TRACE_STACK.set([FakeSpan()])
+    set_trace_status(is_error=False, description=ok_message)
+    trace_stack = TRACE_STACK.get([])
+    assert len(trace_stack) == 1
+    assert trace_stack[0].status.status_code == StatusCode.OK
+    # Note: when the status is OK, the description is not set.
+    assert trace_stack[0].status.description is None
+    # Ensure we don't attempt to set the description when the status is OK.
+    assert (
+        "description should only be set when status_code is set to StatusCode.ERROR"
+        not in caplog.text
+    )
+
+
+def test_append_trace_stack_multithread():
+    """test calling _append_trace_stack in multiple threads.
+
+    When multiple threads call _append_trace_stack, TRACE_STACK should only be updated
+    to contain the task name of the thread that called _append_trace_stack.
+    """
+    number_of_tasks = 10
+    passing = set()
+
+    def try_append_trace_stack(_task_name: str, _passing: Set[str]):
+        """
+        Helper to call `_append_trace_stack()` in a thread. It checks TRACE_STACK in
+        the current thread starts out empty and the correct task name is added to it
+        after `_append_trace_stack()` is called. If both checks out, the task name will
+        be added to the _passing.
+        """
+        trace_stack_before = TRACE_STACK.get([])
+        assert trace_stack_before == []
+        _append_trace_stack(_task_name)
+        trace_stack_after = TRACE_STACK.get()
+        assert trace_stack_after == [_task_name]
+        passing.add(_task_name)
+
+    tasks = []
+    for i in range(number_of_tasks):
+        t = Thread(target=try_append_trace_stack, args=(f"task{i}", passing))
+        t.start()
+        tasks.append(t)
+
+    for task in tasks:
+        task.join()
+
+    assert len(passing) == number_of_tasks
+
+
+def test_batched_span_attached_to_first_request_trace():
+    """Ensure span created inside a batched method attaches to the first request's trace.
+
+    With 6 requests and max_batch_size=3, Serve should create 2 batches. Only the first request
+    in each batch should contribute the parent trace to the 'batched_span', yielding exactly
+    2 spans whose trace_ids match the traces of those first requests.
+    """
+
+    @serve.deployment
+    class BatchedDeployment:
+        def __init__(self):
+            # We keep a counter so we can assert two unique batches producing two unique spans
+            self._batch_idx = 0
+
+        @serve.batch(
+            max_batch_size=3, batch_wait_timeout_s=1.0, max_concurrent_batches=2
+        )
+        async def handle_batch(self, reqs):
+            tracer = trace.get_tracer(__name__)
+
+            # whichever request is at index 0 is the one whose context is attached
+            first_req_id = None
+            try:
+                first_req_id = reqs[0].headers.get("req-id")
+            except Exception:
+                pass
+
+            batch_idx = self._batch_idx
+            self._batch_idx += 1
+
+            with tracer.start_as_current_span(
+                "batched_span", context=get_trace_context()
+            ) as span:
+                if first_req_id is not None:
+                    span.set_attribute("first-req-id", first_req_id)
+                span.set_attribute("batch-idx", batch_idx)
+                return ["ok" for _ in reqs]
+
+        async def __call__(self, request: Request):
+            return await self.handle_batch(request)
+
+    serve.start(http_options=HTTPOptions(host="0.0.0.0"))
+    serve.run(BatchedDeployment.bind())
+
+    setup_tracing(
+        component_name="upstream_app",
+        component_id="batching_test_upstream_multi",
+        tracing_sampling_ratio=1.0,
+    )
+
+    tracer = trace.get_tracer("test_tracing_batching_multi")
+
+    def do_request(span_name: str):
+        req_id = str(uuid.uuid4())
+        with tracer.start_as_current_span(span_name) as span:
+            # tag the upstream span so we can map req-id -> trace_id later
+            span.set_attribute("req-id", req_id)
+
+            # build headers from current OTEL context
+            ctx = get_trace_context()
+            headers = {"req-id": req_id}
+            TraceContextTextMapPropagator().inject(headers, ctx)
+
+            url = get_application_url("HTTP")
+            r = httpx.post(f"{url}/", headers=headers)
+            r.raise_for_status()
+
+    # Launch 6 requests -> expect 2 batches of 3 requests each
+    threads = [Thread(target=do_request, args=(f"upstream_{i}",)) for i in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    serve.shutdown()
+
+    # Load span files
+    serve_logs_dir = get_serve_logs_dir()
+    spans_dir = os.path.join(serve_logs_dir, "spans")
+    files = os.listdir(spans_dir)
+    assert files, "No span files found. Tracing may not be configured."
+
+    replica_filename = None
+    upstream_filename = None
+    for file in files:
+        if "replica" in file:
+            replica_filename = file
+        elif "upstream" in file:
+            upstream_filename = file
+    assert replica_filename and upstream_filename
+
+    upstream_spans = load_spans(os.path.join(spans_dir, upstream_filename))
+    replica_spans = load_spans(os.path.join(spans_dir, replica_filename))
+
+    id_to_trace = {}
+    for s in upstream_spans:
+        rid = s.get("attributes", {}).get("req-id")
+        if rid:
+            id_to_trace[rid] = s["context"]["trace_id"]
+    assert (
+        len(id_to_trace) == 6
+    ), f"Expected 6 upstream request spans, saw {len(id_to_trace)}"
+
+    # Exactly two batch spans, one per each batch, are expected
+    batched_spans = [s for s in replica_spans if s["name"] == "batched_span"]
+    assert (
+        len(batched_spans) == 2
+    ), f"Expected 2 batched spans, saw {len(batched_spans)}"
+
+    # For each batched span, its trace_id should equal the trace of the first request in the batch
+    batched_trace_ids = set()
+    batch_indices = set()
+    for bs in batched_spans:
+        first_req_id = bs.get("attributes", {}).get("first-req-id")
+        assert (
+            first_req_id in id_to_trace
+        ), f"first-req-id {first_req_id} not found among upstream req-ids"
+        assert bs["context"]["trace_id"] == id_to_trace[first_req_id]
+        batched_trace_ids.add(bs["context"]["trace_id"])
+        batch_indices.add(bs.get("attributes", {}).get("batch-idx"))
+
+    # The two batched spans must correspond to two unique traces
+    assert (
+        len(batched_trace_ids) == 2
+    ), "Batched spans did not map to two unique upstream traces"
+
+    # And they must be from distinct batches
+    assert (
+        len(batch_indices) == 2
+    ), f"Expected two distinct batch indices, got {batch_indices}"
+
+    shutil.rmtree(spans_dir)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_proxy.py
+++ b/python/ray/serve/tests/unit/test_proxy.py
@@ -179,6 +179,9 @@ class FakeProxyRequest(ProxyRequest):
     def is_health_request(self) -> bool:
         return self._is_health_request
 
+    def populate_tracing_context(self):
+        pass
+
 
 class FakeHTTPHandle:
     def __init__(self, messages):

--- a/python/ray/serve/utils.py
+++ b/python/ray/serve/utils.py
@@ -1,0 +1,35 @@
+from typing import Dict, Optional
+
+from ray.serve._private.tracing_utils import get_trace_context as _get_trace_context
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="alpha")
+def get_trace_context() -> Optional[Dict[str, str]]:
+    """Get the current OpenTelemetry trace context.
+
+    This can be used inside a deployment to create child spans that are linked
+    to the Serve request trace. Requires tracing to be enabled via the
+    ``RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH`` environment variable.
+
+    Returns:
+        The current OpenTelemetry context, or None if tracing is not enabled.
+
+    Example:
+
+    .. code-block:: python
+
+        from opentelemetry import trace
+        from ray import serve
+
+        tracer = trace.get_tracer(__name__)
+
+        @serve.deployment
+        class MyDeployment:
+            def __call__(self, request):
+                with tracer.start_as_current_span(
+                    "my_span", context=serve.get_trace_context()
+                ):
+                    ...
+    """
+    return _get_trace_context()


### PR DESCRIPTION
- Adds distributed tracing to Ray Serve using OpenTelemetry, enabling end-to-end visibility across proxy, router, replica, and user application spans.
- Tracing is **opt-in** via the `RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH` environment variable (disabled by default).
- Exposes `ray.serve.get_trace_context()` as a public API so users can create child spans linked to the Serve request trace from within their deployments.

## Details

**Core tracing infrastructure** (`ray/serve/_private/tracing_utils.py`):
- `TraceContextManager` and `BatchTraceContextManager` for span lifecycle management
- `tracing_decorator_factory` for instrumenting functions with spans
- Trace context propagation helpers (`create_propagated_context`, `extract_propagated_context`)
- Configurable sampling via `RAY_SERVE_TRACING_SAMPLING_RATIO` and pluggable exporters

**Instrumented components:**
- **Proxy** (`proxy.py`, `proxy_request_response.py`): Extracts `traceparent`/`tracestate` from incoming HTTP headers and gRPC metadata; creates proxy-level spans with HTTP/RPC semantic attributes
- **Router** (`router.py`): Creates routing spans and propagates context to replicas
- **Replica** (`replica.py`): Creates replica-level spans, records error attributes and status codes
- **Batching** (`batching.py`): Links batched execution spans to the first request's trace context

**Public API** (`ray.serve.get_trace_context()`):
```python
from opentelemetry import trace
from ray import serve

tracer = trace.get_tracer(__name__)

@serve.deployment
class MyDeployment:
    def __call__(self, request):
        with tracer.start_as_current_span("my_span", context=serve.get_trace_context()):
            ...
```

## Test plan

- Added `test_tracing_utils.py` with unit tests for span lifecycle, status setting, multithreaded trace stacks, and custom exporters
- E2E tests covering HTTP, streaming, and gRPC protocols validating span parent-child associations and semantic attributes
- E2E error path tests verifying error status propagation across all protocols
- Batching trace context test verifying spans attach to the correct request's trace