### PR TITLE
[Serve] deflake test metrics

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1221,7 +1221,20 @@ def get_metric_dictionaries(
     name: str,
     timeout: float = 20,
     timeseries: Optional[PrometheusTimeseries] = None,
+    wait: bool = True,
 ) -> List[Dict]:
+    """Get metric samples as list of label dicts.
+
+    Args:
+        name: Metric name to fetch.
+        timeout: Timeout for each fetch attempt.
+        timeseries: Optional shared timeseries to populate.
+        wait: If True (default), wait for metric to appear before returning.
+            If False, fetch once and return immediately (possibly empty).
+
+    Returns:
+        List of metric samples as label dicts.
+    """
     if timeseries is None:
         timeseries = PrometheusTimeseries()
 
@@ -1235,7 +1248,18 @@ def get_metric_dictionaries(
         )
         return True
 
-    wait_for_condition(metric_available, retry_interval_ms=1000, timeout=timeout * 4)
+    if wait:
+        wait_for_condition(
+            metric_available, retry_interval_ms=1000, timeout=timeout * 4
+        )
+    else:
+        # Fetch once without asserting - allows outer wait_for_condition to retry
+        fetch_prometheus_metric_timeseries(
+            [f"localhost:{TEST_METRICS_EXPORT_PORT}"],
+            timeseries,
+            timeout=PROMETHEUS_METRICS_TIMEOUT_S,
+        )
+
     metric_dicts = []
     for sample in timeseries.metric_samples.values():
         if sample.name == name:

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -811,7 +811,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
 
     wait_for_condition(
         lambda: len(
-            get_metric_dictionaries("ray_serve_deployment_request_counter_total")
+            get_metric_dictionaries(
+                "ray_serve_deployment_request_counter_total", wait=False
+            )
         )
         == 2,
         timeout=40,
@@ -843,7 +845,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
     # Latency metrics
     wait_for_condition(
         lambda: len(
-            get_metric_dictionaries("ray_serve_deployment_processing_latency_ms_count")
+            get_metric_dictionaries(
+                "ray_serve_deployment_processing_latency_ms_count", wait=False
+            )
         )
         == 2,
         timeout=40,
@@ -862,7 +866,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
         } == expected_output
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("ray_serve_replica_processing_queries"))
+        lambda: len(
+            get_metric_dictionaries("ray_serve_replica_processing_queries", wait=False)
+        )
         == 2
     )
     processing_queries = get_metric_dictionaries("ray_serve_replica_processing_queries")
@@ -880,7 +886,11 @@ def test_replica_metrics_fields(metrics_start_shutdown):
     url_h = get_application_url("HTTP", "app3")
     assert 500 == httpx.get(url_h).status_code
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("ray_serve_deployment_error_counter_total"))
+        lambda: len(
+            get_metric_dictionaries(
+                "ray_serve_deployment_error_counter_total", wait=False
+            )
+        )
         == 1,
         timeout=40,
     )
@@ -895,7 +905,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
     assert err_requests[0]["exception_type"] == "ZeroDivisionError"
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("ray_serve_deployment_replica_healthy"))
+        lambda: len(
+            get_metric_dictionaries("ray_serve_deployment_replica_healthy", wait=False)
+        )
         == 3,
         timeout=40,
     )
@@ -926,7 +938,7 @@ def test_deployment_error_counter_exception_type(metrics_start_shutdown):
 
     def check_metric():
         err_metrics = get_metric_dictionaries(
-            "ray_serve_deployment_error_counter_total"
+            "ray_serve_deployment_error_counter_total", wait=False
         )
         value_error_metrics = [
             m for m in err_metrics if m.get("exception_type") == "ValueError"
@@ -964,7 +976,9 @@ def test_queue_wait_time_metric(metrics_start_shutdown):
 
     def check_queue_wait_time_metric():
         metrics = get_metric_dictionaries(
-            "ray_serve_request_router_fulfillment_time_ms_sum", timeseries=timeseries
+            "ray_serve_request_router_fulfillment_time_ms_sum",
+            timeseries=timeseries,
+            wait=False,
         )
         if not metrics:
             return False
@@ -1020,7 +1034,7 @@ def test_router_queue_len_metric(metrics_start_shutdown):
         # Check that the router queue length metric appears with correct tags
         def check_router_queue_len():
             metrics = get_metric_dictionaries(
-                "ray_serve_request_router_queue_len", timeseries=timeseries
+                "ray_serve_request_router_queue_len", timeseries=timeseries, wait=False
             )
             if not metrics:
                 return False
@@ -1168,7 +1182,9 @@ def test_proxy_metrics_with_route_patterns(metrics_start_shutdown, use_factory_p
 
     # Wait for metrics to be updated
     def metrics_available():
-        metrics = get_metric_dictionaries("ray_serve_num_http_requests_total")
+        metrics = get_metric_dictionaries(
+            "ray_serve_num_http_requests_total", wait=False
+        )
         api_metrics = [m for m in metrics if m.get("application") == "api_app"]
         return len(api_metrics) >= 3
 
@@ -1265,7 +1281,7 @@ def test_routing_stats_delay_metric(metrics_start_shutdown):
     # This metric is recorded when the controller polls routing stats from replicas
     def check_routing_stats_delay_metric():
         metrics = get_metric_dictionaries(
-            "ray_serve_routing_stats_delay_ms_count", timeseries=timeseries
+            "ray_serve_routing_stats_delay_ms_count", timeseries=timeseries, wait=False
         )
         if not metrics:
             return False
@@ -1341,7 +1357,7 @@ def test_routing_stats_error_metric(metrics_start_shutdown):
     # Check that error metric with error_type="exception" is reported
     def check_exception_error_metric():
         metrics = get_metric_dictionaries(
-            "ray_serve_routing_stats_error_total", timeseries=timeseries
+            "ray_serve_routing_stats_error_total", timeseries=timeseries, wait=False
         )
         for metric in metrics:
             if (
@@ -1367,7 +1383,7 @@ def test_routing_stats_error_metric(metrics_start_shutdown):
     # Check that error metric with error_type="timeout" is reported
     def check_timeout_error_metric():
         metrics = get_metric_dictionaries(
-            "ray_serve_routing_stats_error_total", timeseries=timeseries
+            "ray_serve_routing_stats_error_total", timeseries=timeseries, wait=False
         )
         for metric in metrics:
             if (
@@ -1435,7 +1451,9 @@ def test_replica_utilization_metric(metrics_start_shutdown):
         # Wait for the utilization metric to be reported
         def check_utilization_metric_exists():
             metrics = get_metric_dictionaries(
-                "ray_serve_replica_utilization_percent", timeseries=timeseries
+                "ray_serve_replica_utilization_percent",
+                timeseries=timeseries,
+                wait=False,
             )
             if not metrics:
                 return False

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -125,6 +125,7 @@ class TestRequestContextMetrics:
                 get_metric_dictionaries(
                     "ray_serve_deployment_processing_latency_ms_sum",
                     timeseries=timeseries,
+                    wait=False,
                 )
             )
             == 3,
@@ -239,6 +240,7 @@ class TestRequestContextMetrics:
                 get_metric_dictionaries(
                     "ray_serve_deployment_processing_latency_ms_sum",
                     timeseries=timeseries,
+                    wait=False,
                 )
             )
             == 5,
@@ -365,8 +367,10 @@ class TestRequestContextMetrics:
         wait_for_condition(
             lambda: len(
                 get_metric_dictionaries(
-                    "ray_serve_deployment_request_counter_total", timeseries=timeseries
-                ),
+                    "ray_serve_deployment_request_counter_total",
+                    timeseries=timeseries,
+                    wait=False,
+                )
             )
             == 4,
             timeout=40,
@@ -416,7 +420,9 @@ class TestRequestContextMetrics:
         wait_for_condition(
             lambda: len(
                 get_metric_dictionaries(
-                    "ray_serve_deployment_request_counter_total", timeseries=timeseries
+                    "ray_serve_deployment_request_counter_total",
+                    timeseries=timeseries,
+                    wait=False,
                 )
             )
             == 2,
@@ -486,7 +492,9 @@ class TestRequestContextMetrics:
         deployment_name, replica_id = resp.json()
         wait_for_condition(
             lambda: len(
-                get_metric_dictionaries("ray_my_gauge", timeseries=timeseries),
+                get_metric_dictionaries(
+                    "ray_my_gauge", timeseries=timeseries, wait=False
+                ),
             )
             == 1,
             timeout=40,
@@ -631,7 +639,9 @@ class TestRequestContextMetrics:
         timeseries = PrometheusTimeseries()
         wait_for_condition(
             lambda: len(
-                get_metric_dictionaries("ray_my_gauge", timeseries=timeseries),
+                get_metric_dictionaries(
+                    "ray_my_gauge", timeseries=timeseries, wait=False
+                ),
             )
             == 1,
             timeout=40,
@@ -971,7 +981,7 @@ class TestProxyStateMetrics:
         # Wait for the proxy to become healthy and metric to be reported
         def check_proxy_status():
             metrics = get_metric_dictionaries(
-                "ray_serve_proxy_status", timeseries=timeseries
+                "ray_serve_proxy_status", timeseries=timeseries, wait=False
             )
             if not metrics:
                 return False
@@ -1027,7 +1037,9 @@ class TestProxyStateMetrics:
         # The histogram metric will have _sum and _count suffixes
         def check_shutdown_duration_metric_exists():
             metrics = get_metric_dictionaries(
-                "ray_serve_proxy_shutdown_duration_ms_sum", timeseries=timeseries
+                "ray_serve_proxy_shutdown_duration_ms_sum",
+                timeseries=timeseries,
+                wait=False,
             )
             if not metrics:
                 return False
@@ -1041,7 +1053,9 @@ class TestProxyStateMetrics:
 
         # Verify the metric has the expected tags
         metrics = get_metric_dictionaries(
-            "ray_serve_proxy_shutdown_duration_ms_sum", timeseries=timeseries
+            "ray_serve_proxy_shutdown_duration_ms_sum",
+            timeseries=timeseries,
+            wait=False,
         )
         assert len(metrics) == 1
         for metric in metrics:
@@ -1050,7 +1064,9 @@ class TestProxyStateMetrics:
 
         # Also verify _count metric exists
         count_metrics = get_metric_dictionaries(
-            "ray_serve_proxy_shutdown_duration_ms_count", timeseries=timeseries
+            "ray_serve_proxy_shutdown_duration_ms_count",
+            timeseries=timeseries,
+            wait=False,
         )
         assert len(count_metrics) == 1
 

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -70,14 +70,14 @@ def test_deployment_and_application_status_metrics(metrics_start_shutdown):
     def check_status_metrics():
         # Check deployment status metrics
         deployment_metrics = get_metric_dictionaries(
-            "ray_serve_deployment_status", timeseries=timeseries
+            "ray_serve_deployment_status", timeseries=timeseries, wait=False
         )
         if len(deployment_metrics) < 2:
             return False
 
         # Check application status metrics
         app_metrics = get_metric_dictionaries(
-            "ray_serve_application_status", timeseries=timeseries
+            "ray_serve_application_status", timeseries=timeseries, wait=False
         )
         if len(app_metrics) < 2:
             return False
@@ -183,7 +183,8 @@ def test_replica_startup_and_initialization_latency_metrics(metrics_start_shutdo
     # Assert that 2 metrics are recorded (one per replica)
     def check_metrics_count():
         metrics = get_metric_dictionaries(
-            "ray_serve_replica_initialization_latency_ms_count"
+            "ray_serve_replica_initialization_latency_ms_count",
+            wait=False,
         )
         assert len(metrics) == 2, f"Expected 2 metrics, got {len(metrics)}"
         # All metrics should have same deployment and application
@@ -593,6 +594,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
                 "ray_serve_autoscaling_handle_metrics_delay_ms",
                 timeout=5,
                 timeseries=timeseries,
+                wait=False,
             )
             for m in metrics_dicts:
                 if (
@@ -616,6 +618,7 @@ def test_autoscaling_metrics(metrics_start_shutdown):
                 "ray_serve_autoscaling_replica_metrics_delay_ms",
                 timeout=5,
                 timeseries=timeseries,
+                wait=False,
             )
             for m in metrics_dicts:
                 if (
@@ -705,6 +708,7 @@ def test_async_inference_task_queue_metrics_delay(
                 "ray_serve_autoscaling_async_inference_task_queue_metrics_delay_ms",
                 timeout=5,
                 timeseries=timeseries,
+                wait=False,
             )
             for m in metrics_dicts:
                 if (
@@ -786,6 +790,7 @@ def test_user_autoscaling_stats_metrics(metrics_start_shutdown):
                 "ray_serve_user_autoscaling_stats_latency_ms_sum",
                 timeout=5,
                 timeseries=timeseries,
+                wait=False,
             )
             for m in metrics_dicts:
                 if (
@@ -838,6 +843,7 @@ def test_user_autoscaling_stats_failure_metrics(metrics_start_shutdown):
             "ray_serve_record_autoscaling_stats_failed_total",
             timeout=5,
             timeseries=timeseries,
+            wait=False,
         )
         for m in metrics_dicts:
             if (
@@ -1102,6 +1108,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             "ray_serve_event_loop_monitoring_iterations_total",
             timeout=10,
             timeseries=timeseries,
+            wait=False,
         )
         for m in metrics:
             if m.get("component") == "proxy" and m.get("loop_type") == "main":
@@ -1119,6 +1126,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             "ray_serve_event_loop_monitoring_iterations_total",
             timeout=10,
             timeseries=timeseries,
+            wait=False,
         )
         for m in metrics:
             if m.get("component") == "proxy" and m.get("loop_type") == "router":
@@ -1139,6 +1147,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             "ray_serve_event_loop_monitoring_iterations_total",
             timeout=10,
             timeseries=timeseries,
+            wait=False,
         )
         for m in metrics:
             if m.get("component") == "replica" and m.get("loop_type") == "main":
@@ -1161,6 +1170,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             "ray_serve_event_loop_monitoring_iterations_total",
             timeout=10,
             timeseries=timeseries,
+            wait=False,
         )
         for m in metrics:
             if m.get("component") == "replica" and m.get("loop_type") == "user_code":
@@ -1186,6 +1196,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             "ray_serve_event_loop_monitoring_iterations_total",
             timeout=10,
             timeseries=timeseries,
+            wait=False,
         )
         for m in metrics:
             if m.get("component") == "replica" and m.get("loop_type") == "router":
@@ -1207,6 +1218,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             "ray_serve_event_loop_scheduling_latency_ms_count",
             timeout=10,
             timeseries=timeseries,
+            wait=False,
         )
         # Should have metrics for proxy main, replica main, replica user_code, router
         component_loop_pairs = set()
@@ -1236,6 +1248,7 @@ def test_event_loop_monitoring_metrics(metrics_start_shutdown):
             "ray_serve_event_loop_tasks",
             timeout=10,
             timeseries=timeseries,
+            wait=False,
         )
         # Should have metrics for proxy main, replica main, replica user_code, router
         component_loop_pairs = set()

--- a/python/ray/serve/tests/test_metrics_haproxy.py
+++ b/python/ray/serve/tests/test_metrics_haproxy.py
@@ -801,7 +801,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
 
     wait_for_condition(
         lambda: len(
-            get_metric_dictionaries("ray_serve_deployment_request_counter_total")
+            get_metric_dictionaries(
+                "ray_serve_deployment_request_counter_total", wait=False
+            )
         )
         == 2,
         timeout=40,
@@ -833,7 +835,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
     # Latency metrics
     wait_for_condition(
         lambda: len(
-            get_metric_dictionaries("ray_serve_deployment_processing_latency_ms_count")
+            get_metric_dictionaries(
+                "ray_serve_deployment_processing_latency_ms_count", wait=False
+            )
         )
         == 2,
         timeout=40,
@@ -852,7 +856,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
         } == expected_output
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("ray_serve_replica_processing_queries"))
+        lambda: len(
+            get_metric_dictionaries("ray_serve_replica_processing_queries", wait=False)
+        )
         == 2
     )
     processing_queries = get_metric_dictionaries("ray_serve_replica_processing_queries")
@@ -870,7 +876,11 @@ def test_replica_metrics_fields(metrics_start_shutdown):
     url_h = get_application_url("HTTP", "app3")
     assert 500 == httpx.get(url_h).status_code
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("ray_serve_deployment_error_counter_total"))
+        lambda: len(
+            get_metric_dictionaries(
+                "ray_serve_deployment_error_counter_total", wait=False
+            )
+        )
         == 1,
         timeout=40,
     )
@@ -884,7 +894,9 @@ def test_replica_metrics_fields(metrics_start_shutdown):
     ) == expected_output
 
     wait_for_condition(
-        lambda: len(get_metric_dictionaries("ray_serve_deployment_replica_healthy"))
+        lambda: len(
+            get_metric_dictionaries("ray_serve_deployment_replica_healthy", wait=False)
+        )
         == 3,
         timeout=40,
     )


### PR DESCRIPTION
`get_metric_dictionaries` internally calls `wait_for_condition` to block until a metric appears. When tests wrap this call inside their own `wait_for_condition` (the common pattern for checking metric values or counts), the two waits nest: the inner one times out and raises, preventing the outer loop from ever retrying. This caused intermittent failures in `test_metrics`, `test_metrics_2`, `test_metrics_3`, and `test_metrics_haproxy` depending on how quickly Prometheus scraped.

**What**

Added a `wait: bool = True` parameter to `get_metric_dictionaries`:

- `wait=True` (default): preserves existing behavior — blocks until the metric appears.
- `wait=False`: performs a single fetch and returns immediately (possibly empty), letting the caller's `wait_for_condition` drive the retry loop.

All call sites inside test `check_*` / `metrics_available` lambdas that are already wrapped in `wait_for_condition` are switched to `wait=False`.