### PR TITLE
[Doc] List TPUs as fully tested/supported

### DIFF
--- a/doc/source/ray-core/scheduling/accelerators.rst
+++ b/doc/source/ray-core/scheduling/accelerators.rst
@@ -29,7 +29,7 @@ The accelerators natively supported by Ray Core are:
      - Experimental, supported by the community
    * - Google TPU
      - TPU
-     - Experimental, supported by the community
+     - Fully tested, supported by the Ray team
    * - Intel Gaudi
      - HPU
      - Experimental, supported by the community


### PR DESCRIPTION
## Description
This PR updates the Ray documentation to list TPUs as a supported accelerator that's tested in CI. With https://github.com/ray-project/ray/pull/61175 adding TPU images to the build pipeline, we now have TPU specific images that are fully tested - similar to Nvidia GPU. While features are still being added related to TPU across libraries (i.e. elastic training, Ray Data, etc.), baseline support has been fully added and it'd be good to reflect that in the docs.

## Related issues
https://github.com/ray-project/ray/issues/57832

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
