### PR TITLE
[Serve] Add missing tracing attributes to gRPC client/bidi streaming paths

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -313,6 +313,53 @@ class GenericProxy(ABC):
         self._ongoing_requests -= 1
         self.num_ongoing_requests_gauge.set(self._ongoing_requests)
 
+    def _setup_proxy_tracing(
+        self,
+        request_id: str,
+        handle: DeploymentHandle,
+        proxy_request: ProxyRequest,
+        additional_attributes: Optional[Dict[str, Any]] = None,
+    ):
+        """Set up tracing attributes for proxy requests.
+
+        Args:
+            request_id: The unique request ID.
+            handle: The deployment handle.
+            proxy_request: The proxy request object.
+            additional_attributes: Optional additional tracing attributes to set.
+        """
+        trace_attributes = {
+            "request_id": request_id,
+            "deployment": handle.deployment_name,
+            "app": handle.app_name,
+            "request_type": proxy_request.request_type,
+        }
+        if additional_attributes:
+            trace_attributes.update(additional_attributes)
+        set_span_attributes(trace_attributes)
+
+    def _finalize_proxy_tracing(
+        self,
+        status: Optional[ResponseStatus],
+        exc: Optional[BaseException],
+    ):
+        """Finalize tracing for proxy requests.
+
+        Set exception and trace status. This is a common helper used by
+        both HTTP and gRPC proxies. Protocol-specific attributes should be
+        set separately (e.g., via set_http_span_attributes or set_rpc_span_attributes).
+
+        Args:
+            status: The response status, if available.
+            exc: The exception that occurred, if any.
+        """
+        if exc:
+            set_span_exception(exc, escaped=True)
+            if status is not None:
+                set_trace_status(status.is_error, str(exc))
+        elif status is not None:
+            set_trace_status(status.is_error)
+
     def _get_health_or_routes_reponse(
         self, proxy_request: ProxyRequest
     ) -> ResponseHandlerInfo:
@@ -852,6 +899,47 @@ class gRPCProxy(GenericProxy):
             _, cancel_event = session
             cancel_event.set()
 
+    def _setup_grpc_tracing(
+        self,
+        request_id: str,
+        handle: DeploymentHandle,
+        proxy_request: "gRPCProxyRequest",
+    ):
+        """Set up tracing for gRPC requests.
+
+        This helper function sets up span attributes and span name for gRPC requests,
+        used by both standard and streaming request paths.
+        """
+        self._setup_proxy_tracing(
+            request_id=request_id,
+            handle=handle,
+            proxy_request=proxy_request,
+        )
+        set_span_name(
+            f"proxy_{proxy_request.request_type}_request {handle.deployment_name} {proxy_request.method}"
+        )
+
+    def _finalize_grpc_tracing(
+        self,
+        proxy_request: "gRPCProxyRequest",
+        status: Optional[ResponseStatus],
+        exc: Optional[BaseException],
+    ):
+        """Finalize tracing for gRPC requests.
+
+        This helper function sets RPC span attributes, exception tracking, and trace status
+        in the finally block, used by both standard and streaming request paths.
+        """
+        if status is not None:
+            set_rpc_span_attributes(
+                system=proxy_request.request_type,
+                method=proxy_request.method,
+                status_code=status.code.name
+                if isinstance(status.code, grpc.StatusCode)
+                else grpc.StatusCode.UNKNOWN.name,
+            )
+        self._finalize_proxy_tracing(status=status, exc=exc)
+
     @tracing_decorator_factory(
         trace_name="proxy_grpc_request",
     )
@@ -878,16 +966,7 @@ class gRPCProxy(GenericProxy):
             return
 
         # Standard server-unary/server-streaming path
-        trace_attributes = {
-            "request_id": request_id,
-            "deployment": handle.deployment_name,
-            "app": handle.app_name,
-            "request_type": proxy_request.request_type,
-        }
-        set_span_attributes(trace_attributes)
-        set_span_name(
-            f"proxy_{proxy_request.request_type}_request {handle.deployment_name} {proxy_request.method}"
-        )
+        self._setup_grpc_tracing(request_id, handle, proxy_request)
 
         response_generator = ProxyResponseGenerator(
             handle.remote(proxy_request.serialized_replica_arg()),
@@ -905,18 +984,7 @@ class gRPCProxy(GenericProxy):
             status = get_grpc_response_status(e, self.request_timeout_s, request_id)
             exc = e
         finally:
-            set_rpc_span_attributes(
-                system=proxy_request.request_type,
-                method=proxy_request.method,
-                status_code=status.code.name
-                if isinstance(status.code, grpc.StatusCode)
-                else grpc.StatusCode.UNKNOWN.name,
-            )
-            if exc:
-                set_span_exception(exc, escaped=True)
-                set_trace_status(status.is_error, str(exc))
-            else:
-                set_trace_status(status.is_error)
+            self._finalize_grpc_tracing(proxy_request, status, exc)
 
         # The status code should always be set.
         assert status is not None
@@ -937,6 +1005,9 @@ class gRPCProxy(GenericProxy):
         For bidirectional streaming (stream_stream), we do the same but the
         response is also a stream.
         """
+        # Set up tracing attributes for streaming
+        self._setup_grpc_tracing(request_id, handle, proxy_request)
+
         # Create a streaming session
         session_id = internal_request_id
         cancel_event = asyncio.Event()
@@ -945,6 +1016,8 @@ class gRPCProxy(GenericProxy):
             cancel_event,
         )
 
+        status = None
+        exc = None
         try:
             # Get the proxy actor name for callback
             proxy_actor_name = ray.get_runtime_context().get_actor_name()
@@ -971,14 +1044,32 @@ class gRPCProxy(GenericProxy):
                 status = ResponseStatus(code=grpc.StatusCode.OK)
             except BaseException as e:
                 status = get_grpc_response_status(e, self.request_timeout_s, request_id)
+                exc = e
+                # Yield the error status and return immediately to avoid falling through
+                # to the outer except block, which would produce a duplicate ResponseStatus.
+                yield status
+                return
 
             # The status code should always be set.
             assert status is not None
             yield status
-
+        except Exception as e:
+            # Handle exceptions that occur before response_generator is created
+            # (e.g., in get_actor_name, pickle.dumps, ProxyResponseGenerator)
+            status = get_grpc_response_status(e, self.request_timeout_s, request_id)
+            exc = e
+            yield status
         finally:
-            # Clean up the streaming session
+            # Clean up the streaming session first to ensure no resource leaks
             self._cleanup_streaming_session(session_id)
+
+            # Finalize tracing for streaming requests (best-effort)
+            try:
+                self._finalize_grpc_tracing(proxy_request, status, exc)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to finalize tracing for session {session_id}: {e}"
+                )
 
 
 class HTTPProxy(GenericProxy):
@@ -1145,6 +1236,51 @@ class HTTPProxy(GenericProxy):
         )
         return handle, request_context_info["request_id"]
 
+    def _setup_http_tracing(
+        self,
+        request_id: str,
+        handle: DeploymentHandle,
+        proxy_request: ProxyRequest,
+    ):
+        """Set up tracing for HTTP requests.
+
+        This helper function sets up span attributes and span name for HTTP requests.
+        """
+        self._setup_proxy_tracing(
+            request_id=request_id,
+            handle=handle,
+            proxy_request=proxy_request,
+            additional_attributes={
+                "request_method": proxy_request.method,
+                "request_route_path": proxy_request.route_path,
+            },
+        )
+        set_span_name(
+            f"proxy_{proxy_request.request_type}_request {handle.deployment_name} {proxy_request.method} {proxy_request.route_path}"
+        )
+
+    def _finalize_http_tracing(
+        self,
+        proxy_request: ProxyRequest,
+        status_code: str,
+        is_error: bool,
+        exc: Optional[BaseException],
+    ):
+        """Finalize tracing for HTTP requests.
+
+        This helper function sets HTTP span attributes, exception tracking, and trace status
+        in finally block.
+        """
+        set_http_span_attributes(
+            method=proxy_request.method,
+            status_code=int(status_code),
+            route=proxy_request.route_path,
+        )
+        self._finalize_proxy_tracing(
+            status=ResponseStatus(code=status_code, is_error=is_error),
+            exc=exc,
+        )
+
     async def _format_handle_arg_for_java(
         self,
         proxy_request: ProxyRequest,
@@ -1178,18 +1314,7 @@ class HTTPProxy(GenericProxy):
         the status code.
         """
         if is_span_recording():
-            trace_attributes = {
-                "request_id": request_id,
-                "deployment": handle.deployment_name,
-                "app": handle.app_name,
-                "request_type": proxy_request.request_type,
-                "request_method": proxy_request.method,
-                "request_route_path": proxy_request.route_path,
-            }
-            set_span_attributes(trace_attributes)
-            set_span_name(
-                f"proxy_{proxy_request.request_type}_request {handle.deployment_name} {proxy_request.method} {proxy_request.route_path}"
-            )
+            self._setup_http_tracing(request_id, handle, proxy_request)
 
         if app_is_cross_language:
             handle_arg_bytes = await self._format_handle_arg_for_java(proxy_request)
@@ -1314,17 +1439,9 @@ class HTTPProxy(GenericProxy):
             del self.asgi_receive_queues[internal_request_id]
 
             if is_span_recording():
-                set_http_span_attributes(
-                    method=proxy_request.method,
-                    status_code=int(status_code),
-                    route=proxy_request.route_path,
+                self._finalize_http_tracing(
+                    proxy_request, status_code, status.is_error, exc
                 )
-
-                if exc:
-                    set_span_exception(exc, escaped=True)
-                    set_trace_status(status.is_error, str(exc))
-                else:
-                    set_trace_status(status.is_error)
 
         # The status code should always be set.
         assert status is not None

--- a/python/ray/serve/tests/test_tracing_utils.py
+++ b/python/ray/serve/tests/test_tracing_utils.py
@@ -37,6 +37,7 @@ from ray.serve._private.tracing_utils import (
 )
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
+from ray.serve.grpc_util import gRPCInputStream
 from ray.serve.tests.conftest import *  # noqa
 from ray.serve.utils import get_trace_context
 from ray.tests.conftest import *  # noqa
@@ -1021,6 +1022,105 @@ def test_batched_span_attached_to_first_request_trace():
     assert (
         len(batch_indices) == 2
     ), f"Expected two distinct batch indices, got {batch_indices}"
+
+    shutil.rmtree(spans_dir)
+
+
+@pytest.mark.parametrize(
+    "method_name",
+    ["ClientStreaming", "BidiStreaming"],
+)
+def test_grpc_streaming_tracing_attributes(serve_and_ray_shutdown, method_name):
+    """Test that tracing attributes are correctly set for gRPC streaming requests.
+
+    Verifies that for client streaming and bidirectional streaming methods,
+    the proxy gRPC span contains the expected tracing attributes including
+    request_id, deployment, app, request_type, and RPC-specific attributes.
+    """
+    if RAY_SERVE_ENABLE_HA_PROXY:
+        pytest.skip()
+
+    grpc_port = 9000
+
+    serve.start(
+        grpc_options=gRPCOptions(
+            port=grpc_port,
+            grpc_servicer_functions=[
+                "ray.serve.generated.serve_pb2_grpc.add_UserDefinedServiceServicer_to_server",
+            ],
+        ),
+    )
+
+    @serve.deployment
+    class StreamingDeployment:
+        async def ClientStreaming(self, request_stream: gRPCInputStream):
+            async for _ in request_stream:
+                pass
+            return serve_pb2.UserDefinedResponse(greeting="ok", num_x2=0)
+
+        async def BidiStreaming(self, request_stream: gRPCInputStream):
+            async for request in request_stream:
+                yield serve_pb2.UserDefinedResponse(
+                    greeting=f"Hello {request.name}",
+                    num_x2=request.num * 2,
+                )
+
+    serve.run(StreamingDeployment.options(name="streaming-deployment").bind())
+
+    setup_tracing(
+        component_name="upstream_app",
+        component_id="345",
+        tracing_sampling_ratio=1.0,
+    )
+
+    tracer = trace.get_tracer("test_tracing")
+    with tracer.start_as_current_span("upstream_streaming"):
+        ctx = get_trace_context()
+        headers = {}
+        TraceContextTextMapPropagator().inject(headers, ctx)
+        metadata = tuple(headers.items())
+
+        channel = grpc.insecure_channel("localhost:9000")
+        stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
+
+        def request_generator():
+            for i in range(2):
+                yield serve_pb2.UserDefinedMessage(name=f"msg_{i}", num=i, foo="bar")
+
+        if method_name == "ClientStreaming":
+            stub.ClientStreaming(request_generator(), metadata=metadata)
+        else:
+            list(stub.BidiStreaming(request_generator(), metadata=metadata))
+
+    serve.shutdown()
+
+    # Find proxy spans
+    serve_logs_dir = get_serve_logs_dir()
+    spans_dir = os.path.join(serve_logs_dir, "spans")
+    files = os.listdir(spans_dir)
+
+    proxy_spans = None
+    for file in files:
+        if "proxy" in file:
+            proxy_spans = load_spans(os.path.join(spans_dir, file))
+            break
+
+    grpc_proxy_span = next(
+        (span for span in proxy_spans if "proxy_grpc_request" in span["name"]),
+        None,
+    )
+    assert grpc_proxy_span is not None
+    attrs = grpc_proxy_span["attributes"]
+
+    # Verify tracing attributes are set up correctly
+    assert "request_id" in attrs
+    assert attrs["deployment"] == "streaming-deployment"
+    assert "app" in attrs
+    assert attrs["request_type"] == "grpc"
+    assert attrs["rpc.system"] == "grpc"
+    assert f"/ray.serve.UserDefinedService/{method_name}" == attrs["rpc.method"]
+    assert attrs["rpc.grpc.status_code"] == "OK"
+    assert grpc_proxy_span["status"]["status_code"] == "OK"
 
     shutil.rmtree(spans_dir)
 


### PR DESCRIPTION
## Description
When a client-streaming or bidi-streaming gRPC request is handled, `send_request_to_replica` returns early, completely skipping the tracing setup. The `_send_streaming_request_to_replica` method has no equivalent tracing logic.

While the `@tracing_decorator_factory decorator` still creates a span, that span lacks:

- Request attributes (request_id, deployment, app, request_type)
- Descriptive span name
- RPC span attributes
- Exception tracking via set_span_exception
- Trace status

This creates a significant observability gap for streaming requests in production environments.

## Changes
Add complete tracing support to streaming requests and refactor helper functions:

1. Streaming request tracing - Add full tracing to `_send_streaming_request_to_replica`:
    -  Set span attributes (request_id, deployment, app, request_type)
    -  Set descriptive span name
    -  Track status and exceptions
    -  Set RPC span attributes in finally block
    -  Handle exceptions that occur before response_generator creation
2. Refactor base helpers - Add to `GenericProxy` class:
    - `_setup_proxy_tracing`: Sets common span attributes
    - `_finalize_proxy_tracing`: Handles exception tracking and trace status

3. Refactor gRPC helpers - Update `gRPCProxy` class:

    - `_setup_grpc_tracing`: Calls base helper + sets span name
    - `_finalize_grpc_tracing`: Calls base helper + sets RPC attributes

4. Refactor HTTP helpers - Add to `HTTPProxy` class:

    - `_setup_http_tracing`: Calls base helper + sets span name and HTTP attributes
    - `_finalize_http_tracing`: Calls base helper + sets HTTP attributes

5. Update HTTP request path - Modify `HTTPProxy.send_request_to_replica` to use new helpers


## Related issues
Closes #61359 

