### PR TITLE
[core] Fix mock dependency for gcs/store_client

### DIFF
--- a/src/mock/ray/gcs/store_client/BUILD.bazel
+++ b/src/mock/ray/gcs/store_client/BUILD.bazel
@@ -1,0 +1,19 @@
+load("//bazel:ray.bzl", "ray_cc_library")
+
+ray_cc_library(
+    name = "mock_store_client",
+    hdrs = ["store_client.h"],
+    deps = [
+        "//src/ray/gcs/store_client:store_client",
+        "@com_google_googletest//:gtest",
+    ],
+)
+
+ray_cc_library(
+    name = "mock_redis_store_client",
+    hdrs = ["redis_store_client.h"],
+    deps = [
+        "//src/ray/gcs/store_client:redis_store_client",
+        "@com_google_googletest//:gtest",
+    ],
+)

--- a/src/mock/ray/gcs/store_client/redis_store_client.h
+++ b/src/mock/ray/gcs/store_client/redis_store_client.h
@@ -12,10 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
+#include "gmock/gmock.h"
+#include "ray/gcs/store_client/redis_store_client.h"
+
 namespace ray {
 namespace gcs {
 
-class MockStoreClient : public StoreClient {
+class MockRedisStoreClient : public RedisStoreClient {
  public:
   MOCK_METHOD(void,
               AsyncPut,

--- a/src/mock/ray/gcs/store_client/store_client.h
+++ b/src/mock/ray/gcs/store_client/store_client.h
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
+#include "gmock/gmock.h"
+#include "ray/gcs/store_client/store_client.h"
+
 namespace ray {
 namespace gcs {
 


### PR DESCRIPTION
## What\nFix mock dependency in src/mock/ray/gcs/store_client/. Mock headers now properly include the classes they mock.\n\n## Changes\n- Added `#pragma once` and proper includes to `store_client.h`\n- Added `#pragma once` and proper includes to `redis_store_client.h`\n- Changed `MockStoreClient` to `MockRedisStoreClient` in redis_store_client.h (it was incorrectly duplicating MockStoreClient)\n- Created BUILD.bazel with proper dependencies for both mocks\n\n## Why\nPreviously, mock headers did not declare dependencies on the classes they mock, requiring test files to include headers in a specific order with `clang-format off` to avoid linter reordering.\n\n## Related Issue\nCloses #50718 (partial - fixes gcs/store_client sub-task)\n\n## Testing\n- Verified the includes are correct by checking the actual StoreClient and RedisStoreClient class definitions\n- BUILD.bazel follows the same pattern as other fixed mock directories (e.g., pubsub)\n\n---\nThis PR was created by an autonomous agent (ClawOSS).