### PR TITLE
[Core] Add labels as ref IDs to the actor definition OneEvent to be able to link actor and Ray Data operator

### DIFF
--- a/src/ray/gcs/actor/gcs_actor.h
+++ b/src/ray/gcs/actor/gcs_actor.h
@@ -168,6 +168,8 @@ class GcsActor {
       *actor_table_data_.mutable_label_selector() =
           ray::LabelSelector(task_spec_->label_selector()).ToStringMap();
     }
+    actor_table_data_.mutable_labels()->insert(task_spec_->labels().begin(),
+                                               task_spec_->labels().end());
     lease_spec_ = std::make_unique<LeaseSpecification>(*task_spec_);
     RefreshMetrics();
   }

--- a/src/ray/observability/ray_actor_definition_event.cc
+++ b/src/ray/observability/ray_actor_definition_event.cc
@@ -41,6 +41,7 @@ RayActorDefinitionEvent::RayActorDefinitionEvent(const rpc::ActorTableData &data
   }
   data_.mutable_label_selector()->insert(data.label_selector().begin(),
                                          data.label_selector().end());
+  data_.mutable_ref_ids()->insert(data.labels().begin(), data.labels().end());
   if (data.has_call_site()) {
     data_.set_call_site(data.call_site());
   }

--- a/src/ray/observability/tests/ray_actor_definition_event_test.cc
+++ b/src/ray/observability/tests/ray_actor_definition_event_test.cc
@@ -37,6 +37,8 @@ TEST_F(RayActorDefinitionEventTest, TestSerialize) {
   (*data.mutable_label_selector())["tier"] = "prod";
   data.set_call_site("test_call_site.py:123");
   data.set_parent_id("parent_actor_id");
+  // Labels (e.g. from Ray Data actor pool) are serialized into ref_ids in the event.
+  (*data.mutable_labels())["__data_operator_id"] = "op_id_0";
 
   auto event = std::make_unique<RayActorDefinitionEvent>(data, "test_session_name");
   auto serialized_event = std::move(*event).Serialize();
@@ -62,6 +64,7 @@ TEST_F(RayActorDefinitionEventTest, TestSerialize) {
   ASSERT_EQ(actor_def.label_selector().at("tier"), "prod");
   ASSERT_EQ(actor_def.call_site(), "test_call_site.py:123");
   ASSERT_EQ(actor_def.parent_id(), "parent_actor_id");
+  ASSERT_EQ(actor_def.ref_ids().at("__data_operator_id"), "op_id_0");
 }
 
 }  // namespace observability

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -162,6 +162,8 @@ message ActorTableData {
   map<string, string> label_selector = 35;
   // Number of times this actor is restarted due to node preemption.
   uint64 num_restarts_due_to_node_preemption = 36;
+  // The key-value labels for actor.
+  map<string, string> labels = 37;
 }
 
 message ErrorTableData {

--- a/src/ray/protobuf/public/events_actor_definition_event.proto
+++ b/src/ray/protobuf/public/events_actor_definition_event.proto
@@ -44,4 +44,6 @@ message ActorDefinitionEvent {
   string call_site = 12;
   // The ID of the caller of the actor creation task (parent actor/driver).
   bytes parent_id = 13;
+  // The ids that can be used to correlate the actor with other events.
+  map<string, bytes> ref_ids = 14;
 }


### PR DESCRIPTION
We have already added `labels` field as `ref_ids` at some other OneEvents, including [TaskDefinitionEvent](https://github.com/ray-project/ray/blob/master/src/ray/protobuf/public/events_task_definition_event.proto#L44) and [ActorTaskDefinitionEvent](https://github.com/ray-project/ray/blob/master/src/ray/protobuf/public/events_actor_task_definition_event.proto#L43), to correlate the tasks with entities, such as Ray Data operators. In this PR, we add it to the `ActorDefinitionEvent`, so that actors can be correlated other entities as well, for further observability purpose.