### PR TITLE
[serve] Skip tracing tests for windows

### DIFF
--- a/python/ray/serve/tests/test_tracing_utils.py
+++ b/python/ray/serve/tests/test_tracing_utils.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import uuid
 from pathlib import Path
 from threading import Thread
@@ -55,6 +56,12 @@ except ImportError:
     )
 
 CUSTOM_EXPORTER_OUTPUT_FILENAME = "spans.txt"
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Tracing is not supported on Windows.",
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
disabling `test_tracing_utils` on windows. creating this issue for future work: https://github.com/ray-project/ray/issues/61443