### PR TITLE
[History server] Add cluster selection page

### DIFF
--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -13,6 +13,8 @@ import TokenAuthenticationDialog from "./authentication/TokenAuthenticationDialo
 import ActorDetailPage, { ActorDetailLayout } from "./pages/actor/ActorDetail";
 import { ActorLayout } from "./pages/actor/ActorLayout";
 import Loading from "./pages/exception/Loading";
+// Historyserver import
+import { HistoryserverPage } from "./pages/historyserver/HistoryserverPage";
 import JobList, { JobsLayout } from "./pages/job";
 import { JobDetailChartsPage } from "./pages/job/JobDetail";
 import {
@@ -394,6 +396,8 @@ const App = () => {
               <Routes>
                 {/* Redirect people hitting the /new path to root. TODO(aguo): Delete this redirect in ray 2.5 */}
                 <Route element={<Navigate replace to="/" />} path="/new" />
+                {/* HistoryServer specific page */}
+                <Route element={<HistoryserverPage />} path="historyserver" />
                 <Route element={<MainNavLayout />} path="/">
                   <Route element={<Navigate replace to="overview" />} path="" />
                   <Route element={<OverviewPage />} path="overview" />

--- a/python/ray/dashboard/client/src/pages/historyserver/HistoryserverPage.tsx
+++ b/python/ray/dashboard/client/src/pages/historyserver/HistoryserverPage.tsx
@@ -1,0 +1,138 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CircularProgress,
+  Grid,
+  Typography,
+} from "@mui/material";
+import React, { useEffect, useState } from "react";
+
+export type Cluster = {
+  name: string;
+  namespace: string;
+  sessionName: string;
+  createTime: string;
+};
+
+export const HistoryserverPage = () => {
+  const [clusters, setClusters] = useState<Cluster[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [entering, setEntering] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchClusters = async () => {
+      try {
+        const response = await fetch("/clusters");
+        if (!response.ok) {
+          throw new Error("Failed to fetch clusters");
+        }
+        const data = await response.json();
+        setClusters(data);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchClusters();
+  }, []);
+
+  const handleEnterCluster = async (cluster: Cluster) => {
+    setEntering(`${cluster.name}_${cluster.namespace}`);
+    setError(null);
+    try {
+      const response = await fetch(
+        `/enter_cluster/${cluster.namespace}/${cluster.name}/${cluster.sessionName}`,
+      );
+      if (response.ok) {
+        // Redirect to the main dashboard now that the cookie is set
+        window.location.href = "/#/overview";
+      } else {
+        const errorText = await response.text();
+        throw new Error(
+          `Failed to enter cluster. Server responded with: ${
+            errorText || response.statusText
+          }`,
+        );
+      }
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "An unknown error occurred while connecting to the server.",
+      );
+    } finally {
+      setEntering(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" p={10}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box p={4}>
+      <Typography variant="h4" gutterBottom>
+        KubeRay History Server
+      </Typography>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      <Alert severity="info" sx={{ mb: 4 }}>
+        Select a cluster to view its historical dashboard.
+      </Alert>
+      <Grid container spacing={3}>
+        {clusters.map((cluster) => {
+          const clusterId = `${cluster.name}_${cluster.namespace}`;
+          return (
+            <Grid item xs={12} sm={6} md={4} key={clusterId}>
+              <Card
+                variant="outlined"
+                sx={{
+                  p: 3,
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <Typography variant="h6" color="primary" gutterBottom>
+                  {cluster.name}
+                </Typography>
+                <Typography variant="body2" color="textSecondary">
+                  <strong>Namespace:</strong> {cluster.namespace}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="textSecondary"
+                  sx={{ mb: 2 }}
+                >
+                  <strong>Created:</strong> {cluster.createTime}
+                </Typography>
+                <Box sx={{ mt: "auto" }}>
+                  <Button
+                    fullWidth
+                    variant="contained"
+                    color="primary"
+                    disabled={entering !== null}
+                    onClick={() => handleEnterCluster(cluster)}
+                  >
+                    {entering === clusterId ? "Entering..." : "Enter Cluster"}
+                  </Button>
+                </Box>
+              </Card>
+            </Grid>
+          );
+        })}
+      </Grid>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Description
This PR follows https://github.com/ray-project/ray/pull/61295 and adds a page for history server and allows users to select the cluster to look at.

## Related issues
related to https://github.com/ray-project/ray/pull/61295

## Additional information
What the page looks like: 
<img width="2513" height="929" alt="image" src="https://github.com/user-attachments/assets/78250e9b-5731-4c20-824a-26f595822e51" />

