### PR TITLE
[data] Refactor hanging detector to avoid deep nesting logic + get_task only on filtered tasks[1/N]

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -141,7 +141,7 @@ class RunningTaskInfo:
     cum_block_gen_time_s: float
     cum_block_ser_time_s: float
     task_id: ray.TaskID
-    last_updated: float = field(init=False, default_factory=time.perf_counter)
+    last_updated: float = field(init=False, default_factory=lambda: time.perf_counter())
 
 
 @dataclass

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -144,7 +144,7 @@ class RunningTaskInfo:
     last_updated: float = field(init=False)
 
     def __post_init__(self):
-        self.last_updated = self.start_time
+        self.last_updated = time.time()
 
 
 @dataclass
@@ -941,7 +941,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             num_outputs=0,
             bytes_output=0,
             num_rows_produced=0,
-            start_time=time.time(),
+            start_time=time.perf_counter(),
             cum_block_gen_time_s=0,
             cum_block_ser_time_s=0,
             task_id=ray.TaskID.nil() if task_id is None else task_id,
@@ -970,7 +970,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         # Checkpoint time to first block
         is_first_block: bool = task_info.num_outputs == 0
         time_to_first_output_s = (
-            time.time() - task_info.start_time if is_first_block else None
+            time.perf_counter() - task_info.start_time if is_first_block else None
         )
 
         task_info.num_outputs += num_outputs
@@ -1045,7 +1045,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         # NOTE: This metric tracks task's wall-clock time as measured by
         #       the driver which starts upon scheduling of the task and runs
         #       until this callback is invoked
-        task_wall_time_s = time.time() - task_info.start_time
+        task_wall_time_s = time.perf_counter() - task_info.start_time
 
         self.task_completion_time_s += task_wall_time_s
         self.task_completion_time.observe(task_wall_time_s)

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -976,7 +976,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         task_info.num_outputs += num_outputs
         task_info.bytes_output += output_bytes
         task_info.num_rows_produced += num_rows_produced
-        task_info.last_updated = time.time()
+        task_info.last_updated = time.perf_counter()
 
         for block_ref, meta in output.blocks:
             exec_stats = meta.exec_stats

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -941,7 +941,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             num_outputs=0,
             bytes_output=0,
             num_rows_produced=0,
-            start_time=time.perf_counter(),
+            start_time=time.time(),
             cum_block_gen_time_s=0,
             cum_block_ser_time_s=0,
             task_id=ray.TaskID.nil() if task_id is None else task_id,
@@ -970,13 +970,13 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         # Checkpoint time to first block
         is_first_block: bool = task_info.num_outputs == 0
         time_to_first_output_s = (
-            time.perf_counter() - task_info.start_time if is_first_block else None
+            time.time() - task_info.start_time if is_first_block else None
         )
 
         task_info.num_outputs += num_outputs
         task_info.bytes_output += output_bytes
         task_info.num_rows_produced += num_rows_produced
-        task_info.last_updated = time.perf_counter()
+        task_info.last_updated = time.time()
 
         for block_ref, meta in output.blocks:
             exec_stats = meta.exec_stats
@@ -1045,7 +1045,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         # NOTE: This metric tracks task's wall-clock time as measured by
         #       the driver which starts upon scheduling of the task and runs
         #       until this callback is invoked
-        task_wall_time_s = time.perf_counter() - task_info.start_time
+        task_wall_time_s = time.time() - task_info.start_time
 
         self.task_completion_time_s += task_wall_time_s
         self.task_completion_time.observe(task_wall_time_s)

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -135,7 +135,7 @@ def metric_property(
 class RunningTaskInfo:
     inputs: RefBundle
     num_outputs: int
-    bytes_outputs: int
+    bytes_output: int
     num_rows_produced: int
     start_time: float
     cum_block_gen_time_s: float
@@ -935,7 +935,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         self._running_tasks[task_index] = RunningTaskInfo(
             inputs=inputs,
             num_outputs=0,
-            bytes_outputs=0,
+            bytes_output=0,
             num_rows_produced=0,
             start_time=time.perf_counter(),
             cum_block_gen_time_s=0,
@@ -970,7 +970,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         )
 
         task_info.num_outputs += num_outputs
-        task_info.bytes_outputs += output_bytes
+        task_info.bytes_output += output_bytes
         task_info.num_rows_produced += num_rows_produced
 
         for block_ref, meta in output.blocks:
@@ -1034,7 +1034,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         task_info = self._running_tasks[task_index]
 
         self.num_outputs_of_finished_tasks += task_info.num_outputs
-        self.bytes_outputs_of_finished_tasks += task_info.bytes_outputs
+        self.bytes_outputs_of_finished_tasks += task_info.bytes_output
         self.rows_outputs_of_finished_tasks += task_info.num_rows_produced
 
         # NOTE: This metric tracks task's wall-clock time as measured by

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -144,7 +144,7 @@ class RunningTaskInfo:
     last_updated: float = field(init=False)
 
     def __post_init__(self):
-        self.last_updated = time.time()
+        self.last_updated = time.perf_counter()
 
 
 @dataclass

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -141,6 +141,10 @@ class RunningTaskInfo:
     cum_block_gen_time_s: float
     cum_block_ser_time_s: float
     task_id: ray.TaskID
+    last_updated: float = field(init=False)
+
+    def __post_init__(self):
+        self.last_updated = self.start_time
 
 
 @dataclass
@@ -972,6 +976,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         task_info.num_outputs += num_outputs
         task_info.bytes_output += output_bytes
         task_info.num_rows_produced += num_rows_produced
+        task_info.last_updated = time.perf_counter()
 
         for block_ref, meta in output.blocks:
             exec_stats = meta.exec_stats

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -141,10 +141,7 @@ class RunningTaskInfo:
     cum_block_gen_time_s: float
     cum_block_ser_time_s: float
     task_id: ray.TaskID
-    last_updated: float = field(init=False)
-
-    def __post_init__(self):
-        self.last_updated = time.perf_counter()
+    last_updated: float = field(init=False, default_factory=time.perf_counter)
 
 
 @dataclass

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -302,6 +302,9 @@ def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
     except (RayStateApiException, requests.exceptions.RequestException):
         logger.debug(f"Failed to grab task state with task_id={task_id}", exc_info=True)
         return None
+    except Exception:
+        logger.debug(f"Unexpected error when grabbing task state with task_id={task_id}", exc_info=True)
+        return None
     if isinstance(task_state, list):
         # get the latest task
         task_state = max(task_state, key=lambda ts: ts.attempt_number)

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional
 
 import requests
-from pandas.core.resample import is_subperiod
 
 import ray
 from ray.data._internal.execution.interfaces.op_runtime_metrics import RunningTaskInfo
@@ -68,7 +67,7 @@ class HangingExecutionState:
     bytes_output: int
     start_time_hanging: float = field(compare=False)
 
-    def time_since_submission(self):
+    def time_since_hanging(self):
         return time.perf_counter() - self.start_time_hanging
 
 
@@ -133,13 +132,13 @@ class HangingExecutionIssueDetector(IssueDetector):
 
         meta = hes.task_metadata
         metadata_info = ""
-        if meta.pid is not None:
+        if meta is not None:
             metadata_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
 
         message = (
             f"A task (task_id={hes.task_id}) of operator "
             f"{operator.name} {metadata_info}has been running for "
-            f"{hes.time_since_submission():.2f}s, which is longer than the average task "
+            f"{hes.time_since_hanging():.2f}s, which is longer than the average task "
             f"duration + z-score * stdev of this operator "
             f"({avg_duration:.2f} + "
             f"{self._op_task_stats_std_factor_threshold} * "
@@ -192,46 +191,48 @@ class HangingExecutionIssueDetector(IssueDetector):
 
     def detect(self) -> List[Issue]:
 
-        issues: List[is_subperiod] = []
-        for operator in self._operators:
+        issues: List[Issue] = []
+        # Build a fresh map each cycle so that tasks which finished or
+        # dropped below the threshold are automatically pruned.
+        hanging_op_tasks: DefaultDict[
+            OpId, Dict[TaskIdx, HangingExecutionState]
+        ] = defaultdict(dict)
 
+        for operator in self._operators:
             if operator.has_execution_finished():
-                # Remove finished operators / tasks from the _hanging_op_tasks map
-                if operator.id in self._hanging_op_tasks:
-                    del self._hanging_op_tasks[operator.id]
                 continue
 
             op_metrics = operator.metrics
-            # Iterate directly over running tasks tracked in metrics
+            op_task_stats = op_metrics._op_task_duration_stats
+            # 1) Skip if not reached minimum task count
+            if op_task_stats.count() < self._op_task_stats_min_count:
+                continue
+
+            # 2) Skip if under threshold of mean + z-score * stdev
+            mean = op_task_stats.mean()
+            stddev = op_task_stats.stddev()
+            threshold = mean + self._op_task_stats_std_factor_threshold * stddev
+
             for task_idx, task_info in op_metrics._running_tasks.items():
-
-                # 1) Skip if not reached minimum task count
-                op_task_stats = op_metrics._op_task_duration_stats
-                if op_task_stats.count() < self._op_task_stats_min_count:
-                    continue
-
-                # 2) Skip if under threshold of mean + z-score * stdev
-                mean = op_task_stats.mean()
-                stddev = op_task_stats.stddev()
-                threshold = mean + self._op_task_stats_std_factor_threshold * stddev
                 current_task_duration = time.perf_counter() - task_info.start_time
                 if current_task_duration < threshold:
                     continue
 
-                # 3) Skip if there wasn't any meaningful update to the task. For example,
-                # a task may have made some progress (yield bytes), or a task is retried
-                # giving a different node_id/attempt_number
-                old_state = self._hanging_op_tasks[operator.id].get(task_idx)
+                old_state = self._hanging_op_tasks.get(operator.id, {}).get(task_idx)
                 new_state = self._refresh_state(
                     operator=operator,
                     task_idx=task_idx,
                     old_state=old_state,
                     task_info=task_info,
                 )
+
+                hanging_op_tasks[operator.id][task_idx] = new_state
+
+                # 3) Skip if there wasn't any meaningful update to the task. For example,
+                # a task may have made some progress (yield bytes), or a task is retried
+                # giving a different node_id/attempt_number
                 if old_state == new_state:
                     continue
-
-                self._hanging_op_tasks[operator.id][task_idx] = new_state
 
                 issues.append(
                     self._create_issue(
@@ -239,6 +240,7 @@ class HangingExecutionIssueDetector(IssueDetector):
                     )
                 )
 
+        self._hanging_op_tasks = hanging_op_tasks
         return issues
 
     def detection_time_interval_s(self) -> float:

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -70,11 +70,11 @@ class HangingExecutionState:
     task_id: ray.TaskID
     task_metadata: Optional[TaskMetadata]
     bytes_output: int
-    # from time.time()
+    # NOTE This is from perf_couinter()
     start_time_hanging: float
 
     def hanging_time(self):
-        return time.time() - self.start_time_hanging
+        return time.perf_counter() - self.start_time_hanging
 
 
 @dataclass
@@ -139,12 +139,13 @@ class HangingExecutionIssueDetector(IssueDetector):
         if meta is not None:
             task_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
 
-        hanging_since = _format_timestamp(hes.start_time_hanging)
+        hanging_time = hes.hanging_time()
+        hanging_since = _format_timestamp(time.time() - hanging_time)
 
         message = (
             f"A task (task_id={hes.task_id}) of operator "
             f"{operator.name} {task_info}has been running or stuck in scheduling for "
-            f"{hes.hanging_time():.2f}s, which is longer than the average task "
+            f"{hanging_time:.2f}s, which is longer than the average task "
             f"duration + z-score * stddev of this operator "
             f"({avg_duration:.2f} + "
             f"{self._op_task_stats_std_factor_threshold} * "

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -70,7 +70,7 @@ class HangingExecutionState:
     task_id: ray.TaskID
     task_metadata: TaskMetadata | None
     bytes_output: int
-    task_start_time: float
+    # from time.time()
     start_time_hanging: float
 
     def hanging_time(self):
@@ -139,7 +139,6 @@ class HangingExecutionIssueDetector(IssueDetector):
         if meta is not None:
             metadata_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
 
-        task_started = _format_timestamp(hes.task_start_time)
         hanging_since = _format_timestamp(hes.start_time_hanging)
 
         message = (
@@ -150,8 +149,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             f"({avg_duration:.2f} + "
             f"{self._op_task_stats_std_factor_threshold} * "
             f"{stdev:.2f}s). "
-            f"Task started at {task_started} and "
-            f"last time task produced output or made any progress was {hanging_since}. "
+            f"Last time task produced output or made any progress was {hanging_since}. "
             f"If this message persists, please check "
             f"the stack trace of the task for potential hanging "
             f"issues. To adjust the z-score value, set "
@@ -197,7 +195,6 @@ class HangingExecutionIssueDetector(IssueDetector):
             task_id=task_info.task_id,
             task_metadata=task_metadata,
             bytes_output=task_info.bytes_output,
-            task_start_time=task_info.start_time,
             start_time_hanging=task_info.last_updated,
         )
 

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -31,8 +31,8 @@ DEFAULT_OP_TASK_STATS_STD_FACTOR = 10
 # Default detection time interval.
 DEFAULT_DETECTION_TIME_INTERVAL_S = 30.0
 # Max failed attempts to fetch task state before giving up for a task.
-# 1 is chosen for now, because the get_state API is known to be slow when
-# processing many http requests.
+# 1 is a lower # chosen for now, because the get_state API is known
+# to be slow when processing many http requests.
 _MAX_STATE_FETCH_FAILED_ATTEMPTS = 1
 
 logger = logging.getLogger(__name__)
@@ -303,7 +303,10 @@ def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
         logger.debug(f"Failed to grab task state with task_id={task_id}", exc_info=True)
         return None
     except Exception:
-        logger.debug(f"Unexpected error when grabbing task state with task_id={task_id}", exc_info=True)
+        logger.debug(
+            f"Unexpected error when grabbing task state with task_id={task_id}",
+            exc_info=True,
+        )
         return None
     if isinstance(task_state, list):
         # get the latest task

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -68,8 +68,6 @@ class HangingExecutionIssueDetector(IssueDetector):
         # Map of operator id to dict of task_idx to hanging execution info (bytes read and
         # start time for hanging time calculation)
         self._state_map: Dict[str, Dict[int, HangingExecutionState]] = defaultdict(dict)
-        # Map of operator id to set of task_idx that are hanging
-        self._hanging_op_tasks: Dict[str, Set[int]] = defaultdict(set)
         # Map of operator id to operator name
         self._op_id_to_name: Dict[str, str] = {}
 
@@ -153,7 +151,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                     )
                 )
                 state.logged_already = True
-                self._hanging_op_tasks[state.operator_id].add(state.task_idx)
 
         return issues
 
@@ -167,8 +164,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                 # Remove finished operators / tasks from the state map
                 if operator.id in self._state_map:
                     del self._state_map[operator.id]
-                if operator.id in self._hanging_op_tasks:
-                    del self._hanging_op_tasks[operator.id]
             else:
                 active_tasks_idx = set()
                 # Iterate directly over running tasks tracked in metrics
@@ -201,7 +196,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                 )
                 for task_idx in task_idxs_to_remove:
                     del self._state_map[operator.id][task_idx]
-                    self._hanging_op_tasks[operator.id].discard(task_idx)
 
         hanging_op_tasks = []
         for op_id, op_state_values in self._state_map.items():

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -2,20 +2,23 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional
+from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional
+
+import requests
+from pandas.core.resample import is_subperiod
 
 import ray
+from ray.data._internal.execution.interfaces.op_runtime_metrics import RunningTaskInfo
 from ray.data._internal.issue_detection.issue_detector import (
     Issue,
     IssueDetector,
     IssueType,
 )
+from ray.util.state import get_task
 from ray.util.state.common import TaskState
+from ray.util.state.exception import RayStateApiException
 
 if TYPE_CHECKING:
-    from ray.data._internal.execution.interfaces.op_runtime_metrics import (
-        TaskDurationStats,
-    )
     from ray.data._internal.execution.interfaces.physical_operator import (
         PhysicalOperator,
     )
@@ -30,16 +33,43 @@ DEFAULT_DETECTION_TIME_INTERVAL_S = 30.0
 
 logger = logging.getLogger(__name__)
 
+OpId = str
+TaskIdx = int
+
+
+@dataclass
+class TaskMetadata:
+    """Subset of TaskState fields relevant for hanging detection."""
+
+    attempt_number: int
+    node_id: str
+    pid: int
+
+    @classmethod
+    def from_task_state(cls, task_state: TaskState) -> "TaskMetadata":
+        return cls(
+            attempt_number=task_state.attempt_number,
+            node_id=task_state.node_id,
+            pid=task_state.worker_pid,
+        )
+
 
 @dataclass
 class HangingExecutionState:
-    operator_id: str
-    task_idx: int
-    task_id: ray.TaskID
-    task_state: Optional[TaskState]
-    logged_already: bool
+    # Equality is based on bytes_output and task_metadata: a change in
+    # output means the task made progress, and a change in metadata means
+    # the task was retried on a different node/worker.  Both warrant a
+    # new log entry.  The remaining fields are static identifiers that
+    # don't indicate a meaningful state change worth re-logging.
+    operator_id: OpId = field(compare=False)
+    task_idx: TaskIdx = field(compare=False)
+    task_id: ray.TaskID = field(compare=False)
+    task_metadata: Optional[TaskMetadata]
     bytes_output: int
-    start_time_hanging: float
+    start_time_hanging: float = field(compare=False)
+
+    def time_since_submission(self):
+        return time.perf_counter() - self.start_time_hanging
 
 
 @dataclass
@@ -65,11 +95,10 @@ class HangingExecutionIssueDetector(IssueDetector):
             self._detector_cfg.op_task_stats_std_factor
         )
 
-        # Map of operator id to dict of task_idx to hanging execution info (bytes read and
-        # start time for hanging time calculation)
-        self._state_map: Dict[str, Dict[int, HangingExecutionState]] = defaultdict(dict)
-        # Map of operator id to operator name
-        self._op_id_to_name: Dict[str, str] = {}
+        # Map of operator id to Dict[task index, state]
+        self._hanging_op_tasks: DefaultDict[
+            OpId, Dict[TaskIdx, HangingExecutionState]
+        ] = defaultdict(dict)
 
     @classmethod
     def from_executor(
@@ -91,130 +120,124 @@ class HangingExecutionIssueDetector(IssueDetector):
             config=ctx.issue_detectors_config.hanging_detector_config,
         )
 
-    def _create_issues(
+    def _create_issue(
         self,
-        hanging_op_tasks: List[HangingExecutionState],
-        op_task_stats_map: Dict[str, "TaskDurationStats"],
-    ) -> List[Issue]:
-        issues = []
-        failed_get_task = False
-        for state in hanging_op_tasks:
-            if state.task_state is None:
-                if not failed_get_task:
-                    latest = get_latest_state_for_task(state.task_id)
-                    if latest is None:
-                        # There exists more sophisticated ways to handle failure across multiple tasks, but for simplicity,
-                        # any failure grabbing the task info means we stop grabbing task info for the rest
-                        # of the tasks. This prevents a flood of state API calls, which can be slow. On the
-                        # next detection cycle, we will only retry the ones that are None.
-                        failed_get_task = True
-                    state.task_state = latest
+        operator: "PhysicalOperator",
+        hanging_execution_state: HangingExecutionState,
+    ) -> Issue:
 
-                if state.logged_already and state.task_state is None:
-                    # If we succeeded grabbing task info, or it failed only once, then create an
-                    # issue. We don't want to spam log messages if there are continued failures.
-                    continue
+        hes = hanging_execution_state
+        op_task_stats = operator.metrics._op_task_duration_stats
+        avg_duration = op_task_stats.mean()
+        stdev = op_task_stats.stddev()
 
-                op_name = self._op_id_to_name.get(state.operator_id, state.operator_id)
-                duration = time.perf_counter() - state.start_time_hanging
-                op_task_stats = op_task_stats_map[state.operator_id]
-                avg_duration = op_task_stats.mean()
-                stdev = op_task_stats.stddev()
+        meta = hes.task_metadata
+        metadata_info = ""
+        if meta.pid is not None:
+            metadata_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
 
-                node_id = None
-                pid = None
-                attempt_number = None
-                metadata_info = ""
-                if state.task_state is not None:
-                    node_id = state.task_state.node_id
-                    pid = state.task_state.worker_pid
-                    attempt_number = state.task_state.attempt_number
-                    metadata_info = (
-                        f"(pid={pid}, node_id={node_id}, attempt={attempt_number}) "
-                    )
+        message = (
+            f"A task (task_id={hes.task_id}) of operator "
+            f"{operator.name} {metadata_info}has been running for "
+            f"{hes.time_since_submission():.2f}s, which is longer than the average task "
+            f"duration + z-score * stdev of this operator "
+            f"({avg_duration:.2f} + "
+            f"{self._op_task_stats_std_factor_threshold} * "
+            f"{stdev:.2f}s). If this message persists, please check "
+            f"the stack trace of the task for potential hanging "
+            f"issues. To adjust the z-score value, set "
+            f"`ray.data.DataContext.get_current()"
+            f".issue_detectors_config.hanging_detector_config"
+            f".op_task_stats_std_factor`."
+        )
 
-                message = (
-                    f"A task (task_id={state.task_id}) of operator {op_name} {metadata_info}has been running for {duration:.2f}s, which is longer"
-                    f" than the average task duration + z-score * stdev of this operator ({avg_duration:.2f} + {self._op_task_stats_std_factor_threshold} * {stdev:.2f}s)."
-                    f" If this message persists, please check the stack trace of the "
-                    "task for potential hanging issues."
-                    " To adjust the z-score threshold, set"
-                    " `ray.data.DataContext.get_current().issue_detectors_config.hanging_detector_config.op_task_stats_std_factor`."
-                )
+        return Issue(
+            dataset_name=self._dataset_id,
+            operator_id=hes.operator_id,
+            issue_type=IssueType.HANGING,
+            message=message,
+        )
 
-                issues.append(
-                    Issue(
-                        dataset_name=self._dataset_id,
-                        operator_id=state.operator_id,
-                        issue_type=IssueType.HANGING,
-                        message=message,
-                    )
-                )
-                state.logged_already = True
+    def _refresh_state(
+        self,
+        operator: "PhysicalOperator",
+        task_idx: TaskIdx,
+        old_state: Optional[HangingExecutionState],
+        task_info: RunningTaskInfo,
+    ) -> HangingExecutionState:
+        """Return a HangingExecutionState for the task, creating one if new.
 
-        return issues
+        Reuses the previously fetched task metadata if available, otherwise
+        attempts to fetch it from the state API.
+        """
+        task_metadata: Optional[TaskMetadata] = (
+            old_state.task_metadata if old_state is not None else None
+        )
+        if task_metadata is None:
+            task_state = get_latest_state_for_task(task_info.task_id)
+            task_metadata = (
+                TaskMetadata.from_task_state(task_state)
+                if task_state is not None
+                else None
+            )
+
+        return HangingExecutionState(
+            operator_id=operator.id,
+            task_idx=task_idx,
+            task_id=task_info.task_id,
+            task_metadata=task_metadata,
+            bytes_output=task_info.bytes_output,
+            start_time_hanging=task_info.start_time,
+        )
 
     def detect(self) -> List[Issue]:
-        op_task_stats_map: Dict[str, "TaskDurationStats"] = {}
+
+        issues: List[is_subperiod] = []
         for operator in self._operators:
-            op_metrics = operator.metrics
-            op_task_stats_map[operator.id] = op_metrics._op_task_duration_stats
-            self._op_id_to_name[operator.id] = operator.name
+
             if operator.has_execution_finished():
-                # Remove finished operators / tasks from the state map
-                if operator.id in self._state_map:
-                    del self._state_map[operator.id]
-            else:
-                active_tasks_idx = set()
-                # Iterate directly over running tasks tracked in metrics
-                for task_idx, task_info in op_metrics._running_tasks.items():
-                    active_tasks_idx.add(task_idx)
-                    bytes_output = task_info.bytes_outputs
-                    prev_state_value = self._state_map[operator.id].get(task_idx, None)
+                # Remove finished operators / tasks from the _hanging_op_tasks map
+                if operator.id in self._hanging_op_tasks:
+                    del self._hanging_op_tasks[operator.id]
+                continue
 
-                    if (
-                        prev_state_value is None
-                        or bytes_output != prev_state_value.bytes_output
-                    ):
-                        self._state_map[operator.id][task_idx] = HangingExecutionState(
-                            operator_id=operator.id,
-                            task_idx=task_idx,
-                            task_id=task_info.task_id,
-                            task_state=(
-                                None
-                                if prev_state_value is None
-                                else prev_state_value.task_state
-                            ),
-                            logged_already=False,
-                            bytes_output=bytes_output,
-                            start_time_hanging=time.perf_counter(),
-                        )
+            op_metrics = operator.metrics
+            # Iterate directly over running tasks tracked in metrics
+            for task_idx, task_info in op_metrics._running_tasks.items():
 
-                # Remove any tasks that are no longer active
-                task_idxs_to_remove = (
-                    set(self._state_map[operator.id].keys()) - active_tasks_idx
+                # 1) Skip if not reached minimum task count
+                op_task_stats = op_metrics._op_task_duration_stats
+                if op_task_stats.count() < self._op_task_stats_min_count:
+                    continue
+
+                # 2) Skip if under threshold of mean + z-score * stdev
+                mean = op_task_stats.mean()
+                stddev = op_task_stats.stddev()
+                threshold = mean + self._op_task_stats_std_factor_threshold * stddev
+                current_task_duration = time.perf_counter() - task_info.start_time
+                if current_task_duration < threshold:
+                    continue
+
+                # 3) Skip if there wasn't any meaningful update to the task. For example,
+                # a task may have made some progress (yield bytes), or a task is retried
+                # giving a different node_id/attempt_number
+                old_state = self._hanging_op_tasks[operator.id].get(task_idx)
+                new_state = self._refresh_state(
+                    operator=operator,
+                    task_idx=task_idx,
+                    old_state=old_state,
+                    task_info=task_info,
                 )
-                for task_idx in task_idxs_to_remove:
-                    del self._state_map[operator.id][task_idx]
+                if old_state == new_state:
+                    continue
 
-        hanging_op_tasks = []
-        for op_id, op_state_values in self._state_map.items():
-            op_task_stats = op_task_stats_map[op_id]
-            for task_idx, state_value in op_state_values.items():
-                curr_time = time.perf_counter() - state_value.start_time_hanging
-                if op_task_stats.count() >= self._op_task_stats_min_count:
-                    mean = op_task_stats.mean()
-                    stddev = op_task_stats.stddev()
-                    threshold = mean + self._op_task_stats_std_factor_threshold * stddev
+                self._hanging_op_tasks[operator.id][task_idx] = new_state
 
-                    if curr_time > threshold:
-                        hanging_op_tasks.append(state_value)
-
-        # create issues for newly detected hanging tasks, then update the hanging task set
-        issues = self._create_issues(
-            hanging_op_tasks=hanging_op_tasks,
-            op_task_stats_map=op_task_stats_map,
-        )
+                issues.append(
+                    self._create_issue(
+                        operator=operator, hanging_execution_state=new_state
+                    )
+                )
 
         return issues
 
@@ -223,16 +246,23 @@ class HangingExecutionIssueDetector(IssueDetector):
 
 
 def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
+    """Query the Ray State API for the latest attempt of a task.
+
+    Returns the TaskState with the highest attempt_number when multiple
+    attempts exist, or None if the task is not found (can happen when
+    get_task() is called shortly after submission, before the state API
+    has indexed it) or the API is unreachable.
+    """
     try:
-        task_state: TaskState | List[TaskState] | None = ray.util.state.get_task(
+        task_state: TaskState | List[TaskState] | None = get_task(
             task_id.hex(),
-            timeout=1.0,
+            timeout=0,
             _explain=True,
         )
-        if isinstance(task_state, list):
-            # get the latest task
-            task_state = max(task_state, key=lambda ts: ts.attempt_number)
-        return task_state
-    except Exception as e:
-        logger.debug(f"Failed to grab task state with task_id={task_id}: {e}")
+    except (RayStateApiException, requests.exceptions.RequestException):
+        logger.debug(f"Failed to grab task state with task_id={task_id}", exc_info=True)
         return None
+    if isinstance(task_state, list):
+        # get the latest task
+        task_state = max(task_state, key=lambda ts: ts.attempt_number)
+    return task_state

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -184,7 +184,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             task_metadata = old_state.task_metadata
             bytes_output = old_state.bytes_output
 
-        elif bytes_output != task_info.bytes_output:
+        if old_state is None or bytes_output != task_info.bytes_output:
             task_metadata = get_latest_state_for_task(task_info.task_id)
 
         return HangingExecutionState(

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -218,7 +218,7 @@ class HangingExecutionIssueDetector(IssueDetector):
 
             for task_idx, task_info in op_metrics._running_tasks.items():
 
-                time_since_last_update = time.time() - task_info.last_updated
+                time_since_last_update = time.perf_counter() - task_info.last_updated
                 if time_since_last_update < threshold:
                     continue
 

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -39,6 +39,10 @@ logger = logging.getLogger(__name__)
 
 OpId = str
 TaskIdx = int
+# Map of operator id -> task index -> hanging execution state.
+HangingOpTasks = DefaultDict[OpId, Dict[TaskIdx, "HangingExecutionState"]]
+# Map of operator id -> task index -> number of failed metadata fetch attempts.
+StateFetchFailures = DefaultDict[OpId, Dict[TaskIdx, int]]
 
 
 def _format_timestamp(epoch: float) -> str:
@@ -70,7 +74,7 @@ class HangingExecutionState:
     operator_id: OpId
     task_idx: TaskIdx
     task_id: ray.TaskID
-    task_metadata: TaskMetadata
+    task_metadata: TaskMetadata | None
     bytes_output: int
     task_start_time: float
     start_time_hanging: float
@@ -103,14 +107,10 @@ class HangingExecutionIssueDetector(IssueDetector):
         )
 
         # Map of operator id to Dict[task index, state]
-        self._hanging_op_tasks: DefaultDict[
-            OpId, Dict[TaskIdx, HangingExecutionState]
-        ] = defaultdict(dict)
+        self._hanging_op_tasks: HangingOpTasks = defaultdict(dict)
         # Per-task count of failed get_latest_state_for_task attempts.
         # After _MAX_STATE_FETCH_FAILED_ATTEMPTS, we stop retrying for that task.
-        self._state_fetch_failures: DefaultDict[OpId, Dict[TaskIdx, int]] = defaultdict(
-            dict
-        )
+        self._state_fetch_failures: StateFetchFailures = defaultdict(dict)
 
     @classmethod
     def from_executor(
@@ -176,19 +176,22 @@ class HangingExecutionIssueDetector(IssueDetector):
             message=message,
         )
 
-    def _can_retry_metadata_fetch(self, op_id: OpId, task_idx: TaskIdx) -> bool:
-        """Whether we haven't exhausted fetch attempts for this task."""
+    @staticmethod
+    def _should_fetch_metadata(
+        task_metadata: TaskMetadata | None, failure_count: int
+    ) -> bool:
+        """Whether metadata is missing and we haven't exhausted fetch attempts."""
         return (
-            self._state_fetch_failures[op_id].get(task_idx, 0)
-            < _MAX_STATE_FETCH_FAILED_ATTEMPTS
+            task_metadata is None and failure_count < _MAX_STATE_FETCH_FAILED_ATTEMPTS
         )
 
-    def _reset_fetch_failures(self, op_id: OpId, task_idx: TaskIdx):
-        self._state_fetch_failures[op_id][task_idx] = 0
-
-    def _record_fetch_failure(self, op_id: OpId, task_idx: TaskIdx):
-        failures = self._state_fetch_failures[op_id]
-        failures[task_idx] = failures.get(task_idx, 0) + 1
+    @staticmethod
+    def _reset_fetch_failures(
+        state_fetch_failures: StateFetchFailures,
+        op_id: OpId,
+        task_idx: TaskIdx,
+    ):
+        state_fetch_failures[op_id][task_idx] = 0
 
     def _refresh_state(
         self,
@@ -196,6 +199,7 @@ class HangingExecutionIssueDetector(IssueDetector):
         task_idx: TaskIdx,
         old_state: HangingExecutionState | None,
         task_info: RunningTaskInfo,
+        state_fetch_failures: StateFetchFailures,
     ) -> HangingExecutionState:
         """Build a HangingExecutionState, fetching task metadata lazily.
 
@@ -212,15 +216,14 @@ class HangingExecutionIssueDetector(IssueDetector):
             bytes_output = old_state.bytes_output
 
         if bytes_output != task_info.bytes_output:
-            self._reset_fetch_failures(operator.id, task_idx)
+            state_fetch_failures[operator.id][task_idx] = 0
             task_metadata = None
 
-        if task_metadata is None and self._can_retry_metadata_fetch(
-            operator.id, task_idx
-        ):
+        prev_failures = state_fetch_failures[operator.id].get(task_idx, 0)
+        if self._should_fetch_metadata(task_metadata, prev_failures):
             task_state = get_latest_state_for_task(task_info.task_id)
             if task_state is None:
-                self._record_fetch_failure(operator.id, task_idx)
+                state_fetch_failures[operator.id][task_idx] = prev_failures + 1
             else:
                 task_metadata = TaskMetadata.from_task_state(task_state)
 
@@ -237,11 +240,10 @@ class HangingExecutionIssueDetector(IssueDetector):
     def detect(self) -> List[Issue]:
 
         issues: List[Issue] = []
-        # Build fresh map each cycle so that tasks which finished or
+        # Build fresh maps each cycle so that tasks which finished or
         # dropped below the threshold are automatically pruned.
-        hanging_op_tasks: DefaultDict[
-            OpId, Dict[TaskIdx, HangingExecutionState]
-        ] = defaultdict(dict)
+        hanging_op_tasks: HangingOpTasks = defaultdict(dict)
+        state_fetch_failures: StateFetchFailures = defaultdict(dict)
 
         for operator in self._operators:
             if operator.has_execution_finished():
@@ -265,22 +267,27 @@ class HangingExecutionIssueDetector(IssueDetector):
                     continue
 
                 old_state = self._hanging_op_tasks[operator.id].get(task_idx)
+
+                old_failures = self._state_fetch_failures[operator.id].get(task_idx, 0)
+                state_fetch_failures[operator.id][task_idx] = old_failures
+
                 new_state = self._refresh_state(
                     operator=operator,
                     task_idx=task_idx,
                     old_state=old_state,
                     task_info=task_info,
+                    state_fetch_failures=state_fetch_failures,
                 )
 
                 hanging_op_tasks[operator.id][task_idx] = new_state
+                failure_count = state_fetch_failures[operator.id].get(task_idx, 0)
 
                 # 3) Skip if there wasn't any meaningful update to the task. For example,
                 # a task may have made some progress (yield bytes), or a task is retried
                 # giving a different node_id/attempt_number. Also skip, if we still have
                 # metadata retry attempts (so that we don't double log w/ and w/o the metadata.)
-                if old_state == new_state or (
-                    new_state.task_metadata is None
-                    and self._can_retry_metadata_fetch(operator.id, task_idx)
+                if old_state == new_state or self._should_fetch_metadata(
+                    new_state.task_metadata, failure_count
                 ):
                     continue
 
@@ -291,6 +298,7 @@ class HangingExecutionIssueDetector(IssueDetector):
                 )
 
         self._hanging_op_tasks = hanging_op_tasks
+        self._state_fetch_failures = state_fetch_failures
         return issues
 
     def detection_time_interval_s(self) -> float:

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -101,8 +101,8 @@ class HangingExecutionIssueDetector(IssueDetector):
         issues = []
         failed_get_task = False
         for state in hanging_op_tasks:
-            if state.task_idx not in self._hanging_op_tasks[state.operator_id]:
-                if state.task_state is None and not failed_get_task:
+            if state.task_state is None:
+                if not failed_get_task:
                     latest = get_latest_state_for_task(state.task_id)
                     if latest is None:
                         # There exists more sophisticated ways to handle failure across multiple tasks, but for simplicity,
@@ -153,8 +153,7 @@ class HangingExecutionIssueDetector(IssueDetector):
                     )
                 )
                 state.logged_already = True
-                if state.task_state is not None:
-                    self._hanging_op_tasks[state.operator_id].add(state.task_idx)
+                self._hanging_op_tasks[state.operator_id].add(state.task_idx)
 
         return issues
 

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -39,10 +39,11 @@ OpId = str
 TaskIdx = int
 
 
-def _perf_counter_to_datetime(perf_value: float) -> datetime:
-    """Convert a ``time.perf_counter()`` value to a wall-clock datetime."""
-    wall = time.time() - (time.perf_counter() - perf_value)
-    return datetime.fromtimestamp(wall, tz=timezone.utc)
+def _format_timestamp(epoch: float) -> str:
+    """Format a ``time.time()`` epoch value as a human-readable UTC string."""
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).strftime(
+        "%Y-%m-%d %H:%M:%S %Z"
+    )
 
 
 @dataclass
@@ -78,7 +79,7 @@ class HangingExecutionState:
     start_time_hanging: float
 
     def hanging_time(self):
-        return time.perf_counter() - self.start_time_hanging
+        return time.time() - self.start_time_hanging
 
 
 @dataclass
@@ -113,8 +114,6 @@ class HangingExecutionIssueDetector(IssueDetector):
         self._state_fetch_failures: DefaultDict[OpId, Dict[TaskIdx, int]] = defaultdict(
             dict
         )
-
-        self._last_detection_cycle: float = time.perf_counter()
 
     @classmethod
     def from_executor(
@@ -152,8 +151,8 @@ class HangingExecutionIssueDetector(IssueDetector):
         if meta is not None:
             metadata_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
 
-        task_started = _perf_counter_to_datetime(hes.task_start_time)
-        hanging_since = _perf_counter_to_datetime(hes.start_time_hanging)
+        task_started = _format_timestamp(hes.task_start_time)
+        hanging_since = _format_timestamp(hes.start_time_hanging)
 
         message = (
             f"A task (task_id={hes.task_id}) of operator "
@@ -163,8 +162,8 @@ class HangingExecutionIssueDetector(IssueDetector):
             f"({avg_duration:.2f} + "
             f"{self._op_task_stats_std_factor_threshold} * "
             f"{stdev:.2f}s). "
-            f"Task started at {task_started:%Y-%m-%d %H:%M:%S %Z}, "
-            f"hanging since {hanging_since:%Y-%m-%d %H:%M:%S %Z}. "
+            f"Task started at {task_started} and "
+            f"last time task produced output was {hanging_since}. "
             f"If this message persists, please check "
             f"the stack trace of the task for potential hanging "
             f"issues. To adjust the z-score value, set "
@@ -249,7 +248,7 @@ class HangingExecutionIssueDetector(IssueDetector):
 
             for task_idx, task_info in op_metrics._running_tasks.items():
 
-                time_since_last_update = time.perf_counter() - task_info.last_updated
+                time_since_last_update = time.time() - task_info.last_updated
                 if time_since_last_update < threshold:
                     continue
 
@@ -267,8 +266,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                 # 3) Skip if there wasn't any meaningful update to the task. For example,
                 # a task may have made some progress (yield bytes), or a task is retried
                 # giving a different node_id/attempt_number
-                # print(f"old_state={old_state}")
-                # print(f"new_state={new_state}")
                 if old_state == new_state:
                     continue
 
@@ -280,7 +277,6 @@ class HangingExecutionIssueDetector(IssueDetector):
 
         self._hanging_op_tasks = hanging_op_tasks
         self._state_fetch_failures = state_fetch_failures
-        self._last_detection_cycle = time.perf_counter()
         return issues
 
     def detection_time_interval_s(self) -> float:

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -179,12 +179,9 @@ class HangingExecutionIssueDetector(IssueDetector):
         task made progress then stalled again).
         """
         task_metadata: Optional[TaskMetadata] = None
-        bytes_output: Optional[int] = None
         if old_state is not None:
             task_metadata = old_state.task_metadata
-            bytes_output = old_state.bytes_output
-
-        if old_state is None or bytes_output != task_info.bytes_output:
+        else:
             task_metadata = get_latest_state_for_task(task_info.task_id)
 
         return HangingExecutionState(

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -30,10 +30,6 @@ DEFAULT_OP_TASK_STATS_MIN_COUNT = 10
 DEFAULT_OP_TASK_STATS_STD_FACTOR = 10
 # Default detection time interval.
 DEFAULT_DETECTION_TIME_INTERVAL_S = 30.0
-# Max failed attempts to fetch task state before giving up for a task.
-# 1 is a lower # chosen for now, because the get_state API is known
-# to be slow when processing many http requests.
-_MAX_STATE_FETCH_FAILED_ATTEMPTS = 1
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +37,6 @@ OpId = str
 TaskIdx = int
 # Map of operator id -> task index -> hanging execution state.
 HangingOpTasks = DefaultDict[OpId, Dict[TaskIdx, "HangingExecutionState"]]
-# Map of operator id -> task index -> number of failed metadata fetch attempts.
-StateFetchFailures = DefaultDict[OpId, Dict[TaskIdx, int]]
 
 
 def _format_timestamp(epoch: float) -> str:
@@ -108,9 +102,6 @@ class HangingExecutionIssueDetector(IssueDetector):
 
         # Map of operator id to Dict[task index, state]
         self._hanging_op_tasks: HangingOpTasks = defaultdict(dict)
-        # Per-task count of failed get_latest_state_for_task attempts.
-        # After _MAX_STATE_FETCH_FAILED_ATTEMPTS, we stop retrying for that task.
-        self._state_fetch_failures: StateFetchFailures = defaultdict(dict)
 
     @classmethod
     def from_executor(
@@ -176,30 +167,18 @@ class HangingExecutionIssueDetector(IssueDetector):
             message=message,
         )
 
-    @staticmethod
-    def _should_fetch_metadata(
-        task_metadata: TaskMetadata | None, failure_count: int
-    ) -> bool:
-        """Whether metadata is missing and we haven't exhausted fetch attempts."""
-        return (
-            task_metadata is None and failure_count < _MAX_STATE_FETCH_FAILED_ATTEMPTS
-        )
-
     def _refresh_state(
         self,
         operator: "PhysicalOperator",
         task_idx: TaskIdx,
         old_state: HangingExecutionState | None,
         task_info: RunningTaskInfo,
-        state_fetch_failures: StateFetchFailures,
     ) -> HangingExecutionState:
         """Build a HangingExecutionState, fetching task metadata lazily.
 
         Task metadata (pid, node_id, attempt) is fetched from the Ray
         State API only when unknown or potentially stale (e.g. after the
-        task made progress then stalled again).  Fetches that fail are
-        counted in ``state_fetch_failures`` (mutated in-place) and
-        skipped after ``_MAX_STATE_FETCH_FAILED_ATTEMPTS``.
+        task made progress then stalled again).
         """
         task_metadata: TaskMetadata | None = None
         bytes_output: int | None = None
@@ -207,16 +186,9 @@ class HangingExecutionIssueDetector(IssueDetector):
             task_metadata = old_state.task_metadata
             bytes_output = old_state.bytes_output
 
-        if bytes_output != task_info.bytes_output:
-            state_fetch_failures[operator.id][task_idx] = 0
-            task_metadata = None
-
-        prev_failures = state_fetch_failures[operator.id].get(task_idx, 0)
-        if self._should_fetch_metadata(task_metadata, prev_failures):
+        if old_state is None or bytes_output != task_info.bytes_output:
             task_state = get_latest_state_for_task(task_info.task_id)
-            if task_state is None:
-                state_fetch_failures[operator.id][task_idx] = prev_failures + 1
-            else:
+            if task_state is not None:
                 task_metadata = TaskMetadata.from_task_state(task_state)
 
         return HangingExecutionState(
@@ -235,7 +207,6 @@ class HangingExecutionIssueDetector(IssueDetector):
         # Build fresh maps each cycle so that tasks which finished or
         # dropped below the threshold are automatically pruned.
         hanging_op_tasks: HangingOpTasks = defaultdict(dict)
-        state_fetch_failures: StateFetchFailures = defaultdict(dict)
 
         for operator in self._operators:
             if operator.has_execution_finished():
@@ -260,31 +231,16 @@ class HangingExecutionIssueDetector(IssueDetector):
 
                 old_state = self._hanging_op_tasks[operator.id].get(task_idx)
 
-                old_fail_count = self._state_fetch_failures[operator.id].get(
-                    task_idx, 0
-                )
-                state_fetch_failures[operator.id][task_idx] = old_fail_count
-
                 new_state = self._refresh_state(
                     operator=operator,
                     task_idx=task_idx,
                     old_state=old_state,
                     task_info=task_info,
-                    state_fetch_failures=state_fetch_failures,
                 )
 
                 hanging_op_tasks[operator.id][task_idx] = new_state
-                new_fail_count = state_fetch_failures[operator.id].get(task_idx, 0)
 
-                # Skip if we're still waiting for metadata (will retry next cycle).
-                if self._should_fetch_metadata(new_state.task_metadata, new_fail_count):
-                    continue
-                # Skip if nothing meaningful changed: the execution state
-                # is identical AND the failure count didn't just cross the
-                # exhaustion threshold (which would mean we deferred logging
-                # while retrying and should now emit the issue).
-                fetch_metadata_attempt_failed = old_fail_count < new_fail_count
-                if old_state == new_state and not fetch_metadata_attempt_failed:
+                if old_state == new_state:
                     continue
 
                 issues.append(
@@ -294,7 +250,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                 )
 
         self._hanging_op_tasks = hanging_op_tasks
-        self._state_fetch_failures = state_fetch_failures
         return issues
 
     def detection_time_interval_s(self) -> float:

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -37,6 +37,7 @@ class HangingExecutionState:
     task_idx: int
     task_id: ray.TaskID
     task_state: Optional[TaskState]
+    logged_already: bool
     bytes_output: int
     start_time_hanging: float
 
@@ -98,8 +99,24 @@ class HangingExecutionIssueDetector(IssueDetector):
         op_task_stats_map: Dict[str, "TaskDurationStats"],
     ) -> List[Issue]:
         issues = []
+        failed_get_task = False
         for state in hanging_op_tasks:
             if state.task_idx not in self._hanging_op_tasks[state.operator_id]:
+                if state.task_state is None and not failed_get_task:
+                    latest = get_latest_state_for_task(state.task_id)
+                    if latest is None:
+                        # There exists more sophisticated ways to handle failure across multiple tasks, but for simplicity,
+                        # any failure grabbing the task info means we stop grabbing task info for the rest
+                        # of the tasks. This prevents a flood of state API calls, which can be slow. On the
+                        # next detection cycle, we will only retry the ones that are None.
+                        failed_get_task = True
+                    state.task_state = latest
+
+                if state.logged_already and state.task_state is None:
+                    # If we succeeded grabbing task info, or it failed only once, then create an
+                    # issue. We don't want to spam log messages if there are continued failures.
+                    continue
+
                 op_name = self._op_id_to_name.get(state.operator_id, state.operator_id)
                 duration = time.perf_counter() - state.start_time_hanging
                 op_task_stats = op_task_stats_map[state.operator_id]
@@ -109,19 +126,24 @@ class HangingExecutionIssueDetector(IssueDetector):
                 node_id = None
                 pid = None
                 attempt_number = None
+                metadata_info = ""
                 if state.task_state is not None:
                     node_id = state.task_state.node_id
                     pid = state.task_state.worker_pid
                     attempt_number = state.task_state.attempt_number
+                    metadata_info = (
+                        f"(pid={pid}, node_id={node_id}, attempt={attempt_number}) "
+                    )
 
                 message = (
-                    f"A task (task_id={state.task_id}) of operator {op_name} (pid={pid}, node_id={node_id}, attempt={attempt_number}) has been running for {duration:.2f}s, which is longer"
+                    f"A task (task_id={state.task_id}) of operator {op_name} {metadata_info}has been running for {duration:.2f}s, which is longer"
                     f" than the average task duration + z-score * stdev of this operator ({avg_duration:.2f} + {self._op_task_stats_std_factor_threshold} * {stdev:.2f}s)."
                     f" If this message persists, please check the stack trace of the "
                     "task for potential hanging issues."
                     " To adjust the z-score threshold, set"
                     " `ray.data.DataContext.get_current().issue_detectors_config.hanging_detector_config.op_task_stats_std_factor`."
                 )
+
                 issues.append(
                     Issue(
                         dataset_name=self._dataset_id,
@@ -130,7 +152,9 @@ class HangingExecutionIssueDetector(IssueDetector):
                         message=message,
                     )
                 )
-                self._hanging_op_tasks[state.operator_id].add(state.task_idx)
+                state.logged_already = True
+                if state.task_state is not None:
+                    self._hanging_op_tasks[state.operator_id].add(state.task_idx)
 
         return issues
 
@@ -167,6 +191,7 @@ class HangingExecutionIssueDetector(IssueDetector):
                                 if prev_state_value is None
                                 else prev_state_value.task_state
                             ),
+                            logged_already=False,
                             bytes_output=bytes_output,
                             start_time_hanging=time.perf_counter(),
                         )
@@ -180,7 +205,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                     self._hanging_op_tasks[operator.id].discard(task_idx)
 
         hanging_op_tasks = []
-        failed_get_task = False
         for op_id, op_state_values in self._state_map.items():
             op_task_stats = op_task_stats_map[op_id]
             for task_idx, state_value in op_state_values.items():
@@ -191,17 +215,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                     threshold = mean + self._op_task_stats_std_factor_threshold * stddev
 
                     if curr_time > threshold:
-                        if state_value.task_state is None and not failed_get_task:
-                            latest_task_state = get_latest_state_for_task(
-                                state_value.task_id
-                            )
-                            if latest_task_state is None:
-                                # There exists more sophisticated ways to handle failure, but for simplicity,
-                                # any failure grabbing the task info means we stop grabbing task info for the rest
-                                # of the tasks. This prevents a flood of state API calls, which can be slow. On the
-                                # next detection cycle, we will only retry the ones that are None.
-                                failed_get_task = True
-                            state_value.task_state = latest_task_state
                         hanging_op_tasks.append(state_value)
 
         # create issues for newly detected hanging tasks, then update the hanging task set
@@ -229,5 +242,4 @@ def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
         return task_state
     except Exception as e:
         logger.debug(f"Failed to grab task state with task_id={task_id}: {e}")
-        pass
-    return None
+        return None

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -67,11 +67,6 @@ class TaskMetadata:
 
 @dataclass
 class HangingExecutionState:
-    # Equality includes everything except task_metadata: a change
-    # in output means the task made progress and warrants a new log entry.
-    # A change in metadata alone (node/worker reassignment) doesn't
-    # indicate progress, so it's excluded from comparison.  The remaining
-    # fields are static identifiers or timestamps.
     operator_id: OpId
     task_idx: TaskIdx
     task_id: ray.TaskID
@@ -188,10 +183,10 @@ class HangingExecutionIssueDetector(IssueDetector):
             < _MAX_STATE_FETCH_FAILED_ATTEMPTS
         )
 
-    def _reset_fetch_failures(self, op_id: OpId, task_idx: TaskIdx) -> None:
+    def _reset_fetch_failures(self, op_id: OpId, task_idx: TaskIdx):
         self._state_fetch_failures[op_id][task_idx] = 0
 
-    def _record_fetch_failure(self, op_id: OpId, task_idx: TaskIdx) -> None:
+    def _record_fetch_failure(self, op_id: OpId, task_idx: TaskIdx):
         failures = self._state_fetch_failures[op_id]
         failures[task_idx] = failures.get(task_idx, 0) + 1
 

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -176,7 +176,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             message=message,
         )
 
-    def _should_retry_metadata_fetch(self, op_id: OpId, task_idx: TaskIdx) -> bool:
+    def _can_retry_metadata_fetch(self, op_id: OpId, task_idx: TaskIdx) -> bool:
         """Whether we haven't exhausted fetch attempts for this task."""
         return (
             self._state_fetch_failures[op_id].get(task_idx, 0)
@@ -215,7 +215,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             self._reset_fetch_failures(operator.id, task_idx)
             task_metadata = None
 
-        if task_metadata is None and self._should_retry_metadata_fetch(
+        if task_metadata is None and self._can_retry_metadata_fetch(
             operator.id, task_idx
         ):
             task_state = get_latest_state_for_task(task_info.task_id)
@@ -280,7 +280,7 @@ class HangingExecutionIssueDetector(IssueDetector):
                 # metadata retry attempts (so that we don't double log w/ and w/o the metadata.)
                 if old_state == new_state or (
                     new_state.task_metadata is None
-                    and self._should_retry_metadata_fetch(operator.id, task_idx)
+                    and self._can_retry_metadata_fetch(operator.id, task_idx)
                 ):
                     continue
 

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -160,7 +160,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             f"{self._op_task_stats_std_factor_threshold} * "
             f"{stdev:.2f}s). "
             f"Task started at {task_started} and "
-            f"last time task produced output was {hanging_since}. "
+            f"last time task produced output or made any progress was {hanging_since}. "
             f"If this message persists, please check "
             f"the stack trace of the task for potential hanging "
             f"issues. To adjust the z-score value, set "

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import ray
 from ray.data._internal.issue_detection.issue_detector import (

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional
+from typing import TYPE_CHECKING, DefaultDict, Dict, List
 
 import requests
 
@@ -29,6 +29,8 @@ DEFAULT_OP_TASK_STATS_MIN_COUNT = 10
 DEFAULT_OP_TASK_STATS_STD_FACTOR = 10
 # Default detection time interval.
 DEFAULT_DETECTION_TIME_INTERVAL_S = 30.0
+# Max failed attempts to fetch task state before giving up for a task.
+_MAX_STATE_FETCH_ATTEMPTS = 3
 
 logger = logging.getLogger(__name__)
 
@@ -60,14 +62,14 @@ class HangingExecutionState:
     # the task was retried on a different node/worker.  Both warrant a
     # new log entry.  The remaining fields are static identifiers that
     # don't indicate a meaningful state change worth re-logging.
-    operator_id: OpId = field(compare=False)
-    task_idx: TaskIdx = field(compare=False)
-    task_id: ray.TaskID = field(compare=False)
-    task_metadata: Optional[TaskMetadata]
+    operator_id: OpId
+    task_idx: TaskIdx
+    task_id: ray.TaskID
+    task_metadata: TaskMetadata | None
     bytes_output: int
-    start_time_hanging: float = field(compare=False)
+    start_time_hanging: float
 
-    def time_since_hanging(self):
+    def hanging_time(self):
         return time.perf_counter() - self.start_time_hanging
 
 
@@ -98,6 +100,13 @@ class HangingExecutionIssueDetector(IssueDetector):
         self._hanging_op_tasks: DefaultDict[
             OpId, Dict[TaskIdx, HangingExecutionState]
         ] = defaultdict(dict)
+        # Per-task count of failed get_latest_state_for_task attempts.
+        # After _MAX_STATE_FETCH_ATTEMPTS, we stop retrying for that task.
+        self._state_fetch_failures: DefaultDict[OpId, Dict[TaskIdx, int]] = defaultdict(
+            dict
+        )
+
+        self._last_detection_cycle: float = time.perf_counter()
 
     @classmethod
     def from_executor(
@@ -138,7 +147,7 @@ class HangingExecutionIssueDetector(IssueDetector):
         message = (
             f"A task (task_id={hes.task_id}) of operator "
             f"{operator.name} {metadata_info}has been running for "
-            f"{hes.time_since_hanging():.2f}s, which is longer than the average task "
+            f"{hes.hanging_time():.2f}s, which is longer than the average task "
             f"duration + z-score * stdev of this operator "
             f"({avg_duration:.2f} + "
             f"{self._op_task_stats_std_factor_threshold} * "
@@ -161,24 +170,33 @@ class HangingExecutionIssueDetector(IssueDetector):
         self,
         operator: "PhysicalOperator",
         task_idx: TaskIdx,
-        old_state: Optional[HangingExecutionState],
+        old_state: HangingExecutionState | None,
         task_info: RunningTaskInfo,
+        state_fetch_failures: Dict[TaskIdx, int],
     ) -> HangingExecutionState:
-        """Return a HangingExecutionState for the task, creating one if new.
+        """Build a HangingExecutionState, fetching task metadata lazily.
 
-        Reuses the previously fetched task metadata if available, otherwise
-        attempts to fetch it from the state API.
+        Task metadata (pid, node_id, attempt) is fetched from the Ray
+        State API only when unknown or potentially stale (e.g. after the
+        task made progress then stalled again).  Fetches that fail are
+        counted in ``state_fetch_failures`` (mutated in-place) and
+        skipped after ``_MAX_STATE_FETCH_ATTEMPTS``.
         """
-        task_metadata: Optional[TaskMetadata] = (
-            old_state.task_metadata if old_state is not None else None
-        )
-        if task_metadata is None:
+        task_metadata: TaskMetadata | None = None
+        bytes_output: int | None = None
+        if old_state is not None:
+            task_metadata = old_state.task_metadata
+            bytes_output = old_state.bytes_output
+
+        fetch_failures = state_fetch_failures.get(task_idx, 0)
+        if (
+            bytes_output != task_info.bytes_output or task_metadata is None
+        ) and fetch_failures < _MAX_STATE_FETCH_ATTEMPTS:
             task_state = get_latest_state_for_task(task_info.task_id)
-            task_metadata = (
-                TaskMetadata.from_task_state(task_state)
-                if task_state is not None
-                else None
-            )
+            if task_state is None:
+                state_fetch_failures[task_idx] = fetch_failures + 1
+            else:
+                task_metadata = TaskMetadata.from_task_state(task_state)
 
         return HangingExecutionState(
             operator_id=operator.id,
@@ -186,17 +204,18 @@ class HangingExecutionIssueDetector(IssueDetector):
             task_id=task_info.task_id,
             task_metadata=task_metadata,
             bytes_output=task_info.bytes_output,
-            start_time_hanging=task_info.start_time,
+            start_time_hanging=task_info.last_updated,
         )
 
     def detect(self) -> List[Issue]:
 
         issues: List[Issue] = []
-        # Build a fresh map each cycle so that tasks which finished or
+        # Build fresh maps each cycle so that tasks which finished or
         # dropped below the threshold are automatically pruned.
         hanging_op_tasks: DefaultDict[
             OpId, Dict[TaskIdx, HangingExecutionState]
         ] = defaultdict(dict)
+        state_fetch_failures: DefaultDict[OpId, Dict[TaskIdx, int]] = defaultdict(dict)
 
         for operator in self._operators:
             if operator.has_execution_finished():
@@ -214,16 +233,18 @@ class HangingExecutionIssueDetector(IssueDetector):
             threshold = mean + self._op_task_stats_std_factor_threshold * stddev
 
             for task_idx, task_info in op_metrics._running_tasks.items():
-                current_task_duration = time.perf_counter() - task_info.start_time
-                if current_task_duration < threshold:
+
+                time_since_last_update = time.perf_counter() - task_info.last_updated
+                if time_since_last_update < threshold:
                     continue
 
-                old_state = self._hanging_op_tasks.get(operator.id, {}).get(task_idx)
+                old_state = self._hanging_op_tasks[operator.id].get(task_idx)
                 new_state = self._refresh_state(
                     operator=operator,
                     task_idx=task_idx,
                     old_state=old_state,
                     task_info=task_info,
+                    state_fetch_failures=state_fetch_failures[operator.id],
                 )
 
                 hanging_op_tasks[operator.id][task_idx] = new_state
@@ -231,6 +252,8 @@ class HangingExecutionIssueDetector(IssueDetector):
                 # 3) Skip if there wasn't any meaningful update to the task. For example,
                 # a task may have made some progress (yield bytes), or a task is retried
                 # giving a different node_id/attempt_number
+                # print(f"old_state={old_state}")
+                # print(f"new_state={new_state}")
                 if old_state == new_state:
                     continue
 
@@ -241,6 +264,8 @@ class HangingExecutionIssueDetector(IssueDetector):
                 )
 
         self._hanging_op_tasks = hanging_op_tasks
+        self._state_fetch_failures = state_fetch_failures
+        self._last_detection_cycle = time.perf_counter()
         return issues
 
     def detection_time_interval_s(self) -> float:

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -257,9 +257,11 @@ def get_latest_state_for_task(task_id: ray.TaskID) -> Optional[TaskMetadata]:
     has indexed it) or the API is unreachable.
     """
     try:
+        # NOTE: timeout is set to 1 because ray will take max(1, timeout).
+        # TODO(Justin): Make this asynchronous
         task_state: Union[TaskState, List[TaskState], None] = get_task(
             task_id.hex(),
-            timeout=0,
+            timeout=1,
             _explain=True,
         )
     except (RayStateApiException, requests.exceptions.RequestException):

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -219,7 +219,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             for task_idx, task_info in op_metrics._running_tasks.items():
 
                 time_since_last_update = time.perf_counter() - task_info.last_updated
-                if time_since_last_update < threshold:
+                if time_since_last_update <= threshold:
                     continue
 
                 old_state = self._hanging_op_tasks[operator.id].get(task_idx)

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -2,6 +2,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, DefaultDict, Dict, List
 
 import requests
@@ -38,6 +39,12 @@ OpId = str
 TaskIdx = int
 
 
+def _perf_counter_to_datetime(perf_value: float) -> datetime:
+    """Convert a ``time.perf_counter()`` value to a wall-clock datetime."""
+    wall = time.time() - (time.perf_counter() - perf_value)
+    return datetime.fromtimestamp(wall, tz=timezone.utc)
+
+
 @dataclass
 class TaskMetadata:
     """Subset of TaskState fields relevant for hanging detection."""
@@ -67,6 +74,7 @@ class HangingExecutionState:
     task_id: ray.TaskID
     task_metadata: TaskMetadata | None
     bytes_output: int
+    task_start_time: float
     start_time_hanging: float
 
     def hanging_time(self):
@@ -144,14 +152,20 @@ class HangingExecutionIssueDetector(IssueDetector):
         if meta is not None:
             metadata_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
 
+        task_started = _perf_counter_to_datetime(hes.task_start_time)
+        hanging_since = _perf_counter_to_datetime(hes.start_time_hanging)
+
         message = (
             f"A task (task_id={hes.task_id}) of operator "
-            f"{operator.name} {metadata_info}has been running for "
+            f"{operator.name} {metadata_info}has been running or stuck in scheduling for "
             f"{hes.hanging_time():.2f}s, which is longer than the average task "
             f"duration + z-score * stdev of this operator "
             f"({avg_duration:.2f} + "
             f"{self._op_task_stats_std_factor_threshold} * "
-            f"{stdev:.2f}s). If this message persists, please check "
+            f"{stdev:.2f}s). "
+            f"Task started at {task_started:%Y-%m-%d %H:%M:%S %Z}, "
+            f"hanging since {hanging_since:%Y-%m-%d %H:%M:%S %Z}. "
+            f"If this message persists, please check "
             f"the stack trace of the task for potential hanging "
             f"issues. To adjust the z-score value, set "
             f"`ray.data.DataContext.get_current()"
@@ -204,6 +218,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             task_id=task_info.task_id,
             task_metadata=task_metadata,
             bytes_output=task_info.bytes_output,
+            task_start_time=task_info.start_time,
             start_time_hanging=task_info.last_updated,
         )
 

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -3,7 +3,7 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, DefaultDict, Dict, List
+from typing import TYPE_CHECKING, DefaultDict, Dict, List, Optional, Union
 
 import requests
 
@@ -68,7 +68,7 @@ class HangingExecutionState:
     operator_id: OpId
     task_idx: TaskIdx
     task_id: ray.TaskID
-    task_metadata: TaskMetadata | None
+    task_metadata: Optional[TaskMetadata]
     bytes_output: int
     # from time.time()
     start_time_hanging: float
@@ -135,15 +135,15 @@ class HangingExecutionIssueDetector(IssueDetector):
         stdev = op_task_stats.stddev()
 
         meta = hes.task_metadata
-        metadata_info = ""
+        task_info = ""
         if meta is not None:
-            metadata_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
+            task_info = f"(pid={meta.pid}, node_id={meta.node_id}, attempt={meta.attempt_number}) "
 
         hanging_since = _format_timestamp(hes.start_time_hanging)
 
         message = (
             f"A task (task_id={hes.task_id}) of operator "
-            f"{operator.name} {metadata_info}has been running or stuck in scheduling for "
+            f"{operator.name} {task_info}has been running or stuck in scheduling for "
             f"{hes.hanging_time():.2f}s, which is longer than the average task "
             f"duration + z-score * stddev of this operator "
             f"({avg_duration:.2f} + "
@@ -169,7 +169,7 @@ class HangingExecutionIssueDetector(IssueDetector):
         self,
         operator: "PhysicalOperator",
         task_idx: TaskIdx,
-        old_state: HangingExecutionState | None,
+        old_state: Optional[HangingExecutionState],
         task_info: RunningTaskInfo,
     ) -> HangingExecutionState:
         """Build a HangingExecutionState, fetching task metadata lazily.
@@ -178,16 +178,14 @@ class HangingExecutionIssueDetector(IssueDetector):
         State API only when unknown or potentially stale (e.g. after the
         task made progress then stalled again).
         """
-        task_metadata: TaskMetadata | None = None
-        bytes_output: int | None = None
+        task_metadata: Optional[TaskMetadata] = None
+        bytes_output: Optional[int] = None
         if old_state is not None:
             task_metadata = old_state.task_metadata
             bytes_output = old_state.bytes_output
 
-        if old_state is None or bytes_output != task_info.bytes_output:
-            task_state = get_latest_state_for_task(task_info.task_id)
-            if task_state is not None:
-                task_metadata = TaskMetadata.from_task_state(task_state)
+        elif bytes_output != task_info.bytes_output:
+            task_metadata = get_latest_state_for_task(task_info.task_id)
 
         return HangingExecutionState(
             operator_id=operator.id,
@@ -253,16 +251,16 @@ class HangingExecutionIssueDetector(IssueDetector):
         return self._detector_cfg.detection_time_interval_s
 
 
-def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
+def get_latest_state_for_task(task_id: ray.TaskID) -> Optional[TaskMetadata]:
     """Query the Ray State API for the latest attempt of a task.
 
-    Returns the TaskState with the highest attempt_number when multiple
+    Returns a TaskMetadata with the highest attempt_number when multiple
     attempts exist, or None if the task is not found (can happen when
     get_task() is called shortly after submission, before the state API
     has indexed it) or the API is unreachable.
     """
     try:
-        task_state: TaskState | List[TaskState] | None = get_task(
+        task_state: Union[TaskState, List[TaskState], None] = get_task(
             task_id.hex(),
             timeout=0,
             _explain=True,
@@ -279,4 +277,6 @@ def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
     if isinstance(task_state, list):
         # get the latest task
         task_state = max(task_state, key=lambda ts: ts.attempt_number, default=None)
-    return task_state
+    if task_state is None:
+        return None
+    return TaskMetadata.from_task_state(task_state)

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -67,15 +67,15 @@ class TaskMetadata:
 
 @dataclass
 class HangingExecutionState:
-    # Equality is based on bytes_output and task_metadata: a change in
-    # output means the task made progress, and a change in metadata means
-    # the task was retried on a different node/worker.  Both warrant a
-    # new log entry.  The remaining fields are static identifiers that
-    # don't indicate a meaningful state change worth re-logging.
+    # Equality includes everything except task_metadata: a change
+    # in output means the task made progress and warrants a new log entry.
+    # A change in metadata alone (node/worker reassignment) doesn't
+    # indicate progress, so it's excluded from comparison.  The remaining
+    # fields are static identifiers or timestamps.
     operator_id: OpId
     task_idx: TaskIdx
     task_id: ray.TaskID
-    task_metadata: TaskMetadata | None
+    task_metadata: TaskMetadata
     bytes_output: int
     task_start_time: float
     start_time_hanging: float
@@ -181,6 +181,20 @@ class HangingExecutionIssueDetector(IssueDetector):
             message=message,
         )
 
+    def _should_retry_metadata_fetch(self, op_id: OpId, task_idx: TaskIdx) -> bool:
+        """Whether we haven't exhausted fetch attempts for this task."""
+        return (
+            self._state_fetch_failures[op_id].get(task_idx, 0)
+            < _MAX_STATE_FETCH_FAILED_ATTEMPTS
+        )
+
+    def _reset_fetch_failures(self, op_id: OpId, task_idx: TaskIdx) -> None:
+        self._state_fetch_failures[op_id][task_idx] = 0
+
+    def _record_fetch_failure(self, op_id: OpId, task_idx: TaskIdx) -> None:
+        failures = self._state_fetch_failures[op_id]
+        failures[task_idx] = failures.get(task_idx, 0) + 1
+
     def _refresh_state(
         self,
         operator: "PhysicalOperator",
@@ -198,21 +212,20 @@ class HangingExecutionIssueDetector(IssueDetector):
         """
         task_metadata: TaskMetadata | None = None
         bytes_output: int | None = None
-        state_fetch_failures = self._state_fetch_failures[operator.id]
         if old_state is not None:
             task_metadata = old_state.task_metadata
             bytes_output = old_state.bytes_output
 
         if bytes_output != task_info.bytes_output:
-            # reset fetch failures when progress is made
-            state_fetch_failures[task_idx] = 0
+            self._reset_fetch_failures(operator.id, task_idx)
             task_metadata = None
 
-        fetch_failures = state_fetch_failures.get(task_idx, 0)
-        if task_metadata is None and fetch_failures < _MAX_STATE_FETCH_FAILED_ATTEMPTS:
+        if task_metadata is None and self._should_retry_metadata_fetch(
+            operator.id, task_idx
+        ):
             task_state = get_latest_state_for_task(task_info.task_id)
             if task_state is None:
-                state_fetch_failures[task_idx] = fetch_failures + 1
+                self._record_fetch_failure(operator.id, task_idx)
             else:
                 task_metadata = TaskMetadata.from_task_state(task_state)
 
@@ -268,8 +281,12 @@ class HangingExecutionIssueDetector(IssueDetector):
 
                 # 3) Skip if there wasn't any meaningful update to the task. For example,
                 # a task may have made some progress (yield bytes), or a task is retried
-                # giving a different node_id/attempt_number
-                if old_state == new_state:
+                # giving a different node_id/attempt_number. Also skip, if we still have
+                # metadata retry attempts (so that we don't double log w/ and w/o the metadata.)
+                if old_state == new_state or (
+                    new_state.task_metadata is None
+                    and self._should_retry_metadata_fetch(operator.id, task_idx)
+                ):
                     continue
 
                 issues.append(

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -185,14 +185,6 @@ class HangingExecutionIssueDetector(IssueDetector):
             task_metadata is None and failure_count < _MAX_STATE_FETCH_FAILED_ATTEMPTS
         )
 
-    @staticmethod
-    def _reset_fetch_failures(
-        state_fetch_failures: StateFetchFailures,
-        op_id: OpId,
-        task_idx: TaskIdx,
-    ):
-        state_fetch_failures[op_id][task_idx] = 0
-
     def _refresh_state(
         self,
         operator: "PhysicalOperator",
@@ -282,13 +274,14 @@ class HangingExecutionIssueDetector(IssueDetector):
                 hanging_op_tasks[operator.id][task_idx] = new_state
                 failure_count = state_fetch_failures[operator.id].get(task_idx, 0)
 
-                # 3) Skip if there wasn't any meaningful update to the task. For example,
-                # a task may have made some progress (yield bytes), or a task is retried
-                # giving a different node_id/attempt_number. Also skip, if we still have
-                # metadata retry attempts (so that we don't double log w/ and w/o the metadata.)
-                if old_state == new_state or self._should_fetch_metadata(
-                    new_state.task_metadata, failure_count
-                ):
+                # Skip if we're still waiting for metadata (will retry next cycle).
+                if self._should_fetch_metadata(new_state.task_metadata, failure_count):
+                    continue
+                # Skip if nothing meaningful changed: the execution state
+                # is identical AND the failure count didn't just cross the
+                # exhaustion threshold (which would mean we deferred logging
+                # while retrying and should now emit the issue).
+                if old_state == new_state and old_failures == failure_count:
                     continue
 
                 issues.append(
@@ -330,5 +323,5 @@ def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
         return None
     if isinstance(task_state, list):
         # get the latest task
-        task_state = max(task_state, key=lambda ts: ts.attempt_number)
+        task_state = max(task_state, key=lambda ts: ts.attempt_number, default=None)
     return task_state

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -31,7 +31,9 @@ DEFAULT_OP_TASK_STATS_STD_FACTOR = 10
 # Default detection time interval.
 DEFAULT_DETECTION_TIME_INTERVAL_S = 30.0
 # Max failed attempts to fetch task state before giving up for a task.
-_MAX_STATE_FETCH_ATTEMPTS = 3
+# 1 is chosen for now, because the get_state API is known to be slow when
+# processing many http requests.
+_MAX_STATE_FETCH_FAILED_ATTEMPTS = 1
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +112,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             OpId, Dict[TaskIdx, HangingExecutionState]
         ] = defaultdict(dict)
         # Per-task count of failed get_latest_state_for_task attempts.
-        # After _MAX_STATE_FETCH_ATTEMPTS, we stop retrying for that task.
+        # After _MAX_STATE_FETCH_FAILED_ATTEMPTS, we stop retrying for that task.
         self._state_fetch_failures: DefaultDict[OpId, Dict[TaskIdx, int]] = defaultdict(
             dict
         )
@@ -158,7 +160,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             f"A task (task_id={hes.task_id}) of operator "
             f"{operator.name} {metadata_info}has been running or stuck in scheduling for "
             f"{hes.hanging_time():.2f}s, which is longer than the average task "
-            f"duration + z-score * stdev of this operator "
+            f"duration + z-score * stddev of this operator "
             f"({avg_duration:.2f} + "
             f"{self._op_task_stats_std_factor_threshold} * "
             f"{stdev:.2f}s). "
@@ -185,7 +187,6 @@ class HangingExecutionIssueDetector(IssueDetector):
         task_idx: TaskIdx,
         old_state: HangingExecutionState | None,
         task_info: RunningTaskInfo,
-        state_fetch_failures: Dict[TaskIdx, int],
     ) -> HangingExecutionState:
         """Build a HangingExecutionState, fetching task metadata lazily.
 
@@ -193,18 +194,22 @@ class HangingExecutionIssueDetector(IssueDetector):
         State API only when unknown or potentially stale (e.g. after the
         task made progress then stalled again).  Fetches that fail are
         counted in ``state_fetch_failures`` (mutated in-place) and
-        skipped after ``_MAX_STATE_FETCH_ATTEMPTS``.
+        skipped after ``_MAX_STATE_FETCH_FAILED_ATTEMPTS``.
         """
         task_metadata: TaskMetadata | None = None
         bytes_output: int | None = None
+        state_fetch_failures = self._state_fetch_failures[operator.id]
         if old_state is not None:
             task_metadata = old_state.task_metadata
             bytes_output = old_state.bytes_output
 
+        if bytes_output != task_info.bytes_output:
+            # reset fetch failures when progress is made
+            state_fetch_failures[task_idx] = 0
+            task_metadata = None
+
         fetch_failures = state_fetch_failures.get(task_idx, 0)
-        if (
-            bytes_output != task_info.bytes_output or task_metadata is None
-        ) and fetch_failures < _MAX_STATE_FETCH_ATTEMPTS:
+        if task_metadata is None and fetch_failures < _MAX_STATE_FETCH_FAILED_ATTEMPTS:
             task_state = get_latest_state_for_task(task_info.task_id)
             if task_state is None:
                 state_fetch_failures[task_idx] = fetch_failures + 1
@@ -224,12 +229,11 @@ class HangingExecutionIssueDetector(IssueDetector):
     def detect(self) -> List[Issue]:
 
         issues: List[Issue] = []
-        # Build fresh maps each cycle so that tasks which finished or
+        # Build fresh map each cycle so that tasks which finished or
         # dropped below the threshold are automatically pruned.
         hanging_op_tasks: DefaultDict[
             OpId, Dict[TaskIdx, HangingExecutionState]
         ] = defaultdict(dict)
-        state_fetch_failures: DefaultDict[OpId, Dict[TaskIdx, int]] = defaultdict(dict)
 
         for operator in self._operators:
             if operator.has_execution_finished():
@@ -241,7 +245,7 @@ class HangingExecutionIssueDetector(IssueDetector):
             if op_task_stats.count() < self._op_task_stats_min_count:
                 continue
 
-            # 2) Skip if under threshold of mean + z-score * stdev
+            # 2) Skip if under threshold of mean + z-score * stddev
             mean = op_task_stats.mean()
             stddev = op_task_stats.stddev()
             threshold = mean + self._op_task_stats_std_factor_threshold * stddev
@@ -258,7 +262,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                     task_idx=task_idx,
                     old_state=old_state,
                     task_info=task_info,
-                    state_fetch_failures=state_fetch_failures[operator.id],
                 )
 
                 hanging_op_tasks[operator.id][task_idx] = new_state
@@ -276,7 +279,6 @@ class HangingExecutionIssueDetector(IssueDetector):
                 )
 
         self._hanging_op_tasks = hanging_op_tasks
-        self._state_fetch_failures = state_fetch_failures
         return issues
 
     def detection_time_interval_s(self) -> float:

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -260,8 +260,10 @@ class HangingExecutionIssueDetector(IssueDetector):
 
                 old_state = self._hanging_op_tasks[operator.id].get(task_idx)
 
-                old_failures = self._state_fetch_failures[operator.id].get(task_idx, 0)
-                state_fetch_failures[operator.id][task_idx] = old_failures
+                old_fail_count = self._state_fetch_failures[operator.id].get(
+                    task_idx, 0
+                )
+                state_fetch_failures[operator.id][task_idx] = old_fail_count
 
                 new_state = self._refresh_state(
                     operator=operator,
@@ -272,16 +274,17 @@ class HangingExecutionIssueDetector(IssueDetector):
                 )
 
                 hanging_op_tasks[operator.id][task_idx] = new_state
-                failure_count = state_fetch_failures[operator.id].get(task_idx, 0)
+                new_fail_count = state_fetch_failures[operator.id].get(task_idx, 0)
 
                 # Skip if we're still waiting for metadata (will retry next cycle).
-                if self._should_fetch_metadata(new_state.task_metadata, failure_count):
+                if self._should_fetch_metadata(new_state.task_metadata, new_fail_count):
                     continue
                 # Skip if nothing meaningful changed: the execution state
                 # is identical AND the failure count didn't just cross the
                 # exhaustion threshold (which would mean we deferred logging
                 # while retrying and should now emit the issue).
-                if old_state == new_state and old_failures == failure_count:
+                fetch_metadata_attempt_failed = old_fail_count < new_fail_count
+                if old_state == new_state and not fetch_metadata_attempt_failed:
                     continue
 
                 issues.append(

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -102,7 +102,9 @@ class HangingExecutionIssueDetector(IssueDetector):
             if state.task_idx not in self._hanging_op_tasks[state.operator_id]:
                 op_name = self._op_id_to_name.get(state.operator_id, state.operator_id)
                 duration = time.perf_counter() - state.start_time_hanging
-                avg_duration = op_task_stats_map[state.operator_id].mean()
+                op_task_stats = op_task_stats_map[state.operator_id]
+                avg_duration = op_task_stats.mean()
+                stdev = op_task_stats.stddev()
 
                 node_id = None
                 pid = None
@@ -114,9 +116,11 @@ class HangingExecutionIssueDetector(IssueDetector):
 
                 message = (
                     f"A task (task_id={state.task_id}) of operator {op_name} (pid={pid}, node_id={node_id}, attempt={attempt_number}) has been running for {duration:.2f}s, which is longer"
-                    f" than the average task duration of this operator ({avg_duration:.2f}s)."
+                    f" than the average task duration + z-score * stdev of this operator ({avg_duration:.2f} + {self._op_task_stats_std_factor_threshold} * {stdev:.2f}s)."
                     f" If this message persists, please check the stack trace of the "
                     "task for potential hanging issues."
+                    " To adjust the z-score threshold, set"
+                    " `ray.data.DataContext.get_current().issue_detectors_config.hanging_detector_config.op_task_stats_std_factor`."
                 )
                 issues.append(
                     Issue(
@@ -158,7 +162,11 @@ class HangingExecutionIssueDetector(IssueDetector):
                             operator_id=operator.id,
                             task_idx=task_idx,
                             task_id=task_info.task_id,
-                            task_state=None,
+                            task_state=(
+                                None
+                                if prev_state_value is None
+                                else prev_state_value.task_state
+                            ),
                             bytes_output=bytes_output,
                             start_time_hanging=time.perf_counter(),
                         )
@@ -172,20 +180,28 @@ class HangingExecutionIssueDetector(IssueDetector):
                     self._hanging_op_tasks[operator.id].discard(task_idx)
 
         hanging_op_tasks = []
+        failed_get_task = False
         for op_id, op_state_values in self._state_map.items():
             op_task_stats = op_task_stats_map[op_id]
             for task_idx, state_value in op_state_values.items():
                 curr_time = time.perf_counter() - state_value.start_time_hanging
                 if op_task_stats.count() >= self._op_task_stats_min_count:
-                    if state_value.task_state is None:
-                        state_value.task_state = get_latest_state_for_task(
-                            state_value.task_id
-                        )
                     mean = op_task_stats.mean()
                     stddev = op_task_stats.stddev()
                     threshold = mean + self._op_task_stats_std_factor_threshold * stddev
 
                     if curr_time > threshold:
+                        if state_value.task_state is None and not failed_get_task:
+                            latest_task_state = get_latest_state_for_task(
+                                state_value.task_id
+                            )
+                            if latest_task_state is None:
+                                # There exists more sophisticated ways to handle failure, but for simplicity,
+                                # any failure grabbing the task info means we stop grabbing task info for the rest
+                                # of the tasks. This prevents a flood of state API calls, which can be slow. On the
+                                # next detection cycle, we will only retry the ones that are None.
+                                failed_get_task = True
+                            state_value.task_state = latest_task_state
                         hanging_op_tasks.append(state_value)
 
         # create issues for newly detected hanging tasks, then update the hanging task set

--- a/python/ray/data/_internal/issue_detection/issue_detector_manager.py
+++ b/python/ray/data/_internal/issue_detection/issue_detector_manager.py
@@ -94,5 +94,5 @@ class IssueDetectorManager:
                 operator.metrics._issue_detector_high_memory += 1
         if len(issues) > 0:
             logger.warning(
-                "To disable issue detection, run DataContext.get_current().issue_detectors_config.detectors = []."
+                f"Found {len(issues)} issues. To disable issue detection, run DataContext.get_current().issue_detectors_config.detectors = []."
             )

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -195,7 +195,6 @@ class TestHangingExecutionIssueDetector:
         assert issues[0].issue_type.value == "hanging"
         assert "has been running for" in issues[0].message
         assert "longer than the average task duration" in issues[0].message
-        assert "op_task_stats_std_factor" in issues[0].message
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -124,7 +124,7 @@ class TestHangingExecutionIssueDetector:
         _ = ray.data.range(1).map(f1).materialize()
 
         log_output = log_capture.getvalue()
-        warn_msg = r"A task of operator .+ \(pid=.+, node_id=.+, attempt=.+\) has been running for [\d\.]+s"
+        warn_msg = r"A task \(task_id=.+\) .+ \(pid=.+, node_id=.+, attempt=.+\) has been running for [\d\.]+s"
         assert re.search(warn_msg, log_output) is None, log_output
 
         # # test hanging does log hanging warning

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -124,7 +124,7 @@ class TestHangingExecutionIssueDetector:
         _ = ray.data.range(1).map(f1).materialize()
 
         log_output = log_capture.getvalue()
-        warn_msg = r"A task \(task_id=.+\) .+ \(pid=.+, node_id=.+, attempt=.+\) has been running for [\d\.]+s"
+        warn_msg = r"A task \(task_id=.+\) of operator .+(?:\(pid=.+, node_id=.+, attempt=.+\) )?has been running for [\d\.]+s"
         assert re.search(warn_msg, log_output) is None, log_output
 
         # # test hanging does log hanging warning

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -137,9 +137,9 @@ class TestHangingExecutionIssueDetector:
         log_output = log_capture.getvalue()
         assert re.search(warn_msg, log_output) is not None, log_output
 
-    @patch("time.perf_counter")
-    def test_hanging_deitector_detects_issues(
-        self, mock_perf_counter, ray_start_regular_shared
+    @patch("time.time")
+    def test_hanging_detector_detects_issues(
+        self, mock_time, ray_start_regular_shared
     ):
         """Test that the hanging detector correctly identifies tasks that exceed the adaptive threshold."""
 
@@ -163,7 +163,7 @@ class TestHangingExecutionIssueDetector:
             blocks=((block_ref, metadata),), owns_blocks=True, schema=None
         )
 
-        mock_perf_counter.return_value = 0.0
+        mock_time.return_value = 0.0
 
         # Submit three tasks. Two of them finish immediately, while the third one hangs.
         op.metrics.on_task_submitted(0, input_bundle)
@@ -187,7 +187,7 @@ class TestHangingExecutionIssueDetector:
         assert len(issues) == 0
 
         # Set the perf_counter to trigger the issue detection
-        mock_perf_counter.return_value = 10.0
+        mock_time.return_value = 10.0
 
         # On the second detect() call, the hanging task should be detected
         issues = detector.detect()

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -138,9 +138,7 @@ class TestHangingExecutionIssueDetector:
         assert re.search(warn_msg, log_output) is not None, log_output
 
     @patch("time.time")
-    def test_hanging_detector_detects_issues(
-        self, mock_time, ray_start_regular_shared
-    ):
+    def test_hanging_detector_detects_issues(self, mock_time, ray_start_regular_shared):
         """Test that the hanging detector correctly identifies tasks that exceed the adaptive threshold."""
 
         # Configure hanging detector with extreme std_factor values

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -195,6 +195,7 @@ class TestHangingExecutionIssueDetector:
         assert issues[0].issue_type.value == "hanging"
         assert "has been running for" in issues[0].message
         assert "longer than the average task duration" in issues[0].message
+        assert "op_task_stats_std_factor" in issues[0].message
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -137,8 +137,10 @@ class TestHangingExecutionIssueDetector:
         log_output = log_capture.getvalue()
         assert re.search(warn_msg, log_output) is not None, log_output
 
-    @patch("time.time")
-    def test_hanging_detector_detects_issues(self, mock_time, ray_start_regular_shared):
+    @patch("time.perf_counter")
+    def test_hanging_detector_detects_issues(
+        self, mock_perf_counter, ray_start_regular_shared
+    ):
         """Test that the hanging detector correctly identifies tasks that exceed the adaptive threshold."""
 
         # Configure hanging detector with extreme std_factor values
@@ -161,7 +163,7 @@ class TestHangingExecutionIssueDetector:
             blocks=((block_ref, metadata),), owns_blocks=True, schema=None
         )
 
-        mock_time.return_value = 0.0
+        mock_perf_counter.return_value = 0.0
 
         # Submit three tasks. Two of them finish immediately, while the third one hangs.
         op.metrics.on_task_submitted(0, input_bundle)
@@ -170,22 +172,22 @@ class TestHangingExecutionIssueDetector:
         op.metrics.on_task_finished(
             0,
             exception=None,
-            task_exec_stats=TaskExecWorkerStats(task_wall_time_s=0.0),
+            task_exec_stats=TaskExecWorkerStats(task_wall_time_s=1.0),
             task_exec_driver_stats=TaskExecDriverStats(task_output_backpressure_s=0),
         )
         op.metrics.on_task_finished(
             1,
             exception=None,
-            task_exec_stats=TaskExecWorkerStats(task_wall_time_s=0.0),
+            task_exec_stats=TaskExecWorkerStats(task_wall_time_s=1.0),
             task_exec_driver_stats=TaskExecDriverStats(task_output_backpressure_s=0),
         )
 
-        # Start detecting
+        # Start detecting — all tasks were submitted at t=0, so no time has elapsed.
         issues = detector.detect()
         assert len(issues) == 0
 
-        # Set the perf_counter to trigger the issue detection
-        mock_time.return_value = 10.0
+        # Advance perf_counter to trigger the issue detection
+        mock_perf_counter.return_value = 10.0
 
         # On the second detect() call, the hanging task should be detected
         issues = detector.detect()

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -124,7 +124,7 @@ class TestHangingExecutionIssueDetector:
         _ = ray.data.range(1).map(f1).materialize()
 
         log_output = log_capture.getvalue()
-        warn_msg = r"A task \(task_id=.+\) of operator .+(?:\(pid=.+, node_id=.+, attempt=.+\) )?has been running for [\d\.]+s"
+        warn_msg = r"A task \(task_id=.+\) of operator .+(?:\(pid=.+, node_id=.+, attempt=.+\) )?has been running or stuck in scheduling for [\d\.]+s"
         assert re.search(warn_msg, log_output) is None, log_output
 
         # # test hanging does log hanging warning

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -193,7 +193,7 @@ class TestHangingExecutionIssueDetector:
         issues = detector.detect()
         assert len(issues) > 0, "Expected hanging issue to be detected"
         assert issues[0].issue_type.value == "hanging"
-        assert "has been running for" in issues[0].message
+        assert "has been running or stuck in scheduling for" in issues[0].message
         assert "longer than the average task duration" in issues[0].message
 
 

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -129,7 +129,7 @@ class TestHangingExecutionIssueDetector:
 
         # # test hanging does log hanging warning
         def f2(x):
-            time.sleep(600.0)  # Increase from 1.1 to 5.0 seconds to exceed new threshold
+            time.sleep(5.0)  # Increase from 1.1 to 5.0 seconds to exceed new threshold
             return x
 
         _ = ray.data.range(1).map(f2).materialize()

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -129,7 +129,7 @@ class TestHangingExecutionIssueDetector:
 
         # # test hanging does log hanging warning
         def f2(x):
-            time.sleep(5.0)  # Increase from 1.1 to 5.0 seconds to exceed new threshold
+            time.sleep(600.0)  # Increase from 1.1 to 5.0 seconds to exceed new threshold
             return x
 
         _ = ray.data.range(1).map(f2).materialize()


### PR DESCRIPTION
## Description

- refactor to avoid deep nesting and shared responsibility
- filter tasks above threshold, then call `get_task`
- Rename from `bytes_outputs` to `bytes_output`
- Added `last_updated` to running task info to make the timing of hanging a bit more accurate
- Update warning message to include stdev, zscore
- Update warning message to include timestamp of when hanging

## Related issues
https://github.com/ray-project/ray/pull/61633

## Additional information
