### PR TITLE
[ci] Add removed-state check in test_remove_pending_placement_group

### DIFF
--- a/python/ray/tests/test_placement_group_4.py
+++ b/python/ray/tests/test_placement_group_4.py
@@ -181,9 +181,13 @@ def test_remove_pending_placement_group(ray_start_cluster):
 
     # Create a placement group that cannot be scheduled now.
     placement_group = ray.util.placement_group([{"GPU": 2}, {"CPU": 2}])
+    wait_for_condition(
+        lambda: (ray.util.placement_group_table(placement_group) or {}).get("state")
+        == "PENDING"
+    )
     ray.util.remove_placement_group(placement_group)
+    wait_for_condition(lambda: is_placement_group_removed(placement_group))
 
-    # TODO(sang): Add state check here.
     @ray.remote(num_cpus=4)
     def f():
         return 3


### PR DESCRIPTION

## Description
The test removed a pending placement group but did not verify that the state transition to removed had completed, which could introduce timing flakiness.

This makes the test deterministic before validating task schedulability and placement-group leak checks.


## Related issues
https://github.com/ray-project/ray/issues/61679

