### PR TITLE
[train] Delete ray get safe

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/accelerators.py
+++ b/python/ray/train/v2/_internal/callbacks/accelerators.py
@@ -3,6 +3,7 @@ import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Dict, List
 
+import ray
 import ray._private.ray_constants as ray_constants
 from ray._private.accelerators.nvidia_gpu import CUDA_VISIBLE_DEVICES_ENV_VAR
 from ray._private.ray_constants import env_bool
@@ -10,7 +11,6 @@ from ray.train import BackendConfig
 from ray.train.constants import ENABLE_SHARE_CUDA_VISIBLE_DEVICES_ENV
 from ray.train.v2._internal.execution.callback import WorkerGroupCallback
 from ray.train.v2._internal.execution.worker_group import ActorMetadata
-from ray.train.v2._internal.util import ray_get_safe
 from ray.train.v2.api.config import ScalingConfig
 
 if TYPE_CHECKING:
@@ -117,7 +117,7 @@ def _share_accelerator_ids(
                 set_accelerator_ids, accelerator_ids=visible_accelerator_ids
             )
         )
-    ray_get_safe(futures)
+    ray.get(futures)
 
 
 def _get_visible_accelerator_ids_per_worker(

--- a/python/ray/train/v2/_internal/util.py
+++ b/python/ray/train/v2/_internal/util.py
@@ -21,7 +21,6 @@ from typing import (
 import ray
 from ray.train._internal.utils import count_required_parameters
 from ray.train.v2._internal.exceptions import UserExceptionWithTraceback
-from ray.types import ObjectRef
 
 logger = logging.getLogger(__name__)
 
@@ -121,44 +120,6 @@ def _copy_doc(copy_func):
         return func
 
     return wrapped
-
-
-def ray_get_safe(
-    object_refs: Union[ObjectRef, List[ObjectRef]],
-) -> Union[Any, List[Any]]:
-    """This is a safe version of `ray.get` that raises an exception immediately
-    if an input task dies, while the others are still running.
-
-    TODO(ml-team, core-team): This is NOT a long-term solution,
-    and we should not maintain this function indefinitely.
-    This is a mitigation for a Ray Core bug, and should be removed when
-    that is fixed.
-    See here: https://github.com/ray-project/ray/issues/47204
-
-    Args:
-        object_refs: A single or list of object refs to wait on.
-
-    Returns:
-        task_outputs: The outputs of the tasks.
-
-    Raises:
-        `RayTaskError`/`RayActorError`: if any of the tasks encounter a runtime error
-            or fail due to actor/task death (ex: node failure).
-    """
-    is_list = isinstance(object_refs, list)
-    object_refs = object_refs if is_list else [object_refs]
-
-    unready = object_refs
-    task_to_output = {}
-    while unready:
-        ready, unready = ray.wait(unready, num_returns=1)
-        if ready:
-            for task, task_output in zip(ready, ray.get(ready)):
-                task_to_output[task] = task_output
-
-    assert len(task_to_output) == len(object_refs)
-    ordered_outputs = [task_to_output[task] for task in object_refs]
-    return ordered_outputs if is_list else ordered_outputs[0]
 
 
 @contextlib.contextmanager

--- a/python/ray/train/v2/tests/test_util.py
+++ b/python/ray/train/v2/tests/test_util.py
@@ -1,54 +1,7 @@
 import pytest
 
-import ray
 from ray.train.utils import _in_ray_train_worker
-from ray.train.v2._internal.util import ray_get_safe
 from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
-
-
-@pytest.mark.parametrize("type", ["task", "actor_task"])
-@pytest.mark.parametrize("failing", [True, False])
-@pytest.mark.parametrize("task_list", [True, False])
-def test_ray_get_safe(ray_start_4_cpus, type, failing, task_list):
-    num_tasks = 4
-
-    if type == "task":
-
-        @ray.remote
-        def f():
-            if failing:
-                raise ValueError("failing")
-            return 1
-
-        if task_list:
-            object_refs = [f.remote() for _ in range(num_tasks)]
-        else:
-            object_refs = f.remote()
-    elif type == "actor_task":
-
-        @ray.remote
-        class Actor:
-            def f(self):
-                if failing:
-                    raise ValueError("failing")
-                return 1
-
-        if task_list:
-            actors = [Actor.remote() for _ in range(num_tasks)]
-            object_refs = [actor.f.remote() for actor in actors]
-        else:
-            actor = Actor.remote()
-            object_refs = actor.f.remote()
-
-    if failing:
-        with pytest.raises(ValueError, match="failing"):
-            ray_get_safe(object_refs)
-    else:
-        out = ray_get_safe(object_refs)
-        if task_list:
-            assert out == [1] * num_tasks
-        else:
-            assert out == 1
 
 
 def test_in_ray_train_worker(ray_start_4_cpus):


### PR DESCRIPTION
## Description
Ray get safe isn't needed anymore because the relevant ray core bug has been fixed - https://github.com/ray-project/ray/issues/47204