### PR TITLE
[cluster launcher] [azure] fix: do not delete shared msi in azure when taking down clusters

### DIFF
--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -192,9 +192,7 @@ def _configure_resource_group(config):
 
     # Get or create an MSI name and resource group.
     # Defaults to current resource group if not provided.
-    use_existing_msi = (
-        "msi_name" in config["provider"] and "msi_resource_group" in config["provider"]
-    )
+    use_existing_msi = _is_shared_msi(config["provider"])
     msi_resource_group = config["provider"].get("msi_resource_group", resource_group)
     msi_name = config["provider"].get("msi_name", f"ray-{cluster_id}-msi")
     logger.info(
@@ -578,3 +576,11 @@ def _generate_arm_guid(*values: Any) -> str:
 
     concatenated = "".join(str(v) for v in values)
     return str(UUID(md5(concatenated.encode("utf-8")).hexdigest()))
+
+
+def _is_shared_msi(provider_config: dict) -> bool:
+    """Checks if the provider config specifies a shared/pre-existing MSI."""
+    return (
+        provider_config.get("msi_name") is not None
+        and provider_config.get("msi_resource_group") is not None
+    )

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -20,6 +20,7 @@ from ray._common.usage.usage_lib import get_cloud_from_metadata_requests
 from ray.autoscaler._private._azure.config import (
     _delete_role_assignments_for_principal,
     _generate_arm_guid,
+    _is_shared_msi,
     bootstrap_azure,
     get_azure_sdk_function,
 )
@@ -748,11 +749,7 @@ class AzureNodeProvider(NodeProvider):
                 exc,
             )
 
-        shared_msi = (
-            self.provider_config.get("msi_name") is not None
-            and self.provider_config.get("msi_resource_group") is not None
-        )
-        if shared_msi:
+        if _is_shared_msi(self.provider_config):
             return msi_principal_id
 
         try:

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -748,6 +748,13 @@ class AzureNodeProvider(NodeProvider):
                 exc,
             )
 
+        shared_msi = (
+            self.provider_config.get("msi_name") is not None
+            and self.provider_config.get("msi_resource_group") is not None
+        )
+        if shared_msi:
+            return msi_principal_id
+
         try:
             logger.info("Deleting Managed Service Identity: %s", msi_name)
             delete = get_azure_sdk_function(


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
Fixes an issue where running ray down with a shared MSI would delete the shared MSI on Azure clusters.

## Related issues
Fixes #61810.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
