### PR TITLE
[Train] Pin test_xgboost_trainer to data autoscaler V1

### DIFF
--- a/python/ray/train/BUILD.bazel
+++ b/python/ray/train/BUILD.bazel
@@ -1013,7 +1013,10 @@ py_test(
     name = "test_xgboost_trainer",
     size = "medium",
     srcs = ["tests/test_xgboost_trainer.py"],
-    env = {"RAY_TRAIN_V2_ENABLED": "0"},
+    env = {
+        "RAY_DATA_CLUSTER_AUTOSCALER": "V1",
+        "RAY_TRAIN_V2_ENABLED": "0",
+    },
     tags = [
         "exclusive",
         "team:ml",


### PR DESCRIPTION
## Description
### What This Fixes

This PR pins `//python/ray/train:test_xgboost_trainer` to `RAY_DATA_CLUSTER_AUTOSCALER=V1` while keeping `RAY_TRAIN_V2_ENABLED=0`.

This PR fixes the failure in `//python/ray/train:test_xgboost_trainer`, specifically `python/ray/train/tests/test_xgboost_trainer.py::test_fit`

```shell
AssertionError: Global limits should be non-negative, got ExecutionResources(cpu=-1.0, ...)
```

Link: https://buildkite.com/organizations/ray-project/pipelines/premerge/builds/61679/jobs/019cd6c3-42db-4d07-82de-01c9332fbe89/log


```
[2026-03-10T08:17:33Z] python/ray/train/tests/test_xgboost_trainer.py::test_fit FAILED          [  7%]
--
[2026-03-10T08:17:33Z]
[2026-03-10T08:17:33Z] =================================== FAILURES ===================================
[2026-03-10T08:17:33Z] ___________________________________ test_fit ___________________________________
[2026-03-10T08:17:33Z] ray.exceptions.RayTaskError(AssertionError): ray::_Inner.train() (pid=25597, ip=172.16.0.5, actor_id=1f96e0427d4c2ddea34cdf4701000000, repr=XGBoostTrainer)
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/tune/trainable/trainable.py", line 331, in train
[2026-03-10T08:17:33Z]     raise skipped from exception_cause(skipped)
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/train/_internal/utils.py", line 57, in check_for_failure
[2026-03-10T08:17:33Z]     ray.get(object_ref)
[2026-03-10T08:17:33Z] ray.exceptions.RayTaskError(AssertionError): ray.data.exceptions.SystemException
[2026-03-10T08:17:33Z]
[2026-03-10T08:17:33Z] ray::_RayTrainWorker__execute.get_next() (pid=25674, ip=172.16.0.5, actor_id=f633b291af75f8f520f2bf6c01000000, repr=<ray.train._internal.worker_group.RayTrainWorker object at 0x7f439d017580>)
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/train/_internal/worker_group.py", line 35, in __execute
[2026-03-10T08:17:33Z]     raise skipped from exception_cause(skipped)
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/train/_internal/utils.py", line 160, in discard_return_wrapper
[2026-03-10T08:17:33Z]     train_func(*args, **kwargs)
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/train/xgboost/xgboost_trainer.py", line 52, in _xgboost_train_fn_per_worker
[2026-03-10T08:17:33Z]     train_df = train_ds_iter.materialize().to_pandas()
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/data/dataset.py", line 6321, in to_pandas
[2026-03-10T08:17:33Z]     for batch in self.iter_batches(batch_format="pandas", batch_size=None):
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/data/iterator.py", line 216, in _create_iterator
[2026-03-10T08:17:33Z]     ) = self._to_ref_bundle_iterator()
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/data/_internal/iterator/iterator_impl.py", line 37, in _to_ref_bundle_iterator
[2026-03-10T08:17:33Z]     ) = self._base_dataset._execute_to_iterator()
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/data/dataset.py", line 7022, in _execute_to_iterator
[2026-03-10T08:17:33Z]     bundle_iter, stats, executor = self._plan.execute_to_iterator()
[2026-03-10T08:17:33Z]   File "/rayci/python/ray/data/exceptions.py", line 89, in handle_trace
[2026-03-10T08:17:33Z]     raise e.with_traceback(None) from SystemException()
[2026-03-10T08:17:33Z] AssertionError: Global limits should be non-negative, got ExecutionResources(cpu=-1.0, gpu=0.0, object_store_memory=2.2GiB, memory=10.2GiB)
[2026-03-10T08:17:33Z]
[2026-03-10T08:17:33Z] The above exception was the direct cause of the following exception:

```



The underlying behavior change came from #60474, which made Ray Data autoscaler V2 the default. The issue was then surfaced as a hard failure by the non-negative resource assertion added in #61580.

The failure happens because Train V1 still reserves resources through `exclude_resources`, while Data autoscaler V2 reports per-execution allocated resources; this mismatch can cause the effective CPU limit to go negative. This PR keeps the fix local to the failing Train V1 test target by pinning it to `RAY_DATA_CLUSTER_AUTOSCALER=V1`.





