### PR TITLE
Remove redundant text tfrecords tests

### DIFF
--- a/python/ray/data/tests/datasource/test_file_based_datasource.py
+++ b/python/ray/data/tests/datasource/test_file_based_datasource.py
@@ -4,10 +4,15 @@ from urllib.parse import urlparse
 
 import pyarrow
 import pytest
+from fsspec.implementations.http import HTTPFileSystem
 from pytest_lazy_fixtures import lf as lazy_fixture
 
 import ray
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+from ray.data._internal.execution.interfaces.ref_bundle import (
+    _ref_bundles_iterator_to_block_refs_list,
+)
+from ray.data.tests.mock_http_server import *
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.datasource import ReadTask
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
@@ -468,6 +473,55 @@ def test_read_s3_file_error(shutdown_only, s3_path):
             "Error [code 15]: No response body.. Is this a 'parquet' file?"
         )
         _handle_read_os_error(error, dummy_path)
+
+
+def test_read_ray_remote_args(ray_start_cluster, tmp_path):
+    cluster = ray_start_cluster
+    cluster.add_node(
+        resources={"foo": 100},
+        num_cpus=1,
+        _system_config={"max_direct_call_object_size": 0},
+    )
+    cluster.add_node(resources={"bar": 100}, num_cpus=1)
+
+    ray.shutdown()
+    ray.init(cluster.address)
+
+    @ray.remote
+    def get_node_id():
+        return ray.get_runtime_context().get_node_id()
+
+    bar_node_id = ray.get(get_node_id.options(resources={"bar": 1}).remote())
+
+    path = os.path.join(tmp_path, "test_text")
+    os.mkdir(path)
+    with open(os.path.join(path, "file1.txt"), "w") as f:
+        f.write("hello\n")
+        f.write("world")
+    with open(os.path.join(path, "file2.txt"), "w") as f:
+        f.write("goodbye")
+
+    ds = ray.data.read_text(
+        path, override_num_blocks=2, ray_remote_args={"resources": {"bar": 1}}
+    )
+
+    block_refs = _ref_bundles_iterator_to_block_refs_list(
+        ds.iter_internal_ref_bundles()
+    )
+    ray.wait(block_refs, num_returns=len(block_refs), fetch_local=False)
+    location_data = ray.experimental.get_object_locations(block_refs)
+    locations = []
+    for block in block_refs:
+        locations.extend(location_data[block]["node_ids"])
+    assert set(locations) == {bar_node_id}, locations
+    assert ds.count() == 3
+
+
+def test_fsspec_http_file_system(ray_start_regular_shared, http_server, http_file):
+    ds = ray.data.read_text(http_file, filesystem=HTTPFileSystem())
+    assert ds.count() > 0
+    ds = ray.data.read_text(http_file)
+    assert ds.count() > 0
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_tfrecords.py
+++ b/python/ray/data/tests/datasource/test_tfrecords.py
@@ -2,7 +2,6 @@ import json
 import os
 import sys
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -457,38 +456,6 @@ def test_read_tfrecords(
     assert np.array_equal(df["string_empty"][0], np.array([], dtype=np.bytes_))
 
 
-@pytest.fixture
-def mock_ray_data_read_tfrecords(mocker):
-    mock_read_tfrecords = mocker.patch("ray.data.read_tfrecords")
-    mock_read_tfrecords.return_value = MagicMock(spec=Dataset)
-    return mock_read_tfrecords
-
-
-@pytest.mark.parametrize("num_cpus", [1, 2, 4])
-def test_read_tfrecords_ray_remote_args(
-    ray_start_regular_shared_2_cpus,
-    mock_ray_data_read_tfrecords,
-    tmp_path,
-    num_cpus,
-):
-    import tensorflow as tf
-
-    example = tf_records_empty()[0]
-    path = os.path.join(tmp_path, "data.tfrecords")
-    with tf.io.TFRecordWriter(path=path) as writer:
-        writer.write(example.SerializeToString())
-    ray_remote_args = {"num_cpus": num_cpus}
-    ds = read_tfrecords_with_tfx_read_override(
-        paths=[path],
-        ray_remote_args=ray_remote_args,
-    )
-    assert isinstance(ds, Dataset)
-    mock_ray_data_read_tfrecords.assert_called_once()
-    args, kwargs = mock_ray_data_read_tfrecords.call_args
-    assert kwargs["paths"] == [path]
-    assert kwargs["ray_remote_args"] == ray_remote_args
-
-
 @pytest.mark.parametrize("with_tf_schema", (True, False))
 def test_write_tfrecords(
     with_tf_schema,
@@ -775,19 +742,6 @@ def test_read_with_invalid_schema(
         "Schema field type mismatch during read: "
         "specified type is int, but underlying type is bytes"
     )
-
-
-@pytest.mark.parametrize("min_rows_per_file", [5, 10, 50])
-def test_write_min_rows_per_file(
-    tmp_path, ray_start_regular_shared_2_cpus, min_rows_per_file
-):
-    ray.data.range(100, override_num_blocks=20).write_tfrecords(
-        tmp_path, min_rows_per_file=min_rows_per_file
-    )
-
-    for filename in os.listdir(tmp_path):
-        dataset = tf.data.TFRecordDataset(os.path.join(tmp_path, filename))
-        assert len(list(dataset)) == min_rows_per_file
 
 
 def read_tfrecords_with_tfx_read_override(paths, tfx_read=False, **read_opts):


### PR DESCRIPTION
Remove generic file-based datasource tests from format-specific test files, keeping only format-specific tests.

### Change
**test_text**
- Removed test_read_text_remote_args (tests generic ray_remote_args scheduling, not text-specific)
- Removed test_fsspec_http_file_system (tests generic HTTP filesystem support, not text-specific)
- Cleaned up unused imports (HTTPFileSystem, _ref_bundles_iterator_to_block_refs_list, mock_http_server)

**test_tfrecords**
- Removed test_write_min_rows_per_file (tests generic min_rows_per_file write behavior, not TFRecords-specific)

Related to https://github.com/ray-project/ray/issues/61222


