### PR TITLE
[Core] Skip _SUCCESS in parquet

### DIFF
--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -471,9 +471,7 @@ def _expand_directory(
         file_path = file_.path
         if not file_path.startswith(base_path):
             continue
-        relative = file_path[len(base_path) :]
-        if relative.startswith("/"):
-            relative = relative[1:]
+        relative = file_path[len(base_path):].lstrip("/")
         if any(relative.startswith(prefix) for prefix in exclude_prefixes):
             continue
         out.append((file_path, file_.size))

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -471,7 +471,7 @@ def _expand_directory(
         file_path = file_.path
         if not file_path.startswith(base_path):
             continue
-        relative = file_path[len(base_path):].lstrip("/")
+        relative = file_path[len(base_path) :].lstrip("/")
         if any(relative.startswith(prefix) for prefix in exclude_prefixes):
             continue
         out.append((file_path, file_.size))

--- a/python/ray/data/datasource/file_meta_provider.py
+++ b/python/ray/data/datasource/file_meta_provider.py
@@ -472,6 +472,8 @@ def _expand_directory(
         if not file_path.startswith(base_path):
             continue
         relative = file_path[len(base_path) :]
+        if relative.startswith("/"):
+            relative = relative[1:]
         if any(relative.startswith(prefix) for prefix in exclude_prefixes):
             continue
         out.append((file_path, file_.size))

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -209,6 +209,35 @@ def test_parquet_read_basic(
         (None, lazy_fixture("local_path")),
         (lazy_fixture("local_fs"), lazy_fixture("local_path")),
         (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+)
+def test_parquet_read_with_success_file(ray_start_regular_shared, fs, data_path):
+    df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+    table = pa.Table.from_pandas(df)
+    setup_data_path = _unwrap_protocol(data_path)
+    path = os.path.join(setup_data_path, "test.parquet")
+    pq.write_table(table, path, filesystem=fs)
+
+    # Add _SUCCESS file to ensure it's ignored
+    success_path = os.path.join(setup_data_path, "_SUCCESS")
+    if fs is None:
+        open(success_path, "wb").close()
+    else:
+        with fs.open_output_stream(success_path):
+            pass
+
+    ds = ray.data.read_parquet(data_path, filesystem=fs)
+    assert ds.count() == 3
+    values = [s["one"] for s in ds.take_all()]
+    assert sorted(values) == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "fs,data_path",
+    [
+        (None, lazy_fixture("local_path")),
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
         (
             lazy_fixture("s3_fs_with_space"),
             lazy_fixture("s3_path_with_space"),


### PR DESCRIPTION
## Description

- _SUCCESS files in parquet directories are not skipped. Fixed this by adjusting the relative path calculation.
- Added code to existing tests to verify this feature and prevent potential regression in the future.

My team ran into this problem and contribute our solution here.

## Related issues

A potentially related issue
https://github.com/ray-project/ray/issues/57704

## Additional information

To run the added test:
```
python -m pytest python/ray/data/tests/datasource/test_parquet.py -k test_parquet_read_with_success_file
```
