### PR TITLE
[Data] Get correct logical resource usage

### DIFF
--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1067,10 +1067,14 @@ class _ActorPool(AutoscalingActorPool):
 
         return None
 
-    def _create_actor(self) -> Tuple[ray.actor.ActorHandle, ObjectRef, ExecutionResources]:
+    def _create_actor(
+        self,
+    ) -> Tuple[ray.actor.ActorHandle, ObjectRef, ExecutionResources]:
         logical_actor_id = str(uuid.uuid4())
         labels = {self.get_logical_id_label_key(): logical_actor_id}
-        actor, ready_ref, resource_usage = self._create_actor_fn(labels, logical_actor_id)
+        actor, ready_ref, resource_usage = self._create_actor_fn(
+            labels, logical_actor_id
+        )
         self._actor_to_logical_id[actor] = logical_actor_id
         return actor, ready_ref, resource_usage
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -552,6 +552,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         gen: ObjectRefGenerator,
         inputs: RefBundle,
         task_done_callback: Optional[Callable[[], None]] = None,
+        task_resource_bundle: Optional[ExecutionResources] = None,
     ):
         """Submit a new data-handling task."""
         # TODO(hchen):
@@ -610,6 +611,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
             gen,
             lambda output: _output_ready_callback(task_index, output),
             functools.partial(_task_done_callback, task_index),
+            task_resource_bundle=task_resource_bundle,
         )
         self._metrics.on_task_submitted(
             task_index, inputs, task_id=data_task.get_task_id()

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -120,11 +120,11 @@ class TestActorPool(unittest.TestCase):
         self,
         labels: Dict[str, Any],
         logical_actor_id: str = "Actor1",
-    ) -> Tuple[ActorHandle, ObjectRef[Any]]:
+    ) -> Tuple[ActorHandle, ObjectRef[Any], ExecutionResources]:
         actor = PoolWorker.options(_labels=labels).remote(self._actor_node_id)
         ready_ref = actor.get_location.remote()
         self._last_created_actor_and_ready_ref = actor, ready_ref
-        return actor, ready_ref
+        return actor, ready_ref, ExecutionResources(cpu=1)
 
     def _create_actor_pool(
         self,
@@ -807,9 +807,9 @@ def test_actor_pool_scale_logs_include_map_worker_cls_name(
     def create_actor_fn(
         labels: Dict[str, Any],
         logical_actor_id: str = "Actor1",
-    ) -> Tuple[ActorHandle, ObjectRef[Any]]:
+    ) -> Tuple[ActorHandle, ObjectRef[Any], ExecutionResources]:
         actor = PoolWorker.options(_labels=labels).remote("node1")
-        return actor, actor.get_location.remote()
+        return actor, actor.get_location.remote(), ExecutionResources(cpu=1)
 
     pool = _ActorPool(
         create_actor_fn,

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -240,7 +240,7 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
 
 
 def test_task_pool_resource_reporting_with_dynamic_remote_args(
-    ray_start_10_cpus_shared
+    ray_start_10_cpus_shared,
 ):
     """Test that current_logical_usage reflects dynamic resources from ray_remote_args_fn,
     not just the statically defined ray_remote_args."""
@@ -448,7 +448,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
 
 
 def test_actor_pool_resource_reporting_with_dynamic_remote_args(
-    ray_start_10_cpus_shared
+    ray_start_10_cpus_shared,
 ):
     """Test that current_logical_usage reflects dynamic resources from ray_remote_args_fn,
     not just the statically defined ray_remote_args."""


### PR DESCRIPTION
## Description

`TaskPoolMapOperator` and `ActorPoolMapOperator` report logical resource usage based on statically-defined `ray_remote_args`. If `ray_remote_args_fn` is defined, then the operator can launch tasks with more logical resources than the statically defined `ray_remote_args`. This leads to resource manager undercounting logical resource usage. We should record the actual resources we used.

In this PR, we did the following changes:

`actor_pool_map_operator.py`:

- Get the resources after considering `_ray_remote_args_fn`
- Store `resource_usage` in `_ActorState` (value of `_running_actors`) for tracking the actual resource usage for a running actor
- Store `ExecutionResources` in `_pending_actors` to record the resources for pending actors

`task_pool_map_operator.py`:

- Get the resources after considering `_ray_remote_args_fn`
- Add `task_resource_bundle` in `_submit_data_task` to pass down to `DataOpTask`'s `task_resource_bundle` args
- Use `get_requested_resource_bundle()` from `DataOpTask` to retrieve the resource usage for the task

`test_executor_resource_management.py`:

- Add test to ensure `current_logical_usage` reflects dynamic resources from `ray_remote_args_fn` for both `TaskPoolMapOperator` and `ActorPoolMapOperator`

## Related issues

Closes #61395

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
