### PR TITLE
[2/n][serve] Use fallback server in haproxy

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -18,6 +18,7 @@ from ray.serve._private.common import (
     NodeId,
     ReplicaID,
     RequestMetadata,
+    RequestProtocol,
 )
 from ray.serve._private.constants import (
     DRAINING_MESSAGE,
@@ -248,6 +249,9 @@ class BackendConfig:
     # List of servers in this backend
     servers: List[ServerConfig] = field(default_factory=list)
 
+    # The fallback server for this backend.
+    fallback_server: Optional[ServerConfig] = None
+
     # The app name for this backend.
     app_name: str = field(default_factory=str)
 
@@ -318,7 +322,7 @@ class BackendConfig:
         }
 
     def __str__(self) -> str:
-        return f"BackendConfig(app_name='{self.app_name}', name='{self.name}', path_prefix='{self.path_prefix}', servers={self.servers})"
+        return f"BackendConfig(app_name='{self.app_name}', name='{self.name}', path_prefix='{self.path_prefix}', servers={self.servers}, fallback_server={self.fallback_server})"
 
     def __repr__(self) -> str:
         return str(self)
@@ -487,7 +491,6 @@ class HAProxyApi(ProxyApi):
     ):
         self.cfg = cfg
         self.backend_configs = backend_configs or {}
-        self.fallback_server = None
         self.config_file_path = config_file_path
         # Lock to prevent concurrent config modifications
         self._config_lock = asyncio.Lock()
@@ -665,7 +668,6 @@ class HAProxyApi(ProxyApi):
                 {
                     "config": self.cfg,
                     "backends": backends,
-                    "fallback_server": self.fallback_server,
                     "backends_with_health_config": backends_with_health_config,
                     "healthz_rules": healthz_rules,
                     "route_info": health_route_info,
@@ -909,12 +911,6 @@ class HAProxyApi(ProxyApi):
             len(bc.servers) > 0 for bc in backend_configs.values()
         )
 
-    def set_fallback_server(
-        self,
-        fallback_server: Optional[ServerConfig],
-    ) -> None:
-        self.fallback_server = fallback_server
-
     async def is_running(self) -> bool:
         try:
             await self._send_socket_command("show info")
@@ -956,7 +952,10 @@ class HAProxyManager(ProxyActorInterface):
         self.event_loop = get_or_create_event_loop()
 
         self._target_groups: List[TargetGroup] = []
-        self._fallback_target: Optional[Target] = None
+
+        # Fallback targets.
+        self._http_fallback_target: Optional[Target] = None
+        self._grpc_fallback_target: Optional[Target] = None
 
         # Lock to serialize HAProxy reloads and prevent concurrent reload operations
         # which can cause race conditions with SO_REUSEPORT
@@ -967,6 +966,7 @@ class HAProxyManager(ProxyActorInterface):
             {
                 LongPollNamespace.GLOBAL_LOGGING_CONFIG: self._update_logging_config,
                 LongPollNamespace.TARGET_GROUPS: self.update_target_groups,
+                LongPollNamespace.FALLBACK_TARGETS: self.update_fallback_targets,
             },
             call_in_event_loop=self.event_loop,
         )
@@ -1142,22 +1142,29 @@ class HAProxyManager(ProxyActorInterface):
             port=target.port,
         )
 
-    def _target_group_to_backend(self, target_group: TargetGroup) -> BackendConfig:
-        """Convert a target group to a backend name."""
-        servers = [
-            self._target_to_server(target)
-            for target in target_group.targets
-        ]
-        # The name is lowercased and formatted as <protocol>-<app_name>. Special
-        # characters in the name are converted to comply with haproxy config's
-        # allowed characters, e.g. `#` -> `-`.
+    def _create_backend_config(
+        self,
+        target_group: TargetGroup,
+        fallback_target: Optional[Target],
+    ) -> BackendConfig:
+        """Create a backend configuration from a target group and fallback target."""
+        servers = [self._target_to_server(target) for target in target_group.targets]
+
+        fallback_server = None
+        if fallback_target is not None:
+            fallback_server = self._target_to_server(fallback_target)
+
         return BackendConfig(
+            # The name is lowercased and formatted as <protocol>-<app_name>. Special
+            # characters in the name are converted to comply with haproxy config's
+            # allowed characters, e.g. `#` -> `-`.
             name=self.get_safe_name(
                 f"{target_group.protocol.value.lower()}-{target_group.app_name}"
             ),
             path_prefix=target_group.route_prefix,
             servers=servers,
             app_name=target_group.app_name,
+            fallback_server=fallback_server,
         )
 
     async def _reload_haproxy(self) -> None:
@@ -1168,23 +1175,20 @@ class HAProxyManager(ProxyActorInterface):
             await self._haproxy_start_task
             await self._haproxy.reload()
 
-    def update_target_groups(self, target_groups: List[TargetGroup]) -> None:
-        self._target_groups = target_groups
+    def _update_haproxy_backends(self) -> None:
+        backend_configs = []
+        for target_group in self._target_groups:
+            fallback_target = None
+            if target_group.protocol == RequestProtocol.HTTP:
+                fallback_target = self._http_fallback_target
+            elif target_group.protocol == RequestProtocol.GRPC:
+                fallback_target = self._grpc_fallback_target
 
-        # The fallback target is the same for all target groups.
-        fallback_server = None
-        if len(target_groups) > 0:
-            fallback_target = target_groups[0].fallback_target
-            if fallback_target:
-                fallback_server = self._target_to_server(fallback_target)
-
-        backend_configs = [
-            self._target_group_to_backend(target_group)
-            for target_group in target_groups
-        ]
+            backend_config = self._create_backend_config(target_group, fallback_target)
+            backend_configs.append(backend_config)
 
         logger.info(
-            f"Got updated backend configs: {backend_configs} and fallback server: {fallback_server}.",
+            f"Got updated backend configs: {backend_configs}.",
             extra={"log_to_stderr": True},
         )
 
@@ -1193,8 +1197,27 @@ class HAProxyManager(ProxyActorInterface):
         }
 
         self._haproxy.set_backend_configs(name_to_backend_configs)
-        self._haproxy.set_fallback_server(fallback_server)
         self.event_loop.create_task(self._reload_haproxy())
+
+    def update_target_groups(self, target_groups: List[TargetGroup]) -> None:
+        self._target_groups = target_groups
+        self._update_haproxy_backends()
+
+    def update_fallback_targets(
+        self,
+        fallback_targets: Dict[RequestProtocol, Target],
+    ) -> None:
+        # Reset so that fallbacks are repopulated from LongPoll.
+        self._http_fallback_target = None
+        self._grpc_fallback_target = None
+
+        for protocol, target in fallback_targets.items():
+            if protocol == RequestProtocol.HTTP:
+                self._http_fallback_target = target
+            elif protocol == RequestProtocol.GRPC:
+                self._grpc_fallback_target = target
+
+        self._update_haproxy_backends()
 
     def get_target_groups(self) -> List[TargetGroup]:
         """Get current target groups."""

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -487,6 +487,7 @@ class HAProxyApi(ProxyApi):
     ):
         self.cfg = cfg
         self.backend_configs = backend_configs or {}
+        self.fallback_server = None
         self.config_file_path = config_file_path
         # Lock to prevent concurrent config modifications
         self._config_lock = asyncio.Lock()
@@ -664,6 +665,7 @@ class HAProxyApi(ProxyApi):
                 {
                     "config": self.cfg,
                     "backends": backends,
+                    "fallback_server": self.fallback_server,
                     "backends_with_health_config": backends_with_health_config,
                     "healthz_rules": healthz_rules,
                     "route_info": health_route_info,
@@ -907,6 +909,12 @@ class HAProxyApi(ProxyApi):
             len(bc.servers) > 0 for bc in backend_configs.values()
         )
 
+    def set_fallback_server(
+        self,
+        fallback_server: Optional[ServerConfig],
+    ) -> None:
+        self.fallback_server = fallback_server
+
     async def is_running(self) -> bool:
         try:
             await self._send_socket_command("show info")
@@ -948,6 +956,7 @@ class HAProxyManager(ProxyActorInterface):
         self.event_loop = get_or_create_event_loop()
 
         self._target_groups: List[TargetGroup] = []
+        self._fallback_target: Optional[Target] = None
 
         # Lock to serialize HAProxy reloads and prevent concurrent reload operations
         # which can cause race conditions with SO_REUSEPORT
@@ -1119,26 +1128,26 @@ class HAProxyManager(ProxyActorInterface):
 
         return log_file_path
 
-    def _targets_to_servers(self, targets: List[Target]) -> List[ServerConfig]:
-        """Convert a list of targets to a list of servers."""
-        # The server name is derived from the replica's actor name, with the
-        # format `SERVE_REPLICA::<app>#<deployment>#<replica_id>`, or the
-        # proxy's actor name, with the format `SERVE_PROXY_ACTOR-<node_id>`.
-        # Special characters in the names are converted to comply with haproxy
-        # config's allowed characters, e.g. `#` -> `-`.
-        return [
-            ServerConfig(
-                name=self.get_safe_name(target.name),
-                # Use localhost if target is on the same node as HAProxy
-                host="127.0.0.1" if target.ip == self._node_ip_address else target.ip,
-                port=target.port,
-            )
-            for target in targets
-        ]
+    def _target_to_server(self, target: Target) -> ServerConfig:
+        """Convert a target to a server."""
+        return ServerConfig(
+            # The server name is derived from the replica's actor name, with the
+            # format `SERVE_REPLICA::<app>#<deployment>#<replica_id>`, or the
+            # proxy's actor name, with the format `SERVE_PROXY_ACTOR-<node_id>`.
+            # Special characters in the names are converted to comply with haproxy
+            # config's allowed characters, e.g. `#` -> `-`.
+            name=self.get_safe_name(target.name),
+            # Use localhost if target is on the same node as HAProxy
+            host="127.0.0.1" if target.ip == self._node_ip_address else target.ip,
+            port=target.port,
+        )
 
     def _target_group_to_backend(self, target_group: TargetGroup) -> BackendConfig:
         """Convert a target group to a backend name."""
-        servers = self._targets_to_servers(target_group.targets)
+        servers = [
+            self._target_to_server(target)
+            for target in target_group.targets
+        ]
         # The name is lowercased and formatted as <protocol>-<app_name>. Special
         # characters in the name are converted to comply with haproxy config's
         # allowed characters, e.g. `#` -> `-`.
@@ -1162,13 +1171,20 @@ class HAProxyManager(ProxyActorInterface):
     def update_target_groups(self, target_groups: List[TargetGroup]) -> None:
         self._target_groups = target_groups
 
+        # The fallback target is the same for all target groups.
+        fallback_server = None
+        if len(target_groups) > 0:
+            fallback_target = target_groups[0].fallback_target
+            if fallback_target:
+                fallback_server = self._target_to_server(fallback_target)
+
         backend_configs = [
             self._target_group_to_backend(target_group)
             for target_group in target_groups
         ]
 
         logger.info(
-            f"Got updated backend configs: {backend_configs}.",
+            f"Got updated backend configs: {backend_configs} and fallback server: {fallback_server}.",
             extra={"log_to_stderr": True},
         )
 
@@ -1177,6 +1193,7 @@ class HAProxyManager(ProxyActorInterface):
         }
 
         self._haproxy.set_backend_configs(name_to_backend_configs)
+        self._haproxy.set_fallback_server(fallback_server)
         self.event_loop.create_task(self._reload_haproxy())
 
     def get_target_groups(self) -> List[TargetGroup]:

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -127,9 +127,9 @@ backend {{ backend.name or 'unknown' }}
     {%- for server in backend.servers %}
     server {{ server.name }} {{ server.host }}:{{ server.port }} check
     {%- endfor %}
-    {%- if fallback_server %}
+    {%- if backend.fallback_server %}
     # Fallback to head node's Serve proxy when no ingress replicas are available
-    server {{ fallback_server.name }} {{ fallback_server.host }}:{{ fallback_server.port }} check backup
+    server {{ backend.fallback_server.name }} {{ backend.fallback_server.host }}:{{ backend.fallback_server.port }} check backup
     {%- endif %}
 {%- endfor %}
 listen stats

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -127,6 +127,10 @@ backend {{ backend.name or 'unknown' }}
     {%- for server in backend.servers %}
     server {{ server.name }} {{ server.host }}:{{ server.port }} check
     {%- endfor %}
+    {%- if fallback_server %}
+    # Fallback to head node's Serve proxy when no ingress replicas are available
+    server {{ fallback_server.name }} {{ fallback_server.host }}:{{ fallback_server.port }} check backup
+    {%- endif %}
 {%- endfor %}
 listen stats
   bind *:{{ config.stats_port }}

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -164,7 +164,7 @@ class ActorProxyWrapper(ProxyWrapper):
         except ValueError:
             addr = build_address(http_options.host, http_options.port)
             logger.info(
-                f"Starting proxy on node '{node_id}' listening on '{addr}'.",
+                f"Starting proxy '{name}' on node '{node_id}' listening on '{addr}'.",
                 extra={"log_to_stderr": False},
             )
 
@@ -872,7 +872,6 @@ class ProxyStateManager:
             and self._running_native_proxies
             and self._fallback_proxy_state is None
         ):
-            logger.info(f"Starting fallback proxy on head node '{node_id}'.")
             name = self._generate_actor_name(node_id=f"fallback-{node_id}")
 
             http_options = deepcopy(self._http_options)

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -767,7 +767,7 @@ def test_haproxy_healthcheck_multiple_apps_and_backends(ray_shutdown):
     Expectations:
     - With two servers per backend, healthz returns 200 (all backends have a primary UP).
     - Disabling one primary in each backend keeps health at 200 (the other primary is UP).
-    - Disabling all servers in each backend results in healthz 503.
+    - Disabling all servers in each backend results in healthz 200 (the fallback proxy is UP).
     """
     ray.init(num_cpus=8)
     serve.start()
@@ -856,7 +856,7 @@ def test_haproxy_healthcheck_multiple_apps_and_backends(ray_shutdown):
 
     wait_health(200, timeout=20)
 
-    # Disable the remaining primary per backend, should become unhealthy (no servers UP)
+    # Disable the remaining primary per backend, should remain healthy (the fallback proxy is UP).
     disabled_all = []
     for be in backends:
         servers = list_primary_servers(be)
@@ -867,9 +867,10 @@ def test_haproxy_healthcheck_multiple_apps_and_backends(ray_shutdown):
                 disabled_all.append((be, sv))
                 break
 
-    wait_health(503, timeout=20)
+    # The fallback proxy is UP.
+    wait_health(200, timeout=20)
 
-    # Re-enable all servers and expect health back to 200
+    # Re-enable all servers and expect health to be 200.
     for be, sv in disabled_servers + disabled_all:
         set_server_state(be, sv, "ready")
     wait_health(200, timeout=20)

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -965,5 +965,70 @@ def test_fallback_proxy_starts_with_native_proxy_on_head_node(
     serve.shutdown()
 
 
+def test_scale_from_zero_via_fallback_proxy(ray_shutdown):
+    """Test that a request to an app scaled to zero succeeds via the fallback proxy.
+
+    Flow:
+    1. Deploy an app with autoscaling min_replicas=0
+    2. Wait for it to scale down to 0 replicas
+    3. Send an HTTP request through HAProxy
+    4. HAProxy routes to the fallback Serve proxy (backup server) since
+       there are no ingress replicas
+    5. The fallback proxy queues the request and triggers upscaling
+    6. Once a replica starts, the request completes successfully
+    """
+    ray.init(num_cpus=4)
+    serve.start()
+
+    @serve.deployment(
+        autoscaling_config={
+            "min_replicas": 0,
+            "max_replicas": 1,
+            "metrics_interval_s": 0.1,
+            "look_back_period_s": 0.2,
+            "downscale_delay_s": 5,
+            "upscale_delay_s": 0,
+        },
+    )
+    class ScaleToZeroApp:
+        def __call__(self):
+            return "hello from scale-to-zero"
+
+    serve.run(ScaleToZeroApp.bind(), name="s2z_app", route_prefix="/s2z")
+
+    # Wait for the app to be running and initially serve a request
+    wait_for_condition(
+        lambda: httpx.get("http://localhost:8000/s2z").status_code == 200,
+        timeout=30,
+    )
+    assert httpx.get("http://localhost:8000/s2z").text == "hello from scale-to-zero"
+
+    # Wait for the app to scale down to 0 replicas
+    def check_zero_replicas():
+        actors = list_actors(
+            filters=[
+                ("ray_namespace", "=", SERVE_NAMESPACE),
+                ("state", "=", "ALIVE"),
+                ("class_name", "=", "ServeReplica:s2z_app:ScaleToZeroApp"),
+            ],
+        )
+        return len(actors) == 0
+
+    wait_for_condition(check_zero_replicas, timeout=30)
+
+    # Now send a request. HAProxy has no primary servers for this backend,
+    # so it should route to the fallback Serve proxy (backup server).
+    # The fallback proxy will queue the request and trigger upscaling.
+    # The request should eventually succeed once a replica starts.
+    response = httpx.get("http://localhost:8000/s2z", timeout=30)
+    assert response.status_code == 200, (
+        f"Expected 200 after scale-from-zero, got {response.status_code}: "
+        f"{response.text}"
+    )
+    assert response.text == "hello from scale-to-zero"
+
+    serve.shutdown()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -222,6 +222,9 @@ def test_generate_config_file_internal(haproxy_api_cleanup):
                     ServerConfig(name="api_server1", host="127.0.0.1", port=8001),
                     ServerConfig(name="api_server2", host="127.0.0.1", port=8002),
                 ],
+                fallback_server=ServerConfig(
+                    name="api_fallback_server", host="127.0.0.1", port=8500
+                ),
             ),
             "web_backend": BackendConfig(
                 name="web_backend",
@@ -335,6 +338,8 @@ backend api_backend
     # Servers in this backend
     server api_server1 127.0.0.1:8001 check
     server api_server2 127.0.0.1:8002 check
+    # Fallback to head node's Serve proxy when no ingress replicas are available
+    server api_fallback_server 127.0.0.1:8500 check backup
 backend web_backend
     log global
     balance leastconn

--- a/python/ray/serve/tests/unit/test_controller_direct_ingress.py
+++ b/python/ray/serve/tests/unit/test_controller_direct_ingress.py
@@ -89,6 +89,7 @@ class FakeProxyStateManager:
             grpc_servicer_functions=["f1"],
         )
         self._fallback_proxy_targets = {}
+        self._started_fallback_proxy = False
 
     def add_proxy_details(self, node_id, node_ip, name):
 
@@ -136,6 +137,9 @@ class FakeProxyStateManager:
 
     def get_fallback_proxy_targets(self):
         return deepcopy(self._fallback_proxy_targets)
+
+    def started_fallback_proxy_at_least_once(self):
+        return self._started_fallback_proxy
 
 
 class FakeReplicaStateContainer:

--- a/python/ray/serve/tests/unit/test_controller_haproxy.py
+++ b/python/ray/serve/tests/unit/test_controller_haproxy.py
@@ -205,10 +205,6 @@ def test_get_target_groups_app_with_no_running_replicas(
         running_replica_infos=running_replica_infos,
     )
 
-    haproxy_controller.proxy_state_manager.add_proxy_details(
-        "proxy_node1", "10.0.0.1", "proxy1"
-    )
-
     target_groups = haproxy_controller.get_target_groups(
         from_proxy_manager=True,
     )


### PR DESCRIPTION
This PR is part 2 of supporting scale from zero in HAProxy mode. In part 1, we added the ability to start a fallback serve proxy and broadcast its information via long poll when HAProxy is running. 

In this PR, we have HAProxyManager consume the long poll so that it can configure HAProxy with the fallback server. The fallback server is added as a backup server to each backend in the config (so that if the backend doesn't have any healthy targets, the request will be forwarded to the fallback proxy). This accomplishes scale from zero since the fallback proxy will then trigger upscaling.

We also slightly change the `get_target_groups` API such that when there are apps with no running replicas in HAProxy mode, we always return target groups with empty targets instead of no target groups. This is important to prevent haproxy from receiving no target groups (from the TARGET_GROUPS long poll) when controller recovers (since the haproxymanager starts out as "STARTING" state when controller recovers).

Stack:
* https://github.com/ray-project/ray/pull/61276
* https://github.com/ray-project/ray/pull/61180
* __&rarr;__ https://github.com/ray-project/ray/pull/61271