### PR TITLE
[core] Enable multiple gRPC connections by default with two connections

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -980,7 +980,7 @@ RAY_CONFIG(int64_t, nums_py_gcs_reconnect_retry, 5)
 RAY_CONFIG(int64_t, py_gcs_connect_timeout_s, 30)
 
 // The number of grpc clients between object managers.
-RAY_CONFIG(int, object_manager_client_connection_num, 4)
+RAY_CONFIG(int, object_manager_client_connection_num, 2)
 
 // The actual number of threads for object transfers through the object manager is this
 // number * 3. There num_threads started for each of these 3 things:
@@ -1075,4 +1075,4 @@ RAY_CONFIG(uint64_t, gcs_resource_broadcast_max_batch_delay_ms, 0)
 
 // Whether to enable/disable multiple gRPC connections to improve object transfer
 // throughput.
-RAY_CONFIG(bool, experimental_object_manager_enable_multiple_connections, false)
+RAY_CONFIG(bool, experimental_object_manager_enable_multiple_connections, true)


### PR DESCRIPTION
PR https://github.com/ray-project/ray/pull/61121 added a config variable to enable multiple gRPC connections. After testing it, we are now turning on the config `experimental_object_manager_enable_multiple_connections` true by default keeping the number of connections per client to 2 (using config `object_manager_client_connection_num`).

Setting the optimal value of connections per client is not trivial. This is because while increasing the connections would increase throughput to a point, but since the number of connections is peer-to-peer, a very high value would lead to a lot of connections per client, which increases the resource usage for gRPC connections. An optimal value balancing throughput with resource usage should be found. To start with, we are keeping a value of 2.
Resolves: https://anyscale1.atlassian.net/browse/CORE-2887
