### PR TITLE
[Serve] Add a micro benchmark for serve controller

### DIFF
--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -5,7 +5,7 @@ import random
 import string
 import time
 from functools import partial
-from typing import Any, Callable, Coroutine, List, Optional, Tuple
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple
 
 import aiohttp
 import aiohttp.client_exceptions
@@ -15,7 +15,9 @@ import pandas as pd
 from starlette.responses import StreamingResponse
 from tqdm import tqdm
 
+import ray
 from ray import serve
+from ray._common.test_utils import SignalActor as _SignalActor
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.serve.handle import DeploymentHandle
 
@@ -312,3 +314,311 @@ class Benchmarker:
             num_trials=num_trials,
             trial_runtime=trial_runtime,
         )
+
+
+# =============================================================================
+# Controller Benchmark
+# =============================================================================
+# See https://github.com/ray-project/ray/issues/60680 for more details.
+
+CONTROLLER_BENCH_CONFIG = {
+    "checkpoints": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048],
+    "marination_period_s": 180,
+    "sample_interval_s": 5,
+}
+
+_CONTROLLER_AUTOSCALING_CONFIG = {
+    "min_replicas": 1,
+    "max_replicas": 4096,
+    "target_ongoing_requests": 1,
+    "upscale_delay_s": 1,
+}
+
+_CONTROLLER_WAITER_TIMEOUT_S = 1200
+
+# SignalActor from ray._common.test_utils; use high max_concurrency for many
+# concurrent waiters (up to 2048+ in controller benchmark).
+_SignalActorForController = _SignalActor.options(max_concurrency=100000)
+
+
+@serve.deployment(
+    graceful_shutdown_timeout_s=1,
+    ray_actor_options={"num_cpus": 0.2},
+    max_ongoing_requests=100000,
+    autoscaling_config={
+        "min_replicas": 5,
+        "max_replicas": 10,
+        "target_ongoing_requests": 100000,
+        "upscale_delay_s": 1,
+    },
+)
+class ControllerBenchHelloWorld:
+    """Backend deployment that blocks on SignalActor. Fixed replicas."""
+
+    def __init__(self, signal_actor):
+        self.signal = signal_actor
+
+    async def __call__(self):
+        await self.signal.wait.remote()
+        return "hello"
+
+
+@serve.deployment(
+    autoscaling_config=_CONTROLLER_AUTOSCALING_CONFIG,
+    max_ongoing_requests=2,
+    graceful_shutdown_timeout_s=1,
+    ray_actor_options={"num_cpus": 0.2},
+)
+class ControllerBenchMetricsGenerator:
+    """Autoscaling deployment that generates handle metrics to stress the controller."""
+
+    def __init__(self, hello_world: DeploymentHandle):
+        self.hello_world = hello_world
+
+    async def __call__(self):
+        return await self.hello_world.remote()
+
+
+def _controller_get_active_nodes() -> int:
+    """Get number of active nodes in the cluster."""
+    return len([n for n in ray.nodes() if n.get("Alive", False)])
+
+
+async def _controller_get_replica_count(
+    deployment_name: str = "ControllerBenchMetricsGenerator",
+) -> int:
+    """Get current number of running replicas for the specified deployment."""
+    try:
+        status = serve.status()
+        for app in status.applications.values():
+            for name, deployment in app.deployments.items():
+                if name == deployment_name:
+                    return deployment.replica_states.get("RUNNING", 0)
+    except Exception:
+        pass
+    return 0
+
+
+async def _controller_get_health_metrics() -> Dict[str, Any]:
+    """Get controller health metrics. Fails the run if unavailable."""
+    client = serve.context._global_client
+    if client is None:
+        raise RuntimeError(
+            "Serve is not connected. get_health_metrics requires an active Serve "
+            "controller. Ensure Serve is started before running the controller benchmark."
+        )
+    controller = client._controller
+    if not hasattr(controller, "get_health_metrics"):
+        raise RuntimeError(
+            "Controller does not have get_health_metrics. This API is required for "
+            "the controller benchmark. Please use a Ray version that supports "
+            "controller health metrics."
+        )
+    return await controller.get_health_metrics.remote()
+
+
+def _controller_extract_metrics_row(
+    health_metrics: Dict[str, Any],
+    checkpoint: int,
+    sample: int,
+    target_replicas: int,
+    actual_replicas: int,
+    num_nodes: int,
+    autoscale_duration_s: float,
+) -> Dict[str, Any]:
+    """Extract a flat row from health metrics with all available fields."""
+
+    def get_stat(d: dict, key: str, stat: str, default=0):
+        return d.get(key, {}).get(stat, default)
+
+    return {
+        "checkpoint": checkpoint,
+        "sample": sample,
+        "target_replicas": target_replicas,
+        "actual_replicas": actual_replicas,
+        "num_nodes": num_nodes,
+        "autoscale_duration_s": round(autoscale_duration_s, 3),
+        "loop_duration_mean_s": get_stat(health_metrics, "loop_duration_s", "mean"),
+        "loop_duration_std_s": get_stat(health_metrics, "loop_duration_s", "std"),
+        "loops_per_second": health_metrics.get("loops_per_second", 0),
+        "event_loop_delay_s": health_metrics.get("event_loop_delay_s", 0),
+        "num_asyncio_tasks": health_metrics.get("num_asyncio_tasks", 0),
+        "deployment_state_update_mean_s": get_stat(
+            health_metrics, "deployment_state_update_duration_s", "mean"
+        ),
+        "application_state_update_mean_s": get_stat(
+            health_metrics, "application_state_update_duration_s", "mean"
+        ),
+        "proxy_state_update_mean_s": get_stat(
+            health_metrics, "proxy_state_update_duration_s", "mean"
+        ),
+        "proxy_state_update_std_s": get_stat(
+            health_metrics, "proxy_state_update_duration_s", "std"
+        ),
+        "node_update_mean_s": get_stat(
+            health_metrics, "node_update_duration_s", "mean"
+        ),
+        "node_update_std_s": get_stat(health_metrics, "node_update_duration_s", "std"),
+        "node_update_min_s": get_stat(health_metrics, "node_update_duration_s", "min"),
+        "handle_metrics_delay_mean_ms": get_stat(
+            health_metrics, "handle_metrics_delay_ms", "mean"
+        ),
+        "replica_metrics_delay_mean_ms": get_stat(
+            health_metrics, "replica_metrics_delay_ms", "mean"
+        ),
+        "process_memory_mb": health_metrics.get("process_memory_mb", 0),
+    }
+
+
+async def _controller_wait_for_replicas_up(target: int, timeout: float = 300) -> float:
+    start = time.time()
+    while time.time() - start < timeout:
+        actual = await _controller_get_replica_count()
+        if actual >= target:
+            return time.time() - start
+        await asyncio.sleep(0.5)
+    actual = await _controller_get_replica_count()
+    raise RuntimeError(
+        f"Timeout: Only {actual}/{target} replicas after {timeout}s. Ending experiment."
+    )
+
+
+async def _controller_wait_for_replicas_down(
+    target: int, timeout: float = 600
+) -> float:
+    start = time.time()
+    while time.time() - start < timeout:
+        actual = await _controller_get_replica_count()
+        if actual <= target:
+            return time.time() - start
+        if int(time.time() - start) % 10 == 0:
+            logging.info(f"  Waiting for scale down... {actual} -> {target}")
+        await asyncio.sleep(1.0)
+    actual = await _controller_get_replica_count()
+    raise RuntimeError(
+        f"Timeout: Still {actual} replicas (target {target}) after {timeout}s. "
+        "Ending experiment."
+    )
+
+
+async def _controller_wait_for_waiters(
+    signal_actor, expected: int, timeout: float = 300
+) -> float:
+    start = time.time()
+    while time.time() - start < timeout:
+        num_waiters = await signal_actor.cur_num_waiters.remote()
+        if num_waiters >= expected:
+            return time.time() - start
+        await asyncio.sleep(0.5)
+        logging.info(f"Waiting for {expected} waiters... {num_waiters}/{expected}")
+    num_waiters = await signal_actor.cur_num_waiters.remote()
+    raise RuntimeError(
+        f"Timeout: Only {num_waiters}/{expected} requests reached replicas after "
+        f"{timeout}s. Ending experiment."
+    )
+
+
+async def _controller_run_checkpoint(
+    handle: DeploymentHandle,
+    signal_actor,
+    checkpoint: int,
+    target_replicas: int,
+    marination_period_s: int,
+    sample_interval_s: int,
+) -> List[Dict[str, Any]]:
+    """Run a single checkpoint and collect metrics."""
+    start_time = time.time()
+    num_requests = int(target_replicas)
+
+    pending_requests = [handle.remote() for _ in range(num_requests)]
+
+    await _controller_wait_for_waiters(
+        signal_actor, num_requests, timeout=_CONTROLLER_WAITER_TIMEOUT_S
+    )
+    await _controller_wait_for_replicas_up(
+        target_replicas, timeout=_CONTROLLER_WAITER_TIMEOUT_S
+    )
+    autoscale_duration_s = time.time() - start_time
+
+    samples = []
+    num_samples = marination_period_s // sample_interval_s
+    for sample_idx in range(num_samples):
+        health_metrics = await _controller_get_health_metrics()
+        actual_replicas = await _controller_get_replica_count()
+        num_nodes = _controller_get_active_nodes()
+        row = _controller_extract_metrics_row(
+            health_metrics=health_metrics,
+            checkpoint=checkpoint,
+            sample=sample_idx,
+            target_replicas=target_replicas,
+            actual_replicas=actual_replicas,
+            num_nodes=num_nodes,
+            autoscale_duration_s=autoscale_duration_s,
+        )
+        samples.append(row)
+        if sample_idx < num_samples - 1:
+            await asyncio.sleep(sample_interval_s)
+
+    await signal_actor.send.remote(clear=True)
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*pending_requests, return_exceptions=True),
+            timeout=30.0,
+        )
+    except asyncio.TimeoutError:
+        pass
+
+    return samples
+
+
+async def run_controller_benchmark(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Run the controller health metrics benchmark and return raw samples.
+
+    Uses MetricsGenerator (autoscaling) -> HelloWorld (fixed) -> SignalActor
+    to stress the controller as replicas scale. Fails if get_health_metrics
+    is unavailable.
+
+    Args:
+        config: Optional benchmark config (checkpoints, marination_period_s,
+            sample_interval_s). Uses CONTROLLER_BENCH_CONFIG if None.
+
+    Returns:
+        List of sample dicts (one per marination sample). Each sample has
+        target_replicas, autoscale_duration_s, loop_duration_mean_s,
+        loops_per_second, event_loop_delay_s, num_asyncio_tasks, etc.
+        Caller converts to perf_metrics via convert_controller_samples_to_perf_metrics.
+    """
+    cfg = config or CONTROLLER_BENCH_CONFIG
+    checkpoints = cfg["checkpoints"]
+    marination_period_s = cfg["marination_period_s"]
+    sample_interval_s = cfg["sample_interval_s"]
+
+    if not ray.is_initialized():
+        ray.init()
+
+    signal_actor = _SignalActorForController.remote()
+    all_samples: List[Dict[str, Any]] = []
+
+    try:
+        for checkpoint_idx, target_replicas in enumerate(checkpoints):
+            hello_world = ControllerBenchHelloWorld.bind(signal_actor)
+            app = ControllerBenchMetricsGenerator.bind(hello_world)
+            handle = serve.run(app, name="default", route_prefix=None)
+
+            samples = await _controller_run_checkpoint(
+                handle=handle,
+                signal_actor=signal_actor,
+                checkpoint=checkpoint_idx,
+                target_replicas=target_replicas,
+                marination_period_s=marination_period_s,
+                sample_interval_s=sample_interval_s,
+            )
+            all_samples.extend(samples)
+            serve.shutdown()
+    finally:
+        serve.shutdown()
+
+    return all_samples

--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -478,24 +478,6 @@ async def _controller_wait_for_replicas_up(target: int, timeout: float = 300) ->
     )
 
 
-async def _controller_wait_for_replicas_down(
-    target: int, timeout: float = 600
-) -> float:
-    start = time.time()
-    while time.time() - start < timeout:
-        actual = await _controller_get_replica_count()
-        if actual <= target:
-            return time.time() - start
-        if int(time.time() - start) % 10 == 0:
-            logging.info(f"  Waiting for scale down... {actual} -> {target}")
-        await asyncio.sleep(1.0)
-    actual = await _controller_get_replica_count()
-    raise RuntimeError(
-        f"Timeout: Still {actual} replicas (target {target}) after {timeout}s. "
-        "Ending experiment."
-    )
-
-
 async def _controller_wait_for_waiters(
     signal_actor, expected: int, timeout: float = 300
 ) -> float:

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -109,6 +109,7 @@ py_test_module_list(
         "test_callback.py",
         "test_cluster.py",
         "test_controller.py",
+        "test_controller_benchmark.py",
         "test_controller_recovery.py",
         "test_deploy_2.py",
         "test_deployment_scheduler.py",

--- a/python/ray/serve/tests/test_controller_benchmark.py
+++ b/python/ray/serve/tests/test_controller_benchmark.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from ray.serve._private.benchmarks.common import run_controller_benchmark
@@ -45,3 +47,7 @@ async def test_run_controller_benchmark(ray_start_stop):
         assert sample["loops_per_second"] >= 0
         assert sample["process_memory_mb"] >= 0
         assert sample["autoscale_duration_s"] >= 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_controller_benchmark.py
+++ b/python/ray/serve/tests/test_controller_benchmark.py
@@ -1,0 +1,47 @@
+import pytest
+
+from ray.serve._private.benchmarks.common import run_controller_benchmark
+
+
+@pytest.mark.asyncio
+async def test_run_controller_benchmark(ray_start_stop):
+    """Test that run_controller_benchmark runs and returns valid samples."""
+    config = {
+        "checkpoints": [1, 2],
+        "marination_period_s": 15,
+        "sample_interval_s": 5,
+    }
+    samples = await run_controller_benchmark(config=config)
+
+    assert len(samples) > 0, "Expected at least one sample"
+
+    expected_keys = [
+        "target_replicas",
+        "autoscale_duration_s",
+        "loop_duration_mean_s",
+        "loops_per_second",
+        "event_loop_delay_s",
+        "num_asyncio_tasks",
+        "deployment_state_update_mean_s",
+        "application_state_update_mean_s",
+        "proxy_state_update_mean_s",
+        "node_update_min_s",
+        "handle_metrics_delay_mean_ms",
+        "replica_metrics_delay_mean_ms",
+        "process_memory_mb",
+    ]
+
+    for sample in samples:
+        for key in expected_keys:
+            assert key in sample, f"Sample missing expected key: {key}"
+
+    # Verify we have samples for each checkpoint
+    replicas_seen = {s["target_replicas"] for s in samples}
+    assert 1 in replicas_seen
+    assert 2 in replicas_seen
+
+    # Verify numeric fields are reasonable
+    for sample in samples:
+        assert sample["loops_per_second"] >= 0
+        assert sample["process_memory_mb"] >= 0
+        assert sample["autoscale_duration_s"] >= 0

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1458,6 +1458,35 @@
           runtime_env:
             - RAY_SERVE_ENABLE_HA_PROXY=1
 
+- name: serve_controller_benchmark_haproxy
+  python: "3.10"
+  group: Serve tests
+  working_dir: serve_tests
+
+  frequency: nightly
+  team: serve
+
+  cluster:
+    byod:
+      runtime_env:
+        # specifically testing haproxy here because with serve
+        # proxy the benchmark profile changes significantly.
+        # Given that haproxy is going to be the path forward, make sense
+        # to use that here.
+        - RAY_SERVE_THROUGHPUT_OPTIMIZED=1
+        - RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S=0.01
+        - RAY_SERVE_REPLICA_GRPC_MAX_MESSAGE_LENGTH=10500000
+    cluster_compute: compute_tpl_8_cpu_autoscaling.yaml
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
+    project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
+
+  run:
+    timeout: 14400
+    long_running: false
+    script: python workloads/microbenchmarks.py --run-controller
+
+  alert: default
+
 - name: pytest_serve_microbenchmarks
   python: "3.10"
   group: Serve tests

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1473,9 +1473,8 @@
         # proxy the benchmark profile changes significantly.
         # Given that haproxy is going to be the path forward, make sense
         # to use that here.
-        - RAY_SERVE_THROUGHPUT_OPTIMIZED=1
+        - RAY_SERVE_ENABLE_HA_PROXY=1
         - RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S=0.01
-        - RAY_SERVE_REPLICA_GRPC_MAX_MESSAGE_LENGTH=10500000
     cluster_compute: compute_tpl_8_cpu_autoscaling.yaml
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
     project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1463,7 +1463,7 @@
   group: Serve tests
   working_dir: serve_tests
 
-  frequency: nightly
+  frequency: weekly
   team: serve
 
   cluster:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1487,6 +1487,14 @@
 
   alert: default
 
+  variations:
+    - __suffix__: aws
+    - __suffix__: gce
+      env: gce
+      frequency: manual
+      cluster:
+        cluster_compute: compute_tpl_single_node_gce.yaml
+
 - name: pytest_serve_microbenchmarks
   python: "3.10"
   group: Serve tests

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -11,6 +11,7 @@ head_node_type:
     resources:
       custom_resources:
         proxy: 1
+        CPU: 0
 
 worker_node_types:
     - name: worker_node

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -18,6 +18,7 @@ import grpc
 import pandas as pd
 import requests
 from typing import Dict, List, Optional
+from collections import defaultdict
 
 from ray import serve
 from ray.serve._private.benchmarks.common import (
@@ -113,7 +114,6 @@ def convert_controller_samples_to_perf_metrics(
     samples: List[Dict],
 ) -> List[Dict]:
     """Convert controller benchmark raw samples to perf_metrics with std and sample_size."""
-    from collections import defaultdict
 
     def _mean(vals: List[float]) -> float:
         return sum(vals) / len(vals) if vals else 0.0

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -159,6 +159,11 @@ def convert_controller_samples_to_perf_metrics(
             "LATENCY",
         )
         _add_metric(
+            f"controller_actual_replicas{suffix}",
+            "actual_replicas",
+            "THROUGHPUT",
+        )
+        _add_metric(
             f"controller_loops_per_second{suffix}",
             "loops_per_second",
             "THROUGHPUT",

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -30,6 +30,7 @@ from ray.serve._private.benchmarks.common import (
     GrpcDeployment,
     GrpcModelComp,
     IntermediateRouter,
+    run_controller_benchmark,
     run_latency_benchmark,
     run_throughput_benchmark,
     Streamer,
@@ -108,6 +109,119 @@ def convert_latencies_to_perf_metrics(name: str, latencies: pd.Series) -> List[D
     ]
 
 
+def convert_controller_samples_to_perf_metrics(
+    samples: List[Dict],
+) -> List[Dict]:
+    """Convert controller benchmark raw samples to perf_metrics with std and sample_size."""
+    from collections import defaultdict
+
+    def _mean(vals: List[float]) -> float:
+        return sum(vals) / len(vals) if vals else 0.0
+
+    def _std(vals: List[float]) -> float:
+        if len(vals) < 2:
+            return 0.0
+        m = _mean(vals)
+        return (sum((v - m) ** 2 for v in vals) / len(vals)) ** 0.5
+
+    groups: Dict[int, List[Dict]] = defaultdict(list)
+    for row in samples:
+        groups[int(row["target_replicas"])].append(row)
+
+    perf_metrics: List[Dict] = []
+    for replicas in sorted(groups.keys()):
+        samples_list = groups[replicas]
+        n = len(samples_list)
+        suffix = f"_{replicas}_replicas"
+
+        def _get_vals(key: str) -> List[float]:
+            return [
+                float(s[key])
+                for s in samples_list
+                if isinstance(s.get(key), (int, float))
+            ]
+
+        def _add_metric(name: str, key: str, metric_type: str) -> None:
+            vals = _get_vals(key)
+            perf_metrics.append(
+                {
+                    "perf_metric_name": name,
+                    "perf_metric_value": _mean(vals),
+                    "perf_metric_type": metric_type,
+                    "perf_metric_std": _std(vals),
+                    "perf_metric_sample_size": n,
+                }
+            )
+
+        _add_metric(
+            f"controller_autoscale_duration_s{suffix}",
+            "autoscale_duration_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_loops_per_second{suffix}",
+            "loops_per_second",
+            "THROUGHPUT",
+        )
+        _add_metric(
+            f"controller_loop_duration_mean_s{suffix}",
+            "loop_duration_mean_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_event_loop_delay_s{suffix}",
+            "event_loop_delay_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_num_asyncio_tasks{suffix}",
+            "num_asyncio_tasks",
+            "THROUGHPUT",
+        )
+        _add_metric(
+            f"controller_deployment_state_update_mean_s{suffix}",
+            "deployment_state_update_mean_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_application_state_update_mean_s{suffix}",
+            "application_state_update_mean_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_proxy_state_update_mean_s{suffix}",
+            "proxy_state_update_mean_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_proxy_state_update_std_s{suffix}",
+            "proxy_state_update_std_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_node_update_min_s{suffix}",
+            "node_update_min_s",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_handle_metrics_delay_mean_ms{suffix}",
+            "handle_metrics_delay_mean_ms",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_replica_metrics_delay_mean_ms{suffix}",
+            "replica_metrics_delay_mean_ms",
+            "LATENCY",
+        )
+        _add_metric(
+            f"controller_process_memory_mb{suffix}",
+            "process_memory_mb",
+            "LATENCY",
+        )
+
+    return perf_metrics
+
+
 def get_throughput_test_name(test_type: str, max_ongoing_requests: int) -> str:
     if max_ongoing_requests == DEFAULT_MAX_ONGOING_REQUESTS:
         return test_type
@@ -123,12 +237,20 @@ async def _main(
     run_latency: bool,
     run_throughput: bool,
     run_streaming: bool,
+    run_controller: bool,
     throughput_max_ongoing_requests: List[int],
     concurrencies: List[int],
 ):
     perf_metrics = []
     payload_1mb = generate_payload(1000000)
     payload_10mb = generate_payload(10000000)
+
+    # Controller benchmark (separate release test, excluded from --run-all)
+    if run_controller:
+        controller_samples = await run_controller_benchmark()
+        perf_metrics.extend(
+            convert_controller_samples_to_perf_metrics(controller_samples)
+        )
 
     # HTTP
     if run_http:
@@ -411,6 +533,11 @@ async def _main(
 @click.option("--run-throughput", is_flag=True)
 @click.option("--run-streaming", is_flag=True)
 @click.option(
+    "--run-controller",
+    is_flag=True,
+    help="Run controller health benchmark only (separate from --run-all).",
+)
+@click.option(
     "--throughput-max-ongoing-requests",
     "-t",
     multiple=True,
@@ -435,6 +562,7 @@ def main(
     run_latency: bool,
     run_throughput: bool,
     run_streaming: bool,
+    run_controller: bool,
     throughput_max_ongoing_requests: List[int],
     concurrencies: List[int],
 ):
@@ -442,7 +570,7 @@ def main(
         concurrencies
     ), "Must have the same number of --throughput-max-ongoing-requests and --concurrencies"
 
-    # If none of the flags are set, default to run all
+    # If none of the flags are set, default to run all (excluding controller)
     if not (
         run_http
         or run_grpc
@@ -450,6 +578,7 @@ def main(
         or run_latency
         or run_throughput
         or run_streaming
+        or run_controller
     ):
         run_all = True
 
@@ -460,6 +589,7 @@ def main(
         run_latency = True
         run_throughput = True
         run_streaming = True
+        # run_controller stays False - controller benchmark is a separate release test
 
     asyncio.run(
         _main(
@@ -470,6 +600,7 @@ def main(
             run_latency,
             run_throughput,
             run_streaming,
+            run_controller,
             throughput_max_ongoing_requests,
             concurrencies,
         )


### PR DESCRIPTION
relates to https://github.com/ray-project/ray/issues/60680

making it official


make output
```bash
❯ cd /home/ubuntu/ray/release/serve_tests/workloads && conda activate ray_310 && python microbenchmarks.py --run-controller
2026-02-26 19:53:29,383 INFO worker.py:1984 -- Started a local Ray instance. View the dashboard at 127.0.0.1:8265 
/home/ubuntu/ray/python/ray/_private/worker.py:2032: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
INFO 2026-02-26 19:53:30,914 serve 2829385 -- Started Serve in namespace "serve".
(ProxyActor pid=2830329) INFO 2026-02-26 19:53:30,857 proxy 172.31.7.228 -- Proxy starting on node 45c883d622f0fd5acd8ad80cdb43253334c49886c47b61679fd76de8 (HTTP port: 8000).
(ProxyActor pid=2830329) INFO 2026-02-26 19:53:30,912 proxy 172.31.7.228 -- Got updated endpoints: {}.
(ServeController pid=2830327) INFO 2026-02-26 19:53:30,949 controller 2830327 -- Registering autoscaling state for deployment Deployment(name='ControllerBenchHelloWorld', app='default')
(ServeController pid=2830327) INFO 2026-02-26 19:53:30,950 controller 2830327 -- Deploying new version of Deployment(name='ControllerBenchHelloWorld', app='default') (initial target replicas: 5).
(ServeController pid=2830327) INFO 2026-02-26 19:53:30,951 controller 2830327 -- Registering autoscaling state for deployment Deployment(name='ControllerBenchMetricsGenerator', app='default')
(ServeController pid=2830327) INFO 2026-02-26 19:53:30,951 controller 2830327 -- Deploying new version of Deployment(name='ControllerBenchMetricsGenerator', app='default') (initial target replicas: 1).
(ServeController pid=2830327) INFO 2026-02-26 19:53:31,055 controller 2830327 -- Adding 5 replicas to Deployment(name='ControllerBenchHelloWorld', app='default').
(ServeController pid=2830327) INFO 2026-02-26 19:53:31,058 controller 2830327 -- Adding 1 replica to Deployment(name='ControllerBenchMetricsGenerator', app='default').
INFO 2026-02-26 19:53:32,025 serve 2829385 -- Application 'default' is ready.
INFO 2026-02-26 19:53:32,030 serve 2829385 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7f43252db3d0>.
(ServeReplica:default:ControllerBenchMetricsGenerator pid=2830337) INFO 2026-02-26 19:53:32,051 default_ControllerBenchMetricsGenerator v1unpyde 789d78f7-6570-4153-8145-fc2fb1fa1cb1 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7fddbc1a3fa0>.
INFO:root:Waiting for 1 waiters... 0/1
(ServeController pid=2830327) INFO 2026-02-26 19:53:42,733 controller 2830327 -- Removing 5 replicas from Deployment(name='ControllerBenchHelloWorld', app='default').
(ServeController pid=2830327) INFO 2026-02-26 19:53:42,733 controller 2830327 -- Removing 1 replica from Deployment(name='ControllerBenchMetricsGenerator', app='default').
(ServeReplica:default:ControllerBenchMetricsGenerator pid=2830337) INFO 2026-02-26 19:53:42,658 default_ControllerBenchMetricsGenerator v1unpyde 789d78f7-6570-4153-8145-fc2fb1fa1cb1 -- CALL __call__ OK 10614.6ms
(ServeReplica:default:ControllerBenchHelloWorld pid=2830333) INFO 2026-02-26 19:53:42,657 default_ControllerBenchHelloWorld 6jqvhiuw 789d78f7-6570-4153-8145-fc2fb1fa1cb1 -- CALL __call__ OK 10560.9ms
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,790 controller 2830327 -- Replica(id='s7rtkgqo', deployment='ControllerBenchHelloWorld', app='default') did not shut down after grace period, force-killing it.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,790 controller 2830327 -- Replica(id='6jqvhiuw', deployment='ControllerBenchHelloWorld', app='default') did not shut down after grace period, force-killing it.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,791 controller 2830327 -- Replica(id='wvhpc2ja', deployment='ControllerBenchHelloWorld', app='default') did not shut down after grace period, force-killing it.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,791 controller 2830327 -- Replica(id='vc84x5sp', deployment='ControllerBenchHelloWorld', app='default') did not shut down after grace period, force-killing it.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,792 controller 2830327 -- Replica(id='lph9g5ol', deployment='ControllerBenchHelloWorld', app='default') did not shut down after grace period, force-killing it.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,792 controller 2830327 -- Replica(id='v1unpyde', deployment='ControllerBenchMetricsGenerator', app='default') did not shut down after grace period, force-killing it.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,897 controller 2830327 -- Replica(id='s7rtkgqo', deployment='ControllerBenchHelloWorld', app='default') is stopped.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,898 controller 2830327 -- Replica(id='6jqvhiuw', deployment='ControllerBenchHelloWorld', app='default') is stopped.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,898 controller 2830327 -- Replica(id='wvhpc2ja', deployment='ControllerBenchHelloWorld', app='default') is stopped.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,898 controller 2830327 -- Replica(id='vc84x5sp', deployment='ControllerBenchHelloWorld', app='default') is stopped.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,898 controller 2830327 -- Replica(id='lph9g5ol', deployment='ControllerBenchHelloWorld', app='default') is stopped.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,899 controller 2830327 -- Replica(id='v1unpyde', deployment='ControllerBenchMetricsGenerator', app='default') is stopped.
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,899 controller 2830327 -- Deregistering autoscaling state for deployment Deployment(name='ControllerBenchHelloWorld', app='default')
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,900 controller 2830327 -- Deregistering autoscaling state for deployment Deployment(name='ControllerBenchMetricsGenerator', app='default')
(ServeController pid=2830327) INFO 2026-02-26 19:53:43,900 controller 2830327 -- Deregistering autoscaling state for application default
(raylet) Task ServeController.listen_for_change failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.
(raylet) Task ServeController.graceful_shutdown failed. There are infinite retries remaining, so the task will be retried. Error: The actor is dead because it was killed by `ray.kill`.
INFO 2026-02-26 19:53:44,740 serve 2829385 -- Nothing to shut down. There's no Serve application running on this Ray cluster.
INFO:root:Perf metrics:
 [
    {
        "perf_metric_name": "controller_autoscale_duration_s_1_replicas",
        "perf_metric_value": 0.607,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.0,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_loops_per_second_1_replicas",
        "perf_metric_value": 9.65389619032342,
        "perf_metric_type": "THROUGHPUT",
        "perf_metric_std": 0.09286657353281695,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_loop_duration_mean_s_1_replicas",
        "perf_metric_value": 0.003209107533714174,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.0008379861759230361,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_event_loop_delay_s_1_replicas",
        "perf_metric_value": 0.0005937258402506455,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 1.8601063804801846e-05,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_num_asyncio_tasks_1_replicas",
        "perf_metric_value": 15.666666666666666,
        "perf_metric_type": "THROUGHPUT",
        "perf_metric_std": 1.8856180831641267,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_deployment_state_update_mean_s_1_replicas",
        "perf_metric_value": 0.0011320094547361277,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.0006216958165767311,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_application_state_update_mean_s_1_replicas",
        "perf_metric_value": 0.0007386383825115703,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 6.958868726899188e-07,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_proxy_state_update_mean_s_1_replicas",
        "perf_metric_value": 0.00026131975208140826,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.00022749108829674003,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_proxy_state_update_std_s_1_replicas",
        "perf_metric_value": 0.0012349092770402939,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.0009483969431511507,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_node_update_min_s_1_replicas",
        "perf_metric_value": 7.0730845133463544e-06,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 6.293929377626842e-06,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_handle_metrics_delay_mean_ms_1_replicas",
        "perf_metric_value": 0.8769035339355469,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.14532233366556263,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_replica_metrics_delay_mean_ms_1_replicas",
        "perf_metric_value": 0.0,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.0,
        "perf_metric_sample_size": 3
    },
    {
        "perf_metric_name": "controller_process_memory_mb_1_replicas",
        "perf_metric_value": 184.66666666666666,
        "perf_metric_type": "LATENCY",
        "perf_metric_std": 0.6377709970028862,
        "perf_metric_sample_size": 3
    }
]
```