### PR TITLE
[autoscaler]Fix a bug where using autoscaler.sdk.request_resources causes an issue during fallback from autoscaler v2 to v1

### DIFF
--- a/doc/source/cluster/running-applications/autoscaling/reference.rst
+++ b/doc/source/cluster/running-applications/autoscaling/reference.rst
@@ -10,5 +10,11 @@ ray.autoscaler.sdk.request_resources
 
 Within a Ray program, you can command the autoscaler to scale the cluster up to a desired size with ``request_resources()`` call. The cluster will immediately attempt to scale to accommodate the requested resources, bypassing normal upscaling speed constraints.
 
+.. note::
+
+    ``bundle_label_selectors`` are enforced only by autoscaler v2.
+    If you switch from autoscaler v2 to v1, label selector constraints are
+    ignored and only resource quantities in bundles are considered.
+    
 .. autofunction:: ray.autoscaler.sdk.request_resources
     :noindex:

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -208,7 +208,9 @@ def request_resources(
         bundle_label_selectors (List[Dict[str,str]]): Optional label selectors
             that new nodes must satisfy. (e.g. [{"accelerator-type": "A100"}])
             The elements in the bundle_label_selectors should be one-to-one mapping
-            to the elements in bundles.
+            to the elements in bundles. Selector constraints are honored by
+            autoscaler v2; autoscaler v1 ignores selectors and uses only the
+            requested resource bundles.
     """
     if not ray.is_initialized():
         raise RuntimeError("Ray is not initialized yet")

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -315,9 +315,30 @@ class LoadMetrics:
     def set_resource_requests(self, requested_resources):
         if requested_resources is not None:
             assert isinstance(requested_resources, list), requested_resources
-        self.resource_requests = [
-            request for request in requested_resources if len(request) > 0
-        ]
+        resource_requests = []
+        for request in requested_resources:
+            if len(request) == 0:
+                continue
+
+            # request_resources() may include per-bundle metadata,
+            # e.g. {"resources": {...}, "label_selector": {...}}.
+            # v1 autoscaler consumes only resource bundles, so normalize here.
+            if isinstance(request, dict) and isinstance(request.get("resources"), dict):
+                if request.get("label_selector"):
+                    logger.warning(
+                        "Ignoring bundle label_selector in autoscaler v1 request: %s",
+                        request.get("label_selector"),
+                    )
+                request = request["resources"]
+
+            if not isinstance(request, dict):
+                logger.warning("Ignoring malformed resource request: %s", request)
+                continue
+
+            if len(request) > 0:
+                resource_requests.append(request)
+
+        self.resource_requests = resource_requests
 
     def info_string(self):
         return " - " + "\n - ".join(

--- a/python/ray/autoscaler/sdk/sdk.py
+++ b/python/ray/autoscaler/sdk/sdk.py
@@ -238,6 +238,8 @@ def request_resources(
             corresponding item in the list is an empty dictionary. For each bundle.
             Label selectors consist of zero or more key-value pairs where the key is
             a label and the value is a operator (in, !in, etc.) and label value.
+            This is honored by autoscaler v2. In autoscaler v1, selectors are ignored
+            and only resource quantities are used.
 
     Examples:
         >>> from ray.autoscaler.sdk import request_resources

--- a/python/ray/tests/test_resource_demand_scheduler.py
+++ b/python/ray/tests/test_resource_demand_scheduler.py
@@ -1940,6 +1940,50 @@ class LoadMetricsTest(unittest.TestCase):
         summary_dict["head_ip"] = "1.1.1.1"
         # No compatibility issue.
         LoadMetricsSummary(**summary_dict)
+        
+    def testSetResourceRequestsWithLabelSelectors(self):
+        lm = LoadMetrics()
+
+        lm.set_resource_requests(
+            [
+                {
+                    "resources": {"CPU": 1},
+                    "label_selector": {"accelerator-type": "A100"},
+                },
+                {
+                    "resources": {"GPU": 2},
+                    "label_selector": {},
+                },
+            ]
+        )
+
+        assert lm.get_resource_requests() == [{"CPU": 1}, {"GPU": 2}]
+
+        summary = lm.summary()
+        assert ({"CPU": 1}, 1) in summary.request_demand
+        assert ({"GPU": 2}, 1) in summary.request_demand
+
+    def testSetResourceRequestsWithLabelSelectorsLogsWarning(self):
+        lm = LoadMetrics()
+
+        with mock.patch(
+            "ray.autoscaler._private.load_metrics.logger.warning"
+        ) as mock_warning:
+            lm.set_resource_requests(
+                [
+                    {
+                        "resources": {"CPU": 1},
+                        "label_selector": {"accelerator-type": "A100"},
+                    }
+                ]
+            )
+
+        assert lm.get_resource_requests() == [{"CPU": 1}]
+        mock_warning.assert_called_once()
+        assert (
+            "Ignoring bundle label_selector in autoscaler v1 request"
+            in mock_warning.call_args.args[0]
+        )
 
 
 class AutoscalingTest(unittest.TestCase):


### PR DESCRIPTION
Clarifies autoscaler v1 ignores bundle label selectors

Updates documentation and code to clarify that bundle label selectors
are only enforced by autoscaler v2, while v1 ignores them and only
uses resource quantities. Adds normalization logic and logging to
skip label selectors in v1, and introduces tests to verify correct
behavior and warning emission when selectors are present.

try to fix https://github.com/ray-project/ray/issues/61673

## Related issues

https://github.com/ray-project/ray/issues/61673

