### PR TITLE
[Ray Dashboard] Support On Demand Kineto Traces

### DIFF
--- a/python/ray/dashboard/client/src/components/WorkerTable.tsx
+++ b/python/ray/dashboard/client/src/components/WorkerTable.tsx
@@ -128,10 +128,12 @@ const RayletWorkerTable = ({
   workers = [],
   actorMap,
   mini,
+  gpuProfilingEnabled,
 }: {
   workers: Worker[];
   actorMap: { [actorId: string]: ActorDetail };
   mini?: boolean;
+  gpuProfilingEnabled?: boolean;
 }) => {
   const { changeFilter, filterFunc } = useFilter();
   const [key, setKey] = useState("");
@@ -315,6 +317,21 @@ const RayletWorkerTable = ({
                           }}
                         >
                           jstat
+                        </Button>
+                      </div>
+                    ) : language === "PYTHON" &&
+                      gpuProfilingEnabled &&
+                      coreWorkerStats[0]?.ipAddress &&
+                      !cmdline[0]?.includes("IDLE") ? (
+                      <div>
+                        <Button
+                          onClick={() => {
+                            window.open(
+                              `#/cmd/torchtrace/${coreWorkerStats[0]?.ipAddress}/${pid}`,
+                            );
+                          }}
+                        >
+                          Torch Trace
                         </Button>
                       </div>
                     ) : (

--- a/python/ray/dashboard/client/src/pages/cmd/CMDResult.tsx
+++ b/python/ray/dashboard/client/src/pages/cmd/CMDResult.tsx
@@ -1,10 +1,21 @@
-import { Box, Button, Grid, MenuItem, Select } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Grid,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@mui/material";
 import React, { useCallback, useContext, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { GlobalContext } from "../../App";
 import LogVirtualView from "../../components/LogView/LogVirtualView";
 import TitleCard from "../../components/TitleCard";
 import { getJmap, getJstack, getJstat } from "../../service/util";
+
+const PERFETTO_UI_URL = "https://ui.perfetto.dev/";
 
 const CMDResult = () => {
   const { cmd, ip, pid } = useParams() as {
@@ -15,6 +26,9 @@ const CMDResult = () => {
   const [result, setResult] = useState<string>();
   const [option, setOption] = useState("gcutil");
   const { themeMode } = useContext(GlobalContext);
+  const [numIterations, setNumIterations] = useState(4);
+  const [traceLoading, setTraceLoading] = useState(false);
+  const [traceSuccess, setTraceSuccess] = useState(false);
   const executeJstat = useCallback(
     () =>
       getJstat(ip, pid, option)
@@ -28,6 +42,72 @@ const CMDResult = () => {
         .catch((err) => setResult(err.toString())),
     [ip, pid, option],
   );
+
+  const executeTorchTrace = useCallback(async () => {
+    setTraceLoading(true);
+    setTraceSuccess(false);
+    setResult(
+      "Starting Torch trace... This may take a few minutes depending on the number of iterations.\n" +
+        "Server timeout is 5 minutes.",
+    );
+    try {
+      const url = `/worker/gpu_profile?ip=${encodeURIComponent(
+        ip,
+      )}&pid=${encodeURIComponent(pid)}&num_iterations=${numIterations}`;
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `Request failed: ${response.status} ${response.statusText}. ${errorText}`,
+        );
+      }
+
+      const blob = await response.blob();
+      const downloadUrl = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.style.display = "none";
+      a.href = downloadUrl;
+
+      const now = new Date();
+      const dateStr = now.toISOString().replace(/[:.]/g, "-").slice(0, 19);
+      let filename = `gputrace_${dateStr}.json`;
+      const contentDisposition = response.headers.get("content-disposition");
+      if (contentDisposition) {
+        const filenameMatch = contentDisposition.match(/filename="(.+)"/);
+        if (filenameMatch && filenameMatch.length === 2) {
+          filename = filenameMatch[1];
+        }
+      }
+      a.download = filename;
+
+      document.body.appendChild(a);
+      a.click();
+
+      window.URL.revokeObjectURL(downloadUrl);
+      a.remove();
+
+      const timestamp = new Date().toLocaleString();
+      setResult(
+        `Torch trace downloaded successfully!\n\n` +
+          `Captured at: ${timestamp}\n` +
+          `The trace was captured for ${numIterations} training iterations.\n` +
+          `Drag and drop the downloaded file into Perfetto UI to view it.`,
+      );
+      setTraceSuccess(true);
+    } catch (error) {
+      setResult(
+        `Failed to capture Torch trace. Error: ${(error as Error).message}\n\n` +
+          `Please ensure:\n` +
+          `1. KINETO_USE_DAEMON=1 and KINETO_DAEMON_INIT_DELAY_S=5 env vars are set for the worker.\n` +
+          `2. The process is running a PyTorch training script.\n` +
+          `3. The 'dynolog' package is installed on the node.`,
+      );
+      setTraceSuccess(false);
+    } finally {
+      setTraceLoading(false);
+    }
+  }, [ip, pid, numIterations]);
 
   useEffect(() => {
     switch (cmd) {
@@ -55,6 +135,12 @@ const CMDResult = () => {
         break;
       case "jstat":
         executeJstat();
+        break;
+      case "torchtrace":
+        setResult(
+          `Click "Start Trace" to capture a Torch GPU profiling trace.\n\n` +
+            `Configure the number of training iterations (calls to optimizer.step()) to profile, then click Start Trace.`,
+        );
         break;
       default:
         setResult(`Command ${cmd} is not supported.`);
@@ -98,8 +184,58 @@ const CMDResult = () => {
             </Grid>
           </Box>
         )}
+        {cmd === "torchtrace" && (
+          <Box sx={{ padding: 2, marginTop: 2 }}>
+            <Typography variant="body2" sx={{ marginBottom: 2 }}>
+              Capture a PyTorch/Kineto GPU profiling trace using Dynolog.
+            </Typography>
+            <Grid container spacing={2} alignItems="center">
+              <Grid item>
+                <TextField
+                  label="Iterations"
+                  type="number"
+                  size="small"
+                  value={numIterations}
+                  onChange={(e) =>
+                    setNumIterations(
+                      Math.min(100, Math.max(1, parseInt(e.target.value) || 1)),
+                    )
+                  }
+                  inputProps={{ min: 1, max: 100 }}
+                  helperText="Number of optimizer.step() calls to profile"
+                />
+              </Grid>
+              <Grid item>
+                <Button
+                  variant="contained"
+                  onClick={executeTorchTrace}
+                  disabled={traceLoading}
+                  startIcon={traceLoading ? <CircularProgress size={20} /> : null}
+                >
+                  {traceLoading ? "Starting..." : "Start Trace"}
+                </Button>
+              </Grid>
+            </Grid>
+          </Box>
+        )}
       </TitleCard>
       <TitleCard title={`IP: ${ip} / Pid: ${pid}`}>
+        {traceSuccess && cmd === "torchtrace" && (
+          <Box sx={{ mb: 2 }}>
+            <Button
+              variant="contained"
+              color="primary"
+              href={PERFETTO_UI_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Open Perfetto UI
+            </Button>
+            <Typography variant="body2" sx={{ mt: 1, color: "text.secondary" }}>
+              Drag and drop the downloaded trace file into Perfetto to view it.
+            </Typography>
+          </Box>
+        )}
         <LogVirtualView
           content={result || "loading"}
           language="prolog"

--- a/python/ray/dashboard/client/src/pages/node/NodeDetail.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeDetail.tsx
@@ -216,6 +216,7 @@ const NodeDetailPage = () => {
               <RayletWorkerTable
                 workers={nodeDetail?.workers}
                 actorMap={nodeDetail?.actors}
+                gpuProfilingEnabled={nodeDetail?.gpuProfilingEnabled}
               />
             </TableContainer>
           </React.Fragment>

--- a/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
@@ -282,6 +282,18 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
         <CpuStackTraceLink pid={pid} nodeId={nodeId} type="" />
         <br />
         <MemoryProfilingButton pid={pid} nodeId={nodeId} />
+        {node.gpuProfilingEnabled &&
+          worker.language === "PYTHON" &&
+          coreWorker?.ipAddress &&
+          !cmdline[0]?.includes("IDLE") && (
+            <Link
+              component={RouterLink}
+              to={`/cmd/torchtrace/${coreWorker.ipAddress}/${pid}`}
+              target="_blank"
+            >
+              Torch Trace
+            </Link>
+          )}
       </TableCell>
       <TableCell>
         <PercentageBar num={Number(cpu)} total={100}>

--- a/python/ray/dashboard/client/src/type/node.d.ts
+++ b/python/ray/dashboard/client/src/type/node.d.ts
@@ -10,6 +10,7 @@ export type NodeDetail = {
   cpus?: number[]; // Logic CPU Count, Physical CPU Count
   mem?: number[]; // total memory, free memory, memory used ratio
   gpus?: GPUStats[]; // GPU stats fetched from node, 1 entry per GPU
+  gpuProfilingEnabled?: boolean; // Whether GPU/Kineto profiling daemon is running on this node
   bootTime: number; // start time
   loadAvg: number[][]; // recent 1，5，15 minitues system load，load per cpu http://man7.org/linux/man-pages/man3/getloadavg.3.html
   disk: {

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -536,9 +536,11 @@ class ReporterAgent(
 
     async def GpuProfiling(self, request, context):
         pid = request.pid
-        num_iterations = request.num_iterations
+        # Extract optional fields - use None if not set
+        num_iterations = request.num_iterations if request.HasField("num_iterations") else None
+        duration_ms = request.duration_ms if request.HasField("duration_ms") else None
         success, output = await self._gpu_profiling_manager.gpu_profile(
-            pid=pid, num_iterations=num_iterations
+            pid=pid, num_iterations=num_iterations, duration_ms=duration_ms
         )
         return reporter_pb2.GpuProfilingReply(success=success, output=output)
 

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1145,6 +1145,10 @@ class ReporterAgent(
             "disk_io_speed": disk_speed_stats,
             "gpus": gpus,
             "tpus": self._get_tpu_usage(),
+            "gpuProfilingEnabled": (
+                self._gpu_profiling_manager.enabled
+                and self._gpu_profiling_manager.is_monitoring_daemon_running
+            ),
             "network": network_stats,
             "network_speed": network_speed_stats,
             # Deprecated field, should be removed with frontend.

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -590,6 +590,11 @@ class ReportHead(SubprocessModule):
         num_iterations_str = req.query.get("num_iterations")
         duration_ms_str = req.query.get("duration_ms")
 
+        if num_iterations_str and duration_ms_str:
+            return aiohttp.web.HTTPBadRequest(
+                text="Only one of num_iterations or duration_ms can be provided, not both."
+            )
+
         # Build the request based on which parameter is provided
         request_kwargs = {"pid": int(pid)}
         if duration_ms_str:

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -540,8 +540,12 @@ class ReportHead(SubprocessModule):
             req: A request with the following query parameters:
                 pid: Required. The PID of the GPU training worker.
                 ip or node_id: Required. The IP address or hex ID of the node where the GPU training worker is running.
-                num_iterations: Number of training steps for profiling. Defaults to 4
+                num_iterations: Number of training steps for profiling. Defaults to 4.
                     This is the number of calls to the torch Optimizer.step().
+                    Mutually exclusive with duration_ms.
+                duration_ms: Duration in milliseconds for profiling.
+                    Useful for data loader processes without gradient computation.
+                    Mutually exclusive with num_iterations.
 
         Returns:
             A redirect to the log API to download the GPU profiling trace file.
@@ -582,18 +586,30 @@ class ReportHead(SubprocessModule):
         node_id, ip, http_port, grpc_port = addrs
         reporter_stub = self._make_stub(build_address(ip, grpc_port))
 
-        # Profile for num_iterations training steps (calls to optimizer.step())
-        num_iterations = int(req.query.get("num_iterations", 4))
+        # Get profiling mode: either iterations or duration
+        num_iterations_str = req.query.get("num_iterations")
+        duration_ms_str = req.query.get("duration_ms")
 
-        logger.info(
-            f"Sending GPU profiling request to {build_address(ip, grpc_port)}, pid {pid}. "
-            f"Profiling for {num_iterations} training steps."
-        )
+        # Build the request based on which parameter is provided
+        request_kwargs = {"pid": int(pid)}
+        if duration_ms_str:
+            duration_ms = int(duration_ms_str)
+            request_kwargs["duration_ms"] = duration_ms
+            logger.info(
+                f"Sending GPU profiling request to {build_address(ip, grpc_port)}, pid {pid}. "
+                f"Profiling for {duration_ms}ms duration."
+            )
+        else:
+            # Default to iterations mode with 4 iterations
+            num_iterations = int(num_iterations_str) if num_iterations_str else 4
+            request_kwargs["num_iterations"] = num_iterations
+            logger.info(
+                f"Sending GPU profiling request to {build_address(ip, grpc_port)}, pid {pid}. "
+                f"Profiling for {num_iterations} training steps."
+            )
 
         reply = await reporter_stub.GpuProfiling(
-            reporter_pb2.GpuProfilingRequest(
-                pid=int(pid), num_iterations=num_iterations
-            )
+            reporter_pb2.GpuProfilingRequest(**request_kwargs)
         )
 
         if not reply.success:

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
@@ -332,5 +332,141 @@ async def test_gpu_profile_success(
     assert output == str(dumped_trace_filepath.relative_to(tmp_path))
 
 
+def test_dynolog_available(tmp_path, mock_node_has_gpus, mock_dynolog_binaries):
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    assert gpu_profiler.dynolog_available
+
+
+def test_dynolog_not_available(tmp_path, mock_node_has_gpus):
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    assert not gpu_profiler.dynolog_available
+
+
+@pytest.mark.asyncio
+async def test_gpu_profile_no_params(
+    tmp_path, mock_node_has_gpus, mock_dynolog_binaries
+):
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    success, output = await gpu_profiler.gpu_profile(pid=123)
+    assert not success
+    assert "Either num_iterations or duration_ms must be provided" in output
+
+
+@pytest.mark.asyncio
+async def test_gpu_profile_both_params(
+    tmp_path, mock_node_has_gpus, mock_dynolog_binaries
+):
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    success, output = await gpu_profiler.gpu_profile(
+        pid=123, num_iterations=4, duration_ms=5000
+    )
+    assert not success
+    assert "Only one of num_iterations or duration_ms can be provided" in output
+
+
+@pytest.mark.asyncio
+async def test_gpu_profile_invalid_num_iterations(
+    tmp_path,
+    mock_node_has_gpus,
+    mock_dynolog_binaries,
+    mock_subprocess_popen,
+):
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    gpu_profiler.start_monitoring_daemon()
+
+    _, mocked_proc = mock_subprocess_popen
+    mocked_proc.pid = 123
+    mocked_proc.poll.return_value = None
+
+    success, output = await gpu_profiler.gpu_profile(pid=456, num_iterations=0)
+    assert not success
+    assert "Invalid num_iterations=0" in output
+
+    success, output = await gpu_profiler.gpu_profile(pid=456, num_iterations=101)
+    assert not success
+    assert "Invalid num_iterations=101" in output
+
+
+@pytest.mark.asyncio
+async def test_gpu_profile_invalid_duration_ms(
+    tmp_path,
+    mock_node_has_gpus,
+    mock_dynolog_binaries,
+    mock_subprocess_popen,
+):
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    gpu_profiler.start_monitoring_daemon()
+
+    _, mocked_proc = mock_subprocess_popen
+    mocked_proc.pid = 123
+    mocked_proc.poll.return_value = None
+
+    success, output = await gpu_profiler.gpu_profile(pid=456, duration_ms=0)
+    assert not success
+    assert "Invalid duration_ms=0" in output
+
+    success, output = await gpu_profiler.gpu_profile(pid=456, duration_ms=300_001)
+    assert not success
+    assert "Invalid duration_ms=300001" in output
+
+
+@pytest.mark.asyncio
+async def test_gpu_profile_success_with_duration_ms(
+    tmp_path,
+    monkeypatch,
+    mock_node_has_gpus,
+    mock_dynolog_binaries,
+    mock_subprocess_popen,
+    mock_asyncio_create_subprocess_exec,
+):
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    gpu_profiler.start_monitoring_daemon()
+
+    # Mock the daemon process
+    _, mocked_daemon_proc = mock_subprocess_popen
+    mocked_daemon_proc.pid = 123
+    mocked_daemon_proc.poll.return_value = None
+
+    monkeypatch.setattr(GpuProfilingManager, "is_pid_alive", lambda cls, pid: True)
+    monkeypatch.setattr(
+        GpuProfilingManager, "_get_trace_filename", lambda cls: "dummy_trace.json"
+    )
+    dumped_trace_filepath = gpu_profiler._profile_dir_path / "dummy_trace.json"
+    dumped_trace_filepath.touch()
+
+    # Mock the asyncio.create_subprocess_exec
+    (
+        mocked_create_subprocess_exec,
+        mocked_async_proc,
+    ) = mock_asyncio_create_subprocess_exec
+    process_pid = 456
+    duration_ms = 10000
+    success, output = await gpu_profiler.gpu_profile(
+        pid=process_pid, duration_ms=duration_ms
+    )
+
+    # Verify the command was launched correctly
+    assert mocked_create_subprocess_exec.call_count == 1
+    profile_launch_args = list(mocked_create_subprocess_exec.call_args[0])
+    assert profile_launch_args[:6] == [
+        "/usr/bin/fake_dyno",
+        "--port",
+        str(gpu_profiler._DYNOLOG_PORT),
+        "gputrace",
+        "--pids",
+        str(process_pid),
+    ]
+
+    # Should use --duration-ms instead of --iterations
+    assert "--duration-ms" in profile_launch_args
+    assert profile_launch_args[profile_launch_args.index("--duration-ms") + 1] == str(
+        duration_ms
+    )
+    assert "--iterations" not in profile_launch_args
+
+    assert success
+    assert output == str(dumped_trace_filepath.relative_to(tmp_path))
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
@@ -349,7 +349,7 @@ async def test_gpu_profile_no_params(
     gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     success, output = await gpu_profiler.gpu_profile(pid=123)
     assert not success
-    assert "Either num_iterations or duration_ms must be provided" in output
+    assert "Exactly one of num_iterations or duration_ms must be provided" in output
 
 
 @pytest.mark.asyncio
@@ -361,7 +361,7 @@ async def test_gpu_profile_both_params(
         pid=123, num_iterations=4, duration_ms=5000
     )
     assert not success
-    assert "Only one of num_iterations or duration_ms can be provided" in output
+    assert "Exactly one of num_iterations or duration_ms must be provided" in output
 
 
 @pytest.mark.asyncio

--- a/src/ray/protobuf/reporter.proto
+++ b/src/ray/protobuf/reporter.proto
@@ -46,6 +46,7 @@ message CpuProfilingReply {
 message GpuProfilingRequest {
   uint32 pid = 1;
   optional uint32 num_iterations = 2;
+  optional uint32 duration_ms = 3;  // Duration in milliseconds (alternative to iterations)
 }
 
 message GpuProfilingReply {


### PR DESCRIPTION
## Description
Currently, the Ray Dashboard has no way to capture on Demand GPU profiling traces for PyTorch workers.
                                                            
This PR adds GPU profiling support to the Ray Dashboard using [dynolog](https://github.com/facebookincubator/dynolog), allowing users to capture On Demand PyTorch Kineto GPU traces directly from the worker detail page. It supports two profiling modes:

  1. **Iteration-based**: Profiles a specified number of `optimizer.step()` calls. Best for training loops.
  2. **Duration-based**: Profiles for a specified time window. Best for data loader processes or workloads without gradient computation.

 ## Changes

  **Backend:**
  - Add `GpuProfilingManager` support for duration-based profiling via `--duration-ms` flag
  - Add `dynolog_available` property to decouple daemon availability from GPU presence
  - Add `gpuProfilingEnabled` field to node stats so the frontend knows when profiling is available
  - Add `duration_ms` field to `GpuProfilingRequest` protobuf
  - Update `/worker/gpu_profile` endpoint to accept either `num_iterations` or `duration_ms`
  - Input validation for both parameters (iterations: 1-100, duration: 1-300000ms)

  **Frontend:**
  - Add "Torch Trace" link on worker table rows (visible when Kineto daemon is running, worker is Python, and not IDLE)
  - Add trace capture UI with configurable iterations, auto-download of `.json` trace file, and link to Perfetto UI
  - Add profiling mode toggle (Iterations/Duration)

  **Dependencies:**
  - Requires [`dynolog`](https://github.com/facebookincubator/dynolog) installed on worker nodes
  - Workers must set `KINETO_USE_DAEMON=1` and `KINETO_DAEMON_INIT_DELAY_S=5` env vars