### PR TITLE
[RLLib] Reset EvnRunner on Connector error

### DIFF
--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -286,7 +286,11 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
         agent_ts = 0
         eps = 0
 
-        if self._cached_to_module is None:
+        reset_required = (
+            force_reset or num_episodes is not None or self._needs_initial_reset
+        )
+
+        if self._cached_to_module is None and not reset_required:
             # This can happen if we error out in a previous sample call.
             # Primarily, because a connector fails.
             # In this case, we need to reset the envs and episodes to start over.
@@ -294,10 +298,10 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
                 logger.warning(
                     "Error in sample call detected. Resetting envs and episodes to start over. You can ignore this warning if a connector is expectedly unstable."
                 )
-            force_reset = True
+            reset_required = True
 
         # Have to reset the env (on all vector sub_envs).
-        if force_reset or num_episodes is not None or self._needs_initial_reset:
+        if reset_required:
             env_ts = 0
             agent_ts = 0
             self._reset_envs_and_episodes(explore)

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -26,7 +26,7 @@ from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
 from ray.rllib.env.utils import _gym_env_creator
 from ray.rllib.env.vector.registration import make_vec
 from ray.rllib.env.vector.vector_multi_agent_env import VectorMultiAgentEnv
-from ray.rllib.utils import force_list
+from ray.rllib.utils import force_list, log_once
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.checkpoints import Checkpointable
 from ray.rllib.utils.framework import get_device, try_import_torch
@@ -287,6 +287,13 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
         eps = 0
 
         if self._cached_to_module is None:
+            # This can happen if we error out in a previous sample call.
+            # Primarily, because a connector fails.
+            # In this case, we need to reset the envs and episodes to start over.
+            if log_once("sample_error_reset_envs"):
+                logger.warning(
+                    "Error in sample call detected. Resetting envs and episodes to start over. You can ignore this warning if a connector is expectedly unstable."
+                )
             force_reset = True
 
         # Have to reset the env (on all vector sub_envs).

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -291,10 +291,13 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
             force_reset or num_episodes is not None or self._needs_initial_reset
         )
 
-        if self._cached_to_module is None and not reset_required:
-            # This can happen if we error out in a previous sample call.
-            # Primarily, because a connector fails.
-            # In this case, we need to reset the envs and episodes to start over.
+        if (
+            self._cached_to_module is None
+            and self.module is not None
+            and not reset_required
+        ):
+            # Cached module connector outputs can be none if a connector fails.
+            # self._cached_to_module is always None if the module is None.
             if log_once("sample_error_reset_envs"):
                 logger.warning(
                     "Error in sample call detected. Resetting envs and episodes to start over. You can ignore this warning if a connector is expectedly unstable."

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -286,6 +286,9 @@ class MultiAgentEnvRunner(EnvRunner, Checkpointable):
         agent_ts = 0
         eps = 0
 
+        if self._cached_to_module is None:
+            force_reset = True
+
         # Have to reset the env (on all vector sub_envs).
         if force_reset or num_episodes is not None or self._needs_initial_reset:
             env_ts = 0

--- a/rllib/env/multi_agent_env_runner.py
+++ b/rllib/env/multi_agent_env_runner.py
@@ -26,7 +26,7 @@ from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
 from ray.rllib.env.utils import _gym_env_creator
 from ray.rllib.env.vector.registration import make_vec
 from ray.rllib.env.vector.vector_multi_agent_env import VectorMultiAgentEnv
-from ray.rllib.utils import force_list, log_once
+from ray.rllib.utils import force_list
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.checkpoints import Checkpointable
 from ray.rllib.utils.framework import get_device, try_import_torch
@@ -59,6 +59,7 @@ from ray.rllib.utils.metrics import (
 from ray.rllib.utils.pre_checks.env import check_multiagent_environments
 from ray.rllib.utils.typing import EpisodeID, ModelWeights, ResultDict, StateDict
 from ray.tune.registry import ENV_CREATOR, _global_registry
+from ray.util import log_once
 from ray.util.annotations import PublicAPI
 
 torch, _ = try_import_torch()

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -25,7 +25,7 @@ from ray.rllib.env import INPUT_ENV_SINGLE_SPACES, INPUT_ENV_SPACES
 from ray.rllib.env.env_context import EnvContext
 from ray.rllib.env.env_runner import ENV_STEP_FAILURE, EnvRunner
 from ray.rllib.env.single_agent_episode import SingleAgentEpisode
-from ray.rllib.utils import force_list
+from ray.rllib.utils import force_list, log_once
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.checkpoints import Checkpointable
 from ray.rllib.utils.error import ERR_MSG_INVALID_ENV_DESCRIPTOR, EnvError
@@ -284,6 +284,13 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
         done_episodes_to_return: List[SingleAgentEpisode] = []
 
         if self._cached_to_module is None:
+            # This can happen if we error out in a previous sample call.
+            # Primarily, because a connector fails.
+            # In this case, we need to reset the envs and episodes to start over.
+            if log_once("sample_error_reset_envs"):
+                logger.warning(
+                    "Error in sample call detected. Resetting envs and episodes to start over. You can ignore this warning if a connector is expectedly unstable."
+                )
             force_reset = True
 
         # Have to reset the env (on all vector sub_envs).

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -283,7 +283,11 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
         eps = 0
         done_episodes_to_return: List[SingleAgentEpisode] = []
 
-        if self._cached_to_module is None:
+        reset_required = (
+            force_reset or num_episodes is not None or self._needs_initial_reset
+        )
+
+        if self._cached_to_module is None and not reset_required:
             # This can happen if we error out in a previous sample call.
             # Primarily, because a connector fails.
             # In this case, we need to reset the envs and episodes to start over.
@@ -291,10 +295,10 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
                 logger.warning(
                     "Error in sample call detected. Resetting envs and episodes to start over. You can ignore this warning if a connector is expectedly unstable."
                 )
-            force_reset = True
+            reset_required = True
 
         # Have to reset the env (on all vector sub_envs).
-        if force_reset or num_episodes is not None or self._needs_initial_reset:
+        if reset_required:
             ts = 0
             self._reset_envs_and_episodes(explore)
 

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -25,7 +25,7 @@ from ray.rllib.env import INPUT_ENV_SINGLE_SPACES, INPUT_ENV_SPACES
 from ray.rllib.env.env_context import EnvContext
 from ray.rllib.env.env_runner import ENV_STEP_FAILURE, EnvRunner
 from ray.rllib.env.single_agent_episode import SingleAgentEpisode
-from ray.rllib.utils import force_list, log_once
+from ray.rllib.utils import force_list
 from ray.rllib.utils.annotations import override
 from ray.rllib.utils.checkpoints import Checkpointable
 from ray.rllib.utils.error import ERR_MSG_INVALID_ENV_DESCRIPTOR, EnvError
@@ -56,6 +56,7 @@ from ray.rllib.utils.metrics import (
 from ray.rllib.utils.spaces.space_utils import unbatch
 from ray.rllib.utils.typing import EpisodeID, ResultDict, StateDict
 from ray.tune.registry import ENV_CREATOR, _global_registry
+from ray.util import log_once
 from ray.util.annotations import PublicAPI
 
 logger = logging.getLogger("ray.rllib")

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -288,10 +288,13 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
             force_reset or num_episodes is not None or self._needs_initial_reset
         )
 
-        if self._cached_to_module is None and not reset_required:
-            # This can happen if we error out in a previous sample call.
-            # Primarily, because a connector fails.
-            # In this case, we need to reset the envs and episodes to start over.
+        if (
+            self._cached_to_module is None
+            and self.module is not None
+            and not reset_required
+        ):
+            # Cached module connector outputs can be none if a connector fails.
+            # self._cached_to_module is always None if the module is None.
             if log_once("sample_error_reset_envs"):
                 logger.warning(
                     "Error in sample call detected. Resetting envs and episodes to start over. You can ignore this warning if a connector is expectedly unstable."

--- a/rllib/env/single_agent_env_runner.py
+++ b/rllib/env/single_agent_env_runner.py
@@ -283,6 +283,9 @@ class SingleAgentEnvRunner(EnvRunner, Checkpointable):
         eps = 0
         done_episodes_to_return: List[SingleAgentEpisode] = []
 
+        if self._cached_to_module is None:
+            force_reset = True
+
         # Have to reset the env (on all vector sub_envs).
         if force_reset or num_episodes is not None or self._needs_initial_reset:
             ts = 0


### PR DESCRIPTION
## Description

This PR makes it so that, if we error out in an EnvRunner.sample() call at a point where we have consumed self._cached_to_module but not set it again, the next consecutive call will reset the envrunner.

This situation is useful if there is some stochasticity to the a (probably user-provided) connector where the connector will fail based on the appearance of some observations such as an observation of some not well-defined state. In this case, the connector will raise an exception and leave the EnvRunner sampling loop broken so we should reset.