### PR TITLE
[Data] Optimize triple loop in default_autoscaling_coordinator.py

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -404,12 +404,16 @@ class _AutoscalingCoordinatorActor:
         # Allocate resources to ongoing requests.
         maybe_subtract_resources = self._maybe_subtract_resources
         num_nodes = len(cluster_node_resources)
-        # Cache search positions for repeated bundles. Since node resources only
-        # decrease during this allocation pass, the first feasible node index for
-        # the same bundle never moves left.
+        # Assumption for this optimization (within one _reallocate_resources pass):
+        # node resources only decrease, never increase. Therefore for identical
+        # bundles:
+        # 1) the first feasible node index can only stay or move right;
+        # 2) if one identical bundle cannot fit any node, later identical bundles
+        #    also cannot fit in this pass.
+        # This is most beneficial when requested_resources has many duplicate
+        # bundles (e.g., homogeneous node shapes and/or multiple executors
+        # requesting similar specs).
         first_fit_start_idx = {}
-        # Once a bundle cannot fit any node, later identical bundles cannot fit
-        # either within this pass because resources are monotonically decreasing.
         impossible_bundles = set()
         for ongoing_req in ongoing_reqs:
             allocated_resources = []

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -402,14 +402,34 @@ class _AutoscalingCoordinatorActor:
             [req for req in self._ongoing_reqs.values() if req.expiration_time >= now]
         )
         # Allocate resources to ongoing requests.
-        # TODO(hchen): Optimize the following triple loop.
+        maybe_subtract_resources = self._maybe_subtract_resources
+        num_nodes = len(cluster_node_resources)
+        # Cache search positions for repeated bundles. Since node resources only
+        # decrease during this allocation pass, the first feasible node index for
+        # the same bundle never moves left.
+        first_fit_start_idx = {}
+        # Once a bundle cannot fit any node, later identical bundles cannot fit
+        # either within this pass because resources are monotonically decreasing.
+        impossible_bundles = set()
         for ongoing_req in ongoing_reqs:
-            ongoing_req.allocated_resources = []
+            allocated_resources = []
+            ongoing_req.allocated_resources = allocated_resources
             for req in ongoing_req.requested_resources:
-                for node_resource in cluster_node_resources:
-                    if self._maybe_subtract_resources(node_resource, req):
-                        ongoing_req.allocated_resources.append(req)
+                req_key = frozenset(req.items())
+                if req_key in impossible_bundles:
+                    continue
+
+                start_idx = first_fit_start_idx.get(req_key, 0)
+                allocated = False
+                for node_idx in range(start_idx, num_nodes):
+                    if maybe_subtract_resources(cluster_node_resources[node_idx], req):
+                        allocated_resources.append(req)
+                        first_fit_start_idx[req_key] = node_idx
+                        allocated = True
                         break
+
+                if not allocated:
+                    impossible_bundles.add(req_key)
         # Allocate remaining resources.
         # NOTE: to handle the case where multiple datasets are running concurrently,
         # we divide remaining resources equally to all requesters with `request_remaining=True`.


### PR DESCRIPTION

## Description
This issue addresses a resource-allocation performance bottleneck in Ray Data autoscaling.

Previously, the coordinator used a triple nested loop when reallocating resources (requesters × requested bundles × cluster nodes). That made allocation cost grow quickly as concurrency increased, causing unnecessary CPU overhead and slower autoscaler reaction times. It was especially inefficient for repeated identical bundles, which were rescanned across nodes from the beginning each time.

## Related issues
https://github.com/ray-project/ray/issues/61485


