### PR TITLE
[Serve][docs] Add speech-to-text bidirectional streaming example to examples section

### DIFF
--- a/doc/source/serve/examples.yml
+++ b/doc/source/serve/examples.yml
@@ -138,6 +138,12 @@ examples:
       - natural language processing
     link: tutorials/streaming
     related_technology: ml applications
+  - title: Serve Speech-to-Text with Bidirectional gRPC Streaming
+    skill_level: intermediate
+    use_cases:
+      - natural language processing
+    link: advanced-guides/grpc-guide
+    related_technology: integrations
   - title: Serving models with Triton Server in Ray Serve
     skill_level: intermediate
     use_cases:


### PR DESCRIPTION
## Summary
Adds a Ray Serve examples card for speech-to-text with bidirectional gRPC streaming, as requested in #61494.

## Changes
- Added a new entry in `doc/source/serve/examples.yml`:
  - **Serve Speech-to-Text with Bidirectional gRPC Streaming**
  - Links to `advanced-guides/grpc-guide`
  - Tagged under `natural language processing` and `integrations`

Fixes #61494