### PR TITLE
[Data] Prevent operators from dominating entire shared object store budget with outputs

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -900,13 +900,16 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         if op not in self._op_budgets:
             return None
 
-        res = self._op_budgets[op].object_store_memory
-        # Add the remaining of `_reserved_for_op_outputs`.
+        budget_obj_store = self._op_budgets[op].object_store_memory
+        # The total output ceiling is the general budget plus the output reservation.
+        # Subtract current output usage to get how much more can be read.
         op_outputs_usage = self._resource_manager.get_mem_op_outputs(
             op, include_ineligible_downstream=True
         )
 
-        res += max(self._reserved_for_op_outputs[op] - op_outputs_usage, 0)
+        res = max(
+            budget_obj_store + self._reserved_for_op_outputs[op] - op_outputs_usage, 0
+        )
         if math.isinf(res):
             self._output_budgets[op] = res
             return None

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -96,9 +96,12 @@ def test_output_backpressure_shared_pool_leak(restore_data_context):
     # The fixed formula computes:
     #   res = max(budget(375) + reserved_for_outputs(125) - usage(5000), 0)
     #   res = max(500 - 5000, 0) = 0  <-- correctly backpressured
+    allocator._should_unblock_streaming_output_backpressure = MagicMock(
+        return_value=False
+    )
     result = allocator.max_task_output_bytes_to_read(o2)
-    assert result == 0 or result == 1, (
-        f"Expected 0 (or 1 for liveness unblock), got {result}. "
+    assert result == 0, (
+        f"Expected 0, got {result}. "
         "Shared pool budget is leaking through output backpressure."
     )
 

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -27,6 +27,82 @@ from ray.data.tests.test_resource_manager import (
 )
 
 
+@patch(
+    "ray.data._internal.execution.DEFAULT_USE_OP_RESOURCE_ALLOCATOR_VERSION",
+    new="V1",
+)
+def test_output_backpressure_shared_pool_leak(restore_data_context):
+    """Regression test: shared pool budget should not leak through output backpressure.
+
+    Previously, max_task_output_bytes_to_read used:
+        res = budget + max(reserved_for_outputs - op_outputs_usage, 0)
+
+    When op_outputs_usage far exceeds reserved_for_outputs, the max(...) term
+    becomes 0, but the shared pool budget (in `budget`) still allows reading
+    more outputs. The fix treats budget + reserved_for_outputs as a combined
+    ceiling:
+        res = max(budget + reserved_for_outputs - op_outputs_usage, 0)
+    """
+    DataContext.get_current().op_resource_reservation_enabled = True
+    DataContext.get_current().op_resource_reservation_ratio = 0.5
+
+    o1 = InputDataBuffer(DataContext.get_current(), [])
+    o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 1})
+    o3 = mock_map_op(o2, ray_remote_args={"num_cpus": 1})
+    o4 = LimitOperator(1, o3, DataContext.get_current())
+
+    for op in [o2, o3]:
+        op.min_max_resource_requirements = MagicMock(
+            return_value=(ExecutionResources.zero(), ExecutionResources.inf())
+        )
+
+    op_usages = {op: ExecutionResources.zero() for op in [o1, o2, o3, o4]}
+    op_internal_usage = dict.fromkeys([o1, o2, o3, o4], 0)
+    op_outputs_usages = dict.fromkeys([o1, o2, o3, o4], 0)
+
+    topo = build_streaming_topology(o4, ExecutionOptions())
+
+    global_limits = ExecutionResources(cpu=16, gpu=0, object_store_memory=1000)
+
+    resource_manager = ResourceManager(
+        topo, ExecutionOptions(), MagicMock(), DataContext.get_current()
+    )
+    resource_manager.get_op_usage = MagicMock(
+        side_effect=lambda op, **kwargs: op_usages[op]
+    )
+    resource_manager._mem_op_internal = op_internal_usage
+    resource_manager._mem_op_outputs = op_outputs_usages
+    resource_manager.get_global_limits = MagicMock(return_value=global_limits)
+
+    assert resource_manager.op_resource_allocator_enabled()
+    allocator = resource_manager._op_resource_allocator
+    assert isinstance(allocator, ReservationOpResourceAllocator)
+
+    # With 2 eligible ops, 50% reservation ratio:
+    #   reserved_for_outputs[o2] = 125
+    #   shared pool per op = 250
+    #   budget[o2].object_store_memory = 125 (reserved) + 250 (shared) = 375
+    allocator.update_budgets(limits=global_limits)
+    assert allocator._reserved_for_op_outputs[o2] == 125
+
+    # Now simulate o2 having massive output usage (5000 bytes) that far
+    # exceeds the reserved_for_outputs (125) AND the total budget (375 + 125 = 500).
+    op_outputs_usages[o2] = 5000
+
+    # The old formula would compute:
+    #   res = budget(375) + max(reserved_for_outputs(125) - usage(5000), 0)
+    #   res = 375 + 0 = 375  <-- shared pool leaks through!
+    #
+    # The fixed formula computes:
+    #   res = max(budget(375) + reserved_for_outputs(125) - usage(5000), 0)
+    #   res = max(500 - 5000, 0) = 0  <-- correctly backpressured
+    result = allocator.max_task_output_bytes_to_read(o2)
+    assert result == 0 or result == 1, (
+        f"Expected 0 (or 1 for liveness unblock), got {result}. "
+        "Shared pool budget is leaking through output backpressure."
+    )
+
+
 class TestReservationOpResourceAllocator:
     """Tests for ReservationOpResourceAllocator."""
 


### PR DESCRIPTION
## Description

  Previously, `max_task_output_bytes_to_read` in `ReservationOpResourceAllocator`                                                                                                          
  allowed operators to grow their output queues without an effective cap. The shared
  pool budget always leaked through to output reads, even when the operator's output
  usage far exceeded its allocation. This caused upstream operators (e.g., ReadFiles)
  to accumulate 20-30 GiB of outputs and dominate the entire object store.

  The root cause was the formula:

`max_output_bytes_to_read = budget + max(reserved_for_outputs - op_outputs_usage, 0)`

  When `op_outputs_usage` exceeds `reserved_for_outputs`, the `max(...)` term becomes 0,
  but `budget` (which is `reserved_budget + shared_pool_budget`) passes through unconditionally.
  The only way this max bytes to read could reach 0 was if the shared pool was
  completely exhausted across all operators. This is what eventually stops task outputs from
  being pulled, but at this point some operators have already dumped a massive output
  queue into the object store memory, and this unnecessarily large buffer can lead to spilling
  on certain nodes that are overloaded.
  (NOTE: Uneven object store usage on nodes is a separate problem to tackle, but this PR may address the spilling problem by actually backpressuring the object store memory usage of outputs earlier on.)

  The fix combines budget and reserved_for_outputs into a single ceiling:

  `max_output_bytes_to_read = max(budget + reserved_for_outputs - op_outputs_usage, 0)`

  This effectively caps each operator's output budget at roughly
  `total_obj_store_memory / num_eligible_ops`, preventing any single operator from
  dominating the object store with its outputs.

  ### Example: 2 eligible operators, 100 GiB object store budget

  **Reservation phase** (`reservation_ratio=0.5`):
  - Per-op `reserved_for_tasks` = 100 × 0.5 / 2 / 2 = **12.5 GiB**
  - Per-op `reserved_for_outputs` = 100 × 0.5 / 2 / 2 = **12.5 GiB**
  - Shared pool = 100 − 2 × (12.5 + 12.5) = **50 GiB**

  **Scenario**: op1 has accumulated 40 GiB of outputs, op2 is idle.

  **Budget computation for op1** (`update_budgets`):
  - Output overflow beyond reservation: `max(40 − 12.5, 0)` = **27.5 GiB**
  - Charged to general budget: `internal(0) + overflow(27.5)` = **27.5 GiB**
  - Exceeds tasks reservation by: `27.5 − 12.5` = **15 GiB** → subtracted from shared pool
  - Remaining shared pool: `50 − 15` = **35 GiB**
  - op1 shared pool share: `35 / 2` = **17.5 GiB**
  - op1 general budget: `reserved_remaining(0) + shared(17.5)` = **17.5 GiB**

  **Before** — `max_task_output_bytes_to_read(op1)`:
```python
  res = budget + max(reserved_for_outputs − outputs, 0)
      = 17.5  + max(12.5 − 40, 0)
      = 17.5  + 0
      = 17.5 GiB  # ← shared pool says that that we can add more outputs,
# even though we're over budget on outputs (by 27.5GiB).
# This keeps happening until the shared pool runs out.
```

  **After**:
```python
  res = max(budget + reserved_for_outputs − outputs, 0)
      = max(17.5 + 12.5 − 40, 0)
      = max(−10, 0)
      = 0  ← correctly backpressured
```

  The effective output ceiling per operator is `budget + reserved_for_outputs` ≈
  `total / num_ops`. Before the fix, op1 could grow its outputs indefinitely
  because the shared pool (17.5 GiB) was always available regardless of output usage.

## Testing

Testing a union workload and seeing:
* Before: Peak object store memory usage 107.3 GiB (the full budget), 40+GiB spilling on multiple nodes, throughput: really inconsistent, goes down to like 500 rows/second 
* After: Peak object store memory usage 70.4 GiB, no spilling, throughput 2.5k rows/second