### PR TITLE
[Data] Make text embedding release test using cross-AZ scaling

### DIFF
--- a/release/nightly_tests/dataset/autoscaling_gpu_g6e_2xl_aws.yaml
+++ b/release/nightly_tests/dataset/autoscaling_gpu_g6e_2xl_aws.yaml
@@ -16,3 +16,6 @@ worker_node_types:
       max_workers: 20
       min_workers: 0
       use_spot: false
+
+flags:
+  allow-cross-zone-autoscaling: true

--- a/release/nightly_tests/dataset/fixed_size_gpu_g6e_2xl_aws.yaml
+++ b/release/nightly_tests/dataset/fixed_size_gpu_g6e_2xl_aws.yaml
@@ -16,3 +16,6 @@ worker_node_types:
       max_workers: 20
       min_workers: 20
       use_spot: false
+
+flags:
+  allow-cross-zone-autoscaling: true


### PR DESCRIPTION
This release test sometimes fails because it's not able to provision nodes (see https://buildkite.com/ray-project/release/builds/83650#019cdbc2-1cf7-4d43-b864-0b1ae14bbb4e). To mitigate this failure mode, this PR enables cross-AZ autoscaling.
