### PR TITLE
Remove redundant tests from test mcap and test webdataset

### DIFF
--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -7,7 +7,6 @@ import os
 import tarfile
 
 import pytest
-import webdataset as wds
 
 import ray
 from ray.tests.conftest import *  # noqa
@@ -259,17 +258,6 @@ def test_webdataset_decoding(ray_start_2_cpus, tmp_path):
 
     meta_json = json.loads(samples[0]["json"].decode("utf-8"))
     assert meta_json["e"]["img_filename"] == "for_test.jpg"
-
-
-@pytest.mark.parametrize("min_rows_per_file", [5, 10, 50])
-def test_write_min_rows_per_file(tmp_path, ray_start_regular_shared, min_rows_per_file):
-    ray.data.from_items(
-        [{"id": str(i)} for i in range(100)], override_num_blocks=20
-    ).write_webdataset(tmp_path, min_rows_per_file=min_rows_per_file)
-
-    for filename in os.listdir(tmp_path):
-        dataset = wds.WebDataset(os.path.join(tmp_path, filename))
-        assert len(list(dataset)) == min_rows_per_file
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Clean up test mcap and test webdataset to focus on format specific tests only.

### Changes
**test_mcap**
Generic tests that are already covered in test file based datasource were deleted
These test generic file I/O behavior which is not specific to the MCAP format

**test_webdataset**
- Removed test write min rows per file, as it validates the generic min rows per file write parameter rather than WebDataset specific functionality
- Cleaned up unused imports in both files

Part of https://github.com/ray-project/ray/issues/61222
