### PR TITLE
[Serve] Fix autoscaling feedback loop that scales to max_replicas dur…

### DIFF
--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -25,6 +25,13 @@ def _apply_scaling_factors(
     The computation uses the difference between desired and current to scale.
 
     """
+    # When scaling from zero, the scaling factor is not meaningful: the
+    # entire desired count would be treated as the delta and amplified,
+    # creating a feedback loop that compounds every control-loop tick.
+    # Return the raw desired value and let bounds handle the rest.
+    if current_num_replicas == 0:
+        return math.ceil(desired_num_replicas)
+
     replicas_delta = desired_num_replicas - current_num_replicas
     scaling_factor = (
         autoscaling_config.get_upscaling_factor()

--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -2261,6 +2261,50 @@ def test_class_callable_autoscaling_policy(serve_instance, policy):
     ray.kill(signal)
 
 
+def test_warmup_no_runaway_scaling_with_control_loop(serve_instance):
+    """Deploy with upscaling_factor > 1 and no traffic.
+
+    After the deployment becomes healthy the replica count must stay at
+    min_replicas for several seconds — the control loop must not amplify
+    the target while replicas are warming up.
+    """
+
+    min_replicas = 2
+    max_replicas = 10
+
+    @serve.deployment(
+        autoscaling_config={
+            "min_replicas": min_replicas,
+            "max_replicas": max_replicas,
+            "target_ongoing_requests": 1,
+            "upscaling_factor": 2.0,
+            "metrics_interval_s": 0.1,
+            "look_back_period_s": 0.2,
+            "upscale_delay_s": 0,
+            "downscale_delay_s": 30,
+        },
+    )
+    class A:
+        def __call__(self):
+            return "ok"
+
+    serve.run(A.bind())
+
+    wait_for_condition(
+        check_deployment_status, name="A", expected_status=DeploymentStatus.HEALTHY
+    )
+
+    # Give the control loop time to run many iterations with no traffic.
+    for _ in range(10):
+        time.sleep(0.5)
+        num = get_num_alive_replicas("A")
+        assert num <= min_replicas, (
+            f"Expected at most {min_replicas} replicas with no traffic, "
+            f"but found {num}. The autoscaler may be runaway-scaling "
+            f"during warmup due to the upscaling_factor feedback loop bug."
+        )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1236,5 +1236,65 @@ class TestGangSchedulingAutoscalingPolicy:
         assert decision == 4
 
 
+class TestWarmupScalingFeedbackLoop:
+    """Regression tests for a feedback loop that causes deployments to scale
+    to max_replicas during warmup when upscaling_factor > 1.
+
+    When current_num_replicas == 0 (replicas scheduled but not yet RUNNING)
+    and there is no traffic, the policy should hold the target steady.
+    """
+
+    @pytest.mark.parametrize("upscaling_factor", [0.5, 1.0, 1.5, 2.0, 10.0])
+    def test_no_runaway_scaling_during_warmup(self, upscaling_factor):
+        min_replicas = 2
+        max_replicas = 10
+        config = AutoscalingConfig(
+            min_replicas=min_replicas,
+            max_replicas=max_replicas,
+            target_ongoing_requests=0.2,
+            upscaling_factor=upscaling_factor,
+            upscale_delay_s=5.0,
+            downscale_delay_s=30.0,
+        )
+
+        target = min_replicas
+        policy_state = {}
+
+        for tick in range(100):
+            ctx = AutoscalingContext(
+                config=config,
+                current_num_replicas=0,
+                target_num_replicas=target,
+                total_num_requests=0,
+                total_queued_requests=0,
+                capacity_adjusted_min_replicas=min_replicas,
+                capacity_adjusted_max_replicas=max_replicas,
+                policy_state=policy_state,
+                deployment_id=None,
+                deployment_name=None,
+                app_name=None,
+                running_replicas=[],
+                current_time=None,
+                aggregated_metrics=None,
+                raw_metrics=None,
+                last_scale_up_time=None,
+                last_scale_down_time=None,
+                total_pending_async_requests=0,
+            )
+
+            new_target, policy_state = wrapped_replica_queue_length_autoscaling_policy(
+                ctx=ctx
+            )
+            assert new_target == target, (
+                f"Tick {tick}: target changed from {target} to {new_target} "
+                f"with upscaling_factor={upscaling_factor}, "
+                f"current_num_replicas=0, total_num_requests=0. "
+                f"This indicates a feedback loop bug."
+            )
+            target = new_target
+
+        assert target == min_replicas
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
When a deployment starts up and replicas are scheduled but not yet RUNNING (`current_num_replicas=0`), the autoscaling policy runs with `total_num_requests=0`. The cold start fast path returns `None` (no traffic), so the core policy returns `target_num_replicas` and it flows into `_apply_scaling_factors`.

The scaling formula is: `ceil(current + factor * (desired - current))`

When `current=0`, this becomes `ceil(factor * desired)`, which amplifies the entire target as if it were growth. Combined with the delay bypass for `current==0`, this compounds every tick:

| Tick | target\_in | formula | target\_out |
|------|-----------|---------|------------|
| 0 | 2 | `ceil(2.0 × 2)` | **4** |
| 1 | 4 | `ceil(2.0 × 4)` | **8** |
| 2 | 8 | `ceil(2.0 × 8) → 16, clamped` | **10 (max)** |

In 3 ticks, with zero traffic, a `min_replicas=2, max_replicas=10, upscaling_factor=2.0` deployment scales to `max_replicas`.

This was introduced in #60851 which removed the cold start fallback (`return ctx.target_num_replicas` when `current==0` and no traffic) so that custom policies like `AsyncInferenceAutoscalingPolicy` could detect queue work. That change was correct for custom policies but exposed the default policy to the amplification loop.

## Fix

Skip scaling factor amplification when `current_num_replicas == 0` in `_apply_scaling_factors`. Scaling factors control the *rate of change from a baseline* — when there is no baseline, amplifying the full target as delta is incorrect. The cold start fast path already handles the `current==0` with-traffic case separately (applying `upscaling_factor` once), so this is consistent.

This preserves the async inference scale-from-zero behavior: custom policies still run, return their desired value (e.g. `1` for queue work, `0` for idle), and the delay bypass lets legitimate scale-ups through immediately.
