### PR TITLE
[ci] Patch gRPC BUILD files to disable layering_check

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -283,6 +283,14 @@ def ray_deps_setup():
             "@io_ray//thirdparty/patches:grpc-cython-copts.patch",
             "@io_ray//thirdparty/patches:grpc-zlib-fdopen.patch",
             "@io_ray//thirdparty/patches:grpc-configurable-thread-count.patch",
+            # gRPC v1.57.1 explicitly opts into layering_check. With clang-14 and
+            # --spawn_strategy=local, clang reads transitive .cppmap files already
+            # on disk and includes them in the depfile, causing "undeclared inclusion"
+            # errors across ~200 gRPC targets. This is a Bazel bug (https://github.com/bazelbuild/bazel/issues/21592)
+            # fixed in Bazel 7.3.0. LLVM applied the same workaround in their BUILD
+            # files (https://github.com/llvm/llvm-project/commit/5bba176). Remove the
+            # opt-in from the two affected BUILD files until gRPC or Bazel is upgraded.
+            "@io_ray//thirdparty/patches:grpc-disable-layering-check.patch",
         ],
     )
 

--- a/thirdparty/patches/grpc-disable-layering-check.patch
+++ b/thirdparty/patches/grpc-disable-layering-check.patch
@@ -1,0 +1,24 @@
+diff -u BUILD BUILD
+--- BUILD
++++ BUILD
+@@ -30,7 +30,6 @@
+ package(
+     default_visibility = ["//visibility:public"],
+     features = [
+-        "layering_check",
+         "-parse_headers",
+     ],
+ )
+diff -u src/core/BUILD src/core/BUILD
+--- src/core/BUILD
++++ src/core/BUILD
+@@ -24,9 +24,6 @@
+
+ package(
+     default_visibility = ["//:__subpackages__"],
+-    features = [
+-        "layering_check",
+-    ],
+ )
+
+ # This is needed as a transitionary mechanism to build the src/core targets in


### PR DESCRIPTION
clang-14's Bazel toolchain enables the layering_check feature, which generates per-rule .cppmap module-map files and enforces that headers are only included through declared BUILD dependencies. gRPC v1.57.1 explicitly opts into this feature via package(features = ["layering_check"]) in two BUILD files (BUILD and src/core/BUILD), but has undeclared cross-rule transitive header inclusions that pass with clang-12 but fail with clang-14.

With --spawn_strategy=local (used in test:ci), actions run unsandboxed and the compiler can access .cppmap files present in the output directory but not declared as inputs, producing "undeclared inclusion" errors across ~200 gRPC targets.

Rather than disabling layering_check globally, patch the two gRPC BUILD files to remove the explicit feature opt-in. This keeps layering_check active for Ray's own C++ code.

Topic: layering-check

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: andrew <andrew@anyscale.com>