### PR TITLE
[ci] Replace PyGithub with GitHubClient in get_contributors.py

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -314,9 +314,27 @@ py_binary(
     srcs = ["get_contributors.py"],
     exec_compatible_with = ["//bazel:py3"],
     deps = [
+        "//release:github_client",
         ci_require("click"),
-        ci_require("pygithub"),
         ci_require("tqdm"),
+    ],
+)
+
+py_test(
+    name = "test_get_contributors",
+    size = "small",
+    srcs = ["test_get_contributors.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":get_contributors",
+        "//release:github_client",
+        ci_require("click"),
+        ci_require("pytest"),
+        ci_require("responses"),
     ],
 )
 

--- a/ci/ray_ci/automation/get_contributors.py
+++ b/ci/ray_ci/automation/get_contributors.py
@@ -4,8 +4,9 @@ from collections import defaultdict
 from subprocess import check_output
 
 import click
-from github import Github
 from tqdm import tqdm
+
+from ray_release.github_client import GitHubClient, GitHubException
 
 
 def _find_pr_number(line: str) -> str:
@@ -94,14 +95,14 @@ def run(access_token, prev_release_commit, curr_release_commit):
     # Sort the PR numbers
     print("PR numbers", pr_numbers)
 
-    # Use Github API to fetch the
-    g = Github(access_token)
-    ray_repo = g.get_repo("ray-project/ray")
+    # Use Github API to fetch PR authors
+    client = GitHubClient(access_token)
+    ray_repo = client.get_repo("ray-project/ray")
     logins = set()
     for num in tqdm(pr_numbers):
         try:
             logins.add(ray_repo.get_pull(num).user.login)
-        except Exception as e:
+        except GitHubException as e:
             print(e)
 
     print()

--- a/ci/ray_ci/automation/test_get_contributors.py
+++ b/ci/ray_ci/automation/test_get_contributors.py
@@ -1,0 +1,194 @@
+import sys
+from unittest import mock
+
+import pytest
+import responses
+from click.testing import CliRunner
+
+from ci.ray_ci.automation.get_contributors import _find_pr_number, run
+
+BASE = "https://api.github.com"
+REPO = "ray-project/ray"
+
+_COMMIT_LOG = "\n".join(
+    [
+        "[core] Fix scheduler bug (#100)",
+        "[serve] Add new endpoint (#101)",
+        "No category commit (#102)",
+        "",
+    ]
+)
+
+_COMMIT_LOG_NO_PRS = "\n".join(
+    [
+        "[core] Fix scheduler bug",
+        "[serve] Add new endpoint",
+        "No category commit",
+        "",
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# _find_pr_number
+# ---------------------------------------------------------------------------
+
+
+def test_find_pr_number_standard_format():
+    assert _find_pr_number("[fix] Fix crash in serve (#12345)") == "12345"
+
+
+def test_find_pr_number_no_pr():
+    assert _find_pr_number("[fix] Fix crash in serve") == ""
+
+
+def test_find_pr_number_empty_string():
+    assert _find_pr_number("") == ""
+
+
+def test_find_pr_number_unclosed_paren():
+    assert _find_pr_number("[fix] Fix crash (#12345") == ""
+
+
+def test_find_pr_number_at_start_of_line():
+    assert _find_pr_number("(#99)") == "99"
+
+
+# ---------------------------------------------------------------------------
+# run (CLI) — uses `responses` for HTTP, one mock for subprocess
+# ---------------------------------------------------------------------------
+
+
+@responses.activate
+def test_run_collects_contributor_logins():
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/100",
+        json={"number": 100, "user": {"login": "alice"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/101",
+        json={"number": 101, "user": {"login": "bob"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/102",
+        json={"number": 102, "user": {"login": "carol"}},
+    )
+
+    with (
+        mock.patch(
+            "ci.ray_ci.automation.get_contributors.check_output",
+            return_value=_COMMIT_LOG.encode(),
+        ),
+        mock.patch.dict("os.environ", {"BUILD_WORKSPACE_DIRECTORY": "/fake/repo"}),
+    ):
+        result = CliRunner().invoke(
+            run,
+            [
+                "--access-token",
+                "tok",
+                "--prev-release-commit",
+                "abc",
+                "--curr-release-commit",
+                "def",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "alice" in result.output
+    assert "bob" in result.output
+    assert "carol" in result.output
+
+
+@responses.activate
+def test_run_skips_failed_pr_lookups():
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/100",
+        json={"message": "Not Found"},
+        status=404,
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/101",
+        json={"number": 101, "user": {"login": "bob"}},
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/102",
+        json={"number": 102, "user": {"login": "carol"}},
+    )
+
+    with (
+        mock.patch(
+            "ci.ray_ci.automation.get_contributors.check_output",
+            return_value=_COMMIT_LOG.encode(),
+        ),
+        mock.patch.dict("os.environ", {"BUILD_WORKSPACE_DIRECTORY": "/fake/repo"}),
+    ):
+        result = CliRunner().invoke(
+            run,
+            [
+                "--access-token",
+                "tok",
+                "--prev-release-commit",
+                "abc",
+                "--curr-release-commit",
+                "def",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "bob" in result.output
+    assert "carol" in result.output
+
+
+def test_run_writes_commits_file_with_categories():
+    with (
+        mock.patch(
+            "ci.ray_ci.automation.get_contributors.check_output",
+            return_value=_COMMIT_LOG_NO_PRS.encode(),
+        ),
+        mock.patch.dict("os.environ", {"BUILD_WORKSPACE_DIRECTORY": "/fake/repo"}),
+    ):
+        result = CliRunner().invoke(
+            run,
+            [
+                "--access-token",
+                "tok",
+                "--prev-release-commit",
+                "abc",
+                "--curr-release-commit",
+                "def",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    with open("/tmp/commits.txt") as f:
+        content = f.read()
+    assert "[CORE]" in content
+    assert "[SERVE]" in content
+    assert "[NO_CATEGORY]" in content
+    assert "No category commit" in content
+
+
+def test_run_fails_without_workspace_dir():
+    with mock.patch.dict("os.environ", {}, clear=True):
+        result = CliRunner().invoke(
+            run,
+            [
+                "--access-token",
+                "tok",
+                "--prev-release-commit",
+                "abc",
+                "--curr-release-commit",
+                "def",
+            ],
+        )
+    assert result.exit_code != 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -424,6 +424,7 @@ py_library(
     visibility = ["//ci/ray_ci:__pkg__"],
     deps = [
         ":aws",
+        ":github_client",
         ":global_config",
         ":logger",
         ":result",
@@ -431,7 +432,6 @@ py_library(
         bk_require("aioboto3"),
         bk_require("boto3"),
         bk_require("botocore"),
-        bk_require("pygithub"),
     ],
 )
 
@@ -445,8 +445,8 @@ py_library(
     imports = ["."],
     visibility = ["//ci/ray_ci:__pkg__"],
     deps = [
+        ":github_client",
         ":test",
-        bk_require("pygithub"),
         bk_require("pybuildkite"),
     ],
 )
@@ -513,7 +513,6 @@ py_library(
         bk_require("jinja2"),
         bk_require("msal"),
         bk_require("pybuildkite"),
-        bk_require("pygithub"),
         bk_require("requests"),
     ],
 )
@@ -910,6 +909,7 @@ py_test(
         ":bazel",
         ":test",
         bk_require("pytest"),
+        bk_require("responses"),
     ],
 )
 

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -15,7 +15,7 @@ import boto3
 from botocore.exceptions import ClientError
 
 if TYPE_CHECKING:
-    from github import Repository
+    from ray_release.github_client import GitHubRepo
 
 from ray_release.aws import s3_put_rayci_test_data
 from ray_release.configs.global_config import get_global_config
@@ -357,11 +357,11 @@ class Test(dict):
         except subprocess.CalledProcessError:
             return set()
 
-    def is_jailed_with_open_issue(self, ray_github: "Repository") -> bool:
+    def is_jailed_with_open_issue(self, ray_github: "GitHubRepo") -> bool:
         """
         Returns whether this test is jailed with open issue.
         """
-        from github import GithubException
+        from ray_release.github_client import GitHubException
 
         # is jailed
         state = self.get_state()
@@ -375,7 +375,7 @@ class Test(dict):
         try:
             issue = ray_github.get_issue(issue_number)
             return issue.state == "open"
-        except GithubException as e:
+        except GitHubException as e:
             logger.warning(
                 f"Failed to get issue {issue_number} for test {self.get_name()} from GitHub: {e}"
             )

--- a/release/ray_release/test_automation/state_machine.py
+++ b/release/ray_release/test_automation/state_machine.py
@@ -2,11 +2,10 @@ import abc
 from datetime import datetime, timedelta
 from typing import List
 
-import github
-from github import Github
 from pybuildkite.buildkite import Buildkite
 
 from ray_release.aws import get_secret_token
+from ray_release.github_client import GitHubClient, GitHubIssue
 from ray_release.logger import logger
 from ray_release.test import (
     Test,
@@ -63,7 +62,7 @@ class TestStateMachine(abc.ABC):
 
     @classmethod
     def get_github(cls):
-        return Github(get_secret_token(AWS_SECRET_GITHUB))
+        return GitHubClient(get_secret_token(AWS_SECRET_GITHUB))
 
     @classmethod
     def get_ray_repo(cls):
@@ -78,13 +77,13 @@ class TestStateMachine(abc.ABC):
             cls.ray_buildkite.set_access_token(buildkite_token)
 
     @classmethod
-    def get_release_blockers(cls) -> List[github.Issue.Issue]:
+    def get_release_blockers(cls) -> List[GitHubIssue]:
         repo = cls.get_ray_repo()
         blocker_label = repo.get_label(WEEKLY_RELEASE_BLOCKER_TAG)
         return list(repo.get_issues(state="open", labels=[blocker_label]))
 
     @classmethod
-    def get_issue_owner(cls, issue: github.Issue.Issue) -> str:
+    def get_issue_owner(cls, issue: GitHubIssue) -> str:
         labels = issue.get_labels()
         for label in labels:
             if label.name in TEAM:

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -2,11 +2,13 @@ import os
 import sys
 import tempfile
 import unittest
-from typing import Callable, Dict
+from typing import TYPE_CHECKING, Callable, Dict
+
+if TYPE_CHECKING:
+    from ray_release.github_client import GitHubRepo
 from unittest.mock import patch
 
 import yaml
-from github import Repository
 
 from ray_release.bazel import bazel_runfile
 from ray_release.buildkite.concurrency import (
@@ -72,7 +74,7 @@ class MockTest(Test):
     def update_from_s3(self) -> None:
         self["update_from_s3"] = True
 
-    def is_jailed_with_open_issue(self, ray_github: Repository) -> bool:
+    def is_jailed_with_open_issue(self, ray_github: "GitHubRepo") -> bool:
         return False
 
 

--- a/release/ray_release/tests/test_github_client.py
+++ b/release/ray_release/tests/test_github_client.py
@@ -64,6 +64,24 @@ def test_auth_header_is_sent():
     assert "X-GitHub-Api-Version" in sent_headers
 
 
+@responses.activate
+def test_token_not_leaked_on_api_error():
+    responses.add(
+        responses.GET,
+        f"{BASE}/repos/{REPO}/pulls/1",
+        json={"message": "Bad credentials"},
+        status=401,
+    )
+    secret = "super-secret-token-xyz"
+    with pytest.raises(GitHubException) as exc_info:
+        GitHubClient(secret).get_repo(REPO).get_pull(1)
+
+    exc = exc_info.value
+    assert secret not in str(exc)
+    assert secret not in str(exc.data)
+    assert secret not in str(dict(exc.headers))
+
+
 # ---------------------------------------------------------------------------
 # GitHubRepo.get_issue
 # ---------------------------------------------------------------------------

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -10,12 +10,14 @@ from unittest.mock import AsyncMock, patch
 import aioboto3
 import boto3
 import pytest
+import responses
 
 from ray_release.bazel import bazel_runfile
 from ray_release.configs.global_config import (
     get_global_config,
     init_global_config,
 )
+from ray_release.github_client import GitHubClient
 from ray_release.test import (
     DATAPLANE_ECR_ML_REPO,
     DATAPLANE_ECR_REPO,
@@ -176,28 +178,44 @@ def test_get_anyscale_byod_image_ray_version():
     )
 
 
-@patch("github.Repository")
-@patch("github.Issue")
-def test_is_jailed_with_open_issue(mock_repo, mock_issue) -> None:
-    assert not Test(state="passing").is_jailed_with_open_issue(mock_repo)
-    mock_repo.get_issue.return_value = mock_issue
-    mock_issue.state = "open"
+_ISSUE_URL = "https://api.github.com/repos/owner/repo/issues/1"
+_ISSUE_JSON = {"number": 1, "state": "open", "title": "", "html_url": "", "labels": []}
+
+
+def _repo():
+    return GitHubClient("token").get_repo("owner/repo")
+
+
+def test_is_jailed_with_open_issue_not_jailed() -> None:
+    assert not Test(state="passing").is_jailed_with_open_issue(_repo())
+
+
+def test_is_jailed_with_open_issue_no_issue_number() -> None:
+    assert not Test(state="jailed").is_jailed_with_open_issue(_repo())
+
+
+@responses.activate
+def test_is_jailed_with_open_issue_open() -> None:
+    responses.add(responses.GET, _ISSUE_URL, json={**_ISSUE_JSON, "state": "open"})
     assert Test(state="jailed", github_issue_number="1").is_jailed_with_open_issue(
-        mock_repo
+        _repo()
     )
-    mock_issue.state = "closed"
+
+
+@responses.activate
+def test_is_jailed_with_open_issue_closed() -> None:
+    responses.add(responses.GET, _ISSUE_URL, json={**_ISSUE_JSON, "state": "closed"})
     assert not Test(state="jailed", github_issue_number="1").is_jailed_with_open_issue(
-        mock_repo
+        _repo()
     )
 
 
-@patch("github.Repository")
-def test_is_jailed_with_open_issue_github_exception(mock_repo) -> None:
-    from github import GithubException
-
-    mock_repo.get_issue.side_effect = GithubException(404, {"message": "Not Found"}, {})
-    test = Test(name="test", state="jailed", github_issue_number="1")
-    assert not test.is_jailed_with_open_issue(mock_repo)
+@responses.activate
+def test_is_jailed_with_open_issue_github_exception() -> None:
+    responses.add(responses.GET, _ISSUE_URL, json={"message": "Not Found"}, status=404)
+    assert not Test(
+        name="test", state="jailed", github_issue_number="1"
+    ).is_jailed_with_open_issue(_repo())
 
 
 def test_is_stable() -> None:


### PR DESCRIPTION
Use GitHubClient.get_repo().get_pull() instead of the PyGithub
Github/repo.get_pull() calls.

Topic: remove-pygithub-ci
Relative: remove-pygithub-release
Signed-off-by: andrew <andrew@anyscale.com>