### PR TITLE
perf: use deque for BFS queues and FIFO buffers across core modules

### DIFF
--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -5,7 +5,7 @@ import time
 import traceback
 import uuid
 import weakref
-from collections import defaultdict
+from collections import defaultdict, deque
 from contextlib import nullcontext
 from dataclasses import asdict, dataclass
 from typing import (
@@ -1576,11 +1576,11 @@ class CompiledDAG:
             assert self._dag_output_fetcher is not None
             return
 
-        frontier = [self.input_task_idx]
+        frontier = deque([self.input_task_idx])
         visited = set()
         # Create output buffers. This loop does a breadth-first search through the DAG.
         while frontier:
-            cur_idx = frontier.pop(0)
+            cur_idx = frontier.popleft()
             if cur_idx in visited:
                 continue
             visited.add(cur_idx)

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import uuid
+from collections import deque
 from itertools import chain
 from typing import (
     Any,
@@ -529,11 +530,11 @@ class DAGNode(DAGNodeBase):
         the `self` node, and apply the given function to each node.
         """
         visited = set()
-        queue = [self]
+        queue = deque([self])
         cgraph_output_node: Optional[DAGNode] = None
 
         while queue:
-            node = queue.pop(0)
+            node = queue.popleft()
             if node._args_contain_nested_dag_node:
                 self._raise_nested_dag_node_error(node._bound_args)
 

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -1,3 +1,4 @@
+from collections import deque
 from typing import TYPE_CHECKING, Any, Callable, List, TypeVar
 
 import ray
@@ -58,7 +59,7 @@ class ActorPool:
         self._next_return_index = 0
 
         # next work depending when actors free
-        self._pending_submits = []
+        self._pending_submits = deque()
 
     def map(self, fn: Callable[["ray.actor.ActorHandle", V], Any], values: List[V]):
         """Apply the given function in parallel over the actors and values.
@@ -372,7 +373,7 @@ class ActorPool:
     def _return_actor(self, actor):
         self._idle_actors.append(actor)
         if self._pending_submits:
-            self.submit(*self._pending_submits.pop(0))
+            self.submit(*self._pending_submits.popleft())
 
     def has_free(self):
         """Returns whether there are any idle actors available.


### PR DESCRIPTION
## Problem

Four files use `.pop(0)` for FIFO queue processing — BFS traversals, actor pool scheduling, and log file monitoring. Each `.pop(0)` on a Python list is **O(n)** because it shifts all remaining elements.

## Solution

Switch to `collections.deque` with `.popleft()` for **O(1)** front removal.

## Changes

| File | Pattern |
|------|---------|
| `python/ray/dag/dag_node.py` | BFS graph traversal in `traverse_and_apply()` |
| `python/ray/dag/compiled_dag_node.py` | BFS frontier traversal |
| `python/ray/util/actor_pool.py` | Pending submits FIFO queue in `ActorPool` |
| `python/ray/_private/log_monitor.py` | Open/closed file info FIFO queues in `LogMonitor` |

All existing `.append()` and `len()` calls work identically on deque.