### PR TITLE
 [Data] Serialize Pandas UDF batches as Arrow blocks internally

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -268,19 +268,25 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def schema(self) -> "pyarrow.lib.Schema":
         return self._table.schema
 
-    def to_pandas(self) -> "pandas.DataFrame":
+    def to_pandas(self, copy: bool = False) -> "pandas.DataFrame":
         from ray.data.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
 
         # We specify ignore_metadata=True because pyarrow will use the metadata
         # to build the Table. This is handled incorrectly for older pyarrow versions
         ctx = DataContext.get_current()
-        df = self._table.to_pandas(ignore_metadata=ctx.pandas_block_ignore_metadata)
+        df = self._table.to_pandas(
+            ignore_metadata=ctx.pandas_block_ignore_metadata,
+        )
         if ctx.enable_tensor_extension_casting:
             df = _cast_tensor_columns_to_ndarrays(df, arrow_schema=self._table.schema)
+        # Copy the DataFrame to ensure it's writable (Arrow->Pandas creates
+        # zero-copy views which are read-only).
+        if copy:
+            df = df.copy()
         return df
 
     def to_numpy(
-        self, columns: Optional[Union[str, List[str]]] = None
+        self, columns: Optional[Union[str, List[str]]] = None, copy: bool = False
     ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
         if columns is None:
             columns = self._table.column_names
@@ -308,9 +314,12 @@ class ArrowBlockAccessor(TableBlockAccessor):
             # (making them compatible with numpy format)
             combined_array = transform_pyarrow.combine_chunked_array(col)
 
-            column_values_ndarrays.append(
-                transform_pyarrow.to_numpy(combined_array, zero_copy_only=False)
-            )
+            arr = transform_pyarrow.to_numpy(combined_array, zero_copy_only=False)
+            # Copy the array to ensure it's writable (Arrow arrays may be
+            # read-only views).
+            if copy:
+                arr = arr.copy()
+            column_values_ndarrays.append(arr)
 
         if should_be_single_ndarray:
             assert len(columns) == 1

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -42,6 +42,7 @@ def batch_blocks(
         ),
         batch_format=batch_format,
         stats=stats,
+        ensure_copy=ensure_copy
     )
 
     if collate_fn is not None:

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -192,6 +192,7 @@ class BatchIterator:
             batch_format=self._batch_format,
             collate_fn=self._collate_fn,
             num_threadpool_workers=num_threadpool_workers,
+            ensure_copy=self._ensure_copy,
         )
 
     def _finalize_batches(
@@ -312,6 +313,7 @@ def _format_in_threadpool(
     batch_format: Optional[str],
     collate_fn: Optional[Callable[[DataBatch], Any]],
     num_threadpool_workers: int,
+    ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Executes the batching, formatting, and collation logic in a threadpool.
 
@@ -326,6 +328,7 @@ def _format_in_threadpool(
             as batches.
         collate_fn: A function to apply to each data batch before returning it.
         num_threadpool_workers: The number of threads to use in the threadpool.
+        ensure_copy: Whether to ensure batches are copies (not zero-copy views).
     """
 
     def threadpool_computations_format_collate(
@@ -333,7 +336,7 @@ def _format_in_threadpool(
     ) -> Iterator[Batch]:
         # Step 4a: Format the batches.
         formatted_batch_iter = format_batches(
-            batch_iter, batch_format=batch_format, stats=stats
+            batch_iter, batch_format=batch_format, stats=stats, ensure_copy=ensure_copy
         )
 
         # Step 4b: Apply the collate function if applicable.

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -193,10 +193,12 @@ def _format_batch(
     batch: Batch,
     batch_format: Optional[str],
     stats: Optional[DatasetStats],
+    ensure_copy: bool = False,
 ) -> Batch:
     with stats.iter_format_batch_s.timer() if stats else nullcontext():
         formatted_data = BlockAccessor.for_block(batch.data).to_batch_format(
-            batch_format
+            batch_format,
+            ensure_copy=ensure_copy,
         )
     return dataclasses.replace(batch, data=formatted_data)
 
@@ -205,11 +207,12 @@ def format_batches(
     batch_iter: Iterator[Batch],
     batch_format: Optional[str],
     stats: Optional[DatasetStats] = None,
+    ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Given an iterator of batches, returns an iterator of formatted batches."""
     return _MappingIterator(
         batch_iter,
-        functools.partial(_format_batch, batch_format=batch_format, stats=stats),
+        functools.partial(_format_batch, batch_format=batch_format, stats=stats, ensure_copy=ensure_copy),
     )
 
 

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -426,17 +426,19 @@ class PandasBlockAccessor(TableBlockAccessor):
             )
         return schema
 
-    def to_pandas(self) -> "pandas.DataFrame":
+    def to_pandas(self, copy: bool = False) -> "pandas.DataFrame":
         from ray.data.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
 
         ctx = DataContext.get_current()
         table = self._table
         if ctx.enable_tensor_extension_casting:
             table = _cast_tensor_columns_to_ndarrays(table)
+        if copy:
+            table = table.copy()
         return table
 
     def to_numpy(
-        self, columns: Optional[Union[str, List[str]]] = None
+        self, columns: Optional[Union[str, List[str]]] = None, copy: bool = False
     ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
         if columns is None:
             columns = self._table.columns.tolist()
@@ -457,7 +459,10 @@ class PandasBlockAccessor(TableBlockAccessor):
 
         arrays = []
         for column in columns:
-            arrays.append(self._table[column].to_numpy())
+            arr = self._table[column].to_numpy()
+            if copy:
+                arr = arr.copy()
+            arrays.append(arr)
 
         if should_be_single_ndarray:
             arrays = arrays[0]
@@ -469,10 +474,20 @@ class PandasBlockAccessor(TableBlockAccessor):
         import pyarrow as pa
 
         from ray.data._internal.tensor_extensions.pandas import TensorDtype
+        from ray.data.util.data_batch_conversion import (
+            _cast_ndarray_columns_to_tensor_extension,
+        )
+
+        ctx = DataContext.get_current()
+        table = self._table
+
+        # Convert tensor columns to TensorArray before Arrow conversion
+        if ctx.enable_tensor_extension_casting:
+            table = _cast_ndarray_columns_to_tensor_extension(table)
 
         # Set `preserve_index=False` so that Arrow doesn't add a '__index_level_0__'
         # column to the resulting table.
-        arrow_table = pa.Table.from_pandas(self._table, preserve_index=False)
+        arrow_table = pa.Table.from_pandas(table, preserve_index=False)
 
         # NOTE: Pandas by default coerces all-null column types (including None,
         #       NaN, etc) into "double" type by default, which is incorrect in a
@@ -484,8 +499,8 @@ class PandasBlockAccessor(TableBlockAccessor):
         #       containing non-null values and carrying appropriate type later.
         null_coerced_columns = {}
 
-        for idx, col_name in enumerate(self._table.columns):
-            col = self._table[col_name]
+        for idx, col_name in enumerate(table.columns):
+            col = table[col_name]
 
             # Skip coercing tensors to null-type to avoid type information loss
             # See https://github.com/ray-project/ray/issues/59087 for context

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -301,14 +301,22 @@ class PandasBlockBuilder(TableBlockBuilder):
 
         pandas = lazy_import_pandas()
 
+        def _convert_column(column_name, column_values):
+            if len(column_values) == 0:
+                return column_values
+            if not _should_convert_to_tensor(column_values, column_name):
+                return column_values
+            # Convert to numpy first
+            converted = convert_to_numpy(column_values)
+            # Only wrap in TensorArray if result is a multi-dimensional tensor
+            # (ndim > 1). This avoids issues with 1D arrays from aggregations.
+            if isinstance(converted, np.ndarray) and converted.ndim > 1:
+                return TensorArray(converted)
+            return converted
+
         return pandas.DataFrame(
             {
-                column_name: (
-                    TensorArray(convert_to_numpy(column_values))
-                    if len(column_values) > 0
-                    and _should_convert_to_tensor(column_values, column_name)
-                    else column_values
-                )
+                column_name: _convert_column(column_name, column_values)
                 for column_name, column_values in columns.items()
             }
         )

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -174,10 +174,10 @@ class TableBlockAccessor(BlockAccessor):
     def _munge_conflict(name, count):
         return f"{name}_{count + 1}"
 
-    def to_default(self) -> Block:
+    def to_default(self, copy: bool = False) -> Block:
         # Always promote Arrow blocks to pandas for consistency, since
         # we lazily convert pandas->Arrow internally for efficiency.
-        default = self.to_pandas()
+        default = self.to_pandas(copy=copy)
 
         return default
 

--- a/python/ray/data/_internal/tensor_extensions/pandas.py
+++ b/python/ray/data/_internal/tensor_extensions/pandas.py
@@ -1457,6 +1457,9 @@ def column_needs_tensor_extension(s: pd.Series) -> bool:
         Whether the provided Series needs a tensor extension representation.
     """
     # NOTE: This is an O(1) check.
-    return (
-        s.dtype.type is np.object_ and not s.empty and isinstance(s.iloc[0], np.ndarray)
-    )
+    # Only convert if first element is a multi-dimensional array (ndim > 1).
+    # 1D arrays (like aggregation results) stay as regular object columns.
+    if s.dtype.type is not np.object_ or s.empty:
+        return False
+    first = s.iloc[0]
+    return isinstance(first, np.ndarray) and first.ndim > 1

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -890,9 +890,13 @@ def find_partition_index(
         col_vals = table[col_name].to_numpy()[left:right]
         desired_val = desired[i]
 
-        # Handle null values - replace them with sentinel values
+        # Handle null values. Nulls sort last.
+        # Filter nulls (None or nan) to avoid TypeError in searchsorted.
+        col_vals = col_vals[~pd.isna(col_vals)]
+
+        # If desired_val is None, return position where nulls start.
         if desired_val is None:
-            desired_val = NULL_SENTINEL
+            return left + len(col_vals)
 
         prevleft = left
         if descending[i] is True:

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -939,21 +939,25 @@ class Quantile(AggregateFnV2[List[Any], List[Any]]):
             return current_accumulator
 
         if isinstance(current_accumulator, List) and (not isinstance(new, List)):
-            if new is not None and new != "":
+            if new is not None and not (isinstance(new, str) and new == ""):
                 current_accumulator.append(new)
             return current_accumulator
 
         if isinstance(new, List) and (not isinstance(current_accumulator, List)):
-            if current_accumulator is not None and current_accumulator != "":
+            if current_accumulator is not None and not (
+                isinstance(current_accumulator, str) and current_accumulator == ""
+            ):
                 new.append(current_accumulator)
             return new
 
         ls = []
 
-        if current_accumulator is not None and current_accumulator != "":
+        if current_accumulator is not None and not (
+            isinstance(current_accumulator, str) and current_accumulator == ""
+        ):
             ls.append(current_accumulator)
 
-        if new is not None and new != "":
+        if new is not None and not (isinstance(new, str) and new == ""):
             ls.append(new)
 
         return ls
@@ -968,6 +972,10 @@ class Quantile(AggregateFnV2[List[Any], List[Any]]):
         return ls
 
     def finalize(self, accumulator: List[Any]) -> Optional[Any]:
+        # Convert numpy array to list if needed (from Arrow deserialization)
+        if isinstance(accumulator, np.ndarray):
+            accumulator = accumulator.tolist()
+
         if self._ignore_nulls:
             accumulator = [v for v in accumulator if not is_null(v)]
         else:
@@ -977,7 +985,7 @@ class Quantile(AggregateFnV2[List[Any], List[Any]]):
                 # Return the first null encountered to preserve column type.
                 return nulls[0]
 
-        if not accumulator:
+        if len(accumulator) == 0:
             # If the list is empty (e.g., all values were null and ignored, or no values),
             # quantile is undefined.
             return None
@@ -1238,7 +1246,6 @@ class ValueCounter(AggregateFnV2):
         current_accumulator: Dict[str, List],
         new_accumulator: Dict[str, List],
     ) -> Dict[str, List]:
-
         values = current_accumulator["values"]
         counts = current_accumulator["counts"]
 
@@ -1329,6 +1336,27 @@ def _null_safe_finalize(
     return _safe_finalize
 
 
+def _convert_numpy_to_python(val: AccumulatorType) -> AccumulatorType:
+    """Convert numpy arrays to Python lists for combine() compatibility.
+
+    Arrow blocks return numpy arrays for list columns, but aggregates expect
+    Python lists. This helper ensures accumulators are in the expected format.
+    Handles nested numpy arrays recursively.
+    """
+    if isinstance(val, np.ndarray):
+        # Use tolist() which recursively converts nested arrays to lists
+        return val.tolist()
+    if isinstance(val, list):
+        # Handle lists that may contain numpy arrays (e.g., after partial tolist)
+        return [v.tolist() if isinstance(v, np.ndarray) else v for v in val]
+    if isinstance(val, dict):
+        # Handle dict accumulators like ValueCounter
+        return {
+            k: v.tolist() if isinstance(v, np.ndarray) else v for k, v in val.items()
+        }
+    return val
+
+
 def _null_safe_combine(
     combine: Callable[[AccumulatorType, AccumulatorType], AccumulatorType],
     ignore_nulls: bool,
@@ -1364,6 +1392,9 @@ def _null_safe_combine(
             elif is_null(new):
                 return cur
             else:
+                # Convert numpy arrays to Python types before combining
+                cur = _convert_numpy_to_python(cur)
+                new = _convert_numpy_to_python(new)
                 return combine(cur, new)
 
     else:
@@ -1376,6 +1407,9 @@ def _null_safe_combine(
             elif is_null(cur):
                 return cur
             else:
+                # Convert numpy arrays to Python types before combining
+                cur = _convert_numpy_to_python(cur)
+                new = _convert_numpy_to_python(new)
                 return combine(cur, new)
 
     return _safe_combine

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -22,6 +22,7 @@ import numpy as np
 import pyarrow as pa
 
 import ray
+from ray._private.ray_constants import env_bool
 from ray.data._internal.util import _check_pyarrow_version, _truncated_repr
 from ray.types import ObjectRef
 from ray.util import log_once
@@ -323,6 +324,10 @@ class BlockAccessor:
     as a top-level Ray object, without a wrapping class (issue #17186).
     """
 
+    _DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
+        "RAY_DATA_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT", True
+    )
+
     def num_rows(self) -> int:
         """Return the number of rows contained in this block."""
         raise NotImplementedError
@@ -487,6 +492,17 @@ class BlockAccessor:
                 "allowed in Ray 2.5. Return a dict of field -> array, "
                 "e.g., `{'data': array}` instead of `array`."
             )
+
+        elif cls._DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT:
+            import pandas as pd
+
+            assert block_type is None or block_type == BlockType.ARROW
+
+            if isinstance(batch, pd.DataFrame):
+                return cls.for_block(batch).to_arrow()
+
+            elif isinstance(batch, collections.abc.Mapping):
+                return cls.batch_to_arrow_block(batch)
 
         elif isinstance(batch, collections.abc.Mapping):
             if block_type is None or block_type == BlockType.ARROW:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -394,17 +394,24 @@ class BlockAccessor:
         """Randomly shuffle this block."""
         raise NotImplementedError
 
-    def to_pandas(self) -> "pandas.DataFrame":
-        """Convert this block into a Pandas dataframe."""
+    def to_pandas(self, copy: bool = False) -> "pandas.DataFrame":
+        """Convert this block into a Pandas dataframe.
+
+        Args:
+            copy: Whether to ensure the returned DataFrame is a copy
+                (not a zero-copy view).
+        """
         raise NotImplementedError
 
     def to_numpy(
-        self, columns: Optional[Union[str, List[str]]] = None
+        self, columns: Optional[Union[str, List[str]]] = None, copy: bool = False
     ) -> Union[np.ndarray, Dict[str, np.ndarray]]:
         """Convert this block (or columns of block) into a NumPy ndarray.
 
         Args:
             columns: Name of columns to convert, or None if converting all columns.
+            copy: Whether to ensure the returned arrays are copies
+                (not zero-copy views).
         """
         raise NotImplementedError
 
@@ -416,15 +423,24 @@ class BlockAccessor:
         """Return the base block that this accessor wraps."""
         raise NotImplementedError
 
-    def to_default(self) -> Block:
-        """Return the default data format for this accessor."""
+    def to_default(self, copy: bool = False) -> Block:
+        """Return the default data format for this accessor.
+
+        Args:
+            copy: Whether to ensure the returned batch is a copy
+                (not a zero-copy view).
+        """
         return self.to_block()
 
-    def to_batch_format(self, batch_format: Optional[str]) -> DataBatch:
+    def to_batch_format(
+        self, batch_format: Optional[str], ensure_copy: bool = False
+    ) -> DataBatch:
         """Convert this block into the provided batch format.
 
         Args:
             batch_format: The batch format to convert this block to.
+            ensure_copy: Whether to ensure the returned batch is a copy
+                (not a zero-copy view).
 
         Returns:
             This block formatted as the provided batch format.
@@ -432,13 +448,13 @@ class BlockAccessor:
         if batch_format is None:
             return self.to_block()
         elif batch_format == "default" or batch_format == "native":
-            return self.to_default()
+            return self.to_default(copy=ensure_copy)
         elif batch_format == "pandas":
-            return self.to_pandas()
+            return self.to_pandas(copy=ensure_copy)
         elif batch_format == "pyarrow":
             return self.to_arrow()
         elif batch_format == "numpy":
-            return self.to_numpy()
+            return self.to_numpy(copy=ensure_copy)
         else:
             raise ValueError(
                 f"The batch format must be one of {VALID_BATCH_FORMATS}, got: "

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -28,6 +28,7 @@ import ray
 import ray.cloudpickle as pickle
 from ray._common.usage import usage_lib
 from ray._private.thirdparty.tabulate.tabulate import tabulate
+from ray.data._internal.arrow_block import ArrowBlockBuilder
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.dataset_repr import _build_dataset_ascii_repr
 from ray.data._internal.datasource.bigquery_datasink import BigQueryDatasink
@@ -77,7 +78,7 @@ from ray.data._internal.logical.operators import (
     Write,
     Zip,
 )
-from ray.data._internal.pandas_block import PandasBlockBuilder, PandasBlockSchema
+from ray.data._internal.pandas_block import PandasBlockSchema
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 from ray.data._internal.remote_fn import cached_remote_fn
@@ -6317,14 +6318,11 @@ class Dataset:
                     "ds.to_pandas(limit=None) to disable limits."
                 )
 
-        builder = PandasBlockBuilder()
-        for batch in self.iter_batches(batch_format="pandas", batch_size=None):
+        builder = ArrowBlockBuilder()
+        for batch in self.iter_batches(batch_format="pyarrow", batch_size=None):
             builder.add_block(batch)
         block = builder.build()
 
-        # `PandasBlockBuilder` creates a dataframe with internal extension types like
-        # 'TensorDtype'. We use the `to_pandas` method to convert these extension
-        # types to regular types.
         return BlockAccessor.for_block(block).to_pandas()
 
     @ConsumptionAPI(pattern="Time complexity:")

--- a/python/ray/data/tests/test_benchmark_pandas_batch_2_arrow_block.py
+++ b/python/ray/data/tests/test_benchmark_pandas_batch_2_arrow_block.py
@@ -1,0 +1,127 @@
+"""
+Benchmark for Pandas batch handling in Ray Data.
+
+Compares performance with RAY_DATA_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT=0 vs 1.
+
+Usage:
+    python bench_pandas_batch_to_arrow.py
+"""
+
+import time
+
+import numpy as np
+import pandas as pd
+from tabulate import tabulate
+
+import ray
+from ray.data.block import BlockAccessor
+
+
+def create_dataset(num_rows: int):
+    """Create dataset with 10 columns: 4 int, 3 float, 3 string."""
+    string_pool = [f"str_{i}" for i in range(1000)]
+    df = pd.DataFrame(
+        {
+            "int_0": np.random.randint(0, 1000000, num_rows),
+            "int_1": np.random.randint(0, 1000000, num_rows),
+            "int_2": np.random.randint(0, 1000000, num_rows),
+            "int_3": np.random.randint(0, 1000000, num_rows),
+            "float_0": np.random.randn(num_rows),
+            "float_1": np.random.randn(num_rows),
+            "float_2": np.random.randn(num_rows),
+            "str_0": np.random.choice(string_pool, num_rows),
+            "str_1": np.random.choice(string_pool, num_rows),
+            "str_2": np.random.choice(string_pool, num_rows),
+        }
+    )
+    return ray.data.from_pandas(df).materialize()
+
+
+def run_benchmark(num_rows, num_map_batches, iter_batch_size):
+    """Run a single benchmark iteration."""
+    ds = create_dataset(num_rows)
+
+    # Chain multiple map_batches that don't fuse
+    start = time.perf_counter()
+    result_ds = ds
+    for i in range(num_map_batches):
+        result_ds = result_ds.map_batches(
+            lambda x: x,
+            batch_format="pandas",
+            batch_size=iter_batch_size * (i + 1),
+        )
+    result_ds = result_ds.materialize()
+    map_batches_time = time.perf_counter() - start
+
+    # iter_batches (on result of map_batches)
+    start = time.perf_counter()
+    for _ in result_ds.iter_batches(batch_size=iter_batch_size, batch_format="pandas"):
+        pass
+    iter_time = time.perf_counter() - start
+
+    return map_batches_time, iter_time
+
+
+def main():
+    ray.init(ignore_reinit_error=True)
+
+    row_counts = [10_000, 1_000_000, 10_000_000]
+    num_map_batches_list = [1, 2, 3, 5, 10]
+    iter_batch_size = 1000
+    results = []
+
+    for num_rows in row_counts:
+        for num_map_batches in num_map_batches_list:
+            print(f"\n=== {num_rows:,} rows, {num_map_batches} maps_batches ===")
+
+            # Run with arrow_format=False (default)
+            BlockAccessor._DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = False
+            map_batches_time_0, iter_time_0 = run_benchmark(
+                num_rows, num_map_batches, iter_batch_size
+            )
+            print(
+                f"  fmt=0: map_batches={map_batches_time_0:.3f}s iter={iter_time_0:.3f}s"
+            )
+
+            # Run with arrow_format=True
+            BlockAccessor._DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = True
+            map_batches_time_1, iter_time_1 = run_benchmark(
+                num_rows, num_map_batches, iter_batch_size
+            )
+            print(
+                f"  fmt=1: map_batches={map_batches_time_1:.3f}s iter={iter_time_1:.3f}s"
+            )
+
+            # Calculate speedup (positive = arrow_format=1 is faster)
+            map_speedup = (
+                (map_batches_time_0 / map_batches_time_1 - 1) * 100
+                if map_batches_time_1 > 0
+                else 0
+            )
+            iter_speedup = (
+                (iter_time_0 / iter_time_1 - 1) * 100 if iter_time_1 > 0 else 0
+            )
+
+            results.append(
+                {
+                    "num_rows": f"{num_rows:,}",
+                    "num_map_batches": num_map_batches,
+                    "map_batches(pandas block) (s)": f"{map_batches_time_0:.3f}",
+                    "map_batches(arrow block) (s)": f"{map_batches_time_1:.3f}",
+                    "map_batches Δ%": f"{map_speedup:+.1f}%",
+                    "iter_batches(pandas block) (s)": f"{iter_time_0:.3f}",
+                    "iter_batches(arrow block) (s)": f"{iter_time_1:.3f}",
+                    "iter_batches Δ%": f"{iter_speedup:+.1f}%",
+                }
+            )
+
+    # Reset to default
+    BlockAccessor._DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = False
+
+    print("\n" + tabulate(results, headers="keys", tablefmt="grid"))
+    print("\nNote: Δ% = speedup when arrow_format=1 (positive = faster)")
+    ray.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/ray/data/tests/test_map_batches.py
+++ b/python/ray/data/tests/test_map_batches.py
@@ -16,6 +16,7 @@ from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_TYPE_PROMOTION,
 )
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
 from ray.data.dataset import Dataset
 from ray.data.exceptions import UserCodeException
@@ -836,6 +837,65 @@ def test_map_batches_struct_field_type_divergence(shutdown_only):
     # Rows with a=1.5 should have float a, with b=None
     assert rows[2]["data"] == {"a": 1.5, "b": None, "c": 100}
     assert rows[3]["data"] == {"a": 1.5, "b": None, "c": 100}
+
+
+@pytest.mark.parametrize("default_batch_to_block_arrow_format", [True, False])
+def test_map_batches_pandas_batch_to_block_arrow_format(
+    ray_start_regular_shared,
+    default_batch_to_block_arrow_format,
+    monkeypatch,
+):
+    """Test chained map_batches with pandas format and arrow format flag."""
+
+    # Patch class attribute since env var is evaluated at import time
+    monkeypatch.setattr(
+        BlockAccessor,
+        "_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT",
+        default_batch_to_block_arrow_format,
+    )
+
+    # Create dataset with mixed types (int, float, string)
+    num_rows = 100
+    string_pool = [f"str_{i}" for i in range(10)]
+    df = pd.DataFrame(
+        {
+            "int_col": np.random.randint(0, 1000, num_rows),
+            "float_col": np.random.randn(num_rows),
+            "str_col": np.random.choice(string_pool, num_rows),
+        }
+    )
+    ds = ray.data.from_pandas(df)
+
+    # Chain multiple map_batches with pandas format
+    batch_size = 10
+    result_ds = (
+        ds.map_batches(lambda x: x, batch_format="pandas", batch_size=batch_size)
+        .map_batches(lambda x: x, batch_format="pandas", batch_size=batch_size * 2)
+        .map_batches(lambda x: x, batch_format="pandas", batch_size=batch_size * 3)
+        .sort("int_col")
+        .materialize()
+    )
+
+    # Verify row count preserved
+    assert result_ds.count() == num_rows
+
+    # Verify result is sorted by int_col
+    result_df = result_ds.to_pandas()
+    assert result_df["int_col"].is_monotonic_increasing
+
+    # Verify iter_batches works and maintains sort order
+    total_rows = 0
+    prev_max = None
+    for batch in result_ds.iter_batches(batch_size=batch_size, batch_format="pandas"):
+        assert isinstance(batch, pd.DataFrame)
+        # Verify batch is sorted
+        assert batch["int_col"].is_monotonic_increasing
+        # Verify batches maintain order across iterations
+        if prev_max is not None:
+            assert batch["int_col"].iloc[0] >= prev_max
+        prev_max = batch["int_col"].iloc[-1]
+        total_rows += len(batch)
+    assert total_rows == num_rows
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -366,6 +366,31 @@ def test_find_partition_index_with_nulls():
     assert find_partition_index(table, (None,), sort_key) == 3
 
 
+def test_find_partition_index_with_nulls_object_dtype():
+    # Test object dtype columns with None values (e.g., from Pandas DataFrames).
+    # This tests the fix for TypeError when None appears in object arrays.
+    import pandas as pd
+
+    # Pandas DataFrame with object dtype containing None
+    df = pd.DataFrame({"value": ["a", "b", "c", None, None]})
+    sort_key = SortKey(key=["value"], descending=[False])
+
+    # Insert "b" -> belongs after "a", before "b" => index 1
+    assert find_partition_index(df, ("b",), sort_key) == 1
+    # Insert "d" -> belongs after "c", before nulls => index 3
+    assert find_partition_index(df, ("d",), sort_key) == 3
+    # Insert None -> belongs where nulls start (index 3)
+    assert find_partition_index(df, (None,), sort_key) == 3
+
+    # Test with mixed float/None in object dtype (edge case)
+    df_mixed = pd.DataFrame({"value": [1.0, 2.0, 3.0, None, None]}, dtype=object)
+    sort_key = SortKey(key=["value"], descending=[False])
+
+    assert find_partition_index(df_mixed, (2.0,), sort_key) == 1
+    assert find_partition_index(df_mixed, (4.0,), sort_key) == 3
+    assert find_partition_index(df_mixed, (None,), sort_key) == 3
+
+
 def test_find_partition_index_duplicates():
     table = pa.table({"value": [2, 2, 2, 2, 2]})
     sort_key = SortKey(key=["value"], descending=[False])


### PR DESCRIPTION
## Description                                                                                                      
                                                                                                                        
  When a UDF returns a `pd.DataFrame` or dict batch, Ray Data previously stored it as a Pandas block in the object    
store. This PR changes that behavior: UDF output is now immediately converted to an Arrow block before being stored, making Arrow the single internal block format. 

  Along with the core change, several downstream bugs that surface when Arrow is used as the internal block format are
  fixed:
  - `ensure_copy` wired through the full batch format pipeline to prevent read-only view errors when UDFs mutate batches
   in-place
  - `PandasBlockAccessor.to_arrow()`: cast tensor columns before conversion
  - `find_partition_index()`: fix null handling with `np.searchsorted` (nulls now correctly sort last)
  - `Quantile` aggregation: handle Arrow-deserialized numpy arrays in accumulator combine/finalize paths
  - `column_needs_tensor_extension()`: restrict `TensorArray` wrapping to `ndim > 1` to prevent 1D aggregation results
  from being misclassified as tensors
  - `Dataset.to_pandas()`: switch to Arrow path internally
