### PR TITLE
[Data] Remove special skip-write handling in Dataset.write_datasink

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -182,6 +182,7 @@ class ParquetDatasink(_FileDatasink):
         blocks = list(blocks)
 
         if all(BlockAccessor.for_block(block).num_rows() == 0 for block in blocks):
+            self._set_actual_write_stats(ctx, num_rows=0, size_bytes=0)
             return
 
         blocks = [

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -4,6 +4,7 @@ from typing import Callable, Iterator, List, Union
 
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
+from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
@@ -16,6 +17,9 @@ from ray.data.datasource.datasink import Datasink
 from ray.data.datasource.datasource import Datasource
 
 WRITE_UUID_KWARG_NAME = "write_uuid"
+DATASINK_WRITE_RETURN_KWARG_NAME = "_datasink_write_return"
+DATASINK_WRITE_ROWS_KWARG_NAME = "_datasink_num_rows"
+DATASINK_WRITE_SIZE_BYTES_KWARG_NAME = "_datasink_size_bytes"
 
 
 def generate_write_fn(
@@ -28,9 +32,9 @@ def generate_write_fn(
         # Create a copy of the iterator, so we can return the original blocks.
         it1, it2 = itertools.tee(blocks, 2)
         if isinstance(datasink_or_legacy_datasource, Datasink):
-            ctx.kwargs["_datasink_write_return"] = datasink_or_legacy_datasource.write(
-                it1, ctx
-            )
+            ctx.kwargs[
+                DATASINK_WRITE_RETURN_KWARG_NAME
+            ] = datasink_or_legacy_datasource.write(it1, ctx)
         else:
             datasink_or_legacy_datasource.write(it1, ctx, **write_args)
 
@@ -46,9 +50,13 @@ def generate_collect_write_stats_fn() -> BlockMapTransformFn:
     # execution outcomes with `on_write_complete()`` and `on_write_failed()``.
     def fn(blocks: Iterator[Block], ctx: TaskContext) -> Iterator[Block]:
         """Handles stats collection for block writes."""
-        block_accessors = [BlockAccessor.for_block(block) for block in blocks]
-        total_num_rows = sum(ba.num_rows() for ba in block_accessors)
-        total_size_bytes = sum(ba.size_bytes() for ba in block_accessors)
+        total_num_rows = ctx.kwargs.get(DATASINK_WRITE_ROWS_KWARG_NAME)
+        total_size_bytes = ctx.kwargs.get(DATASINK_WRITE_SIZE_BYTES_KWARG_NAME)
+
+        if total_num_rows is None or total_size_bytes is None:
+            block_accessors = [BlockAccessor.for_block(block) for block in blocks]
+            total_num_rows = sum(ba.num_rows() for ba in block_accessors)
+            total_size_bytes = sum(ba.size_bytes() for ba in block_accessors)
 
         # NOTE: Write tasks can return anything, so we need to wrap it in a valid block
         # type.
@@ -58,7 +66,7 @@ def generate_collect_write_stats_fn() -> BlockMapTransformFn:
             {
                 "num_rows": [total_num_rows],
                 "size_bytes": [total_size_bytes],
-                "write_return": [ctx.kwargs.get("_datasink_write_return", None)],
+                "write_return": [ctx.kwargs.get(DATASINK_WRITE_RETURN_KWARG_NAME)],
             }
         )
         return iter([block])
@@ -92,6 +100,13 @@ def _plan_write_op_internal(
     input_physical_dag = physical_children[0]
 
     datasink = op.datasink_or_legacy_datasource
+    from ray.data.datasource.file_datasink import _FileDatasink
+
+    if isinstance(datasink, _FileDatasink):
+        datasink._pre_write_check()
+        if datasink._skip_write:
+            return InputDataBuffer(data_context, input_data=[])
+
     write_fn = generate_write_fn(datasink, **op.write_args)
 
     # Create a MapTransformer for a write operator
@@ -106,9 +121,6 @@ def _plan_write_op_internal(
 
     map_transformer = MapTransformer(transform_fns)
 
-    # Set up on_start callback for datasinks.
-    # This allows on_write_start to receive the schema from the first input bundle,
-    # enabling schema-dependent initialization (e.g., Iceberg schema evolution).
     on_start = None
     if isinstance(datasink, Datasink):
         on_start = datasink.on_write_start

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -117,7 +117,6 @@ from ray.data.block import (
 from ray.data.context import DataContext
 from ray.data.datasource import Connection, Datasink, FilenameProvider, SaveMode
 from ray.data.datasource.datasink import WriteResult, _gen_datasink_write_result
-from ray.data.datasource.file_datasink import _FileDatasink
 from ray.data.datasource.util import (
     _validate_head_node_resources_for_local_scheduling,
 )
@@ -5557,19 +5556,6 @@ class Dataset:
         logical_plan = LogicalPlan(write_op, self.context)
 
         try:
-            # Call on_write_start for _FileDatasink before execution to handle
-            # SaveMode checks (ERROR raises, OVERWRITE deletes contents, IGNORE skips)
-            # and directory creation. For other datasinks, on_write_start is called
-            # automatically by the Write operator when the first input bundle arrives.
-            if isinstance(datasink, _FileDatasink):
-                datasink.on_write_start()
-                # TODO (https://github.com/ray-project/ray/issues/59326): There should be no special handling for skipping writes.
-                if datasink._skip_write:
-                    logger.info(
-                        f"Ignoring write because {datasink.path} already exists"
-                    )
-                    return
-
             self._write_ds = Dataset(plan, logical_plan).materialize()
 
             iter_, stats, _ = self._write_ds._execute_to_iterator()

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -6,7 +6,11 @@ from urllib.parse import urlparse
 from ray._common.retry import call_with_retry
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import TaskContext
-from ray.data._internal.planner.plan_write_op import WRITE_UUID_KWARG_NAME
+from ray.data._internal.planner.plan_write_op import (
+    DATASINK_WRITE_ROWS_KWARG_NAME,
+    DATASINK_WRITE_SIZE_BYTES_KWARG_NAME,
+    WRITE_UUID_KWARG_NAME,
+)
 from ray.data._internal.savemode import SaveMode
 from ray.data._internal.util import (
     RetryingPyFileSystem,
@@ -84,15 +88,16 @@ class _FileDatasink(Datasink[None]):
         self._skip_write = False
         self._write_started = False
 
+    def _set_actual_write_stats(
+        self, ctx: TaskContext, *, num_rows: int, size_bytes: int
+    ) -> None:
+        ctx.kwargs[DATASINK_WRITE_ROWS_KWARG_NAME] = num_rows
+        ctx.kwargs[DATASINK_WRITE_SIZE_BYTES_KWARG_NAME] = size_bytes
+
     def open_output_stream(self, path: str) -> "pyarrow.NativeFile":
         return self.filesystem.open_output_stream(path, **self.open_stream_args)
 
-    def on_write_start(self, schema: Optional["pyarrow.Schema"] = None) -> None:
-        # Make idempotent - if already called, return early.
-        if self._write_started:
-            return
-        self._write_started = True
-
+    def _pre_write_check(self) -> None:
         from pyarrow.fs import FileType
 
         dir_exists = (
@@ -111,6 +116,12 @@ class _FileDatasink(Datasink[None]):
             if self.mode == SaveMode.OVERWRITE:
                 logger.warning(f"[SaveMode={self.mode}] Replacing contents {self.path}")
                 self.filesystem.delete_dir_contents(self.path)
+
+    def on_write_start(self, schema: Optional["pyarrow.Schema"] = None) -> None:
+        # Make idempotent - if already called, return early.
+        if self._write_started:
+            return
+        self._write_started = True
         self.has_created_dir = self._create_dir(self.path)
 
     def _create_dir(self, dest) -> bool:
@@ -157,6 +168,7 @@ class _FileDatasink(Datasink[None]):
         block_accessor = BlockAccessor.for_block(block)
 
         if block_accessor.num_rows() == 0:
+            self._set_actual_write_stats(ctx, num_rows=0, size_bytes=0)
             logger.warning(f"Skipped writing empty block to {self.path}")
             return
 

--- a/python/ray/data/tests/datasource/test_file_datasink.py
+++ b/python/ray/data/tests/datasource/test_file_datasink.py
@@ -6,8 +6,10 @@ import pytest
 from pyarrow.fs import LocalFileSystem
 
 import ray
+from ray.data._internal.savemode import SaveMode
 from ray.data.block import BlockAccessor
 from ray.data.datasource import BlockBasedFileDatasink, RowBasedFileDatasink
+from ray.data.datasource.datasink import WriteResult
 
 
 class FlakyOutputStream:
@@ -145,6 +147,74 @@ def test_write_creates_dir(tmp_path, ray_start_regular_shared):
     ds.write_datasink(MockFileDatasink(path=path, try_create_dir=True))
 
     assert os.path.isdir(path)
+
+
+def test_ignore_save_mode_reports_zero_rows(tmp_path, ray_start_regular_shared):
+    class MockFileDatasink(BlockBasedFileDatasink):
+        def __init__(self, path: str):
+            super().__init__(path=path, mode=SaveMode.IGNORE)
+            self.num_rows_written = None
+
+        def write_block_to_file(self, block: BlockAccessor, file: "pyarrow.NativeFile"):
+            file.write(b"")
+
+        def on_write_complete(self, write_result: WriteResult[None]):
+            self.num_rows_written = write_result.num_rows
+            super().on_write_complete(write_result)
+
+    path = os.path.join(tmp_path, "existing")
+    os.mkdir(path)
+
+    datasink = MockFileDatasink(path=path)
+    ray.data.range(10, override_num_blocks=2).write_datasink(datasink)
+
+    assert datasink.num_rows_written == 0
+    assert os.path.isdir(path)
+    assert os.listdir(path) == []
+
+
+def test_ignore_save_mode_short_circuits_upstream_execution(
+    tmp_path, ray_start_regular_shared
+):
+    class MockFileDatasink(BlockBasedFileDatasink):
+        def __init__(self, path: str):
+            super().__init__(path=path, mode=SaveMode.IGNORE)
+
+        def write_block_to_file(self, block: BlockAccessor, file: "pyarrow.NativeFile"):
+            file.write(b"")
+
+    def fail_on_execute(row):
+        raise ValueError("should not execute")
+
+    path = os.path.join(tmp_path, "existing")
+    os.mkdir(path)
+
+    ds = ray.data.range(1, override_num_blocks=1).map(fail_on_execute)
+    ds.write_datasink(MockFileDatasink(path=path))
+
+    assert os.listdir(path) == []
+
+
+def test_file_datasink_on_write_start_receives_schema(
+    tmp_path, ray_start_regular_shared
+):
+    class SchemaAwareFileDatasink(BlockBasedFileDatasink):
+        def __init__(self, path: str):
+            super().__init__(path=path)
+            self.received_schema = None
+
+        def on_write_start(self, schema):
+            self.received_schema = schema
+            super().on_write_start(schema)
+
+        def write_block_to_file(self, block: BlockAccessor, file: "pyarrow.NativeFile"):
+            file.write(b"")
+
+    datasink = SchemaAwareFileDatasink(path=str(tmp_path / "schema-aware"))
+    ray.data.from_items([{"id": 1, "value": "x"}]).write_datasink(datasink)
+
+    assert datasink.received_schema is not None
+    assert datasink.received_schema.names == ["id", "value"]
 
 
 @pytest.mark.parametrize("min_rows_per_file", [5, 10, 50])

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -18,6 +18,7 @@ from pytest_lazy_fixtures import lf as lazy_fixture
 
 import ray
 from ray.data import FileShuffleConfig, Schema
+from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
 from ray.data._internal.datasource.parquet_datasource import (
     ParquetDatasource,
 )
@@ -746,6 +747,32 @@ def test_parquet_write_ignore_save_mode(ray_start_regular_shared, local_path):
     on_disk_table = pq.read_table(path)
 
     assert in_memory_table.equals(on_disk_table)
+
+
+def test_parquet_write_ignore_save_mode_reports_zero_rows(
+    ray_start_regular_shared, local_path
+):
+    path = os.path.join(local_path, "test_parquet_ignore_num_rows")
+    os.mkdir(path)
+
+    num_rows_written = None
+    original_on_write_complete = ParquetDatasink.on_write_complete
+
+    def patched_on_write_complete(self, write_result):
+        nonlocal num_rows_written
+        num_rows_written = write_result.num_rows
+        return original_on_write_complete(self, write_result)
+
+    ParquetDatasink.on_write_complete = patched_on_write_complete
+    try:
+        ray.data.range(10, override_num_blocks=2).write_parquet(
+            path, filesystem=None, mode="ignore"
+        )
+    finally:
+        ParquetDatasink.on_write_complete = original_on_write_complete
+
+    assert num_rows_written == 0
+    assert os.listdir(path) == []
 
 
 def test_parquet_write_error_save_mode(ray_start_regular_shared, local_path):


### PR DESCRIPTION
## Description
This PR removes the file-datasink skip-write special handling from Dataset.write_datasink().

Before this change, _FileDatasink writes in SaveMode.IGNORE relied on a dedicated early return in `Dataset.write_datasink()`. That special-case branch is the behavior tracked by #59326.

This PR moves the skip decision into write planning instead:

- _FileDatasink runs a pre-write check during plan_write_op()
- if the write should be ignored, planning returns an empty InputDataBuffer, so upstream execution is short-circuited
- otherwise, execution continues through the normal write path

This keeps skipped writes reporting 0 written rows / bytes, and preserves schema-aware on_write_start(schema) for file datasinks.

## Related issues

Link related issues: "Fixes #59326", "Closes #59326", or "Related to #59326".

## Additional information