### PR TITLE
[train][tests] Abort cancels validation tasks and has deterministic behavior for resumption

### DIFF
--- a/python/ray/train/v2/_internal/execution/callback.py
+++ b/python/ray/train/v2/_internal/execution/callback.py
@@ -144,6 +144,10 @@ class ControllerCallback(RayTrainCallback):
         """
         pass
 
+    def before_controller_abort(self):
+        """Called during `TrainController.abort` before the actor process exits."""
+        pass
+
 
 # TODO: consider consolidating all metrics into one dict, possibly with UDF
 @DeveloperAPI

--- a/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
+++ b/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
@@ -187,13 +187,18 @@ class ValidationManager(ControllerCallback, ReportCallback, WorkerGroupCallback)
             )
         self._checkpoint_manager.update_checkpoints_with_metrics(checkpoint_to_metrics)
 
+    def before_controller_abort(self):
+        for task in self._pending_validations.keys():
+            ray.cancel(task)
+
     def after_controller_state_update(
         self,
         previous_state: "TrainControllerState",
         current_state: "TrainControllerState",
     ):
         # TODO: figure out if there's a better place to poll validations
-        # TODO: consider cleaning up validation tasks in before_controller_abort
+        if current_state.is_terminal():
+            return
         self._poll_validations()
         self._kick_off_validations()
 

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -639,6 +639,10 @@ class TrainController:
         # Do not abort run if it's already finished.
         if self.get_state().is_terminal():
             return
+
+        for callback in self._controller_callbacks:
+            callback.before_controller_abort()
+
         # Intentionally abort worker group before setting train run state because
         # we only reconcile the states of live train runs.
         if self._worker_group:

--- a/python/ray/train/v2/tests/test_async_checkpointing_validation.py
+++ b/python/ray/train/v2/tests/test_async_checkpointing_validation.py
@@ -1,5 +1,7 @@
+import multiprocessing
 import os
 import shutil
+import signal
 import time
 from unittest.mock import create_autospec
 
@@ -428,6 +430,41 @@ def test_report_validation_fn_success_after_retry():
     assert result.best_checkpoints[0][1] == {"score": 100}
 
 
+def _run_first_trainer_for_resumption(storage_path, validation_task_config):
+    """Subprocess target: run a trainer with a stalling validation, then get SIGINT'd."""
+    # Lives outside the test because multiprocessing cannot pickle nested functions.
+    ray.init(address="auto")
+
+    def validation_fn_stall(checkpoint, score):
+        signal_actor = ray.get_actor(
+            "validation_resumption_signal", namespace="test_validation_resumption"
+        )
+        ray.get(signal_actor.send.remote())
+        while True:
+            time.sleep(1)
+
+    def train_fn():
+        with create_dict_checkpoint({}) as cp:
+            ray.train.report(
+                metrics={},
+                checkpoint=cp,
+                validation=validation_task_config,
+            )
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        validation_config=ValidationConfig(
+            fn=validation_fn_stall,
+            task_config=ValidationTaskConfig(fn_kwargs={"score": 1}),
+        ),
+        scaling_config=ScalingConfig(num_workers=1),
+        run_config=RunConfig(
+            name="validation_fn_resumption", storage_path=storage_path
+        ),
+    )
+    trainer.fit()
+
+
 @pytest.mark.parametrize(
     "validation_task_config, expected_score",
     [
@@ -439,52 +476,46 @@ def test_report_validation_fn_resumption(
     tmp_path, validation_task_config, expected_score
 ):
     """Start train run with interrupted validations. Confirm second run finishes validations."""
-    signal_actor = create_remote_signal_actor(ray).remote()
+    signal_actor = (
+        create_remote_signal_actor(ray)
+        .options(
+            name="validation_resumption_signal",
+            namespace="test_validation_resumption",
+        )
+        .remote()
+    )
 
-    def validation_fn_stall(checkpoint, score):
-        signal_actor.send.remote()
-        while True:
-            time.sleep(1)
+    multiprocessing.set_start_method("spawn", force=True)
+    process = multiprocessing.Process(
+        target=_run_first_trainer_for_resumption,
+        args=(str(tmp_path), validation_task_config),
+    )
+    process.start()
+
+    # Wait for validation to start, then SIGINT the trainer process.
+    ray.get(signal_actor.wait.remote())
+    os.kill(process.pid, signal.SIGINT)
+    process.join()
 
     def validation_fn_finish(checkpoint, score):
         return {"score": score}
 
-    def train_fn_first():
-        with create_dict_checkpoint({}) as cp:
-            ray.train.report(
-                metrics={},
-                checkpoint=cp,
-                validation=validation_task_config,
-            )
-
     def train_fn_second():
         pass
 
-    @ray.remote
-    def run_trainer(validation_fn, train_fn):
-        trainer = DataParallelTrainer(
-            train_fn,
-            validation_config=ValidationConfig(
-                fn=validation_fn,
-                task_config=ValidationTaskConfig(fn_kwargs={"score": 1}),
-            ),
-            scaling_config=ScalingConfig(num_workers=1),
-            run_config=RunConfig(
-                name="validation_fn_resumption", storage_path=str(tmp_path)
-            ),
-        )
-        return trainer.fit()
-
-    # Run trainer. Wait until validation kicked off. Cancel training.
-    training_task = run_trainer.remote(validation_fn_stall, train_fn_first)
-    ray.get(signal_actor.wait.remote())
-    ray.cancel(training_task)
-    with pytest.raises(ray.exceptions.TaskCancelledError):
-        ray.get(training_task)
-
     # Run second trainer that should finish interrupted validations.
-    training_task = run_trainer.remote(validation_fn_finish, train_fn_second)
-    result = ray.get(training_task)
+    trainer = DataParallelTrainer(
+        train_fn_second,
+        validation_config=ValidationConfig(
+            fn=validation_fn_finish,
+            task_config=ValidationTaskConfig(fn_kwargs={"score": 1}),
+        ),
+        scaling_config=ScalingConfig(num_workers=1),
+        run_config=RunConfig(
+            name="validation_fn_resumption", storage_path=str(tmp_path)
+        ),
+    )
+    result = trainer.fit()
     assert result.metrics == {"score": expected_score}
 
 

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -258,7 +258,7 @@ async def test_poll_frequency(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_controller_callback():
+async def test_controller_callback(monkeypatch):
     """Check that all controller callback hooks are called."""
 
     class AssertCallback(ControllerCallback):
@@ -268,6 +268,7 @@ async def test_controller_callback():
             self.failure_decision_called = False
             self.resize_decision_called = False
             self.shutdown_called = False
+            self.before_abort_called = False
 
         def after_controller_start(self, train_run_context: TrainRunContext):
             self.start_called = True
@@ -294,6 +295,9 @@ async def test_controller_callback():
         def before_controller_shutdown(self):
             self.shutdown_called = True
 
+        def before_controller_abort(self):
+            self.before_abort_called = True
+
     callback = AssertCallback()
 
     scaling_policy = MockScalingPolicy(scaling_config=ScalingConfig())
@@ -310,6 +314,16 @@ async def test_controller_callback():
 
     controller._start()
     assert callback.start_called
+
+    mock_exit_actor = create_autospec(ray.actor.exit_actor)
+    monkeypatch.setattr("ray.actor.exit_actor", mock_exit_actor)
+
+    await controller.abort()
+    assert callback.before_abort_called
+    assert isinstance(callback.latest_state_update[1], AbortedState)
+
+    # Reset the state to InitializingState to test the control loop
+    controller._set_state(InitializingState())
 
     scaling_policy.queue_recovery_decision(
         ResizeDecision(num_workers=2, resources_per_worker={})


### PR DESCRIPTION
# Summary

We observed the following flaky behavior in `test_report_validation_fn_resumption`

```                                                                    
  [2026-03-04T02:25:25Z] (TrainController pid=6108) Launched async validation task for checkpoint      
  Checkpoint(filesystem=local, path=/tmp/pytest-of-root/pytest-0/test_report_validation_fn_resu0/valid 
  ation_fn_resumption/checkpoint_2026-03-04_02-21-22.230987)                                           
  [2026-03-04T02:25:25Z] (run_trainer pid=6028) Received SIGINT. Gracefully aborting the training run  
  — this may take a few seconds. To forcefully abort immediately, you can send a different signal,     
  such as SIGKILL.                                                                                     
  [2026-03-04T02:25:25Z] (TrainController pid=6108) Finished async validation task(s) for              
  checkpoint(s): [Checkpoint(filesystem=local, path=/tmp/pytest-of-root/pytest-0/test_report_validatio 
  n_fn_resu0/validation_fn_resumption/checkpoint_2026-03-04_02-21-22.230987)].                         
 ...                                
  [2026-03-04T02:25:25Z] (TrainController pid=6108) ray.exceptions.TaskCancelledError: Task:           
  TaskID(4e6f2dd62797ace7ffffffffffffffffffffffff01000000) was cancelled.                              
  [2026-03-04T02:25:25Z] (TrainController pid=6362) A run snapshot was found in storage folder at:     
  '/tmp/pytest-of-root/pytest-0/test_report_validation_fn_resu0/validation_fn_resumption'              
  [2026-03-04T02:25:25Z] (TrainController pid=6362) This snapshot contains a list of checkpoints       
  reported via `ray.train.report` and will be loaded. This allows the latest checkpoint found in the   
  snapshot to be accessible within your training function via `ray.train.get_checkpoint`.              
```

Essentially what happened was
1) The unit test called `ray.cancel`
2) This sent a `SIGINT` to the trainer and recursively cancelled the validation task
3) `SIGINT` made Ray Train go through the abortion code, which includes transitioning to the `ABORTED` state
4) `after_controller_state_update` sometimes (I think there's a race between when `after_controller_state_update` is called and when the validation task is cancelled) saw the cancelled validation task and updated the metrics accordingly. 
5) The second train run had no validations to resume.

This PR avoids this race by:
1) Changing `after_controller_state_update` to do nothing if the state is terminal. We will process validation tasks from `FINISHED` and `ERRORED` train runs in `before_controller_shutdown` and cancel validation tasks in `ABORTED` train runs in `before_controller_abort`.
2) Changing `test_report_validation_fn_resumption` to SIGINT a process (the same pattern as `test_sigint_abort`) rather than `ray.cancel` a task (the old pattern) to deterministically test the graceful abortion path.

# Testing

Unit tests.