### PR TITLE
[ci] add docker/base-deps, base-extra, ray-llm to .wandaspecs

### DIFF
--- a/.wandaspecs
+++ b/.wandaspecs
@@ -8,3 +8,6 @@
 # to have been built by prior pipeline steps and are pulled from the work repo.
 
 ci/docker/
+docker/base-deps/
+docker/base-extra/
+docker/ray-llm/


### PR DESCRIPTION
Registers the local Dockerfile directories for base-deps, base-extra, and ray-llm so raymake can resolve their wanda specs during local builds.

Topic: wandaspecs
Signed-off-by: andrew <andrew@anyscale.com>