### PR TITLE
[Data] Remove default task-level timeout and clamp `end_offset` to watermark in Kafka datasource

### DIFF
--- a/python/ray/data/_internal/datasource/kafka_datasource.py
+++ b/python/ray/data/_internal/datasource/kafka_datasource.py
@@ -63,7 +63,7 @@ _KAFKA_AUTH_TO_CONFLUENT: Dict[str, str] = {
 KAFKA_TOPIC_METADATA_TIMEOUT_S = 10
 KAFKA_QUERY_OFFSET_TIMEOUT_S = 10
 # Cap each consume timeout to keep responsiveness of timeout/position checks.
-KAFKA_CONSUME_TIMEOUT_MAX_MS = 10_000  # 10 seconds per consume call
+KAFKA_CONSUME_TIMEOUT_MAX_S = 10  # 10 seconds per consume call
 
 KAFKA_MSG_SCHEMA = pa.schema(
     [
@@ -368,6 +368,12 @@ def _resolve_offsets(
             consumer, topic_partition, end_offset, latest_offset
         )
 
+    # Clamp end_offset to the high watermark so we never try to read beyond
+    # what is currently available.  This prevents the read loop from polling
+    # indefinitely when a user-supplied integer end_offset exceeds the number
+    # of messages in the partition.
+    end_offset = min(end_offset, latest_offset)
+
     if start_offset > end_offset:
         start_str = (
             f"{original_start}"
@@ -401,7 +407,7 @@ class KafkaDatasource(Datasource):
         end_offset: Union[int, datetime, Literal["latest"]] = "latest",
         kafka_auth_config: Optional[KafkaAuthConfig] = None,
         consumer_config: Optional[Dict[str, Any]] = None,
-        timeout_ms: int = 10000,
+        timeout_ms: Optional[int] = None,
     ):
         """Initialize Kafka datasource.
 
@@ -423,9 +429,10 @@ class KafkaDatasource(Datasource):
                 Keys and values are passed through to the underlying client. The
                 `bootstrap.servers` option is derived from `bootstrap_servers` and
                 cannot be overridden here.
-            timeout_ms: Timeout in milliseconds for every read task to poll until reaching end_offset (default 10000ms).
-                If the read task does not reach end_offset within the timeout, it will stop polling and return the messages
-                it has read so far.
+            timeout_ms: Optional timeout in milliseconds for every read task to poll until reaching end_offset.
+                If None (default), no task-level timeout is applied and each read task
+                will poll until it reaches end_offset. If set, the read task will stop
+                polling after the timeout and return the messages it has read so far.
 
         Raises:
             ValueError: If required configuration is missing.
@@ -439,7 +446,7 @@ class KafkaDatasource(Datasource):
         if not bootstrap_servers:
             raise ValueError("bootstrap_servers cannot be empty")
 
-        if timeout_ms <= 0:
+        if timeout_ms is not None and timeout_ms <= 0:
             raise ValueError("timeout_ms must be positive")
 
         if isinstance(start_offset, int) and isinstance(end_offset, int):
@@ -562,7 +569,7 @@ class KafkaDatasource(Datasource):
                 ] = end_offset,
                 kafka_auth_config: Optional[KafkaAuthConfig] = self._kafka_auth_config,
                 user_consumer_config: Optional[Dict[str, Any]] = self._consumer_config,
-                timeout_ms: int = timeout_ms,
+                timeout_ms: Optional[int] = timeout_ms,
                 target_max_block_size: int = target_max_block_size,
             ):
                 """Create a Kafka read function with captured variables."""
@@ -597,7 +604,9 @@ class KafkaDatasource(Datasource):
 
                         if resolved_start < resolved_end:
                             start_time = time.perf_counter()
-                            timeout_seconds = timeout_ms / 1000.0
+                            timeout_seconds = (
+                                timeout_ms / 1000.0 if timeout_ms is not None else None
+                            )
 
                             tp_with_offset = TopicPartition(
                                 topic_name, partition_id, resolved_start
@@ -611,22 +620,14 @@ class KafkaDatasource(Datasource):
                                 if next_offset >= resolved_end:
                                     break
 
-                                elapsed_time_s = time.perf_counter() - start_time
-                                if elapsed_time_s >= timeout_seconds:
-                                    logger.warning(
-                                        f"Kafka read task timed out after {timeout_ms}ms while reading partition {partition_id} of topic {topic_name}; "
-                                        f"end_offset {resolved_end} was not reached. Returning {len(records)} messages collected in this read task so far."
-                                    )
-                                    break
-
-                                remaining_timeout_ms = int(
-                                    max(0, timeout_seconds - elapsed_time_s) * 1000
-                                )
-                                poll_timeout_ms = min(
-                                    remaining_timeout_ms,
-                                    KAFKA_CONSUME_TIMEOUT_MAX_MS,
-                                )
-                                consume_timeout_s = poll_timeout_ms / 1000.0
+                                if timeout_seconds is not None:
+                                    elapsed_time_s = time.perf_counter() - start_time
+                                    if elapsed_time_s >= timeout_seconds:
+                                        logger.warning(
+                                            f"Kafka read task timed out after {timeout_ms}ms while reading partition {partition_id} of topic {topic_name}; "
+                                            f"end_offset {resolved_end} was not reached. Returning {len(records)} messages collected in this read task so far."
+                                        )
+                                        break
 
                                 remaining = resolved_end - next_offset
                                 batch_size = min(
@@ -635,7 +636,7 @@ class KafkaDatasource(Datasource):
                                 )
                                 msgs = consumer.consume(
                                     num_messages=batch_size,
-                                    timeout=consume_timeout_s,
+                                    timeout=KAFKA_CONSUME_TIMEOUT_MAX_S,
                                 )
 
                                 if not msgs:

--- a/python/ray/data/_internal/datasource/kafka_datasource.py
+++ b/python/ray/data/_internal/datasource/kafka_datasource.py
@@ -628,6 +628,14 @@ class KafkaDatasource(Datasource):
                                             f"end_offset {resolved_end} was not reached. Returning {len(records)} messages collected in this read task so far."
                                         )
                                         break
+                                    remaining_timeout_s = (
+                                        timeout_seconds - elapsed_time_s
+                                    )
+                                    consume_timeout_s = min(
+                                        remaining_timeout_s, KAFKA_CONSUME_TIMEOUT_MAX_S
+                                    )
+                                else:
+                                    consume_timeout_s = KAFKA_CONSUME_TIMEOUT_MAX_S
 
                                 remaining = resolved_end - next_offset
                                 batch_size = min(
@@ -636,7 +644,7 @@ class KafkaDatasource(Datasource):
                                 )
                                 msgs = consumer.consume(
                                     num_messages=batch_size,
-                                    timeout=KAFKA_CONSUME_TIMEOUT_MAX_S,
+                                    timeout=consume_timeout_s,
                                 )
 
                                 if not msgs:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -4407,7 +4407,7 @@ def read_kafka(
     memory: Optional[float] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     override_num_blocks: Optional[int] = None,
-    timeout_ms: int = 10000,
+    timeout_ms: Optional[int] = None,
 ) -> Dataset:
     """Read data from Kafka topics.
 
@@ -4473,9 +4473,10 @@ def read_kafka(
             By default, the number of output blocks is dynamically decided based on
             input data size and available resources. You shouldn't manually set this
             value in most cases.
-        timeout_ms: Timeout in milliseconds for every read task to poll until reaching end_offset (default 10000ms).
-            If the read task does not reach end_offset within the timeout, it will stop polling and return the messages
-            it has read so far.
+        timeout_ms: Optional timeout in milliseconds for every read task to poll until reaching end_offset.
+            If None (default), no task-level timeout is applied and each read task
+            will poll until it reaches end_offset. If set, the read task will stop
+            polling after the timeout and return the messages it has read so far.
 
     Returns:
         A :class:`~ray.data.Dataset` containing Kafka messages with the following schema:

--- a/python/ray/data/tests/datasource/test_kafka.py
+++ b/python/ray/data/tests/datasource/test_kafka.py
@@ -361,9 +361,8 @@ def test_read_kafka_with_message_headers(
 
 
 @pytest.mark.parametrize(
-    "start_offset,end_offset,expected_count, test_id",
+    "start_offset,end_offset,expected_count,test_id",
     [
-        (150, 200, 0, "start-offset-exceeds-available-messages"),
         (0, 150, 100, "end-offset-exceeds-available-messages"),
         (
             "earliest",
@@ -382,8 +381,6 @@ def test_read_kafka_offset_exceeds_available_messages(
     expected_count,
     test_id,
 ):
-    import time
-
     topic = f"test-offset-timeout-{test_id}"
 
     for i in range(100):
@@ -392,26 +389,44 @@ def test_read_kafka_offset_exceeds_available_messages(
     kafka_producer.flush()
     time.sleep(0.3)
 
-    # Try to read up to offset 200 (way beyond available messages)
-    # This should timeout and only return the 50 available messages
-
-    start_time = time.time()
+    # end_offset exceeds available messages, but it gets clamped to the high
+    # watermark during offset resolution, so the read completes without
+    # hanging.
     ds = ray.data.read_kafka(
         topics=[topic],
         bootstrap_servers=[bootstrap_server],
         start_offset=start_offset,
         end_offset=end_offset,
-        timeout_ms=3000,  # 3 second timeout
     )
 
     records = ds.take_all()
 
-    elapsed_time = time.time() - start_time
-
-    # Should get all 50 available messages
     assert len(records) == expected_count
 
-    assert elapsed_time >= 3, f"Expected timeout wait, but only took {elapsed_time}s"
+
+def test_read_kafka_default_no_timeout(
+    bootstrap_server, kafka_producer, ray_start_regular_shared
+):
+    topic = "test-default-no-timeout"
+
+    for i in range(50):
+        message = {"id": i, "value": f"message-{i}"}
+        kafka_producer.produce(topic, value=message)
+    kafka_producer.flush()
+    time.sleep(0.3)
+
+    # timeout_ms is intentionally omitted (defaults to None).
+    # Verifies the no-timeout code path works correctly.
+    ds = ray.data.read_kafka(
+        topics=[topic],
+        bootstrap_servers=[bootstrap_server],
+        start_offset=0,
+        end_offset=50,
+    )
+
+    records = ds.take_all()
+
+    assert len(records) == 50
 
 
 def test_read_kafka_invalid_topic(bootstrap_server, ray_start_regular_shared):
@@ -434,6 +449,12 @@ def test_read_kafka_invalid_topic(bootstrap_server, ray_start_regular_shared):
             "latest",
             r"start_offset \(150\) > end_offset \(latest \(resolved to 100\)\) for partition 0 in topic test-invalid-offsets-3",
             "test-invalid-offsets-3",
+        ),
+        (
+            150,
+            200,
+            r"start_offset \(150\) > end_offset \(200 \(resolved to 100\)\) for partition 0 in topic test-invalid-offsets-4",
+            "test-invalid-offsets-4",
         ),
     ],
 )


### PR DESCRIPTION
## Description
- Default `timeout_ms` to None (no task-level timeout) for read_kafka. Each consumer.consume() call
   is already capped at 10s, which is sufficient.
- Clamp `end_offset` to the high watermark during offset resolution so reads never target offsets
  beyond available data.
- Raise ValueError if `start_offset` exceeds the clamped `end_offset`.
- Simplify the read loop by removing per-consume timeout shrinking logic.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
