### PR TITLE
[RLlib] Fix KeyError on agent_id in UnBatchToIndividualItems

### DIFF
--- a/rllib/connectors/module_to_env/unbatch_to_individual_items.py
+++ b/rllib/connectors/module_to_env/unbatch_to_individual_items.py
@@ -97,9 +97,17 @@ class UnBatchToIndividualItems(ConnectorV2):
                         # If an episode has not just started and the agent's episode
                         # is done do not return data.
                         # This should not be `True` for new `MultiAgentEpisode`s.
+                        # Use .get() to safely handle agent IDs that may have been
+                        # removed from the multi-agent environment (e.g. when
+                        # agents leave mid-episode).
+                        agent_episode = (
+                            episode.agent_episodes.get(agent_id)
+                            if episode.agent_episodes
+                            else None
+                        )
                         if (
-                            episode.agent_episodes
-                            and episode.agent_episodes[agent_id].is_done
+                            agent_episode is not None
+                            and agent_episode.is_done
                             and not episode.is_done
                         ):
                             continue


### PR DESCRIPTION
## Why are these changes needed?

Fixes #61602.

When training a multi-agent environment where agents can be added/removed dynamically, `UnBatchToIndividualItems.__call__()` crashes with `KeyError` on `agent_id` at:

```python
episode.agent_episodes[agent_id].is_done
```

This happens because after an agent is removed from the environment, its `agent_id` no longer exists in `episode.agent_episodes`, but the `memorized_map_structure` still references it from the previous step.

## What changes were made?

Changed the direct dict access `episode.agent_episodes[agent_id]` to use `.get(agent_id)` which returns `None` for missing agents instead of raising `KeyError`. When the agent episode is `None` (agent no longer present), the check is safely skipped and data flows through normally.

**Before:**
```python
if (
    episode.agent_episodes
    and episode.agent_episodes[agent_id].is_done  # KeyError!
    and not episode.is_done
):
```

**After:**
```python
agent_episode = (
    episode.agent_episodes.get(agent_id)
    if episode.agent_episodes
    else None
)
if (
    agent_episode is not None
    and agent_episode.is_done
    and not episode.is_done
):
```

## Related issue number

Fixes #61602

## Checks

- [x] I've signed the [CLA](http://ray.io/cla)