### PR TITLE
[serve] Fix HAProxy startup timeout propagation

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -556,7 +556,7 @@ class HAProxyApi(ProxyApi):
         )
 
         try:
-            await self._wait_for_hap_availability(proc)
+            await self._wait_for_hap_availability(proc, timeout_s=timeout_s)
         except Exception:
             # If startup fails, ensure the process is killed to avoid orphaned processes
             if proc.returncode is None:


### PR DESCRIPTION
## Description
`HAProxyApi._start_and_wait_for_haproxy()` accepted a `timeout_s` argument, but it did not pass that value through to `_wait_for_hap_availability()`. In practice, this made the parameter ineffective and always fell back to the callee's default timeout.

Forward `timeout_s` explicitly so the startup path honors the caller's configured timeout and the method signature matches the actual behavior.

## Related issues
https://github.com/ray-project/ray/issues/61751
