### PR TITLE
[Serve] Prioritize min_replicas recovery over scale-up in replica scheduling

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -1291,3 +1291,19 @@ class AutoscalingStateManager:
             return None
         dep_state = app_state._deployment_autoscaling_states.get(deployment_id)
         return dep_state.get_deployment_snapshot() if dep_state else None
+
+    def get_num_replicas_lower_bound(
+        self, deployment_id: DeploymentID
+    ) -> Optional[int]:
+        """Get the lower bound (min_replicas) for a deployment.
+
+        Returns the capacity-adjusted min_replicas for autoscaling deployments.
+        Returns None if the deployment is not registered for autoscaling.
+        """
+        app_state = self._app_autoscaling_states.get(deployment_id.app_name)
+        if not app_state:
+            return None
+        dep_state = app_state._deployment_autoscaling_states.get(deployment_id)
+        if not dep_state:
+            return None
+        return dep_state.get_num_replicas_lower_bound()

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -495,6 +495,14 @@ RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY = get_env_bool(
     os.environ.get("RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY", "0"),
 )
 
+# Prioritize scheduling replicas that recover deployments to min_replicas
+# over replicas that scale up beyond the minimum. When enabled, if multiple
+# deployments are competing for limited resources, deployments that have
+# fallen below their min_replicas will be scheduled first.
+RAY_SERVE_PRIORITIZE_MIN_REPLICAS_RECOVERY = get_env_bool(
+    "RAY_SERVE_PRIORITIZE_MIN_REPLICAS_RECOVERY", "1"
+)
+
 # Comma-separated list of custom resources prioritized in scheduling. Sorted from highest to lowest priority.
 # Example: "customx,customy"
 RAY_SERVE_HIGH_PRIORITY_CUSTOM_RESOURCES: List[str] = str_to_list(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -569,11 +569,19 @@ class ActorReplicaWrapper:
         self,
         deployment_info: DeploymentInfo,
         assign_rank_callback: Callable[[ReplicaID], ReplicaRank],
+        is_min_replica_recovery: bool = False,
     ) -> ReplicaSchedulingRequest:
         """Start the current DeploymentReplica instance.
 
         The replica will be in the STARTING and PENDING_ALLOCATION states
         until the deployment scheduler schedules the underlying actor.
+
+        Args:
+            deployment_info: The deployment info.
+            assign_rank_callback: Callback to assign rank to the replica.
+            is_min_replica_recovery: Whether this replica is being scheduled
+                to recover to min_replicas. Used by the scheduler to prioritize
+                min_replicas recovery over scale-up requests.
         """
         self._assign_rank_callback = assign_rank_callback
         self._actor_resources = deployment_info.replica_config.resource_dict
@@ -694,6 +702,7 @@ class ActorReplicaWrapper:
             max_replicas_per_node=(
                 deployment_info.replica_config.max_replicas_per_node
             ),
+            is_min_replica_recovery=is_min_replica_recovery,
             on_scheduled=self.on_scheduled,
         )
 
@@ -1347,12 +1356,22 @@ class DeploymentReplica:
         self,
         deployment_info: DeploymentInfo,
         assign_rank_callback: Callable[[ReplicaID], ReplicaRank],
+        is_min_replica_recovery: bool = False,
     ) -> ReplicaSchedulingRequest:
         """
         Start a new actor for current DeploymentReplica instance.
+
+        Args:
+            deployment_info: The deployment info.
+            assign_rank_callback: Callback to assign rank to the replica.
+            is_min_replica_recovery: Whether this replica is being scheduled
+                to recover to min_replicas. Used by the scheduler to prioritize
+                min_replicas recovery over scale-up requests.
         """
         replica_scheduling_request = self._actor.start(
-            deployment_info, assign_rank_callback=assign_rank_callback
+            deployment_info,
+            assign_rank_callback=assign_rank_callback,
+            is_min_replica_recovery=is_min_replica_recovery,
         )
         self._start_time = time.time()
         self.update_actor_details(start_time_s=self._start_time)
@@ -2906,16 +2925,37 @@ class DeploymentState:
             to_add = delta_replicas
             if to_add > 0 and not self._terminally_failed():
                 logger.info(f"Adding {to_add} replica{'s' * (to_add>1)} to {self._id}.")
-                for _ in range(to_add):
+
+                # Determine the effective min_replicas for this deployment.
+                # For autoscaling deployments, use the capacity-adjusted min_replicas.
+                # For non-autoscaling deployments, num_replicas is effectively the min.
+                min_replicas = self._autoscaling_state_manager.get_num_replicas_lower_bound(
+                    self._id
+                )
+                if min_replicas is None:
+                    # Non-autoscaling deployment: num_replicas is the fixed target,
+                    # so all replicas below target are effectively "recovery" replicas.
+                    min_replicas = self._target_state.target_num_replicas
+
+                # Total replicas that will exist after recovery (current + recovering)
+                total_existing = current_replicas + recovering_replicas
+
+                for i in range(to_add):
                     replica_id = ReplicaID(get_random_string(), deployment_id=self._id)
 
                     new_deployment_replica = DeploymentReplica(
                         replica_id,
                         self._target_state.version,
                     )
+
+                    # A replica is a "min_replica recovery" if adding it brings us
+                    # closer to min_replicas (i.e., we're still below min_replicas).
+                    is_min_replica_recovery = (total_existing + i) < min_replicas
+
                     scheduling_request = new_deployment_replica.start(
                         self._target_state.info,
                         assign_rank_callback=self._rank_manager.assign_rank,
+                        is_min_replica_recovery=is_min_replica_recovery,
                     )
 
                     upscale.append(scheduling_request)


### PR DESCRIPTION
## Why are these changes needed?

When multiple Ray Serve deployments compete for limited cluster resources, the scheduler currently treats all replica requests equally—sorted only by resource size. This means a deployment that wants to scale up from 3→4 replicas can consume resources before a deployment that has crashed and needs to recover from 0→1 replicas (its `min_replicas`). This violates user expectations that `min_replicas` is a guarantee, not a best-effort target.

This PR ensures that replicas recovering to `min_replicas` are always scheduled before replicas scaling up beyond the minimum, providing predictable behavior under resource contention.

## Solution

Added a priority tier to replica scheduling:
1. **First**, schedule all replicas needed to bring deployments up to their `min_replicas` (sorted by resource size)
2. **Then**, schedule scale-up replicas beyond the minimum (sorted by resource size)

This is controlled by a new feature flag `RAY_SERVE_PRIORITIZE_MIN_REPLICAS_RECOVERY` (enabled by default). Users can disable it via environment variable if needed.

## Notes for Reviewers

**File changes:**

| File | Change |
|------|--------|
| `deployment_scheduler.py` | Added `is_min_replica_recovery` field to `ReplicaSchedulingRequest`. Modified `_schedule_with_pack_strategy` and `_schedule_with_spread_strategy` to partition requests by priority before scheduling. |
| `deployment_state.py` | Modified `scale_deployment_replicas()` to compute whether each new replica is a recovery (below `min_replicas`) or scale-up. Threaded the flag through `DeploymentReplica.start()`. |
| `autoscaling_state.py` | Added `get_num_replicas_lower_bound()` to `AutoscalingStateManager` to expose capacity-adjusted `min_replicas` for a deployment. |
| `constants.py` | Added `RAY_SERVE_PRIORITIZE_MIN_REPLICAS_RECOVERY` feature flag (default: enabled). |
| `test_deployment_scheduler.py` | Added `TestMinReplicasPriorityScheduling` class with 5 parametrized tests covering both PACK and SPREAD strategies, feature flag behavior, and mixed recovery/scale-up scenarios. |

## Related issue number

<!-- Link to GitHub issue if applicable -->

## Checks

- [x] I've signed off every commit
- [ ] I've run `scripts/format.sh` to lint the changes
- [ ] I've included any doc changes needed
- [ ] I've added tests to cover the changes
- [x] All existing tests pass