### PR TITLE
[Java] Upgrade jackson-databind 2.16.1 -> 2.18.6 to fix GHSA-72hv-8253-57qq

### DIFF
--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -4,7 +4,7 @@ load("@rules_jvm_external//:specs.bzl", "maven")
 def gen_java_deps():
     maven_install(
         artifacts = [
-            "com.fasterxml.jackson.core:jackson-databind:2.16.1",
+            "com.fasterxml.jackson.core:jackson-databind:2.18.6",
             "com.github.java-json-tools:json-schema-validator:2.2.14",
             "com.google.code.gson:gson:2.9.1",
             "com.google.guava:guava:32.0.1-jre",


### PR DESCRIPTION
Addresses security advisory GHSA-72hv-8253-57qq (HIGH severity), where the async JSON parser in jackson-core bypasses the maxNumberLength constraint, allowing DoS via arbitrarily long numbers. Upgrading jackson-databind to 2.18.6 pulls in the fixed jackson-core 2.18.6 transitively.

Closes #61645

Topic: upgrade-jackson
Labels: draft

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: andrew <andrew@anyscale.com>