### PR TITLE
[Data] Display filter inline w/ ReadOperator in `.explain()` plan after performing Predicate Pushdown

### DIFF
--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -203,11 +203,12 @@ class Read(
         clone.datasource_or_legacy_reader = predicated_datasource
 
         # Append filter expression to name for plan display when predicate is pushed down.
+        # Use base datasource name to avoid accumulation when apply_predicate is called
+        # multiple times (e.g., filters separated by passthrough operators like Sort).
         applied_predicate = predicated_datasource.get_current_predicate()
         if applied_predicate is not None:
-
-            # Walk the predicate expression to get a string representation.
+            base_name = f"Read{predicated_datasource.get_name()}"
             expr_str = _InlineExprReprVisitor().visit(applied_predicate)
-            clone._name = f"{self._name}->Filter({expr_str})"
+            clone._name = f"{base_name}->Filter({expr_str})"
 
         return clone

--- a/python/ray/data/tests/test_predicate_pushdown.py
+++ b/python/ray/data/tests/test_predicate_pushdown.py
@@ -34,7 +34,7 @@ from ray.tests.conftest import *  # noqa
 # Parquet, CSV, Range, etc. The ->Filter(...) suffix appears when
 # predicates are pushed down into the datasource.
 READ_OPERATOR_PATTERN = (
-    r"^(Read\[Read\w+(?:->Filter\(.+\))?\]|"
+    r"^(Read\[Read\w+(?:->Filter\(.+?\))?\]|"
     r"ListFiles\[ListFiles\] -> ReadFiles\[ReadFiles\])"
 )
 


### PR DESCRIPTION
## Description
In https://github.com/ray-project/ray/pull/58150, predicate pushdown was introduced for parquet reading. However, the plans would simply remove the filter operation entirely leaving just the `ReadParquet` operator. Other systems like Spark explicitly show the predicate is pushed down. I think this should be implemented for Ray too because it helps the user/developer feel confident that things are working how they want it to.

## Related issues
Fixes #61346

## Additional information

Before this change: The predicate is just dropped from the display.
```
-------- Logical Plan --------
Filter[Filter(col('id') > 50)]
+- Read[ReadParquet]

-------- Logical Plan (Optimized) --------
Read[ReadParquet]

-------- Physical Plan --------
TaskPoolMapOperator[ReadParquet]
+- InputDataBuffer[Input]

-------- Physical Plan (Optimized) --------
TaskPoolMapOperator[ReadParquet]  -- No filter shown. It just disappears.
+- InputDataBuffer[Input]
```

After this change, the predicate is shown inline with the ReadParquet operator.
```
-------- Logical Plan --------
Filter[Filter(<lambda>)]
+- Filter[Filter(col('id') > 50)]
   +- Read[ReadParquet]

-------- Logical Plan (Optimized) --------
Filter[Filter(<lambda>)]
+- Read[ReadParquet->Filter(col('id') > 50)]

-------- Physical Plan --------
TaskPoolMapOperator[Filter(<lambda>)]
+- TaskPoolMapOperator[ReadParquet->Filter(col('id') > 50)]
   +- InputDataBuffer[Input]

-------- Physical Plan (Optimized) --------
TaskPoolMapOperator[ReadParquet->Filter(col('id') > 50)->Filter(<lambda>)]
+- InputDataBuffer[Input]  -- ^Filter is now shown explicitly
```

To compare, here's what it already looks like for `ReadRange`
```
-------- Logical Plan (Optimized) --------
Filter[Filter(<lambda>)]
+- Filter[Filter(<lambda>)]
   +- Read[ReadRange]

...
-------- Physical Plan (Optimized) --------
TaskPoolMapOperator[ReadRange->Filter(<lambda>)->Filter(<lambda>)]
+- InputDataBuffer[Input]
```

Here's how Spark displays it atm. It shows you exactly that the predicate pushdown was performed through the `PushedFilters` field.
```
== Physical Plan ==
*(1) Filter (isnotnull(id#26L) AND (id#26L > 50))
+- *(1) ColumnarToRow
   +- FileScan parquet [id#26L] Batched: true, DataFilters: [isnotnull(id#26L), (id#26L > 50)], Format: Parquet, Location: InMemoryFileIndex(1 paths)[file:/Users/peter/Documents/open-source/ray/python/ray/data/tmp/test.p..., PartitionFilters: [], PushedFilters: [IsNotNull(id), GreaterThan(id,50)], ReadSchema: struct<id:bigint>
```