### PR TITLE
[Data] Fix operator name in metadata timeout warning and improve mess…

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -996,6 +996,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                 task_resource_bundle=(
                     ExecutionResources.from_resource_dict(finalize_task_resource_bundle)
                 ),
+                operator_name=self.name,
             )
             self._finalizing_tasks[partition_id] = data_task
 

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -610,6 +610,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
             gen,
             lambda output: _output_ready_callback(task_index, output),
             functools.partial(_task_done_callback, task_index),
+            operator_name=self.name,
         )
         self._metrics.on_task_submitted(
             task_index, inputs, task_id=data_task.get_task_id()


### PR DESCRIPTION
[Data] Fix operator name in metadata timeout warning and improve message clarity

Pass the actual operator name to DataOpTask so the GetTimeoutError warning identifies the specific pipeline stage instead of always showing 'DataOpTask'. Also rewrites the message to include the timeout duration and actionable causes.

Fixes #61334

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
