### PR TITLE
[docs] using ray-project pandas mirror for doc builds

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -834,7 +834,10 @@ intersphinx_mapping = {
     "modin": ("https://modin.readthedocs.io/en/stable/", None),
     "nevergrad": ("https://facebookresearch.github.io/nevergrad/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "pandas": (
+        "https://pandas.pydata.org/pandas-docs/stable/",
+        "https://github.com/ray-project/pandas/releases/download/object-mirror-0.1.0/objects.inv",
+    ),
     "pyarrow": ("https://arrow.apache.org/docs", None),
     "pydantic": ("https://docs.pydantic.dev/latest/", None),
     "pymongoarrow": ("https://mongo-arrow.readthedocs.io/en/latest/", None),


### PR DESCRIPTION
creating object mirror for pandas for ray doc builds 

cloned pandas repo and added objects.inv as an artifact