### PR TITLE
[core] Fix publisher_id type mismatch in GCS pubsub

### DIFF
--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -142,11 +142,11 @@ class _AioSubscriber(_SubscriberBase):
             try:
                 self._last_batch_size = len(poll.result().pub_messages)
                 if poll.result().publisher_id != self._publisher_id:
-                    if self._publisher_id != "":
+                    if self._publisher_id != b"":
                         logger.debug(
-                            f"replied publisher_id {poll.result().publisher_id}"
+                            f"replied publisher_id {poll.result().publisher_id} "
                             f"different from {self._publisher_id}, this should "
-                            "only happens during gcs failover."
+                            "only happen during gcs failover."
                         )
                     self._publisher_id = poll.result().publisher_id
                     self._max_processed_sequence_id = 0

--- a/python/ray/tests/test_advanced.py
+++ b/python/ray/tests/test_advanced.py
@@ -199,9 +199,17 @@ def test_internal_get_local_ongoing_lineage_reconstruction_tasks(
 
         return True
 
-    wait_for_condition(lambda: verify(common_pb2.TaskStatus.PENDING_NODE_ASSIGNMENT))
+    wait_for_condition(
+        lambda: verify(common_pb2.TaskStatus.PENDING_NODE_ASSIGNMENT),
+        timeout=30,
+        retry_interval_ms=1000,
+    )
     cluster.add_node(resources={"worker": 2})
-    wait_for_condition(lambda: verify(common_pb2.TaskStatus.SUBMITTED_TO_WORKER))
+    wait_for_condition(
+        lambda: verify(common_pb2.TaskStatus.SUBMITTED_TO_WORKER),
+        timeout=30,
+        retry_interval_ms=1000,
+    )
 
 
 def test_multiple_waits_and_gets(shutdown_only):


### PR DESCRIPTION
- Fix comparison of bytes vs str: self._publisher_id is initialized as b"" (bytes) but was compared against "" (str). In Python 3, b"" != "" is always True, causing spurious debug logs on first connection.
- Add missing space between f-string fragments in debug log.
- Fix grammar: "only happens" -> "only happen".

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Type Comparing Error

## Related issues
> Related to [issue-61517](https://github.com/ray-project/ray/issues/61517)

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
