### PR TITLE
[Data] Fix from_tf for RaggedTensor datasets

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3821,7 +3821,31 @@ def from_tf(
     Returns:
         A :class:`MaterializedDataset` that contains the samples stored in the `TensorFlow Dataset`_.
     """  # noqa: E501
-    # FIXME: `as_numpy_iterator` errors if `dataset` contains ragged tensors.
+    try:
+        import tensorflow as tf
+    except ImportError:
+        tf = None
+
+    if tf is not None:
+
+        def _contains_ragged(spec) -> bool:
+            return any(
+                isinstance(s, tf.RaggedTensorSpec) for s in tf.nest.flatten(spec)
+            )
+
+        def _to_numpy_or_list(value):
+            if isinstance(value, tf.RaggedTensor):
+                return value.to_list()
+            if tf.is_tensor(value):
+                return value.numpy()
+            return value
+
+        if _contains_ragged(dataset.element_spec):
+            items = [
+                tf.nest.map_structure(_to_numpy_or_list, element) for element in dataset
+            ]
+            return from_items(items)
+
     return from_items(list(dataset.as_numpy_iterator()))
 
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3828,19 +3828,22 @@ def from_tf(
 
     if tf is not None:
 
-        def _contains_ragged(spec) -> bool:
+        def _contains_ragged_or_sparse(spec) -> bool:
             return any(
-                isinstance(s, tf.RaggedTensorSpec) for s in tf.nest.flatten(spec)
+                isinstance(s, (tf.RaggedTensorSpec, tf.SparseTensorSpec))
+                for s in tf.nest.flatten(spec)
             )
 
         def _to_numpy_or_list(value):
             if isinstance(value, tf.RaggedTensor):
                 return value.to_list()
+            if isinstance(value, tf.SparseTensor):
+                return tf.sparse.to_dense(value).numpy()
             if tf.is_tensor(value):
                 return value.numpy()
             return value
 
-        if _contains_ragged(dataset.element_spec):
+        if _contains_ragged_or_sparse(dataset.element_spec):
             items = [
                 tf.nest.map_structure(_to_numpy_or_list, element) for element in dataset
             ]

--- a/python/ray/data/tests/datasource/test_tensorflow_datasets.py
+++ b/python/ray/data/tests/datasource/test_tensorflow_datasets.py
@@ -34,5 +34,18 @@ def test_from_tf_e2e(ray_start_regular_shared_2_cpus):
     _check_usage_record(["FromItems"])
 
 
+def test_from_tf_ragged(ray_start_regular_shared_2_cpus):
+    import tensorflow as tf
+
+    tf_dataset = tf.data.Dataset.from_tensor_slices(tf.ragged.constant([[1, 2], [3]]))
+
+    ray_dataset = ray.data.from_tf(tf_dataset)
+
+    assert ray_dataset.take_all() == [
+        {"item": [1, 2]},
+        {"item": [3]},
+    ]
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

Fix `ray.data.from_tf()` to handle TensorFlow RaggedTensor datasets. The current implementation uses `as_numpy_iterator()`, which fails on ragged tensors. This change detects ragged element specs and converts RaggedTensor to Python lists while converting regular Tensor to NumPy arrays, preserving the fast path for non‑ragged datasets.

## Related issues
> Link related issues: "Fixes #61570", "Closes #61570", or "Related to #61570".

## Additional information

- Implementation uses `dataset.element_spec` to detect `tf.RaggedTensorSpec`.
- For ragged inputs, iterates the dataset and applies 
`tf.nest.map_structure()` with:
   - `tf.RaggedTensor -> to_list()`
   - `tf.Tensor -> numpy()`
- Adds a unit test covering ragged input handling.