### PR TITLE
[Data][Core] Add data operator id to ActorPoolMapOperator tasks

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3788,7 +3788,8 @@ cdef class CoreWorker:
                           c_string concurrency_group_name,
                           int64_t generator_backpressure_num_objects,
                           c_bool enable_task_events,
-                          tensor_transport: Optional[str]):
+                          tensor_transport: Optional[str],
+                          dict labels=None):
 
         cdef:
             CActorID c_actor_id = actor_id.native()
@@ -3822,6 +3823,7 @@ cdef class CoreWorker:
         with self.profile_event(b"submit_task"):
             if num_method_cpus > 0:
                 c_resources[b"CPU"] = num_method_cpus
+            prepare_labels(labels, &c_labels)
             ray_function = CRayFunction(
                 language.lang, function_descriptor.descriptor)
             prepare_args_and_increment_put_refs(

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -1036,6 +1036,7 @@ class ActorMethod:
         _generator_backpressure_num_objects=None,
         enable_task_events=None,
         tensor_transport: Optional[str] = None,
+        _labels: Optional[Dict[str, str]] = None,
     ):
         if num_returns is None:
             num_returns = self._num_returns
@@ -1108,6 +1109,7 @@ class ActorMethod:
                 ),
                 enable_task_events=enable_task_events,
                 tensor_transport=tensor_transport,
+                labels=_labels,
             )
 
         # Apply the decorator if there is one.
@@ -2318,6 +2320,7 @@ class ActorHandle(Generic[T]):
         generator_backpressure_num_objects: Optional[int] = None,
         enable_task_events: Optional[bool] = None,
         tensor_transport: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
     ):
         """Method execution stub for an actor handle.
 
@@ -2341,6 +2344,7 @@ class ActorHandle(Generic[T]):
             enable_task_events: True if tracing is enabled, i.e., task events from
                 the actor should be reported.
             tensor_transport: The tensor transport protocol to use for the actor method.
+            labels: Optional key-value labels to attach to this actor method task.
 
         Returns:
             object_refs: A list of object refs returned by the remote actor
@@ -2405,6 +2409,7 @@ class ActorHandle(Generic[T]):
             generator_backpressure_num_objects,
             enable_task_events,
             tensor_transport,
+            labels,
         )
 
         if num_returns == STREAMING_GENERATOR_RETURN:

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2444,7 +2444,7 @@ Status CoreWorker::SubmitActorTask(
                       /*generator_backpressure_num_objects=*/
                       task_options.generator_backpressure_num_objects,
                       /*enable_task_events=*/task_options.enable_task_events,
-                      /*labels=*/{},
+                      /*labels=*/task_options.labels,
                       /*label_selector=*/{},
                       /*fallback_strategy=*/{});
   // NOTE: placement_group_capture_child_tasks and runtime_env will


### PR DESCRIPTION
Data operator id needs to be added as a [label](https://github.com/ray-project/ray/blob/0b5b80df5774ba49520001d80fcfd34136d25e05/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py#L261) so that it can be associated with task definition [events](https://github.com/ray-project/ray/blob/02559bb098120729e0d4b9d0d175278908a9c79d/src/ray/core_worker/task_event_buffer.cc#L200). In this PR, we add it to other places for ActorPoolMapOperator tasks to enable the operator-task binding for further observability features.