### PR TITLE
[ci][docker] Add TPU image build and publish pipeline for aarch64

### DIFF
--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -44,6 +44,22 @@ steps:
       PYTHON_VERSION: "{{matrix}}"
       ARCH_SUFFIX: "-aarch64"
 
+  - name: raytpubase-aarch64
+    label: "wanda: ray-py{{matrix}}-tpu-base (aarch64)"
+    tags:
+      - python_dependencies
+      - docker
+    wanda: docker/base-deps/tpu.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    instance_type: builder-arm64
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: "-aarch64"
+
   - name: raycpubaseextra-aarch64
     label: "wanda: ray.py{{matrix}}.cpu.base-extra (aarch64)"
     wanda: docker/base-extra/cpu.wanda.yaml
@@ -260,6 +276,42 @@ steps:
       - raycpubase-aarch64
     instance_type: builder-arm64
 
+  - name: ray-image-tpu-build-aarch64
+    label: "wanda: ray py{{matrix}} tpu (aarch64)"
+    wanda: ci/docker/ray-image-tpu.wanda.yaml
+    matrix:
+      - "3.10"
+      - "3.11"
+      - "3.12"
+      - "3.13"
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "{{matrix}}"
+      ARCH_SUFFIX: "-aarch64"
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    depends_on:
+      - ray-wheel-build-aarch64
+      - raytpubase-aarch64
+    instance_type: builder-arm64
+
+  - label: ":tapioca: smoke test: ray tpu image (aarch64)"
+    instance_type: medium-arm64
+    tags:
+      - python_dependencies
+      - docker
+      - oss
+    commands:
+      - aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 029272617770.dkr.ecr.us-west-2.amazonaws.com
+      - docker run --rm
+        "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-ray-py3.10-tpu-aarch64
+        /bin/bash -c "python -c \"import ray; print('ray', ray.__version__); import jax; print('jax', jax.__version__)\""
+    depends_on:
+      - ray-image-tpu-build-aarch64
+      - forge-aarch64
+
   - name: ray-image-cuda-build-aarch64
     label: "wanda: ray py{{matrix.python}} cu{{matrix.cuda}} (aarch64)"
     wanda: ci/docker/ray-image-cuda.wanda.yaml
@@ -302,6 +354,7 @@ steps:
       - bazel run //ci/ray_ci/automation:push_ray_image --
         --python-version {{matrix}}
         --platform cpu
+        --platform tpu
         --platform cu11.7.1-cudnn8
         --platform cu11.8.0-cudnn8
         --platform cu12.1.1-cudnn8
@@ -320,6 +373,7 @@ steps:
       - "3.13"
     depends_on:
       - ray-image-cpu-build-aarch64
+      - ray-image-tpu-build-aarch64
       - ray-image-cuda-build-aarch64
     tags:
       - python_dependencies

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -43,6 +43,7 @@ python/_raylet.pyx: ml tune train data python dashboard linux_wheels macos_wheel
 .buildkite/lint.rayci.yml: tools
 .buildkite/macos.rayci.yml: macos_wheels
 .buildkite/base.rayci.yml: docker linux_wheels tools
+.buildkite/linux_aarch64.rayci.yml: docker linux_wheels tools
 
 # === Min installation ===
 

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -221,6 +221,7 @@ build-image.sh
 
 .buildkite/base.rayci.yml
 .buildkite/build.rayci.yml
+.buildkite/linux_aarch64.rayci.yml
 .buildkite/pipeline.arm64.yml
 ci/docker/manylinux.Dockerfile
 ci/docker/manylinux.wanda.yaml


### PR DESCRIPTION
Add TPU image build and publish steps to the aarch64 Buildkite pipeline, mirroring the x86_64 TPU support added in c8ee9fa6ad6e.

New steps:
- raytpubase-aarch64: builds TPU base image using docker/base-deps/tpu.wanda.yaml
- ray-image-tpu-build-aarch64: assembles final Ray TPU image for aarch64
- smoke test: verifies ray and jax are importable in the aarch64 TPU image
- publish: adds --platform tpu to the aarch64 image publish step

Topic: arm64-tpu
Signed-off-by: andrew <andrew@anyscale.com>