### PR TITLE
[Data] Fix floating point error from average calculator

### DIFF
--- a/python/ray/data/_internal/average_calculator.py
+++ b/python/ray/data/_internal/average_calculator.py
@@ -45,3 +45,7 @@ class TimeWindowAverageCalculator:
         # from repeated += / -= operations.
         if len(self._values) == 0:
             self._sum = 0
+        # Recalculate the sum if the sum is negative to avoid accumulated floating-point error
+        # from repeated += / -= operations.
+        if self._sum < 0:
+            self._sum = sum(val for _, val in self._values)

--- a/python/ray/data/_internal/average_calculator.py
+++ b/python/ray/data/_internal/average_calculator.py
@@ -41,11 +41,7 @@ class TimeWindowAverageCalculator:
             _, value = self._values.popleft()
             self._sum -= value
 
-        # Set sum to 0 if there are no values to avoid accumulated floating-point error
+        # Set sum to 0 if there are no values or the sum is negative to avoid accumulated floating-point error
         # from repeated += / -= operations.
-        if len(self._values) == 0:
+        if len(self._values) == 0 or self._sum < 0:
             self._sum = 0
-        # Recalculate the sum if the sum is negative to avoid accumulated floating-point error
-        # from repeated += / -= operations.
-        if self._sum < 0:
-            self._sum = sum(val for _, val in self._values)


### PR DESCRIPTION
## Description
  `TimeWindowAverageCalculator._trim()` accumulates floating-point error from repeated _sum -= value operations. Over time,  _sum can drift to a small negative value while the deque still has entries, bypassing the existing
  empty-deque guard. This causes `ClusterUtil.__post_init__` to fail with `assert 0 <= self.object_store_memory.`

  Fix: clamp _sum to 0 when it goes negative, since all reported values are non-negative utilization metrics.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
