### PR TITLE
[docs] Keep local search result links local for local doc builds

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -163,7 +163,10 @@ nb_mime_priority_overrides = [
 
 html_extra_path = ["robots.txt"]
 
-html_baseurl = "https://docs.ray.io/en/latest"
+# Keep local search results on localhost when building docs locally.
+# Only set an absolute base URL on hosted docs builds.
+if os.getenv("READTHEDOCS") == "True":
+    html_baseurl = "https://docs.ray.io/en/latest"
 
 # This pattern matches:
 # - Python Repl prompts (">>> ") and it's continuation ("... ")


### PR DESCRIPTION
## Why
When docs are built locally, the top search bar currently links results to `https://docs.ray.io/...` instead of the local server, which makes local verification confusing.

## What changed
- Set `html_baseurl` in `doc/source/conf.py` only for ReadTheDocs builds (`READTHEDOCS=True`).
- Leave it unset for local builds, so generated search links remain local.

## Validation
- `python3 -m py_compile doc/source/conf.py`

Fixes #61238