### PR TITLE
[data] Unify actor pool state with assignment logic

### DIFF
--- a/python/ray/data/_internal/actor_autoscaler/autoscaling_actor_pool.py
+++ b/python/ray/data/_internal/actor_autoscaler/autoscaling_actor_pool.py
@@ -30,6 +30,21 @@ class ActorPoolScalingRequest:
         return ActorPoolScalingRequest(delta=delta, force=force, reason=reason)
 
 
+@dataclass(frozen=True)
+class ActorPoolInfo:
+    """Breakdown of the state of the actors used by the ``PhysicalOperator``"""
+
+    running: int
+    pending: int
+    restarting: int
+
+    def __str__(self):
+        return (
+            f"running={self.running}, restarting={self.restarting}, "
+            f"pending={self.pending}"
+        )
+
+
 @DeveloperAPI
 class AutoscalingActorPool(ABC):
     """Abstract interface of an autoscaling actor pool.
@@ -97,6 +112,7 @@ class AutoscalingActorPool(ABC):
 
     def get_pool_util(self) -> float:
         """Calculate the utilization of the given actor pool."""
+
         # If there are no running actors, we set the utilization to indicate that the pool should be scaled up immediately.
         if self.current_size() == 0:
             return float("inf")

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -20,6 +20,7 @@ import ray
 from .ref_bundle import RefBundle
 from ray._raylet import ObjectRefGenerator
 from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import (
+    ActorPoolInfo,
     AutoscalingActorPool,
 )
 from ray.data._internal.execution.interfaces.execution_options import (
@@ -332,21 +333,6 @@ class MetadataOpTask(OpTask):
     def on_task_finished(self):
         """Callback when the task is finished."""
         self._task_done_callback()
-
-
-@dataclass
-class _ActorPoolInfo:
-    """Breakdown of the state of the actors used by the ``PhysicalOperator``"""
-
-    running: int
-    pending: int
-    restarting: int
-
-    def __str__(self):
-        return (
-            f"running={self.running}, restarting={self.restarting}, "
-            f"pending={self.pending}"
-        )
 
 
 class PhysicalOperator(Operator):
@@ -926,9 +912,9 @@ class PhysicalOperator(Operator):
         """
         pass
 
-    def get_actor_info(self) -> _ActorPoolInfo:
+    def get_actor_info(self) -> ActorPoolInfo:
         """Returns the current status of actors being used by the operator"""
-        return _ActorPoolInfo(running=0, pending=0, restarting=0)
+        return ActorPoolInfo(running=0, pending=0, restarting=0)
 
     def _cancel_active_tasks(self, force: bool):
         tasks: List[OpTask] = self.get_active_tasks()

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -1,9 +1,7 @@
-import abc
 import logging
 import time
 import uuid
 import warnings
-from abc import abstractmethod
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -17,6 +15,8 @@ from typing import (
     Union,
 )
 
+from typing_extensions import override
+
 if TYPE_CHECKING:
     import pyarrow as pa
 
@@ -27,11 +27,11 @@ from ray.data._internal.actor_autoscaler import (
     AutoscalingActorPool,
 )
 from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import (
+    ActorPoolInfo,
     ActorPoolScalingRequest,
 )
 from ray.data._internal.compute import ActorPoolStrategy
 from ray.data._internal.execution.bundle_queue import (
-    QueueWithRemoval,
     create_bundle_queue,
 )
 from ray.data._internal.execution.interfaces import (
@@ -43,7 +43,6 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
 from ray.data._internal.execution.node_trackers.actor_location import (
     ActorLocationTracker,
     get_or_create_actor_location_tracker,
@@ -65,6 +64,9 @@ from ray.types import ObjectRef
 from ray.util.common import INT32_MAX
 
 logger = logging.getLogger(__name__)
+
+# Type alias for the logical identifier of an actor (used in labels and actor-to-id maps).
+LogicalActorId = str
 
 
 class ActorPoolMapOperator(MapOperator):
@@ -154,14 +156,6 @@ class ActorPoolMapOperator(MapOperator):
         self._ray_actor_task_remote_args = self._apply_default_actor_task_remote_args(
             ray_actor_task_remote_args, self.data_context
         )
-
-        per_actor_resource_usage = ExecutionResources(
-            cpu=self._ray_remote_args.get("num_cpus"),
-            gpu=self._ray_remote_args.get("num_gpus"),
-            memory=self._ray_remote_args.get("memory"),
-        )
-
-        max_actor_concurrency = self._ray_remote_args.get("max_concurrency", 1)
         map_worker_cls_name = f"MapWorker({self.name})"
         # We set the actor class name to include operator name to disambiguate
         # logs in the Actor Pool
@@ -171,27 +165,7 @@ class ActorPoolMapOperator(MapOperator):
         # class per operator with a unique name.
         self._map_worker_cls = type(map_worker_cls_name, (_MapWorker,), {})
 
-        self._actor_pool = _ActorPool(
-            self._start_actor,
-            per_actor_resource_usage,
-            min_size=compute_strategy.min_size,
-            max_size=compute_strategy.max_size,
-            initial_size=compute_strategy.initial_size,
-            max_actor_concurrency=max_actor_concurrency,
-            max_tasks_in_flight_per_actor=(
-                # Unless explicitly overridden by the user, max tasks-in-flight config
-                # will fall back to be:
-                #
-                #   DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR * max_concurrency,
-                compute_strategy.max_tasks_in_flight_per_actor
-                or data_context.max_tasks_in_flight_per_actor
-                or max_actor_concurrency
-                * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR
-            ),
-            map_worker_cls_name=self._map_worker_cls_name,
-            _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
-        )
-        self._actor_task_selector = self._create_task_selector(self._actor_pool)
+        self._actor_pool = self._create_actor_pool(compute_strategy)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = create_bundle_queue()
         # Cached actor class.
@@ -202,9 +176,32 @@ class ActorPoolMapOperator(MapOperator):
         self._locality_hits = 0
         self._locality_misses = 0
 
-    @staticmethod
-    def _create_task_selector(actor_pool: "_ActorPool") -> "_ActorTaskSelector":
-        return _ActorTaskSelectorImpl(actor_pool)
+    def _create_actor_pool(
+        self, compute_strategy: ActorPoolStrategy
+    ) -> "AutoscalingActorPool":
+        per_actor_resource_usage = ExecutionResources(
+            cpu=self._ray_remote_args.get("num_cpus"),
+            gpu=self._ray_remote_args.get("num_gpus"),
+            memory=self._ray_remote_args.get("memory"),
+        )
+        max_actor_concurrency = self._ray_remote_args.get("max_concurrency", 1)
+        max_tasks_in_flight_per_actor = (
+            compute_strategy.max_tasks_in_flight_per_actor
+            or self.data_context.max_tasks_in_flight_per_actor
+            or max_actor_concurrency
+            * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR
+        )
+        return _ActorPool(
+            create_actor_fn=self._start_actor,
+            min_size=compute_strategy.min_size,
+            max_size=compute_strategy.max_size,
+            initial_size=compute_strategy.initial_size,
+            max_tasks_in_flight_per_actor=max_tasks_in_flight_per_actor,
+            max_actor_concurrency=max_actor_concurrency,
+            per_actor_resource_usage=per_actor_resource_usage,
+            map_worker_cls_name=self._map_worker_cls_name,
+            _enable_actor_pool_on_exit_hook=self.data_context._enable_actor_pool_on_exit_hook,
+        )
 
     @staticmethod
     def _apply_default_actor_task_remote_args(
@@ -294,10 +291,10 @@ class ActorPoolMapOperator(MapOperator):
             should be able to launch a task.
 
         """
-        return self._actor_task_selector.can_schedule_task()
+        return self._actor_pool.can_schedule_task()
 
     def _start_actor(
-        self, labels: Dict[str, str], logical_actor_id: str
+        self, labels: Dict[str, str], logical_actor_id: LogicalActorId
     ) -> Tuple[ActorHandle, ObjectRef]:
         """Start a new actor and add it to the actor pool as a pending actor.
 
@@ -328,7 +325,7 @@ class ActorPoolMapOperator(MapOperator):
         def _task_done_callback(res_ref):
             # res_ref is a future for a now-ready actor; move actor from pending to the
             # active actor pool.
-            has_actor = self._actor_pool.pending_to_running(res_ref)
+            has_actor = self._actor_pool.pending_to_running(res_ref) is not None
             if not has_actor:
                 # Actor has already been killed.
                 return
@@ -354,24 +351,29 @@ class ActorPoolMapOperator(MapOperator):
             assert self.can_add_input(), f"Operator {self} can not handle input!"
 
         # Try to dispatch new tasks
-        submitted = self._try_schedule_tasks_internal(strict=strict)
+        submitted = self._try_schedule_tasks_internal()
 
         if strict:
             assert (
                 submitted >= 1
             ), f"Expected at least 1 task launched (launched {submitted})"
 
-    def _try_schedule_tasks_internal(self, strict: bool) -> int:
-        """Try to dispatch tasks from the internal queue"""
+    def _try_schedule_tasks_internal(self) -> int:
+        """Try to dispatch tasks from the internal queue. Returns the # of tasks submitted"""
 
         num_submitted_tasks = 0
+        while self._bundle_queue.has_next():
 
-        for bundle, actor in self._actor_task_selector.select_actors(
-            self._bundle_queue,
-            self._actor_locality_enabled,
-            strict=strict,
-        ):
-            # Submit the map task.
+            bundle = self._bundle_queue.peek_next()
+            actor = self._actor_pool.select_actors(
+                bundle=bundle,
+                actor_locality_enabled=self._actor_locality_enabled,
+            )
+            if actor is None:
+                break
+
+            self._bundle_queue.remove(bundle)
+
             self._metrics.on_input_dequeued(bundle, input_index=0)
             input_blocks = [block for block, _ in bundle.blocks]
             self._actor_pool.on_task_submitted(actor)
@@ -409,7 +411,7 @@ class ActorPoolMapOperator(MapOperator):
 
             # Update locality metrics
             if (
-                self._actor_pool.running_actors()[actor].actor_location
+                self._actor_pool._get_actor_node_id(actor)
                 in bundle.get_preferred_object_locations()
             ):
                 self._locality_hits += 1
@@ -449,7 +451,7 @@ class ActorPoolMapOperator(MapOperator):
                 )
 
             # Schedule tasks handling remaining bundles
-            self._try_schedule_tasks_internal(strict=False)
+            self._try_schedule_tasks_internal()
 
         return super().has_next()
 
@@ -611,9 +613,8 @@ class ActorPoolMapOperator(MapOperator):
 
         # Trigger Actor Pool's state refresh
         self._actor_pool.refresh_actor_state()
-        self._actor_task_selector.refresh_state()
 
-    def get_actor_info(self) -> _ActorPoolInfo:
+    def get_actor_info(self) -> ActorPoolInfo:
         """Returns Actor counts for Alive, Restarting and Pending Actors."""
         return self._actor_pool.get_actor_info()
 
@@ -629,8 +630,8 @@ class _MapWorker:
         ctx: DataContext,
         src_fn_name: str,
         map_transformer: MapTransformer,
-        logical_actor_id: str,
-        actor_location_tracker: ray.actor.ActorHandle[ActorLocationTracker],
+        logical_actor_id: LogicalActorId,
+        actor_location_tracker: ActorHandle[ActorLocationTracker],
     ):
         self.src_fn_name: str = src_fn_name
         self._map_transformer = map_transformer
@@ -707,7 +708,9 @@ class _MapWorker:
 
 @dataclass
 class _ActorState:
-    """Actor state"""
+    """Actor state. Not to be confused with Ray Core actor state that tracks
+    DEAD, RESTARTING, or ALIVE statuses, but rather, tracks additional info
+    in order to inform Ray Data scheduling decisions."""
 
     # Number of tasks in flight per actor
     num_tasks_in_flight: int
@@ -717,157 +720,6 @@ class _ActorState:
 
     # Is Actor state restarting or alive
     is_restarting: bool
-
-
-class _ActorTaskSelector(abc.ABC):
-    def __init__(self, actor_pool: "_ActorPool"):
-        """Initialize the actor task selector.
-
-        Args:
-            actor_pool: The actor pool to select tasks from.
-        """
-        self._actor_pool = actor_pool
-
-    def refresh_state(self):
-        """Callback to refresh selector's state that might depend on external data
-
-        NOTE: This data has to be snapshotted inside the selector, and
-              can only change upon this method invocation"""
-        pass
-
-    @abstractmethod
-    def can_schedule_task(self) -> bool:
-        """Checks whether there are actors available to schedule at least 1 task
-
-        NOTE: This method has to be consistent with `select_actors(...)` method, ie
-
-            - If `can_schedule_task` returns `True`, then
-            - `select_actors` must return at least 1 actor
-
-        TODO deduplicate with select_actors
-        """
-        ...
-
-    @abstractmethod
-    def select_actors(
-        self,
-        input_queue: QueueWithRemoval,
-        actor_locality_enabled: bool,
-        strict: bool,
-    ) -> Iterator[Tuple[RefBundle, ActorHandle]]:
-        """Select actors for bundles in the input queue.
-
-        Args:
-            input_queue: The input queue to select actors for.
-            actor_locality_enabled: Whether actor locality is enabled.
-            strict: Controls whether strict input handling protocol is enforced,
-                requiring at least 1 bundle to be matched with an actor
-
-        Returns:
-            Iterator of tuples of the bundle and the selected actor for that bundle.
-            Iteration stops when there are no more bundles to be selected in the input queue
-        """
-        pass
-
-
-class _ActorTaskSelectorImpl(_ActorTaskSelector):
-    def __init__(self, actor_pool: "_ActorPool"):
-        super().__init__(actor_pool)
-
-    def can_schedule_task(self) -> bool:
-        available_actors = self._actor_pool.schedulable_actors()
-
-        return len(available_actors) > 0
-
-    def select_actors(
-        self,
-        input_queue: QueueWithRemoval,
-        actor_locality_enabled: bool,
-        strict: bool,
-    ) -> Iterator[Tuple[RefBundle, ActorHandle]]:
-        assert (
-            not strict or self.can_schedule_task()
-        ), "select_actors(...) might not be invoked unless can_schedule_task(...) returns true"
-
-        while input_queue:
-            # Filter out actors that are invalid, i.e. actors with number of tasks in
-            # flight >= _max_tasks_in_flight or actor_state is not ALIVE.
-            bundle = input_queue.peek_next()
-            # Fetch available actors
-            available_actors = self._actor_pool.schedulable_actors()
-            if not available_actors:
-                return
-
-            # Rank all valid actors
-            ranks = self._rank_actors(
-                available_actors, bundle if actor_locality_enabled else None
-            )
-
-            assert len(ranks) == len(
-                available_actors
-            ), f"{len(ranks)} != {len(available_actors)}"
-
-            # Pick the actor with the highest rank (lower value, higher rank)
-            target_actor_idx = min(
-                range(len(available_actors)), key=lambda idx: ranks[idx]
-            )
-
-            target_actor = available_actors[target_actor_idx]
-
-            # We remove the bundle and yield the actor to the operator. We do not use pop()
-            # in case the queue has changed the order of the bundles.
-            input_queue.remove(bundle)
-            yield bundle, target_actor
-
-    def _rank_actors(
-        self,
-        actors: List[ActorHandle],
-        bundle: Optional[RefBundle],
-    ) -> List[Tuple[int, int]]:
-        """Return ranks for each actor based on node affinity with the blocks in the provided
-        bundle and current Actor's load.
-
-        The rank for each actor is a tuple of
-
-            1. Locality rank: a rank of a node Actor is scheduled on determined based on
-            the ranking of preferred locations for provided ``RefBundle`` (defined by
-            ``RefBundle.get_preferred_locations``). Lower is better.
-            2. Number of tasks currently executed by Actor. Lower is better.
-
-        Args:
-            actors: List of actors to rank
-            bundle: Optional bundle whose locality preferences should be considered
-
-        Returns:
-            List of (locality_rank, num_tasks) tuples, one per input actor
-        """
-        locs_priorities = (
-            {
-                # NOTE: We're negating total bytes to maintain an invariant
-                #       of the rank used -- lower value corresponding to a higher rank
-                node_id: -total_bytes
-                for node_id, total_bytes in bundle.get_preferred_object_locations().items()
-            }
-            if bundle is not None
-            else {}
-        )
-
-        # NOTE: Ranks are ordered in descending order (ie rank[0] is the highest
-        #       and rank[-1] is the lowest)
-        ranks = [
-            (
-                # Priority/rank of the location (based on the object size).
-                # Defaults to int32 max value (ie no rank)
-                locs_priorities.get(
-                    self._actor_pool.running_actors()[actor].actor_location, INT32_MAX
-                ),
-                # Number of tasks currently in flight at the given actor
-                self._actor_pool.running_actors()[actor].num_tasks_in_flight,
-            )
-            for actor in actors
-        ]
-
-        return ranks
 
 
 class _ActorPool(AutoscalingActorPool):
@@ -884,86 +736,61 @@ class _ActorPool(AutoscalingActorPool):
 
     def __init__(
         self,
-        create_actor_fn: "Callable[[Dict[str, str]], Tuple[ActorHandle, ObjectRef[Any]]]",
-        per_actor_resource_usage: ExecutionResources,
-        *,
+        create_actor_fn: Callable[[Dict[str, str]], Tuple[ActorHandle, ObjectRef[Any]]],
         min_size: int,
         max_size: int,
         initial_size: int,
-        max_actor_concurrency: int,
         max_tasks_in_flight_per_actor: int,
+        max_actor_concurrency: int,
+        per_actor_resource_usage: ExecutionResources,
         map_worker_cls_name: str = "MapWorker",
         debounce_period_s: int = _ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S,
         _enable_actor_pool_on_exit_hook: bool = False,
     ):
-        """Initialize the actor pool.
+        assert min_size >= 1
+        assert max_size >= min_size
+        assert initial_size <= max_size
+        assert initial_size >= min_size
+        assert max_tasks_in_flight_per_actor >= 1
 
-        Args:
-            create_actor_fn: This function should take key-value labels as input, and
-                create an actor with those labels. The function should return the actor
-                handle and a reference to the actor's node ID.
-            per_actor_resource_usage: The resource usage per actor.
-            min_size: The minimum number of running actors to be maintained
-                in the pool. Note, that this constraint could be violated when
-                no new work is available for scheduling in the actor pool (ie
-                when operator completes execution).
-            max_size: The maximum number of running actors to be maintained
-                in the pool.
-            initial_size: The initial number of actors to start with.
-            max_actor_concurrency: The maximum number of concurrent tasks a
-                single actor can execute (derived from `ray_remote_args`
-                passed to the operator).
-            max_tasks_in_flight_per_actor: The maximum number of tasks that can
-                be submitted to a single actor at any given time.
-            map_worker_cls_name: Name of the map worker class for logging purposes.
-            debounce_period_s: Debounce period for scaling down after scaling up
-            _enable_actor_pool_on_exit_hook: Whether to enable the actor pool
-                on exit hook.
-        """
-
-        self._min_size: int = min_size
-        self._max_size: int = max_size
-        self._initial_size: int = initial_size
-        self._max_actor_concurrency: int = max_actor_concurrency
-        self._max_tasks_in_flight: int = max_tasks_in_flight_per_actor
-        self._map_worker_cls_name = map_worker_cls_name
-        self._debounce_period_s = debounce_period_s
-        self._create_actor_fn = create_actor_fn
+        self._min_size = min_size
+        self._max_size = max_size
+        self._initial_size = initial_size
+        self._max_tasks_in_flight_per_actor = max_tasks_in_flight_per_actor
+        self._max_actor_concurrency = max_actor_concurrency
         self._per_actor_resource_usage = per_actor_resource_usage
 
-        assert self._min_size >= 1
-        assert self._max_size >= self._min_size
-        assert self._initial_size <= self._max_size
-        assert self._initial_size >= self._min_size
-        assert self._max_tasks_in_flight >= 1
-        assert self._create_actor_fn is not None
-
+        self._create_actor_fn = create_actor_fn
+        self._enable_actor_pool_on_exit_hook = _enable_actor_pool_on_exit_hook
+        self._map_worker_cls_name = map_worker_cls_name
+        self._debounce_period_s = debounce_period_s
         # Timestamp of the last scale up action
         self._last_upscaled_at: Optional[float] = None
         self._last_downscaling_debounce_warning_ts: Optional[float] = None
         # Actors that have started running, including alive and restarting actors.
-        self._running_actors: Dict[ray.actor.ActorHandle, _ActorState] = {}
+        self._running_actors: Dict[ActorHandle, _ActorState] = {}
         # Actors that are not yet ready (still pending creation).
-        self._pending_actors: Dict[ObjectRef, ray.actor.ActorHandle] = {}
+        self._pending_actors: Dict[ObjectRef, ActorHandle] = {}
         # Map from actor handle to its logical ID.
-        self._actor_to_logical_id: Dict[ray.actor.ActorHandle, str] = {}
-        self._enable_actor_pool_on_exit_hook = _enable_actor_pool_on_exit_hook
+        self._actor_to_logical_id: Dict[ActorHandle, LogicalActorId] = {}
         # Cached values for actor / task counts
         self._num_restarting_actors: int = 0
         self._num_active_actors: int = 0
         self._total_num_tasks_in_flight: int = 0
 
-    # === Overriding methods of AutoscalingActorPool ===
-
+    @override
     def min_size(self) -> int:
         return self._min_size
 
+    @override
     def max_size(self) -> int:
         return self._max_size
 
+    @override
     def current_size(self) -> int:
         return self.num_pending_actors() + self.num_running_actors()
 
+    @override
     def num_running_actors(self) -> int:
         return len(self._running_actors)
 
@@ -971,23 +798,28 @@ class _ActorPool(AutoscalingActorPool):
         """Restarting actors are all the running actors not in ALIVE state."""
         return self._num_restarting_actors
 
+    @override
     def num_active_actors(self) -> int:
         """Active actors are all the running actors with inflight tasks."""
         return self._num_active_actors
 
     def num_alive_actors(self) -> int:
         """Alive actors are all the running actors in ALIVE state."""
-        return len(self._running_actors) - self._num_restarting_actors
+        return self.num_running_actors() - self.num_restarting_actors()
 
+    @override
     def num_pending_actors(self) -> int:
         return len(self._pending_actors)
 
+    @override
     def max_tasks_in_flight_per_actor(self) -> int:
-        return self._max_tasks_in_flight
+        return self._max_tasks_in_flight_per_actor
 
+    @override
     def max_actor_concurrency(self) -> int:
         return self._max_actor_concurrency
 
+    @override
     def num_tasks_in_flight(self) -> int:
         return self._total_num_tasks_in_flight
 
@@ -998,13 +830,16 @@ class _ActorPool(AutoscalingActorPool):
     def map_worker_cls_name(self) -> str:
         return self._map_worker_cls_name
 
-    def get_actor_id(self, actor: ActorHandle) -> str:
+    def _get_actor_logical_id(self, actor: ActorHandle) -> LogicalActorId:
         return self._actor_to_logical_id[actor]
 
-    def _can_apply(self, config: ActorPoolScalingRequest) -> bool:
+    def _get_actor_node_id(self, actor: ActorHandle):
+        return self._running_actors[actor].actor_location
+
+    def _can_apply(self, req: ActorPoolScalingRequest) -> bool:
         """Returns whether Actor Pool is able to execute scaling request"""
 
-        if config.delta < 0:
+        if req.delta < 0:
             # To prevent bouncing back and forth, we disallow scale down for
             # a "cool-off" period after the most recent scaling up, with an intention
             # to allow application to actually utilize newly provisioned resources
@@ -1014,7 +849,7 @@ class _ActorPool(AutoscalingActorPool):
             # scaling up, ie if actor pool just scaled down, it'd still be able
             # to scale back up immediately.
             if (
-                not config.force
+                not req.force
                 and self._last_upscaled_at is not None
                 and (time.time() <= self._last_upscaled_at + self._debounce_period_s)
             ):
@@ -1022,7 +857,7 @@ class _ActorPool(AutoscalingActorPool):
                 #       per upscaling event
                 if self._last_upscaled_at != self._last_downscaling_debounce_warning_ts:
                     logger.debug(
-                        f"Ignoring scaling down request (request={config}; reason=debounced from scaling up at {self._last_upscaled_at})"
+                        f"Ignoring scaling down request (request={req}; reason=debounced from scaling up at {self._last_upscaled_at})"
                     )
                     self._last_downscaling_debounce_warning_ts = self._last_upscaled_at
 
@@ -1030,6 +865,7 @@ class _ActorPool(AutoscalingActorPool):
 
         return True
 
+    @override
     def scale(self, req: ActorPoolScalingRequest) -> Optional[int]:
         # Verify request could be applied
         if not self._can_apply(req):
@@ -1039,6 +875,7 @@ class _ActorPool(AutoscalingActorPool):
 
         if req.delta > 0:
             target_num_actors = req.delta
+
             logger.debug(
                 f"Scaling up {map_worker_cls_name} actor pool by {target_num_actors} (reason={req.reason}, "
                 f"{self.get_actor_info()})"
@@ -1046,7 +883,7 @@ class _ActorPool(AutoscalingActorPool):
 
             for _ in range(target_num_actors):
                 actor, ready_ref = self._create_actor()
-                self.add_pending_actor(actor, ready_ref)
+                self._add_pending_actor(actor, ready_ref)
 
             # Capture last scale up timestamp
             self._last_upscaled_at = time.time()
@@ -1071,19 +908,14 @@ class _ActorPool(AutoscalingActorPool):
 
         return None
 
-    def _create_actor(self) -> Tuple[ray.actor.ActorHandle, ObjectRef]:
+    def _create_actor(self) -> Tuple[ActorHandle, ObjectRef]:
         logical_actor_id = str(uuid.uuid4())
         labels = {self.get_logical_id_label_key(): logical_actor_id}
         actor, ready_ref = self._create_actor_fn(labels, logical_actor_id)
         self._actor_to_logical_id[actor] = logical_actor_id
         return actor, ready_ref
 
-    # === End of overriding methods of AutoscalingActorPool ===
-
-    def running_actors(self) -> Dict[ray.actor.ActorHandle, _ActorState]:
-        return self._running_actors
-
-    def schedulable_actors(self) -> List[ray.actor.ActorHandle]:
+    def _schedulable_actors(self) -> List[ActorHandle]:
         return [
             actor
             for actor, state in self._running_actors.items()
@@ -1091,50 +923,70 @@ class _ActorPool(AutoscalingActorPool):
             and not state.is_restarting
         ]
 
-    def on_task_submitted(self, actor: ray.actor.ActorHandle):
-        self._running_actors[actor].num_tasks_in_flight += 1
+    def can_schedule_task(self) -> bool:
+        """Returns `True` iff the actor pool has an available actor that can run a task."""
+        return self.select_actors() is not None
+
+    def select_actors(
+        self,
+        bundle: Optional[RefBundle] = None,
+        actor_locality_enabled: bool = False,
+    ) -> Optional[ActorHandle]:
+        available_actors = self._schedulable_actors()
+        if not available_actors:
+            return None
+
+        ranks = self._rank_actors(
+            available_actors, bundle if actor_locality_enabled else None
+        )
+
+        target_actor_idx = min(range(len(available_actors)), key=lambda idx: ranks[idx])
+        return available_actors[target_actor_idx]
+
+    def on_task_submitted(self, actor: ActorHandle):
+        state = self._running_actors[actor]
+        state.num_tasks_in_flight += 1
         self._total_num_tasks_in_flight += 1
 
-        if self._running_actors[actor].num_tasks_in_flight == 1:
+        if state.num_tasks_in_flight == 1:
             self._num_active_actors += 1
 
     def refresh_actor_state(self):
-        for actor in self.get_running_actor_refs():
-            actor_state = actor._get_local_state()
-            if actor_state in (None, gcs_pb2.ActorTableData.ActorState.DEAD):
-                # actor._get_local_state can return None if the state is Unknown
-                # If actor_state is None or dead, there is nothing to do.
-                continue
-            elif actor_state != gcs_pb2.ActorTableData.ActorState.ALIVE:
-                # The actors can be either ALIVE or RESTARTING here because they will
-                # be restarted indefinitely until execution finishes.
-                assert (
-                    actor_state == gcs_pb2.ActorTableData.ActorState.RESTARTING
-                ), actor_state
-                self._update_running_actor_state(actor, True)
-            else:
-                self._update_running_actor_state(actor, False)
+        for actor in self._running_actors:
+            self._update_running_actor_state(actor)
 
-    def _update_running_actor_state(
-        self, actor: ray.actor.ActorHandle, is_restarting: bool
-    ) -> None:
-        """Update running actor state.
+    def _update_running_actor_state(self, actor: ActorHandle) -> _ActorState:
+        """Update running actor state. This is called for every actor
+        in `refresh_actor_state`.
 
         Args:
             actor: The running actor that needs state update.
-            is_restarting: Whether running actor is restarting or alive.
+
+        Returns:
+            The new actor state
         """
-        assert actor in self._running_actors
-        if self._running_actors[actor].is_restarting == is_restarting:
-            return
-
-        self._running_actors[actor].is_restarting = is_restarting
-        if is_restarting:
-            self._num_restarting_actors += 1
+        actor_state = actor._get_local_state()
+        running_actor_state = self._running_actors[actor]
+        if actor_state in (None, gcs_pb2.ActorTableData.ActorState.DEAD):
+            # actor._get_local_state can return None if the state is Unknown
+            # If actor_state is None or dead, there is nothing to do.
+            return running_actor_state
+        elif actor_state != gcs_pb2.ActorTableData.ActorState.ALIVE:
+            # The actors can be either ALIVE or RESTARTING here because they will
+            # be restarted indefinitely until execution finishes.
+            assert (
+                actor_state == gcs_pb2.ActorTableData.ActorState.RESTARTING
+            ), actor_state
+            if not running_actor_state.is_restarting:
+                self._num_restarting_actors += 1
+                running_actor_state.is_restarting = True
         else:
-            self._num_restarting_actors -= 1
+            if running_actor_state.is_restarting:
+                self._num_restarting_actors -= 1
+                running_actor_state.is_restarting = False
+        return running_actor_state
 
-    def add_pending_actor(self, actor: ray.actor.ActorHandle, ready_ref: ray.ObjectRef):
+    def _add_pending_actor(self, actor: ActorHandle, ready_ref: ray.ObjectRef):
         """Adds a pending actor to the pool.
 
         This actor won't be pickable until it is marked as running via a
@@ -1146,7 +998,7 @@ class _ActorPool(AutoscalingActorPool):
         """
         self._pending_actors[ready_ref] = actor
 
-    def pending_to_running(self, ready_ref: ray.ObjectRef) -> bool:
+    def pending_to_running(self, ready_ref: ray.ObjectRef) -> Optional[ActorHandle]:
         """Mark the actor corresponding to the provided ready future as running, making
         the actor pickable.
 
@@ -1154,8 +1006,8 @@ class _ActorPool(AutoscalingActorPool):
             ready_ref: The ready future for the actor that we wish to mark as running.
 
         Returns:
-            Whether the actor was still pending. This can return False if the actor had
-            already been killed.
+            The actor handle of the pending/now ready actor. Otherwise, returns `None`
+            if actor has already been killed
 
         Raises:
             RayError: If the actor initialization failed. The actor is cleaned up
@@ -1163,7 +1015,7 @@ class _ActorPool(AutoscalingActorPool):
         """
         if ready_ref not in self._pending_actors:
             # The actor has been removed from the pool before becoming running.
-            return False
+            return None
         actor = self._pending_actors.pop(ready_ref)
         try:
             actor_location = ray.get(ready_ref)
@@ -1178,28 +1030,25 @@ class _ActorPool(AutoscalingActorPool):
             actor_location=actor_location,
             is_restarting=False,
         )
-        return True
+        return actor
 
-    def on_task_completed(self, actor: ray.actor.ActorHandle):
+    def on_task_completed(self, actor: ActorHandle):
         """Called when a task completes. Returns the provided actor to the pool."""
-        assert actor in self._running_actors
-        assert self._running_actors[actor].num_tasks_in_flight > 0
-        self._running_actors[actor].num_tasks_in_flight -= 1
+        state = self._running_actors[actor]
+        assert state.num_tasks_in_flight > 0
+        state.num_tasks_in_flight -= 1
         self._total_num_tasks_in_flight -= 1
-        if not self._running_actors[actor].num_tasks_in_flight:
+        if not state.num_tasks_in_flight:
             self._num_active_actors -= 1
 
     def get_pending_actor_refs(self) -> List[ray.ObjectRef]:
         return list(self._pending_actors.keys())
 
-    def get_running_actor_refs(self) -> List[ActorHandle]:
-        return list(self._running_actors.keys())
-
-    def get_logical_ids(self) -> List[str]:
+    def _get_logical_ids(self) -> List[LogicalActorId]:
         """Get the logical IDs for pending and running actors in the actor pool.
 
-        We can’t use Ray Core actor IDs because we need to identify actors by labels,
-        but labels must be set before creation, and actor IDs aren’t available until
+        We can't use Ray Core actor IDs because we need to identify actors by labels,
+        but labels must be set before creation, and actor IDs aren't available until
         after.
         """
         return list(self._actor_to_logical_id.values())
@@ -1213,7 +1062,7 @@ class _ActorPool(AutoscalingActorPool):
 
     def num_idle_actors(self) -> int:
         """Return the number of idle actors in the pool."""
-        return len(self._running_actors) - self._num_active_actors
+        return self.num_running_actors() - self.num_active_actors()
 
     def _remove_inactive_actor(self) -> bool:
         """Kills a single pending or idle actor, if any actors are pending/idle.
@@ -1287,9 +1136,7 @@ class _ActorPool(AutoscalingActorPool):
             for actor in running:
                 ray.kill(actor)
 
-    def _release_running_actor(
-        self, actor: ray.actor.ActorHandle
-    ) -> Optional[ObjectRef]:
+    def _release_running_actor(self, actor: ActorHandle) -> Optional[ObjectRef]:
         """Remove the given actor from the pool and trigger its `on_exit` callback.
 
         This method returns a ``ref`` to the result
@@ -1327,14 +1174,64 @@ class _ActorPool(AutoscalingActorPool):
 
         return ref
 
-    def get_actor_info(self) -> _ActorPoolInfo:
+    def get_actor_info(self) -> ActorPoolInfo:
         """Returns current snapshot of actors' being used in the pool"""
-        return _ActorPoolInfo(
+        return ActorPoolInfo(
             running=self.num_alive_actors(),
             pending=self.num_pending_actors(),
             restarting=self.num_restarting_actors(),
         )
 
+    @override
     def per_actor_resource_usage(self) -> ExecutionResources:
-        """Per actor resource usage."""
         return self._per_actor_resource_usage
+
+    def _rank_actors(
+        self,
+        actors: List[ActorHandle],
+        bundle: Optional[RefBundle],
+    ) -> List[Tuple[int, int]]:
+        """Return ranks for each actor based on node affinity with the blocks in the provided
+        bundle and current Actor's load.
+
+        The rank for each actor is a tuple of
+
+            1. Locality rank: a rank of a node Actor is scheduled on determined based on
+            the ranking of preferred locations for provided ``RefBundle`` (defined by
+            ``RefBundle.get_preferred_locations``). Lower is better.
+            2. Number of tasks currently executed by Actor. Lower is better.
+
+        Args:
+            actors: List of actors to rank
+            bundle: Optional bundle whose locality preferences should be considered
+
+        Returns:
+            List of (locality_rank, num_tasks) tuples, one per input actor
+        """
+        locs_priorities = (
+            {
+                # NOTE: We're negating total bytes to maintain an invariant
+                #       of the rank used -- lower value corresponding to a higher rank
+                node_id: -total_bytes
+                for node_id, total_bytes in bundle.get_preferred_object_locations().items()
+            }
+            if bundle is not None
+            else {}
+        )
+
+        # NOTE: Ranks are ordered in descending order (ie rank[0] is the highest
+        #       and rank[-1] is the lowest)
+        ranks = [
+            (
+                # Priority/rank of the location (based on the object size).
+                # Defaults to int32 max value (ie no rank)
+                locs_priorities.get(
+                    self._running_actors[actor].actor_location, INT32_MAX
+                ),
+                # Number of tasks currently in flight at the given actor
+                self._running_actors[actor].num_tasks_in_flight,
+            )
+            for actor in actors
+        ]
+
+        return ranks

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import ray
+from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import ActorPoolInfo
 from ray.data._internal.execution.backpressure_policy import BackpressurePolicy
 from ray.data._internal.execution.bundle_queue import create_bundle_queue
 from ray.data._internal.execution.interfaces import (
@@ -23,7 +24,6 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     MetadataOpTask,
     OpTask,
     Waitable,
-    _ActorPoolInfo,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
     InternalQueueOperatorMixin,
@@ -682,7 +682,7 @@ def select_operator_to_run(
     return next_op
 
 
-def _actor_info_summary_str(info: _ActorPoolInfo) -> str:
+def _actor_info_summary_str(info: ActorPoolInfo) -> str:
     total = info.running + info.pending + info.restarting
     base = f"Actors: {total}"
 

--- a/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
+++ b/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
@@ -603,11 +603,11 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
 
     def get_actor_info(self):
         from ray.data._internal.execution.interfaces.physical_operator import (
-            _ActorPoolInfo,
+            ActorPoolInfo,
         )
 
         n = len(self._rank_pool.actors)
-        return _ActorPoolInfo(running=n, pending=0, restarting=0)
+        return ActorPoolInfo(running=n, pending=0, restarting=0)
 
     # ------------------------------------------------------------------
     # SubProgressBarMixin

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -18,7 +18,11 @@ import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private.ray_constants import ID_SIZE
 from ray.actor import ActorHandle
+from ray.core.generated import gcs_pb2
 from ray.data._internal.actor_autoscaler import ActorPoolScalingRequest
+from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import (
+    ActorPoolInfo,
+)
 from ray.data._internal.actor_autoscaler.default_actor_autoscaler import (
     _estimate_total_available_task_slots,
 )
@@ -29,13 +33,10 @@ from ray.data._internal.execution.interfaces import (
     ExecutionResources,
     PhysicalOperator,
 )
-from ray.data._internal.execution.interfaces.physical_operator import _ActorPoolInfo
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.actor_pool_map_operator import (
-    ActorPoolMapOperator,
     _ActorPool,
-    _ActorTaskSelector,
     _MapWorker,
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
@@ -78,6 +79,36 @@ class PoolWorker:
         pass
 
 
+def _make_bundle_queue(n_or_bundles) -> HashLinkedQueue:
+    """Build a HashLinkedQueue from an int (generates n ref bundles) or a bundle list."""
+    if isinstance(n_or_bundles, int):
+        bundles = make_ref_bundles([[i] for i in range(n_or_bundles)])
+    else:
+        bundles = n_or_bundles
+    queue = HashLinkedQueue()
+    for b in bundles:
+        queue.add(b)
+    return queue
+
+
+def _schedule_bundles(
+    pool: _ActorPool,
+    queue: HashLinkedQueue,
+    actor_locality_enabled: bool = False,
+) -> list:
+    """Schedule all bundles via select_actors; return list of actors."""
+    results = []
+    while queue.has_next() and pool.can_schedule_task():
+        bundle = queue.get_next()
+        actor = pool.select_actors(
+            bundle=bundle,
+            actor_locality_enabled=actor_locality_enabled,
+        )
+        pool.on_task_submitted(actor)
+        results.append(actor)
+    return results
+
+
 class TestActorPool(unittest.TestCase):
     def setup_class(self):
         self._last_created_actor_and_ready_ref: Optional[
@@ -89,35 +120,24 @@ class TestActorPool(unittest.TestCase):
     def teardown_class(self):
         ray.shutdown()
 
-    def _create_task_selector(self, pool: _ActorPool) -> _ActorTaskSelector:
-        return ActorPoolMapOperator._create_task_selector(pool)
-
     def _assign_actor(
         self,
         pool: _ActorPool,
         bundle: Optional[RefBundle] = None,
         actor_locality_enabled: bool = False,
     ) -> Optional[ActorHandle]:
-        if bundle is None:
-            bundles = make_ref_bundles([[0]])
-        else:
-            bundles = [bundle]
+        queue = _make_bundle_queue([bundle] if bundle is not None else 1)
 
-        queue = HashLinkedQueue()
-        for bundle in bundles:
-            queue.add(bundle)
-
-        selector = self._create_task_selector(pool)
-        if not selector.can_schedule_task():
+        if not pool.can_schedule_task() or not queue.has_next():
             return None
 
-        it = selector.select_actors(queue, actor_locality_enabled, strict=True)
-        try:
-            actor = next(it)[1]
-            pool.on_task_submitted(actor)
-            return actor
-        except StopIteration:
-            return None
+        bundle = queue.get_next()
+        actor = pool.select_actors(
+            bundle=bundle,
+            actor_locality_enabled=actor_locality_enabled,
+        )
+        pool.on_task_submitted(actor)
+        return actor
 
     def _create_actor_fn(
         self,
@@ -135,15 +155,18 @@ class TestActorPool(unittest.TestCase):
         max_size=4,
         initial_size=1,
         max_tasks_in_flight=4,
+        map_worker_cls_name="MapWorker",
     ):
         pool = _ActorPool(
+            create_actor_fn=self._create_actor_fn,
             min_size=min_size,
             max_size=max_size,
             initial_size=initial_size,
-            max_actor_concurrency=1,
             max_tasks_in_flight_per_actor=max_tasks_in_flight,
-            create_actor_fn=self._create_actor_fn,
+            max_actor_concurrency=1,
             per_actor_resource_usage=ExecutionResources(cpu=1),
+            map_worker_cls_name=map_worker_cls_name,
+            _enable_actor_pool_on_exit_hook=False,
         )
         return pool
 
@@ -257,8 +280,13 @@ class TestActorPool(unittest.TestCase):
         pool = self._create_actor_pool(max_tasks_in_flight=1)
         actor = self._add_ready_actor(pool)
 
-        # Mark the actor as restarting and test pick_actor fails
-        pool._update_running_actor_state(actor, True)
+        # Mark the actor as restarting (mock _get_local_state) and test pick_actor fails
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
         assert self._assign_actor(pool) is None
         assert pool.current_size() == 1
         assert pool.num_pending_actors() == 0
@@ -268,12 +296,17 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert _estimate_total_available_task_slots(pool) == 1
-        assert pool.get_actor_info() == _ActorPoolInfo(
+        assert pool.get_actor_info() == ActorPoolInfo(
             running=0, pending=0, restarting=1
         )
 
-        # Mark the actor as alive and test pick_actor succeeds
-        pool._update_running_actor_state(actor, False)
+        # Mark the actor as alive (mock _get_local_state) and test pick_actor succeeds
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.ALIVE,
+        ):
+            pool.refresh_actor_state()
         picked_actor = self._assign_actor(pool)
         assert picked_actor == actor
         assert pool.current_size() == 1
@@ -284,7 +317,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 1
         assert pool.num_idle_actors() == 0
         assert _estimate_total_available_task_slots(pool) == 0
-        assert pool.get_actor_info() == _ActorPoolInfo(
+        assert pool.get_actor_info() == ActorPoolInfo(
             running=1, pending=0, restarting=0
         )
 
@@ -298,7 +331,7 @@ class TestActorPool(unittest.TestCase):
         assert pool.num_active_actors() == 0
         assert pool.num_idle_actors() == 1
         assert _estimate_total_available_task_slots(pool) == 1
-        assert pool.get_actor_info() == _ActorPoolInfo(
+        assert pool.get_actor_info() == ActorPoolInfo(
             running=1, pending=0, restarting=0
         )
 
@@ -535,115 +568,62 @@ class TestActorPool(unittest.TestCase):
         actor1 = self._add_ready_actor(pool, node_id="node1")
         actor2 = self._add_ready_actor(pool, node_id="node2")
 
-        # Create the mock bundle queue
-        bundle_queue = HashLinkedQueue()
-        for bundle in bundles:
-            bundle_queue.add(bundle)
-
-        # Create the mock task actor selector iterator
-        task_selector = self._create_task_selector(pool)
-        it = task_selector.select_actors(
-            bundle_queue, actor_locality_enabled=True, strict=True
+        # Schedule bundles via select_actors (one bundle at a time)
+        results = _schedule_bundles(
+            pool, _make_bundle_queue(bundles), actor_locality_enabled=True
         )
 
         # Actors on node1 should be preferred
-        res1 = next(it)[1]
-        pool.on_task_submitted(res1)
-        assert res1 == actor1
-
-        # Actors on node1 should be preferred still
-        res2 = next(it)[1]
-        pool.on_task_submitted(res2)
-        assert res2 == actor1
-
-        # Fallback to remote actors
-        res3 = next(it)[1]
-        pool.on_task_submitted(res3)
-        assert res3 == actor2
+        assert results[0] == actor1
+        assert results[1] == actor1
 
         # NOTE: Actor 2 is selected (since Actor 1 is at capacity)
-        res4 = next(it)[1]
-        pool.on_task_submitted(res4)
-        assert res4 == actor2
+        assert results[2] == actor2
+        assert results[3] == actor2
 
-        # NOTE: Actor 2 is at max requests in-flight, hence excluded
-        try:
-            res5 = next(it)[1]
-        except StopIteration:
-            res5 = None
-        assert res5 is None
+        # NOTE: Only 4 tasks scheduled (Actor 2 is at max requests in-flight)
+        assert len(results) == 4
 
     @patch.object(RefBundle, "get_preferred_object_locations", return_value={})
     def test_selector_locality_based_actor_ranking_no_locations(self, _mock_locs):
         pool = self._create_actor_pool(max_tasks_in_flight=2)
 
-        # Setup bundle mocks
-        bundles = make_ref_bundles([[0] for _ in range(10)])
-
         # Create the mock bundle queue
-        bundle_queue = HashLinkedQueue()
-        for bundle in bundles:
-            bundle_queue.add(bundle)
+        bundle_queue = _make_bundle_queue(10)
 
         # Add one actor to the pool
         actor1 = self._add_ready_actor(pool, node_id="node1")
 
-        # Create the mock task actor selector iterator
-        task_selector = self._create_task_selector(pool)
-        it = task_selector.select_actors(
-            bundle_queue, actor_locality_enabled=True, strict=True
-        )
-
-        # Select one actor to schedule it on actor1
-        res1 = next(it)[1]
+        # Schedule one bundle on actor1
+        assert bundle_queue.has_next() and pool.can_schedule_task()
+        bundle = bundle_queue.get_next()
+        res1 = pool.select_actors(bundle=bundle, actor_locality_enabled=True)
         pool.on_task_submitted(res1)
         assert res1 == actor1
+        pool.on_task_completed(actor1)
 
         # Add another actor to the pool
-        actor2 = self._add_ready_actor(pool, node_id="node2")
+        self._add_ready_actor(pool, node_id="node2")
 
-        # Re-create the mock task actor selector iterator
-        task_selector = self._create_task_selector(pool)
-        it = task_selector.select_actors(
-            bundle_queue, actor_locality_enabled=True, strict=True
-        )
+        # Schedule remaining bundles via select_actors
+        results = _schedule_bundles(pool, bundle_queue, actor_locality_enabled=True)
 
-        # Select and actor, it should be scheudled on actor2
-        res2 = next(it)[1]
-        pool.on_task_submitted(res2)
-        assert res2 == actor2
+        # After 4 total tasks (2 per actor at max_tasks_in_flight=2), no more
+        assert len(results) == 4
+        first_half = results[:2]
+        last_half = results[2:]
+        # Since we are picking least loaded actors, the actor selection
+        # should be unique within each half.
+        assert len(set(first_half)) == 2
+        assert len(set(last_half)) == 2
 
-        # Select another actor, it could be either actor1 or actor2
-        res3 = next(it)[1]
-        pool.on_task_submitted(res3)
-
-        # Select another actor, it should be the other actor
-        res4 = next(it)[1]
-        pool.on_task_submitted(res4)
-        if res3 == actor1:
-            assert res4 == actor2
-        else:
-            assert res4 == actor1
-
-        # Nothing left
-        try:
-            res5 = next(it)[1]
-        except StopIteration:
-            res5 = None
-        assert res5 is None
+        assert not pool.can_schedule_task()
 
     def test_selector_select_actors_strict(self):
-        """Tests that `select_actors` enforces strict input handling protocol correctly.
-
-         - When strict=True, select_actors() asserts that can_schedule_task() returns
-        True. This assures that calling select_actors() when no actors are available.
-
-        - When strict=False, select_actors() allows the call even when no actors
-        are available, returning an empty iterator instead of raising an error.
-        """
+        """Tests that `select_actors` returns None when no capacity."""
         pool = self._create_actor_pool(max_tasks_in_flight=2)
 
-        # Add a 1 actor
+        # Add 1 actor
         actor = self._add_ready_actor(pool)
 
         # Assign it 1 task
@@ -653,12 +633,10 @@ class TestActorPool(unittest.TestCase):
         # Verify 1 slot remaining
         assert _estimate_total_available_task_slots(pool) == 1
 
-        selector = self._create_task_selector(pool)
-
         # Verify still can schedule
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
-        # Assign another task
+        # Assign another task (exhaust both slots)
         picked = self._assign_actor(pool)
         assert picked == actor
 
@@ -666,82 +644,100 @@ class TestActorPool(unittest.TestCase):
         assert _estimate_total_available_task_slots(pool) == 0
 
         # Verify can_schedule_task() returns False when actor is busy
-        assert not selector.can_schedule_task()
+        assert not pool.can_schedule_task()
 
-        # Create a bundle queue with items to process
-        queue = HashLinkedQueue()
-        for bundle in make_ref_bundles([[0]]):
-            queue.add(bundle)
+        # select_actors() returns None when no capacity
+        bundle = make_ref_bundles([[0]])[0]
+        assert pool.select_actors(bundle=bundle, actor_locality_enabled=False) is None
 
-        # strict=True should raise AssertionError when can_schedule_task() is False
-        with pytest.raises(AssertionError):
-            list(
-                selector.select_actors(queue, actor_locality_enabled=False, strict=True)
-            )
+    def test_select_actors_none_probes_schedulability(self):
+        """select_actors(bundle=None) is equivalent to can_schedule_task."""
+        pool = self._create_actor_pool(max_tasks_in_flight=2)
 
-        # strict=False should NOT raise, just return empty iterator
-        result = list(
-            selector.select_actors(queue, actor_locality_enabled=False, strict=False)
-        )
+        # Empty pool
+        assert pool.select_actors() is None
+        assert not pool.can_schedule_task()
 
-        assert result == []
+        # One actor ready
+        actor = self._add_ready_actor(pool)
+        assert pool.select_actors() is not None
+        assert pool.can_schedule_task()
+
+        # Exhaust capacity
+        pool.on_task_submitted(actor)
+        pool.on_task_submitted(actor)
+        assert pool.select_actors() is None
+        assert not pool.can_schedule_task()
+
+        # Free a slot
+        pool.on_task_completed(actor)
+        assert pool.select_actors() is not None
+        assert pool.can_schedule_task()
 
     def test_selector_can_schedule_task_basic(self):
         pool = self._create_actor_pool(max_tasks_in_flight=2)
-        selector = self._create_task_selector(pool)
 
         # Case 1: Empty pool - no actors at all
         assert pool.current_size() == 0
-        assert not selector.can_schedule_task()
+        assert not pool.can_schedule_task()
 
         # Case 2: Only pending actors (not yet ready)
         _, ready_ref = self._add_pending_actor(pool)
         assert pool.num_pending_actors() == 1
         assert pool.num_running_actors() == 0
-        assert not selector.can_schedule_task()
+        assert not pool.can_schedule_task()
 
         # Case 3: Actor becomes ready - should be schedulable
         self._wait_for_actor_ready(pool, ready_ref)
         assert pool.num_running_actors() == 1
         assert _estimate_total_available_task_slots(pool) == 2
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
         # Case 4: Actor partially busy (1 of 2 slots used) - still schedulable
         actor = self._assign_actor(pool)
         assert actor is not None
         assert _estimate_total_available_task_slots(pool) == 1
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
         # Case 5: Actor fully busy (2 of 2 slots used) - not schedulable
         actor2 = self._assign_actor(pool)
         assert actor2 == actor
         assert _estimate_total_available_task_slots(pool) == 0
-        assert not selector.can_schedule_task()
+        assert not pool.can_schedule_task()
 
         # Case 6: Task completes, slot freed - schedulable again
         pool.on_task_completed(actor)
         assert _estimate_total_available_task_slots(pool) == 1
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
-        # Case 7: Actor restarting - not schedulable
-        pool._update_running_actor_state(actor, is_restarting=True)
+        # Case 7: Actor restarting - not schedulable (mock _get_local_state)
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
         assert pool.num_restarting_actors() == 1
-        assert not selector.can_schedule_task()
+        assert not pool.can_schedule_task()
 
         # Case 8: Actor recovered from restart - schedulable again
-        pool._update_running_actor_state(actor, is_restarting=False)
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.ALIVE,
+        ):
+            pool.refresh_actor_state()
         assert pool.num_restarting_actors() == 0
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
     def test_selector_can_schedule_task_multi_actor(self):
         pool = self._create_actor_pool(max_tasks_in_flight=1)
-        selector = self._create_task_selector(pool)
 
         # Add two actors
         actor1 = self._add_ready_actor(pool)
         actor2 = self._add_ready_actor(pool)
         assert pool.num_running_actors() == 2
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
         # Make actor1 busy
         assigned = self._assign_actor(pool)
@@ -750,52 +746,37 @@ class TestActorPool(unittest.TestCase):
         idle_actor = actor2 if busy_actor == actor1 else actor1
 
         # Still schedulable (actor2 or actor1 is free)
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
         # Make both busy
         assigned2 = self._assign_actor(pool)
         assert assigned2 == idle_actor
         assert _estimate_total_available_task_slots(pool) == 0
-        assert not selector.can_schedule_task()
+        assert not pool.can_schedule_task()
 
         # Free one actor
         pool.on_task_completed(busy_actor)
         assert _estimate_total_available_task_slots(pool) == 1
-        assert selector.can_schedule_task()
+        assert pool.can_schedule_task()
 
-        # Make one actor restarting, but other is still available
-        pool._update_running_actor_state(assigned, is_restarting=True)
+        # Make one actor restarting (mock _get_local_state), but other is still available
+        with patch.object(
+            assigned,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
         # assigned now has 0 tasks but is restarting
         # assigned2 still has 1 task (at max)
-        assert not selector.can_schedule_task()
+        assert not pool.can_schedule_task()
 
         # Free the non-restarting actor
         pool.on_task_completed(assigned2)
-        assert selector.can_schedule_task()
-
-
-def test_setting_initial_size_for_actor_pool():
-    data_context = ray.data.DataContext.get_current()
-    op = MapOperator.create(
-        map_transformer=MagicMock(),
-        input_op=InputDataBuffer(data_context, input_data=MagicMock()),
-        data_context=data_context,
-        compute_strategy=ray.data.ActorPoolStrategy(
-            min_size=1, max_size=4, initial_size=2
-        ),
-        ray_remote_args={"num_cpus": 1},
-    )
-
-    op.start(ExecutionOptions())
-
-    assert op._actor_pool.get_actor_info() == _ActorPoolInfo(
-        running=0, pending=2, restarting=0
-    )
-    ray.shutdown()
+        assert pool.can_schedule_task()
 
 
 def test_actor_pool_scale_logs_include_map_worker_cls_name(
-    ray_start_regular_shared, caplog, propagate_logs
+    caplog, propagate_logs, ray_start_regular_shared
 ):
     """Test that scale-up and scale-down debug logs include the map worker class name."""
     logger_name = "ray.data._internal.execution.operators.actor_pool_map_operator"
@@ -808,15 +789,16 @@ def test_actor_pool_scale_logs_include_map_worker_cls_name(
         return actor, actor.get_location.remote()
 
     pool = _ActorPool(
-        create_actor_fn,
-        ExecutionResources(cpu=1),
+        create_actor_fn=create_actor_fn,
         min_size=1,
-        max_size=1,
+        max_size=4,
         initial_size=1,
+        max_tasks_in_flight_per_actor=4,
         max_actor_concurrency=1,
-        max_tasks_in_flight_per_actor=1,
+        per_actor_resource_usage=ExecutionResources(cpu=1),
         map_worker_cls_name="MapWorker(TestOp)",
         debounce_period_s=0,
+        _enable_actor_pool_on_exit_hook=False,
     )
 
     with caplog.at_level(logging.DEBUG, logger=logger_name):
@@ -836,6 +818,26 @@ def test_actor_pool_scale_logs_include_map_worker_cls_name(
             r"\(reason=scale down test",
             caplog.text,
         ), f"Expected scale-down log with map worker name; got: {caplog.text}"
+
+
+def test_setting_initial_size_for_actor_pool():
+    data_context = ray.data.DataContext.get_current()
+    op = MapOperator.create(
+        map_transformer=MagicMock(),
+        input_op=InputDataBuffer(data_context, input_data=MagicMock()),
+        data_context=data_context,
+        compute_strategy=ray.data.ActorPoolStrategy(
+            min_size=1, max_size=4, initial_size=2
+        ),
+        ray_remote_args={"num_cpus": 1},
+    )
+
+    op.start(ExecutionOptions())
+
+    assert op._actor_pool.get_actor_info() == ActorPoolInfo(
+        running=0, pending=2, restarting=0
+    )
+    ray.shutdown()
 
 
 def _create_bundle_with_single_row(row):
@@ -897,9 +899,7 @@ def test_actor_pool_input_queue_draining(
     The bug: `select_actors()` has an assertion `assert self.can_schedule_task()`
     which crashes when called with no available actors. Both `all_inputs_done()`
     (via `_try_schedule_task(strict=False)`) and `has_next()` call
-    `_try_schedule_tasks_internal()` which invokes `select_actors()`. When
-    `strict=False`, the code explicitly expects that actors may be busy and task
-    scheduling may not succeed, but the assertion contradicts this design intent.
+    `_try_schedule_tasks_internal()` which invokes `select_actors()`.
     """
     ctx = ray.data.DataContext.get_current()
     ctx._max_num_blocks_in_streaming_gen_buffer = 1
@@ -929,7 +929,7 @@ def test_actor_pool_input_queue_draining(
 
     # Assert actor is running
     assert op._actor_pool.num_pending_actors() == 0
-    assert len(op._actor_pool.running_actors()) == 1
+    assert op._actor_pool.num_running_actors() == 1
 
     # Add inputs to fill a bundle and launch a task (saturating the single actor)
     for _ in range(MIN_ROWS_PER_BUNDLE):

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -50,7 +50,6 @@ def test_actor_pool_scaling():
         num_active_actors=MagicMock(return_value=10),
         num_running_actors=MagicMock(return_value=10),
         num_pending_actors=MagicMock(return_value=0),
-        num_free_task_slots=MagicMock(return_value=5),
         num_tasks_in_flight=MagicMock(return_value=15),
         per_actor_resource_usage=MagicMock(return_value=ExecutionResources(cpu=1)),
         max_tasks_in_flight_per_actor=MagicMock(return_value=2),
@@ -105,12 +104,11 @@ def test_actor_pool_scaling():
 
     # Should scale up immediately when the actor pool has no running actors.
     with patch(actor_pool, "num_running_actors", 0):
-        with patch(actor_pool, "num_free_task_slots", 0):
-            with patch(actor_pool, "get_pool_util", float("inf")):
-                assert_autoscaling_action(
-                    delta=1,
-                    expected_reason="no running actors, scale up immediately",
-                )
+        with patch(actor_pool, "get_pool_util", float("inf")):
+            assert_autoscaling_action(
+                delta=1,
+                expected_reason="no running actors, scale up immediately",
+            )
 
     # Should be no-op since the util is below the threshold.
     with patch(actor_pool, "num_tasks_in_flight", 9):
@@ -245,7 +243,6 @@ def autoscaler_max_upscaling_delta_setup():
         current_size=MagicMock(return_value=10),
         get_current_size=MagicMock(return_value=10),
         num_pending_actors=MagicMock(return_value=0),
-        num_free_task_slots=MagicMock(return_value=0),
         num_tasks_in_flight=MagicMock(return_value=40),
         max_tasks_in_flight_per_actor=MagicMock(return_value=4),
         get_pool_util=MagicMock(return_value=2.0),
@@ -664,6 +661,8 @@ def test_actor_pool_respects_max_size(ray_start_10_cpus_shared, restore_data_con
         ).take_all()
 
 
+# TODO(DATA-1356) re-enable
+@pytest.mark.skip(reason="DATA-1356")
 def test_autoscaling_config_validation_warnings(
     ray_start_10_cpus_shared, restore_data_context
 ):

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -661,8 +661,6 @@ def test_actor_pool_respects_max_size(ray_start_10_cpus_shared, restore_data_con
         ).take_all()
 
 
-# TODO(DATA-1356) re-enable
-@pytest.mark.skip(reason="DATA-1356")
 def test_autoscaling_config_validation_warnings(
     ray_start_10_cpus_shared, restore_data_context
 ):

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -9,10 +9,7 @@ from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data.context import (
-    MAX_SAFE_BLOCK_SIZE_FACTOR,
-    DataContext,
-)
+from ray.data.context import DataContext
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_operators import _mul2_map_data_prcessor
 from ray.data.tests.util import run_op_tasks_sync
@@ -215,8 +212,8 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is 0.
-    assert op.metrics.obj_store_mem_pending_task_outputs == 0
+    # No tasks running yet, so pending task outputs is None.
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
     op.add_input(input_op.get_next(), 0)
     op.add_input(input_op.get_next(), 0)
@@ -224,11 +221,8 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(1600, rel=0.5)
-    # No sample available yet, uses fallback estimate: 2 tasks * per_task_output.
-    assert (
-        op.metrics.obj_store_mem_pending_task_outputs
-        == 2 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
-    )
+    # No sample available yet, so pending task outputs is None.
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
     run_op_tasks_sync(op)
 
@@ -259,8 +253,8 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is 0.
-    assert op.metrics.obj_store_mem_pending_task_outputs == 0
+    # No tasks running yet, so pending task outputs is None.
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
@@ -268,8 +262,8 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(800, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is 0.
-    assert op.metrics.obj_store_mem_pending_task_outputs == 0
+    # No tasks running yet, so pending task outputs is None.
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
@@ -277,8 +271,8 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(1600, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is 0.
-    assert op.metrics.obj_store_mem_pending_task_outputs == 0
+    # No tasks running yet, so pending task outputs is None.
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
     op.add_input(input_op.get_next(), 0)
     # Task has now been submitted since we've met the minimum bundle size.
@@ -286,11 +280,8 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(2400, rel=0.5)
-    # No sample available yet, uses fallback estimate: 1 task * per_task_output.
-    assert (
-        op.metrics.obj_store_mem_pending_task_outputs
-        == 1 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
-    )
+    # No sample available yet, so pending task outputs is None.
+    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
 
 def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
@@ -361,7 +352,7 @@ def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):
     assert op.num_active_tasks() == 4
 
     assert op._actor_pool.num_pending_actors() == 0
-    assert len(op._actor_pool.running_actors()) == 2
+    assert op._actor_pool.num_running_actors() == 2
 
     assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
@@ -465,7 +456,7 @@ def test_actor_pool_scheduling_with_bundling(
 
     # Assert all actors are running
     assert op._actor_pool.num_pending_actors() == 0
-    assert len(op._actor_pool.running_actors()) == 2
+    assert op._actor_pool.num_running_actors() == 2
 
     # Add inputs
     for i in range(MIN_ROWS_PER_BUNDLE - 1):

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -9,7 +9,10 @@ from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data.context import DataContext
+from ray.data.context import (
+    MAX_SAFE_BLOCK_SIZE_FACTOR,
+    DataContext,
+)
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_operators import _mul2_map_data_prcessor
 from ray.data.tests.util import run_op_tasks_sync
@@ -212,8 +215,8 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is None.
-    assert op.metrics.obj_store_mem_pending_task_outputs is None
+    # No tasks running yet, so pending task outputs is 0.
+    assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
     op.add_input(input_op.get_next(), 0)
     op.add_input(input_op.get_next(), 0)
@@ -221,8 +224,11 @@ def test_task_pool_resource_reporting(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(1600, rel=0.5)
-    # No sample available yet, so pending task outputs is None.
-    assert op.metrics.obj_store_mem_pending_task_outputs is None
+    # No sample available yet, uses fallback estimate: 2 tasks * per_task_output.
+    assert (
+        op.metrics.obj_store_mem_pending_task_outputs
+        == 2 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    )
 
     run_op_tasks_sync(op)
 
@@ -253,8 +259,8 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is None.
-    assert op.metrics.obj_store_mem_pending_task_outputs is None
+    # No tasks running yet, so pending task outputs is 0.
+    assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
@@ -262,8 +268,8 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(800, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is None.
-    assert op.metrics.obj_store_mem_pending_task_outputs is None
+    # No tasks running yet, so pending task outputs is 0.
+    assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
     op.add_input(input_op.get_next(), 0)
     # No tasks submitted yet due to bundling.
@@ -271,16 +277,19 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.metrics.obj_store_mem_internal_inqueue == pytest.approx(1600, rel=0.5)
     assert op.metrics.obj_store_mem_internal_outqueue == 0
     assert op.metrics.obj_store_mem_pending_task_inputs == 0
-    # No tasks running yet, so pending task outputs is None.
-    assert op.metrics.obj_store_mem_pending_task_outputs is None
+    # No tasks running yet, so pending task outputs is 0.
+    assert op.metrics.obj_store_mem_pending_task_outputs == 0
 
     op.add_input(input_op.get_next(), 0)
     # Task has now been submitted since we've met the minimum bundle size.
     assert op.current_logical_usage() == ExecutionResources(cpu=1, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
-    assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(2400, rel=0.5)
-    # No sample available yet, so pending task outputs is None.
+    # No sample available yet, uses fallback estimate: 1 task * per_task_output.
+    assert (
+        op.metrics.obj_store_mem_pending_task_outputs
+        == 1 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
+    )
     assert op.metrics.obj_store_mem_pending_task_outputs is None
 
 

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -285,12 +285,12 @@ def test_task_pool_resource_reporting_with_bundling(ray_start_10_cpus_shared):
     assert op.current_logical_usage() == ExecutionResources(cpu=1, gpu=0, memory=0)
     assert op.metrics.obj_store_mem_internal_inqueue == 0
     assert op.metrics.obj_store_mem_internal_outqueue == 0
+    assert op.metrics.obj_store_mem_pending_task_inputs == pytest.approx(2400, rel=0.5)
     # No sample available yet, uses fallback estimate: 1 task * per_task_output.
     assert (
         op.metrics.obj_store_mem_pending_task_outputs
         == 1 * op.data_context.target_max_block_size * MAX_SAFE_BLOCK_SIZE_FACTOR
     )
-    assert op.metrics.obj_store_mem_pending_task_outputs is None
 
 
 def test_actor_pool_scheduling(ray_start_10_cpus_shared, restore_data_context):

--- a/python/ray/data/tests/test_map_operator.py
+++ b/python/ray/data/tests/test_map_operator.py
@@ -113,7 +113,9 @@ def test_map_operator_streamed(ray_start_regular_shared, use_actors):
 
     # Feed data and implement streaming exec.
     output = []
-    op.start(ExecutionOptions(actor_locality_enabled=True))
+    # Use preserve_order so output order matches input order (required for
+    # actor pool, which otherwise returns results in completion order).
+    op.start(ExecutionOptions(actor_locality_enabled=True, preserve_order=True))
 
     if use_actors:
         # Wait for actors to be ready before adding inputs.


### PR DESCRIPTION
## Description
- Remove `ActorTaskSelector` and combine it's previous logic with `_ActorPool`
  - `_ActorPool` now responsible for selecting the best actor, given a bundle
  - keeps track of restarting actors + num tasks in flight


## Related issues

## Additional information
