### PR TITLE
[data] Install mongodb-org from official repo, start mongod directly in tests

### DIFF
--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -23,10 +23,13 @@ if [[ -n "$ARROW_MONGO_VERSION" ]]; then
   pip install numpy==1.23.5
 fi
 
-# Install MongoDB
-sudo apt-get purge -y mongodb*
-sudo apt-get install -y mongodb
-sudo rm -rf /var/lib/mongodb/mongod.lock
+curl -fsSL https://pgp.mongodb.com/server-8.0.asc | \
+  sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
+echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] \
+  https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/8.0 multiverse" | \
+  sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+sudo apt-get update
+sudo apt-get install -y mongodb-org
 
 if [[ $RAY_CI_JAVA_BUILD == 1 ]]; then
   # These packages increase the image size quite a bit, so we only install them

--- a/python/ray/data/tests/datasource/test_mongo.py
+++ b/python/ray/data/tests/datasource/test_mongo.py
@@ -1,4 +1,7 @@
+import shutil
 import subprocess
+import tempfile
+import time
 
 import pandas as pd
 import pyarrow as pa
@@ -9,18 +12,38 @@ from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.mock_http_server import *  # noqa
 from ray.tests.conftest import *  # noqa
 
-# To run tests locally, make sure you install mongodb
-# and start a local service:
-# sudo apt-get install -y mongodb
+# To run tests locally, make sure you install mongodb-org and have mongod
+# available on your PATH. Started directly since mongodb-org has no SysV init
+# script. See https://hub.docker.com/_/mongo
 
 
 @pytest.fixture
 def start_mongo():
     import pymongo
 
-    subprocess.check_call(["service", "mongodb", "start"])
+    dbpath = tempfile.mkdtemp(prefix="mongod_test_")
+    proc = subprocess.Popen(
+        ["mongod", "--dbpath", dbpath, "--bind_ip", "127.0.0.1"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    # Wait for mongod to accept connections.
     mongo_url = "mongodb://localhost:27017"
-    client = pymongo.MongoClient(mongo_url)
+    for _ in range(30):
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"mongod exited unexpectedly (returncode={proc.returncode})"
+            )
+        try:
+            client = pymongo.MongoClient(mongo_url, serverSelectionTimeoutMS=1000)
+            client.admin.command("ping")
+            break
+        except pymongo.errors.PyMongoError:
+            time.sleep(0.5)
+    else:
+        proc.kill()
+        raise RuntimeError("mongod failed to start")
+
     # Make sure a clean slate for each test by dropping
     # previously created ones (if any).
     for db in client.list_database_names():
@@ -29,7 +52,9 @@ def start_mongo():
             client.drop_database(db)
     yield client, mongo_url
 
-    subprocess.check_call(["service", "mongodb", "stop"])
+    proc.terminate()
+    proc.wait(timeout=10)
+    shutil.rmtree(dbpath)
 
 
 def test_read_write_mongo(ray_start_regular_shared, start_mongo):


### PR DESCRIPTION
Switches from the Ubuntu universe `mongodb` package (only available on focal
and providing an old 2.x version) to mongodb-org 8.0 from the official MongoDB
apt repo. The focal codename is hardcoded; the follow-on Ubuntu 22.04 upgrade
PR updates it to jammy.

Replaces the SysV `service mongodb start/stop` wrapper in test_mongo.py with a
direct `mongod --dbpath` invocation, since mongodb-org 8.0 ships without a
SysV init script. The fixture creates a temp dbpath, polls for readiness, and
terminates the process on teardown.

Topic: data-mongodb-direct-launch

Signed-off-by: andrew andrew@anyscale.com
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>