### PR TITLE
[ci] Fix Bazel remote cache URL mismatch in Docker builds

### DIFF
--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -43,9 +43,12 @@ BAZEL_CACHE_ARGS=""
 if [[ -z "${BUILDKITE_BAZEL_CACHE_URL:-}" ]]; then
   # Disable remote cache for local builds (no credentials)
   BAZEL_CACHE_ARGS="--remote_cache="
-elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-  # Read-only mode: disable uploads only
-  BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
+else
+  # Override whatever the base image baked into ~/.bazelrc
+  BAZEL_CACHE_ARGS="--remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+  if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+    BAZEL_CACHE_ARGS="$BAZEL_CACHE_ARGS --remote_upload_local_results=false"
+  fi
 fi
 
 BAZEL_RESOURCE_FLAGS=""

--- a/ci/docker/ray-cpp-core.Dockerfile
+++ b/ci/docker/ray-cpp-core.Dockerfile
@@ -45,9 +45,12 @@ BAZEL_CACHE_ARGS=""
 if [[ -z "${BUILDKITE_BAZEL_CACHE_URL:-}" ]]; then
   # Disable remote cache for local builds (no credentials)
   BAZEL_CACHE_ARGS="--remote_cache="
-elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-  # Read-only mode: disable uploads only
-  BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
+else
+  # Override whatever the base image baked into ~/.bazelrc
+  BAZEL_CACHE_ARGS="--remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+  if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+    BAZEL_CACHE_ARGS="$BAZEL_CACHE_ARGS --remote_upload_local_results=false"
+  fi
 fi
 
 bazelisk --output_base=$BAZEL_CACHE build --config=ci \

--- a/ci/docker/ray-java.Dockerfile
+++ b/ci/docker/ray-java.Dockerfile
@@ -37,9 +37,12 @@ BAZEL_CACHE_ARGS=""
 if [[ -z "${BUILDKITE_BAZEL_CACHE_URL:-}" ]]; then
   # Disable remote cache for local builds (no credentials)
   BAZEL_CACHE_ARGS="--remote_cache="
-elif [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
-  # Read-only mode: disable uploads only
-  BAZEL_CACHE_ARGS="--remote_upload_local_results=false"
+else
+  # Override whatever the base image baked into ~/.bazelrc
+  BAZEL_CACHE_ARGS="--remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+  if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
+    BAZEL_CACHE_ARGS="$BAZEL_CACHE_ARGS --remote_upload_local_results=false"
+  fi
 fi
 
 BAZEL_RESOURCE_FLAGS=""


### PR DESCRIPTION
The manylinux base image bakes a --remote_cache URL into ~/.bazelrc at build time.

When a downstream pipeline (e.g. a fork) passes a different URL, this will silently fail to overwrite.

Fix by always explicitly setting --remote_cache from the build arg when provided, overriding whatever the base image has baked in.

Topic: fix-cache-url
Signed-off-by: andrew <andrew@anyscale.com>