### PR TITLE
[core] Fix test_autoscaler_yaml test

### DIFF
--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -308,7 +308,10 @@ class AutoscalingConfigTest(unittest.TestCase):
         ] = 0
         assert prepared_config == expected_prepared
 
-    @pytest.mark.skipif(sys.platform.startswith("win"), reason="Fails on Windows.")
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="SSL cert verification fails on Windows CI due to outdated Miniconda CA bundle. Working to update the bundle in https://github.com/ray-project/ray/pull/61545.",
+    )
     def testValidateNetworkConfigForBackwardsCompatibility(self):
         web_yaml = (
             "https://raw.githubusercontent.com/ray-project/ray/"

--- a/python/ray/tests/test_autoscaler_yaml.py
+++ b/python/ray/tests/test_autoscaler_yaml.py
@@ -308,6 +308,7 @@ class AutoscalingConfigTest(unittest.TestCase):
         ] = 0
         assert prepared_config == expected_prepared
 
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="Fails on Windows.")
     def testValidateNetworkConfigForBackwardsCompatibility(self):
         web_yaml = (
             "https://raw.githubusercontent.com/ray-project/ray/"


### PR DESCRIPTION
Fix for this: https://github.com/anyscale/ray/issues/915

The failure is specifically in the test `testValidateNetworkConfigForBackwardsCompatibility`. While trying to make HTTP connection with `raw.githubusercontent.com`, SSL certificate validation fails. 

Fix: We are skipping the windows test to unblock the release pipeline for now (a bunch of other tests are also disabled for Windows in this test suite). Meanwhile, we are also trying to update the CA cert bundle on the windows machine in this PR: https://github.com/ray-project/ray/pull/61545
cc: @rueian 
