### PR TITLE
[WIP][core] Marking child tasks failed on worker death

### DIFF
--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -1328,5 +1328,186 @@ class TestIsActorTaskRunning:
         wait_for_condition(lambda: not _is_actor_task_running(pid, task_name))
 
 
+def test_owner_ungraceful_death_marks_child_tree_failed(shutdown_only):
+    """
+    Test that when an owner worker dies ungracefully (os._exit), the entire tree of
+    child tasks is marked FAILED with error_type OWNER_DIED.
+
+    Task tree:
+        owner_task -> child_task_1 (sleeping)
+                   -> child_task_2 -> grandchild_task (sleeping)
+
+    owner_task crashes via os._exit(1). All descendants should be marked FAILED.
+    """
+    ray.init(num_cpus=8, _system_config=_SYSTEM_CONFIG)
+
+    @ray.remote(max_retries=0)
+    def grandchild_task():
+        time.sleep(999)
+
+    @ray.remote(max_retries=0)
+    def child_task_1():
+        time.sleep(999)
+
+    @ray.remote(max_retries=0)
+    def child_task_2():
+        ray.get(grandchild_task.remote())
+
+    @ray.remote(max_retries=0)
+    def owner_task():
+        child_task_1.remote()
+        child_task_2.remote()
+        # Wait until all children are running before crashing.
+        def children_running():
+            tasks = list_tasks(filters=[("name", "!=", "owner_task")], detail=True)
+            running = [t for t in tasks if t["state"] == "RUNNING"]
+            # child_task_1, child_task_2, grandchild_task
+            return len(running) >= 3
+
+        wait_for_condition(children_running, timeout=15)
+        os._exit(1)
+
+    with pytest.raises(ray.exceptions.WorkerCrashedError):
+        ray.get(owner_task.remote())
+
+    def verify():
+        for name in ["child_task_1", "child_task_2", "grandchild_task"]:
+            tasks = list_tasks(filters=[("name", "=", name)], detail=True)
+            assert len(tasks) == 1, f"Expected 1 task for {name}, got {len(tasks)}"
+            t = tasks[0]
+            assert t["state"] == "FAILED", f"{name} should be FAILED, got {t['state']}"
+            assert (
+                t["error_type"] == "OWNER_DIED"
+            ), f"{name} error_type should be OWNER_DIED, got {t['error_type']}"
+        return True
+
+    wait_for_condition(verify, timeout=30, retry_interval_ms=1000)
+
+
+@pytest.mark.parametrize("worker_dead_delay_ms", [30000, 0])
+def test_owner_graceful_death_waited_does_not_fail_children(
+    shutdown_only, worker_dead_delay_ms
+):
+    """
+    Test that when an owner exits gracefully after waiting for all children
+    (via ray.get), the children are NOT incorrectly marked as FAILED.
+
+    Parametrized with delay=30000 (task events will be reported) and delay=0 (worst-case race where
+    OnWorkerDead fires before task events arrive — should still not mark children
+    failed because the death is graceful).
+    """
+    sys_config = _SYSTEM_CONFIG.copy()
+    sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = worker_dead_delay_ms
+    ray.init(num_cpus=8, _system_config=sys_config)
+
+    @ray.remote
+    def child_task():
+        return 1
+
+    @ray.remote
+    def owner_task():
+        refs = [child_task.remote() for _ in range(3)]
+        ray.get(refs)  # Wait for all children.
+        return "done"
+
+    ray.get(owner_task.remote())
+
+    def verify():
+        tasks = list_tasks(filters=[("name", "=", "child_task")], detail=True)
+        assert len(tasks) == 3, f"Expected 3 child tasks, got {len(tasks)}"
+        for t in tasks:
+            assert (
+                t["state"] == "FINISHED"
+            ), f"child_task should be FINISHED, got {t['state']}"
+        return True
+
+    wait_for_condition(verify, timeout=15, retry_interval_ms=500)
+
+
+@pytest.mark.parametrize("worker_dead_delay_ms", [30000, 0])
+def test_owner_graceful_death_no_wait_does_not_fail_children(
+    shutdown_only, worker_dead_delay_ms
+):
+    """
+    Test that when an owner exits gracefully WITHOUT waiting for children,
+    the children are NOT incorrectly marked as FAILED. The worker process stays
+    alive in the pool and remains the owner, so it will relay the statuses.
+
+    Parametrized with delay=30000 (task events will be reported) and delay=0 (worst-case race — should
+    still not mark children failed because the death is graceful).
+    """
+    sys_config = _SYSTEM_CONFIG.copy()
+    sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = worker_dead_delay_ms
+    ray.init(num_cpus=8, _system_config=sys_config)
+
+    @ray.remote
+    def short_child():
+        return 1
+
+    @ray.remote
+    def owner_no_wait():
+        # Spawn children but don't ray.get them.
+        refs = [short_child.remote() for _ in range(3)]  # noqa: F841
+        return "done"
+
+    ray.get(owner_no_wait.remote())
+
+    # Give time for children to finish and events to be reported.
+    time.sleep(3)
+
+    def verify():
+        tasks = list_tasks(filters=[("name", "=", "short_child")], detail=True)
+        assert len(tasks) == 3, f"Expected 3 child tasks, got {len(tasks)}"
+        for t in tasks:
+            assert (
+                t["state"] == "FINISHED"
+            ), f"short_child should be FINISHED, got {t['state']}"
+        return True
+
+    wait_for_condition(verify, timeout=15, retry_interval_ms=500)
+
+
+def test_completed_task_not_marked_failed_on_worker_death(shutdown_only):
+    """
+    Repro test for: https://github.com/ray-project/ray/issues/56427.
+    Workers with max_calls=1 die (INTENDED_SYSTEM_EXIT) after each task completes.
+    The worker death notification races with the task event buffer flush from the
+    owner. Completed tasks should NOT be incorrectly marked as FAILED.
+
+    With delay=0, OnWorkerDead fires immediately — maximizing the chance of the
+    race. Since we don't mark tasks on the dead worker as failed, this prevents marking
+    it as failed.
+    """
+    sys_config = _SYSTEM_CONFIG.copy()
+    # Zero delay to maximize the race between OnWorkerDead and task events.
+    sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = 0
+    ray.init(num_cpus=8, _system_config=sys_config)
+
+    @ray.remote(max_calls=1)
+    def one_shot(i):
+        return 42 + i
+
+    num_tasks = 50
+    refs = [one_shot.remote(i) for i in range(num_tasks)]
+    results = ray.get(refs)
+    assert results == list(range(42, 42 + num_tasks))
+
+    # Give time for worker death notifications and task events to be processed.
+    time.sleep(3)
+
+    def verify():
+        tasks = list_tasks(filters=[("name", "=", "one_shot")], detail=True)
+        assert len(tasks) == num_tasks, f"Expected {num_tasks} tasks, got {len(tasks)}"
+        for t in tasks:
+            assert t["state"] == "FINISHED", (
+                f"one_shot task should be FINISHED, got {t['state']}. "
+                f"error_type={t.get('error_type')}, "
+                f"error_message={t.get('error_message')}"
+            )
+        return True
+
+    wait_for_condition(verify, timeout=15, retry_interval_ms=500)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -104,7 +104,7 @@ std::vector<rpc::TaskEvents> GcsTaskManager::GcsTaskManagerStorage::GetTaskEvent
   return result;
 }
 
-void GcsTaskManager::GcsTaskManagerStorage::MarkTasksFailedOnWorkerDead(
+void GcsTaskManager::GcsTaskManagerStorage::MarkChildTasksFailedOnWorkerDead(
     const WorkerID &worker_id, const rpc::WorkerTableData &worker_failure_data) {
   auto task_attempts_itr = worker_index_.find(worker_id);
   if (task_attempts_itr == worker_index_.end()) {
@@ -113,16 +113,38 @@ void GcsTaskManager::GcsTaskManagerStorage::MarkTasksFailedOnWorkerDead(
   }
 
   rpc::RayErrorInfo error_info;
-  error_info.set_error_type(rpc::ErrorType::WORKER_DIED);
-  std::stringstream error_message;
-  error_message << "Worker running the task (" << worker_id.Hex()
-                << ") died with exit_type: " << worker_failure_data.exit_type()
-                << " with error_message: " << worker_failure_data.exit_detail();
-  error_info.set_error_message(error_message.str());
+  error_info.set_error_type(rpc::ErrorType::OWNER_DIED);
+  int64_t failed_ts_ns = worker_failure_data.end_time_ms() * 1000 * 1000;
 
-  for (const auto &task_locator : task_attempts_itr->second) {
-    MarkTaskAttemptFailedIfNeeded(
-        task_locator, worker_failure_data.end_time_ms() * 1000 * 1000, error_info);
+  // DFS over the subtree rooted at a given task, marking all descendants failed.
+  // The root task itself is skipped — its owner is responsible for marking it failed.
+  std::function<void(const TaskID &)> dfs_mark_failed = [&](const TaskID &task_id) {
+    auto children_itr = parent_to_child_index_.find(task_id);
+    if (children_itr == parent_to_child_index_.end()) {
+      return;
+    }
+    for (const auto &child_locator : children_itr->second) {
+      TaskID child_task_id =
+          TaskID::FromBinary(child_locator->GetTaskEventsMutable().task_id());
+      std::stringstream error_message;
+      error_message << "Task (" << child_task_id.Hex() << ") failed because owner ("
+                    << worker_id.Hex()
+                    << ") died with exit_type: " << worker_failure_data.exit_type()
+                    << " with error_message: " << worker_failure_data.exit_detail();
+      error_info.set_error_message(error_message.str());
+      // This marking failure could be overwritten if a task event for the task comes up.
+      // But currently, final state is determined by the highest numbered state present in
+      // the state_ts map. Therefore, FAILED will persist over FINISHED.
+      MarkTaskAttemptFailedIfNeeded(child_locator, failed_ts_ns, error_info);
+      dfs_mark_failed(child_task_id);
+    }
+  };
+
+  for (const auto &parent_task_locator : task_attempts_itr->second) {
+    TaskID parent_task_id =
+        TaskID::FromBinary(parent_task_locator->GetTaskEventsMutable().task_id());
+    RAY_CHECK(!parent_task_id.IsNil());
+    dfs_mark_failed(parent_task_id);
   }
 }
 
@@ -248,6 +270,19 @@ void GcsTaskManager::GcsTaskManagerStorage::UpdateIndex(
   if (!worker_id.IsNil()) {
     worker_index_[worker_id].insert(loc);
   }
+
+  // build parent->child index.
+  if (task_events.has_task_info()) {
+    const auto &task_info = task_events.task_info();
+    TaskID parent_task_id = TaskID::FromBinary(task_info.parent_task_id());
+
+    if (!parent_task_id.IsNil()) {
+      // inserting here would mean that we might, at some point, have two entries for two
+      // attempts of the same child task. Shouldn't be a problem though, since its fine to
+      // mark both attempts of the child task failed.
+      parent_to_child_index_[parent_task_id].insert(loc);
+    }
+  }
 }
 
 void GcsTaskManager::GcsTaskManagerStorage::RemoveFromIndex(
@@ -281,6 +316,19 @@ void GcsTaskManager::GcsTaskManagerStorage::RemoveFromIndex(
     RAY_CHECK(worker_attempts_iter->second.erase(loc) == 1);
     if (worker_attempts_iter->second.empty()) {
       worker_index_.erase(worker_attempts_iter);
+    }
+  }
+
+  if (task_events.has_task_info()) {
+    const auto &task_info = task_events.task_info();
+    TaskID parent_task_id = TaskID::FromBinary(task_info.parent_task_id());
+    if (!parent_task_id.IsNil()) {
+      auto child_tasks_itr = parent_to_child_index_.find(parent_task_id);
+      RAY_CHECK(child_tasks_itr != parent_to_child_index_.end());
+      RAY_CHECK(child_tasks_itr->second.erase(loc) == 1);
+      if (child_tasks_itr->second.empty()) {
+        parent_to_child_index_.erase(child_tasks_itr);
+      }
     }
   }
 
@@ -728,7 +776,20 @@ void GcsTaskManager::SetUsageStatsClient(UsageStatsClient *usage_stats_client) {
 
 void GcsTaskManager::OnWorkerDead(
     const WorkerID &worker_id, const std::shared_ptr<rpc::WorkerTableData> &worker_data) {
-  RAY_LOG(DEBUG) << "Marking all running tasks of worker " << worker_id << " as failed.";
+  // Only mark child tasks as failed on ungraceful death. On graceful death, the owner
+  // will flush the task buffer and the events would receive GCS eventually. If owner dies
+  // ungracefully, the events for child tasks will never reach GCS, so mark them
+  // explicitly.
+  if (worker_data->exit_type() == rpc::WorkerExitType::INTENDED_USER_EXIT ||
+      worker_data->exit_type() == rpc::WorkerExitType::INTENDED_SYSTEM_EXIT) {
+    RAY_LOG(DEBUG) << "Worker " << worker_id
+                   << " died gracefully (exit_type=" << worker_data->exit_type()
+                   << "), not marking child tasks as failed.";
+    return;
+  }
+
+  RAY_LOG(DEBUG) << "Marking all running tasks owned by the worker " << worker_id
+                 << " as failed (exit_type=" << worker_data->exit_type() << ").";
 
   auto timer = std::make_shared<boost::asio::deadline_timer>(
       io_service_,
@@ -741,9 +802,8 @@ void GcsTaskManager::OnWorkerDead(
           // timer canceled or aborted.
           return;
         }
-        // If there are any non-terminated tasks from the worker, mark them failed since
-        // all workers associated with the worker will be failed.
-        task_event_storage_->MarkTasksFailedOnWorkerDead(worker_id, *worker_data);
+        // Mark the entire tree of child tasks for each task on the dead worker as FAILED.
+        task_event_storage_->MarkChildTasksFailedOnWorkerDead(worker_id, *worker_data);
       });
 }
 

--- a/src/ray/gcs/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_task_manager.h
@@ -234,12 +234,12 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
     /// failed time.
     void MarkTasksFailedOnJobEnds(const JobID &job_id, int64_t job_finish_time_ns);
 
-    /// Mark tasks from a worker as failed as worker dies.
+    /// Mark the whole tree of child tasks FAILED for each task on the dead worker.
     ///
     /// \param worker_id Worker ID
     /// \param worker_failure_data Worker failure data.
-    void MarkTasksFailedOnWorkerDead(const WorkerID &worker_id,
-                                     const rpc::WorkerTableData &worker_failure_data);
+    void MarkChildTasksFailedOnWorkerDead(
+        const WorkerID &worker_id, const rpc::WorkerTableData &worker_failure_data);
 
     /// Get the job task summary given a job id.
     ///
@@ -465,6 +465,21 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
         job_index_;
     absl::flat_hash_map<WorkerID, absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>
         worker_index_;
+
+    // Tracks a TaskId to its child tasks. Used by MarkChildTasksFailedOnWorkerDead to
+    // mark the task tree of owner FAILED on worker death. The should ideally be
+    // TaskAttempt instead of TaskId, to mark only the child tasks that are created for
+    // that attempt as FAILED. But task events dont store parent task's attempt number
+    // currently.
+    //
+    // TODO(karticam): Keying by TaskId rather than TaskAttempt can mark wrong tasks as
+    // failed. Consider this race - attempt 0's worker dies, attempt 1's worker starts and
+    // spawns new children before GCS processes the death notification. The map would
+    // contain children from both attempts under the same TaskId. The DFS triggered by
+    // attempt 0's death would then incorrectly mark attempt 1's live children as FAILED.
+    // Fix can be take in a separate PR.
+    absl::flat_hash_map<TaskID, absl::flat_hash_set<std::shared_ptr<TaskEventLocator>>>
+        parent_to_child_index_;
 
     // A summary for per job stats.
     absl::flat_hash_map<JobID, JobTaskSummary> job_task_summary_;

--- a/src/ray/gcs/tests/gcs_task_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_task_manager_test.cc
@@ -40,7 +40,8 @@ class GcsTaskManagerTest : public ::testing::Test {
         R"(
 {
   "task_events_max_num_task_in_gcs": 1000,
-  "gcs_mark_task_failed_on_job_done_delay_ms": 100
+  "gcs_mark_task_failed_on_job_done_delay_ms": 100,
+  "gcs_mark_task_failed_on_worker_dead_delay_ms": 100
 }
   )");
   }
@@ -1811,6 +1812,389 @@ TEST_F(GcsTaskManagerMemoryLimitedTest, TestLimitGcPriorityBased) {
     reply = SyncGetTaskEvents({});
     EXPECT_EQ(reply.events_by_task_size(), num_limit);
     EXPECT_EQ(reply.num_status_task_events_dropped(), 3);
+  }
+}
+
+// Helper to build WorkerTableData for OnWorkerDead tests.
+static std::shared_ptr<rpc::WorkerTableData> GenWorkerFailureData(
+    rpc::WorkerExitType exit_type,
+    int64_t end_time_ms = 10,
+    const std::string &exit_detail = "test worker death") {
+  auto data = std::make_shared<rpc::WorkerTableData>();
+  data->set_exit_type(exit_type);
+  data->set_end_time_ms(end_time_ms);
+  data->set_exit_detail(exit_detail);
+  return data;
+}
+
+// Test that when a worker dies ungracefully, the entire tree of child tasks owned by that
+// worker is marked FAILED.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadMarksChildTaskTreeFailed) {
+  // Setup: owner_worker runs parent_task, which spawned child_task_1 and child_task_2.
+  // child_task_1 in turn spawned grandchild_task.
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_tasks = GenTaskIDs(2);
+  auto grandchild_task = GenTaskIDs(1)[0];
+
+  // Add parent task (running on owner_worker).
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child tasks (parent_task_id = parent_task).
+  auto child_events = GenTaskEvents(child_tasks,
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Add grandchild task (parent_task_id = child_tasks[0]).
+  auto grandchild_events = GenTaskEvents({grandchild_task},
+                                         0,
+                                         0,
+                                         absl::nullopt,
+                                         GenStateUpdate({{rpc::TaskStatus::RUNNING, 3}}),
+                                         GenTaskInfo(JobID::FromInt(0), child_tasks[0]));
+  SyncAddTaskEventData(GenTaskEventsData(grandchild_events));
+
+  // Owner worker dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Parent task should NOT be marked failed (its own owner is responsible).
+  {
+    auto reply = SyncGetTaskEvents({parent_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+
+  // Child tasks should be marked FAILED with OWNER_DIED error.
+  for (const auto &child_id : child_tasks) {
+    auto reply = SyncGetTaskEvents({child_id});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    auto &task_event = reply.events_by_task(0);
+    EXPECT_TRUE(
+        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+    EXPECT_EQ(task_event.state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
+              10 * 1000 * 1000);
+    EXPECT_EQ(task_event.state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+
+  // Grandchild task should also be marked FAILED (DFS walks the full tree).
+  {
+    auto reply = SyncGetTaskEvents({grandchild_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    auto &task_event = reply.events_by_task(0);
+    EXPECT_TRUE(
+        task_event.state_updates().state_ts_ns().contains(rpc::TaskStatus::FAILED));
+    EXPECT_EQ(task_event.state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
+  }
+}
+
+// Test that graceful worker death (INTENDED_USER_EXIT) does NOT mark child tasks as
+// failed.
+TEST_F(GcsTaskManagerTest, TestGracefulWorkerDeadDoesNotMarkChildTasksFailed) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child task.
+  auto child_events = GenTaskEvents({child_task},
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Owner worker dies gracefully (INTENDED_USER_EXIT).
+  task_manager->OnWorkerDead(
+      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_USER_EXIT, 10));
+
+  // Wait for the delay timer (even though it should return early).
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Child task should NOT be marked failed.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that graceful worker death (INTENDED_SYSTEM_EXIT) does NOT mark child tasks as
+// failed.
+TEST_F(GcsTaskManagerTest, TestIntendedSystemExitDoesNotMarkChildTasksFailed) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child task.
+  auto child_events = GenTaskEvents({child_task},
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Owner worker dies with INTENDED_SYSTEM_EXIT (e.g., job teardown).
+  task_manager->OnWorkerDead(
+      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::INTENDED_SYSTEM_EXIT, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Child task should NOT be marked failed.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that already-terminated child tasks are not overwritten when owner dies.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadDoesNotOverrideTerminatedChildTasks) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_finished = GenTaskIDs(1)[0];
+  auto child_failed = GenTaskIDs(1)[0];
+  auto child_running = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child that already finished.
+  auto finished_events = GenTaskEvents({child_finished},
+                                       0,
+                                       0,
+                                       absl::nullopt,
+                                       GenStateUpdate({{rpc::TaskStatus::FINISHED, 2}}),
+                                       GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(finished_events));
+
+  // Add child that already failed.
+  auto failed_events = GenTaskEvents({child_failed},
+                                     0,
+                                     0,
+                                     absl::nullopt,
+                                     GenStateUpdate({{rpc::TaskStatus::FAILED, 3}}),
+                                     GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(failed_events));
+
+  // Add child that is still running.
+  auto running_events = GenTaskEvents({child_running},
+                                      0,
+                                      0,
+                                      absl::nullopt,
+                                      GenStateUpdate({{rpc::TaskStatus::RUNNING, 4}}),
+                                      GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(running_events));
+
+  // Owner dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Finished child should not be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({child_finished});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().state_ts_ns().at(
+                  rpc::TaskStatus::FINISHED),
+              2);
+  }
+
+  // Already failed child should keep its original failure timestamp.
+  {
+    auto reply = SyncGetTaskEvents({child_failed});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_EQ(
+        reply.events_by_task(0).state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
+        3);
+  }
+
+  // Running child should now be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({child_running});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(
+        reply.events_by_task(0).state_updates().state_ts_ns().at(rpc::TaskStatus::FAILED),
+        10 * 1000 * 1000);
+  }
+}
+
+// Test that OnWorkerDead with no tasks for the worker doesn't crash.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadNoTasks) {
+  auto unknown_worker = WorkerID::FromRandom();
+  task_manager->OnWorkerDead(unknown_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Should not crash, no events to check.
+  auto reply = SyncGetTaskEvents({});
+  EXPECT_EQ(reply.events_by_task_size(), 0);
+}
+
+// Test that when a worker dies ungracefully but has no child tasks (leaf executor),
+// nothing extra is marked failed.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadLeafTaskNoChildren) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto leaf_task = GenTaskIDs(1)[0];
+
+  // Add a leaf task running on owner_worker (no children).
+  auto events =
+      GenTaskEvents({leaf_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(events));
+
+  // Worker dies ungracefully.
+  task_manager->OnWorkerDead(owner_worker,
+                             GenWorkerFailureData(rpc::WorkerExitType::SYSTEM_ERROR, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Leaf task itself should NOT be marked failed (no children to mark, and the task
+  // itself is the responsibility of its own owner).
+  {
+    auto reply = SyncGetTaskEvents({leaf_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_FALSE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+  }
+}
+
+// Test that NODE_OUT_OF_MEMORY exit type (ungraceful) marks child tasks as failed.
+TEST_F(GcsTaskManagerTest, TestWorkerDeadOOMMarksChildTasksFailed) {
+  auto owner_worker = WorkerID::FromRandom();
+  auto parent_task = GenTaskIDs(1)[0];
+  auto child_task = GenTaskIDs(1)[0];
+
+  // Add parent task running on owner_worker.
+  auto parent_events =
+      GenTaskEvents({parent_task},
+                    0,
+                    0,
+                    absl::nullopt,
+                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 1}}, owner_worker),
+                    GenTaskInfo(JobID::FromInt(0)));
+  SyncAddTaskEventData(GenTaskEventsData(parent_events));
+
+  // Add child task.
+  auto child_events = GenTaskEvents({child_task},
+                                    0,
+                                    0,
+                                    absl::nullopt,
+                                    GenStateUpdate({{rpc::TaskStatus::RUNNING, 2}}),
+                                    GenTaskInfo(JobID::FromInt(0), parent_task));
+  SyncAddTaskEventData(GenTaskEventsData(child_events));
+
+  // Worker dies from OOM.
+  task_manager->OnWorkerDead(
+      owner_worker, GenWorkerFailureData(rpc::WorkerExitType::NODE_OUT_OF_MEMORY, 10));
+
+  // Wait for the delay timer.
+  boost::asio::io_context io;
+  boost::asio::deadline_timer timer(
+      io,
+      boost::posix_time::milliseconds(
+          2 * RayConfig::instance().gcs_mark_task_failed_on_worker_dead_delay_ms()));
+  timer.wait();
+
+  // Child task should be marked FAILED.
+  {
+    auto reply = SyncGetTaskEvents({child_task});
+    ASSERT_EQ(reply.events_by_task_size(), 1);
+    EXPECT_TRUE(reply.events_by_task(0).state_updates().state_ts_ns().contains(
+        rpc::TaskStatus::FAILED));
+    EXPECT_EQ(reply.events_by_task(0).state_updates().error_info().error_type(),
+              rpc::ErrorType::OWNER_DIED);
   }
 }
 


### PR DESCRIPTION
In this [issue](https://github.com/ray-project/ray/issues/56427), some tasks with `max_calls = 1` are marked failed even when actually completed. 

Reason: When a worker dies (say, due to `max_calls = 1` for a task), GCS receives an `OnWorkerDead` notification, which marks tasks as `FAILED` for which it has not yet received a terminal status (`FINISHED`/`FAILED`). The terminal status of a task is usually sent by the task owner via a periodic flush of the `task_event_buffer`. If the `FINISHED` task event emitted by the task owner doesn't reach the GCS before `OnWorkerDead` notification, the task is wrongly marked as `FAILED`.

Fix: One approach to fix this could be to skip marking tasks `FAILED` on worker death notifications if the worker exit is intended (`INTENDED_USER_EXIT` or `INTENDED_SYSTEM_EXIT`), and instead rely on the owner to transmit the task's final state. However, this approach doesn't work if the owner also dies before emitting the `task_event_buffer`. Since the owner holds the responsibility of relaying child tasks' state, if the owner dies we should mark all child tasks (immediate children + the whole tree of tasks) as `FAILED`. Moreover, this should be done only when the owner worker death is ungraceful because for a graceful death, the owner emits the `task_event_buffer` and hence the GCS can rely upon them to get the final task states.

Changes: Added `parent_to_child_index_` in `gcs_task_manager` to track child tasks for each task. Use this index to mark the task tree of owner tasks as `FAILED`. 

More discussions on why the first approach doesn't work and some other discussions for the fix are in this doc: https://docs.google.com/document/d/1Ythr_3aTjcEzZpWCr4Guqq_5NayZpHdfSWd-661XOqU/edit?tab=t.0

The updated version of this PR is reopened in https://github.com/ray-project/ray/pull/63738