### PR TITLE
fix: allow zero env/agent steps in custom eval functions

### DIFF
--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1583,7 +1583,7 @@ class Algorithm(Checkpointable, Trainable):
                 env_steps,
                 agent_steps,
             ) = self.config.custom_evaluation_function(self, self.eval_env_runner_group)
-            if not env_steps or not agent_steps:
+            if not isinstance(env_steps, int) or not isinstance(agent_steps, int):
                 raise ValueError(
                     "Custom eval function must return "
                     "`Tuple[ResultDict, int, int]` with `int, int` being "


### PR DESCRIPTION
## Why are these changes needed?

Custom evaluation functions that legitimately return zero for `env_steps` and `agent_steps` (e.g., when no checkpoints exist yet to evaluate against) currently trigger a `ValueError` at line 1633 of `algorithm.py`.

The root cause is that the check uses Python truthiness (`not env_steps or not agent_steps`), which treats `0` as falsy. This rejects valid zero values even though the return type is correct (`Tuple[ResultDict, int, int]`).

## What changes were made?

Replace the truthiness check with an `isinstance` type check:

```python
# Before (rejects 0):
if not env_steps or not agent_steps:

# After (allows 0, rejects non-int):
if not isinstance(env_steps, int) or not isinstance(agent_steps, int):
```

This validates that the return values are integers (as the error message and type hint expect) while allowing zero as a valid value.

Fixes #61513

## Related issue number

#61513

## Checks

- [x] I've signed the [CLA](http://ray.io/cla)
- [x] This change targets the `master` branch