### PR TITLE
[Data] Convert one-to-one logical operators to frozen dataclasses

### DIFF
--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -6,6 +6,7 @@ from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, 
 from ray.data._internal.logical.operators import (
     AbstractMap,
     AbstractOneToOne,
+    Download,
     Limit,
     Union,
 )
@@ -199,6 +200,14 @@ class LimitPushdownRule(Rule):
 
         if isinstance(original_op, Limit):
             return Limit(new_input, original_op.limit)
+        if isinstance(original_op, Download):
+            return Download(
+                new_input,
+                uri_column_names=original_op.uri_column_names,
+                output_bytes_column_names=original_op.output_bytes_column_names,
+                ray_remote_args=original_op.ray_remote_args,
+                filesystem=original_op.filesystem,
+            )
 
         # Use copy and replace input dependencies approach
         new_op = copy.copy(original_op)

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -9,7 +9,7 @@ from ray.data._internal.logical.interfaces import (
     PredicatePassThroughBehavior,
     Rule,
 )
-from ray.data._internal.logical.operators import Filter, Project
+from ray.data._internal.logical.operators import Filter, Limit, Project
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     _ColumnSubstitutionVisitor,
 )
@@ -317,6 +317,9 @@ class PredicatePushdown(Rule):
         Returns:
             A shallow copy of the operator with updated input dependencies
         """
+        if isinstance(op, Limit):
+            assert len(new_inputs) == 1, len(new_inputs)
+            return Limit(new_inputs[0], op.limit)
         new_op = copy.copy(op)
         new_op.input_dependencies = new_inputs
         return new_op


### PR DESCRIPTION
## Description

This PR implements converting one-to-one logical operators to frozen dataclasses.

#### Why this is needed:

- This is the first operator-group step for the frozen logical-operator migration under #60312.
- It removes in-place mutation paths for one-to-one logical operators.
- It keeps the change scoped to logical-layer behavior needed for D1.

#### What this PR changes:

- Converts one-to-one logical operators to frozen dataclasses:
  - `Limit`
  - `Download`
- Applies one-to-one construction cleanup for frozen compatibility:
  - uses `InitVar[LogicalOperator]` + `__post_init__` to initialize `_name`, `_input_dependencies`, and `_num_outputs`
  - makes `Download.ray_remote_args` a canonical dict field (`default_factory=dict`)
- Adds frozen-safe transform behavior:
  - `Limit._apply_transform()` recreates `Limit` when input changes
  - `Download._apply_transform()` recreates `Download` when input changes
- Updates optimizer rules to avoid mutating frozen instances:
  - `limit_pushdown.py`: recreate `Limit`/`Download` on input replacement
  - `predicate_pushdown.py`: recreate `Limit` on input replacement
- Adds regression coverage for `Limit(Download(...))` under limit pushdown.
- Scope is intentionally D1-only (one-to-one logical operators); no map/all-to-all or physical-layer changes in this PR.

## Related issues

Link related issues: "Fixes #60312", or "Related to #60312".

## Additional information

### Tests

Added/updated:
- `python/ray/data/tests/test_execution_optimizer_limit_pushdown.py`
  - adds regression for `Limit(Download(...))` under limit pushdown with frozen operators

Validated with targeted existing tests:
- `python/ray/data/tests/test_execution_optimizer_limit_pushdown.py`
- `python/ray/data/tests/test_predicate_pushdown.py`
- `python/ray/data/tests/test_operator_fusion.py`
- `python/ray/data/tests/test_execution_optimizer_basic.py`
- `python/ray/data/tests/test_execution_optimizer_advanced.py`
- `python/ray/data/tests/test_projection_fusion.py`
- `python/ray/data/tests/test_randomize_block_order.py`
- `python/ray/data/tests/test_state_export.py::test_logical_op_args`
- `python/ray/data/tests/unit/test_logical_plan.py`

### Stack Plan

To complete [#60312](https://github.com/ray-project/ray/issues/60312), the original stack was:

1. https://github.com/ray-project/ray/pull/60529
2. https://github.com/ray-project/ray/pull/60528
3. https://github.com/ray-project/ray/pull/60530
4. https://github.com/ray-project/ray/pull/60531

Since PR4 was still too large, it is being further split:

1. PR-A: default `LogicalOperator` naming behavior https://github.com/ray-project/ray/pull/61020
2. PR-B: move `output_dependencies` responsibility to physical side https://github.com/ray-project/ray/pull/61107
3. PR-C: make `LogicalOperator` an ABC with abstract `num_outputs` https://github.com/ray-project/ray/pull/61308
4. PR-D: convert logical operators to frozen dataclasses in small groups (D1/D2/D3)
    - D1: one-to-one operators （this PR）
    - D2: map operators
    - D3: all-to-all + join/read/write groups (as needed)

Planned follow-ups (not blocking this stack):
- Converting all `input_op` usage to `input_dependencies`
- Potential `AbstractFrom` restructuring

