### PR TITLE
[WIP][Serve] Fix perf regression in autoscaling snapshot cache refresh

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1395,6 +1395,12 @@ class ApplicationStateManager:
         """Return app names without instantiating status objects."""
         return list(self._application_states.keys())
 
+    def get_app_target_deployments(self, name: str) -> List[str]:
+        """Return deployment names for an app without constructing status objects."""
+        if name not in self._application_states:
+            return []
+        return self._application_states[name].target_deployments
+
     def list_deployment_details(self, name: str) -> Dict[str, DeploymentDetails]:
         """Gets detailed info on all deployments in specified application."""
         if name not in self._application_states:

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1391,6 +1391,10 @@ class ApplicationStateManager:
                 if self.get_app_source(name) is source
             }
 
+    def list_app_names(self) -> List[str]:
+        """Return app names without instantiating status objects."""
+        return list(self._application_states.keys())
+
     def list_deployment_details(self, name: str) -> Dict[str, DeploymentDetails]:
         """Gets detailed info on all deployments in specified application."""
         if name not in self._application_states:
@@ -1411,8 +1415,13 @@ class ApplicationStateManager:
             return None
         return self._application_states[app_name].get_deployment_topology()
 
-    def update(self):
-        """Update each application state."""
+    def update(self) -> bool:
+        """
+        Update each application state.
+
+        Returns:
+            bool: True if any application's target state changed during this update.
+        """
         apps_to_be_deleted = []
         any_target_state_changed = False
         for name, app in self._application_states.items():
@@ -1442,6 +1451,7 @@ class ApplicationStateManager:
         if any_target_state_changed:
             self.save_checkpoint()
             self._deployment_state_manager.save_checkpoint()
+        return any_target_state_changed
 
     def shutdown(self) -> None:
         self._shutting_down = True

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -732,67 +732,6 @@ class DeploymentAutoscalingState:
         else:
             return self._calculate_total_requests_simple_mode()
 
-    def _create_deployment_snapshot(
-        self,
-        *,
-        ctx: AutoscalingContext,
-        target_replicas: int,
-    ) -> DeploymentSnapshot:
-        """Create a fully-populated DeploymentSnapshot using data already available in
-        AutoscalingState and the provided context.
-        """
-        current_replicas = ctx.current_num_replicas
-        min_replicas = ctx.capacity_adjusted_min_replicas
-        max_replicas = ctx.capacity_adjusted_max_replicas
-
-        queued_requests = ctx.total_queued_requests
-
-        if self._latest_metrics_timestamp is not None:
-            time_since_last_collected_metrics_s = (
-                time.time() - self._latest_metrics_timestamp
-            )
-        else:
-            time_since_last_collected_metrics_s = None
-
-        if target_replicas > current_replicas:
-            scaling_status_raw = AutoscalingStatus.UPSCALE
-        elif target_replicas < current_replicas:
-            scaling_status_raw = AutoscalingStatus.DOWNSCALE
-        else:
-            scaling_status_raw = AutoscalingStatus.STABLE
-
-        scaling_status = AutoscalingStatus.format_scaling_status(scaling_status_raw)
-
-        look_back_period_s = self._config.look_back_period_s
-        metrics_health = DeploymentSnapshot.format_metrics_health_text(
-            time_since_last_collected_metrics_s=time_since_last_collected_metrics_s,
-            look_back_period_s=look_back_period_s,
-        )
-
-        errors: List[str] = []
-
-        if time_since_last_collected_metrics_s is None:
-            errors.append(AutoscalingSnapshotError.METRICS_UNAVAILABLE)
-
-        policy = ctx.config.policy.get_policy()
-        policy_name_str = f"{policy.__module__}.{policy.__name__}"
-        return DeploymentSnapshot(
-            timestamp_str=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            app=self._deployment_id.app_name,
-            deployment=self._deployment_id.name,
-            current_replicas=current_replicas,
-            target_replicas=target_replicas,
-            min_replicas=min_replicas,
-            max_replicas=max_replicas,
-            scaling_status=scaling_status,
-            policy_name=policy_name_str,
-            look_back_period_s=look_back_period_s,
-            queued_requests=float(queued_requests),
-            ongoing_requests=float(ctx.total_num_requests),
-            metrics_health=metrics_health,
-            errors=errors,
-        )
-
     def get_deployment_snapshot(self) -> Optional[DeploymentSnapshot]:
         """Return the cached deployment snapshot, building it lazily if needed."""
         if self._cached_deployment_snapshot is not None:

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -9,7 +9,10 @@ from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
     ApplicationName,
     AsyncInferenceTaskQueueMetricReport,
+    AutoscalingSnapshotError,
+    AutoscalingStatus,
     DeploymentID,
+    DeploymentSnapshot,
     HandleMetricReport,
     ReplicaID,
     ReplicaMetricReport,
@@ -92,6 +95,8 @@ class DeploymentAutoscalingState:
         self._cached_running_replica_strs: Set[str] = set()
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
+        self._cached_deployment_snapshot: Optional[DeploymentSnapshot] = None
+        self._latest_metrics_timestamp: Optional[float] = None
         # Track timestamps of last scale up and scale down events
         self._last_scale_up_time: Optional[float] = None
         self._last_scale_down_time: Optional[float] = None
@@ -241,6 +246,12 @@ class DeploymentAutoscalingState:
             replica_id not in self._replica_metrics
             or send_timestamp > self._replica_metrics[replica_id].timestamp
         ):
+            if self._latest_metrics_timestamp is None:
+                self._latest_metrics_timestamp = send_timestamp
+            else:
+                self._latest_metrics_timestamp = max(
+                    self._latest_metrics_timestamp, send_timestamp
+                )
             self._replica_metrics[replica_id] = replica_metric_report
 
     def record_request_metrics_for_handle(
@@ -257,6 +268,12 @@ class DeploymentAutoscalingState:
             or send_timestamp > self._handle_requests[handle_id].timestamp
         ):
             self._handle_requests[handle_id] = handle_metric_report
+            if self._latest_metrics_timestamp is None:
+                self._latest_metrics_timestamp = send_timestamp
+            else:
+                self._latest_metrics_timestamp = max(
+                    self._latest_metrics_timestamp, send_timestamp
+                )
 
     def record_async_inference_task_queue_metrics(
         self, report: AsyncInferenceTaskQueueMetricReport
@@ -355,7 +372,13 @@ class DeploymentAutoscalingState:
         if _skip_bound_check:
             return decision_num_replicas
 
-        return self.apply_bounds(decision_num_replicas)
+        decision_num_replicas = self.apply_bounds(decision_num_replicas)
+
+        self._cached_deployment_snapshot = self._create_deployment_snapshot(
+            ctx=autoscaling_context,
+            target_replicas=decision_num_replicas,
+        )
+        return decision_num_replicas
 
     def get_autoscaling_context(
         self,
@@ -699,6 +722,73 @@ class DeploymentAutoscalingState:
         else:
             return self._calculate_total_requests_simple_mode()
 
+    def _create_deployment_snapshot(
+        self,
+        *,
+        ctx: AutoscalingContext,
+        target_replicas: int,
+    ) -> DeploymentSnapshot:
+        """Create a fully-populated DeploymentSnapshot using data already available in
+        AutoscalingState and the provided context.
+        """
+        current_replicas = ctx.current_num_replicas
+        min_replicas = ctx.capacity_adjusted_min_replicas
+        max_replicas = ctx.capacity_adjusted_max_replicas
+
+        queued_requests = ctx.total_queued_requests
+
+        if self._latest_metrics_timestamp is not None:
+            time_since_last_collected_metrics_s = (
+                time.time() - self._latest_metrics_timestamp
+            )
+        else:
+            time_since_last_collected_metrics_s = None
+
+        if target_replicas > current_replicas:
+            scaling_status_raw = AutoscalingStatus.UPSCALE
+        elif target_replicas < current_replicas:
+            scaling_status_raw = AutoscalingStatus.DOWNSCALE
+        else:
+            scaling_status_raw = AutoscalingStatus.STABLE
+
+        scaling_status = AutoscalingStatus.format_scaling_status(scaling_status_raw)
+
+        look_back_period_s = self._config.look_back_period_s
+        metrics_health = DeploymentSnapshot.format_metrics_health_text(
+            time_since_last_collected_metrics_s=time_since_last_collected_metrics_s,
+            look_back_period_s=look_back_period_s,
+        )
+
+        errors: List[str] = []
+
+        if time_since_last_collected_metrics_s is None:
+            errors.append(AutoscalingSnapshotError.METRICS_UNAVAILABLE)
+
+        policy = ctx.config.policy.get_policy()
+        policy_name_str = f"{policy.__module__}.{policy.__name__}"
+        return DeploymentSnapshot(
+            timestamp_str=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            app=self._deployment_id.app_name,
+            deployment=self._deployment_id.name,
+            current_replicas=current_replicas,
+            target_replicas=target_replicas,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            scaling_status=scaling_status,
+            policy_name=policy_name_str,
+            look_back_period_s=look_back_period_s,
+            queued_requests=float(queued_requests),
+            ongoing_requests=float(ctx.total_num_requests),
+            metrics_health=metrics_health,
+            errors=errors,
+        )
+
+    def get_deployment_snapshot(self) -> Optional[DeploymentSnapshot]:
+        """
+        Return the cached deployment snapshot if available.
+        """
+        return self._cached_deployment_snapshot
+
     def get_replica_metrics(self) -> Dict[ReplicaID, List[TimeSeries]]:
         """Get the raw replica metrics dict."""
         metric_values = defaultdict(list)
@@ -907,6 +997,7 @@ class ApplicationAutoscalingState:
         """
         if self.has_policy():
             # Using app-level policy
+            # TODO(nadongjun): App-level autoscaling bypasses per-deployment snapshot creation; add snapshot support here.
             autoscaling_contexts = {
                 deployment_id: state.get_autoscaling_context(
                     deployment_to_target_num_replicas[deployment_id],
@@ -1233,3 +1324,12 @@ class AutoscalingStateManager:
     def drop_stale_handle_metrics(self, alive_serve_actor_ids: Set[str]) -> None:
         for app_state in self._app_autoscaling_states.values():
             app_state.drop_stale_handle_metrics(alive_serve_actor_ids)
+
+    def get_deployment_snapshot(
+        self, deployment_id: DeploymentID
+    ) -> Optional[DeploymentSnapshot]:
+        app_state = self._app_autoscaling_states.get(deployment_id.app_name)
+        if not app_state:
+            return None
+        dep_state = app_state._deployment_autoscaling_states.get(deployment_id)
+        return dep_state.get_deployment_snapshot() if dep_state else None

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -96,6 +96,8 @@ class DeploymentAutoscalingState:
         self._target_capacity: Optional[float] = None
         self._target_capacity_direction: Optional[TargetCapacityDirection] = None
         self._cached_deployment_snapshot: Optional[DeploymentSnapshot] = None
+        self._cached_snapshot_key: Optional[tuple] = None
+        self._cached_snapshot_metrics: Optional[tuple] = None
         self._latest_metrics_timestamp: Optional[float] = None
         # Track timestamps of last scale up and scale down events
         self._last_scale_up_time: Optional[float] = None
@@ -374,10 +376,18 @@ class DeploymentAutoscalingState:
 
         decision_num_replicas = self.apply_bounds(decision_num_replicas)
 
-        self._cached_deployment_snapshot = self._create_deployment_snapshot(
-            ctx=autoscaling_context,
-            target_replicas=decision_num_replicas,
+        self._cached_snapshot_key = (
+            decision_num_replicas,
+            autoscaling_context.current_num_replicas,
+            autoscaling_context.capacity_adjusted_min_replicas,
+            autoscaling_context.capacity_adjusted_max_replicas,
         )
+        self._cached_snapshot_metrics = (
+            float(autoscaling_context.total_queued_requests),
+            float(autoscaling_context.total_num_requests),
+        )
+        self._cached_deployment_snapshot = None
+
         return decision_num_replicas
 
     def get_autoscaling_context(
@@ -784,10 +794,63 @@ class DeploymentAutoscalingState:
         )
 
     def get_deployment_snapshot(self) -> Optional[DeploymentSnapshot]:
-        """
-        Return the cached deployment snapshot if available.
-        """
+        """Return the cached deployment snapshot, building it lazily if needed."""
+        if self._cached_deployment_snapshot is not None:
+            return self._cached_deployment_snapshot
+
+        if self._cached_snapshot_key is None:
+            return None
+
+        (
+            target_replicas,
+            current_replicas,
+            min_replicas,
+            max_replicas,
+        ) = self._cached_snapshot_key
+        queued_requests, ongoing_requests = self._cached_snapshot_metrics
+
+        if target_replicas > current_replicas:
+            scaling_status_raw = AutoscalingStatus.UPSCALE
+        elif target_replicas < current_replicas:
+            scaling_status_raw = AutoscalingStatus.DOWNSCALE
+        else:
+            scaling_status_raw = AutoscalingStatus.STABLE
+
+        if self._latest_metrics_timestamp is not None:
+            elapsed = time.time() - self._latest_metrics_timestamp
+        else:
+            elapsed = None
+
+        look_back_period_s = self._config.look_back_period_s
+        errors: List[str] = []
+        if elapsed is None:
+            errors.append(AutoscalingSnapshotError.METRICS_UNAVAILABLE)
+
+        policy = self._config.policy.get_policy()
+
+        self._cached_deployment_snapshot = DeploymentSnapshot(
+            timestamp_str=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            app=self._deployment_id.app_name,
+            deployment=self._deployment_id.name,
+            current_replicas=current_replicas,
+            target_replicas=target_replicas,
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            scaling_status=AutoscalingStatus.format_scaling_status(scaling_status_raw),
+            policy_name=f"{policy.__module__}.{policy.__name__}",
+            look_back_period_s=look_back_period_s,
+            queued_requests=queued_requests,
+            ongoing_requests=ongoing_requests,
+            metrics_health=DeploymentSnapshot.format_metrics_health_text(
+                time_since_last_collected_metrics_s=elapsed,
+                look_back_period_s=look_back_period_s,
+            ),
+            errors=errors,
+        )
         return self._cached_deployment_snapshot
+
+    def get_cached_snapshot_key(self) -> Optional[tuple]:
+        return self._cached_snapshot_key
 
     def get_replica_metrics(self) -> Dict[ReplicaID, List[TimeSeries]]:
         """Get the raw replica metrics dict."""
@@ -1333,3 +1396,10 @@ class AutoscalingStateManager:
             return None
         dep_state = app_state._deployment_autoscaling_states.get(deployment_id)
         return dep_state.get_deployment_snapshot() if dep_state else None
+
+    def get_cached_snapshot_key(self, deployment_id: DeploymentID) -> Optional[tuple]:
+        app_state = self._app_autoscaling_states.get(deployment_id.app_name)
+        if not app_state:
+            return None
+        dep_state = app_state._deployment_autoscaling_states.get(deployment_id)
+        return dep_state.get_cached_snapshot_key() if dep_state else None

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -971,23 +971,6 @@ class DeploymentSnapshot(BaseModel):
             return f"{val * 1000:.0f}ms"
         return f"{val:.2f}s"
 
-    def is_scaling_equivalent(self, other: "DeploymentSnapshot") -> bool:
-        """Return True if scaling-related fields are equal.
-
-        Used for autoscaling snapshot log deduplication. Compares only:
-        target_replicas, min_replicas, max_replicas, scaling_status
-        """
-        if not isinstance(other, DeploymentSnapshot):
-            return False
-        return (
-            self.app == other.app
-            and self.deployment == other.deployment
-            and self.target_replicas == other.target_replicas
-            and self.min_replicas == other.min_replicas
-            and self.max_replicas == other.max_replicas
-            and self.scaling_status == other.scaling_status
-        )
-
 
 RUNNING_REQUESTS_KEY = "running_requests"
 ONGOING_REQUESTS_KEY = "ongoing_requests"

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -6,6 +6,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 from starlette.types import Scope
 
 import ray
+from ray._common.pydantic_compat import BaseModel
 from ray.actor import ActorHandle
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME, SERVE_NAMESPACE
 from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
@@ -920,6 +921,74 @@ OBJ_REF_NOT_SUPPORTED_ERROR = RuntimeError(
     "Use handle.options(_by_reference=True) to enable it."
 )
 
+
+class AutoscalingStatus(str, Enum):
+    UPSCALE = "AUTOSCALING_UPSCALE"
+    DOWNSCALE = "AUTOSCALING_DOWNSCALE"
+    STABLE = "AUTOSCALING_STABLE"
+
+    @staticmethod
+    def format_scaling_status(trigger: "AutoscalingStatus") -> str:
+        mapping = {
+            AutoscalingStatus.UPSCALE: "scaling up",
+            AutoscalingStatus.DOWNSCALE: "scaling down",
+            AutoscalingStatus.STABLE: "stable",
+        }
+        return mapping.get(trigger, str(trigger).lower())
+
+
+class DeploymentSnapshot(BaseModel):
+    snapshot_type: str = "deployment"
+    timestamp_str: str
+    app: str
+    deployment: str
+    current_replicas: int
+    target_replicas: int
+    min_replicas: Optional[int]
+    max_replicas: Optional[int]
+    scaling_status: str
+    policy_name: str
+    look_back_period_s: Optional[float]
+    queued_requests: Optional[float]
+    ongoing_requests: float
+    metrics_health: str
+    errors: List[str]
+
+    @staticmethod
+    def format_metrics_health_text(
+        *,
+        time_since_last_collected_metrics_s: Optional[float],
+        look_back_period_s: Optional[float],
+    ) -> str:
+        """
+        - < 1s  -> integer milliseconds
+        - >= 1s -> seconds with two decimals
+        """
+        if time_since_last_collected_metrics_s is None:
+            return "unknown"
+        val = time_since_last_collected_metrics_s
+        if val < 1.0:
+            return f"{val * 1000:.0f}ms"
+        return f"{val:.2f}s"
+
+    def is_scaling_equivalent(self, other: "DeploymentSnapshot") -> bool:
+        """Return True if scaling-related fields are equal.
+
+        Used for autoscaling snapshot log deduplication. Compares only:
+        target_replicas, min_replicas, max_replicas, scaling_status
+        """
+        if not isinstance(other, DeploymentSnapshot):
+            return False
+        return (
+            self.app == other.app
+            and self.deployment == other.deployment
+            and self.target_replicas == other.target_replicas
+            and self.min_replicas == other.min_replicas
+            and self.max_replicas == other.max_replicas
+            and self.scaling_status == other.scaling_status
+        )
+
+
 RUNNING_REQUESTS_KEY = "running_requests"
 ONGOING_REQUESTS_KEY = "ongoing_requests"
 QUEUED_REQUESTS_KEY = "queued_requests"
@@ -1030,3 +1099,7 @@ class AsyncInferenceTaskQueueMetricReport:
     deployment_id: DeploymentID
     queue_length: int
     timestamp_s: float
+
+
+class AutoscalingSnapshotError(str, Enum):
+    METRICS_UNAVAILABLE = "METRICS_UNAVAILABLE"

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -292,9 +292,7 @@ class ServeController:
 
         # Caches for autoscaling observability
         self._last_autoscaling_snapshots: Dict[DeploymentID, DeploymentSnapshot] = {}
-        self._autoscaling_enabled_deployments_cache: List[
-            Tuple[str, str, DeploymentDetails, Any]
-        ] = []
+        self._autoscaling_enabled_deployment_ids: List[DeploymentID] = []
         self._refresh_autoscaling_deployments_cache()
 
     def reconfigure_global_logging_config(self, global_logging_config: LoggingConfig):
@@ -491,15 +489,18 @@ class ServeController:
         result = []
         active_dep_ids = set()
         for app_name in self.application_state_manager.list_app_names():
-            deployment_details = self.application_state_manager.list_deployment_details(
+            for dep_name in self.application_state_manager.get_app_target_deployments(
                 app_name
-            )
-            for dep_name, details in deployment_details.items():
-                active_dep_ids.add(DeploymentID(name=dep_name, app_name=app_name))
-                autoscaling_config = details.deployment_config.autoscaling_config
-                if autoscaling_config:
-                    result.append((app_name, dep_name, details, autoscaling_config))
-        self._autoscaling_enabled_deployments_cache = result
+            ):
+                dep_id = DeploymentID(name=dep_name, app_name=app_name)
+                active_dep_ids.add(dep_id)
+                dep_info = self.deployment_state_manager.get_deployment(dep_id)
+                if (
+                    dep_info is not None
+                    and dep_info.deployment_config.autoscaling_config
+                ):
+                    result.append(dep_id)
+        self._autoscaling_enabled_deployment_ids = result
         self._last_autoscaling_snapshots = {
             k: v
             for k, v in self._last_autoscaling_snapshots.items()
@@ -513,13 +514,7 @@ class ServeController:
 
         snapshots_to_log: List[Dict[str, Any]] = []
 
-        for (
-            app_name,
-            dep_name,
-            details,
-            autoscaling_config,
-        ) in self._autoscaling_enabled_deployments_cache:
-            dep_id = DeploymentID(name=dep_name, app_name=app_name)
+        for dep_id in self._autoscaling_enabled_deployment_ids:
             deployment_snapshot = (
                 self.autoscaling_state_manager.get_deployment_snapshot(dep_id)
             )
@@ -627,19 +622,14 @@ class ServeController:
         try:
             asm_update_start_time = time.time()
             any_target_state_changed = self.application_state_manager.update()
-            if any_recovering or any_target_state_changed:
-                self._refresh_autoscaling_deployments_cache()
             asm_duration = time.time() - asm_update_start_time
             self.asm_update_duration_gauge_s.set(asm_duration)
             self._health_metrics_tracker.record_asm_update_duration(asm_duration)
-        except Exception:
-            logger.exception("Exception updating application state.")
-
-        try:
-            # Emit one autoscaling snapshot per deployment per loop using existing state.
+            if any_recovering or any_target_state_changed:
+                self._refresh_autoscaling_deployments_cache()
             self._emit_deployment_autoscaling_snapshots()
         except Exception:
-            logger.exception("Exception emitting deployment autoscaling snapshots.")
+            logger.exception("Exception updating application state.")
         # Update the proxy nodes set before updating the proxy states,
         # so they are more consistent.
         node_update_start_time = time.time()

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -25,7 +25,6 @@ from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
     AsyncInferenceTaskQueueMetricReport,
     DeploymentID,
-    DeploymentSnapshot,
     HandleMetricReport,
     NodeId,
     ReplicaMetricReport,
@@ -290,8 +289,7 @@ class ServeController:
 
         self._last_broadcasted_fallback_targets: Dict[RequestProtocol, Target] = {}
 
-        # Caches for autoscaling observability
-        self._last_autoscaling_snapshots: Dict[DeploymentID, DeploymentSnapshot] = {}
+        self._last_autoscaling_snapshot_keys: Dict[DeploymentID, tuple] = {}
         self._autoscaling_enabled_deployment_ids: List[DeploymentID] = []
         self._refresh_autoscaling_deployments_cache()
 
@@ -501,9 +499,9 @@ class ServeController:
                 ):
                     result.append(dep_id)
         self._autoscaling_enabled_deployment_ids = result
-        self._last_autoscaling_snapshots = {
+        self._last_autoscaling_snapshot_keys = {
             k: v
-            for k, v in self._last_autoscaling_snapshots.items()
+            for k, v in self._last_autoscaling_snapshot_keys.items()
             if k in active_dep_ids
         }
 
@@ -515,18 +513,21 @@ class ServeController:
         snapshots_to_log: List[Dict[str, Any]] = []
 
         for dep_id in self._autoscaling_enabled_deployment_ids:
+            key = self.autoscaling_state_manager.get_cached_snapshot_key(dep_id)
+            if key is None:
+                continue
+
+            if key == self._last_autoscaling_snapshot_keys.get(dep_id):
+                continue
+
             deployment_snapshot = (
                 self.autoscaling_state_manager.get_deployment_snapshot(dep_id)
             )
             if deployment_snapshot is None:
                 continue
 
-            last = self._last_autoscaling_snapshots.get(dep_id)
-            if last is not None and last.is_scaling_equivalent(deployment_snapshot):
-                continue
-
             snapshots_to_log.append(deployment_snapshot.dict(exclude_none=True))
-            self._last_autoscaling_snapshots[dep_id] = deployment_snapshot
+            self._last_autoscaling_snapshot_keys[dep_id] = key
 
         if snapshots_to_log:
             # Single write per control-loop iteration
@@ -627,9 +628,13 @@ class ServeController:
             self._health_metrics_tracker.record_asm_update_duration(asm_duration)
             if any_recovering or any_target_state_changed:
                 self._refresh_autoscaling_deployments_cache()
-            self._emit_deployment_autoscaling_snapshots()
         except Exception:
             logger.exception("Exception updating application state.")
+
+        try:
+            self._emit_deployment_autoscaling_snapshots()
+        except Exception:
+            logger.exception("Exception emitting deployment autoscaling snapshots.")
         # Update the proxy nodes set before updating the proxy states,
         # so they are more consistent.
         node_update_start_time = time.time()

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -25,6 +25,7 @@ from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
     AsyncInferenceTaskQueueMetricReport,
     DeploymentID,
+    DeploymentSnapshot,
     HandleMetricReport,
     NodeId,
     ReplicaMetricReport,
@@ -64,6 +65,7 @@ from ray.serve._private.http_util import (
     configure_http_options_with_defaults,
 )
 from ray.serve._private.logging_utils import (
+    configure_autoscaling_snapshot_logger,
     configure_component_logger,
     configure_component_memory_profiler,
     get_component_logger_file_path,
@@ -162,6 +164,9 @@ class ServeController:
 
         self.long_poll_host = LongPollHost()
         self.done_recovering_event = asyncio.Event()
+
+        # Autoscaling snapshot logger
+        self._autoscaling_logger: Optional[logging.Logger] = None
 
         # Try to read config from checkpoint
         # logging config from checkpoint take precedence over the one passed in
@@ -285,6 +290,13 @@ class ServeController:
 
         self._last_broadcasted_fallback_targets: Dict[RequestProtocol, Target] = {}
 
+        # Caches for autoscaling observability
+        self._last_autoscaling_snapshots: Dict[DeploymentID, DeploymentSnapshot] = {}
+        self._autoscaling_enabled_deployments_cache: List[
+            Tuple[str, str, DeploymentDetails, Any]
+        ] = []
+        self._refresh_autoscaling_deployments_cache()
+
     def reconfigure_global_logging_config(self, global_logging_config: LoggingConfig):
         if (
             self.global_logging_config
@@ -301,6 +313,11 @@ class ServeController:
         )
         configure_component_logger(
             component_name="controller",
+            component_id=str(os.getpid()),
+            logging_config=global_logging_config,
+        )
+
+        self._autoscaling_logger = configure_autoscaling_snapshot_logger(
             component_id=str(os.getpid()),
             logging_config=global_logging_config,
         )
@@ -470,6 +487,56 @@ class ServeController:
         new_proxy_nodes.add(self._controller_node_id)
         self._proxy_nodes = new_proxy_nodes
 
+    def _refresh_autoscaling_deployments_cache(self) -> None:
+        result = []
+        active_dep_ids = set()
+        for app_name in self.application_state_manager.list_app_names():
+            deployment_details = self.application_state_manager.list_deployment_details(
+                app_name
+            )
+            for dep_name, details in deployment_details.items():
+                active_dep_ids.add(DeploymentID(name=dep_name, app_name=app_name))
+                autoscaling_config = details.deployment_config.autoscaling_config
+                if autoscaling_config:
+                    result.append((app_name, dep_name, details, autoscaling_config))
+        self._autoscaling_enabled_deployments_cache = result
+        self._last_autoscaling_snapshots = {
+            k: v
+            for k, v in self._last_autoscaling_snapshots.items()
+            if k in active_dep_ids
+        }
+
+    def _emit_deployment_autoscaling_snapshots(self) -> None:
+        """Emit structured autoscaling snapshot logs in a single batch per loop."""
+        if self._autoscaling_logger is None:
+            return
+
+        snapshots_to_log: List[Dict[str, Any]] = []
+
+        for (
+            app_name,
+            dep_name,
+            details,
+            autoscaling_config,
+        ) in self._autoscaling_enabled_deployments_cache:
+            dep_id = DeploymentID(name=dep_name, app_name=app_name)
+            deployment_snapshot = (
+                self.autoscaling_state_manager.get_deployment_snapshot(dep_id)
+            )
+            if deployment_snapshot is None:
+                continue
+
+            last = self._last_autoscaling_snapshots.get(dep_id)
+            if last is not None and last.is_scaling_equivalent(deployment_snapshot):
+                continue
+
+            snapshots_to_log.append(deployment_snapshot.dict(exclude_none=True))
+            self._last_autoscaling_snapshots[dep_id] = deployment_snapshot
+
+        if snapshots_to_log:
+            # Single write per control-loop iteration
+            self._autoscaling_logger.info({"snapshots": snapshots_to_log})
+
     async def run_control_loop(self) -> None:
         # NOTE(edoakes): we catch all exceptions here and simply log them,
         # because an unhandled exception would cause the main control loop to
@@ -559,13 +626,20 @@ class ServeController:
 
         try:
             asm_update_start_time = time.time()
-            self.application_state_manager.update()
+            any_target_state_changed = self.application_state_manager.update()
+            if any_recovering or any_target_state_changed:
+                self._refresh_autoscaling_deployments_cache()
             asm_duration = time.time() - asm_update_start_time
             self.asm_update_duration_gauge_s.set(asm_duration)
             self._health_metrics_tracker.record_asm_update_duration(asm_duration)
         except Exception:
             logger.exception("Exception updating application state.")
 
+        try:
+            # Emit one autoscaling snapshot per deployment per loop using existing state.
+            self._emit_deployment_autoscaling_snapshots()
+        except Exception:
+            logger.exception("Exception emitting deployment autoscaling snapshots.")
         # Update the proxy nodes set before updating the proxy states,
         # so they are more consistent.
         node_update_start_time = time.time()

--- a/python/ray/serve/_private/logging_utils.py
+++ b/python/ray/serve/_private/logging_utils.py
@@ -408,6 +408,42 @@ def configure_component_logger(
     logger.addHandler(memory_handler)
 
 
+# Configure a dedicated rotating file logger for autoscaling snapshots.
+def configure_autoscaling_snapshot_logger(
+    *, component_id: str, logging_config: LoggingConfig
+) -> logging.Logger:
+    """Configure a dedicated logger for autoscaling snapshots.
+
+    - Writes to `autoscaling_snapshot_<pid>.log` under the Serve logs dir.
+    """
+    logger_obj = logging.getLogger(f"{SERVE_LOGGER_NAME}.snapshot")
+    logger_obj.propagate = False
+    logger_obj.setLevel(logging_config.log_level)
+    logger_obj.handlers.clear()
+
+    logs_dir = logging_config.logs_dir or get_serve_logs_dir()
+    os.makedirs(logs_dir, exist_ok=True)
+
+    max_bytes = ray._private.worker._global_node.max_bytes
+    backup_count = ray._private.worker._global_node.backup_count
+
+    file_name = get_component_file_name(
+        component_name="autoscaling_snapshot",
+        component_id=component_id,
+        component_type=None,
+        suffix=".log",
+    )
+    file_path = os.path.join(logs_dir, file_name)
+
+    handler = logging.handlers.RotatingFileHandler(
+        file_path, maxBytes=max_bytes, backupCount=backup_count
+    )
+    handler.setFormatter(JSONFormatter())
+
+    logger_obj.addHandler(handler)
+    return logger_obj
+
+
 def configure_default_serve_logger():
     """Helper function to configure the default Serve logger that's used outside of
     individual Serve components."""

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -1,5 +1,9 @@
+import ast
+import glob
 import json
+import os
 import time
+from typing import Any, Dict, List, Optional, Sequence
 
 import pytest
 
@@ -13,6 +17,7 @@ from ray.serve._private.constants import (
     SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
+from ray.serve._private.logging_utils import get_serve_logs_dir
 from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.context import _get_global_client
 from ray.serve.generated.serve_pb2 import DeploymentRoute
@@ -396,6 +401,384 @@ def test_get_health_metrics(serve_instance):
     # Verify the metrics are JSON serializable
     metrics_json = json.dumps(metrics)
     assert isinstance(metrics_json, str)
+
+
+def _parse_snapshot_payload(message: Any) -> Optional[Dict[str, Any]]:
+    """Try to parse a snapshot payload from a log message."""
+    if not message:
+        return None
+
+    # If message is already a dict (e.g., from JSON parsing)
+    if isinstance(message, dict):
+        return message
+
+    # Try to parse as a string representation of a dict
+    try:
+        payload = ast.literal_eval(str(message))
+        if isinstance(payload, dict):
+            return payload
+    except (ValueError, SyntaxError):
+        pass
+
+    # Try JSON parsing
+    try:
+        payload = json.loads(str(message))
+        if isinstance(payload, dict):
+            return payload
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    return None
+
+
+def _parse_batched_snapshots_from_log(
+    log_paths: Sequence[str],
+    target_deployment_name: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Parse autoscaling snapshots from batched log format.
+
+    The new log format writes snapshots in batches:
+    {"snapshots": [snap1, snap2, ...]}
+
+    Args:
+        log_paths: List of log file paths to parse.
+        target_deployment_name: If provided, only return snapshots for this deployment.
+
+    Returns:
+        List of individual snapshot dicts, sorted by timestamp.
+    """
+    snaps = []
+    for path in log_paths:
+        if not os.path.exists(path):
+            continue
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                # Try to parse the line as JSON first
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                # Get the message field
+                message = rec.get("message", "")
+                if not message:
+                    continue
+
+                # Parse the message payload
+                payload = _parse_snapshot_payload(message)
+                if not payload:
+                    continue
+
+                # Handle batched format: {"snapshots": [...]}
+                if "snapshots" in payload:
+                    for snap in payload.get("snapshots", []):
+                        if not isinstance(snap, dict):
+                            continue
+                        if snap.get("snapshot_type") != "deployment":
+                            continue
+                        if (
+                            target_deployment_name is None
+                            or snap.get("deployment") == target_deployment_name
+                        ):
+                            snaps.append(snap)
+                # Handle legacy single snapshot format (for backward compatibility)
+                elif payload.get("snapshot_type") == "deployment":
+                    if (
+                        target_deployment_name is None
+                        or payload.get("deployment") == target_deployment_name
+                    ):
+                        snaps.append(payload)
+
+    return sorted(snaps, key=lambda s: s.get("timestamp_str", ""))
+
+
+def test_autoscaling_snapshot_log_emitted_and_well_formed(serve_instance):
+    """Validate controller emits well-formed autoscaling snapshot structured logs.
+
+    Tests deterministic autoscaling: 1 -> 2 replicas.
+    """
+
+    DEPLOY_NAME = f"snap_app_{int(time.time())}"
+
+    @serve.deployment(
+        name=DEPLOY_NAME,
+        autoscaling_config={
+            "min_replicas": 1,
+            "max_replicas": 2,
+            "initial_replicas": 1,
+            "metrics_interval_s": 0.2,
+            "look_back_period_s": 0.5,
+            "upscale_delay_s": 0.0,
+            "downscale_delay_s": 600.0,
+            "target_ongoing_requests": 1.0,
+        },
+    )
+    async def snap_app():
+        return "ok"
+
+    handle = serve.run(snap_app.bind())
+
+    serve_logs_dir = get_serve_logs_dir()
+
+    def get_snapshots():
+        """Read all snapshots for deployment from batched log format."""
+        log_paths = glob.glob(
+            os.path.join(serve_logs_dir, "autoscaling_snapshot_*.log")
+        )
+        return _parse_batched_snapshots_from_log(log_paths, DEPLOY_NAME)
+
+    def wait_for_replicas(current, timeout=10):
+        """Wait for exact current replica count."""
+        wait_for_condition(
+            lambda: any(s.get("current_replicas") == current for s in get_snapshots()),
+            timeout=timeout,
+        )
+
+    # Wait for initial replica to be ready
+    wait_for_replicas(1, timeout=5)
+    initial = [s for s in get_snapshots() if s["current_replicas"] == 1][0]
+    assert initial["current_replicas"] == 1
+    assert initial["min_replicas"] == 1
+    assert initial["max_replicas"] == 2
+
+    reqs = [handle.remote() for _ in range(6)]
+    # Wait for scaling to 2 replicas.
+    wait_for_replicas(2, timeout=5)
+
+    all_snaps = get_snapshots()
+
+    snap_1 = next((s for s in all_snaps if s["current_replicas"] == 1), None)
+    snap_2 = next((s for s in all_snaps if s["current_replicas"] == 2), None)
+
+    assert snap_1 is not None
+    assert snap_2 is not None and snap_2["target_replicas"] == 2
+
+    seen_states = []
+    for snap in all_snaps:
+        current = snap["current_replicas"]
+        if current not in seen_states:
+            seen_states.append(current)
+
+    assert seen_states in [[0, 1, 2], [1, 2]]
+    assert 1 in seen_states and 2 in seen_states
+
+    for snap in [snap_1, snap_2]:
+        for key in [
+            "timestamp_str",
+            "app",
+            "deployment",
+            "current_replicas",
+            "target_replicas",
+            "min_replicas",
+            "max_replicas",
+            "policy_name",
+            "metrics_health",
+            "look_back_period_s",
+            "snapshot_type",
+        ]:
+            assert key in snap, f"Missing {key}"
+
+    for req in reqs:
+        assert req.result() == "ok"
+
+
+# Test that no autoscaling snapshot logs are emitted for deployments without autoscaling_config
+def test_autoscaling_snapshot_not_emitted_without_config(serve_instance):
+    """Ensure no deployment-type autoscaling snapshot logs are emitted without autoscaling_config."""
+
+    DEPLOY_NAME = f"snap_no_auto_{int(time.time())}"
+
+    @serve.deployment(name=DEPLOY_NAME)
+    def app():
+        return "no autoscale"
+
+    serve.run(app.bind())
+
+    serve_logs_dir = get_serve_logs_dir()
+    candidate_paths = sorted(
+        glob.glob(os.path.join(serve_logs_dir, "autoscaling_snapshot_*.log"))
+    )
+    assert (
+        candidate_paths
+    ), f"No autoscaling snapshot logs found; checked {serve_logs_dir}"
+
+    found = _parse_batched_snapshots_from_log(candidate_paths, DEPLOY_NAME)
+
+    assert not found, (
+        f"Found deployment-type autoscaling snapshot logs for deployment {DEPLOY_NAME} "
+        f"even though no autoscaling_config was set: {found}"
+    )
+
+
+def test_autoscaling_snapshot_not_emitted_every_iteration(serve_instance):
+    """Ensure identical autoscaling snapshots are not written repeatedly."""
+
+    DEPLOY_NAME = f"snap_dedupe_{int(time.time())}"
+
+    @serve.deployment(
+        name=DEPLOY_NAME,
+        autoscaling_config={
+            "min_replicas": 1,
+            "max_replicas": 1,
+            "initial_replicas": 1,
+            "metrics_interval_s": 0.1,
+            "look_back_period_s": 0.2,
+            "upscale_delay_s": 0.0,
+            "downscale_delay_s": 600.0,
+            "target_ongoing_requests": 1.0,
+        },
+    )
+    def app():
+        return "ok"
+
+    serve.run(app.bind())
+
+    serve_logs_dir = get_serve_logs_dir()
+
+    def get_snapshots():
+        log_paths = glob.glob(
+            os.path.join(serve_logs_dir, "autoscaling_snapshot_*.log")
+        )
+        return _parse_batched_snapshots_from_log(log_paths, DEPLOY_NAME)
+
+    # Wait until the first stable snapshot shows up
+    def has_initial_snapshot():
+        snaps = get_snapshots()
+        return bool(snaps) and snaps[-1]["current_replicas"] == 1
+
+    wait_for_condition(has_initial_snapshot, timeout=10)
+
+    controller = _get_global_client()._controller
+
+    # ensure deployment is in autoscaling cache
+    ray.get(controller._refresh_autoscaling_deployments_cache.remote())
+
+    # Count current snapshots
+    initial_count = len(get_snapshots())
+
+    # Force multiple emits
+    for _ in range(5):
+        ray.get(controller._emit_deployment_autoscaling_snapshots.remote())
+
+    final_count = len(get_snapshots())
+
+    # No new snapshots should be added after the first stable write
+    assert final_count == initial_count
+
+
+def test_autoscaling_snapshot_batched_single_write_per_loop(serve_instance):
+    """Ensure multiple deployments are batched in a single log write per loop."""
+
+    ts = int(time.time())
+    NUM_DEPLOYMENTS = 3
+    APP_NAME = f"batch_app_{ts}"
+
+    # Create multiple deployments in a SINGLE application
+    deployments = []
+    deployment_names = []
+
+    for i in range(NUM_DEPLOYMENTS):
+        dep_name = f"Dep{i}"
+        deployment_names.append(dep_name)
+
+        @serve.deployment(
+            name=dep_name,
+            autoscaling_config={
+                "min_replicas": 1,
+                "max_replicas": 1,
+                "initial_replicas": 1,
+                "metrics_interval_s": 0.1,
+                "look_back_period_s": 0.2,
+            },
+        )
+        class Deployment:
+            def __call__(self):
+                return "ok"
+
+        deployments.append(Deployment.bind())
+
+    # Create ingress that references all deployments
+    @serve.deployment
+    class Ingress:
+        def __init__(self, *deps):
+            self.deps = deps
+
+        def __call__(self):
+            return "ok"
+
+    # Bind all deployments to ingress and run as single app
+    app = Ingress.bind(*deployments)
+    serve.run(app, name=APP_NAME, route_prefix=f"/{APP_NAME}")
+
+    serve_logs_dir = get_serve_logs_dir()
+
+    def get_batch_payloads():
+        """Return list of (deployment_names_set, batch_dict) for target deployments."""
+        log_paths = glob.glob(
+            os.path.join(serve_logs_dir, "autoscaling_snapshot_*.log")
+        )
+        batches = []
+        for path in log_paths:
+            if not os.path.exists(path):
+                continue
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                for line in f:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    message = rec.get("message")
+                    if message is None:
+                        continue
+
+                    payload = _parse_snapshot_payload(message)
+                    if not payload or "snapshots" not in payload:
+                        continue
+
+                    names_in_batch = set()
+                    target_snaps = []
+                    for snap in payload.get("snapshots", []):
+                        if not isinstance(snap, dict):
+                            continue
+                        if snap.get("snapshot_type") != "deployment":
+                            continue
+                        dep_name = snap.get("deployment")
+                        if snap.get("app") == APP_NAME and dep_name in deployment_names:
+                            names_in_batch.add(dep_name)
+                            target_snaps.append(snap)
+
+                    if names_in_batch:
+                        batches.append((names_in_batch, {"snapshots": target_snaps}))
+        return batches
+
+    # Wait until a batch containing ALL deployments appears
+    def has_full_batch():
+        batches = get_batch_payloads()
+        for names, _ in batches:
+            if names == set(deployment_names):
+                return True
+        return False
+
+    wait_for_condition(has_full_batch, timeout=15)
+    batches = get_batch_payloads()
+
+    # Only verify batches that contain all deployments (full batches)
+    # Partial batches can occur due to individual deployment state changes
+    full_batches = [
+        (names, batch) for names, batch in batches if names == set(deployment_names)
+    ]
+
+    assert len(full_batches) >= 1, (
+        f"Expected at least one batch containing all {NUM_DEPLOYMENTS} deployments "
+        f"{sorted(deployment_names)}, but none found"
+    )
+
+    for names, batch in full_batches:
+        assert len(batch["snapshots"]) == NUM_DEPLOYMENTS, (
+            f"Expected {NUM_DEPLOYMENTS} snapshots in batch, "
+            f"but found {len(batch['snapshots'])}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Improved controller performance degradation at scale (2048 replicas: `loop_duration` +15%, `handle_metrics_delay` +28%) introduced after PR #56225.

**Root causes:**
1. `_refresh_autoscaling_deployments_cache()` called `list_deployment_details()`, constructing O(N) `ReplicaDetails` Pydantic objects per deployment on every control loop
2. `_create_deployment_snapshot()` built a 14-field Pydantic `DeploymentSnapshot` on every autoscaling tick, regardless of whether scaling state had changed

**Fixes:**
1. Replaced `list_deployment_details()` with O(1) `get_deployment()` lookups
2. Replaced eager Pydantic construction with tuple key caching (~0.3us) + lazy `DeploymentSnapshot` construction (only when scaling state changes)
3. Separated `_emit` try/except from application state update to prevent error masking
4. Moved cache refresh after ASM timer to avoid polluting `application_state_update_duration_s` metrics
5. Removed dead code (`_create_deployment_snapshot`, `is_scaling_equivalent`)

## Related issues

Re-lands #56225 (reverted in #61557) with performance fix.

## Additional information

### Benchmark
[bench_fix_validation.py](https://github.com/user-attachments/files/26171241/bench_fix_validation.py)

Measured per-tick cost by importing actual Ray Serve modules (`DeploymentAutoscalingState`, `get_decision_num_replicas()`, etc.) without requiring a cluster. `bench_fix_validation.py` compares three code paths:

**A) No snapshot (baseline)** — autoscale logic only, no snapshot creation:
```python
ctx = state.get_autoscaling_context(n)
decision, _ = state._policy(ctx)
decision = state.apply_bounds(decision)
```

**B) Original PR #56225** — Pydantic `DeploymentSnapshot` created every tick:
```python
ctx = state.get_autoscaling_context(n)
decision, _ = state._policy(ctx)
decision = state.apply_bounds(decision)
# 14-field Pydantic model constructed every tick (includes time.strftime, enum lookup)
DeploymentSnapshot(
    timestamp_str=time.strftime(...), app=..., deployment=...,
    current_replicas=..., target_replicas=..., min_replicas=...,
    max_replicas=..., scaling_status=..., policy_name=...,
    look_back_period_s=..., queued_requests=..., ongoing_requests=...,
    metrics_health=..., errors=...,
)
```

**C) This fix** — tuple cache + lazy Pydantic:
```python
# Inside get_decision_num_replicas(): only caches tuples
state.get_decision_num_replicas(curr_target_num_replicas=n)
# In _emit(): tuple key comparison, Pydantic only built on state change
key = state.get_cached_snapshot_key()
if key != last_keys.get(dep_id):
    snap = state.get_deployment_snapshot()  # lazy Pydantic construction
    snap.dict(exclude_none=True)
```

`create_state(n_replicas)` creates a `DeploymentAutoscalingState` at 1–2048 replica scale. Each path is measured via `time.perf_counter_ns()` over 200 warmup + 2000 iterations:

```
  Replicas   A) No snapshot   B) Original #56225   C) This fix    B vs C
  --------   --------------   ------------------   -----------    ------
         1           3.2us               16.9us          7.0us     2.43x
        64           3.2us               16.5us          6.9us     2.38x
      1024           3.3us               17.0us          7.3us     2.34x
      2048           3.4us               17.1us          7.3us     2.35x
```

- Original PR overhead vs baseline: **+405%** (17.1us vs 3.4us)
- This fix overhead vs baseline: **+115%** (7.3us vs 3.4us, ~4us added)
- **2.35x faster** than original PR, consistent across all replica counts
- O(1) per deployment: cost does not scale with replica count
- 4us added cost is **< 0.01%** of controller loop duration at 2048 replicas

### Test results

All 11 tests in `test_controller.py` pass, including 4 snapshot-specific tests.
