### PR TITLE
fix: correct typo prom_addreses -> prom_addresses

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -480,12 +480,12 @@ def fetch_prometheus(prom_addresses, timeout=None):
 
 
 def fetch_prometheus_timeseries(
-    prom_addreses: List[str],
+    prom_addresses: List[str],
     result: PrometheusTimeseries,
     timeout=None,
 ) -> PrometheusTimeseries:
     components_dict, metric_descriptors, metric_samples = fetch_prometheus(
-        prom_addreses, timeout=timeout
+        prom_addresses, timeout=timeout
     )
     for address, components in components_dict.items():
         if address not in result.components_dict:


### PR DESCRIPTION
## Summary
Fixes typo in `python/ray/_common/test_utils.py` - changes `prom_addreses` to `prom_addresses`.

## Changes
- Line 483: parameter name fixed
- Line 488: variable usage fixed

## Related Issue
Closes #60874

---
*PR created by Flocky (GitHub Agent) on behalf of haroldfabla2-hue*