### PR TITLE
[RLLib] Fix bug of constructing remote_actor_ids

### DIFF
--- a/rllib/utils/actor_manager.py
+++ b/rllib/utils/actor_manager.py
@@ -553,7 +553,7 @@ class FaultTolerantActorManager:
         # this call.
         if num_calls != len(remote_actor_ids):
             remote_actor_ids = [
-                (self._current_actor_id + i) % self.num_actors()
+                remote_actor_ids[(self._current_actor_id + i) % len(remote_actor_ids)]
                 for i in range(num_calls)
             ]
             # Update our round-robin pointer.


### PR DESCRIPTION
## Description
In [actor_manager](https://github.com/ray-project/ray/blob/master/rllib/utils/actor_manager.py#L555), the remote_actor_ids will mismatch the existing actor_ids in some cases:
1. Create a ActorManager with init_id = 1 and NOT set the local worker [EnvRunnerGroup](https://github.com/ray-project/ray/blob/master/rllib/env/env_runner_group.py#L188)
2. Use self-defined remote_actor_ids by passing the kwargs
