### PR TITLE
[data] Make Union ineligible + fix per-input memory attribution in Union outqueue

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -125,6 +125,7 @@ class DataOpTask(OpTask):
         ] = lambda metadata_ref: None,
         task_resource_bundle: Optional[ExecutionResources] = None,
         operator_name: str = "Unknown",
+        operator_id: Optional[str] = None,
     ):
         """Create a DataOpTask
         Args:
@@ -140,6 +141,8 @@ class DataOpTask(OpTask):
             task_resource_bundle: The execution resources of this task.
             operator_name: The name of the physical operator that created this task.
                 Used for logging the operator name in warnings/errors.
+            operator_id: The UUID of the operator that created this task.
+                Used to stamp producer_op_id on output RefBundles.
         """
         super().__init__(task_index, task_resource_bundle)
         # TODO(hchen): Right now, the streaming generator is required to yield a Block
@@ -147,6 +150,7 @@ class DataOpTask(OpTask):
         # interface. So each individual operator don't need to take care of the
         # BlockMetadata.
         self._streaming_gen = streaming_gen
+        self._operator_id = operator_id
         self._output_ready_callback = output_ready_callback
         self._task_done_callback = task_done_callback
         self._block_ready_callback = block_ready_callback
@@ -273,6 +277,7 @@ class DataOpTask(OpTask):
                     [(self._pending_block_ref, meta)],
                     owns_blocks=True,
                     schema=meta_with_schema.schema,
+                    producer_op_id=self._operator_id,
                 ),
             )
 

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -64,6 +64,11 @@ class RefBundle:
     # output splits. It is otherwise None.
     output_split_idx: Optional[int] = None
 
+    # Tracks which input dependency this bundle originated from in multi-input
+    # operators (e.g., Union). Used for per-input memory attribution in the
+    # external output queue.
+    input_index: Optional[int] = None
+
     # Object metadata (size, locations, spilling status)
     _cached_object_meta: Optional[Dict[ObjectRef, "_ObjectMetadata"]] = None
 

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -344,7 +344,6 @@ class RefBundle:
             schema=schema,
             owns_blocks=owns_blocks,
             slices=merged_slices,
-            producer_op_id=bundles[0].producer_op_id,
         )
 
     def __eq__(self, other) -> bool:

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -64,10 +64,10 @@ class RefBundle:
     # output splits. It is otherwise None.
     output_split_idx: Optional[int] = None
 
-    # Tracks which input dependency this bundle originated from in multi-input
-    # operators (e.g., Union). Used for per-input memory attribution in the
-    # external output queue.
-    input_index: Optional[int] = None
+    # Tracks the UUID of the eligible operator that produced this bundle.
+    # Used for per-producer memory attribution in downstream ineligible
+    # operators' external output queues.
+    producer_op_id: Optional[str] = None
 
     # Object metadata (size, locations, spilling status)
     _cached_object_meta: Optional[Dict[ObjectRef, "_ObjectMetadata"]] = None
@@ -296,6 +296,7 @@ class RefBundle:
             schema=self.schema,
             owns_blocks=False,
             slices=consumed_slices if consumed_slices else None,
+            producer_op_id=self.producer_op_id,
         )
 
         remaining_bundle = RefBundle(
@@ -303,6 +304,7 @@ class RefBundle:
             schema=self.schema,
             owns_blocks=False,
             slices=remaining_slices if remaining_slices else None,
+            producer_op_id=self.producer_op_id,
         )
 
         return sliced_bundle, remaining_bundle
@@ -342,6 +344,7 @@ class RefBundle:
             schema=schema,
             owns_blocks=owns_blocks,
             slices=merged_slices,
+            producer_op_id=bundles[0].producer_op_id,
         )
 
     def __eq__(self, other) -> bool:

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -997,6 +997,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                     ExecutionResources.from_resource_dict(finalize_task_resource_bundle)
                 ),
                 operator_name=self.name,
+                operator_id=self.id,
             )
             self._finalizing_tasks[partition_id] = data_task
 

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -80,6 +80,7 @@ class LimitOperator(OneToOneOperator):
             list(zip(out_blocks, out_metadata)),
             owns_blocks=refs.owns_blocks,
             schema=refs.schema,
+            input_index=refs.input_index,
         )
         self._buffer.append(out_refs)
         self._metrics.on_output_queued(out_refs)

--- a/python/ray/data/_internal/execution/operators/limit_operator.py
+++ b/python/ray/data/_internal/execution/operators/limit_operator.py
@@ -80,7 +80,7 @@ class LimitOperator(OneToOneOperator):
             list(zip(out_blocks, out_metadata)),
             owns_blocks=refs.owns_blocks,
             schema=refs.schema,
-            input_index=refs.input_index,
+            producer_op_id=refs.producer_op_id,
         )
         self._buffer.append(out_refs)
         self._metrics.on_output_queued(out_refs)

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -611,6 +611,7 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
             lambda output: _output_ready_callback(task_index, output),
             functools.partial(_task_done_callback, task_index),
             operator_name=self.name,
+            operator_id=self.id,
         )
         self._metrics.on_task_submitted(
             task_index, inputs, task_id=data_task.get_task_id()

--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -368,11 +368,13 @@ def _split(bundle: RefBundle, left_size: int) -> Tuple[RefBundle, RefBundle]:
         list(zip(left_blocks, left_meta)),
         owns_blocks=bundle.owns_blocks,
         schema=bundle.schema,
+        producer_op_id=bundle.producer_op_id,
     )
     right = RefBundle(
         list(zip(right_blocks, right_meta)),
         owns_blocks=bundle.owns_blocks,
         schema=bundle.schema,
+        producer_op_id=bundle.producer_op_id,
     )
     assert left.num_rows() == left_size
     assert left.num_rows() + right.num_rows() == bundle.num_rows()

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -46,6 +46,9 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
         self._current_input_index = 0
         super().__init__(data_context, *input_ops)
 
+    def throttling_disabled(self) -> bool:
+        return True
+
     def start(self, options: ExecutionOptions):
         # Whether to preserve deterministic ordering of output blocks.
         # When True, blocks are emitted in round-robin order across inputs,
@@ -99,6 +102,7 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert not self.has_completed()
         assert 0 <= input_index <= len(self._input_dependencies), input_index
+        refs.input_index = input_index
         if self._preserve_order:
             self._input_buffers[input_index].add(refs)
             self._metrics.on_input_queued(refs, input_index=input_index)

--- a/python/ray/data/_internal/execution/operators/union_operator.py
+++ b/python/ray/data/_internal/execution/operators/union_operator.py
@@ -102,7 +102,6 @@ class UnionOperator(InternalQueueOperatorMixin, NAryOperator):
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert not self.has_completed()
         assert 0 <= input_index <= len(self._input_dependencies), input_index
-        refs.input_index = input_index
         if self._preserve_order:
             self._input_buffers[input_index].add(refs)
             self._metrics.on_input_queued(refs, input_index=input_index)

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -3,7 +3,6 @@ import math
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from functools import reduce
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional
 
 from ray._common.utils import env_bool, env_float
@@ -318,11 +317,44 @@ class ResourceManager:
     def _get_downstream_ineligible_ops_usage(
         self, op: PhysicalOperator
     ) -> ExecutionResources:
-        return reduce(
-            lambda x, y: x.add(y),
-            [self.get_op_usage(op) for op in self._get_downstream_ineligible_ops(op)],
-            ExecutionResources.zero(),
-        )
+        """Get the total resource usage of downstream ineligible operators,
+        attributed to the given upstream operator.
+
+        For multi-input ineligible operators (e.g., Union), only the portion
+        of the external output queue originating from `op` is attributed,
+        rather than the full output queue.
+        """
+        total = ExecutionResources.zero()
+        for next_op in op.output_dependencies:
+            if not self.is_op_eligible(next_op):
+                usage = self._get_ineligible_op_usage_for_input(next_op, op)
+                total = total.add(usage)
+                # Continue down the ineligible chain.
+                total = total.add(self._get_downstream_ineligible_ops_usage(next_op))
+        return total
+
+    def _get_ineligible_op_usage_for_input(
+        self,
+        ineligible_op: PhysicalOperator,
+        upstream_op: PhysicalOperator,
+    ) -> ExecutionResources:
+        """Get the resource usage of an ineligible op attributed to a specific
+        upstream input.
+
+        For multi-input operators, adjusts the object store memory to only
+        include the portion of the external output queue from `upstream_op`.
+        """
+        usage = self.get_op_usage(ineligible_op)
+        if len(ineligible_op.input_dependencies) > 1:
+            input_idx = ineligible_op.input_dependencies.index(upstream_op)
+            state = self._topology[ineligible_op]
+            total_ext_outqueue = state.output_queue_bytes()
+            per_input_ext_outqueue = state.output_queue_bytes(input_index=input_idx)
+            adjustment = per_input_ext_outqueue - total_ext_outqueue
+            usage = usage.copy(
+                object_store_memory=max(0, usage.object_store_memory + adjustment)
+            )
+        return usage
 
     def get_mem_op_internal(self, op: PhysicalOperator) -> int:
         """Return the memory usage of pending task outputs for the given operator."""

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -315,41 +315,72 @@ class ResourceManager:
         return own_usage.add(self._get_downstream_ineligible_ops_usage(op))
 
     def _get_downstream_ineligible_ops_usage(
-        self, op: PhysicalOperator
+        self, op: PhysicalOperator, input_index: Optional[int] = None
     ) -> ExecutionResources:
         """Get the total resource usage of downstream ineligible operators,
         attributed to the given upstream operator.
 
         For multi-input ineligible operators (e.g., Union), only the portion
         of the external output queue originating from `op` is attributed,
-        rather than the full output queue.
+        rather than the full output queue. The `input_index` is propagated
+        through the ineligible chain so that downstream single-input operators
+        (e.g., Limit after Union) also attribute only the correct portion.
+
+        Args:
+            op: The operator whose downstream ineligible usage to compute.
+            input_index: If set, only attribute output queue bytes with this
+                input_index tag. This is set when traversing past a multi-input
+                operator (e.g., Union) and propagated to downstream ops.
+
+        Returns:
+            The total resource usage attributed to `op` from downstream
+            ineligible operators.
         """
         total = ExecutionResources.zero()
         for next_op in op.output_dependencies:
             if not self.is_op_eligible(next_op):
-                usage = self._get_ineligible_op_usage_for_input(next_op, op)
-                total = total.add(usage)
-                # Continue down the ineligible chain.
-                total = total.add(self._get_downstream_ineligible_ops_usage(next_op))
+                if len(next_op.input_dependencies) > 1:
+                    # Multi-input op (e.g., Union): determine the input_index
+                    # for this upstream op, and use it for attribution.
+                    idx = next_op.input_dependencies.index(op)
+                    usage = self._get_ineligible_op_usage(next_op, input_index=idx)
+                    total = total.add(usage)
+                    # Propagate this input_index downstream.
+                    total = total.add(
+                        self._get_downstream_ineligible_ops_usage(
+                            next_op, input_index=idx
+                        )
+                    )
+                else:
+                    # Single-input op: propagate the existing input_index tag.
+                    usage = self._get_ineligible_op_usage(
+                        next_op, input_index=input_index
+                    )
+                    total = total.add(usage)
+                    total = total.add(
+                        self._get_downstream_ineligible_ops_usage(
+                            next_op, input_index=input_index
+                        )
+                    )
         return total
 
-    def _get_ineligible_op_usage_for_input(
+    def _get_ineligible_op_usage(
         self,
         ineligible_op: PhysicalOperator,
-        upstream_op: PhysicalOperator,
+        input_index: Optional[int] = None,
     ) -> ExecutionResources:
-        """Get the resource usage of an ineligible op attributed to a specific
-        upstream input.
+        """Get the resource usage of an ineligible op, optionally filtered
+        by input_index for per-input memory attribution.
 
-        For multi-input operators, adjusts the object store memory to only
-        include the portion of the external output queue from `upstream_op`.
+        When `input_index` is set, the object store memory is adjusted to
+        only include the portion of the external output queue tagged with
+        that input_index, rather than the full output queue.
         """
         usage = self.get_op_usage(ineligible_op)
-        if len(ineligible_op.input_dependencies) > 1:
-            input_idx = ineligible_op.input_dependencies.index(upstream_op)
+        if input_index is not None:
             state = self._topology[ineligible_op]
             total_ext_outqueue = state.output_queue_bytes()
-            per_input_ext_outqueue = state.output_queue_bytes(input_index=input_idx)
+            per_input_ext_outqueue = state.output_queue_bytes(input_index=input_index)
             adjustment = per_input_ext_outqueue - total_ext_outqueue
             usage = usage.copy(
                 object_store_memory=max(0, usage.object_store_memory + adjustment)

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -395,10 +395,15 @@ class ResourceManager:
             verbose = LOG_DEBUG_TELEMETRY_FOR_RESOURCE_MANAGER_OVERRIDE
 
         if verbose:
+            own_out = self.get_mem_op_outputs(op)
+            total_out = self.get_mem_op_outputs(op, include_ineligible_downstream=True)
             usage_str += (
                 f" (in={memory_string(self.get_mem_op_internal(op))},"
-                f"out={memory_string(self.get_mem_op_outputs(op))})"
+                f"out={memory_string(own_out)}"
             )
+            if total_out != own_out:
+                usage_str += f",out+downstream={memory_string(total_out)}"
+            usage_str += ")"
             if self._op_resource_allocator is not None:
                 allocation = self._op_resource_allocator.get_allocation(op)
                 if allocation:
@@ -932,13 +937,16 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         if op not in self._op_budgets:
             return None
 
-        res = self._op_budgets[op].object_store_memory
-        # Add the remaining of `_reserved_for_op_outputs`.
+        budget_obj_store = self._op_budgets[op].object_store_memory
+        # The total output ceiling is the general budget plus the output reservation.
+        # Subtract current output usage to get how much more can be read.
         op_outputs_usage = self._resource_manager.get_mem_op_outputs(
             op, include_ineligible_downstream=True
         )
 
-        res += max(self._reserved_for_op_outputs[op] - op_outputs_usage, 0)
+        res = max(
+            budget_obj_store + self._reserved_for_op_outputs[op] - op_outputs_usage, 0
+        )
         if math.isinf(res):
             self._output_budgets[op] = res
             return None

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -312,25 +312,28 @@ class ResourceManager:
         if not include_ineligible_downstream:
             return own_usage
 
-        return own_usage.add(self._get_downstream_ineligible_ops_usage(op))
+        return own_usage.add(
+            self._get_downstream_ineligible_ops_usage(op, producer_op_id=op.id)
+        )
 
     def _get_downstream_ineligible_ops_usage(
-        self, op: PhysicalOperator, input_index: Optional[int] = None
+        self,
+        op: PhysicalOperator,
+        producer_op_id: str,
     ) -> ExecutionResources:
         """Get the total resource usage of downstream ineligible operators,
         attributed to the given upstream operator.
 
-        For multi-input ineligible operators (e.g., Union), only the portion
-        of the external output queue originating from `op` is attributed,
-        rather than the full output queue. The `input_index` is propagated
-        through the ineligible chain so that downstream single-input operators
-        (e.g., Limit after Union) also attribute only the correct portion.
+        Uses `producer_op_id` stamped on each RefBundle to attribute only
+        the portion of each downstream ineligible operator's output queue
+        that originated from the eligible producer. This is necessary for
+        operators that mix multiple producers' data in their output queue,
+        such as Union.
 
         Args:
             op: The operator whose downstream ineligible usage to compute.
-            input_index: If set, only attribute output queue bytes with this
-                input_index tag. This is set when traversing past a multi-input
-                operator (e.g., Union) and propagated to downstream ops.
+            producer_op_id: The UUID of the eligible operator to filter by.
+                Carried through the ineligible chain unchanged.
 
         Returns:
             The total resource usage attributed to `op` from downstream
@@ -339,53 +342,34 @@ class ResourceManager:
         total = ExecutionResources.zero()
         for next_op in op.output_dependencies:
             if not self.is_op_eligible(next_op):
-                if len(next_op.input_dependencies) > 1:
-                    # Multi-input op (e.g., Union): determine the input_index
-                    # for this upstream op, and use it for attribution.
-                    idx = next_op.input_dependencies.index(op)
-                    usage = self._get_ineligible_op_usage(next_op, input_index=idx)
-                    total = total.add(usage)
-                    # Propagate this input_index downstream.
-                    total = total.add(
-                        self._get_downstream_ineligible_ops_usage(
-                            next_op, input_index=idx
-                        )
+                usage = self._get_ineligible_op_usage(
+                    next_op, producer_op_id=producer_op_id
+                )
+                total = total.add(usage)
+                total = total.add(
+                    self._get_downstream_ineligible_ops_usage(
+                        next_op, producer_op_id=producer_op_id
                     )
-                else:
-                    # Single-input op: propagate the existing input_index tag.
-                    usage = self._get_ineligible_op_usage(
-                        next_op, input_index=input_index
-                    )
-                    total = total.add(usage)
-                    total = total.add(
-                        self._get_downstream_ineligible_ops_usage(
-                            next_op, input_index=input_index
-                        )
-                    )
+                )
         return total
 
     def _get_ineligible_op_usage(
         self,
         ineligible_op: PhysicalOperator,
-        input_index: Optional[int] = None,
+        producer_op_id: str,
     ) -> ExecutionResources:
-        """Get the resource usage of an ineligible op, optionally filtered
-        by input_index for per-input memory attribution.
-
-        When `input_index` is set, the object store memory is adjusted to
-        only include the portion of the external output queue tagged with
-        that input_index, rather than the full output queue.
+        """Get the resource usage of an ineligible op, with its external output
+        queue memory filtered to only the portion from `producer_op_id`.
         """
         usage = self.get_op_usage(ineligible_op)
-        if input_index is not None:
-            state = self._topology[ineligible_op]
-            total_ext_outqueue = state.output_queue_bytes()
-            per_input_ext_outqueue = state.output_queue_bytes(input_index=input_index)
-            adjustment = per_input_ext_outqueue - total_ext_outqueue
-            usage = usage.copy(
-                object_store_memory=max(0, usage.object_store_memory + adjustment)
-            )
-        return usage
+        state = self._topology[ineligible_op]
+        total_ext_outqueue = state.output_queue_bytes()
+        producer_ext_outqueue = state.output_queue_bytes(producer_op_id=producer_op_id)
+        attributed_memory = (
+            usage.object_store_memory - total_ext_outqueue + producer_ext_outqueue
+        )
+        assert attributed_memory >= 0
+        return usage.copy(object_store_memory=attributed_memory)
 
     def get_mem_op_internal(self, op: PhysicalOperator) -> int:
         """Return the memory usage of pending task outputs for the given operator."""

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -390,7 +390,9 @@ class ResourceManager:
         # Also account the downstream ineligible operators' memory usage.
         return (
             op_outputs_usage
-            + self._get_downstream_ineligible_ops_usage(op).object_store_memory
+            + self._get_downstream_ineligible_ops_usage(
+                op, producer_op_id=op.id
+            ).object_store_memory
         )
 
     def get_op_usage_str(self, op: PhysicalOperator, *, verbose: bool) -> str:

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -60,6 +60,8 @@ class OpBufferQueue:
         self._lock = threading.Lock()
         # Used to buffer output RefBundles indexed by output splits.
         self._outputs_by_split = defaultdict(create_bundle_queue)
+        # Per-input-index memory tracking for multi-input operators (e.g., Union).
+        self._memory_per_input_index: defaultdict = defaultdict(int)
         super().__init__()
 
     @property
@@ -105,6 +107,8 @@ class OpBufferQueue:
             self._num_blocks += len(ref.blocks)
             if ref.output_split_idx is not None:
                 self._num_per_split[ref.output_split_idx] += 1
+            if ref.input_index is not None:
+                self._memory_per_input_index[ref.input_index] += ref.size_bytes()
 
     def pop(self, output_split_idx: Optional[int] = None) -> Optional[RefBundle]:
         """Pop a RefBundle from the queue.
@@ -145,13 +149,21 @@ class OpBufferQueue:
             self._num_blocks -= len(ret.blocks)
             if ret.output_split_idx is not None:
                 self._num_per_split[ret.output_split_idx] -= 1
+            if ret.input_index is not None:
+                self._memory_per_input_index[ret.input_index] -= ret.size_bytes()
         return ret
+
+    def memory_usage_for_input(self, input_index: int) -> int:
+        """Return the memory usage of bundles from a specific input index."""
+        with self._lock:
+            return self._memory_per_input_index.get(input_index, 0)
 
     def clear(self):
         with self._lock:
             self._queue.clear()
             self._num_blocks = 0
             self._num_per_split.clear()
+            self._memory_per_input_index.clear()
 
 
 @dataclass
@@ -353,8 +365,19 @@ class OpState:
                 total += inq.memory_usage
         return total
 
-    def output_queue_bytes(self) -> int:
-        """Return the object store memory of this operator's outqueue."""
+    def output_queue_bytes(self, input_index: Optional[int] = None) -> int:
+        """Return the object store memory of this operator's outqueue.
+
+        Args:
+            input_index: If specified, only return bytes attributable to the
+                given input dependency index. Used for per-input memory
+                attribution in multi-input operators like Union.
+
+        Returns:
+            The object store memory usage in bytes.
+        """
+        if input_index is not None:
+            return self.output_queue.memory_usage_for_input(input_index)
         return self.output_queue.memory_usage
 
     def mark_finished(self, exception: Optional[Exception] = None):

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -60,8 +60,8 @@ class OpBufferQueue:
         self._lock = threading.Lock()
         # Used to buffer output RefBundles indexed by output splits.
         self._outputs_by_split = defaultdict(create_bundle_queue)
-        # Per-input-index memory tracking for multi-input operators (e.g., Union).
-        self._memory_per_input_index: defaultdict = defaultdict(int)
+        # Per-producer memory tracking for attribution in downstream ineligible ops.
+        self._memory_per_producer: Dict[str, int] = defaultdict(int)
         super().__init__()
 
     @property
@@ -107,8 +107,8 @@ class OpBufferQueue:
             self._num_blocks += len(ref.blocks)
             if ref.output_split_idx is not None:
                 self._num_per_split[ref.output_split_idx] += 1
-            if ref.input_index is not None:
-                self._memory_per_input_index[ref.input_index] += ref.size_bytes()
+            if ref.producer_op_id is not None:
+                self._memory_per_producer[ref.producer_op_id] += ref.size_bytes()
 
     def pop(self, output_split_idx: Optional[int] = None) -> Optional[RefBundle]:
         """Pop a RefBundle from the queue.
@@ -149,21 +149,21 @@ class OpBufferQueue:
             self._num_blocks -= len(ret.blocks)
             if ret.output_split_idx is not None:
                 self._num_per_split[ret.output_split_idx] -= 1
-            if ret.input_index is not None:
-                self._memory_per_input_index[ret.input_index] -= ret.size_bytes()
+            if ret.producer_op_id is not None:
+                self._memory_per_producer[ret.producer_op_id] -= ret.size_bytes()
         return ret
 
-    def memory_usage_for_input(self, input_index: int) -> int:
-        """Return the memory usage of bundles from a specific input index."""
+    def memory_usage_for_producer(self, producer_op_id: str) -> int:
+        """Return the memory usage of bundles from a specific producer operator."""
         with self._lock:
-            return self._memory_per_input_index.get(input_index, 0)
+            return self._memory_per_producer.get(producer_op_id, 0)
 
     def clear(self):
         with self._lock:
             self._queue.clear()
             self._num_blocks = 0
             self._num_per_split.clear()
-            self._memory_per_input_index.clear()
+            self._memory_per_producer.clear()
 
 
 @dataclass
@@ -365,19 +365,19 @@ class OpState:
                 total += inq.memory_usage
         return total
 
-    def output_queue_bytes(self, input_index: Optional[int] = None) -> int:
+    def output_queue_bytes(self, producer_op_id: Optional[str] = None) -> int:
         """Return the object store memory of this operator's outqueue.
 
         Args:
-            input_index: If specified, only return bytes attributable to the
-                given input dependency index. Used for per-input memory
-                attribution in multi-input operators like Union.
+            producer_op_id: If specified, only return bytes attributable to
+                the given producer operator UUID. Used for per-producer memory
+                attribution in downstream ineligible operators.
 
         Returns:
             The object store memory usage in bytes.
         """
-        if input_index is not None:
-            return self.output_queue.memory_usage_for_input(input_index)
+        if producer_op_id is not None:
+            return self.output_queue.memory_usage_for_producer(producer_op_id)
         return self.output_queue.memory_usage
 
     def mark_finished(self, exception: Optional[Exception] = None):
@@ -853,6 +853,7 @@ def dedupe_schemas_with_validation(
             schema=old_schema,
             owns_blocks=bundle.owns_blocks,
             output_split_idx=bundle.output_split_idx,
+            producer_op_id=bundle.producer_op_id,
             _cached_object_meta=bundle._cached_object_meta,
             _cached_preferred_locations=bundle._cached_preferred_locations,
         ),

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -1,12 +1,15 @@
 import gc
 from typing import List
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
 import ray
+from ray.data._internal.execution import create_resource_allocator
 from ray.data._internal.execution.interfaces import (
     ExecutionOptions,
+    ExecutionResources,
     RefBundle,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
@@ -14,6 +17,11 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.union_operator import UnionOperator
+from ray.data._internal.execution.resource_manager import ResourceManager
+from ray.data._internal.execution.streaming_executor_state import (
+    build_streaming_topology,
+)
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.progress.base_progress import NoopSubProgressBar
 from ray.data.block import BlockAccessor
@@ -215,6 +223,40 @@ def test_input_data_buffer_does_not_free_inputs():
     # `InputDataBuffer` should still hold a reference to the input block even after
     # `get_next` is called.
     assert len(gc.get_referrers(block_ref)) > 0
+
+
+def test_union_operator_throttling_disabled(ray_start_regular_shared):
+    """Test that UnionOperator has throttling disabled.
+
+    UnionOperator only manipulates bundle metadata and doesn't launch any tasks,
+    so it should not be allocated resources.
+    """
+    ctx = DataContext.get_current()
+    union_op = UnionOperator(ctx)
+
+    # Verify that throttling_disabled() returns True
+    assert union_op.throttling_disabled() is True
+
+
+def test_union_operator_not_allocated_resources(
+    ray_start_regular_shared, restore_data_context
+):
+    ctx = DataContext.get_current()
+    ctx.op_resource_reservation_enabled = True
+    input_op1 = InputDataBuffer(ctx, make_ref_bundles([[1, 2, 3]]))
+    input_op2 = InputDataBuffer(ctx, make_ref_bundles([[4, 5, 6]]))
+    union_op = UnionOperator(ctx, input_op1, input_op2)
+
+    topo = build_streaming_topology(union_op, ExecutionOptions())
+    resource_manager = ResourceManager(topo, ExecutionOptions(), MagicMock(), ctx)
+    allocator = create_resource_allocator(resource_manager, ctx)
+    assert allocator is not None
+
+    allocator.update_budgets(
+        limits=ExecutionResources(cpu=1, gpu=0, object_store_memory=1000)
+    )
+    allocation = allocator.get_allocation(union_op)
+    assert allocation is None
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -1126,69 +1126,70 @@ class TestReservationOpResourceAllocator:
         resource_manager._update_allocated_budgets()
 
         """
+        UnionOperator (o6) has throttling disabled, so only o8 gets budget allocation.
         global_limits (20 CPU, 2000 mem) - o2 usage (2 CPU, 150 mem) - o3 usage (2 CPU, 50 mem) - o5 usage (3 CPU, 100 mem) - o7 usage (1 CPU, 100 mem) = remaining (12 CPU, 1600 mem)
         +-----+------------------+------------------+--------------+
         |     | _op_reserved     | _reserved_for    | used shared  |
         |     | (used/remaining) | _op_outputs      | resources    |
         |     |                  | (used/remaining) |              |
         +-----+------------------+------------------+--------------+
-        | op6 | 0/200            | 0/200            | 0            |
-        +-----+------------------+------------------+--------------+
-        | op8 | 0/200            | 0/200            | 0            |
+        | op8 | 0/400            | 0/400            | 0            |
         +-----+------------------+------------------+--------------+
         """
         allocator = resource_manager._op_resource_allocator
 
-        assert set(allocator._op_budgets.keys()) == {o6, o8}
-        assert set(allocator._op_reserved.keys()) == {o6, o8}
-        assert allocator._op_reserved[o6] == ExecutionResources(
-            cpu=3, object_store_memory=200
-        )
+        # Verify o6 (UnionOperator) is not in eligible ops due to throttling disabled
+        eligible_ops = set(resource_manager.get_eligible_ops())
+        assert o6 not in eligible_ops
+        assert o8 in eligible_ops
+
+        # Only o8 (JoinOperator) gets budget allocation since o6 (UnionOperator) has throttling disabled
+        assert set(allocator._op_budgets.keys()) == {o8}
+        assert set(allocator._op_reserved.keys()) == {o8}
         assert allocator._op_reserved[o8] == ExecutionResources(
-            cpu=3, object_store_memory=200
+            cpu=6, object_store_memory=400
         )
-        assert allocator._reserved_for_op_outputs[o6] == 200
-        assert allocator._reserved_for_op_outputs[o8] == 200
+        assert allocator._reserved_for_op_outputs[o8] == 400
         assert allocator._total_shared == ExecutionResources(
             cpu=6, object_store_memory=800
         )
-        assert allocator._op_budgets[o6] == ExecutionResources(
-            cpu=6, object_store_memory=600
-        )
         # object_store_memory budget is unlimited, since join is a materializing
-        # operator
+        # operator. CPU budget gets all remaining 12 CPU.
         assert allocator._op_budgets[o8] == ExecutionResources(
-            cpu=6, object_store_memory=float("inf")
+            cpu=12, object_store_memory=float("inf")
         )
 
         # Test when resources are used.
-        op_usages[o6] = ExecutionResources(2, 0, 500)
-        op_internal_usage[o6] = 300
-        op_outputs_usages[o6] = 200
+        op_usages[o6] = ExecutionResources.zero()
+        op_internal_usage[o6] = 0
+        op_outputs_usages[o6] = 0
         op_usages[o8] = ExecutionResources(2, 0, 100)
         op_internal_usage[o8] = 50
         op_outputs_usages[o8] = 50
+
         """
+        global_limits (20 CPU, 2000 mem) - o2 usage (2 CPU, 150 mem) - o3 usage (2 CPU, 50 mem) - o5 usage (3 CPU, 100 mem) - o7 usage (1 CPU, 100 mem) = remaining (12 CPU, 1600 mem)
         +-----+------------------+------------------+--------------+
         |     | _op_reserved     | _reserved_for    | used shared  |
         |     | (used/remaining) | _op_outputs      | resources    |
         |     |                  | (used/remaining) |              |
         +-----+------------------+------------------+--------------+
-        | op6 | 200/0            | 200/0            | 100          |
-        +-----+------------------+------------------+--------------+
-        | op8 | 50/150           | 50/150           | 0            |
+        | op8 | 50/350           | 50/350           | 0            |
         +-----+------------------+------------------+--------------+
         """
-
         resource_manager._update_allocated_budgets()
 
-        assert allocator._op_budgets[o6] == ExecutionResources(
-            cpu=4, object_store_memory=350
+        assert allocator._op_reserved[o8] == ExecutionResources(
+            cpu=6, object_store_memory=400
+        )
+        assert allocator._reserved_for_op_outputs[o8] == 400
+        assert allocator._total_shared == ExecutionResources(
+            cpu=6, object_store_memory=800
         )
         # object_store_memory budget is unlimited, since join is a materializing
-        # operator
+        # operator. CPU budget = 12 - 2 (o8 internal) = 10
         assert allocator._op_budgets[o8] == ExecutionResources(
-            cpu=4, object_store_memory=float("inf")
+            cpu=10, object_store_memory=float("inf")
         )
 
         # Test when completed ops update the usage.
@@ -1203,32 +1204,22 @@ class TestReservationOpResourceAllocator:
         |     | (used/remaining) | _op_outputs      | resources    |
         |     |                  | (used/remaining) |              |
         +-----+------------------+------------------+--------------+
-        | op6 | 213/0            | 200/13           | 300-213=87   |
-        +-----+------------------+------------------+--------------+
-        | op8 | 50/163           | 50/163           | 0            |
+        | op8 | 50/375           | 50/375           | 0            |
         +-----+------------------+------------------+--------------+
         """
-        assert set(allocator._op_budgets.keys()) == {o6, o8}
-        assert set(allocator._op_reserved.keys()) == {o6, o8}
-        assert allocator._op_reserved[o6] == ExecutionResources(
-            cpu=3.75, object_store_memory=213
-        )
+        assert set(allocator._op_budgets.keys()) == {o8}
+        assert set(allocator._op_reserved.keys()) == {o8}
         assert allocator._op_reserved[o8] == ExecutionResources(
-            cpu=3.75, object_store_memory=213
+            cpu=7.5, object_store_memory=425
         )
-        assert allocator._reserved_for_op_outputs[o6] == 212
-        assert allocator._reserved_for_op_outputs[o8] == 212
+        assert allocator._reserved_for_op_outputs[o8] == 425
         assert allocator._total_shared == ExecutionResources(
             cpu=7.5, object_store_memory=850
         )
-        # object_store_memory budget = 0 + (850 - 87) / 2 = 381 (rounded down)
-        assert allocator._op_budgets[o6] == ExecutionResources(
-            cpu=5.5, object_store_memory=381
-        )
         # object_store_memory budget is unlimited, since join is a materializing
-        # operator
+        # operator. CPU budget = 15 - 2 (o8 internal) = 13
         assert allocator._op_budgets[o8] == ExecutionResources(
-            cpu=5.5, object_store_memory=float("inf")
+            cpu=13, object_store_memory=float("inf")
         )
 
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1227,6 +1227,24 @@ class TestDataOpTask:
         task_default = DataOpTask(1, streaming_gen2)
         assert task_default._operator_name == "Unknown"
 
+    def test_on_data_ready_stamps_producer_op_id(self, ray_start_regular_shared):
+        streaming_gen = create_stub_streaming_gen(block_nbytes=[128])
+        output_bundles = []
+
+        data_op_task = DataOpTask(
+            0,
+            streaming_gen,
+            output_ready_callback=lambda bundle: output_bundles.append(bundle),
+            operator_id="test-operator-uuid",
+        )
+
+        while not data_op_task.has_finished:
+            ray.wait([streaming_gen], fetch_local=False)
+            data_op_task.on_data_ready(None)
+
+        assert len(output_bundles) == 1
+        assert output_bundles[0].producer_op_id == "test-operator-uuid"
+
     @pytest.mark.parametrize(
         "preempt_on", ["block_ready_callback", "metadata_ready_callback"]
     )

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -6,6 +6,7 @@ from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionOptions,
     ExecutionResources,
 )
+from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.resource_manager import (
     ResourceManager,
@@ -55,9 +56,9 @@ def test_physical_apply_transform_rewires_when_current_node_is_replaced():
     root = PhysicalOperator("root", [left_input, right_input], ctx)
 
     transformed_root = root._apply_transform(
-        lambda op: PhysicalOperator("replacement", [left_input], ctx)
-        if op is root
-        else op
+        lambda op: (
+            PhysicalOperator("replacement", [left_input], ctx) if op is root else op
+        )
     )
 
     assert transformed_root is not root
@@ -154,7 +155,7 @@ def test_does_not_double_count_usage_from_union():
     assert total_object_store_memory == 2, total_object_store_memory
 
 
-def test_per_input_inqueue_attribution_for_union():
+def test_union_memory_attribution_internal_inqueue():
     """Test that per-input attribution correctly charges each upstream operator
     only for the blocks it produced in the union's internal input queue.
 
@@ -211,7 +212,7 @@ def test_per_input_inqueue_attribution_for_union():
     assert input2_usage == 20
 
 
-def test_union_ext_outqueue_per_input_attribution():
+def test_union_memory_attribution_outqueue():
     """Test that Union's external output queue memory is attributed per-input
     to upstream operators, avoiding double-counting.
 
@@ -219,6 +220,8 @@ def test_union_ext_outqueue_per_input_attribution():
     into upstream operators via _get_downstream_ineligible_ops_usage. With
     per-input tracking on RefBundle.input_index, each upstream only gets
     charged for the bytes it contributed to Union's ext output queue.
+
+    Regression test for https://github.com/ray-project/ray/pull/61040.
     """
     # Topology:
     #   input1 ───┐
@@ -267,6 +270,86 @@ def test_union_ext_outqueue_per_input_attribution():
     # Total should be 40, not 80 (which would happen with double-counting).
     total = input1_usage + input2_usage
     assert total == 40, f"Expected 40, got {total}"
+
+
+def test_union_memory_attribution_through_limit():
+    """Test that input_index survives through other ineligible operators (e.g., Limit)
+    so that per-input memory attribution works for longer ineligible chains.
+
+    Topology:
+        input1 ─▶ limit1 ───┐
+                             ├─▶ union_op ──▶ limit_out
+        input2 ─▶ limit2 ───┘
+
+    Simulates a steady-state snapshot where bundles accumulate at multiple
+    queues of operators simultaneously, matching real execution behavior.
+    """
+    input1 = PhysicalOperator("op1", [], DataContext.get_current())
+    limit1 = LimitOperator(100, input1, DataContext.get_current())
+    input2 = PhysicalOperator("op2", [], DataContext.get_current())
+    limit2 = LimitOperator(100, input2, DataContext.get_current())
+    union_op = UnionOperator(DataContext.get_current(), limit1, limit2)
+    limit_out = LimitOperator(100, union_op, DataContext.get_current())
+    topology = build_streaming_topology(limit_out, ExecutionOptions())
+
+    total_resources = ExecutionResources(cpu=0, object_store_memory=1000)
+    resource_manager = ResourceManager(
+        topology, ExecutionOptions(), lambda: total_resources, DataContext.get_current()
+    )
+
+    def make_bundle(ref_byte, size_bytes, input_index=None):
+        block_ref = ray.ObjectRef(ref_byte * 28)
+        meta = BlockMetadata(
+            num_rows=1, size_bytes=size_bytes, input_files=None, exec_stats=None
+        )
+        return RefBundle(
+            [(block_ref, meta)],
+            owns_blocks=True,
+            schema=None,
+            input_index=input_index,
+        )
+
+    def get_attributed_usage(op):
+        return resource_manager.get_op_usage(
+            op, include_ineligible_downstream=True
+        ).object_store_memory
+
+    # Place bundles at different points in the ineligible chain,
+    # simulating a steady-state snapshot:
+    #
+    # limit1 outqueue:    [B_a(10MB)]           ← from input1, not yet tagged
+    # union_op outqueue:  [B_b(10MB, idx=0)]    ← from input1, tagged by Union
+    # limit_out outqueue: [B_c(30MB, idx=1)]    ← from input2, tag survived Limit
+
+    # Bundle waiting in limit1's outqueue (pre-Union, no input_index yet).
+    topology[limit1].add_output(make_bundle(b"a", 10))
+    # Bundle in Union's outqueue, tagged as input_index=0 (from limit1/input1).
+    topology[union_op].add_output(make_bundle(b"b", 10, input_index=0))
+    # Feed a tagged bundle through limit_out via _add_input_inner to test that
+    # LimitOperator propagates input_index onto the new RefBundle it creates.
+    # This ends up in limit_out's internal buffer, then drain to its outqueue.
+    limit_out._add_input_inner(make_bundle(b"c", 30, input_index=1), input_index=0)
+    while limit_out.has_next():
+        topology[limit_out].add_output(limit_out.get_next())
+
+    resource_manager.update_usages()
+
+    # input1 should be charged for:
+    #   - B_a in limit1 outqueue (10MB) — full attribution, single-input op
+    #   - B_b in union_op outqueue (10MB) — per-input attribution, input_index=0
+    #   - nothing in limit_out — no bundles with input_index=0 there
+    # Total for input1: 20MB
+    assert get_attributed_usage(input1) == 20, get_attributed_usage(input1)
+
+    # input2 should be charged for:
+    #   - nothing in limit2 outqueue
+    #   - nothing in union_op outqueue — no bundles with input_index=1 there
+    #   - B_c in limit_out outqueue (30MB) — per-input attribution, input_index=1
+    # Total for input2: 30MB
+    assert get_attributed_usage(input2) == 30, get_attributed_usage(input2)
+
+    total = get_attributed_usage(input1) + get_attributed_usage(input2)
+    assert total == 50, f"Expected 50, got {total}"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -111,50 +111,6 @@ def test_physical_apply_transform_rejects_in_place_input_mutation():
         root._apply_transform(transform)
 
 
-def test_does_not_double_count_usage_from_union():
-    """Regression test for https://github.com/ray-project/ray/pull/61040."""
-    # Create a mock topology:
-    #
-    #   input1 ───┐
-    #             ├─▶ union_op
-    #   input2 ───┘
-    input1 = PhysicalOperator("op1", [], DataContext.get_current())
-    input2 = PhysicalOperator("op2", [], DataContext.get_current())
-    union_op = UnionOperator(DataContext.get_current(), input1, input2)
-    topology = build_streaming_topology(union_op, ExecutionOptions())
-
-    # Create a resource manager.
-    total_resources = ExecutionResources(cpu=0, object_store_memory=2)
-    resource_manager = ResourceManager(
-        topology, ExecutionOptions(), lambda: total_resources, DataContext.get_current()
-    )
-
-    # Create a 1-byte `RefBundle`.
-    block_ref = ray.ObjectRef(b"1" * 28)
-    block_metadata = BlockMetadata(
-        num_rows=1, size_bytes=1, input_files=None, exec_stats=None
-    )
-    bundle = RefBundle([(block_ref, block_metadata)], owns_blocks=True, schema=None)
-
-    # Add two 1-byte `RefBundle` to the union operator.
-    topology[union_op].add_output(bundle)
-    topology[union_op].add_output(bundle)
-    resource_manager.update_usages()
-
-    # The total object store memory usage should be 2. If the resource manager double-
-    # counts the usage from the union operator, the total object store memory usage can
-    # be greater than 2.
-    total_object_store_memory = sum(
-        [
-            resource_manager.get_op_usage(
-                op, include_ineligible_downstream=True
-            ).object_store_memory
-            for op in topology.keys()
-        ]
-    )
-    assert total_object_store_memory == 2, total_object_store_memory
-
-
 def test_union_memory_attribution_internal_inqueue():
     """Test that per-input attribution correctly charges each upstream operator
     only for the blocks it produced in the union's internal input queue.

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -169,12 +169,12 @@ def test_union_memory_attribution_internal_inqueue():
 
 
 def test_union_memory_attribution_outqueue():
-    """Test that Union's external output queue memory is attributed per-input
+    """Test that Union's external output queue memory is attributed per-producer
     to upstream operators, avoiding double-counting.
 
     When Union is ineligible (throttling_disabled=True), its memory is rolled
     into upstream operators via _get_downstream_ineligible_ops_usage. With
-    per-input tracking on RefBundle.input_index, each upstream only gets
+    per-producer tracking on RefBundle.producer_op_id, each upstream only gets
     charged for the bytes it contributed to Union's ext output queue.
 
     Regression test for https://github.com/ray-project/ray/pull/61040.
@@ -193,16 +193,22 @@ def test_union_memory_attribution_outqueue():
         topology, ExecutionOptions(), lambda: total_resources, DataContext.get_current()
     )
 
-    # Create RefBundles tagged with input_index (as Union._add_input_inner does).
+    # Create RefBundles tagged with producer_op_id (stamped by DataOpTask).
     block_ref1 = ray.ObjectRef(b"1" * 28)
     block_ref2 = ray.ObjectRef(b"2" * 28)
     meta1 = BlockMetadata(num_rows=1, size_bytes=10, input_files=None, exec_stats=None)
     meta2 = BlockMetadata(num_rows=1, size_bytes=30, input_files=None, exec_stats=None)
     bundle1 = RefBundle(
-        [(block_ref1, meta1)], owns_blocks=True, schema=None, input_index=0
+        [(block_ref1, meta1)],
+        owns_blocks=True,
+        schema=None,
+        producer_op_id=input1.id,
     )
     bundle2 = RefBundle(
-        [(block_ref2, meta2)], owns_blocks=True, schema=None, input_index=1
+        [(block_ref2, meta2)],
+        owns_blocks=True,
+        schema=None,
+        producer_op_id=input2.id,
     )
 
     # Add to Union's ext output queue (simulating process_completed_tasks drain).
@@ -229,8 +235,8 @@ def test_union_memory_attribution_outqueue():
 
 
 def test_union_memory_attribution_through_limit():
-    """Test that input_index survives through other ineligible operators (e.g., Limit)
-    so that per-input memory attribution works for longer ineligible chains.
+    """Test that producer_op_id survives through other ineligible operators (e.g., Limit)
+    so that per-producer memory attribution works for longer ineligible chains.
 
     Topology:
         input1 ─▶ limit1 ───┐
@@ -253,7 +259,7 @@ def test_union_memory_attribution_through_limit():
         topology, ExecutionOptions(), lambda: total_resources, DataContext.get_current()
     )
 
-    def make_bundle(ref_byte, size_bytes, input_index=None):
+    def make_bundle(ref_byte, size_bytes, producer_op_id=None):
         block_ref = ray.ObjectRef(ref_byte * 28)
         meta = BlockMetadata(
             num_rows=1, size_bytes=size_bytes, input_files=None, exec_stats=None
@@ -262,7 +268,7 @@ def test_union_memory_attribution_through_limit():
             [(block_ref, meta)],
             owns_blocks=True,
             schema=None,
-            input_index=input_index,
+            producer_op_id=producer_op_id,
         )
 
     def get_attributed_usage(op):
@@ -273,34 +279,36 @@ def test_union_memory_attribution_through_limit():
     # Place bundles at different points in the ineligible chain,
     # simulating a steady-state snapshot:
     #
-    # limit1 outqueue:    [B_a(10MB)]           ← from input1, not yet tagged
-    # union_op outqueue:  [B_b(10MB, idx=0)]    ← from input1, tagged by Union
-    # limit_out outqueue: [B_c(30MB, idx=1)]    ← from input2, tag survived Limit
+    # limit1 outqueue:    [B_a(10MB, input1.id)]  ← from input1
+    # union_op outqueue:  [B_b(10MB, input1.id)]  ← from input1
+    # limit_out outqueue: [B_c(30MB, input2.id)]  ← from input2, tag survived Limit
 
-    # Bundle waiting in limit1's outqueue (pre-Union, no input_index yet).
-    topology[limit1].add_output(make_bundle(b"a", 10))
-    # Bundle in Union's outqueue, tagged as input_index=0 (from limit1/input1).
-    topology[union_op].add_output(make_bundle(b"b", 10, input_index=0))
+    # Bundle waiting in limit1's outqueue (tagged with input1's id).
+    topology[limit1].add_output(make_bundle(b"a", 10, producer_op_id=input1.id))
+    # Bundle in Union's outqueue, tagged with input1's id.
+    topology[union_op].add_output(make_bundle(b"b", 10, producer_op_id=input1.id))
     # Feed a tagged bundle through limit_out via _add_input_inner to test that
-    # LimitOperator propagates input_index onto the new RefBundle it creates.
+    # LimitOperator propagates producer_op_id onto the new RefBundle it creates.
     # This ends up in limit_out's internal buffer, then drain to its outqueue.
-    limit_out._add_input_inner(make_bundle(b"c", 30, input_index=1), input_index=0)
+    limit_out._add_input_inner(
+        make_bundle(b"c", 30, producer_op_id=input2.id), input_index=0
+    )
     while limit_out.has_next():
         topology[limit_out].add_output(limit_out.get_next())
 
     resource_manager.update_usages()
 
     # input1 should be charged for:
-    #   - B_a in limit1 outqueue (10MB) — full attribution, single-input op
-    #   - B_b in union_op outqueue (10MB) — per-input attribution, input_index=0
-    #   - nothing in limit_out — no bundles with input_index=0 there
+    #   - B_a in limit1 outqueue (10MB) — per-producer attribution, input1.id
+    #   - B_b in union_op outqueue (10MB) — per-producer attribution, input1.id
+    #   - nothing in limit_out — no bundles with input1.id there
     # Total for input1: 20MB
     assert get_attributed_usage(input1) == 20, get_attributed_usage(input1)
 
     # input2 should be charged for:
     #   - nothing in limit2 outqueue
-    #   - nothing in union_op outqueue — no bundles with input_index=1 there
-    #   - B_c in limit_out outqueue (30MB) — per-input attribution, input_index=1
+    #   - nothing in union_op outqueue — no bundles with input2.id there
+    #   - B_c in limit_out outqueue (30MB) — per-producer attribution, input2.id
     # Total for input2: 30MB
     assert get_attributed_usage(input2) == 30, get_attributed_usage(input2)
 

--- a/python/ray/data/tests/unit/test_resource_manager.py
+++ b/python/ray/data/tests/unit/test_resource_manager.py
@@ -211,6 +211,64 @@ def test_per_input_inqueue_attribution_for_union():
     assert input2_usage == 20
 
 
+def test_union_ext_outqueue_per_input_attribution():
+    """Test that Union's external output queue memory is attributed per-input
+    to upstream operators, avoiding double-counting.
+
+    When Union is ineligible (throttling_disabled=True), its memory is rolled
+    into upstream operators via _get_downstream_ineligible_ops_usage. With
+    per-input tracking on RefBundle.input_index, each upstream only gets
+    charged for the bytes it contributed to Union's ext output queue.
+    """
+    # Topology:
+    #   input1 ───┐
+    #             ├─▶ union_op
+    #   input2 ───┘
+    input1 = PhysicalOperator("op1", [], DataContext.get_current())
+    input2 = PhysicalOperator("op2", [], DataContext.get_current())
+    union_op = UnionOperator(DataContext.get_current(), input1, input2)
+    topology = build_streaming_topology(union_op, ExecutionOptions())
+
+    total_resources = ExecutionResources(cpu=0, object_store_memory=200)
+    resource_manager = ResourceManager(
+        topology, ExecutionOptions(), lambda: total_resources, DataContext.get_current()
+    )
+
+    # Create RefBundles tagged with input_index (as Union._add_input_inner does).
+    block_ref1 = ray.ObjectRef(b"1" * 28)
+    block_ref2 = ray.ObjectRef(b"2" * 28)
+    meta1 = BlockMetadata(num_rows=1, size_bytes=10, input_files=None, exec_stats=None)
+    meta2 = BlockMetadata(num_rows=1, size_bytes=30, input_files=None, exec_stats=None)
+    bundle1 = RefBundle(
+        [(block_ref1, meta1)], owns_blocks=True, schema=None, input_index=0
+    )
+    bundle2 = RefBundle(
+        [(block_ref2, meta2)], owns_blocks=True, schema=None, input_index=1
+    )
+
+    # Add to Union's ext output queue (simulating process_completed_tasks drain).
+    topology[union_op].add_output(bundle1)
+    topology[union_op].add_output(bundle2)
+    resource_manager.update_usages()
+
+    # Union is ineligible, so its memory is attributed to upstream ops.
+    # input1 should only be charged for bundle1 (10 bytes).
+    # input2 should only be charged for bundle2 (30 bytes).
+    input1_usage = resource_manager.get_op_usage(
+        input1, include_ineligible_downstream=True
+    ).object_store_memory
+    input2_usage = resource_manager.get_op_usage(
+        input2, include_ineligible_downstream=True
+    ).object_store_memory
+
+    assert input1_usage == 10, f"Expected 10, got {input1_usage}"
+    assert input2_usage == 30, f"Expected 30, got {input2_usage}"
+
+    # Total should be 40, not 80 (which would happen with double-counting).
+    total = input1_usage + input2_usage
+    assert total == 40, f"Expected 40, got {total}"
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Summary

* Turn Union into an ineligible operator that doesn't get allocated resources.
  * Currently, Union is an eligible operator that owns its outputs.
  * Union's output queue can build up to be really large.
  * Then, because Union doesn't actually spawn tasks, backpressure is not able to limit the memory usage to the allotted budget, so Union outputs can greatly exceed the budget.
* Fix double-counting of Union's output queue memory when attributing to upstream operators
  * Previously, [we tried making Union ineligible](https://github.com/ray-project/ray/pull/61040) but ran into this double-counting issue. This led to a deadlock when preserve_order=True since Union does strict round robining, but then backpressure applies to all input branches equally due to the double counting.
* Tag `RefBundle` with input_index in Union, track per-input bytes in `OpBufferQueue`, and thread `input_index` through _get_downstream_ineligible_ops_usage recursion
* Propagate input_index tag through ineligible operator chains (ex: Union -> Limit) so per-input attribution works end-to-end         

<img width="842" height="712" alt="Screenshot 2026-03-09 at 5 34 05 PM" src="https://github.com/user-attachments/assets/ffdbfae1-113b-4d65-9bf9-719c539a0f68" />

## Implementation notes

* `merge_ref_bundles`: This is used in `StreamingRepartitionRefBundler` and `BlockRefBundler`. It produces a merged `RefBundle` that combines bundles from potentially different producers (e.g., in streaming repartition, a single task can consume inputs from multiple upstream operators via Union). In a map with a BlockRefBundler to get some minimum batch size, multiple ref bundles can be merged together.
  * These merged ref bundles live as pending_task_inputs, which needs to be tackled as a followup. See bullet point below.
* Known limitation: obj_store_mem_pending_task_inputs on eligible operators is not split by producer. When an eligible operator (e.g, streaming repartition) sits downstream of an ineligible operator (e.g., Union), its pending task inputs may contain blocks from multiple upstream producers, but they're attributed to the eligible operator as a whole rather than back to individual upstream producers.
  * This is the last leg of fixing the memory attribution for the union case: `op_outputs + downstream_ineligible[op] + downstream_eligible_pending_inputs[op]`

## Alternative approach considered

Remove external output queues for ineligible ops. Since ineligible ops are always drained immediately (their internal buffer → external outqueue happens at the start of each step, then consumed in the same step), the external queue is just a staging ground. If ineligible ops just forwarded directly to their downstream op's input, we'd eliminate the queues where attribution goes wrong. However, this is a bit of a sweeping change that affects other operators like Limit.

## Related PRs

https://github.com/ray-project/ray/pull/61208 solved the attribution problem for the Union internal inqueues. This PR also fixes the tracking for bundles in the output queue.