### PR TITLE
Add middleware proxy for history server

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -814,15 +814,7 @@ python/ray/dag/tests/experimental/test_torch_tensor_transport.py
     DOC106: Function `run_worker_to_driver_dag`: The option `--arg-type-hints-in-signature` is `True` but there are no argument type hints in the signature
     DOC107: Function `run_worker_to_driver_dag`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
 --------------------
-python/ray/dashboard/dashboard.py
-    DOC101: Method `Dashboard.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `Dashboard.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [minimal: bool, modules_to_load: Optional[Set[str]], session_dir: str, temp_dir: str].
---------------------
 python/ray/dashboard/head.py
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `DashboardHead.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `DashboardHead.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [cluster_id_hex: str, gcs_address: str, http_host: str, http_port: int, http_port_retries: int, log_dir: str, logging_filename: str, logging_format: str, logging_level: int, logging_rotate_backup_count: int, logging_rotate_bytes: int, minimal: bool, modules_to_load: Optional[Set[str]], node_ip_address: str, serve_frontend: bool, session_dir: str, temp_dir: str].
     DOC103: Method `DashboardHead._load_dashboard_head_modules`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [modules_to_load: Optional[Set[str]]]. Arguments in the docstring but not in the function signature: [modules: ].
     DOC201: Method `DashboardHead._load_dashboard_head_modules` does not have a return section in docstring
     DOC103: Method `DashboardHead._load_subprocess_module_handles`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [modules_to_load: Optional[Set[str]]]. Arguments in the docstring but not in the function signature: [modules: ].

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1075,6 +1075,7 @@ class Node:
             backup_count=self.backup_count,
             stdout_filepath=stdout_log_fname,
             stderr_filepath=stderr_log_fname,
+            proxy_server_url=self._ray_params.proxy_server_url,
         )
         assert ray_constants.PROCESS_TYPE_DASHBOARD not in self.all_processes
         if process_info is not None:

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -122,6 +122,9 @@ class RayParams:
         cluster_id: The cluster ID in hex string.
         resource_isolation_config: settings for cgroupv2 based isolation of ray
             system processes (defaults to no isolation if config not provided)
+        proxy_server_url: The proxy url to redirect dashboard backend request to.
+            By default, the dashboard requests will be directed to the Ray api server.
+            Ex: http://historyserver:8080
     """
 
     def __init__(
@@ -184,6 +187,7 @@ class RayParams:
         cluster_id: Optional[str] = None,
         node_id: Optional[str] = None,
         resource_isolation_config: Optional[ResourceIsolationConfig] = None,
+        proxy_server_url: Optional[str] = None,
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address
@@ -243,6 +247,7 @@ class RayParams:
         self._check_usage()
         self.cluster_id = cluster_id
         self.node_id = node_id
+        self.proxy_server_url = proxy_server_url
 
         self.resource_isolation_config = resource_isolation_config
         if not self.resource_isolation_config:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1190,6 +1190,7 @@ def start_api_server(
     backup_count: int = 0,
     stdout_filepath: Optional[str] = None,
     stderr_filepath: Optional[str] = None,
+    proxy_server_url: Optional[str] = None,
 ):
     """Start a API server process.
 
@@ -1221,6 +1222,8 @@ def start_api_server(
             If None, stdout is not redirected.
         stderr_filepath: The file path to dump dashboard stderr.
             If None, stderr is not redirected.
+        proxy_server_url: The url to redirect dashboard backend api requests to
+            Ex: http://historyserver:8080
 
     Returns:
         A tuple of :
@@ -1299,6 +1302,7 @@ def start_api_server(
             f"--gcs-address={gcs_address}",
             f"--cluster-id-hex={cluster_id_hex}",
             f"--node-ip-address={node_ip_address}",
+            f"--proxy-server-url={proxy_server_url or ''}",
         ]
 
         if stdout_filepath:

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1428,6 +1428,7 @@ def init(
     cgroup_path: Optional[str] = None,
     system_reserved_cpu: Optional[float] = None,
     system_reserved_memory: Optional[int] = None,
+    proxy_server_url: Optional[str] = None,
     **kwargs,
 ) -> BaseContext:
     """
@@ -1547,6 +1548,11 @@ def init(
             The process starting ray must have read/write permissions to this path.
             Cgroup memory and cpu controllers must be enabled for this cgroup.
             This option only works if enable_resource_isolation is True.
+        proxy_server_url:[Experimental] The server url to redirect dashboard backend requests to.
+            By default, the dashboard requests will be directed to the Ray api server.
+            If you have a custom server to serve the dashboard requests,
+            you can set this option to override the server url.
+            Ex: proxy_server_url=http://historyserver:8080
         system_reserved_cpu: The number of cpu cores to reserve for ray system processes.
             Cores can be fractional i.e. 1.5 means one and a half a cpu core.
             By default, the value will be atleast 1 core, and at maximum 3 cores. The default value
@@ -1889,6 +1895,7 @@ def init(
             tracing_startup_hook=_tracing_startup_hook,
             node_name=_node_name,
             resource_isolation_config=resource_isolation_config,
+            proxy_server_url=proxy_server_url,
         )
         # Start the Ray processes. We set shutdown_at_exit=False because we
         # shutdown the node in the ray.shutdown call that happens in the atexit

--- a/python/ray/dashboard/dashboard.py
+++ b/python/ray/dashboard/dashboard.py
@@ -44,14 +44,21 @@ class Dashboard:
         gcs_address: GCS address of the cluster.
         cluster_id_hex: Cluster ID hex string.
         node_ip_address: The IP address of the dashboard.
-        serve_frontend: If configured, frontend HTML
-            is not served from the dashboard.
         log_dir: Log directory of dashboard.
         logging_level: The logging level (e.g. logging.INFO, logging.DEBUG)
         logging_format: The format string for log messages
         logging_filename: The name of the log file
         logging_rotate_bytes: Max size in bytes before rotating log file
         logging_rotate_backup_count: Number of backup files to keep when rotating
+        temp_dir: Specify the path of the temporary directory use by Ray process
+        session_dir: Specify the path of the session directory of the cluster under the temp_dir
+        minimal: Whether or not it will load the minimal modules.
+        serve_frontend: Whether to serve the frontend HTML from the dashboard.
+        modules_to_load: Specify the list of module names in [module_1],[module_2] format.
+            E.g., JobHead,StateHead...
+            If nothing is specified, all modules are loaded.
+        proxy_server_url: The url to redirect api requests to
+            Ex: proxy_server_url=http://historyserver:8080
     """
 
     def __init__(
@@ -73,6 +80,7 @@ class Dashboard:
         minimal: bool = False,
         serve_frontend: bool = True,
         modules_to_load: Optional[Set[str]] = None,
+        proxy_server_url: Optional[str] = None,
     ):
         self.dashboard_head = dashboard_head.DashboardHead(
             http_host=host,
@@ -92,6 +100,7 @@ class Dashboard:
             minimal=minimal,
             serve_frontend=serve_frontend,
             modules_to_load=modules_to_load,
+            proxy_server_url=proxy_server_url,
         )
 
     async def run(self):
@@ -226,6 +235,14 @@ if __name__ == "__main__":
         default="",
         help="The filepath to dump dashboard stderr.",
     )
+    parser.add_argument(
+        "--proxy-server-url",
+        required=False,
+        type=str,
+        default="",
+        help="The proxy server url to redirect requests to"
+        "Ex: --proxy-server-url=http://historyserver:8080 ",
+    )
 
     args = parser.parse_args()
 
@@ -279,6 +296,7 @@ if __name__ == "__main__":
             minimal=args.minimal,
             serve_frontend=(not args.disable_frontend),
             modules_to_load=modules_to_load,
+            proxy_server_url=args.proxy_server_url,
         )
 
         def sigterm_handler():

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -66,13 +66,18 @@ class DashboardHead:
         minimal: bool,
         serve_frontend: bool,
         modules_to_load: Optional[Set[str]] = None,
+        proxy_server_url: Optional[str] = None,
     ):
         """
+        Dashboard head
+
         Args:
             http_host: The host address for the Http server.
             http_port: The port for the Http server.
             http_port_retries: The maximum retry to bind ports for the Http server.
             gcs_address: The GCS address in the {address}:{port} format.
+            cluster_id_hex: Cluster ID in hex
+            node_ip_address: The IP address of the dashboard
             log_dir: The log directory. E.g., /tmp/session_latest/logs.
             logging_level: The logging level (e.g. logging.INFO, logging.DEBUG)
             logging_format: The format string for log messages
@@ -88,6 +93,8 @@ class DashboardHead:
                 By default (None), it loads all available modules.
                 Note that available modules could be changed depending on
                 minimal flags.
+            proxy_server_url: The proxy url to redirect api requests to
+                Ex: proxy_server_url=http://historyserver:8080
         """
         self.minimal = minimal
         self.serve_frontend = serve_frontend
@@ -125,6 +132,7 @@ class DashboardHead:
         self.ip = node_ip_address
         self.pid = os.getpid()
         self.dashboard_proc = psutil.Process()
+        self.proxy_server_url = proxy_server_url
 
         # If the dashboard is started as non-minimal version, http server should
         # be configured to expose APIs.
@@ -145,6 +153,7 @@ class DashboardHead:
             self.gcs_address,
             self.session_name,
             self.metrics,
+            self.proxy_server_url,
         )
         await self.http_server.run(dashboard_head_modules, subprocess_module_handles)
 

--- a/python/ray/dashboard/http_server_head.py
+++ b/python/ray/dashboard/http_server_head.py
@@ -10,6 +10,7 @@ import time
 from math import floor
 from typing import List
 
+import multidict
 from packaging.version import Version
 
 import ray
@@ -93,6 +94,7 @@ class HttpServerDashboardHead:
         gcs_address: str,
         session_name: str,
         metrics: DashboardPrometheusMetrics,
+        proxy_server_url: str | None = None,
     ):
         self.ip = ip
         self.http_host = http_host
@@ -101,6 +103,7 @@ class HttpServerDashboardHead:
         self.head_node_ip = parse_address(gcs_address)[0]
         self.metrics = metrics
         self._session_name = session_name
+        self.proxy_server_url = proxy_server_url
 
         # Below attirubtes are filled after `run` API is invoked.
         self.runner = None
@@ -283,6 +286,93 @@ class HttpServerDashboardHead:
         return await handler(request)
 
     @aiohttp.web.middleware
+    async def proxy_server_middleware(self, request, handler):
+        """Redirects the request to the proxy server if the related proxy server
+        url env var is set.
+        """
+        # paths/endpoints that should not be directed when RAY_API_PROXY_URL_ENV_VAR is set
+        ignored_path = (
+            "/api/gcs_healthz",
+            "/usage_stats_enabled",
+            "/api/healthz",
+            "/api/local_raylet_healthz",
+        )
+
+        rel_path = str(request.rel_url)
+        body_data = None
+        if self.proxy_server_url and not rel_path.startswith(ignored_path):
+            logger.debug(f"Redirecting request to {self.proxy_server_url}")
+            body_data = await request.read()
+
+            # Headers that should be removed from the new request
+            # Case sensitive, keep everything lowercase for checking purposes.
+            headers_to_remove = {
+                "content-encoding",  # This could cause the browser to try to unzip plain-text
+                "content-length",  # Let aiohttp calculate instead
+                "host",
+                "connection",
+                "keep-alive",
+                "te",
+                "trailers",
+                "upgrade",
+                "proxy-authenticate",
+                "proxy-authorization",
+                "transfer-encoding",
+            }
+            # We have to use multidict here since there are multiple cookies being set
+            proxy_headers = multidict.CIMultiDict(
+                (k, v)
+                for k, v in request.headers.items()
+                if k.lower() not in headers_to_remove
+            )
+
+            # This is to fix 415 error caused by content-type not in headers
+            proxy_headers.setdefault("Content-Type", "application/json")
+
+            timeout = aiohttp.ClientTimeout(total=30)
+            try:
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    # Manual concatenation to preserve potential paths in proxy_server_url
+                    full_url = f"{self.proxy_server_url.rstrip('/')}{rel_path}"
+                    logger.debug(
+                        f"Sending request to proxy server instead. {full_url=}"
+                    )
+
+                    async with session.request(
+                        method=request.method,
+                        url=full_url,
+                        headers=proxy_headers,
+                        data=body_data,
+                    ) as resp:
+                        body = await resp.read()
+                        # only fallback if the reponse from the proxy server is not found
+                        if not resp.status == 404:
+                            resp_headers = multidict.CIMultiDict(
+                                (k, v)
+                                for k, v in resp.headers.items()
+                                if k.lower()
+                                not in {
+                                    "transfer-encoding",
+                                    "content-encoding",
+                                    "content-length",
+                                }
+                            )
+
+                            return aiohttp.web.Response(
+                                body=body, status=resp.status, headers=resp_headers
+                            )
+                        else:
+                            logger.warning(
+                                f"Calling endpoint {request.rel_url} returned status {resp.status} and {body}, falling back"
+                            )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to use proxy server endpoint: {e}. Falling back to original handler."
+                )
+
+        return await handler(request)
+
+    @aiohttp.web.middleware
     async def metrics_middleware(self, request, handler):
         start_time = time.monotonic()
 
@@ -365,6 +455,7 @@ class HttpServerDashboardHead:
                     allowed_paths=["/api/authenticate"],
                 ),
                 self.cache_control_static_middleware,
+                self.proxy_server_middleware,
             ],
         )
         app.add_routes(routes=routes.bound_routes())

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1488,6 +1488,56 @@ def test_dashboard_module_no_warnings(enable_test_module):
         debug._disabled = old_val
 
 
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+def test_middleware_with_httpserver_for_proxy_server(
+    httpserver, ray_start_with_dashboard_and_proxy
+):
+    """
+    Test that the dashboard middleware correctly forwards requests to an external server.
+    """
+    target_path = "/api/call"
+    mock_response = {"status": "success", "data": "mocked_payload"}
+    httpserver.expect_request(target_path).respond_with_json(mock_response)
+
+    assert (
+        wait_until_server_available(ray_start_with_dashboard_and_proxy["webui_url"])
+        is True
+    )
+    address_info = ray_start_with_dashboard_and_proxy
+    webui_url = address_info["webui_url"]
+    webui_url = format_web_url(webui_url)
+
+    response = requests.get(f"{webui_url}{target_path}")
+    assert response.json() == mock_response
+    assert response.status_code == 200
+
+
+@pytest.mark.skipif(
+    os.environ.get("RAY_MINIMAL") == "1",
+    reason="This test is not supposed to work for minimal installation.",
+)
+def test_middleware_with_httpserver_for_proxy_server_with_ray_start(
+    httpserver, call_ray_start_context_with_proxy_server
+):
+    """
+    Test that the dashboard middleware correctly forwards requests to an external server when using `ray start`.
+    """
+    target_path = "/api/call"
+    mock_response = {"status": "success", "data": "mocked_payload"}
+    httpserver.expect_request(target_path).respond_with_json(mock_response)
+
+    address = ray.init(address=call_ray_start_context_with_proxy_server)
+    webui_url = address["webui_url"]
+    webui_url = format_web_url(webui_url)
+
+    response = requests.get(f"{webui_url}{target_path}")
+    assert response.json() == mock_response
+    assert response.status_code == 200
+
+
 def test_dashboard_not_included_ray_init(shutdown_only, capsys):
     addr = ray.init(include_dashboard=False, dashboard_port=8265)
     dashboard_url = addr["webui_url"]

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -676,6 +676,16 @@ Windows powershell users need additional escaping:
     "Cgroup memory and cpu controllers be enabled for this cgroup. "
     "This option only works if enable_resource_isolation is True.",
 )
+@click.option(
+    "--proxy-server-url",
+    required=False,
+    type=str,
+    help="[Experimental] The server url to redirect dashboard backend requests to. "
+    "By default, the dashboard requests will be directed to the Ray api server. "
+    "If you have a custom server to serve the dashboard requests, "
+    "you can set this option to override the server url. "
+    "Ex: --proxy-server-url=http://historyserver:8080 ",
+)
 @add_click_logging_options
 @PublicAPI
 def start(
@@ -724,6 +734,7 @@ def start(
     system_reserved_cpu,
     system_reserved_memory,
     cgroup_path,
+    proxy_server_url,
 ):
     """Start Ray processes manually on the local machine."""
 
@@ -843,6 +854,7 @@ def start(
         ray_debugger_external=ray_debugger_external,
         include_log_monitor=include_log_monitor,
         resource_isolation_config=resource_isolation_config,
+        proxy_server_url=proxy_server_url,
         env_vars=env_vars,
     )
 

--- a/python/ray/tests/conftest.py
+++ b/python/ray/tests/conftest.py
@@ -569,6 +569,17 @@ def ray_start_with_dashboard(request, maybe_setup_external_redis):
 
 
 @pytest.fixture
+def ray_start_with_dashboard_and_proxy(request, httpserver, maybe_setup_external_redis):
+    hsurl = httpserver.url_for("/")
+
+    param = getattr(request, "param", {})
+    if param.get("num_cpus") is None:
+        param["num_cpus"] = 1
+    with _ray_start(include_dashboard=True, proxy_server_url=hsurl, **param) as info:
+        yield info
+
+
+@pytest.fixture
 def make_sure_dashboard_http_port_unused():
     """Make sure the dashboard agent http port is unused."""
     for process in psutil.process_iter():
@@ -777,6 +788,17 @@ def ray_start_object_store_memory(request, maybe_setup_external_redis):
 @pytest.fixture
 def call_ray_start(request):
     with call_ray_start_context(request) as address:
+        yield address
+
+
+# This fixture will start an httpserver and use it as the proxy-server-url parameters
+@pytest.fixture
+def call_ray_start_context_with_proxy_server(httpserver):
+    hsurl = httpserver.url_for("/")
+    cmd = f"ray start --head --num-cpus=1 --proxy-server-url={hsurl} --port 0 --min-worker-port=0 --max-worker-port=0"
+    tempObject = type("Temp", (), {"param": cmd})
+
+    with call_ray_start_context(tempObject) as address:
         yield address
 
 


### PR DESCRIPTION
issue: https://github.com/ray-project/ray/issues/60750

## Description
This PR adds a  middleware that acts like a "proxy" to the dashboard server so that when a request comes in, it will redirect request to the history-server-url. If the history-server-url request fails, it will fallback to original request handler.

## Related issues

## Additional information
Manual testing process
1. Started Kind Cluster with KubeRay, History Server, and few RayClusters.
2. Created a head-only RayCluster with the ray changes with env var `HISTORY_SERVER_URL`
ex: 
```
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: dashboard-only-cluster
  namespace: <same-ns-as-historyserver>
spec:
  rayVersion: '2.52.1'
  headGroupSpec:
    rayStartParams:
      dashboard-host: '0.0.0.0'
    template:
      spec:
        containers:
        - name: ray-head
          image: local-ray-image:v1
          imagePullPolicy: IfNotPresent
          env: 
          - name: HISTORY_SERVER_URL        
            value: "http://historyserver:30080"
          ports:
          - containerPort: 8265 # Dashboard
            name: dashboard
          - containerPort: 6379
            name: gcs
          resources:
            limits:
              cpu: "5"
              memory: 10G
            requests:
              cpu: "50m"
              memory: 1G
  workerGroupSpecs: []
```
3. port-forward the head-only RayCluster

The logs under `dashboard.logs` should show lines like
```
2026-02-24 12:55:45,825 INFO http_server_head.py:336 -- Sending request to history server instead. full_url='http://historyserver:30080/api/jobs/'
...
2026-02-24 12:55:45,827 INFO web_log.py:214 -- 10.244.0.33 [24/Feb/2026:12:55:15 -0800] 'GET /nodes?view=summary HTTP/1.1' 200 0 bytes 30174274 us 'http://localhost:8265/' 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36'
...
2026-02-24 12:55:45,446 INFO http_server_head.py:336 -- Sending request to history server instead. full_url='http://historyserver:30080/api/grafana_health'
```
