### PR TITLE
[fix/serve] add locality routing vars to deploy options and prioritize them over env

### DIFF
--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -143,6 +143,8 @@ class DeploymentConfig(BaseModel):
         request_router_config: Configuration for deployment request router.
         max_constructor_retry_count: Maximum number of times to retry the
             deployment constructor. Defaults to 20.
+        prefer_local_node_routing: Feature flag to turn on node locality routing for proxies. On by default.
+        prefer_local_az_routing: Feature flag to turn on AZ locality routing for proxies. On by default.
     """
 
     num_replicas: Optional[NonNegativeInt] = Field(
@@ -217,6 +219,16 @@ class DeploymentConfig(BaseModel):
     deployment_actors: Optional[List[DeploymentActorConfig]] = Field(
         default=None,
         update_type=DeploymentOptionUpdateType.HeavyWeight,
+    )
+
+    prefer_local_node_routing: Optional[bool] = Field(
+        default=1,
+        update_type=DeploymentOptionUpdateType.LightWeight,
+    )
+
+    prefer_local_az_routing: Optional[bool] = Field (
+        default=1,
+        update_type=DeploymentOptionUpdateType.LightWeight,
     )
 
     # Contains the names of deployment options manually set by the user

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -40,6 +40,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
+    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
     SERVE_LOGGER_NAME,
 )
 from ray.serve._private.event_loop_monitoring import EventLoopMonitor
@@ -557,6 +558,7 @@ class AsyncioRouter:
         self._node_id = node_id
         self._availability_zone = availability_zone
         self._prefer_local_node_routing = prefer_local_node_routing
+        self._prefer_local_az_routing = RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING
         # By default, deployment is available unless we receive news
         # otherwise through a long poll broadcast from the controller.
         self._deployment_available = True
@@ -663,7 +665,7 @@ class AsyncioRouter:
                 use_replica_queue_len_cache=self._enable_strict_max_ongoing_requests,
                 create_replica_wrapper_func=lambda r: RunningReplica(r),
                 prefer_local_node_routing=self._prefer_local_node_routing,
-                prefer_local_az_routing=RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
+                prefer_local_az_routing=self._prefer_local_az_routing,
                 self_availability_zone=self._availability_zone,
             )
             request_router.initialize_state(**(self._request_router_kwargs))
@@ -710,6 +712,41 @@ class AsyncioRouter:
         self._request_router_kwargs = (
             deployment_config.request_router_config.request_router_kwargs
         )
+
+        # Priority is: explicit DeploymentConfig setting > env var > default.
+        if (
+            "prefer_local_node_routing"
+            in deployment_config.user_configured_option_names
+        ):
+            self._prefer_local_node_routing = (
+                deployment_config.prefer_local_node_routing
+            )
+        else:
+            self._prefer_local_node_routing = RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING
+
+        if (
+            "prefer_local_az_routing"
+            in deployment_config.user_configured_option_names
+        ):
+            self._prefer_local_az_routing = deployment_config.prefer_local_az_routing
+        else:
+            self._prefer_local_az_routing = RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING
+
+        # Propagate to the request router if it has already been initialized.
+        if self._request_router is not None:
+            if hasattr(self._request_router, "_prefer_local_node_routing"):
+                setattr(
+                    self._request_router,
+                    "_prefer_local_node_routing",
+                    self._prefer_local_node_routing,
+                )
+            if hasattr(self._request_router, "_prefer_local_az_routing"):
+                setattr(
+                    self._request_router,
+                    "_prefer_local_az_routing",
+                    self._prefer_local_az_routing,
+                )
+
         self._metrics_manager.update_deployment_config(
             deployment_config,
             curr_num_replicas=len(self.request_router.curr_replicas),

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1,6 +1,8 @@
 import collections
 import inspect
 import logging
+import os
+import warnings
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
@@ -22,6 +24,8 @@ from ray.serve._private.constants import (
     RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
     SERVE_DEFAULT_APP_NAME,
     SERVE_LOGGER_NAME,
+    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
+    RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
 )
 from ray.serve._private.http_util import (
     ASGIAppReplicaWrapper,
@@ -351,6 +355,8 @@ def deployment(
     gang_scheduling_config: Default[
         Union[Dict, GangSchedulingConfig, None]
     ] = DEFAULT.VALUE,
+    prefer_local_node_routing: Default[bool] = DEFAULT.VALUE,
+    prefer_local_az_routing: Default[bool] = DEFAULT.VALUE,
 ) -> Callable[[Callable], Deployment]:
     """Decorator that converts a Python class to a `Deployment`.
 
@@ -425,6 +431,8 @@ def deployment(
             Gang scheduling ensures that groups of replicas are scheduled together
             atomically, which is essential for distributed workloads that require
             coordination between replicas. See `GangSchedulingConfig` for options.
+        prefer_local_node_routing: Feature flag to turn on node locality routing for proxies. On by default.
+        prefer_local_az_routing: Feature flag to turn on AZ locality routing for proxies. On by default.
     Returns:
         `Deployment`
     """
@@ -493,6 +501,26 @@ def deployment(
             "Explicitly specifying version will raise an error in the future!"
         )
 
+    # check for deprecated environment variable usage
+    if "RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING" in os.environ:
+        warnings.warn(
+            "The environment variable 'RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING' "
+            "is deprecated and will be removed in a future release. "
+            "Please use 'prefer_local_node_routing' in @serve.deployment instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    # check for deprecated environment variable usage
+    if "RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING" in os.environ:
+        warnings.warn(
+            "The environment variable 'RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING' "
+            "is deprecated and will be removed in a future release. "
+            "Please use 'prefer_local_az_routing' in @serve.deployment instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if isinstance(logging_config, LoggingConfig):
         logging_config = logging_config.model_dump()
 
@@ -510,6 +538,8 @@ def deployment(
         request_router_config=request_router_config,
         max_constructor_retry_count=max_constructor_retry_count,
         gang_scheduling_config=gang_scheduling_config,
+        prefer_local_node_routing=prefer_local_node_routing,
+        prefer_local_az_routing=prefer_local_az_routing,
     )
     deployment_config.user_configured_option_names = set(user_configured_option_names)
 

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -234,6 +234,12 @@ message DeploymentConfig {
 
   // Deployment-scoped actors managed by the controller.
   repeated DeploymentActorConfig deployment_actors = 22;
+
+  // Prefer routing requests to replicas on the same node as the caller.
+  bool prefer_local_node_routing = 23;
+
+  // Prefer routing requests to replicas in the same availability zone as the caller.
+  bool prefer_local_az_routing = 24;
 }
 
 // Deployment language.


### PR DESCRIPTION
## Description
Enables migration from env-var-only control to per-deployment control without breaking current users

What this changes:
* Adds deployment-level support for:  
  * `prefer_local_node_routing`, `prefer_local_az_routing`
* Precedence is: 
  * Explicit deployment config value > env var fallback > existing default behavior
* Updates router runtime config propagation
* Warning when the env vars are present
* Adds protobuf schema fields for these deployment config options so config serialization/deserialization remains consistent

## Related issues
Fixes #59929 - **Phase 1**

## Additional information
* Protobuf deployment config schema now includes locality routing fields to prevent runtime serialization errors.
