### PR TITLE
[Data] Convert Pandas UDF batches as Arrow blocks internally

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -23,6 +23,7 @@ import pyarrow as pa
 
 import ray
 from ray.data._internal.util import _check_pyarrow_version, _truncated_repr
+from ray.data.context import DataContext
 from ray.types import ObjectRef
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
@@ -543,6 +544,13 @@ class BlockAccessor:
         # to_arrow() instead of the slow column-by-column Mapping path.
         elif _is_cudf_dataframe(batch):
             return batch.to_arrow()
+
+        elif isinstance(batch, pandas.DataFrame):
+            if (block_type == BlockType.ARROW) or (
+                block_type is None
+                and DataContext.get_current().batch_to_block_arrow_format
+            ):
+                return cls.for_block(batch).to_arrow()
 
         elif isinstance(batch, collections.abc.Mapping):
             if block_type is None or block_type == BlockType.ARROW:

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -530,7 +530,8 @@ class BlockAccessor:
         block_type: Optional[BlockType] = None,
     ) -> Block:
         """Create a block from user-facing data formats."""
-
+        import pandas
+        
         if isinstance(batch, np.ndarray):
             raise ValueError(
                 f"Error validating {_truncated_repr(batch)}: "

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -531,7 +531,7 @@ class BlockAccessor:
     ) -> Block:
         """Create a block from user-facing data formats."""
         import pandas
-        
+
         if isinstance(batch, np.ndarray):
             raise ValueError(
                 f"Error validating {_truncated_repr(batch)}: "

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -70,6 +70,10 @@ DEFAULT_PANDAS_BLOCK_IGNORE_METADATA = env_bool(
     "RAY_DATA_PANDAS_BLOCK_IGNORE_METADATA", False
 )
 
+DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
+    "RAY_DATA_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT", True
+)
+
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
@@ -565,6 +569,7 @@ class DataContext:
         enforce_schemas: Whether to enforce schema consistency across dataset operations.
         pandas_block_ignore_metadata: Whether to ignore pandas metadata when converting
             between Arrow and pandas formats for better type inference.
+        batch_to_block_arrow_format: Whether to convert Pandas batches to Arrow blocks by default when calling `BlockAccessor.batch_to_block`.
     """
 
     # `None` means the block size is infinite.
@@ -713,6 +718,8 @@ class DataContext:
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS
 
     pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
+
+    batch_to_block_arrow_format: bool = DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT
 
     _checkpoint_config: Optional[CheckpointConfig] = None
 


### PR DESCRIPTION
## Description                                                                                                      
                                                                                                                        
 When a UDF returns a `pd.DataFrame` or dict batch, Ray Data previously stored it as a Pandas block in the object    
store. This PR changes that behavior: UDF output is now immediately converted to an Arrow block before being stored, making Arrow the single internal block format