### PR TITLE
[Serve][LLM] Replace SGLang format_messages_to_prompt with _build_chat_messages

### DIFF
--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -327,7 +327,9 @@ class SGLangServer:
             prompt = request.input
         else:
             # Chat embedding request - convert messages to prompt
-            prompt = format_messages_to_prompt(request.messages)
+            prompt = self._render_fallback_prompt(
+                self._build_chat_messages(request.messages)
+            )
 
         # async_encode handles both single strings and lists of strings
         results = await self.engine.async_encode(prompt)


### PR DESCRIPTION
Fix
```
[2026-02-26T22:03:30Z] use logger.warning(......................................................Passed
[2026-02-26T22:03:30Z] + for HOOK in "${HOOKS[@]}"
[2026-02-26T22:03:30Z] + pre-commit run ruff --all-files --show-diff-on-failure
[2026-02-26T22:03:30Z] [INFO] Installing environment for https://github.com/astral-sh/ruff-pre-commit.
[2026-02-26T22:03:30Z] [INFO] Once installed this environment will be reused.
[2026-02-26T22:03:30Z] [INFO] This may take a few minutes...
[2026-02-26T22:03:41Z] ruff.....................................................................Failed
[2026-02-26T22:03:41Z] - hook id: ruff
[2026-02-26T22:03:41Z] - exit code: 1
[2026-02-26T22:03:41Z]
[2026-02-26T22:03:41Z] python/ray/llm/examples/sglang/modules/sglang_engine.py:330:22: F821 Undefined name `format_messages_to_prompt`
[2026-02-26T22:03:41Z]     |
[2026-02-26T22:03:41Z] 328 |         else:
[2026-02-26T22:03:41Z] 329 |             # Chat embedding request - convert messages to prompt
[2026-02-26T22:03:41Z] 330 |             prompt = format_messages_to_prompt(request.messages)
[2026-02-26T22:03:41Z]     |                      ^^^^^^^^^^^^^^^^^^^^^^^^^ F821
[2026-02-26T22:03:41Z] 331 |
[2026-02-26T22:03:41Z] 332 |         # async_encode handles both single strings and lists of strings
[2026-02-26T22:03:41Z]     |
[2026-02-26T22:03:41Z]
[2026-02-26T22:03:41Z] Found 1 error.
[2026-02-26T22:03:41Z] All checks passed!
[2026-02-26T22:03:41Z]
[2026-02-26T22:03:42Z] ruff.....................................................................Passed
[2026-02-26T22:03:42Z] 🚨 Error: The command exited with status 1
```