### PR TITLE
[core] Handle CppFunctionDescriptor without function_id in FunctionActorManager

### DIFF
--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -131,13 +131,32 @@ class FunctionActorManager:
         # This is to protect self._num_exported when doing exporting
         self._export_lock = threading.Lock()
 
+    @staticmethod
+    def _cross_language_descriptor_key(function_descriptor):
+        function_name = getattr(function_descriptor, "function_name", None)
+        if function_name is None:
+            return None
+        class_name = getattr(function_descriptor, "class_name", "")
+        return (class_name, function_name)
+
+    @staticmethod
+    def _descriptor_cache_key(function_descriptor):
+        function_id = getattr(function_descriptor, "function_id", None)
+        if function_id is not None:
+            return function_id
+        return FunctionActorManager._cross_language_descriptor_key(function_descriptor)
+
     def increase_task_counter(self, function_descriptor):
-        function_id = function_descriptor.function_id
-        self._num_task_executions[function_id] += 1
+        key = self._descriptor_cache_key(function_descriptor)
+        if key is None:
+            return
+        self._num_task_executions[key] += 1
 
     def get_task_counter(self, function_descriptor):
-        function_id = function_descriptor.function_id
-        return self._num_task_executions[function_id]
+        key = self._descriptor_cache_key(function_descriptor)
+        if key is None:
+            return 0
+        return self._num_task_executions[key]
 
     def compute_collision_identifier(self, function_or_class):
         """The identifier is used to detect excessive duplicate exports.
@@ -356,11 +375,16 @@ class FunctionActorManager:
         Returns:
             A FunctionExecutionInfo object.
         """
-        function_id = function_descriptor.function_id
+        key = self._descriptor_cache_key(function_descriptor)
+        if key is None:
+            raise KeyError(
+                "Error occurs in get_execution_info: unsupported function descriptor "
+                f"{function_descriptor}."
+            )
         # If the function has already been loaded,
         # There's no need to load again
-        if function_id in self._function_execution_info:
-            return self._function_execution_info[function_id]
+        if key in self._function_execution_info:
+            return self._function_execution_info[key]
         if self._worker.load_code_from_local:
             # Load function from local code.
             if not function_descriptor.is_actor_method():
@@ -368,7 +392,7 @@ class FunctionActorManager:
                 # try to load it from GCS,
                 # even if load_code_from_local is set True
                 if self._load_function_from_local(function_descriptor) is True:
-                    return self._function_execution_info[function_id]
+                    return self._function_execution_info[key]
         # Load function from GCS.
         # Wait until the function to be executed has actually been
         # registered on this worker. We will push warnings to the user if
@@ -378,8 +402,7 @@ class FunctionActorManager:
         with profiling.profile("wait_for_function"):
             self._wait_for_function(function_descriptor, job_id)
         try:
-            function_id = function_descriptor.function_id
-            info = self._function_execution_info[function_id]
+            info = self._function_execution_info[key]
         except KeyError as e:
             message = (
                 "Error occurs in get_execution_info: "
@@ -391,7 +414,9 @@ class FunctionActorManager:
 
     def _load_function_from_local(self, function_descriptor):
         assert not function_descriptor.is_actor_method()
-        function_id = function_descriptor.function_id
+        function_id = getattr(function_descriptor, "function_id", None)
+        if function_id is None:
+            return False
 
         module_name, function_name = (
             function_descriptor.module_name,
@@ -435,13 +460,20 @@ class FunctionActorManager:
         while True:
             with self.lock:
                 if self._worker.actor_id.is_nil():
-                    if function_descriptor.function_id in self._function_execution_info:
+                    function_id = getattr(function_descriptor, "function_id", None)
+                    if function_id is None:
+                        raise RuntimeError(
+                            "Received a function descriptor without function_id "
+                            "on a non-actor worker: "
+                            f"{function_descriptor}."
+                        )
+                    if function_id in self._function_execution_info:
                         break
                     else:
                         key = make_function_table_key(
                             b"RemoteFunction",
                             job_id,
-                            function_descriptor.function_id.binary(),
+                            function_id.binary(),
                         )
                         if self.fetch_and_register_remote_function(key) is True:
                             break
@@ -595,6 +627,7 @@ class FunctionActorManager:
                         module_name, actor_method_name, actor_class_name
                     )
                 method_id = method_descriptor.function_id
+                method_cross_lang_key = (actor_class_name, actor_method_name)
                 executor = self._make_actor_method_executor(
                     actor_method_name, actor_method
                 )
@@ -603,7 +636,11 @@ class FunctionActorManager:
                     function_name=actor_method_name,
                     max_calls=0,
                 )
+                self._function_execution_info[method_cross_lang_key] = (
+                    self._function_execution_info[method_id]
+                )
                 self._num_task_executions[method_id] = 0
+                self._num_task_executions[method_cross_lang_key] = 0
             self._num_task_executions[function_id] = 0
         return actor_class
 

--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -125,6 +125,10 @@ class FunctionActorManager:
         self.lock = threading.RLock()
 
         self.execution_infos = {}
+        # Maps (class_name, function_name) keys to canonical function_id.
+        # This allows cross-language descriptors without function_id to reuse
+        # the same execution and task-counter buckets.
+        self._cross_lang_key_to_id = {}
         # This is the counter to keep track of how many keys have already
         # been exported so that we can find next key quicker.
         self._num_exported = 0
@@ -139,12 +143,14 @@ class FunctionActorManager:
         class_name = getattr(function_descriptor, "class_name", "")
         return (class_name, function_name)
 
-    @staticmethod
-    def _descriptor_cache_key(function_descriptor):
+    def _descriptor_cache_key(self, function_descriptor):
         function_id = getattr(function_descriptor, "function_id", None)
         if function_id is not None:
             return function_id
-        return FunctionActorManager._cross_language_descriptor_key(function_descriptor)
+        cross_lang_key = FunctionActorManager._cross_language_descriptor_key(
+            function_descriptor
+        )
+        return self._cross_lang_key_to_id.get(cross_lang_key, cross_lang_key)
 
     def increase_task_counter(self, function_descriptor):
         key = self._descriptor_cache_key(function_descriptor)
@@ -628,6 +634,7 @@ class FunctionActorManager:
                     )
                 method_id = method_descriptor.function_id
                 method_cross_lang_key = (actor_class_name, actor_method_name)
+                self._cross_lang_key_to_id[method_cross_lang_key] = method_id
                 executor = self._make_actor_method_executor(
                     actor_method_name, actor_method
                 )
@@ -640,7 +647,6 @@ class FunctionActorManager:
                     self._function_execution_info[method_id]
                 )
                 self._num_task_executions[method_id] = 0
-                self._num_task_executions[method_cross_lang_key] = 0
             self._num_task_executions[function_id] = 0
         return actor_class
 

--- a/python/ray/_private/function_manager.py
+++ b/python/ray/_private/function_manager.py
@@ -393,7 +393,8 @@ class FunctionActorManager:
             return self._function_execution_info[key]
         if self._worker.load_code_from_local:
             # Load function from local code.
-            if not function_descriptor.is_actor_method():
+            is_actor_method = getattr(function_descriptor, "is_actor_method", None)
+            if is_actor_method is not None and not is_actor_method():
                 # If the function is not able to be loaded,
                 # try to load it from GCS,
                 # even if load_code_from_local is set True

--- a/python/ray/tests/test_function_manager.py
+++ b/python/ray/tests/test_function_manager.py
@@ -1,0 +1,57 @@
+import sys
+
+import pytest
+
+from ray._private.function_manager import FunctionActorManager, FunctionExecutionInfo
+from ray._raylet import CppFunctionDescriptor
+
+
+class _DummyActorID:
+    def __init__(self, is_nil: bool):
+        self._is_nil = is_nil
+
+    def is_nil(self):
+        return self._is_nil
+
+
+class _DummyWorker:
+    def __init__(self, is_actor_worker: bool):
+        self.actor_id = _DummyActorID(is_nil=not is_actor_worker)
+        self.actors = {self.actor_id: object()} if is_actor_worker else {}
+        self.load_code_from_local = False
+        self.node_ip_address = "127.0.0.1"
+        self.worker_id = b"0" * 28
+
+
+def test_get_execution_info_cpp_actor_descriptor_uses_cross_language_key():
+    worker = _DummyWorker(is_actor_worker=True)
+    manager = FunctionActorManager(worker)
+
+    descriptor = CppFunctionDescriptor("foo", "PYTHON", "Bar")
+    expected = FunctionExecutionInfo(
+        function=lambda *_args, **_kwargs: None,
+        function_name="foo",
+        max_calls=0,
+    )
+
+    manager._function_execution_info[("Bar", "foo")] = expected
+
+    info = manager.get_execution_info(job_id="job-id", function_descriptor=descriptor)
+
+    assert info is expected
+
+
+def test_get_execution_info_cpp_non_actor_descriptor_raises_runtime_error():
+    worker = _DummyWorker(is_actor_worker=False)
+    manager = FunctionActorManager(worker)
+
+    descriptor = CppFunctionDescriptor("foo", "PYTHON", "Bar")
+
+    with pytest.raises(
+        RuntimeError, match="without function_id on a non-actor worker"
+    ):
+        manager.get_execution_info(job_id="job-id", function_descriptor=descriptor)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_function_manager.py
+++ b/python/ray/tests/test_function_manager.py
@@ -23,6 +23,11 @@ class _DummyWorker:
         self.worker_id = b"0" * 28
 
 
+class _DummyPythonDescriptor:
+    def __init__(self, function_id):
+        self.function_id = function_id
+
+
 def test_get_execution_info_cpp_actor_descriptor_uses_cross_language_key():
     worker = _DummyWorker(is_actor_worker=True)
     manager = FunctionActorManager(worker)
@@ -51,6 +56,24 @@ def test_get_execution_info_cpp_non_actor_descriptor_raises_runtime_error():
         RuntimeError, match="without function_id on a non-actor worker"
     ):
         manager.get_execution_info(job_id="job-id", function_descriptor=descriptor)
+
+
+def test_cross_language_and_python_descriptor_share_task_counter_bucket():
+    worker = _DummyWorker(is_actor_worker=True)
+    manager = FunctionActorManager(worker)
+
+    cpp_descriptor = CppFunctionDescriptor("foo", "PYTHON", "Bar")
+    function_id = object()
+    python_descriptor = _DummyPythonDescriptor(function_id=function_id)
+
+    manager._cross_lang_key_to_id[("Bar", "foo")] = function_id
+    manager._num_task_executions[function_id] = 0
+
+    manager.increase_task_counter(python_descriptor)
+    manager.increase_task_counter(cpp_descriptor)
+
+    assert manager.get_task_counter(python_descriptor) == 2
+    assert manager.get_task_counter(cpp_descriptor) == 2
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_function_manager.py
+++ b/python/ray/tests/test_function_manager.py
@@ -58,6 +58,19 @@ def test_get_execution_info_cpp_non_actor_descriptor_raises_runtime_error():
         manager.get_execution_info(job_id="job-id", function_descriptor=descriptor)
 
 
+def test_get_execution_info_cpp_non_actor_with_local_code_raises_runtime_error():
+    worker = _DummyWorker(is_actor_worker=False)
+    worker.load_code_from_local = True
+    manager = FunctionActorManager(worker)
+
+    descriptor = CppFunctionDescriptor("foo", "PYTHON", "Bar")
+
+    with pytest.raises(
+        RuntimeError, match="without function_id on a non-actor worker"
+    ):
+        manager.get_execution_info(job_id="job-id", function_descriptor=descriptor)
+
+
 def test_cross_language_and_python_descriptor_share_task_counter_bucket():
     worker = _DummyWorker(is_actor_worker=True)
     manager = FunctionActorManager(worker)


### PR DESCRIPTION
## Summary
This PR fixes a crash path in `FunctionActorManager.get_execution_info` when the descriptor is `CppFunctionDescriptor` (which may not expose `function_id`).

## What changed
- Added descriptor key helpers that fall back from `function_id` to `(class_name, function_name)` for descriptors without `function_id`.
- Updated execution-info and task-counter lookups to use the fallback key.
- Added an explicit `RuntimeError` in the non-actor wait path when a descriptor without `function_id` is received, instead of raising `AttributeError`.
- Added cross-language actor-method aliases so actor methods are discoverable by `(class_name, method_name)` keys.

## Tests
Added `python/ray/tests/test_function_manager.py` with coverage for:
- actor worker lookup with `CppFunctionDescriptor` via cross-language key
- non-actor worker error path raising the new explicit `RuntimeError`

## Issue
Fixes #59381