### PR TITLE
[Build] Make -undefined dynamic_lookup explicit in _raylet.so macOS linkopts

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -177,6 +177,11 @@ pyx_library(
         linkopts = select({
             "@platforms//os:osx": [
                 "-Wl,-exported_symbols_list,$(location //:src/ray/ray_exported_symbols.lds)",
+                # The Apple CC toolchain adds -undefined dynamic_lookup implicitly via
+                # cc_toolchain_config.bzl for dynamic library link actions. Making it
+                # explicit here ensures Python extension .so files link correctly regardless
+                # of which CC toolchain is active (Apple CC or generic @local_config_cc).
+                "-Wl,-undefined,dynamic_lookup",
             ],
             "@platforms//os:windows": [],
             "//conditions:default": [


### PR DESCRIPTION
Unblocker for Bazel 7.5 upgrade.

The Apple CC toolchain's cc_toolchain_config.bzl adds -undefined dynamic_lookup
implicitly for all DYNAMIC_LIBRARY link actions on macOS. Python extension .so
files require this flag so that Python C API symbols are resolved at load time
by the interpreter, not at link time.

Making the flag explicit in the target's linkopts ensures correct behavior
regardless of which CC toolchain is active (Apple CC or generic @local_config_cc),
without relying on toolchain-internal behavior.

Topic: macos-raylet-dynamic-lookup
Signed-off-by: andrew <andrew@anyscale.com>