### PR TITLE
[core][rdt] Avoid blocking through rdt if upstream task errored out

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -437,9 +437,7 @@ class SerializationContext:
                     return b""
                 return data.to_pybytes()
             elif metadata_fields[0] == ray_constants.OBJECT_METADATA_TYPE_ACTOR_HANDLE:
-                obj = self._deserialize_msgpack_data(
-                    data, metadata_fields, out_of_band_tensors
-                )
+                obj = self._deserialize_msgpack_data(data, metadata_fields)
                 # The last character is a 1 if weak_ref=True and 0 else.
                 serialized, weak_ref = obj[:-1], obj[-1:] == b"1"
                 return _actor_handle_deserializer(serialized, weak_ref)
@@ -456,9 +454,7 @@ class SerializationContext:
             # TODO (kfstorm): exception serialization should be language
             # independent.
             if error_type == ErrorType.Value("TASK_EXECUTION_EXCEPTION"):
-                obj = self._deserialize_msgpack_data(
-                    data, metadata_fields, out_of_band_tensors
-                )
+                obj = self._deserialize_msgpack_data(data, metadata_fields)
                 return RayError.from_bytes(obj)
             elif error_type == ErrorType.Value("WORKER_DIED"):
                 return WorkerCrashedError()
@@ -481,9 +477,7 @@ class SerializationContext:
                 except google.protobuf.message.DecodeError:
                     # Deserialization from Python. The TaskCancelledError is
                     # serialized and returned directly.
-                    obj = self._deserialize_msgpack_data(
-                        data, metadata_fields, out_of_band_tensors
-                    )
+                    obj = self._deserialize_msgpack_data(data, metadata_fields)
                     return RayError.from_bytes(obj)
             elif error_type == ErrorType.Value("OBJECT_LOST"):
                 return ObjectLostError(
@@ -570,7 +564,7 @@ class SerializationContext:
         if not hasattr(self._thread_local, "object_ref_stack"):
             self._thread_local.object_ref_stack = []
         results = []
-        for object_ref, (data, metadata, transport) in zip(
+        for object_ref, (data, metadata, _transport) in zip(
             object_refs, serialized_ray_objects
         ):
             try:

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -910,10 +910,21 @@ class Worker:
         use_object_store: bool = False,
     ):
         rdt_objects: Dict[str, List["torch.Tensor"]] = {}
-        for obj_ref, (_, _, tensor_transport) in zip(object_refs, serialized_objects):
+        for obj_ref, (_, metadata, tensor_transport) in zip(
+            object_refs, serialized_objects
+        ):
             if tensor_transport is None:
                 # The object is not an RDT object, so we cannot use other external transport to
                 # fetch it.
+                continue
+
+            # Assures that the upstream task didn't error out. This logic comes from the
+            # serialization_context deserialize_objects path. RDT tensors are only used
+            # if the metadata field contains that constant
+            if not metadata:
+                continue
+            metadata_fields = metadata.split(b",")
+            if metadata_fields[0] != ray_constants.OBJECT_METADATA_TYPE_PYTHON:
                 continue
 
             object_id = obj_ref.hex()

--- a/python/ray/tests/rdt/test_rdt_gloo.py
+++ b/python/ray/tests/rdt/test_rdt_gloo.py
@@ -957,6 +957,20 @@ def test_send_fails(ray_start_regular):
         ray.get(result_ref)
 
 
+def test_send_actor_dies_before_creating(ray_start_regular):
+    actors = [ErrorActor.remote() for _ in range(2)]
+    create_collective_group(actors, backend="torch_gloo")
+
+    # Block the main thread so the object doesn't get created before the kill
+    actors[0].block_main_thread.remote()
+    gpu_obj_ref = actors[0].send.remote(torch.randn(100, 100))
+    result_ref = actors[1].recv.remote(gpu_obj_ref)
+    ray.kill(actors[0])
+
+    with pytest.raises(ray.exceptions.ActorDiedError):
+        ray.get(result_ref)
+
+
 def test_send_actor_dies_before_sending(ray_start_regular):
     actors = [ErrorActor.remote() for _ in range(2)]
     create_collective_group(actors, backend="torch_gloo")

--- a/python/ray/tests/rdt/test_rdt_nixl.py
+++ b/python/ray/tests/rdt/test_rdt_nixl.py
@@ -234,6 +234,27 @@ def test_send_duplicate_tensor(ray_start_regular):
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_nixl_abort_sender_dies_before_creating(ray_start_regular):
+    actors = [GPUTestActor.remote() for _ in range(2)]
+
+    # Trigger transfer and kill sender before the receiver starts receiving
+    signal_actor = SignalActor.remote()
+    actors[0].block_main_thread.remote(signal_actor)
+    ref = actors[0].echo.remote(torch.randn((100, 100)), "cuda")
+    result = actors[1].sum.remote(ref, "cuda")
+    ray.kill(actors[0])
+
+    with pytest.raises(ray.exceptions.ActorDiedError):
+        ray.get(result)
+
+    # Try a transfer with actor[1] receiving again
+    new_actor = GPUTestActor.remote()
+    ref = new_actor.echo.remote(torch.tensor([4, 5, 6]), "cuda")
+    result = actors[1].sum.remote(ref, "cuda")
+    assert ray.get(result) == 15
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
 def test_nixl_abort_sender_dies_before_sending(ray_start_regular):
     actors = [GPUTestActor.remote() for _ in range(2)]
 
@@ -286,6 +307,39 @@ def test_nixl_del_before_creating(ray_start_regular):
     wait_for_condition(
         lambda: ray.get(actor.get_num_rdt_objects.remote()) == 0,
     )
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_nixl_owner_gets_from_launched_task(ray_start_regular):
+    actor = GPUTestActor.remote()
+    tensor = torch.randn((100, 100))
+
+    ref = actor.echo.remote(tensor, "cuda")
+    assert torch.equal(ray.get(ref), tensor.to("cuda"))
+
+
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_out_of_order_actors(ray_start_regular):
+    @ray.remote(num_cpus=0, num_gpus=1, max_concurrency=10)
+    class GPUTestActor:
+        def __init__(self):
+            self.tensor = torch.tensor([4, 5, 6], device="cuda")
+
+        @ray.method(tensor_transport="nixl")
+        async def get_tensor(self):
+            return self.tensor
+
+        async def sum(self, data):
+            return data.sum().item()
+
+    actors = [GPUTestActor.remote() for _ in range(2)]
+    results = []
+    for _ in range(100):
+        ref = actors[0].get_tensor.remote()
+        result = actors[1].sum.remote(ref)
+        results.append(result)
+    results = ray.get(results)
+    assert sum(results) == 1500
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
## Description

After https://github.com/ray-project/ray/pull/59610, upstream errors would not be propagated to downstream tasks. 

RDT tensors are only used if the metadata matches a specific constant, so now only trying to fetch in that case.

https://github.com/ray-project/ray/blob/16ea23e18a85fdddcb3da9f05591ddc9f903defa/python/ray/_private/serialization.py#L418

The logic to determine if the upstream task failed is based on parsing this metadata, can look at the func above as the reference, so this stays consistent with that.



Also adding some extra nixl tests.
