### PR TITLE
[core][ippr][1/N] add ResizeRayletResourceInstances to GcsAutoscalerStateManager

### DIFF
--- a/src/mock/ray/raylet_client/raylet_client.h
+++ b/src/mock/ray/raylet_client/raylet_client.h
@@ -132,6 +132,12 @@ class MockRayletClientInterface : public RayletClientInterface {
               (override));
   MOCK_METHOD(
       void,
+      ResizeLocalResourceInstances,
+      ((google::protobuf::Map<std::string, double>) resources,
+       const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback),
+      (override));
+  MOCK_METHOD(
+      void,
       CancelLeasesWithResourceShapes,
       ((const std::vector<google::protobuf::Map<std::string, double>>)&resource_shapes,
        const rpc::ClientCallback<rpc::CancelLeasesWithResourceShapesReply> &callback),

--- a/src/mock/ray/raylet_client/raylet_client.h
+++ b/src/mock/ray/raylet_client/raylet_client.h
@@ -133,7 +133,7 @@ class MockRayletClientInterface : public RayletClientInterface {
   MOCK_METHOD(
       void,
       ResizeLocalResourceInstances,
-      ((google::protobuf::Map<std::string, double>) resources,
+      ((google::protobuf::Map<std::string, double>)resources,
        const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback),
       (override));
   MOCK_METHOD(

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -390,6 +390,7 @@ ray_cc_library(
         "//src/ray/util:thread_checker",
         "//src/ray/util:time",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/strings",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -19,6 +19,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/str_format.h"
 #include "ray/common/protobuf_utils.h"
 #include "ray/util/string_utils.h"
 #include "ray/util/time.h"
@@ -523,23 +524,23 @@ void GcsAutoscalerStateManager::HandleResizeRayletResourceInstances(
     rpc::autoscaler::ResizeRayletResourceInstancesRequest request,
     rpc::autoscaler::ResizeRayletResourceInstancesReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  RAY_CHECK(thread_checker_.IsOnSameThread());
   const NodeID node_id = NodeID::FromBinary(request.node_id());
 
   auto maybe_node = gcs_node_manager_.GetAliveNode(node_id);
   if (!maybe_node.has_value()) {
-    std::ostringstream stream;
-    stream << "Raylet " << node_id.Hex() << " is not alive.";
-    send_reply_callback(Status::NotFound(stream.str()), nullptr, nullptr);
+    send_reply_callback(
+        Status::NotFound(absl::StrFormat("Raylet %s is not alive.", node_id.Hex())),
+        nullptr,
+        nullptr);
     return;
   }
 
-  auto node = std::move(maybe_node.value());
+  auto &node = maybe_node.value();
   auto raylet_address = rpc::RayletClientPool::GenerateRayletAddress(
       node_id, node->node_manager_address(), node->node_manager_port());
   const auto raylet_client = raylet_client_pool_.GetOrConnectByAddress(raylet_address);
   raylet_client->ResizeLocalResourceInstances(
-      request.resources(),
+      std::move(*request.mutable_resources()),
       [reply, send_reply_callback](
           const Status &status,
           const rpc::ResizeLocalResourceInstancesReply &raylet_reply) {

--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -524,9 +524,19 @@ void GcsAutoscalerStateManager::HandleResizeRayletResourceInstances(
     rpc::autoscaler::ResizeRayletResourceInstancesRequest request,
     rpc::autoscaler::ResizeRayletResourceInstancesReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
+  if (request.node_id().size() != NodeID::Size()) {
+    send_reply_callback(Status::InvalidArgument(absl::StrFormat(
+                            "Expected node_id to be %d bytes, but got %d bytes.",
+                            NodeID::Size(),
+                            request.node_id().size())),
+                        nullptr,
+                        nullptr);
+    return;
+  }
   const NodeID node_id = NodeID::FromBinary(request.node_id());
 
-  auto maybe_node = gcs_node_manager_.GetAliveNode(node_id);
+  std::optional<std::shared_ptr<const rpc::GcsNodeInfo>> maybe_node =
+      gcs_node_manager_.GetAliveNode(node_id);
   if (!maybe_node.has_value()) {
     send_reply_callback(
         Status::NotFound(absl::StrFormat("Raylet %s is not alive.", node_id.Hex())),

--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -519,6 +519,38 @@ void GcsAutoscalerStateManager::HandleDrainNode(
       });
 }
 
+void GcsAutoscalerStateManager::HandleResizeRayletResourceInstances(
+    rpc::autoscaler::ResizeRayletResourceInstancesRequest request,
+    rpc::autoscaler::ResizeRayletResourceInstancesReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
+  RAY_CHECK(thread_checker_.IsOnSameThread());
+  const NodeID node_id = NodeID::FromBinary(request.node_id());
+
+  auto maybe_node = gcs_node_manager_.GetAliveNode(node_id);
+  if (!maybe_node.has_value()) {
+    std::ostringstream stream;
+    stream << "Raylet " << node_id.Hex() << " is not alive.";
+    send_reply_callback(Status::NotFound(stream.str()), nullptr, nullptr);
+    return;
+  }
+
+  auto node = std::move(maybe_node.value());
+  auto raylet_address = rpc::RayletClientPool::GenerateRayletAddress(
+      node_id, node->node_manager_address(), node->node_manager_port());
+  const auto raylet_client = raylet_client_pool_.GetOrConnectByAddress(raylet_address);
+  raylet_client->ResizeLocalResourceInstances(
+      request.resources(),
+      [reply, send_reply_callback](
+          const Status &status,
+          const rpc::ResizeLocalResourceInstancesReply &raylet_reply) {
+        if (status.ok()) {
+          reply->mutable_total_resources()->insert(raylet_reply.total_resources().begin(),
+                                                   raylet_reply.total_resources().end());
+        }
+        send_reply_callback(status, nullptr, nullptr);
+      });
+}
+
 std::string GcsAutoscalerStateManager::DebugString() const {
   RAY_CHECK(thread_checker_.IsOnSameThread());
   std::ostringstream stream;

--- a/src/ray/gcs/gcs_autoscaler_state_manager.h
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.h
@@ -72,6 +72,11 @@ class GcsAutoscalerStateManager : public rpc::autoscaler::AutoscalerStateService
                        rpc::autoscaler::DrainNodeReply *reply,
                        rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleResizeRayletResourceInstances(
+      rpc::autoscaler::ResizeRayletResourceInstancesRequest request,
+      rpc::autoscaler::ResizeRayletResourceInstancesReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override;
+
   void HandleReportClusterConfig(rpc::autoscaler::ReportClusterConfigRequest request,
                                  rpc::autoscaler::ReportClusterConfigReply *reply,
                                  rpc::SendReplyCallback send_reply_callback) override;

--- a/src/ray/gcs/grpc_service_interfaces.h
+++ b/src/ray/gcs/grpc_service_interfaces.h
@@ -318,6 +318,11 @@ class AutoscalerStateServiceHandler {
                                DrainNodeReply *reply,
                                SendReplyCallback send_reply_callback) = 0;
 
+  virtual void HandleResizeRayletResourceInstances(
+      ResizeRayletResourceInstancesRequest request,
+      ResizeRayletResourceInstancesReply *reply,
+      SendReplyCallback send_reply_callback) = 0;
+
   virtual void HandleReportClusterConfig(ReportClusterConfigRequest request,
                                          ReportClusterConfigReply *reply,
                                          SendReplyCallback send_reply_callback) = 0;

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -190,6 +190,8 @@ void AutoscalerStateGrpcService::InitServerCallFactories(
   RPC_SERVICE_HANDLER(
       AutoscalerStateService, GetClusterStatus, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(AutoscalerStateService, DrainNode, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER(
+      AutoscalerStateService, ResizeRayletResourceInstances, max_active_rpcs_per_handler_)
 }
 
 }  // namespace autoscaler

--- a/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
@@ -916,11 +916,9 @@ TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstancesErrors) {
   AddNode(node);
 
   rpc::autoscaler::ResizeRayletResourceInstancesRequest request;
-  request.Clear();
   request.set_node_id(node->node_id());
   request.mutable_resources()->insert({{"GPU", 1}});
   rpc::autoscaler::ResizeRayletResourceInstancesReply reply;
-  reply.Clear();
   Status callback_status = Status::OK();
   auto send_reply_callback = [&callback_status](ray::Status status,
                                                 std::function<void()> f1,

--- a/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
@@ -859,6 +859,82 @@ TEST_F(GcsAutoscalerStateManagerTest, TestDrainNodeRaceCondition) {
   ASSERT_TRUE(reply.is_accepted());
 }
 
+TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstances) {
+  auto node = GenNodeInfo();
+  node->mutable_resources_total()->insert({"CPU", 2});
+  node->mutable_resources_total()->insert({"memory", 1024});
+  node->set_instance_id("instance_1");
+  AddNode(node);
+
+  rpc::autoscaler::ResizeRayletResourceInstancesRequest request;
+  request.set_node_id(node->node_id());
+  request.mutable_resources()->insert({{"CPU", 8}, {"memory", 4096}});
+  rpc::autoscaler::ResizeRayletResourceInstancesReply reply;
+  Status callback_status = Status::OK();
+  auto send_reply_callback = [&callback_status](ray::Status status,
+                                                std::function<void()> f1,
+                                                std::function<void()> f2) {
+    callback_status = std::move(status);
+  };
+  gcs_autoscaler_state_manager_->HandleResizeRayletResourceInstances(
+      request, &reply, send_reply_callback);
+
+  ASSERT_EQ(raylet_client_->last_resize_local_resource_instances_request.size(), 2);
+  ASSERT_EQ(raylet_client_->last_resize_local_resource_instances_request.at("CPU"), 8);
+  ASSERT_EQ(raylet_client_->last_resize_local_resource_instances_request.at("memory"),
+            4096);
+
+  ASSERT_TRUE(
+      raylet_client_->ReplyResizeLocalResourceInstances({{"CPU", 8}, {"memory", 4096}}));
+  ASSERT_TRUE(callback_status.ok());
+  ASSERT_EQ(reply.total_resources_size(), 2);
+  ASSERT_EQ(reply.total_resources().at("CPU"), 8);
+  ASSERT_EQ(reply.total_resources().at("memory"), 4096);
+}
+
+TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstancesNotFound) {
+  rpc::autoscaler::ResizeRayletResourceInstancesRequest request;
+  request.set_node_id(NodeID::FromRandom().Binary());
+  request.mutable_resources()->insert({{"CPU", 8}});
+  rpc::autoscaler::ResizeRayletResourceInstancesReply reply;
+  Status callback_status = Status::OK();
+  auto send_reply_callback = [&callback_status](ray::Status status,
+                                                std::function<void()> f1,
+                                                std::function<void()> f2) {
+    callback_status = std::move(status);
+  };
+  gcs_autoscaler_state_manager_->HandleResizeRayletResourceInstances(
+      request, &reply, send_reply_callback);
+  ASSERT_TRUE(callback_status.IsNotFound());
+  ASSERT_EQ(reply.total_resources_size(), 0);
+}
+
+TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstancesErrors) {
+  auto node = GenNodeInfo();
+  node->mutable_resources_total()->insert({"CPU", 2});
+  node->set_instance_id("instance_1");
+  AddNode(node);
+
+  rpc::autoscaler::ResizeRayletResourceInstancesRequest request;
+  request.Clear();
+  request.set_node_id(node->node_id());
+  request.mutable_resources()->insert({{"GPU", 1}});
+  rpc::autoscaler::ResizeRayletResourceInstancesReply reply;
+  reply.Clear();
+  Status callback_status = Status::OK();
+  auto send_reply_callback = [&callback_status](ray::Status status,
+                                                std::function<void()> f1,
+                                                std::function<void()> f2) {
+    callback_status = std::move(status);
+  };
+  gcs_autoscaler_state_manager_->HandleResizeRayletResourceInstances(
+      request, &reply, send_reply_callback);
+  ASSERT_TRUE(raylet_client_->ReplyResizeLocalResourceInstances(
+      {}, Status::InvalidArgument("Cannot resize unit instance resource 'GPU'.")));
+  ASSERT_TRUE(callback_status.IsInvalidArgument());
+  ASSERT_EQ(reply.total_resources_size(), 0);
+}
+
 TEST_F(GcsAutoscalerStateManagerTest, TestIdleTime) {
   auto node = GenNodeInfo();
 

--- a/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_autoscaler_state_manager_test.cc
@@ -860,7 +860,7 @@ TEST_F(GcsAutoscalerStateManagerTest, TestDrainNodeRaceCondition) {
 }
 
 TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstances) {
-  auto node = GenNodeInfo();
+  std::shared_ptr<rpc::GcsNodeInfo> node = GenNodeInfo();
   node->mutable_resources_total()->insert({"CPU", 2});
   node->mutable_resources_total()->insert({"memory", 1024});
   node->set_instance_id("instance_1");
@@ -906,6 +906,48 @@ TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstancesNotFound)
   gcs_autoscaler_state_manager_->HandleResizeRayletResourceInstances(
       request, &reply, send_reply_callback);
   ASSERT_TRUE(callback_status.IsNotFound());
+  ASSERT_EQ(reply.total_resources_size(), 0);
+}
+
+TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstancesInvalidNodeId) {
+  rpc::autoscaler::ResizeRayletResourceInstancesRequest request;
+  request.set_node_id("invalid");
+  request.mutable_resources()->insert({{"CPU", 8}});
+  rpc::autoscaler::ResizeRayletResourceInstancesReply reply;
+  Status callback_status = Status::OK();
+  auto send_reply_callback = [&callback_status](ray::Status status,
+                                                std::function<void()> f1,
+                                                std::function<void()> f2) {
+    callback_status = std::move(status);
+  };
+  gcs_autoscaler_state_manager_->HandleResizeRayletResourceInstances(
+      request, &reply, send_reply_callback);
+  ASSERT_TRUE(callback_status.IsInvalidArgument());
+  ASSERT_EQ(callback_status.message(),
+            absl::StrFormat("Expected node_id to be %d bytes, but got %d bytes.",
+                            NodeID::Size(),
+                            request.node_id().size()));
+  ASSERT_EQ(reply.total_resources_size(), 0);
+}
+
+TEST_F(GcsAutoscalerStateManagerTest, TestResizeRayletResourceInstancesEmptyNodeId) {
+  rpc::autoscaler::ResizeRayletResourceInstancesRequest request;
+  request.set_node_id("");
+  request.mutable_resources()->insert({{"CPU", 8}});
+  rpc::autoscaler::ResizeRayletResourceInstancesReply reply;
+  Status callback_status = Status::OK();
+  auto send_reply_callback = [&callback_status](ray::Status status,
+                                                std::function<void()> f1,
+                                                std::function<void()> f2) {
+    callback_status = std::move(status);
+  };
+  gcs_autoscaler_state_manager_->HandleResizeRayletResourceInstances(
+      request, &reply, send_reply_callback);
+  ASSERT_TRUE(callback_status.IsInvalidArgument());
+  ASSERT_EQ(callback_status.message(),
+            absl::StrFormat("Expected node_id to be %d bytes, but got %d bytes.",
+                            NodeID::Size(),
+                            request.node_id().size()));
   ASSERT_EQ(reply.total_resources_size(), 0);
 }
 

--- a/src/ray/gcs_rpc_client/rpc_client.h
+++ b/src/ray/gcs_rpc_client/rpc_client.h
@@ -581,6 +581,14 @@ class GcsRpcClient {
                                   /*method_timeout_ms*/ -1,
                                   /*handle_payload_status=*/false, )
 
+  VOID_GCS_RPC_CLIENT_METHOD_FULL(ray::rpc::autoscaler,
+                                  ray::rpc::autoscaler,
+                                  AutoscalerStateService,
+                                  ResizeRayletResourceInstances,
+                                  autoscaler_state_grpc_client_,
+                                  /*method_timeout_ms*/ -1,
+                                  /*handle_payload_status=*/false, )
+
   /// Runtime Env GCS Service
   VOID_GCS_RPC_CLIENT_METHOD(RuntimeEnvGcsService,
                              PinRuntimeEnvURI,

--- a/src/ray/protobuf/autoscaler.proto
+++ b/src/ray/protobuf/autoscaler.proto
@@ -348,6 +348,19 @@ message DrainNodeReply {
   string rejection_reason_message = 2;
 }
 
+message ResizeRayletResourceInstancesRequest {
+  // The binary format id of the node whose raylet local resources should be resized.
+  bytes node_id = 1;
+  // Map of resource names to their desired total quantities.
+  // For example: {"CPU": 4, "memory": 1000000}
+  map<string, double> resources = 2;
+}
+
+message ResizeRayletResourceInstancesReply {
+  // Current total resources after the resize operation.
+  map<string, double> total_resources = 1;
+}
+
 message NodeGroupConfig {
   map<string, uint64> resources = 1;
   // The minimum number of nodes to launch.
@@ -394,4 +407,9 @@ service AutoscalerStateService {
   // Caller should not read `is_accepted` from the reply
   // if the return status is not OK.
   rpc DrainNode(DrainNodeRequest) returns (DrainNodeReply);
+  // Resize the local resources of a specified raylet.
+  // Success: Returns the updated total resources for the raylet.
+  // Failure: Returns NOT_FOUND if the target raylet is not alive.
+  rpc ResizeRayletResourceInstances(ResizeRayletResourceInstancesRequest)
+      returns (ResizeRayletResourceInstancesReply);
 }

--- a/src/ray/raylet_rpc_client/fake_raylet_client.h
+++ b/src/ray/raylet_rpc_client/fake_raylet_client.h
@@ -286,7 +286,7 @@ class FakeRayletClient : public RayletClientInterface {
   }
 
   void ResizeLocalResourceInstances(
-      const google::protobuf::Map<std::string, double> &resources,
+      google::protobuf::Map<std::string, double> resources,
       const ClientCallback<ResizeLocalResourceInstancesReply> &callback) override {
     last_resize_local_resource_instances_request.clear();
     last_resize_local_resource_instances_request.insert(resources.begin(),

--- a/src/ray/raylet_rpc_client/fake_raylet_client.h
+++ b/src/ray/raylet_rpc_client/fake_raylet_client.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/time/clock.h"
 #include "ray/common/id.h"
 #include "ray/common/scheduling/scheduling_ids.h"
@@ -157,6 +158,22 @@ class FakeRayletClient : public RayletClientInterface {
     }
   }
 
+  bool ReplyResizeLocalResourceInstances(
+      const absl::flat_hash_map<std::string, double> &total_resources,
+      const Status &status = Status::OK()) {
+    if (resize_local_resource_instances_callbacks.empty()) {
+      return false;
+    } else {
+      ResizeLocalResourceInstancesReply reply;
+      reply.mutable_total_resources()->insert(total_resources.begin(),
+                                              total_resources.end());
+      auto callback = resize_local_resource_instances_callbacks.front();
+      callback(status, std::move(reply));
+      resize_local_resource_instances_callbacks.pop_front();
+      return true;
+    }
+  }
+
   void PrepareBundleResources(
       const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
       const ClientCallback<PrepareBundleResourcesReply> &callback) override {
@@ -268,6 +285,15 @@ class FakeRayletClient : public RayletClientInterface {
     drain_raylet_callbacks.push_back(callback);
   }
 
+  void ResizeLocalResourceInstances(
+      const google::protobuf::Map<std::string, double> &resources,
+      const ClientCallback<ResizeLocalResourceInstancesReply> &callback) override {
+    last_resize_local_resource_instances_request.clear();
+    last_resize_local_resource_instances_request.insert(resources.begin(),
+                                                        resources.end());
+    resize_local_resource_instances_callbacks.push_back(callback);
+  }
+
   void CancelLeasesWithResourceShapes(
       const std::vector<google::protobuf::Map<std::string, double>> &resource_shapes,
       const ClientCallback<CancelLeasesWithResourceShapesReply> &callback) override {}
@@ -308,7 +334,10 @@ class FakeRayletClient : public RayletClientInterface {
   int num_release_unused_bundles_requested = 0;
   NodeID node_id_ = NodeID::FromRandom();
   std::vector<ActorID> killed_actors;
+  absl::flat_hash_map<std::string, double> last_resize_local_resource_instances_request;
   std::list<ClientCallback<DrainRayletReply>> drain_raylet_callbacks = {};
+  std::list<ClientCallback<ResizeLocalResourceInstancesReply>>
+      resize_local_resource_instances_callbacks = {};
   std::list<ClientCallback<RequestWorkerLeaseReply>> callbacks = {};
   std::list<ClientCallback<CancelWorkerLeaseReply>> cancel_callbacks = {};
   std::list<ClientCallback<ReleaseUnusedActorWorkersReply>> release_callbacks = {};

--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -387,6 +387,19 @@ void RayletClient::DrainRaylet(
                             /*method_timeout_ms*/ -1);
 }
 
+void RayletClient::ResizeLocalResourceInstances(
+    const google::protobuf::Map<std::string, double> &resources,
+    const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback) {
+  rpc::ResizeLocalResourceInstancesRequest request;
+  request.mutable_resources()->insert(resources.begin(), resources.end());
+  INVOKE_RPC_CALL(NodeManagerService,
+                  ResizeLocalResourceInstances,
+                  request,
+                  callback,
+                  grpc_client_,
+                  /*method_timeout_ms*/ -1);
+}
+
 void RayletClient::IsLocalWorkerDead(
     const WorkerID &worker_id,
     const rpc::ClientCallback<rpc::IsLocalWorkerDeadReply> &callback) {

--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -388,10 +388,10 @@ void RayletClient::DrainRaylet(
 }
 
 void RayletClient::ResizeLocalResourceInstances(
-    const google::protobuf::Map<std::string, double> &resources,
+    google::protobuf::Map<std::string, double> resources,
     const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback) {
   rpc::ResizeLocalResourceInstancesRequest request;
-  request.mutable_resources()->insert(resources.begin(), resources.end());
+  *request.mutable_resources() = std::move(resources);
   INVOKE_RPC_CALL(NodeManagerService,
                   ResizeLocalResourceInstances,
                   request,

--- a/src/ray/raylet_rpc_client/raylet_client.h
+++ b/src/ray/raylet_rpc_client/raylet_client.h
@@ -131,6 +131,11 @@ class RayletClient : public RayletClientInterface {
                    int64_t deadline_timestamp_ms,
                    const rpc::ClientCallback<rpc::DrainRayletReply> &callback) override;
 
+  void ResizeLocalResourceInstances(
+      const google::protobuf::Map<std::string, double> &resources,
+      const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback)
+      override;
+
   void CancelLeasesWithResourceShapes(
       const std::vector<google::protobuf::Map<std::string, double>> &resource_shapes,
       const rpc::ClientCallback<rpc::CancelLeasesWithResourceShapesReply> &callback)

--- a/src/ray/raylet_rpc_client/raylet_client.h
+++ b/src/ray/raylet_rpc_client/raylet_client.h
@@ -132,7 +132,7 @@ class RayletClient : public RayletClientInterface {
                    const rpc::ClientCallback<rpc::DrainRayletReply> &callback) override;
 
   void ResizeLocalResourceInstances(
-      const google::protobuf::Map<std::string, double> &resources,
+      google::protobuf::Map<std::string, double> resources,
       const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback)
       override;
 

--- a/src/ray/raylet_rpc_client/raylet_client_interface.h
+++ b/src/ray/raylet_rpc_client/raylet_client_interface.h
@@ -197,6 +197,10 @@ class RayletClientInterface {
       int64_t deadline_timestamp_ms,
       const rpc::ClientCallback<rpc::DrainRayletReply> &callback) = 0;
 
+  virtual void ResizeLocalResourceInstances(
+      const google::protobuf::Map<std::string, double> &resources,
+      const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback) = 0;
+
   virtual void CancelLeasesWithResourceShapes(
       const std::vector<google::protobuf::Map<std::string, double>> &resource_shapes,
       const rpc::ClientCallback<rpc::CancelLeasesWithResourceShapesReply> &callback) = 0;

--- a/src/ray/raylet_rpc_client/raylet_client_interface.h
+++ b/src/ray/raylet_rpc_client/raylet_client_interface.h
@@ -198,7 +198,7 @@ class RayletClientInterface {
       const rpc::ClientCallback<rpc::DrainRayletReply> &callback) = 0;
 
   virtual void ResizeLocalResourceInstances(
-      const google::protobuf::Map<std::string, double> &resources,
+      google::protobuf::Map<std::string, double> resources,
       const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback) = 0;
 
   virtual void CancelLeasesWithResourceShapes(


### PR DESCRIPTION
## Description

Introduce the `ResizeRayletResourceInstances` rpc method on the `GcsAutoscalerStateManager`, which will proxy
`ResizeLocalResourceInstances` to the requested Raylet with node ID. This allows the autoscaler to do the resizing on a raylet through GCS.

