### PR TITLE
[Docs][Serve] Add interdeployment gRPC transport guide

### DIFF
--- a/doc/source/serve/advanced-guides/index.md
+++ b/doc/source/serve/advanced-guides/index.md
@@ -12,6 +12,7 @@ dyn-req-batch
 inplace-updates
 dev-workflow
 grpc-guide
+interdeployment-grpc
 replica-ranks
 replica-scheduling
 managing-java-deployments
@@ -32,6 +33,7 @@ Use these advanced guides for more options and configurations:
 - [In-Place Updates for Serve](serve-inplace-updates)
 - [Development Workflow](serve-dev-workflow)
 - [gRPC Support](serve-set-up-grpc-service)
+- [Interdeployment gRPC Transport](serve-interdeployment-grpc)
 - [Replica Ranks](serve-replica-ranks)
 - [Replica Scheduling](serve-replica-scheduling)
 - [Ray Serve Dashboard](dash-serve-view)

--- a/doc/source/serve/advanced-guides/interdeployment-grpc.md
+++ b/doc/source/serve/advanced-guides/interdeployment-grpc.md
@@ -1,0 +1,93 @@
+(serve-interdeployment-grpc)=
+# Interdeployment gRPC Transport
+
+By default, when one Ray Serve deployment calls another via a `DeploymentHandle`, requests are sent through Ray's actor RPC system ("by reference"). You can optionally switch this internal transport to gRPC, which serializes requests over the network instead.
+
+This is separate from the [gRPC ingress proxy](serve-set-up-grpc-service), which handles external gRPC clients. Interdeployment gRPC controls how deployments talk to *each other* internally.
+
+## How it works
+
+When gRPC transport is enabled for a handle:
+1. Each replica starts an internal gRPC server on a random port at startup.
+2. The calling deployment's `DeploymentHandle` sends serialized requests over gRPC to the target replica's port, bypassing Ray's actor RPC.
+3. Serialization format is configurable (cloudpickle, pickle, msgpack, or orjson).
+
+## Enabling gRPC transport
+
+### Per-handle
+
+Use `handle.options(_by_reference=False)` to enable gRPC transport for a specific handle:
+
+```python
+from ray import serve
+from ray.serve.handle import DeploymentHandle
+
+
+@serve.deployment
+class Downstream:
+    def __call__(self, request):
+        return "Hello from downstream"
+
+
+@serve.deployment
+class Upstream:
+    def __init__(self, downstream: DeploymentHandle):
+        # Enable gRPC transport for this handle
+        self._downstream = downstream.options(_by_reference=False)
+
+    async def __call__(self, request):
+        return await self._downstream.remote()
+
+
+app = Upstream.bind(Downstream.bind())
+```
+
+### Globally
+
+Set the `RAY_SERVE_USE_GRPC_BY_DEFAULT` environment variable to `1` on all nodes before starting Ray:
+
+```bash
+export RAY_SERVE_USE_GRPC_BY_DEFAULT=1
+```
+
+This makes all `DeploymentHandle` calls use gRPC transport by default. Individual handles can still override this with `handle.options(_by_reference=True)`.
+
+:::{note}
+When `RAY_SERVE_USE_GRPC_BY_DEFAULT=1` is set, proxy-to-replica communication also uses gRPC by default. You can control this independently with `RAY_SERVE_PROXY_USE_GRPC=0` or `RAY_SERVE_PROXY_USE_GRPC=1`.
+:::
+
+## Serialization options
+
+The gRPC transport supports multiple serialization formats. Configure them per-handle:
+
+```python
+handle.options(
+    _by_reference=False,
+    request_serialization="msgpack",
+    response_serialization="msgpack",
+)
+```
+
+Available formats:
+- `"cloudpickle"` (default) — most flexible, supports arbitrary Python objects.
+- `"pickle"` — standard library pickle, slightly faster than cloudpickle.
+- `"msgpack"` — fast binary format, requires data to be msgpack-serializable.
+- `"orjson"` — fast JSON format, requires data to be JSON-serializable.
+
+:::{note}
+Using `msgpack` or `orjson` can improve serialization performance but restricts the types of objects you can pass. Use them when your request/response data consists of simple types (dicts, lists, strings, numbers).
+:::
+
+## Configuration
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `RAY_SERVE_USE_GRPC_BY_DEFAULT` | `0` | Set to `1` to use gRPC transport for all interdeployment calls. |
+| `RAY_SERVE_PROXY_USE_GRPC` | Inherits from above | Set to `1` or `0` to independently control proxy-to-replica transport. |
+| `RAY_SERVE_REPLICA_GRPC_MAX_MESSAGE_LENGTH` | `4194304` (4 MB) | Maximum gRPC message size for interdeployment calls. Increase if you send large payloads between deployments. |
+
+## Limitations
+
+- **No `_to_object_ref` support.** Handles using gRPC transport (`_by_reference=False`) cannot call `._to_object_ref()` or `._to_object_ref_sync()`. These methods require Ray actor RPC.
+- **Java deployments not supported.** gRPC transport is only available for Python deployments.
+- **Data must be serializable.** When using non-cloudpickle formats, request and response data must be compatible with the chosen serializer.

--- a/doc/source/serve/advanced-guides/interdeployment-grpc.md
+++ b/doc/source/serve/advanced-guides/interdeployment-grpc.md
@@ -70,4 +70,4 @@ Using `msgpack` or `orjson` can improve serialization performance but restricts 
 
 - **No `_to_object_ref` support.** Handles using gRPC transport (`_by_reference=False`) cannot call `._to_object_ref()` or `._to_object_ref_sync()`. These methods require Ray actor RPC.
 - **Java deployments not supported.** gRPC transport is only available for Python deployments.
-- **Data must be serializable.** When using non-cloudpickle formats, request and response data must be compatible with the chosen serializer.
+- **Data must be serializable.** While `cloudpickle` can serialize most Python objects, other formats like `msgpack` or `orjson` are more restrictive. Ensure your data is compatible with the chosen serializer.

--- a/doc/source/serve/advanced-guides/interdeployment-grpc.md
+++ b/doc/source/serve/advanced-guides/interdeployment-grpc.md
@@ -18,28 +18,10 @@ When gRPC transport is enabled for a handle:
 
 Use `handle.options(_by_reference=False)` to enable gRPC transport for a specific handle:
 
-```python
-from ray import serve
-from ray.serve.handle import DeploymentHandle
-
-
-@serve.deployment
-class Downstream:
-    def __call__(self, request):
-        return "Hello from downstream"
-
-
-@serve.deployment
-class Upstream:
-    def __init__(self, downstream: DeploymentHandle):
-        # Enable gRPC transport for this handle
-        self._downstream = downstream.options(_by_reference=False)
-
-    async def __call__(self, request):
-        return await self._downstream.remote()
-
-
-app = Upstream.bind(Downstream.bind())
+```{literalinclude} ../doc_code/interdeployment_grpc.py
+:start-after: __begin_per_handle__
+:end-before: __end_per_handle__
+:language: python
 ```
 
 ### Globally
@@ -60,12 +42,10 @@ When `RAY_SERVE_USE_GRPC_BY_DEFAULT=1` is set, proxy-to-replica communication al
 
 The gRPC transport supports multiple serialization formats. Configure them per-handle:
 
-```python
-handle.options(
-    _by_reference=False,
-    request_serialization="msgpack",
-    response_serialization="msgpack",
-)
+```{literalinclude} ../doc_code/interdeployment_grpc.py
+:start-after: __begin_serialization_options__
+:end-before: __end_serialization_options__
+:language: python
 ```
 
 Available formats:

--- a/doc/source/serve/doc_code/interdeployment_grpc.py
+++ b/doc/source/serve/doc_code/interdeployment_grpc.py
@@ -7,7 +7,7 @@ from ray.serve.handle import DeploymentHandle
 
 @serve.deployment
 class Downstream:
-    def __call__(self, request):
+    def __call__(self):
         return "Hello from downstream"
 
 
@@ -17,7 +17,7 @@ class Upstream:
         # Enable gRPC transport for this handle
         self._downstream = downstream.options(_by_reference=False)
 
-    async def __call__(self, request):
+    async def __call__(self):
         return await self._downstream.remote()
 
 

--- a/doc/source/serve/doc_code/interdeployment_grpc.py
+++ b/doc/source/serve/doc_code/interdeployment_grpc.py
@@ -1,0 +1,37 @@
+# flake8: noqa
+
+# __begin_per_handle__
+from ray import serve
+from ray.serve.handle import DeploymentHandle
+
+
+@serve.deployment
+class Downstream:
+    def __call__(self, request):
+        return "Hello from downstream"
+
+
+@serve.deployment
+class Upstream:
+    def __init__(self, downstream: DeploymentHandle):
+        # Enable gRPC transport for this handle
+        self._downstream = downstream.options(_by_reference=False)
+
+    async def __call__(self, request):
+        return await self._downstream.remote()
+
+
+app = Upstream.bind(Downstream.bind())
+# __end_per_handle__
+
+
+# __begin_serialization_options__
+# Configure serialization format per-handle.
+# Use msgpack or orjson for better performance when data is simple
+# (dicts, lists, strings, numbers).
+handle = downstream.options(  # noqa: F821
+    _by_reference=False,
+    request_serialization="msgpack",
+    response_serialization="msgpack",
+)
+# __end_serialization_options__


### PR DESCRIPTION
## Summary
- Add a new advanced guide documenting Ray Serve's interdeployment gRPC transport
- Explains the difference from the existing gRPC ingress proxy guide
- Covers per-handle (`_by_reference=False`) and global (`RAY_SERVE_USE_GRPC_BY_DEFAULT=1`) enablement
- Documents serialization options (cloudpickle, pickle, msgpack, orjson)
- Lists environment variables (`RAY_SERVE_USE_GRPC_BY_DEFAULT`, `RAY_SERVE_PROXY_USE_GRPC`, `RAY_SERVE_REPLICA_GRPC_MAX_MESSAGE_LENGTH`)
- Documents limitations (`_to_object_ref` not supported, Python-only)

## Test plan
- [ ] Verify the doc builds cleanly with Sphinx
- [ ] Verify the `(serve-interdeployment-grpc)=` cross-reference resolves
- [ ] Review env var table against `python/ray/serve/_private/constants.py` for accuracy