### PR TITLE
bugfix streaming_repartition

### DIFF
--- a/python/ray/data/_internal/streaming_repartition.py
+++ b/python/ray/data/_internal/streaming_repartition.py
@@ -1,3 +1,4 @@
+import threading
 from collections import deque
 from typing import Deque, List, Tuple
 
@@ -40,64 +41,86 @@ class StreamingRepartitionRefBundler(BaseRefBundler):
         self._ready_bundles: Deque[RefBundle] = deque()
         self._consumed_input_bundles: List[RefBundle] = []
         self._total_pending_rows = 0
+        # Thread lock to protect concurrent access to deques
+        self._lock = threading.Lock()
 
     def _try_build_ready_bundle(self, flush_remaining: bool = False):
-        if self._total_pending_rows >= self._target_num_rows:
-            rows_needed_from_last_bundle = (
-                self._pending_bundles[-1].num_rows()
-                - self._total_pending_rows % self._target_num_rows
-            )
-            assert rows_needed_from_last_bundle >= 0  # This will never be negative
-            pending_bundles = list(self._pending_bundles)
-            remaining_bundle = None
-            if (
-                rows_needed_from_last_bundle > 0
-                and rows_needed_from_last_bundle < pending_bundles[-1].num_rows()
-            ):
-                last_bundle = pending_bundles.pop()
-                sliced_bundle, remaining_bundle = last_bundle.slice(
-                    rows_needed_from_last_bundle
+        with self._lock:
+            if self._total_pending_rows >= self._target_num_rows:
+                rows_needed_from_last_bundle = (
+                    self._pending_bundles[-1].num_rows()
+                    - self._total_pending_rows % self._target_num_rows
                 )
-                pending_bundles.append(sliced_bundle)
-            self._ready_bundles.append(RefBundle.merge_ref_bundles(pending_bundles))
-            self._pending_bundles.clear()
-            self._total_pending_rows = 0
-            if remaining_bundle and remaining_bundle.num_rows() > 0:
-                self._pending_bundles.append(remaining_bundle)
-                self._total_pending_rows += remaining_bundle.num_rows()
-        if flush_remaining and len(self._pending_bundles) > 0:
-            self._ready_bundles.append(
-                RefBundle.merge_ref_bundles(self._pending_bundles)
-            )
-            self._pending_bundles.clear()
-            self._total_pending_rows = 0
+                assert rows_needed_from_last_bundle >= 0  # This will never be negative
+                pending_bundles = list(self._pending_bundles)
+                remaining_bundle = None
+                if (
+                    rows_needed_from_last_bundle > 0
+                    and rows_needed_from_last_bundle < pending_bundles[-1].num_rows()
+                ):
+                    last_bundle = pending_bundles.pop()
+                    sliced_bundle, remaining_bundle = last_bundle.slice(
+                        rows_needed_from_last_bundle
+                    )
+                    pending_bundles.append(sliced_bundle)
+                self._ready_bundles.append(RefBundle.merge_ref_bundles(pending_bundles))
+                self._pending_bundles.clear()
+                self._total_pending_rows = 0
+                if remaining_bundle and remaining_bundle.num_rows() > 0:
+                    self._pending_bundles.append(remaining_bundle)
+                    self._total_pending_rows += remaining_bundle.num_rows()
+            if flush_remaining and self._total_pending_rows > 0:
+                self._ready_bundles.append(
+                    RefBundle.merge_ref_bundles(self._pending_bundles)
+                )
+                self._pending_bundles.clear()
+                self._total_pending_rows = 0
 
     def add_bundle(self, ref_bundle: RefBundle):
-        self._total_pending_rows += ref_bundle.num_rows()
-        self._pending_bundles.append(ref_bundle)
+        with self._lock:
+            self._total_pending_rows += ref_bundle.num_rows()
+            self._pending_bundles.append(ref_bundle)
+            self._consumed_input_bundles.append(ref_bundle)
+        # Call _try_build_ready_bundle outside the lock to avoid deadlock
+        # (it will acquire the lock internally)
         self._try_build_ready_bundle()
-        self._consumed_input_bundles.append(ref_bundle)
 
     def has_bundle(self) -> bool:
-        return len(self._ready_bundles) > 0
+        with self._lock:
+            return len(self._ready_bundles) > 0
 
     def get_next_bundle(
         self,
     ) -> Tuple[List[RefBundle], RefBundle]:
-        consumed_input_bundles = self._consumed_input_bundles
-        self._consumed_input_bundles = []
-        return consumed_input_bundles, self._ready_bundles.popleft()
+        with self._lock:
+            consumed_input_bundles = self._consumed_input_bundles
+            self._consumed_input_bundles = []
+            return consumed_input_bundles, self._ready_bundles.popleft()
 
     def done_adding_bundles(self):
-        if len(self._pending_bundles) > 0:
+        # Check if there are pending bundles inside the lock
+        with self._lock:
+            has_pending = len(self._pending_bundles) > 0
+        if has_pending:
             self._try_build_ready_bundle(flush_remaining=True)
 
     def num_blocks(self):
-        return sum(len(bundle) for bundle in self._pending_bundles) + sum(
-            len(bundle) for bundle in self._ready_bundles
+        # Create copies of the deques inside the lock to avoid "deque mutated during iteration"
+        with self._lock:
+            pending_list = list(self._pending_bundles)
+            ready_list = list(self._ready_bundles)
+        # Calculate outside the lock to avoid holding it for too long
+        return sum(len(bundle) for bundle in pending_list) + sum(
+            len(bundle) for bundle in ready_list
         )
 
     def size_bytes(self) -> int:
-        return sum(bundle.size_bytes() for bundle in self._pending_bundles) + sum(
-            bundle.size_bytes() for bundle in self._ready_bundles
+        # Create copies of the deques inside the lock to avoid "deque mutated during iteration"
+        # This prevents race conditions when another thread modifies the deques while we're iterating
+        with self._lock:
+            pending_list = list(self._pending_bundles)
+            ready_list = list(self._ready_bundles)
+        # Calculate outside the lock to avoid holding it for too long
+        return sum(bundle.size_bytes() for bundle in pending_list) + sum(
+            bundle.size_bytes() for bundle in ready_list
         )


### PR DESCRIPTION
## Description
## Summary
When executing streaming repartition with `write_datasink` on a large Ray cluster, a race condition causes `RuntimeError: deque mutated during iteration` error in the progress bar refresh logic. This occurs when concurrent threads attempt to iterate over deques that are being modified simultaneously.

## Environment
- **Ray Version**: 2.53.0
- **Python Version**: 3.10
- **Cluster Configuration**: 100 workers × 224 CPUs = 22,400 concurrent tasks

## Issue Description
The error occurs during data materialization when using `repartition()` followed by `write_datasink()` operations on large datasets. The failure happens not during the core computation but during progress bar state reporting.

### Minimal Reproducible Example

```python
import ray
from ray.data import from_pandas
import pandas as pd

# Initialize Ray cluster with multiple workers
ray.init(ignore_reinit_error=True)

# Create a large dataset
ds = ray.data.range(10000000, parallelism=10000)
ds = ds.map_batches(lambda batch: batch * 2, batch_size=1000)

# This operation triggers the race condition
target_num_rows_per_block = 50000
result = ds.repartition(target_num_rows_per_block=target_num_rows_per_block)

# Attempt to materialize - error occurs here
try:
    result.write_datasink(CustomDatasink(...))  # Any datasink operation
except RuntimeError as e:
    print(f"Error: {e}")
    # RuntimeError: deque mutated during iteration
```

## Root Cause

The bug is a **thread-safety race condition** between two concurrent execution paths:

### Path 1: Stream Executor - Adding Bundles (Producer Thread)
```
StreamingExecutor.run()  [background thread]
  └─> Continuously executes stream loop
      └─> MapOperator processes tasks
          └─> StreamingRepartitionRefBundler.add_bundle()  [Modifies _pending_bundles]
              └─> Mutates deque: _pending_bundles.append(), _pending_bundles.clear()
```

### Path 2: Main Thread - Progress Bar Refresh (Consumer Thread)
```
_bundles_to_block_list()  [main thread]
  └─> list(bundles)  # Iterating executor
      └─> StreamingExecutor.get_next()
          └─> _refresh_progress_bars()  [Line 542]
              └─> OpState.refresh_progress_bar()
                  └─> OpState.summary_str()
                      └─> MapOperator.internal_input_queue_num_bytes()
                          └─> StreamingRepartitionRefBundler.size_bytes()
                              └─> Iterates over _pending_bundles WITHOUT lock  [BUG]
```

### The Race Condition
- **Thread 1** (Producer): Calls `add_bundle()` → modifies `_pending_bundles` deque
- **Thread 2** (Consumer): Calls `size_bytes()` → iterates over `_pending_bundles` deque WITHOUT acquiring lock
- **Result**: `RuntimeError: deque mutated during iteration` when the deque is modified during iteration

### Error Stack Trace
```
RuntimeError: deque mutated during iteration
  File "ray/data/_internal/streaming_repartition.py", line 101, in size_bytes
    return sum(bundle.size_bytes() for bundle in self._pending_bundles) + sum(
  File "ray/data/_internal/streaming_repartition.py", line 101, in <genexpr>
    return sum(bundle.size_bytes() for bundle in self._pending_bundles) + sum(
```

The iteration generator is interrupted by `add_bundle()` modifying the deque mid-iteration.

## Related issues
> Link related issues: "Fixes #61681 https://github.com/ray-project/ray/issues/61681

