### PR TITLE
[ci] Always pull base BYOD images from AWS ECR

### DIFF
--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -1,8 +1,6 @@
 release_byod:
-  ray_ecr: rayproject
   byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
   byod_ecr_region: us-west-2
-  aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
   gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
   azure_cr: rayreleasetest.azurecr.io
   aws2gce_credentials: release/aws2gce_iam.json

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -5,10 +5,8 @@ import yaml
 
 
 class GlobalConfig(TypedDict):
-    byod_ray_ecr: str
     byod_ecr: str
     byod_ecr_region: str
-    byod_aws_cr: str
     byod_gcp_cr: str
     byod_azure_cr: str
     state_machine_pr_aws_bucket: str
@@ -48,10 +46,6 @@ def _init_global_config(config_file: str):
     global config
     config_content = yaml.safe_load(open(config_file, "rt"))
     config = GlobalConfig(
-        byod_ray_ecr=(
-            config_content.get("byod", {}).get("ray_ecr")
-            or config_content.get("release_byod", {}).get("ray_ecr")
-        ),
         byod_ecr=(
             config_content.get("byod", {}).get("byod_ecr")
             or config_content.get("release_byod", {}).get("byod_ecr")
@@ -59,10 +53,6 @@ def _init_global_config(config_file: str):
         byod_ecr_region=(
             config_content.get("byod", {}).get("byod_ecr_region")
             or config_content.get("release_byod", {}).get("byod_ecr_region")
-        ),
-        byod_aws_cr=(
-            config_content.get("byod", {}).get("aws_cr")
-            or config_content.get("release_byod", {}).get("aws_cr")
         ),
         byod_gcp_cr=(
             config_content.get("byod", {}).get("gcp_cr")

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -588,7 +588,8 @@ class Test(dict):
 
     def get_anyscale_base_byod_image(self, build_id: Optional[str] = None) -> str:
         """
-        Returns the anyscale byod image to use for this test.
+        Returns the anyscale base byod image to use for this test.
+        Base images are always pulled from AWS ECR.
         """
         ray_version = self.get_ray_version()
         if ray_version:
@@ -597,8 +598,10 @@ class Test(dict):
             if tag_suffix == "gpu":
                 tag_suffix = "cu121"
             return f"{ANYSCALE_RAY_IMAGE_PREFIX}:{ray_version}-{python_version}-{tag_suffix}"
+        global_config = get_global_config()
+        base_ecr = global_config["byod_aws_cr"]
         return (
-            f"{self.get_byod_ecr()}/"
+            f"{base_ecr}/"
             f"{self.get_byod_repo()}:{self.get_byod_base_image_tag(build_id)}"
         )
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -581,9 +581,6 @@ class Test(dict):
             return global_config["byod_gcp_cr"]
         if self.is_azure():
             return global_config["byod_azure_cr"]
-        byod_ecr = global_config["byod_aws_cr"]
-        if byod_ecr:
-            return byod_ecr
         return global_config["byod_ecr"]
 
     def get_anyscale_base_byod_image(self, build_id: Optional[str] = None) -> str:
@@ -599,7 +596,7 @@ class Test(dict):
                 tag_suffix = "cu121"
             return f"{ANYSCALE_RAY_IMAGE_PREFIX}:{ray_version}-{python_version}-{tag_suffix}"
         global_config = get_global_config()
-        base_ecr = global_config["byod_aws_cr"]
+        base_ecr = global_config["byod_ecr"]
         return (
             f"{base_ecr}/"
             f"{self.get_byod_repo()}:{self.get_byod_base_image_tag(build_id)}"

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -157,24 +157,12 @@ def test_get_anyscale_base_byod_image_always_uses_aws_ecr() -> None:
             "RAYCI_BUILD_ID": "a1b2c3d4",
         },
     ):
-        aws_test = Test(name="t", env="aws", cluster={"byod": {}})
-        gce_test = Test(name="t", env="gce", cluster={"byod": {}})
-        azure_test = Test(name="t", env="azure", cluster={"byod": {}})
-        kuberay_test = Test(name="t", env="kuberay", cluster={"byod": {}})
-        gpu_test = Test(name="t", env="gce", cluster={"byod": {"type": "gpu"}})
+        expected_cpu = f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
+        for env in ("aws", "gce", "azure", "kuberay"):
+            test = Test(name="t", env=env, cluster={"byod": {}})
+            assert test.get_anyscale_base_byod_image() == expected_cpu, env
 
-        assert aws_test.get_anyscale_base_byod_image() == (
-            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
-        )
-        assert gce_test.get_anyscale_base_byod_image() == (
-            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
-        )
-        assert azure_test.get_anyscale_base_byod_image() == (
-            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
-        )
-        assert kuberay_test.get_anyscale_base_byod_image() == (
-            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
-        )
+        gpu_test = Test(name="t", env="gce", cluster={"byod": {"type": "gpu"}})
         assert gpu_test.get_anyscale_base_byod_image() == (
             f"{aws_cr}/anyscale/ray-ml:a1b2c3d4-py310-gpu"
         )

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -133,7 +133,8 @@ def test_build_anyscale_base_byod_images() -> None:
         images = build_anyscale_base_byod_images(tests)
         global_config = get_global_config()
         aws_cr = global_config["byod_aws_cr"]
-        gcp_cr = global_config["byod_gcp_cr"]
+        # Base images are always from AWS ECR (see get_anyscale_base_byod_image),
+        # so GCE and AWS CPU tests resolve to the same image (6 unique, not 7).
         assert set(images) == {
             f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu",
             f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cu116",
@@ -141,8 +142,61 @@ def test_build_anyscale_base_byod_images() -> None:
             f"{aws_cr}/anyscale/ray:a1b2c3d4-py311-cu118",
             f"{aws_cr}/anyscale/ray-ml:a1b2c3d4-py310-gpu",
             f"{aws_cr}/anyscale/ray:a1b2c3d4-py311-cpu",
-            f"{gcp_cr}/anyscale/ray:a1b2c3d4-py310-cpu",
         }
+
+
+def test_get_anyscale_base_byod_image_always_uses_aws_ecr() -> None:
+    """Base images should always come from AWS ECR, regardless of test env."""
+    global_config = get_global_config()
+    aws_cr = global_config["byod_aws_cr"]
+
+    with patch.dict(
+        "os.environ",
+        {
+            "BUILDKITE_COMMIT": "abc123",
+            "RAYCI_BUILD_ID": "a1b2c3d4",
+        },
+    ):
+        aws_test = Test(name="t", env="aws", cluster={"byod": {}})
+        gce_test = Test(name="t", env="gce", cluster={"byod": {}})
+        azure_test = Test(name="t", env="azure", cluster={"byod": {}})
+        kuberay_test = Test(name="t", env="kuberay", cluster={"byod": {}})
+        gpu_test = Test(name="t", env="gce", cluster={"byod": {"type": "gpu"}})
+
+        assert aws_test.get_anyscale_base_byod_image() == (
+            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
+        )
+        assert gce_test.get_anyscale_base_byod_image() == (
+            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
+        )
+        assert azure_test.get_anyscale_base_byod_image() == (
+            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
+        )
+        assert kuberay_test.get_anyscale_base_byod_image() == (
+            f"{aws_cr}/anyscale/ray:a1b2c3d4-py310-cpu"
+        )
+        assert gpu_test.get_anyscale_base_byod_image() == (
+            f"{aws_cr}/anyscale/ray-ml:a1b2c3d4-py310-gpu"
+        )
+
+        # When ray_version is set, base image uses anyscale/ray prefix
+        # instead of byod_aws_cr.
+        versioned_cpu_test = Test(
+            name="t",
+            env="gce",
+            cluster={"byod": {}, "ray_version": "2.50.0"},
+        )
+        versioned_gpu_test = Test(
+            name="t",
+            env="gce",
+            cluster={"byod": {"type": "gpu"}, "ray_version": "2.50.0"},
+        )
+        assert versioned_cpu_test.get_anyscale_base_byod_image() == (
+            "anyscale/ray:2.50.0-py310-cpu"
+        )
+        assert versioned_gpu_test.get_anyscale_base_byod_image() == (
+            "anyscale/ray:2.50.0-py310-cu121"
+        )
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_byod_build.py
+++ b/release/ray_release/tests/test_byod_build.py
@@ -132,7 +132,7 @@ def test_build_anyscale_base_byod_images() -> None:
         ]
         images = build_anyscale_base_byod_images(tests)
         global_config = get_global_config()
-        aws_cr = global_config["byod_aws_cr"]
+        aws_cr = global_config["byod_ecr"]
         # Base images are always from AWS ECR (see get_anyscale_base_byod_image),
         # so GCE and AWS CPU tests resolve to the same image (6 unique, not 7).
         assert set(images) == {
@@ -148,7 +148,7 @@ def test_build_anyscale_base_byod_images() -> None:
 def test_get_anyscale_base_byod_image_always_uses_aws_ecr() -> None:
     """Base images should always come from AWS ECR, regardless of test env."""
     global_config = get_global_config()
-    aws_cr = global_config["byod_aws_cr"]
+    aws_cr = global_config["byod_ecr"]
 
     with patch.dict(
         "os.environ",
@@ -168,7 +168,7 @@ def test_get_anyscale_base_byod_image_always_uses_aws_ecr() -> None:
         )
 
         # When ray_version is set, base image uses anyscale/ray prefix
-        # instead of byod_aws_cr.
+        # instead of byod_ecr.
         versioned_cpu_test = Test(
             name="t",
             env="gce",

--- a/release/ray_release/tests/test_global_config.py
+++ b/release/ray_release/tests/test_global_config.py
@@ -11,14 +11,14 @@ from ray_release.configs.global_config import (
 
 _TEST_CONFIG = """
 byod:
-  ray_ecr: rayproject
   ray_cr_repo: ray
 release_byod:
   ray_ml_cr_repo: ray-ml
   ray_llm_cr_repo: ray-llm
   byod_ecr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
-  aws_cr: 029272617770.dkr.ecr.us-west-2.amazonaws.com
+  byod_ecr_region: us-west-2
   gcp_cr: us-west1-docker.pkg.dev/anyscale-oss-ci
+  azure_cr: rayreleasetest.azurecr.io
 state_machine:
   pr:
     aws_bucket: ray-ci-pr-results
@@ -47,7 +47,6 @@ def test_init_global_config() -> None:
             f.write(_TEST_CONFIG)
         init_global_config(os.path.join(tmp, "config"))
         config = get_global_config()
-        assert config["byod_ray_ecr"] == "rayproject"
         assert config["aws2gce_credentials"] == "release/aws2gce_iam.json"
         assert config["ci_pipeline_premerge"] == ["w00t"]
         assert config["ci_pipeline_postmerge"] == ["hi", "three"]
@@ -60,6 +59,11 @@ def test_init_global_config() -> None:
         assert config["release_image_step_ray"] == "anyscalebuild"
         assert config["release_image_step_ray_ml"] == "anyscalemlbuild"
         assert config["release_image_step_ray_llm"] == "anyscalellmbuild"
+        assert config["byod_ecr"] == "029272617770.dkr.ecr.us-west-2.amazonaws.com"
+        assert config["byod_ecr_region"] == "us-west-2"
+        assert config["byod_gcp_cr"] == "us-west1-docker.pkg.dev/anyscale-oss-ci"
+        assert config["byod_azure_cr"] == "rayreleasetest.azurecr.io"
+        assert config["state_machine_branch_aws_bucket"] == "ray-ci-results"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Base images should always come from AWS ECR regardless of test environment (gce, azure, kuberay). Updated get_anyscale_base_byod_image to use byod_aws_cr from global config instead of self.get_byod_ecr(), and added unit tests to verify this behavior.

## Related issues
None

## Additional information
None
