### PR TITLE
[ci] Upgrade forge Dockerfiles from clang-12 to clang-14

### DIFF
--- a/.buildkite/release-automation/forge_arm64.Dockerfile
+++ b/.buildkite/release-automation/forge_arm64.Dockerfile
@@ -11,9 +11,9 @@ set -euo pipefail
 
 apt-get update
 apt-get upgrade -y
-apt-get install -y curl zip clang-12
+apt-get install -y curl zip clang-14
 
-ln -s /usr/bin/clang-12 /usr/bin/clang
+ln -s /usr/bin/clang-14 /usr/bin/clang
 
 # Install miniforge3
 curl -fsSL https://github.com/conda-forge/miniforge/releases/download/25.3.0-1/Miniforge3-25.3.0-1-Linux-aarch64.sh > /tmp/miniforge3.sh
@@ -50,6 +50,6 @@ uv pip install --system pip==25.2 cffi==1.16.0
 EOF
 
 ENV CC=clang
-ENV CXX=clang++-12
+ENV CXX=clang++-14
 
 CMD ["echo", "ray release-automation forge"]

--- a/.buildkite/release-automation/forge_x86_64.Dockerfile
+++ b/.buildkite/release-automation/forge_x86_64.Dockerfile
@@ -11,14 +11,14 @@ set -euo pipefail
 
 apt-get update
 apt-get upgrade -y
-apt-get install -y curl zip clang-12 git
+apt-get install -y curl zip clang-14 git
 
 # Needs to be synchronized to the host group id as we map /var/run/docker.sock
 # into the container.
 addgroup --gid 993 docker
 addgroup --gid 992 docker1 # docker group on buildkite AMI as of 2025-06-07
 
-ln -s /usr/bin/clang-12 /usr/bin/clang
+ln -s /usr/bin/clang-14 /usr/bin/clang
 
 # Install miniforge3
 curl -fsSL https://github.com/conda-forge/miniforge/releases/download/25.3.0-1/Miniforge3-25.3.0-1-Linux-x86_64.sh > /tmp/miniforge3.sh
@@ -61,6 +61,6 @@ EOF
 
 USER forge
 ENV CC=clang
-ENV CXX=clang++-12
+ENV CXX=clang++-14
 
 CMD ["echo", "ray release-automation forge"]


### PR DESCRIPTION
The forge wanda configs were updated to ubuntu:22.04 but the corresponding
Dockerfiles still installed clang-12, creating a mismatch with CI test
images (base.test, base.gpu, base.build) which all use clang-14 on 22.04.

Topic: forge-clang-14
Relative: ubuntu-22-04-test

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Signed-off-by: andrew <andrew@anyscale.com>