### PR TITLE
 [Data] Scale actor pool more when upstream has DownstreamCapacity backpressure

### DIFF
--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -144,15 +144,19 @@ class DefaultActorAutoscaler(ActorAutoscaler):
 
         if util >= self._actor_pool_scaling_up_threshold:
             average_num_inputs_per_task = op.metrics.average_num_inputs_per_task or 1
-            upstream_dc_backpressured = (
-                self._is_upstream_backpressured_by_downstream_capacity(op)
+            upstream_dc_backpressured = self._is_upstream_backpressured_by_downstream_capacity(
+                op
+            )
+            upscale_boost_enabled = (
+                upstream_dc_backpressured
+                and self._actor_pool_upscaling_ratio_on_upstream_backpressure > 1.0
             )
             if (
                 op_state.total_enqueued_input_blocks()
                 <= actor_pool.num_free_task_slots() * average_num_inputs_per_task
                 # If an upstream operator is DC-backpressured, don't short-circuit here:
                 # we may want to scale up more aggressively to relieve upstream pressure.
-                and not upstream_dc_backpressured
+                and not upscale_boost_enabled
             ):
                 return ActorPoolScalingRequest.no_op(
                     reason="enough free task slots to consume the existing inputs"
@@ -180,7 +184,7 @@ class DefaultActorAutoscaler(ActorAutoscaler):
                 )
             # When upstream has DC backpressure, pass inflated util so policy scales more.
             effective_util = util
-            if upstream_dc_backpressured:
+            if upscale_boost_enabled:
                 effective_util *= (
                     self._actor_pool_upscaling_ratio_on_upstream_backpressure
                 )
@@ -189,10 +193,7 @@ class DefaultActorAutoscaler(ActorAutoscaler):
                 delta = min(delta, max_scale_up)
             delta = max(1, delta)  # At least scale up by 1
 
-            if (
-                upstream_dc_backpressured
-                and self._actor_pool_upscaling_ratio_on_upstream_backpressure > 1.0
-            ):
+            if upscale_boost_enabled:
                 reason = (
                     f"utilization of {util} "
                     f"(x{self._actor_pool_upscaling_ratio_on_upstream_backpressure} "

--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -37,6 +37,9 @@ class DefaultActorAutoscaler(ActorAutoscaler):
             config.actor_pool_util_downscaling_threshold
         )
         self._actor_pool_max_upscaling_delta = config.actor_pool_max_upscaling_delta
+        self._actor_pool_upscaling_ratio_on_upstream_backpressure = (
+            config.actor_pool_upscaling_ratio_on_upstream_backpressure
+        )
 
         self._actor_pool_resizing_policy = (
             actor_pool_resizing_policy
@@ -95,6 +98,15 @@ class DefaultActorAutoscaler(ActorAutoscaler):
         """
         return self._actor_pool_resizing_policy.compute_downscale_delta(actor_pool)
 
+    def _is_upstream_backpressured_by_downstream_capacity(self, op: "PhysicalOperator") -> bool:
+        """True if any upstream of op is backpressured by the DownstreamCapacity policy."""
+        return any(
+            getattr(upstream, "_in_task_submission_backpressure", False)
+            and getattr(upstream, "_task_submission_backpressure_policy", None)
+            == "DownstreamCapacity"
+            for upstream in op.input_dependencies
+        )
+
     def _derive_target_scaling_config(
         self,
         actor_pool: AutoscalingActorPool,
@@ -132,10 +144,6 @@ class DefaultActorAutoscaler(ActorAutoscaler):
 
         if util >= self._actor_pool_scaling_up_threshold:
             average_num_inputs_per_task = op.metrics.average_num_inputs_per_task or 1
-            # Skip scaling up if the current free task slots can handle all pending work.
-            # Each task consumes `average_num_inputs_per_task` input blocks on average,
-            # so the total input capacity is: free_slots × avg_inputs_per_task.
-            # If enqueued blocks ≤ capacity, we have enough resources already.
             if (
                 op_state.total_enqueued_input_blocks()
                 <= actor_pool.num_free_task_slots() * average_num_inputs_per_task
@@ -164,7 +172,13 @@ class DefaultActorAutoscaler(ActorAutoscaler):
                 return ActorPoolScalingRequest.upscale(
                     delta=1, reason="no running actors, scale up immediately"
                 )
-            delta = self._compute_upscale_delta(actor_pool, util)
+            # When upstream has DC backpressure, pass inflated util so policy scales more.
+            delta = self._compute_upscale_delta(
+                actor_pool,
+                util * self._actor_pool_upscaling_ratio_on_upstream_backpressure
+                if self._is_upstream_backpressured_by_downstream_capacity(op)
+                else util,
+            )
             if max_scale_up is not None:
                 delta = min(delta, max_scale_up)
             delta = max(1, delta)  # At least scale up by 1
@@ -214,6 +228,11 @@ class DefaultActorAutoscaler(ActorAutoscaler):
             raise ValueError(
                 f"actor_pool_util_upscaling_threshold must be positive, "
                 f"got {self._actor_pool_scaling_up_threshold}"
+            )
+        if self._actor_pool_upscaling_ratio_on_upstream_backpressure < 1.0:
+            raise ValueError(
+                "actor_pool_upscaling_ratio_on_upstream_backpressure must be >= 1.0, "
+                f"got {self._actor_pool_upscaling_ratio_on_upstream_backpressure}"
             )
 
         for op, state in self._topology.items():

--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -173,22 +173,38 @@ class DefaultActorAutoscaler(ActorAutoscaler):
                     delta=1, reason="no running actors, scale up immediately"
                 )
             # When upstream has DC backpressure, pass inflated util so policy scales more.
-            delta = self._compute_upscale_delta(
-                actor_pool,
-                util * self._actor_pool_upscaling_ratio_on_upstream_backpressure
-                if self._is_upstream_backpressured_by_downstream_capacity(op)
-                else util,
+            upstream_dc_backpressured = (
+                self._is_upstream_backpressured_by_downstream_capacity(op)
             )
+            effective_util = util
+            if upstream_dc_backpressured:
+                effective_util *= (
+                    self._actor_pool_upscaling_ratio_on_upstream_backpressure
+                )
+            delta = self._compute_upscale_delta(actor_pool, effective_util)
             if max_scale_up is not None:
                 delta = min(delta, max_scale_up)
             delta = max(1, delta)  # At least scale up by 1
 
-            return ActorPoolScalingRequest.upscale(
-                delta=delta,
-                reason=(
+            if (
+                upstream_dc_backpressured
+                and self._actor_pool_upscaling_ratio_on_upstream_backpressure > 1.0
+            ):
+                reason = (
+                    f"utilization of {util} "
+                    f"(x{self._actor_pool_upscaling_ratio_on_upstream_backpressure} "
+                    "due to upstream DownstreamCapacity backpressure) >= "
+                    f"{self._actor_pool_scaling_up_threshold}"
+                )
+            else:
+                reason = (
                     f"utilization of {util} >= "
                     f"{self._actor_pool_scaling_up_threshold}"
-                ),
+                )
+
+            return ActorPoolScalingRequest.upscale(
+                delta=delta,
+                reason=reason,
             )
         elif util <= self._actor_pool_scaling_down_threshold:
             if actor_pool.current_size() <= actor_pool.min_size():

--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -144,9 +144,15 @@ class DefaultActorAutoscaler(ActorAutoscaler):
 
         if util >= self._actor_pool_scaling_up_threshold:
             average_num_inputs_per_task = op.metrics.average_num_inputs_per_task or 1
+            upstream_dc_backpressured = (
+                self._is_upstream_backpressured_by_downstream_capacity(op)
+            )
             if (
                 op_state.total_enqueued_input_blocks()
                 <= actor_pool.num_free_task_slots() * average_num_inputs_per_task
+                # If an upstream operator is DC-backpressured, don't short-circuit here:
+                # we may want to scale up more aggressively to relieve upstream pressure.
+                and not upstream_dc_backpressured
             ):
                 return ActorPoolScalingRequest.no_op(
                     reason="enough free task slots to consume the existing inputs"
@@ -173,9 +179,6 @@ class DefaultActorAutoscaler(ActorAutoscaler):
                     delta=1, reason="no running actors, scale up immediately"
                 )
             # When upstream has DC backpressure, pass inflated util so policy scales more.
-            upstream_dc_backpressured = (
-                self._is_upstream_backpressured_by_downstream_capacity(op)
-            )
             effective_util = util
             if upstream_dc_backpressured:
                 effective_util *= (

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -343,6 +343,9 @@ class AutoscalingConfig:
         actor_pool_max_upscaling_delta: Maximum number of actors to scale up in a single scaling decision.
             This limits how many actors can be added at once to prevent resource contention
             and scheduling pressure. Defaults to 1 for conservative scaling.
+        actor_pool_upscaling_ratio_on_upstream_backpressure: Scale-up ratio (>= 1) when upstream
+            is backpressured (by DownstreamCapacity policy). Effective util is multiplied by this
+            so this op scales more aggressively. Default 1 (disabled). Set to e.g. 2 to enable.
     """
 
     actor_pool_util_upscaling_threshold: float = (
@@ -356,6 +359,9 @@ class AutoscalingConfig:
 
     # Maximum number of actors to scale up in a single scaling decision
     actor_pool_max_upscaling_delta: int = DEFAULT_ACTOR_POOL_MAX_UPSCALING_DELTA
+
+    # Scale-up ratio when upstream is backpressured. 1 = disabled; > 1 = more aggressive (e.g. 2).
+    actor_pool_upscaling_ratio_on_upstream_backpressure: float = 1.0
 
 
 def _execution_options_factory() -> "ExecutionOptions":

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -273,7 +273,7 @@ def test_actor_pool_scaling_reason_mentions_upstream_dc_backpressure():
     op_state._scheduling_status = MagicMock(under_resource_limits=True)
 
     # Ensure the scale-up code path executes deterministically.
-    with patch(autoscaler, "_compute_upscale_delta", 1):
+    with patch.object(autoscaler, "_compute_upscale_delta", return_value=1):
         assert autoscaler._derive_target_scaling_config(
             actor_pool=actor_pool, op=op, op_state=op_state
         ) == ActorPoolScalingRequest(

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -225,6 +225,67 @@ def test_actor_pool_scaling():
         )
 
 
+def test_actor_pool_scaling_reason_mentions_upstream_dc_backpressure():
+    resource_manager = MagicMock(
+        spec=ResourceManager, get_budget=MagicMock(return_value=None)
+    )
+    autoscaler = DefaultActorAutoscaler(
+        topology=MagicMock(),
+        resource_manager=resource_manager,
+        config=AutoscalingConfig(
+            actor_pool_util_upscaling_threshold=1.0,
+            actor_pool_util_downscaling_threshold=0.5,
+            actor_pool_upscaling_ratio_on_upstream_backpressure=2.0,
+        ),
+    )
+
+    actor_pool: _ActorPool = MagicMock(
+        spec=_ActorPool,
+        min_size=MagicMock(return_value=5),
+        max_size=MagicMock(return_value=15),
+        current_size=MagicMock(return_value=10),
+        num_active_actors=MagicMock(return_value=10),
+        num_running_actors=MagicMock(return_value=10),
+        num_pending_actors=MagicMock(return_value=0),
+        num_free_task_slots=MagicMock(return_value=5),
+        num_tasks_in_flight=MagicMock(return_value=15),
+        per_actor_resource_usage=MagicMock(return_value=ExecutionResources(cpu=1)),
+        max_actor_concurrency=MagicMock(return_value=1),
+        get_pool_util=MagicMock(
+            side_effect=lambda: MethodType(_ActorPool.get_pool_util, actor_pool)()
+        ),
+    )
+
+    upstream = MagicMock()
+    upstream._in_task_submission_backpressure = True
+    upstream._task_submission_backpressure_policy = "DownstreamCapacity"
+    op = MagicMock(
+        spec=InternalQueueOperatorMixin,
+        has_completed=MagicMock(return_value=False),
+        _inputs_complete=False,
+        input_dependencies=[upstream],
+        internal_input_queue_num_blocks=MagicMock(return_value=1),
+        metrics=MagicMock(average_num_inputs_per_task=1, num_inputs_received=1),
+    )
+    op_state = OpState(
+        op, inqueues=[MagicMock(__len__=MagicMock(return_value=10), num_blocks=10)]
+    )
+    op_state._scheduling_status = MagicMock(under_resource_limits=True)
+
+    # Ensure the scale-up code path executes deterministically.
+    with patch(autoscaler, "_compute_upscale_delta", 1):
+        assert autoscaler._derive_target_scaling_config(
+            actor_pool=actor_pool, op=op, op_state=op_state
+        ) == ActorPoolScalingRequest(
+            delta=1,
+            force=False,
+            reason=(
+                "utilization of 1.5 (x2.0 due to upstream DownstreamCapacity "
+                "backpressure) >= 1.0"
+            ),
+        )
+
+
 @pytest.fixture
 def autoscaler_max_upscaling_delta_setup():
     resource_manager = MagicMock(

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -286,6 +286,65 @@ def test_actor_pool_scaling_reason_mentions_upstream_dc_backpressure():
         )
 
 
+def test_default_ratio_does_not_bypass_free_slots_short_circuit_on_upstream_dc_backpressure():
+    resource_manager = MagicMock(
+        spec=ResourceManager, get_budget=MagicMock(return_value=None)
+    )
+    autoscaler = DefaultActorAutoscaler(
+        topology=MagicMock(),
+        resource_manager=resource_manager,
+        config=AutoscalingConfig(
+            actor_pool_util_upscaling_threshold=1.0,
+            actor_pool_util_downscaling_threshold=0.5,
+            # Keep default behavior (disabled) by using ratio=1.0.
+            actor_pool_upscaling_ratio_on_upstream_backpressure=1.0,
+        ),
+    )
+
+    actor_pool: _ActorPool = MagicMock(
+        spec=_ActorPool,
+        min_size=MagicMock(return_value=5),
+        max_size=MagicMock(return_value=15),
+        current_size=MagicMock(return_value=10),
+        num_active_actors=MagicMock(return_value=10),
+        num_running_actors=MagicMock(return_value=10),
+        num_pending_actors=MagicMock(return_value=0),
+        num_free_task_slots=MagicMock(return_value=5),
+        num_tasks_in_flight=MagicMock(return_value=15),
+        per_actor_resource_usage=MagicMock(return_value=ExecutionResources(cpu=1)),
+        max_actor_concurrency=MagicMock(return_value=1),
+        get_pool_util=MagicMock(
+            side_effect=lambda: MethodType(_ActorPool.get_pool_util, actor_pool)()
+        ),
+    )
+
+    upstream = MagicMock()
+    upstream._in_task_submission_backpressure = True
+    upstream._task_submission_backpressure_policy = "DownstreamCapacity"
+    op = MagicMock(
+        spec=InternalQueueOperatorMixin,
+        has_completed=MagicMock(return_value=False),
+        _inputs_complete=False,
+        input_dependencies=[upstream],
+        internal_input_queue_num_blocks=MagicMock(return_value=1),
+        metrics=MagicMock(average_num_inputs_per_task=1, num_inputs_received=1),
+    )
+    # Make the "enough free task slots" short-circuit condition true.
+    op_state = OpState(
+        op, inqueues=[MagicMock(__len__=MagicMock(return_value=1), num_blocks=1)]
+    )
+    op_state._scheduling_status = MagicMock(under_resource_limits=True)
+
+    with patch.object(
+        autoscaler, "_compute_upscale_delta", side_effect=AssertionError
+    ):
+        assert autoscaler._derive_target_scaling_config(
+            actor_pool=actor_pool, op=op, op_state=op_state
+        ) == ActorPoolScalingRequest.no_op(
+            reason="enough free task slots to consume the existing inputs"
+        )
+
+
 @pytest.fixture
 def autoscaler_max_upscaling_delta_setup():
     resource_manager = MagicMock(


### PR DESCRIPTION
## Description

This PR adds an optional **upscaling boost** for actor pools when their upstream operator is under **DownstreamCapacity** backpressure. In such cases, the current operator’s effective utilization is multiplied by a configurable ratio before computing the scale-up delta, so this operator can scale up more aggressively and relieve the backpressure faster.

**Motivation:** When an operator’s upstream is backpressured by the `DownstreamCapacityBackpressurePolicy` (e.g. downstream is waiting for data), the downstream operator’s utilization can stay low while the pipeline is actually blocked. Without this change, the autoscaler may scale up slowly. Multiplying utilization by a ratio (e.g. 2) in that situation makes the scaling policy request a larger scale-up, reducing latency and improving throughput in backpressure-heavy pipelines.

**Changes:**
- **`AutoscalingConfig`** (in `context.py`): New field `actor_pool_upscaling_ratio_on_upstream_backpressure` (default `1.0` = disabled; set to e.g. `2.0` to enable).
- **`DefaultActorAutoscaler`**:  
  - New helper `_is_upstream_backpressured_by_downstream_capacity(op)` to detect when any upstream of `op` is backpressured by the DownstreamCapacity policy.  
  - When deriving the target scaling, if upstream has DownstreamCapacity backpressure, the utilization passed to `_compute_upscale_delta` is multiplied by this ratio.  
  - Validation ensures the ratio is `>= 1.0`.

**Backward compatibility:** Default is `1.0` (no change in behavior). Existing jobs and configs are unchanged.