### PR TITLE
[release] Add GitHubClient: core HTTP infrastructure and exception

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -408,6 +408,16 @@ py_library(
 )
 
 py_library(
+    name = "github_client",
+    srcs = ["ray_release/github_client.py"],
+    imports = ["."],
+    visibility = ["//ci/ray_ci:__subpackages__"],
+    deps = [
+        bk_require("requests"),
+    ],
+)
+
+py_library(
     name = "test",
     srcs = ["ray_release/test.py"],
     imports = ["."],
@@ -865,6 +875,22 @@ py_test(
     deps = [
         ":kuberay_util",
         bk_require("pytest"),
+    ],
+)
+
+py_test(
+    name = "test_github_client",
+    size = "small",
+    srcs = ["ray_release/tests/test_github_client.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":github_client",
+        bk_require("pytest"),
+        bk_require("responses"),
     ],
 )
 

--- a/release/ray_release/github_client.py
+++ b/release/ray_release/github_client.py
@@ -1,0 +1,87 @@
+"""
+Minimal GitHub REST API client using requests, replacing PyGithub.
+
+Supports the operations used by ray_release: reading/creating/updating issues,
+reading labels, and reading pull requests.
+"""
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class GitHubException(Exception):
+    """Raised when the GitHub API returns a non-2xx response."""
+
+    def __init__(self, status: int, data: Any = None, headers: Any = None) -> None:
+        self.status = status
+        self.data = data
+        self.headers = headers
+        super().__init__(f"GitHub API error {status}: {data}")
+
+
+@dataclass
+class GitHubRepo:
+    """A GitHub repository."""
+
+    full_name: str
+    _client: "GitHubClient"
+
+
+class GitHubClient:
+    """Authenticated client for the GitHub REST API."""
+
+    BASE_URL = "https://api.github.com"
+
+    def __init__(self, token: str) -> None:
+        """Initialize the client with a personal access token or app token."""
+        self._session = requests.Session()
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        )
+
+    def get_repo(self, full_name: str) -> "GitHubRepo":
+        """Return a repo handle for owner/name (e.g. 'ray-project/ray')."""
+        return GitHubRepo(full_name=full_name, _client=self)
+
+    def _raise_for_response(self, resp: requests.Response) -> None:
+        if not resp.ok:
+            try:
+                data = resp.json()
+            except requests.exceptions.JSONDecodeError:
+                data = resp.text
+            raise GitHubException(resp.status_code, data, resp.headers)
+
+    def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> dict:
+        resp = self._session.get(f"{self.BASE_URL}{path}", params=params)
+        self._raise_for_response(resp)
+        return resp.json()
+
+    def _get_paginated(
+        self, path: str, params: Optional[Dict[str, Any]] = None
+    ) -> list:
+        params = dict(params or {})
+        params["per_page"] = 100
+        results = []
+        url: Optional[str] = f"{self.BASE_URL}{path}"
+        while url:
+            resp = self._session.get(url, params=params)
+            self._raise_for_response(resp)
+            results.extend(resp.json())
+            url = resp.links.get("next", {}).get("url")
+            params = None  # subsequent URLs from Link header already include all params
+        return results
+
+    def _post(self, path: str, data: dict) -> dict:
+        resp = self._session.post(f"{self.BASE_URL}{path}", json=data)
+        self._raise_for_response(resp)
+        return resp.json()
+
+    def _patch(self, path: str, data: dict) -> dict:
+        resp = self._session.patch(f"{self.BASE_URL}{path}", json=data)
+        self._raise_for_response(resp)
+        return resp.json()

--- a/release/ray_release/tests/test_github_client.py
+++ b/release/ray_release/tests/test_github_client.py
@@ -1,0 +1,48 @@
+"""
+Tests for the GitHub REST API client.
+
+Uses the `responses` library to intercept outbound HTTP requests without
+patching Python internals, so tests exercise the full client code path:
+URL construction, headers, JSON parsing, and dataclass population.
+"""
+import sys
+
+import pytest
+
+from ray_release.github_client import (
+    GitHubClient,
+    GitHubException,
+    GitHubRepo,
+)
+
+REPO = "owner/repo"
+BASE = "https://api.github.com"
+
+
+def _client() -> GitHubClient:
+    return GitHubClient("test-token")
+
+
+def _repo(client: GitHubClient = None) -> GitHubRepo:
+    return (_client() if client is None else client).get_repo(REPO)
+
+
+# ---------------------------------------------------------------------------
+# GitHubException
+# ---------------------------------------------------------------------------
+
+
+def test_github_exception_stores_status_and_data():
+    exc = GitHubException(404, {"message": "Not Found"}, {"x-header": "val"})
+    assert exc.status == 404
+    assert exc.data == {"message": "Not Found"}
+    assert exc.headers == {"x-header": "val"}
+    assert "404" in str(exc)
+
+
+def test_github_exception_is_exception():
+    assert isinstance(GitHubException(500), Exception)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/requirements_py310.in
+++ b/release/requirements_py310.in
@@ -13,6 +13,7 @@ jinja2
 msal
 protobuf >= 3.15.3, != 3.19.5
 pytest
+responses
 pyyaml
 pybuildkite
 PyGithub

--- a/release/requirements_py310.txt
+++ b/release/requirements_py310.txt
@@ -1663,6 +1663,10 @@ requests-toolbelt==1.0.0 \
     --hash=sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6 \
     --hash=sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06
     # via twine
+responses==0.25.3 \
+    --hash=sha256:521efcbc82081ab8daa588e08f7e8a64ce79b91c39f6e62199b19159bea7dbcb \
+    --hash=sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba
+    # via -r release/requirements_py310.in
 rfc3986==2.0.0 \
     --hash=sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd \
     --hash=sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c


### PR DESCRIPTION
Hand-written REST client using requests. This commit adds the core layer:
GitHubException, a bare GitHubRepo handle, and GitHubClient with all
HTTP methods (_get, _get_paginated, _post, _patch). Tests use the
responses library to intercept HTTP at the transport layer.

Topic: github-client
Relative: fix-requirements-update
Signed-off-by: andrew <andrew@anyscale.com>