### PR TITLE
[data] Clamp rolling utilization averages to zero

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/resource_utilization_gauge.py
+++ b/python/ray/data/_internal/cluster_autoscaler/resource_utilization_gauge.py
@@ -128,10 +128,12 @@ class RollingLogicalUtilizationGauge(ResourceUtilizationGauge):
 
     def get(self) -> ClusterUtil:
         """Get the average cluster utilization based on global usage / global limits."""
+        # Clamp to 0 to handle floating-point drift in the rolling average.
         return ClusterUtil(
-            cpu=self._cluster_cpu_util_calculator.get_average() or 0,
-            gpu=self._cluster_gpu_util_calculator.get_average() or 0,
-            memory=self._cluster_mem_util_calculator.get_average() or 0,
-            object_store_memory=self._cluster_obj_mem_util_calculator.get_average()
-            or 0,
+            cpu=max(0, self._cluster_cpu_util_calculator.get_average() or 0),
+            gpu=max(0, self._cluster_gpu_util_calculator.get_average() or 0),
+            memory=max(0, self._cluster_mem_util_calculator.get_average() or 0),
+            object_store_memory=max(
+                0, self._cluster_obj_mem_util_calculator.get_average() or 0
+            ),
         )


### PR DESCRIPTION
## Description
LLM post-merge tests are failing with the following error:
<img width="1098" height="269" alt="Screenshot 2026-03-06 at 10 14 28 AM" src="https://github.com/user-attachments/assets/cf4a23f9-b862-4b7a-8edc-2713c003dac2" />

https://github.com/ray-project/ray/blob/645d4f17a4c15b4a8875ccb0a64b178a7eceb358/python/ray/data/_internal/cluster_autoscaler/resource_utilization_gauge.py#L129-L137
`get()` reads rolling averages from `TimeWindowAverageCalculator`, which maintains a running _sum updated on `report()` and reduced in `_trim()` as values expire. Due to floating-point rounding, `_sum` can drift slightly negative after all values are trimmed, producing a negative average and violating the `ClusterUtil` assertion.

## Approach
Clamp the rolling average to `max(0, ...)` in `RollingLogicalUtilizationGauge.get()`, since utilization ratios are inherently non-negative and small negative values are just floating-point artifacts.

## Test
`python -m pytest python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py -vs` passes after the fix.

## Related issues
- Postmerge failure: https://buildkite.com/ray-project/postmerge/builds/16343/steps/canvas?sid=019cc1c1-e7c2-4a1c-9a86-a44211b14e66&tab=output
- Related PR: https://github.com/ray-project/ray/pull/61436

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
