### PR TITLE
[release-automation] Exclude aarch64 from TPU image tag generation

### DIFF
--- a/ci/ray_ci/automation/docker_tags_lib.py
+++ b/ci/ray_ci/automation/docker_tags_lib.py
@@ -26,6 +26,7 @@ from ci.ray_ci.docker_container import (
     PYTHON_VERSIONS_RAY_ML,
     RayType,
 )
+from ci.ray_ci.supported_images import get_exceptions
 from ci.ray_ci.utils import logger
 
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
@@ -196,10 +197,18 @@ def list_image_tags(
     if ray_type not in RayType.__members__.values():
         raise ValueError(f"Ray type {ray_type} not supported.")
 
+    exceptions = get_exceptions(ray_type)
     tag_suffixes = []
     for python_version in python_versions:
         for platf in platforms:
             for architecture in architectures:
+                if any(
+                    ("architectures" not in e or architecture in e["architectures"])
+                    and ("platforms" not in e or platf in e["platforms"])
+                    and ("python" not in e or python_version in e["python"])
+                    for e in exceptions
+                ):
+                    continue
                 tag_suffixes += list_image_tag_suffixes(
                     ray_type, python_version, platf, architecture
                 )

--- a/ci/ray_ci/automation/test_docker_tags_lib.py
+++ b/ci/ray_ci/automation/test_docker_tags_lib.py
@@ -488,6 +488,26 @@ def test_backup_release_tags(
                 "test-py310-gpu",
             ],
         ),
+        # tpu + aarch64 excluded via exceptions in ray-images.yaml
+        (
+            "test",
+            "ray",
+            ["3.10"],
+            ["cpu", "tpu"],
+            ["x86_64", "aarch64"],
+            [
+                "test",
+                "test-aarch64",
+                "test-cpu",
+                "test-cpu-aarch64",
+                "test-py310",
+                "test-py310-aarch64",
+                "test-py310-cpu",
+                "test-py310-cpu-aarch64",
+                "test-py310-tpu",
+                "test-tpu",
+            ],
+        ),
     ],
 )
 def test_list_image_tags(

--- a/ci/ray_ci/supported_images.py
+++ b/ci/ray_ci/supported_images.py
@@ -41,5 +41,9 @@ def get_architectures(image_type: str) -> List[str]:
     return get_image_config(image_type)["architectures"]
 
 
+def get_exceptions(image_type: str) -> List[dict]:
+    return get_image_config(image_type).get("exceptions", [])
+
+
 def get_default(image_type: str, key: str) -> str:
     return get_image_config(image_type)["defaults"][key]

--- a/ray-images.yaml
+++ b/ray-images.yaml
@@ -8,6 +8,9 @@ ray:
 
   python: ["3.10", "3.11", "3.12", "3.13"]
   architectures: [x86_64, aarch64]
+  exceptions:
+    - architectures: [aarch64]
+      platforms: [tpu]  # JAX does not support aarch64 TPU: https://docs.jax.dev/en/latest/installation.html#supported-platforms
   platforms:
     - cpu
     - tpu


### PR DESCRIPTION
JAX does not support aarch64 TPU (https://docs.jax.dev/en/latest/installation.html#supported-platforms),
so nightly-py*-tpu-aarch64 images are never built. Add an exceptions list to
ray-images.yaml to encode unsupported platform/architecture/python combinations,
and apply it in list_image_tags to skip generating tags for those combinations.

Topic: arm64-tpu-exclusion
Signed-off-by: andrew <andrew@anyscale.com>