### PR TITLE
[core][autoscaler] Allow ALLOCATION_TIMEOUT -> TERMINATED when instance disappears

### DIFF
--- a/python/ray/autoscaler/v2/tests/test_instance_util.py
+++ b/python/ray/autoscaler/v2/tests/test_instance_util.py
@@ -73,7 +73,10 @@ class InstanceUtilTest(unittest.TestCase):
         }
         all_status.remove(Instance.RAY_RUNNING)
 
-        assert g[Instance.ALLOCATION_TIMEOUT] == {Instance.TERMINATING}
+        assert g[Instance.ALLOCATION_TIMEOUT] == {
+            Instance.TERMINATING,
+            Instance.TERMINATED,
+        }
         all_status.remove(Instance.ALLOCATION_TIMEOUT)
 
         assert g[Instance.RAY_STOP_REQUESTED] == {
@@ -101,7 +104,10 @@ class InstanceUtilTest(unittest.TestCase):
         }
         all_status.remove(Instance.TERMINATING)
 
-        assert g[Instance.TERMINATION_FAILED] == {Instance.TERMINATING}
+        assert g[Instance.TERMINATION_FAILED] == {
+            Instance.TERMINATING,
+            Instance.TERMINATED,
+        }
         all_status.remove(Instance.TERMINATION_FAILED)
 
         assert g[Instance.TERMINATED] == set()


### PR DESCRIPTION
## Summary
Fixes an invalid status transition when a KubeRay pod disappears after the instance was marked `ALLOCATION_TIMEOUT`. The reconciler correctly marks the instance `TERMINATED`, but the state machine disallowed the transition, causing an assertion failure.

## Motivation / Context
Observed error:

```
2026-02-27 18:01:22,253 INFO instance_manager.py:263 -- Update instance ALLOCATION_TIMEOUT->TERMINATED (id=d21f8546-3b42-4c93-bf64-6e99e64260c4, type=gpu-elastic-h100, cloud_instance_id=gpu-elastic-0gv5tulyov-gpu-elastic-h100-worker-jtwk9, ray_id=): cloud instance gpu-elastic-0gv5tulyov-gpu-elastic-h100-worker-jtwk9 no longer found
2026-02-27 18:01:22,253 ERROR autoscaler.py:222 -- Invalid status transition from ALLOCATION_TIMEOUT to TERMINATED
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ray/autoscaler/v2/autoscaler.py", line 206, in update_autoscaling_state
    return Reconciler.reconcile(
  File "/usr/local/lib/python3.10/dist-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 116, in reconcile
    Reconciler._sync_from(
  File "/usr/local/lib/python3.10/dist-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 215, in _sync_from
    Reconciler._handle_cloud_instance_terminated(
  File "/usr/local/lib/python3.10/dist-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 565, in _handle_cloud_instance_terminated
    Reconciler._update_instance_manager(instance_manager, version, updates)
  File "/usr/local/lib/python3.10/dist-packages/ray/autoscaler/v2/instance_manager/reconciler.py", line 635, in _update_instance_manager
    reply = instance_manager.update_instance_manager_state(
  File "/usr/local/lib/python3.10/dist-packages/ray/autoscaler/v2/instance_manager/instance_manager.py", line 94, in update_instance_manager_state
    instance = self._update_instance(
  File "/usr/local/lib/python3.10/dist-packages/ray/autoscaler/v2/instance_manager/instance_manager.py", line 264, in _update_instance
    assert InstanceUtil.set_status(instance, update.new_instance_status), (
AssertionError: Invalid status transition from ALLOCATION_TIMEOUT to TERMINATED
```

In KubeRay, `cloud_instance_id` is the pod name. When a pending pod is deleted (or disappears from the provider list), `_handle_cloud_instance_terminated` sets `TERMINATED` directly. The state machine didn’t allow this transition for `ALLOCATION_TIMEOUT`.

## Changes
- Allow `ALLOCATION_TIMEOUT -> TERMINATED` in `InstanceUtil.get_valid_transitions()`
- Update transition graph test