### PR TITLE
[deps] pinning numpy and pandas

### DIFF
--- a/ci/docker/ml.build.Dockerfile
+++ b/ci/docker/ml.build.Dockerfile
@@ -33,6 +33,7 @@ fi
 
 if [[ "$RAYCI_IS_GPU_BUILD" == "true" ]]; then
   pip install -Ur ./python/requirements/ml/dl-gpu-requirements.txt
+  pip install pandas==2.2.2 numpy==1.26.4
 fi
 
 if [[ "$RAYCI_LIGHTNING_2" == "true" ]]; then


### PR DESCRIPTION
pinning numpy and pandas for mlgpubuild-py images due to numpy>2 breaking tests

Successful test runs (that include this change): https://buildkite.com/ray-project/microcheck/builds/39459