### PR TITLE
[core] Fix typo: prom_addreses -> prom_addresses in fetch_prometheus_timeseries

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -477,11 +477,11 @@ def fetch_prometheus(prom_addresses):
 
 
 def fetch_prometheus_timeseries(
-    prom_addreses: List[str],
+    prom_addresses: List[str],
     result: PrometheusTimeseries,
 ) -> PrometheusTimeseries:
     components_dict, metric_descriptors, metric_samples = fetch_prometheus(
-        prom_addreses
+        prom_addresses
     )
     for address, components in components_dict.items():
         if address not in result.components_dict:


### PR DESCRIPTION
## Summary

Fixes a typo in `python/ray/_common/test_utils.py`: the parameter `prom_addreses` was misspelled (missing an 's'). This caused inconsistency between the function signature and its usage.

Fixes #60874

## Changes
- Renamed `prom_addreses` → `prom_addresses` in `fetch_prometheus_timeseries` (lines 480 and 484)

## Tests
No functional changes — this is a pure rename of a local parameter name.