### PR TITLE
[core][ippr][2/N] add resize_raylet_resource_instances to the python gcs client

### DIFF
--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -647,6 +647,13 @@ cdef extern from "ray/gcs_rpc_client/accessor.h" nogil:
             c_string &rejection_reason_message
         )
 
+        CRayStatus ResizeRayletResourceInstances(
+            const c_string &node_id,
+            const unordered_map[c_string, double] &resources,
+            int64_t timeout_ms,
+            unordered_map[c_string, double] &total_resources
+        )
+
     cdef cppclass CPublisherAccessor "ray::gcs::PublisherAccessor":
         CRayStatus PublishError(
             c_string key_id,

--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -655,6 +655,23 @@ cdef class InnerGcsClient:
 
         return (is_accepted, rejection_reason_message.decode())
 
+    def resize_raylet_resource_instances(
+            self,
+            node_id: c_string,
+            resources: unordered_map[c_string, cython.double],
+            timeout_s=None):
+        """Send the ResizeRayletResourceInstances request to GCS."""
+        cdef:
+            int64_t timeout_ms = round(1000 * timeout_s) if timeout_s else -1
+            unordered_map[c_string, cython.double] total_resources
+        with nogil:
+            check_status_timeout_as_rpc_error(
+                self.inner.get().Autoscaler().ResizeRayletResourceInstances(
+                    node_id, resources, timeout_ms, total_resources
+                )
+            )
+        return {key.decode(): value for key, value in total_resources}
+
     #############################################################
     # Publisher methods
     #############################################################

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -328,6 +328,7 @@ py_test_module_list(
         "test_ray_debugger.py",
         "test_ray_init.py",
         "test_ray_shutdown.py",
+        "test_resize_raylet.py",
         "test_resource_metrics.py",
         "test_runtime_context.py",
         "test_runtime_env_env_vars.py",

--- a/python/ray/tests/test_resize_raylet.py
+++ b/python/ray/tests/test_resize_raylet.py
@@ -1,0 +1,36 @@
+import sys
+
+import pytest
+
+import ray
+from ray._raylet import GcsClient
+
+
+def test_resize_raylet_resource_instances(ray_start_cluster):
+    cluster = ray_start_cluster
+    cluster.add_node()
+    ray.init(address=cluster.address)
+    worker_node = cluster.add_node(num_cpus=2)
+    cluster.wait_for_nodes()
+
+    gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
+    total_resources = gcs_client.resize_raylet_resource_instances(
+        worker_node.node_id,
+        {"CPU": 3.0},
+    )
+
+    assert total_resources["CPU"] == 3.0
+
+    missing_node_id = ray.NodeID.from_random().hex()
+    with pytest.raises(
+        ValueError,
+        match=f"Raylet {missing_node_id} is not alive.",
+    ):
+        gcs_client.resize_raylet_resource_instances(
+            missing_node_id,
+            {"CPU": 3.0},
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -552,11 +552,10 @@ void GcsAutoscalerStateManager::HandleResizeRayletResourceInstances(
   raylet_client->ResizeLocalResourceInstances(
       std::move(*request.mutable_resources()),
       [reply, send_reply_callback](
-          const Status &status,
-          const rpc::ResizeLocalResourceInstancesReply &raylet_reply) {
+          const Status &status, rpc::ResizeLocalResourceInstancesReply &&raylet_reply) {
         if (status.ok()) {
-          reply->mutable_total_resources()->insert(raylet_reply.total_resources().begin(),
-                                                   raylet_reply.total_resources().end());
+          *reply->mutable_total_resources() =
+              std::move(*raylet_reply.mutable_total_resources());
         }
         send_reply_callback(status, nullptr, nullptr);
       });

--- a/src/ray/gcs_rpc_client/accessor.cc
+++ b/src/ray/gcs_rpc_client/accessor.cc
@@ -1233,6 +1233,22 @@ Status AutoscalerStateAccessor::DrainNode(const std::string &node_id,
   return Status::OK();
 }
 
+Status AutoscalerStateAccessor::ResizeRayletResourceInstances(
+    const std::string &node_id,
+    const std::unordered_map<std::string, double> &resources,
+    int64_t timeout_ms,
+    std::unordered_map<std::string, double> &total_resources) {
+  rpc::autoscaler::ResizeRayletResourceInstancesRequest request;
+  request.set_node_id(NodeID::FromHex(node_id).Binary());
+  request.mutable_resources()->insert(resources.begin(), resources.end());
+
+  rpc::autoscaler::ResizeRayletResourceInstancesReply reply;
+  RAY_RETURN_NOT_OK(client_impl_->GetGcsRpcClient().SyncResizeRayletResourceInstances(
+      std::move(request), &reply, timeout_ms));
+  total_resources.insert(reply.total_resources().begin(), reply.total_resources().end());
+  return Status::OK();
+}
+
 PublisherAccessor::PublisherAccessor(GcsClient *client_impl)
     : client_impl_(client_impl) {}
 

--- a/src/ray/gcs_rpc_client/accessor.h
+++ b/src/ray/gcs_rpc_client/accessor.h
@@ -792,6 +792,12 @@ class AutoscalerStateAccessor {
                            bool &is_accepted,
                            std::string &rejection_reason_message);
 
+  virtual Status ResizeRayletResourceInstances(
+      const std::string &node_id,
+      const std::unordered_map<std::string, double> &resources,
+      int64_t timeout_ms,
+      std::unordered_map<std::string, double> &total_resources);
+
  private:
   GcsClient *client_impl_;
 };

--- a/src/ray/raylet_rpc_client/raylet_client.cc
+++ b/src/ray/raylet_rpc_client/raylet_client.cc
@@ -392,12 +392,13 @@ void RayletClient::ResizeLocalResourceInstances(
     const rpc::ClientCallback<rpc::ResizeLocalResourceInstancesReply> &callback) {
   rpc::ResizeLocalResourceInstancesRequest request;
   *request.mutable_resources() = std::move(resources);
-  INVOKE_RPC_CALL(NodeManagerService,
-                  ResizeLocalResourceInstances,
-                  request,
-                  callback,
-                  grpc_client_,
-                  /*method_timeout_ms*/ -1);
+  INVOKE_RETRYABLE_RPC_CALL(retryable_grpc_client_,
+                            NodeManagerService,
+                            ResizeLocalResourceInstances,
+                            request,
+                            callback,
+                            grpc_client_,
+                            /*method_timeout_ms*/ -1);
 }
 
 void RayletClient::IsLocalWorkerDead(


### PR DESCRIPTION
## Description

This PR adds the `resize_raylet_resource_instances` function to the GCS Cython client. It will be used by the autoscaler in a follow-up PR for IPPR.

This PR also addresses comments in the previous review https://github.com/ray-project/ray/pull/61654#discussion_r2935765277 and https://github.com/ray-project/ray/pull/61654#discussion_r2935767650.
