### PR TITLE
Revert "[Serve] Set RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1 to run sync in…

### DIFF
--- a/ci/ray_ci/serve_di_test_names.txt
+++ b/ci/ray_ci/serve_di_test_names.txt
@@ -31,7 +31,7 @@
 //python/ray/serve/tests:test_http_routes
 //python/ray/serve/tests:test_backpressure
 //python/ray/serve/tests:test_batching
-//python/ray/serve/tests:test_replica_sync_methods
+//python/ray/serve/tests:test_replica_sync_methods_with_run_sync_in_threadpool
 //python/ray/serve/tests:test_replica_request_context
 //python/ray/serve/tests:test_direct_ingress
 //python/ray/serve/tests:test_direct_ingress_standalone

--- a/ci/ray_ci/serve_hap_test_names.txt
+++ b/ci/ray_ci/serve_hap_test_names.txt
@@ -33,7 +33,7 @@
 //python/ray/serve/tests:test_logging
 //python/ray/serve/tests:test_model_composition
 //python/ray/serve/tests:test_replica_request_context
-//python/ray/serve/tests:test_replica_sync_methods
+//python/ray/serve/tests:test_replica_sync_methods_with_run_sync_in_threadpool
 //python/ray/serve/tests:test_request_timeout
 //python/ray/serve/tests:test_streaming_response
 //python/ray/serve/tests:test_target_capacity

--- a/doc/source/serve/advanced-guides/asyncio-best-practices.md
+++ b/doc/source/serve/advanced-guides/asyncio-best-practices.md
@@ -75,8 +75,8 @@ For a synchronous deployment:
 
 How this method executes depends on configuration:
 
-- With `RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1` (default), Serve offloads `__call__` to a threadpool so the event loop stays responsive.
-- With `RAY_SERVE_RUN_SYNC_IN_THREADPOOL=0`, `__call__` runs directly on the user event loop and blocks it for 1 second.
+- With `RAY_SERVE_RUN_SYNC_IN_THREADPOOL=0` (current default), `__call__` runs directly on the user event loop and blocks it for 1 second.
+- With `RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1`, Serve offloads `__call__` to a threadpool so the event loop stays responsive.
 
 ### FastAPI ingress (`@serve.ingress`)
 
@@ -88,7 +88,10 @@ When you use FastAPI ingress, FastAPI controls how endpoints run:
 :language: python
 ```
 
-Both FastAPI and Serve dispatch `def` methods to threadpool.
+Important differences:
+
+- FastAPI  always dispatches `def` endpoints to a threadpool.
+- In pure Serve, `def` methods run on the event loop unless you opt into threadpool behavior.
 
 ## Threadpool sizing and overrides
 
@@ -266,34 +269,30 @@ Ray Serve exposes several environment variables that control how user code inter
 
 ### `RAY_SERVE_RUN_SYNC_IN_THREADPOOL`
 
-By default (`RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1`), synchronous methods in a deployment run in a threadpool. This keeps the event loop responsive while sync handlers execute.
+By default (`RAY_SERVE_RUN_SYNC_IN_THREADPOOL=0`), which means synchronous methods in a deployment run directly on the user event loop. To help you migrate to a safer model, Serve emits a warning like:
 
-When this flag is `1` (default):
+> `RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING`: Calling sync method '...' directly on the asyncio loop. In a future version, sync methods will be run in a threadpool by default...
+
+This warning means:
+
+- You have a `def` method that is currently running on the event loop.
+- In a future version, that method runs in a threadpool instead.
+
+You can opt in to the future behavior now by setting:
+
+```bash
+export RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1
+```
+
+When this flag is `1`:
 
 - Serve runs synchronous methods in a threadpool.
 - The event loop is free to keep serving other requests while sync methods run.
 
-Ensure your handlers and shared state are thread-safe. The following example is **not** thread-safe. Concurrent requests can race on shared mutable state.
+Before enabling this in production, make sure:
 
-```{literalinclude} ../doc_code/asyncio_best_practices.py
-:start-after: __non_thread_safe_begin__
-:end-before: __non_thread_safe_end__
-:language: python
-```
-
-Use a lock to protect shared state:
-
-```{literalinclude} ../doc_code/asyncio_best_practices.py
-:start-after: __thread_safe_counter_begin__
-:end-before: __thread_safe_counter_end__
-:language: python
-```
-
-You can opt out of the threadpool by setting:
-
-```bash
-export RAY_SERVE_RUN_SYNC_IN_THREADPOOL=0
-```
+- Your handler code and any shared state are thread-safe.
+- Your model objects can safely be used from multiple threads, or you protect them with locks.
 
 ### `RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD`
 
@@ -454,5 +453,5 @@ This pattern:
 
 - Use `async def` for I/O-bound and streaming work so the event loop can stay responsive.
 - Use `max_ongoing_requests` to bound concurrency per replica, but remember that blocking `def` handlers can still serialize work if they run on the event loop.
-- Ensure sync handlers are thread-safe.
+- Consider enabling `RAY_SERVE_RUN_SYNC_IN_THREADPOOL` once your code is thread-safe, and be aware of the sync-in-threadpool warning.
 - For CPU-heavy workloads, scale replicas or GIL-releasing native code for real parallelism.

--- a/doc/source/serve/doc_code/asyncio_best_practices.py
+++ b/doc/source/serve/doc_code/asyncio_best_practices.py
@@ -155,42 +155,11 @@ class BlockingCPU:
 @serve.deployment(max_ongoing_requests=100)
 class CPUWithThreadpool:
     def __call__(self, request):
-        # With RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1 (default), each call runs in a thread.
+        # With RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1, each call runs in a thread.
         import time
         time.sleep(1)
         return "ok"
 # __cpu_with_threadpool_end__
-
-
-# __non_thread_safe_begin__
-@serve.deployment
-class NonThreadSafeCounter:
-    def __init__(self):
-        self.count = 0  # Shared mutable state across concurrent requests
-
-    def __call__(self, request):
-        # Race condition: multiple threads can read-modify-write
-        # self.count concurrently, leading to lost updates.
-        self.count += 1
-        return self.count
-# __non_thread_safe_end__
-
-
-# __thread_safe_counter_begin__
-import threading
-
-@serve.deployment
-class ThreadSafeCounter:
-    def __init__(self):
-        self._lock = threading.Lock()
-        self.count = 0
-
-    def __call__(self, request):
-        # Lock protects shared state from concurrent access.
-        with self._lock:
-            self.count += 1
-            return self.count
-# __thread_safe_counter_end__
 
 
 # __batched_model_begin__
@@ -409,21 +378,6 @@ if __name__ == "__main__":
     result = batched_model_offload_handle.remote(1).result()
     print(f"BatchedModelOffload result: {result}")
     assert result == "result_1"
-
-    print("\nTesting NonThreadSafeCounter deployment...")
-    # Test NonThreadSafeCounter
-    non_thread_safe_handle = serve.run(NonThreadSafeCounter.bind())
-    result = non_thread_safe_handle.remote(None).result()
-    print(f"NonThreadSafeCounter result: {result}")
-    assert result == 1
-
-    print("\nTesting ThreadSafeCounter deployment...")
-    # Test ThreadSafeCounter
-    thread_safe_handle = serve.run(ThreadSafeCounter.bind())
-    for i in range(3):
-        result = thread_safe_handle.remote(None).result()
-        print(f"ThreadSafeCounter call {i + 1} result: {result}")
-        assert result == i + 1
     
     # Test HTTP-related deployments with try-except
     print("\n--- Testing HTTP-related deployments (may fail due to network) ---")

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -515,19 +515,15 @@ RAY_SERVE_FORCE_LOCAL_TESTING_MODE = get_env_bool(
 )
 
 # Run sync methods defined in the replica in a thread pool by default.
-RAY_SERVE_RUN_SYNC_IN_THREADPOOL = get_env_bool("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "1")
+RAY_SERVE_RUN_SYNC_IN_THREADPOOL = get_env_bool("RAY_SERVE_RUN_SYNC_IN_THREADPOOL", "0")
 
-RAY_SERVE_RUN_SYNC_IN_EVENT_LOOP_WARNING = (
-    "Calling sync method '{method_name}' directly on the asyncio loop because "
-    "RAY_SERVE_RUN_SYNC_IN_THREADPOOL=0. This blocks async operations. To run "
-    "sync methods in a threadpool, set RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1, or "
-    "convert to `async def`."
-)
-
-RAY_SERVE_RUN_SYNC_IN_THREADPOOL_THREAD_SAFETY_WARNING = (
-    "Sync method '{method_name}' is running in a threadpool. Ensure your "
-    "handler and shared state are thread-safe, or convert to `async def` for "
-    "event-loop execution."
+RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING = (
+    "Calling sync method '{method_name}' directly on the "
+    "asyncio loop. In a future version, sync methods will be run in a "
+    "threadpool by default. Ensure your sync methods are thread safe "
+    "or keep the existing behavior by making them `async def`. Opt "
+    "into the new behavior by setting "
+    "RAY_SERVE_RUN_SYNC_IN_THREADPOOL=1."
 )
 
 # Feature flag to turn off GC optimizations in the proxy (in case there is a

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -74,9 +74,8 @@ from ray.serve._private.constants import (
     RAY_SERVE_REPLICA_UTILIZATION_REPORT_INTERVAL_S,
     RAY_SERVE_REPLICA_UTILIZATION_WINDOW_S,
     RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
-    RAY_SERVE_RUN_SYNC_IN_EVENT_LOOP_WARNING,
     RAY_SERVE_RUN_SYNC_IN_THREADPOOL,
-    RAY_SERVE_RUN_SYNC_IN_THREADPOOL_THREAD_SAFETY_WARNING,
+    RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING,
     RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD,
     RECONFIGURE_METHOD,
     REQUEST_LATENCY_BUCKETS_MS,
@@ -2853,8 +2852,7 @@ class UserCallableWrapper:
         self._destructor_called = False
         self._run_sync_methods_in_threadpool = run_sync_methods_in_threadpool
         self._run_user_code_in_separate_thread = run_user_code_in_separate_thread
-        self._warned_about_sync_method_event_loop = False
-        self._warned_about_sync_method_threadpool = False
+        self._warned_about_sync_method_change = False
         self._cached_user_method_info: Dict[str, UserMethodInfo] = {}
         # This is for performance optimization https://docs.python.org/3/howto/logging.html#optimization
         self._is_enabled_for_debug = logger.isEnabledFor(logging.DEBUG)
@@ -3043,16 +3041,6 @@ class UserCallableWrapper:
         )
 
         if is_sync_method and run_sync_in_threadpool:
-            if (
-                not self._warned_about_sync_method_threadpool
-                and run_sync_methods_in_threadpool_override is None
-            ):
-                self._warned_about_sync_method_threadpool = True
-                warnings.warn(
-                    RAY_SERVE_RUN_SYNC_IN_THREADPOOL_THREAD_SAFETY_WARNING.format(
-                        method_name=callable.__name__,
-                    )
-                )
             is_generator = inspect.isgeneratorfunction(callable)
             if is_generator:
                 sync_gen_consumed = True
@@ -3083,12 +3071,12 @@ class UserCallableWrapper:
         else:
             if (
                 is_sync_method
-                and not self._warned_about_sync_method_event_loop
+                and not self._warned_about_sync_method_change
                 and run_sync_methods_in_threadpool_override is None
             ):
-                self._warned_about_sync_method_event_loop = True
+                self._warned_about_sync_method_change = True
                 warnings.warn(
-                    RAY_SERVE_RUN_SYNC_IN_EVENT_LOOP_WARNING.format(
+                    RAY_SERVE_RUN_SYNC_IN_THREADPOOL_WARNING.format(
                         method_name=callable.__name__,
                     )
                 )

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -163,7 +163,6 @@ py_test_module_list(
         "test_gcs_failure.py",
         "test_gradio.py",
         "test_replica_ranks.py",
-        "test_replica_sync_methods.py",
     ],
     tags = [
         "exclusive",
@@ -565,6 +564,27 @@ py_test_module_list(
         "test_handle_streaming.py",
     ],
     name_suffix = "_with_local_testing_mode",
+    tags = [
+        "exclusive",
+        "no_windows",
+        "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
+# Test currently off-by-default behavior to run replica sync methods in a threadpool.
+# TODO(edoakes): remove this once the FF is flipped on by default.
+py_test_module_list(
+    size = "medium",
+    env = {"RAY_SERVE_RUN_SYNC_IN_THREADPOOL": "1"},
+    files = [
+        "test_replica_sync_methods.py",
+    ],
+    name_suffix = "_with_run_sync_in_threadpool",
     tags = [
         "exclusive",
         "no_windows",


### PR DESCRIPTION
… threadpool by default (#61229)"

This reverts commit 9e1fa2e28c109493f770b3632bfaf9826d4afadc. Enabling the flag by default introduces a significant perf regression for lightweight workloads that are sensitive to context switching and that do not take full advantage of offloading work from python. will post a RFC for community feedback before making this the default

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
