### PR TITLE
[Data] Deflake `streaming_train_test_split` doctest 

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2658,9 +2658,9 @@ class Dataset:
             >>> import ray
             >>> ds = ray.data.range(8)
             >>> train, test = ds.streaming_train_test_split(test_size=0.25, split_type="hash", hash_column="id")
-            >>> train.take_batch()
+            >>> train.take_batch()  # doctest: +SKIP
             {'id': array([0, 2, 3, 4, 5, 6])}
-            >>> test.take_batch()
+            >>> test.take_batch()  # doctest: +SKIP
             {'id': array([1, 7])}
 
         Args:


### PR DESCRIPTION
The `streaming_train_test_split` docstring example disables `preserve_order`, calls the API without a seed, and expects `take_batch` to produce a specific output. 

As a result, the doctest can fail like this:
```
[2026-03-08T23:29:18Z] =================================== FAILURES ===================================
--
[2026-03-08T23:29:18Z] _____ [doctest] python.ray.data.dataset.Dataset.streaming_train_test_split _____
[2026-03-08T23:29:18Z] 2652             >>> test.count()
[2026-03-08T23:29:18Z] 2653             2
[2026-03-08T23:29:18Z] 2654             >>> ctx.execution_options.preserve_order = False
[2026-03-08T23:29:18Z] 2655
[2026-03-08T23:29:18Z] 2656             Examples with Hash split:
[2026-03-08T23:29:18Z] 2657
[2026-03-08T23:29:18Z] 2658             >>> import ray
[2026-03-08T23:29:18Z] 2659             >>> ds = ray.data.range(8)
[2026-03-08T23:29:18Z] 2660             >>> train, test = ds.streaming_train_test_split(test_size=0.25, split_type="hash", hash_column="id")
[2026-03-08T23:29:18Z] 2661             >>> train.take_batch()
[2026-03-08T23:29:18Z] Expected:
[2026-03-08T23:29:18Z]     {'id': array([0, 2, 3, 4, 5, 6])}
[2026-03-08T23:29:18Z] Got:
[2026-03-08T23:29:18Z]     {'id': array([0, 2, 4, 5, 6, 3])}
```

To mitigate this flakiness, this PR skips the flaky lines.