### PR TITLE
[Data][Refactor] Remove redundant tests from test_numpy.py

### DIFF
--- a/python/ray/data/tests/datasource/test_numpy.py
+++ b/python/ray/data/tests/datasource/test_numpy.py
@@ -11,7 +11,6 @@ from ray.data.context import DataContext
 from ray.data.dataset import Schema
 from ray.data.extensions.tensor_extension import ArrowTensorType
 from ray.data.tests.conftest import *  # noqa
-from ray.data.tests.mock_http_server import *  # noqa
 from ray.data.tests.util import extract_values
 from ray.tests.conftest import *  # noqa
 
@@ -90,20 +89,7 @@ def test_to_numpy_refs(ray_start_regular_shared):
     )
 
 
-def test_numpy_roundtrip(ray_start_regular_shared, tmp_path):
-    tensor_type = _get_tensor_type()
-
-    ds = ray.data.range_tensor(10, override_num_blocks=2)
-    ds.write_numpy(tmp_path, column="data")
-    ds = ray.data.read_numpy(tmp_path)
-    assert ds.count() == 10
-    assert ds.schema() == Schema(pa.schema([("data", tensor_type((1,), pa.int64()))]))
-    assert sorted(ds.take_all(), key=lambda row: row["data"]) == [
-        {"data": np.array([i])} for i in range(10)
-    ]
-
-
-def test_numpy_read_x(ray_start_regular_shared, tmp_path):
+def test_numpy_read(ray_start_regular_shared, tmp_path):
     tensor_type = _get_tensor_type()
 
     path = os.path.join(tmp_path, "test_np_dir")
@@ -116,16 +102,6 @@ def test_numpy_read_x(ray_start_regular_shared, tmp_path):
         extract_values("data", ds.take(2)), [np.array([0]), np.array([1])]
     )
 
-    # Add a file with a non-matching file extension. This file should be ignored.
-    with open(os.path.join(path, "foo.txt"), "w") as f:
-        f.write("foobar")
-
-    ds = ray.data.read_numpy(path, override_num_blocks=1)
-    assert ds._plan.initial_num_blocks() == 1
-    assert ds.count() == 10
-    assert ds.schema() == Schema(pa.schema([("data", tensor_type((1,), pa.int64()))]))
-    assert [v["data"].item() for v in ds.take(2)] == [0, 1]
-
 
 def test_numpy_write(ray_start_regular_shared, tmp_path):
     ds = ray.data.range_tensor(1)
@@ -136,17 +112,6 @@ def test_numpy_write(ray_start_regular_shared, tmp_path):
         [np.load(os.path.join(tmp_path, filename)) for filename in os.listdir(tmp_path)]
     )
     assert actual_array == np.array((0,))
-
-
-@pytest.mark.parametrize("min_rows_per_file", [5, 10, 50])
-def test_write_min_rows_per_file(tmp_path, ray_start_regular_shared, min_rows_per_file):
-    ray.data.range(100, override_num_blocks=20).write_numpy(
-        tmp_path, column="id", min_rows_per_file=min_rows_per_file
-    )
-
-    for filename in os.listdir(tmp_path):
-        array = np.load(os.path.join(tmp_path, filename))
-        assert len(array) == min_rows_per_file
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

`test_numpy.py` has redundant tests for common file I/O behavior already covered in `test_file_based_datasource.py`and `test_file_datasink.py`.

## What's included?

**Simplified:**
- `test_numpy_read_x` → `test_numpy_read` - Removed file extension filtering portion (generic file I/O behavior handled by `FileBasedDatasource`)

**Deleted:**
- `test_numpy_roundtrip` - Redundant with separate read/write tests;
- `test_write_min_rows_per_file` - Already tested in `test_file_datasink.py`; `min_rows_per_file` parameter is implemented in base `FileBasedDatasink` class

**Removed:**
- Unused `mock_http_server` import

## Screenshots

<img width="710" height="319" alt="Screenshot 2026-02-21 at 22 41 03" src="https://github.com/user-attachments/assets/3798e038-0809-458b-b11a-10ae677da33e" />

## Benefits

- Removes redundant tests
- Clearer separation: base handles file I/O, NumPy handles format-specific features
- Faster test execution

## Note

Closes #61224
