### PR TITLE
[Data] Add mitigation to floating point errors in `TimeWindowAverageCalculator`

### DIFF
--- a/python/ray/data/_internal/average_calculator.py
+++ b/python/ray/data/_internal/average_calculator.py
@@ -21,8 +21,6 @@ class TimeWindowAverageCalculator:
 
     def report(self, value: float):
         """Report a value to the calculator."""
-        assert value >= 0, f"Value should be non-negative, got {value}"
-
         now = time.time()
         self._values.append((now, value))
         self._sum += value
@@ -35,14 +33,7 @@ class TimeWindowAverageCalculator:
         self._trim(time.time())
         if len(self._values) == 0:
             return None
-
-        avg = self._sum / len(self._values)
-
-        assert avg >= 0, (
-            f"Average should be non-negative, got {avg} "
-            f"(sum={self._sum}, count={len(self._values)})"
-        )
-        return avg
+        return self._sum / len(self._values)
 
     def _trim(self, now):
         """Remove the values reported outside of the time window."""
@@ -50,7 +41,7 @@ class TimeWindowAverageCalculator:
             _, value = self._values.popleft()
             self._sum -= value
 
-        # Set sum to 0 if it's negative to avoid accumulated floating-point error from
-        # repeated += / -= operations.
-        if self._sum < 0:
+        # Set sum to 0 if there are no values to avoid accumulated floating-point error
+        # from repeated += / -= operations.
+        if len(self._values) == 0:
             self._sum = 0

--- a/python/ray/data/_internal/average_calculator.py
+++ b/python/ray/data/_internal/average_calculator.py
@@ -21,6 +21,8 @@ class TimeWindowAverageCalculator:
 
     def report(self, value: float):
         """Report a value to the calculator."""
+        assert value >= 0, f"Value should be non-negative, got {value}"
+
         now = time.time()
         self._values.append((now, value))
         self._sum += value
@@ -33,10 +35,22 @@ class TimeWindowAverageCalculator:
         self._trim(time.time())
         if len(self._values) == 0:
             return None
-        return self._sum / len(self._values)
+
+        avg = self._sum / len(self._values)
+
+        assert avg >= 0, (
+            f"Average should be non-negative, got {avg} "
+            f"(sum={self._sum}, count={len(self._values)})"
+        )
+        return avg
 
     def _trim(self, now):
         """Remove the values reported outside of the time window."""
         while len(self._values) > 0 and now - self._values[0][0] > self._window_s:
             _, value = self._values.popleft()
             self._sum -= value
+
+        # Set sum to 0 if it's negative to avoid accumulated floating-point error from
+        # repeated += / -= operations.
+        if self._sum < 0:
+            self._sum = 0

--- a/python/ray/data/_internal/cluster_autoscaler/resource_utilization_gauge.py
+++ b/python/ray/data/_internal/cluster_autoscaler/resource_utilization_gauge.py
@@ -17,10 +17,12 @@ class ClusterUtil:
 
     def __post_init__(self):
         # If we overcommit tasks, the logical utilization can exceed 1.0.
-        assert math.isfinite(self.cpu) and 0 <= self.cpu
-        assert math.isfinite(self.gpu) and 0 <= self.gpu
-        assert math.isfinite(self.memory) and 0 <= self.memory
-        assert math.isfinite(self.object_store_memory) and 0 <= self.object_store_memory
+        assert math.isfinite(self.cpu) and 0 <= self.cpu, self.cpu
+        assert math.isfinite(self.gpu) and 0 <= self.gpu, self.gpu
+        assert math.isfinite(self.memory) and 0 <= self.memory, self.memory
+        assert (
+            math.isfinite(self.object_store_memory) and 0 <= self.object_store_memory
+        ), self.object_store_memory
 
 
 class ResourceUtilizationGauge(abc.ABC):

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -263,6 +263,9 @@ class ResourceManager:
 
     def get_global_usage(self) -> ExecutionResources:
         """Return the global resource usage at the current time."""
+        assert (
+            self._global_usage.is_non_negative()
+        ), f"Global usage should be non-negative, got {self._global_usage}"
         return self._global_usage
 
     def get_global_running_usage(self) -> ExecutionResources:
@@ -296,6 +299,9 @@ class ResourceManager:
             * default_mem_fraction
         )
         self._global_limits = default_limits.min(total_resources).subtract(exclude)
+        assert (
+            self._global_limits.is_non_negative()
+        ), f"Global limits should be non-negative, got {self._global_limits}"
         return self._global_limits
 
     def get_op_usage(


### PR DESCRIPTION
The `aggregate_groups` release tests have been flaky recently because they've been failing this assertion: `assert math.isfinite(self.object_store_memory) and 0 <= self.object_store_memory`.

In an attempt to deflake this test, this PR:
* Adds a minor mitigation to floating-point errors in `TimeWindowAverageCalculator`
* Adds assertions that `get_global_usage` and `get_global_limits` are non-negative
* Adds more context to the failing assertion error in `ClsuterUtilizationGauge`