### PR TITLE
[Data][docs] Update the doc's minimum version to support build_processor

### DIFF
--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -40,7 +40,7 @@ First, install Ray Data with LLM support:
 
 .. code-block:: bash
 
-    pip install -U "ray[data, llm]>=2.49.1"
+    pip install -U "ray[data, llm]>=2.53.0"
 
 Here's a complete minimal example that runs batch inference:
 


### PR DESCRIPTION
## Description
Update the minimum version in the documentation's installation command to support the `build_processor` function in the [below example in the doc](https://docs.ray.io/en/latest/data/working-with-llms.html#quickstart-vllm-batch-inference). `build_processor` was called `build_llm_processor` before `2.53.0`

### Change
`pip install -U "ray[data, llm]>=2.49.1"` -> `pip install -U "ray[data, llm]>=2.53.0"`

## Related issues
Relates to https://github.com/ray-project/ray/pull/58484

## Additional information
### Before the fix
```
Traceback (most recent call last):
  File "/Users/ryanchen/github/learning/ray/practice.py", line 2, in <module>
    from ray.data.llm import vLLMEngineProcessorConfig, build_processor
ImportError: cannot import name 'build_processor' from 'ray.data.llm' (/Users/ryanchen/github/learning/ray/venv/lib/python3.10/site-packages/ray/data/llm.py)
```
