### PR TITLE
[Data] warn on non-templatized custom parquet filenames

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -9,7 +9,7 @@ from ray.data._internal.savemode import SaveMode
 from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import _resolve_kwargs
 from ray.data.datasource.file_datasink import _FileDatasink
-from ray.data.datasource.filename_provider import FilenameProvider
+from ray.data.datasource.filename_provider import FilenameProvider, _DefaultFilenameProvider
 
 if TYPE_CHECKING:
     import pyarrow
@@ -171,6 +171,7 @@ class ParquetDatasink(_FileDatasink):
             file_format=FILE_FORMAT,
             mode=mode,
         )
+        self._warned_custom_filename_not_templated = False
 
     def write(
         self,
@@ -249,8 +250,16 @@ class ParquetDatasink(_FileDatasink):
             # No extension and not templatized, add extension and template
             basename_template = f"{filename}-{{i}}.{FILE_FORMAT}"
         else:
-            # TODO(@goutamvenkat-anyscale): Add a warning if you pass in a custom
-            # filename provider and it isn't templatized.
+            if (
+                not self._warned_custom_filename_not_templated
+                and not isinstance(self.filename_provider, _DefaultFilenameProvider)
+            ):
+                logger.warning(
+                    "Custom FilenameProvider returned non-templatized filename '%s'. "
+                    "Ray Data will append '-{i}' to avoid file overwrite conflicts.",
+                    filename,
+                )
+                self._warned_custom_filename_not_templated = True
             # Use pathlib.Path to properly handle filenames with dots
             filename_path = Path(filename)
             stem = filename_path.stem  # filename without extension

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pathlib
 import shutil
@@ -819,24 +820,24 @@ def test_parquet_write_append_save_mode(ray_start_regular_shared, local_path):
 
 
 @pytest.mark.parametrize(
-    "filename_template,should_raise_error",
+    "filename_template,should_raise_error,should_warn",
     [
         # Case 1: No UUID, no extension - should raise error in append mode
-        ("myfile", True),
+        ("myfile", True, False),
         # Case 2: No UUID, has extension - should raise error in append mode
-        ("myfile.parquet", True),
+        ("myfile.parquet", True, False),
         # Case 3: No UUID, different extension - should raise error in append mode
-        ("myfile.txt", True),
+        ("myfile.txt", True, False),
         # Case 4: Already has UUID - should not raise error
-        ("myfile_{write_uuid}", False),
+        ("myfile_{write_uuid}", False, False),
         # Case 5: Already has UUID with extension - should not raise error
-        ("myfile_{write_uuid}.parquet", False),
+        ("myfile_{write_uuid}.parquet", False, True),
         # Case 6: Templated filename without UUID - should raise error in append mode
-        ("myfile-{i}", True),
+        ("myfile-{i}", True, False),
         # Case 7: Templated filename with extension but no UUID - should raise error in append mode
-        ("myfile-{i}.parquet", True),
+        ("myfile-{i}.parquet", True, False),
         # Case 8: Templated filename with UUID already present - should not raise error
-        ("myfile_{write_uuid}-{i}.parquet", False),
+        ("myfile_{write_uuid}-{i}.parquet", False, False),
     ],
     ids=[
         "no_uuid_no_ext",
@@ -854,6 +855,8 @@ def test_parquet_write_uuid_handling_with_custom_filename_provider(
     tmp_path,
     filename_template,
     should_raise_error,
+    should_warn,
+    caplog,
     target_max_block_size_infinite_or_default,
 ):
     """Test that write_parquet correctly handles UUID validation in filenames when using custom filename providers in append mode."""
@@ -890,7 +893,13 @@ def test_parquet_write_uuid_handling_with_custom_filename_provider(
             ds.write_parquet(tmp_path, filename_provider=custom_provider, mode="append")
     else:
         # Should succeed when UUID is present
-        ds.write_parquet(tmp_path, filename_provider=custom_provider, mode="append")
+        with caplog.at_level(logging.WARNING):
+            ds.write_parquet(tmp_path, filename_provider=custom_provider, mode="append")
+        warning_msg = "Custom FilenameProvider returned non-templatized filename"
+        if should_warn:
+            assert warning_msg in caplog.text
+        else:
+            assert warning_msg not in caplog.text
 
         # Check that files were created
         written_files = os.listdir(tmp_path)

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -852,6 +852,7 @@ def test_parquet_write_append_save_mode(ray_start_regular_shared, local_path):
 )
 def test_parquet_write_uuid_handling_with_custom_filename_provider(
     ray_start_regular_shared,
+    propagate_logs,
     tmp_path,
     filename_template,
     should_raise_error,
@@ -896,10 +897,15 @@ def test_parquet_write_uuid_handling_with_custom_filename_provider(
         with caplog.at_level(logging.WARNING):
             ds.write_parquet(tmp_path, filename_provider=custom_provider, mode="append")
         warning_msg = "Custom FilenameProvider returned non-templatized filename"
+        warning_logs = [
+            record.getMessage()
+            for record in caplog.records
+            if warning_msg in record.getMessage()
+        ]
         if should_warn:
-            assert warning_msg in caplog.text
+            assert len(warning_logs) >= 1
         else:
-            assert warning_msg not in caplog.text
+            assert len(warning_logs) == 0
 
         # Check that files were created
         written_files = os.listdir(tmp_path)


### PR DESCRIPTION
## Summary
- Add a warning in `ParquetDatasink` when a custom `FilenameProvider` returns a non-templatized filename with an explicit extension.
- Keep existing behavior of appending `-{i}` to avoid write collisions while making the behavior explicit to users.
- Extend parquet datasource tests to assert warning behavior for the relevant custom filename case.

## Test plan
- [x] Lint checks pass for changed files.
- [ ] Run `python -m pytest -v python/ray/data/tests/datasource/test_parquet.py::test_parquet_write_uuid_handling_with_custom_filename_provider`

Made with [Cursor](https://cursor.com)