### PR TITLE
[ci] add ci/build to unit tests, smoketest build-wheel.sh

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -388,6 +388,17 @@ steps:
       - oss
       - skip-on-premerge
 
+  - label: ":tapioca: smoke test build-wheel.sh --help"
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    instance_type: small
+    commands:
+      - ./build-wheel.sh --help
+    depends_on:
+      - forge
+
   - label: ":tapioca: smoke test build-docker.sh"
     tags:
       - python_dependencies

--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -14,7 +14,7 @@ steps:
     key: reef-tests
     commands:
       - bazel run //ci/ray_ci:test_in_docker --
-          //ci/ray_ci/... //release/... //ci/pipeline/... ci
+          //ci/ray_ci/... //ci/build/... //release/... //ci/pipeline/... ci
           --only-tags=release_unit,ci_unit
           --cache-test-results --parallelism-per-worker 2
           --build-name forge

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -80,6 +80,11 @@ ci/lint/lint.sh: tools
 ci/ray_ci/tester.py: tools
 ci/ci.sh: tools
 
+# === Build Scripts ===
+
+build-wheel.sh: tools
+ci/build/build_common.py: tools
+
 # === Root Files ===
 
 BUILD.bazel: ml tune train data serve core_cpp cpp java python doc linux_wheels macos_wheels dashboard tools release_tests

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -214,6 +214,7 @@ ci/docker/forge.aarch64.wanda.yaml
 .buildkite/hooks/post-command
 .buildkite/release/
 .buildkite/release-automation/
+build-wheel.sh
 @ tools
 ;
 


### PR DESCRIPTION
Ensures build-wheel successfully starts up and prints helpful message. Unit tests were also missing from running in CI, so this adds those as well.

Topic: reef-test-ci-build
Signed-off-by: andrew <andrew@anyscale.com>