### PR TITLE
[ci] add CLI for local Docker image builder (build_image.py)

### DIFF
--- a/ci/build/build_image.py
+++ b/ci/build/build_image.py
@@ -8,9 +8,11 @@ Build Ray Docker images locally using raymake.
 """
 from __future__ import annotations
 
+import argparse
 import os
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -317,3 +319,209 @@ class ImageBuilder:
         )
         if result.returncode != 0:
             raise BuildError(f"docker tag failed: {result.stderr.strip()}")
+
+
+def _image_type_table() -> str:
+    """Build an ASCII table of all image types from IMAGE_TYPE_CONFIG."""
+
+    def _tag_default(items, default):
+        return [f"{v} (default)" if v == default else v for v in items]
+
+    def _wrap(items, width):
+        """Join items with ', ' and wrap into lines that fit in *width*."""
+        lines: list[str] = []
+        cur = ""
+        for item in items:
+            entry = item if not cur else f", {item}"
+            if cur and len(cur) + len(entry) > width:
+                lines.append(cur)
+                cur = item
+            else:
+                cur += entry
+        if cur:
+            lines.append(cur)
+        return lines
+
+    headers = ("IMAGE TYPE", "PYTHON VERSIONS (-p)", "PLATFORMS (--platform)")
+    plat_width = 52  # wrap platforms to this width
+
+    def _build_rows(type_list):
+        rows: list[tuple[str, str, list[str]]] = []
+        for name in type_list:
+            cfg = IMAGE_TYPE_CONFIG[name]
+            py_cell = ", ".join(
+                _tag_default(cfg["python_versions"], cfg["default_python"])
+            )
+            plat_lines = _wrap(
+                _tag_default(cfg["platforms"], cfg["default_platform"]),
+                plat_width,
+            )
+            rows.append((name, py_cell, plat_lines))
+        return rows
+
+    rows = _build_rows(SUPPORTED_IMAGE_TYPES)
+
+    # Compute column widths.
+    widths = [len(h) for h in headers]
+    for label, py_cell, plat_lines in rows:
+        widths[0] = max(widths[0], len(label))
+        widths[1] = max(widths[1], len(py_cell))
+        widths[2] = max(widths[2], *(len(l) for l in plat_lines))
+
+    sep = "  "
+
+    def fmt(cells):
+        return sep.join(c.ljust(widths[i]) for i, c in enumerate(cells))
+
+    lines = [fmt(headers), sep.join("-" * w for w in widths)]
+    for label, py_cell, plat_lines in rows:
+        lines.append(fmt((label, py_cell, plat_lines[0])))
+        for cont in plat_lines[1:]:
+            lines.append(fmt(("", "", cont)))
+
+    return "\n".join(lines)
+
+
+def _nightly_table() -> str:
+    """Build a table mapping build commands to nightly docker run commands."""
+    headers = ("BUILD", "RUN")
+    rows = []
+    for name in SUPPORTED_IMAGE_TYPES:
+        cfg = IMAGE_TYPE_CONFIG[name]
+        img = RayImage(name, cfg["default_python"], cfg["default_platform"])
+        tag = f"{REGISTRY_PREFIX}{img.repo}:nightly{img.variation_suffix}"
+        rows.append((f"./build-image.sh {name}", f"docker run -it {tag}"))
+
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    sep = "  "
+
+    def fmt(cells):
+        return sep.join(c.ljust(widths[i]) for i, c in enumerate(cells))
+
+    lines = [fmt(headers), sep.join("-" * w for w in widths)]
+    lines.extend(fmt(row) for row in rows)
+    return "\n".join(lines)
+
+
+def _build_examples() -> str:
+    """Generate non-default example commands from IMAGE_TYPE_CONFIG."""
+    ray_cfg = IMAGE_TYPE_CONFIG["ray"]
+    ray_py = ray_cfg["default_python"]
+    ray_plat = ray_cfg["default_platform"]
+    alt_py = next((v for v in ray_cfg["python_versions"] if v != ray_py), None)
+    alt_plat = next((p for p in ray_cfg["platforms"] if p != ray_plat), None)
+
+    examples: list[tuple[str, str]] = []
+    if alt_py:
+        examples.append(
+            (f"ray -p {alt_py}", f"ray {ray_plat} py{alt_py}"),
+        )
+    if alt_plat:
+        examples.append(
+            (f"ray --platform {alt_plat}", f"ray {alt_plat} py{ray_py}"),
+        )
+    if alt_py and alt_plat:
+        examples.append(
+            (f"ray -p {alt_py} --platform {alt_plat}", f"ray {alt_plat} py{alt_py}"),
+        )
+
+    if not examples:
+        return ""
+
+    cmd_prefix = "  ./build-image.sh "
+    cmds = [cmd_prefix + args for args, _ in examples]
+    max_cmd = max(len(c) for c in cmds)
+    lines = []
+    for cmd, (_, comment) in zip(cmds, examples):
+        lines.append(f"{cmd:<{max_cmd}}  # {comment}")
+    return "\n".join(lines)
+
+
+def main():
+    epilog_parts = [
+        "Supported image types:",
+        _image_type_table(),
+        "",
+        "Nightly images (built with defaults):",
+        _nightly_table(),
+        "",
+        "Examples:",
+        _build_examples(),
+    ]
+
+    parser = argparse.ArgumentParser(
+        prog="./build-image.sh",
+        description="Build Ray Docker images locally using raymake.",
+        epilog="\n".join(epilog_parts),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    parser.add_argument(
+        "image_type",
+        choices=SUPPORTED_IMAGE_TYPES,
+        metavar="IMAGE_TYPE",
+        help=f"Image type: {', '.join(SUPPORTED_IMAGE_TYPES)}",
+    )
+    parser.add_argument(
+        "-p",
+        "--python-version",
+        default=None,
+        metavar="VERSION",
+        help="Python version (default depends on image type; see table below)",
+    )
+    parser.add_argument(
+        "--platform",
+        default=None,
+        metavar="PLATFORM",
+        help="Target platform (default depends on image type; see table below)",
+    )
+    parser.add_argument(
+        "--list-platforms",
+        action="store_true",
+        help="List valid platforms for the given image type and exit",
+    )
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(0)
+
+    args = parser.parse_args()
+
+    cfg = IMAGE_TYPE_CONFIG[args.image_type]
+
+    if args.list_platforms:
+        print(f"Valid platforms for {args.image_type}:")
+        for p in cfg["platforms"]:
+            marker = " (default)" if p == cfg["default_platform"] else ""
+            print(f"  {p}{marker}")
+        sys.exit(0)
+
+    python_version = args.python_version or cfg["default_python"]
+    platform_choice = args.platform or cfg["default_platform"]
+
+    try:
+        config = ImageBuildConfig.from_args(
+            args.image_type, python_version, platform_choice
+        )
+        builder = ImageBuilder(config)
+        image_tag = builder.build()
+
+        print()
+        log.info("Success!")
+        print(f"  docker run -it {image_tag}")
+        alias = config.nightly_alias
+        if alias:
+            print(f"  docker run -it {alias}")
+    except BuildError as e:
+        log.error(e)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build/build_image_test.py
+++ b/ci/build/build_image_test.py
@@ -16,6 +16,7 @@ from build_image import (
     ImageBuildConfig,
     RayImage,
     RayImageError,
+    main,
 )
 
 
@@ -431,6 +432,16 @@ class TestSupportedImageTypes(unittest.TestCase):
     def test_wanda_spec_keys_use_valid_image_types(self):
         for image_type, _ in WANDA_SPEC_PATHS:
             self.assertIn(image_type, IMAGE_TYPE_CONFIG)
+
+
+class TestHelpOutput(unittest.TestCase):
+    """Test that --help prints without error."""
+
+    def test_no_args_prints_help_and_exits_zero(self):
+        with mock.patch("build_image.sys.argv", ["build_image"]):
+            with self.assertRaises(SystemExit) as ctx:
+                main()
+        self.assertEqual(ctx.exception.code, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add argparse CLI with image type/platform tables, nightly alias quick-reference, and example commands. Supports --list-platforms and sensible defaults per image type.

Topic: build-image-cli
Relative: build-image-builder
Signed-off-by: andrew <andrew@anyscale.com>