### PR TITLE
[Core] Define Autoscaller event schema

### DIFF
--- a/src/ray/observability/python_event_interface.cc
+++ b/src/ray/observability/python_event_interface.cc
@@ -15,6 +15,7 @@
 #include "ray/observability/python_event_interface.h"
 
 #include <google/protobuf/util/json_util.h>
+#include <unistd.h>
 
 #include "google/protobuf/descriptor.h"
 #include "google/protobuf/message.h"
@@ -65,6 +66,13 @@ rpc::events::RayEvent PythonRayEvent::Serialize() && {
   event.set_session_name(session_name_);
   event.mutable_timestamp()->CopyFrom(AbslTimeNanosToProtoTimestamp(
       absl::ToInt64Nanoseconds(event_timestamp_ - absl::UnixEpoch())));
+
+  // Set source process metadata.
+  char hostname_buf[256];
+  if (gethostname(hostname_buf, sizeof(hostname_buf)) == 0) {
+    event.set_source_hostname(hostname_buf);
+  }
+  event.set_source_pid(getpid());
 
   // Use protobuf reflection to set the nested event message by field number.
   // this way, adding new Python event types will not require C++ changes.

--- a/src/ray/protobuf/public/BUILD.bazel
+++ b/src/ray/protobuf/public/BUILD.bazel
@@ -10,6 +10,9 @@ proto_library(
         ":events_actor_definition_event_proto",
         ":events_actor_lifecycle_event_proto",
         ":events_actor_task_definition_event_proto",
+        ":events_autoscaler_config_definition_event_proto",
+        ":events_autoscaler_node_provisioning_event_proto",
+        ":events_autoscaler_scaling_decision_event_proto",
         ":events_driver_job_definition_event_proto",
         ":events_driver_job_lifecycle_event_proto",
         ":events_node_definition_event_proto",
@@ -170,6 +173,39 @@ cc_proto_library(
 cc_proto_library(
     name = "events_node_lifecycle_event_cc_proto",
     deps = [":events_node_lifecycle_event_proto"],
+)
+
+proto_library(
+    name = "events_autoscaler_config_definition_event_proto",
+    srcs = ["events_autoscaler_config_definition_event.proto"],
+)
+
+cc_proto_library(
+    name = "events_autoscaler_config_definition_event_cc_proto",
+    deps = [":events_autoscaler_config_definition_event_proto"],
+)
+
+proto_library(
+    name = "events_autoscaler_scaling_decision_event_proto",
+    srcs = ["events_autoscaler_scaling_decision_event.proto"],
+)
+
+cc_proto_library(
+    name = "events_autoscaler_scaling_decision_event_cc_proto",
+    deps = [":events_autoscaler_scaling_decision_event_proto"],
+)
+
+proto_library(
+    name = "events_autoscaler_node_provisioning_event_proto",
+    srcs = ["events_autoscaler_node_provisioning_event.proto"],
+    deps = [
+        "@com_google_protobuf//:timestamp_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "events_autoscaler_node_provisioning_event_cc_proto",
+    deps = [":events_autoscaler_node_provisioning_event_proto"],
 )
 
 proto_library(

--- a/src/ray/protobuf/public/events_autoscaler_config_definition_event.proto
+++ b/src/ray/protobuf/public/events_autoscaler_config_definition_event.proto
@@ -1,0 +1,48 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package ray.rpc.events;
+
+// Emitted when there is a change in autoscaler configuration.
+message AutoscalerConfigDefinitionEvent {
+  message NodeTypeConfig {
+    string node_type_name = 1;
+    int32 min_worker_nodes = 2;
+    int32 max_worker_nodes = 3;
+    // Per-type idle timeout (seconds). -1 if not set.
+    int32 idle_timeout_s = 4;
+    // Resource shape for this node type.
+    map<string, double> resources = 5;
+    // Node labels.
+    map<string, string> labels = 6;
+  }
+
+  enum AutoscalerVersion {
+    AUTOSCALER_VERSION_UNSPECIFIED = 0;
+    V1 = 1;
+    V2 = 2;
+  }
+  // Autoscaler version.
+  AutoscalerVersion autoscaler_version = 1;
+  // e.g., "aws", "gcp", "kuberay", "readonly", "local"
+  string cloud_provider_type = 2;
+  // Global max worker nodes across all types (cluster-wide cap).
+  int32 max_workers = 3;
+  // Available node types and their resource shapes.
+  repeated NodeTypeConfig available_node_types = 4;
+  // Upscaling speed (aggressiveness).
+  double upscaling_speed = 5;
+}

--- a/src/ray/protobuf/public/events_autoscaler_node_provisioning_event.proto
+++ b/src/ray/protobuf/public/events_autoscaler_node_provisioning_event.proto
@@ -1,0 +1,54 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package ray.rpc.events;
+
+import "google/protobuf/timestamp.proto";
+
+// Emitted when pending/failed instance state changes.
+message AutoscalerNodeProvisioningEvent {
+  // Instances requested from cloud provider but not yet allocated.
+  // Lifecycle: LaunchAction -> RequestedInstance -> AllocatedInstance ->
+  //            NodeDefinitionEvent / FailedInstance
+  message RequestedInstance {
+    string instance_type_name = 1;
+    string ray_node_type_name = 2;
+    int32 count = 3;
+    google.protobuf.Timestamp request_ts = 4;
+  }
+
+  // Instances allocated by cloud provider but Ray not yet running.
+  message AllocatedInstance {
+    string instance_type_name = 1;
+    string ray_node_type_name = 2;
+    string instance_id = 3;
+    string ip_address = 4;
+  }
+
+  // Instance launch requests that failed.
+  message FailedInstance {
+    string instance_type_name = 1;
+    string ray_node_type_name = 2;
+    int32 count = 3;
+    string reason = 4;
+    google.protobuf.Timestamp start_ts = 5;
+    google.protobuf.Timestamp failed_ts = 6;
+  }
+
+  repeated RequestedInstance requested_instances = 1;
+  repeated AllocatedInstance allocated_instances = 2;
+  repeated FailedInstance failed_instances = 3;
+}

--- a/src/ray/protobuf/public/events_autoscaler_scaling_decision_event.proto
+++ b/src/ray/protobuf/public/events_autoscaler_scaling_decision_event.proto
@@ -1,0 +1,76 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package ray.rpc.events;
+
+// Emitted for every autoscaler scaling decision.
+message AutoscalerScalingDecisionEvent {
+  message LaunchAction {
+    string instance_type = 1;
+    int32 count = 2;
+  }
+
+  message TerminateAction {
+    enum TerminationCause {
+      TERMINATION_CAUSE_UNSPECIFIED = 0;
+      IDLE = 1;
+      MAX_NUM_NODE_PER_TYPE = 2;
+      MAX_NUM_NODES = 3;
+      OUTDATED = 4;
+    }
+    TerminationCause cause = 1;
+    string instance_type = 2;
+    int32 count = 3;
+  }
+
+  // A label constraint attached to a resource request (e.g. node affinity).
+  message LabelConstraint {
+    string label_key = 1;
+    // Operator: "IN" or "NOT_IN".
+    string operator = 2;
+    repeated string values = 3;
+  }
+
+  message ResourceBundle {
+    map<string, double> resources = 1;
+    // Label constraints from the original resource request, if any.
+    repeated LabelConstraint label_constraints = 2;
+  }
+
+  message GangResourceBundle {
+    repeated ResourceBundle bundles = 1;
+    string details = 2;
+  }
+
+  message ClusterResourceConstraintBundle {
+    message ResourceRequestByCount {
+      ResourceBundle request = 1;
+      int64 count = 2;
+    }
+    repeated ResourceRequestByCount resource_requests = 1;
+  }
+
+  repeated LaunchAction launch_actions = 1;
+  repeated TerminateAction terminate_actions = 2;
+  // Cluster resource summary after this decision.
+  map<string, double> cluster_resources_after = 3;
+  // Resource requests that could not be satisfied by any available node type.
+  repeated ResourceBundle infeasible_resource_requests = 4;
+  // Gang/placement group requests that could not be scheduled.
+  repeated GangResourceBundle infeasible_gang_resource_requests = 5;
+  // Cluster-level resource constraints that could not be satisfied.
+  repeated ClusterResourceConstraintBundle infeasible_cluster_resource_constraints = 6;
+}

--- a/src/ray/protobuf/public/events_autoscaler_scaling_decision_event.proto
+++ b/src/ray/protobuf/public/events_autoscaler_scaling_decision_event.proto
@@ -48,6 +48,9 @@ message AutoscalerScalingDecisionEvent {
     map<string, double> resources = 1;
     // Label constraints from the original resource request, if any.
     repeated LabelConstraint label_constraints = 2;
+    // Number of identical bundles with this shape. Defaults to 0;
+    // callers should treat 0 as 1 for backward compatibility.
+    int64 count = 3;
   }
 
   message GangResourceBundle {

--- a/src/ray/protobuf/public/events_base_event.proto
+++ b/src/ray/protobuf/public/events_base_event.proto
@@ -123,4 +123,9 @@ message RayEvent {
   AutoscalerConfigDefinitionEvent autoscaler_config_definition_event = 21;
   AutoscalerScalingDecisionEvent autoscaler_scaling_decision_event = 22;
   AutoscalerNodeProvisioningEvent autoscaler_node_provisioning_event = 23;
+
+  // Hostname of the process that emitted this event.
+  string source_hostname = 24;
+  // PID of the process that emitted this event.
+  int32 source_pid = 25;
 }

--- a/src/ray/protobuf/public/events_base_event.proto
+++ b/src/ray/protobuf/public/events_base_event.proto
@@ -29,6 +29,9 @@ import "src/ray/protobuf/public/events_node_definition_event.proto";
 import "src/ray/protobuf/public/events_node_lifecycle_event.proto";
 import "src/ray/protobuf/public/events_submission_job_definition_event.proto";
 import "src/ray/protobuf/public/events_submission_job_lifecycle_event.proto";
+import "src/ray/protobuf/public/events_autoscaler_config_definition_event.proto";
+import "src/ray/protobuf/public/events_autoscaler_scaling_decision_event.proto";
+import "src/ray/protobuf/public/events_autoscaler_node_provisioning_event.proto";
 
 // This is the base message for all ray events.
 message RayEvent {
@@ -62,6 +65,9 @@ message RayEvent {
     ACTOR_LIFECYCLE_EVENT = 10;
     SUBMISSION_JOB_DEFINITION_EVENT = 11;
     SUBMISSION_JOB_LIFECYCLE_EVENT = 12;
+    AUTOSCALER_CONFIG_DEFINITION_EVENT = 13;
+    AUTOSCALER_SCALING_DECISION_EVENT = 14;
+    AUTOSCALER_NODE_PROVISIONING_EVENT = 15;
   }
 
   // The severities of events that can be generated.
@@ -113,4 +119,8 @@ message RayEvent {
 
   SubmissionJobDefinitionEvent submission_job_definition_event = 19;
   SubmissionJobLifecycleEvent submission_job_lifecycle_event = 20;
+
+  AutoscalerConfigDefinitionEvent autoscaler_config_definition_event = 21;
+  AutoscalerScalingDecisionEvent autoscaler_scaling_decision_event = 22;
+  AutoscalerNodeProvisioningEvent autoscaler_node_provisioning_event = 23;
 }


### PR DESCRIPTION
## Description
define autoscaler event schema (proto changes only). this pr introduces three new event types:

`AutoscalerConfigDefinitionEvent` - Emitted everytime there is a change in autoscaler configuration
`AutoscalerScalingDecisionEvent` - Emitted for every scaling decision
`AutoscalerNodeProvisioningEvent` - Emitted when pending/failed instance state changes

in these events will be emitted in a [subsequent pr](https://github.com/ray-project/ray/pull/61586).

