### PR TITLE
[Data] Add local aggregation fast-path for small datasets (#61016)

### DIFF
--- a/python/ray/data/_internal/planner/aggregate.py
+++ b/python/ray/data/_internal/planner/aggregate.py
@@ -1,4 +1,7 @@
+import logging
 from typing import List, Optional, Union
+
+import ray
 
 from ray.data._internal.execution.interfaces import (
     AllToAllTransformFn,
@@ -21,6 +24,61 @@ from ray.data._internal.planner.exchange.sort_task_spec import SortKey, SortTask
 from ray.data._internal.util import unify_ref_bundles_schema
 from ray.data.aggregate import AggregateFn
 from ray.data.context import DataContext, ShuffleStrategy
+
+logger = logging.getLogger(__name__)
+
+
+def _local_aggregate(
+    refs: List[RefBundle],
+    sort_key: SortKey,
+    aggs: List[AggregateFn],
+    batch_format: str,
+) -> AllToAllTransformFnResult:
+    """Execute aggregation locally on the driver for small datasets.
+
+    This avoids the overhead of spawning a distributed actor pool when the
+    total input data size is below the configured threshold.
+    """
+    all_block_refs = [ref for bundle in refs for ref in bundle.block_refs]
+    blocks = ray.get(all_block_refs)
+
+    # Partially aggregate each block (map step): sort by key, then aggregate
+    # within a single partition (boundaries=[]).
+    partial_agg_blocks = []
+    for idx, block in enumerate(blocks):
+        map_result = SortAggregateTaskSpec.map(
+            idx=idx,
+            block=block,
+            output_num_blocks=1,
+            boundaries=[],
+            sort_key=sort_key,
+            aggs=aggs,
+        )
+        # map() returns [partial_agg_block_0, ..., BlockMetadataWithSchema]
+        partial_agg_blocks.extend(map_result[:-1])
+
+    # Filter out any empty partial blocks before combining.
+    from ray.data.block import BlockAccessor
+
+    partial_agg_blocks = [
+        b for b in partial_agg_blocks if BlockAccessor.for_block(b).num_rows() > 0
+    ]
+
+    if not partial_agg_blocks:
+        return ([], {})
+
+    # Combine and finalize all partial results (reduce step).
+    result_block, meta_with_schema = SortAggregateTaskSpec.reduce(
+        sort_key, aggs, batch_format, *partial_agg_blocks
+    )
+
+    result_ref = ray.put(result_block)
+    result_bundle = RefBundle(
+        [(result_ref, meta_with_schema.metadata)],
+        owns_blocks=True,
+        schema=meta_with_schema.schema,
+    )
+    return ([result_bundle], {})
 
 
 def generate_aggregate_fn(
@@ -57,9 +115,21 @@ def generate_aggregate_fn(
         for agg_fn in aggs:
             agg_fn._validate(unified_schema)
 
-        num_mappers = len(blocks)
-
         sort_key = SortKey(key)
+
+        # Fast-path: for small datasets, run aggregation locally on the driver
+        # to avoid actor pool startup and distributed coordination overhead.
+        threshold = data_context.small_dataset_agg_threshold_bytes
+        if threshold > 0:
+            total_bytes = sum(bundle.size_bytes() for bundle in refs)
+            if total_bytes <= threshold:
+                logger.debug(
+                    f"Using local aggregation fast-path for small dataset "
+                    f"({total_bytes} bytes <= threshold {threshold} bytes)."
+                )
+                return _local_aggregate(refs, sort_key, aggs, batch_format)
+
+        num_mappers = len(blocks)
 
         if key is None:
             num_outputs = 1

--- a/python/ray/data/_internal/planner/aggregate.py
+++ b/python/ray/data/_internal/planner/aggregate.py
@@ -39,8 +39,7 @@ def _local_aggregate(
     This avoids the overhead of spawning a distributed actor pool when the
     total input data size is below the configured threshold.
     """
-    all_block_refs = [ref for bundle in refs for ref in bundle.block_refs]
-    blocks = ray.get(all_block_refs)
+    blocks = ray.get(ref for bundle in refs for ref in bundle.block_refs)
 
     # Partially aggregate each block (map step): sort by key, then aggregate
     # within a single partition (boundaries=[]).

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -198,6 +198,13 @@ DEFAULT_ICEBERG_CATALOG_RETRIED_ERRORS = (
 
 DEFAULT_WARN_ON_DRIVER_MEMORY_USAGE_BYTES = 2 * 1024 * 1024 * 1024
 
+# If the total input size of a groupby/aggregate is below this threshold (bytes),
+# Ray Data will execute the aggregation locally on the driver instead of spawning
+# a distributed actor pool. This avoids significant overhead for small datasets.
+DEFAULT_SMALL_DATASET_AGG_THRESHOLD_BYTES = env_integer(
+    "RAY_DATA_SMALL_DATASET_AGG_THRESHOLD_BYTES", 10 * 1024 * 1024
+)
+
 DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS = False
 
 DEFAULT_ACTOR_INIT_RETRY_ON_ERRORS = False
@@ -552,6 +559,13 @@ class DataContext:
         enforce_schemas: Whether to enforce schema consistency across dataset operations.
         pandas_block_ignore_metadata: Whether to ignore pandas metadata when converting
             between Arrow and pandas formats for better type inference.
+        small_dataset_agg_threshold_bytes: If the total input size of a
+            groupby/aggregate is below this threshold (bytes), the aggregation is
+            executed locally on the driver rather than through a distributed actor
+            pool. This avoids startup and coordination overhead for small datasets.
+            Set to 0 to disable the fast-path and always use distributed aggregation.
+            Defaults to 10 MiB. Configurable via the environment variable
+            ``RAY_DATA_SMALL_DATASET_AGG_THRESHOLD_BYTES``.
     """
 
     # `None` means the block size is infinite.
@@ -697,6 +711,8 @@ class DataContext:
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS
 
     pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
+
+    small_dataset_agg_threshold_bytes: int = DEFAULT_SMALL_DATASET_AGG_THRESHOLD_BYTES
 
     _checkpoint_config: Optional[CheckpointConfig] = None
 


### PR DESCRIPTION
For small datasets (below a configurable threshold, default 10 MiB), groupby/aggregate now executes entirely on the driver using existing map/reduce primitives instead of spawning a distributed actor pool. This eliminates actor startup and coordination overhead that caused ~350x slowdown vs pandas on 1M-row single-node workloads.

The fast-path is controlled by:
- DataContext.small_dataset_agg_threshold_bytes (default: 10 MiB)
- Env var: RAY_DATA_SMALL_DATASET_AGG_THRESHOLD_BYTES

Set threshold to 0 to always use distributed aggregation.

Fixes #61016

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
