### PR TITLE
[hotfix][core] Correct the right log field when logging in ObjectManager::PushObjectInternal

### DIFF
--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -454,7 +454,7 @@ void ObjectManager::PushObjectInternal(const ObjectID &object_id,
     return;
   }
 
-  RAY_LOG(DEBUG).WithField(node_id).WithField(node_id)
+  RAY_LOG(DEBUG).WithField(object_id).WithField(node_id)
       << "Sending object chunks of object to node, number of chunks: "
       << chunk_reader->GetNumChunks()
       << ", total data size: " << chunk_reader->GetObject().GetObjectSize();


### PR DESCRIPTION

## Description
[hotfix][core] Correct the right log field when logging in ObjectManager::PushObjectInternal


## Related issues
a hotfix.

## Additional information
[hotfix][core] Correct the right log field when logging in ObjectManager::PushObjectInternal
