### PR TITLE
fix: [RLlib] ``use_kl_loss`` is ignored in the loss function

### DIFF
--- a/rllib/algorithms/ppo/ppo_tf_policy.py
+++ b/rllib/algorithms/ppo/ppo_tf_policy.py
@@ -144,7 +144,7 @@ def get_ppo_tf_policy(name: str, base: TFPolicyV2Type) -> TFPolicyV2Type:
             )
 
             # Only calculate kl loss if necessary (kl-coeff > 0.0).
-            if self.config["kl_coeff"] > 0.0:
+            if self.config["use_kl_loss"] and self.config["kl_coeff"] > 0.0:
                 action_kl = prev_action_dist.kl(curr_action_dist)
                 mean_kl_loss = reduce_mean_valid(action_kl)
                 warn_if_infinite_kl_divergence(self, mean_kl_loss)
@@ -186,7 +186,7 @@ def get_ppo_tf_policy(name: str, base: TFPolicyV2Type) -> TFPolicyV2Type:
             )
             # Add mean_kl_loss (already processed through `reduce_mean_valid`),
             # if necessary.
-            if self.config["kl_coeff"] > 0.0:
+            if self.config["use_kl_loss"] and self.config["kl_coeff"] > 0.0:
                 total_loss += self.kl_coeff * mean_kl_loss
 
             # Store stats in policy for stats_fn.

--- a/rllib/algorithms/ppo/ppo_torch_policy.py
+++ b/rllib/algorithms/ppo/ppo_torch_policy.py
@@ -114,7 +114,7 @@ class PPOTorchPolicy(
         )
 
         # Only calculate kl loss if necessary (kl-coeff > 0.0).
-        if self.config["kl_coeff"] > 0.0:
+        if self.config["use_kl_loss"] and self.config["kl_coeff"] > 0.0:
             action_kl = prev_action_dist.kl(curr_action_dist)
             mean_kl_loss = reduce_mean_valid(action_kl)
             # TODO smorad: should we do anything besides warn? Could discard KL term
@@ -155,7 +155,7 @@ class PPOTorchPolicy(
 
         # Add mean_kl_loss (already processed through `reduce_mean_valid`),
         # if necessary.
-        if self.config["kl_coeff"] > 0.0:
+        if self.config["use_kl_loss"] and self.config["kl_coeff"] > 0.0:
             total_loss += self.kl_coeff * mean_kl_loss
 
         # Store values for stats function in model (tower), such that for


### PR DESCRIPTION
Fixes #52286

The `use_kl_loss` config flag was ignored in both the TF and Torch old-style PPO policies -- the KL loss was computed and applied whenever `kl_coeff > 0.0`, regardless of whether `use_kl_loss` was set to `False`. The root cause was missing `use_kl_loss` checks in the loss functions of `ppo_tf_policy.py` and `ppo_torch_policy.py`. The fix adds `self.config["use_kl_loss"]` as a short-circuit condition before the `kl_coeff` check in both the KL computation and loss accumulation branches of `PPOTorchPolicy.loss()` and the equivalent TF policy. Verified by confirming the config contract now matches the behavior documented for `use_kl_loss`.