### PR TITLE
[docs][RLlib] Fix outdated parametric DQN link

### DIFF
--- a/doc/source/rllib/rllib-algorithms.rst
+++ b/doc/source/rllib/rllib-algorithms.rst
@@ -108,7 +108,7 @@ Deep Q Networks (DQN, Rainbow, Parametric DQN)
 
 
 All of the DQN improvements evaluated in `Rainbow <https://arxiv.org/abs/1710.02298>`__ are available, though not all are enabled by default.
-See also how to use `parametric-actions in DQN <rllib-models.html#variable-length-parametric-action-spaces>`__.
+See also how to use `parametric actions in DQN <rl-modules.html#variable-length-parametric-action-spaces>`__.
 
 **Tuned examples:**
 `PongDeterministic-v4 <https://github.com/ray-project/ray/blob/master/rllib/examples/algorithms/dqn/pong-dqn.yaml>`__,


### PR DESCRIPTION
## Summary
Fixes an outdated RLlib docs link in the DQN section.

- Replace stale target `rllib-models.html#variable-length-parametric-action-spaces`
- Point to current section in RLModules docs: `rl-modules.html#variable-length-parametric-action-spaces`

Fixes #59079.
