### PR TITLE
[Data] Make LogicalOperator an ABC with abstract num_outputs

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ray.data.block import Schema
 
 
-class LogicalOperator(Operator):
+class LogicalOperator(Operator, ABC):
     """Abstract class for logical operators.
 
     A logical operator describes transformation, and later is converted into
@@ -33,7 +33,13 @@ class LogicalOperator(Operator):
         for x in input_dependencies:
             assert isinstance(x, LogicalOperator), x
 
-        self.num_outputs: Optional[int] = num_outputs
+        self._num_outputs: Optional[int] = num_outputs
+
+    @property
+    @abstractmethod
+    def num_outputs(self) -> Optional[int]:
+        """Expected number of output blocks, if known."""
+        ...
 
     def estimated_num_outputs(self) -> Optional[int]:
         """Returns the estimated number of blocks that

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -60,6 +60,10 @@ class AbstractAllToAll(LogicalOperator):
         self.ray_remote_args = ray_remote_args or {}
         self.sub_progress_bar_names = sub_progress_bar_names
 
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs
+
 
 class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for randomize_block_order."""

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from ray.data._internal.logical.interfaces import LogicalOperator
 
 __all__ = [
@@ -20,3 +22,7 @@ class Count(LogicalOperator):
         input_op: LogicalOperator,
     ):
         super().__init__(input_dependencies=[input_op])
+
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -58,6 +58,10 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
     def output_data(self) -> Optional[List[RefBundle]]:
         return self.input_data
 
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs
+
     @functools.cached_property
     def _cached_output_metadata(self) -> BlockMetadata:
         return BlockMetadata(

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -27,6 +27,10 @@ class InputData(LogicalOperator, SourceOperator):
     def output_data(self) -> Optional[List[RefBundle]]:
         return self.input_data
 
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs
+
     def infer_metadata(self) -> BlockMetadata:
         return self._cached_output_metadata
 

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -30,6 +30,10 @@ class NAry(LogicalOperator):
             num_outputs=num_outputs,
         )
 
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs
+
 
 class Zip(NAry):
     """Logical operator for zip."""

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -51,6 +51,10 @@ class AbstractOneToOne(LogicalOperator):
         self.can_modify_num_rows = can_modify_num_rows
 
     @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs
+
+    @property
     def input_dependency(self) -> LogicalOperator:
         return self.input_dependencies[0]
 

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -24,3 +24,7 @@ class StreamingSplit(LogicalOperator):
         self.num_splits = num_splits
         self.equal = equal
         self.locality_hints = locality_hints
+
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -136,6 +136,10 @@ class DummyLogicalOperator(LogicalOperator):
 
         self._data_class = TestDataclass()
 
+    @property
+    def num_outputs(self):
+        return self._num_outputs
+
 
 @pytest.fixture
 def dummy_dataset_topology():

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -2,39 +2,45 @@ from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan
 from ray.data.context import DataContext
 
 
+class DummyLogicalOperator(LogicalOperator):
+    @property
+    def num_outputs(self):
+        return self._num_outputs
+
+
 def test_sources_singleton():
     ctx = DataContext.get_current()
 
-    source = LogicalOperator([], name="source")
+    source = DummyLogicalOperator([], name="source")
     assert LogicalPlan(source, ctx).sources() == [source]
 
 
 def test_sources_chain():
     ctx = DataContext.get_current()
 
-    source = LogicalOperator([], name="source")
-    sink = LogicalOperator([source], name="sink")
+    source = DummyLogicalOperator([], name="source")
+    sink = DummyLogicalOperator([source], name="sink")
     assert LogicalPlan(sink, ctx).sources() == [source]
 
 
 def test_sources_multiple_sources():
     ctx = DataContext.get_current()
 
-    source1 = LogicalOperator([], name="source1")
-    source2 = LogicalOperator([], name="source2")
-    sink = LogicalOperator([source1, source2], name="sink")
+    source1 = DummyLogicalOperator([], name="source1")
+    source2 = DummyLogicalOperator([], name="source2")
+    sink = DummyLogicalOperator([source1, source2], name="sink")
     assert LogicalPlan(sink, ctx).sources() == [source1, source2]
 
 
 def test_logical_operator_defaults_name_to_class_name():
-    op = LogicalOperator([])
-    assert op.name == "LogicalOperator"
-    assert op.dag_str == "LogicalOperator[LogicalOperator]"
+    op = DummyLogicalOperator([])
+    assert op.name == "DummyLogicalOperator"
+    assert op.dag_str == "DummyLogicalOperator[DummyLogicalOperator]"
 
 
 def test_logical_operator_does_not_track_output_dependencies():
-    source = LogicalOperator([], name="source")
-    sink = LogicalOperator([source], name="sink")
+    source = DummyLogicalOperator([], name="source")
+    sink = DummyLogicalOperator([source], name="sink")
 
     # Logical operators should not maintain reverse output-dependency state.
     assert not hasattr(source, "_output_dependencies")


### PR DESCRIPTION
## Description

This PR makes `LogicalOperator` an abstract base class (ABC) and introduces an abstract `num_outputs` property.

#### Why this is needed:

- This PR implements Step C of the split from #60531, as part of the broader #60312 effort.
- It makes LogicalOperator an abstract base class with an explicit num_outputs contract.
- It provides a clean interface boundary for the next step (frozen dataclass migration), without changing physical-layer behavior.



#### What this PR changes:

- Updates `LogicalOperator` to inherit from `ABC`.
- Adds abstract property `num_outputs` on `LogicalOperator`.
- API Compatibility:The constructor still accepts num_outputs for API compatibility, 
  stores it in _num_outputs as a backing field, and subclasses expose it via the num_outputs property to satisfy the new abstract contract without breaking existing call sites.
- Implements `num_outputs` in core logical operator base classes:
  - `AbstractOneToOne`
  - `AbstractAllToAll`
  - `NAry`
  - `AbstractFrom`
- Implements `num_outputs` in direct concrete `LogicalOperator` subclasses that do not go through those bases:
  - `InputData`
  - `StreamingSplit`
  - `Count`
- Updates tests that instantiated `LogicalOperator` directly to use a local dummy concrete subclass.

## Related issues

Link related issues: "Fixes #60312", or "Related to #60312".

## Additional information

This PR is intentionally scoped to logical interface contract changes only (PR-C):
- no physical-layer behavior changes
- no frozen dataclass conversion yet
- no broader constructor/API reshaping beyond what is required for the abstract property contract

### Tests

Added/updated:
- `python/ray/data/tests/unit/test_logical_plan.py`
  - uses a concrete dummy logical operator for ABC compatibility
- `python/ray/data/tests/test_state_export.py`
  - updates dummy logical operator used in export-args tests

Validated with targeted existing tests:
- `python/ray/data/tests/unit/test_logical_plan.py`
- `python/ray/data/tests/test_state_export.py::test_logical_op_args`
- `python/ray/data/tests/test_operator_fusion.py`
- `python/ray/data/tests/test_execution_optimizer_basic.py`
- `python/ray/data/tests/test_execution_optimizer_advanced.py`
- `python/ray/data/tests/test_randomize_block_order.py`
- `python/ray/data/tests/test_execution_optimizer_limit_pushdown.py`
- `python/ray/data/tests/test_predicate_pushdown.py`
- `python/ray/data/tests/test_projection_fusion.py`

### Stack Plan

To complete [#60312](https://github.com/ray-project/ray/issues/60312), the original stack was:

1. https://github.com/ray-project/ray/pull/60529
2. https://github.com/ray-project/ray/pull/60528
3. https://github.com/ray-project/ray/pull/60530
4. https://github.com/ray-project/ray/pull/60531

Since PR4 was still too large, it is being further split:

1. PR-A: default `LogicalOperator` naming behavior https://github.com/ray-project/ray/pull/61020
2. PR-B: move `output_dependencies` responsibility to physical side https://github.com/ray-project/ray/pull/61107
3. PR-C: make `LogicalOperator` an ABC with abstract `num_outputs` (this PR)
4. PR-D: convert logical operators to frozen dataclasses in small groups (D1/D2/D3)
    - D1: one-to-one operators
    - D2: map operators
    - D3: all-to-all + join/read/write groups (as needed)

Planned follow-ups (not blocking this stack):
- Converting all `input_op` usage to `input_dependencies`
- Potential `AbstractFrom` restructuring