### PR TITLE
Fix deprecated radial/busyboxplus:curl image in RayService quickstart…

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
@@ -114,7 +114,7 @@ Below is a screenshot example of the Serve page in the Ray dashboard.
 ```sh
 # Step 6.1: Run a curl Pod.
 # If you already have a curl Pod, you can use `kubectl exec -it <curl-pod> -- sh` to access the Pod.
-kubectl run curl --image=radial/busyboxplus:curl -i --tty
+kubectl run curl --image=curlimages/curl -it --command -- sh
 
 # Step 6.2: Send a request to the fruit stand app.
 curl -X POST -H 'Content-Type: application/json' rayservice-sample-serve-svc:8000/fruit/ -d '["MANGO", 2]'


### PR DESCRIPTION
## What does this PR do?

The RayService quickstart documentation uses the image:

radial/busyboxplus:curl

This image uses a deprecated Docker manifest format
(application/vnd.docker.distribution.manifest.v1+prettyjws),
which is no longer supported by modern container runtimes
like containerd.

Running the command results in:

ErrImagePull / ImagePullBackOff

This PR replaces the image with:

curlimages/curl

which works correctly with Kubernetes.

## Testing

Tested on a local Kubernetes cluster (Docker Desktop).
The pod starts successfully and curl works.

Closes #61538