### PR TITLE
[CI] Add Windows smoke test for ray stop hanging processes

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -29,6 +29,19 @@ steps:
       - "3.12"
     depends_on: windowsbuild
 
+  - label: ":windows: smoke test: ray stop {{matrix}}"
+    tags:
+      - python
+      - windows
+    job_env: WINDOWS
+    instance_type: windows
+    commands:
+      - bash ci/ray_ci/windows/install_tools.sh
+      - python ci/ray_ci/windows/run_smoke_test_stop.py "{{matrix}}"
+    matrix:
+      - "3.10"
+    depends_on: windows_wheels
+
   - label: ":ray: core: :windows: cpp tests"
     tags:
       - core_cpp

--- a/ci/ray_ci/windows/run_smoke_test_stop.py
+++ b/ci/ray_ci/windows/run_smoke_test_stop.py
@@ -1,0 +1,94 @@
+"""Runner for the ray-stop Windows smoke test.
+
+Invoked from the CI step (inside job_env: WINDOWS). Spawns a Docker container
+using the windowsbuild image with the built wheel artifact mounted, then runs
+smoke_test_stop.py inside that container.
+
+Usage:
+    python ci/ray_ci/windows/run_smoke_test_stop.py <python-version>
+
+    e.g.  python ci/ray_ci/windows/run_smoke_test_stop.py 3.11
+"""
+import os
+import subprocess
+import sys
+
+
+def _ecr_login(ecr_registry: str) -> None:
+    """Login to ECR using the AWS CLI (avoids boto3 / ci.ray_ci imports)."""
+    password = subprocess.check_output(
+        ["aws", "ecr", "get-login-password", "--region", "us-west-2"],
+        text=True,
+    ).strip()
+    subprocess.run(
+        ["docker", "login", "--username", "AWS", "--password-stdin", ecr_registry],
+        input=password,
+        text=True,
+        check=True,
+        stdout=sys.stdout,
+        stderr=sys.stderr,
+    )
+
+
+def main(python_version: str) -> int:
+    py_tag = "cp" + python_version.replace(".", "")
+
+    rayci_work_repo = os.environ["RAYCI_WORK_REPO"]
+    windowsbuild_image = (
+        f"{rayci_work_repo}:{os.environ['RAYCI_BUILD_ID']}-windowsbuild"
+    )
+
+    # Required before docker pull/run against ECR.
+    # Uses AWS CLI (installed by install_tools.sh) rather than boto3 so this
+    # script has no dependencies outside the standard library.
+    ecr_registry = rayci_work_repo.split("/")[0]
+    _ecr_login(ecr_registry)
+    checkout_dir = os.path.abspath(os.environ["RAYCI_CHECKOUT_DIR"])
+
+    # The artifact mount mirrors the convention in WindowsContainer.get_artifact_mount():
+    #   host  C:\tmp\artifacts  <->  container  C:\artifact-mount
+    artifact_host = "C:\\tmp\\artifacts"
+    artifact_container = "C:\\artifact-mount"
+
+    # Inside the container, the wheel is at C:\artifact-mount\python\dist\
+    # (POSIX path for bash: /c/artifact-mount/python/dist/)
+    inner_script = "\n".join(
+        [
+            "set -euo pipefail",
+            f"WHEEL=$(ls /c/artifact-mount/python/dist/ray-*-{py_tag}-*-win_amd64.whl 2>/dev/null | head -1)",
+            'if [[ -z "$WHEEL" ]]; then',
+            '  echo "ERROR: no wheel found for ' + py_tag + '" >&2',
+            "  ls /c/artifact-mount/python/dist/ >&2 || true",
+            "  exit 1",
+            "fi",
+            'echo "Installing wheel: $WHEEL"',
+            'pip install "$WHEEL"',
+            "python ci/ray_ci/windows/smoke_test_stop.py",
+        ]
+    )
+
+    cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "--volume",
+        f"{artifact_host}:{artifact_container}",
+        "--volume",
+        f"{checkout_dir}:C:\\rayci",
+        "--workdir",
+        "C:\\rayci",
+        windowsbuild_image,
+        "bash",
+        "-c",
+        inner_script,
+    ]
+
+    result = subprocess.run(cmd, stdout=sys.stdout, stderr=sys.stderr)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <python-version>", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(main(sys.argv[1]))

--- a/ci/ray_ci/windows/smoke_test_stop.py
+++ b/ci/ray_ci/windows/smoke_test_stop.py
@@ -1,0 +1,90 @@
+"""Smoke test: verify ray stop kills all Ray Python processes on Windows.
+
+Installs via the built wheel (not source), so this faithfully reproduces
+the environment a user would have after pip-installing Ray.
+
+Expected to be invoked by run_smoke_test_stop.py, which handles
+installing the wheel and setting up the container environment.
+"""
+import subprocess
+import sys
+
+_PS_FILTER = (
+    "Get-CimInstance Win32_Process -Filter \"name='python.exe'\""
+    " | Where-Object { $_.CommandLine -like '*ray*' }"
+)
+
+
+def _ps_ray_python_pids():
+    """Return PIDs of python.exe processes with 'ray' in their command line."""
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            f"{_PS_FILTER} | Select-Object -ExpandProperty ProcessId",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    pids = set()
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line.isdigit():
+            pids.add(int(line))
+    return pids
+
+
+def _ps_ray_python_info():
+    """Return a PowerShell listing of Ray Python processes (PIDs + command lines)."""
+    result = subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            f"{_PS_FILTER} | Select-Object ProcessId,CommandLine | Format-List",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def main():
+    import ray  # imported here so the import itself doesn't affect pids_before
+
+    pids_before = _ps_ray_python_pids()
+
+    ray.init(include_dashboard=True)
+    subprocess.run(["ray", "stop"], check=False)
+    ray.shutdown()
+
+    pids_after = _ps_ray_python_pids()
+    hanging = pids_after - pids_before
+
+    if not hanging:
+        print("OK: no Ray Python processes remain after ray stop")
+        sys.exit(0)
+
+    print(
+        f"FAIL: ray stop left {len(hanging)} Ray Python process(es) running "
+        f"(PIDs: {sorted(hanging)}):",
+        file=sys.stderr,
+    )
+    print(_ps_ray_python_info(), file=sys.stderr)
+
+    # Clean up so the CI machine isn't left dirty.
+    subprocess.run(
+        [
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            f"{_PS_FILTER} | ForEach-Object {{ $_.Terminate() }}",
+        ],
+        capture_output=True,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/windows/smoke_test_stop.py
+++ b/ci/ray_ci/windows/smoke_test_stop.py
@@ -57,7 +57,6 @@ def main():
 
     ray.init(include_dashboard=True)
     subprocess.run(["ray", "stop"], check=False)
-    ray.shutdown()
 
     pids_after = _ps_ray_python_pids()
     hanging = pids_after - pids_before


### PR DESCRIPTION
Adds a CI smoke test that installs the built Windows wheel and verifies that `ray stop` kills all Ray Python processes (dashboard agent and runtime_env agent), which were observed to survive on Windows Server after `ray stop` reports successful shutdown.

The test runs after the wheel build step, installs the actual .whl artifact into a fresh windowsbuild container (not from source), and uses PowerShell Get-CimInstance to detect any surviving python.exe processes.

Topic: windows-ray-stop-smoke-test
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>