### PR TITLE
[ci] update ca-certificates on windows ci images

### DIFF
--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -13,6 +13,8 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.9.22/install.p
 
 conda init
 conda install -q -y python="${PYTHON_FULL_VERSION}" requests=2.32.3
+# Force CA trust stack to the newest versions available at build time.
+conda update -c conda-forge -q -y ca-certificates certifi
 
 # Install torch first, as some dependencies (e.g. torch-spline-conv) need torch to be
 # installed for their own install.


### PR DESCRIPTION

## Description
We got `CERTIFICATE_VERIFY_FAILED` from accessing `https://raw.githubusercontent.com/ray-project/ray/master/python/ray/autoscaler/aws/example-full.yaml` in the CI test `windows://python/ray/tests:test_autoscaler_yaml`. 
```
--
[2026-03-04T03:17:00Z] self = <ssl.SSLSocket [closed] fd=-1, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0>
[2026-03-04T03:17:00Z] block = False
[2026-03-04T03:17:00Z]
[2026-03-04T03:17:00Z]     @_sslcopydoc
[2026-03-04T03:17:00Z]     def do_handshake(self, block=False):
[2026-03-04T03:17:00Z]         self._check_connected()
[2026-03-04T03:17:00Z]         timeout = self.gettimeout()
[2026-03-04T03:17:00Z]         try:
[2026-03-04T03:17:00Z]             if timeout == 0.0 and block:
[2026-03-04T03:17:00Z]                 self.settimeout(None)
[2026-03-04T03:17:00Z] >           self._sslobj.do_handshake()
[2026-03-04T03:17:00Z] E           ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1017)
[2026-03-04T03:17:00Z]
[2026-03-04T03:17:00Z] C:\Miniconda3\lib\ssl.py:1375: SSLCertVerificationError
[2026-03-04T03:17:00Z]
[2026-03-04T03:17:00Z] During handling of the above exception, another exception occurred:
[2026-03-04T03:17:00Z]
[2026-03-04T03:17:00Z] self = <io_ray.python.ray.tests.test_autoscaler_yaml.AutoscalingConfigTest testMethod=testValidateNetworkConfigForBackwardsCompatibility>
[2026-03-04T03:17:00Z]
[2026-03-04T03:17:00Z]     def testValidateNetworkConfigForBackwardsCompatibility(self):
[2026-03-04T03:17:00Z]         web_yaml = (
[2026-03-04T03:17:00Z]             "https://raw.githubusercontent.com/ray-project/ray/"
[2026-03-04T03:17:00Z]             "master/python/ray/autoscaler/aws/example-full.yaml"
[2026-03-04T03:17:00Z]         )
[2026-03-04T03:17:00Z] >       response = urllib.request.urlopen(web_yaml, timeout=5)
[2026-03-04T03:17:00Z]
[2026-03-04T03:17:00Z] python\ray\tests\test_autoscaler_yaml.py:316:
```

This PR fixes by updating the certs. The test now passes: https://buildkite.com/ray-project/postmerge/builds/16352

## Related issues
Fixes https://github.com/anyscale/ray/issues/915

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
