### PR TITLE
[Core] VLLM engine v0.16.0 add backward compatibility

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
+++ b/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
@@ -21,11 +21,22 @@ from vllm.entrypoints.openai.engine.protocol import (
     ErrorInfo as vLLMErrorInfo,
     ErrorResponse as vLLMErrorResponse,
 )
-from vllm.entrypoints.openai.translations.protocol import (
-    TranscriptionRequest as vLLMTranscriptionRequest,
-    TranscriptionResponse as vLLMTranscriptionResponse,
-    TranscriptionStreamResponse as vLLMTranscriptionStreamResponse,
-)
+
+try:
+    # https://github.com/vllm-project/vllm/pull/33904
+    from vllm.entrypoints.openai.speech_to_text.protocol import (
+        TranscriptionRequest as vLLMTranscriptionRequest,
+        TranscriptionResponse as vLLMTranscriptionResponse,
+        TranscriptionStreamResponse as vLLMTranscriptionStreamResponse,
+    )
+except ImportError:
+    # backward compatibility
+    from vllm.entrypoints.openai.translations.protocol import (
+        TranscriptionRequest as vLLMTranscriptionRequest,
+        TranscriptionResponse as vLLMTranscriptionResponse,
+        TranscriptionStreamResponse as vLLMTranscriptionStreamResponse,
+    )
+
 from vllm.entrypoints.pooling.embed.protocol import (
     EmbeddingChatRequest as vLLMEmbeddingChatRequest,
     EmbeddingCompletionRequest as vLLMEmbeddingCompletionRequest,


### PR DESCRIPTION
## Description

Your code contains imports that have changed in vllm 0.16.0 and future versions.

https://github.com/ray-project/ray/blob/master/python/ray/llm/_internal/serve/core/configs/openai_api_models.py#L24-L28

```
from vllm.entrypoints.openai.translations.protocol import (
    TranscriptionRequest as vLLMTranscriptionRequest,
    TranscriptionResponse as vLLMTranscriptionResponse,
    TranscriptionStreamResponse as vLLMTranscriptionStreamResponse,
)
```

VLLM from February 5:
https://github.com/vllm-project/vllm/commits/92f5d0f070ec9e0ca5fe72af672138a9bbd1cb68/vllm/entrypoints/openai/speech_to_text
https://github.com/vllm-project/vllm/pull/33904

## Related issues
https://github.com/ray-project/ray/issues/61424
