### PR TITLE
[Core] Ensure Node._node_labels initializes regardless of connect_only

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -426,7 +426,7 @@ class Node:
                 self._node_id,
             )
         # Set node labels from GCS
-        self._node_labels = node_info.get("labels") or {}
+        self._node_labels = node_info.get("labels", {})
 
         # port can be 0 or None for two cases:
         # 1. user is starting a new ray cluster and does not specify the port, components self-bind.

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -426,7 +426,7 @@ class Node:
                 self._node_id,
             )
         # Set node labels from GCS
-        self._node_labels = node_info.get("labels", {})
+        self._node_labels = node_info.get("labels", {}) if node_info else {}
 
         # port can be 0 or None for two cases:
         # 1. user is starting a new ray cluster and does not specify the port, components self-bind.

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -426,7 +426,7 @@ class Node:
                 self._node_id,
             )
         # Set node labels from GCS
-        self._node_labels = node_info.get("labels", {})
+        self._node_labels = node_info.get("labels") or {}
 
         # port can be 0 or None for two cases:
         # 1. user is starting a new ray cluster and does not specify the port, components self-bind.

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -425,8 +425,8 @@ class Node:
                 self.gcs_address,
                 self._node_id,
             )
-            # Set node labels from GCS if provided at node init.
-            self._node_labels = node_info.get("labels", {})
+        # Set node labels from GCS
+        self._node_labels = node_info.get("labels", {})
 
         # port can be 0 or None for two cases:
         # 1. user is starting a new ray cluster and does not specify the port, components self-bind.

--- a/python/ray/tests/test_node_labels.py
+++ b/python/ray/tests/test_node_labels.py
@@ -71,6 +71,24 @@ def test_ray_init_set_node_labels(shutdown_only):
     assert node_info["Labels"] == add_default_labels_for_test(node_info, {})
 
 
+def test_node_labels_connect_only_false(shutdown_only):
+    labels = {"key": "value"}
+    ray.init(labels=labels)
+    node_labels = ray.get_runtime_context().get_node_labels()
+    assert node_labels["key"] == "value"
+
+
+@pytest.mark.parametrize(
+    "call_ray_start",
+    ['ray start --head --labels={"key":"value"}'],
+    indirect=True,
+)
+def test_node_labels_connect_only_true(call_ray_start):
+    ray.init(address=call_ray_start)
+    node_labels = ray.get_runtime_context().get_node_labels()
+    assert node_labels["key"] == "value"
+
+
 def test_ray_init_set_node_labels_value_error(ray_start_cluster):
     cluster = ray_start_cluster
 


### PR DESCRIPTION
## Description
This PR ensure `Node._node_labels` initializes regardless of `connect_only`. The original code only initializesd`Node._node_labels` when `connect_only = true`

## Related issues
Closes https://github.com/ray-project/ray/issues/61604

## Additional information
### Verification
#### Testing Script
``` python
import ray

ray.init()
print(ray.runtime_context.get_runtime_context().get_node_labels())
```

#### Before Fix
```
Traceback (most recent call last):
  File "/code/labs/jakob/ray/node_labels.py", line 7, in <module>
    print(ray.runtime_context.get_runtime_context().get_node_labels())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/ray/runtime_context.py", line 598, in get_node_labels
    return worker.current_node_labels
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/ray/_private/worker.py", line 634, in current_node_labels
    return self.node.node_labels
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/ray/_private/node.py", line 685, in node_labels
    return self._node_labels
           ^^^^^^^^^^^^^^^^^
AttributeError: 'Node' object has no attribute '_node_labels'. Did you mean: 'node_labels'?
```

#### After Fix
```
{'ray.io/node-id': 'b32f99e4d621a79a6a001662c1e0fd54b929765b0f69bb12e263c2b7'}
```
