### PR TITLE
[Data] Convert map logical operators to frozen dataclasses

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -509,7 +509,6 @@ class StreamingRepartition(AbstractMap):
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     compute: Optional[ComputeStrategy] = None
     per_block_limit: Optional[int] = None
-    _strict: bool = field(init=False, repr=False)
     _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
@@ -528,7 +527,6 @@ class StreamingRepartition(AbstractMap):
             "_name",
             f"StreamingRepartition[num_rows_per_block={self.target_num_rows_per_block},strict={self.strict}]",
         )
-        object.__setattr__(self, "_strict", self.strict)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,6 +1,7 @@
 import functools
 import inspect
 import logging
+from dataclasses import InitVar, dataclass, field, replace
 from typing import Any, Callable, Dict, Iterable, Optional
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
@@ -182,113 +183,142 @@ class AbstractUDFMap(AbstractMap):
             return "<unknown>"
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class MapBatches(AbstractUDFMap):
     """Logical operator for map_batches."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        fn: UserDefinedFunction,
-        can_modify_num_rows: bool = False,
-        batch_size: Optional[int] = None,
-        batch_format: Optional[str] = "default",
-        zero_copy_batch: bool = True,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        min_rows_per_bundled_input: Optional[int] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            self.__class__.__name__,
-            input_op,
-            fn,
-            can_modify_num_rows=can_modify_num_rows,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            min_rows_per_bundled_input=min_rows_per_bundled_input,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
+    input_op: InitVar[LogicalOperator]
+    fn: UserDefinedFunction
+    can_modify_num_rows: bool = False
+    batch_size: Optional[int] = None
+    batch_format: Optional[str] = "default"
+    zero_copy_batch: bool = True
+    fn_args: Optional[Iterable[Any]] = None
+    fn_kwargs: Optional[Dict[str, Any]] = None
+    fn_constructor_args: Optional[Iterable[Any]] = None
+    fn_constructor_kwargs: Optional[Dict[str, Any]] = None
+    min_rows_per_bundled_input: Optional[int] = None
+    compute: Optional[ComputeStrategy] = None
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.compute is None:
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(
+            self,
+            "_name",
+            self._get_operator_name(self.__class__.__name__, self.fn),
         )
-        self.batch_size = batch_size
-        self.batch_format = batch_format
-        self.zero_copy_batch = zero_copy_batch
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class MapRows(AbstractUDFMap):
     """Logical operator for map."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        fn: UserDefinedFunction,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            "Map",
-            input_op,
-            fn,
-            can_modify_num_rows=False,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
-        )
+    input_op: InitVar[LogicalOperator]
+    fn: UserDefinedFunction
+    fn_args: Optional[Iterable[Any]] = None
+    fn_kwargs: Optional[Dict[str, Any]] = None
+    fn_constructor_args: Optional[Iterable[Any]] = None
+    fn_constructor_kwargs: Optional[Dict[str, Any]] = None
+    compute: Optional[ComputeStrategy] = None
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    can_modify_num_rows: bool = field(init=False, default=False)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.compute is None:
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(self, "_name", self._get_operator_name("Map", self.fn))
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Filter(AbstractUDFMap):
     """Logical operator for filter."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        predicate_expr: Optional[Expr] = None,
-        fn: Optional[UserDefinedFunction] = None,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        # Ensure exactly one of fn, or predicate_expr is provided
-        provided_params = sum([fn is not None, predicate_expr is not None])
+    input_op: InitVar[LogicalOperator]
+    predicate_expr: Optional[Expr] = None
+    fn: Optional[UserDefinedFunction] = None
+    fn_args: Optional[Iterable[Any]] = None
+    fn_kwargs: Optional[Dict[str, Any]] = None
+    fn_constructor_args: Optional[Iterable[Any]] = None
+    fn_constructor_kwargs: Optional[Dict[str, Any]] = None
+    compute: Optional[ComputeStrategy] = None
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    can_modify_num_rows: bool = field(init=False, default=True)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        provided_params = sum([self.fn is not None, self.predicate_expr is not None])
         if provided_params != 1:
             raise ValueError(
-                f"Exactly one of 'fn', or 'predicate_expr' must be provided (received fn={fn}, predicate_expr={predicate_expr})"
+                "Exactly one of 'fn', or 'predicate_expr' must be provided "
+                f"(received fn={self.fn}, predicate_expr={self.predicate_expr})"
             )
-
-        self.predicate_expr = predicate_expr
-
-        super().__init__(
-            self.__class__.__name__,
-            input_op,
-            can_modify_num_rows=True,
-            fn=fn,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
+        if self.compute is None:
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(
+            self,
+            "_name",
+            self._get_operator_name(self.__class__.__name__, self.fn),
         )
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
     def is_expression_based(self) -> bool:
         return self.predicate_expr is not None
@@ -311,37 +341,51 @@ class Filter(AbstractUDFMap):
         return super()._get_operator_name(op_name, fn)
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for all Projection Operations."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        exprs: list["Expr"],
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        # Auto-select compute strategy based on whether expressions contain callable class UDFs
-        if compute is None:
-            compute = self._detect_and_get_compute_strategy(exprs)
+    input_op: InitVar[LogicalOperator]
+    exprs: list["Expr"]
+    compute: Optional[ComputeStrategy] = None
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    can_modify_num_rows: bool = field(init=False, default=False)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    batch_size: Optional[int] = field(init=False, default=None)
+    batch_format: str = field(init=False, default="pyarrow")
+    zero_copy_batch: bool = field(init=False, default=True)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-        super().__init__(
-            input_op=input_op,
-            can_modify_num_rows=False,
-            ray_remote_args=ray_remote_args,
-            compute=compute,
-        )
-        self.batch_size = None
-        self.exprs = exprs
-        self.batch_format = "pyarrow"
-        self.zero_copy_batch = True
-
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.compute is None:
+            object.__setattr__(
+                self, "compute", self._detect_and_get_compute_strategy(self.exprs)
+            )
         for expr in self.exprs:
             if expr.name is None and not isinstance(expr, StarExpr):
                 raise TypeError(
                     "All Project expressions must be named (use .alias(name) or col(name)), "
                     "or be a star() expression."
                 )
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
     def _detect_and_get_compute_strategy(self, exprs: list["Expr"]) -> ComputeStrategy:
         """Detect if expressions contain callable class UDFs and return appropriate compute strategy.
@@ -397,36 +441,51 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
         return rename_map if rename_map else None
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class FlatMap(AbstractUDFMap):
     """Logical operator for flat_map."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        fn: UserDefinedFunction,
-        fn_args: Optional[Iterable[Any]] = None,
-        fn_kwargs: Optional[Dict[str, Any]] = None,
-        fn_constructor_args: Optional[Iterable[Any]] = None,
-        fn_constructor_kwargs: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-        ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            self.__class__.__name__,
-            input_op,
-            fn,
-            can_modify_num_rows=True,
-            fn_args=fn_args,
-            fn_kwargs=fn_kwargs,
-            fn_constructor_args=fn_constructor_args,
-            fn_constructor_kwargs=fn_constructor_kwargs,
-            compute=compute,
-            ray_remote_args_fn=ray_remote_args_fn,
-            ray_remote_args=ray_remote_args,
+    input_op: InitVar[LogicalOperator]
+    fn: UserDefinedFunction
+    fn_args: Optional[Iterable[Any]] = None
+    fn_kwargs: Optional[Dict[str, Any]] = None
+    fn_constructor_args: Optional[Iterable[Any]] = None
+    fn_constructor_kwargs: Optional[Dict[str, Any]] = None
+    compute: Optional[ComputeStrategy] = None
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    can_modify_num_rows: bool = field(init=False, default=True)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.compute is None:
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(
+            self,
+            "_name",
+            self._get_operator_name(self.__class__.__name__, self.fn),
         )
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class StreamingRepartition(AbstractMap):
     """Logical operator for streaming repartition operation.
 
@@ -441,21 +500,45 @@ class StreamingRepartition(AbstractMap):
             Defaults to False.
     """
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        target_num_rows_per_block: int,
-        strict: bool = False,
-    ):
-        if target_num_rows_per_block <= 0:
+    input_op: InitVar[LogicalOperator]
+    target_num_rows_per_block: int
+    strict: bool = False
+    can_modify_num_rows: bool = field(init=False, default=False)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    compute: Optional[ComputeStrategy] = None
+    per_block_limit: Optional[int] = None
+    _strict: bool = field(init=False, repr=False)
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.target_num_rows_per_block <= 0:
             raise ValueError(
                 "target_num_rows_per_block must be positive for streaming repartition, "
-                f"got {target_num_rows_per_block}"
+                f"got {self.target_num_rows_per_block}"
             )
-        super().__init__(
-            f"StreamingRepartition[num_rows_per_block={target_num_rows_per_block},strict={strict}]",
-            input_op,
-            can_modify_num_rows=False,
+        if self.compute is None:
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(
+            self,
+            "_name",
+            f"StreamingRepartition[num_rows_per_block={self.target_num_rows_per_block},strict={self.strict}]",
         )
-        self.target_num_rows_per_block = target_num_rows_per_block
-        self._strict = strict
+        object.__setattr__(self, "_strict", self.strict)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)

--- a/python/ray/data/_internal/logical/rules/combine_shuffles.py
+++ b/python/ray/data/_internal/logical/rules/combine_shuffles.py
@@ -56,7 +56,7 @@ class CombineShuffles(Rule):
         elif isinstance(input_op, StreamingRepartition) and isinstance(
             op, StreamingRepartition
         ):
-            strict = input_op._strict or op._strict
+            strict = input_op.strict or op.strict
             return StreamingRepartition(
                 input_op.input_dependencies[0],
                 target_num_rows_per_block=op.target_num_rows_per_block,

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from dataclasses import is_dataclass, replace
 from typing import List
 
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
@@ -188,6 +189,13 @@ class LimitPushdownRule(Rule):
     ) -> LogicalOperator:
         """Apply per-block limit to operators that support it."""
         if isinstance(op, AbstractMap):
+            if is_dataclass(op):
+                assert len(op.input_dependencies) == 1, len(op.input_dependencies)
+                return replace(
+                    op,
+                    input_op=op.input_dependency,
+                    per_block_limit=limit,
+                )
             new_op = copy.copy(op)
             new_op.set_per_block_limit(limit)
             return new_op
@@ -208,6 +216,8 @@ class LimitPushdownRule(Rule):
                 ray_remote_args=original_op.ray_remote_args,
                 filesystem=original_op.filesystem,
             )
+        if isinstance(original_op, AbstractMap) and is_dataclass(original_op):
+            return replace(original_op, input_op=new_input)
 
         # Use copy and replace input dependencies approach
         new_op = copy.copy(original_op)

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -287,7 +287,7 @@ class FuseOperators(Rule):
 
             # Non-strict mode: can always fuse, no matter what batch_size is.
             # This allows fusion without cross-task buffering by using default bundler.
-            if not down_logical_op._strict:
+            if not down_logical_op.strict:
                 return True
 
             # Strict mode: only fuse when batch_size is a multiple of target_num_rows_per_block.
@@ -324,7 +324,7 @@ class FuseOperators(Rule):
         batch_size = up_logical_op.batch_size
 
         # Choose ref_bundler and fusion behavior based on strict mode
-        if down_logical_op._strict:
+        if down_logical_op.strict:
             # Strict mode: use StreamingRepartitionRefBundler for stitching.
             # Only works when batch_size % target == 0 (verified in _can_fuse).
             assert batch_size % down_logical_op.target_num_rows_per_block == 0, (
@@ -357,7 +357,7 @@ class FuseOperators(Rule):
 
         # In non-strict mode, use min_rows_per_bundle to ensure creating batches with batch_size.
         # In strict mode, ref_bundler handles bundling, so do not set min_rows_per_bundle.
-        min_rows = None if down_logical_op._strict else batch_size
+        min_rows = None if down_logical_op.strict else batch_size
 
         op = MapOperator.create(
             up_op.get_map_transformer().fuse(down_op.get_map_transformer()),

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -1,4 +1,5 @@
 import copy
+from dataclasses import is_dataclass, replace
 from typing import List
 
 from ray.data._internal.logical.interfaces import (
@@ -9,7 +10,7 @@ from ray.data._internal.logical.interfaces import (
     PredicatePassThroughBehavior,
     Rule,
 )
-from ray.data._internal.logical.operators import Filter, Limit, Project
+from ray.data._internal.logical.operators import AbstractMap, Filter, Limit, Project
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     _ColumnSubstitutionVisitor,
 )
@@ -320,6 +321,9 @@ class PredicatePushdown(Rule):
         if isinstance(op, Limit):
             assert len(new_inputs) == 1, len(new_inputs)
             return Limit(new_inputs[0], op.limit)
+        if isinstance(op, AbstractMap) and is_dataclass(op):
+            assert len(new_inputs) == 1, len(new_inputs)
+            return replace(op, input_op=new_inputs[0])
         new_op = copy.copy(op)
         new_op.input_dependencies = new_inputs
         return new_op

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -194,7 +194,7 @@ def plan_streaming_repartition_op(
     )
     map_transformer = MapTransformer([transform_fn])
 
-    if op._strict:
+    if op.strict:
         ref_bundler = StreamingRepartitionRefBundler(op.target_num_rows_per_block)
     else:
         ref_bundler = None


### PR DESCRIPTION
## Description

This PR implements converting map logical operators to frozen dataclasses.

#### Why this is needed:

- This is the second operator-group step under #60312.
- It removes in-place mutation paths for map logical operators.
- It keeps the scope limited to logical map operators and the minimum rule updates needed for frozen compatibility.

#### What this PR changes:

- Converts map logical operators to frozen dataclasses:
  - `MapBatches`
  - `MapRows`
  - `Filter`
  - `Project`
  - `FlatMap`
  - `StreamingRepartition`
- Applies map construction cleanup for frozen compatibility:
  - uses `InitVar[LogicalOperator]` + `__post_init__` to initialize `_name`, `_input_dependencies`, and `_num_outputs`
  - uses canonical dict defaults (`default_factory=dict`) for map remote args fields
  - keeps `eq=False` intentionally to avoid introducing field-based equality/hash semantics for operators with mutable fields (e.g., lists/dicts), and to stay aligned with prior identity-based behavior
- Adds frozen-safe transform behavior for map operators:
  - map operators recreate nodes on input change (no in-place input mutation)
- Updates optimizer rules to avoid mutating frozen map operators:
  - `limit_pushdown.py`: uses frozen-safe recreation/replace logic for map operators (including per-block-limit path)
  - `predicate_pushdown.py`: uses frozen-safe recreation/replace logic when cloning map operators with new inputs
  - these rule changes are required because the generic clone path (`copy.copy` + input reassignment / setter mutation) is not valid for frozen map operators and can raise `FrozenInstanceError`
- Scope is intentionally D2-only: no all-to-all/join/read/write conversion in this PR; no physical-layer behavior changes

## Related issues

Link related issues: "Fixes #60312", or "Related to #60312".

## Additional information

### Tests
Validated with targeted existing tests

### Stack Plan

To complete [#60312](https://github.com/ray-project/ray/issues/60312), the original stack was:

1. https://github.com/ray-project/ray/pull/60529
2. https://github.com/ray-project/ray/pull/60528
3. https://github.com/ray-project/ray/pull/60530
4. https://github.com/ray-project/ray/pull/60531

Since PR4 was still too large, it is being further split:

1. PR-A: default `LogicalOperator` naming behavior https://github.com/ray-project/ray/pull/61020
2. PR-B: move `output_dependencies` responsibility to physical side https://github.com/ray-project/ray/pull/61107
3. PR-C: make `LogicalOperator` an ABC with abstract `num_outputs` https://github.com/ray-project/ray/pull/61308
4. PR-D: convert logical operators to frozen dataclasses in small groups (D1/D2/D3)
    - D1: one-to-one operators https://github.com/ray-project/ray/pull/61364
    - D2: map operators （this PR）
    - D3: all-to-all + join/read/write groups (as needed)

Planned follow-ups (not blocking this stack):
- Converting all `input_op` usage to `input_dependencies`
- Potential `AbstractFrom` restructuring