### PR TITLE
[Build] Supports repeated execution of setup-dev.py

### DIFF
--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -90,8 +90,7 @@ def do_link(package, force=False, skip_list=None, allow_list=None, local_path=No
             generated_folder = os.path.join(package_home, "generated")
             if os.path.exists(serve_temp_dir):
                 subprocess.check_call(sudo + ["rm", "-rf", serve_temp_dir])
-            else:
-                subprocess.check_call(sudo + ["mkdir", "-p", serve_temp_dir])
+            subprocess.check_call(sudo + ["mkdir", "-p", serve_temp_dir])
             subprocess.check_call(sudo + ["mv", generated_folder, serve_temp_dir])
 
         # Create backup of the old directory if it exists

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -79,9 +79,8 @@ def do_link(package, force=False, skip_list=None, allow_list=None, local_path=No
         print(f"Creating symbolic link from \n {local_home} to \n {package_home}")
 
         if os.path.exists(package_home) and os.path.realpath(
-            package_home) == os.path.realpath(
-            local_home
-        ):
+            package_home
+        ) == os.path.realpath(local_home):
             print(f"{package} is already linked to source. Skipping.")
             return
 

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -72,26 +72,27 @@ def do_link(package, force=False, skip_list=None, allow_list=None, local_path=No
 
     # Posix: Use `ln -s` to create softlink.
     else:
+        if os.path.exists(package_home) and os.path.realpath(
+            package_home
+        ) == os.path.realpath(local_home):
+            print(f"{package} is already linked to source. Skipping.")
+            return
         sudo = []
         if not os.access(os.path.dirname(package_home), os.W_OK):
             print("You don't have write permission " f"to {package_home}, using sudo:")
             sudo = ["sudo"]
         print(f"Creating symbolic link from \n {local_home} to \n {package_home}")
 
-        if os.path.exists(package_home) and os.path.realpath(
-            package_home
-        ) == os.path.realpath(local_home):
-            print(f"{package} is already linked to source. Skipping.")
-            return
-
         # Preserve ray/serve/generated
         serve_temp_dir = "/tmp/ray/_serve/"
         if package == "serve":
             # Copy generated folder to a temp dir
             generated_folder = os.path.join(package_home, "generated")
-            subprocess.check_call(sudo + ["rm", "-rf", serve_temp_dir])
-            os.makedirs(serve_temp_dir)
-            subprocess.check_call(["mv", generated_folder, serve_temp_dir])
+            if os.path.exists(serve_temp_dir):
+                subprocess.check_call(sudo + ["rm", "-rf", serve_temp_dir])
+            else:
+                subprocess.check_call(sudo + ["mkdir", "-p", serve_temp_dir])
+            subprocess.check_call(sudo + ["mv", generated_folder, serve_temp_dir])
 
         # Create backup of the old directory if it exists
         if os.path.exists(package_home):

--- a/python/ray/setup-dev.py
+++ b/python/ray/setup-dev.py
@@ -78,13 +78,20 @@ def do_link(package, force=False, skip_list=None, allow_list=None, local_path=No
             sudo = ["sudo"]
         print(f"Creating symbolic link from \n {local_home} to \n {package_home}")
 
+        if os.path.exists(package_home) and os.path.realpath(
+            package_home) == os.path.realpath(
+            local_home
+        ):
+            print(f"{package} is already linked to source. Skipping.")
+            return
+
         # Preserve ray/serve/generated
         serve_temp_dir = "/tmp/ray/_serve/"
         if package == "serve":
             # Copy generated folder to a temp dir
             generated_folder = os.path.join(package_home, "generated")
-            if not os.path.exists(serve_temp_dir):
-                os.makedirs(serve_temp_dir)
+            subprocess.check_call(sudo + ["rm", "-rf", serve_temp_dir])
+            os.makedirs(serve_temp_dir)
             subprocess.check_call(["mv", generated_folder, serve_temp_dir])
 
         # Create backup of the old directory if it exists


### PR DESCRIPTION
## Description
When setup-dev.py is executed again, it's very likely encounter a `many symbolic link error` or a problem where the `/tmp/ray/_serve/ directory already exists`.

If symbolic link exists just skip it
## Related issues

## Additional information
