### PR TITLE
[Data] Deprecate Pandas (#2/2) Fix aggregation/discretizer/null failures on converting to Arrow Blocks internally

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -968,7 +968,6 @@ python/ray/data/_internal/arrow_ops/transform_pyarrow.py
     DOC201: Function `combine_chunked_array` does not have a return section in docstring
 --------------------
 python/ray/data/_internal/block_batching/iter_batches.py
-    DOC103: Function `_format_in_threadpool`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [batch_iter: Iterator[Batch]]. Arguments in the docstring but not in the function signature: [logical_batch_iterator: ].
     DOC201: Function `_format_in_threadpool` does not have a return section in docstring
 --------------------
 python/ray/data/_internal/block_batching/util.py

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -215,7 +215,6 @@ def _reconstruct_chunked_array(
 
     # Reconstruct chunks from serialization payloads.
     chunks = [chunk.to_array() for chunk in chunks]
-
     return pa.chunked_array(chunks, type_)
 
 
@@ -266,7 +265,11 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
         # Array.from_buffers() doesn't work for DictionaryArrays.
         assert len(children) == 2, len(children)
         indices, dictionary = children
-        return pa.DictionaryArray.from_arrays(indices, dictionary)
+        return pa.DictionaryArray.from_arrays(
+            indices,
+            dictionary,
+            ordered=payload.type.ordered,  # Explicitly pass the ordered flag to from_arrays() to prevent dropping it as ordered=False by default
+        )
     elif pa.types.is_map(payload.type) and len(children) > 1:
         # In pyarrow<7.0.0, the underlying map child array is not exposed, so we work
         # with the key and item arrays.

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -192,6 +192,7 @@ class BatchIterator:
             batch_format=self._batch_format,
             collate_fn=self._collate_fn,
             num_threadpool_workers=num_threadpool_workers,
+            ensure_copy=self._ensure_copy,
         )
 
     def _finalize_batches(
@@ -312,6 +313,7 @@ def _format_in_threadpool(
     batch_format: Optional[str],
     collate_fn: Optional[Callable[[DataBatch], Any]],
     num_threadpool_workers: int,
+    ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Executes the batching, formatting, and collation logic in a threadpool.
 
@@ -333,7 +335,7 @@ def _format_in_threadpool(
     ) -> Iterator[Batch]:
         # Step 4a: Format the batches.
         formatted_batch_iter = format_batches(
-            batch_iter, batch_format=batch_format, stats=stats
+            batch_iter, batch_format=batch_format, stats=stats, ensure_copy=ensure_copy
         )
 
         # Step 4b: Apply the collate function if applicable.

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -318,7 +318,7 @@ def _format_in_threadpool(
     """Executes the batching, formatting, and collation logic in a threadpool.
 
     Args:
-        logical_batch_iterator: An iterator over logical batches.
+        batch_iter: An iterator over logical batches.
         stats: DatasetStats object to record timing and other statistics.
         batch_format: The format in which to return each batch.
             Specify "default" to use the current block format (promoting
@@ -328,6 +328,8 @@ def _format_in_threadpool(
             as batches.
         collate_fn: A function to apply to each data batch before returning it.
         num_threadpool_workers: The number of threads to use in the threadpool.
+        ensure_copy: Whether batches are always copied from the underlying base
+            blocks (not zero-copy views).
     """
 
     def threadpool_computations_format_collate(

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -354,7 +354,6 @@ class PandasBlockBuilder(TableBlockBuilder):
         from ray.data.extensions.tensor_extension import TensorArray
 
         pandas = lazy_import_pandas()
-
         return pandas.DataFrame(
             {
                 column_name: (

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -92,7 +92,7 @@ def _safe_from_pandas(df: "pandas.DataFrame") -> "pyarrow.Table":
     # Convert non-object columns via from_pandas so their dtypes and metadata are
     # preserved (e.g. TensorDtype via __arrow_array__, extension types, etc.).
     object_col_set = set(object_col_names)
-    non_object_col_names = [c for c in df.columns if c not in object_col_set]
+    non_object_col_names = df.columns.drop(object_col_names).tolist()
     non_object_table = pa.Table.from_pandas(
         df[non_object_col_names], preserve_index=False
     )

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -72,46 +72,33 @@ def _safe_from_pandas(df: "pandas.DataFrame") -> "pyarrow.Table":
     This function routes object-dtype columns through ``convert_to_pyarrow_array``,
     which produces ``ArrowTensorArray`` for ndarray elements and falls back to
     ``ArrowPythonObjectArray`` (pickle) for arbitrary Python objects. All other columns
-    go through ``pa.Table.from_pandas`` on the reduced DataFrame so their dtypes,
-    metadata, and null handling are unchanged.
+    go through ``pa.array(col, from_pandas=True)`` which handles nullable dtypes and
+    extension types via ``__arrow_array__``.
     """
     import pyarrow as pa
 
     from ray.data._internal.tensor_extensions.arrow import convert_to_pyarrow_array
 
-    # Identify object-dtype columns
-    object_col_names = [
-        col_name for col_name in df.columns if is_object_dtype(df[col_name].dtype)
-    ]
-
     # If no object-dtype columns, use fast path with regular from_pandas()
-    if not object_col_names:
+    if not any(is_object_dtype(df[col].dtype) for col in df.columns):
         # Set `preserve_index=False` so that Arrow doesn't add a '__index_level_0__'
         return pa.Table.from_pandas(df, preserve_index=False)
 
-    # Convert non-object columns via from_pandas so their dtypes and metadata are
-    # preserved (e.g. TensorDtype via __arrow_array__, extension types, etc.).
-    object_col_set = set(object_col_names)
-    non_object_col_names = df.columns.drop(object_col_names).tolist()
-    non_object_table = pa.Table.from_pandas(
-        df[non_object_col_names], preserve_index=False
-    )
+    # Convert column by column: object-dtype columns go through
+    # convert_to_pyarrow_array (handles tensors, PIL images, arbitrary objects),
+    # all others go through pa.array() with from_pandas=True.
+    arrays = []
+    fields = []
+    for col_name in df.columns:
+        col = df[col_name]
+        if is_object_dtype(col.dtype):
+            arr = convert_to_pyarrow_array(col.values, col_name)
+        else:
+            arr = pa.array(col, from_pandas=True)
+        arrays.append(arr)
+        fields.append(pa.field(col_name, arr.type))
 
-    # Assemble the final table column-by-column in the original order.
-    return pa.table(
-        {
-            col: (
-                convert_to_pyarrow_array(
-                    df[col].values, col
-                )  # use convert_to_pyarrow_array for object-dtype columns
-                if col in object_col_set
-                else non_object_table.column(
-                    col
-                )  # use regular column access for non-object-dtype columns
-            )
-            for col in df.columns
-        }
-    )
+    return pa.table(dict(zip(df.columns, arrays)), schema=pa.schema(fields))
 
 
 class PandasRow(Mapping):

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -341,7 +341,6 @@ class PandasBlockBuilder(TableBlockBuilder):
         from ray.data.extensions.tensor_extension import TensorArray
 
         pandas = lazy_import_pandas()
-
         return pandas.DataFrame(
             {
                 column_name: (

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -14,6 +14,8 @@ from typing import (
     Union,
 )
 
+import numpy as np
+
 from ray._common.utils import env_integer
 from ray.data._internal.block_builder import BlockBuilder
 from ray.data._internal.size_estimator import SizeEstimator
@@ -164,6 +166,13 @@ class TableBlockBuilder(BlockBuilder):
         self._columns.clear()
         self._num_compactions += 1
         self._num_uncompacted_rows = 0
+
+
+def _coerce_1d_ndarray_to_list(v: Any) -> Any:
+    """Return ``v.tolist()`` if ``v`` is a 1-D numpy array, otherwise return ``v`` unchanged."""
+    if isinstance(v, np.ndarray) and v.ndim == 1:
+        return v.tolist()
+    return v
 
 
 class TableBlockAccessor(BlockAccessor):
@@ -457,12 +466,16 @@ class TableBlockAccessor(BlockAccessor):
                                 )
                             count[name] += 1
                             resolved_agg_names[i] = name
-                            accumulators[i] = r[name]
+                            # pa.ListArray entries become 1-D numpy arrays after
+                            # Arrow→Pandas; coerce back to lists so tensor-extension
+                            # casting doesn't misidentify accumulator columns.
+                            accumulators[i] = _coerce_1d_ndarray_to_list(r[name])
                         first = False
                     else:
                         for i in range(len(aggs)):
                             accumulators[i] = aggs[i].merge(
-                                accumulators[i], r[resolved_agg_names[i]]
+                                accumulators[i],
+                                _coerce_1d_ndarray_to_list(r[resolved_agg_names[i]]),
                             )
                 # Build the row.
                 row = {}

--- a/python/ray/data/_internal/tensor_extensions/pandas.py
+++ b/python/ray/data/_internal/tensor_extensions/pandas.py
@@ -774,11 +774,22 @@ class TensorArray(
                     # Try to convert ndarrays of ndarrays/TensorArrayElements with an
                     # opaque object type to a properly typed ndarray of ndarrays.
                     values = _create_possibly_ragged_ndarray(values)
-                else:
+                else:  # If any of the values in the array do not conform to the expected types, raise an error
+                    # Find the first offending value in the array
+                    offending = next(
+                        v
+                        for v in values
+                        if not (
+                            isinstance(v, (np.ndarray, TensorArrayElement, Sequence))
+                            and not isinstance(v, str)
+                        )
+                    )
+                    # Raise an error with the type and value of the offending element
                     raise TypeError(
                         "Expected a well-typed ndarray or an object-typed ndarray of "
-                        "ndarray pointers, but got an object-typed ndarray whose "
-                        f"subndarrays are of type {type(values[0])}."
+                        "ndarray pointers, but got an object-typed ndarray containing "
+                        f"an unsupported element of type {type(offending)} "
+                        f"(value: {offending!r})."
                     )
         elif isinstance(values, TensorArray):
             raise TypeError("Use the copy() method to create a copy of a TensorArray.")

--- a/python/ray/data/_internal/tensor_extensions/pandas.py
+++ b/python/ray/data/_internal/tensor_extensions/pandas.py
@@ -439,17 +439,31 @@ class TensorDtype(pd.api.extensions.ExtensionDtype):
         https://pandas.pydata.org/pandas-docs/stable/development/extending.html#compatibility-with-apache-arrow
         for more information.
         """
+        # zero_copy_only=False is needed for ARROW_NATIVE (pa.fixed_shape_tensor).
+        # V1/V2 use ArrowTensorArray.to_numpy() which explicitly ignores zero_copy_only
+        # and always reads directly from the raw buffer. PyArrow's built-in
+        # FixedShapeTensorArray.to_numpy() enforces it and requires a copy.
         if isinstance(array, pa.ChunkedArray):
             if array.num_chunks > 1:
                 # TODO(Clark): Remove concat and construct from list with
                 # shape.
                 values = np.concatenate(
-                    [chunk.to_numpy() for chunk in array.iterchunks()]
+                    [
+                        chunk.to_numpy(zero_copy_only=False)
+                        for chunk in array.iterchunks()
+                    ]
                 )
             else:
-                values = array.chunk(0).to_numpy()
+                values = array.chunk(0).to_numpy(zero_copy_only=False)
         else:
-            values = array.to_numpy()
+            values = array.to_numpy(zero_copy_only=False)
+
+        # For ARROW_NATIVE format (pa.fixed_shape_tensor), to_numpy() flattens the
+        # inner tensor dimensions (e.g. shape (3,2,2,2) becomes (3,8)). Stack to collapse the object array into a real numeric array and then reshape to match the dimensions of the tensor from the metadata
+        if self.element_shape and all(s is not None for s in self.element_shape):
+            if values.dtype == object:
+                values = np.stack(values)
+            values = values.reshape((-1,) + self.element_shape)
 
         return TensorArray(values)
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -890,9 +890,15 @@ def find_partition_index(
         col_vals = table[col_name].to_numpy()[left:right]
         desired_val = desired[i]
 
-        # Handle null values - replace them with sentinel values
+        # Nulls sort last in Arrow, so they accumulate at the tail of col_vals.
+        # Stripping them before searching avoids a TypeError from np.searchsorted
+        # on None values — and if desired_val is also None, the answer is simply
+        # the end of the non-null region.
+        col_vals = col_vals[
+            ~pd.isna(col_vals)
+        ]  # remove nulls from the tail of col_vals
         if desired_val is None:
-            desired_val = NULL_SENTINEL
+            return left + len(col_vals)
 
         prevleft = left
         if descending[i] is True:

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -977,7 +977,9 @@ class Quantile(AggregateFnV2[List[Any], List[Any]]):
                 # Return the first null encountered to preserve column type.
                 return nulls[0]
 
-        if not accumulator:
+        if (
+            len(accumulator) == 0
+        ):  # Use len(accumulator) == 0 instead of not accumulator as a valid empty check for list or numpy array
             # If the list is empty (e.g., all values were null and ignored, or no values),
             # quantile is undefined.
             return None

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -552,6 +552,7 @@ class BlockAccessor:
                 and DataContext.get_current().batch_to_block_arrow_format
             ):
                 return cls.for_block(batch).to_arrow()
+            return batch
 
         elif isinstance(batch, collections.abc.Mapping):
             if block_type is None or block_type == BlockType.ARROW:


### PR DESCRIPTION
Stacked on #61733 

This PR adds Agg/Null test fixes on top of the minimal change to ensure result batches from UDFs are converted to Arrow instead of Pandas blocks.