### PR TITLE
[WIP] support RAY_TLS_REQUIRE_CLIENT_AUTH to allow one-way TLS

### DIFF
--- a/python/ray/_common/tls_utils.py
+++ b/python/ray/_common/tls_utils.py
@@ -71,30 +71,63 @@ def add_port_to_grpc_server(server, address):
     import grpc
 
     if os.environ.get("RAY_USE_TLS", "0").lower() in ("1", "true"):
-        server_cert_chain, private_key, ca_cert = load_certs_from_env()
+        server_cert_chain, private_key, ca_cert = load_certs_from_env(is_server=True)
+        if server_cert_chain is None or private_key is None:
+            raise RuntimeError(
+                "When RAY_USE_TLS is enabled for a server, RAY_TLS_SERVER_CERT and "
+                "RAY_TLS_SERVER_KEY must be provided."
+            )
+
+        require_client_auth = os.environ.get(
+            "RAY_TLS_REQUIRE_CLIENT_AUTH", "1"
+        ).lower() in ("1", "true")
         credentials = grpc.ssl_server_credentials(
             [(private_key, server_cert_chain)],
             root_certificates=ca_cert,
-            require_client_auth=ca_cert is not None,
+            require_client_auth=require_client_auth and ca_cert is not None,
         )
         return server.add_secure_port(address, credentials)
     else:
         return server.add_insecure_port(address)
 
 
-def load_certs_from_env():
-    tls_env_vars = ["RAY_TLS_SERVER_CERT", "RAY_TLS_SERVER_KEY", "RAY_TLS_CA_CERT"]
-    if any(v not in os.environ for v in tls_env_vars):
+def load_certs_from_env(is_server: bool = False):
+    # RAY_TLS_CA_CERT is always required for TLS
+    if "RAY_TLS_CA_CERT" not in os.environ:
         raise RuntimeError(
             "If the environment variable RAY_USE_TLS is set to true "
-            "then RAY_TLS_SERVER_CERT, RAY_TLS_SERVER_KEY and "
-            "RAY_TLS_CA_CERT must also be set."
+            "then RAY_TLS_CA_CERT must also be set."
         )
 
-    with open(os.environ["RAY_TLS_SERVER_CERT"], "rb") as f:
-        server_cert_chain = f.read()
-    with open(os.environ["RAY_TLS_SERVER_KEY"], "rb") as f:
-        private_key = f.read()
+    require_client_auth = os.environ.get(
+        "RAY_TLS_REQUIRE_CLIENT_AUTH", "1"
+    ).lower() in ("1", "true")
+
+    # RAY_TLS_SERVER_CERT and RAY_TLS_SERVER_KEY are required if we are a server,
+    # or if we are a client in mTLS mode.
+    # For simplicity, we check them if they are provided, or if require_client_auth
+    # is true or is_server is true.
+
+    server_cert_chain = None
+    if "RAY_TLS_SERVER_CERT" in os.environ:
+        with open(os.environ["RAY_TLS_SERVER_CERT"], "rb") as f:
+            server_cert_chain = f.read()
+    elif require_client_auth or is_server:
+        raise RuntimeError(
+            "RAY_TLS_SERVER_CERT must be set if "
+            "RAY_TLS_REQUIRE_CLIENT_AUTH is true or if it's a server."
+        )
+
+    private_key = None
+    if "RAY_TLS_SERVER_KEY" in os.environ:
+        with open(os.environ["RAY_TLS_SERVER_KEY"], "rb") as f:
+            private_key = f.read()
+    elif require_client_auth or is_server:
+        raise RuntimeError(
+            "RAY_TLS_SERVER_KEY must be set if "
+            "RAY_TLS_REQUIRE_CLIENT_AUTH is true or if it's a server."
+        )
+
     with open(os.environ["RAY_TLS_CA_CERT"], "rb") as f:
         ca_cert = f.read()
 

--- a/python/ray/_private/grpc_utils.py
+++ b/python/ray/_private/grpc_utils.py
@@ -66,7 +66,7 @@ def init_grpc_channel(
         base_args = (address, credentials)
     elif os.environ.get("RAY_USE_TLS", "0").lower() in ("1", "true"):
         # Use TLS from environment variables
-        server_cert_chain, private_key, ca_cert = load_certs_from_env()
+        server_cert_chain, private_key, ca_cert = load_certs_from_env(is_server=False)
         tls_credentials = grpc.ssl_channel_credentials(
             certificate_chain=server_cert_chain,
             private_key=private_key,

--- a/python/ray/tests/test_tls_one_way.py
+++ b/python/ray/tests/test_tls_one_way.py
@@ -1,0 +1,69 @@
+import os
+import sys
+import tempfile
+
+import pytest
+
+from ray._common.test_utils import run_string_as_driver
+from ray._common.tls_utils import generate_self_signed_tls_certs
+
+
+def build_env():
+    env = os.environ.copy()
+    if sys.platform == "win32" and "SYSTEMROOT" not in env:
+        env["SYSTEMROOT"] = r"C:\Windows"
+    return env
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason=("Cryptography (TLS dependency) doesn't install in Mac build pipeline"),
+)
+def test_one_way_tls():
+    cert, key = generate_self_signed_tls_certs()
+    with tempfile.TemporaryDirectory() as temp_dir:
+        cert_filepath = os.path.join(temp_dir, "server.crt")
+        key_filepath = os.path.join(temp_dir, "server.key")
+        with open(cert_filepath, "w") as fh:
+            fh.write(cert)
+        with open(key_filepath, "w") as fh:
+            fh.write(key)
+
+        # Set up environment for one-way TLS
+        # Server will use these certs, but won't verify client.
+        env = build_env()
+        env["RAY_USE_TLS"] = "1"
+        env["RAY_TLS_SERVER_CERT"] = cert_filepath
+        env["RAY_TLS_SERVER_KEY"] = key_filepath
+        env["RAY_TLS_CA_CERT"] = cert_filepath
+        env["RAY_TLS_REQUIRE_CLIENT_AUTH"] = "0"
+
+        # Client doesn't need to specify SERVER_CERT and SERVER_KEY if it doesn't want to send them.
+        # But for ray.init() in the same process (or its children), it will pick them up from env if present.
+        # So we'll run a driver that explicitly unsets them for the client.
+
+        driver_script = """
+import ray
+import os
+
+# Unset client certs to simulate a client that doesn't have them
+if "RAY_TLS_SERVER_CERT" in os.environ:
+    del os.environ["RAY_TLS_SERVER_CERT"]
+if "RAY_TLS_SERVER_KEY" in os.environ:
+    del os.environ["RAY_TLS_SERVER_KEY"]
+
+try:
+    ray.init()
+    assert ray.is_initialized()
+    @ray.remote
+    def f(x):
+        return x + 1
+    assert ray.get(f.remote(1)) == 2
+finally:
+    ray.shutdown()
+"""
+        run_string_as_driver(driver_script, env=env)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -860,6 +860,7 @@ RAY_CONFIG(bool, USE_TLS, false)
 RAY_CONFIG(std::string, TLS_SERVER_CERT, "")
 RAY_CONFIG(std::string, TLS_SERVER_KEY, "")
 RAY_CONFIG(std::string, TLS_CA_CERT, "")
+RAY_CONFIG(bool, TLS_REQUIRE_CLIENT_AUTH, true)
 
 /// Location of Redis TLS credentials
 /// https://github.com/redis/hiredis/blob/c78d0926bf169670d15cfc1214e4f5d21673396b/README.md#hiredis-openssl-wrappers

--- a/src/ray/rpc/grpc_client.cc
+++ b/src/ray/rpc/grpc_client.cc
@@ -52,8 +52,10 @@ std::shared_ptr<grpc::Channel> BuildChannel(
 
     grpc::SslCredentialsOptions ssl_opts;
     ssl_opts.pem_root_certs = cacert;
-    ssl_opts.pem_private_key = private_key;
-    ssl_opts.pem_cert_chain = server_cert_chain;
+    if (::RayConfig::instance().TLS_REQUIRE_CLIENT_AUTH()) {
+      ssl_opts.pem_private_key = private_key;
+      ssl_opts.pem_cert_chain = server_cert_chain;
+    }
     channel_creds = grpc::SslCredentials(ssl_opts);
   } else {
     channel_creds = grpc::InsecureChannelCredentials();

--- a/src/ray/rpc/grpc_server.cc
+++ b/src/ray/rpc/grpc_server.cc
@@ -100,8 +100,11 @@ void GrpcServer::Run() {
     std::string servercert = ReadCert(RayConfig::instance().TLS_SERVER_CERT());
     std::string serverkey = ReadCert(RayConfig::instance().TLS_SERVER_KEY());
     grpc::SslServerCredentialsOptions::PemKeyCertPair pkcp = {serverkey, servercert};
-    grpc::SslServerCredentialsOptions ssl_opts(
-        GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY);
+    grpc_ssl_client_certificate_request_type ssl_client_auth_request_type =
+        RayConfig::instance().TLS_REQUIRE_CLIENT_AUTH()
+            ? GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
+            : GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE;
+    grpc::SslServerCredentialsOptions ssl_opts(ssl_client_auth_request_type);
     ssl_opts.pem_root_certs = rootcert;
     ssl_opts.pem_key_cert_pairs.push_back(pkcp);
 


### PR DESCRIPTION
## Description

Since Ray recently added support for token authentication, I suspect less users will rely on mTLS for client auth but may still require TLS  for node-to-node and user request encryption. This PR adds a new config RAY_TLS_REQUIRE_CLIENT_AUTH that allows Ray clusters to enable one-way TLS (server doesn't require client auth), which can significantly reduce the toil of managing client-side certificates for a Ray cluster.  `RAY_TLS_REQUIRE_CLIENT_AUTH` defaults to true (mTLS) for backwards compatibility.  

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
