### PR TITLE
[ci] use COPY --chown to resolve permission denied errors in build-image.sh

### DIFF
--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -20,7 +20,7 @@ ENV BAZEL_CACHE=${CACHE_DIR}/bazel
 
 WORKDIR /home/forge/ray
 
-COPY . .
+COPY --chown=forge . .
 
 RUN --mount=type=cache,target=${DOWNLOAD_CACHE},uid=2000,gid=100,id=ray-downloads-${HOSTTYPE} \
     --mount=type=cache,target=${BAZEL_CACHE},uid=2000,gid=100,id=ray-bazel-${HOSTTYPE}-py${PYTHON_VERSION} \

--- a/ci/docker/ray-java.Dockerfile
+++ b/ci/docker/ray-java.Dockerfile
@@ -19,7 +19,7 @@ ENV BAZEL_CACHE=${CACHE_DIR}/bazel
 
 WORKDIR /home/forge/ray
 
-COPY . .
+COPY --chown=forge . .
 
 RUN --mount=type=cache,target=${DOWNLOAD_CACHE},uid=2000,gid=100,id=ray-downloads-${HOSTTYPE} \
     --mount=type=cache,target=${BAZEL_CACHE},uid=2000,gid=100,id=ray-bazel-${HOSTTYPE} \

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -109,8 +109,8 @@ USER $RAY_UID
 ENV HOME=/home/ray
 WORKDIR /home/ray
 
-COPY "$CONSTRAINTS_FILE" /home/ray/requirements_compiled.txt
-COPY "$PYTHON_DEPSET" /home/ray/python_depset.lock
+COPY --chown=ray "$CONSTRAINTS_FILE" /home/ray/requirements_compiled.txt
+COPY --chown=ray "$PYTHON_DEPSET" /home/ray/python_depset.lock
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
## Description

Resolve multiple `permission denied` errors when running `build-image.sh` by setting `--chown` in COPY. 

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
