### PR TITLE
[Rllib] Add Preallocate Buffer for Episodes as backend option

### DIFF
--- a/rllib/env/tests/test_pre_allocated_lookback_buffer.py
+++ b/rllib/env/tests/test_pre_allocated_lookback_buffer.py
@@ -1,0 +1,503 @@
+"""Tests for PreAllocatedLookbackBuffer.
+
+Parity tests run against both InfiniteLookbackBuffer and
+PreAllocatedLookbackBuffer to verify behavioural equivalence.
+"""
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from ray.rllib.env.utils.infinite_lookback_buffer import InfiniteLookbackBuffer
+from ray.rllib.env.utils.pre_allocated_lookback_buffer import (
+    PreAllocatedLookbackBuffer,
+)
+from ray.rllib.utils.test_utils import check
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+DICT_SPACE = gym.spaces.Dict(
+    {
+        "a": gym.spaces.Discrete(4),
+        "b": gym.spaces.Box(0.0, 3.0, (2, 3), np.float32),
+        "c": gym.spaces.Tuple(
+            [
+                gym.spaces.MultiDiscrete([4, 4]),
+                gym.spaces.Box(0.0, 3.0, (1,), np.float32),
+            ]
+        ),
+    }
+)
+
+_SAMPLES = [
+    {
+        "a": i % 4,
+        "b": np.full((2, 3), i, dtype=np.float32),
+        "c": (np.array([i % 4, i % 4]), np.array([i], dtype=np.float32)),
+    }
+    for i in range(8)
+]
+
+_SIMPLE_SPACE = gym.spaces.Discrete(20)
+
+_BUFFER_CLASSES = [InfiniteLookbackBuffer, PreAllocatedLookbackBuffer]
+_IDS = ["InfiniteLookbackBuffer", "PreAllocatedLookbackBuffer"]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_pair():
+    """ILB and PALB seeded with range(6), no lookback."""
+    data = list(range(6))
+    ilb = InfiniteLookbackBuffer(data=data, space=_SIMPLE_SPACE)
+    ilb.finalize()
+    palb = PreAllocatedLookbackBuffer(
+        data=data, space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    palb.finalize()
+    return ilb, palb
+
+
+@pytest.fixture
+def lookback_pair():
+    """ILB and PALB seeded with range(6), lookback=2."""
+    data = list(range(6))
+    ilb = InfiniteLookbackBuffer(data=data, lookback=2, space=_SIMPLE_SPACE)
+    ilb.finalize()
+    palb = PreAllocatedLookbackBuffer(
+        data=data, lookback=2, space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    palb.finalize()
+    return ilb, palb
+
+
+@pytest.fixture
+def dict_pair():
+    """ILB and PALB seeded with DICT_SPACE samples, lookback=2."""
+    data = _SAMPLES[:6]
+    ilb = InfiniteLookbackBuffer(data=data, lookback=2, space=DICT_SPACE)
+    ilb.finalize()
+    palb = PreAllocatedLookbackBuffer(
+        data=data, lookback=2, space=DICT_SPACE, initial_capacity=8
+    )
+    palb.finalize()
+    return ilb, palb
+
+
+def _make_simple_pair():
+    """Fresh mutable pair for tests that mutate buffers."""
+    ilb = InfiniteLookbackBuffer(data=list(range(6)), space=_SIMPLE_SPACE)
+    ilb.finalize()
+    palb = PreAllocatedLookbackBuffer(
+        data=list(range(6)), space=_SIMPLE_SPACE, initial_capacity=12
+    )
+    palb.finalize()
+    return ilb, palb
+
+
+# ---------------------------------------------------------------------------
+# Construction
+# ---------------------------------------------------------------------------
+
+
+def test_requires_space():
+    with pytest.raises(ValueError):
+        PreAllocatedLookbackBuffer(space=None)
+
+
+def test_empty_construction():
+    buf = PreAllocatedLookbackBuffer(space=_SIMPLE_SPACE, initial_capacity=4)
+    assert len(buf) == 0
+    assert buf.len_incl_lookback() == 0
+    assert buf.finalized
+    assert buf._growing
+
+
+def test_construction_with_data():
+    data = list(range(5))
+    buf = PreAllocatedLookbackBuffer(
+        data=data, lookback=2, space=_SIMPLE_SPACE, initial_capacity=4
+    )
+    assert len(buf) == 3
+    assert buf.lookback == 2
+    assert buf._capacity >= len(data)
+    assert buf._length == 5
+    check(buf.get(), [2, 3, 4])
+
+
+# ---------------------------------------------------------------------------
+# Append / extend / pop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", _BUFFER_CLASSES, ids=_IDS)
+def test_append_extend_pop(cls):
+    if cls is InfiniteLookbackBuffer:
+        buf = cls(data=[0, 1, 2, 3], space=_SIMPLE_SPACE)
+    else:
+        buf = cls(data=[0, 1, 2, 3], space=_SIMPLE_SPACE, initial_capacity=8)
+
+    assert len(buf) == 4
+    buf.append(4)
+    assert len(buf) == 5
+    buf.append(5)
+    assert len(buf) == 6
+    buf.pop()
+    assert len(buf) == 5
+    buf.pop()
+    assert len(buf) == 4
+    buf.append(10)
+    assert len(buf) == 5
+    buf.finalize()
+
+    # Post-finalize appends still work.
+    buf.append(11)
+    check(buf.get(indices=-1), 11)
+    buf.extend([12, 13])
+    check(buf.get(indices=-1), 13)
+    buf.pop()
+    check(buf.get(indices=-1), 12)
+    check(buf.get(indices=0), 0)
+
+
+def test_grow_doubles_capacity():
+    buf = PreAllocatedLookbackBuffer(space=_SIMPLE_SPACE, initial_capacity=2)
+    for i in range(10):
+        buf.append(i)
+    assert len(buf) == 10
+    check(buf.get(), list(range(10)))
+    assert buf._capacity >= 10
+
+
+# ---------------------------------------------------------------------------
+# finalize()
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_trims_capacity():
+    buf = PreAllocatedLookbackBuffer(space=_SIMPLE_SPACE, initial_capacity=128)
+    for i in range(5):
+        buf.append(i)
+    assert buf._capacity == 128
+    buf.finalize()
+    assert buf._capacity == 5
+    assert buf._length == 5
+    assert not buf._growing
+    check(buf.get(), list(range(5)))
+
+
+def test_finalize_idempotent():
+    buf = PreAllocatedLookbackBuffer(space=_SIMPLE_SPACE, initial_capacity=8)
+    for i in range(3):
+        buf.append(i)
+    buf.finalize()
+    buf.finalize()  # second call is a no-op
+    assert buf._length == 3
+
+
+def test_empty_finalize():
+    buf = PreAllocatedLookbackBuffer(space=_SIMPLE_SPACE, initial_capacity=8)
+    buf.finalize()
+    assert buf._length == 0
+    assert not buf._growing
+
+
+# ---------------------------------------------------------------------------
+# get() parity — simple space, no lookback
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_simple(simple_pair):
+    ilb, palb = simple_pair
+    check(ilb.get(), palb.get())
+
+
+def test_get_int_simple(simple_pair):
+    ilb, palb = simple_pair
+    for i in range(6):
+        check(ilb.get(i), palb.get(i))
+
+
+def test_get_negative_int_simple(simple_pair):
+    ilb, palb = simple_pair
+    for i in range(-1, -7, -1):
+        check(ilb.get(i), palb.get(i))
+
+
+def test_get_slice_simple(simple_pair):
+    ilb, palb = simple_pair
+    check(ilb.get(slice(1, 4)), palb.get(slice(1, 4)))
+    check(ilb.get(slice(-3, None)), palb.get(slice(-3, None)))
+    check(ilb.get(slice(None, -2)), palb.get(slice(None, -2)))
+
+
+def test_get_list_indices_simple(simple_pair):
+    ilb, palb = simple_pair
+    check(ilb.get([0, 2, 4]), palb.get([0, 2, 4]))
+
+
+def test_get_with_fill_simple(simple_pair):
+    ilb, palb = simple_pair
+    check(
+        ilb.get(slice(-10, None), fill=99),
+        palb.get(slice(-10, None), fill=99),
+    )
+    check(
+        ilb.get(slice(3, 12), fill=99),
+        palb.get(slice(3, 12), fill=99),
+    )
+
+
+# ---------------------------------------------------------------------------
+# get() parity — with lookback
+# ---------------------------------------------------------------------------
+
+
+def test_len_lookback(lookback_pair):
+    ilb, palb = lookback_pair
+    assert len(ilb) == len(palb)
+
+
+def test_len_incl_lookback(lookback_pair):
+    ilb, palb = lookback_pair
+    assert ilb.len_incl_lookback() == palb.len_incl_lookback()
+
+
+def test_get_all_lookback(lookback_pair):
+    ilb, palb = lookback_pair
+    check(ilb.get(), palb.get())
+
+
+def test_get_int_positive_lookback(lookback_pair):
+    ilb, palb = lookback_pair
+    for i in range(4):
+        check(ilb.get(i), palb.get(i))
+
+
+def test_get_int_negative_lookback(lookback_pair):
+    ilb, palb = lookback_pair
+    for i in range(-1, -5, -1):
+        check(ilb.get(i), palb.get(i))
+
+
+@pytest.mark.parametrize(
+    "sl",
+    [slice(-4, None), slice(None, -1), slice(0, 3), slice(-2, 2)],
+    ids=["neg4_to_end", "start_to_neg1", "0_to_3", "neg2_to_2"],
+)
+def test_get_slice_lookback(lookback_pair, sl):
+    ilb, palb = lookback_pair
+    check(ilb.get(sl), palb.get(sl))
+
+
+@pytest.mark.parametrize("i", [-1, -2])
+def test_neg_index_as_lookback(lookback_pair, i):
+    ilb, palb = lookback_pair
+    check(
+        ilb.get(i, neg_index_as_lookback=True),
+        palb.get(i, neg_index_as_lookback=True),
+    )
+
+
+def test_fill_left_lookback(lookback_pair):
+    ilb, palb = lookback_pair
+    check(
+        ilb.get(slice(-8, None), fill=0),
+        palb.get(slice(-8, None), fill=0),
+    )
+
+
+def test_fill_right_lookback(lookback_pair):
+    ilb, palb = lookback_pair
+    check(
+        ilb.get(slice(2, 8), fill=0),
+        palb.get(slice(2, 8), fill=0),
+    )
+
+
+def test_out_of_range_raises(lookback_pair):
+    _, palb = lookback_pair
+    with pytest.raises(IndexError):
+        palb.get(100)
+    with pytest.raises(IndexError):
+        palb.get(-100)
+
+
+# ---------------------------------------------------------------------------
+# get() parity — dict space
+# ---------------------------------------------------------------------------
+
+
+def test_get_all_dict(dict_pair):
+    ilb, palb = dict_pair
+    ilb_res = ilb.get()
+    palb_res = palb.get()
+    for key in ["a", "b"]:
+        check(ilb_res[key], palb_res[key])
+
+
+def test_get_int_dict(dict_pair):
+    ilb, palb = dict_pair
+    for i in range(4):
+        ilb_res = ilb.get(i)
+        palb_res = palb.get(i)
+        check(ilb_res["a"], palb_res["a"])
+        np.testing.assert_array_equal(ilb_res["b"], palb_res["b"])
+
+
+def test_get_slice_dict(dict_pair):
+    ilb, palb = dict_pair
+    ilb_res = ilb.get(slice(0, 3))
+    palb_res = palb.get(slice(0, 3))
+    check(ilb_res["a"], palb_res["a"])
+    np.testing.assert_array_equal(ilb_res["b"], palb_res["b"])
+
+
+# ---------------------------------------------------------------------------
+# set() parity
+# ---------------------------------------------------------------------------
+
+
+def test_set_int_index():
+    ilb, palb = _make_simple_pair()
+    ilb.set(15, at_indices=2)
+    palb.set(15, at_indices=2)
+    check(ilb.get(2), palb.get(2))
+
+
+def test_set_slice():
+    ilb, palb = _make_simple_pair()
+    # new_data must be a numpy array so tree.map_structure sees matching
+    # leaf types (ndarray vs ndarray, not ndarray vs list).
+    new_data = np.array([10, 11])
+    ilb.set(new_data, at_indices=slice(1, 3))
+    palb.set(new_data, at_indices=slice(1, 3))
+    check(ilb.get(slice(1, 3)), palb.get(slice(1, 3)))
+
+
+def test_setitem():
+    ilb, palb = _make_simple_pair()
+    ilb[3] = 5
+    palb[3] = 5
+    check(ilb.get(3), palb.get(3))
+
+
+# ---------------------------------------------------------------------------
+# pop() parity
+# ---------------------------------------------------------------------------
+
+
+def test_pop_last():
+    ilb = InfiniteLookbackBuffer(data=[0, 1, 2, 3, 4], space=_SIMPLE_SPACE)
+    ilb.finalize()
+    palb = PreAllocatedLookbackBuffer(
+        data=[0, 1, 2, 3, 4], space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    palb.finalize()
+    ilb.pop(-1)
+    palb.pop(-1)
+    check(ilb.get(), palb.get())
+
+
+def test_pop_middle():
+    data = list(range(6))
+    ilb = InfiniteLookbackBuffer(data=data, space=_SIMPLE_SPACE)
+    ilb.finalize()
+    palb = PreAllocatedLookbackBuffer(
+        data=data, space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    palb.finalize()
+    ilb.pop(-3)
+    palb.pop(-3)
+    check(ilb.get(), palb.get())
+
+
+def test_pop_out_of_range():
+    palb = PreAllocatedLookbackBuffer(
+        data=[0, 1, 2], space=_SIMPLE_SPACE, initial_capacity=4
+    )
+    with pytest.raises(IndexError):
+        palb.pop(100)
+    with pytest.raises(IndexError):
+        palb.pop(-100)
+
+
+# ---------------------------------------------------------------------------
+# concat() / extend()
+# ---------------------------------------------------------------------------
+
+
+def test_concat():
+    a = PreAllocatedLookbackBuffer(
+        data=[0, 1, 2], space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    b = PreAllocatedLookbackBuffer(
+        data=[3, 4, 5], space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    a.concat(b)
+    check(a.get(), list(range(6)))
+
+
+def test_extend():
+    buf = PreAllocatedLookbackBuffer(
+        data=[0, 1], space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    buf.extend([2, 3, 4])
+    check(buf.get(), list(range(5)))
+
+
+# ---------------------------------------------------------------------------
+# State serialization
+# ---------------------------------------------------------------------------
+
+
+def test_state_roundtrip():
+    data = list(range(6))
+    original = PreAllocatedLookbackBuffer(
+        data=data, lookback=2, space=_SIMPLE_SPACE, initial_capacity=8
+    )
+    original.finalize()
+    state = original.get_state()
+    restored = PreAllocatedLookbackBuffer.from_state(state)
+    assert restored._length == original._length
+    assert restored.lookback == original.lookback
+    assert not restored._growing
+    check(restored.get(), original.get())
+
+
+def test_state_roundtrip_dict_space():
+    data = _SAMPLES[:4]
+    original = PreAllocatedLookbackBuffer(
+        data=data, lookback=1, space=DICT_SPACE, initial_capacity=8
+    )
+    original.finalize()
+    state = original.get_state()
+    restored = PreAllocatedLookbackBuffer.from_state(state)
+    orig_res = original.get()
+    rest_res = restored.get()
+    check(orig_res["a"], rest_res["a"])
+    np.testing.assert_array_equal(orig_res["b"], rest_res["b"])
+
+
+# ---------------------------------------------------------------------------
+# one_hot_discrete parity
+# ---------------------------------------------------------------------------
+
+
+def test_one_hot_discrete():
+    space = gym.spaces.Discrete(4)
+    data = [0, 1, 2, 3, 0, 1]
+    ilb = InfiniteLookbackBuffer(data=data, space=space)
+    ilb.finalize()
+    palb = PreAllocatedLookbackBuffer(data=data, space=space, initial_capacity=8)
+    palb.finalize()
+    ilb_res = ilb.get(one_hot_discrete=True)
+    palb_res = palb.get(one_hot_discrete=True)
+    np.testing.assert_array_equal(ilb_res, palb_res)
+
+

--- a/rllib/env/tests/test_single_agent_episode.py
+++ b/rllib/env/tests/test_single_agent_episode.py
@@ -94,7 +94,7 @@ class TestSingleAgentEpisode(unittest.TestCase):
         self.assertTrue(episode.t_started == 0)
         self.assertTrue(episode.t == 90)
         self.assertTrue(len(episode.rewards) == 90)
-        self.assertTrue(len(episode.rewards.data) == 100)
+        self.assertTrue(episode.rewards.len_incl_lookback() == 100)
 
         # Build the same episode, but with a 10 ts lookback buffer AND a specific
         # `t_started`.
@@ -106,7 +106,7 @@ class TestSingleAgentEpisode(unittest.TestCase):
         self.assertTrue(episode.t_started == 50)
         self.assertTrue(episode.t == 140)
         self.assertTrue(len(episode.rewards) == 90)
-        self.assertTrue(len(episode.rewards.data) == 100)
+        self.assertTrue(episode.rewards.len_incl_lookback() == 100)
 
     def test_add_env_reset(self):
         """Tests adding initial observations and infos.

--- a/rllib/env/tests/test_space_utils.py
+++ b/rllib/env/tests/test_space_utils.py
@@ -1,0 +1,159 @@
+import numpy as np
+import pytest
+from gymnasium.spaces import (
+    Box,
+    Dict,
+    Discrete,
+    Graph,
+    MultiBinary,
+    MultiDiscrete,
+    OneOf,
+    Sequence,
+    Space,
+    Text,
+    Tuple,
+)
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector.utils import concatenate
+from space_utils import create_mutable_array, read_from_buffer, write_to_buffer
+
+TESTING_FUNDAMENTAL_SPACES = [
+    Discrete(3),
+    Discrete(3, start=-1),
+    Discrete(n=4, dtype=np.int32, start=1),
+    Box(low=0.0, high=1.0),
+    Box(low=0.0, high=np.inf, shape=(2, 2)),
+    Box(low=np.array([-10.0, 0.0]), high=np.array([10.0, 10.0]), dtype=np.float64),
+    Box(low=-np.inf, high=0.0, shape=(2, 1)),
+    Box(low=0.0, high=np.inf, shape=(2, 1)),
+    Box(low=0, high=255, shape=(2, 2, 3), dtype=np.uint8),
+    Box(low=np.array([0, 0, 1]), high=np.array([1, 0, 1]), dtype=np.bool_),
+    Box(
+        low=np.array([-np.inf, -np.inf, 0, -10]),
+        high=np.array([np.inf, 0, np.inf, 10]),
+        dtype=np.int32,
+    ),
+    MultiDiscrete([2, 2]),
+    MultiDiscrete([[2, 3], [3, 2]]),
+    MultiDiscrete([2, 2], start=[10, 10]),
+    MultiDiscrete([[2, 3], [3, 2]], start=[[10, 20], [30, 40]]),
+    MultiDiscrete([2, 3], dtype=np.int8),
+    MultiDiscrete([2, 3], dtype=np.uint16),
+    MultiBinary(8),
+    MultiBinary([2, 3]),
+    Text(6),
+    Text(min_length=3, max_length=6),
+    Text(6, charset="abcdef"),
+]
+TESTING_FUNDAMENTAL_SPACES_IDS = [f"{space}" for space in TESTING_FUNDAMENTAL_SPACES]
+
+
+TESTING_COMPOSITE_SPACES = [
+    # Tuple spaces
+    Tuple([Discrete(5), Discrete(4)]),
+    Tuple(
+        (
+            Discrete(5),
+            Box(
+                low=np.array([0.0, 0.0]),
+                high=np.array([1.0, 5.0]),
+                dtype=np.float64,
+            ),
+        )
+    ),
+    Tuple((Discrete(5), Tuple((Box(low=0.0, high=1.0, shape=(3,)), Discrete(2))))),
+    Tuple((Discrete(3), Dict(position=Box(low=0.0, high=1.0), velocity=Discrete(2)))),
+    Tuple((Graph(node_space=Box(-1, 1, shape=(2, 1)), edge_space=None), Discrete(2))),
+    # Dict spaces
+    Dict(
+        {
+            "position": Discrete(5),
+            "velocity": Box(
+                low=np.array([0.0, 0.0]),
+                high=np.array([1.0, 5.0]),
+                dtype=np.float64,
+            ),
+        }
+    ),
+    Dict(
+        position=Discrete(6),
+        velocity=Box(
+            low=np.array([0.0, 0.0]),
+            high=np.array([1.0, 5.0]),
+            dtype=np.float64,
+        ),
+    ),
+    Dict(
+        {
+            "a": Box(low=0, high=1, shape=(3, 3)),
+            "b": Dict(
+                {
+                    "b_1": Box(low=-100, high=100, shape=(2,)),
+                    "b_2": Box(low=-1, high=1, shape=(2,)),
+                }
+            ),
+            "c": Discrete(4),
+        }
+    ),
+    Dict(
+        a=Dict(
+            a=Graph(node_space=Box(-100, 100, shape=(2, 2)), edge_space=None),
+            b=Box(-100, 100, shape=(2, 2)),
+        ),
+        b=Tuple((Box(-100, 100, shape=(2,)), Box(-100, 100, shape=(2,)))),
+    ),
+    # Graph spaces
+    Graph(node_space=Box(-1, 1, shape=(2,)), edge_space=None),
+    Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
+    Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
+    Graph(node_space=Discrete(3), edge_space=Discrete(4)),
+    # Sequence spaces
+    Sequence(Discrete(4)),
+    Sequence(Dict({"feature": Box(0, 1, (3,))})),
+    Sequence(Graph(node_space=Box(-100, 100, shape=(2, 2)), edge_space=Discrete(4))),
+    Sequence(Box(low=0.0, high=1.0), stack=True),
+    Sequence(Dict({"a": Box(0, 1, (3,)), "b": Discrete(5)}), stack=True),
+    # OneOf spaces
+    OneOf([Discrete(3), Box(low=0.0, high=1.0)]),
+    OneOf([MultiBinary(2), MultiDiscrete([2, 2])]),
+]
+TESTING_COMPOSITE_SPACES_IDS = [f"{space}" for space in TESTING_COMPOSITE_SPACES]
+
+TESTING_SPACES: list[Space] = TESTING_FUNDAMENTAL_SPACES + TESTING_COMPOSITE_SPACES
+TESTING_SPACES_IDS = TESTING_FUNDAMENTAL_SPACES_IDS + TESTING_COMPOSITE_SPACES_IDS
+assert len(TESTING_SPACES_IDS) == len(TESTING_SPACES)
+
+
+def _fix_concatenate(space, result):
+    if isinstance(space, (Text, Graph, Sequence, OneOf)):
+        return list(result)
+    elif isinstance(space, Tuple):
+        return tuple(_fix_concatenate(ss, r) for ss, r in zip(space.spaces, result))
+    elif isinstance(space, Dict):
+        return {k: _fix_concatenate(space[k], result[k]) for k in space.keys()}
+    return result  # numpy-backed: leave as-is
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+def test_read_write(space, size: int = 10):
+    buffer = create_mutable_array(space, size)
+
+    samples = [space.sample() for _ in range(size)]
+    for idx, sample in enumerate(samples):
+        write_to_buffer(space, buffer, idx, sample)
+
+    for idx in [0, 1, -1]:
+        expected_sample = samples[idx]
+        read_sample = read_from_buffer(space, buffer, idx)
+
+        assert data_equivalence(expected_sample, read_sample)
+
+    idxs = slice(3, 7)
+    expected_samples = _fix_concatenate(
+        space,
+        concatenate(
+            space, samples[idxs], create_mutable_array(space, len(samples[idxs]))
+        ),
+    )
+    read_samples = read_from_buffer(space, buffer, idxs)
+    assert data_equivalence(expected_samples, read_samples)

--- a/rllib/env/utils/infinite_lookback_buffer.py
+++ b/rllib/env/utils/infinite_lookback_buffer.py
@@ -5,6 +5,7 @@ import numpy as np
 import tree  # pip install dm_tree
 from gymnasium.utils.env_checker import data_equivalence
 
+from ray.rllib.env.utils.lookback_buffer_base import BaseLookbackBuffer
 from ray.rllib.utils.numpy import LARGE_INTEGER, one_hot, one_hot_multidiscrete
 from ray.rllib.utils.serialization import gym_space_from_dict, gym_space_to_dict
 from ray.rllib.utils.spaces.space_utils import (
@@ -16,7 +17,7 @@ from ray.util.annotations import DeveloperAPI
 
 
 @DeveloperAPI
-class InfiniteLookbackBuffer:
+class InfiniteLookbackBuffer(BaseLookbackBuffer):
     def __init__(
         self,
         data: Optional[Union[List, np.ndarray]] = None,

--- a/rllib/env/utils/lookback_buffer_base.py
+++ b/rllib/env/utils/lookback_buffer_base.py
@@ -1,0 +1,92 @@
+"""Abstract base class for lookback buffers."""
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class BaseLookbackBuffer(ABC):
+    """Abstract base class defining the public contract for lookback buffers.
+
+    Both :class:`InfiniteLookbackBuffer` and
+    :class:`PreAllocatedLookbackBuffer` implement this interface so they are
+    interchangeable drop-in replacements for each other.
+    """
+
+    @abstractmethod
+    def append(self, item) -> None:
+        """Appends the given item to the end of this buffer."""
+
+    @abstractmethod
+    def extend(self, items) -> None:
+        """Appends all items in `items` to the end of this buffer."""
+
+    @abstractmethod
+    def concat(self, other: "BaseLookbackBuffer") -> None:
+        """Concatenates the data of `other` (w/o its lookback) to self."""
+
+    @abstractmethod
+    def pop(self, index: int = -1) -> None:
+        """Removes the item at `index` from this buffer (does NOT return it)."""
+
+    @abstractmethod
+    def finalize(self) -> None:
+        """Converts / trims internal storage to batch (numpy) format."""
+
+    @abstractmethod
+    def get(
+        self,
+        indices=None,
+        *,
+        neg_index_as_lookback: bool = False,
+        fill=None,
+        one_hot_discrete: bool = False,
+        _ignore_last_ts: bool = False,
+        _add_last_ts_value=None,
+    ) -> Any:
+        """Returns data, based on the given args, from this buffer."""
+
+    @abstractmethod
+    def set(
+        self,
+        new_data,
+        *,
+        at_indices=None,
+        neg_index_as_lookback: bool = False,
+    ) -> None:
+        """Overwrites all or some of the data in this buffer."""
+
+    @abstractmethod
+    def __len__(self) -> int:
+        """Return the length of our data, excluding the lookback buffer."""
+
+    @abstractmethod
+    def __getitem__(self, item):
+        """Support squared bracket syntax, e.g. buffer[:5]."""
+
+    @abstractmethod
+    def __setitem__(self, key, value):
+        """Support squared bracket assignment, e.g. buffer[0] = x."""
+
+    @abstractmethod
+    def __repr__(self) -> str:
+        ...
+
+    @abstractmethod
+    def __add__(self, other):
+        ...
+
+    @abstractmethod
+    def __eq__(self, other) -> bool:
+        ...
+
+    @abstractmethod
+    def len_incl_lookback(self) -> int:
+        """Return the total data length including the lookback buffer."""
+
+    @abstractmethod
+    def get_state(self) -> Dict[str, Any]:
+        """Returns the pickable state of this buffer."""
+
+    @classmethod
+    @abstractmethod
+    def from_state(cls, state: Dict[str, Any]) -> "BaseLookbackBuffer":
+        """Creates a new buffer instance from a state dict."""

--- a/rllib/env/utils/pre_allocated_lookback_buffer.py
+++ b/rllib/env/utils/pre_allocated_lookback_buffer.py
@@ -1,0 +1,718 @@
+"""Pre-allocated lookback buffer for efficient episode finalization.
+
+``InfiniteLookbackBuffer.finalize()`` converts an internal Python list to a
+batched numpy struct via ``batch()``, which is O(n) and allocates a second
+full copy of the data.  ``PreAllocatedLookbackBuffer`` allocates numpy arrays
+up-front and writes samples directly into them.  ``finalize()`` then becomes a
+near-free trim of the excess capacity.
+"""
+from typing import Any, Dict, List, Optional
+
+import gymnasium as gym
+import numpy as np
+import tree  # pip install dm_tree
+from gymnasium.spaces import Graph, OneOf, Sequence, Text
+from gymnasium.utils.env_checker import data_equivalence
+
+from ray.rllib.env.utils.lookback_buffer_base import BaseLookbackBuffer
+from ray.rllib.env.utils.space_utils import (
+    create_mutable_array,
+    read_from_buffer,
+    write_to_buffer,
+)
+from ray.rllib.utils.numpy import LARGE_INTEGER, one_hot, one_hot_multidiscrete
+from ray.rllib.utils.serialization import gym_space_from_dict, gym_space_to_dict
+from ray.rllib.utils.spaces.space_utils import (
+    batch,
+    get_base_struct_from_space,
+    get_dummy_batch_for_space,
+)
+from ray.util.annotations import DeveloperAPI
+
+# Space types whose buffers are Python lists rather than numpy arrays.
+_LIST_SPACES = (Graph, Text, Sequence, OneOf)
+
+
+@DeveloperAPI
+class PreAllocatedLookbackBuffer(BaseLookbackBuffer):
+    """A lookback buffer that pre-allocates numpy arrays for O(1) finalize().
+
+    Unlike :class:`InfiniteLookbackBuffer`, which collects samples in a Python
+    list and batch-converts them on ``finalize()``, this buffer allocates a
+    numpy array up-front and writes samples directly into it.  ``finalize()``
+    trims excess capacity rather than performing a full ``batch()`` conversion.
+
+    Requires a ``gym.Space`` at construction time.  If no space is available,
+    fall back to :class:`InfiniteLookbackBuffer`.
+
+    Args:
+        data: Optional initial data as a Python list of samples.
+        lookback: Number of initial items to treat as lookback buffer.
+        space: The gymnasium observation space.  **Required.**
+        initial_capacity: Number of rows to pre-allocate in each leaf array.
+    """
+
+    def __init__(
+        self,
+        data: Optional[List] = None,
+        lookback: int = 0,
+        space: Optional[gym.Space] = None,
+        initial_capacity: int = 40,
+    ):
+        if space is None:
+            raise ValueError(
+                "PreAllocatedLookbackBuffer requires `space` to be provided. "
+                "If space is not available use InfiniteLookbackBuffer instead."
+            )
+
+        # Initialise space property (sets _space and _space_struct).
+        self._space: Optional[gym.Space] = None
+        self._space_struct = None
+        self.space = space
+
+        # Always in batch (numpy) format.
+        self.finalized = False
+        # True while we can write into pre-allocated slots.
+        self._growing = True
+
+        if data is not None and len(data) > 0:
+            n = len(data)
+            self._capacity = max(initial_capacity, n * 2)
+            self._length = n
+            self.lookback = min(lookback, n)
+            self.data = create_mutable_array(space, n=self._capacity)
+            # `data` may be a Python list of individual samples (from the episode
+            # constructor) or an already-batched struct-of-arrays (from another
+            # buffer's .get() call, e.g. in _slice()).  Only call batch() for lists.
+            batched = batch(data) if isinstance(data, list) else data
+            write_to_buffer(space, self.data, slice(0, n), batched)
+        else:
+            self._capacity = initial_capacity
+            self._length = 0
+            self.lookback = 0
+            self.data = create_mutable_array(space, n=self._capacity)
+
+    # ------------------------------------------------------------------
+    # Space property
+    # ------------------------------------------------------------------
+
+    @property
+    def space(self) -> Optional[gym.Space]:
+        return self._space
+
+    @space.setter
+    def space(self, value: Optional[gym.Space]) -> None:
+        self._space = value
+        self._space_struct = get_base_struct_from_space(value)
+
+    @property
+    def space_struct(self):
+        return self._space_struct
+
+    # ------------------------------------------------------------------
+    # Length / capacity
+    # ------------------------------------------------------------------
+
+    def len_incl_lookback(self) -> int:
+        """Return valid data length (incl. lookback), NOT allocated capacity."""
+        return self._length
+
+    def __len__(self) -> int:
+        """Return the length of our data, excluding the lookback buffer."""
+        return max(self._length - self.lookback, 0)
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def append(self, item) -> None:
+        """Appends *item* to the buffer.
+
+        While growing: writes directly into the next pre-allocated slot.
+        After ``finalize()`` (sealed mode): falls back to ``np.concatenate``
+        — this path is rare (replay-buffer merge) and acceptable.
+        """
+        if not self._growing:
+            # Sealed: concatenate (rare post-finalize merge path).
+            self.data = tree.map_structure(
+                lambda d, i: np.concatenate([d, np.array([i])], axis=0),
+                self.data,
+                item,
+            )
+            self._length += 1
+            self._capacity += 1
+            return
+
+        if self._length >= self._capacity:
+            self._grow()
+
+        write_to_buffer(self.space, self.data, self._length, item)
+        self._length += 1
+
+    def extend(self, items) -> None:
+        """Appends all items in *items* to the end of this buffer."""
+        for item in items:
+            self.append(item)
+
+    def concat(self, other: "BaseLookbackBuffer") -> None:
+        """Concatenates the data of *other* (w/o its lookback) to self."""
+        self.extend(other.get())
+
+    def pop(self, index: int = -1) -> None:
+        """Removes the item at *index* from this buffer (does NOT return it).
+
+        Matches finalized ``InfiniteLookbackBuffer`` semantics: *index* is a
+        direct array index (negative means from end of valid data).
+        """
+        abs_idx = self._length + index if index < 0 else index
+        if abs_idx < 0 or abs_idx >= self._length:
+            raise IndexError(
+                f"pop index {index} is out of range for buffer length "
+                f"{self._length}."
+            )
+        # Shift elements [abs_idx+1 .. _length-1] one position to the left.
+        if abs_idx < self._length - 1:
+            tail = read_from_buffer(
+                self.space, self.data, slice(abs_idx + 1, self._length)
+            )
+            write_to_buffer(
+                self.space, self.data, slice(abs_idx, self._length - 1), tail
+            )
+        self._length -= 1
+
+    def finalize(self) -> None:
+        """Trim excess capacity so the buffer contains exactly valid rows.
+
+        After ``finalize()``, ``_growing=False`` and ``_capacity==_length``.
+        Subsequent ``append()`` calls fall back to ``np.concatenate`` (the
+        rare post-finalize merge path).
+        """
+        self.finalized = True
+        if self._growing:
+            if self._capacity > self._length:
+                trimmed = create_mutable_array(self.space, n=self._length)
+                if self._length > 0:
+                    write_to_buffer(
+                        self.space,
+                        trimmed,
+                        slice(0, self._length),
+                        read_from_buffer(self.space, self.data, slice(0, self._length)),
+                    )
+                self.data = trimmed
+                self._capacity = self._length
+            self._growing = False
+
+    def _grow(self) -> None:
+        """Double the allocated capacity and migrate existing valid data."""
+        new_capacity = max(self._capacity * 2, 1)
+        new_data = create_mutable_array(self.space, n=new_capacity)
+        if self._length > 0:
+            write_to_buffer(
+                self.space,
+                new_data,
+                slice(0, self._length),
+                read_from_buffer(self.space, self.data, slice(0, self._length)),
+            )
+        self.data = new_data
+        self._capacity = new_capacity
+
+    # ------------------------------------------------------------------
+    # Data view helper
+    # ------------------------------------------------------------------
+
+    def _get_base_data(self):
+        """Return data trimmed to the *_length* valid rows.
+
+        For numpy-leaf spaces this returns numpy *views* (no copy).  For
+        list-based spaces (Graph / Text / Sequence / OneOf) it returns a
+        shallow list slice.
+
+        When ``_growing=False`` and ``_capacity==_length`` (the normal sealed
+        state), we return ``self.data`` directly with no overhead.  The extra
+        ``_capacity > _length`` guard also handles the edge case where
+        ``pop()`` is called in sealed mode, leaving a single orphaned slot
+        at the end of the backing array.
+        """
+        if self._capacity > self._length:
+            if isinstance(self.space, _LIST_SPACES):
+                # self.data is a flat Python list; plain slice avoids dm-tree
+                # descending into list elements.
+                return self.data[: self._length]
+            return tree.map_structure(lambda s: s[: self._length], self.data)
+        return self.data
+
+    # ------------------------------------------------------------------
+    # get / set  (mirrors InfiniteLookbackBuffer finalized=True branches)
+    # ------------------------------------------------------------------
+
+    def get(
+        self,
+        indices=None,
+        *,
+        neg_index_as_lookback: bool = False,
+        fill=None,
+        one_hot_discrete: bool = False,
+        _ignore_last_ts: bool = False,
+        _add_last_ts_value=None,
+    ) -> Any:
+        """Returns data from this buffer.  Identical API to
+        :meth:`InfiniteLookbackBuffer.get`.
+        """
+        if indices is None:
+            data = self._get_all_data(
+                one_hot_discrete=one_hot_discrete,
+                _ignore_last_ts=_ignore_last_ts,
+            )
+        elif isinstance(indices, slice):
+            data = self._get_slice(
+                indices,
+                fill=fill,
+                neg_index_as_lookback=neg_index_as_lookback,
+                one_hot_discrete=one_hot_discrete,
+                _ignore_last_ts=_ignore_last_ts,
+                _add_last_ts_value=_add_last_ts_value,
+            )
+        elif isinstance(indices, list):
+            data = [
+                self._get_int_index(
+                    idx,
+                    fill=fill,
+                    neg_index_as_lookback=neg_index_as_lookback,
+                    one_hot_discrete=one_hot_discrete,
+                    _ignore_last_ts=_ignore_last_ts,
+                    _add_last_ts_value=_add_last_ts_value,
+                )
+                for idx in indices
+            ]
+            data = batch(data)
+        else:
+            assert isinstance(indices, int)
+            data = self._get_int_index(
+                indices,
+                fill=fill,
+                neg_index_as_lookback=neg_index_as_lookback,
+                one_hot_discrete=one_hot_discrete,
+                _ignore_last_ts=_ignore_last_ts,
+                _add_last_ts_value=_add_last_ts_value,
+            )
+        return data
+
+    def set(
+        self,
+        new_data,
+        *,
+        at_indices=None,
+        neg_index_as_lookback: bool = False,
+    ) -> None:
+        """Overwrites data in this buffer.  Identical API to
+        :meth:`InfiniteLookbackBuffer.set`.
+        """
+        if at_indices is None:
+            self._set_all_data(new_data)
+        elif isinstance(at_indices, slice):
+            self._set_slice(
+                new_data,
+                slice_=at_indices,
+                neg_index_as_lookback=neg_index_as_lookback,
+            )
+        elif isinstance(at_indices, list):
+            for i, idx in enumerate(at_indices):
+                self._set_int_index(
+                    new_data[i], idx=idx, neg_index_as_lookback=neg_index_as_lookback
+                )
+        else:
+            assert isinstance(at_indices, int)
+            self._set_int_index(
+                new_data, idx=at_indices, neg_index_as_lookback=neg_index_as_lookback
+            )
+
+    def __getitem__(self, item):
+        return self.get(item)
+
+    def __setitem__(self, key, value):
+        self.set(new_data=value, at_indices=key)
+
+    def __add__(self, other):
+        raise RuntimeError(
+            f"Cannot `add` to a {type(self).__name__}.  "
+            "Use append() / extend() / concat() instead."
+        )
+
+    def __eq__(self, other: "PreAllocatedLookbackBuffer") -> bool:
+        return (
+            isinstance(other, PreAllocatedLookbackBuffer)
+            and data_equivalence(self._get_base_data(), other._get_base_data())
+            and self.lookback == other.lookback
+            and self.finalized == other.finalized
+            and self.space_struct == other.space_struct
+            and self.space == other.space
+        )
+
+    def __repr__(self) -> str:
+        bd = self._get_base_data()
+        try:
+            lb_part = bd[: self.lookback]
+            rest_part = bd[self.lookback :]
+        except Exception:
+            lb_part = rest_part = "?"
+        return (
+            f"{type(self).__name__}({lb_part} <- "
+            f"lookback({self.lookback}) | {rest_part})"
+        )
+
+    # ------------------------------------------------------------------
+    # State serialization
+    # ------------------------------------------------------------------
+
+    def get_state(self) -> Dict[str, Any]:
+        """Returns the pickable state.  Serialises only valid *_length* rows
+        so unused capacity is not included in the snapshot.
+        """
+        if self._length > 0:
+            serialised_data = read_from_buffer(
+                self.space, self.data, slice(0, self._length)
+            )
+        else:
+            serialised_data = None
+        return {
+            "data": serialised_data,
+            "lookback": self.lookback,
+            "space": gym_space_to_dict(self.space) if self.space else None,
+            "_length": self._length,
+            "_growing": self._growing,
+        }
+
+    @classmethod
+    def from_state(cls, state: Dict[str, Any]) -> "PreAllocatedLookbackBuffer":
+        """Creates a new :class:`PreAllocatedLookbackBuffer` from a state dict.
+
+        Args:
+            state: The state dict, as returned by :meth:`get_state`.
+
+        Returns:
+            A new ``PreAllocatedLookbackBuffer`` with the data and metadata
+            from the state dict.  The restored buffer starts in sealed mode
+            (``_growing=False``) because a deserialized episode is complete.
+        """
+        space = gym_space_from_dict(state["space"]) if state["space"] else None
+        n = state.get("_length", 0)
+
+        buf = cls.__new__(cls)
+        buf._space = None
+        buf._space_struct = None
+        buf.space = space
+        buf.finalized = True
+        buf._growing = False  # deserialized episodes are sealed
+        buf._length = n
+        buf._capacity = n
+        buf.lookback = state["lookback"]
+
+        if n > 0 and state.get("data") is not None:
+            buf.data = state["data"]  # already a struct-of-arrays
+        else:
+            buf.data = create_mutable_array(space, n=0) if space is not None else None
+
+        return buf
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_all_data(self, one_hot_discrete=False, _ignore_last_ts=False):
+        data = self[: (None if not _ignore_last_ts else -1)]
+        if one_hot_discrete:
+            data = self._one_hot(data, space_struct=self.space_struct)
+        return data
+
+    def _set_all_data(self, new_data):
+        self._set_slice(new_data, slice(0, None))
+
+    def _get_slice(
+        self,
+        slice_,
+        fill=None,
+        neg_index_as_lookback=False,
+        one_hot_discrete=False,
+        _ignore_last_ts=False,
+        _add_last_ts_value=None,
+    ):
+        # _get_base_data() returns views trimmed to _length, which is
+        # essential for the _add_last_ts_value path: np.append must append
+        # after the last *valid* element, not after the allocated capacity.
+        base_data = self._get_base_data()
+        data_to_use = base_data
+
+        if _ignore_last_ts:
+            if isinstance(self.space, _LIST_SPACES):
+                data_to_use = base_data[:-1]
+            else:
+                data_to_use = tree.map_structure(lambda s: s[:-1], base_data)
+
+        if _add_last_ts_value is not None:
+            if isinstance(self.space, _LIST_SPACES):
+                data_to_use = data_to_use + [_add_last_ts_value]
+            else:
+                data_to_use = tree.map_structure(
+                    lambda s, t: np.append(s, t), data_to_use, _add_last_ts_value
+                )
+
+        slice_, slice_len, fill_left_count, fill_right_count = self._interpret_slice(
+            slice_,
+            neg_index_as_lookback,
+            len_self_plus_lookback=(
+                self.len_incl_lookback()
+                + int(_add_last_ts_value is not None)
+                - int(_ignore_last_ts)
+            ),
+        )
+
+        data_slice = None
+        if slice_len > 0:
+            if isinstance(self.space, _LIST_SPACES):
+                data_slice = data_to_use[slice_]
+            else:
+                data_slice = tree.map_structure(lambda s: s[slice_], data_to_use)
+            if one_hot_discrete:
+                data_slice = self._one_hot(data_slice, space_struct=self.space_struct)
+
+        if fill is not None and (fill_right_count > 0 or fill_left_count > 0):
+            if fill_left_count:
+                if self.space is None:
+                    fill_batch = np.array([fill] * fill_left_count)
+                else:
+                    fill_batch = get_dummy_batch_for_space(
+                        self.space,
+                        fill_value=fill,
+                        batch_size=fill_left_count,
+                        one_hot_discrete=one_hot_discrete,
+                    )
+                if data_slice is not None:
+                    data_slice = tree.map_structure(
+                        lambda s0, s: np.concatenate([s0, s]),
+                        fill_batch,
+                        data_slice,
+                    )
+                else:
+                    data_slice = fill_batch
+            if fill_right_count:
+                if self.space is None:
+                    fill_batch = np.array([fill] * fill_right_count)
+                else:
+                    fill_batch = get_dummy_batch_for_space(
+                        self.space,
+                        fill_value=fill,
+                        batch_size=fill_right_count,
+                        one_hot_discrete=one_hot_discrete,
+                    )
+                if data_slice is not None:
+                    data_slice = tree.map_structure(
+                        lambda s0, s: np.concatenate([s, s0]),
+                        fill_batch,
+                        data_slice,
+                    )
+                else:
+                    data_slice = fill_batch
+
+        if data_slice is None:
+            if isinstance(self.space, _LIST_SPACES):
+                return data_to_use[slice_]
+            return tree.map_structure(lambda s: s[slice_], data_to_use)
+        return data_slice
+
+    def _set_slice(
+        self,
+        new_data,
+        slice_,
+        neg_index_as_lookback=False,
+    ):
+        slice_, _, _, _ = self._interpret_slice(slice_, neg_index_as_lookback)
+
+        try:
+            if isinstance(self.space, _LIST_SPACES):
+                assert len(self.data[slice_]) == len(new_data)
+                self.data[slice_] = new_data
+            else:
+
+                def __set(s, n):
+                    if self.space:
+                        assert self.space.contains(n[0])
+                    assert len(s[slice_]) == len(n)
+                    s[slice_] = n
+
+                tree.map_structure(__set, self.data, new_data)
+        except AssertionError:
+            raise IndexError(
+                f"Cannot `set()` value via at_indices={slice_} (option "
+                f"neg_index_as_lookback={neg_index_as_lookback})! Slice of data "
+                "does NOT have the same size as `new_data`."
+            )
+
+    def _get_int_index(
+        self,
+        idx: int,
+        fill=None,
+        neg_index_as_lookback=False,
+        one_hot_discrete=False,
+        _ignore_last_ts=False,
+        _add_last_ts_value=None,
+    ):
+        # Same _get_base_data() fix: avoids reading uninitialized capacity rows.
+        base_data = self._get_base_data()
+        data_to_use = base_data
+
+        if _ignore_last_ts:
+            if isinstance(self.space, _LIST_SPACES):
+                data_to_use = base_data[:-1]
+            else:
+                data_to_use = tree.map_structure(lambda s: s[:-1], base_data)
+
+        if _add_last_ts_value is not None:
+            if isinstance(self.space, _LIST_SPACES):
+                data_to_use = data_to_use + [_add_last_ts_value]
+            else:
+                data_to_use = tree.map_structure(
+                    lambda s, last: np.append(s, last), data_to_use, _add_last_ts_value
+                )
+
+        if idx >= 0 or neg_index_as_lookback:
+            idx = self.lookback + idx
+        if neg_index_as_lookback and idx < 0:
+            idx = len(self) + self.lookback - (_ignore_last_ts is True)
+
+        try:
+            if isinstance(self.space, _LIST_SPACES):
+                data = data_to_use[idx]
+            else:
+                data = tree.map_structure(lambda s: s[idx], data_to_use)
+        except IndexError as e:
+            if fill is not None:
+                if self.space is None:
+                    return fill
+                return get_dummy_batch_for_space(
+                    self.space,
+                    fill_value=fill,
+                    batch_size=0,
+                    one_hot_discrete=one_hot_discrete,
+                )
+            else:
+                raise e from ValueError(
+                    f"Trying to get index {idx} from buffer of length {self._length}"
+                )
+
+        if one_hot_discrete:
+            data = self._one_hot(data, self.space_struct)
+        return data
+
+    def _set_int_index(self, new_data, idx, neg_index_as_lookback):
+        actual_idx = idx
+        if actual_idx >= 0 or neg_index_as_lookback:
+            actual_idx = self.lookback + actual_idx
+        elif actual_idx < 0:
+            # Negative index (not lookback): resolve against valid data length so
+            # that e.g. -1 refers to the last *filled* element, not the last
+            # element of the (potentially over-allocated) backing array.
+            actual_idx = self._length + actual_idx
+        if neg_index_as_lookback and actual_idx < 0:
+            actual_idx = len(self) + self.lookback
+
+        try:
+            if isinstance(self.space, _LIST_SPACES):
+                self.data[actual_idx] = new_data
+            else:
+
+                def __set(s, n):
+                    if self.space:
+                        assert self.space.contains(n), n
+                    s[actual_idx] = n
+
+                tree.map_structure(__set, self.data, new_data)
+        except IndexError:
+            raise IndexError(
+                f"Cannot `set()` value at index {idx} (option "
+                f"neg_index_as_lookback={neg_index_as_lookback})! Out of range "
+                f"of buffer data."
+            )
+
+    def _interpret_slice(
+        self,
+        slice_,
+        neg_index_as_lookback,
+        len_self_plus_lookback=None,
+    ):
+        """Identical to InfiniteLookbackBuffer._interpret_slice."""
+        if len_self_plus_lookback is None:
+            len_self_plus_lookback = len(self) + self.lookback
+
+        start = slice_.start
+        stop = slice_.stop
+
+        if start is None:
+            start = self.lookback
+        elif start < 0:
+            if neg_index_as_lookback:
+                start = self.lookback + start
+            else:
+                start = len_self_plus_lookback + start
+        else:
+            start = self.lookback + start
+
+        if stop is None:
+            stop = len_self_plus_lookback
+        elif stop < 0:
+            if neg_index_as_lookback:
+                stop = self.lookback + stop
+            else:
+                stop = len_self_plus_lookback + stop
+        else:
+            stop = self.lookback + stop
+
+        fill_left_count = fill_right_count = 0
+        if start < 0 and stop < 0:
+            fill_left_count = abs(start - stop)
+            fill_right_count = 0
+            start = stop = 0
+        elif start >= len_self_plus_lookback and stop >= len_self_plus_lookback:
+            fill_right_count = abs(start - stop)
+            fill_left_count = 0
+            start = stop = len_self_plus_lookback
+        elif start < 0:
+            fill_left_count = -start
+            start = 0
+        elif stop >= len_self_plus_lookback:
+            fill_right_count = stop - len_self_plus_lookback
+            stop = len_self_plus_lookback
+        elif stop < 0:
+            if start >= len_self_plus_lookback:
+                fill_left_count = start - len_self_plus_lookback + 1
+                start = len_self_plus_lookback - 1
+            fill_right_count = -stop - 1
+            stop = -LARGE_INTEGER
+
+        assert start >= 0 and (stop >= 0 or stop == -LARGE_INTEGER), (start, stop)
+
+        step = slice_.step if slice_.step is not None else 1
+        slice_ = slice(start, stop, step)
+        slice_len = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
+        return slice_, slice_len, fill_left_count, fill_right_count
+
+    def _one_hot(self, data, space_struct):
+        if space_struct is None:
+            raise ValueError(
+                f"Cannot `one_hot` data in `{type(self).__name__}` if a "
+                "gym.Space was NOT provided during construction!"
+            )
+
+        def _convert(dat_, space):
+            if isinstance(space, gym.spaces.Discrete):
+                return one_hot(dat_, depth=space.n)
+            elif isinstance(space, gym.spaces.MultiDiscrete):
+                return one_hot_multidiscrete(dat_, depths=space.nvec)
+            return dat_
+
+        if isinstance(data, list):
+            data = [
+                tree.map_structure(_convert, dslice, space_struct) for dslice in data
+            ]
+        else:
+            data = tree.map_structure(_convert, data, space_struct)
+        return data

--- a/rllib/env/utils/space_utils.py
+++ b/rllib/env/utils/space_utils.py
@@ -1,0 +1,196 @@
+from functools import singledispatch
+from typing import Any
+
+import numpy as np
+from gymnasium.spaces import (
+    Box,
+    Dict,
+    Discrete,
+    Graph,
+    GraphInstance,
+    MultiBinary,
+    MultiDiscrete,
+    OneOf,
+    Sequence,
+    Space,
+    Text,
+    Tuple,
+)
+
+
+@singledispatch
+def create_mutable_array(
+    space: Space, n: int = 1
+) -> tuple[Any, ...] | dict[str, Any] | np.ndarray:
+    """Create an empty (possibly nested and normally numpy-based) array, used in conjunction with ``concatenate(..., out=array)``.
+
+    In most cases, the array will be contained within the batched space, however, this is not guaranteed.
+
+    Args:
+        space: Observation space of a single environment in the vectorized environment.
+        n: Number of environments in the vectorized environment. If ``None``, creates an empty sample from ``space``.
+
+    Returns:
+        The output object. This object is a (possibly nested) numpy array.
+
+    Raises:
+        ValueError: Space is not a valid :class:`gymnasium.Space` instance
+
+    Example:
+        >>> from gymnasium.spaces import Box, Dict
+        >>> import numpy as np
+        >>> space = Dict({
+        ... 'position': Box(low=0, high=1, shape=(3,), dtype=np.float32),
+        ... 'velocity': Box(low=0, high=1, shape=(2,), dtype=np.float32)})
+        >>> create_mutable_array(space, n=2, fn=np.zeros)
+        {'position': array([[0., 0., 0.],
+               [0., 0., 0.]], dtype=float32), 'velocity': array([[0., 0.],
+               [0., 0.]], dtype=float32)}
+    """
+    raise TypeError(
+        f"The space provided to `create_mutable_array` is not a gymnasium Space instance, type: {type(space)}, {space}"
+    )
+
+
+# It is possible for some of the Box low to be greater than 0, then array is not in space
+@create_mutable_array.register(Box)
+# If the Discrete start > 0 or start + length < 0 then array is not in space
+@create_mutable_array.register(Discrete)
+@create_mutable_array.register(MultiDiscrete)
+@create_mutable_array.register(MultiBinary)
+def _create_mutable_array_multi(space: Box, n: int = 1) -> np.ndarray:
+    return np.zeros((n,) + space.shape, dtype=space.dtype)
+
+
+@create_mutable_array.register(Tuple)
+def _create_mutable_array_tuple(space: Tuple, n: int = 1) -> list[Any]:
+    return [create_mutable_array(subspace, n=n) for subspace in space.spaces]
+
+
+@create_mutable_array.register(Dict)
+def _create_mutable_array_dict(space: Dict, n: int = 1, fn=np.zeros) -> dict[str, Any]:
+    return {key: create_mutable_array(subspace, n=n) for key, subspace in space.items()}
+
+
+@create_mutable_array.register(Graph)
+def _create_mutable_array_graph(space: Graph, n: int = 1) -> list[GraphInstance]:
+    if space.edge_space is not None:
+        return [
+            GraphInstance(
+                nodes=np.zeros(
+                    (1,) + space.node_space.shape, dtype=space.node_space.dtype
+                ),
+                edges=np.zeros(
+                    (1,) + space.edge_space.shape, dtype=space.edge_space.dtype
+                ),
+                edge_links=np.zeros((1, 2), dtype=np.int64),
+            )
+            for _ in range(n)
+        ]
+    else:
+        return [
+            GraphInstance(
+                nodes=np.zeros(
+                    (1,) + space.node_space.shape, dtype=space.node_space.dtype
+                ),
+                edges=None,
+                edge_links=None,
+            )
+            for _ in range(n)
+        ]
+
+
+@create_mutable_array.register(Text)
+def _create_mutable_array_text(space: Text, n: int = 1) -> list[str]:
+    return [space.characters[0] * space.min_length for _ in range(n)]
+
+
+@create_mutable_array.register(Sequence)
+def _create_mutable_array_sequence(space: Sequence, n: int = 1) -> list[Any]:
+    if space.stack:
+        return [create_mutable_array(space.feature_space, n=1) for _ in range(n)]
+    else:
+        return [list() for _ in range(n)]
+
+
+@create_mutable_array.register(OneOf)
+def _create_mutable_array_oneof(space: OneOf, n: int = 1):
+    return [list() for _ in range(n)]
+
+
+@singledispatch
+def write_to_buffer(space: Space, buffer: Any, index: int | slice, sample: Any) -> None:
+    """Write to a mutable buffer in the index position with the sample."""
+    raise NotImplementedError
+
+
+@write_to_buffer.register(Box)
+@write_to_buffer.register(Discrete)
+@write_to_buffer.register(MultiDiscrete)
+@write_to_buffer.register(MultiBinary)
+def _fundamental_write_to_buffer(
+    space: Space, buffer: Any, index: int | slice, sample: Any
+) -> None:
+    buffer[index] = sample
+
+
+@write_to_buffer.register(Tuple)
+def _tuple_write_to_buffer(
+    space: Tuple, buffer: Any, index: int | slice, sample: Any
+) -> None:
+    for subspace, subbuffer, subsample in zip(space, buffer, sample):
+        write_to_buffer(subspace, subbuffer, index, subsample)
+
+
+@write_to_buffer.register(Dict)
+def _dict_write_to_buffer(
+    space: Dict, buffer: Any, index: int | slice, sample: Any
+) -> None:
+    for key in space.keys():
+        write_to_buffer(space[key], buffer[key], index, sample[key])
+
+
+@write_to_buffer.register(Graph)
+@write_to_buffer.register(Text)
+@write_to_buffer.register(Sequence)
+@write_to_buffer.register(OneOf)
+def _list_write_to_buffer(
+    space: Space, buffer: Any, index: int | slice, sample: Any
+) -> None:
+    buffer[index] = sample
+
+
+@singledispatch
+def read_from_buffer(space: Space, buffer: Any, index: int | slice) -> Any:
+    """Read from a mutable buffer in the index position with the sample."""
+    raise NotImplementedError
+
+
+@read_from_buffer.register(Box)
+@read_from_buffer.register(Discrete)
+@read_from_buffer.register(MultiDiscrete)
+@read_from_buffer.register(MultiBinary)
+def _fundamental_read_from_buffer(space: Space, buffer: Any, index: int | slice) -> Any:
+    return buffer[index]
+
+
+@read_from_buffer.register(Tuple)
+def _tuple_read_from_buffer(space: Tuple, buffer: Any, index: int | slice) -> Any:
+    return tuple(
+        read_from_buffer(ss, sb, index) for ss, sb in zip(space.spaces, buffer)
+    )
+
+
+@read_from_buffer.register(Dict)
+def _dict_read_from_buffer(space: Dict, buffer: Any, index: int | slice) -> Any:
+    return {
+        key: read_from_buffer(space[key], buffer[key], index) for key in space.keys()
+    }
+
+
+@read_from_buffer.register(Graph)
+@read_from_buffer.register(Text)
+@read_from_buffer.register(Sequence)
+@read_from_buffer.register(OneOf)
+def _list_read_from_buffer(space: Space, buffer: Any, index: int | slice) -> Any:
+    return buffer[index]


### PR DESCRIPTION
## Description
This PR adds alternative `InfiniteLookbackBuffer` option, `PreAllocatedLookbackBuffer` where the data is a pre-allocated array rather than a list of python object. 
This has the advantage as the buffer's data is already batched for when `finalized` is called. 

Personally, I don't like the implementation currently and want to clean it up but this is for benchmarking the initial performance