### PR TITLE
fix build-image, build-wheels test tags

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -427,9 +427,7 @@ steps:
 
   - label: ":tapioca: smoke test build-wheel.sh --help"
     tags:
-      - python_dependencies
-      - docker
-      - oss
+      - tools
     instance_type: small
     commands:
       - ./build-wheel.sh --help
@@ -453,9 +451,7 @@ steps:
 
   - label: ":tapioca: smoke test build-image.sh --help"
     tags:
-      - python_dependencies
-      - docker
-      - oss
+      - tools
     instance_type: small
     commands:
       - ./build-image.sh --help

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -227,6 +227,7 @@ ci/docker/manylinux.aarch64.wanda.yaml
 ci/docker/windows.build.Dockerfile
 ci/docker/windows.build.wanda.yaml
 build-docker.sh
+build-image.sh
 @ docker linux_wheels tools
 ;
 

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -215,6 +215,7 @@ ci/docker/forge.aarch64.wanda.yaml
 .buildkite/release/
 .buildkite/release-automation/
 build-wheel.sh
+build-image.sh
 @ tools
 ;
 
@@ -227,7 +228,6 @@ ci/docker/manylinux.aarch64.wanda.yaml
 ci/docker/windows.build.Dockerfile
 ci/docker/windows.build.wanda.yaml
 build-docker.sh
-build-image.sh
 @ docker linux_wheels tools
 ;
 


### PR DESCRIPTION
Add-ons for making sure we test https://github.com/ray-project/ray/pull/61042 , and properly tag alongside changes to `ci/build/(build_wheel || build_image).py`