### PR TITLE
[TRIVIAL] usage_lib.py: fix warning on 3.14

### DIFF
--- a/python/ray/_common/usage/usage_lib.py
+++ b/python/ray/_common/usage/usage_lib.py
@@ -656,8 +656,8 @@ def _get_cluster_status_to_report_v2(gcs_client: GcsClient) -> ClusterStatusToRe
         )
     except Exception as e:
         logger.info(f"Failed to get cluster status to report {e}")
-    finally:
-        return result
+
+    return result
 
 
 def get_cluster_status_to_report(gcs_client: GcsClient) -> ClusterStatusToReport:


### PR DESCRIPTION
this code is raising a warning on python 3.14.
you should not return inside of a finally. easy fix.

I don't think the code is a problem, it was already catching Exception on purpose.  (the finally implies to catch all exceptions which is error prone if you didn't know about that and didn't mean to do that).

ticket on 3.14 support https://github.com/ray-project/ray/issues/56434

```
...lib/python3.14/site-packages/ray/_common/usage/usage_lib.py:660
  .../lib/python3.14/site-packages/ray/_common/usage/usage_lib.py:660: SyntaxWarning: 'return' in a 'finally' block
    return result
```
