### PR TITLE
[Build] Upgrade rules_apple/apple_support and set macOS toolchain flags for Bazel 7

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -237,5 +237,23 @@ try-import %workspace%/.user.bazelrc
 # Work around for https://github.com/bazelbuild/bazel/issues/8053
 build:macos --sandbox_block_path=/usr/local/
 build:macos --copt="-Wno-error=deprecated-declarations"
+# Disable build_bazel_apple_support's Apple CC toolchain on macOS CI machines
+# that only have Xcode CLT (no full Xcode.app). With BAZEL_NO_APPLE_CPP_TOOLCHAIN=1,
+# apple_cc_configure's _apple_cc_autoconf generates an empty local_config_apple_cc,
+# and Bazel falls back to the generic @local_config_cc (CLT clang), which worked
+# fine with Bazel 6.5. Without this, apple_cc_toolchain fails at analysis time with
+# "Xcode version must be specified to use an Apple CROSSTOOL" on CLT-only machines.
+build:macos --repo_env=BAZEL_NO_APPLE_CPP_TOOLCHAIN=1
+# The generic @local_config_cc CC toolchain (CLT-based, used when
+# BAZEL_NO_APPLE_CPP_TOOLCHAIN=1) defaults to -mmacosx-version-min=10.11 from
+# Bazel's built-in template. That's too old for std::filesystem (10.15+) and
+# std::visit/std::variant (10.13+) used by Ray and opentelemetry. Override to
+# 12.0 which matches the arm64 CI machines (Apple Silicon requires macOS 11+).
+build:macos --copt=-mmacosx-version-min=12.0
+build:macos --linkopt=-mmacosx-version-min=12.0
+# Host/exec-configuration builds (e.g. flatc, protoc built as tools) also need
+# the deployment target override; --host_copt applies to the exec configuration.
+build:macos --host_copt=-mmacosx-version-min=12.0
+build:macos --host_linkopt=-mmacosx-version-min=12.0
 # This option controls whether javac checks for missing direct dependencies.
 build --experimental_strict_java_deps=off

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -84,6 +84,32 @@ def auto_http_archive(
     )
 
 def ray_deps_setup():
+    # Override build_bazel_rules_apple and build_bazel_apple_support before
+    # grpc_deps() runs. gRPC's rules_apple 1.1.3 uses apple_common.multi_arch_split
+    # which was removed in Bazel 7. rules_apple 3.2.1 is compatible with Bazel 6/7/8
+    # but requires apple_support >= 1.11.1 (for the configs/ package layout).
+    auto_http_archive(
+        name = "build_bazel_rules_apple",
+        sha256 = "9c4f1e1ec4fdfeac5bddb07fa0e872c398e3d8eb0ac596af9c463f9123ace292",
+        url = "https://github.com/bazelbuild/rules_apple/releases/download/3.2.1/rules_apple.3.2.1.tar.gz",
+        strip_prefix = "",
+    )
+
+    auto_http_archive(
+        name = "build_bazel_apple_support",
+        sha256 = "cf4d63f39c7ba9059f70e995bf5fe1019267d3f77379c2028561a5d7645ef67c",
+        url = "https://github.com/bazelbuild/apple_support/releases/download/1.11.1/apple_support.1.11.1.tar.gz",
+        strip_prefix = "",
+        patches = [
+            # In Bazel 7, local_config_apple_cc calls is_xcode_at_least_version
+            # during analysis. On CI machines with only Xcode CLT (no full Xcode
+            # app) xcode_config.xcode_version() returns None, causing a hard
+            # failure. Return False instead so the feature is disabled gracefully.
+            "//thirdparty/patches:build-bazel-apple-support-xcode.patch",
+        ],
+        patch_args = ["-p1"],
+    )
+
     # Explicitly bring in protobuf dependency to work around
     # https://github.com/ray-project/ray/issues/14117
     # This is copied from grpc's bazel/grpc_deps.bzl

--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -95,6 +95,7 @@ def ray_deps_setup():
         url = "https://github.com/protocolbuffers/protobuf/archive/2c5fa078d8e86e5f4bd34e6f4c9ea9e8d7d4d44a.tar.gz",
         patches = [
             "@com_github_grpc_grpc//third_party:protobuf.patch",
+            "//thirdparty/patches:protobuf-bazel7.patch",
         ],
         patch_args = ["-p1"],
     )
@@ -167,7 +168,8 @@ def ray_deps_setup():
     # Using a local build_file forces content-based cache invalidation:
     # changing org_lzma_lzma.BUILD.bazel triggers re-setup on all machines,
     # including Windows CI with persistent output bases where patching
-    # rules_boost's BUILD.lzma would not propagate.
+    # rules_boost's BUILD.lzma would not propagate (build_file label strings
+    # are used for fingerprinting, not file contents of external-repo labels).
     auto_http_archive(
         name = "org_lzma_lzma",
         sha256 = "06327c2ddc81e126a6d9a78b0be5014b976a2c0832f492dcfc4755d7facf6d33",

--- a/thirdparty/patches/build-bazel-apple-support-xcode.patch
+++ b/thirdparty/patches/build-bazel-apple-support-xcode.patch
@@ -1,0 +1,11 @@
+--- a/lib/xcode_support.bzl
++++ b/lib/xcode_support.bzl
+@@ -33,7 +33,6 @@
+     current_version = xcode_config.xcode_version()
+     if not current_version:
+-        fail("Could not determine Xcode version at all. This likely means Xcode isn't available; " +
+-             "if you think this is a mistake, please file an issue.")
++        return False
+
+     desired_version = apple_common.dotted_version(version)
+     return current_version >= desired_version

--- a/thirdparty/patches/protobuf-bazel7.patch
+++ b/thirdparty/patches/protobuf-bazel7.patch
@@ -1,0 +1,20 @@
+--- a/src/google/protobuf/BUILD.bazel
++++ b/src/google/protobuf/BUILD.bazel
+@@ -141,1 +141,1 @@
+-    exec_tools = ["//:protoc"],
++    tools = ["//:protoc"],
+
+--- a/build_defs/internal_shell.bzl
++++ b/build_defs/internal_shell.bzl
+@@ -35,1 +35,1 @@
+-        exec_tools = tools,
++        tools = tools,
+@@ -80,1 +80,1 @@
+-        exec_tools = tools,
++        tools = tools,
+
+--- a/objectivec/BUILD.bazel
++++ b/objectivec/BUILD.bazel
+@@ -45,1 +45,1 @@
+-    exec_tools = ["//:protoc"],
++    tools = ["//:protoc"],


### PR DESCRIPTION
gRPC's grpc_deps() pulls in rules_apple 1.1.3 which uses
apple_common.multi_arch_split, removed in Bazel 7. Override to 3.2.1
(compatible with Bazel 6/7/8) before grpc_deps() runs so the maybe()
call is a no-op.

rules_apple 3.2.1 requires apple_support >= 1.11.1. Patch
is_xcode_at_least_version to return False instead of fail() on
CLT-only CI machines where xcode_config.xcode_version() is None.

Set BAZEL_NO_APPLE_CPP_TOOLCHAIN=1 to skip apple_cc_toolchain on
CLT-only machines where it would fail with "Xcode version must be
specified". Override -mmacosx-version-min to 12.0 to satisfy
std::filesystem and std::variant requirements (generic toolchain
defaults to 10.11).

Topic: macos-apple-toolchain-bazel7
Relative: protobuf-bazel7-exec-tools
Signed-off-by: andrew <andrew@anyscale.com>