### PR TITLE
[Data] Route random_shuffle through push based shuffle when HASH_SHUFFLE strategy is set

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1055,7 +1055,7 @@ python/ray/data/_internal/execution/operators/base_physical_operator.py
 --------------------
 python/ray/data/_internal/execution/operators/hash_shuffle.py
     DOC104: Function `_shuffle_block`: Arguments are the same in the docstring and the function signature, but are in a different order.
-    DOC105: Function `_shuffle_block`: Argument names match, but type hints in these args do not match: block, input_index, key_columns, pool, block_transformer, send_empty_blocks, override_partition_id
+    DOC105: Function `_shuffle_block`: Argument names match, but type hints in these args do not match: block, input_index, key_columns, pool, block_transformer, send_empty_blocks, override_partition_id, random_partition_seed
 --------------------
 python/ray/data/_internal/execution/operators/map_operator.py
     DOC103: Method `MapOperator.create`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [init_fn: , transform_fn: ].

--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1053,10 +1053,6 @@ python/ray/data/_internal/execution/operators/base_physical_operator.py
     DOC103: Method `OneToOneOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext].
     DOC103: Method `NAryOperator.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [*input_ops: LogicalOperator, data_context: DataContext]. Arguments in the docstring but not in the function signature: [input_op: , name: ].
 --------------------
-python/ray/data/_internal/execution/operators/hash_shuffle.py
-    DOC104: Function `_shuffle_block`: Arguments are the same in the docstring and the function signature, but are in a different order.
-    DOC105: Function `_shuffle_block`: Argument names match, but type hints in these args do not match: block, input_index, key_columns, pool, block_transformer, send_empty_blocks, override_partition_id, random_partition_seed
---------------------
 python/ray/data/_internal/execution/operators/map_operator.py
     DOC103: Method `MapOperator.create`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [data_context: DataContext, map_transformer: MapTransformer]. Arguments in the docstring but not in the function signature: [init_fn: , transform_fn: ].
     DOC201: Method `MapOperator.create` does not have a return section in docstring

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1498,7 +1498,7 @@ py_test(
 
 py_test(
     name = "test_shuffle_diagnostics",
-    size = "large",
+    size = "enormous",
     srcs = ["tests/test_shuffle_diagnostics.py"],
     tags = [
         "data_non_parallel",

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1508,7 +1508,11 @@ class RandomShuffleOperator(HashShufflingOperatorBase):
         return (None, self._seed + cur_shuffle_task_idx)
 
     def _get_operator_num_cpus_override(self) -> float:
-        return self.data_context.hash_shuffle_operator_actor_num_cpus_override
+        if self.data_context.hash_shuffle_operator_actor_num_cpus_override is not None:
+            return self.data_context.hash_shuffle_operator_actor_num_cpus_override
+        # Random shuffle aggregators are lightweight (concat + permute) until
+        # finalization. Use minimal CPU to avoid starving shuffle tasks.
+        return self._DEFAULT_AGGREGATORS_MIN_CPUS
 
     # Concat + permutation has the same memory profile as HashShuffleOperator.
     _estimate_aggregator_memory_allocation = (

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -55,6 +55,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     TaskExecDriverStats,
     estimate_total_num_of_blocks,
 )
+from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.output_buffer import BlockOutputBuffer, OutputBlockSizeOption
@@ -278,6 +279,7 @@ def _shuffle_block(
     send_empty_blocks: bool = False,
     override_partition_id: Optional[int] = None,
     random_partition_seed: Optional[int] = None,
+    task_idx: int = 0,
 ) -> Tuple[BlockMetadata, Dict[int, "_PartitionStats"]]:
     """Shuffles provided block following the algorithm:
 
@@ -293,6 +295,8 @@ def _shuffle_block(
         key_columns: Columns to be used by hash-partitioning algorithm
         pool: Hash-shuffling operator's pool of aggregators that are due to receive
               corresponding partitions (of the block)
+        block_transformer: Block transformer that will be applied to every block prior
+            to shuffling
         send_empty_blocks: If set to true, empty blocks will NOT be filtered and
             still be fanned out to individual aggregators to distribute schemas
             (only known once we receive incoming block)
@@ -300,8 +304,8 @@ def _shuffle_block(
             assigned to
         random_partition_seed: Seed for random partitioning. When provided, rows are
             randomly assigned to partitions instead of hash-partitioned.
-        block_transformer: Block transformer that will be applied to every block prior
-            to shuffling
+        task_idx: Index of this shuffle task, used to set up TaskContext for fused
+            transforms that require it (e.g. monotonically_increasing_id)
 
     Returns:
         A tuple of
@@ -323,8 +327,11 @@ def _shuffle_block(
         f"random_partition_seed ({random_partition_seed}) must be provided!"
     )
 
-    # Apply block transformer prior to shuffling (if any)
+    # Apply block transformer prior to shuffling (if any).
+    # Set up TaskContext so fused transforms that need it (e.g.
+    # monotonically_increasing_id) can access the task index.
     if block_transformer is not None:
+        TaskContext.set_current(TaskContext(task_idx=task_idx, op_name="fused_shuffle"))
         block = block_transformer(block)
 
     # Make sure we're handling Arrow blocks
@@ -795,6 +802,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                 send_empty_blocks=should_broadcast_schemas,
                 override_partition_id=override_partition_id,
                 random_partition_seed=random_partition_seed,
+                task_idx=cur_shuffle_task_idx,
             )
 
             if should_broadcast_schemas:

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -656,6 +656,18 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
             ),
         )
 
+        # Compute shuffle task CPU, accounting for aggregator actor overhead to
+        # avoid resource deadlock on small clusters where the shuffle task (1.0
+        # CPU) + aggregator actors together exceed available CPUs.
+        total_aggregator_cpus = num_aggregators * ray_remote_args["num_cpus"]
+        self._shuffle_block_num_cpus = min(
+            self._DEFAULT_SHUFFLE_BLOCK_NUM_CPUS,
+            max(
+                self._DEFAULT_AGGREGATORS_MIN_CPUS,
+                total_available_cluster_resources.cpu - total_aggregator_cpus,
+            ),
+        )
+
         # We track the running usage total because iterating
         # and summing over all shuffling tasks can be expensive
         # if the # of shuffling tasks is large
@@ -744,7 +756,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
             input_key_column_names = self._key_column_names[input_index]
             # Compose shuffling task resource bundle
             shuffle_task_resource_bundle = {
-                "num_cpus": self._DEFAULT_SHUFFLE_BLOCK_NUM_CPUS,
+                "num_cpus": self._shuffle_block_num_cpus,
                 "memory": self._estimate_shuffling_memory_req(
                     block_metadata,
                     target_max_block_size=(
@@ -1128,8 +1140,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
 
     def incremental_resource_usage(self) -> ExecutionResources:
         return ExecutionResources(
-            cpu=self._DEFAULT_SHUFFLE_BLOCK_NUM_CPUS,
-            # cpu=self._shuffle_block_ray_remote_args.get("num_cpus", 0),
+            cpu=self._shuffle_block_num_cpus,
             # TODO estimate (twice avg block size)
             object_store_memory=0,
             gpu=0,

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -571,6 +571,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         partition_size_hint: Optional[int] = None,
         input_block_transformer: Optional[BlockTransformer] = None,
         aggregator_ray_remote_args_override: Optional[Dict[str, Any]] = None,
+        shuffle_ray_remote_args_override: Optional[Dict[str, Any]] = None,
         shuffle_progress_bar_name: Optional[str] = None,
         finalize_progress_bar_name: Optional[str] = None,
         disallow_block_splitting: bool = False,
@@ -681,6 +682,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         self._shuffling_resource_usage = ExecutionResources.zero()
 
         self._input_block_transformer = input_block_transformer
+        self._shuffle_ray_remote_args_override = shuffle_ray_remote_args_override or {}
 
         self._next_shuffle_tasks_idx: int = 0
         # Shuffling tasks are mapped like following
@@ -771,6 +773,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                         or DEFAULT_TARGET_MAX_BLOCK_SIZE
                     ),
                 ),
+                **self._shuffle_ray_remote_args_override,
             }
 
             cur_shuffle_task_idx = self._next_shuffle_tasks_idx
@@ -1487,6 +1490,7 @@ class RandomShuffleOperator(HashShufflingOperatorBase, SubProgressBarMixin):
         seed: int,
         num_partitions: Optional[int] = None,
         aggregator_ray_remote_args_override: Optional[Dict[str, Any]] = None,
+        shuffle_ray_remote_args_override: Optional[Dict[str, Any]] = None,
         input_block_transformer: Optional[BlockTransformer] = None,
     ):
         self._seed = seed
@@ -1504,6 +1508,7 @@ class RandomShuffleOperator(HashShufflingOperatorBase, SubProgressBarMixin):
             num_input_seqs=1,
             num_partitions=num_partitions,
             aggregator_ray_remote_args_override=aggregator_ray_remote_args_override,
+            shuffle_ray_remote_args_override=shuffle_ray_remote_args_override,
             partition_aggregation_factory=_create_random_shuffle_aggregation,
             shuffle_progress_bar_name="Shuffle",
             input_block_transformer=input_block_transformer,

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -65,7 +65,14 @@ def _make_block_transformer(map_transformer):
     map_transformer.override_target_max_block_size(None)  # avoid double-shaping
 
     def block_transformer(block):
-        ctx = TaskContext(task_idx=0, op_name="fused_read")
+        # Use externally-set TaskContext if available (e.g. set by
+        # _shuffle_block with the correct task_idx), otherwise fall back
+        # to a default.  The context must be current on the thread so that
+        # expressions like monotonically_increasing_id() can read it.
+        ctx = TaskContext.get_current()
+        if ctx is None:
+            ctx = TaskContext(task_idx=0, op_name="fused_read")
+            TaskContext.set_current(ctx)
         output_iter = map_transformer.apply_transform([block], ctx)
         builder = None
         for out_block in output_iter:

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -296,6 +296,20 @@ class FuseOperators(Rule):
         ):
             return False
 
+        # Do not fuse MapOperator into RandomShuffleOperator when either
+        # operator has custom resources. Hash shuffle's aggregator actors may
+        # consume CPU on nodes where the fused shuffle task is pinned,
+        # causing a scheduling deadlock.
+        if isinstance(down_op, RandomShuffleOperator):
+            up_resources = getattr(up_logical_op, "ray_remote_args", {}).get(
+                "resources", {}
+            )
+            down_resources = getattr(down_logical_op, "ray_remote_args", {}).get(
+                "resources", {}
+            )
+            if up_resources or down_resources:
+                return False
+
         # Do not fuse if either op specifies a `ray_remote_args_fn`,
         # since it is not known whether the generated args will be compatible.
         if getattr(up_logical_op, "ray_remote_args_fn", None) or getattr(
@@ -730,12 +744,29 @@ class FuseOperators(Rule):
         input_op = input_deps[0]
 
         assert up_op.data_context is down_op.data_context
+
+        # Merge ray_remote_args from both operators so that the fused shuffle
+        # tasks carry the upstream operator's resource requirements (e.g.,
+        # custom resources for scheduling on specific nodes).
+        merged_ray_remote_args = {
+            **up_logical_op.ray_remote_args,
+            **down_logical_op.ray_remote_args,
+        }
+        # Filter out args that are handled separately by the shuffle operator
+        # (num_cpus and memory are computed internally).
+        shuffle_ray_remote_args = {
+            k: v
+            for k, v in merged_ray_remote_args.items()
+            if k not in ("num_cpus", "memory")
+        }
+
         op = RandomShuffleOperator(
             input_op,
             down_op.data_context,
             seed=down_op._seed,
             num_partitions=down_op._num_partitions,
             input_block_transformer=block_transformer,
+            shuffle_ray_remote_args_override=shuffle_ray_remote_args or None,
         )
         op._name = name
 
@@ -743,7 +774,8 @@ class FuseOperators(Rule):
         logical_op = RandomShuffle(
             up_logical_op,
             name=name,
-            ray_remote_args=up_logical_op.ray_remote_args,
+            seed=down_logical_op.seed,
+            ray_remote_args=merged_ray_remote_args,
         )
         self._op_map[op] = logical_op
         return op

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -17,6 +17,7 @@ from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )
 from ray.data.block import BlockAccessor
+from ray.data.context import ShuffleStrategy
 from ray.data.dataset import Dataset, MaterializedDataset
 from ray.data.datasource.util import (
     _validate_head_node_resources_for_local_scheduling,
@@ -490,31 +491,62 @@ def test_dataset_explain(ray_start_regular_shared, capsys):
     ds = ds.random_shuffle().map(lambda x: x)
     ds.explain()
     captured = capsys.readouterr()
-    assert captured.out.strip() == (
-        "-------- Logical Plan --------\n"
-        "MapRows[Map(<lambda>)]\n"
-        "+- RandomShuffle[RandomShuffle]\n"
-        "   +- Filter[Filter(<lambda>)]\n"
-        "      +- MapRows[Map(<lambda>)]\n"
-        "         +- Read[ReadRange]\n"
-        "\n-------- Logical Plan (Optimized) --------\n"
-        "MapRows[Map(<lambda>)]\n"
-        "+- RandomShuffle[RandomShuffle]\n"
-        "   +- Filter[Filter(<lambda>)]\n"
-        "      +- MapRows[Map(<lambda>)]\n"
-        "         +- Read[ReadRange]\n"
-        "\n-------- Physical Plan --------\n"
-        "TaskPoolMapOperator[Map(<lambda>)]\n"
-        "+- AllToAllOperator[RandomShuffle]\n"
-        "   +- TaskPoolMapOperator[Filter(<lambda>)]\n"
-        "      +- TaskPoolMapOperator[Map(<lambda>)]\n"
-        "         +- TaskPoolMapOperator[ReadRange]\n"
-        "            +- InputDataBuffer[Input]\n"
-        "\n-------- Physical Plan (Optimized) --------\n"
-        "TaskPoolMapOperator[Map(<lambda>)]\n"
-        "+- AllToAllOperator[ReadRange->Map(<lambda>)->Filter(<lambda>)->RandomShuffle]\n"
-        "   +- InputDataBuffer[Input]"
+    use_hash_shuffle = (
+        ray.data.DataContext.get_current().shuffle_strategy
+        == ShuffleStrategy.HASH_SHUFFLE
     )
+    if use_hash_shuffle:
+        assert captured.out.strip() == (
+            "-------- Logical Plan --------\n"
+            "MapRows[Map(<lambda>)]\n"
+            "+- RandomShuffle[RandomShuffle]\n"
+            "   +- Filter[Filter(<lambda>)]\n"
+            "      +- MapRows[Map(<lambda>)]\n"
+            "         +- Read[ReadRange]\n"
+            "\n-------- Logical Plan (Optimized) --------\n"
+            "MapRows[Map(<lambda>)]\n"
+            "+- RandomShuffle[RandomShuffle]\n"
+            "   +- Filter[Filter(<lambda>)]\n"
+            "      +- MapRows[Map(<lambda>)]\n"
+            "         +- Read[ReadRange]\n"
+            "\n-------- Physical Plan --------\n"
+            "TaskPoolMapOperator[Map(<lambda>)]\n"
+            "+- RandomShuffleOperator[RandomShuffle(num_partitions=10)]\n"
+            "   +- TaskPoolMapOperator[Filter(<lambda>)]\n"
+            "      +- TaskPoolMapOperator[Map(<lambda>)]\n"
+            "         +- TaskPoolMapOperator[ReadRange]\n"
+            "            +- InputDataBuffer[Input]\n"
+            "\n-------- Physical Plan (Optimized) --------\n"
+            "TaskPoolMapOperator[Map(<lambda>)]\n"
+            "+- RandomShuffleOperator[ReadRange->Map(<lambda>)->Filter(<lambda>)->RandomShuffle(num_partitions=10)]\n"
+            "   +- InputDataBuffer[Input]"
+        )
+    else:
+        assert captured.out.strip() == (
+            "-------- Logical Plan --------\n"
+            "MapRows[Map(<lambda>)]\n"
+            "+- RandomShuffle[RandomShuffle]\n"
+            "   +- Filter[Filter(<lambda>)]\n"
+            "      +- MapRows[Map(<lambda>)]\n"
+            "         +- Read[ReadRange]\n"
+            "\n-------- Logical Plan (Optimized) --------\n"
+            "MapRows[Map(<lambda>)]\n"
+            "+- RandomShuffle[RandomShuffle]\n"
+            "   +- Filter[Filter(<lambda>)]\n"
+            "      +- MapRows[Map(<lambda>)]\n"
+            "         +- Read[ReadRange]\n"
+            "\n-------- Physical Plan --------\n"
+            "TaskPoolMapOperator[Map(<lambda>)]\n"
+            "+- AllToAllOperator[RandomShuffle]\n"
+            "   +- TaskPoolMapOperator[Filter(<lambda>)]\n"
+            "      +- TaskPoolMapOperator[Map(<lambda>)]\n"
+            "         +- TaskPoolMapOperator[ReadRange]\n"
+            "            +- InputDataBuffer[Input]\n"
+            "\n-------- Physical Plan (Optimized) --------\n"
+            "TaskPoolMapOperator[Map(<lambda>)]\n"
+            "+- AllToAllOperator[ReadRange->Map(<lambda>)->Filter(<lambda>)->RandomShuffle]\n"
+            "   +- InputDataBuffer[Input]"
+        )
 
 
 def test_convert_types(ray_start_regular_shared):

--- a/python/ray/data/tests/test_shuffle_diagnostics.py
+++ b/python/ray/data/tests/test_shuffle_diagnostics.py
@@ -60,6 +60,9 @@ def test_sort_object_ref_warnings(
     propagate_logs,
     caplog,
 ):
+    if configure_shuffle_method == ShuffleStrategy.HASH_SHUFFLE:
+        pytest.skip("Not supported by hash-shuffle")
+
     # Test that we warn iff expected driver memory usage from
     # storing ObjectRefs is higher than the configured
     # threshold.
@@ -93,6 +96,9 @@ def test_sort_inlined_objects_warnings(
     propagate_logs,
     caplog,
 ):
+    if configure_shuffle_method == ShuffleStrategy.HASH_SHUFFLE:
+        pytest.skip("Not supported by hash-shuffle")
+
     # Test that we warn iff expected driver memory usage from
     # storing tiny Ray objects on driver heap is higher than
     # the configured threshold.

--- a/release/nightly_tests/dataset/sort_benchmark.py
+++ b/release/nightly_tests/dataset/sort_benchmark.py
@@ -11,7 +11,7 @@ import ray
 from ray._private.internal_api import memory_summary
 from ray.data._internal.util import _check_pyarrow_version, GiB
 from ray.data.block import Block, BlockMetadata
-from ray.data.context import DataContext
+from ray.data.context import DataContext, ShuffleStrategy
 from ray.data.datasource import Datasource, ReadTask
 
 
@@ -139,6 +139,7 @@ if __name__ == "__main__":
         )
 
         if args.shuffle:
+            DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
             ds = ds.random_shuffle()
         else:
             ds = ds.sort(key="c_0")


### PR DESCRIPTION
## Description
 ## Why

  `random_shuffle()` currently only uses pull-based or push-based shuffle, both of which
  hold O(N×M) or O(N×M/R) object refs on the driver. With 100k input blocks (and default
  100k output blocks), pull-based shuffle creates ~10B intermediate refs — completely
  unworkable at scale. The hash shuffle infrastructure (aggregator actors, worker-to-worker
  push) already exists for `repartition` and `groupby().aggregate()` with O(M) driver
  memory. This change routes `RandomShuffle` through hash shuffle when
  `ShuffleStrategy.HASH_SHUFFLE` is set.

  ## What

  **`transform_pyarrow.py`** — Refactored partitioning into shared helpers
  (`_short_circuit_partitioning`, `_split_by_partition_ids`) and added `random_partition()`
  which assigns rows to partitions via `np.random.RandomState(seed).randint()` instead of
  hashing key columns.

  **`hash_shuffle.py`** — Core shuffle changes:
  - `_shuffle_block`: Added `random_partition_seed` parameter as a third partitioning mode
    alongside key-column hashing and override partition ID.
  - `RandomShuffleAggregation`: New aggregation that concatenates shards, sorts to a
    canonical order (necessary because shards arrive from concurrent map tasks in
    non-deterministic order), then applies a seeded random permutation.
  - `_get_partition_mode` hook on `HashShufflingOperatorBase`: Lets subclasses control
    partitioning strategy without duplicating `_do_add_input_inner`. Default preserves
    existing round-robin / hash behavior.
  - `_on_finalized_bundle_ready` hook: Lets subclasses control output ordering. Default
    appends to output queue immediately.
  - `RandomShuffleOperator`: Subclass that uses per-task seeds
    (`base_seed + task_index`) for deterministic random partitioning, and buffers
    finalized outputs to flush in partition-ID order for deterministic output.

  **`plan_all_to_all_op.py`** — Routes `RandomShuffle` to `RandomShuffleOperator` when
  `HASH_SHUFFLE` strategy is active. Seeds are pinned via `time.time_ns() % INT32_MAX`
  when not user-specified (matching existing pull-based pattern for retry determinism).

  ## Determinism

  Seeded `random_shuffle(seed=N)` produces identical output across runs:
  1. Per-task seeds (`seed + task_idx`) ensure the same rows land in the same partitions.
  2. Canonical sort before permutation makes output independent of shard arrival order.
  3. Buffered output flush in partition-ID order eliminates finalization ordering variance.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
