### PR TITLE
[Serve] Fix incorrect replica death detection when ActorDiedError originates from dependency deployments

### DIFF
--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -758,12 +758,17 @@ class AsyncioRouter:
             # Replica has died but controller hasn't notified the router yet.
             # Don't consider this replica for requests in the future, and retry
             # routing request.
-            if self.request_router:
-                self.request_router.on_replica_actor_died(replica_id)
-            logger.warning(
-                f"{replica_id} will not be considered for future "
-                "requests because it has died."
-            )
+            if replica_id.actor_id == result.actor_id:
+                if self.request_router:
+                    self.request_router.on_replica_actor_died(replica_id)
+                logger.warning(
+                    f"{replica_id} will not be considered for future requests because it has died."
+                )
+            else:
+                logger.warning(
+                    f"ActorDiedError observed for request on replica {replica_id}, "
+                    "but the error originated from a dependency. Not marking replica dead."
+                )
         elif isinstance(result, ActorUnavailableError):
             # There are network issues, or replica has died but GCS is down so
             # ActorUnavailableError will be raised until GCS recovers. For the
@@ -843,16 +848,21 @@ class AsyncioRouter:
                 result.cancel()
 
             raise
-        except ActorDiedError:
+        except ActorDiedError as e:
             # Replica has died but controller hasn't notified the router yet.
             # Don't consider this replica for requests in the future, and retry
             # routing request.
             if replica is not None:
-                self.request_router.on_replica_actor_died(replica.replica_id)
-                logger.warning(
-                    f"{replica.replica_id} will not be considered for future "
-                    "requests because it has died."
-                )
+                if replica.replica_id.actor_id == e.actor_id:
+                    self.request_router.on_replica_actor_died(replica.replica_id)
+                    logger.warning(
+                        f"{replica.replica_id} will not be considered for future requests because it has died."
+                    )
+                else:
+                    logger.warning(
+                        f"ActorDiedError occurred but originated from dependency. "
+                        f"Replica {replica.replica_id} remains valid."
+                    )
         except ActorUnavailableError:
             # There are network issues, or replica has died but GCS is down so
             # ActorUnavailableError will be raised until GCS recovers. For the


### PR DESCRIPTION
## Problem

When using chained deployments (A → B → C), an `ActorDiedError` from an upstream
deployment can propagate through downstream replicas.

The Serve router currently interprets this as the replica itself dying and
calls `on_replica_actor_died`, which removes healthy replicas from routing.

This can lead to request deadlocks and unnecessary replica removal.

## Fix 

Avoid marking the replica dead when `ActorDiedError` may originate from a
dependency deployment in a chained request pipeline.

## Reproduction

The issue can be reproduced using the `Reproduction.py` script where:

Ingress → Multiplier → Adder

If `Adder` exits (`os._exit(0)`), the router incorrectly marks `Multiplier`
as dead.

With this patch, the router no longer incorrectly removes healthy replicas.

Closes #61594