### PR TITLE
[Core] Cache ActorHandle.__hash__ and fix __eq__ correctness

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2519,7 +2519,7 @@ class ActorHandle(Generic[T]):
         try:
             return self._cached_hash
         except AttributeError:
-            h = hash(self._actor_id)
+            h = hash(self._ray_actor_id)
             self._cached_hash = h
             return h
 

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2516,10 +2516,17 @@ class ActorHandle(Generic[T]):
         )
 
     def __hash__(self):
-        return hash(self._actor_id)
+        try:
+            return self._cached_hash
+        except AttributeError:
+            h = hash(self._actor_id)
+            self._cached_hash = h
+            return h
 
-    def __eq__(self, __value):
-        return hash(self) == hash(__value)
+    def __eq__(self, other):
+        if not isinstance(other, ActorHandle):
+            return NotImplemented
+        return self._ray_actor_id == other._ray_actor_id
 
     @property
     def _actor_id(self):

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2520,10 +2520,10 @@ class ActorHandle(Generic[T]):
         # cross-language actors returns an ActorMethod instead of raising
         # AttributeError.
         try:
-            return self.__dict__["_cached_hash"]
+            return self.__dict__["_ray_cached_hash"]
         except KeyError:
             h = hash(self._ray_actor_id)
-            self._cached_hash = h
+            self._ray_cached_hash = h
             return h
 
     def __eq__(self, other):

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2516,9 +2516,12 @@ class ActorHandle(Generic[T]):
         )
 
     def __hash__(self):
+        # Look up directly in __dict__ to avoid __getattr__, which for
+        # cross-language actors returns an ActorMethod instead of raising
+        # AttributeError.
         try:
-            return self._cached_hash
-        except AttributeError:
+            return self.__dict__["_cached_hash"]
+        except KeyError:
             h = hash(self._ray_actor_id)
             self._cached_hash = h
             return h

--- a/python/ray/dag/tests/experimental/test_execution_schedule.py
+++ b/python/ray/dag/tests/experimental/test_execution_schedule.py
@@ -193,8 +193,12 @@ class TestSelectNextNodes:
         )
         set_sync_idxs_p2p(mock_graph, task_idx_1, task_idx_2)
         mock_actor_to_candidates = {
-            fake_actor_1._actor_id: [mock_graph[task_idx_1][_DAGNodeOperationType.WRITE]],
-            fake_actor_2._actor_id: [mock_graph[task_idx_2][_DAGNodeOperationType.READ]],
+            fake_actor_1._actor_id: [
+                mock_graph[task_idx_1][_DAGNodeOperationType.WRITE]
+            ],
+            fake_actor_2._actor_id: [
+                mock_graph[task_idx_2][_DAGNodeOperationType.READ]
+            ],
         }
         next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
         assert next_nodes == [
@@ -334,8 +338,12 @@ class TestSelectNextNodes:
         set_sync_idxs_collective(mock_graph, [dag_idx_1, dag_idx_2])
 
         mock_actor_to_candidates = {
-            fake_actor_1._actor_id: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_2._actor_id: [mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_1._actor_id: [
+                mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]
+            ],
+            fake_actor_2._actor_id: [
+                mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]
+            ],
         }
         next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
         assert set(next_nodes) == {
@@ -393,10 +401,18 @@ class TestSelectNextNodes:
         set_sync_idxs_collective(mock_graph, [dag_idx_3, dag_idx_4])
 
         mock_actor_to_candidates = {
-            fake_actor_1._actor_id: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_2._actor_id: [mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_3._actor_id: [mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_4._actor_id: [mock_graph[dag_idx_4][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_1._actor_id: [
+                mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]
+            ],
+            fake_actor_2._actor_id: [
+                mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]
+            ],
+            fake_actor_3._actor_id: [
+                mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE]
+            ],
+            fake_actor_4._actor_id: [
+                mock_graph[dag_idx_4][_DAGNodeOperationType.COMPUTE]
+            ],
         }
         next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
         assert set(next_nodes) == {

--- a/python/ray/dag/tests/experimental/test_execution_schedule.py
+++ b/python/ray/dag/tests/experimental/test_execution_schedule.py
@@ -26,6 +26,7 @@ if sys.platform != "linux" and sys.platform != "darwin":
 
 def mock_actor_handle_init(self, actor_id: str):
     self._ray_actor_id = actor_id
+    self._ray_weak_ref = False
 
 
 def mock_class_method_call_init(self):
@@ -136,7 +137,7 @@ class TestSelectNextNodes:
             False,
         )
         mock_actor_to_candidates = {
-            fake_actor: [
+            fake_actor._actor_id: [
                 dag_node_1,
                 dag_node_2,
             ],
@@ -192,8 +193,8 @@ class TestSelectNextNodes:
         )
         set_sync_idxs_p2p(mock_graph, task_idx_1, task_idx_2)
         mock_actor_to_candidates = {
-            fake_actor_1: [mock_graph[task_idx_1][_DAGNodeOperationType.WRITE]],
-            fake_actor_2: [mock_graph[task_idx_2][_DAGNodeOperationType.READ]],
+            fake_actor_1._actor_id: [mock_graph[task_idx_1][_DAGNodeOperationType.WRITE]],
+            fake_actor_2._actor_id: [mock_graph[task_idx_2][_DAGNodeOperationType.READ]],
         }
         next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
         assert next_nodes == [
@@ -286,11 +287,11 @@ class TestSelectNextNodes:
             set_sync_idxs_p2p(mock_graph, task_idx_1_0, task_idx_2_1)
             set_sync_idxs_p2p(mock_graph, task_idx_2_0, task_idx_1_1)
             mock_actor_to_candidates = {
-                fake_actor_1: [
+                fake_actor_1._actor_id: [
                     mock_graph[task_idx_1_0][_DAGNodeOperationType.WRITE],
                     mock_graph[task_idx_1_1][_DAGNodeOperationType.READ],
                 ],
-                fake_actor_2: [
+                fake_actor_2._actor_id: [
                     mock_graph[task_idx_2_0][_DAGNodeOperationType.WRITE],
                     mock_graph[task_idx_2_1][_DAGNodeOperationType.READ],
                 ],
@@ -333,8 +334,8 @@ class TestSelectNextNodes:
         set_sync_idxs_collective(mock_graph, [dag_idx_1, dag_idx_2])
 
         mock_actor_to_candidates = {
-            fake_actor_1: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_2: [mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_1._actor_id: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_2._actor_id: [mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]],
         }
         next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
         assert set(next_nodes) == {
@@ -392,10 +393,10 @@ class TestSelectNextNodes:
         set_sync_idxs_collective(mock_graph, [dag_idx_3, dag_idx_4])
 
         mock_actor_to_candidates = {
-            fake_actor_1: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_2: [mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_3: [mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE]],
-            fake_actor_4: [mock_graph[dag_idx_4][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_1._actor_id: [mock_graph[dag_idx_1][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_2._actor_id: [mock_graph[dag_idx_2][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_3._actor_id: [mock_graph[dag_idx_3][_DAGNodeOperationType.COMPUTE]],
+            fake_actor_4._actor_id: [mock_graph[dag_idx_4][_DAGNodeOperationType.COMPUTE]],
         }
         next_nodes = _select_next_nodes(mock_actor_to_candidates, mock_graph)
         assert set(next_nodes) == {

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -1572,6 +1572,27 @@ def test_actor_equal(ray_start_regular_shared):
     assert origin == remote
 
 
+@pytest.mark.parametrize("cross_language", [False, True], ids=["python", "cross_lang"])
+def test_actor_handle_hash_eq(ray_start_regular_shared, cross_language):
+    """hash()/eq/set/dict ops must work for both Python and cross-language handles."""
+
+    @ray.remote
+    class Actor:
+        pass
+
+    handle = Actor.remote()
+    if cross_language:
+        handle._ray_is_cross_language = True
+
+    h = hash(handle)
+    assert isinstance(h, int)
+    assert hash(handle) == h
+
+    assert handle == handle
+    assert handle in {handle}
+    assert {handle: "v"}[handle] == "v"
+
+
 def test_actor_handle_weak_ref_counting(ray_start_regular_shared):
     """
     Actors can get handles to themselves or to named actors but these count


### PR DESCRIPTION
## Description

1. Improve `ActorHandle.__hash__` implementation:

ActorHandle.__hash__ traverses Python property -> Cython -> C++ on every call.
Since actor IDs are immutable, cache the hash result on first computation. This benefits any code using ActorHandle as a dict key, which is pervasive in Ray Data's actor pool operator.

2. Fix `ActorHandle.__eq__` which was comparing hash(self) == hash(other)
Existing implementation is both slow (recomputes hashes) and semantically incorrect (hash collisions would produce false equality). Replace with direct actor ID comparison and proper NotImplemented return for non-ActorHandle types.

## Microbenchmark results

[microbench.py](https://github.com/user-attachments/files/25885470/actor_handle_microbench.py)

On master
```
❯ cd /Users/marwan/Repos/open_source/ray
git checkout master
cp python/ray/actor.py .bench_venv/lib/python3.12/site-packages/ray/actor.py
./.bench_venv/bin/python -u snap/actor_handle_microbench.py --quick
M       python/ray/data/_internal/execution/operators/hash_shuffle.py
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
Usage stats collection is enabled. To disable this, run the following command: `ray disable-usage-stats` before starting Ray. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.
2026-03-10 16:04:59,804 INFO worker.py:2004 -- Started a local Ray instance.
/Users/marwan/Repos/open_source/ray/.bench_venv/lib/python3.12/site-packages/ray/_private/worker.py:2043: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
ActorHandle microbenchmark (ns per operation)
Run on master for 'before', on marwan/fix-actor-handle-hash-eq for 'after'.

Creating 50 actors...
(raylet) WARNING: 40 PYTHON worker processes have been started on node: 6fe8b098053de3706e740cdd2e527bf14917b157b557b768009ed21f with address: 127.0.0.1, which is 4x the maximum expected startup concurrency (10). This could be a result of using a large number of actors, tasks blocked in ray.get() calls, or tasks with fractional CPU requests (e.g., num_cpus=0.1) allowing high concurrency. See https://github.com/ray-project/ray/issues/3644 for some discussion of workarounds.
N = 50:

  BEFORE cache_handle_hashes() (cold: every hash/eq pays full cost)
  Eq improvements expected: __eq__ no longer calls hash(); compares actor IDs.
  Dict improvements expected: first use of each key calls hash(); __eq__ used in collision resolution.
    eq same (h == h):      335 ns
    eq different (a==b):   331 ns
    eq non-ActorHandle:    206 ns
    dict insert d[h]=i:   151 ns
    dict lookup d[h]:     128 ns
    in check (h in d):    124 ns

  AFTER cache_handle_hashes() (warm: hash cached; dict ops reuse cached hash)
  Hash improvement expected: cached __hash__ returns stored value. Dict improvement: no repeated hash on same key.
    hash(handle) cached:   131 ns
    dict insert d[h]=i:   153 ns
    dict lookup d[h]:     126 ns
    in check (h in d):    126 ns
```

On this branch
```
❯ cd /Users/marwan/Repos/open_source/ray
git checkout marwan/fix-actor-handle-hash-eq
cp python/ray/actor.py .bench_venv/lib/python3.12/site-packages/ray/actor.py
./.bench_venv/bin/python -u snap/actor_handle_microbench.py --quick
M       python/ray/data/_internal/execution/operators/hash_shuffle.py
Switched to branch 'marwan/fix-actor-handle-hash-eq'
Your branch is up to date with 'origin/marwan/fix-actor-handle-hash-eq'.
Usage stats collection is enabled. To disable this, run the following command: `ray disable-usage-stats` before starting Ray. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.
2026-03-10 17:06:48,463 INFO worker.py:2004 -- Started a local Ray instance.
/Users/marwan/Repos/open_source/ray/.bench_venv/lib/python3.12/site-packages/ray/_private/worker.py:2043: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
  warnings.warn(
ActorHandle microbenchmark (ns per operation)
Run on master for 'before', on marwan/fix-actor-handle-hash-eq for 'after'.

Creating 50 actors...
(raylet) WARNING: 40 PYTHON worker processes have been started on node: 11b12a552bf560d6e5961261eb7ae09303865a17832a860dc4a37026 with address: 127.0.0.1, which is 4x the maximum expected startup concurrency (10). This could be a result of using a large number of actors, tasks blocked in ray.get() calls, or tasks with fractional CPU requests (e.g., num_cpus=0.1) allowing high concurrency. See https://github.com/ray-project/ray/issues/3644 for some discussion of workarounds.
N = 50:

  BEFORE cache_handle_hashes() (cold: every hash/eq pays full cost)
  Eq improvements expected: __eq__ no longer calls hash(); compares actor IDs.
  Dict improvements expected: first use of each key calls hash(); __eq__ used in collision resolution.
    eq same (h == h):      217 ns
    eq different (a==b):   209 ns
    eq non-ActorHandle:    78 ns
    dict insert d[h]=i:   106 ns
    dict lookup d[h]:     86 ns
    in check (h in d):    242 ns

  AFTER cache_handle_hashes() (warm: hash cached; dict ops reuse cached hash)
  Hash improvement expected: cached __hash__ returns stored value. Dict improvement: no repeated hash on same key.
    hash(handle) cached:   121 ns
    dict insert d[h]=i:   118 ns
    dict lookup d[h]:     91 ns
    in check (h in d):    82 ns
  ```

## Related issues
https://github.com/ray-project/ray/issues/54790
