### PR TITLE
[Dashboard] Add Queued Blocks metric to Ray Data Dashboard

### DIFF
--- a/python/ray/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/python/ray/dashboard/client/src/components/DataOverviewTable.tsx
@@ -34,6 +34,15 @@ const columns = [
   { label: "State", align: "center" },
   { label: "Rows Outputted" },
   {
+    label: "Queued Blocks",
+    helpInfo: (
+      <Typography>
+        Number of blocks currently queued in the operator's input queue,
+        waiting to be processed.
+      </Typography>
+    ),
+  },
+  {
     label: "Memory Usage (current / max)",
     helpInfo: (
       <Typography>
@@ -212,6 +221,7 @@ const DataRow = ({
         <StatusChip type="task" status={data.state} />
       </TableCell>
       <TableCell align="right">{data.ray_data_output_rows.max}</TableCell>
+      <TableCell align="right">{data.queued_blocks}</TableCell>
       <TableCell align="right">
         {memoryConverter(Number(data.ray_data_current_bytes.value))}/
         {memoryConverter(Number(data.ray_data_current_bytes.max))}

--- a/python/ray/dashboard/client/src/components/DataOverviewTable.tsx
+++ b/python/ray/dashboard/client/src/components/DataOverviewTable.tsx
@@ -37,8 +37,7 @@ const columns = [
     label: "Queued Blocks",
     helpInfo: (
       <Typography>
-        Number of blocks currently queued in the operator's input queue,
-        waiting to be processed.
+        Number of blocks waiting in an input queue to be processed.
       </Typography>
     ),
   },
@@ -221,7 +220,9 @@ const DataRow = ({
         <StatusChip type="task" status={data.state} />
       </TableCell>
       <TableCell align="right">{data.ray_data_output_rows.max}</TableCell>
-      <TableCell align="right">{data.queued_blocks}</TableCell>
+      <TableCell align="right">
+        {isOperatorRow ? operatorMetrics.queued_blocks : ""}
+      </TableCell>
       <TableCell align="right">
         {memoryConverter(Number(data.ray_data_current_bytes.value))}/
         {memoryConverter(Number(data.ray_data_current_bytes.max))}

--- a/python/ray/dashboard/client/src/pages/data/DataOverview.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/data/DataOverview.component.test.tsx
@@ -13,7 +13,6 @@ describe("DataOverview", () => {
         state: "RUNNING",
         progress: 50,
         total: 100,
-        queued_blocks: 5,
         start_time: 0,
         end_time: undefined,
         ray_data_output_rows: {
@@ -69,7 +68,6 @@ describe("DataOverview", () => {
         state: "FINISHED",
         progress: 200,
         total: 200,
-        queued_blocks: 0,
         start_time: 1,
         end_time: 2,
         ray_data_output_rows: {
@@ -111,6 +109,8 @@ describe("DataOverview", () => {
     expect(screen.queryByText("test_ds1_op")).toBeNull();
     await user.click(screen.getByTitle("Expand Dataset test_ds1"));
     expect(screen.getByText("test_ds1_op")).toBeVisible();
+    // Verify queued_blocks is rendered for operator row
+    expect(screen.getByText("3")).toBeVisible();
     await user.click(screen.getByTitle("Collapse Dataset test_ds1"));
     expect(screen.queryByText("test_ds1_op")).toBeNull();
 

--- a/python/ray/dashboard/client/src/pages/data/DataOverview.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/data/DataOverview.component.test.tsx
@@ -13,6 +13,7 @@ describe("DataOverview", () => {
         state: "RUNNING",
         progress: 50,
         total: 100,
+        queued_blocks: 5,
         start_time: 0,
         end_time: undefined,
         ray_data_output_rows: {
@@ -40,6 +41,7 @@ describe("DataOverview", () => {
             state: "RUNNING",
             progress: 99,
             total: 101,
+            queued_blocks: 3,
             ray_data_output_rows: {
               max: 11,
             },
@@ -67,6 +69,7 @@ describe("DataOverview", () => {
         state: "FINISHED",
         progress: 200,
         total: 200,
+        queued_blocks: 0,
         start_time: 1,
         end_time: 2,
         ray_data_output_rows: {

--- a/python/ray/dashboard/client/src/type/data.ts
+++ b/python/ray/dashboard/client/src/type/data.ts
@@ -13,6 +13,7 @@ export type DatasetMetrics = DataMetrics & {
 export type OperatorMetrics = DataMetrics & {
   operator: string;
   name: string;
+  queued_blocks: number;
 };
 
 export type DataMetrics = {
@@ -37,4 +38,5 @@ export type DataMetrics = {
   };
   progress: number;
   total: number;
+  queued_blocks: number;
 };

--- a/python/ray/dashboard/client/src/type/data.ts
+++ b/python/ray/dashboard/client/src/type/data.ts
@@ -38,5 +38,4 @@ export type DataMetrics = {
   };
   progress: number;
   total: number;
-  queued_blocks: number;
 };


### PR DESCRIPTION

## Description

This PR adds the **Queued Blocks** metric to the Ray Data Dashboard overview table, making it easier for users to observe data backlog directly in the dashboard without needing to check logs or Grafana.

Ray Data already exposes `queued_blocks` via the `/api/data/datasets/{dataset_id}` API endpoint. This change surfaces that metric in the `DataOverviewTable` component so users can monitor how many blocks are waiting to be processed in each operator's input queue during dataset execution.

**Changes:**
- Added `queued_blocks` field to the [`DataMetrics`](python/ray/dashboard/client/src/type/data.ts:19-42) type definition, making it available for both dataset-level and operator-level rows.
- Added a **"Queued Blocks"** column to the [`DataOverviewTable`](python/ray/dashboard/client/src/components/DataOverviewTable.tsx) with a tooltip explaining its meaning.
- Rendered the `queued_blocks` value in each [`DataRow`](python/ray/dashboard/client/src/components/DataOverviewTable.tsx:163-250) for both dataset and operator rows.

## Related issues

Closes #61714

## Additional information

The `queued_blocks` metric reflects the number of blocks currently waiting in an operator's input queue. A consistently high value may indicate a data backlog or pipeline bottleneck, helping users diagnose performance issues at a glance directly from the Ray Dashboard.

**Column added to the table:**

| Column | Description |
|---|---|
| Queued Blocks | Number of blocks currently queued in the operator's input queue, waiting to be processed. |
<img width="1577" height="583" alt="image" src="https://github.com/user-attachments/assets/e0a8d5bf-0e4a-4f3e-add6-14f94a130a00" />
