### PR TITLE
[core][autoscaler] suppress autoscaler action logs when using a read-only provider

### DIFF
--- a/python/ray/autoscaler/v2/event_logger.py
+++ b/python/ray/autoscaler/v2/event_logger.py
@@ -24,8 +24,9 @@ class AutoscalerEventLogger:
     - Rate limit the events if too spammy.
     """
 
-    def __init__(self, logger: EventLoggerAdapter):
+    def __init__(self, logger: EventLoggerAdapter, log_cluster_shape: bool = True):
         self._logger = logger
+        self._log_cluster_shape = log_cluster_shape
 
     def log_cluster_scheduling_update(
         self,
@@ -65,7 +66,7 @@ class AutoscalerEventLogger:
         """
 
         # Log any launch events.
-        if launch_requests:
+        if self._log_cluster_shape and launch_requests:
             launch_type_count = defaultdict(int)
             for req in launch_requests:
                 launch_type_count[req.instance_type] += req.count
@@ -76,7 +77,7 @@ class AutoscalerEventLogger:
                 logger.info(f"{log_str}")
 
         # Log any terminate events.
-        if terminate_requests:
+        if self._log_cluster_shape and terminate_requests:
             termination_by_causes_and_type = defaultdict(int)
             for req in terminate_requests:
                 termination_by_causes_and_type[(req.cause, req.instance_type)] += 1
@@ -96,7 +97,7 @@ class AutoscalerEventLogger:
                 logger.info(f"{log_str}")
 
         # Cluster shape changes.
-        if launch_requests or terminate_requests:
+        if self._log_cluster_shape and (launch_requests or terminate_requests):
             num_cpus = cluster_resources.get("CPU", 0)
             log_str = f"Resized to {int(num_cpus)} CPUs"
 

--- a/python/ray/autoscaler/v2/monitor.py
+++ b/python/ray/autoscaler/v2/monitor.py
@@ -34,6 +34,7 @@ from ray.autoscaler.v2.event_logger import AutoscalerEventLogger
 from ray.autoscaler.v2.instance_manager.config import (
     FileConfigReader,
     IConfigReader,
+    Provider,
     ReadOnlyProviderConfigReader,
 )
 from ray.autoscaler.v2.metrics_reporter import AutoscalerMetricsReporter
@@ -95,7 +96,11 @@ class AutoscalerMonitor:
                 ray_event_logger = get_event_logger(
                     RayEvent.SourceType.AUTOSCALER, log_dir
                 )
-                self.event_logger = AutoscalerEventLogger(ray_event_logger)
+                self.event_logger = AutoscalerEventLogger(
+                    ray_event_logger,
+                    log_cluster_shape=config_reader.get_cached_autoscaling_config().provider
+                    != Provider.READ_ONLY,
+                )
             except Exception:
                 self.event_logger = None
         else:

--- a/python/ray/autoscaler/v2/tests/test_event_logger.py
+++ b/python/ray/autoscaler/v2/tests/test_event_logger.py
@@ -106,6 +106,24 @@ def test_log_scheduling_updates():
     ]
 
 
+def test_log_scheduling_updates_without_cluster_shape():
+    mock_logger = MockEventLogger(logger)
+    event_logger = AutoscalerEventLogger(mock_logger, log_cluster_shape=False)
+
+    event_logger.log_cluster_scheduling_update(
+        launch_requests=[launch_request("m4.large", 1)],
+        terminate_requests=[termination_request("m4.xlarge", OUTDATED)],
+        infeasible_requests=[ResourceRequestUtil.make({"CPU": 4})],
+        cluster_resources={"CPU": 5},
+    )
+
+    assert mock_logger.get_logs("info") == []
+    assert mock_logger.get_logs("warning") == [
+        "No available node types can fulfill resource requests {'CPU': 4.0}*1. Add suitable node types to this cluster to resolve this issue."
+    ]
+    assert mock_logger.get_logs("debug") == []
+
+
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):
         sys.exit(pytest.main(["-n", "auto", "--boxed", "-vs", __file__]))


### PR DESCRIPTION
## Description

On a static Ray cluster, the autoscaler works with a read-only cloud provider, so that it can still keep reconciling to print out warnings for infeasible requests, but not do the actual scaling. However, it still emits other logs that are misleading for a static cluster.

For example, we will see these annoying logs on a static Ray cluster:
<img width="876" height="366" alt="image" src="https://github.com/user-attachments/assets/42dd8027-1a1b-4cd0-834d-ba928b157ad8" />

This PR makes the event logger only emit warnings for infeasible requests, but suppresses autoscaler action logs if the cloud provider is read-only.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
