### PR TITLE
[Serve] Fix simple-mode autoscaling request accounting for zero replica metrics

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -648,15 +648,15 @@ class DeploymentAutoscalingState:
             Total number of requests (running + queued) across all replicas/handles.
         """
         total_requests = 0
+        metrics_collected_on_replicas = False
 
         # Iterate over _replica_metrics but only count running replicas. Stale metrics from
         # stopped replicas can remain until on_replica_stopped runs; filtering avoids inflation.
         for report in self._replica_metrics.values():
             # TODO(abrar): Store replica_id as string in report to avoid this conversion.
             if report.replica_id.to_full_id_str() in self._cached_running_replica_strs:
+                metrics_collected_on_replicas = True
                 total_requests += report.aggregated_metrics.get(RUNNING_REQUESTS_KEY, 0)
-
-        metrics_collected_on_replicas = total_requests > 0
 
         # Add handle metrics
         for handle_metric in self._handle_requests.values():

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -7,7 +7,10 @@ import pytest
 
 from ray._common.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
 from ray._raylet import NodeID
-from ray.serve._private.autoscaling_state import AutoscalingStateManager
+from ray.serve._private.autoscaling_state import (
+    AutoscalingStateManager,
+    DeploymentAutoscalingState,
+)
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
     DeploymentHandleSource,
@@ -3414,6 +3417,45 @@ class TestAutoscaling:
 
             # Set replica finished stopping
             replica._actor.set_done_stopping()
+
+    def test_simple_mode_prefers_zero_replica_metrics_over_handle_running_metrics(self):
+        autoscaling_state = DeploymentAutoscalingState(TEST_DEPLOYMENT_ID)
+        replica_id = ReplicaID("replica", deployment_id=TEST_DEPLOYMENT_ID)
+        replica_str = replica_id.to_full_id_str()
+        autoscaling_state.update_running_replica_ids([replica_id])
+
+        autoscaling_state.record_request_metrics_for_handle(
+            HandleMetricReport(
+                deployment_id=TEST_DEPLOYMENT_ID,
+                handle_id="handle",
+                actor_id="actor_id",
+                handle_source=DeploymentHandleSource.UNKNOWN,
+                queued_requests=[TimeStampedValue(0, 0)],
+                aggregated_queued_requests=0,
+                aggregated_metrics={RUNNING_REQUESTS_KEY: {replica_str: 2}},
+                metrics={
+                    RUNNING_REQUESTS_KEY: {
+                        replica_str: [TimeStampedValue(0, 2)],
+                    }
+                },
+                timestamp=1,
+            )
+        )
+        autoscaling_state.record_request_metrics_for_replica(
+            ReplicaMetricReport(
+                replica_id=replica_id,
+                aggregated_metrics={RUNNING_REQUESTS_KEY: 0},
+                metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(0, 0)]},
+                timestamp=1,
+            )
+        )
+
+        with patch.object(
+            autoscaling_state,
+            "_should_aggregate_metrics_at_controller",
+            return_value=False,
+        ):
+            assert autoscaling_state.get_total_num_requests() == 0
 
     @pytest.mark.skipif(
         not RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,


### PR DESCRIPTION
## Description
In simple autoscaling mode, the request accounting logic treated replica metrics as “present” only when the total number of running requests reported by replicas was greater than zero. This is not rigorous enough, because a replica report with value 0 is still a valid metrics update.

When all running replicas reported 0 requests, the controller would fall back to handle-side running request metrics. This behavior is not rigorous enough.

The fix is to treat replica metrics as present whenever there is a metrics report from a running replica, regardless of the reported value.

## Related issues
https://github.com/ray-project/ray/issues/61794

## Additional information
Also added a regression test to cover this scenario.