### PR TITLE
[train] Deflake test_xgboost_trainer::test_fit by increasing CPU allocation

### DIFF
--- a/python/ray/train/tests/test_xgboost_trainer.py
+++ b/python/ray/train/tests/test_xgboost_trainer.py
@@ -43,7 +43,7 @@ params = {
 }
 
 
-def test_fit(ray_start_4_cpus):
+def test_fit(ray_start_8_cpus):
     train_dataset = ray.data.from_pandas(train_df)
     valid_dataset = ray.data.from_pandas(test_df)
     trainer = XGBoostTrainer(


### PR DESCRIPTION
## Summary

`test_fit` in `test_xgboost_trainer.py` is failing in CI due to a regression from the V2 cluster autoscaler becoming the default (`#60474`). The V2 autoscaler divides cluster resources equally among registered data executors via the `AutoscalingCoordinator`. With 2 datasets (train + valid), each executor gets `4 // 2 = 2` CPUs, but `exclude_resources` subtracts 3 CPUs (1 trainer + 2 workers), resulting in a negative resource limit (`-1 CPU`) and an assertion failure. Increasing from 4 to 8 CPUs avoids this: `8 // 2 = 4`, and `4 - 3 = 1 CPU`, which is non-negative.

## Changes

- Update `test_fit` in `test_xgboost_trainer.py` to use `ray_start_8_cpus` fixture instead of `ray_start_4_cpus`

### Why this is a temporary mitigation

The root cause is a conflict between the V2 autoscaler's resource partitioning and `exclude_resources` subtraction in `ResourceManager.get_global_limits()`. The `exclude_resources` mechanism assumes `total_resources` reflects the full cluster, but V2 returns only each executor's allocated share. A proper fix should reconcile these two resource-scoping mechanisms. This change unblocks CI in the meantime.

## Tests

No new tests. This modifies the existing `test_fit` to run with sufficient resources to avoid the V2 autoscaler regression.