### PR TITLE
[RLlib] GAE boostrap refactor - Faster learner connectors 1/n

### DIFF
--- a/doc/source/rllib/rllib-offline.rst
+++ b/doc/source/rllib/rllib-offline.rst
@@ -1245,10 +1245,9 @@ it relies on fully prepared batches containing `OBS`, `REWARDS`, `NEXT_OBS`, `TE
 
 To meet these requirements, the pipeline must include the following sequence of :py:class:`~ray.rllib.connectors.connector_v2.ConnectorV2` instances:
 
-1. :py:class:`ray.rllib.connectors.learner.add_one_ts_to_episodes_and_truncate.AddOneTsToEpisodesAndTruncate` ensures the :py:class:`~ray.rllib.env.single_agent_episode.SingleAgentEpisode` objects are elongated by one timestep.
-2. :py:class:`ray.rllib.connectors.common.add_observations_from_episodes_to_batch.AddObservationsFromEpisodesToBatch` incorporates the observations (`OBS`) into the batch.
-3. :py:class:`ray.rllib.connectors.learner.add_next_observations_from_episodes_to_train_batch.AddNextObservationsFromEpisodesToTrainBatch` adds the next observations (`NEXT_OBS`).
-4. Finally, the :py:class:`ray.rllib.connectors.learner.general_advantage_estimation.GeneralAdvantageEstimation` connector piece is applied.
+1. :py:class:`ray.rllib.connectors.common.add_observations_from_episodes_to_batch.AddObservationsFromEpisodesToBatch` incorporates the observations (`OBS`) into the batch.
+2. :py:class:`ray.rllib.connectors.learner.add_next_observations_from_episodes_to_train_batch.AddNextObservationsFromEpisodesToTrainBatch` adds the next observations (`NEXT_OBS`).
+3. Finally, the :py:class:`ray.rllib.connectors.learner.general_advantage_estimation.GeneralAdvantageEstimation` connector piece is applied.
 
 Below is the example code snippet from `RLlib's MARWIL algorithm <https://github.com/ray-project/ray/tree/master/rllib/algorithms/marwil>`__ demonstrating this setup:
 

--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -3199,6 +3199,25 @@ py_test(
 )
 
 # --------------------------------------------------------------------
+# connectors/ directory
+#
+# Tag: connectors
+#
+# NOTE: Add tests alphabetically into this list.
+# --------------------------------------------------------------------
+
+py_test(
+    name = "connectors/common/tests/test_frame_stacking",
+    size = "small",
+    srcs = ["connectors/common/tests/test_frame_stacking"],
+    main = "connectors/common/tests/test_frame_stacking",
+    tags = [
+        "no_main",
+        "team:rllib",
+    ],
+)
+
+# --------------------------------------------------------------------
 # examples/ directory
 #
 # Tag: examples

--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -3209,7 +3209,7 @@ py_test(
 py_test(
     name = "connectors/common/tests/test_frame_stacking",
     size = "small",
-    srcs = ["connectors/common/tests/test_frame_stacking"],
+    srcs = ["connectors/common/tests/test_frame_stacking.py"],
     main = "connectors/common/tests/test_frame_stacking",
     tags = [
         "no_main",

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1284,8 +1284,12 @@ class AlgorithmConfig(_Config):
         )
         if self.add_default_connectors_to_learner_pipeline:
             # De-duplicate episode chunk IDs first so all downstream connectors
-            # see unique batch keys. Must be the first default connector.
-            pipeline.append(EpisodeIdDeduplication())
+            # (including custom ones) see unique batch keys. Must be the very
+            # first connector in the pipeline — prepend so it runs before any
+            # user-provided custom connectors that may cache data keyed by
+            # episode ID (e.g. FrameStackingLearner stores bootstrap obs in
+            # shared_data under episode IDs).
+            pipeline.prepend(EpisodeIdDeduplication())
             # Append OBS handling.
             pipeline.append(
                 AddObservationsFromEpisodesToBatch(as_learner_connector=True)

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -1248,6 +1248,7 @@ class AlgorithmConfig(_Config):
             AddTimeDimToBatchAndZeroPad,
             AgentToModuleMapping,
             BatchIndividualItems,
+            EpisodeIdDeduplication,
             LearnerConnectorPipeline,
             NumpyToTensor,
         )
@@ -1282,6 +1283,9 @@ class AlgorithmConfig(_Config):
             input_action_space=input_action_space,
         )
         if self.add_default_connectors_to_learner_pipeline:
+            # De-duplicate episode chunk IDs first so all downstream connectors
+            # see unique batch keys. Must be the first default connector.
+            pipeline.append(EpisodeIdDeduplication())
             # Append OBS handling.
             pipeline.append(
                 AddObservationsFromEpisodesToBatch(as_learner_connector=True)

--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -703,6 +703,7 @@ class DQN(Algorithm):
                         gamma=self.config.gamma,
                         beta=self.config.replay_buffer_config.get("beta"),
                         sample_episodes=True,
+                        to_numpy=True,
                     )
 
                     # Get the replay buffer metrics.

--- a/rllib/algorithms/marwil/marwil.py
+++ b/rllib/algorithms/marwil/marwil.py
@@ -8,7 +8,6 @@ from ray.rllib.algorithms.algorithm_config import AlgorithmConfig, NotProvided
 from ray.rllib.connectors.learner import (
     AddNextObservationsFromEpisodesToTrainBatch,
     AddObservationsFromEpisodesToBatch,
-    AddOneTsToEpisodesAndTruncate,
     GeneralAdvantageEstimation,
 )
 from ray.rllib.core.learner.learner import Learner
@@ -361,12 +360,6 @@ class MARWILConfig(AlgorithmConfig):
             input_action_space=input_action_space,
             device=device,
         )
-
-        # Before anything, add one ts to each episode (and record this in the loss
-        # mask, so that the computations at this extra ts are not used to compute
-        # the loss).
-        pipeline.prepend(AddOneTsToEpisodesAndTruncate())
-
         # Prepend the "add-NEXT_OBS-from-episodes-to-train-batch" connector piece (right
         # after the corresponding "add-OBS-..." default piece).
         pipeline.insert_after(

--- a/rllib/algorithms/ppo/ppo_learner.py
+++ b/rllib/algorithms/ppo/ppo_learner.py
@@ -7,7 +7,6 @@ from ray.rllib.algorithms.ppo.ppo import (
     PPOConfig,
 )
 from ray.rllib.connectors.learner import (
-    AddOneTsToEpisodesAndTruncate,
     GeneralAdvantageEstimation,
 )
 from ray.rllib.core.learner.learner import Learner
@@ -52,22 +51,18 @@ class PPOLearner(Learner):
             )
         )
 
-        # Extend all episodes by one artificial timestep to allow the value function net
-        # to compute the bootstrap values (and add a mask to the batch to know, which
-        # slots to mask out).
         if (
             self._learner_connector is not None
             and self.config.add_default_connectors_to_learner_pipeline
         ):
-            # Before anything, add one ts to each episode (and record this in the loss
-            # mask, so that the computations at this extra ts are not used to compute
-            # the loss).
-            self._learner_connector.prepend(AddOneTsToEpisodesAndTruncate())
             # At the end of the pipeline (when the batch is already completed), add the
             # GAE connector, which performs a vf forward pass, then computes the GAE
             # computations, and puts the results of this (advantages, value targets)
             # directly back in the batch. This is then the batch used for
             # `forward_train` and `compute_losses`.
+            # Note: bootstrap values for in-progress episodes are computed inside
+            # GeneralAdvantageEstimation via a second small forward pass, so episodes
+            # no longer need to be artificially extended by one timestep beforehand.
             self._learner_connector.append(
                 GeneralAdvantageEstimation(
                     gamma=self.config.gamma, lambda_=self.config.lambda_

--- a/rllib/algorithms/ppo/ppo_learner.py
+++ b/rllib/algorithms/ppo/ppo_learner.py
@@ -60,9 +60,6 @@ class PPOLearner(Learner):
             # computations, and puts the results of this (advantages, value targets)
             # directly back in the batch. This is then the batch used for
             # `forward_train` and `compute_losses`.
-            # Note: bootstrap values for in-progress episodes are computed inside
-            # GeneralAdvantageEstimation via a second small forward pass, so episodes
-            # no longer need to be artificially extended by one timestep beforehand.
             self._learner_connector.append(
                 GeneralAdvantageEstimation(
                     gamma=self.config.gamma, lambda_=self.config.lambda_

--- a/rllib/connectors/common/add_observations_from_episodes_to_batch.py
+++ b/rllib/connectors/common/add_observations_from_episodes_to_batch.py
@@ -153,6 +153,14 @@ class AddObservationsFromEpisodesToBatch(ConnectorV2):
                 #  performs this very task.
                 if "_" not in sa_episode.id_:
                     sa_episode.id_ += "_" + str(i)
+                # Ensure the batch key is unique per sub-episode in the learner
+                # pipeline. Multiple sub-games from the same MA episode share the same
+                # `multi_agent_episode_id`, causing key collisions: OBS is split via
+                # `split_and_zero_pad` treating all sub-episodes as a single stream
+                # (ceil(sum(T_i)/m) sequences), while STATE_IN is computed per episode
+                # (sum(ceil(T_i/m)) items). The ceiling inequality means STATE_IN >
+                # OBS, crashing the LSTM forward pass.
+                sa_episode.multi_agent_episode_id = sa_episode.id_
 
                 self.add_n_batch_items(
                     batch,

--- a/rllib/connectors/common/add_states_from_episodes_to_batch.py
+++ b/rllib/connectors/common/add_states_from_episodes_to_batch.py
@@ -52,8 +52,8 @@ class AddStatesFromEpisodesToBatch(ConnectorV2):
     and restructured under a new STATE_IN key.
     As a Learner connector, the resulting STATE_IN batch has the shape (B', ...).
     Here, B' is the sum of splits we have to do over the given episodes, such that each
-    chunk is at most `max_seq_len` long (T-axis).
-    As a EnvToModule connector, the resulting STATE_IN batch simply consists of n
+    chunk is as long as possible, but at most `max_seq_len` long (T-axis).
+    As an EnvToModule connector, the resulting STATE_IN batch simply consists of n
     states coming from n vectorized environments/episodes.
 
     Also, all other data (observations, rewards, etc.. if applicable) will be properly
@@ -62,8 +62,6 @@ class AddStatesFromEpisodesToBatch(ConnectorV2):
 
     This ConnectorV2:
     - Operates on a list of Episode objects.
-    - Gets the most recent STATE_OUT from all the given episodes and adds them under
-    the STATE_IN key to the batch under construction.
     - Does NOT alter any data in the given episodes.
     - Can be used in EnvToModule and Learner connector pipelines.
 

--- a/rllib/connectors/common/add_states_from_episodes_to_batch.py
+++ b/rllib/connectors/common/add_states_from_episodes_to_batch.py
@@ -238,14 +238,9 @@ class AddStatesFromEpisodesToBatch(ConnectorV2):
                 if not sa_module.is_stateful():
                     continue
 
-                # Skip SA episodes with no actual timesteps in this batch. For T=0
-                # episodes, `split_and_zero_pad` correctly produces 0 OBS sequences,
-                # but the STATE_IN formula produces 1 entry (the initial/lookback state),
-                # causing a STATE_IN vs OBS count mismatch that crashes stateful modules
-                # (e.g. LSTM: "Expected hidden[0] size (1, N, 128), got [1, N+1, 128]").
-                # T=0 can arise when a MultiAgentEpisode slice covers an env-step range
-                # where a particular agent did not step (e.g. after early termination or
-                # non-simultaneous stepping).
+                # Skip SA episodes with no actual timesteps in this batch. For empty single agent
+                # episodes, the incoming episode is expected to have 0 obs sequences,
+                # so we don't want to add any state in for these.
                 if len(sa_episode) == 0:
                     continue
 
@@ -303,12 +298,11 @@ class AddStatesFromEpisodesToBatch(ConnectorV2):
                     if sa_episode.is_numpy
                     else ([look_back_state] + state_outs[:-1])[::max_seq_len]
                 )
-                num_items = int(math.ceil(len(sa_episode) / max_seq_len))
                 self.add_n_batch_items(
                     batch=batch,
                     column=Columns.STATE_IN,
                     items_to_add=items_to_add,
-                    num_items=num_items,
+                    num_items=int(math.ceil(len(sa_episode) / max_seq_len)),
                     single_agent_episode=sa_episode,
                 )
                 if Columns.NEXT_OBS in batch:

--- a/rllib/connectors/common/add_time_dim_to_batch_and_zero_pad.py
+++ b/rllib/connectors/common/add_time_dim_to_batch_and_zero_pad.py
@@ -266,6 +266,14 @@ class AddTimeDimToBatchAndZeroPad(ConnectorV2):
                 if not sa_module.is_stateful():
                     continue
 
+                # Skip SA episodes with no actual timesteps — consistent with
+                # AddStatesFromEpisodesToBatch's guard: a T=0 episode contributes 0
+                # OBS sequences after split_and_zero_pad, so SEQ_LENS/LOSS_MASK must
+                # also produce 0 entries (create_mask_and_seq_lens(0, m) wrongly
+                # produces 1 entry).
+                if len(sa_episode) == 0:
+                    continue
+
                 max_seq_len = sa_module.model_config["max_seq_len"]
 
                 # Also, create the loss mask (b/c of our now possibly zero-padded data)

--- a/rllib/connectors/common/add_time_dim_to_batch_and_zero_pad.py
+++ b/rllib/connectors/common/add_time_dim_to_batch_and_zero_pad.py
@@ -266,11 +266,8 @@ class AddTimeDimToBatchAndZeroPad(ConnectorV2):
                 if not sa_module.is_stateful():
                     continue
 
-                # Skip SA episodes with no actual timesteps — consistent with
-                # AddStatesFromEpisodesToBatch's guard: a T=0 episode contributes 0
-                # OBS sequences after split_and_zero_pad, so SEQ_LENS/LOSS_MASK must
-                # also produce 0 entries (create_mask_and_seq_lens(0, m) wrongly
-                # produces 1 entry).
+                # Skip SA episodes with no actual timesteps in this batch. For empty single agent
+                # episodes, we don't want to add seq_lens and loss_mask for these.
                 if len(sa_episode) == 0:
                     continue
 

--- a/rllib/connectors/common/frame_stacking.py
+++ b/rllib/connectors/common/frame_stacking.py
@@ -39,6 +39,7 @@ class FrameStacking(ConnectorV2):
         num_frames: int = 1,
         multi_agent: bool = False,
         as_learner_connector: bool = False,
+        used_together_with_gae: bool = True,
         **kwargs,
     ):
         """Initializes a FrameStackingConnector instance.
@@ -50,6 +51,9 @@ class FrameStacking(ConnectorV2):
                 observation space mapping AgentIDs to individual agents' observations.
             as_learner_connector: Whether this connector is part of a Learner connector
                 pipeline, as opposed to an env-to-module pipeline.
+            used_together_with_gae: Whether this connector is used together with the GAE connector.
+                This is important, because the GAE connector expects the bootstrap observation to be stacked,
+                so we need to stack it here. You can disable this
         """
         super().__init__(
             input_observation_space=input_observation_space,
@@ -60,6 +64,7 @@ class FrameStacking(ConnectorV2):
         self._multi_agent = multi_agent
         self.num_frames = num_frames
         self._as_learner_connector = as_learner_connector
+        self._used_together_with_gae = used_together_with_gae
 
     @override(ConnectorV2)
     def __call__(
@@ -116,7 +121,11 @@ class FrameStacking(ConnectorV2):
                 # frame-stacked bootstrap observation (s_T, one step beyond the
                 # training window). GAE uses this to bootstrap the value estimate
                 # for truncated / in-progress episodes.
-                if not sa_episode.is_terminated and shared_data is not None:
+                if (
+                    self._used_together_with_gae
+                    and not sa_episode.is_terminated
+                    and shared_data is not None
+                ):
 
                     def _bootstrap_map_fn(s, _sa_episode=sa_episode):
                         s = np.squeeze(s, axis=-1)
@@ -131,7 +140,7 @@ class FrameStacking(ConnectorV2):
                                 s, shape=new_shape, strides=new_strides
                             )[-1],
                             axes=[1, 2, 0],
-                        ).copy()
+                        )
 
                     stacked_bootstrap = tree.map_structure(
                         _bootstrap_map_fn,

--- a/rllib/connectors/common/frame_stacking.py
+++ b/rllib/connectors/common/frame_stacking.py
@@ -130,8 +130,9 @@ class FrameStacking(ConnectorV2):
                     def _bootstrap_map_fn(s, _sa_episode=sa_episode):
                         s = np.squeeze(s, axis=-1)
                         # One extra timestep compared to the training slice.
-                        T_plus_1 = len(_sa_episode) + 1
-                        new_shape = (T_plus_1, self.num_frames) + s.shape[1:]
+                        new_shape = (len(_sa_episode) + 1, self.num_frames) + s.shape[
+                            1:
+                        ]
                         new_strides = (s.strides[0],) + s.strides
                         # Take only the last row (the bootstrap timestep) and
                         # transpose from (num_frames, H, W) to (H, W, num_frames).

--- a/rllib/connectors/common/frame_stacking.py
+++ b/rllib/connectors/common/frame_stacking.py
@@ -77,6 +77,14 @@ class FrameStacking(ConnectorV2):
         shared_data: Optional[dict] = None,
         **kwargs,
     ) -> Any:
+        if self._used_together_with_gae:
+            assert (
+                shared_data is not None
+            ), "Shared data is required when used together with GAE"
+            assert (
+                "stacked_bootstrap_obs" not in shared_data
+            ), "Stacked bootstrap observation already exists in shared data, can not be added."
+            shared_data["stacked_bootstrap_obs"] = {}
         # Learner connector pipeline. Episodes have been numpy'ized.
         if self._as_learner_connector:
             for sa_episode in self.single_agent_episode_iterator(
@@ -84,20 +92,14 @@ class FrameStacking(ConnectorV2):
             ):
 
                 def _map_fn(s, _sa_episode=sa_episode):
-                    # Squeeze out last dim.
+                    # (N, H, W, 1) → (N, H, W) → (T, H, W, num_frames)
                     s = np.squeeze(s, axis=-1)
-                    # Calculate new shape and strides
-                    new_shape = (len(_sa_episode), self.num_frames) + s.shape[1:]
-                    new_strides = (s.strides[0],) + s.strides
-                    # Create a strided view of the array.
-                    # But return a copy to avoid non-contiguous memory in the object
-                    # store (which is very expensive to deserialize).
-                    return np.transpose(
-                        np.lib.stride_tricks.as_strided(
-                            s, shape=new_shape, strides=new_strides
-                        ),
-                        axes=[0, 2, 3, 1],
-                    ).copy()
+                    stacked = np.lib.stride_tricks.sliding_window_view(
+                        s, self.num_frames, axis=0
+                    )
+                    # Copy to ensure contiguous memory (expensive to
+                    # deserialize otherwise).
+                    return stacked.copy()
 
                 # Get all observations from the episode in one np array (except for
                 # the very last one, which is the final observation not needed for
@@ -128,20 +130,12 @@ class FrameStacking(ConnectorV2):
                 ):
 
                     def _bootstrap_map_fn(s, _sa_episode=sa_episode):
+                        # (N, H, W, 1) → (N, H, W) → (T+1, H, W, num_frames)
+                        # Take only the last row: the bootstrap observation.
                         s = np.squeeze(s, axis=-1)
-                        # One extra timestep compared to the training slice.
-                        new_shape = (len(_sa_episode) + 1, self.num_frames) + s.shape[
-                            1:
-                        ]
-                        new_strides = (s.strides[0],) + s.strides
-                        # Take only the last row (the bootstrap timestep) and
-                        # transpose from (num_frames, H, W) to (H, W, num_frames).
-                        return np.transpose(
-                            np.lib.stride_tricks.as_strided(
-                                s, shape=new_shape, strides=new_strides
-                            )[-1],
-                            axes=[1, 2, 0],
-                        )
+                        return np.lib.stride_tricks.sliding_window_view(
+                            s, self.num_frames, axis=0
+                        )[-1]
 
                     stacked_bootstrap = tree.map_structure(
                         _bootstrap_map_fn,
@@ -151,7 +145,7 @@ class FrameStacking(ConnectorV2):
                             fill=0.0,
                         ),
                     )
-                    shared_data.setdefault("stacked_bootstrap_obs", {})[
+                    shared_data["stacked_bootstrap_obs"][
                         sa_episode.id_
                     ] = stacked_bootstrap
 

--- a/rllib/connectors/common/tests/test_frame_stacking.py
+++ b/rllib/connectors/common/tests/test_frame_stacking.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+from ray.rllib.connectors.common.frame_stacking import FrameStacking
+from ray.rllib.core.columns import Columns
+from ray.rllib.env.single_agent_episode import SingleAgentEpisode
+from ray.rllib.utils.test_utils import check
+
+H, W = 4, 4
+
+
+def _make_episode(T, num_frames, *, terminated=False):
+    """Numpy-ized episode: lookback is zeros, obs_t is filled with (t+1)."""
+    lookback = num_frames - 1
+    observations = [np.zeros((H, W, 1))] * lookback + [
+        np.full((H, W, 1), float(t + 1)) for t in range(T + 1)
+    ]
+    actions = [0] * lookback + list(range(T))
+    rewards = [0.0] * lookback + [1.0] * T
+    episode = SingleAgentEpisode(
+        observations=observations,
+        actions=actions,
+        rewards=rewards,
+        terminated=terminated,
+        len_lookback_buffer=lookback,
+    )
+    episode.to_numpy()
+    return episode
+
+
+def _run(episode, num_frames, with_gae=False):
+    """Run the frame stacking connector and return the observations and the bootstrap observation."""
+    connector = FrameStacking(
+        input_observation_space=None,
+        input_action_space=None,
+        num_frames=num_frames,
+        as_learner_connector=True,
+        used_together_with_gae=with_gae,
+    )
+    batch, shared_data = {}, {} if with_gae else None
+    connector(rl_module=None, batch=batch, episodes=[episode], shared_data=shared_data)
+    obs = batch[Columns.OBS][(episode.id_,)][0]
+    bootstrap = None
+    if with_gae and not episode.is_terminated:
+        bootstrap = shared_data["stacked_bootstrap_obs"].get(episode.id_)
+    return obs, bootstrap
+
+
+class TestFrameStackingLearner:
+    def test_bootstrap_non_terminated(self):
+        """Test that the bootstrap observation is correctly computed for a non-terminated episode."""
+        _, bootstrap = _run(
+            _make_episode(T=6, num_frames=4), num_frames=4, with_gae=True
+        )
+        check(bootstrap.shape, (H, W, 4))
+        # Window ending at obs[6]=7: channels [4, 5, 6, 7]
+        for c, val in enumerate([4, 5, 6, 7]):
+            check(bootstrap[:, :, c], val)
+
+    def test_no_bootstrap_terminated(self):
+        """Test that the bootstrap observation is None for a terminated episode."""
+        _, bootstrap = _run(
+            _make_episode(T=6, num_frames=4, terminated=True),
+            num_frames=4,
+            with_gae=True,
+        )
+        check(bootstrap, None)
+
+    @pytest.mark.parametrize("T,num_frames", [(1, 4), (3, 2), (8, 1)])
+    def test_output_shape(self, T, num_frames):
+        obs, _ = _run(_make_episode(T, num_frames), num_frames)
+        check(obs.shape, (T, H, W, num_frames))
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/connectors/common/tests/test_frame_stacking.py
+++ b/rllib/connectors/common/tests/test_frame_stacking.py
@@ -48,7 +48,14 @@ def _run(episode, num_frames, with_gae=False):
 
 class TestFrameStackingLearner:
     def test_bootstrap_non_terminated(self):
-        """Test that the bootstrap observation is correctly computed for a non-terminated episode."""
+        """Test that the bootstrap observation is correctly computed for a non-terminated episode.
+
+        For this test, we construct an episode that has 3 obserations that are all zeros.
+        This is followed by 6 observations that are [<all ones>, <all twos>, ..., <all sevens>].
+        We then stack 4 frames and check that the bootstrap observation is correctly computed.
+        The bootstrap observation should be the last 4 observations,
+        which are [<all fours>, <all fives>, <all sixes>, <all sevens>].
+        """
         _, bootstrap = _run(
             _make_episode(T=6, num_frames=4), num_frames=4, with_gae=True
         )
@@ -68,6 +75,7 @@ class TestFrameStackingLearner:
 
     @pytest.mark.parametrize("T,num_frames", [(1, 4), (3, 2), (8, 1)])
     def test_output_shape(self, T, num_frames):
+        """Test that the output shape is correct for a given number of frames."""
         obs, _ = _run(_make_episode(T, num_frames), num_frames)
         check(obs.shape, (T, H, W, num_frames))
 

--- a/rllib/connectors/learner/__init__.py
+++ b/rllib/connectors/learner/__init__.py
@@ -23,6 +23,9 @@ from ray.rllib.connectors.learner.add_one_ts_to_episodes_and_truncate import (
     AddOneTsToEpisodesAndTruncate,
 )
 from ray.rllib.connectors.learner.compute_returns_to_go import ComputeReturnsToGo
+from ray.rllib.connectors.learner.episode_id_deduplication import (
+    EpisodeIdDeduplication,
+)
 from ray.rllib.connectors.learner.general_advantage_estimation import (
     GeneralAdvantageEstimation,
 )
@@ -32,6 +35,7 @@ from ray.rllib.connectors.learner.learner_connector_pipeline import (
 
 __all__ = [
     "AddColumnsFromEpisodesToTrainBatch",
+    "EpisodeIdDeduplication",
     "AddInfosFromEpisodesToTrainBatch",
     "AddNextObservationsFromEpisodesToTrainBatch",
     "AddObservationsFromEpisodesToBatch",

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -121,16 +121,20 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     col = batch.get(Columns.ACTIONS)
                     if col is None:
                         batch[Columns.ACTIONS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 if need_rewards:
                     data = sa_episode.get_rewards(slice(0, n)).view(BatchedNdArray)
                     col = batch.get(Columns.REWARDS)
                     if col is None:
                         batch[Columns.REWARDS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 if need_terminateds:
                     terminateds = np.zeros(n, dtype=np.bool_)
@@ -140,8 +144,10 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     col = batch.get(Columns.TERMINATEDS)
                     if col is None:
                         batch[Columns.TERMINATEDS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 if need_truncateds:
                     truncateds = np.zeros(n, dtype=np.bool_)
@@ -151,8 +157,10 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     col = batch.get(Columns.TRUNCATEDS)
                     if col is None:
                         batch[Columns.TRUNCATEDS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 for column in sa_episode.extra_model_outputs.keys():
                     if column not in skip_columns:
@@ -166,8 +174,10 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                         col = batch.get(column)
                         if col is None:
                             batch[column] = {sub_key: [data]}
-                        else:
+                        elif sub_key in col:
                             col[sub_key].append(data)
+                        else:
+                            col[sub_key] = [data]
 
             else:
                 # General (multi-agent) path: use the standard API.

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -1,13 +1,9 @@
 from typing import Any, Dict, List, Optional
 
-import numpy as np
-import tree
-
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
 from ray.rllib.utils.annotations import override
-from ray.rllib.utils.spaces.space_utils import BatchedNdArray
 from ray.rllib.utils.typing import EpisodeType
 from ray.util.annotations import PublicAPI
 
@@ -62,10 +58,6 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
     their own data and store it in `data` under those keys. In this case, the default
     connector will not change the data under these keys and simply act as a
     pass-through.
-
-
-    We expect that `episodes` are numpy'ized.
-    In standard training flows, episodes have already been numpy'ized before they enter this connector via EnvRunners, ReplayBuffers or offline sampling.
     """
 
     @override(ConnectorV2)
@@ -80,155 +72,92 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
         **kwargs,
     ) -> Any:
 
-        # Determine which standard columns still need to be filled (skip any that a
-        # custom upstream connector has already populated).
-        need_actions = Columns.ACTIONS not in batch
-        need_rewards = Columns.REWARDS not in batch
-        need_terminateds = Columns.TERMINATEDS not in batch
-        need_truncateds = Columns.TRUNCATEDS not in batch
+        # Actions.
+        if Columns.ACTIONS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                self.add_n_batch_items(
+                    batch,
+                    Columns.ACTIONS,
+                    # Bulk extraction: get all actions at once instead of per-timestep.
+                    items_to_add=sa_episode.get_actions(slice(0, len(sa_episode))),
+                    num_items=len(sa_episode),
+                    single_agent_episode=sa_episode,
+                )
+
+        # Rewards.
+        if Columns.REWARDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                self.add_n_batch_items(
+                    batch,
+                    Columns.REWARDS,
+                    # Bulk extraction: get all rewards at once instead of per-timestep.
+                    items_to_add=sa_episode.get_rewards(slice(0, len(sa_episode))),
+                    num_items=len(sa_episode),
+                    single_agent_episode=sa_episode,
+                )
+
+        # Terminateds.
+        if Columns.TERMINATEDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                self.add_n_batch_items(
+                    batch,
+                    Columns.TERMINATEDS,
+                    items_to_add=(
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_terminated]
+                        if len(sa_episode) > 0
+                        else []
+                    ),
+                    num_items=len(sa_episode),
+                    single_agent_episode=sa_episode,
+                )
+
+        # Truncateds.
+        if Columns.TRUNCATEDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                self.add_n_batch_items(
+                    batch,
+                    Columns.TRUNCATEDS,
+                    items_to_add=(
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_truncated]
+                        if len(sa_episode) > 0
+                        else []
+                    ),
+                    num_items=len(sa_episode),
+                    single_agent_episode=sa_episode,
+                )
 
         # Extra model outputs (except for STATE_OUT, which will be handled by another
         # default connector piece). Also, like with all the fields above, skip
         # those that the user already seemed to have populated via custom connector
         # pieces.
         skip_columns = set(batch.keys()) | {Columns.STATE_IN, Columns.STATE_OUT}
-
-        # Single pass over all episodes: compute len(sa_episode) and sub_key once and
-        # reuse them for every column.
         for sa_episode in self.single_agent_episode_iterator(
             episodes,
             agents_that_stepped_only=False,
         ):
-            n = len(sa_episode)
-
-            # For single-agent episodes (agent_id=None), sub_key is always (id_,).
-            # We can use a fast path to extend the batch.
-            # For multi-agent episodes, we need to use add_n_batch_items path.
-            if sa_episode.agent_id is None:
-                # Fast path: inline the dict operations, skipping the function call
-                # overhead of add_n_batch_items / add_batch_item and the repeated
-                # sub_key computation those would do per column.
-                sub_key = (sa_episode.id_,)
-
-                if need_actions:
-                    # Actions may be a composite action space, so we need to map the structure.
-                    data = sa_episode.get_actions(slice(0, n))
-                    # Check if the we have to call tree.map_structure to convert the data to a BatchedNdArray.
-                    if isinstance(data, np.ndarray):
-                        data = data.view(BatchedNdArray)
-                    else:
-                        data = tree.map_structure(BatchedNdArray, data)
-                    col = batch.get(Columns.ACTIONS)
-                    if col is None:
-                        batch[Columns.ACTIONS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_rewards:
-                    data = sa_episode.get_rewards(slice(0, n)).view(BatchedNdArray)
-                    col = batch.get(Columns.REWARDS)
-                    if col is None:
-                        batch[Columns.REWARDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_terminateds:
-                    terminateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        terminateds[-1] = sa_episode.is_terminated
-                    data = terminateds.view(BatchedNdArray)
-                    col = batch.get(Columns.TERMINATEDS)
-                    if col is None:
-                        batch[Columns.TERMINATEDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_truncateds:
-                    truncateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        truncateds[-1] = sa_episode.is_truncated
-                    data = truncateds.view(BatchedNdArray)
-                    col = batch.get(Columns.TRUNCATEDS)
-                    if col is None:
-                        batch[Columns.TRUNCATEDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                for column in sa_episode.extra_model_outputs.keys():
-                    if column not in skip_columns:
-                        # Extra model outputs may be a composite space, so we need to map the structure.
-                        data = tree.map_structure(
-                            BatchedNdArray,
-                            sa_episode.get_extra_model_outputs(
-                                key=column, indices=slice(0, n)
-                            ),
-                        )
-                        col = batch.get(column)
-                        if col is None:
-                            batch[column] = {sub_key: [data]}
-                        elif sub_key in col:
-                            col[sub_key].append(data)
-                        else:
-                            col[sub_key] = [data]
-
-            else:
-                # General (multi-agent) path: use the standard API.
-                if need_actions:
+            for column in sa_episode.extra_model_outputs.keys():
+                if column not in skip_columns:
                     self.add_n_batch_items(
                         batch,
-                        Columns.ACTIONS,
-                        items_to_add=sa_episode.get_actions(slice(0, n)),
-                        num_items=n,
+                        column,
+                        # Bulk extraction: get all extra outputs at once.
+                        items_to_add=sa_episode.get_extra_model_outputs(
+                            key=column, indices=slice(0, len(sa_episode))
+                        ),
+                        num_items=len(sa_episode),
                         single_agent_episode=sa_episode,
                     )
-                if need_rewards:
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.REWARDS,
-                        items_to_add=sa_episode.get_rewards(slice(0, n)),
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                if need_terminateds:
-                    terminateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        terminateds[-1] = sa_episode.is_terminated
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.TERMINATEDS,
-                        items_to_add=terminateds,
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                if need_truncateds:
-                    truncateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        truncateds[-1] = sa_episode.is_truncated
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.TRUNCATEDS,
-                        items_to_add=truncateds,
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                for column in sa_episode.extra_model_outputs.keys():
-                    if column not in skip_columns:
-                        self.add_n_batch_items(
-                            batch,
-                            column,
-                            items_to_add=sa_episode.get_extra_model_outputs(
-                                key=column, indices=slice(0, n)
-                            ),
-                            num_items=n,
-                            single_agent_episode=sa_episode,
-                        )
 
         return batch

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -6,6 +6,7 @@ import tree
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
+from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.spaces.space_utils import BatchedNdArray
 from ray.rllib.utils.typing import EpisodeType
@@ -101,10 +102,8 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
         ):
             n = len(sa_episode)
 
-            # For single-agent episodes (agent_id=None), sub_key is always (id_,).
-            # We can use a fast path to extend the batch.
-            # For multi-agent episodes, we need to use add_n_batch_items path.
-            if sa_episode.agent_id is None:
+            # For single-agent episodes, we can use a fast path to extend the batch.
+            if isinstance(sa_episode, SingleAgentEpisode):
                 # Fast path: inline the dict operations, skipping the function call
                 # overhead of add_n_batch_items / add_batch_item and the repeated
                 # sub_key computation those would do per column.
@@ -113,7 +112,7 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                 if need_actions:
                     # Actions may be a composite action space, so we need to map the structure.
                     data = sa_episode.get_actions(slice(0, n))
-                    # Check if the we have to call tree.map_structure to convert the data to a BatchedNdArray.
+                    # Check if we have to call tree.map_structure to convert the data to a BatchedNdArray.
                     if isinstance(data, np.ndarray):
                         data = data.view(BatchedNdArray)
                     else:
@@ -179,8 +178,8 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                         else:
                             col[sub_key] = [data]
 
-            else:
-                # General (multi-agent) path: use the standard API.
+            else:  # episode will be MultiAgentEpisode.
+                # For multi-agent episodes, we need to use the add_n_batch_items path.
                 if need_actions:
                     self.add_n_batch_items(
                         batch,

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-import numpy as np
-
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
@@ -60,10 +58,6 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
     their own data and store it in `data` under those keys. In this case, the default
     connector will not change the data under these keys and simply act as a
     pass-through.
-
-
-    We expect that `episodes` are numpy'ized.
-    In standard training flows, episodes have already been numpy'ized before they enter this connector via EnvRunners, ReplayBuffers or offline sampling.
     """
 
     @override(ConnectorV2)
@@ -114,15 +108,15 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                 episodes,
                 agents_that_stepped_only=False,
             ):
-                n = len(sa_episode)
-                terminateds = np.zeros(n, dtype=np.bool_)
-                if n > 0:
-                    terminateds[-1] = sa_episode.is_terminated
                 self.add_n_batch_items(
                     batch,
                     Columns.TERMINATEDS,
-                    items_to_add=terminateds,
-                    num_items=n,
+                    items_to_add=(
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_terminated]
+                        if len(sa_episode) > 0
+                        else []
+                    ),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
 
@@ -132,15 +126,15 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                 episodes,
                 agents_that_stepped_only=False,
             ):
-                n = len(sa_episode)
-                truncateds = np.zeros(n, dtype=np.bool_)
-                if n > 0:
-                    truncateds[-1] = sa_episode.is_truncated
                 self.add_n_batch_items(
                     batch,
                     Columns.TRUNCATEDS,
-                    items_to_add=truncateds,
-                    num_items=n,
+                    items_to_add=(
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_truncated]
+                        if len(sa_episode) > 0
+                        else []
+                    ),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
 

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -1,14 +1,11 @@
 from typing import Any, Dict, List, Optional
 
 import numpy as np
-import tree
 
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
-from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.rllib.utils.annotations import override
-from ray.rllib.utils.spaces.space_utils import BatchedNdArray
 from ray.rllib.utils.typing import EpisodeType
 from ray.util.annotations import PublicAPI
 
@@ -94,140 +91,62 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
         # pieces.
         skip_columns = set(batch.keys()) | {Columns.STATE_IN, Columns.STATE_OUT}
 
-        # Single pass over all episodes: compute len(sa_episode) and sub_key once and
-        # reuse them for every column.
+        # Single pass over all episodes: compute len(sa_episode) once and
+        # reuse it for every column.
         for sa_episode in self.single_agent_episode_iterator(
             episodes,
             agents_that_stepped_only=False,
         ):
             n = len(sa_episode)
 
-            # For single-agent episodes, we can use a fast path to extend the batch.
-            if isinstance(sa_episode, SingleAgentEpisode):
-                # Fast path: inline the dict operations, skipping the function call
-                # overhead of add_n_batch_items / add_batch_item and the repeated
-                # sub_key computation those would do per column.
-                sub_key = (sa_episode.id_,)
-
-                if need_actions:
-                    # Actions may be a composite action space, so we need to map the structure.
-                    data = sa_episode.get_actions(slice(0, n))
-                    # Check if we have to call tree.map_structure to convert the data to a BatchedNdArray.
-                    if isinstance(data, np.ndarray):
-                        data = data.view(BatchedNdArray)
-                    else:
-                        data = tree.map_structure(BatchedNdArray, data)
-                    col = batch.get(Columns.ACTIONS)
-                    if col is None:
-                        batch[Columns.ACTIONS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_rewards:
-                    data = sa_episode.get_rewards(slice(0, n)).view(BatchedNdArray)
-                    col = batch.get(Columns.REWARDS)
-                    if col is None:
-                        batch[Columns.REWARDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_terminateds:
-                    terminateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        terminateds[-1] = sa_episode.is_terminated
-                    data = terminateds.view(BatchedNdArray)
-                    col = batch.get(Columns.TERMINATEDS)
-                    if col is None:
-                        batch[Columns.TERMINATEDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_truncateds:
-                    truncateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        truncateds[-1] = sa_episode.is_truncated
-                    data = truncateds.view(BatchedNdArray)
-                    col = batch.get(Columns.TRUNCATEDS)
-                    if col is None:
-                        batch[Columns.TRUNCATEDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                for column in sa_episode.extra_model_outputs.keys():
-                    if column not in skip_columns:
-                        # Extra model outputs may be a composite space, so we need to map the structure.
-                        data = tree.map_structure(
-                            BatchedNdArray,
-                            sa_episode.get_extra_model_outputs(
-                                key=column, indices=slice(0, n)
-                            ),
-                        )
-                        col = batch.get(column)
-                        if col is None:
-                            batch[column] = {sub_key: [data]}
-                        elif sub_key in col:
-                            col[sub_key].append(data)
-                        else:
-                            col[sub_key] = [data]
-
-            else:  # episode will be MultiAgentEpisode.
-                # For multi-agent episodes, we need to use the add_n_batch_items path.
-                if need_actions:
+            if need_actions:
+                self.add_n_batch_items(
+                    batch,
+                    Columns.ACTIONS,
+                    items_to_add=sa_episode.get_actions(slice(0, n)),
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            if need_rewards:
+                self.add_n_batch_items(
+                    batch,
+                    Columns.REWARDS,
+                    items_to_add=sa_episode.get_rewards(slice(0, n)),
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            if need_terminateds:
+                terminateds = np.zeros(n, dtype=np.bool_)
+                if n > 0:
+                    terminateds[-1] = sa_episode.is_terminated
+                self.add_n_batch_items(
+                    batch,
+                    Columns.TERMINATEDS,
+                    items_to_add=terminateds,
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            if need_truncateds:
+                truncateds = np.zeros(n, dtype=np.bool_)
+                if n > 0:
+                    truncateds[-1] = sa_episode.is_truncated
+                self.add_n_batch_items(
+                    batch,
+                    Columns.TRUNCATEDS,
+                    items_to_add=truncateds,
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            for column in sa_episode.extra_model_outputs.keys():
+                if column not in skip_columns:
                     self.add_n_batch_items(
                         batch,
-                        Columns.ACTIONS,
-                        items_to_add=sa_episode.get_actions(slice(0, n)),
+                        column,
+                        items_to_add=sa_episode.get_extra_model_outputs(
+                            key=column, indices=slice(0, n)
+                        ),
                         num_items=n,
                         single_agent_episode=sa_episode,
                     )
-                if need_rewards:
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.REWARDS,
-                        items_to_add=sa_episode.get_rewards(slice(0, n)),
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                if need_terminateds:
-                    terminateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        terminateds[-1] = sa_episode.is_terminated
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.TERMINATEDS,
-                        items_to_add=terminateds,
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                if need_truncateds:
-                    truncateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        truncateds[-1] = sa_episode.is_truncated
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.TRUNCATEDS,
-                        items_to_add=truncateds,
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                for column in sa_episode.extra_model_outputs.keys():
-                    if column not in skip_columns:
-                        self.add_n_batch_items(
-                            batch,
-                            column,
-                            items_to_add=sa_episode.get_extra_model_outputs(
-                                key=column, indices=slice(0, n)
-                            ),
-                            num_items=n,
-                            single_agent_episode=sa_episode,
-                        )
 
         return batch

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -78,44 +78,43 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
         **kwargs,
     ) -> Any:
 
-        # Determine which standard columns still need to be filled (skip any that a
-        # custom upstream connector has already populated).
-        need_actions = Columns.ACTIONS not in batch
-        need_rewards = Columns.REWARDS not in batch
-        need_terminateds = Columns.TERMINATEDS not in batch
-        need_truncateds = Columns.TRUNCATEDS not in batch
-
-        # Extra model outputs (except for STATE_OUT, which will be handled by another
-        # default connector piece). Also, like with all the fields above, skip
-        # those that the user already seemed to have populated via custom connector
-        # pieces.
-        skip_columns = set(batch.keys()) | {Columns.STATE_IN, Columns.STATE_OUT}
-
-        # Single pass over all episodes: compute len(sa_episode) once and
-        # reuse it for every column.
-        for sa_episode in self.single_agent_episode_iterator(
-            episodes,
-            agents_that_stepped_only=False,
-        ):
-            n = len(sa_episode)
-
-            if need_actions:
+        # Actions.
+        if Columns.ACTIONS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
                 self.add_n_batch_items(
                     batch,
                     Columns.ACTIONS,
-                    items_to_add=sa_episode.get_actions(slice(0, n)),
-                    num_items=n,
+                    # Bulk extraction: get all actions at once instead of per-timestep.
+                    items_to_add=sa_episode.get_actions(slice(0, len(sa_episode))),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
-            if need_rewards:
+
+        # Rewards.
+        if Columns.REWARDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
                 self.add_n_batch_items(
                     batch,
                     Columns.REWARDS,
-                    items_to_add=sa_episode.get_rewards(slice(0, n)),
-                    num_items=n,
+                    # Bulk extraction: get all rewards at once instead of per-timestep.
+                    items_to_add=sa_episode.get_rewards(slice(0, len(sa_episode))),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
-            if need_terminateds:
+
+        # Terminateds.
+        if Columns.TERMINATEDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                n = len(sa_episode)
                 terminateds = np.zeros(n, dtype=np.bool_)
                 if n > 0:
                     terminateds[-1] = sa_episode.is_terminated
@@ -126,7 +125,14 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     num_items=n,
                     single_agent_episode=sa_episode,
                 )
-            if need_truncateds:
+
+        # Truncateds.
+        if Columns.TRUNCATEDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                n = len(sa_episode)
                 truncateds = np.zeros(n, dtype=np.bool_)
                 if n > 0:
                     truncateds[-1] = sa_episode.is_truncated
@@ -137,15 +143,26 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     num_items=n,
                     single_agent_episode=sa_episode,
                 )
+
+        # Extra model outputs (except for STATE_OUT, which will be handled by another
+        # default connector piece). Also, like with all the fields above, skip
+        # those that the user already seemed to have populated via custom connector
+        # pieces.
+        skip_columns = set(batch.keys()) | {Columns.STATE_IN, Columns.STATE_OUT}
+        for sa_episode in self.single_agent_episode_iterator(
+            episodes,
+            agents_that_stepped_only=False,
+        ):
             for column in sa_episode.extra_model_outputs.keys():
                 if column not in skip_columns:
                     self.add_n_batch_items(
                         batch,
                         column,
+                        # Bulk extraction: get all extra outputs at once.
                         items_to_add=sa_episode.get_extra_model_outputs(
-                            key=column, indices=slice(0, n)
+                            key=column, indices=slice(0, len(sa_episode))
                         ),
-                        num_items=n,
+                        num_items=len(sa_episode),
                         single_agent_episode=sa_episode,
                     )
 

--- a/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
+++ b/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-import numpy as np
-
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
@@ -140,8 +138,7 @@ class AddOneTsToEpisodesAndTruncate(ConnectorV2):
             # Extend all episodes by one ts.
             add_one_ts_to_episodes_and_truncate([sa_episode])
 
-            loss_mask = np.ones(len_ + 1, dtype=np.bool_)
-            loss_mask[-1] = False
+            loss_mask = [True for _ in range(len_)] + [False]
             self.add_n_batch_items(
                 batch,
                 Columns.LOSS_MASK,
@@ -150,10 +147,11 @@ class AddOneTsToEpisodesAndTruncate(ConnectorV2):
                 sa_episode,
             )
 
-            terminateds = np.zeros(len_ + 1, dtype=np.bool_)
-            if len_ > 0:
-                terminateds[len_ - 1] = sa_episode.is_terminated
-            terminateds[len_] = True  # extra timestep always terminated
+            terminateds = (
+                [False for _ in range(len_ - 1)]
+                + [bool(sa_episode.is_terminated)]
+                + [True]  # extra timestep
+            )
             self.add_n_batch_items(
                 batch,
                 Columns.TERMINATEDS,

--- a/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
+++ b/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+from ray._common.deprecation import Deprecated
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
@@ -11,6 +12,11 @@ from ray.util.annotations import PublicAPI
 
 
 @PublicAPI(stability="alpha")
+@Deprecated(
+    error=False,
+    old="ray.rllib.connectors.learner.add_one_ts_to_episodes_and_truncate.AddOneTsToEpisodesAndTruncate",
+    help="Use GeneralAdvantageEstimation connector standalone instead",
+)
 class AddOneTsToEpisodesAndTruncate(ConnectorV2):
     """Adds an artificial timestep to all incoming episodes at the end.
 

--- a/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
+++ b/rllib/connectors/learner/add_one_ts_to_episodes_and_truncate.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-import numpy as np
-
 from ray._common.deprecation import Deprecated
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
@@ -146,8 +144,7 @@ class AddOneTsToEpisodesAndTruncate(ConnectorV2):
             # Extend all episodes by one ts.
             add_one_ts_to_episodes_and_truncate([sa_episode])
 
-            loss_mask = np.ones(len_ + 1, dtype=np.bool_)
-            loss_mask[-1] = False
+            loss_mask = [True for _ in range(len_)] + [False]
             self.add_n_batch_items(
                 batch,
                 Columns.LOSS_MASK,
@@ -156,10 +153,11 @@ class AddOneTsToEpisodesAndTruncate(ConnectorV2):
                 sa_episode,
             )
 
-            terminateds = np.zeros(len_ + 1, dtype=np.bool_)
-            if len_ > 0:
-                terminateds[len_ - 1] = sa_episode.is_terminated
-            terminateds[len_] = True  # extra timestep always terminated
+            terminateds = (
+                [False for _ in range(len_ - 1)]
+                + [bool(sa_episode.is_terminated)]
+                + [True]  # extra timestep
+            )
             self.add_n_batch_items(
                 batch,
                 Columns.TERMINATEDS,

--- a/rllib/connectors/learner/episode_id_deduplication.py
+++ b/rllib/connectors/learner/episode_id_deduplication.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Optional
+
+from ray.rllib.connectors.connector_v2 import ConnectorV2
+from ray.rllib.core.rl_module.rl_module import RLModule
+from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
+from ray.rllib.utils.annotations import override
+from ray.rllib.utils.typing import EpisodeType
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="alpha")
+class EpisodeIdDeduplication(ConnectorV2):
+    """Ensures unique episode IDs across all episodes in the learner pipeline.
+
+    Must be the first connector in the learner pipeline. All subsequent connectors
+    write data to the batch using keys derived from episode IDs; those keys must be
+    unique across the entire training batch or data from different episodes will
+    collide into the same batch slot.
+
+    Two scenarios require de-duplication:
+
+    1. **Multi-agent setups**: Multiple chunks of the same ongoing episode may
+       arrive in one training batch (e.g. in APPO, when a long episode spans more
+       than one rollout window, or when sub-games within a single
+       `MultiAgentEpisode` rollout are collected). All such chunks share the same
+       `MultiAgentEpisode.id_`, so their child
+       `SingleAgentEpisode.multi_agent_episode_id` values collide. This connector
+       appends a running index to `ma_episode.id_` and propagates it to each child
+       SA episode's `multi_agent_episode_id`.
+
+    2. **Single-agent setups**: Same scenario for plain `SingleAgentEpisode`
+       objects: two chunks from the same episode share `id_`. This connector
+       appends a running index to make them unique.
+
+    This was previously handled as a side-effect inside
+    `AddOneTsToEpisodesAndTruncate`. Extracting it into a dedicated connector
+    satisfies the TODOs in `AddOneTsToEpisodesAndTruncate` and
+    `AddObservationsFromEpisodesToBatch`.
+    """
+
+    @override(ConnectorV2)
+    def __call__(
+        self,
+        *,
+        rl_module: RLModule,
+        batch: Dict[str, Any],
+        episodes: List[EpisodeType],
+        explore: Optional[bool] = None,
+        shared_data: Optional[dict] = None,
+        **kwargs,
+    ) -> Any:
+        for i, episode in enumerate(episodes):
+            if isinstance(episode, MultiAgentEpisode):
+                # Make this MA episode's ID unique in case multiple chunks from
+                # the same ongoing episode appear in the training batch.
+                episode.id_ += "_" + str(i)
+                # Propagate the new MA episode ID to all child SA episodes so
+                # that their batch key (multi_agent_episode_id, agent_id,
+                # module_id) is unique per episode.
+                for sa_episode in episode.agent_episodes.values():
+                    sa_episode.multi_agent_episode_id = episode.id_
+            else:
+                # Single-agent case: make the SA episode's own ID unique.
+                episode.id_ += "_" + str(i)
+
+        return batch

--- a/rllib/connectors/learner/episode_id_deduplication.py
+++ b/rllib/connectors/learner/episode_id_deduplication.py
@@ -21,8 +21,7 @@ class EpisodeIdDeduplication(ConnectorV2):
 
     1. **Multi-agent setups**: Multiple chunks of the same ongoing episode may
        arrive in one training batch (e.g. in APPO, when a long episode spans more
-       than one rollout window, or when sub-games within a single
-       `MultiAgentEpisode` rollout are collected). All such chunks share the same
+       than one rollout window). All such chunks share the same
        `MultiAgentEpisode.id_`, so their child
        `SingleAgentEpisode.multi_agent_episode_id` values collide. This connector
        appends a running index to `ma_episode.id_` and propagates it to each child
@@ -31,11 +30,6 @@ class EpisodeIdDeduplication(ConnectorV2):
     2. **Single-agent setups**: Same scenario for plain `SingleAgentEpisode`
        objects: two chunks from the same episode share `id_`. This connector
        appends a running index to make them unique.
-
-    This was previously handled as a side-effect inside
-    `AddOneTsToEpisodesAndTruncate`. Extracting it into a dedicated connector
-    satisfies the TODOs in `AddOneTsToEpisodesAndTruncate` and
-    `AddObservationsFromEpisodesToBatch`.
     """
 
     @override(ConnectorV2)

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -10,7 +10,9 @@ from ray.rllib.core.rl_module.multi_rl_module import MultiRLModule
 from ray.rllib.evaluation.postprocessing import Postprocessing
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.numpy import convert_to_numpy
-from ray.rllib.utils.postprocessing.value_predictions import compute_value_targets
+from ray.rllib.utils.postprocessing.value_predictions import (
+    compute_value_targets_with_bootstrap,
+)
 from ray.rllib.utils.postprocessing.zero_padding import (
     split_and_zero_pad_n_episodes,
     unpad_data_if_necessary,
@@ -26,18 +28,17 @@ class GeneralAdvantageEstimation(ConnectorV2):
     - Should be used only in the Learner pipeline and as one of the last pieces (due
     to the fact that it requires the batch for the value functions to be already
     complete).
-    - Requires the incoming episodes to already be elongated by one artificial timestep
-    at the end  (last obs, actions, states, etc.. repeated, last reward=0.0, etc..),
-    making it possible to combine the per-timestep value computations with the
-    necessary "bootstrap" value computations at the episode (chunk) truncation points.
-    The extra timestep should be added using the `ray.rllib.connectors.learner.
-    add_one_ts_to_episodes_and_truncate.AddOneTsToEpisodesAndTruncate` connector piece.
+    - Does NOT require episodes to be artificially elongated beforehand. Bootstrap
+    values for truncated / in-progress episodes are computed via a second, small
+    forward pass on the final observation of each such episode.
 
-    The GAE computation is performed in an efficient way through using the arriving
-    `batch` as forward batch for the value function, extracting the bootstrap values
-    (at the artificially added time steos) and all other value predictions (all other
-    timesteps), performing GAE, and adding the results back into `batch` (under
-    Postprocessing.ADVANTAGES and Postprocessing.VALUE_TARGETS.
+    The GAE computation is performed per-episode using explicit bootstrap values:
+    - Terminated episodes: bootstrap = 0.
+    - Truncated / in-progress episodes: bootstrap = V(last_obs), obtained from the
+      second forward pass.
+
+    Results are added back into `batch` under Postprocessing.ADVANTAGES and
+    Postprocessing.VALUE_TARGETS.
     """
 
     def __init__(
@@ -53,14 +54,6 @@ class GeneralAdvantageEstimation(ConnectorV2):
         Args:
             gamma: The discount factor gamma.
             lambda_: The lambda parameter for General Advantage Estimation (GAE).
-                Defines the exponential weight used between actually measured rewards
-                vs value function estimates over multiple time steps. Specifically,
-                `lambda_` balances short-term, low-variance estimates with longer-term,
-                high-variance returns. A `lambda_` or 0.0 makes the GAE rely only on
-                immediate rewards (and vf predictions from there on, reducing variance,
-                but increasing bias), while a `lambda_` of 1.0 only incorporates vf
-                predictions at the truncation points of the given episodes or episode
-                chunks (reducing bias but increasing variance).
         """
         super().__init__(input_observation_space, input_action_space)
         self.gamma = gamma
@@ -86,7 +79,8 @@ class GeneralAdvantageEstimation(ConnectorV2):
         sa_episodes_list = list(
             self.single_agent_episode_iterator(episodes, agents_that_stepped_only=False)
         )
-        # Perform the value nets' forward passes.
+
+        # Perform the value nets' forward passes on the main batch.
         # TODO (sven): We need to check here in the pipeline already, whether a module
         #  should even be updated or not (which we usually do after(!) the Learner
         #  pipeline). This is an open TODO to move this filter into a connector as well.
@@ -99,6 +93,68 @@ class GeneralAdvantageEstimation(ConnectorV2):
             ),
             return_dict=True,
         )
+
+        # Build bootstrap obs batches: for each module, collect the last observation
+        # of each non-terminated episode. These are already stored in the episode
+        # (episode.observations[-1] = s_L); no episode mutation needed.
+        bootstrap_obs_per_module = {}  # module_id -> np.ndarray (N_bootstrap, obs_dim)
+        bootstrap_mask_per_module = (
+            {}
+        )  # module_id -> list[bool] (True = needs bootstrap)
+        for module_id, module_vf_preds in vf_preds.items():
+            if module_vf_preds is None:
+                continue
+            module = rl_module[module_id]
+            if module.is_stateful():
+                # Stateful (LSTM) modules need the last hidden state for the bootstrap
+                # forward pass, which requires additional handling. Fall back to the
+                # old path (not implemented here); skip separate bootstrap pass.
+                bootstrap_obs_per_module[module_id] = None
+                bootstrap_mask_per_module[module_id] = None
+                continue
+
+            eps_for_module = [
+                e for e in sa_episodes_list if e.module_id in [None, module_id]
+            ]
+            obs_list = []
+            mask = []
+            for ep in eps_for_module:
+                if not ep.is_terminated:
+                    obs_list.append(ep.get_observations(-1))
+                    mask.append(True)
+                else:
+                    mask.append(False)
+            bootstrap_obs_per_module[module_id] = (
+                np.stack(obs_list, axis=0) if obs_list else None
+            )
+            bootstrap_mask_per_module[module_id] = mask
+
+        # Run the bootstrap forward pass for non-stateful modules.
+        # This is a small pass (N_non_terminated x obs_dim) compared to the main batch.
+        bootstrap_vf_preds_per_module = {}
+        for module_id, bootstrap_obs in bootstrap_obs_per_module.items():
+            if bootstrap_obs is None:
+                bootstrap_vf_preds_per_module[module_id] = None
+                continue
+            # Lazily create the numpy-to-tensor connector (needs a device).
+            module = rl_module[module_id]
+            if self._numpy_to_tensor_connector is None:
+                # We'll set the device after the first successful VF forward pass below.
+                pass
+            # Convert bootstrap obs to a tensor batch and run compute_values.
+            if self._numpy_to_tensor_connector is not None:
+                bs_tensor_batch = self._numpy_to_tensor_connector(
+                    rl_module=rl_module,
+                    batch={module_id: {Columns.OBS: bootstrap_obs}},
+                    episodes=episodes,
+                )
+                bs_vf = module.compute_values(bs_tensor_batch[module_id])
+                bootstrap_vf_preds_per_module[module_id] = convert_to_numpy(bs_vf)
+            else:
+                # _numpy_to_tensor_connector not yet initialised; will be set below
+                # after the first module is processed.
+                bootstrap_vf_preds_per_module[module_id] = None
+
         # Loop through all modules and perform each one's GAE computation.
         for module_id, module_vf_preds in vf_preds.items():
             # Skip those outputs of RLModules that are not implementers of
@@ -108,48 +164,99 @@ class GeneralAdvantageEstimation(ConnectorV2):
 
             module = rl_module[module_id]
             device = module_vf_preds.device
-            # Convert to numpy for the upcoming GAE computations.
-            module_vf_preds = convert_to_numpy(module_vf_preds)
 
-            # Collect (single-agent) episode lengths for this particular module.
-            episode_lens = [
-                len(e) for e in sa_episodes_list if e.module_id in [None, module_id]
+            # Initialise the numpy-to-tensor connector on first use.
+            if self._numpy_to_tensor_connector is None:
+                self._numpy_to_tensor_connector = NumpyToTensor(
+                    as_learner_connector=True, device=device
+                )
+                # Now that the connector is available, redo any bootstrap passes that
+                # were skipped above (i.e., the first module).
+                for mid2, bs_obs in bootstrap_obs_per_module.items():
+                    if (
+                        bs_obs is not None
+                        and bootstrap_vf_preds_per_module[mid2] is None
+                    ):
+                        bs_tensor_batch = self._numpy_to_tensor_connector(
+                            rl_module=rl_module,
+                            batch={mid2: {Columns.OBS: bs_obs}},
+                            episodes=episodes,
+                        )
+                        bs_vf = rl_module[mid2].compute_values(bs_tensor_batch[mid2])
+                        bootstrap_vf_preds_per_module[mid2] = convert_to_numpy(bs_vf)
+
+            # Convert main VF preds to numpy.
+            module_vf_preds_np = convert_to_numpy(module_vf_preds)
+
+            # Collect episode lengths for this module.
+            eps_for_module = [
+                e for e in sa_episodes_list if e.module_id in [None, module_id]
             ]
+            episode_lens = [len(e) for e in eps_for_module]
 
-            # Remove all zero-padding again, if applicable, for the upcoming
-            # GAE computations.
-            module_vf_preds = unpad_data_if_necessary(episode_lens, module_vf_preds)
-            # Compute value targets.
-            module_value_targets = compute_value_targets(
-                values=module_vf_preds,
-                rewards=unpad_data_if_necessary(
-                    episode_lens,
-                    convert_to_numpy(batch[module_id][Columns.REWARDS]),
-                ),
-                terminateds=unpad_data_if_necessary(
-                    episode_lens,
-                    convert_to_numpy(batch[module_id][Columns.TERMINATEDS]),
-                ),
-                truncateds=unpad_data_if_necessary(
-                    episode_lens,
-                    convert_to_numpy(batch[module_id][Columns.TRUNCATEDS]),
-                ),
-                gamma=self.gamma,
-                lambda_=self.lambda_,
+            # Remove zero-padding (for stateful/LSTM modules) before GAE.
+            module_vf_preds_np = unpad_data_if_necessary(
+                episode_lens, module_vf_preds_np
             )
+            rewards_np = unpad_data_if_necessary(
+                episode_lens,
+                convert_to_numpy(batch[module_id][Columns.REWARDS]),
+            )
+            terminateds_np = unpad_data_if_necessary(
+                episode_lens,
+                convert_to_numpy(batch[module_id][Columns.TERMINATEDS]),
+            )
+
+            # Build per-episode bootstrap values.
+            bs_preds = bootstrap_vf_preds_per_module.get(module_id)
+            bs_mask = bootstrap_mask_per_module.get(module_id)
+            if bs_preds is not None and bs_mask is not None:
+                # Non-stateful path: use the bootstrap forward pass results.
+                bs_idx = 0
+                bootstrap_values = []
+                for needs_bootstrap in bs_mask:
+                    if needs_bootstrap:
+                        bootstrap_values.append(float(bs_preds[bs_idx]))
+                        bs_idx += 1
+                    else:
+                        bootstrap_values.append(0.0)
+            else:
+                # Stateful / fallback path: use 0 as bootstrap (conservative).
+                # TODO: implement proper LSTM bootstrap using STATE_OUT.
+                bootstrap_values = [
+                    0.0 if ep.is_terminated else 0.0 for ep in eps_for_module
+                ]
+
+            # Per-episode GAE.
+            all_targets = []
+            pos = 0
+            for i, ep in enumerate(eps_for_module):
+                L = episode_lens[i]
+                ep_values = module_vf_preds_np[pos : pos + L]
+                ep_rewards = rewards_np[pos : pos + L]
+                ep_terminateds = terminateds_np[pos : pos + L]
+                targets = compute_value_targets_with_bootstrap(
+                    values=ep_values,
+                    rewards=ep_rewards,
+                    terminateds=ep_terminateds,
+                    bootstrap_value=bootstrap_values[i],
+                    gamma=self.gamma,
+                    lambda_=self.lambda_,
+                )
+                all_targets.append(targets)
+                pos += L
+
+            module_value_targets = np.concatenate(all_targets)
             assert module_value_targets.shape[0] == sum(episode_lens)
 
-            module_advantages = module_value_targets - module_vf_preds
-            # Drop vf-preds, not needed in loss. Note that in the DefaultPPORLModule,
-            # vf-preds are recomputed with each `forward_train` call anyway to compute
-            # the vf loss.
+            module_advantages = module_value_targets - module_vf_preds_np
             # Standardize advantages (used for more stable and better weighted
             # policy gradient computations).
             module_advantages = (module_advantages - module_advantages.mean()) / max(
                 1e-4, module_advantages.std()
             )
 
-            # Zero-pad the new computations, if necessary.
+            # Zero-pad the new computations, if necessary (stateful modules).
             if module.is_stateful():
                 module_advantages = np.stack(
                     split_and_zero_pad_n_episodes(
@@ -171,10 +278,6 @@ class GeneralAdvantageEstimation(ConnectorV2):
             batch[module_id][Postprocessing.VALUE_TARGETS] = module_value_targets
 
         # Convert all GAE results to tensors.
-        if self._numpy_to_tensor_connector is None:
-            self._numpy_to_tensor_connector = NumpyToTensor(
-                as_learner_connector=True, device=device
-            )
         tensor_results = self._numpy_to_tensor_connector(
             rl_module=rl_module,
             batch={
@@ -185,7 +288,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
                     ),
                 }
                 for mid, module_batch in batch.items()
-                if vf_preds[mid] is not None
+                if vf_preds.get(mid) is not None
             },
             episodes=episodes,
         )

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -159,7 +159,8 @@ class GeneralAdvantageEstimation(ConnectorV2):
                     batch={module_id: {Columns.OBS: bootstrap_obs}},
                     episodes=episodes,
                 )
-                bs_vf = module.compute_values(bs_tensor_batch[module_id])
+                # module may be wrapped in a DDP wrapper (TorchDDPRLModule), so we need to unwrap it to access compute_values.
+                bs_vf = module.unwrapped().compute_values(bs_tensor_batch[module_id])
                 bootstrap_vf_preds_per_module[module_id] = convert_to_numpy(bs_vf)
             else:
                 # _numpy_to_tensor_connector not yet initialised; will be set below
@@ -193,7 +194,12 @@ class GeneralAdvantageEstimation(ConnectorV2):
                             batch={mid2: {Columns.OBS: bs_obs}},
                             episodes=episodes,
                         )
-                        bs_vf = rl_module[mid2].compute_values(bs_tensor_batch[mid2])
+                        # module may be wrapped in a DDP wrapper (TorchDDPRLModule), so we need to unwrap it to access compute_values.
+                        bs_vf = (
+                            rl_module[mid2]
+                            .unwrapped()
+                            .compute_values(bs_tensor_batch[mid2])
+                        )
                         bootstrap_vf_preds_per_module[mid2] = convert_to_numpy(bs_vf)
 
             # Convert main VF preds to numpy.

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -64,6 +64,19 @@ class GeneralAdvantageEstimation(ConnectorV2):
         # vf targets) into tensors.
         self._numpy_to_tensor_connector = None
 
+    def _init_numpy_to_tensor_connector(self, vf_preds: Dict[str, Any]):
+        """Initialize the numpy-to-tensor connector.
+
+        NumpyToTensor is used to convert the GAE results (advantages and vf targets) into tensors.
+        We therefore
+        """
+        device = next((v.device for v in vf_preds.values() if v is not None), None)
+        assert device is not None, "Device is not set"
+
+        self._numpy_to_tensor_connector = NumpyToTensor(
+            as_learner_connector=True, device=device
+        )
+
     @override(ConnectorV2)
     def __call__(
         self,
@@ -74,19 +87,11 @@ class GeneralAdvantageEstimation(ConnectorV2):
         shared_data: Optional[dict] = None,
         **kwargs,
     ):
-        # Device to place all GAE result tensors (advantages and value targets) on.
-        device = None
-
-        # Extract all single-agent episodes.
         sa_episodes_list = list(
             self.single_agent_episode_iterator(episodes, agents_that_stepped_only=False)
         )
 
-        # Perform the value nets' forward passes on the main batch.
-        # TODO (sven): We need to check here in the pipeline already, whether a module
-        #  should even be updated or not (which we usually do after(!) the Learner
-        #  pipeline). This is an open TODO to move this filter into a connector as well.
-        #  For now, we'll just check, whether `mid` is in batch and skip if it isn't.
+        # Main VF forward pass on the full training batch.
         vf_preds = rl_module.foreach_module(
             func=lambda mid, module: (
                 module.compute_values(batch[mid])
@@ -95,123 +100,37 @@ class GeneralAdvantageEstimation(ConnectorV2):
             ),
             return_dict=True,
         )
+        # Filter Non-VF modules (modules that are not ValueFunctionAPI return None above)
+        vf_preds = {mid: preds for mid, preds in vf_preds.items() if preds is not None}
 
-        # Build bootstrap obs batches: for each module, collect the last observation
-        # of each non-terminated episode. These are already stored in the episode
-        # (episode.observations[-1] = s_L).
-        bootstrap_obs_per_module = {}  # module_id -> np.ndarray (N_bootstrap, obs_dim)
-        bootstrap_mask_per_module = (
-            {}
-        )  # module_id -> list[bool] (True = needs bootstrap)
+        # Eagerly initialize the numpy-to-tensor connector (needed for the bootstrap
+        # forward pass below). Device is taken from the first available VF prediction.
+        if self._numpy_to_tensor_connector is None:
+            self._init_numpy_to_tensor_connector(vf_preds)
+
+        # Pre-compute per-module episode lists (used for both bootstrap and GAE).
+        eps_per_module = {
+            mid: [e for e in sa_episodes_list if e.module_id in (None, mid)]
+            for mid in vf_preds.keys()
+        }
+
+        # Compute bootstrap values for non-terminated episodes via a small VF pass.
+        bootstrap_values = self._compute_bootstrap_values(
+            rl_module, vf_preds, eps_per_module, episodes, shared_data
+        )
+
+        # Per-module GAE computation.
         for module_id, module_vf_preds in vf_preds.items():
             if module_vf_preds is None:
                 continue
-            module = rl_module[module_id]
-            if module.is_stateful():
-                # Stateful (LSTM) modules need the last hidden state for the bootstrap
-                # forward pass, which requires additional handling. Fall back to the
-                # old path (not implemented here); skip separate bootstrap pass.
-                bootstrap_obs_per_module[module_id] = None
-                bootstrap_mask_per_module[module_id] = None
-                continue
-
-            eps_for_module = [
-                e for e in sa_episodes_list if e.module_id in [None, module_id]
-            ]
-            stacked_bootstrap_obs = shared_data["stacked_bootstrap_obs"]
-            obs_list = []
-            mask = []
-            for ep in eps_for_module:
-                if not ep.is_terminated:
-                    # Use the frame-stacked bootstrap obs pre-computed by
-                    # FrameStackingLearner if available; otherwise fall back to
-                    # the raw last observation (correct for non-frame-stacked setups).
-                    stacked = stacked_bootstrap_obs.get(ep.id_)
-                    obs_list.append(
-                        stacked if stacked is not None else ep.get_observations(-1)
-                    )
-                    mask.append(True)
-                else:
-                    mask.append(False)
-            bootstrap_obs_per_module[module_id] = tree.map_structure(
-                lambda *s: np.stack(s, axis=0), *obs_list
-            )
-            bootstrap_mask_per_module[module_id] = mask
-
-        # Run the bootstrap forward pass for non-stateful modules.
-        # This is a small pass (N_non_terminated x obs_dim) compared to the main batch.
-        bootstrap_vf_preds_per_module = {}
-        for module_id, bootstrap_obs in bootstrap_obs_per_module.items():
-            if bootstrap_obs is None:
-                bootstrap_vf_preds_per_module[module_id] = None
-                continue
-            # Lazily create the numpy-to-tensor connector (needs a device).
-            module = rl_module[module_id]
-            if self._numpy_to_tensor_connector is None:
-                # We'll set the device after the first successful VF forward pass below.
-                pass
-            # Convert bootstrap obs to a tensor batch and run compute_values.
-            if self._numpy_to_tensor_connector is not None:
-                bs_tensor_batch = self._numpy_to_tensor_connector(
-                    rl_module=rl_module,
-                    batch={module_id: {Columns.OBS: bootstrap_obs}},
-                    episodes=episodes,
-                )
-                # module may be wrapped in a DDP wrapper (TorchDDPRLModule), so we need to unwrap it to access compute_values.
-                bs_vf = module.unwrapped().compute_values(bs_tensor_batch[module_id])
-                bootstrap_vf_preds_per_module[module_id] = convert_to_numpy(bs_vf)
-            else:
-                # _numpy_to_tensor_connector not yet initialised; will be set below
-                # after the first module is processed.
-                bootstrap_vf_preds_per_module[module_id] = None
-
-        # Loop through all modules and perform each one's GAE computation.
-        for module_id, module_vf_preds in vf_preds.items():
-            # Skip those outputs of RLModules that are not implementers of
-            # `ValueFunctionAPI`.
-            if module_vf_preds is None:
-                continue
 
             module = rl_module[module_id]
-            device = module_vf_preds.device
+            eps = eps_per_module[module_id]
+            episode_lens = [len(e) for e in eps]
 
-            # Initialise the numpy-to-tensor connector on first use.
-            if self._numpy_to_tensor_connector is None:
-                self._numpy_to_tensor_connector = NumpyToTensor(
-                    as_learner_connector=True, device=device
-                )
-                # Now that the connector is available, redo any bootstrap passes that
-                # were skipped above (i.e., the first module).
-                for mid2, bs_obs in bootstrap_obs_per_module.items():
-                    if (
-                        bs_obs is not None
-                        and bootstrap_vf_preds_per_module[mid2] is None
-                    ):
-                        bs_tensor_batch = self._numpy_to_tensor_connector(
-                            rl_module=rl_module,
-                            batch={mid2: {Columns.OBS: bs_obs}},
-                            episodes=episodes,
-                        )
-                        # module may be wrapped in a DDP wrapper (TorchDDPRLModule), so we need to unwrap it to access compute_values.
-                        bs_vf = (
-                            rl_module[mid2]
-                            .unwrapped()
-                            .compute_values(bs_tensor_batch[mid2])
-                        )
-                        bootstrap_vf_preds_per_module[mid2] = convert_to_numpy(bs_vf)
-
-            # Convert main VF preds to numpy.
-            module_vf_preds_np = convert_to_numpy(module_vf_preds)
-
-            # Collect episode lengths for this module.
-            eps_for_module = [
-                e for e in sa_episodes_list if e.module_id in [None, module_id]
-            ]
-            episode_lens = [len(e) for e in eps_for_module]
-
-            # Remove zero-padding (for stateful/LSTM modules) before GAE.
+            # Convert to numpy, removing zero-padding (for stateful modules).
             module_vf_preds_np = unpad_data_if_necessary(
-                episode_lens, module_vf_preds_np
+                episode_lens, convert_to_numpy(module_vf_preds)
             )
             rewards_np = unpad_data_if_necessary(
                 episode_lens,
@@ -222,39 +141,16 @@ class GeneralAdvantageEstimation(ConnectorV2):
                 convert_to_numpy(batch[module_id][Columns.TERMINATEDS]),
             )
 
-            # Build per-episode bootstrap values.
-            bs_preds = bootstrap_vf_preds_per_module.get(module_id)
-            bs_mask = bootstrap_mask_per_module.get(module_id)
-            if bs_preds is not None and bs_mask is not None:
-                # Non-stateful path: use the bootstrap forward pass results.
-                bs_idx = 0
-                bootstrap_values = []
-                for needs_bootstrap in bs_mask:
-                    if needs_bootstrap:
-                        bootstrap_values.append(float(bs_preds[bs_idx]))
-                        bs_idx += 1
-                    else:
-                        bootstrap_values.append(0.0)
-            else:
-                # Stateful / fallback path: use 0 as bootstrap (conservative).
-                # TODO: implement proper LSTM bootstrap using STATE_OUT.
-                bootstrap_values = [
-                    0.0 if ep.is_terminated else 0.0 for ep in eps_for_module
-                ]
-
             # Per-episode GAE.
             all_targets = []
             pos = 0
-            for i, ep in enumerate(eps_for_module):
+            for i, ep in enumerate(eps):
                 L = episode_lens[i]
-                ep_values = module_vf_preds_np[pos : pos + L]
-                ep_rewards = rewards_np[pos : pos + L]
-                ep_terminateds = terminateds_np[pos : pos + L]
                 targets = compute_value_targets_with_bootstrap(
-                    values=ep_values,
-                    rewards=ep_rewards,
-                    terminateds=ep_terminateds,
-                    bootstrap_value=bootstrap_values[i],
+                    values=module_vf_preds_np[pos : pos + L],
+                    rewards=rewards_np[pos : pos + L],
+                    terminateds=terminateds_np[pos : pos + L],
+                    bootstrap_value=bootstrap_values[module_id][i],
                     gamma=self.gamma,
                     lambda_=self.lambda_,
                 )
@@ -271,13 +167,14 @@ class GeneralAdvantageEstimation(ConnectorV2):
                 1e-4, module_advantages.std()
             )
 
-            # Zero-pad the new computations, if necessary (stateful modules).
+            # Re-apply zero-padding for stateful modules.
             if module.is_stateful():
+                max_seq_len = module.model_config["max_seq_len"]
                 module_advantages = np.stack(
                     split_and_zero_pad_n_episodes(
                         module_advantages,
                         episode_lens=episode_lens,
-                        max_seq_len=module.model_config["max_seq_len"],
+                        max_seq_len=max_seq_len,
                     ),
                     axis=0,
                 )
@@ -285,10 +182,11 @@ class GeneralAdvantageEstimation(ConnectorV2):
                     split_and_zero_pad_n_episodes(
                         module_value_targets,
                         episode_lens=episode_lens,
-                        max_seq_len=module.model_config["max_seq_len"],
+                        max_seq_len=max_seq_len,
                     ),
                     axis=0,
                 )
+
             batch[module_id][Postprocessing.ADVANTAGES] = module_advantages
             batch[module_id][Postprocessing.VALUE_TARGETS] = module_value_targets
 
@@ -297,18 +195,86 @@ class GeneralAdvantageEstimation(ConnectorV2):
             rl_module=rl_module,
             batch={
                 mid: {
-                    Postprocessing.ADVANTAGES: module_batch[Postprocessing.ADVANTAGES],
-                    Postprocessing.VALUE_TARGETS: (
-                        module_batch[Postprocessing.VALUE_TARGETS]
-                    ),
+                    Postprocessing.ADVANTAGES: batch[mid][Postprocessing.ADVANTAGES],
+                    Postprocessing.VALUE_TARGETS: batch[mid][
+                        Postprocessing.VALUE_TARGETS
+                    ],
                 }
-                for mid, module_batch in batch.items()
-                if vf_preds.get(mid) is not None
+                for mid, preds in vf_preds.items()
+                if preds is not None
             },
             episodes=episodes,
         )
-        # Move converted tensors back to `batch`.
         for mid, module_batch in tensor_results.items():
             batch[mid].update(module_batch)
 
         return batch
+
+    def _compute_bootstrap_values(
+        self, rl_module, vf_preds, eps_per_module, episodes, shared_data
+    ):
+        """Compute per-episode bootstrap values for each module.
+
+        Returns a dict mapping module_id -> list[float] of bootstrap values (one per
+        episode). Terminated episodes get 0.0; non-terminated episodes get V(last_obs)
+        from a small forward pass.
+        """
+        result = {}
+
+        for module_id, eps in eps_per_module.items():
+            module = rl_module[module_id]
+
+            if module.is_stateful():
+                # TODO: implement proper LSTM bootstrap using STATE_OUT.
+                result[module_id] = [0.0] * len(eps)
+                continue
+
+            # Collect last observations for non-terminated episodes.
+            obs_list = []
+            all_terminated = True
+            needs_bootstrap = []
+            for ep in eps:
+                if not ep.is_terminated:
+                    # Use frame-stacked bootstrap obs if pre-computed by
+                    # FrameStackingLearner; otherwise use the raw last observation.
+                    if "stacked_bootstrap_obs" in shared_data:
+                        obs = shared_data["stacked_bootstrap_obs"]["ep.id_"]
+                    else:
+                        obs = ep.get_observations(-1)
+                    obs_list.append(obs)
+                    needs_bootstrap.append(True)
+                else:
+                    needs_bootstrap.append(False)
+                    all_terminated = False
+
+            if all_terminated:
+                # Fast path: all episodes terminated; bootstrap values are all zero.
+                # All episodes terminated; bootstrap values are all zero.
+                result[module_id] = [0.0] * len(eps)
+                continue
+
+            # Stack bootstrap obs and run a batched VF forward pass.
+            bootstrap_obs = tree.map_structure(
+                lambda *s: np.stack(s, axis=0), *obs_list
+            )
+            bs_tensor_batch = self._numpy_to_tensor_connector(
+                rl_module=rl_module,
+                batch={module_id: {Columns.OBS: bootstrap_obs}},
+                episodes=episodes,
+            )
+            bs_preds = convert_to_numpy(
+                module.unwrapped().compute_values(bs_tensor_batch[module_id])
+            )
+
+            # Scatter bootstrap predictions back into per-episode order.
+            bs_idx = 0
+            values = []
+            for flag in needs_bootstrap:
+                if flag:
+                    values.append(float(bs_preds[bs_idx]))
+                    bs_idx += 1
+                else:
+                    values.append(0.0)
+            result[module_id] = values
+
+        return result

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -116,7 +116,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
 
         # Compute bootstrap values for non-terminated episodes via a small VF pass.
         bootstrap_values = self._compute_bootstrap_values(
-            rl_module, vf_preds, eps_per_module, episodes, shared_data
+            rl_module, eps_per_module, episodes, shared_data
         )
 
         # Loop through all modules and perform each one's GAE computation.
@@ -211,7 +211,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
         return batch
 
     def _compute_bootstrap_values(
-        self, rl_module, vf_preds, eps_per_module, episodes, shared_data
+        self, rl_module, eps_per_module, episodes, shared_data
     ):
         """Compute per-episode bootstrap values for each module.
 

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -119,7 +119,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
             rl_module, vf_preds, eps_per_module, episodes, shared_data
         )
 
-        # Per-module GAE computation.
+        # Loop through all modules and perform each one's GAE computation.
         for module_id, module_vf_preds in vf_preds.items():
             if module_vf_preds is None:
                 continue
@@ -224,14 +224,11 @@ class GeneralAdvantageEstimation(ConnectorV2):
         for module_id, eps in eps_per_module.items():
             module = rl_module[module_id]
 
-            if module.is_stateful():
-                # TODO: implement proper LSTM bootstrap using STATE_OUT.
-                result[module_id] = [0.0] * len(eps)
-                continue
-
-            # Collect last observations for non-terminated episodes.
+            # Collect last observations (and states for stateful modules)
+            # for non-terminated episodes.
+            is_stateful = module.is_stateful()
             obs_list = []
-            all_terminated = True
+            state_list = []
             needs_bootstrap = []
             for ep in eps:
                 if not ep.is_terminated:
@@ -242,29 +239,53 @@ class GeneralAdvantageEstimation(ConnectorV2):
                     else:
                         obs = ep.get_observations(-1)
                     obs_list.append(obs)
+                    if is_stateful:
+                        state_list.append(
+                            ep.get_extra_model_outputs(
+                                key=Columns.STATE_OUT, indices=-1
+                            )
+                        )
                     needs_bootstrap.append(True)
                 else:
                     needs_bootstrap.append(False)
-                    all_terminated = False
 
-            if all_terminated:
-                # Fast path: all episodes terminated; bootstrap values are all zero.
+            if not obs_list:
                 # All episodes terminated; bootstrap values are all zero.
                 result[module_id] = [0.0] * len(eps)
                 continue
 
             # Stack bootstrap obs and run a batched VF forward pass.
-            bootstrap_obs = tree.map_structure(
-                lambda *s: np.stack(s, axis=0), *obs_list
-            )
+            if is_stateful:
+                # Stateful modules expect (B, T, ...) obs with T=1 for a
+                # single-step bootstrap.
+                bootstrap_obs = tree.map_structure(
+                    lambda *s: np.stack(s, axis=0)[:, np.newaxis], *obs_list
+                )
+                bootstrap_states = tree.map_structure(
+                    lambda *s: np.stack(s, axis=0), *state_list
+                )
+                bs_batch = {
+                    module_id: {
+                        Columns.OBS: bootstrap_obs,
+                        Columns.STATE_IN: bootstrap_states,
+                    }
+                }
+            else:
+                bootstrap_obs = tree.map_structure(
+                    lambda *s: np.stack(s, axis=0), *obs_list
+                )
+                bs_batch = {module_id: {Columns.OBS: bootstrap_obs}}
+
             bs_tensor_batch = self._numpy_to_tensor_connector(
                 rl_module=rl_module,
-                batch={module_id: {Columns.OBS: bootstrap_obs}},
+                batch=bs_batch,
                 episodes=episodes,
             )
             bs_preds = convert_to_numpy(
                 module.unwrapped().compute_values(bs_tensor_batch[module_id])
             )
+            # Stateful modules return (B, T) with T=1; flatten to (B,).
+            bs_preds = bs_preds.reshape(-1)
 
             # Scatter bootstrap predictions back into per-episode order.
             bs_idx = 0

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -235,7 +235,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
                     # Use frame-stacked bootstrap obs if pre-computed by
                     # FrameStackingLearner; otherwise use the raw last observation.
                     if "stacked_bootstrap_obs" in shared_data:
-                        obs = shared_data["stacked_bootstrap_obs"]["ep.id_"]
+                        obs = shared_data["stacked_bootstrap_obs"][ep.id_]
                     else:
                         obs = ep.get_observations(-1)
                     obs_list.append(obs)

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -98,7 +98,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
 
         # Build bootstrap obs batches: for each module, collect the last observation
         # of each non-terminated episode. These are already stored in the episode
-        # (episode.observations[-1] = s_L); no episode mutation needed.
+        # (episode.observations[-1] = s_L).
         bootstrap_obs_per_module = {}  # module_id -> np.ndarray (N_bootstrap, obs_dim)
         bootstrap_mask_per_module = (
             {}
@@ -118,7 +118,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
             eps_for_module = [
                 e for e in sa_episodes_list if e.module_id in [None, module_id]
             ]
-            stacked_bootstrap_obs = (shared_data or {}).get("stacked_bootstrap_obs", {})
+            stacked_bootstrap_obs = shared_data["stacked_bootstrap_obs"]
             obs_list = []
             mask = []
             for ep in eps_for_module:
@@ -133,10 +133,8 @@ class GeneralAdvantageEstimation(ConnectorV2):
                     mask.append(True)
                 else:
                     mask.append(False)
-            bootstrap_obs_per_module[module_id] = (
-                tree.map_structure(lambda *s: np.stack(s, axis=0), *obs_list)
-                if obs_list
-                else None
+            bootstrap_obs_per_module[module_id] = tree.map_structure(
+                lambda *s: np.stack(s, axis=0), *obs_list
             )
             bootstrap_mask_per_module[module_id] = mask
 

--- a/rllib/connectors/learner/general_advantage_estimation.py
+++ b/rllib/connectors/learner/general_advantage_estimation.py
@@ -221,6 +221,10 @@ class GeneralAdvantageEstimation(ConnectorV2):
         """
         result = {}
 
+        stacked_bootstrap_obs = (
+            shared_data is not None and "stacked_bootstrap_obs" in shared_data
+        )
+
         for module_id, eps in eps_per_module.items():
             module = rl_module[module_id]
 
@@ -234,7 +238,7 @@ class GeneralAdvantageEstimation(ConnectorV2):
                 if not ep.is_terminated:
                     # Use frame-stacked bootstrap obs if pre-computed by
                     # FrameStackingLearner; otherwise use the raw last observation.
-                    if "stacked_bootstrap_obs" in shared_data:
+                    if stacked_bootstrap_obs:
                         obs = shared_data["stacked_bootstrap_obs"][ep.id_]
                     else:
                         obs = ep.get_observations(-1)

--- a/rllib/env/utils/infinite_lookback_buffer.py
+++ b/rllib/env/utils/infinite_lookback_buffer.py
@@ -165,6 +165,27 @@ class InfiniteLookbackBuffer:
             self.data = batch(self.data)
             self.finalized = True
 
+    def _ensure_data_is_writeable(self):
+        """Ensure finalized numpy data is writeable (copy-on-write).
+
+        After deserialization from Ray's object store, numpy arrays are backed by
+        read-only shared memory. This method replaces any read-only leaf arrays
+        with writeable copies on the first mutation attempt.
+        """
+
+        # Fast path for numpy arrays.
+        if isinstance(self.data, np.ndarray):
+            if not self.data.flags.writeable:
+                self.data = self.data.copy()
+            return
+
+        def _ensure_writeable(d):
+            if isinstance(d, np.ndarray) and not d.flags.writeable:
+                return d.copy()
+            return d
+
+        self.data = tree.map_structure(_ensure_writeable, self.data)
+
     def get(
         self,
         indices: Optional[Union[int, slice, List[int]]] = None,
@@ -333,6 +354,10 @@ class InfiniteLookbackBuffer:
                 at_indices=slice(-2, 1), neg_index_as_lookback=True)` with
                 `[5, 6,  7]` being replaced by `[98, 99,  100]`.
         """
+        if self.finalized:
+            # Finalized episodes have numpy arrays as data, so we need to make sure these are writeable.
+            self._ensure_data_is_writeable()
+
         # `at_indices` is None -> Override all our data (excluding the lookback buffer).
         if at_indices is None:
             self._set_all_data(new_data)

--- a/rllib/examples/algorithms/ppo/cartpole_heavy_ppo.py
+++ b/rllib/examples/algorithms/ppo/cartpole_heavy_ppo.py
@@ -19,7 +19,7 @@ config = (
     .environment(CartPoleWithLargeObservationSpace)
     .env_runners(
         env_to_module_connector=lambda env, spaces, device: FlattenObservations(),
-        episodes_to_numpy=False,
+        episodes_to_numpy=True,
     )
     .training(
         lr=0.0003,

--- a/rllib/examples/algorithms/ppo/cartpole_heavy_ppo.py
+++ b/rllib/examples/algorithms/ppo/cartpole_heavy_ppo.py
@@ -19,7 +19,6 @@ config = (
     .environment(CartPoleWithLargeObservationSpace)
     .env_runners(
         env_to_module_connector=lambda env, spaces, device: FlattenObservations(),
-        episodes_to_numpy=False,
     )
     .training(
         lr=0.0003,

--- a/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py
+++ b/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py
@@ -166,7 +166,6 @@ config = (
         num_envs_per_env_runner=1,
         batch_mode="truncate_episodes",
         rollout_fragment_length=args.rollout_fragment_length,
-        episodes_to_numpy=False,
         create_env_on_local_worker=True,
     )
     .training(

--- a/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py
+++ b/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py
@@ -166,7 +166,7 @@ config = (
         num_envs_per_env_runner=1,
         batch_mode="truncate_episodes",
         rollout_fragment_length=args.rollout_fragment_length,
-        episodes_to_numpy=False,
+        episodes_to_numpy=True,
         create_env_on_local_worker=True,
     )
     .training(

--- a/rllib/examples/connectors/frame_stacking.py
+++ b/rllib/examples/connectors/frame_stacking.py
@@ -131,6 +131,7 @@ if __name__ == "__main__":
         return FrameStackingEnvToModule(
             num_frames=args.num_frames,
             multi_agent=args.num_agents > 0,
+            used_together_with_gae=True,  # You can turn this off if you don't use the GAE connector.
         )
 
     def _make_learner_connector(input_observation_space, input_action_space):

--- a/rllib/offline/offline_env_runner.py
+++ b/rllib/offline/offline_env_runner.py
@@ -16,7 +16,6 @@ from ray.rllib.utils.annotations import (
 from ray.rllib.utils.compression import pack_if_needed
 from ray.rllib.utils.typing import EpisodeType
 from ray.util.annotations import PublicAPI
-from ray.util.debug import log_once
 
 logger = logging.Logger(__file__)
 
@@ -33,10 +32,6 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
     def __init__(self, *, config: AlgorithmConfig, **kwargs):
         # Initialize the parent.
         super().__init__(config=config, **kwargs)
-
-        # override SingleAgentEnvRunner
-        self.episodes_to_numpy = False
-
         # Get the data context for this `EnvRunner`.
         data_context = ray.data.DataContext.get_current()
         # Limit the resources for Ray Data to the CPUs given to this `EnvRunner`.
@@ -187,15 +182,6 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
             import msgpack
             import msgpack_numpy as mnp
 
-            if log_once("msgpack"):
-                logger.info(
-                    "Packing episodes with `msgpack` and encode array with "
-                    "`msgpack_numpy` for serialization. This is needed for "
-                    "recording episodes."
-                )
-            # Note, we serialize episodes with `msgpack` and `msgpack_numpy` to
-            # ensure version compatibility.
-            assert all(eps.is_numpy is False for eps in samples)
             self._samples.extend(
                 [msgpack.packb(eps.get_state(), default=mnp.encode) for eps in samples]
             )

--- a/rllib/offline/offline_policy_evaluation_runner.py
+++ b/rllib/offline/offline_policy_evaluation_runner.py
@@ -216,7 +216,7 @@ class OfflinePolicyPreEvaluator(OfflinePreLearner):
         # Otherwise we map the batch to episodes.
         else:
             episodes: List[SingleAgentEpisode] = self._map_to_episodes(
-                batch, to_numpy=False
+                batch, to_numpy=True
             )["episodes"]
 
         episode_dicts = []

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -199,7 +199,7 @@ class OfflinePreLearner:
         else:
             episodes: List[SingleAgentEpisode] = self._map_to_episodes(
                 batch,
-                to_numpy=False,
+                to_numpy=True,
             )["episodes"]
 
         # TODO (simon): Sync learner connector state

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -188,6 +188,8 @@ class OfflinePreLearner:
                 )
                 for state in batch["item"]
             ]
+            for ep in episodes:
+                ep.to_numpy()
             episodes = self._postprocess_and_sample(episodes)
 
         elif self.config.input_read_sample_batches:

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -188,14 +188,11 @@ class OfflinePreLearner:
                 )
                 for state in batch["item"]
             ]
-            for ep in episodes:
-                ep.to_numpy()
             episodes = self._postprocess_and_sample(episodes)
 
         elif self.config.input_read_sample_batches:
             episodes: List[SingleAgentEpisode] = self._map_sample_batch_to_episode(
                 batch,
-                to_numpy=True,
             )["episodes"]
             episodes = self._postprocess_and_sample(episodes)
         else:
@@ -203,6 +200,11 @@ class OfflinePreLearner:
                 batch,
                 to_numpy=True,
             )["episodes"]
+
+        # Ensure all episodes are numpy'ized before entering the learner connector.
+        for ep in episodes:
+            if not ep.is_numpy:
+                ep.to_numpy()
 
         # TODO (simon): Sync learner connector state
         # TODO (sven): Add MetricsLogger to non-Learner components that have a LearnerConnector pipeline.

--- a/rllib/offline/tests/test_offline_rl_stateful.py
+++ b/rllib/offline/tests/test_offline_rl_stateful.py
@@ -119,6 +119,10 @@ class OfflineRLStatefulTest(unittest.TestCase):
         if Columns.STATE_IN in episodes[0].extra_model_outputs.keys():
             del episodes[0].extra_model_outputs[Columns.STATE_IN]
 
+        # Numpy'ize episodes before passing to the learner connector.
+        for ep in episodes:
+            ep.to_numpy()
+
         # Build the learner connector.
         obs_space, action_space = self.algo.offline_data.spaces[INPUT_ENV_SPACES]
         learner_connector = self.algo.config.build_learner_connector(
@@ -216,6 +220,10 @@ class OfflineRLStatefulTest(unittest.TestCase):
 
         # Assert the episode has a decent return.
         assert episodes[0].get_return() > 350.0, "Return must be >350.0"
+
+        # Numpy'ize episodes before passing to the learner connector.
+        for ep in episodes:
+            ep.to_numpy()
 
         # Build the learner connector.
         obs_space, action_space = self.algo.offline_data.spaces[INPUT_ENV_SPACES]

--- a/rllib/utils/postprocessing/episodes.py
+++ b/rllib/utils/postprocessing/episodes.py
@@ -2,11 +2,17 @@ from typing import List, Tuple
 
 import numpy as np
 
+from ray._common.deprecation import Deprecated
 from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.util.annotations import DeveloperAPI
 
 
 @DeveloperAPI
+@Deprecated(
+    error=False,
+    old="ray.rllib.utils.postprocessing.episodes.add_one_ts_to_episodes_and_truncate",
+    help="Use GeneralAdvantageEstimation connector standalone instead",
+)
 def add_one_ts_to_episodes_and_truncate(episodes: List[SingleAgentEpisode]):
     """Adds an artificial timestep to an episode at the end.
 

--- a/rllib/utils/postprocessing/tests/test_value_predictions.py
+++ b/rllib/utils/postprocessing/tests/test_value_predictions.py
@@ -1,10 +1,178 @@
 import unittest
 
-from ray.rllib.utils.postprocessing.value_predictions import extract_bootstrapped_values
+import numpy as np
+
+from ray.rllib.utils.postprocessing.value_predictions import (
+    compute_value_targets,
+    compute_value_targets_with_bootstrap,
+    extract_bootstrapped_values,
+)
 from ray.rllib.utils.test_utils import check
 
 
-class TestPostprocessing(unittest.TestCase):
+class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
+    """Tests for compute_value_targets_with_bootstrap."""
+
+    def test_terminated_episode_lambda1(self):
+        """Lambda=1 + terminated episode: targets equal discounted returns."""
+        values = np.array([1.0, 2.0, 3.0])
+        rewards = np.array([10.0, 20.0, 30.0])
+        terminateds = np.array([False, False, True])
+        bootstrap = 0.0
+        gamma = 0.9
+        lambda_ = 1.0
+
+        result = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, bootstrap, gamma, lambda_
+        )
+        # Hand-computed discounted returns (lambda=1):
+        # G_2 = 30                           = 30.0
+        # G_1 = 20 + 0.9 * 30               = 47.0
+        # G_0 = 10 + 0.9 * 47               = 52.3
+        np.testing.assert_allclose(result, [52.3, 47.0, 30.0], atol=1e-5)
+
+    def test_truncated_episode_with_bootstrap(self):
+        """Truncated episode: bootstrap value propagates through GAE."""
+        values = np.array([1.0, 2.0, 3.0])
+        rewards = np.array([10.0, 20.0, 30.0])
+        terminateds = np.array([False, False, False])
+        bootstrap = 4.0
+        gamma = 0.9
+        lambda_ = 1.0
+
+        result = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, bootstrap, gamma, lambda_
+        )
+        # Hand-computed discounted returns (lambda=1):
+        # G_2 = 30 + 0.9 * 4.0              = 33.6
+        # G_1 = 20 + 0.9 * 33.6             = 50.24
+        # G_0 = 10 + 0.9 * 50.24            = 55.216
+        np.testing.assert_allclose(result, [55.216, 50.24, 33.6], atol=1e-5)
+
+    def test_lambda0_gives_one_step_td_targets(self):
+        """Lambda=0: targets collapse to one-step TD targets r + gamma*V(next)."""
+        values = np.array([1.0, 2.0, 3.0])
+        rewards = np.array([10.0, 20.0, 30.0])
+        terminateds = np.array([False, False, False])
+        bootstrap = 4.0
+        gamma = 0.9
+        lambda_ = 0.0
+
+        result = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, bootstrap, gamma, lambda_
+        )
+        # target_t = r_t + gamma * V(s_{t+1})   (lambda=0 => no GAE propagation)
+        # target_0 = 10 + 0.9 * 2  = 11.8
+        # target_1 = 20 + 0.9 * 3  = 22.7
+        # target_2 = 30 + 0.9 * 4  = 33.6
+        np.testing.assert_allclose(result, [11.8, 22.7, 33.6], atol=1e-5)
+
+    def test_gamma0_gives_raw_rewards(self):
+        """Gamma=0: no discounting, targets equal raw rewards."""
+        values = np.array([1.0, 2.0, 3.0])
+        rewards = np.array([10.0, 20.0, 30.0])
+        terminateds = np.array([False, False, False])
+        bootstrap = 100.0  # should be irrelevant
+        gamma = 0.0
+        lambda_ = 0.95
+
+        result = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, bootstrap, gamma, lambda_
+        )
+        np.testing.assert_allclose(result, [10.0, 20.0, 30.0], atol=1e-5)
+
+    def test_single_timestep_terminated(self):
+        """Single terminated timestep: target = reward."""
+        values = np.array([5.0])
+        rewards = np.array([10.0])
+        terminateds = np.array([True])
+        bootstrap = 0.0
+        gamma = 0.99
+        lambda_ = 0.95
+
+        result = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, bootstrap, gamma, lambda_
+        )
+        np.testing.assert_allclose(result, [10.0], atol=1e-5)
+
+    def test_single_timestep_truncated(self):
+        """Single truncated timestep: target = r + gamma * bootstrap."""
+        values = np.array([5.0])
+        rewards = np.array([10.0])
+        terminateds = np.array([False])
+        bootstrap = 3.0
+        gamma = 0.99
+        lambda_ = 0.95
+
+        result = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, bootstrap, gamma, lambda_
+        )
+        # delta = 10 + 0.99*3 - 5 = 7.97;  A = 7.97;  target = 12.97
+        np.testing.assert_allclose(result, [12.97], atol=1e-5)
+
+    def test_intermediate_lambda(self):
+        """GAE with 0 < lambda < 1 matches the reference implementation."""
+        values = np.array([1.0, 2.0, 3.0, 4.0])
+        rewards = np.array([0.5, 1.5, 2.5, 3.5])
+        terminateds = np.array([False, False, False, True])
+        bootstrap = 0.0
+        gamma = 0.99
+        lambda_ = 0.95
+
+        result = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, bootstrap, gamma, lambda_
+        )
+        np.testing.assert_allclose(result, [1.0, 2.0, 3.0, 4.0], atol=1e-5)
+
+    def test_all_zeros(self):
+        """Zero values, rewards, and bootstrap should give zero targets."""
+        T = 5
+        result = compute_value_targets_with_bootstrap(
+            values=np.zeros(T),
+            rewards=np.zeros(T),
+            terminateds=np.zeros(T, dtype=bool),
+            bootstrap_value=0.0,
+            gamma=0.99,
+            lambda_=0.95,
+        )
+        np.testing.assert_allclose(result, np.zeros(T), atol=1e-7)
+
+    def test_matches_old_function_terminated_lambda1(self):
+        """For terminated episodes with lambda=1 both functions must agree.
+
+        With lambda=1 the (1-lambda)*V term vanishes, so the value-zeroing
+        difference in the old function does not matter.
+        """
+        values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        rewards = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+        terminateds = np.array([0.0, 0.0, 0.0, 0.0, 1.0])
+        truncateds = np.zeros(5)
+        gamma = 0.99
+        lambda_ = 1.0
+
+        old_targets = compute_value_targets(
+            values, rewards, terminateds, truncateds, gamma, lambda_
+        )
+        new_targets = compute_value_targets_with_bootstrap(
+            values, rewards, terminateds, 0.0, gamma, lambda_
+        )
+        np.testing.assert_allclose(new_targets, old_targets, atol=1e-5)
+
+    def test_shape_preserved(self):
+        """Output shape must equal input shape."""
+        for T in [1, 5, 20]:
+            result = compute_value_targets_with_bootstrap(
+                values=np.ones(T),
+                rewards=np.ones(T),
+                terminateds=np.zeros(T, dtype=bool),
+                bootstrap_value=1.0,
+                gamma=0.99,
+                lambda_=0.95,
+            )
+            self.assertEqual(result.shape, (T,))
+
+
+class TestExtractBootstrappedValues(unittest.TestCase):
     def test_extract_bootstrapped_values(self):
         """Tests, whether the extract_bootstrapped_values utility works properly."""
 

--- a/rllib/utils/postprocessing/tests/test_value_predictions.py
+++ b/rllib/utils/postprocessing/tests/test_value_predictions.py
@@ -77,35 +77,6 @@ class TestComputeValueTargetsWithBootstrap:
         )
         check(result, [10.0, 20.0, 30.0], atol=1e-5)
 
-    def test_single_timestep_terminated(self):
-        """Single terminated timestep: target = reward."""
-        values = np.array([5.0])
-        rewards = np.array([10.0])
-        terminateds = np.array([True])
-        bootstrap = 0.0
-        gamma = 0.99
-        lambda_ = 0.95
-
-        result = compute_value_targets_with_bootstrap(
-            values, rewards, terminateds, bootstrap, gamma, lambda_
-        )
-        check(result, [10.0], atol=1e-5)
-
-    def test_single_timestep_truncated(self):
-        """Single truncated timestep: target = r + gamma * bootstrap."""
-        values = np.array([5.0])
-        rewards = np.array([10.0])
-        terminateds = np.array([False])
-        bootstrap = 3.0
-        gamma = 0.99
-        lambda_ = 0.95
-
-        result = compute_value_targets_with_bootstrap(
-            values, rewards, terminateds, bootstrap, gamma, lambda_
-        )
-        # delta = 10 + 0.99*3 - 5 = 7.97;  A = 7.97;  target = 12.97
-        check(result, [12.97], atol=1e-5)
-
     def test_intermediate_lambda(self):
         """GAE with 0 < lambda < 1 matches the reference implementation."""
         values = np.array([1.0, 2.0, 3.0, 4.0])
@@ -138,19 +109,6 @@ class TestComputeValueTargetsWithBootstrap:
         #   target_1 =  5.28186 + 2.0 =  7.28186
         #   target_0 =  6.44759 + 1.0 =  7.44759
         check(result, [7.447589, 7.281860, 5.989750, 3.5], atol=1e-5)
-
-    def test_all_zeros(self):
-        """Zero values, rewards, and bootstrap should give zero targets."""
-        T = 5
-        result = compute_value_targets_with_bootstrap(
-            values=np.zeros(T),
-            rewards=np.zeros(T),
-            terminateds=np.zeros(T, dtype=bool),
-            bootstrap_value=0.0,
-            gamma=0.99,
-            lambda_=0.95,
-        )
-        check(result, np.zeros(T), atol=1e-7)
 
 
 if __name__ == "__main__":

--- a/rllib/utils/postprocessing/tests/test_value_predictions.py
+++ b/rllib/utils/postprocessing/tests/test_value_predictions.py
@@ -1,5 +1,3 @@
-import unittest
-
 import numpy as np
 
 from ray.rllib.utils.postprocessing.value_predictions import (
@@ -8,7 +6,7 @@ from ray.rllib.utils.postprocessing.value_predictions import (
 from ray.rllib.utils.test_utils import check
 
 
-class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
+class TestComputeValueTargetsWithBootstrap:
     """Tests for compute_value_targets_with_bootstrap."""
 
     def test_terminated_episode_lambda1(self):

--- a/rllib/utils/postprocessing/tests/test_value_predictions.py
+++ b/rllib/utils/postprocessing/tests/test_value_predictions.py
@@ -3,9 +3,7 @@ import unittest
 import numpy as np
 
 from ray.rllib.utils.postprocessing.value_predictions import (
-    compute_value_targets,
     compute_value_targets_with_bootstrap,
-    extract_bootstrapped_values,
 )
 from ray.rllib.utils.test_utils import check
 
@@ -29,7 +27,7 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
         # G_2 = 30                           = 30.0
         # G_1 = 20 + 0.9 * 30               = 47.0
         # G_0 = 10 + 0.9 * 47               = 52.3
-        np.testing.assert_allclose(result, [52.3, 47.0, 30.0], atol=1e-5)
+        check(result, [52.3, 47.0, 30.0], atol=1e-5)
 
     def test_truncated_episode_with_bootstrap(self):
         """Truncated episode: bootstrap value propagates through GAE."""
@@ -47,7 +45,7 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
         # G_2 = 30 + 0.9 * 4.0              = 33.6
         # G_1 = 20 + 0.9 * 33.6             = 50.24
         # G_0 = 10 + 0.9 * 50.24            = 55.216
-        np.testing.assert_allclose(result, [55.216, 50.24, 33.6], atol=1e-5)
+        check(result, [55.216, 50.24, 33.6], atol=1e-5)
 
     def test_lambda0_gives_one_step_td_targets(self):
         """Lambda=0: targets collapse to one-step TD targets r + gamma*V(next)."""
@@ -65,7 +63,7 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
         # target_0 = 10 + 0.9 * 2  = 11.8
         # target_1 = 20 + 0.9 * 3  = 22.7
         # target_2 = 30 + 0.9 * 4  = 33.6
-        np.testing.assert_allclose(result, [11.8, 22.7, 33.6], atol=1e-5)
+        check(result, [11.8, 22.7, 33.6], atol=1e-5)
 
     def test_gamma0_gives_raw_rewards(self):
         """Gamma=0: no discounting, targets equal raw rewards."""
@@ -79,7 +77,7 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
         result = compute_value_targets_with_bootstrap(
             values, rewards, terminateds, bootstrap, gamma, lambda_
         )
-        np.testing.assert_allclose(result, [10.0, 20.0, 30.0], atol=1e-5)
+        check(result, [10.0, 20.0, 30.0], atol=1e-5)
 
     def test_single_timestep_terminated(self):
         """Single terminated timestep: target = reward."""
@@ -93,7 +91,7 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
         result = compute_value_targets_with_bootstrap(
             values, rewards, terminateds, bootstrap, gamma, lambda_
         )
-        np.testing.assert_allclose(result, [10.0], atol=1e-5)
+        check(result, [10.0], atol=1e-5)
 
     def test_single_timestep_truncated(self):
         """Single truncated timestep: target = r + gamma * bootstrap."""
@@ -108,7 +106,7 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
             values, rewards, terminateds, bootstrap, gamma, lambda_
         )
         # delta = 10 + 0.99*3 - 5 = 7.97;  A = 7.97;  target = 12.97
-        np.testing.assert_allclose(result, [12.97], atol=1e-5)
+        check(result, [12.97], atol=1e-5)
 
     def test_intermediate_lambda(self):
         """GAE with 0 < lambda < 1 matches the reference implementation."""
@@ -122,7 +120,26 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
         result = compute_value_targets_with_bootstrap(
             values, rewards, terminateds, bootstrap, gamma, lambda_
         )
-        np.testing.assert_allclose(result, [1.0, 2.0, 3.0, 4.0], atol=1e-5)
+        # Hand-computed GAE targets (gamma=0.99, lambda=0.95, terminated at t=3):
+        #
+        # TD deltas: delta_t = r_t + gamma * V(t+1) * (1 - term_t) - V(t)
+        #   delta_3 = 3.5 + 0.99 * 0.0 * (1-1) - 4.0     = -0.5
+        #   delta_2 = 2.5 + 0.99 * 4.0 * (1-0) - 3.0     =  3.46
+        #   delta_1 = 1.5 + 0.99 * 3.0 * (1-0) - 2.0     =  2.47
+        #   delta_0 = 0.5 + 0.99 * 2.0 * (1-0) - 1.0     =  1.48
+        #
+        # GAE advantages: A_t = delta_t + gamma * lambda * (1 - term_t) * A_{t+1}
+        #   A_3 = -0.5
+        #   A_2 = 3.46  + 0.99 * 0.95 * 1 * (-0.5)       =  2.98975
+        #   A_1 = 2.47  + 0.99 * 0.95 * 1 * 2.98975      =  5.281860
+        #   A_0 = 1.48  + 0.99 * 0.95 * 1 * 5.281860     =  6.447589
+        #
+        # Value targets: target_t = A_t + V(t)
+        #   target_3 = -0.5     + 4.0 =  3.5
+        #   target_2 =  2.98975 + 3.0 =  5.98975
+        #   target_1 =  5.28186 + 2.0 =  7.28186
+        #   target_0 =  6.44759 + 1.0 =  7.44759
+        check(result, [7.447589, 7.281860, 5.989750, 3.5], atol=1e-5)
 
     def test_all_zeros(self):
         """Zero values, rewards, and bootstrap should give zero targets."""
@@ -135,77 +152,7 @@ class TestComputeValueTargetsWithBootstrap(unittest.TestCase):
             gamma=0.99,
             lambda_=0.95,
         )
-        np.testing.assert_allclose(result, np.zeros(T), atol=1e-7)
-
-    def test_matches_old_function_terminated_lambda1(self):
-        """For terminated episodes with lambda=1 both functions must agree.
-
-        With lambda=1 the (1-lambda)*V term vanishes, so the value-zeroing
-        difference in the old function does not matter.
-        """
-        values = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-        rewards = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
-        terminateds = np.array([0.0, 0.0, 0.0, 0.0, 1.0])
-        truncateds = np.zeros(5)
-        gamma = 0.99
-        lambda_ = 1.0
-
-        old_targets = compute_value_targets(
-            values, rewards, terminateds, truncateds, gamma, lambda_
-        )
-        new_targets = compute_value_targets_with_bootstrap(
-            values, rewards, terminateds, 0.0, gamma, lambda_
-        )
-        np.testing.assert_allclose(new_targets, old_targets, atol=1e-5)
-
-    def test_shape_preserved(self):
-        """Output shape must equal input shape."""
-        for T in [1, 5, 20]:
-            result = compute_value_targets_with_bootstrap(
-                values=np.ones(T),
-                rewards=np.ones(T),
-                terminateds=np.zeros(T, dtype=bool),
-                bootstrap_value=1.0,
-                gamma=0.99,
-                lambda_=0.95,
-            )
-            self.assertEqual(result.shape, (T,))
-
-
-class TestExtractBootstrappedValues(unittest.TestCase):
-    def test_extract_bootstrapped_values(self):
-        """Tests, whether the extract_bootstrapped_values utility works properly."""
-
-        # Fake vf_preds sequence.
-        # Spaces = denote (elongated-by-one-artificial-ts) episode boundaries.
-        # digits = timesteps within the actual episode.
-        # [lower case letters] = bootstrap values at episode truncations.
-        # '-' = bootstrap values at episode terminals (these values are simply zero).
-        sequence = "012345678a 01234A 0- 0123456b 01c 012- 012345e 012-"
-        sequence = sequence.replace(" ", "")
-        sequence = list(sequence)
-        # The actual, non-elongated, episode lengths.
-        episode_lengths = [9, 5, 1, 7, 2, 3, 6, 3]
-        T = 4
-        result = extract_bootstrapped_values(
-            vf_preds=sequence,
-            episode_lengths=episode_lengths,
-            T=T,
-        )
-        check(result, [4, 8, 3, 1, 5, "c", 1, 5, "-"])
-
-        # Another example.
-        sequence = "0123a 012345b 01234567- 012- 012- 012- 012345- 0123456c"
-        sequence = sequence.replace(" ", "")
-        sequence = list(sequence)
-        episode_lengths = [4, 6, 8, 3, 3, 3, 6, 7]
-        T = 5
-        result = extract_bootstrapped_values(
-            vf_preds=sequence,
-            episode_lengths=episode_lengths,
-            T=T,
-        )
-        check(result, [1, "b", 5, 2, 1, 3, 2, "c"])
+        check(result, np.zeros(T), atol=1e-7)
 
 
 if __name__ == "__main__":

--- a/rllib/utils/postprocessing/value_predictions.py
+++ b/rllib/utils/postprocessing/value_predictions.py
@@ -1,9 +1,15 @@
 import numpy as np
 
+from ray._common.deprecation import Deprecated
 from ray.util.annotations import DeveloperAPI
 
 
 @DeveloperAPI
+@Deprecated(
+    error=False,
+    old="ray.rllib.utils.postprocessing.value_predictions.compute_value_targets",
+    new="ray.rllib.utils.postprocessing.value_predictions.compute_value_targets_with_bootstrap",
+)
 def compute_value_targets(
     values,
     rewards,
@@ -68,18 +74,19 @@ def compute_value_targets_with_bootstrap(
         lambda_: GAE lambda parameter.
 
     Returns:
-        Value targets, shape (T,), dtype float32.
+        Value targets, shape (T,), same dtype as `values`.
     """
     T = len(values)
-    advantages = np.zeros(T, dtype=np.float32)
+    advantages = np.zeros_like(values)
     last_gae = 0.0
+    next_val = bootstrap_value
     for t in reversed(range(T)):
-        next_val = float(values[t + 1]) if t < T - 1 else bootstrap_value
         nonterminal = 1.0 - terminateds[t]
         delta = rewards[t] + gamma * next_val * nonterminal - values[t]
         last_gae = delta + gamma * lambda_ * nonterminal * last_gae
         advantages[t] = last_gae
-    return (advantages + values).astype(np.float32)
+        next_val = values[t]
+    return advantages + values
 
 
 def extract_bootstrapped_values(vf_preds, episode_lengths, T):

--- a/rllib/utils/postprocessing/value_predictions.py
+++ b/rllib/utils/postprocessing/value_predictions.py
@@ -6,7 +6,7 @@ from ray.util.annotations import DeveloperAPI
 
 @DeveloperAPI
 @Deprecated(
-    error=False,
+    error=True,
     old="ray.rllib.utils.postprocessing.value_predictions.compute_value_targets",
     new="ray.rllib.utils.postprocessing.value_predictions.compute_value_targets_with_bootstrap",
 )
@@ -18,30 +18,7 @@ def compute_value_targets(
     gamma: float,
     lambda_: float,
 ):
-    """Computes value function (vf) targets given vf predictions and rewards.
-
-    Note that advantages can then easily be computed via the formula:
-    advantages = targets - vf_predictions
-    """
-    # Force-set all values at terminals (not at truncations!) to 0.0.
-    orig_values = flat_values = values * (1.0 - terminateds)
-
-    flat_values = np.append(flat_values, 0.0)
-    intermediates = rewards + gamma * (1 - lambda_) * flat_values[1:]
-    continues = 1.0 - terminateds
-
-    Rs = []
-    last = flat_values[-1]
-    for t in reversed(range(intermediates.shape[0])):
-        last = intermediates[t] + continues[t] * gamma * lambda_ * last
-        Rs.append(last)
-        if truncateds[t]:
-            last = orig_values[t]
-
-    # Reverse back to correct (time) direction.
-    value_targets = np.stack(list(reversed(Rs)), axis=0)
-
-    return value_targets.astype(np.float32)
+    ...
 
 
 @DeveloperAPI
@@ -87,73 +64,3 @@ def compute_value_targets_with_bootstrap(
         advantages[t] = last_gae
         next_val = values[t]
     return advantages + values
-
-
-def extract_bootstrapped_values(vf_preds, episode_lengths, T):
-    """Returns a bootstrapped value batch given value predictions.
-
-    Note that the incoming value predictions must have happened over (artificially)
-    elongated episodes (by 1 timestep at the end). This way, we can either extract the
-    `vf_preds` at these extra timesteps (as "bootstrap values") or skip over them
-    entirely if they lie in the middle of the T-slices.
-
-    For example, given an episodes structure like this:
-    01234a 0123456b 01c 012- 0123e 012-
-    where each episode is separated by a space and goes from 0 to n and ends in an
-    artificially elongated timestep (denoted by 'a', 'b', 'c', '-', or 'e'), where '-'
-    means that the episode was terminated and the bootstrap value at the end should be
-    zero and 'a', 'b', 'c', etc.. represent truncated episode ends with computed vf
-    estimates.
-    The output for the above sequence (and T=4) should then be:
-    4 3 b 2 3 -
-
-    Args:
-        vf_preds: The computed value function predictions over the artificially
-            elongated episodes (by one timestep at the end).
-        episode_lengths: The original (correct) episode lengths, NOT counting the
-            artificially added timestep at the end.
-        T: The size of the time dimension by which to slice the data. Note that the
-            sum of all episode lengths (`sum(episode_lengths)`) must be dividable by T.
-
-    Returns:
-        The batch of bootstrapped values.
-    """
-    bootstrapped_values = []
-    if sum(episode_lengths) % T != 0:
-        raise ValueError(
-            "Can only extract bootstrapped values if the sum of episode lengths "
-            f"({sum(episode_lengths)}) is dividable by the given T ({T})!"
-        )
-
-    # Loop over all episode lengths and collect bootstrap values.
-    # Do not alter incoming `episode_lengths` list.
-    episode_lengths = episode_lengths[:]
-    i = -1
-    while i < len(episode_lengths) - 1:
-        i += 1
-        eps_len = episode_lengths[i]
-        # We can make another T-stride inside this episode ->
-        # - Use a vf prediction within the episode as bootstrapped value.
-        # - "Fix" the episode_lengths array and continue within the same episode.
-        if T < eps_len:
-            bootstrapped_values.append(vf_preds[T])
-            vf_preds = vf_preds[T:]
-            episode_lengths[i] -= T
-            i -= 1
-        # We can make another T-stride inside this episode, but will then be at the end
-        # of it ->
-        # - Use the value function prediction at the artificially added timestep
-        #   as bootstrapped value.
-        # - Skip the additional timestep at the end and ,ove on with next episode.
-        elif T == eps_len:
-            bootstrapped_values.append(vf_preds[T])
-            vf_preds = vf_preds[T + 1 :]
-        # The episode fits entirely into the T-stride ->
-        # - Move on to next episode ("fix" its length by make it seemingly longer).
-        else:
-            # Skip bootstrap value of current episode (not needed).
-            vf_preds = vf_preds[1:]
-            # Make next episode seem longer.
-            episode_lengths[i + 1] += eps_len
-
-    return np.array(bootstrapped_values)

--- a/rllib/utils/spaces/space_utils.py
+++ b/rllib/utils/spaces/space_utils.py
@@ -358,6 +358,13 @@ def batch(
             # Fast path: simple numpy arrays or scalars — no tree traversal needed.
             ret = fast_stack(*list_of_structs)
 
+<<<<<<< HEAD
+=======
+    np_func = np.concatenate if individual_items_already_have_batch_dim else np.stack
+    ret = tree.map_structure(
+        lambda *s: np.ascontiguousarray(np_func(s, axis=0)), *list_of_structs
+    )
+>>>>>>> 8e40ef0425 (revert space utils change)
     return ret
 
 

--- a/rllib/utils/spaces/space_utils.py
+++ b/rllib/utils/spaces/space_utils.py
@@ -358,13 +358,6 @@ def batch(
             # Fast path: simple numpy arrays or scalars — no tree traversal needed.
             ret = fast_stack(*list_of_structs)
 
-<<<<<<< HEAD
-=======
-    np_func = np.concatenate if individual_items_already_have_batch_dim else np.stack
-    ret = tree.map_structure(
-        lambda *s: np.ascontiguousarray(np_func(s, axis=0)), *list_of_structs
-    )
->>>>>>> 8e40ef0425 (revert space utils change)
     return ret
 
 


### PR DESCRIPTION
## Description

Refactors GAE boostrapping such that we don't require AddOneTsToEpisodesAndTruncate anymore.

Why?
- Remove need for costly AddOneTsToEpisodesAndTruncate connector
- Cleans up TODO of prepending a connector that makes sure that episode IDs are unitque
- This speeds up learner connectors (anecdotal: Local benchmark on my laptop improved runtime of learner connector pipeline by ~30%)

Merge https://github.com/ray-project/ray/pull/61319 first