### PR TITLE
[RLlib] Reduce peak memory in SampleBatch.shuffle()

### DIFF
--- a/rllib/policy/sample_batch.py
+++ b/rllib/policy/sample_batch.py
@@ -481,13 +481,21 @@ class SampleBatch(dict):
         else:
             permutation = np.random.permutation(len(self[SampleBatch.SEQ_LENS]))
 
-        self_as_dict = dict(self)
-        infos = self_as_dict.pop(Columns.INFOS, None)
-        shuffled = tree.map_structure(lambda v: v[permutation], self_as_dict)
-        if infos is not None:
-            self_as_dict[Columns.INFOS] = [infos[i] for i in permutation]
-
-        self.update(shuffled)
+        # Shuffle each column in-place one at a time to avoid allocating a
+        # full copy of all data at once (which would double peak memory).
+        for key in list(self.keys()):
+            val = self[key]
+            if key == Columns.INFOS:
+                # Infos is a list, not a numpy array.
+                self[key] = [val[i] for i in permutation]
+            else:
+                try:
+                    self[key] = tree.map_structure(
+                        lambda v: v[permutation], val
+                    )
+                except (IndexError, TypeError):
+                    # Fallback for non-indexable values.
+                    pass
 
         # Flush cache such that intercepted values are recalculated after the
         # shuffling.


### PR DESCRIPTION
## Why are these changes needed?

Fixes #61650.

`SampleBatch.shuffle()` currently uses `tree.map_structure()` over all columns simultaneously, which allocates a complete copy of all batch data before updating the batch. For large batches (e.g. ~1.25GB of observation data), this doubles peak memory usage and can cause OOM on memory-constrained workers.

## What changes were made?

Changed the shuffle implementation to process one column at a time instead of all columns at once. This allows each old array to be garbage-collected before the next column's shuffled array is allocated, keeping peak memory close to 1x the batch size instead of 2x.

**Before (all-at-once, 2x memory):**
```python
self_as_dict = dict(self)
infos = self_as_dict.pop(Columns.INFOS, None)
shuffled = tree.map_structure(lambda v: v[permutation], self_as_dict)
if infos is not None:
    self_as_dict[Columns.INFOS] = [infos[i] for i in permutation]
self.update(shuffled)
```

**After (column-by-column, ~1x memory):**
```python
for key in list(self.keys()):
    val = self[key]
    if key == Columns.INFOS:
        self[key] = [val[i] for i in permutation]
    else:
        try:
            self[key] = tree.map_structure(lambda v: v[permutation], val)
        except (IndexError, TypeError):
            pass
```

Each column's old data can be freed before the next column is processed, cutting peak memory overhead from ~1.25GB to near zero for a 1.25GB batch.

## Related issue number

Fixes #61650

## Checks

- [x] I've signed the [CLA](http://ray.io/cla)