### PR TITLE
[Data] Deprecate Pandas as internal blocks format using types_mapper conversion 

### DIFF
--- a/doc/source/ray-overview/pip_freeze_ray-py310-cpu.txt
+++ b/doc/source/ray-overview/pip_freeze_ray-py310-cpu.txt
@@ -102,7 +102,7 @@ opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
 ormsgpack==1.7.0
 packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1733203243479/work
-pandas==1.5.3
+pandas==2.0.0
 platformdirs==3.11.0
 pluggy @ file:///home/conda/feedstock_root/build_artifacts/pluggy_1733222765875/work
 portalocker==2.8.2

--- a/doc/source/ray-overview/pip_freeze_ray-py310-cpu.txt
+++ b/doc/source/ray-overview/pip_freeze_ray-py310-cpu.txt
@@ -102,7 +102,7 @@ opentelemetry-sdk==1.34.1
 opentelemetry-semantic-conventions==0.55b1
 ormsgpack==1.7.0
 packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1733203243479/work
-pandas==2.0.0
+pandas==2.2.0
 platformdirs==3.11.0
 pluggy @ file:///home/conda/feedstock_root/build_artifacts/pluggy_1733222765875/work
 portalocker==2.8.2

--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -266,7 +266,9 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
         # Array.from_buffers() doesn't work for DictionaryArrays.
         assert len(children) == 2, len(children)
         indices, dictionary = children
-        return pa.DictionaryArray.from_arrays(indices, dictionary)
+        return pa.DictionaryArray.from_arrays(
+            indices, dictionary, ordered=payload.type.ordered
+        )
     elif pa.types.is_map(payload.type) and len(children) > 1:
         # In pyarrow<7.0.0, the underlying map child array is not exposed, so we work
         # with the key and item arrays.

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -280,7 +280,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         #   return None, falling back to their own to_pandas_dtype() hooks which
         #   produce TensorDtype / PythonObjectDtype as appropriate.
         def _types_mapper(t):
-            if isinstance(t, pyarrow.ExtensionType):
+            if isinstance(t, pyarrow.ExtensionType) or pyarrow.types.is_dictionary(t):
                 return None
             return pd.ArrowDtype(t)
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -269,15 +269,25 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return self._table.schema
 
     def to_pandas(self) -> "pandas.DataFrame":
-        from ray.data.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
+        import pandas as pd
 
-        # We specify ignore_metadata=True because pyarrow will use the metadata
-        # to build the Table. This is handled incorrectly for older pyarrow versions
         ctx = DataContext.get_current()
-        df = self._table.to_pandas(ignore_metadata=ctx.pandas_block_ignore_metadata)
-        if ctx.enable_tensor_extension_casting:
-            df = _cast_tensor_columns_to_ndarrays(df, arrow_schema=self._table.schema)
-        return df
+
+        # types_mapper preserves Arrow dtypes through the pandas round-trip:
+        # - Standard Arrow types become pd.ArrowDtype, so pa.Table.from_pandas()
+        #   can reconstruct them exactly without lossy numpy conversion.
+        # - Ray extension types (ArrowTensorType, ArrowPythonObjectType, etc.)
+        #   return None, falling back to their own to_pandas_dtype() hooks which
+        #   produce TensorDtype / PythonObjectDtype as appropriate.
+        def _types_mapper(t):
+            if isinstance(t, pyarrow.ExtensionType):
+                return None
+            return pd.ArrowDtype(t)
+
+        return self._table.to_pandas(
+            ignore_metadata=ctx.pandas_block_ignore_metadata,
+            types_mapper=_types_mapper,
+        )
 
     def to_numpy(
         self, columns: Optional[Union[str, List[str]]] = None

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -42,6 +42,7 @@ def batch_blocks(
         ),
         batch_format=batch_format,
         stats=stats,
+        ensure_copy=ensure_copy,
     )
 
     if collate_fn is not None:

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -189,15 +189,39 @@ class _BatchingIterator(Iterator[Batch]):
                 raise StopIteration
 
 
+def _make_batch_writable(batch):
+    """Return a writable copy of batch where needed.
+
+    ``pa.Array.to_numpy()`` returns read-only views by default, so when
+    ``ensure_copy=True`` (i.e. ``zero_copy_batch=False``) and the block is
+    Arrow, numpy-format batches must be explicitly copied to give UDFs
+    writable arrays.
+    """
+    import numpy as np
+
+    if isinstance(batch, dict):
+        return {
+            k: v.copy() if (isinstance(v, np.ndarray) and not v.flags.writeable) else v
+            for k, v in batch.items()
+        }
+    elif isinstance(batch, np.ndarray) and not batch.flags.writeable:
+        return batch.copy()
+    # pandas DataFrames are writable by default; Arrow tables are immutable by design.
+    return batch
+
+
 def _format_batch(
     batch: Batch,
     batch_format: Optional[str],
     stats: Optional[DatasetStats],
+    ensure_copy: bool = False,
 ) -> Batch:
     with stats.iter_format_batch_s.timer() if stats else nullcontext():
         formatted_data = BlockAccessor.for_block(batch.data).to_batch_format(
             batch_format
         )
+        if ensure_copy:
+            formatted_data = _make_batch_writable(formatted_data)
     return dataclasses.replace(batch, data=formatted_data)
 
 
@@ -205,11 +229,17 @@ def format_batches(
     batch_iter: Iterator[Batch],
     batch_format: Optional[str],
     stats: Optional[DatasetStats] = None,
+    ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Given an iterator of batches, returns an iterator of formatted batches."""
     return _MappingIterator(
         batch_iter,
-        functools.partial(_format_batch, batch_format=batch_format, stats=stats),
+        functools.partial(
+            _format_batch,
+            batch_format=batch_format,
+            stats=stats,
+            ensure_copy=ensure_copy,
+        ),
     )
 
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1601,16 +1601,22 @@ def is_nan(value) -> bool:
 
 
 def is_null(value: Any) -> bool:
-    """This generalization of ``is_nan`` util qualifying both None and np.nan
-    as null values"""
-    return value is None or is_nan(value)
+    """This generalization of ``is_nan`` util qualifying both None, np.nan,
+    and pd.NA as null values"""
+    return value is None or is_nan(value) or value is pd.NA
 
 
 def keys_equal(keys1, keys2):
     if len(keys1) != len(keys2):
         return False
     for k1, k2 in zip(keys1, keys2):
-        if not ((is_nan(k1) and is_nan(k2)) or k1 == k2):
+        k1_null = is_null(k1)
+        k2_null = is_null(k2)
+        if k1_null and k2_null:
+            continue
+        if k1_null or k2_null:
+            return False
+        if k1 != k2:
             return False
     return True
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -23,6 +23,7 @@ import pyarrow as pa
 
 import ray
 from ray.data._internal.util import _check_pyarrow_version, _truncated_repr
+from ray.data.context import DataContext
 from ray.types import ObjectRef
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
@@ -529,6 +530,7 @@ class BlockAccessor:
         block_type: Optional[BlockType] = None,
     ) -> Block:
         """Create a block from user-facing data formats."""
+        import pandas
 
         if isinstance(batch, np.ndarray):
             raise ValueError(
@@ -543,6 +545,13 @@ class BlockAccessor:
         # to_arrow() instead of the slow column-by-column Mapping path.
         elif _is_cudf_dataframe(batch):
             return batch.to_arrow()
+
+        elif isinstance(batch, pandas.DataFrame):
+            if (block_type == BlockType.ARROW) or (
+                block_type is None
+                and DataContext.get_current().batch_to_block_arrow_format
+            ):
+                return cls.for_block(batch).to_arrow()
 
         elif isinstance(batch, collections.abc.Mapping):
             if block_type is None or block_type == BlockType.ARROW:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -70,6 +70,10 @@ DEFAULT_PANDAS_BLOCK_IGNORE_METADATA = env_bool(
     "RAY_DATA_PANDAS_BLOCK_IGNORE_METADATA", False
 )
 
+DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
+    "RAY_DATA_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT", True
+)
+
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
@@ -567,6 +571,9 @@ class DataContext:
         enforce_schemas: Whether to enforce schema consistency across dataset operations.
         pandas_block_ignore_metadata: Whether to ignore pandas metadata when converting
             between Arrow and pandas formats for better type inference.
+        batch_to_block_arrow_format: Whether to convert pandas DataFrame batches
+            returned by UDFs into Arrow blocks by default, keeping Arrow as the
+            internal block format throughout the pipeline.
     """
 
     # `None` means the block size is infinite.
@@ -715,6 +722,8 @@ class DataContext:
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS
 
     pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
+
+    batch_to_block_arrow_format: bool = DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT
 
     _checkpoint_config: Optional[CheckpointConfig] = None
 

--- a/python/ray/data/tests/block_batching/test_block_batching.py
+++ b/python/ray/data/tests/block_batching/test_block_batching.py
@@ -25,8 +25,18 @@ class TestBatchBlocks:
         if batch_format == "pandas":
             assert isinstance(batches[0], pd.DataFrame)
             assert isinstance(batches[1], pd.DataFrame)
-            pd.testing.assert_frame_equal(batches[0], pd.DataFrame({"foo": [0, 1, 2]}))
-            pd.testing.assert_frame_equal(batches[1], pd.DataFrame({"foo": [3, 4, 5]}))
+            pd.testing.assert_frame_equal(
+                batches[0],
+                pd.DataFrame({"foo": [0, 1, 2]}).convert_dtypes(
+                    dtype_backend="pyarrow"
+                ),
+            )
+            pd.testing.assert_frame_equal(
+                batches[1],
+                pd.DataFrame({"foo": [3, 4, 5]}).convert_dtypes(
+                    dtype_backend="pyarrow"
+                ),
+            )
         elif batch_format == "numpy":
             assert isinstance(batches[0], dict)
             assert isinstance(batches[1], dict)

--- a/python/ray/data/tests/datasource/test_tfrecords.py
+++ b/python/ray/data/tests/datasource/test_tfrecords.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import numpy as np
+import pyarrow as pa
 import pytest
-from pandas.api.types import is_float_dtype, is_int64_dtype, is_object_dtype
 
 import ray
 from ray.data._internal.datasource.tfrecords_datasource import TFXReadOptions
@@ -390,35 +390,42 @@ def test_read_tfrecords(
     )
 
     df = ds.to_pandas()
+    dtypes = dict(df.dtypes)
     # Protobuf serializes features in a non-deterministic order.
     if with_tf_schema:
-        assert is_object_dtype(dict(df.dtypes)["int_item"])
+        assert dtypes["int_item"] == pd.ArrowDtype(pa.list_(pa.int64()))
     else:
-        assert is_int64_dtype(dict(df.dtypes)["int_item"])
-    assert is_object_dtype(dict(df.dtypes)["int_list"])
-    assert is_object_dtype(dict(df.dtypes)["int_partial"])
-    assert is_object_dtype(dict(df.dtypes)["int_empty"])
+        assert dtypes["int_item"] == pd.ArrowDtype(pa.int64())
+    assert dtypes["int_list"] == pd.ArrowDtype(pa.list_(pa.int64()))
+    assert dtypes["int_partial"] == pd.ArrowDtype(pa.list_(pa.null()))
+    assert dtypes["int_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
     if with_tf_schema:
-        assert is_object_dtype(dict(df.dtypes)["float_item"])
-        assert is_object_dtype(dict(df.dtypes)["float_partial"])
+        assert dtypes["float_item"] == pd.ArrowDtype(pa.list_(pa.float32()))
+        assert dtypes["float_partial"] == pd.ArrowDtype(pa.list_(pa.float32()))
     else:
-        assert is_float_dtype(dict(df.dtypes)["float_item"])
-        assert is_float_dtype(dict(df.dtypes)["float_partial"])
-    assert is_object_dtype(dict(df.dtypes)["float_list"])
-    assert is_object_dtype(dict(df.dtypes)["float_empty"])
+        assert dtypes["float_item"] == pd.ArrowDtype(pa.float32())
+        assert dtypes["float_partial"] == pd.ArrowDtype(pa.float32())
+    assert dtypes["float_list"] == pd.ArrowDtype(pa.list_(pa.float32()))
+    assert dtypes["float_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
-    # In both cases, bytes are of `object` dtype in pandas
-    assert is_object_dtype(dict(df.dtypes)["bytes_item"])
-    assert is_object_dtype(dict(df.dtypes)["bytes_partial"])
-    assert is_object_dtype(dict(df.dtypes)["bytes_list"])
-    assert is_object_dtype(dict(df.dtypes)["bytes_empty"])
+    # bytes columns: scalar when schema=False (single value unwrapped), list when schema=True
+    if with_tf_schema:
+        assert dtypes["bytes_item"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    else:
+        assert dtypes["bytes_item"] == pd.ArrowDtype(pa.binary())
+    assert dtypes["bytes_partial"] == pd.ArrowDtype(pa.list_(pa.null()))
+    assert dtypes["bytes_list"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    assert dtypes["bytes_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
-    # strings are of `object` dtype in pandas
-    assert is_object_dtype(dict(df.dtypes)["string_item"])
-    assert is_object_dtype(dict(df.dtypes)["string_partial"])
-    assert is_object_dtype(dict(df.dtypes)["string_list"])
-    assert is_object_dtype(dict(df.dtypes)["string_empty"])
+    # string columns (stored as bytes in TF): same pattern as bytes
+    if with_tf_schema:
+        assert dtypes["string_item"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    else:
+        assert dtypes["string_item"] == pd.ArrowDtype(pa.binary())
+    assert dtypes["string_partial"] == pd.ArrowDtype(pa.list_(pa.null()))
+    assert dtypes["string_list"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    assert dtypes["string_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
     # If the schema is specified, we should not perform the
     # automatic unwrapping of single-element lists.

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -471,8 +471,8 @@ def test_groupby_tabular_sum(
 
     expected = pd.DataFrame(
         {
-            "A": [0, 1, 2],
-            "sum(B)": pd.Series([None, None, None], dtype="object"),
+            "A": pd.array([0, 1, 2], dtype=pd.ArrowDtype(pa.int64())),
+            "sum(B)": pd.array([None, None, None], dtype=pd.ArrowDtype(pa.null())),
         },
     )
     result = nan_agg_ds.sort("A").to_pandas()
@@ -652,6 +652,7 @@ def test_groupby_arrow_multi_agg(
 
     agg_df["unique(B)"] = _sort_series_of_lists_elements(agg_df["unique(B)"])
     expected_df["unique(B)"] = _sort_series_of_lists_elements(expected_df["unique(B)"])
+    expected_df = expected_df.convert_dtypes(dtype_backend="pyarrow")
 
     print(f"Expected: {expected_df}")
     print(f"Result: {agg_df}")
@@ -1003,7 +1004,11 @@ def test_groupby_map_groups_for_pandas(
     # aggregate rows, so we still have 3 rows.
     assert mapped.count() == 3
     expected = pd.DataFrame(
-        {"A": ["a", "a", "b"], "B": [0.5, 0.5, 1.000000], "C": [0.4, 0.6, 1.0]}
+        {
+            "A": pd.array(["a", "a", "b"], dtype=pd.ArrowDtype(pa.string())),
+            "B": pd.array([0.5, 0.5, 1.000000], dtype=pd.ArrowDtype(pa.float64())),
+            "C": pd.array([0.4, 0.6, 1.0], dtype=pd.ArrowDtype(pa.float64())),
+        }
     )
 
     result = mapped.sort(["A", "C"]).to_pandas()

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -44,7 +44,7 @@ aiohttp_cors
 dm_tree
 uvicorn
 prometheus_client>=0.7.1
-pandas>=2.0
+pandas>=2.0,<2.3
 tensorboardX
 aiohttp>=3.13.3
 starlette

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -44,7 +44,7 @@ aiohttp_cors
 dm_tree
 uvicorn
 prometheus_client>=0.7.1
-pandas>=2.0,<2.3
+pandas>=2.0
 tensorboardX
 aiohttp>=3.13.3
 starlette

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -44,7 +44,7 @@ aiohttp_cors
 dm_tree
 uvicorn
 prometheus_client>=0.7.1
-pandas>=1.3
+pandas>=2.0
 tensorboardX
 aiohttp>=3.13.3
 starlette

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -11,6 +11,7 @@ crc32c==2.3
 flask_cors
 bokeh==2.4.3; python_version < '3.12'
 modin==0.31.0
-pandas==2.2.0
+pandas==2.2.0; python_version < "3.13"
+pandas>=2.2.3; python_version >= "3.13"
 responses>=0.15.0
 pymars>=0.8.3; python_version < "3.12"

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -11,6 +11,6 @@ crc32c==2.3
 flask_cors
 bokeh==2.4.3; python_version < '3.12'
 modin==0.31.0
-pandas==2.0.0
+pandas==2.2.0
 responses>=0.15.0
 pymars>=0.8.3; python_version < "3.12"

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -10,9 +10,7 @@ aioboto3==12.1.0
 crc32c==2.3
 flask_cors
 bokeh==2.4.3; python_version < '3.12'
-modin==0.22.2; python_version < '3.12'
-pandas==1.5.3; python_version < '3.12'
-modin==0.31.0; python_version >= '3.12'
-pandas==2.2.2; python_version >= '3.12'
+modin==0.31.0
+pandas==2.2.2
 responses>=0.15.0
 pymars>=0.8.3; python_version < "3.12"

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -11,6 +11,6 @@ crc32c==2.3
 flask_cors
 bokeh==2.4.3; python_version < '3.12'
 modin==0.31.0
-pandas==2.3.3
+pandas==2.0.0
 responses>=0.15.0
 pymars>=0.8.3; python_version < "3.12"

--- a/python/requirements/ml/data-requirements.txt
+++ b/python/requirements/ml/data-requirements.txt
@@ -11,6 +11,6 @@ crc32c==2.3
 flask_cors
 bokeh==2.4.3; python_version < '3.12'
 modin==0.31.0
-pandas==2.2.2
+pandas==2.3.3
 responses>=0.15.0
 pymars>=0.8.3; python_version < "3.12"

--- a/python/requirements/test-requirements.txt
+++ b/python/requirements/test-requirements.txt
@@ -71,7 +71,8 @@ werkzeug==2.3.8
 xlrd==2.0.1
 yq==3.2.2
 memray; platform_system != "Windows" and sys_platform != "darwin" and platform_machine != 'aarch64'
-numpy==1.26.4
+numpy==1.26.4; python_version < "3.13"
+numpy>=2.0; python_version >= "3.13"
 ipywidgets==8.1.3
 pyzmq>=27.1.0
 colorama

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1426,7 +1426,7 @@ packaging==24.2
     #   transformers
     #   utilsforecast
     #   wandb
-pandas==2.0.0 ; python_version < "3.12"
+pandas==2.2.0 ; python_version < "3.12"
     # via
     #   -r python/requirements.txt
     #   -r python/requirements/ml/data-requirements.txt

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1080,7 +1080,7 @@ mlflow-skinny==3.1.4
     # via mlflow
 mmh3==4.1.0
     # via pyiceberg
-modin==0.23.1 ; python_version < "3.12"
+modin==0.31.0 ; python_version < "3.12"
     # via -r python/requirements/ml/data-requirements.txt
 monotonic==1.6
     # via

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1080,7 +1080,7 @@ mlflow-skinny==3.1.4
     # via mlflow
 mmh3==4.1.0
     # via pyiceberg
-modin==0.22.2 ; python_version < "3.12"
+modin==0.23.1 ; python_version < "3.12"
     # via -r python/requirements/ml/data-requirements.txt
 monotonic==1.6
     # via
@@ -1426,7 +1426,7 @@ packaging==24.2
     #   transformers
     #   utilsforecast
     #   wandb
-pandas==1.5.3 ; python_version < "3.12"
+pandas==2.0.0 ; python_version < "3.12"
     # via
     #   -r python/requirements.txt
     #   -r python/requirements/ml/data-requirements.txt

--- a/python/requirements_compiled_py3.13.txt
+++ b/python/requirements_compiled_py3.13.txt
@@ -1472,7 +1472,7 @@ packaging==24.2
     #   transformers
     #   utilsforecast
     #   wandb
-pandas==2.0.0
+pandas==2.2.0
     # via
     #   -r python/requirements.txt
     #   -r python/requirements/ml/data-requirements.txt

--- a/python/requirements_compiled_py3.13.txt
+++ b/python/requirements_compiled_py3.13.txt
@@ -1113,7 +1113,7 @@ mlflow-skinny==2.22.0
     # via mlflow
 mmh3==4.1.0
     # via pyiceberg
-modin==0.23.1
+modin==0.31.0
     # via -r python/requirements/ml/data-requirements.txt
 monotonic==1.6
     # via

--- a/python/requirements_compiled_py3.13.txt
+++ b/python/requirements_compiled_py3.13.txt
@@ -1113,7 +1113,7 @@ mlflow-skinny==2.22.0
     # via mlflow
 mmh3==4.1.0
     # via pyiceberg
-modin==0.37.1
+modin==0.23.1
     # via -r python/requirements/ml/data-requirements.txt
 monotonic==1.6
     # via
@@ -1472,7 +1472,7 @@ packaging==24.2
     #   transformers
     #   utilsforecast
     #   wandb
-pandas==2.3.3
+pandas==2.0.0
     # via
     #   -r python/requirements.txt
     #   -r python/requirements/ml/data-requirements.txt

--- a/python/setup.py
+++ b/python/setup.py
@@ -218,7 +218,7 @@ ray_files += [
 # also update the matching section of requirements/requirements.txt
 # in this directory
 if setup_spec.type == SetupType.RAY:
-    pandas_dep = "pandas >= 1.3"
+    pandas_dep = "pandas >= 2.0"
     numpy_dep = "numpy >= 1.20"
     pyarrow_deps = [
         "pyarrow >= 9.0.0",

--- a/release/ray_release/byod/requirements_ml_byod_3.10.txt
+++ b/release/ray_release/byod/requirements_ml_byod_3.10.txt
@@ -1892,7 +1892,7 @@ memray==1.10.0 ; platform_system != "Windows" and sys_platform != "darwin" and p
     # via
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   -r release/ray_release/byod/requirements_ml_byod_3.10.in
-modin==0.22.2 ; python_version < "3.12" \
+modin==0.23.1 ; python_version < "3.12" \
     --hash=sha256:532fe0bfb2dcf06c0ad2d467721ef489fd58bb3ef7150bcf4a7ddd1069be1e4d \
     --hash=sha256:fa897dc59d5b9a8496be044185689fdd337b9f26cc81c4144b217a2a94d029bc
     # via
@@ -2430,7 +2430,7 @@ packaging==23.0 \
     #   transformers
     #   typepy
     #   utilsforecast
-pandas==1.5.3 ; python_version < "3.12" \
+pandas==2.0.0 ; python_version < "3.12" \
     --hash=sha256:14e45300521902689a81f3f41386dc86f19b8ba8dd5ac5a3c7010ef8d2932813 \
     --hash=sha256:26d9c71772c7afb9d5046e6e9cf42d83dd147b5cf5bcb9d97252077118543792 \
     --hash=sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406 \

--- a/release/ray_release/byod/requirements_ml_byod_3.10.txt
+++ b/release/ray_release/byod/requirements_ml_byod_3.10.txt
@@ -2430,7 +2430,7 @@ packaging==23.0 \
     #   transformers
     #   typepy
     #   utilsforecast
-pandas==2.0.0 ; python_version < "3.12" \
+pandas==2.2.0 ; python_version < "3.12" \
     --hash=sha256:14e45300521902689a81f3f41386dc86f19b8ba8dd5ac5a3c7010ef8d2932813 \
     --hash=sha256:26d9c71772c7afb9d5046e6e9cf42d83dd147b5cf5bcb9d97252077118543792 \
     --hash=sha256:3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406 \

--- a/release/ray_release/byod/requirements_ml_byod_3.10.txt
+++ b/release/ray_release/byod/requirements_ml_byod_3.10.txt
@@ -1892,7 +1892,7 @@ memray==1.10.0 ; platform_system != "Windows" and sys_platform != "darwin" and p
     # via
     #   -c release/ray_release/byod/requirements_compiled.txt
     #   -r release/ray_release/byod/requirements_ml_byod_3.10.in
-modin==0.23.1 ; python_version < "3.12" \
+modin==0.31.0 ; python_version < "3.12" \
     --hash=sha256:532fe0bfb2dcf06c0ad2d467721ef489fd58bb3ef7150bcf4a7ddd1069be1e4d \
     --hash=sha256:fa897dc59d5b9a8496be044185689fdd337b9f26cc81c4144b217a2a94d029bc
     # via


### PR DESCRIPTION

## Description                                                                                                      
                                                                                                                        
 When a UDF returns a `pd.DataFrame` or dict batch, Ray Data previously stored it as a Pandas block in the object    
store. This PR changes that behavior: UDF output is now immediately converted to an Arrow block before being stored, making Arrow the single internal block format