### PR TITLE
[docs] Profiling: add legacy RAYLET_PERFTOOLS env aliases

### DIFF
--- a/doc/source/ray-contribute/profiling.rst
+++ b/doc/source/ray-contribute/profiling.rst
@@ -42,8 +42,14 @@ To launch Ray in profiling mode and profile Raylet, define the following variabl
 
 .. code-block:: bash
 
+  # Preferred env vars.
   export PERFTOOLS_PATH=/usr/lib/x86_64-linux-gnu/libprofiler.so
   export PERFTOOLS_LOGFILE=/tmp/pprof.out
+
+  # Legacy-compatible aliases that some environments still expect.
+  export RAYLET_PERFTOOLS_PATH=$PERFTOOLS_PATH
+  export RAYLET_PERFTOOLS_LOGFILE=$PERFTOOLS_LOGFILE
+
   export RAY_RAYLET_PERFTOOLS_PROFILER=1
 
 


### PR DESCRIPTION
Fixes #7735\n\nThe profiling docs currently show the preferred  variables.\nThis PR also documents legacy-compatible  aliases for environments that still expect them, while keeping  as primary.\n\nNo behavior changes; docs only.