### PR TITLE
[Data] Add include_row_hash to read_parquet

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import math
 import os
@@ -358,6 +359,7 @@ class ParquetDatasource(Datasource):
         partitioning: Optional[Partitioning] = Partitioning("hive"),
         shuffle: "FileShuffleConfig" | Literal["files"] | None = None,
         include_paths: bool = False,
+        include_row_hash: bool = False,
         file_extensions: Optional[List[str]] = None,
     ):
         super().__init__()
@@ -500,6 +502,7 @@ class ParquetDatasource(Datasource):
             _block_udf=_block_udf,
             shuffle=shuffle,
             include_paths=include_paths,
+            include_row_hash=include_row_hash,
         )
 
     def _init_state(
@@ -522,6 +525,7 @@ class ParquetDatasource(Datasource):
         _block_udf: Optional[Callable[[Block], Block]],
         shuffle: Union["FileShuffleConfig", Literal["files"], None],
         include_paths: bool,
+        include_row_hash: bool = False,
     ):
         """Shared initialization for all instance state and sampling estimates.
 
@@ -551,6 +555,7 @@ class ParquetDatasource(Datasource):
         self._partition_schema = partition_schema
         self._file_metadata_shuffler = None
         self._include_paths = include_paths
+        self._include_row_hash = include_row_hash
         self._partitioning = partitioning
         _validate_shuffle_arg(shuffle)
         self._shuffle = shuffle
@@ -609,6 +614,7 @@ class ParquetDatasource(Datasource):
         schema: Optional["pyarrow.lib.Schema"] = None,
         shuffle: "FileShuffleConfig" | Literal["files"] | None = None,
         include_paths: bool = False,
+        include_row_hash: bool = False,
     ) -> "ParquetDatasource":
         """Create a ParquetDatasource from a pre-built PyArrow dataset.
 
@@ -676,6 +682,7 @@ class ParquetDatasource(Datasource):
             _block_udf=_block_udf,
             shuffle=shuffle,
             include_paths=include_paths,
+            include_row_hash=include_row_hash,
         )
 
     @property
@@ -753,6 +760,7 @@ class ParquetDatasource(Datasource):
             projected_columns=self.get_current_projection(),
             _block_udf=self._block_udf,
             include_paths=self._include_paths,
+            include_row_hash=self._include_row_hash,
         )
 
         read_tasks = []
@@ -787,6 +795,7 @@ class ParquetDatasource(Datasource):
                 partition_columns,
                 read_schema,
                 include_paths,
+                include_row_hash,
                 partitioning,
             ) = (
                 self._block_udf,
@@ -796,6 +805,7 @@ class ParquetDatasource(Datasource):
                 self._get_partition_columns(),
                 self._read_schema,
                 self._include_paths,
+                self._include_row_hash,
                 self._partitioning,
             )
 
@@ -810,6 +820,7 @@ class ParquetDatasource(Datasource):
                         read_schema,
                         f,
                         include_paths,
+                        include_row_hash,
                         partitioning,
                         filter_expr,
                         filter_columns,
@@ -854,6 +865,8 @@ class ParquetDatasource(Datasource):
             #       via _derive_schema, so we only need to add it when there is a projection.
             if self._include_paths and "path" not in result:
                 result = result + ["path"]
+            if self._include_row_hash and "row_hash" not in result:
+                result = result + ["row_hash"]
 
         return result
 
@@ -913,11 +926,13 @@ class ParquetDatasource(Datasource):
 
         # Get partition columns and filter them out from the projection
         partition_cols = self._partition_columns
-        # Also filter out "path" column if include_paths is True, as it's a
-        # synthetic column added after reading from the file
+        # Also filter out synthetic columns (path, row_hash) as they are
+        # added after reading from the file
         cols_to_filter = set(partition_cols)
         if self._include_paths:
             cols_to_filter.add("path")
+        if self._include_row_hash:
+            cols_to_filter.add("row_hash")
         data_cols = [
             col for col in self._projection_map.keys() if col not in cols_to_filter
         ]
@@ -995,6 +1010,7 @@ class ParquetDatasource(Datasource):
         projected_columns: Optional[List[str]],
         _block_udf,
         include_paths: bool = False,
+        include_row_hash: bool = False,
     ) -> "pyarrow.Schema":
         """Derives target schema for read operation"""
 
@@ -1027,6 +1043,15 @@ class ParquetDatasource(Datasource):
         # Add path column if include_paths is True and path column is not already present
         if include_paths and target_schema.get_field_index("path") == -1:
             target_schema = target_schema.append(pa.field("path", pa.string()))
+
+        if include_row_hash:
+            idx = target_schema.get_field_index("row_hash")
+            if idx == -1:
+                target_schema = target_schema.append(pa.field("row_hash", pa.uint64()))
+            elif target_schema.field(idx).type != pa.uint64():
+                target_schema = target_schema.set(
+                    idx, pa.field("row_hash", pa.uint64())
+                )
 
         # Project schema if necessary
         if projected_columns is not None:
@@ -1064,6 +1089,7 @@ def read_fragments(
     schema: Optional[Union[type, "pyarrow.lib.Schema"]],
     fragments: List[_ParquetFragment],
     include_paths: bool,
+    include_row_hash: bool,
     partitioning: Partitioning,
     filter_expr: Optional["pyarrow.dataset.Expression"] = None,
     filter_columns: Optional[List[str]] = None,
@@ -1089,6 +1115,7 @@ def read_fragments(
                 partition_columns=partition_columns,
                 partitioning=partitioning,
                 include_path=include_paths,
+                include_row_hash=include_row_hash,
                 filter_expr=filter_expr,
                 filter_columns=filter_columns,
                 to_batches_kwargs=to_batches_kwargs,
@@ -1452,6 +1479,7 @@ def _read_batches_from(
     filter_expr: Optional["pyarrow.dataset.Expression"] = None,
     filter_columns: Optional[List[str]] = None,
     include_path: bool = False,
+    include_row_hash: bool = False,
     use_threads: bool = False,
     to_batches_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Iterable["pyarrow.Table"]:
@@ -1492,8 +1520,11 @@ def _read_batches_from(
         fragment, partition_columns, partitioning
     )
 
+    row_offset = 0
+
     def _generate_tables() -> "pa.Table":
         """Inner generator that yields tables without renaming."""
+        nonlocal row_offset
 
         def _postprocess_table(table):
             if partition_col_values:
@@ -1535,7 +1566,16 @@ def _read_batches_from(
                 use_threads=use_threads,
                 to_batches_kwargs=to_batches_kwargs,
             ):
-                yield _postprocess_table(pa.Table.from_batches([batch]))
+                table = _postprocess_table(pa.Table.from_batches([batch]))
+                if include_row_hash:
+                    hashes = _compute_row_hashes(
+                        fragment.path, row_offset, table.num_rows
+                    )
+                    table = ArrowBlockAccessor.for_block(table).fill_column(
+                        "row_hash", pa.array(hashes, type=pa.uint64())
+                    )
+                    row_offset += table.num_rows
+                yield table
 
         except pa.lib.ArrowInvalid as e:
             error_message = str(e)
@@ -1555,6 +1595,38 @@ def _read_batches_from(
     yield from _DatasourceProjectionPushdownMixin._apply_rename_to_tables(
         _generate_tables(), data_columns_rename_map
     )
+
+
+def _compute_row_hashes(file_path: str, start_row: int, num_rows: int) -> np.ndarray:
+    """Compute deterministic uint64 hashes from file path and output row position.
+
+    ``start_row`` is the position within the output stream (post-filter), not
+    the physical file offset.  This means hashes are reproducible for a given
+    pipeline configuration (same file + same filter) but will differ across
+    reads with different filters.
+
+    Hashes the file path with MD5 to obtain a 64-bit seed, adds the row indices,
+    then applies the splitmix64 finalizer (a bijective 64-bit mixing function) to
+    produce well-distributed, reproducible hashes.  Fully vectorized via numpy.
+    """
+    path_seed = np.uint64(
+        int.from_bytes(
+            hashlib.md5(file_path.encode("utf-8")).digest()[:8], byteorder="little"
+        )
+    )
+    keys = path_seed + np.arange(start_row, start_row + num_rows, dtype=np.uint64)
+
+    # splitmix64 finalizer – a bijective 64-bit mixing function from
+    # Steele, Lea & Flood, "Fast Splittable Pseudorandom Number Generators",
+    # OOPSLA 2014.  Also used in Java's SplittableRandom.
+    # Reference: https://xorshift.di.unimi.it/splitmix64.c
+    keys ^= keys >> np.uint64(30)
+    keys *= np.uint64(0xBF58476D1CE4E5B9)
+    keys ^= keys >> np.uint64(27)
+    keys *= np.uint64(0x94D049BB133111EB)
+    keys ^= keys >> np.uint64(31)
+
+    return keys
 
 
 def _parse_partition_column_values(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -960,6 +960,7 @@ def read_parquet(
     partitioning: Optional[Partitioning] = Partitioning("hive"),
     shuffle: Optional[Union[Literal["files"], FileShuffleConfig]] = None,
     include_paths: bool = False,
+    include_row_hash: bool = False,
     file_extensions: Optional[List[str]] = ParquetDatasource._FILE_EXTENSIONS,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
@@ -1072,6 +1073,12 @@ def read_parquet(
             shuffle the input files. Defaults to not shuffle with ``None``.
         include_paths: If ``True``, include the path to each file. File paths are
             stored in the ``'path'`` column.
+        include_row_hash: If ``True``, include a deterministic hash for each row.
+            The hash is a uint64 computed from the source file path and the row's
+            output position, making it reproducible across repeated reads of the
+            same data with the same pipeline configuration. Stored in the
+            ``'row_hash'`` column. If a column named ``'row_hash'`` already
+            exists in the file, it will be overwritten.
         file_extensions: A list of file extensions to filter files by.
         concurrency: The maximum number of Ray tasks to run concurrently. Set this
             to control number of tasks to run concurrently. This doesn't change the
@@ -1121,6 +1128,7 @@ def read_parquet(
         partitioning=partitioning,
         shuffle=shuffle,
         include_paths=include_paths,
+        include_row_hash=include_row_hash,
         file_extensions=file_extensions,
     )
     return read_datasource(

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -141,6 +141,146 @@ def test_include_paths_with_column_projection(
         assert row["path"] == path
 
 
+def test_include_row_hash(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"animals": ["cat", "dog", "bird"]})
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, include_row_hash=True)
+
+    schema_names = ds.schema().names
+    assert "row_hash" in schema_names
+
+    rows = ds.take_all()
+    hashes = [row["row_hash"] for row in rows]
+    assert len(hashes) == 3
+    assert len(set(hashes)) == 3, "Hashes must be unique"
+    assert all(isinstance(h, int) for h in hashes)
+
+
+def test_include_row_hash_reproducible(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"val": list(range(10))})
+    pq.write_table(table, path)
+
+    hashes1 = [
+        row["row_hash"]
+        for row in ray.data.read_parquet(path, include_row_hash=True).take_all()
+    ]
+    hashes2 = [
+        row["row_hash"]
+        for row in ray.data.read_parquet(path, include_row_hash=True).take_all()
+    ]
+    assert hashes1 == hashes2, "Hashes must be reproducible across reads"
+
+
+def test_include_row_hash_unique_across_files(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    for i in range(3):
+        path = os.path.join(tmp_path, f"file{i}.parquet")
+        table = pa.Table.from_pydict({"val": [i * 10, i * 10 + 1]})
+        pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(str(tmp_path), include_row_hash=True)
+    rows = ds.take_all()
+    hashes = [row["row_hash"] for row in rows]
+    assert len(hashes) == 6
+    assert len(set(hashes)) == 6, "Hashes must be unique across files"
+
+
+def test_include_row_hash_same_data_different_files(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    """Files with identical content must produce different hashes because
+    the hash is derived from the file path, not the data."""
+    table = pa.Table.from_pydict({"val": [1, 2, 3]})
+    for name in ("a.parquet", "b.parquet", "c.parquet"):
+        pq.write_table(table, os.path.join(tmp_path, name))
+
+    ds = ray.data.read_parquet(str(tmp_path), include_row_hash=True)
+    rows = ds.take_all()
+    hashes = [row["row_hash"] for row in rows]
+    assert len(hashes) == 9
+    assert (
+        len(set(hashes)) == 9
+    ), "Identical data in different files must produce distinct hashes"
+
+
+def test_include_row_hash_with_column_projection(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"a": [1, 2], "b": [3, 4]})
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, columns=["a"], include_row_hash=True)
+    schema_names = ds.schema().names
+    assert "a" in schema_names
+    assert "b" not in schema_names
+    assert "row_hash" in schema_names
+
+    rows = ds.take_all()
+    assert len(rows) == 2
+    assert all("row_hash" in row and "a" in row and "b" not in row for row in rows)
+
+
+def test_include_row_hash_with_include_paths(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"val": [1, 2]})
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, include_paths=True, include_row_hash=True)
+    schema_names = ds.schema().names
+    assert "path" in schema_names
+    assert "row_hash" in schema_names
+
+    df = ds.to_pandas()
+    assert "path" in df.columns
+    assert len(set(df["row_hash"])) == 2
+
+
+def test_include_row_hash_existing_column(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    """When the file already has a 'row_hash' column, it should be
+    overwritten by the generated one without crashing."""
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"val": [1, 2, 3], "row_hash": [100, 200, 300]})
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, include_row_hash=True)
+    rows = ds.take_all()
+    hashes = [row["row_hash"] for row in rows]
+    assert len(hashes) == 3
+    assert len(set(hashes)) == 3, "Hashes must be unique"
+    assert all(
+        h not in (100, 200, 300) for h in hashes
+    ), "Generated hashes must overwrite the original column values"
+
+
+def test_include_row_hash_existing_column_with_projection(
+    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+):
+    """Column projection + pre-existing row_hash column should work."""
+    path = os.path.join(tmp_path, "test.parquet")
+    table = pa.Table.from_pydict({"val": [1, 2], "row_hash": [10, 20]})
+    pq.write_table(table, path)
+
+    ds = ray.data.read_parquet(path, columns=["val"], include_row_hash=True)
+    schema_names = ds.schema().names
+    assert "val" in schema_names
+    assert "row_hash" in schema_names
+    rows = ds.take_all()
+    assert all(row["row_hash"] not in (10, 20) for row in rows)
+
+
 @pytest.mark.parametrize(
     "fs,data_path",
     [


### PR DESCRIPTION
## Description

This PR adds an `include_row_hash` option to `read_parquet`, which adds a new column. The row hash is computed from the file path, each row's **index after filtering**, and a mixing step (so values are spread across the uint64 range rather than clustering in a few buckets).

Row hashes are unique across the rows you actually read for a given read configuration (same files, same filter, same ordering). They are reproducible under that same configuration, which supports checkpointing for Ray Data and Ray Train.

The column type is unsigned 64-bit integer (`uint64`).

## Row hash semantics (filters and checkpointing)

Each `row_hash` is deterministic for a given read: it uses the file path and the row's **position after filtering** (0-based—the first row that survives the filter is 0, the next is 1, and so on). It is **not** the row's index in the raw Parquet file before filtering.

If you change the filter, which columns you read, or which files you read, which rows appear—and their positions after filtering—can change, so hashes can change too.

For **checkpointing and resume**, we assume you keep the **same read setup**, including the **same filter**, across runs. Rows that were filtered out are not part of the pipeline anyway, so identifying rows **after filtering** is enough; we do not rely on pre-filter physical row positions for that use case.

## Related issues

Closes #61410

## Additional information

How it works:

1. Path seed: For each Parquet file, MD5-hash its file path and take the first 8 bytes as a uint64 seed. Identical data in different files still gets different hashes because paths differ.

2. Row keys: After filtering, add each row's **0-based index in the filtered output** for that file (tracked across batches) to the path seed: `key = path_seed + row_index`.

3. Mix: Apply the splitmix64 finalizer (a bijective 64-bit integer mixing function) to scatter nearby keys across the full uint64 range:

```
  keys ^= keys >> 30
  keys *= 0xBF58476D1CE4E5B9
  keys ^= keys >> 27
  keys *= 0x94D049BB133111EB
  keys ^= keys >> 31
```

All operations are vectorized with NumPy—no Python loops.

Properties:

- **Reproducible:** Same file path + same filter + same position after filtering → same hash.
- **Unique:** Different files get different seeds (via MD5 of path); different rows in the filtered output get different indices. The splitmix64 step is bijective, so distinct inputs do not collide.
- **Fast:** One MD5 call per file, then pure NumPy vectorized arithmetic per batch.
