### PR TITLE
[Data] Compute Expressions: Support uri expression

### DIFF
--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -750,6 +750,13 @@ class Expr(ABC):
 
         return _DatetimeNamespace(self)
 
+    @property
+    def uri(self) -> "_URINamespace":
+        """Access URI operations for this expression."""
+        from ray.data.namespace_expressions.uri_namespace import _URINamespace
+
+        return _URINamespace(self)
+
     def _unalias(self) -> "Expr":
         return self
 
@@ -1662,6 +1669,7 @@ __all__ = [
     "_StructNamespace",
     "_MapNamespace",
     "_DatetimeNamespace",
+    "_URINamespace",
 ]
 
 
@@ -1691,4 +1699,8 @@ def __getattr__(name: str):
         from ray.data.namespace_expressions.dt_namespace import _DatetimeNamespace
 
         return _DatetimeNamespace
+    elif name == "_URINamespace":
+        from ray.data.namespace_expressions.uri_namespace import _URINamespace
+
+        return _URINamespace
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/ray/data/namespace_expressions/uri_namespace.py
+++ b/python/ray/data/namespace_expressions/uri_namespace.py
@@ -35,9 +35,9 @@ class _URINamespace:
         Returns:
             A DownloadExpr that will download content from the URI column.
         """
-        from ray.data.expressions import download
+        from ray.data.expressions import download, ColumnExpr
 
-        if self._expr.name is None:
+        if not isinstance(self._expr, ColumnExpr):
             raise TypeError(
                 "download() can only be called on a column expression, "
                 f"but got {type(self._expr).__name__}"

--- a/python/ray/data/namespace_expressions/uri_namespace.py
+++ b/python/ray/data/namespace_expressions/uri_namespace.py
@@ -1,0 +1,46 @@
+"""URI namespace for expression operations on URI-typed columns."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import pyarrow.fs
+
+if TYPE_CHECKING:
+    from ray.data.expressions import Expr, DownloadExpr
+
+
+@dataclass
+class _URINamespace:
+    """Namespace for URI operations on expression columns.
+
+    Example:
+        >>> from ray.data.expressions import col
+        >>> # Download content from URI column
+        >>> expr = col("uri").uri.download()
+    """
+
+    _expr: Expr
+
+    def download(
+        self, *, filesystem: Optional[pyarrow.fs.FileSystem] = None
+    ) -> "DownloadExpr":
+        """Download content from URI column.
+
+        Args:
+            filesystem: PyArrow filesystem to use for reading remote files.
+                If None, the filesystem is auto-detected from the path scheme.
+
+        Returns:
+            A DownloadExpr that will download content from the URI column.
+        """
+        from ray.data.expressions import download
+
+        if self._expr.name is None:
+            raise TypeError(
+                "download() can only be called on a column expression, "
+                f"but got {type(self._expr).__name__}"
+            )
+
+        return download(self._expr.name, filesystem=filesystem)

--- a/python/ray/data/tests/test_download_expression.py
+++ b/python/ray/data/tests/test_download_expression.py
@@ -72,6 +72,10 @@ class TestDownloadExpressionStructure:
         with pytest.raises(TypeError):
             (col("uri") + lit("test")).uri.download()
 
+        # Should raise error when called on an alias expression
+        with pytest.raises(TypeError):
+            col("uri").alias("x").uri.download()
+
 
 class TestDownloadExpressionFunctionality:
     """Test actual download functionality with real and mocked data."""

--- a/python/ray/data/tests/test_download_expression.py
+++ b/python/ray/data/tests/test_download_expression.py
@@ -49,6 +49,7 @@ class TestDownloadExpressionStructure:
     def test_uri_namespace_download_with_filesystem(self):
         """Test that col('uri').uri.download(filesystem=...) works correctly."""
         import pyarrow.fs as pafs
+
         fs = pafs.LocalFileSystem()
 
         expr_from_namespace = col("uri").uri.download(filesystem=fs)
@@ -63,6 +64,7 @@ class TestDownloadExpressionStructure:
         """Test that uri.download() raises error when not called on a column expression."""
         # Should raise error when called on a literal expression
         from ray.data.expressions import lit
+
         with pytest.raises(TypeError):
             lit("test_uri").uri.download()
 

--- a/python/ray/data/tests/test_download_expression.py
+++ b/python/ray/data/tests/test_download_expression.py
@@ -37,6 +37,39 @@ class TestDownloadExpressionStructure:
         assert not expr1.structurally_equals(non_download_expr)
         assert not non_download_expr.structurally_equals(expr1)
 
+    def test_uri_namespace_download(self):
+        """Test that col('uri').uri.download() creates the same DownloadExpr as download('uri')."""
+        expr_from_namespace = col("uri").uri.download()
+        expr_from_function = download("uri")
+
+        assert isinstance(expr_from_namespace, DownloadExpr)
+        assert expr_from_namespace.uri_column_name == "uri"
+        assert expr_from_namespace.structurally_equals(expr_from_function)
+
+    def test_uri_namespace_download_with_filesystem(self):
+        """Test that col('uri').uri.download(filesystem=...) works correctly."""
+        import pyarrow.fs as pafs
+        fs = pafs.LocalFileSystem()
+
+        expr_from_namespace = col("uri").uri.download(filesystem=fs)
+        expr_from_function = download("uri", filesystem=fs)
+
+        assert isinstance(expr_from_namespace, DownloadExpr)
+        assert expr_from_namespace.uri_column_name == "uri"
+        assert expr_from_namespace.filesystem is fs
+        assert expr_from_namespace.structurally_equals(expr_from_function)
+
+    def test_uri_namespace_download_not_on_column_expr(self):
+        """Test that uri.download() raises error when not called on a column expression."""
+        # Should raise error when called on a literal expression
+        from ray.data.expressions import lit
+        with pytest.raises(TypeError):
+            lit("test_uri").uri.download()
+
+        # Should raise error when called on a binary expression
+        with pytest.raises(TypeError):
+            (col("uri") + lit("test")).uri.download()
+
 
 class TestDownloadExpressionFunctionality:
     """Test actual download functionality with real and mocked data."""
@@ -85,6 +118,47 @@ class TestDownloadExpressionFunctionality:
             assert result["file_id"] == f"id_{i}"
             assert result["metadata"] == f"metadata_{i}"
             assert result["index"] == i
+            assert result["file_uri"] == f"local://{file_paths[i]}"
+
+    def test_uri_namespace_download_with_local_files(self, tmp_path):
+        """Test URI namespace download functionality with local files."""
+        # Create sample files with different content types
+        sample_data = [
+            b"This is test file 1 content via URI namespace",
+            b"Different content for file 2 via URI namespace",
+        ]
+
+        file_paths = []
+        for i, data in enumerate(sample_data):
+            file_path = tmp_path / f"uri_test_file_{i}.txt"
+            file_path.write_bytes(data)
+            file_paths.append(str(file_path))
+
+        # Create dataset with file URIs
+        table = pa.Table.from_arrays(
+            [
+                pa.array([f"local://{path}" for path in file_paths]),
+                pa.array([f"id_{i}" for i in range(len(file_paths))]),
+            ],
+            names=["file_uri", "file_id"],
+        )
+
+        ds = ray.data.from_arrow(table)
+
+        # Add download column using URI namespace
+        ds_with_downloads = ds.with_column("file_bytes", col("file_uri").uri.download())
+
+        # Verify results
+        results = ds_with_downloads.take_all()
+        assert len(results) == len(sample_data)
+
+        for i, result in enumerate(results):
+            # Download column should be added correctly
+            assert "file_bytes" in result
+            assert result["file_bytes"] == sample_data[i]
+
+            # All original columns should be preserved
+            assert result["file_id"] == f"id_{i}"
             assert result["file_uri"] == f"local://{file_paths[i]}"
 
     def test_download_expression_empty_dataset(self):


### PR DESCRIPTION
## Description
This PR adds support for the .uri namespace in Ray Data expressions, following the same pattern as existing namespaces (.dt, .arr, .list, .map, .str, and .struct). The .uri namespace currently supports a single method .download() that reuses the existing download() function, providing a more consistent API for users.

## Related issues
- Partially solves #58674
## Additional information
### Implementation details:
1. New file /python/ray/data/namespace_expressions/uri_namespace.py :
   
   - Implements _URINamespace dataclass with a download() method
   - The download() method checks that it's called on a column expression and delegates to the existing download() function
2. Modified file /python/ray/data/expressions.py :
   
   - Added .uri property to Expr class
   - Added _URINamespace to __all__
   - Added case for "_URINamespace" in __getattr__ lazy import function
3. Modified file /python/ray/data/tests/test_download_expression.py :
   
   - Added comprehensive tests for the URI namespace

### Test

To test the feature, run:
```
python -m pytest python/ray/data/tests/test_download_expression.py -v
```

### Usage example:
```
import ray
from ray.data.expressions import col

# Create dataset with URIs
ds = ray.data.from_items([
    {"uri": "s3://bucket/file1.jpg", "id": "1"},
    {"uri": "s3://bucket/file2.jpg", "id": "2"}
])

# Add downloaded bytes column using URI namespace
ds_with_bytes = ds.with_column("bytes", col("uri").uri.download())
```
This maintains backward compatibility (the existing download() function still works), while providing a more consistent namespace-based API.