### PR TITLE
[Serve] Fix `run_until_complete` in user `__init__` via two-phase event loop startup

### DIFF
--- a/doc/source/serve/doc_code/asyncio_best_practices.py
+++ b/doc/source/serve/doc_code/asyncio_best_practices.py
@@ -95,7 +95,7 @@ from concurrent.futures import ThreadPoolExecutor
 @serve.deployment
 class CustomThreadPool:
     def __init__(self):
-        loop = asyncio.get_running_loop()
+        loop = asyncio.get_event_loop()
         loop.set_default_executor(ThreadPoolExecutor(max_workers=16))
 
     async def __call__(self, request):

--- a/doc/source/serve/doc_code/intel_gaudi_inference_serve.py
+++ b/doc/source/serve/doc_code/intel_gaudi_inference_serve.py
@@ -54,7 +54,7 @@ class LlamaModel:
         self.tokenizer.padding_side = "left"
 
         # Use async loop in streaming
-        self.loop = asyncio.get_running_loop()
+        self.loop = asyncio.get_event_loop()
 
     def tokenize(self, prompt: str):
         """Tokenize the input and move to HPU."""

--- a/doc/source/serve/doc_code/streaming_tutorial.py
+++ b/doc/source/serve/doc_code/streaming_tutorial.py
@@ -26,7 +26,7 @@ fastapi_app = FastAPI()
 @serve.ingress(fastapi_app)
 class Textbot:
     def __init__(self, model_id: str):
-        self.loop = asyncio.get_running_loop()
+        self.loop = asyncio.get_event_loop()
 
         self.model_id = model_id
         self.model = AutoModelForCausalLM.from_pretrained(self.model_id)
@@ -114,7 +114,7 @@ fastapi_app = FastAPI()
 @serve.ingress(fastapi_app)
 class Chatbot:
     def __init__(self, model_id: str):
-        self.loop = asyncio.get_running_loop()
+        self.loop = asyncio.get_event_loop()
 
         self.model_id = model_id
         self.model = AutoModelForCausalLM.from_pretrained(self.model_id)
@@ -265,7 +265,7 @@ fastapi_app = FastAPI()
 @serve.ingress(fastapi_app)
 class Batchbot:
     def __init__(self, model_id: str):
-        self.loop = asyncio.get_running_loop()
+        self.loop = asyncio.get_event_loop()
 
         self.model_id = model_id
         self.model = AutoModelForCausalLM.from_pretrained(self.model_id)

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -181,14 +181,22 @@ def create_router(
             component
         ).set_exception_handler(asyncio_grpc_exception_handler)
     else:
+        # Verify there's an available event loop. A running loop is ideal,
+        # but a set-but-not-running loop (e.g., during two-phase replica init
+        # where the loop is set but not yet in run_forever()) is also OK.
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            raise RuntimeError(
-                "No event loop running. You cannot use a handle initialized with "
-                "`_run_router_in_separate_loop=False` when not inside an asyncio event "
-                "loop."
-            )
+            try:
+                loop = asyncio.get_event_loop()
+                if loop.is_closed():
+                    raise RuntimeError
+            except RuntimeError:
+                raise RuntimeError(
+                    "No event loop available. You cannot use a handle initialized "
+                    "with `_run_router_in_separate_loop=False` when not inside an "
+                    "asyncio event loop."
+                )
 
         router_wrapper_cls = CurrentLoopRouter
 

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -602,6 +602,9 @@ class ASGIAppReplicaWrapper:
     # NOTE: __del__ must be async so that we can run ASGI shutdown
     # in the same event loop.
     async def __del__(self):
+        if not hasattr(self, "_serve_asgi_lifespan"):
+            return
+
         # LifespanOn's logger logs in INFO level thus becomes spammy.
         # Within this block we temporarily uplevel for cleaner logging.
         from ray.serve._private.logging_utils import LoggingContext

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -3018,6 +3018,8 @@ class UserCallableWrapper:
                 finally:
                     # Avoid holding references to user code.
                     self._sync_init_fn = None
+                    if self._init_coro is not None:
+                        self._init_coro.close()
                     self._init_coro = None
 
                 # Phase 2: Start monitoring + run_forever.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1479,7 +1479,9 @@ class ReplicaBase(ABC):
                 try:
                     if request_metadata.is_http_request:
                         scope, receive = request_args
-                        async for msgs in self._user_callable_wrapper.call_http_entrypoint(
+                        async for (
+                            msgs
+                        ) in self._user_callable_wrapper.call_http_entrypoint(
                             request_metadata,
                             status_code_callback,
                             scope,
@@ -1487,7 +1489,9 @@ class ReplicaBase(ABC):
                         ):
                             yield pickle.dumps(msgs)
                     else:
-                        async for result in self._user_callable_wrapper.call_user_generator(
+                        async for (
+                            result
+                        ) in self._user_callable_wrapper.call_user_generator(
                             request_metadata,
                             request_args,
                             request_kwargs,
@@ -1547,7 +1551,9 @@ class ReplicaBase(ABC):
                 try:
                     if request_metadata.is_http_request:
                         scope, receive = request_args
-                        async for msgs in self._user_callable_wrapper.call_http_entrypoint(
+                        async for (
+                            msgs
+                        ) in self._user_callable_wrapper.call_http_entrypoint(
                             request_metadata,
                             status_code_callback,
                             scope,
@@ -1555,7 +1561,9 @@ class ReplicaBase(ABC):
                         ):
                             yield pickle.dumps(msgs)
                     elif request_metadata.is_streaming:
-                        async for result in self._user_callable_wrapper.call_user_generator(
+                        async for (
+                            result
+                        ) in self._user_callable_wrapper.call_user_generator(
                             request_metadata,
                             request_args,
                             request_kwargs,
@@ -2586,7 +2594,9 @@ class Replica(ReplicaBase):
                             user_method_info, scope, receive_proxy, send_user_message
                         )
                     else:
-                        async for asgi_messages in self._user_callable_wrapper.call_http_entrypoint(
+                        async for (
+                            asgi_messages
+                        ) in self._user_callable_wrapper.call_http_entrypoint(
                             request_metadata, status_code_callback, scope, receive_proxy
                         ):
                             for message in asgi_messages:
@@ -2941,9 +2951,9 @@ class UserCallableWrapper:
         self._callable = None
         self._deployment_config = deployment_config
         self._ray_actor_options = ray_actor_options or {}
-        self._user_code_threadpool: Optional[
-            concurrent.futures.ThreadPoolExecutor
-        ] = None
+        self._user_code_threadpool: Optional[concurrent.futures.ThreadPoolExecutor] = (
+            None
+        )
 
         if self._run_user_code_in_separate_thread:
             # All interactions with user code run on this loop to avoid blocking the
@@ -3291,6 +3301,7 @@ class UserCallableWrapper:
             init_method = self._callable.__init__
 
             if inspect.iscoroutinefunction(init_method):
+
                 async def _async_init_and_setup():
                     await self._call_func_or_gen(
                         init_method,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2954,7 +2954,6 @@ class UserCallableWrapper:
         self._user_code_threadpool: Optional[
             concurrent.futures.ThreadPoolExecutor
         ] = None
-        
 
         if self._run_user_code_in_separate_thread:
             # All interactions with user code run on this loop to avoid blocking the

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2951,9 +2951,10 @@ class UserCallableWrapper:
         self._callable = None
         self._deployment_config = deployment_config
         self._ray_actor_options = ray_actor_options or {}
-        self._user_code_threadpool: Optional[concurrent.futures.ThreadPoolExecutor] = (
-            None
-        )
+        self._user_code_threadpool: Optional[
+            concurrent.futures.ThreadPoolExecutor
+        ] = None
+        
 
         if self._run_user_code_in_separate_thread:
             # All interactions with user code run on this loop to avoid blocking the

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2994,6 +2994,7 @@ class UserCallableWrapper:
                 # Phase 1: Wait for initialize_callable to prepare init work.
                 self._init_submit_event.wait()
 
+                result = None
                 try:
                     # Phase 1a: Call sync __init__ directly on this thread.
                     # Event loop is set but NOT running, so
@@ -3002,28 +3003,32 @@ class UserCallableWrapper:
                         self._sync_init_fn(
                             *self._sync_init_args, **self._sync_init_kwargs
                         )
-                        self._sync_init_fn = None
 
                     # Phase 1b: Run async post-init (ASGI lifespan, etc.)
                     # via run_until_complete (loop still not in run_forever).
-                    result = None
                     if self._init_coro is not None:
                         result = self._user_code_event_loop.run_until_complete(
                             self._init_coro
                         )
-                        self._init_coro = None
                 except BaseException as e:
                     self._init_complete_future.set_exception(e)
-                    return
+                    # Fall through to start run_forever anyway so that
+                    # subsequent @_run_user_code calls (e.g. call_destructor
+                    # during shutdown) don't hang on a dead loop.
+                finally:
+                    # Avoid holding references to user code.
+                    self._sync_init_fn = None
+                    self._init_coro = None
 
                 # Phase 2: Start monitoring + run_forever.
                 # call_soon(set_result) resolves the future from INSIDE
                 # run_forever, guaranteeing the loop is running before any
                 # run_coroutine_threadsafe() call.
                 self._user_code_loop_monitor.start(self._user_code_event_loop)
-                self._user_code_event_loop.call_soon(
-                    self._init_complete_future.set_result, result
-                )
+                if not self._init_complete_future.done():
+                    self._user_code_event_loop.call_soon(
+                        self._init_complete_future.set_result, result
+                    )
                 self._user_code_event_loop.run_forever()
 
             self._user_code_event_loop_thread = threading.Thread(

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2965,13 +2965,55 @@ class UserCallableWrapper:
                 },
             )
 
+            # Two-phase init: the thread waits for init work to be prepared,
+            # runs __init__ with the loop NOT running (so run_until_complete
+            # works), then starts run_forever for serving.
+            self._init_submit_event = threading.Event()
+            self._init_complete_future: concurrent.futures.Future = (
+                concurrent.futures.Future()
+            )
+            self._init_coro = None
+            self._sync_init_fn = None
+            self._sync_init_args: tuple = ()
+            self._sync_init_kwargs: dict = {}
+
             def _run_user_code_event_loop():
-                # Required so that calls to get the current running event loop work
-                # properly in user code.
                 asyncio.set_event_loop(self._user_code_event_loop)
                 self._configure_user_code_threadpool()
-                # Start monitoring before run_forever so the task is scheduled.
+
+                # Phase 1: Wait for initialize_callable to prepare init work.
+                self._init_submit_event.wait()
+
+                try:
+                    # Phase 1a: Call sync __init__ directly on this thread.
+                    # Event loop is set but NOT running, so
+                    # loop.run_until_complete() works inside user code.
+                    if self._sync_init_fn is not None:
+                        self._sync_init_fn(
+                            *self._sync_init_args, **self._sync_init_kwargs
+                        )
+                        self._sync_init_fn = None
+
+                    # Phase 1b: Run async post-init (ASGI lifespan, etc.)
+                    # via run_until_complete (loop still not in run_forever).
+                    result = None
+                    if self._init_coro is not None:
+                        result = self._user_code_event_loop.run_until_complete(
+                            self._init_coro
+                        )
+                        self._init_coro = None
+                except BaseException as e:
+                    self._init_complete_future.set_exception(e)
+                    return
+
+                # Phase 2: Start monitoring + run_forever.
+                # call_soon(set_result) resolves the future from INSIDE
+                # run_forever, guaranteeing the loop is running before any
+                # run_coroutine_threadsafe() call.
                 self._user_code_loop_monitor.start(self._user_code_event_loop)
+                self._user_code_event_loop.call_soon(
+                    self._init_complete_future.set_result, result
+                )
                 self._user_code_event_loop.run_forever()
 
             self._user_code_event_loop_thread = threading.Thread(
@@ -3189,24 +3231,33 @@ class UserCallableWrapper:
 
         await self._callable._run_asgi_lifespan_startup()
 
-    @_run_user_code
-    async def initialize_callable(self) -> Optional[ASGIApp]:
+    def initialize_callable(self):
         """Initialize the user callable.
 
         If the callable is an ASGI app wrapper (e.g., using @serve.ingress), returns
         the ASGI app object, which may be used *read only* by the caller.
+
+        When running user code in a separate thread, this uses a two-phase
+        approach: __init__ runs with the event loop set but NOT running (so
+        libraries that call loop.run_until_complete() in __init__ work), then
+        run_forever() starts for serving.
         """
         if self._callable is not None:
             raise RuntimeError("initialize_callable should only be called once.")
 
-        # This closure initializes user code and finalizes replica
-        # startup. By splitting the initialization step like this,
-        # we can already access this actor before the user code
-        # has finished initializing.
-        # The supervising state manager can then wait
-        # for allocation of this replica by using the `is_allocated`
-        # method. After that, it calls `reconfigure` to trigger
-        # user code initialization.
+        if not self._run_user_code_in_separate_thread:
+            return self._do_initialize_callable()
+
+        self._prepare_init_for_user_thread()
+        self._init_submit_event.set()
+
+        if self._local_testing_mode:
+            return self._init_complete_future
+
+        return asyncio.wrap_future(self._init_complete_future)
+
+    async def _do_initialize_callable(self) -> Optional[ASGIApp]:
+        """Initialize callable on the current event loop (non-threaded path)."""
         logger.info(
             "Started initializing replica.",
             extra={"log_to_stderr": False},
@@ -3215,17 +3266,50 @@ class UserCallableWrapper:
         if self._is_function:
             self._callable = self._deployment_def
         else:
-            # This allows deployments to define an async __init__
-            # method (mostly used for testing).
             self._callable = self._deployment_def.__new__(self._deployment_def)
             await self._call_func_or_gen(
                 self._callable.__init__,
                 args=self._init_args,
                 kwargs=self._init_kwargs,
-                # Always run the constructor on the main user code thread.
                 run_sync_methods_in_threadpool_override=False,
             )
 
+        return await self._async_post_init_setup()
+
+    def _prepare_init_for_user_thread(self):
+        """Prepare init work for the user code thread (two-phase init)."""
+        logger.info(
+            "Started initializing replica.",
+            extra={"log_to_stderr": False},
+        )
+
+        if self._is_function:
+            self._callable = self._deployment_def
+            self._init_coro = self._async_post_init_setup()
+        else:
+            self._callable = self._deployment_def.__new__(self._deployment_def)
+            init_method = self._callable.__init__
+
+            if inspect.iscoroutinefunction(init_method):
+                async def _async_init_and_setup():
+                    await self._call_func_or_gen(
+                        init_method,
+                        args=self._init_args,
+                        kwargs=self._init_kwargs,
+                        run_sync_methods_in_threadpool_override=False,
+                    )
+                    return await self._async_post_init_setup()
+
+                self._init_coro = _async_init_and_setup()
+            else:
+                self._sync_init_fn = init_method
+                self._sync_init_args = self._init_args or ()
+                self._sync_init_kwargs = self._init_kwargs or {}
+                self._init_coro = self._async_post_init_setup()
+
+    async def _async_post_init_setup(self) -> Optional[ASGIApp]:
+        """Post-__init__ setup: ASGI lifespan, health checks, etc."""
+        if not self._is_function:
             if isinstance(self._callable, ASGIAppReplicaWrapper):
                 await self._initialize_asgi_callable()
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1228,7 +1228,12 @@ class CurrentLoopRouter(Router):
             "event_loop" not in passthrough_kwargs
         ), "CurrentLoopRouter uses the current event loop."
 
-        self._asyncio_loop = asyncio.get_running_loop()
+        # Support two-phase replica init where the event loop is set on the
+        # thread (via set_event_loop) but not yet running (run_forever).
+        try:
+            self._asyncio_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self._asyncio_loop = asyncio.get_event_loop()
         self._asyncio_router = AsyncioRouter(
             event_loop=self._asyncio_loop,
             _request_router_initialized_event=asyncio.Event(),

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -294,16 +294,6 @@ def ingress(app: Union[ASGIApp, Callable]) -> Callable:
             )
 
         class ASGIIngressWrapper(cls, ASGIAppReplicaWrapper):
-            async def __init__(self, *args, **kwargs):
-                # Call user-defined constructor.
-                if inspect.iscoroutinefunction(cls.__init__):
-                    await cls.__init__(self, *args, **kwargs)
-                else:
-                    cls.__init__(self, *args, **kwargs)
-
-                ServeUsageTag.FASTAPI_USED.record("1")
-                ASGIAppReplicaWrapper.__init__(self, frozen_app_or_func)
-
             async def __del__(self):
                 await ASGIAppReplicaWrapper.__del__(self)
 
@@ -313,6 +303,26 @@ def ingress(app: Union[ASGIApp, Callable]) -> Callable:
                         await cls.__del__(self)
                     else:
                         cls.__del__(self)
+
+        # Define __init__ outside the class body so it can be sync or async
+        # depending on the user's cls.__init__. When sync, the user code thread
+        # can call it directly with the event loop NOT running, allowing
+        # libraries like SGLang to use loop.run_until_complete() in __init__.
+        if inspect.iscoroutinefunction(cls.__init__):
+
+            async def _wrapper_init(self, *args, **kwargs):
+                await cls.__init__(self, *args, **kwargs)
+                ServeUsageTag.FASTAPI_USED.record("1")
+                ASGIAppReplicaWrapper.__init__(self, frozen_app_or_func)
+
+        else:
+
+            def _wrapper_init(self, *args, **kwargs):
+                cls.__init__(self, *args, **kwargs)
+                ServeUsageTag.FASTAPI_USED.record("1")
+                ASGIAppReplicaWrapper.__init__(self, frozen_app_or_func)
+
+        ASGIIngressWrapper.__init__ = _wrapper_init
 
         copy_class_metadata(ASGIIngressWrapper, cls)
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -628,12 +628,14 @@ def _run_many(
                 name=t.name,
                 route_prefix=t.route_prefix,
                 logging_config=t.logging_config,
-                make_deployment_handle=make_local_deployment_handle
-                if _local_testing_mode
-                else None,
-                default_runtime_env=ray.get_runtime_context().runtime_env
-                if not _local_testing_mode
-                else None,
+                make_deployment_handle=(
+                    make_local_deployment_handle if _local_testing_mode else None
+                ),
+                default_runtime_env=(
+                    ray.get_runtime_context().runtime_env
+                    if not _local_testing_mode
+                    else None
+                ),
                 external_scaler_enabled=t.external_scaler_enabled,
             )
         )

--- a/python/ray/serve/tests/test_grpc_e2e.py
+++ b/python/ray/serve/tests/test_grpc_e2e.py
@@ -2,6 +2,7 @@ import os
 import signal
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 import pytest
@@ -131,11 +132,23 @@ def test_no_spammy_errors_in_grpc_proxy(ray_instance, tmp_dir):
 
 
 def test_same_loop_handle(serve_instance):
-    # With a local handle, where there is no running asyncio loop,
+    # With a local handle in a thread with no event loop set,
     # setting _run_router_in_separate_loop=False should error.
     h = serve.run(Downstream.bind())
-    with pytest.raises(RuntimeError, match="No event loop running"):
-        h._init(_run_router_in_separate_loop=False)
+    error = None
+
+    def _test_no_loop():
+        nonlocal error
+        try:
+            h._init(_run_router_in_separate_loop=False)
+        except RuntimeError as e:
+            error = e
+
+    t = threading.Thread(target=_test_no_loop)
+    t.start()
+    t.join()
+    assert error is not None
+    assert "No event loop available" in str(error)
 
     # However setting _run_router_in_separate_loop=False in a replica
     # should work since there is a running asyncio event loop.

--- a/python/ray/serve/tests/test_replica_placement_group.py
+++ b/python/ray/serve/tests/test_replica_placement_group.py
@@ -355,6 +355,15 @@ def test_leaked_gang_pg_removed_on_controller_recovery(serve_instance):
         if new_per_replica_pg == prev_per_replica_pg:
             return False
 
+        # All apps must be RUNNING.
+        try:
+            status = serve.status()
+            for app_name in ("survivor_app", "victim_app", "per_replica_app"):
+                if status.applications[app_name].status != "RUNNING":
+                    return False
+        except Exception:
+            return False
+
         return True
 
     wait_for_condition(recovery_complete, timeout=60)

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -734,7 +734,6 @@ class TestSeparateThread:
         sync_event.set()
         assert await blocked_future == "Sorry I got stuck!"
 
-
     @pytest.mark.asyncio
     async def test_sync_init_can_use_run_until_complete(self):
         """Sync __init__ can call loop.run_until_complete() because
@@ -806,9 +805,7 @@ class TestSeparateThread:
         await user_callable_wrapper.initialize_callable()
 
         request_metadata = _make_request_metadata()
-        await user_callable_wrapper.call_user_method(
-            request_metadata, tuple(), dict()
-        )
+        await user_callable_wrapper.call_user_method(request_metadata, tuple(), dict())
         assert "task_ran" in results
 
     @pytest.mark.asyncio

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -635,7 +635,10 @@ class TestSeparateThread:
 
         class GetLoop:
             def __init__(self):
-                self._constructor_loop = asyncio.get_running_loop()
+                # With two-phase init, the loop is set but NOT running during
+                # sync __init__, so use get_event_loop() instead of
+                # get_running_loop().
+                self._constructor_loop = asyncio.get_event_loop()
 
             async def check_health(self):
                 check_health_loop = asyncio.get_running_loop()
@@ -730,6 +733,101 @@ class TestSeparateThread:
 
         sync_event.set()
         assert await blocked_future == "Sorry I got stuck!"
+
+
+    @pytest.mark.asyncio
+    async def test_sync_init_can_use_run_until_complete(self):
+        """Sync __init__ can call loop.run_until_complete() because
+        the event loop is set but NOT running during Phase 1."""
+
+        class UsesRunUntilComplete:
+            def __init__(self):
+                loop = asyncio.get_event_loop()
+                loop.run_until_complete(asyncio.sleep(0))
+                self._initialized = True
+
+            async def __call__(self):
+                return "ok"
+
+        user_callable_wrapper = _make_user_callable_wrapper(
+            UsesRunUntilComplete,
+            run_user_code_in_separate_thread=True,
+        )
+        await user_callable_wrapper.initialize_callable()
+        assert user_callable_wrapper.user_callable._initialized is True
+
+        request_metadata = _make_request_metadata()
+        result = await user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        )
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_post_init_loop_running(self):
+        """After init, the event loop should be running and async methods
+        should work via run_coroutine_threadsafe."""
+
+        class CheckLoopRunning:
+            async def __call__(self):
+                loop = asyncio.get_running_loop()
+                assert loop.is_running()
+                return "running"
+
+        user_callable_wrapper = _make_user_callable_wrapper(
+            CheckLoopRunning,
+            run_user_code_in_separate_thread=True,
+        )
+        await user_callable_wrapper.initialize_callable()
+
+        request_metadata = _make_request_metadata()
+        result = await user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        )
+        assert result == "running"
+
+    @pytest.mark.asyncio
+    async def test_background_tasks_from_init(self):
+        """Tasks queued via create_task() during __init__ should execute
+        once the loop starts running."""
+        results = []
+
+        class InitWithBackgroundTask:
+            def __init__(self):
+                loop = asyncio.get_event_loop()
+                loop.call_soon(lambda: results.append("task_ran"))
+
+            async def __call__(self):
+                return "ok"
+
+        user_callable_wrapper = _make_user_callable_wrapper(
+            InitWithBackgroundTask,
+            run_user_code_in_separate_thread=True,
+        )
+        await user_callable_wrapper.initialize_callable()
+
+        request_metadata = _make_request_metadata()
+        await user_callable_wrapper.call_user_method(
+            request_metadata, tuple(), dict()
+        )
+        assert "task_ran" in results
+
+    @pytest.mark.asyncio
+    async def test_init_error_propagates(self):
+        """Exceptions in __init__ should propagate to the caller."""
+
+        class FailingInit:
+            def __init__(self):
+                raise ValueError("init failed")
+
+            async def __call__(self):
+                return "ok"
+
+        user_callable_wrapper = _make_user_callable_wrapper(
+            FailingInit,
+            run_user_code_in_separate_thread=True,
+        )
+        with pytest.raises(ValueError, match="init failed"):
+            await user_callable_wrapper.initialize_callable()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Refactors `UserCallableWrapper` initialization when running user code in a separate thread to use a **two-phase approach**, fixing an issue where libraries that call `loop.run_until_complete()` during `__init__` (e.g., `sglang engine`, `httpx`, database drivers) would crash with `"This event loop is already running"`.

### Why the current code breaks

Today, the user-code thread calls `loop.run_forever()` immediately on startup. By the time `initialize_callable` runs, it dispatches user `__init__` into the already-running loop via `run_coroutine_threadsafe`. Any synchronous `__init__` that tries to call `loop.run_until_complete()` — a common pattern in many Python libraries — fails because asyncio prohibits `run_until_complete` on a loop that is already running.

### How the two-phase approach fixes it

- **Phase 1 (loop set, NOT running):** The user-code thread now pauses after `set_event_loop` and waits for init work to be prepared. It then calls the sync `__init__` directly on the thread (not via `run_coroutine_threadsafe`), followed by any async post-init setup (ASGI lifespan, health checks) via `loop.run_until_complete`. Since `run_forever` has not been called yet, `run_until_complete` works normally.
- **Phase 2 (serving):** After init completes, the thread starts `run_forever()`. A `call_soon` callback resolves the init future from inside the running loop, guaranteeing the loop is fully running before any subsequent `run_coroutine_threadsafe` call.

This means user code in `__init__` has full access to `run_until_complete`, `call_soon`, etc., while all post-init request handling continues to use `run_coroutine_threadsafe` on the running loop as before.

### Before / After

<img width="569" height="686" alt="image" src="https://github.com/user-attachments/assets/51a638f0-9426-4011-aa99-f6cb6654e822" />

<img width="486" height="696" alt="image" src="https://github.com/user-attachments/assets/e0bdb6a5-f38c-4087-9df6-ad35446f72f2" />

## Test plan
- [ ] `test_sync_init_can_use_run_until_complete` — verifies `run_until_complete()` works in sync `__init__`
- [ ] `test_post_init_loop_running` — verifies event loop is running after init
- [ ] `test_background_tasks_from_init` — verifies `call_soon` tasks from init execute
- [ ] `test_init_error_propagates` — verifies init exceptions propagate correctly
- [ ] Existing `TestSeparateThread` tests continue to pass