### PR TITLE
[Core] Support publishing events through public dashboard head endpoint

### DIFF
--- a/python/ray/_common/observability/__init__.py
+++ b/python/ray/_common/observability/__init__.py
@@ -1,10 +1,11 @@
-"""This module provides the Python API for emitting internal Ray events
-via the ONE-Event framework. Events are buffered and exported through
-the C++ RayEventRecorder.
-"""
+"""Public Python APIs for building and publishing Ray events."""
 
+from ray._common.observability.dashboard_head_event_publisher import (
+    DashboardHeadRayEventPublisher,
+)
 from ray._common.observability.internal_event import InternalEventBuilder
 
 __all__ = [
+    "DashboardHeadRayEventPublisher",
     "InternalEventBuilder",
 ]

--- a/python/ray/_common/observability/dashboard_head_event_publisher.py
+++ b/python/ray/_common/observability/dashboard_head_event_publisher.py
@@ -8,9 +8,7 @@ from ray._private.authentication.http_token_authentication import (
     format_authentication_http_error,
     get_auth_headers_if_auth_enabled,
 )
-from ray._private.protobuf_compat import message_to_dict
-from ray._raylet import RayEvent, serialize_events_to_ray_events_data
-from ray.core.generated.events_event_aggregator_service_pb2 import RayEventsData
+from ray._raylet import RayEvent, serialize_events_to_ray_events_data_json
 
 _DEFAULT_TIMEOUT_S = 10
 _EXTERNAL_RAY_EVENTS_PATH = "/api/v0/external/ray_events"
@@ -53,21 +51,9 @@ class DashboardHeadRayEventPublisher:
         if not events:
             return
 
-        events_data = RayEventsData()
-        events_data.ParseFromString(serialize_events_to_ray_events_data(events))
-        payload = [
-            message_to_dict(
-                event,
-                always_print_fields_with_no_presence=True,
-                preserving_proto_field_name=False,
-                use_integers_for_enums=False,
-            )
-            for event in events_data.events
-        ]
-
         response = self._session.post(
             f"{self._get_dashboard_url()}{_EXTERNAL_RAY_EVENTS_PATH}",
-            json=payload,
+            data=serialize_events_to_ray_events_data_json(events),
             headers=self._build_headers(),
             timeout=self._timeout_s,
         )
@@ -81,6 +67,7 @@ class DashboardHeadRayEventPublisher:
 
     def _build_headers(self) -> Dict[str, str]:
         headers = dict(self._headers)
+        headers.setdefault("Content-Type", "application/json")
         auth_headers = get_auth_headers_if_auth_enabled(headers)
         headers.update(auth_headers)
         return headers

--- a/python/ray/_common/observability/dashboard_head_event_publisher.py
+++ b/python/ray/_common/observability/dashboard_head_event_publisher.py
@@ -1,0 +1,112 @@
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
+
+import requests
+
+from ray._private import ray_constants
+from ray._private.authentication.http_token_authentication import (
+    format_authentication_http_error,
+    get_auth_headers_if_auth_enabled,
+)
+from ray._private.protobuf_compat import message_to_dict
+from ray._raylet import RayEvent, serialize_events_to_ray_events_data
+from ray.core.generated.events_event_aggregator_service_pb2 import RayEventsData
+
+_DEFAULT_TIMEOUT_S = 10
+_EXTERNAL_RAY_EVENTS_PATH = "/api/v0/external/ray_events"
+
+
+class DashboardHeadRayEventPublisher:
+    """Publish structured RayEvents to the dashboard head HTTP API."""
+
+    def __init__(
+        self,
+        gcs_client=None,
+        dashboard_url: Optional[str] = None,
+        timeout_s: float = _DEFAULT_TIMEOUT_S,
+        headers: Optional[Dict[str, str]] = None,
+        auth_token: Optional[str] = None,
+        session: Optional[requests.Session] = None,
+    ):
+        if gcs_client is None and dashboard_url is None:
+            raise ValueError("Either gcs_client or dashboard_url must be provided.")
+
+        self._gcs_client = gcs_client
+        self._dashboard_url = self._normalize_dashboard_url(dashboard_url)
+        self._timeout_s = timeout_s
+        self._headers = dict(headers or {})
+        has_authorization_header = any(
+            header_name.lower() == "authorization"
+            for header_name in self._headers.keys()
+        )
+        if auth_token is not None and not has_authorization_header:
+            token = auth_token
+            if not auth_token.startswith("Bearer "):
+                token = f"Bearer {auth_token}"
+            self._headers["Authorization"] = token
+        self._session = session or requests.Session()
+
+    def publish(self, event: RayEvent) -> None:
+        self.publish_batch([event])
+
+    def publish_batch(self, events: List[RayEvent]) -> None:
+        if not events:
+            return
+
+        events_data = RayEventsData()
+        events_data.ParseFromString(serialize_events_to_ray_events_data(events))
+        payload = [
+            message_to_dict(
+                event,
+                always_print_fields_with_no_presence=True,
+                preserving_proto_field_name=False,
+                use_integers_for_enums=False,
+            )
+            for event in events_data.events
+        ]
+
+        response = self._session.post(
+            f"{self._get_dashboard_url()}{_EXTERNAL_RAY_EVENTS_PATH}",
+            json=payload,
+            headers=self._build_headers(),
+            timeout=self._timeout_s,
+        )
+        if response.ok:
+            return
+
+        error = format_authentication_http_error(response.status_code, response.text)
+        if error is not None:
+            raise RuntimeError(error)
+        response.raise_for_status()
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers = dict(self._headers)
+        auth_headers = get_auth_headers_if_auth_enabled(headers)
+        headers.update(auth_headers)
+        return headers
+
+    def _get_dashboard_url(self) -> str:
+        if self._dashboard_url is not None:
+            return self._dashboard_url
+
+        dashboard_url = self._gcs_client.internal_kv_get(
+            ray_constants.DASHBOARD_ADDRESS.encode(),
+            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+            timeout=_DEFAULT_TIMEOUT_S,
+        )
+        if dashboard_url is None:
+            raise RuntimeError("Dashboard address not found in GCS.")
+
+        self._dashboard_url = self._normalize_dashboard_url(dashboard_url.decode())
+        return self._dashboard_url
+
+    @staticmethod
+    def _normalize_dashboard_url(url: Optional[str]) -> Optional[str]:
+        if url is None:
+            return None
+        parsed = urlparse(url)
+        if not parsed.scheme or (
+            parsed.scheme and not parsed.netloc and "://" not in url
+        ):
+            url = f"http://{url}"
+        return url.rstrip("/")

--- a/python/ray/_common/observability/tests/BUILD.bazel
+++ b/python/ray/_common/observability/tests/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//bazel:python.bzl", "py_test_module_list")
+
+py_test_module_list(
+    size = "small",
+    files = [
+        "test_dashboard_head_event_publisher.py",
+    ],
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+    deps = [
+        "//:ray_lib",
+    ],
+)

--- a/python/ray/_common/observability/tests/test_dashboard_head_event_publisher.py
+++ b/python/ray/_common/observability/tests/test_dashboard_head_event_publisher.py
@@ -1,0 +1,122 @@
+from types import SimpleNamespace
+
+import pytest
+
+from ray._common.observability.dashboard_head_event_publisher import (
+    DashboardHeadRayEventPublisher,
+)
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_event_aggregator_service_pb2 import RayEventsData
+
+
+class _FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def post(self, url, json, headers, timeout):
+        self.calls.append(
+            {
+                "url": url,
+                "json": json,
+                "headers": headers,
+                "timeout": timeout,
+            }
+        )
+        return SimpleNamespace(ok=True)
+
+
+def _build_serialized_events_data():
+    events_data = RayEventsData(
+        events=[
+            RayEvent(
+                event_id=b"1",
+                source_type=RayEvent.SourceType.JOBS,
+                event_type=RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+                severity=RayEvent.Severity.INFO,
+                message="hello",
+            )
+        ]
+    )
+    return events_data.SerializeToString()
+
+
+def test_dashboard_head_ray_event_publisher_posts_events(monkeypatch):
+    session = _FakeSession()
+    monkeypatch.setattr(
+        "ray._common.observability.dashboard_head_event_publisher.serialize_events_to_ray_events_data",
+        lambda events: _build_serialized_events_data(),
+    )
+    monkeypatch.setattr(
+        "ray._common.observability.dashboard_head_event_publisher.get_auth_headers_if_auth_enabled",
+        lambda headers: {},
+    )
+
+    publisher = DashboardHeadRayEventPublisher(
+        dashboard_url="127.0.0.1:8265",
+        headers={"X-Test": "1"},
+        timeout_s=3,
+        session=session,
+    )
+    publisher.publish_batch([object()])
+
+    assert len(session.calls) == 1
+    call = session.calls[0]
+    assert call["url"] == "http://127.0.0.1:8265/api/v0/external/ray_events"
+    assert call["headers"] == {"X-Test": "1"}
+    assert call["timeout"] == 3
+    assert len(call["json"]) == 1
+    assert call["json"][0]["eventType"] == "DRIVER_JOB_LIFECYCLE_EVENT"
+
+
+def test_dashboard_head_ray_event_publisher_injects_auth_headers(monkeypatch):
+    session = _FakeSession()
+    monkeypatch.setattr(
+        "ray._common.observability.dashboard_head_event_publisher.serialize_events_to_ray_events_data",
+        lambda events: _build_serialized_events_data(),
+    )
+    monkeypatch.setattr(
+        "ray._common.observability.dashboard_head_event_publisher.get_auth_headers_if_auth_enabled",
+        lambda headers: {"Authorization": "Bearer loader-token"},
+    )
+
+    publisher = DashboardHeadRayEventPublisher(
+        dashboard_url="http://127.0.0.1:8265",
+        session=session,
+    )
+    publisher.publish_batch([object()])
+
+    assert session.calls[0]["headers"]["Authorization"] == "Bearer loader-token"
+
+
+def test_dashboard_head_ray_event_publisher_preserves_explicit_auth_header(monkeypatch):
+    session = _FakeSession()
+    seen_headers = {}
+
+    def _get_auth_headers(headers):
+        seen_headers.update(headers)
+        return {}
+
+    monkeypatch.setattr(
+        "ray._common.observability.dashboard_head_event_publisher.serialize_events_to_ray_events_data",
+        lambda events: _build_serialized_events_data(),
+    )
+    monkeypatch.setattr(
+        "ray._common.observability.dashboard_head_event_publisher.get_auth_headers_if_auth_enabled",
+        _get_auth_headers,
+    )
+
+    publisher = DashboardHeadRayEventPublisher(
+        dashboard_url="http://127.0.0.1:8265",
+        headers={"authorization": "Bearer user-token"},
+        auth_token="should-not-be-used",
+        session=session,
+    )
+    publisher.publish_batch([object()])
+
+    assert seen_headers["authorization"] == "Bearer user-token"
+    assert session.calls[0]["headers"]["authorization"] == "Bearer user-token"
+
+
+def test_dashboard_head_ray_event_publisher_requires_target():
+    with pytest.raises(ValueError):
+        DashboardHeadRayEventPublisher()

--- a/python/ray/_common/observability/tests/test_dashboard_head_event_publisher.py
+++ b/python/ray/_common/observability/tests/test_dashboard_head_event_publisher.py
@@ -1,3 +1,5 @@
+import json
+import sys
 from types import SimpleNamespace
 
 import pytest
@@ -5,19 +7,28 @@ import pytest
 from ray._common.observability.dashboard_head_event_publisher import (
     DashboardHeadRayEventPublisher,
 )
-from ray.core.generated.events_base_event_pb2 import RayEvent
-from ray.core.generated.events_event_aggregator_service_pb2 import RayEventsData
+from ray._private.authentication_test_utils import (
+    authentication_env_guard,
+    reset_auth_token_state,
+    set_auth_mode,
+    set_env_auth_token,
+)
+from ray._raylet import RayEvent as CythonRayEvent
+from ray.core.generated.events_base_event_pb2 import RayEvent as RayEventProto
+from ray.core.generated.events_driver_job_lifecycle_event_pb2 import (
+    DriverJobLifecycleEvent,
+)
 
 
 class _FakeSession:
     def __init__(self):
         self.calls = []
 
-    def post(self, url, json, headers, timeout):
+    def post(self, url, data, headers, timeout):
         self.calls.append(
             {
                 "url": url,
-                "json": json,
+                "data": data,
                 "headers": headers,
                 "timeout": timeout,
             }
@@ -25,98 +36,85 @@ class _FakeSession:
         return SimpleNamespace(ok=True)
 
 
-def _build_serialized_events_data():
-    events_data = RayEventsData(
-        events=[
-            RayEvent(
-                event_id=b"1",
-                source_type=RayEvent.SourceType.JOBS,
-                event_type=RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
-                severity=RayEvent.Severity.INFO,
-                message="hello",
-            )
-        ]
+def _make_test_event(entity_id="test-entity"):
+    """Create a real RayEvent for testing."""
+    nested = DriverJobLifecycleEvent(job_id=entity_id.encode())
+    return CythonRayEvent(
+        source_type=RayEventProto.SourceType.JOBS,
+        event_type=RayEventProto.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+        severity=RayEventProto.Severity.INFO,
+        entity_id=entity_id,
+        message="test event",
+        session_name="test-session",
+        serialized_data=nested.SerializeToString(),
+        nested_event_field_number=RayEventProto.DRIVER_JOB_LIFECYCLE_EVENT_FIELD_NUMBER,
     )
-    return events_data.SerializeToString()
 
 
-def test_dashboard_head_ray_event_publisher_posts_events(monkeypatch):
+def test_dashboard_head_ray_event_publisher_posts_events():
     session = _FakeSession()
-    monkeypatch.setattr(
-        "ray._common.observability.dashboard_head_event_publisher.serialize_events_to_ray_events_data",
-        lambda events: _build_serialized_events_data(),
-    )
-    monkeypatch.setattr(
-        "ray._common.observability.dashboard_head_event_publisher.get_auth_headers_if_auth_enabled",
-        lambda headers: {},
-    )
-
     publisher = DashboardHeadRayEventPublisher(
         dashboard_url="127.0.0.1:8265",
         headers={"X-Test": "1"},
         timeout_s=3,
         session=session,
     )
-    publisher.publish_batch([object()])
+    publisher.publish(_make_test_event())
 
     assert len(session.calls) == 1
     call = session.calls[0]
     assert call["url"] == "http://127.0.0.1:8265/api/v0/external/ray_events"
-    assert call["headers"] == {"X-Test": "1"}
+    assert call["headers"] == {"X-Test": "1", "Content-Type": "application/json"}
     assert call["timeout"] == 3
-    assert len(call["json"]) == 1
-    assert call["json"][0]["eventType"] == "DRIVER_JOB_LIFECYCLE_EVENT"
+    payload = json.loads(call["data"])
+    assert len(payload) == 1
+    event_dict = payload[0]
+    assert event_dict["eventType"] == "DRIVER_JOB_LIFECYCLE_EVENT"
+    assert event_dict["sourceType"] == "JOBS"
+    assert "driverJobLifecycleEvent" in event_dict
 
 
-def test_dashboard_head_ray_event_publisher_injects_auth_headers(monkeypatch):
-    session = _FakeSession()
-    monkeypatch.setattr(
-        "ray._common.observability.dashboard_head_event_publisher.serialize_events_to_ray_events_data",
-        lambda events: _build_serialized_events_data(),
-    )
-    monkeypatch.setattr(
-        "ray._common.observability.dashboard_head_event_publisher.get_auth_headers_if_auth_enabled",
-        lambda headers: {"Authorization": "Bearer loader-token"},
-    )
+def test_dashboard_head_ray_event_publisher_injects_auth_headers():
+    with authentication_env_guard():
+        set_auth_mode("token")
+        set_env_auth_token("loader-token-pad-to-pass-validation-checks-1234567")
+        reset_auth_token_state()
 
-    publisher = DashboardHeadRayEventPublisher(
-        dashboard_url="http://127.0.0.1:8265",
-        session=session,
-    )
-    publisher.publish_batch([object()])
+        session = _FakeSession()
+        publisher = DashboardHeadRayEventPublisher(
+            dashboard_url="http://127.0.0.1:8265",
+            session=session,
+        )
+        publisher.publish(_make_test_event())
 
-    assert session.calls[0]["headers"]["Authorization"] == "Bearer loader-token"
+        call_headers = session.calls[0]["headers"]
+        assert call_headers.get("authorization") == (
+            "Bearer loader-token-pad-to-pass-validation-checks-1234567"
+        )
 
 
-def test_dashboard_head_ray_event_publisher_preserves_explicit_auth_header(monkeypatch):
-    session = _FakeSession()
-    seen_headers = {}
+def test_dashboard_head_ray_event_publisher_preserves_explicit_auth_header():
+    with authentication_env_guard():
+        set_auth_mode("token")
+        set_env_auth_token("loader-token-pad-to-pass-validation-checks-1234567")
+        reset_auth_token_state()
 
-    def _get_auth_headers(headers):
-        seen_headers.update(headers)
-        return {}
+        session = _FakeSession()
+        publisher = DashboardHeadRayEventPublisher(
+            dashboard_url="http://127.0.0.1:8265",
+            headers={"authorization": "Bearer user-token"},
+            auth_token="should-not-be-used",
+            session=session,
+        )
+        publisher.publish(_make_test_event())
 
-    monkeypatch.setattr(
-        "ray._common.observability.dashboard_head_event_publisher.serialize_events_to_ray_events_data",
-        lambda events: _build_serialized_events_data(),
-    )
-    monkeypatch.setattr(
-        "ray._common.observability.dashboard_head_event_publisher.get_auth_headers_if_auth_enabled",
-        _get_auth_headers,
-    )
-
-    publisher = DashboardHeadRayEventPublisher(
-        dashboard_url="http://127.0.0.1:8265",
-        headers={"authorization": "Bearer user-token"},
-        auth_token="should-not-be-used",
-        session=session,
-    )
-    publisher.publish_batch([object()])
-
-    assert seen_headers["authorization"] == "Bearer user-token"
-    assert session.calls[0]["headers"]["authorization"] == "Bearer user-token"
+        assert session.calls[0]["headers"]["authorization"] == "Bearer user-token"
 
 
 def test_dashboard_head_ray_event_publisher_requires_target():
     with pytest.raises(ValueError):
         DashboardHeadRayEventPublisher()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/event/event_head.py
+++ b/python/ray/dashboard/modules/event/event_head.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import os
 import time
@@ -9,13 +10,23 @@ from itertools import islice
 from typing import Dict, List, Union
 
 import aiohttp.web
+from google.protobuf.json_format import ParseDict, ParseError as ProtobufParseError
 
 import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._common.network_utils import build_address
 from ray._common.usage.usage_lib import TagKey, record_extra_usage_tag
 from ray._common.utils import get_or_create_event_loop
+from ray._private import ray_constants
+from ray._private.grpc_utils import init_grpc_channel
 from ray._private.ray_constants import env_integer
+from ray.core.generated import (
+    events_base_event_pb2,
+    events_event_aggregator_service_pb2,
+    events_event_aggregator_service_pb2_grpc,
+)
+from ray.dashboard import consts as dashboard_consts
 from ray.dashboard.consts import (
     RAY_STATE_SERVER_MAX_HTTP_REQUEST,
     RAY_STATE_SERVER_MAX_HTTP_REQUEST_ALLOWED,
@@ -106,6 +117,8 @@ class EventHead(
             max_workers=RAY_DASHBOARD_EVENT_HEAD_TPE_MAX_WORKERS,
             thread_name_prefix="event_head_executor",
         )
+        self._head_aggregator_stub = None
+        self._head_node_id = None
 
         # To init gcs_client in internal_kv for record_extra_usage_tag.
         assert self.gcs_client is not None
@@ -147,6 +160,100 @@ class EventHead(
                 while len(job_events) > MAX_EVENTS_TO_CACHE:
                     job_events.popitem(last=False)
 
+    @staticmethod
+    def _parse_external_ray_events(
+        request_body,
+    ) -> List[events_base_event_pb2.RayEvent]:
+        if not isinstance(request_body, list):
+            raise ValueError("Request body must be a list of RayEvent JSON objects.")
+
+        events = []
+        for index, event_json in enumerate(request_body):
+            if not isinstance(event_json, dict):
+                raise ValueError(
+                    f"Event at index {index} must be a JSON object, got {type(event_json).__name__}."
+                )
+            event = events_base_event_pb2.RayEvent()
+            ParseDict(event_json, event)
+            events.append(event)
+        return events
+
+    @staticmethod
+    def _get_external_ray_event_allowlist() -> set[str]:
+        return {
+            event_type
+            for event_type in ray._config.external_ray_event_allowlist()
+            if event_type
+        }
+
+    @classmethod
+    def _validate_external_ray_events(
+        cls, events: List[events_base_event_pb2.RayEvent]
+    ) -> None:
+        allowlist = cls._get_external_ray_event_allowlist()
+        for event in events:
+            event_type_name = events_base_event_pb2.RayEvent.EventType.Name(
+                event.event_type
+            )
+            if event_type_name not in allowlist:
+                raise ValueError(
+                    f"Event type {event_type_name} is not allowed on /api/v0/external/ray_events."
+                )
+
+    async def _get_head_node_id(self) -> Union[str, None]:
+        if self._head_node_id is not None:
+            return self._head_node_id
+
+        head_node_id = await self.gcs_client.async_internal_kv_get(
+            ray_constants.KV_HEAD_NODE_ID_KEY,
+            namespace=ray_constants.KV_NAMESPACE_JOB,
+            timeout=dashboard_consts.GCS_RPC_TIMEOUT_SECONDS,
+        )
+        if head_node_id is None:
+            return None
+
+        self._head_node_id = head_node_id.decode()
+        return self._head_node_id
+
+    async def _get_head_aggregator_stub(self):
+        if self._head_aggregator_stub is not None:
+            return self._head_aggregator_stub
+
+        head_node_id = await self._get_head_node_id()
+        if head_node_id is None:
+            return None
+
+        agent_addr_json = await self.gcs_client.async_internal_kv_get(
+            f"{dashboard_consts.DASHBOARD_AGENT_ADDR_NODE_ID_PREFIX}{head_node_id}".encode(),
+            namespace=ray_constants.KV_NAMESPACE_DASHBOARD,
+            timeout=dashboard_consts.GCS_RPC_TIMEOUT_SECONDS,
+        )
+        if agent_addr_json is None:
+            return None
+
+        ip, _, grpc_port = json.loads(agent_addr_json)
+        channel = init_grpc_channel(
+            build_address(ip, grpc_port),
+            options=ray_constants.GLOBAL_GRPC_OPTIONS,
+            asynchronous=True,
+        )
+        self._head_aggregator_stub = (
+            events_event_aggregator_service_pb2_grpc.EventAggregatorServiceStub(channel)
+        )
+        return self._head_aggregator_stub
+
+    async def _forward_external_ray_events(
+        self, events: List[events_base_event_pb2.RayEvent]
+    ) -> None:
+        stub = await self._get_head_aggregator_stub()
+        if stub is None:
+            raise RuntimeError("Head node aggregator agent is not available.")
+
+        request = events_event_aggregator_service_pb2.AddEventsRequest(
+            events_data=events_event_aggregator_service_pb2.RayEventsData(events=events)
+        )
+        await stub.AddEvents(request)
+
     @routes.post("/report_events")
     async def report_events(self, request):
         """
@@ -167,6 +274,31 @@ class EventHead(
         self._update_events(events)
         self.total_report_events_count += 1
         self.total_events_received += len(events)
+        return dashboard_optional_utils.rest_response(
+            success=True,
+            message="",
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+        )
+
+    @routes.post("/api/v0/external/ray_events")
+    async def report_external_ray_events(self, request):
+        try:
+            request_body = await request.json()
+            events = self._parse_external_ray_events(request_body)
+            self._validate_external_ray_events(events)
+        except (ValueError, ProtobufParseError) as e:
+            logger.warning("Invalid external Ray event payload: %s", e)
+            raise aiohttp.web.HTTPBadRequest(reason=str(e))
+        except Exception as e:
+            logger.warning("Failed to parse external Ray event payload: %s", e)
+            raise aiohttp.web.HTTPBadRequest()
+
+        try:
+            await self._forward_external_ray_events(events)
+        except Exception:
+            logger.exception("Failed to forward external Ray events to aggregator.")
+            raise aiohttp.web.HTTPInternalServerError()
+
         return dashboard_optional_utils.rest_response(
             success=True,
             message="",

--- a/python/ray/dashboard/modules/event/tests/test_event.py
+++ b/python/ray/dashboard/modules/event/tests/test_event.py
@@ -39,7 +39,6 @@ from ray.cluster_utils import AutoscalingCluster
 from ray.core.generated import (
     event_pb2,
     events_base_event_pb2,
-    events_event_aggregator_service_pb2,
     export_submission_job_event_pb2,
 )
 from ray.dashboard.modules.event import event_consts
@@ -700,75 +699,6 @@ async def test_report_external_ray_events_rejects_disallowed_event_types(monkeyp
 
     with pytest.raises(aiohttp.web.HTTPBadRequest):
         await event_head.report_external_ray_events(_FakeRequest(payload))
-
-
-@pytest.mark.asyncio
-async def test_report_external_ray_events_forwards_allowed_events(monkeypatch):
-    event_head = EventHead.__new__(EventHead)
-    captured = {}
-    event = events_base_event_pb2.RayEvent(
-        event_id=b"1",
-        source_type=events_base_event_pb2.RayEvent.SourceType.JOBS,
-        event_type=events_base_event_pb2.RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
-        severity=events_base_event_pb2.RayEvent.Severity.INFO,
-        message="hello",
-    )
-    payload = [
-        message_to_dict(
-            event,
-            always_print_fields_with_no_presence=True,
-            preserving_proto_field_name=False,
-            use_integers_for_enums=False,
-        )
-    ]
-
-    async def _forward(events):
-        captured["events"] = events
-
-    monkeypatch.setattr(
-        EventHead,
-        "_get_external_ray_event_allowlist",
-        lambda: {"DRIVER_JOB_LIFECYCLE_EVENT"},
-    )
-    event_head._forward_external_ray_events = _forward
-
-    response = await event_head.report_external_ray_events(_FakeRequest(payload))
-
-    assert response.status == 200
-    assert len(captured["events"]) == 1
-    assert (
-        captured["events"][0].event_type
-        == events_base_event_pb2.RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT
-    )
-
-
-@pytest.mark.asyncio
-async def test_forward_external_ray_events_builds_aggregator_request():
-    event_head = EventHead.__new__(EventHead)
-    captured = {}
-    event = events_base_event_pb2.RayEvent(
-        event_id=b"1",
-        source_type=events_base_event_pb2.RayEvent.SourceType.JOBS,
-        event_type=events_base_event_pb2.RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
-        severity=events_base_event_pb2.RayEvent.Severity.INFO,
-        message="hello",
-    )
-
-    class _Stub:
-        async def AddEvents(self, request):
-            captured["request"] = request
-
-    async def _get_stub():
-        return _Stub()
-
-    event_head._get_head_aggregator_stub = _get_stub
-
-    await event_head._forward_external_ray_events([event])
-
-    request = captured["request"]
-    assert isinstance(request, events_event_aggregator_service_pb2.AddEventsRequest)
-    assert len(request.events_data.events) == 1
-    assert request.events_data.events[0].message == "hello"
 
 
 def test_export_event_logger(tmp_path):

--- a/python/ray/dashboard/modules/event/tests/test_event.py
+++ b/python/ray/dashboard/modules/event/tests/test_event.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pprint import pprint
 
+import aiohttp
 import numpy as np
 import pytest
 import requests
@@ -37,10 +38,12 @@ from ray._private.test_utils import (
 from ray.cluster_utils import AutoscalingCluster
 from ray.core.generated import (
     event_pb2,
+    events_base_event_pb2,
+    events_event_aggregator_service_pb2,
     export_submission_job_event_pb2,
 )
 from ray.dashboard.modules.event import event_consts
-from ray.dashboard.modules.event.event_head import _list_cluster_events_impl
+from ray.dashboard.modules.event.event_head import EventHead, _list_cluster_events_impl
 from ray.dashboard.modules.event.event_utils import monitor_events
 from ray.dashboard.tests.conftest import *  # noqa
 from ray.job_submission import JobSubmissionClient
@@ -48,6 +51,14 @@ from ray.util.state import list_cluster_events
 from ray.util.state.common import ClusterEventState
 
 logger = logging.getLogger(__name__)
+
+
+class _FakeRequest:
+    def __init__(self, payload):
+        self._payload = payload
+
+    async def json(self):
+        return self._payload
 
 
 def _get_event(msg="empty message", job_id=None, source_type=None):
@@ -657,6 +668,107 @@ async def test_list_cluster_events_impl():
         option=create_api_options(filters=[("severity", "=", "INFO")]),
     )
     assert len(result.result) == 1
+
+
+@pytest.mark.asyncio
+async def test_report_external_ray_events_rejects_invalid_payload():
+    event_head = EventHead.__new__(EventHead)
+
+    with pytest.raises(aiohttp.web.HTTPBadRequest):
+        await event_head.report_external_ray_events(_FakeRequest({"not": "a-list"}))
+
+
+@pytest.mark.asyncio
+async def test_report_external_ray_events_rejects_disallowed_event_types(monkeypatch):
+    event_head = EventHead.__new__(EventHead)
+    event = events_base_event_pb2.RayEvent(
+        event_id=b"1",
+        source_type=events_base_event_pb2.RayEvent.SourceType.JOBS,
+        event_type=events_base_event_pb2.RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+        severity=events_base_event_pb2.RayEvent.Severity.INFO,
+        message="hello",
+    )
+    payload = [
+        message_to_dict(
+            event,
+            always_print_fields_with_no_presence=True,
+            preserving_proto_field_name=False,
+            use_integers_for_enums=False,
+        )
+    ]
+    monkeypatch.setattr(EventHead, "_get_external_ray_event_allowlist", lambda: set())
+
+    with pytest.raises(aiohttp.web.HTTPBadRequest):
+        await event_head.report_external_ray_events(_FakeRequest(payload))
+
+
+@pytest.mark.asyncio
+async def test_report_external_ray_events_forwards_allowed_events(monkeypatch):
+    event_head = EventHead.__new__(EventHead)
+    captured = {}
+    event = events_base_event_pb2.RayEvent(
+        event_id=b"1",
+        source_type=events_base_event_pb2.RayEvent.SourceType.JOBS,
+        event_type=events_base_event_pb2.RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+        severity=events_base_event_pb2.RayEvent.Severity.INFO,
+        message="hello",
+    )
+    payload = [
+        message_to_dict(
+            event,
+            always_print_fields_with_no_presence=True,
+            preserving_proto_field_name=False,
+            use_integers_for_enums=False,
+        )
+    ]
+
+    async def _forward(events):
+        captured["events"] = events
+
+    monkeypatch.setattr(
+        EventHead,
+        "_get_external_ray_event_allowlist",
+        lambda: {"DRIVER_JOB_LIFECYCLE_EVENT"},
+    )
+    event_head._forward_external_ray_events = _forward
+
+    response = await event_head.report_external_ray_events(_FakeRequest(payload))
+
+    assert response.status == 200
+    assert len(captured["events"]) == 1
+    assert (
+        captured["events"][0].event_type
+        == events_base_event_pb2.RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT
+    )
+
+
+@pytest.mark.asyncio
+async def test_forward_external_ray_events_builds_aggregator_request():
+    event_head = EventHead.__new__(EventHead)
+    captured = {}
+    event = events_base_event_pb2.RayEvent(
+        event_id=b"1",
+        source_type=events_base_event_pb2.RayEvent.SourceType.JOBS,
+        event_type=events_base_event_pb2.RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT,
+        severity=events_base_event_pb2.RayEvent.Severity.INFO,
+        message="hello",
+    )
+
+    class _Stub:
+        async def AddEvents(self, request):
+            captured["request"] = request
+
+    async def _get_stub():
+        return _Stub()
+
+    event_head._get_head_aggregator_stub = _get_stub
+
+    await event_head._forward_external_ray_events([event])
+
+    request = captured["request"]
+    assert isinstance(request, events_event_aggregator_service_pb2.AddEventsRequest)
+    assert len(request.events_data.events) == 1
+    assert request.events_data.events[0].message == "hello"
 
 
 def test_export_event_logger(tmp_path):

--- a/python/ray/includes/event_recorder.pxd
+++ b/python/ray/includes/event_recorder.pxd
@@ -17,9 +17,6 @@ cdef extern from "ray/observability/python_event_interface.h" namespace "ray::ob
         const c_string &serialized_event_data,
         int nested_event_field_number)
 
-    c_string SerializeEventsToRayEventsData(
-        c_vector[unique_ptr[CRayEventInterface]] &&events)
-
     c_string SerializeEventsToRayEventsDataJson(
         c_vector[unique_ptr[CRayEventInterface]] &&events)
 

--- a/python/ray/includes/event_recorder.pxd
+++ b/python/ray/includes/event_recorder.pxd
@@ -17,6 +17,9 @@ cdef extern from "ray/observability/python_event_interface.h" namespace "ray::ob
         const c_string &serialized_event_data,
         int nested_event_field_number)
 
+    c_string SerializeEventsToRayEventsData(
+        c_vector[unique_ptr[CRayEventInterface]] &&events)
+
     cdef cppclass CPythonEventRecorder "ray::observability::PythonEventRecorder":
         CPythonEventRecorder(const c_string &aggregator_address,
                              int aggregator_port,

--- a/python/ray/includes/event_recorder.pxd
+++ b/python/ray/includes/event_recorder.pxd
@@ -20,6 +20,9 @@ cdef extern from "ray/observability/python_event_interface.h" namespace "ray::ob
     c_string SerializeEventsToRayEventsData(
         c_vector[unique_ptr[CRayEventInterface]] &&events)
 
+    c_string SerializeEventsToRayEventsDataJson(
+        c_vector[unique_ptr[CRayEventInterface]] &&events)
+
     cdef cppclass CPythonEventRecorder "ray::observability::PythonEventRecorder":
         CPythonEventRecorder(const c_string &aggregator_address,
                              int aggregator_port,

--- a/python/ray/includes/event_recorder.pxi
+++ b/python/ray/includes/event_recorder.pxi
@@ -9,6 +9,7 @@ from ray.includes.event_recorder cimport (
     CPythonEventRecorder,
     CreatePythonRayEvent,
     SerializeEventsToRayEventsData,
+    SerializeEventsToRayEventsDataJson,
 )
 from ray.includes.common cimport move
 from libcpp.memory cimport unique_ptr
@@ -102,6 +103,20 @@ def serialize_events_to_ray_events_data(list events):
     with nogil:
         serialized_data = SerializeEventsToRayEventsData(move(cpp_events))
     return serialized_data
+
+
+def serialize_events_to_ray_events_data_json(list events):
+    """Serialize RayEvent objects directly to a JSON array string."""
+    cdef c_vector[unique_ptr[CRayEventInterface]] cpp_events
+    cdef RayEvent ev
+    cdef c_string json_data
+
+    for ev in events:
+        cpp_events.push_back(move(ev.to_cpp_event()))
+
+    with nogil:
+        json_data = SerializeEventsToRayEventsDataJson(move(cpp_events))
+    return json_data
 
 
 # module-level Singleton instance, lazily created by EventRecorder.initialize().

--- a/python/ray/includes/event_recorder.pxi
+++ b/python/ray/includes/event_recorder.pxi
@@ -8,7 +8,6 @@ from ray.includes.event_recorder cimport (
     CRayEventInterface,
     CPythonEventRecorder,
     CreatePythonRayEvent,
-    SerializeEventsToRayEventsData,
     SerializeEventsToRayEventsDataJson,
 )
 from ray.includes.common cimport move
@@ -89,20 +88,6 @@ cdef class RayEvent:
     @property
     def event_type(self):
         return self._event_type
-
-
-def serialize_events_to_ray_events_data(list events):
-    """Serialize RayEvent objects into RayEventsData bytes."""
-    cdef c_vector[unique_ptr[CRayEventInterface]] cpp_events
-    cdef RayEvent ev
-    cdef c_string serialized_data
-
-    for ev in events:
-        cpp_events.push_back(move(ev.to_cpp_event()))
-
-    with nogil:
-        serialized_data = SerializeEventsToRayEventsData(move(cpp_events))
-    return serialized_data
 
 
 def serialize_events_to_ray_events_data_json(list events):

--- a/python/ray/includes/event_recorder.pxi
+++ b/python/ray/includes/event_recorder.pxi
@@ -8,6 +8,7 @@ from ray.includes.event_recorder cimport (
     CRayEventInterface,
     CPythonEventRecorder,
     CreatePythonRayEvent,
+    SerializeEventsToRayEventsData,
 )
 from ray.includes.common cimport move
 from libcpp.memory cimport unique_ptr
@@ -87,6 +88,20 @@ cdef class RayEvent:
     @property
     def event_type(self):
         return self._event_type
+
+
+def serialize_events_to_ray_events_data(list events):
+    """Serialize RayEvent objects into RayEventsData bytes."""
+    cdef c_vector[unique_ptr[CRayEventInterface]] cpp_events
+    cdef RayEvent ev
+    cdef c_string serialized_data
+
+    for ev in events:
+        cpp_events.push_back(move(ev.to_cpp_event()))
+
+    with nogil:
+        serialized_data = SerializeEventsToRayEventsData(move(cpp_events))
+    return serialized_data
 
 
 # module-level Singleton instance, lazily created by EventRecorder.initialize().

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -2,6 +2,7 @@ from libcpp cimport bool as c_bool
 from libc.stdint cimport int64_t, uint64_t, uint32_t
 from libcpp.string cimport string as c_string
 from libcpp.unordered_map cimport unordered_map
+from libcpp.vector cimport vector as c_vector
 
 
 cdef extern from "ray/common/ray_config.h" nogil:
@@ -86,3 +87,5 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool record_task_actor_creation_sites() const
 
         c_bool start_python_gc_manager_thread() const
+
+        c_vector[c_string] external_ray_event_allowlist() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -1,4 +1,5 @@
 from libcpp.string cimport string as c_string
+from libcpp.vector cimport vector as c_vector
 from ray.includes.ray_config cimport RayConfig
 
 cdef class Config:
@@ -139,3 +140,10 @@ cdef class Config:
     @staticmethod
     def start_python_gc_manager_thread():
         return RayConfig.instance().start_python_gc_manager_thread()
+
+    @staticmethod
+    def external_ray_event_allowlist():
+        cdef c_vector[c_string] allowlist = (
+            RayConfig.instance().external_ray_event_allowlist()
+        )
+        return [allowlist[i].decode("utf-8") for i in range(allowlist.size())]

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -1002,6 +1002,10 @@ RAY_CONFIG(bool, enable_core_worker_task_event_to_gcs, true)
 // event aggregator.
 RAY_CONFIG(bool, enable_core_worker_ray_event_to_aggregator, false)
 
+// Comma-separated list of RayEvent event types accepted by the dashboard head's
+// external event ingestion endpoint.
+RAY_CONFIG(std::vector<std::string>, external_ray_event_allowlist, {})
+
 // Configuration for pipe logger buffer size.
 RAY_CONFIG(uint64_t, pipe_logger_read_buf_size, 1024)
 

--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -179,6 +179,7 @@ ray_cc_library(
         "//src/ray/common:asio",
         "//src/ray/common:grpc_util",
         "//src/ray/common:id",
+        "//src/ray/protobuf:events_event_aggregator_service_cc_proto",
         "//src/ray/protobuf/public:events_base_event_cc_proto",
         "//src/ray/rpc:event_aggregator_client",
         "//src/ray/util:logging",

--- a/src/ray/observability/python_event_interface.cc
+++ b/src/ray/observability/python_event_interface.cc
@@ -106,6 +106,19 @@ std::unique_ptr<RayEventInterface> CreatePythonRayEvent(
       nested_event_field_number);
 }
 
+std::string SerializeEventsToRayEventsData(
+    std::vector<std::unique_ptr<RayEventInterface>> &&events) {
+  rpc::events::RayEventsData data;
+  auto *serialized_events = data.mutable_events();
+  serialized_events->Reserve(events.size());
+  for (auto &event : events) {
+    auto serialized_event = std::move(*event).Serialize();
+    auto *dst = serialized_events->Add();
+    dst->Swap(&serialized_event);
+  }
+  return data.SerializeAsString();
+}
+
 PythonEventRecorder::PythonEventRecorder(const std::string &aggregator_address,
                                          int aggregator_port,
                                          const std::string &node_ip,

--- a/src/ray/observability/python_event_interface.cc
+++ b/src/ray/observability/python_event_interface.cc
@@ -108,19 +108,6 @@ std::unique_ptr<RayEventInterface> CreatePythonRayEvent(
       nested_event_field_number);
 }
 
-std::string SerializeEventsToRayEventsData(
-    std::vector<std::unique_ptr<RayEventInterface>> &&events) {
-  rpc::events::RayEventsData data;
-  auto *serialized_events = data.mutable_events();
-  serialized_events->Reserve(events.size());
-  for (auto &event : events) {
-    auto serialized_event = std::move(*event).Serialize();
-    auto *dst = serialized_events->Add();
-    dst->Swap(&serialized_event);
-  }
-  return data.SerializeAsString();
-}
-
 std::string SerializeEventsToRayEventsDataJson(
     std::vector<std::unique_ptr<RayEventInterface>> &&events) {
   google::protobuf::util::JsonPrintOptions options;

--- a/src/ray/observability/python_event_interface.cc
+++ b/src/ray/observability/python_event_interface.cc
@@ -14,6 +14,8 @@
 
 #include "ray/observability/python_event_interface.h"
 
+#include <google/protobuf/util/json_util.h>
+
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/message.h"
 #include "ray/common/grpc_util.h"
@@ -117,6 +119,31 @@ std::string SerializeEventsToRayEventsData(
     dst->Swap(&serialized_event);
   }
   return data.SerializeAsString();
+}
+
+std::string SerializeEventsToRayEventsDataJson(
+    std::vector<std::unique_ptr<RayEventInterface>> &&events) {
+  google::protobuf::util::JsonPrintOptions options;
+  options.always_print_primitive_fields = true;
+  // preserve_proto_field_names defaults to false → camelCase output,
+  // Enums print as strings by default
+
+  std::string result = "[";
+  bool first = true;
+  for (auto &event : events) {
+    auto serialized_event = std::move(*event).Serialize();
+    std::string json_str;
+    auto status =
+        google::protobuf::util::MessageToJsonString(serialized_event, &json_str, options);
+    RAY_CHECK(status.ok()) << "Failed to serialize event to JSON: " << status.message();
+    if (!first) {
+      result += ",";
+    }
+    result += json_str;
+    first = false;
+  }
+  result += "]";
+  return result;
 }
 
 PythonEventRecorder::PythonEventRecorder(const std::string &aggregator_address,

--- a/src/ray/observability/python_event_interface.h
+++ b/src/ray/observability/python_event_interface.h
@@ -101,13 +101,6 @@ std::unique_ptr<RayEventInterface> CreatePythonRayEvent(
     const std::string &serialized_event_data,
     int nested_event_field_number);
 
-/// Serialize Python-emitted events into a RayEventsData payload.
-///
-/// Each event is serialized through RayEventInterface::Serialize and appended to
-/// the RayEventsData.events list. The protobuf is returned as serialized bytes.
-std::string SerializeEventsToRayEventsData(
-    std::vector<std::unique_ptr<RayEventInterface>> &&events);
-
 /// Serialize Python-emitted events directly to a JSON array string.
 ///
 /// Each event is serialized through RayEventInterface::Serialize, then converted

--- a/src/ray/observability/python_event_interface.h
+++ b/src/ray/observability/python_event_interface.h
@@ -25,6 +25,7 @@
 #include "ray/observability/ray_event_recorder.h"
 #include "ray/rpc/event_aggregator_client.h"
 #include "ray/stats/metric.h"
+#include "src/ray/protobuf/events_event_aggregator_service.pb.h"
 #include "src/ray/protobuf/public/events_base_event.pb.h"
 
 namespace ray {
@@ -99,6 +100,13 @@ std::unique_ptr<RayEventInterface> CreatePythonRayEvent(
     const std::string &session_name,
     const std::string &serialized_event_data,
     int nested_event_field_number);
+
+/// Serialize Python-emitted events into a RayEventsData payload.
+///
+/// Each event is serialized through RayEventInterface::Serialize and appended to
+/// the RayEventsData.events list. The protobuf is returned as serialized bytes.
+std::string SerializeEventsToRayEventsData(
+    std::vector<std::unique_ptr<RayEventInterface>> &&events);
 
 /// Owns all infrastructure for the Python-side event recorder: io_context,
 /// background thread, gRPC client, metrics counter, and the recorder itself.

--- a/src/ray/observability/python_event_interface.h
+++ b/src/ray/observability/python_event_interface.h
@@ -108,6 +108,14 @@ std::unique_ptr<RayEventInterface> CreatePythonRayEvent(
 std::string SerializeEventsToRayEventsData(
     std::vector<std::unique_ptr<RayEventInterface>> &&events);
 
+/// Serialize Python-emitted events directly to a JSON array string.
+///
+/// Each event is serialized through RayEventInterface::Serialize, then converted
+/// to JSON via protobuf's MessageToJsonString. Returns a JSON array string
+/// (e.g., "[{...}, {...}]")
+std::string SerializeEventsToRayEventsDataJson(
+    std::vector<std::unique_ptr<RayEventInterface>> &&events);
+
 /// Owns all infrastructure for the Python-side event recorder: io_context,
 /// background thread, gRPC client, metrics counter, and the recorder itself.
 ///


### PR DESCRIPTION
## Description
Expose a public dashboard head endpoint for accepting events from external components like autoscaler, the dashboard head will then be responsible for forwarding these events to aggregator which can then expose these events to configured consumers.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
