### PR TITLE
[core] Disable compiled graph flaky tests

### DIFF
--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -268,6 +268,9 @@ def test_torch_tensor_nccl(
         assert ray.get(ref) == (i, shape, dtype)
 
 
+@pytest.mark.skip(
+    reason="Flaky: compiled DAG worker hangs on shared memory channel read"
+)
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 def test_torch_tensor_shm(ray_start_regular):
@@ -314,6 +317,9 @@ def test_torch_tensor_shm(ray_start_regular):
     compiled_dag.teardown()
 
 
+@pytest.mark.skip(
+    reason="Flaky: compiled DAG worker hangs on shared memory channel read"
+)
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
 @pytest.mark.parametrize("num_gpus", [[0, 0], [1, 0], [0, 1], [1, 1], [0.5, 0.5]])

--- a/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
+++ b/python/ray/dag/tests/experimental/test_torch_tensor_dag.py
@@ -268,8 +268,9 @@ def test_torch_tensor_nccl(
         assert ray.get(ref) == (i, shape, dtype)
 
 
-@pytest.mark.skip(
-    reason="Flaky: compiled DAG worker hangs on shared memory channel read"
+@pytest.mark.skipif(
+    torch.version.cuda is not None and torch.version.cuda >= "13.0",
+    reason="Flaky: worker hangs on shared memory channel read on cu130",
 )
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)
@@ -317,8 +318,9 @@ def test_torch_tensor_shm(ray_start_regular):
     compiled_dag.teardown()
 
 
-@pytest.mark.skip(
-    reason="Flaky: compiled DAG worker hangs on shared memory channel read"
+@pytest.mark.skipif(
+    torch.version.cuda is not None and torch.version.cuda >= "13.0",
+    reason="Flaky: worker hangs on shared memory channel read on cu130",
 )
 @pytest.mark.skipif(not USE_GPU, reason="Skipping GPU Test")
 @pytest.mark.parametrize("ray_start_regular", [{"num_cpus": 4}], indirect=True)


### PR DESCRIPTION
## Description
We observe compiled graph test [flakiness](https://buildkite.com/ray-project/postmerge/builds/16492/steps/canvas?jid=019cfad3-9b2f-42fb-8b7c-a86864ff29ee&tab=output) on cuda 13, and therefore we'd like to disable them to avoid noise.

### Why are we still testing compiled graph on cuda 13 even though we plan to deprecate compiled graph?
This is because we plan to provide rudimental support for running the Ray executor backend in vLLM, while vLLM is moving to cuda 13 in its default image by the end of this month. Although we are actively working on a new Ray executor backend (w/o compiled graph), it isn't guaranteed to land in time. During this transition, we want to continue supporting the existing Ray executor backend based on the compiled graph implementation.

### Why don't we fix the underlying issue?
The effort required isn't justified given that the compiled graph will be deprecated soon.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
