### PR TITLE
[release] Replace PyGithub with GitHubClient in ray_release

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -424,6 +424,7 @@ py_library(
     visibility = ["//ci/ray_ci:__pkg__"],
     deps = [
         ":aws",
+        ":github_client",
         ":global_config",
         ":logger",
         ":result",
@@ -431,7 +432,6 @@ py_library(
         bk_require("aioboto3"),
         bk_require("boto3"),
         bk_require("botocore"),
-        bk_require("pygithub"),
     ],
 )
 
@@ -445,8 +445,8 @@ py_library(
     imports = ["."],
     visibility = ["//ci/ray_ci:__pkg__"],
     deps = [
+        ":github_client",
         ":test",
-        bk_require("pygithub"),
         bk_require("pybuildkite"),
     ],
 )
@@ -513,7 +513,6 @@ py_library(
         bk_require("jinja2"),
         bk_require("msal"),
         bk_require("pybuildkite"),
-        bk_require("pygithub"),
         bk_require("requests"),
     ],
 )
@@ -910,6 +909,7 @@ py_test(
         ":bazel",
         ":test",
         bk_require("pytest"),
+        bk_require("responses"),
     ],
 )
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -15,7 +15,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 if TYPE_CHECKING:
-    from github import Repository
+    from ray_release.github_client import GitHubRepo
 
 from ray_release.aws import s3_put_rayci_test_data
 from ray_release.configs.global_config import get_global_config
@@ -357,11 +357,11 @@ class Test(dict):
         except subprocess.CalledProcessError:
             return set()
 
-    def is_jailed_with_open_issue(self, ray_github: "Repository") -> bool:
+    def is_jailed_with_open_issue(self, ray_github: "GitHubRepo") -> bool:
         """
         Returns whether this test is jailed with open issue.
         """
-        from github import GithubException
+        from ray_release.github_client import GitHubException
 
         # is jailed
         state = self.get_state()
@@ -375,7 +375,7 @@ class Test(dict):
         try:
             issue = ray_github.get_issue(issue_number)
             return issue.state == "open"
-        except GithubException as e:
+        except GitHubException as e:
             logger.warning(
                 f"Failed to get issue {issue_number} for test {self.get_name()} from GitHub: {e}"
             )

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -2,11 +2,10 @@ import abc
 from datetime import datetime, timedelta
 from typing import List
 
-import github
-from github import Github
 from pybuildkite.buildkite import Buildkite
 
 from ray_release.aws import get_secret_token
+from ray_release.github_client import GitHubClient, GitHubIssue
 from ray_release.logger import logger
 from ray_release.test import (
     Test,
@@ -63,7 +62,7 @@ class TestStateMachine(abc.ABC):
 
     @classmethod
     def get_github(cls):
-        return Github(get_secret_token(AWS_SECRET_GITHUB))
+        return GitHubClient(get_secret_token(AWS_SECRET_GITHUB))
 
     @classmethod
     def get_ray_repo(cls):
@@ -78,13 +77,13 @@ class TestStateMachine(abc.ABC):
             cls.ray_buildkite.set_access_token(buildkite_token)
 
     @classmethod
-    def get_release_blockers(cls) -> List[github.Issue.Issue]:
+    def get_release_blockers(cls) -> List[GitHubIssue]:
         repo = cls.get_ray_repo()
         blocker_label = repo.get_label(WEEKLY_RELEASE_BLOCKER_TAG)
         return list(repo.get_issues(state="open", labels=[blocker_label]))
 
     @classmethod
-    def get_issue_owner(cls, issue: github.Issue.Issue) -> str:
+    def get_issue_owner(cls, issue: GitHubIssue) -> str:
         labels = issue.get_labels()
         for label in labels:
             if label.name in TEAM:

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -2,11 +2,13 @@ import os
 import sys
 import tempfile
 import unittest
-from typing import Callable, Dict
+from typing import TYPE_CHECKING, Callable, Dict
+
+if TYPE_CHECKING:
+    from ray_release.github_client import GitHubRepo
 from unittest.mock import patch
 
 import yaml
-from github import Repository
 
 from ray_release.bazel import bazel_runfile
 from ray_release.buildkite.concurrency import (
@@ -72,7 +74,7 @@ class MockTest(Test):
     def update_from_s3(self) -> None:
         self["update_from_s3"] = True
 
-    def is_jailed_with_open_issue(self, ray_github: Repository) -> bool:
+    def is_jailed_with_open_issue(self, ray_github: "GitHubRepo") -> bool:
         return False
 
 

--- a/release/ray_release/tests/test_github_client.py
+++ b/release/ray_release/tests/test_github_client.py
@@ -64,6 +64,24 @@ def test_auth_header_is_sent():
     assert "X-GitHub-Api-Version" in sent_headers
 
 
+@responses.activate
+def test_token_not_leaked_on_api_error():
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/1",
+        json={"message": "Bad credentials"},
+        status=401,
+    )
+    secret = "super-secret-token-xyz"
+    with pytest.raises(GitHubException) as exc_info:
+        GitHubClient(secret).get_repo(REPO).get_pull(1)
+
+    exc = exc_info.value
+    assert secret not in str(exc)
+    assert secret not in str(exc.data)
+    assert secret not in str(dict(exc.headers))
+
+
 # ---------------------------------------------------------------------------
 # GitHubRepo.get_issue
 # ---------------------------------------------------------------------------

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -10,12 +10,14 @@ from unittest.mock import AsyncMock, patch
 import aioboto3
 import boto3
 import pytest
+import responses
 
 from ray_release.bazel import bazel_runfile
 from ray_release.configs.global_config import (
     get_global_config,
     init_global_config,
 )
+from ray_release.github_client import GitHubClient
 from ray_release.test import (
     DATAPLANE_ECR_ML_REPO,
     DATAPLANE_ECR_REPO,
@@ -176,28 +178,44 @@ def test_get_anyscale_byod_image_ray_version():
     )
 
 
-@patch("github.Repository")
-@patch("github.Issue")
-def test_is_jailed_with_open_issue(mock_repo, mock_issue) -> None:
-    assert not Test(state="passing").is_jailed_with_open_issue(mock_repo)
-    mock_repo.get_issue.return_value = mock_issue
-    mock_issue.state = "open"
+_ISSUE_URL = "https://api.github.com/repos/owner/repo/issues/1"
+_ISSUE_JSON = {"number": 1, "state": "open", "title": "", "html_url": "", "labels": []}
+
+
+def _repo():
+    return GitHubClient("token").get_repo("owner/repo")
+
+
+def test_is_jailed_with_open_issue_not_jailed() -> None:
+    assert not Test(state="passing").is_jailed_with_open_issue(_repo())
+
+
+def test_is_jailed_with_open_issue_no_issue_number() -> None:
+    assert not Test(state="jailed").is_jailed_with_open_issue(_repo())
+
+
+@responses.activate
+def test_is_jailed_with_open_issue_open() -> None:
+    responses.add(responses.GET, _ISSUE_URL, json={**_ISSUE_JSON, "state": "open"})
     assert Test(state="jailed", github_issue_number="1").is_jailed_with_open_issue(
-        mock_repo
+        _repo()
     )
-    mock_issue.state = "closed"
+
+
+@responses.activate
+def test_is_jailed_with_open_issue_closed() -> None:
+    responses.add(responses.GET, _ISSUE_URL, json={**_ISSUE_JSON, "state": "closed"})
     assert not Test(state="jailed", github_issue_number="1").is_jailed_with_open_issue(
-        mock_repo
+        _repo()
     )
 
 
-@patch("github.Repository")
-def test_is_jailed_with_open_issue_github_exception(mock_repo) -> None:
-    from github import GithubException
-
-    mock_repo.get_issue.side_effect = GithubException(404, {"message": "Not Found"}, {})
-    test = Test(name="test", state="jailed", github_issue_number="1")
-    assert not test.is_jailed_with_open_issue(mock_repo)
+@responses.activate
+def test_is_jailed_with_open_issue_github_exception() -> None:
+    responses.add(responses.GET, _ISSUE_URL, json={"message": "Not Found"}, status=404)
+    assert not Test(
+        name="test", state="jailed", github_issue_number="1"
+    ).is_jailed_with_open_issue(_repo())
 
 
 def test_is_stable() -> None:


### PR DESCRIPTION
Update state_machine.py, test.py, and their tests to use the new
GitHubClient instead of PyGithub. The type annotation for
is_jailed_with_open_issue changes from Repository to GitHubRepo,
and GithubException becomes GitHubException.

Topic: remove-pygithub-release
Relative: github-client-issues
Signed-off-by: andrew <andrew@anyscale.com>