### PR TITLE
[serve][llm] add SGLang tokenize and detokenize endpoints

### DIFF
--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -15,6 +15,10 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionResponse,
     CompletionRequest,
     CompletionResponse,
+    DetokenizeRequest,
+    DetokenizeResponse,
+    TokenizeRequest,
+    TokenizeResponse,
 )
 
 
@@ -78,6 +82,29 @@ class SGLangServer:
             self.engine = sglang.Engine(**self.engine_kwargs)
         finally:
             signal.signal = original_signal_func
+
+    def _get_tokenizer(self) -> Any:
+        tokenizer = getattr(self.engine, "tokenizer", None)
+        if tokenizer is None and hasattr(self.engine, "get_tokenizer"):
+            tokenizer = self.engine.get_tokenizer()
+        if tokenizer is None:
+            tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+            tokenizer = getattr(tokenizer_manager, "tokenizer", None)
+        if tokenizer is None:
+            raise RuntimeError("Failed to resolve tokenizer from SGLang engine.")
+        return tokenizer
+
+    def _get_max_model_len(self, tokenizer: Any) -> int:
+        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+        max_model_len = getattr(tokenizer_manager, "max_req_input_len", None)
+        if isinstance(max_model_len, int) and max_model_len > 0:
+            return max_model_len
+
+        model_max_length = getattr(tokenizer, "model_max_length", None)
+        if isinstance(model_max_length, int) and model_max_length > 0:
+            return model_max_length
+
+        return 0
 
     async def _generate_and_extract_metadata(
         self, request: Any, prompt_string: str
@@ -231,6 +258,83 @@ class SGLangServer:
         )
 
         yield resp
+
+    async def tokenize(
+        self, request: TokenizeRequest, raw_request: Optional[Any] = None
+    ) -> AsyncGenerator[TokenizeResponse, None]:
+        tokenizer = self._get_tokenizer()
+
+        prompt = getattr(request, "prompt", None)
+        if prompt is None:
+            messages = getattr(request, "messages", None)
+            if messages is not None:
+                prompt = format_messages_to_prompt(messages)
+        if prompt is None:
+            raise ValueError(
+                "Tokenize request must include either 'prompt' or 'messages'."
+            )
+
+        encode_kwargs = {}
+        add_special_tokens = getattr(request, "add_special_tokens", None)
+        if add_special_tokens is not None:
+            encode_kwargs["add_special_tokens"] = bool(add_special_tokens)
+
+        if isinstance(prompt, list):
+            tokens = [
+                [int(token) for token in tokenizer.encode(text, **encode_kwargs)]
+                for text in prompt
+            ]
+            count: Any = [len(token_ids) for token_ids in tokens]
+            token_strs: Optional[Any] = None
+            if getattr(request, "return_token_strs", False):
+                if hasattr(tokenizer, "convert_ids_to_tokens"):
+                    token_strs = [
+                        tokenizer.convert_ids_to_tokens(token_ids)
+                        for token_ids in tokens
+                    ]
+                else:
+                    token_strs = [
+                        [tokenizer.decode([token]) for token in token_ids]
+                        for token_ids in tokens
+                    ]
+        else:
+            tokens = [
+                int(token) for token in tokenizer.encode(prompt, **encode_kwargs)
+            ]
+            count = len(tokens)
+            token_strs = None
+            if getattr(request, "return_token_strs", False):
+                if hasattr(tokenizer, "convert_ids_to_tokens"):
+                    token_strs = tokenizer.convert_ids_to_tokens(tokens)
+                else:
+                    token_strs = [tokenizer.decode([token]) for token in tokens]
+
+        yield TokenizeResponse(
+            count=count,
+            max_model_len=self._get_max_model_len(tokenizer),
+            tokens=tokens,
+            token_strs=token_strs,
+        )
+
+    async def detokenize(
+        self, request: DetokenizeRequest, raw_request: Optional[Any] = None
+    ) -> AsyncGenerator[DetokenizeResponse, None]:
+        tokenizer = self._get_tokenizer()
+
+        decode_kwargs = {}
+        skip_special_tokens = getattr(request, "skip_special_tokens", None)
+        if skip_special_tokens is not None:
+            decode_kwargs["skip_special_tokens"] = bool(skip_special_tokens)
+
+        tokens = request.tokens
+        if tokens and isinstance(tokens[0], list):
+            prompt: Any = [
+                tokenizer.decode(token_ids, **decode_kwargs) for token_ids in tokens
+            ]
+        else:
+            prompt = tokenizer.decode(tokens, **decode_kwargs)
+
+        yield DetokenizeResponse(prompt=prompt)
 
     async def llm_config(self) -> Optional[LLMConfig]:
         return self._llm_config

--- a/python/ray/llm/examples/sglang/readme.md
+++ b/python/ray/llm/examples/sglang/readme.md
@@ -17,13 +17,13 @@ This document provides a guide for deploying and interacting with the custom **S
 What is NOT supported in this implementation:
 
 - Support for engine replicas
-- SGLangServer implemented chat and completions methods but no embeddings, transcriptions, and score methods
+- SGLangServer implements chat, completions, tokenize, and detokenize methods but no embeddings, transcriptions, and score methods
 - Support for TP/PP/DP
 
 ## Core Components
 
 Your custom deployment consists of two main components:
-1. `SGLangServer` (**Backend**): The core Ray Serve deployment that initializes the SGLang runtime and model. This deployment contains the model's business logic, including resource requirements and generation methods (`completions` and `chat_completions`).
+1. `SGLangServer` (**Backend**): The core Ray Serve deployment that initializes the SGLang runtime and model. This deployment contains the model's business logic, including resource requirements and generation methods (`chat`, `completions`, `tokenize`, and `detokenize`).
 2. enable ENV-VAR: `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0` on CUDA device or `RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=0` on ROCm device
 ### Deploy an LLM model using SGLang Engine
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_server.py
@@ -1,0 +1,92 @@
+from types import SimpleNamespace
+
+import pytest
+
+from ray.llm._internal.serve.core.configs.openai_api_models import (
+    DetokenizeRequest,
+    TokenizeChatRequest,
+    TokenizeCompletionRequest,
+)
+from ray.llm.examples.sglang.modules.sglang_engine import (
+    SGLangServer,
+    format_messages_to_prompt,
+)
+from ray.llm.tests.serve.utils.testing_utils import LLMResponseValidator
+
+
+class _StubTokenizer:
+    model_max_length = 8192
+
+    def encode(self, text, add_special_tokens=True):
+        return [ord(ch) for ch in text]
+
+    def decode(self, tokens, skip_special_tokens=True):
+        return "".join(chr(token) for token in tokens)
+
+    def convert_ids_to_tokens(self, tokens):
+        return [chr(token) for token in tokens]
+
+
+class _StubEngine:
+    def __init__(self, tokenizer):
+        self.tokenizer_manager = SimpleNamespace(
+            tokenizer=tokenizer,
+            max_req_input_len=4096,
+        )
+
+
+def _make_server(engine):
+    server = object.__new__(SGLangServer)
+    server.engine = engine
+    server._llm_config = None
+    return server
+
+
+class TestSGLangServerTokenization:
+    @pytest.mark.asyncio
+    async def test_tokenize_completion_request(self):
+        server = _make_server(_StubEngine(_StubTokenizer()))
+        request = TokenizeCompletionRequest(
+            model="test-model",
+            prompt="Hello, world!",
+            add_special_tokens=False,
+            return_token_strs=True,
+        )
+
+        async for response in server.tokenize(request):
+            LLMResponseValidator.validate_tokenize_response(
+                response,
+                expected_prompt="Hello, world!",
+                return_token_strs=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_tokenize_chat_request_uses_chat_prompt_format(self):
+        tokenizer = _StubTokenizer()
+        server = _make_server(SimpleNamespace(get_tokenizer=lambda: tokenizer))
+        request = TokenizeChatRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Hello"}],
+            add_special_tokens=False,
+            return_token_strs=False,
+        )
+        expected_prompt = format_messages_to_prompt(request.messages)
+
+        async for response in server.tokenize(request):
+            assert response.tokens == [ord(ch) for ch in expected_prompt]
+            assert response.count == len(expected_prompt)
+            assert response.max_model_len == tokenizer.model_max_length
+
+    @pytest.mark.asyncio
+    async def test_detokenize_request(self):
+        server = _make_server(_StubEngine(_StubTokenizer()))
+        request = DetokenizeRequest(
+            model="test-model",
+            tokens=[72, 101, 108, 108, 111],
+        )
+
+        async for response in server.detokenize(request):
+            LLMResponseValidator.validate_detokenize_response(
+                response,
+                expected_text="Hello",
+            )


### PR DESCRIPTION
## Summary
- add tokenizer-backed `tokenize()` and `detokenize()` to the SGLang example server
- support prompt-based tokenization plus chat-request fallback via the existing prompt formatter
- document the newly supported endpoints and add focused unit coverage for tokenization behavior

## Testing
- `python3 -m py_compile python/ray/llm/examples/sglang/modules/sglang_engine.py python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_server.py`
- `python3 -m pytest python/ray/llm/tests/serve/cpu/deployments/llm/test_sglang_server.py -q` *(not runnable in this workspace: `pytest` is not installed)*

Related to #61113.