### PR TITLE
[ci] Add ray-images.yaml schema and validation test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,6 +20,11 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+exports_files([
+    ".rayciversion",
+    "ray-images.yaml",
+])
+
 # C/C++ toolchain constraint configs.
 
 config_setting(

--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -9,10 +9,18 @@ py_library(
         "docker_container.py",
         "linux_container.py",
         "ray_image.py",
+        "supported_images.py",
+    ],
+    data = [
+        "//:.rayciversion",
+        "//:ray-images.yaml",
     ],
     visibility = [
         "//ci/build:__pkg__",
         "//ci/ray_ci:__subpackages__",
+    ],
+    deps = [
+        ci_require("pyyaml"),
     ],
 )
 
@@ -42,7 +50,10 @@ py_library(
             "build_in_docker_windows.py",
         ],
     ),
-    data = glob(["*.yaml"]),
+    data = glob(["*.yaml"]) + [
+        "//:.rayciversion",
+        "//:ray-images.yaml",
+    ],
     visibility = ["//ci/ray_ci:__subpackages__"],
     deps = [
         "//release:bazel",
@@ -269,4 +280,24 @@ py_test(
         "team:ci",
     ],
     deps = [ci_require("pytest")],
+)
+
+py_test(
+    name = "test_supported_images",
+    size = "small",
+    srcs = ["test_supported_images.py"],
+    data = [
+        "//:.rayciversion",
+        "//:ray-images.yaml",
+    ],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_image_lib",
+        ci_require("pytest"),
+        ci_require("pyyaml"),
+    ],
 )

--- a/ci/ray_ci/supported_images.py
+++ b/ci/ray_ci/supported_images.py
@@ -1,0 +1,45 @@
+from functools import lru_cache
+from pathlib import Path
+from typing import List
+
+import yaml
+
+_RAYCI_VERSION_FILE = ".rayciversion"
+
+
+def _find_ray_root() -> Path:
+    """Walk up from this file and cwd looking for .rayciversion."""
+    start = Path(__file__).resolve()
+    for parent in start.parents:
+        if (parent / _RAYCI_VERSION_FILE).exists():
+            return parent
+    if (Path.cwd() / _RAYCI_VERSION_FILE).exists():
+        return Path.cwd()
+    raise FileNotFoundError("Could not find Ray root (missing .rayciversion).")
+
+
+@lru_cache(maxsize=1)
+def load_supported_images():
+    yaml_path = _find_ray_root() / "ray-images.yaml"
+    with open(yaml_path) as f:
+        return yaml.safe_load(f)
+
+
+def get_image_config(image_type: str) -> dict:
+    return load_supported_images()[image_type]
+
+
+def get_python_versions(image_type: str) -> List[str]:
+    return get_image_config(image_type)["python"]
+
+
+def get_platforms(image_type: str) -> List[str]:
+    return get_image_config(image_type)["platforms"]
+
+
+def get_architectures(image_type: str) -> List[str]:
+    return get_image_config(image_type)["architectures"]
+
+
+def get_default(image_type: str, key: str) -> str:
+    return get_image_config(image_type)["defaults"][key]

--- a/ci/ray_ci/test_supported_images.py
+++ b/ci/ray_ci/test_supported_images.py
@@ -1,0 +1,74 @@
+"""
+Validates that ray-images.yaml is well-formed and internally consistent.
+"""
+
+import pytest
+
+from ci.ray_ci.supported_images import get_image_config, load_supported_images
+
+IMAGE_TYPES = list(load_supported_images().keys())
+REQUIRED_KEYS = ["defaults", "python", "platforms", "architectures"]
+REQUIRED_DEFAULTS = ["python", "gpu_platform", "architecture"]
+
+
+class TestRayImagesSchema:
+    def test_has_image_types(self):
+        assert len(IMAGE_TYPES) > 0, "ray-images.yaml has no image types defined"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_required_keys(self, image_type):
+        cfg = get_image_config(image_type)
+        for key in REQUIRED_KEYS:
+            assert key in cfg, f"{image_type}: missing required key '{key}'"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_required_defaults(self, image_type):
+        defaults = get_image_config(image_type)["defaults"]
+        for key in REQUIRED_DEFAULTS:
+            assert key in defaults, f"{image_type}: missing required default '{key}'"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_defaults_in_supported(self, image_type):
+        cfg = get_image_config(image_type)
+        defaults = cfg["defaults"]
+
+        assert defaults["python"] in cfg["python"], (
+            f"{image_type}: default python '{defaults['python']}' "
+            f"not in supported {cfg['python']}"
+        )
+        assert defaults["gpu_platform"] in cfg["platforms"], (
+            f"{image_type}: default gpu_platform '{defaults['gpu_platform']}' "
+            f"not in supported {cfg['platforms']}"
+        )
+        assert defaults["architecture"] in cfg["architectures"], (
+            f"{image_type}: default architecture '{defaults['architecture']}' "
+            f"not in supported {cfg['architectures']}"
+        )
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_no_empty_lists(self, image_type):
+        cfg = get_image_config(image_type)
+        for key in ["python", "platforms", "architectures"]:
+            assert len(cfg[key]) > 0, f"{image_type}: '{key}' list is empty"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_python_versions_are_strings(self, image_type):
+        for v in get_image_config(image_type)["python"]:
+            assert isinstance(v, str), (
+                f"{image_type}: python version {v!r} is {type(v).__name__}, "
+                f"not str (missing quotes in YAML?)"
+            )
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_platforms_are_strings(self, image_type):
+        for v in get_image_config(image_type)["platforms"]:
+            assert isinstance(
+                v, str
+            ), f"{image_type}: platform {v!r} is {type(v).__name__}, not str"
+
+    @pytest.mark.parametrize("image_type", IMAGE_TYPES)
+    def test_architectures_are_strings(self, image_type):
+        for v in get_image_config(image_type)["architectures"]:
+            assert isinstance(
+                v, str
+            ), f"{image_type}: architecture {v!r} is {type(v).__name__}, not str"

--- a/ray-images.yaml
+++ b/ray-images.yaml
@@ -1,0 +1,42 @@
+# Ray image configurations, consumed by CI and build scripts.
+
+ray:
+  defaults:
+    python: "3.10"
+    gpu_platform: cu12.1.1-cudnn8
+    architecture: x86_64
+
+  python: ["3.10", "3.11", "3.12", "3.13"]
+  architectures: [x86_64, aarch64]
+  platforms:
+    - cpu
+    - tpu
+    - cu11.7.1-cudnn8
+    - cu11.8.0-cudnn8
+    - cu12.1.1-cudnn8
+    - cu12.3.2-cudnn9
+    - cu12.4.1-cudnn
+    - cu12.5.1-cudnn
+    - cu12.6.3-cudnn
+    - cu12.8.1-cudnn
+    - cu12.9.1-cudnn
+
+ray-ml:
+  defaults:
+    python: "3.10"
+    gpu_platform: cu12.1.1-cudnn8
+    architecture: x86_64
+
+  python: ["3.10", "3.11"]
+  architectures: [x86_64]
+  platforms: [cpu, cu12.1.1-cudnn8]
+
+ray-llm:
+  defaults:
+    python: "3.11"
+    gpu_platform: cu12.8.1-cudnn
+    architecture: x86_64
+
+  python: ["3.11", "3.12"]
+  architectures: [x86_64]
+  platforms: [cu12.8.1-cudnn, cu12.9.1-cudnn]


### PR DESCRIPTION
Add ray-images.yaml as a single source of truth for supported Ray Docker image configurations (ray, ray-ml, ray-llm). Each image type declares its defaults, supported python versions, platforms, and architectures.

Add a loader module (ci/ray_ci/supported_images.py) and a Bazel test (test_supported_images) that validates the YAML schema is well-formed and internally consistent.

Topic: ray-images-schema
Signed-off-by: andrew <andrew@anyscale.com>