### PR TITLE
[ci] add ImageBuildConfig and ImageBuilder for local Docker builds

### DIFF
--- a/ci/build/build_image.py
+++ b/ci/build/build_image.py
@@ -8,11 +8,22 @@ Build Ray Docker images locally using raymake.
 """
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 
 import yaml
 
-from ci.build.build_common import BuildError, find_ray_root
+from ci.build.build_common import (
+    BuildError,
+    detect_host_arch,
+    find_ray_root,
+    get_git_commit,
+    log,
+    parse_file,
+)
 
 DEFAULT_ARCHITECTURE = "x86_64"
 
@@ -157,3 +168,152 @@ WANDA_SPEC_PATHS: dict[WandaSpecKey, str] = {
 
 SUPPORTED_IMAGE_TYPES: list[str] = list(dict.fromkeys(t for t, _ in WANDA_SPEC_PATHS))
 REGISTRY_PREFIX = "cr.ray.io/rayproject/"
+
+
+@dataclass(frozen=True)
+class ImageBuildConfig:
+    ray_image: RayImage
+    ray_root: Path
+    raymake_version: str
+    manylinux_version: str
+    ray_version: str
+    commit: str
+    wanda_spec_path: str
+    wanda_image_tag: str
+    nightly_alias: str | None
+    build_env: dict[str, str]
+
+    @classmethod
+    def from_args(
+        cls,
+        image_type: str,
+        python_version: str,
+        image_platform: str,
+    ) -> ImageBuildConfig:
+        ray_image = RayImage(
+            image_type=image_type,
+            python_version=python_version,
+            platform=image_platform,
+            architecture=cls._detect_host_arch(),
+        )
+        try:
+            ray_image.validate()
+            ray_image.get_wanda_spec_path()
+        except RayImageError as e:
+            raise BuildError(str(e)) from e
+
+        root = find_ray_root()
+        manylinux_version = parse_file(
+            root / "rayci.env", r'MANYLINUX_VERSION=["\']?([^"\'\s]+)'
+        )
+        ray_version = parse_file(root / "rayci.env", r'RAY_VERSION=["\']?([^"\'\s]+)')
+        commit = get_git_commit(root)
+
+        cfg = IMAGE_TYPE_CONFIG[image_type]
+        nightly_alias = (
+            f"{REGISTRY_PREFIX}{ray_image.repo}:nightly{ray_image.variation_suffix}"
+            if (
+                ray_image.python_version == cfg["default_python"]
+                and ray_image.platform == cfg["default_platform"]
+                and ray_image.architecture == DEFAULT_ARCHITECTURE
+            )
+            else None
+        )
+
+        build_env: dict[str, str] = {
+            "PYTHON_VERSION": ray_image.python_version,
+            "MANYLINUX_VERSION": manylinux_version,
+            "HOSTTYPE": ray_image.architecture,
+            "ARCH_SUFFIX": ray_image.arch_suffix,
+            "BUILDKITE_COMMIT": commit,
+            "RAY_VERSION": ray_version,
+            "IS_LOCAL_BUILD": "true",
+            "IMAGE_TYPE": ray_image.repo,
+        }
+        if ray_image.platform.startswith("cu"):
+            build_env["CUDA_VERSION"] = ray_image.platform.removeprefix("cu")
+
+        return cls(
+            ray_image=ray_image,
+            ray_root=root,
+            raymake_version=(root / ".rayciversion").read_text().strip(),
+            manylinux_version=manylinux_version,
+            ray_version=ray_version,
+            commit=commit,
+            wanda_spec_path=ray_image.get_wanda_spec_path(),
+            wanda_image_tag=f"{REGISTRY_PREFIX}{ray_image.wanda_image_name}",
+            nightly_alias=nightly_alias,
+            build_env=build_env,
+        )
+
+    @staticmethod
+    def _detect_host_arch() -> str:
+        return detect_host_arch()
+
+
+class ImageBuilder:
+    def __init__(self, config: ImageBuildConfig):
+        self.config = config
+
+    def build(self) -> str:
+        """Build the image and return the primary image tag."""
+        if not shutil.which("raymake"):
+            raise BuildError("raymake not found. Run via ./build-image.sh")
+
+        log.info("Build configuration:")
+        summary = {
+            "Image Type": self.config.ray_image.image_type,
+            "Python": self.config.ray_image.python_version,
+            "Platform": self.config.ray_image.platform,
+            "Arch": self.config.ray_image.architecture,
+            "Commit": self.config.commit,
+            "Raymake": self.config.raymake_version,
+            "Ray Version": self.config.ray_version,
+            "Wanda Spec": self.config.wanda_spec_path,
+        }
+        print("-" * 50)
+        for k, v in summary.items():
+            print(f"{k:<12}: {v}")
+        print("-" * 50)
+
+        cmd = [
+            "raymake",
+            str(self.config.wanda_spec_path),
+        ]
+
+        log.info(f"Running raymake: {self.config.wanda_spec_path}")
+        log.info(f"Build environment: {self.config.build_env}")
+        proc = subprocess.Popen(
+            cmd,
+            cwd=self.config.ray_root,
+            env={**os.environ, **self.config.build_env},
+        )
+        try:
+            if proc.wait() != 0:
+                raise BuildError("raymake failed")
+        except KeyboardInterrupt:
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            raise
+
+        image_tag = self.config.wanda_image_tag
+        log.info(f"Built image: {image_tag}")
+
+        alias = self.config.nightly_alias
+        if alias:
+            self._docker_tag(image_tag, alias)
+            log.info(f"Tagged alias: {alias}")
+
+        return image_tag
+
+    @staticmethod
+    def _docker_tag(source: str, dest: str) -> None:
+        result = subprocess.run(
+            ["docker", "tag", source, dest],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise BuildError(f"docker tag failed: {result.stderr.strip()}")

--- a/ci/build/build_image_test.py
+++ b/ci/build/build_image_test.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
 """Tests for build_image.py"""
 
+import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
 from build_image import (
+    DEFAULT_ARCHITECTURE,
+    IMAGE_TYPE_CONFIG,
+    REGISTRY_PREFIX,
     SUPPORTED_IMAGE_TYPES,
+    WANDA_SPEC_PATHS,
+    BuildError,
+    ImageBuildConfig,
     RayImage,
     RayImageError,
 )
@@ -109,6 +118,304 @@ class TestGetWandaSpecPath(unittest.TestCase):
         )
 
 
+class TestValidation(unittest.TestCase):
+    """Test from_args() rejects invalid combinations."""
+
+    def test_unknown_build_image_type(self):
+        with (
+            mock.patch("ci.build.build_common._platform.system", return_value="Linux"),
+            mock.patch(
+                "ci.build.build_common._platform.machine", return_value="x86_64"
+            ),
+        ):
+            with self.assertRaises(BuildError) as ctx:
+                ImageBuildConfig.from_args("ray-ml", "3.10", "cpu")
+        self.assertIn("Unknown image type", str(ctx.exception))
+
+    def test_invalid_python_raises_build_error(self):
+        with (
+            mock.patch("ci.build.build_common._platform.system", return_value="Linux"),
+            mock.patch(
+                "ci.build.build_common._platform.machine", return_value="x86_64"
+            ),
+        ):
+            with self.assertRaises(BuildError):
+                ImageBuildConfig.from_args("ray-llm", "3.10", "cu12.8.1-cudnn")
+
+
+def _config(**kwargs):
+    image_type = kwargs.pop("image_type", "ray")
+    python_version = kwargs.pop("python_version", "3.10")
+    image_platform = kwargs.pop("platform", "cpu")
+    architecture = kwargs.pop("architecture", "x86_64")
+    ray_version = kwargs.pop("ray_version", "3.0.0.dev0")
+    commit = kwargs.pop("commit", "fake1234")
+
+    ray_image = RayImage(
+        image_type=image_type,
+        python_version=python_version,
+        platform=image_platform,
+        architecture=architecture,
+    )
+
+    cfg = IMAGE_TYPE_CONFIG[image_type]
+    nightly_alias = (
+        f"{REGISTRY_PREFIX}{ray_image.repo}:nightly{ray_image.variation_suffix}"
+        if (
+            ray_image.python_version == cfg["default_python"]
+            and ray_image.platform == cfg["default_platform"]
+            and ray_image.architecture == DEFAULT_ARCHITECTURE
+        )
+        else None
+    )
+
+    build_env: dict[str, str] = {
+        "PYTHON_VERSION": ray_image.python_version,
+        "MANYLINUX_VERSION": "",
+        "HOSTTYPE": ray_image.architecture,
+        "ARCH_SUFFIX": ray_image.arch_suffix,
+        "BUILDKITE_COMMIT": commit,
+        "RAY_VERSION": ray_version,
+        "IS_LOCAL_BUILD": "true",
+        "IMAGE_TYPE": ray_image.repo,
+    }
+    if ray_image.platform.startswith("cu"):
+        build_env["CUDA_VERSION"] = ray_image.platform.removeprefix("cu")
+
+    defaults = dict(
+        ray_image=ray_image,
+        ray_root=Path("/fake/ray"),
+        raymake_version="0.0.0",
+        manylinux_version="",
+        ray_version=ray_version,
+        commit=commit,
+        wanda_spec_path=ray_image.get_wanda_spec_path(),
+        wanda_image_tag=f"{REGISTRY_PREFIX}{ray_image.wanda_image_name}",
+        nightly_alias=nightly_alias,
+        build_env=build_env,
+    )
+    defaults.update(kwargs)
+    return ImageBuildConfig(**defaults)
+
+
+class TestConfigWandaImageTag(unittest.TestCase):
+    """Test wanda_image_name and wanda_image_tag on ImageBuildConfig."""
+
+    def test_ray_cpu(self):
+        c = _config()
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-py3.10-cpu")
+        self.assertEqual(c.wanda_image_tag, f"{REGISTRY_PREFIX}ray-py3.10-cpu")
+
+    def test_ray_cuda(self):
+        c = _config(platform="cu12.8.1-cudnn")
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-py3.10-cu12.8.1-cudnn")
+
+    def test_ray_extra_cpu(self):
+        c = _config(image_type="ray-extra")
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-extra-py3.10-cpu")
+
+    def test_ray_llm_cuda(self):
+        c = _config(
+            image_type="ray-llm", python_version="3.11", platform="cu12.8.1-cudnn"
+        )
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-llm-py3.11-cu12.8.1-cudnn")
+
+    def test_aarch64_suffix(self):
+        c = _config(architecture="aarch64")
+        self.assertEqual(c.ray_image.wanda_image_name, "ray-py3.10-cpu-aarch64")
+
+
+class TestConfigNightlyAlias(unittest.TestCase):
+    """Test nightly_alias on ImageBuildConfig."""
+
+    def test_ray_default_has_nightly(self):
+        c = _config()
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray:nightly")
+
+    def test_ray_extra_default_has_nightly_extra(self):
+        c = _config(image_type="ray-extra")
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray:nightly-extra")
+
+    def test_ray_llm_default_has_nightly(self):
+        c = _config(
+            image_type="ray-llm", python_version="3.11", platform="cu12.8.1-cudnn"
+        )
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray-llm:nightly")
+
+    def test_ray_llm_extra_default_has_nightly_extra(self):
+        c = _config(
+            image_type="ray-llm-extra",
+            python_version="3.11",
+            platform="cu12.8.1-cudnn",
+        )
+        self.assertEqual(c.nightly_alias, f"{REGISTRY_PREFIX}ray-llm:nightly-extra")
+
+    def test_non_default_python_no_alias(self):
+        c = _config(python_version="3.12")
+        self.assertIsNone(c.nightly_alias)
+
+    def test_non_default_platform_no_alias(self):
+        c = _config(platform="cu12.8.1-cudnn")
+        self.assertIsNone(c.nightly_alias)
+
+
+def _make_ray_root(tmpdir):
+    """Create a minimal ray root with config files for property tests."""
+    root = Path(tmpdir)
+    (root / ".rayciversion").write_text("0.31.0")
+    (root / "rayci.env").write_text(
+        "MANYLINUX_VERSION=260128.221a193\nRAY_VERSION=3.0.0.dev0\n"
+    )
+    return root
+
+
+class TestBuildEnv(unittest.TestCase):
+    """Test build_env returns correct environment variables."""
+
+    def test_cpu_env(self):
+        env = _config().build_env
+        self.assertEqual(env["PYTHON_VERSION"], "3.10")
+        self.assertEqual(env["HOSTTYPE"], "x86_64")
+        self.assertEqual(env["ARCH_SUFFIX"], "")
+        self.assertEqual(env["IS_LOCAL_BUILD"], "true")
+        self.assertEqual(env["IMAGE_TYPE"], "ray")
+        self.assertNotIn("CUDA_VERSION", env)
+
+    def test_cuda_env(self):
+        env = _config(platform="cu12.8.1-cudnn").build_env
+        self.assertEqual(env["CUDA_VERSION"], "12.8.1-cudnn")
+
+    def test_tpu_env(self):
+        env = _config(platform="tpu").build_env
+        self.assertNotIn("CUDA_VERSION", env)
+
+    def test_ray_extra_image_type(self):
+        env = _config(image_type="ray-extra").build_env
+        self.assertEqual(env["IMAGE_TYPE"], "ray")
+
+    def test_ray_llm_image_type(self):
+        env = _config(
+            image_type="ray-llm", python_version="3.11", platform="cu12.8.1-cudnn"
+        ).build_env
+        self.assertEqual(env["IMAGE_TYPE"], "ray-llm")
+
+    def test_ray_llm_extra_image_type(self):
+        env = _config(
+            image_type="ray-llm-extra",
+            python_version="3.11",
+            platform="cu12.8.1-cudnn",
+        ).build_env
+        self.assertEqual(env["IMAGE_TYPE"], "ray-llm")
+
+
+class TestPlatformDetection(unittest.TestCase):
+    """Test _detect_host_arch() returns correct values."""
+
+    def test_darwin_arm64(self):
+        with (
+            mock.patch("ci.build.build_common._platform.system", return_value="Darwin"),
+            mock.patch("ci.build.build_common._platform.machine", return_value="arm64"),
+        ):
+            arch = ImageBuildConfig._detect_host_arch()
+        self.assertEqual(arch, "aarch64")
+
+    def test_linux_x86_64(self):
+        with (
+            mock.patch("ci.build.build_common._platform.system", return_value="Linux"),
+            mock.patch(
+                "ci.build.build_common._platform.machine", return_value="x86_64"
+            ),
+        ):
+            arch = ImageBuildConfig._detect_host_arch()
+        self.assertEqual(arch, "x86_64")
+
+    def test_linux_aarch64(self):
+        with (
+            mock.patch("ci.build.build_common._platform.system", return_value="Linux"),
+            mock.patch(
+                "ci.build.build_common._platform.machine", return_value="aarch64"
+            ),
+        ):
+            arch = ImageBuildConfig._detect_host_arch()
+        self.assertEqual(arch, "aarch64")
+
+    def test_unsupported_platform_raises(self):
+        with (
+            mock.patch(
+                "ci.build.build_common._platform.system", return_value="Windows"
+            ),
+            mock.patch("ci.build.build_common._platform.machine", return_value="AMD64"),
+        ):
+            with self.assertRaises(BuildError):
+                ImageBuildConfig._detect_host_arch()
+
+
+class TestFromArgs(unittest.TestCase):
+    """Test ImageBuildConfig.from_args() factory method."""
+
+    def test_from_args_creates_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ray_root = _make_ray_root(tmpdir)
+
+            with (
+                mock.patch(
+                    "ci.build.build_common._platform.system", return_value="Linux"
+                ),
+                mock.patch(
+                    "ci.build.build_common._platform.machine", return_value="x86_64"
+                ),
+                mock.patch("build_image.find_ray_root", return_value=ray_root),
+                mock.patch("build_image.get_git_commit", return_value="abc1234"),
+            ):
+                config = ImageBuildConfig.from_args("ray", "3.10", "cpu")
+
+            self.assertEqual(config.ray_image.image_type, "ray")
+            self.assertEqual(config.ray_image.python_version, "3.10")
+            self.assertEqual(config.ray_image.platform, "cpu")
+            self.assertEqual(config.ray_image.architecture, "x86_64")
+            self.assertEqual(config.ray_image.arch_suffix, "")
+            self.assertEqual(config.raymake_version, "0.31.0")
+            self.assertEqual(config.manylinux_version, "260128.221a193")
+            self.assertEqual(config.ray_version, "3.0.0.dev0")
+
+    def test_from_args_rejects_invalid(self):
+        with (
+            mock.patch("ci.build.build_common._platform.system", return_value="Linux"),
+            mock.patch(
+                "ci.build.build_common._platform.machine", return_value="x86_64"
+            ),
+        ):
+            with self.assertRaises(BuildError):
+                ImageBuildConfig.from_args("ray-llm", "3.10", "cpu")
+
+    def test_from_args_rejects_missing_wanda_spec(self):
+        """ray-extra + tpu passes validate() but has no wanda spec."""
+        with (
+            mock.patch("ci.build.build_common._platform.system", return_value="Linux"),
+            mock.patch(
+                "ci.build.build_common._platform.machine", return_value="x86_64"
+            ),
+        ):
+            with self.assertRaises(BuildError):
+                ImageBuildConfig.from_args("ray-extra", "3.10", "tpu")
+
+    def test_from_args_rejects_unsupported_arch(self):
+        """ray-llm only supports x86_64; aarch64 should be rejected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ray_root = _make_ray_root(tmpdir)
+            with (
+                mock.patch(
+                    "ci.build.build_common._platform.system", return_value="Linux"
+                ),
+                mock.patch(
+                    "ci.build.build_common._platform.machine", return_value="aarch64"
+                ),
+                mock.patch("build_image.find_ray_root", return_value=ray_root),
+            ):
+                with self.assertRaises(BuildError):
+                    ImageBuildConfig.from_args("ray-llm", "3.11", "cu12.8.1-cudnn")
+
+
 class TestSupportedImageTypes(unittest.TestCase):
     """Test SUPPORTED_IMAGE_TYPES covers all expected types."""
 
@@ -120,6 +427,10 @@ class TestSupportedImageTypes(unittest.TestCase):
         for name in SUPPORTED_IMAGE_TYPES:
             self.assertIsInstance(name, str)
             self.assertNotIn(".", name)  # not "RayType.RAY"
+
+    def test_wanda_spec_keys_use_valid_image_types(self):
+        for image_type, _ in WANDA_SPEC_PATHS:
+            self.assertIn(image_type, IMAGE_TYPE_CONFIG)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add ImageBuildConfig (build environment, wanda spec resolution, nightly alias logic) and ImageBuilder (raymake invocation, docker tagging). Also add wanda spec discovery paths for local builds.

Topic: build-image-builder
Relative: wandaspecs
Signed-off-by: andrew <andrew@anyscale.com>