### PR TITLE
[Data] Fix DatabricksUCDatasource schema() shadowing by schema string attribute

### DIFF
--- a/python/ray/data/_internal/datasource/databricks_uc_datasource.py
+++ b/python/ray/data/_internal/datasource/databricks_uc_datasource.py
@@ -43,7 +43,7 @@ class DatabricksUCDatasource(Datasource):
         self.host = self._credential_provider.get_host()
         self.warehouse_id = warehouse_id
         self.catalog = catalog
-        self.schema = schema
+        self.schema_name = schema
         self.query = query
 
         if not self.host.startswith(("http://", "https://")):
@@ -59,7 +59,7 @@ class DatabricksUCDatasource(Datasource):
                 "disposition": "EXTERNAL_LINKS",
                 "format": "ARROW_STREAM",
                 "catalog": self.catalog,
-                "schema": self.schema,
+                "schema": self.schema_name,
             }
         )
 

--- a/python/ray/data/tests/datasource/test_databricks_uc_datasource.py
+++ b/python/ray/data/tests/datasource/test_databricks_uc_datasource.py
@@ -342,7 +342,6 @@ class TestDatabricksUCDatasourceCredentials:
 
     def test_schema_name_does_not_shadow_datasource_fields(self, requests_mocker):
         """Test that schema name is stored without using the `schema` attribute.
-        
         This is a regression test for https://github.com/ray-project/ray/issues/46481.
         """
         requests_mocker["post"].return_value = mock.Mock(

--- a/python/ray/data/tests/datasource/test_databricks_uc_datasource.py
+++ b/python/ray/data/tests/datasource/test_databricks_uc_datasource.py
@@ -341,7 +341,10 @@ class TestDatabricksUCDatasourceCredentials:
     """Tests for credential provider handling."""
 
     def test_schema_name_does_not_shadow_datasource_fields(self, requests_mocker):
-        """Test that schema name is stored without using the `schema` attribute."""
+        """Test that schema name is stored without using the `schema` attribute.
+        
+        This is a regression test for https://github.com/ray-project/ray/issues/46481.
+        """
         requests_mocker["post"].return_value = mock.Mock(
             status_code=200,
             raise_for_status=lambda: None,


### PR DESCRIPTION
## Description
This PR fixes a Ray Data bug in `DatabricksUCDatasource`.

In affected versions (including Ray 2.31.0, and reproduced on 2.54.0), `DatabricksUCDatasource.__init__` stores the input schema as `self.schema` (a string), which can shadow schema-related member lookup and cause runtime errors (e.g. `TypeError: 'str' object is not callable`) during schema resolution paths.

## Changes Made

- Renamed the instance field:
  - `self.schema` -> `self.schema_name`
- Updated Databricks statement payload to use `self.schema_name`.
- Added a regression test to ensure the constructor does not create a string `self.schema` member and that request payload schema is preserved.

## Related issues

Closes #46481
