### PR TITLE
[RDT] Add UCCL Tensor Transport

### DIFF
--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -4,7 +4,7 @@ import time
 import traceback
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import ray
 from ray.experimental.rdt.tensor_transport_manager import (
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
 UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE = int(
     os.environ.get("RAY_UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE", "1000")
 )
-UCCL_NUM_CPUS = int(os.environ.get("RAY_UCCL_NUM_CPUS", "4"))
 
 
 @dataclass
@@ -51,23 +50,20 @@ class UCCLTransportMetadata(TensorTransportMetadata):
     __hash__ = object.__hash__
 
 
-@dataclass
-class TensorDesc:
-    desc: Any
-    metadata_count: int
-
-
 class UCCLTensorTransport(TensorTransportManager):
     def __init__(self):
         self._uccl_endpoint = None
         self._endpoint_name = None
         self._aborted_transfer_obj_ids = set()
         self._aborted_transfer_obj_ids_lock = threading.Lock()
-        # Mapping from tensor data pointer to the UCCL descriptor and reference count.
-        self._tensor_desc_cache: Dict[int, TensorDesc] = {}
+        # Mapping from object ID to the registered UCCL descriptors for that object.
+        # UCCL handles deduplication of overlapping memory regions internally via
+        # uccl_regmr's MR cache (acquireCachedMr / containsRange), so we can just
+        # store the descriptors returned per object and deregister them on GC.
+        self._obj_descs: Dict[str, list] = {}
         # Mapping from object ID to the UCCL managed metadata.
         self._managed_meta: Dict[str, UCCLTransportMetadata] = {}
-        # Lock protecting _tensor_desc_cache and _managed_meta since they can be
+        # Lock protecting _obj_descs and _managed_meta since they can be
         # accessed from the main task execution thread or the _ray_system thread.
         self._cache_lock = threading.Lock()
         # LRU cache of remote endpoint connections: endpoint_name -> (conn_id, version).
@@ -98,8 +94,21 @@ class UCCLTensorTransport(TensorTransportManager):
         import torch
         from uccl import p2p
 
-        gpu_idx = torch.cuda.current_device() if torch.cuda.is_available() else 0
-        self._uccl_endpoint = p2p.Endpoint(gpu_idx, UCCL_NUM_CPUS)
+        # CUDA-visible device index for GPU operations.
+        cuda_device = (
+            torch.cuda.current_device() if torch.cuda.is_available() else 0
+        )
+        # Physical GPU index for UCCL identity (shm ring naming, metadata).
+        # Ray remaps CUDA_VISIBLE_DEVICES per actor so each actor sees
+        # device 0, but UCCL needs node-unique physical indices.
+        gpu_ids = ray.get_gpu_ids()
+        if gpu_ids:
+            physical_gpu_idx = int(gpu_ids[cuda_device])
+        else:
+            physical_gpu_idx = cuda_device
+        # print(f"cuda_device, p_gpu_idx:{cuda_device, physical_gpu_idx}")
+        self._uccl_endpoint = p2p.Endpoint(physical_gpu_idx)
+        self._uccl_endpoint.start_passive_accept()
 
         ctx = ray.get_runtime_context()
         actor_id = ctx.get_actor_id()
@@ -116,7 +125,7 @@ class UCCLTensorTransport(TensorTransportManager):
             self: "ray.actor.ActorHandle",
         ) -> bool:
             try:
-                from ray.experimental.gpu_object_manager.util import (
+                from ray.experimental.rdt.util import (
                     get_tensor_transport_manager,
                 )
 
@@ -161,15 +170,10 @@ class UCCLTensorTransport(TensorTransportManager):
                         torch.cuda.synchronize(dev)
 
                 ep = self._get_uccl_endpoint()
-                self._uccl_endpoint.start_passive_accept()
-                self._add_tensor_descs(gpu_object)
+                descs = ep.register_memory(gpu_object)
+                self._obj_descs[obj_id] = descs
 
-                all_descs = []
-                for t in gpu_object:
-                    key = t.data_ptr()
-                    all_descs.append(self._tensor_desc_cache[key].desc)
-
-                serialized_descs = ep.get_serialized_descs(all_descs)
+                serialized_descs = ep.get_serialized_descs(descs)
                 endpoint_meta = ep.get_metadata()
                 endpoint_name = self._endpoint_name
                 endpoint_meta_version = self._uccl_endpoint_meta_version
@@ -205,7 +209,7 @@ class UCCLTensorTransport(TensorTransportManager):
         communicator_metadata: CommunicatorMetadata,
         target_buffers: Optional[List["torch.Tensor"]] = None,
     ) -> List["torch.Tensor"]:
-        from ray.experimental.gpu_object_manager.util import (
+        from ray.experimental.rdt.util import (
             create_empty_tensors_from_metadata,
         )
 
@@ -299,7 +303,6 @@ class UCCLTensorTransport(TensorTransportManager):
                     ep.deregister_memory(local_descs)
                     self._uccl_endpoint_meta_version += 1
 
-
         return tensors
 
     def send_multiple_tensors(
@@ -324,16 +327,11 @@ class UCCLTensorTransport(TensorTransportManager):
             if obj_id not in self._managed_meta:
                 return
             self._managed_meta.pop(obj_id, None)
-            ep = self._get_uccl_endpoint()
-            for tensor in tensors:
-                key = tensor.data_ptr()
-                if key in self._tensor_desc_cache:
-                    tensor_desc = self._tensor_desc_cache[key]
-                    tensor_desc.metadata_count -= 1
-                    if tensor_desc.metadata_count == 0:
-                        self._tensor_desc_cache.pop(key)
-                        ep.deregister_memory([tensor_desc.desc])
-                        self._uccl_endpoint_meta_version += 1
+            descs = self._obj_descs.pop(obj_id, None)
+            if descs:
+                ep = self._get_uccl_endpoint()
+                ep.deregister_memory(descs)
+                self._uccl_endpoint_meta_version += 1
 
     def abort_transport(
         self,
@@ -354,27 +352,3 @@ class UCCLTensorTransport(TensorTransportManager):
 
     def _put_meta(self, object_id: str, meta: UCCLTransportMetadata):
         self._managed_meta[object_id] = meta
-
-    def _add_tensor_descs(self, tensors: List["torch.Tensor"]):
-        """
-        Register tensors with the UCCL endpoint and cache their descriptors.
-        If a tensor is already registered (by data_ptr), its reference count is
-        incremented. New tensors are registered one at a time so that duplicates
-        within the same input list are detected immediately via the cache.
-
-        Unlike NIXL which registers at the storage level, UCCL registers each
-        tensor view individually — ep.register_memory([tensor]) returns a
-        descriptor for that specific view's data region. Using data_ptr() as
-        the key ensures each view gets its own descriptor, which is necessary
-        for correct transfer of overlapping views.
-        """
-        ep = self._get_uccl_endpoint()
-        for tensor in tensors:
-            key = tensor.data_ptr()
-            if key in self._tensor_desc_cache:
-                self._tensor_desc_cache[key].metadata_count += 1
-            else:
-                descs = ep.register_memory([tensor])
-                self._tensor_desc_cache[key] = TensorDesc(
-                    desc=descs[0], metadata_count=1
-                )

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -83,8 +83,6 @@ class UCCLTensorTransport(TensorTransportManager):
     def _get_uccl_endpoint(self):
         """
         Creates a UCCL P2P endpoint with passive accept if not already created.
-        Both sender and receiver endpoints need start_passive_accept() because
-        RDMA connection setup is bidirectional.
         """
         if self._uccl_endpoint is not None:
             return self._uccl_endpoint
@@ -171,7 +169,7 @@ class UCCLTensorTransport(TensorTransportManager):
 
             ret = UCCLTransportMetadata(
                 tensor_meta=tensor_meta,
-                tensor_device=device,
+                tensor_device=device.type if device else None,
                 uccl_serialized_descs=serialized_descs,
                 uccl_endpoint_meta=endpoint_meta,
                 uccl_endpoint_name=endpoint_name,
@@ -192,12 +190,15 @@ class UCCLTensorTransport(TensorTransportManager):
         obj_id: str,
         tensor_transport_metadata: TensorTransportMetadata,
         communicator_metadata: CommunicatorMetadata,
+        target_buffers: Optional[List["torch.Tensor"]] = None,
     ) -> List["torch.Tensor"]:
         from ray.experimental.gpu_object_manager.util import (
             create_empty_tensors_from_metadata,
         )
 
-        tensors = create_empty_tensors_from_metadata(tensor_transport_metadata)
+        tensors = target_buffers or create_empty_tensors_from_metadata(
+            tensor_transport_metadata
+        )
 
         assert isinstance(tensor_transport_metadata, UCCLTransportMetadata)
         assert isinstance(communicator_metadata, UCCLCommunicatorMetadata)
@@ -211,6 +212,7 @@ class UCCLTensorTransport(TensorTransportManager):
             return []
 
         local_descs = None
+        remote_name = None
         try:
             ep = self._get_uccl_endpoint()
 
@@ -231,6 +233,7 @@ class UCCLTensorTransport(TensorTransportManager):
                     and len(self._remote_endpoints)
                     >= UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE
                 ):
+                    # TODO: check if need to destory the endpoint
                     self._remote_endpoints.popitem(last=False)
 
                 success, conn_id = ep.add_remote_endpoint(remote_meta)
@@ -276,6 +279,10 @@ class UCCLTensorTransport(TensorTransportManager):
         finally:
             with self._aborted_transfer_obj_ids_lock:
                 self._aborted_transfer_obj_ids.discard(obj_id)
+            # TODO: check if need to destory the endpoint
+            if local_descs:
+                with self._cache_lock:
+                    ep.deregister_memory(local_descs)
 
         return tensors
 
@@ -301,6 +308,7 @@ class UCCLTensorTransport(TensorTransportManager):
             if obj_id not in self._managed_meta:
                 return
             self._managed_meta.pop(obj_id, None)
+            ep = self._get_uccl_endpoint()
             for tensor in tensors:
                 key = tensor.data_ptr()
                 if key in self._tensor_desc_cache:
@@ -308,6 +316,7 @@ class UCCLTensorTransport(TensorTransportManager):
                     tensor_desc.metadata_count -= 1
                     if tensor_desc.metadata_count == 0:
                         self._tensor_desc_cache.pop(key)
+                        ep.deregister_memory([tensor_desc.desc])
 
     def abort_transport(
         self,

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -1,0 +1,355 @@
+import os
+import threading
+import time
+import traceback
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+import ray
+from ray.experimental.rdt.tensor_transport_manager import (
+    CommunicatorMetadata,
+    TensorTransportManager,
+    TensorTransportMetadata,
+)
+
+if TYPE_CHECKING:
+    import torch
+
+UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE = int(
+    os.environ.get("RAY_UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE", "1000")
+)
+UCCL_NUM_CPUS = int(os.environ.get("RAY_UCCL_NUM_CPUS", "4"))
+
+
+@dataclass
+class UCCLCommunicatorMetadata(CommunicatorMetadata):
+    """Metadata for the UCCL communicator."""
+
+
+@dataclass
+class UCCLTransportMetadata(TensorTransportMetadata):
+    """Metadata for tensors stored in the GPU object store for UCCL transport.
+
+    Args:
+        uccl_serialized_descs: Serialized tensor descriptors for UCCL transport.
+        uccl_endpoint_meta: The endpoint metadata of the remote UCCL endpoint,
+            used by the receiver to establish a connection.
+        uccl_endpoint_name: A unique name identifying the remote UCCL endpoint
+            (derived from the Ray actor ID).
+    """
+
+    uccl_serialized_descs: Optional[bytes] = None
+    uccl_endpoint_meta: Optional[bytes] = None
+    uccl_endpoint_name: Optional[str] = None
+
+    __eq__ = object.__eq__
+    __hash__ = object.__hash__
+
+
+@dataclass
+class TensorDesc:
+    desc: Any
+    metadata_count: int
+
+
+class UCCLTensorTransport(TensorTransportManager):
+    def __init__(self):
+        self._uccl_endpoint = None
+        self._aborted_transfer_obj_ids = set()
+        self._aborted_transfer_obj_ids_lock = threading.Lock()
+        # Mapping from tensor data pointer to the UCCL descriptor and reference count.
+        self._tensor_desc_cache: Dict[int, TensorDesc] = {}
+        # Mapping from object ID to the UCCL managed metadata.
+        self._managed_meta: Dict[str, UCCLTransportMetadata] = {}
+        # Lock protecting _tensor_desc_cache and _managed_meta since they can be
+        # accessed from the main task execution thread or the _ray_system thread.
+        self._cache_lock = threading.Lock()
+        # LRU cache of remote endpoint connections: endpoint_name -> conn_id.
+        # When full, the least recently used entry is evicted.
+        self._remote_endpoints: OrderedDict = OrderedDict()
+
+    def tensor_transport_backend(self) -> str:
+        return "UCCL"
+
+    @staticmethod
+    def is_one_sided() -> bool:
+        return True
+
+    @staticmethod
+    def can_abort_transport() -> bool:
+        return True
+
+    def _get_uccl_endpoint(self):
+        """
+        Creates a UCCL P2P endpoint with passive accept if not already created.
+        Both sender and receiver endpoints need start_passive_accept() because
+        RDMA connection setup is bidirectional.
+        """
+        if self._uccl_endpoint is not None:
+            return self._uccl_endpoint
+
+        import torch
+        from uccl import p2p
+
+        gpu_idx = torch.cuda.current_device() if torch.cuda.is_available() else 0
+        self._uccl_endpoint = p2p.Endpoint(gpu_idx, UCCL_NUM_CPUS)
+        return self._uccl_endpoint
+
+    def actor_has_tensor_transport(self, actor: "ray.actor.ActorHandle") -> bool:
+        def __ray_actor_has_tensor_transport__(
+            self: "ray.actor.ActorHandle",
+        ) -> bool:
+            try:
+                from ray.experimental.gpu_object_manager.util import (
+                    get_tensor_transport_manager,
+                )
+
+                get_tensor_transport_manager("UCCL")._get_uccl_endpoint()
+                return True
+            except Exception:
+                return False
+
+        return ray.get(
+            actor.__ray_call__.options(concurrency_group="_ray_system").remote(
+                __ray_actor_has_tensor_transport__
+            )
+        )
+
+    def extract_tensor_transport_metadata(
+        self,
+        obj_id: str,
+        gpu_object: List["torch.Tensor"],
+    ) -> UCCLTransportMetadata:
+        import torch
+
+        with self._cache_lock:
+            device = None
+            tensor_meta = []
+
+            if gpu_object:
+                devices = set()
+                device = gpu_object[0].device
+                for t in gpu_object:
+                    if t.device.type != device.type:
+                        raise ValueError(
+                            "All tensors in an RDT object must have the same device type."
+                        )
+                    if not t.is_contiguous():
+                        raise ValueError(
+                            "All tensors in an RDT object must be contiguous."
+                        )
+                    tensor_meta.append((t.shape, t.dtype))
+                    devices.add(t.device)
+                if device.type == "cuda":
+                    for dev in devices:
+                        torch.cuda.synchronize(dev)
+
+                ep = self._get_uccl_endpoint()
+                self._uccl_endpoint.start_passive_accept()
+                self._add_tensor_descs(gpu_object)
+
+                all_descs = []
+                for t in gpu_object:
+                    key = t.data_ptr()
+                    all_descs.append(self._tensor_desc_cache[key].desc)
+
+                serialized_descs = ep.get_serialized_descs(all_descs)
+                endpoint_meta = ep.get_metadata()
+
+                ctx = ray.get_runtime_context()
+                actor_id = ctx.get_actor_id()
+                if actor_id is None:
+                    import uuid
+
+                    actor_id = f"RAY-DRIVER-{uuid.uuid4()}"
+                endpoint_name = actor_id
+            else:
+                serialized_descs = None
+                endpoint_meta = None
+                endpoint_name = None
+
+            ret = UCCLTransportMetadata(
+                tensor_meta=tensor_meta,
+                tensor_device=device,
+                uccl_serialized_descs=serialized_descs,
+                uccl_endpoint_meta=endpoint_meta,
+                uccl_endpoint_name=endpoint_name,
+            )
+            self._put_meta(obj_id, ret)
+            return ret
+
+    def get_communicator_metadata(
+        self,
+        src_actor: "ray.actor.ActorHandle",
+        dst_actor: "ray.actor.ActorHandle",
+        backend: Optional[str] = None,
+    ) -> UCCLCommunicatorMetadata:
+        return UCCLCommunicatorMetadata()
+
+    def recv_multiple_tensors(
+        self,
+        obj_id: str,
+        tensor_transport_metadata: TensorTransportMetadata,
+        communicator_metadata: CommunicatorMetadata,
+    ) -> List["torch.Tensor"]:
+        from ray.experimental.gpu_object_manager.util import (
+            create_empty_tensors_from_metadata,
+        )
+
+        tensors = create_empty_tensors_from_metadata(tensor_transport_metadata)
+
+        assert isinstance(tensor_transport_metadata, UCCLTransportMetadata)
+        assert isinstance(communicator_metadata, UCCLCommunicatorMetadata)
+
+        with self._aborted_transfer_obj_ids_lock:
+            if obj_id in self._aborted_transfer_obj_ids:
+                self._aborted_transfer_obj_ids.remove(obj_id)
+                raise RuntimeError(f"UCCL transfer aborted for object id: {obj_id}")
+
+        if not tensors:
+            return []
+
+        local_descs = None
+        try:
+            ep = self._get_uccl_endpoint()
+
+            local_descs = ep.register_memory(tensors)
+
+            remote_name = tensor_transport_metadata.uccl_endpoint_name
+            remote_meta = tensor_transport_metadata.uccl_endpoint_meta
+
+            if (
+                UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0
+                and remote_name in self._remote_endpoints
+            ):
+                conn_id = self._remote_endpoints[remote_name]
+                self._remote_endpoints.move_to_end(remote_name)
+            else:
+                if (
+                    UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0
+                    and len(self._remote_endpoints)
+                    >= UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE
+                ):
+                    self._remote_endpoints.popitem(last=False)
+
+                success, conn_id = ep.add_remote_endpoint(remote_meta)
+                if not success:
+                    raise RuntimeError(
+                        f"Failed to connect to remote UCCL endpoint: {remote_name}"
+                    )
+
+                if UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0:
+                    self._remote_endpoints[remote_name] = conn_id
+
+            remote_descs = ep.deserialize_descs(
+                tensor_transport_metadata.uccl_serialized_descs
+            )
+
+            success, transfer_id = ep.transfer(
+                conn_id, "read", local_descs, remote_descs
+            )
+            if not success:
+                raise RuntimeError("UCCL transfer initiation failed.")
+
+            while True:
+                success, is_done = ep.poll_async(transfer_id)
+                if not success:
+                    raise RuntimeError("UCCL transfer got to Error state.")
+                if is_done:
+                    break
+                with self._aborted_transfer_obj_ids_lock:
+                    if obj_id in self._aborted_transfer_obj_ids:
+                        self._aborted_transfer_obj_ids.remove(obj_id)
+                        raise RuntimeError(
+                            f"UCCL transfer aborted for object id: {obj_id}"
+                        )
+                time.sleep(0.001)
+        except Exception:
+            from ray.exceptions import RayDirectTransportError
+
+            raise RayDirectTransportError(
+                f"The UCCL recv failed for object id: {obj_id}. The source actor may "
+                f"have died during the transfer. The exception thrown from the UCCL "
+                f"recv was:\n {traceback.format_exc()}"
+            ) from None
+        finally:
+            with self._aborted_transfer_obj_ids_lock:
+                self._aborted_transfer_obj_ids.discard(obj_id)
+
+        return tensors
+
+    def send_multiple_tensors(
+        self,
+        tensors: List["torch.Tensor"],
+        tensor_transport_metadata: TensorTransportMetadata,
+        communicator_metadata: CommunicatorMetadata,
+    ):
+        raise NotImplementedError(
+            "UCCL transport does not support send_multiple_tensors, "
+            "since it is a one-sided transport."
+        )
+
+    def garbage_collect(
+        self,
+        obj_id: str,
+        tensor_transport_meta: TensorTransportMetadata,
+        tensors: List["torch.Tensor"],
+    ):
+        with self._cache_lock:
+            assert isinstance(tensor_transport_meta, UCCLTransportMetadata)
+            if obj_id not in self._managed_meta:
+                return
+            self._managed_meta.pop(obj_id, None)
+            for tensor in tensors:
+                key = tensor.data_ptr()
+                if key in self._tensor_desc_cache:
+                    tensor_desc = self._tensor_desc_cache[key]
+                    tensor_desc.metadata_count -= 1
+                    if tensor_desc.metadata_count == 0:
+                        self._tensor_desc_cache.pop(key)
+
+    def abort_transport(
+        self,
+        obj_id: str,
+        communicator_metadata: CommunicatorMetadata,
+    ):
+        with self._aborted_transfer_obj_ids_lock:
+            self._aborted_transfer_obj_ids.add(obj_id)
+
+    def _get_num_managed_meta(self) -> int:
+        with self._cache_lock:
+            return len(self._managed_meta)
+
+    def _get_meta(self, object_id: str) -> Optional[UCCLTransportMetadata]:
+        if object_id in self._managed_meta:
+            return self._managed_meta[object_id]
+        return None
+
+    def _put_meta(self, object_id: str, meta: UCCLTransportMetadata):
+        self._managed_meta[object_id] = meta
+
+    def _add_tensor_descs(self, tensors: List["torch.Tensor"]):
+        """
+        Register tensors with the UCCL endpoint and cache their descriptors.
+        If a tensor is already registered (by data_ptr), its reference count is
+        incremented. New tensors are batch-registered via register_memory.
+        """
+        new_tensors = []
+        new_keys = []
+
+        for tensor in tensors:
+            key = tensor.data_ptr()
+            if key in self._tensor_desc_cache:
+                self._tensor_desc_cache[key].metadata_count += 1
+            else:
+                new_tensors.append(tensor)
+                new_keys.append(key)
+
+        if new_tensors:
+            ep = self._get_uccl_endpoint()
+            new_descs = ep.register_memory(new_tensors)
+            for key, desc in zip(new_keys, new_descs):
+                self._tensor_desc_cache[key] = TensorDesc(
+                    desc=desc, metadata_count=1
+                )

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -37,11 +37,15 @@ class UCCLTransportMetadata(TensorTransportMetadata):
             used by the receiver to establish a connection.
         uccl_endpoint_name: A unique name identifying the remote UCCL endpoint
             (derived from the Ray actor ID).
+        uccl_endpoint_meta_version: Version counter incremented whenever memory
+            is deregistered on the sender. The receiver uses this to detect
+            stale cached connections and re-establish when needed.
     """
 
     uccl_serialized_descs: Optional[bytes] = None
     uccl_endpoint_meta: Optional[bytes] = None
     uccl_endpoint_name: Optional[str] = None
+    uccl_endpoint_meta_version: Optional[int] = 0
 
     __eq__ = object.__eq__
     __hash__ = object.__hash__
@@ -66,9 +70,12 @@ class UCCLTensorTransport(TensorTransportManager):
         # Lock protecting _tensor_desc_cache and _managed_meta since they can be
         # accessed from the main task execution thread or the _ray_system thread.
         self._cache_lock = threading.Lock()
-        # LRU cache of remote endpoint connections: endpoint_name -> conn_id.
+        # LRU cache of remote endpoint connections: endpoint_name -> (conn_id, version).
         # When full, the least recently used entry is evicted.
         self._remote_endpoints: OrderedDict = OrderedDict()
+        # Increment whenever memory is deregistered on this endpoint so that
+        # receivers can detect stale cached connections.
+        self._uccl_endpoint_meta_version = 0
 
     def tensor_transport_backend(self) -> str:
         return "UCCL"
@@ -165,10 +172,12 @@ class UCCLTensorTransport(TensorTransportManager):
                 serialized_descs = ep.get_serialized_descs(all_descs)
                 endpoint_meta = ep.get_metadata()
                 endpoint_name = self._endpoint_name
+                endpoint_meta_version = self._uccl_endpoint_meta_version
             else:
                 serialized_descs = None
                 endpoint_meta = None
                 endpoint_name = None
+                endpoint_meta_version = None
 
             ret = UCCLTransportMetadata(
                 tensor_meta=tensor_meta,
@@ -176,6 +185,7 @@ class UCCLTensorTransport(TensorTransportManager):
                 uccl_serialized_descs=serialized_descs,
                 uccl_endpoint_meta=endpoint_meta,
                 uccl_endpoint_name=endpoint_name,
+                uccl_endpoint_meta_version=endpoint_meta_version,
             )
             self._put_meta(obj_id, ret)
             return ret
@@ -218,35 +228,33 @@ class UCCLTensorTransport(TensorTransportManager):
         remote_name = None
         try:
             ep = self._get_uccl_endpoint()
-
             local_descs = ep.register_memory(tensors)
-
             remote_name = tensor_transport_metadata.uccl_endpoint_name
             remote_meta = tensor_transport_metadata.uccl_endpoint_meta
+            remote_meta_version = tensor_transport_metadata.uccl_endpoint_meta_version
 
-            if (
-                UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0
-                and remote_name in self._remote_endpoints
-            ):
-                conn_id = self._remote_endpoints[remote_name]
-                self._remote_endpoints.move_to_end(remote_name)
-            else:
-                if (
-                    UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0
-                    and len(self._remote_endpoints)
-                    >= UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE
-                ):
-                    # TODO: check if need to destory the endpoint
-                    self._remote_endpoints.popitem(last=False)
+            # Agent reuse is enabled.
+            if UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0:
+                if remote_name in self._remote_endpoints:
+                    cached_conn_id, cached_version = self._remote_endpoints[remote_name]
+                    # If the remote agent metadata version is different from the cached one,
+                    # it means there was memory deregistered. We need to remove the remote endpoint
+                    # before adding it, since there is potential memory overlap.
+                    if remote_meta_version != cached_version:
+                        ep.remove_remote_endpoint(cached_conn_id)
+                    self._remote_endpoints.move_to_end(remote_name)
+                elif len(self._remote_endpoints) >= UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE:
+                    evicted_name, (evicted_conn_id, _) = self._remote_endpoints.popitem(last=False)
+                    ep.remove_remote_endpoint(evicted_conn_id)
 
-                success, conn_id = ep.add_remote_endpoint(remote_meta)
-                if not success:
-                    raise RuntimeError(
-                        f"Failed to connect to remote UCCL endpoint: {remote_name}"
-                    )
-
-                if UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0:
-                    self._remote_endpoints[remote_name] = conn_id
+            # Establish the connection and read the data.
+            success, conn_id = ep.add_remote_endpoint(remote_meta)
+            if not success:
+                raise RuntimeError(
+                    f"Failed to connect to remote UCCL endpoint: {remote_name}"
+                )
+            if UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE > 0:
+                self._remote_endpoints[remote_name] = (conn_id, remote_meta_version)
 
             remote_descs = ep.deserialize_descs(
                 tensor_transport_metadata.uccl_serialized_descs
@@ -270,7 +278,7 @@ class UCCLTensorTransport(TensorTransportManager):
                         raise RuntimeError(
                             f"UCCL transfer aborted for object id: {obj_id}"
                         )
-                time.sleep(0.001)
+                time.sleep(0.001) # Avoid busy waiting.
         except Exception:
             from ray.exceptions import RayDirectTransportError
 
@@ -282,10 +290,15 @@ class UCCLTensorTransport(TensorTransportManager):
         finally:
             with self._aborted_transfer_obj_ids_lock:
                 self._aborted_transfer_obj_ids.discard(obj_id)
-            # TODO: check if need to destory the endpoint
-            # if local_descs:
-            #     with self._cache_lock:
-            #         ep.deregister_memory(local_descs)
+            if UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE == 0 and remote_name:
+                ep.remove_remote_endpoint(
+                    self._remote_endpoints[remote_name][0]
+                )
+            if local_descs:
+                with self._cache_lock:
+                    ep.deregister_memory(local_descs)
+                    self._uccl_endpoint_meta_version += 1
+
 
         return tensors
 
@@ -319,7 +332,8 @@ class UCCLTensorTransport(TensorTransportManager):
                     tensor_desc.metadata_count -= 1
                     if tensor_desc.metadata_count == 0:
                         self._tensor_desc_cache.pop(key)
-                        # ep.deregister_memory([tensor_desc.desc])
+                        ep.deregister_memory([tensor_desc.desc])
+                        self._uccl_endpoint_meta_version += 1
 
     def abort_transport(
         self,
@@ -347,6 +361,12 @@ class UCCLTensorTransport(TensorTransportManager):
         If a tensor is already registered (by data_ptr), its reference count is
         incremented. New tensors are registered one at a time so that duplicates
         within the same input list are detected immediately via the cache.
+
+        Unlike NIXL which registers at the storage level, UCCL registers each
+        tensor view individually — ep.register_memory([tensor]) returns a
+        descriptor for that specific view's data region. Using data_ptr() as
+        the key ensures each view gets its own descriptor, which is necessary
+        for correct transfer of overlapping views.
         """
         ep = self._get_uccl_endpoint()
         for tensor in tensors:

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -86,7 +86,7 @@ class UCCLTensorTransport(TensorTransportManager):
 
     def _get_uccl_endpoint(self):
         """
-        Creates a UCCL P2P endpoint with passive accept if not already created.
+        Creates a UCCL P2P endpoint if not already created.
         """
         if self._uccl_endpoint is not None:
             return self._uccl_endpoint
@@ -94,20 +94,18 @@ class UCCLTensorTransport(TensorTransportManager):
         import torch
         from uccl import p2p
 
-        # CUDA-visible device index for GPU operations.
+        # Currently using physical GPU index when creating the endpoint.
         cuda_device = (
             torch.cuda.current_device() if torch.cuda.is_available() else 0
         )
-        # Physical GPU index for UCCL identity (shm ring naming, metadata).
-        # Ray remaps CUDA_VISIBLE_DEVICES per actor so each actor sees
-        # device 0, but UCCL needs node-unique physical indices.
         gpu_ids = ray.get_gpu_ids()
         if gpu_ids:
             physical_gpu_idx = int(gpu_ids[cuda_device])
         else:
             physical_gpu_idx = cuda_device
-        # print(f"cuda_device, p_gpu_idx:{cuda_device, physical_gpu_idx}")
-        self._uccl_endpoint = p2p.Endpoint(physical_gpu_idx)
+        # TODO: This endpoint API is subject to future changes as UCCL is evolving to
+        # better support GPU index identification for workloads like Ray.
+        self._uccl_endpoint = p2p.Endpoint(cuda_device, physical_gpu_idx)
         self._uccl_endpoint.start_passive_accept()
 
         ctx = ray.get_runtime_context()

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -119,10 +119,7 @@ class UCCLTensorTransport(TensorTransportManager):
         return self._uccl_endpoint
 
     def actor_has_tensor_transport(self, actor: "ray.actor.ActorHandle") -> bool:
-        def __ray_actor_has_tensor_transport__(
-            self: "ray.actor.ActorHandle",
-        ) -> bool:
-            return True
+        return True
 
     def extract_tensor_transport_metadata(
         self,

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -94,9 +94,7 @@ class UCCLTensorTransport(TensorTransportManager):
         import torch
         from uccl import p2p
 
-        cuda_device = (
-            torch.cuda.current_device() if torch.cuda.is_available() else 0
-        )
+        cuda_device = torch.cuda.current_device() if torch.cuda.is_available() else 0
         self._uccl_endpoint = p2p.Endpoint(cuda_device)
         self._uccl_endpoint.start_passive_accept()
 
@@ -221,7 +219,9 @@ class UCCLTensorTransport(TensorTransportManager):
                         ep.remove_remote_endpoint(cached_conn_id)
                     self._remote_endpoints.move_to_end(remote_name)
                 elif len(self._remote_endpoints) >= UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE:
-                    evicted_name, (evicted_conn_id, _) = self._remote_endpoints.popitem(last=False)
+                    evicted_name, (evicted_conn_id, _) = self._remote_endpoints.popitem(
+                        last=False
+                    )
                     ep.remove_remote_endpoint(evicted_conn_id)
 
             # Establish the connection and read the data.
@@ -255,7 +255,7 @@ class UCCLTensorTransport(TensorTransportManager):
                         raise RuntimeError(
                             f"UCCL transfer aborted for object id: {obj_id}"
                         )
-                time.sleep(0.001) # Avoid busy waiting.
+                time.sleep(0.001)  # Avoid busy waiting.
         except Exception:
             from ray.exceptions import RayDirectTransportError
 
@@ -268,9 +268,7 @@ class UCCLTensorTransport(TensorTransportManager):
             with self._aborted_transfer_obj_ids_lock:
                 self._aborted_transfer_obj_ids.discard(obj_id)
             if UCCL_REMOTE_ENDPOINT_CACHE_MAXSIZE == 0 and remote_name:
-                ep.remove_remote_endpoint(
-                    self._remote_endpoints[remote_name][0]
-                )
+                ep.remove_remote_endpoint(self._remote_endpoints[remote_name][0])
             if local_descs:
                 with self._cache_lock:
                     ep.deregister_memory(local_descs)

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -56,6 +56,7 @@ class TensorDesc:
 class UCCLTensorTransport(TensorTransportManager):
     def __init__(self):
         self._uccl_endpoint = None
+        self._endpoint_name = None
         self._aborted_transfer_obj_ids = set()
         self._aborted_transfer_obj_ids_lock = threading.Lock()
         # Mapping from tensor data pointer to the UCCL descriptor and reference count.
@@ -92,6 +93,15 @@ class UCCLTensorTransport(TensorTransportManager):
 
         gpu_idx = torch.cuda.current_device() if torch.cuda.is_available() else 0
         self._uccl_endpoint = p2p.Endpoint(gpu_idx, UCCL_NUM_CPUS)
+
+        ctx = ray.get_runtime_context()
+        actor_id = ctx.get_actor_id()
+        if actor_id is None:
+            import uuid
+
+            actor_id = f"RAY-DRIVER-{uuid.uuid4()}"
+        self._endpoint_name = actor_id
+
         return self._uccl_endpoint
 
     def actor_has_tensor_transport(self, actor: "ray.actor.ActorHandle") -> bool:
@@ -154,14 +164,7 @@ class UCCLTensorTransport(TensorTransportManager):
 
                 serialized_descs = ep.get_serialized_descs(all_descs)
                 endpoint_meta = ep.get_metadata()
-
-                ctx = ray.get_runtime_context()
-                actor_id = ctx.get_actor_id()
-                if actor_id is None:
-                    import uuid
-
-                    actor_id = f"RAY-DRIVER-{uuid.uuid4()}"
-                endpoint_name = actor_id
+                endpoint_name = self._endpoint_name
             else:
                 serialized_descs = None
                 endpoint_meta = None
@@ -280,9 +283,9 @@ class UCCLTensorTransport(TensorTransportManager):
             with self._aborted_transfer_obj_ids_lock:
                 self._aborted_transfer_obj_ids.discard(obj_id)
             # TODO: check if need to destory the endpoint
-            if local_descs:
-                with self._cache_lock:
-                    ep.deregister_memory(local_descs)
+            # if local_descs:
+            #     with self._cache_lock:
+            #         ep.deregister_memory(local_descs)
 
         return tensors
 
@@ -316,7 +319,7 @@ class UCCLTensorTransport(TensorTransportManager):
                     tensor_desc.metadata_count -= 1
                     if tensor_desc.metadata_count == 0:
                         self._tensor_desc_cache.pop(key)
-                        ep.deregister_memory([tensor_desc.desc])
+                        # ep.deregister_memory([tensor_desc.desc])
 
     def abort_transport(
         self,
@@ -342,23 +345,16 @@ class UCCLTensorTransport(TensorTransportManager):
         """
         Register tensors with the UCCL endpoint and cache their descriptors.
         If a tensor is already registered (by data_ptr), its reference count is
-        incremented. New tensors are batch-registered via register_memory.
+        incremented. New tensors are registered one at a time so that duplicates
+        within the same input list are detected immediately via the cache.
         """
-        new_tensors = []
-        new_keys = []
-
+        ep = self._get_uccl_endpoint()
         for tensor in tensors:
             key = tensor.data_ptr()
             if key in self._tensor_desc_cache:
                 self._tensor_desc_cache[key].metadata_count += 1
             else:
-                new_tensors.append(tensor)
-                new_keys.append(key)
-
-        if new_tensors:
-            ep = self._get_uccl_endpoint()
-            new_descs = ep.register_memory(new_tensors)
-            for key, desc in zip(new_keys, new_descs):
+                descs = ep.register_memory([tensor])
                 self._tensor_desc_cache[key] = TensorDesc(
-                    desc=desc, metadata_count=1
+                    desc=descs[0], metadata_count=1
                 )

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -94,18 +94,10 @@ class UCCLTensorTransport(TensorTransportManager):
         import torch
         from uccl import p2p
 
-        # Currently using physical GPU index when creating the endpoint.
         cuda_device = (
             torch.cuda.current_device() if torch.cuda.is_available() else 0
         )
-        gpu_ids = ray.get_gpu_ids()
-        if gpu_ids:
-            physical_gpu_idx = int(gpu_ids[cuda_device])
-        else:
-            physical_gpu_idx = cuda_device
-        # TODO: This endpoint API is subject to future changes as UCCL is evolving to
-        # better support GPU index identification for workloads like Ray.
-        self._uccl_endpoint = p2p.Endpoint(cuda_device, physical_gpu_idx)
+        self._uccl_endpoint = p2p.Endpoint(cuda_device)
         self._uccl_endpoint.start_passive_accept()
 
         ctx = ray.get_runtime_context()

--- a/python/ray/experimental/rdt/uccl_tensor_transport.py
+++ b/python/ray/experimental/rdt/uccl_tensor_transport.py
@@ -122,21 +122,7 @@ class UCCLTensorTransport(TensorTransportManager):
         def __ray_actor_has_tensor_transport__(
             self: "ray.actor.ActorHandle",
         ) -> bool:
-            try:
-                from ray.experimental.rdt.util import (
-                    get_tensor_transport_manager,
-                )
-
-                get_tensor_transport_manager("UCCL")._get_uccl_endpoint()
-                return True
-            except Exception:
-                return False
-
-        return ray.get(
-            actor.__ray_call__.options(concurrency_group="_ray_system").remote(
-                __ray_actor_has_tensor_transport__
-            )
-        )
+            return True
 
     def extract_tensor_transport_metadata(
         self,

--- a/python/ray/experimental/rdt/util.py
+++ b/python/ray/experimental/rdt/util.py
@@ -11,13 +11,12 @@ from ray.experimental.rdt.cuda_ipc_transport import CudaIpcTransport
 from ray.experimental.rdt.nixl_tensor_transport import (
     NixlTensorTransport,
 )
-from ray.experimental.rdt.uccl_tensor_transport import (
-    UCCLTensorTransport,
-)
-
 from ray.experimental.rdt.tensor_transport_manager import (
     TensorTransportManager,
     TensorTransportMetadata,
+)
+from ray.experimental.rdt.uccl_tensor_transport import (
+    UCCLTensorTransport,
 )
 from ray.util.annotations import PublicAPI
 

--- a/python/ray/experimental/rdt/util.py
+++ b/python/ray/experimental/rdt/util.py
@@ -11,6 +11,10 @@ from ray.experimental.rdt.cuda_ipc_transport import CudaIpcTransport
 from ray.experimental.rdt.nixl_tensor_transport import (
     NixlTensorTransport,
 )
+from ray.experimental.rdt.uccl_tensor_transport import (
+    UCCLTensorTransport,
+)
+
 from ray.experimental.rdt.tensor_transport_manager import (
     TensorTransportManager,
     TensorTransportMetadata,
@@ -84,7 +88,7 @@ def register_tensor_transport(
         has_custom_transports = True
 
 
-DEFAULT_TRANSPORTS = ["NIXL", "GLOO", "NCCL", "CUDA_IPC"]
+DEFAULT_TRANSPORTS = ["NIXL", "GLOO", "NCCL", "CUDA_IPC", "UCCL"]
 
 _default_transports_registered = False
 
@@ -109,6 +113,9 @@ def _ensure_default_transports_registered():
             )
             register_tensor_transport(
                 "CUDA_IPC", ["cuda"], CudaIpcTransport, torch.Tensor
+            )
+            register_tensor_transport(
+                "UCCL", ["cuda"], UCCLTensorTransport, torch.Tensor
             )
         except ImportError:
             pass

--- a/python/ray/experimental/rdt/util.py
+++ b/python/ray/experimental/rdt/util.py
@@ -115,7 +115,7 @@ def _ensure_default_transports_registered():
                 "CUDA_IPC", ["cuda"], CudaIpcTransport, torch.Tensor
             )
             register_tensor_transport(
-                "UCCL", ["cuda", "cpu"], UCCLTensorTransport, torch.Tensor
+                "UCCL", ["cuda"], UCCLTensorTransport, torch.Tensor
             )
         except ImportError:
             pass

--- a/python/ray/experimental/rdt/util.py
+++ b/python/ray/experimental/rdt/util.py
@@ -115,7 +115,7 @@ def _ensure_default_transports_registered():
                 "CUDA_IPC", ["cuda"], CudaIpcTransport, torch.Tensor
             )
             register_tensor_transport(
-                "UCCL", ["cuda"], UCCLTensorTransport, torch.Tensor
+                "UCCL", ["cuda", "cpu"], UCCLTensorTransport, torch.Tensor
             )
         except ImportError:
             pass

--- a/python/ray/tests/rdt/test_gpu_objects_uccl.py
+++ b/python/ray/tests/rdt/test_gpu_objects_uccl.py
@@ -133,6 +133,16 @@ def test_p2p(ray_start_regular):
     result = dst_actor.sum.remote(ref, "cuda")
     assert tensor.sum().item() == ray.get(result)
 
+@pytest.mark.skip(
+    "CPU to CPU transfer is a work-in-progress by UCCL."
+)
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_p2p_cpu_to_cpu(ray_start_regular):
+    num_actors = 2
+    actors = [UCCLGPUTestActor.remote() for _ in range(num_actors)]
+
+    src_actor, dst_actor = actors[0], actors[1]
+
     # Test CPU to CPU transfer
     tensor1 = torch.tensor([4, 5, 6])
     ref1 = src_actor.echo.remote(tensor1, "cpu")
@@ -337,8 +347,7 @@ def test_uccl_endpoint_reuse_with_partial_tensors(ray_start_regular):
 def test_data_ptr_level_reference_count(ray_start_regular):
     """Test that UCCL uses data_ptr() as the cache key for tensor deduplication.
 
-    Unlike NIXL (which keys by untyped_storage().data_ptr()), UCCL keys by
-    data_ptr(). Registering the same tensor under two object IDs increments
+    Registering the same tensor under two object IDs increments
     the metadata_count. When each obj ref goes out of scope via garbage_collect,
     the count decrements. After both are freed, the cache entry is removed.
     """

--- a/python/ray/tests/rdt/test_gpu_objects_uccl.py
+++ b/python/ray/tests/rdt/test_gpu_objects_uccl.py
@@ -1,0 +1,402 @@
+import sys
+
+import pytest
+import torch
+
+import ray
+from ray._common.test_utils import SignalActor, wait_for_condition
+from ray.experimental.rdt.util import get_tensor_transport_manager
+
+
+@ray.remote(num_gpus=1, num_cpus=0, enable_tensor_transport=True)
+class UCCLGPUTestActor:
+    def __init__(self):
+        self.reserved_tensor1 = torch.tensor([1, 2, 3]).to("cuda")
+        self.reserved_tensor2 = torch.tensor([4, 5, 6]).to("cuda")
+        self.reserved_tensor3 = torch.tensor([7, 8, 9]).to("cuda")
+
+    @ray.method(tensor_transport="uccl")
+    def echo(self, data, device):
+        return data.to(device)
+
+    def sum(self, data, device):
+        assert data.device.type == device
+        return data.sum().item()
+
+    def produce(self, tensors):
+        refs = []
+        for t in tensors:
+            refs.append(ray.put(t, _tensor_transport="uccl"))
+        return refs
+
+    def consume_with_uccl(self, refs):
+        tensors = [ray.get(ref) for ref in refs]
+        total = 0
+        for t in tensors:
+            assert t.device.type == "cuda"
+            total += t.sum().item()
+        return total
+
+    def gc(self):
+        tensor = torch.tensor([1, 2, 3]).to("cuda")
+        ref = ray.put(tensor, _tensor_transport="uccl")
+        obj_id = ref.hex()
+        gpu_manager = ray._private.worker.global_worker.gpu_object_manager
+        uccl_transport = get_tensor_transport_manager("UCCL")
+
+        assert gpu_manager.gpu_object_store.has_tensor(tensor)
+        assert gpu_manager.is_managed_object(obj_id)
+        assert obj_id in uccl_transport._managed_meta
+        # UCCL uses data_ptr() (not untyped_storage().data_ptr()) as the cache key
+        key = tensor.data_ptr()
+        assert key in uccl_transport._tensor_desc_cache
+        assert uccl_transport._tensor_desc_cache[key].metadata_count == 1
+
+        del ref
+
+        gpu_manager.gpu_object_store.wait_tensor_freed(tensor, timeout=10)
+        assert not gpu_manager.gpu_object_store.has_tensor(tensor)
+        assert not gpu_manager.is_managed_object(obj_id)
+        assert obj_id not in uccl_transport._managed_meta
+        assert key not in uccl_transport._tensor_desc_cache
+        return "Success"
+
+    @ray.method(tensor_transport="uccl")
+    def send_dict1(self):
+        return {"round1-1": self.reserved_tensor1, "round1-2": self.reserved_tensor2}
+
+    @ray.method(tensor_transport="uccl")
+    def send_dict2(self):
+        return {"round2-1": self.reserved_tensor1, "round2-3": self.reserved_tensor3}
+
+    def sum_dict(self, dict):
+        return sum(v.sum().item() for v in dict.values())
+
+    def get_num_gpu_objects(self):
+        gpu_object_manager = ray._private.worker.global_worker.gpu_object_manager
+        return gpu_object_manager.gpu_object_store.get_num_objects()
+
+    def get_num_managed_meta_uccl(self):
+        return get_tensor_transport_manager("UCCL")._get_num_managed_meta()
+
+    def put_shared_tensor_lists(self):
+        """Create two tensor lists sharing a common tensor and put them with UCCL."""
+        t1 = torch.tensor([1, 2, 3]).to("cuda")
+        t2 = torch.tensor([4, 5, 6]).to("cuda")
+        t3 = torch.tensor([7, 8, 9]).to("cuda")
+
+        list1 = [t1, t2]
+        list2 = [t2, t3]
+
+        ref1 = ray.put(list1, _tensor_transport="uccl")
+        # UCCL deduplicates by data_ptr, so t2 is only registered once.
+        ref2 = ray.put(list2, _tensor_transport="uccl")
+
+        return ref1, ref2
+
+    @ray.method(concurrency_group="_ray_system")
+    def block_background_thread(self, signal_actor):
+        ray.get(signal_actor.wait.remote())
+
+    def block_main_thread(self, signal_actor):
+        ray.get(signal_actor.wait.remote())
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
+def test_ray_get_gpu_ref_created_by_actor_task(ray_start_regular):
+    actor = UCCLGPUTestActor.remote()
+    tensor = torch.tensor([1, 2, 3]).to("cuda")
+    ref1 = actor.echo.remote(tensor, "cuda")
+    ref2 = actor.echo.remote(tensor, "cuda")
+    ref3 = actor.echo.remote(tensor, "cuda")
+
+    # Test ray.get with default tensor transport, should use uccl here.
+    assert torch.equal(ray.get(ref1), tensor)
+
+    # Test ray.get with uccl tensor transport
+    assert torch.equal(ray.get(ref2), tensor)
+
+    # Test ray.get with object store tensor transport
+    assert torch.equal(ray.get(ref3, _use_object_store=True), tensor)
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_p2p(ray_start_regular):
+    num_actors = 2
+    actors = [UCCLGPUTestActor.remote() for _ in range(num_actors)]
+
+    src_actor, dst_actor = actors[0], actors[1]
+
+    # Test GPU to GPU transfer
+    tensor = torch.tensor([1, 2, 3])
+    ref = src_actor.echo.remote(tensor, "cuda")
+    result = dst_actor.sum.remote(ref, "cuda")
+    assert tensor.sum().item() == ray.get(result)
+
+    # Test CPU to CPU transfer
+    tensor1 = torch.tensor([4, 5, 6])
+    ref1 = src_actor.echo.remote(tensor1, "cpu")
+    result1 = dst_actor.sum.remote(ref1, "cpu")
+    assert tensor1.sum().item() == ray.get(result1)
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
+def test_intra_gpu_tensor_transfer(ray_start_regular):
+    actor = UCCLGPUTestActor.remote()
+
+    tensor = torch.tensor([1, 2, 3])
+
+    # Intra-actor communication for pure GPU tensors
+    ref = actor.echo.remote(tensor, "cuda")
+    result = actor.sum.remote(ref, "cuda")
+    assert tensor.sum().item() == ray.get(result)
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_put_and_get_object_with_uccl(ray_start_regular):
+    actors = [UCCLGPUTestActor.remote() for _ in range(2)]
+    src_actor, dst_actor = actors[0], actors[1]
+    tensor1 = torch.tensor([1, 2, 3]).to("cuda")
+    tensor2 = torch.tensor([4, 5, 6, 0]).to("cuda")
+    tensor3 = torch.tensor([7, 8, 9, 0, 0]).to("cuda")
+    tensors = [tensor1, tensor2, tensor3]
+    ref = src_actor.produce.remote(tensors)
+    ref1 = dst_actor.consume_with_uccl.remote(ref)
+    result1 = ray.get(ref1)
+    assert result1 == 45
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
+def test_put_gc(ray_start_regular):
+    actor = UCCLGPUTestActor.remote()
+    ref = actor.gc.remote()
+    assert ray.get(ref) == "Success"
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_send_duplicate_tensor(ray_start_regular):
+    actors = [UCCLGPUTestActor.remote() for _ in range(2)]
+    src_actor, dst_actor = actors[0], actors[1]
+    ref1 = src_actor.send_dict1.remote()
+    result1 = dst_actor.sum_dict.remote(ref1)
+    assert ray.get(result1) == 21
+    ref2 = src_actor.send_dict1.remote()
+    result2 = dst_actor.sum_dict.remote(ref2)
+    assert ray.get(result2) == 21
+
+    del ref1
+    del ref2
+    wait_for_condition(
+        lambda: ray.get(src_actor.get_num_gpu_objects.remote()) == 0,
+        timeout=10,
+        retry_interval_ms=100,
+    )
+    wait_for_condition(
+        lambda: ray.get(src_actor.get_num_managed_meta_uccl.remote()) == 0,
+        timeout=10,
+        retry_interval_ms=100,
+    )
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_uccl_abort_sender_dies_before_sending(ray_start_regular):
+    actors = [UCCLGPUTestActor.remote() for _ in range(2)]
+
+    """
+    1. Block background thread on receiver so receive doesn't start
+    2. Wait until the object is created so the transfer gets triggered
+    3. Kill the sender
+    4. Unblock the receiver
+    """
+    signal_actor = SignalActor.remote()
+    actors[1].block_background_thread.remote(signal_actor)
+    ref = actors[0].echo.remote(torch.randn((100, 100)), "cuda")
+    result = actors[1].sum.remote(ref, "cuda")
+    ray.wait([ref])
+    ray.kill(actors[0])
+    signal_actor.send.remote()
+
+    with pytest.raises(ray.exceptions.RayTaskError) as excinfo:
+        ray.get(result)
+
+    exc_str = str(excinfo.value)
+    assert "UCCL" in exc_str and "The source actor may have died" in exc_str
+
+    # Try a transfer with actor[1] receiving again
+    new_actor = UCCLGPUTestActor.remote()
+    ref = new_actor.echo.remote(torch.tensor([4, 5, 6]), "cuda")
+    result = actors[1].sum.remote(ref, "cuda")
+    assert ray.get(result) == 15
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_uccl_del_before_creating(ray_start_regular):
+    """
+    Blocking the main thread until we free the object from the reference counter.
+    Then unblocking the actor's main thread so the object can be created and then
+    asserting that the object was actually freed.
+    """
+    signal_actor = SignalActor.remote()
+    actor = UCCLGPUTestActor.remote()
+    actor.block_main_thread.remote(signal_actor)
+    ref = actor.echo.remote(torch.tensor([4, 5, 6]), "cuda")
+    obj_id = ref.hex()
+    del ref
+    ray.get(signal_actor.send.remote())
+
+    wait_for_condition(
+        lambda: ray._private.worker.global_worker.gpu_object_manager.get_gpu_object_metadata(
+            obj_id
+        )
+        is None,
+    )
+    wait_for_condition(
+        lambda: ray.get(actor.get_num_gpu_objects.remote()) == 0,
+    )
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
+def test_shared_tensor_deduplication(ray_start_regular):
+    """
+    Test that tensors shared across multiple lists are properly deduplicated.
+
+    Creates list1 = [T1, T2] and list2 = [T2, T3] where T2 is shared.
+    UCCL deduplicates by data_ptr, so T2 is only registered once across both puts.
+    """
+    actor = UCCLGPUTestActor.remote()
+    ray.get(actor.put_shared_tensor_lists.remote())
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_uccl_endpoint_reuse(ray_start_regular):
+    """
+    We reuse UCCL remote endpoints by default. The receiver should successfully receive
+    all tensors while the sender may trigger GC in between.
+    """
+    actors = [UCCLGPUTestActor.remote() for _ in range(2)]
+    src_actor, dst_actor = actors[0], actors[1]
+
+    ref1 = src_actor.echo.remote(torch.tensor([1, 2, 3]).to("cuda"), "cuda")
+    assert ray.get(dst_actor.sum.remote(ref1, "cuda")) == 6
+
+    # Trigger another transfer. The receiver successfully gets
+    # the latest tensor (UCCL endpoint connection is reused internally).
+    ref2 = src_actor.echo.remote(torch.tensor([4, 5, 6]).to("cuda"), "cuda")
+    assert ray.get(dst_actor.sum.remote(ref2, "cuda")) == 15
+
+    del ref1, ref2
+
+    # Wait for GC to free the tensors on the sender.
+    wait_for_condition(
+        lambda: ray.get(src_actor.get_num_managed_meta_uccl.remote()) == 0,
+        timeout=10,
+        retry_interval_ms=100,
+    )
+
+    # Transfer after GC. The receiver successfully gets
+    # the latest tensor (UCCL endpoint is reconnected or reused internally).
+    ref3 = src_actor.echo.remote(torch.tensor([7, 8, 9]).to("cuda"), "cuda")
+    assert ray.get(dst_actor.sum.remote(ref3, "cuda")) == 24
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_uccl_endpoint_reuse_with_partial_tensors(ray_start_regular):
+    """
+    We reuse UCCL remote endpoints by default. The receiver should successfully choose
+    and receive part of the tensors.
+    """
+    actors = [UCCLGPUTestActor.remote() for _ in range(2)]
+    src_actor, dst_actor = actors[0], actors[1]
+
+    ref1 = src_actor.echo.remote(torch.tensor([1, 2, 3, 4, 5, 6]).to("cuda"), "cuda")
+    assert ray.get(dst_actor.sum.remote(ref1, "cuda")) == 21
+
+    del ref1
+
+    # Wait for GC to free the tensors on the sender.
+    wait_for_condition(
+        lambda: ray.get(src_actor.get_num_managed_meta_uccl.remote()) == 0,
+        timeout=10,
+        retry_interval_ms=100,
+    )
+
+    # Create the second tensor at the sender. The memory address of
+    # this tensor may overlap with the first tensor (de-registered).
+    ref2 = src_actor.echo.remote(torch.tensor([1, 2, 3]).to("cuda"), "cuda")
+
+    # Create the third tensor at the sender. The memory address of
+    # this tensor may overlap with the first tensor (de-registered).
+    ref3 = src_actor.echo.remote(torch.tensor([4, 5, 6]).to("cuda"), "cuda")
+    # Trigger the transfer. The receiver successfully gets the third tensor.
+    assert ray.get(dst_actor.sum.remote(ref3, "cuda")) == 15
+
+    del ref2, ref3
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
+def test_data_ptr_level_reference_count(ray_start_regular):
+    """Test that UCCL uses data_ptr() as the cache key for tensor deduplication.
+
+    Unlike NIXL (which keys by untyped_storage().data_ptr()), UCCL keys by
+    data_ptr(). Registering the same tensor under two object IDs increments
+    the metadata_count. When each obj ref goes out of scope via garbage_collect,
+    the count decrements. After both are freed, the cache entry is removed.
+    """
+    from ray.experimental.rdt.uccl_tensor_transport import (
+        UCCLTensorTransport,
+    )
+
+    transport = UCCLTensorTransport()
+
+    tensor = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.float32).to("cuda")
+    data_ptr = tensor.data_ptr()
+
+    # Simulate ray.put(tensor) - first registration
+    obj_id1 = "test_obj_id_1"
+    meta1 = transport.extract_tensor_transport_metadata(obj_id1, [tensor])
+    assert len(transport._tensor_desc_cache) == 1
+    assert transport._tensor_desc_cache[data_ptr].metadata_count == 1
+
+    # Simulate ray.put(tensor) again with the same tensor object (same data_ptr).
+    # The cache entry is reused and metadata_count is incremented.
+    obj_id2 = "test_obj_id_2"
+    meta2 = transport.extract_tensor_transport_metadata(obj_id2, [tensor])
+    assert len(transport._tensor_desc_cache) == 1
+    assert transport._tensor_desc_cache[data_ptr].metadata_count == 2
+
+    # Simulate the obj ref for obj_id1 going out of scope.
+    # The cache entry should still exist since obj_id2 is still alive.
+    transport.garbage_collect(obj_id1, meta1, [tensor])
+    assert data_ptr in transport._tensor_desc_cache
+    assert transport._tensor_desc_cache[data_ptr].metadata_count == 1
+
+    # Simulate the obj ref for obj_id2 going out of scope.
+    # The cache entry should now be removed.
+    transport.garbage_collect(obj_id2, meta2, [tensor])
+    assert data_ptr not in transport._tensor_desc_cache
+
+
+@ray.remote(num_gpus=1, num_cpus=0, enable_tensor_transport=True)
+class UCCLOverlappingViewProducer:
+    def produce_overlapping_views(self):
+        tensor = torch.tensor([1, 2, 3, 4, 5], dtype=torch.float32).to("cuda")
+        slices = [tensor[0:2], tensor[1:3], tensor[2:4]]
+        refs = []
+        for s in slices:
+            refs.append(ray.put(s, _tensor_transport="uccl"))
+        return refs
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_overlapping_views(ray_start_regular):
+    """Test that overlapping views of the same storage tensor are properly transferred."""
+    actors = [UCCLOverlappingViewProducer.remote(), UCCLGPUTestActor.remote()]
+    src_actor, dst_actor = actors[0], actors[1]
+
+    refs = ray.get(src_actor.produce_overlapping_views.remote())
+    result = ray.get(dst_actor.consume_with_uccl.remote(refs))
+    assert result == 15
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/rdt/test_gpu_objects_uccl.py
+++ b/python/ray/tests/rdt/test_gpu_objects_uccl.py
@@ -47,7 +47,6 @@ class UCCLGPUTestActor:
         assert gpu_manager.gpu_object_store.has_tensor(tensor)
         assert gpu_manager.is_managed_object(obj_id)
         assert obj_id in uccl_transport._managed_meta
-        # UCCL uses data_ptr() (not untyped_storage().data_ptr()) as the cache key
         key = tensor.data_ptr()
         assert key in uccl_transport._tensor_desc_cache
         assert uccl_transport._tensor_desc_cache[key].metadata_count == 1
@@ -133,9 +132,6 @@ def test_p2p(ray_start_regular):
     result = dst_actor.sum.remote(ref, "cuda")
     assert tensor.sum().item() == ray.get(result)
 
-@pytest.mark.skip(
-    "CPU to CPU transfer is a work-in-progress by UCCL."
-)
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 def test_p2p_cpu_to_cpu(ray_start_regular):
     num_actors = 2

--- a/python/ray/tests/rdt/test_rdt_uccl.py
+++ b/python/ray/tests/rdt/test_rdt_uccl.py
@@ -144,6 +144,7 @@ def test_p2p(ray_start_regular):
     assert tensor.sum().item() == ray.get(result)
 
 
+@pytest.mark.skip(reason="CPU-CPU transfer support is WIP")
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 def test_p2p_cpu_to_cpu(ray_start_regular):
     num_actors = 2
@@ -251,6 +252,7 @@ def test_uccl_abort_sender_dies_before_creating(ray_start_regular):
     assert ray.get(result) == 15
 
 
+@pytest.mark.skip(reason="UCCL connection state corruption after sender killed. Fixing this is WIP.")
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 def test_uccl_abort_sender_dies_before_sending(ray_start_regular):
     actors = [UCCLGPUTestActor.remote() for _ in range(2)]

--- a/python/ray/tests/rdt/test_rdt_uccl.py
+++ b/python/ray/tests/rdt/test_rdt_uccl.py
@@ -251,7 +251,9 @@ def test_uccl_abort_sender_dies_before_creating(ray_start_regular):
     assert ray.get(result) == 15
 
 
-@pytest.mark.skip(reason="UCCL connection state corruption after sender killed. Fixing this is WIP.")
+@pytest.mark.skip(
+    reason="UCCL connection state corruption after sender killed. Fixing this is WIP."
+)
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 def test_uccl_abort_sender_dies_before_sending(ray_start_regular):
     actors = [UCCLGPUTestActor.remote() for _ in range(2)]

--- a/python/ray/tests/rdt/test_rdt_uccl.py
+++ b/python/ray/tests/rdt/test_rdt_uccl.py
@@ -5,6 +5,7 @@ import torch
 
 import ray
 from ray._common.test_utils import SignalActor, wait_for_condition
+from ray.experimental import set_target_for_ref
 from ray.experimental.rdt.util import get_tensor_transport_manager
 
 
@@ -37,27 +38,33 @@ class UCCLGPUTestActor:
             total += t.sum().item()
         return total
 
+    def consume_with_object_store(self, refs):
+        tensors = [ray.get(ref, _use_object_store=True) for ref in refs]
+        total = 0
+        for t in tensors:
+            assert t.device.type == "cuda"
+            total += t.sum().item()
+        return total
+
     def gc(self):
         tensor = torch.tensor([1, 2, 3]).to("cuda")
         ref = ray.put(tensor, _tensor_transport="uccl")
         obj_id = ref.hex()
-        gpu_manager = ray._private.worker.global_worker.gpu_object_manager
+        rdt_manager = ray._private.worker.global_worker.rdt_manager
         uccl_transport = get_tensor_transport_manager("UCCL")
 
-        assert gpu_manager.gpu_object_store.has_tensor(tensor)
-        assert gpu_manager.is_managed_object(obj_id)
+        assert rdt_manager.rdt_store.has_tensor(tensor)
+        assert rdt_manager.is_managed_object(obj_id)
         assert obj_id in uccl_transport._managed_meta
-        key = tensor.data_ptr()
-        assert key in uccl_transport._tensor_desc_cache
-        assert uccl_transport._tensor_desc_cache[key].metadata_count == 1
+        assert obj_id in uccl_transport._obj_descs
 
         del ref
 
-        gpu_manager.gpu_object_store.wait_tensor_freed(tensor, timeout=10)
-        assert not gpu_manager.gpu_object_store.has_tensor(tensor)
-        assert not gpu_manager.is_managed_object(obj_id)
+        rdt_manager.rdt_store.wait_tensor_freed(tensor, timeout=10)
+        assert not rdt_manager.rdt_store.has_tensor(tensor)
+        assert not rdt_manager.is_managed_object(obj_id)
         assert obj_id not in uccl_transport._managed_meta
-        assert key not in uccl_transport._tensor_desc_cache
+        assert obj_id not in uccl_transport._obj_descs
         return "Success"
 
     @ray.method(tensor_transport="uccl")
@@ -71,9 +78,9 @@ class UCCLGPUTestActor:
     def sum_dict(self, dict):
         return sum(v.sum().item() for v in dict.values())
 
-    def get_num_gpu_objects(self):
-        gpu_object_manager = ray._private.worker.global_worker.gpu_object_manager
-        return gpu_object_manager.gpu_object_store.get_num_objects()
+    def get_num_rdt_objects(self):
+        rdt_manager = ray._private.worker.global_worker.rdt_manager
+        return rdt_manager.rdt_store.get_num_objects()
 
     def get_num_managed_meta_uccl(self):
         return get_tensor_transport_manager("UCCL")._get_num_managed_meta()
@@ -88,7 +95,8 @@ class UCCLGPUTestActor:
         list2 = [t2, t3]
 
         ref1 = ray.put(list1, _tensor_transport="uccl")
-        # UCCL deduplicates by data_ptr, so t2 is only registered once.
+        # Each put registers its own descriptors; UCCL deduplicates overlapping
+        # memory regions internally at the RDMA level (uccl_regmr MR cache).
         ref2 = ray.put(list2, _tensor_transport="uccl")
 
         return ref1, ref2
@@ -97,12 +105,15 @@ class UCCLGPUTestActor:
     def block_background_thread(self, signal_actor):
         ray.get(signal_actor.wait.remote())
 
+    def borrow_and_sum(self, ref_list):
+        return ray.get(ref_list[0]).sum().item()
+
     def block_main_thread(self, signal_actor):
         ray.get(signal_actor.wait.remote())
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
-def test_ray_get_gpu_ref_created_by_actor_task(ray_start_regular):
+def test_ray_get_rdt_ref_created_by_actor_task(ray_start_regular):
     actor = UCCLGPUTestActor.remote()
     tensor = torch.tensor([1, 2, 3]).to("cuda")
     ref1 = actor.echo.remote(tensor, "cuda")
@@ -132,6 +143,7 @@ def test_p2p(ray_start_regular):
     result = dst_actor.sum.remote(ref, "cuda")
     assert tensor.sum().item() == ray.get(result)
 
+
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 def test_p2p_cpu_to_cpu(ray_start_regular):
     num_actors = 2
@@ -147,7 +159,7 @@ def test_p2p_cpu_to_cpu(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
-def test_intra_gpu_tensor_transfer(ray_start_regular):
+def test_intra_rdt_tensor_transfer(ray_start_regular):
     actor = UCCLGPUTestActor.remote()
 
     tensor = torch.tensor([1, 2, 3])
@@ -168,6 +180,20 @@ def test_put_and_get_object_with_uccl(ray_start_regular):
     tensors = [tensor1, tensor2, tensor3]
     ref = src_actor.produce.remote(tensors)
     ref1 = dst_actor.consume_with_uccl.remote(ref)
+    result1 = ray.get(ref1)
+    assert result1 == 45
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_put_and_get_object_with_object_store(ray_start_regular):
+    actors = [UCCLGPUTestActor.remote() for _ in range(2)]
+    src_actor, dst_actor = actors[0], actors[1]
+    tensor1 = torch.tensor([1, 2, 3]).to("cuda")
+    tensor2 = torch.tensor([4, 5, 6, 0]).to("cuda")
+    tensor3 = torch.tensor([7, 8, 9, 0, 0]).to("cuda")
+    tensors = [tensor1, tensor2, tensor3]
+    ref = src_actor.produce.remote(tensors)
+    ref1 = dst_actor.consume_with_object_store.remote(ref)
     result1 = ray.get(ref1)
     assert result1 == 45
 
@@ -193,7 +219,7 @@ def test_send_duplicate_tensor(ray_start_regular):
     del ref1
     del ref2
     wait_for_condition(
-        lambda: ray.get(src_actor.get_num_gpu_objects.remote()) == 0,
+        lambda: ray.get(src_actor.get_num_rdt_objects.remote()) == 0,
         timeout=10,
         retry_interval_ms=100,
     )
@@ -202,6 +228,27 @@ def test_send_duplicate_tensor(ray_start_regular):
         timeout=10,
         retry_interval_ms=100,
     )
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_uccl_abort_sender_dies_before_creating(ray_start_regular):
+    actors = [UCCLGPUTestActor.remote() for _ in range(2)]
+
+    # Trigger transfer and kill sender before the receiver starts receiving
+    signal_actor = SignalActor.remote()
+    actors[0].block_main_thread.remote(signal_actor)
+    ref = actors[0].echo.remote(torch.randn((100, 100)), "cuda")
+    result = actors[1].sum.remote(ref, "cuda")
+    ray.kill(actors[0])
+
+    with pytest.raises(ray.exceptions.ActorDiedError):
+        ray.get(result)
+
+    # Try a transfer with actor[1] receiving again
+    new_actor = UCCLGPUTestActor.remote()
+    ref = new_actor.echo.remote(torch.tensor([4, 5, 6]), "cuda")
+    result = actors[1].sum.remote(ref, "cuda")
+    assert ray.get(result) == 15
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
@@ -251,23 +298,55 @@ def test_uccl_del_before_creating(ray_start_regular):
     ray.get(signal_actor.send.remote())
 
     wait_for_condition(
-        lambda: ray._private.worker.global_worker.gpu_object_manager.get_gpu_object_metadata(
-            obj_id
-        )
+        lambda: ray._private.worker.global_worker.rdt_manager.get_rdt_metadata(obj_id)
         is None,
     )
     wait_for_condition(
-        lambda: ray.get(actor.get_num_gpu_objects.remote()) == 0,
+        lambda: ray.get(actor.get_num_rdt_objects.remote()) == 0,
     )
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_uccl_owner_gets_from_launched_task(ray_start_regular):
+    actor = UCCLGPUTestActor.remote()
+    tensor = torch.randn((100, 100))
+
+    ref = actor.echo.remote(tensor, "cuda")
+    assert torch.equal(ray.get(ref), tensor.to("cuda"))
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_out_of_order_actors(ray_start_regular):
+    @ray.remote(num_cpus=0, num_gpus=1, max_concurrency=10)
+    class UCCLAsyncActor:
+        def __init__(self):
+            self.tensor = torch.tensor([4, 5, 6], device="cuda")
+
+        @ray.method(tensor_transport="uccl")
+        async def get_tensor(self):
+            return self.tensor
+
+        async def sum(self, data):
+            return data.sum().item()
+
+    actors = [UCCLAsyncActor.remote() for _ in range(2)]
+    results = []
+    for _ in range(100):
+        ref = actors[0].get_tensor.remote()
+        result = actors[1].sum.remote(ref)
+        results.append(result)
+    results = ray.get(results)
+    assert sum(results) == 1500
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
 def test_shared_tensor_deduplication(ray_start_regular):
     """
-    Test that tensors shared across multiple lists are properly deduplicated.
+    Test that tensors shared across multiple lists are properly handled.
 
     Creates list1 = [T1, T2] and list2 = [T2, T3] where T2 is shared.
-    UCCL deduplicates by data_ptr, so T2 is only registered once across both puts.
+    Each put registers its own descriptors; UCCL deduplicates the underlying
+    RDMA memory region (MR) internally via its uccl_regmr MR cache.
     """
     actor = UCCLGPUTestActor.remote()
     ray.get(actor.put_shared_tensor_lists.remote())
@@ -340,12 +419,12 @@ def test_uccl_endpoint_reuse_with_partial_tensors(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
-def test_data_ptr_level_reference_count(ray_start_regular):
-    """Test that UCCL uses data_ptr() as the cache key for tensor deduplication.
+def test_obj_descs_lifecycle(ray_start_regular):
+    """Test that _obj_descs is populated on put and cleared on GC.
 
-    Registering the same tensor under two object IDs increments
-    the metadata_count. When each obj ref goes out of scope via garbage_collect,
-    the count decrements. After both are freed, the cache entry is removed.
+    Each ray.put gets its own entry in _obj_descs keyed by obj_id.
+    UCCL handles MR deduplication internally; we just track descriptors
+    per object so we can deregister them on garbage_collect.
     """
     from ray.experimental.rdt.uccl_tensor_transport import (
         UCCLTensorTransport,
@@ -354,31 +433,29 @@ def test_data_ptr_level_reference_count(ray_start_regular):
     transport = UCCLTensorTransport()
 
     tensor = torch.tensor([1, 2, 3, 4, 5, 6], dtype=torch.float32).to("cuda")
-    data_ptr = tensor.data_ptr()
 
-    # Simulate ray.put(tensor) - first registration
+    # First put: one entry created.
     obj_id1 = "test_obj_id_1"
     meta1 = transport.extract_tensor_transport_metadata(obj_id1, [tensor])
-    assert len(transport._tensor_desc_cache) == 1
-    assert transport._tensor_desc_cache[data_ptr].metadata_count == 1
+    assert obj_id1 in transport._obj_descs
+    assert len(transport._obj_descs[obj_id1]) == 1
 
-    # Simulate ray.put(tensor) again with the same tensor object (same data_ptr).
-    # The cache entry is reused and metadata_count is incremented.
+    # Second put of the same tensor: a separate entry is created.
+    # UCCL's internal MR cache deduplicates the underlying RDMA registration.
     obj_id2 = "test_obj_id_2"
     meta2 = transport.extract_tensor_transport_metadata(obj_id2, [tensor])
-    assert len(transport._tensor_desc_cache) == 1
-    assert transport._tensor_desc_cache[data_ptr].metadata_count == 2
+    assert obj_id2 in transport._obj_descs
+    assert len(transport._obj_descs) == 2
 
-    # Simulate the obj ref for obj_id1 going out of scope.
-    # The cache entry should still exist since obj_id2 is still alive.
+    # GC of obj_id1 removes only its entry; obj_id2 remains.
     transport.garbage_collect(obj_id1, meta1, [tensor])
-    assert data_ptr in transport._tensor_desc_cache
-    assert transport._tensor_desc_cache[data_ptr].metadata_count == 1
+    assert obj_id1 not in transport._obj_descs
+    assert obj_id2 in transport._obj_descs
 
-    # Simulate the obj ref for obj_id2 going out of scope.
-    # The cache entry should now be removed.
+    # GC of obj_id2 removes the last entry.
     transport.garbage_collect(obj_id2, meta2, [tensor])
-    assert data_ptr not in transport._tensor_desc_cache
+    assert obj_id2 not in transport._obj_descs
+    assert len(transport._obj_descs) == 0
 
 
 @ray.remote(num_gpus=1, num_cpus=0, enable_tensor_transport=True)
@@ -401,6 +478,81 @@ def test_overlapping_views(ray_start_regular):
     refs = ray.get(src_actor.produce_overlapping_views.remote())
     result = ray.get(dst_actor.consume_with_uccl.remote(refs))
     assert result == 15
+
+
+@ray.remote(num_gpus=1, num_cpus=0, enable_tensor_transport=True)
+class UCCLWaitTensorFreedActor:
+    def test_wait_tensor_freed_views(self):
+        from ray.experimental import wait_tensor_freed
+
+        tensor = torch.tensor([1, 2, 3, 4, 5], dtype=torch.float32).to("cuda")
+        slices = [tensor[0:3], tensor[1:4], tensor[2:5]]
+        ref1 = ray.put(slices[0], _tensor_transport="uccl")
+        ref2 = ray.put(slices[1], _tensor_transport="uccl")
+        ref3 = ray.put(slices[2], _tensor_transport="uccl")
+        del ref1
+        wait_tensor_freed(slices[0], timeout=10)
+        with pytest.raises(TimeoutError):
+            wait_tensor_freed(slices[1], timeout=1)
+        with pytest.raises(TimeoutError):
+            wait_tensor_freed(slices[2], timeout=1)
+        del ref2
+        with pytest.raises(TimeoutError):
+            wait_tensor_freed(slices[2], timeout=1)
+        wait_tensor_freed(slices[1], timeout=10)
+        del ref3
+        wait_tensor_freed(slices[2], timeout=10)
+        return "Success"
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
+def test_wait_tensor_freed_views(ray_start_regular):
+    """Test that wait_tensor_freed tracks each view independently,
+    not the shared underlying storage."""
+    actor = UCCLWaitTensorFreedActor.remote()
+    result = ray.get(actor.test_wait_tensor_freed_views.remote())
+    assert result == "Success"
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_uccl_get_into_tensor_buffers(ray_start_regular):
+    @ray.remote(num_gpus=1, num_cpus=0)
+    class UCCLBufferActor:
+        def __init__(self):
+            self.tensor_list = [
+                torch.tensor([1, 2, 3]).to("cuda"),
+                torch.tensor([4, 5, 6]).to("cuda"),
+            ]
+
+        def get_ref(self):
+            return ray.put(self.tensor_list, _tensor_transport="uccl")
+
+        def get_with_buffers(self, refs):
+            set_target_for_ref(refs[0], self.tensor_list)
+            tensors = ray.get(refs[0])
+            # Make sure we ray.get-ted into the buffers
+            for new_tensor, tensor_buffer in zip(tensors, self.tensor_list):
+                assert id(new_tensor) == id(tensor_buffer)
+            return True
+
+        def get_with_wrong_buffers(self, refs):
+            wrong_tensor_buffer = [
+                torch.tensor([1, 2]).to("cuda"),
+                torch.tensor([4, 5]).to("cuda"),
+            ]
+            set_target_for_ref(refs[0], wrong_tensor_buffer)
+            with pytest.raises(ValueError) as excinfo:
+                ray.get(refs[0])
+            assert "Shape of tensor_buffer at index 0" in str(excinfo.value)
+            return True
+
+    actors = [UCCLBufferActor.remote() for _ in range(2)]
+    ref = ray.get(actors[0].get_ref.remote())
+    result = actors[1].get_with_buffers.remote([ref])
+    assert ray.get(result)
+
+    result = actors[1].get_with_wrong_buffers.remote([ref])
+    assert ray.get(result)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/rdt/test_rdt_uccl.py
+++ b/python/ray/tests/rdt/test_rdt_uccl.py
@@ -144,7 +144,6 @@ def test_p2p(ray_start_regular):
     assert tensor.sum().item() == ray.get(result)
 
 
-@pytest.mark.skip(reason="CPU-CPU transfer support is WIP")
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 def test_p2p_cpu_to_cpu(ray_start_regular):
     num_actors = 2


### PR DESCRIPTION
This PR integrates UCCL as a new one-sided GPU tensor transport backend in Ray's experimental GPU object manager, alongside the existing NIXL, NCCL, GLOO, and CUDA IPC transports. The implementation is done with reference to nixl_tensor_transport.py. 

**What it does:**

- Adds UCCLTensorTransport, a new TensorTransportManager implementation that uses UCCL's P2P library (uccl.p2p.Endpoint).
- Uses a one-sided RDMA read model: the receiver connects to the sender's endpoint, registers local memory, and pulls the tensor data directly, without requiring the sender to be actively involved in the transfer.
- Maintains a per-actor uccl.p2p.Endpoint (created lazily) that passively accepts incoming connections.
- Registers UCCL as a default transport for ["cuda", "cpu"] devices alongside the other built-in transports in util.py.
- UCCL supports deduplication when `register_memory()`. See https://github.com/uccl-project/uccl/pull/827 for more details.

**Additional Information:**

- UCCL can also support tensor transfer via ROCm-ROCm. When the bugs are fixed from the UCCL side, I will make a separate PR to enable it.
- Users need to install the necessary dependencies for the UCCL P2P library. More instructions can be found in the [README.md from UCCL](https://github.com/uccl-project/uccl).
- It is important to make sure that you are using the correct RDMA port because the auto-discovery mechanism may not work very well across different devices. Verify that `UCCL_P2P_RDMA_GID_INDEX` is set correctly if you encounter any errors during sending/receiving.
- UCCL's `Endpoint` API is evolving to make it more suitable for Ray's workload requirements. I will make a follow-up PR to update when there is any additional change from UCCL's side.

TODO:

- [x] fix the memory deregister API in UCCL.
- [x] add deduplication support in UCCL.