### PR TITLE
[train][tests] Reduce test_worker_group flake

### DIFF
--- a/python/ray/train/v2/tests/conftest.py
+++ b/python/ray/train/v2/tests/conftest.py
@@ -69,7 +69,7 @@ def disable_state_actor_polling(monkeypatch):
 
 @pytest.fixture
 def mock_runtime_context(monkeypatch):
-    @ray.remote
+    @ray.remote(num_cpus=0)
     class DummyActor:
         pass
 


### PR DESCRIPTION
# Summary

`test_zombie_actor_termination` has been failing flakily with

```
[2026-03-04T06:42:34Z] python/ray/train/v2/tests/test_worker_group.py::test_zombie_actor_termination FAILED [ 32%]
...
[2026-03-04T06:42:34Z]         worker_group_context = _default_worker_group_context(
[2026-03-04T06:42:34Z]             train_fn_ref=train_fn_ref,
[2026-03-04T06:42:34Z]             num_workers=NUM_WORKERS,
[2026-03-04T06:42:34Z]         )
[2026-03-04T06:42:34Z]
[2026-03-04T06:42:34Z]         # Starts the worker group and runs the train function
[2026-03-04T06:42:34Z] >       worker_group = WorkerGroup.create(
[2026-03-04T06:42:34Z]             train_run_context=train_run_context,
[2026-03-04T06:42:34Z]             worker_group_context=worker_group_context,
[2026-03-04T06:42:34Z]             callbacks=[],
[2026-03-04T06:42:34Z]         )
...
[2026-03-04T06:42:34Z]             if not pg_handle.wait(self._worker_group_start_timeout_s):
[2026-03-04T06:42:34Z]                 pg_handle.shutdown()
[2026-03-04T06:42:34Z] >               raise WorkerGroupStartupTimeoutError(
[2026-03-04T06:42:34Z]                     num_workers=worker_group_context.num_workers
[2026-03-04T06:42:34Z]                 )
[2026-03-04T06:42:34Z] E               ray.train.v2._internal.exceptions.WorkerGroupStartupTimeoutError: The worker group startup timed out after 60.0 seconds waiting for 4 workers. Potential causes include: (1) temporary insufficient cluster resources while waiting for autoscaling (ignore this warning in this case), (2) infeasible resource request where the provided `ScalingConfig` cannot be satisfied), and (3) transient network issues. Set the RAY_TRAIN_WORKER_GROUP_START_TIMEOUT_S environment variable to increase the timeout.
```

This could be due to `mock_runtime_context` unintentionally taking up ray cluster resources.

# Testing

I was unable to reproduce the issue locally but this change should be safe.