### PR TITLE
[RLlib] Speed up AddColumnsFromEpisodesToTrainBatch for single agent case

### DIFF
--- a/rllib/algorithms/dqn/dqn.py
+++ b/rllib/algorithms/dqn/dqn.py
@@ -703,6 +703,7 @@ class DQN(Algorithm):
                         gamma=self.config.gamma,
                         beta=self.config.replay_buffer_config.get("beta"),
                         sample_episodes=True,
+                        to_numpy=True,
                     )
 
                     # Get the replay buffer metrics.

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -121,16 +121,20 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     col = batch.get(Columns.ACTIONS)
                     if col is None:
                         batch[Columns.ACTIONS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 if need_rewards:
                     data = sa_episode.get_rewards(slice(0, n)).view(BatchedNdArray)
                     col = batch.get(Columns.REWARDS)
                     if col is None:
                         batch[Columns.REWARDS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 if need_terminateds:
                     terminateds = np.zeros(n, dtype=np.bool_)
@@ -140,8 +144,10 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     col = batch.get(Columns.TERMINATEDS)
                     if col is None:
                         batch[Columns.TERMINATEDS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 if need_truncateds:
                     truncateds = np.zeros(n, dtype=np.bool_)
@@ -151,8 +157,10 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     col = batch.get(Columns.TRUNCATEDS)
                     if col is None:
                         batch[Columns.TRUNCATEDS] = {sub_key: [data]}
-                    else:
+                    elif sub_key in col:
                         col[sub_key].append(data)
+                    else:
+                        col[sub_key] = [data]
 
                 for column in sa_episode.extra_model_outputs.keys():
                     if column not in skip_columns:
@@ -166,8 +174,10 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                         col = batch.get(column)
                         if col is None:
                             batch[column] = {sub_key: [data]}
-                        else:
+                        elif sub_key in col:
                             col[sub_key].append(data)
+                        else:
+                            col[sub_key] = [data]
 
             else:
                 # General (multi-agent) path: use the standard API.

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -6,6 +6,7 @@ import tree
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
+from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.spaces.space_utils import BatchedNdArray
 from ray.rllib.utils.typing import EpisodeType
@@ -101,10 +102,8 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
         ):
             n = len(sa_episode)
 
-            # For single-agent episodes (agent_id=None), sub_key is always (id_,).
-            # We can use a fast path to extend the batch.
-            # For multi-agent episodes, we need to use add_n_batch_items path.
-            if sa_episode.agent_id is None:
+            # For single-agent episodes, we can use a fast path to extend the batch.
+            if isinstance(sa_episode, SingleAgentEpisode):
                 # Fast path: inline the dict operations, skipping the function call
                 # overhead of add_n_batch_items / add_batch_item and the repeated
                 # sub_key computation those would do per column.
@@ -113,7 +112,7 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                 if need_actions:
                     # Actions may be a composite action space, so we need to map the structure.
                     data = sa_episode.get_actions(slice(0, n))
-                    # Check if the we have to call tree.map_structure to convert the data to a BatchedNdArray.
+                    # Check if we have to call tree.map_structure to convert the data to a BatchedNdArray.
                     if isinstance(data, np.ndarray):
                         data = data.view(BatchedNdArray)
                     else:
@@ -179,8 +178,8 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                         else:
                             col[sub_key] = [data]
 
-            else:
-                # General (multi-agent) path: use the standard API.
+            else:  # episode will be MultiAgentEpisode.
+                # For multi-agent episodes, we need to use the add_n_batch_items path.
                 if need_actions:
                     self.add_n_batch_items(
                         batch,

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -1,7 +1,5 @@
 from typing import Any, Dict, List, Optional
 
-import numpy as np
-
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
@@ -60,10 +58,6 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
     their own data and store it in `data` under those keys. In this case, the default
     connector will not change the data under these keys and simply act as a
     pass-through.
-
-
-    We expect that `episodes` are numpy'ized.
-    In standard training flows, episodes have already been numpy'ized before they enter this connector via EnvRunners, ReplayBuffers or offline sampling.
     """
 
     @override(ConnectorV2)
@@ -114,15 +108,15 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                 episodes,
                 agents_that_stepped_only=False,
             ):
-                n = len(sa_episode)
-                terminateds = np.zeros(n, dtype=np.bool_)
-                if n > 0:
-                    terminateds[-1] = sa_episode.is_terminated
                 self.add_n_batch_items(
                     batch,
                     Columns.TERMINATEDS,
-                    items_to_add=terminateds,
-                    num_items=n,
+                    items_to_add=(
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_terminated]
+                        if len(sa_episode) > 0
+                        else []
+                    ),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
 
@@ -132,15 +126,15 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                 episodes,
                 agents_that_stepped_only=False,
             ):
-                n = len(sa_episode)
-                truncateds = np.zeros(n, dtype=np.bool_)
-                if n > 0:
-                    truncateds[-1] = sa_episode.is_truncated
                 self.add_n_batch_items(
                     batch,
                     Columns.TRUNCATEDS,
-                    items_to_add=truncateds,
-                    num_items=n,
+                    items_to_add=(
+                        [False] * (len(sa_episode) - 1) + [sa_episode.is_truncated]
+                        if len(sa_episode) > 0
+                        else []
+                    ),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
 

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -1,14 +1,11 @@
 from typing import Any, Dict, List, Optional
 
 import numpy as np
-import tree
 
 from ray.rllib.connectors.connector_v2 import ConnectorV2
 from ray.rllib.core.columns import Columns
 from ray.rllib.core.rl_module.rl_module import RLModule
-from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.rllib.utils.annotations import override
-from ray.rllib.utils.spaces.space_utils import BatchedNdArray
 from ray.rllib.utils.typing import EpisodeType
 from ray.util.annotations import PublicAPI
 
@@ -94,140 +91,62 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
         # pieces.
         skip_columns = set(batch.keys()) | {Columns.STATE_IN, Columns.STATE_OUT}
 
-        # Single pass over all episodes: compute len(sa_episode) and sub_key once and
-        # reuse them for every column.
+        # Single pass over all episodes: compute len(sa_episode) once and
+        # reuse it for every column.
         for sa_episode in self.single_agent_episode_iterator(
             episodes,
             agents_that_stepped_only=False,
         ):
             n = len(sa_episode)
 
-            # For single-agent episodes, we can use a fast path to extend the batch.
-            if isinstance(sa_episode, SingleAgentEpisode):
-                # Fast path: inline the dict operations, skipping the function call
-                # overhead of add_n_batch_items / add_batch_item and the repeated
-                # sub_key computation those would do per column.
-                sub_key = (sa_episode.id_,)
-
-                if need_actions:
-                    # Actions may be a composite action space, so we need to map the structure.
-                    data = sa_episode.get_actions(slice(0, n))
-                    # Check if we have to call tree.map_structure to convert the data to a BatchedNdArray.
-                    if isinstance(data, np.ndarray):
-                        data = data.view(BatchedNdArray)
-                    else:
-                        data = tree.map_structure(BatchedNdArray, data)
-                    col = batch.get(Columns.ACTIONS)
-                    if col is None:
-                        batch[Columns.ACTIONS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_rewards:
-                    data = sa_episode.get_rewards(slice(0, n)).view(BatchedNdArray)
-                    col = batch.get(Columns.REWARDS)
-                    if col is None:
-                        batch[Columns.REWARDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_terminateds:
-                    terminateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        terminateds[-1] = sa_episode.is_terminated
-                    data = terminateds.view(BatchedNdArray)
-                    col = batch.get(Columns.TERMINATEDS)
-                    if col is None:
-                        batch[Columns.TERMINATEDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                if need_truncateds:
-                    truncateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        truncateds[-1] = sa_episode.is_truncated
-                    data = truncateds.view(BatchedNdArray)
-                    col = batch.get(Columns.TRUNCATEDS)
-                    if col is None:
-                        batch[Columns.TRUNCATEDS] = {sub_key: [data]}
-                    elif sub_key in col:
-                        col[sub_key].append(data)
-                    else:
-                        col[sub_key] = [data]
-
-                for column in sa_episode.extra_model_outputs.keys():
-                    if column not in skip_columns:
-                        # Extra model outputs may be a composite space, so we need to map the structure.
-                        data = tree.map_structure(
-                            BatchedNdArray,
-                            sa_episode.get_extra_model_outputs(
-                                key=column, indices=slice(0, n)
-                            ),
-                        )
-                        col = batch.get(column)
-                        if col is None:
-                            batch[column] = {sub_key: [data]}
-                        elif sub_key in col:
-                            col[sub_key].append(data)
-                        else:
-                            col[sub_key] = [data]
-
-            else:  # episode will be MultiAgentEpisode.
-                # For multi-agent episodes, we need to use the add_n_batch_items path.
-                if need_actions:
+            if need_actions:
+                self.add_n_batch_items(
+                    batch,
+                    Columns.ACTIONS,
+                    items_to_add=sa_episode.get_actions(slice(0, n)),
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            if need_rewards:
+                self.add_n_batch_items(
+                    batch,
+                    Columns.REWARDS,
+                    items_to_add=sa_episode.get_rewards(slice(0, n)),
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            if need_terminateds:
+                terminateds = np.zeros(n, dtype=np.bool_)
+                if n > 0:
+                    terminateds[-1] = sa_episode.is_terminated
+                self.add_n_batch_items(
+                    batch,
+                    Columns.TERMINATEDS,
+                    items_to_add=terminateds,
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            if need_truncateds:
+                truncateds = np.zeros(n, dtype=np.bool_)
+                if n > 0:
+                    truncateds[-1] = sa_episode.is_truncated
+                self.add_n_batch_items(
+                    batch,
+                    Columns.TRUNCATEDS,
+                    items_to_add=truncateds,
+                    num_items=n,
+                    single_agent_episode=sa_episode,
+                )
+            for column in sa_episode.extra_model_outputs.keys():
+                if column not in skip_columns:
                     self.add_n_batch_items(
                         batch,
-                        Columns.ACTIONS,
-                        items_to_add=sa_episode.get_actions(slice(0, n)),
+                        column,
+                        items_to_add=sa_episode.get_extra_model_outputs(
+                            key=column, indices=slice(0, n)
+                        ),
                         num_items=n,
                         single_agent_episode=sa_episode,
                     )
-                if need_rewards:
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.REWARDS,
-                        items_to_add=sa_episode.get_rewards(slice(0, n)),
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                if need_terminateds:
-                    terminateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        terminateds[-1] = sa_episode.is_terminated
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.TERMINATEDS,
-                        items_to_add=terminateds,
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                if need_truncateds:
-                    truncateds = np.zeros(n, dtype=np.bool_)
-                    if n > 0:
-                        truncateds[-1] = sa_episode.is_truncated
-                    self.add_n_batch_items(
-                        batch,
-                        Columns.TRUNCATEDS,
-                        items_to_add=truncateds,
-                        num_items=n,
-                        single_agent_episode=sa_episode,
-                    )
-                for column in sa_episode.extra_model_outputs.keys():
-                    if column not in skip_columns:
-                        self.add_n_batch_items(
-                            batch,
-                            column,
-                            items_to_add=sa_episode.get_extra_model_outputs(
-                                key=column, indices=slice(0, n)
-                            ),
-                            num_items=n,
-                            single_agent_episode=sa_episode,
-                        )
 
         return batch

--- a/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
+++ b/rllib/connectors/learner/add_columns_from_episodes_to_train_batch.py
@@ -78,44 +78,43 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
         **kwargs,
     ) -> Any:
 
-        # Determine which standard columns still need to be filled (skip any that a
-        # custom upstream connector has already populated).
-        need_actions = Columns.ACTIONS not in batch
-        need_rewards = Columns.REWARDS not in batch
-        need_terminateds = Columns.TERMINATEDS not in batch
-        need_truncateds = Columns.TRUNCATEDS not in batch
-
-        # Extra model outputs (except for STATE_OUT, which will be handled by another
-        # default connector piece). Also, like with all the fields above, skip
-        # those that the user already seemed to have populated via custom connector
-        # pieces.
-        skip_columns = set(batch.keys()) | {Columns.STATE_IN, Columns.STATE_OUT}
-
-        # Single pass over all episodes: compute len(sa_episode) once and
-        # reuse it for every column.
-        for sa_episode in self.single_agent_episode_iterator(
-            episodes,
-            agents_that_stepped_only=False,
-        ):
-            n = len(sa_episode)
-
-            if need_actions:
+        # Actions.
+        if Columns.ACTIONS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
                 self.add_n_batch_items(
                     batch,
                     Columns.ACTIONS,
-                    items_to_add=sa_episode.get_actions(slice(0, n)),
-                    num_items=n,
+                    # Bulk extraction: get all actions at once instead of per-timestep.
+                    items_to_add=sa_episode.get_actions(slice(0, len(sa_episode))),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
-            if need_rewards:
+
+        # Rewards.
+        if Columns.REWARDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
                 self.add_n_batch_items(
                     batch,
                     Columns.REWARDS,
-                    items_to_add=sa_episode.get_rewards(slice(0, n)),
-                    num_items=n,
+                    # Bulk extraction: get all rewards at once instead of per-timestep.
+                    items_to_add=sa_episode.get_rewards(slice(0, len(sa_episode))),
+                    num_items=len(sa_episode),
                     single_agent_episode=sa_episode,
                 )
-            if need_terminateds:
+
+        # Terminateds.
+        if Columns.TERMINATEDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                n = len(sa_episode)
                 terminateds = np.zeros(n, dtype=np.bool_)
                 if n > 0:
                     terminateds[-1] = sa_episode.is_terminated
@@ -126,7 +125,14 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     num_items=n,
                     single_agent_episode=sa_episode,
                 )
-            if need_truncateds:
+
+        # Truncateds.
+        if Columns.TRUNCATEDS not in batch:
+            for sa_episode in self.single_agent_episode_iterator(
+                episodes,
+                agents_that_stepped_only=False,
+            ):
+                n = len(sa_episode)
                 truncateds = np.zeros(n, dtype=np.bool_)
                 if n > 0:
                     truncateds[-1] = sa_episode.is_truncated
@@ -137,15 +143,26 @@ class AddColumnsFromEpisodesToTrainBatch(ConnectorV2):
                     num_items=n,
                     single_agent_episode=sa_episode,
                 )
+
+        # Extra model outputs (except for STATE_OUT, which will be handled by another
+        # default connector piece). Also, like with all the fields above, skip
+        # those that the user already seemed to have populated via custom connector
+        # pieces.
+        skip_columns = set(batch.keys()) | {Columns.STATE_IN, Columns.STATE_OUT}
+        for sa_episode in self.single_agent_episode_iterator(
+            episodes,
+            agents_that_stepped_only=False,
+        ):
             for column in sa_episode.extra_model_outputs.keys():
                 if column not in skip_columns:
                     self.add_n_batch_items(
                         batch,
                         column,
+                        # Bulk extraction: get all extra outputs at once.
                         items_to_add=sa_episode.get_extra_model_outputs(
-                            key=column, indices=slice(0, n)
+                            key=column, indices=slice(0, len(sa_episode))
                         ),
-                        num_items=n,
+                        num_items=len(sa_episode),
                         single_agent_episode=sa_episode,
                     )
 

--- a/rllib/examples/algorithms/ppo/cartpole_heavy_ppo.py
+++ b/rllib/examples/algorithms/ppo/cartpole_heavy_ppo.py
@@ -19,7 +19,6 @@ config = (
     .environment(CartPoleWithLargeObservationSpace)
     .env_runners(
         env_to_module_connector=lambda env, spaces, device: FlattenObservations(),
-        episodes_to_numpy=False,
     )
     .training(
         lr=0.0003,

--- a/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py
+++ b/rllib/examples/algorithms/ppo/multi_agent_footsies_ppo.py
@@ -166,7 +166,6 @@ config = (
         num_envs_per_env_runner=1,
         batch_mode="truncate_episodes",
         rollout_fragment_length=args.rollout_fragment_length,
-        episodes_to_numpy=False,
         create_env_on_local_worker=True,
     )
     .training(

--- a/rllib/offline/offline_env_runner.py
+++ b/rllib/offline/offline_env_runner.py
@@ -16,7 +16,6 @@ from ray.rllib.utils.annotations import (
 from ray.rllib.utils.compression import pack_if_needed
 from ray.rllib.utils.typing import EpisodeType
 from ray.util.annotations import PublicAPI
-from ray.util.debug import log_once
 
 logger = logging.Logger(__file__)
 
@@ -33,10 +32,6 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
     def __init__(self, *, config: AlgorithmConfig, **kwargs):
         # Initialize the parent.
         super().__init__(config=config, **kwargs)
-
-        # override SingleAgentEnvRunner
-        self.episodes_to_numpy = False
-
         # Get the data context for this `EnvRunner`.
         data_context = ray.data.DataContext.get_current()
         # Limit the resources for Ray Data to the CPUs given to this `EnvRunner`.
@@ -187,15 +182,6 @@ class OfflineSingleAgentEnvRunner(SingleAgentEnvRunner):
             import msgpack
             import msgpack_numpy as mnp
 
-            if log_once("msgpack"):
-                logger.info(
-                    "Packing episodes with `msgpack` and encode array with "
-                    "`msgpack_numpy` for serialization. This is needed for "
-                    "recording episodes."
-                )
-            # Note, we serialize episodes with `msgpack` and `msgpack_numpy` to
-            # ensure version compatibility.
-            assert all(eps.is_numpy is False for eps in samples)
             self._samples.extend(
                 [msgpack.packb(eps.get_state(), default=mnp.encode) for eps in samples]
             )

--- a/rllib/offline/offline_policy_evaluation_runner.py
+++ b/rllib/offline/offline_policy_evaluation_runner.py
@@ -216,7 +216,7 @@ class OfflinePolicyPreEvaluator(OfflinePreLearner):
         # Otherwise we map the batch to episodes.
         else:
             episodes: List[SingleAgentEpisode] = self._map_to_episodes(
-                batch, to_numpy=False
+                batch, to_numpy=True
             )["episodes"]
 
         episode_dicts = []

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -199,7 +199,7 @@ class OfflinePreLearner:
         else:
             episodes: List[SingleAgentEpisode] = self._map_to_episodes(
                 batch,
-                to_numpy=False,
+                to_numpy=True,
             )["episodes"]
 
         # TODO (simon): Sync learner connector state

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -188,6 +188,8 @@ class OfflinePreLearner:
                 )
                 for state in batch["item"]
             ]
+            for ep in episodes:
+                ep.to_numpy()
             episodes = self._postprocess_and_sample(episodes)
 
         elif self.config.input_read_sample_batches:

--- a/rllib/offline/offline_prelearner.py
+++ b/rllib/offline/offline_prelearner.py
@@ -188,14 +188,11 @@ class OfflinePreLearner:
                 )
                 for state in batch["item"]
             ]
-            for ep in episodes:
-                ep.to_numpy()
             episodes = self._postprocess_and_sample(episodes)
 
         elif self.config.input_read_sample_batches:
             episodes: List[SingleAgentEpisode] = self._map_sample_batch_to_episode(
                 batch,
-                to_numpy=True,
             )["episodes"]
             episodes = self._postprocess_and_sample(episodes)
         else:
@@ -203,6 +200,11 @@ class OfflinePreLearner:
                 batch,
                 to_numpy=True,
             )["episodes"]
+
+        # Ensure all episodes are numpy'ized before entering the learner connector.
+        for ep in episodes:
+            if not ep.is_numpy:
+                ep.to_numpy()
 
         # TODO (simon): Sync learner connector state
         # TODO (sven): Add MetricsLogger to non-Learner components that have a LearnerConnector pipeline.

--- a/rllib/offline/tests/test_offline_rl_stateful.py
+++ b/rllib/offline/tests/test_offline_rl_stateful.py
@@ -119,6 +119,10 @@ class OfflineRLStatefulTest(unittest.TestCase):
         if Columns.STATE_IN in episodes[0].extra_model_outputs.keys():
             del episodes[0].extra_model_outputs[Columns.STATE_IN]
 
+        # Numpy'ize episodes before passing to the learner connector.
+        for ep in episodes:
+            ep.to_numpy()
+
         # Build the learner connector.
         obs_space, action_space = self.algo.offline_data.spaces[INPUT_ENV_SPACES]
         learner_connector = self.algo.config.build_learner_connector(
@@ -216,6 +220,10 @@ class OfflineRLStatefulTest(unittest.TestCase):
 
         # Assert the episode has a decent return.
         assert episodes[0].get_return() > 350.0, "Return must be >350.0"
+
+        # Numpy'ize episodes before passing to the learner connector.
+        for ep in episodes:
+            ep.to_numpy()
 
         # Build the learner connector.
         obs_space, action_space = self.algo.offline_data.spaces[INPUT_ENV_SPACES]


### PR DESCRIPTION
## Description

This PR mainly contains the following changes to speed up learner connector pipelines:
- Refactor AddColumnsFromEpisodesToTrainBatch logic such that we iterate over each episode only once
- Add a "fast path" for  single-agent case
- Switch loss-mask/terminal flag creation to numpy arrays
- Make sure will "numpy'ize" episodes that go into learner connectors from different sources.

To make things a bit faster, we want to make the assumption that inputs are numpy'ized, instead of sometimes being lists. This is ok because the only advantage of having lists is that it enables us to be lazy about our inputs. The downside is that we have to check whether we are looking at nested structures or numpy arrays all the time.

In the future, we'll move towards reimplementing connectors in torch.