### PR TITLE
[Data] Reconcile schemas when merging ref bundles

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -312,9 +312,9 @@ class RefBundle:
         Returns:
             A single RefBundle containing all blocks from the input bundles.
             owns_blocks is True only if all input bundles own their blocks.
-            schema is the first non-empty schema found.
+            schema is the unified schema of the non-empty input bundles.
         """
-        from ray.data.block import _take_first_non_empty_schema
+        from ray.data._internal.util import unify_ref_bundles_schema
 
         bundles = list(bundles)
         if not bundles:
@@ -330,8 +330,7 @@ class RefBundle:
         # destroy blocks when they're no longer needed. To be safe, we only set this
         # to True if all input bundles own their blocks.
         owns_blocks = all(bundle.owns_blocks for bundle in bundles)
-        # TODO: Reconcile the schemas rather than taking the first non-empty schema.
-        schema = _take_first_non_empty_schema(bundle.schema for bundle in bundles)
+        schema = unify_ref_bundles_schema(bundles)
         return cls(
             blocks=tuple(merged_blocks),
             schema=schema,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -62,7 +62,7 @@ from ray.data._internal.execution.operators.map_transformer import (
 )
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.stats import StatsDict
-from ray.data._internal.util import MemoryProfiler
+from ray.data._internal.util import MemoryProfiler, unify_ref_bundles_schema
 from ray.data.block import (
     Block,
     BlockAccessor,
@@ -70,7 +70,6 @@ from ray.data.block import (
     BlockMetadataWithSchema,
     BlockStats,
     TaskExecWorkerStats,
-    _take_first_non_empty_schema,
     to_stats,
 )
 from ray.data.context import DataContext
@@ -902,7 +901,7 @@ def _merge_ref_bundles(*bundles: RefBundle) -> RefBundle:
         itertools.chain(block for bundle in bundles for block in bundle.blocks)
     )
     owns_blocks = all(bundle.owns_blocks for bundle in bundles)
-    schema = _take_first_non_empty_schema(bundle.schema for bundle in bundles)
+    schema = unify_ref_bundles_schema(bundles)
     return RefBundle(blocks, owns_blocks=owns_blocks, schema=schema)
 
 

--- a/python/ray/data/tests/test_ref_bundle.py
+++ b/python/ray/data/tests/test_ref_bundle.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pyarrow as pa
 import pytest
 
 from ray import ObjectRef
@@ -421,6 +422,33 @@ def test_merge_ref_bundles():
         BlockSlice(start_offset=2, end_offset=3),
         BlockSlice(start_offset=3, end_offset=4),
     ]
+
+
+def test_merge_ref_bundles_reconciles_pyarrow_schemas():
+    block_ref_one = ObjectRef(b"1" * 28)
+    block_ref_two = ObjectRef(b"2" * 28)
+
+    metadata_one = BlockMetadata(
+        num_rows=1, size_bytes=10, exec_stats=None, input_files=None
+    )
+    metadata_two = BlockMetadata(
+        num_rows=1, size_bytes=10, exec_stats=None, input_files=None
+    )
+
+    bundle_one = RefBundle(
+        blocks=[(block_ref_one, metadata_one)],
+        owns_blocks=True,
+        schema=pa.schema([("a", pa.int64())]),
+    )
+    bundle_two = RefBundle(
+        blocks=[(block_ref_two, metadata_two)],
+        owns_blocks=True,
+        schema=pa.schema([("a", pa.int64()), ("b", pa.string())]),
+    )
+
+    merged = RefBundle.merge_ref_bundles([bundle_one, bundle_two])
+
+    assert merged.schema == pa.schema([("a", pa.int64()), ("b", pa.string())])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
This PR updates `RefBundle.merge_ref_bundles()` to reconcile schemas across input bundles instead of taking the first non-empty schema.

Before this change, merging multiple `RefBundle`s kept the first non-empty schema, which could produce incorrect merged schema metadata when the input bundles had different but compatible schemas.

After this change, `RefBundle.merge_ref_bundles()` uses the existing `unify_ref_bundles_schema()` path, so the merged bundle schema reflects the unified schema across all input bundles.

This does not change block merging, slice merging, or `owns_blocks` semantics. It only changes how the merged schema is computed.

This PR also adds a test covering PyArrow schema reconciliation during `RefBundle` merging.

## Related issues


## Additional information
Tests run:
- `python -m pytest python/ray/data/tests/test_ref_bundle.py -q`
- `python -m pytest python/ray/data/tests/unit/test_bundler.py -q`
- `python -m pytest python/ray/data/tests/test_repartition_e2e.py -k streaming_repartition -q`