### PR TITLE
[train] Register training resources with AutoscalingCoordinator in FixedScalingPolicy

### DIFF
--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -276,10 +276,6 @@ def _run_data_config_resource_test(data_config):
     num_workers = 2
     # Resources used by training workers.
     cpus_per_worker, gpus_per_worker = 2, 1
-    # Resources used by the trainer actor.
-    default_trainer_cpus, default_trainer_gpus = 1, 0
-    num_train_cpus = num_workers * cpus_per_worker + default_trainer_cpus
-    num_train_gpus = num_workers * gpus_per_worker + default_trainer_gpus
 
     original_execution_options = data_config._get_execution_options("train")
 
@@ -293,19 +289,18 @@ def _run_data_config_resource_test(data_config):
                 if original_execution_options.is_resource_limits_default():
                     # If the original resource limits are default, the new resource
                     # limits should be the default as well.
-                    # And the new exclude_resources should be the resources used by
-                    # Train + user-defined exclude_resources.
+                    # Under the V2 cluster autoscaler (default), training resources
+                    # are registered with the AutoscalingCoordinator directly, so
+                    # exclude_resources should remain as user-configured.
                     assert new_execution_options.is_resource_limits_default()
                     exclude_resources = new_execution_options.exclude_resources
                     assert (
                         exclude_resources.cpu
-                        == num_train_cpus
-                        + original_execution_options.exclude_resources.cpu
+                        == original_execution_options.exclude_resources.cpu
                     )
                     assert (
                         exclude_resources.gpu
-                        == num_train_gpus
-                        + original_execution_options.exclude_resources.gpu
+                        == original_execution_options.exclude_resources.gpu
                     )
                 else:
                     # If the original resource limits are not default, the new resource
@@ -342,7 +337,7 @@ def _run_data_config_resource_test(data_config):
 
 
 def test_data_config_default_resource_limits(shutdown_only):
-    """Test that DataConfig should exclude training resources from Data."""
+    """Test that DataConfig preserves user-configured exclude_resources."""
     execution_options = ExecutionOptions()
     execution_options.exclude_resources = execution_options.exclude_resources.copy(
         cpu=2, gpu=1

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -157,7 +157,7 @@ class DataConfig:
 
     @staticmethod
     def _is_v2_autoscaler() -> bool:
-        """Check if the V2 cluster autoscaler is active."""
+        """Check if Ray Data is set to use the V2 cluster autoscaler."""
         from ray.data._internal.cluster_autoscaler import (
             CLUSTER_AUTOSCALER_ENV_KEY,
             DEFAULT_CLUSTER_AUTOSCALER_VERSION,

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -1,4 +1,5 @@
 import copy
+import os
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
@@ -124,15 +125,19 @@ class DataConfig:
             execution_options = self._get_execution_options(name)
 
             if execution_options.is_resource_limits_default():
-                # If "resource_limits" is not overridden by the user,
-                # add training-reserved resources to Data's exclude_resources.
-                execution_options.exclude_resources = (
-                    execution_options.exclude_resources.add(
-                        ExecutionResources(
-                            cpu=self._num_train_cpus, gpu=self._num_train_gpus
+                if not self._is_v2_autoscaler():
+                    # V1 only: add training-reserved resources to Data's
+                    # exclude_resources. Under the V2 cluster autoscaler,
+                    # the scaling policy registers training resources with
+                    # the AutoscalingCoordinator directly, so
+                    # exclude_resources is not needed.
+                    execution_options.exclude_resources = (
+                        execution_options.exclude_resources.add(
+                            ExecutionResources(
+                                cpu=self._num_train_cpus, gpu=self._num_train_gpus
+                            )
                         )
                     )
-                )
 
             ds = ds.copy(ds)
             ds.context.execution_options = execution_options
@@ -149,6 +154,11 @@ class DataConfig:
                     output[i][name] = ds.iterator()
 
         return output
+
+    @staticmethod
+    def _is_v2_autoscaler() -> bool:
+        """Check if the V2 cluster autoscaler is active."""
+        return os.environ.get("RAY_DATA_CLUSTER_AUTOSCALER", "V2") == "V2"
 
     @staticmethod
     def default_ingest_options() -> "ExecutionOptions":

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -158,7 +158,18 @@ class DataConfig:
     @staticmethod
     def _is_v2_autoscaler() -> bool:
         """Check if the V2 cluster autoscaler is active."""
-        return os.environ.get("RAY_DATA_CLUSTER_AUTOSCALER", "V2") == "V2"
+        from ray.data._internal.cluster_autoscaler import (
+            CLUSTER_AUTOSCALER_ENV_KEY,
+            DEFAULT_CLUSTER_AUTOSCALER_VERSION,
+            ClusterAutoscalerVersion,
+        )
+
+        return (
+            os.environ.get(
+                CLUSTER_AUTOSCALER_ENV_KEY, DEFAULT_CLUSTER_AUTOSCALER_VERSION
+            )
+            == ClusterAutoscalerVersion.V2
+        )
 
     @staticmethod
     def default_ingest_options() -> "ExecutionOptions":

--- a/python/ray/train/v2/_internal/execution/scaling_policy/__init__.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/__init__.py
@@ -1,5 +1,10 @@
 # isort: off
 from .scaling_policy import ScalingDecision, ScalingPolicy, NoopDecision, ResizeDecision
+from .scaling_policy import (
+    AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+    AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+    AUTOSCALING_REQUESTS_INTERVAL_S,
+)
 from .elastic import ElasticScalingPolicy
 from .fixed import FixedScalingPolicy
 from .factory import create_scaling_policy
@@ -8,6 +13,9 @@ from .factory import create_scaling_policy
 
 
 __all__ = [
+    "AUTOSCALING_REQUESTS_EXPIRE_TIME_S",
+    "AUTOSCALING_REQUESTS_GET_TIMEOUT_S",
+    "AUTOSCALING_REQUESTS_INTERVAL_S",
     "ScalingPolicy",
     "ElasticScalingPolicy",
     "FixedScalingPolicy",

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -1,15 +1,15 @@
 import logging
-import uuid
-from functools import cached_property
 from typing import TYPE_CHECKING, Dict, List, Optional
 
 import ray
-from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
     ScalingDecision,
     ScalingPolicy,
+)
+from ray.train.v2._internal.execution.scaling_policy.scaling_policy import (
+    AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
 )
 from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupPollStatus,
@@ -28,12 +28,6 @@ if TYPE_CHECKING:
 
 class ElasticScalingPolicy(ScalingPolicy):
 
-    # The time in seconds after which an autoscaling request will expire.
-    AUTOSCALING_REQUESTS_EXPIRE_TIME_S = 180
-    # Minimum interval in seconds between two consecutive autoscaling requests.
-    AUTOSCALING_REQUESTS_INTERVAL_S = 20
-    # Timeout in seconds for getting the result of a call to the AutoscalingCoordinator.
-    AUTOSCALING_REQUESTS_GET_TIMEOUT_S = 5
     # Minimum interval in seconds between querying the AutoscalingCoordinator for allocated resources.
     GET_ALLOCATED_RESOURCES_INTERVAL_S = 1
     # Minimum interval in seconds between logging warnings about insufficient workers.
@@ -43,13 +37,12 @@ class ElasticScalingPolicy(ScalingPolicy):
         super().__init__(scaling_config)
 
         self._latest_monitor_time = float("-inf")
-        # Requester ID for AutoscalingCoordinator.
-        # Prefer the Train run_id when available (set in after_controller_start).
-        self._requester_id = "train-" + uuid.uuid4().hex
-        self._latest_autoscaling_request_time = float("-inf")
         self._latest_insufficient_workers_warning_time = float("-inf")
         self._latest_allocated_resources_query_time = float("-inf")
         self._latest_allocated_resources: Optional[List["ResourceDict"]] = None
+
+    def _get_num_workers_for_resource_request(self) -> int:
+        return self.scaling_config.max_workers
 
     def _count_possible_workers(
         self, allocated_resources: List[Dict[str, float]]
@@ -180,50 +173,6 @@ class ElasticScalingPolicy(ScalingPolicy):
     # Methods for interacting with AutoscalingCoordinator
     # ---------------------------------------------------
 
-    @cached_property
-    def _autoscaling_coordinator(self):
-        from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
-            get_or_create_autoscaling_coordinator,
-        )
-
-        return get_or_create_autoscaling_coordinator()
-
-    def _maybe_send_resource_request(self):
-        """Send a resource request to AutoscalingCoordinator,
-        if AUTOSCALING_REQUESTS_INTERVAL_S has passed since the last send."""
-        now = time_monotonic()
-        if (
-            now - self._latest_autoscaling_request_time
-            < self.AUTOSCALING_REQUESTS_INTERVAL_S
-        ):
-            return
-
-        resources_per_worker = self.scaling_config._resources_per_worker_not_none
-        max_workers = self.scaling_config.max_workers
-        try:
-            from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
-                ResourceRequestPriority,
-            )
-
-            ray.get(
-                self._autoscaling_coordinator.request_resources.remote(
-                    requester_id=self._requester_id,
-                    resources=[resources_per_worker] * max_workers,
-                    expire_after_s=self.AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
-                    priority=ResourceRequestPriority.HIGH,
-                ),
-                timeout=self.AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
-            )
-            self._latest_autoscaling_request_time = time_monotonic()
-        except Exception:
-            msg = (
-                f"Failed to send resource request for {self._requester_id}."
-                " If this only happens transiently during network partition or"
-                " CPU being overloaded, it's safe to ignore this error."
-                " If this error persists, file a GitHub issue."
-            )
-            logger.warning(msg, exc_info=True)
-
     def _get_allocated_resources(self) -> Optional[List["ResourceDict"]]:
         """Get allocated resources from AutoscalingCoordinator.
         Return None if there is an error."""
@@ -239,7 +188,7 @@ class ElasticScalingPolicy(ScalingPolicy):
                 self._autoscaling_coordinator.get_allocated_resources.remote(
                     self._requester_id
                 ),
-                timeout=self.AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
             )
         except Exception:
             msg = (
@@ -255,45 +204,3 @@ class ElasticScalingPolicy(ScalingPolicy):
             self._latest_allocated_resources = allocated_resources
 
         return self._latest_allocated_resources
-
-    def _cancel_resource_request(self):
-        """Cancel the resource request to AutoscalingCoordinator."""
-        try:
-            ray.get(
-                self._autoscaling_coordinator.cancel_request.remote(
-                    requester_id=self._requester_id,
-                ),
-                timeout=self.AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
-            )
-        except Exception:
-            msg = (
-                f"Failed to cancel resource request for {self._requester_id}."
-                " The request will still expire after the timeout of"
-                f" {self.AUTOSCALING_REQUESTS_EXPIRE_TIME_S} seconds."
-            )
-            logger.warning(msg, exc_info=True)
-
-    # --------------------------
-    # ControllerCallback
-    # --------------------------
-
-    def after_controller_start(self, train_run_context: TrainRunContext):
-        """Send cluster autoscaling requests when the control loop starts."""
-        self._requester_id = f"train-{train_run_context.run_id}"
-        resources_per_worker = self.scaling_config._resources_per_worker_not_none
-        max_workers = self.scaling_config.max_workers
-        logger.info(
-            "Requesting resources to fit the maximum number of workers: "
-            f"{resources_per_worker} * {max_workers}"
-        )
-        self._maybe_send_resource_request()
-
-    def before_controller_shutdown(self):
-        """Clear the autoscaling request eagerly when the control loop shuts down.
-        So that cluster can scale down more quickly before the request timeout.
-        """
-        self._cancel_resource_request()
-
-    def before_controller_abort(self):
-        """Cancel the autoscaling request when the controller is aborted."""
-        self._cancel_resource_request()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
@@ -33,6 +33,7 @@ class FixedScalingPolicy(ScalingPolicy):
         self._latest_autoscaling_request_time = float("-inf")
 
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
+        self._maybe_send_resource_request()
         return ResizeDecision(
             num_workers=self.scaling_config.num_workers,
             resources_per_worker=self.scaling_config._resources_per_worker_not_none,

--- a/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
@@ -1,9 +1,3 @@
-import logging
-import uuid
-from functools import cached_property
-
-import ray
-from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
@@ -14,23 +8,11 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupPollStatus,
     WorkerGroupState,
 )
-from ray.train.v2._internal.util import time_monotonic
-
-logger = logging.getLogger(__name__)
-
-# The time in seconds after which an autoscaling request will expire.
-AUTOSCALING_REQUESTS_EXPIRE_TIME_S = 180
-# Timeout in seconds for getting the result of a call to the AutoscalingCoordinator.
-AUTOSCALING_REQUESTS_GET_TIMEOUT_S = 5
-# Interval in seconds between resource requests to the AutoscalingCoordinator.
-AUTOSCALING_REQUESTS_INTERVAL_S = 20
 
 
 class FixedScalingPolicy(ScalingPolicy):
-    def __init__(self, scaling_config):
-        super().__init__(scaling_config)
-        self._requester_id = "train-" + uuid.uuid4().hex
-        self._latest_autoscaling_request_time = float("-inf")
+    def _get_num_workers_for_resource_request(self) -> int:
+        return self.scaling_config.num_workers
 
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
         self._maybe_send_resource_request()
@@ -46,94 +28,3 @@ class FixedScalingPolicy(ScalingPolicy):
     ) -> ScalingDecision:
         self._maybe_send_resource_request()
         return NoopDecision()
-
-    # ---------------------------------------------------
-    # Methods for interacting with AutoscalingCoordinator
-    # ---------------------------------------------------
-
-    @cached_property
-    def _autoscaling_coordinator(self):
-        from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
-            get_or_create_autoscaling_coordinator,
-        )
-
-        return get_or_create_autoscaling_coordinator()
-
-    def _maybe_send_resource_request(self):
-        """Send a resource request to AutoscalingCoordinator,
-        if AUTOSCALING_REQUESTS_INTERVAL_S has passed since the last send."""
-        now = time_monotonic()
-        if (
-            now - self._latest_autoscaling_request_time
-            < AUTOSCALING_REQUESTS_INTERVAL_S
-        ):
-            return
-        self._send_resource_request()
-
-    def _send_resource_request(self):
-        """Register training resources with the AutoscalingCoordinator."""
-        resources_per_worker = self.scaling_config._resources_per_worker_not_none
-        num_workers = self.scaling_config.num_workers
-        try:
-            from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
-                ResourceRequestPriority,
-            )
-
-            ray.get(
-                self._autoscaling_coordinator.request_resources.remote(
-                    requester_id=self._requester_id,
-                    resources=[resources_per_worker] * num_workers,
-                    expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
-                    priority=ResourceRequestPriority.HIGH,
-                ),
-                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
-            )
-            self._latest_autoscaling_request_time = time_monotonic()
-        except Exception:
-            msg = (
-                f"Failed to send resource request for {self._requester_id}."
-                " If this only happens transiently during network partition or"
-                " CPU being overloaded, it's safe to ignore this error."
-                " If this error persists, file a GitHub issue."
-            )
-            logger.warning(msg, exc_info=True)
-
-    def _cancel_resource_request(self):
-        """Cancel the resource request to AutoscalingCoordinator."""
-        try:
-            ray.get(
-                self._autoscaling_coordinator.cancel_request.remote(
-                    requester_id=self._requester_id,
-                ),
-                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
-            )
-        except Exception:
-            msg = (
-                f"Failed to cancel resource request for {self._requester_id}."
-                " The request will still expire after the timeout of"
-                f" {AUTOSCALING_REQUESTS_EXPIRE_TIME_S} seconds."
-            )
-            logger.warning(msg, exc_info=True)
-
-    # --------------------------
-    # ControllerCallback
-    # --------------------------
-
-    def after_controller_start(self, train_run_context: TrainRunContext):
-        """Register training resources with the AutoscalingCoordinator."""
-        self._requester_id = f"train-{train_run_context.run_id}"
-        resources_per_worker = self.scaling_config._resources_per_worker_not_none
-        num_workers = self.scaling_config.num_workers
-        logger.info(
-            "Requesting resources for fixed worker group: "
-            f"{resources_per_worker} * {num_workers}"
-        )
-        self._send_resource_request()
-
-    def before_controller_shutdown(self):
-        """Cancel the resource request when the controller shuts down."""
-        self._cancel_resource_request()
-
-    def before_controller_abort(self):
-        """Cancel the resource request when the controller is aborted."""
-        self._cancel_resource_request()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
@@ -30,7 +30,7 @@ class FixedScalingPolicy(ScalingPolicy):
     def __init__(self, scaling_config):
         super().__init__(scaling_config)
         self._requester_id = "train-" + uuid.uuid4().hex
-        self._latest_autoscaling_request_time = 0.0
+        self._latest_autoscaling_request_time = float("-inf")
 
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
         return ResizeDecision(

--- a/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/fixed.py
@@ -1,3 +1,9 @@
+import logging
+import uuid
+from functools import cached_property
+
+import ray
+from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
@@ -8,9 +14,24 @@ from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupPollStatus,
     WorkerGroupState,
 )
+from ray.train.v2._internal.util import time_monotonic
+
+logger = logging.getLogger(__name__)
+
+# The time in seconds after which an autoscaling request will expire.
+AUTOSCALING_REQUESTS_EXPIRE_TIME_S = 180
+# Timeout in seconds for getting the result of a call to the AutoscalingCoordinator.
+AUTOSCALING_REQUESTS_GET_TIMEOUT_S = 5
+# Interval in seconds between resource requests to the AutoscalingCoordinator.
+AUTOSCALING_REQUESTS_INTERVAL_S = 20
 
 
 class FixedScalingPolicy(ScalingPolicy):
+    def __init__(self, scaling_config):
+        super().__init__(scaling_config)
+        self._requester_id = "train-" + uuid.uuid4().hex
+        self._latest_autoscaling_request_time = 0.0
+
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
         return ResizeDecision(
             num_workers=self.scaling_config.num_workers,
@@ -22,4 +43,96 @@ class FixedScalingPolicy(ScalingPolicy):
         worker_group_state: WorkerGroupState,
         worker_group_status: WorkerGroupPollStatus,
     ) -> ScalingDecision:
+        self._maybe_send_resource_request()
         return NoopDecision()
+
+    # ---------------------------------------------------
+    # Methods for interacting with AutoscalingCoordinator
+    # ---------------------------------------------------
+
+    @cached_property
+    def _autoscaling_coordinator(self):
+        from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+            get_or_create_autoscaling_coordinator,
+        )
+
+        return get_or_create_autoscaling_coordinator()
+
+    def _maybe_send_resource_request(self):
+        """Send a resource request to AutoscalingCoordinator,
+        if AUTOSCALING_REQUESTS_INTERVAL_S has passed since the last send."""
+        now = time_monotonic()
+        if (
+            now - self._latest_autoscaling_request_time
+            < AUTOSCALING_REQUESTS_INTERVAL_S
+        ):
+            return
+        self._send_resource_request()
+
+    def _send_resource_request(self):
+        """Register training resources with the AutoscalingCoordinator."""
+        resources_per_worker = self.scaling_config._resources_per_worker_not_none
+        num_workers = self.scaling_config.num_workers
+        try:
+            from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+                ResourceRequestPriority,
+            )
+
+            ray.get(
+                self._autoscaling_coordinator.request_resources.remote(
+                    requester_id=self._requester_id,
+                    resources=[resources_per_worker] * num_workers,
+                    expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+                    priority=ResourceRequestPriority.HIGH,
+                ),
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+            self._latest_autoscaling_request_time = time_monotonic()
+        except Exception:
+            msg = (
+                f"Failed to send resource request for {self._requester_id}."
+                " If this only happens transiently during network partition or"
+                " CPU being overloaded, it's safe to ignore this error."
+                " If this error persists, file a GitHub issue."
+            )
+            logger.warning(msg, exc_info=True)
+
+    def _cancel_resource_request(self):
+        """Cancel the resource request to AutoscalingCoordinator."""
+        try:
+            ray.get(
+                self._autoscaling_coordinator.cancel_request.remote(
+                    requester_id=self._requester_id,
+                ),
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+        except Exception:
+            msg = (
+                f"Failed to cancel resource request for {self._requester_id}."
+                " The request will still expire after the timeout of"
+                f" {AUTOSCALING_REQUESTS_EXPIRE_TIME_S} seconds."
+            )
+            logger.warning(msg, exc_info=True)
+
+    # --------------------------
+    # ControllerCallback
+    # --------------------------
+
+    def after_controller_start(self, train_run_context: TrainRunContext):
+        """Register training resources with the AutoscalingCoordinator."""
+        self._requester_id = f"train-{train_run_context.run_id}"
+        resources_per_worker = self.scaling_config._resources_per_worker_not_none
+        num_workers = self.scaling_config.num_workers
+        logger.info(
+            "Requesting resources for fixed worker group: "
+            f"{resources_per_worker} * {num_workers}"
+        )
+        self._send_resource_request()
+
+    def before_controller_shutdown(self):
+        """Cancel the resource request when the controller shuts down."""
+        self._cancel_resource_request()
+
+    def before_controller_abort(self):
+        """Cancel the resource request when the controller is aborted."""
+        self._cancel_resource_request()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
@@ -1,13 +1,28 @@
 import abc
+import logging
+import uuid
 from dataclasses import dataclass
+from functools import cached_property
 from typing import Dict
 
+import ray
 from ray.train.v2._internal.execution.callback import ControllerCallback
+from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupPollStatus,
     WorkerGroupState,
 )
+from ray.train.v2._internal.util import time_monotonic
 from ray.train.v2.api.config import ScalingConfig
+
+logger = logging.getLogger(__name__)
+
+# The time in seconds after which an autoscaling request will expire.
+AUTOSCALING_REQUESTS_EXPIRE_TIME_S = 180
+# Timeout in seconds for getting the result of a call to the AutoscalingCoordinator.
+AUTOSCALING_REQUESTS_GET_TIMEOUT_S = 5
+# Interval in seconds between resource requests to the AutoscalingCoordinator.
+AUTOSCALING_REQUESTS_INTERVAL_S = 20
 
 
 @dataclass
@@ -40,6 +55,8 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
 
     def __init__(self, scaling_config: ScalingConfig):
         self.scaling_config = scaling_config
+        self._requester_id = "train-" + uuid.uuid4().hex
+        self._latest_autoscaling_request_time = float("-inf")
 
     @abc.abstractmethod
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
@@ -55,3 +72,96 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
     ) -> ScalingDecision:
         """Makes a scaling decision when monitoring healthy, running workers."""
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def _get_num_workers_for_resource_request(self) -> int:
+        """Return the number of workers to request resources for."""
+        raise NotImplementedError
+
+    # ---------------------------------------------------
+    # Methods for interacting with AutoscalingCoordinator
+    # ---------------------------------------------------
+
+    @cached_property
+    def _autoscaling_coordinator(self):
+        from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+            get_or_create_autoscaling_coordinator,
+        )
+
+        return get_or_create_autoscaling_coordinator()
+
+    def _maybe_send_resource_request(self):
+        """Send a resource request to AutoscalingCoordinator,
+        if AUTOSCALING_REQUESTS_INTERVAL_S has passed since the last send."""
+        now = time_monotonic()
+        if (
+            now - self._latest_autoscaling_request_time
+            < AUTOSCALING_REQUESTS_INTERVAL_S
+        ):
+            return
+        self._send_resource_request()
+
+    def _send_resource_request(self):
+        """Register training resources with the AutoscalingCoordinator."""
+        resources_per_worker = self.scaling_config._resources_per_worker_not_none
+        num_workers = self._get_num_workers_for_resource_request()
+        try:
+            from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+                ResourceRequestPriority,
+            )
+
+            ray.get(
+                self._autoscaling_coordinator.request_resources.remote(
+                    requester_id=self._requester_id,
+                    resources=[resources_per_worker] * num_workers,
+                    expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+                    priority=ResourceRequestPriority.HIGH,
+                ),
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+            self._latest_autoscaling_request_time = time_monotonic()
+        except Exception:
+            msg = (
+                f"Failed to send resource request for {self._requester_id}."
+                " If this only happens transiently during network partition or"
+                " CPU being overloaded, it's safe to ignore this error."
+                " If this error persists, file a GitHub issue."
+            )
+            logger.warning(msg, exc_info=True)
+
+    def _cancel_resource_request(self):
+        """Cancel the resource request to AutoscalingCoordinator."""
+        try:
+            ray.get(
+                self._autoscaling_coordinator.cancel_request.remote(
+                    requester_id=self._requester_id,
+                ),
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+        except Exception:
+            msg = (
+                f"Failed to cancel resource request for {self._requester_id}."
+                " The request will still expire after the timeout of"
+                f" {AUTOSCALING_REQUESTS_EXPIRE_TIME_S} seconds."
+            )
+            logger.warning(msg, exc_info=True)
+
+    # --------------------------
+    # ControllerCallback
+    # --------------------------
+
+    def after_controller_start(self, train_run_context: TrainRunContext):
+        """Register training resources with the AutoscalingCoordinator."""
+        self._requester_id = f"train-{train_run_context.run_id}"
+        resources_per_worker = self.scaling_config._resources_per_worker_not_none
+        num_workers = self._get_num_workers_for_resource_request()
+        logger.info(f"Requesting resources: {resources_per_worker} * {num_workers}")
+        self._send_resource_request()
+
+    def before_controller_shutdown(self):
+        """Cancel the resource request when the controller shuts down."""
+        self._cancel_resource_request()
+
+    def before_controller_abort(self):
+        """Cancel the resource request when the controller is aborted."""
+        self._cancel_resource_request()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
@@ -48,6 +48,13 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
 
     Recovery decisions are made when workers are in an inactive or unhealthy state.
     Upscale decisions are optional and are made when workers are healthy.
+
+    Note: When adding new scaling policies, revisit the shared defaults- particularly if:
+    - AutoscalingCoordinator integration is not needed or a different interface
+      becomes available
+    - Timeout/expiry constants need to diverge between policies
+    - _get_num_workers_for_resource_request() needs variable worker counts
+    - Controller lifecycle behavior diverges
     """
 
     # TODO: Restructure these APIs to consider different TrainControllerStates

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -742,9 +742,11 @@ def test_fixed_scaling_policy_coordinator_lifecycle():
     from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
         ResourceRequestPriority,
     )
-    from ray.train.v2._internal.execution.scaling_policy.fixed import (
+    from ray.train.v2._internal.execution.scaling_policy import (
         AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
         AUTOSCALING_REQUESTS_INTERVAL_S,
+    )
+    from ray.train.v2._internal.execution.scaling_policy.fixed import (
         FixedScalingPolicy,
     )
 

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -138,14 +138,15 @@ def test_datasets_callback(ray_start_4_cpus):
     assert isinstance(processed_train_ds, StreamSplitDataIterator)
     assert not isinstance(processed_valid_ds, StreamSplitDataIterator)
 
-    # The callback should have excluded the resources reserved for training.
+    # Under the V2 cluster autoscaler (default), the scaling policy registers training resources
+    # with the AutoscalingCoordinator, so exclude_resources should not be set.
     assert (
         processed_train_ds._base_dataset.context.execution_options.exclude_resources
-        == ExecutionResources(cpu=NUM_WORKERS, gpu=NUM_WORKERS)
+        == ExecutionResources.zero()
     )
     assert (
         processed_valid_ds._base_dataset.context.execution_options.exclude_resources
-        == ExecutionResources(cpu=NUM_WORKERS, gpu=NUM_WORKERS)
+        == ExecutionResources.zero()
     )
 
 
@@ -380,10 +381,10 @@ def test_data_config_exclude_resources(ray_start_4_cpus, exclude_resources):
         ds = ray.train.get_dataset_shard("train")
         exclude_resources = config.get("exclude_resources") or ExecutionResources.zero()
 
-        # Ray Data always excludes resources reserved by Ray Train workers.
-        expected_exclude_resources = exclude_resources.add(
-            ExecutionResources(cpu=NUM_WORKERS)
-        )
+        # Under the V2 cluster autoscaler (default), training resources are
+        # registered with the AutoscalingCoordinator, so exclude_resources
+        # only contains what the user explicitly set.
+        expected_exclude_resources = exclude_resources
         assert (
             ds.get_context().execution_options.exclude_resources
             == expected_exclude_resources
@@ -548,8 +549,10 @@ def test_per_dataset_execution_options_dict(ray_start_4_cpus):
 
 
 def test_exclude_train_resources_applies_to_each_dataset(ray_start_4_cpus):
-    """Test that the default behavior of excluding train worker resources
-    applies to each dataset individually when using per-dataset execution options."""
+    """Test that user-defined per-dataset exclude_resources are preserved.
+    Under the V2 cluster autoscaler (default), training resources are NOT added
+    to exclude_resources (they are handled by the AutoscalingCoordinator), so
+    only the user-defined values should appear."""
     NUM_ROWS = 100
     NUM_WORKERS = 2
 
@@ -568,37 +571,36 @@ def test_exclude_train_resources_applies_to_each_dataset(ray_start_4_cpus):
     data_config = ray.train.DataConfig(execution_options=execution_options_dict)
 
     def train_fn():
-        # Check that each dataset has the train resources excluded,
-        # in addition to any per-dataset exclude_resources.
+        # Under the V2 cluster autoscaler, only user-defined exclude_resources
+        # should be present. Training resources are NOT added to exclude_resources.
 
-        # Check train dataset
+        # Check train dataset — only user-defined exclude_resources
         train_ds = ray.train.get_dataset_shard("train")
         train_exec_options = train_ds.get_context().execution_options
         assert train_exec_options.is_resource_limits_default()
-        # Train worker resources: NUM_WORKERS CPUs (default 1 CPU per worker)
-        expected_train_cpu = NUM_WORKERS + 2  # 2 from user-defined
-        expected_train_gpu = 0 + 1  # 1 from user-defined (no GPUs allocated)
-        assert train_exec_options.exclude_resources.cpu == expected_train_cpu
-        assert train_exec_options.exclude_resources.gpu == expected_train_gpu
+        assert train_exec_options.exclude_resources.cpu == 2
+        assert train_exec_options.exclude_resources.gpu == 1
 
-        # Check test dataset
+        # Check test dataset — only user-defined exclude_resources
         test_ds = ray.train.get_dataset_shard("test")
         test_exec_options = test_ds.get_context().execution_options
         assert test_exec_options.is_resource_limits_default()
-        expected_test_cpu = NUM_WORKERS + 1  # 1 from user-defined
-        expected_test_gpu = 0 + 0  # 0 from user-defined
-        assert test_exec_options.exclude_resources.cpu == expected_test_cpu
-        assert test_exec_options.exclude_resources.gpu == expected_test_gpu
+        assert test_exec_options.exclude_resources.cpu == 1
+        assert test_exec_options.exclude_resources.gpu == 0
 
-        # Check val dataset (should have default + train resources excluded)
+        # Check val dataset — no user-defined exclude_resources, so zero
         val_ds = ray.train.get_dataset_shard("val")
         val_exec_options = val_ds.get_context().execution_options
         assert val_exec_options.is_resource_limits_default()
         default_options = ray.train.DataConfig.default_ingest_options()
-        expected_val_cpu = NUM_WORKERS + default_options.exclude_resources.cpu
-        expected_val_gpu = 0 + default_options.exclude_resources.gpu
-        assert val_exec_options.exclude_resources.cpu == expected_val_cpu
-        assert val_exec_options.exclude_resources.gpu == expected_val_gpu
+        assert (
+            val_exec_options.exclude_resources.cpu
+            == default_options.exclude_resources.cpu
+        )
+        assert (
+            val_exec_options.exclude_resources.gpu
+            == default_options.exclude_resources.gpu
+        )
 
     trainer = DataParallelTrainer(
         train_fn,
@@ -611,6 +613,210 @@ def test_exclude_train_resources_applies_to_each_dataset(ray_start_4_cpus):
         scaling_config=ray.train.ScalingConfig(num_workers=NUM_WORKERS),
     )
     trainer.fit()
+
+
+def test_datasets_callback_v1_uses_exclude_resources(ray_start_4_cpus, monkeypatch):
+    """Under the V1 cluster autoscaler, exclude_resources should still be set by DataConfig."""
+    monkeypatch.setenv("RAY_DATA_CLUSTER_AUTOSCALER", "V1")
+
+    NUM_WORKERS = 2
+
+    train_ds = ray.data.range(1000)
+    valid_ds = ray.data.range(1000)
+
+    data_config = ray.train.DataConfig(datasets_to_split=["train"])
+    scaling_config = ray.train.ScalingConfig(
+        num_workers=NUM_WORKERS, use_gpu=True, resources_per_worker={"CPU": 1, "GPU": 1}
+    )
+
+    worker_group_context = WorkerGroupContext(
+        run_attempt_id="attempt_1",
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        num_workers=scaling_config.num_workers,
+        resources_per_worker=scaling_config.resources_per_worker,
+    )
+    train_run_context = create_dummy_run_context(
+        datasets={"train": train_ds, "valid": valid_ds},
+        dataset_config=data_config,
+        scaling_config=scaling_config,
+    )
+    worker_group = DummyWorkerGroup(
+        train_run_context=train_run_context,
+        worker_group_context=worker_group_context,
+    )
+    worker_group._start()
+
+    callback = DatasetsCallback(train_run_context)
+    dataset_manager_for_each_worker = callback.before_init_train_context(
+        worker_group.get_workers()
+    )["dataset_shard_provider"]
+
+    dataset_manager = dataset_manager_for_each_worker[0]
+    processed_train_ds = dataset_manager.get_dataset_shard(
+        DatasetShardMetadata(dataset_name="train")
+    )
+    processed_valid_ds = dataset_manager.get_dataset_shard(
+        DatasetShardMetadata(dataset_name="valid")
+    )
+
+    # Under the V1 cluster autoscaler, exclude_resources should be set with training resources.
+    assert (
+        processed_train_ds._base_dataset.context.execution_options.exclude_resources
+        == ExecutionResources(cpu=NUM_WORKERS, gpu=NUM_WORKERS)
+    )
+    assert (
+        processed_valid_ds._base_dataset.context.execution_options.exclude_resources
+        == ExecutionResources(cpu=NUM_WORKERS, gpu=NUM_WORKERS)
+    )
+
+
+def test_v2_no_negative_exclude_resources(ray_start_4_cpus):
+    """Regression test: under the V2 cluster autoscaler, exclude_resources is not set,
+    so the scenario that previously caused negative global limits (small cluster,
+    multiple datasets, large training reservation) no longer fails.
+
+    Before the fix, with 4 CPUs, 2 datasets (2 executors), and 3 CPUs for training:
+    each executor gets 4 // 2 = 2 CPUs, minus 3 exclude_resources = -1 CPU -> assertion error.
+    """
+    NUM_WORKERS = 3
+
+    train_ds = ray.data.range(100)
+    valid_ds = ray.data.range(100)
+
+    data_config = ray.train.DataConfig(datasets_to_split=["train"])
+    # 3 workers * 1 CPU each = 3 CPUs for training, leaving 1 CPU for data.
+    # With 2 datasets, each data executor gets 4 // 2 = 2 CPUs from coordinator.
+    # If exclude_resources were set to 3, that would give 2 - 3 = -1 -> crash.
+    scaling_config = ray.train.ScalingConfig(num_workers=NUM_WORKERS)
+
+    worker_group_context = WorkerGroupContext(
+        run_attempt_id="attempt_1",
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        num_workers=scaling_config.num_workers,
+        resources_per_worker=scaling_config.resources_per_worker,
+    )
+    train_run_context = create_dummy_run_context(
+        datasets={"train": train_ds, "valid": valid_ds},
+        dataset_config=data_config,
+        scaling_config=scaling_config,
+    )
+    worker_group = DummyWorkerGroup(
+        train_run_context=train_run_context,
+        worker_group_context=worker_group_context,
+    )
+    worker_group._start()
+
+    callback = DatasetsCallback(train_run_context)
+    dataset_manager_for_each_worker = callback.before_init_train_context(
+        worker_group.get_workers()
+    )["dataset_shard_provider"]
+
+    dataset_manager = dataset_manager_for_each_worker[0]
+    processed_train_ds = dataset_manager.get_dataset_shard(
+        DatasetShardMetadata(dataset_name="train")
+    )
+    processed_valid_ds = dataset_manager.get_dataset_shard(
+        DatasetShardMetadata(dataset_name="valid")
+    )
+
+    # Under the V2 cluster autoscaler (default), exclude_resources should be
+    # zero regardless of how many training resources are reserved.
+    assert (
+        processed_train_ds._base_dataset.context.execution_options.exclude_resources
+        == ExecutionResources.zero()
+    )
+    assert (
+        processed_valid_ds._base_dataset.context.execution_options.exclude_resources
+        == ExecutionResources.zero()
+    )
+
+
+def test_fixed_scaling_policy_coordinator_lifecycle():
+    """Test that FixedScalingPolicy registers training resources with the
+    AutoscalingCoordinator on start, periodically re-requests to keep
+    the reservation alive, and cancels on shutdown/abort."""
+    from unittest.mock import patch
+
+    from freezegun import freeze_time
+
+    from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
+        ResourceRequestPriority,
+    )
+    from ray.train.v2._internal.execution.scaling_policy.fixed import (
+        AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+        AUTOSCALING_REQUESTS_INTERVAL_S,
+        FixedScalingPolicy,
+    )
+
+    resources_per_worker = {"CPU": 4, "GPU": 1}
+    num_workers = 2
+    scaling_config = ray.train.ScalingConfig(
+        num_workers=num_workers,
+        use_gpu=True,
+        resources_per_worker=resources_per_worker,
+    )
+
+    mock_coordinator = MagicMock()
+    expected_request_kwargs = dict(
+        requester_id="train-test-run-123",
+        resources=[resources_per_worker] * num_workers,
+        expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+        priority=ResourceRequestPriority.HIGH,
+    )
+
+    with patch(
+        "ray.get",
+        side_effect=lambda x, **_: x,
+    ):
+        policy = FixedScalingPolicy(scaling_config)
+        # Inject mock coordinator
+        policy.__dict__["_autoscaling_coordinator"] = mock_coordinator
+
+        with freeze_time() as frozen_time:
+            # Simulate controller start
+            mock_run_context = MagicMock()
+            mock_run_context.run_id = "test-run-123"
+            policy.after_controller_start(mock_run_context)
+
+            assert policy._requester_id == "train-test-run-123"
+
+            # Verify request_resources was called with the correct arguments
+            mock_coordinator.request_resources.remote.assert_called_once_with(
+                **expected_request_kwargs
+            )
+
+            # Calling make_decision immediately should NOT re-request (interval not passed)
+            worker_group_state = MagicMock()
+            worker_group_status = MagicMock()
+            policy.make_decision_for_running_worker_group(
+                worker_group_state=worker_group_state,
+                worker_group_status=worker_group_status,
+            )
+            assert mock_coordinator.request_resources.remote.call_count == 1
+
+            # Advance past the interval — should re-request
+            frozen_time.tick(AUTOSCALING_REQUESTS_INTERVAL_S)
+            policy.make_decision_for_running_worker_group(
+                worker_group_state=worker_group_state,
+                worker_group_status=worker_group_status,
+            )
+            assert mock_coordinator.request_resources.remote.call_count == 2
+            mock_coordinator.request_resources.remote.assert_called_with(
+                **expected_request_kwargs
+            )
+
+        # Simulate controller shutdown
+        policy.before_controller_shutdown()
+        mock_coordinator.cancel_request.remote.assert_called_once_with(
+            requester_id="train-test-run-123",
+        )
+
+        # Reset and test abort path
+        mock_coordinator.cancel_request.remote.reset_mock()
+        policy.before_controller_abort()
+        mock_coordinator.cancel_request.remote.assert_called_once_with(
+            requester_id="train-test-run-123",
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -8,7 +8,12 @@ from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator impor
     ResourceRequestPriority,
 )
 from ray.train.v2._internal.execution.callback import ControllerCallback
-from ray.train.v2._internal.execution.scaling_policy import NoopDecision, ResizeDecision
+from ray.train.v2._internal.execution.scaling_policy import (
+    AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+    AUTOSCALING_REQUESTS_INTERVAL_S,
+    NoopDecision,
+    ResizeDecision,
+)
 from ray.train.v2._internal.execution.scaling_policy.elastic import (
     ElasticScalingPolicy,
 )
@@ -383,7 +388,7 @@ def test_request_and_clear():
         mock_coordinator.request_resources.remote.assert_called_with(
             requester_id=policy._requester_id,
             resources=[resources_per_worker] * 4,
-            expire_after_s=ElasticScalingPolicy.AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
+            expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
             priority=ResourceRequestPriority.HIGH,
         )
 
@@ -399,14 +404,14 @@ def test_request_and_clear():
         # Test request_resources is only called in
         # `make_decision_for_running_worker_group`,
         # if `AUTOSCALING_REQUESTS_INTERVAL_S` has passed.
-        frozen_time.tick(ElasticScalingPolicy.AUTOSCALING_REQUESTS_INTERVAL_S / 2)
+        frozen_time.tick(AUTOSCALING_REQUESTS_INTERVAL_S / 2)
         policy.make_decision_for_running_worker_group(
             worker_group_state=worker_group_state,
             worker_group_status=worker_group_status,
         )
         assert mock_coordinator.request_resources.remote.call_count == 1
 
-        frozen_time.tick(ElasticScalingPolicy.AUTOSCALING_REQUESTS_INTERVAL_S / 2)
+        frozen_time.tick(AUTOSCALING_REQUESTS_INTERVAL_S / 2)
         policy.make_decision_for_running_worker_group(
             worker_group_state=worker_group_state,
             worker_group_status=worker_group_status,

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -113,6 +113,9 @@ class MockScalingPolicy(ScalingPolicy):
 
         super().__init__(scaling_config)
 
+    def _get_num_workers_for_resource_request(self) -> int:
+        return self.scaling_config.num_workers
+
     def make_decision_for_non_running_worker_group(self) -> ScalingDecision:
         if self._recovery_decision_queue:
             return self._recovery_decision_queue.pop(0)


### PR DESCRIPTION
## Summary

The V2 cluster autoscaler divides cluster resources equally among registered data executors via the `AutoscalingCoordinator`. Previously, `DataConfig.configure()` added training resources to each dataset's `exclude_resources`, which `ResourceManager.get_global_limits()` subtracted from total resources. Under V2, this returns only the executor's allocated share (cluster / num_executors), so subtracting training resources could yield negative limits, causing assertion failures. This was the root cause of the test regression fixed in #61640, and should also help deflake the `pytorch:torch_detection` tests ([buildkite](https://buildkite.com/ray-project/postmerge/builds/16449#019ce823-a291-474d-823d-adaf6c623ebb)).

## Changes

- **Pull up `AutoscalingCoordinator` integration into base `ScalingPolicy`**: `ElasticScalingPolicy` already registered training resources with the coordinator. This PR moves that logic into the base `ScalingPolicy` class so `FixedScalingPolicy` gets the same behavior:
  - `_maybe_send_resource_request()`, `_send_resource_request()`, `_cancel_resource_request()` defined once in the base class
  - Shared constants: `AUTOSCALING_REQUESTS_EXPIRE_TIME_S=180`, `AUTOSCALING_REQUESTS_INTERVAL_S=20`, `AUTOSCALING_REQUESTS_GET_TIMEOUT_S=5`
  - Default `ControllerCallback` lifecycle: `after_controller_start` registers resources, `before_controller_shutdown`/`before_controller_abort` cancel requests
  - Subclasses implement `_get_num_workers_for_resource_request()` to return their worker count (`num_workers` for Fixed, `max_workers` for Elastic)
- **Gate `exclude_resources` on V1 autoscaler**: `DataConfig.configure()` no longer adds training resources to `exclude_resources` under V2 (default). A new `_is_v2_autoscaler()` helper controls this. Under V1 (`RAY_DATA_CLUSTER_AUTOSCALER=V1`), the old path is preserved.

### Considerations when adding new scaling policies

When adding new scaling policies, revisit the shared base class defaults if:

1. AutoscalingCoordinator integration is not necessary or a different interface becomes available
2. Timeout and expiry constants need to diverge between policies
3. `_get_num_workers_for_resource_request()` needs to accommodate variable worker counts beyond a simple fixed/max value
4. Controller lifecycle behavior diverges 

## Tests

- `test_datasets_callback` — updated to assert `exclude_resources == zero()` under V2
- `test_data_config_exclude_resources` — updated to expect only user-set `exclude_resources`
- `test_exclude_train_resources_applies_to_each_dataset` — updated to only assert user-defined per-dataset values
- `test_datasets_callback_v1_uses_exclude_resources` — **new**: verifies `exclude_resources` is still set under V1
- `test_v2_no_negative_exclude_resources` — **new**: regression test verifying the scenario that previously caused negative CPU limits no longer fails
- `test_fixed_scaling_policy_coordinator_lifecycle` — **new**: verifies `FixedScalingPolicy` registers resources on start, re-requests periodically, and cancels on shutdown/abort
- `test_data_config_default_resource_limits` / `_run_data_config_resource_test` — updated to reflect V2 behavior
- `test_elastic_scaling_policy.py` — updated imports to use shared constants from base module