### PR TITLE
[Data] vary `randomize_block_order` and `random_shuffle` seed across executions

### DIFF
--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -82,7 +82,7 @@ def plan_all_to_all_op(
     input_physical_dag = physical_children[0]
 
     if isinstance(op, RandomizeBlocks):
-        fn = generate_randomize_blocks_fn(op)
+        fn = generate_randomize_blocks_fn(op, data_context)
         # Randomize block order does not actually compute anything, so we
         # want to inherit the upstream op's target max block size.
 

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -38,6 +38,11 @@ def generate_random_shuffle_fn(
         refs: List[RefBundle],
         ctx: TaskContext,
     ) -> AllToAllTransformFnResult:
+        from ray.data._internal.util import make_epoch_seed
+
+        execution_idx = data_context._execution_idx if data_context is not None else 0
+        epoch_seed = make_epoch_seed(seed, execution_idx)
+
         num_input_blocks = sum(len(r.blocks) for r in refs)
 
         # If map_transformer is specified (e.g. from fusing
@@ -63,7 +68,7 @@ def generate_random_shuffle_fn(
                 ctx.target_max_block_size_override or data_context.target_max_block_size
             ),
             random_shuffle=True,
-            random_seed=seed,
+            random_seed=epoch_seed,
             upstream_map_fn=upstream_map_fn,
         )
 

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -35,7 +35,14 @@ def generate_randomize_blocks_fn(
             return refs, {op.name: []}
         else:
             if op.seed is not None:
-                random.seed(op.seed)
+                from ray.data._internal.util import make_epoch_seed
+                from ray.data.context import DataContext
+
+                data_context = DataContext.get_current()
+                execution_idx = (
+                    data_context._execution_idx if data_context is not None else 0
+                )
+                random.seed(make_epoch_seed(op.seed, execution_idx))
             input_owned = all(b.owns_blocks for b in refs)
             random.shuffle(blocks_with_metadata)
             output = []

--- a/python/ray/data/_internal/planner/randomize_blocks.py
+++ b/python/ray/data/_internal/planner/randomize_blocks.py
@@ -9,10 +9,12 @@ from ray.data._internal.execution.interfaces.transform_fn import (
     AllToAllTransformFnResult,
 )
 from ray.data._internal.logical.operators import RandomizeBlocks
+from ray.data.context import DataContext
 
 
 def generate_randomize_blocks_fn(
     op: RandomizeBlocks,
+    data_context: DataContext,
 ) -> AllToAllTransformFn:
     """Generate function to randomize order of blocks."""
 
@@ -36,9 +38,7 @@ def generate_randomize_blocks_fn(
         else:
             if op.seed is not None:
                 from ray.data._internal.util import make_epoch_seed
-                from ray.data.context import DataContext
 
-                data_context = DataContext.get_current()
                 execution_idx = (
                     data_context._execution_idx if data_context is not None else 0
                 )

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1816,6 +1816,14 @@ def infer_compression(path: str) -> Optional[str]:
     return compression
 
 
+def make_epoch_seed(seed: int, execution_idx: int) -> int:
+    """Combine a user seed with an execution index to produce a per-epoch seed.
+
+    Modulo ensures the result is in valid NumPy seed range [0, 2**32 - 1].
+    """
+    return hash((seed, execution_idx)) % (2**32)
+
+
 def get_max_task_capacity(
     allocated_resources: Optional["ExecutionResources"],
     min_scheduling_resources: "ExecutionResources",

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1821,7 +1821,7 @@ def make_epoch_seed(seed: int, execution_idx: int) -> int:
 
     Modulo ensures the result is in valid NumPy seed range [0, 2**32 - 1].
     """
-    return hash((seed, execution_idx)) % (2**32)
+    return (seed + execution_idx) % (2**32)
 
 
 def get_max_task_capacity(

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -27,6 +27,7 @@ from ray.data._internal.util import (
     infer_compression,
     iterate_with_retry,
     make_async_gen,
+    make_epoch_seed,
 )
 from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
@@ -116,8 +117,7 @@ class FileShuffleConfig:
         if self.seed is None:
             return None
         elif self.reseed_after_execution:
-            # Modulo ensures the result is in valid NumPy seed range [0, 2**32 - 1].
-            return hash((self.seed, execution_idx)) % (2**32)
+            return make_epoch_seed(self.seed, execution_idx)
         else:
             return self.seed
 

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -1,5 +1,6 @@
 import pytest
 
+import ray
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
 )
@@ -27,6 +28,43 @@ def test_randomize_blocks_operator(ray_start_regular_shared):
     assert isinstance(physical_op, AllToAllOperator)
     assert len(physical_op.input_dependencies) == 1
     assert isinstance(physical_op.input_dependencies[0], MapOperator)
+
+
+@pytest.mark.parametrize("seed", [0, 42])
+def test_randomize_blocks_different_order_per_epoch_with_seed(
+    ray_start_regular_shared, seed
+):
+    ds = ray.data.range(100, override_num_blocks=20).randomize_block_order(seed=seed)
+    it = ds.iterator()
+    epoch1 = [r["id"] for r in it.iter_rows()]
+    epoch2 = [r["id"] for r in it.iter_rows()]
+
+    # Different orderings across epochs.
+    assert epoch1 != epoch2
+    # Same set of values.
+    assert sorted(epoch1) == sorted(epoch2)
+
+
+def test_randomize_blocks_deterministic_with_seed(ray_start_regular_shared):
+    ds1 = ray.data.range(100, override_num_blocks=20).randomize_block_order(seed=42)
+    ds2 = ray.data.range(100, override_num_blocks=20).randomize_block_order(seed=42)
+
+    result1 = [r["id"] for r in ds1.iter_rows()]
+    result2 = [r["id"] for r in ds2.iter_rows()]
+
+    # Same seed and same execution_idx should produce the same ordering.
+    assert result1 == result2
+
+
+def test_randomize_blocks_no_seed_varies(ray_start_regular_shared):
+    ds = ray.data.range(100, override_num_blocks=20).randomize_block_order()
+    it = ds.iterator()
+    epoch1 = [r["id"] for r in it.iter_rows()]
+    epoch2 = [r["id"] for r in it.iter_rows()]
+
+    # Without a seed, different epochs should (almost certainly) differ.
+    assert epoch1 != epoch2
+    assert sorted(epoch1) == sorted(epoch2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
`randomize_block_order(seed=X)` produces the same block ordering every epoch because it always seeds with the fixed user seed. 

This varies the seed per epoch by combining it with `DataContext._execution_idx`, matching the existing pattern in `FileShuffleConfig.get_seed()`. 

Extracts the shared formula into `make_epoch_seed()` in `util.py`.    

