### PR TITLE
[Data] 2-phase commit for checkpointing with prefix trie recovery

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1187,8 +1187,6 @@ python/ray/data/datasource/file_meta_provider.py
     DOC103: Function `_expand_directory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [ignore_missing_path: bool].
 --------------------
 python/ray/data/datasource/filename_provider.py
-    DOC101: Method `FilenameProvider.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `FilenameProvider.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dataset_uuid: Optional[str], file_format: Optional[str]].
     DOC201: Method `FilenameProvider.get_filename_for_block` does not have a return section in docstring
     DOC201: Method `FilenameProvider.get_filename_for_row` does not have a return section in docstring
 --------------------

--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1166,6 +1166,9 @@ python/ray/data/block.py
     DOC102: Method `BlockAccessor._get_group_boundaries_sorted`: Docstring contains more arguments than in function signature.
     DOC103: Method `BlockAccessor._get_group_boundaries_sorted`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [block: ].
 --------------------
+python/ray/data/checkpoint/checkpoint_writer.py
+    DOC201: Method `BatchBasedCheckpointWriter.write_block_checkpoint` does not have a return section in docstring
+--------------------
 python/ray/data/context.py
     DOC201: Method `DataContext.get_current` does not have a return section in docstring
     DOC201: Method `DataContext.get_config` does not have a return section in docstring
@@ -1184,6 +1187,8 @@ python/ray/data/datasource/file_meta_provider.py
     DOC103: Function `_expand_directory`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [ignore_missing_path: bool].
 --------------------
 python/ray/data/datasource/filename_provider.py
+    DOC101: Method `FilenameProvider.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `FilenameProvider.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [dataset_uuid: Optional[str], file_format: Optional[str]].
     DOC201: Method `FilenameProvider.get_filename_for_block` does not have a return section in docstring
     DOC201: Method `FilenameProvider.get_filename_for_row` does not have a return section in docstring
 --------------------

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -188,8 +188,8 @@ class ParquetDatasink(_FileDatasink):
             block for block in blocks if BlockAccessor.for_block(block).num_rows() > 0
         ]
 
-        filename = self.filename_provider.get_filename_for_block(
-            blocks[0], ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx, 0
+        filename = self.filename_provider.get_filename_for_task(
+            ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx
         )
         write_kwargs = _resolve_kwargs(
             self.arrow_parquet_args_fn, **self.arrow_parquet_args

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -1,6 +1,7 @@
-import itertools
-from typing import Iterable, List
+import warnings
+from typing import Iterable, List, Tuple
 
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
@@ -8,45 +9,101 @@ from ray.data._internal.execution.operators.map_transformer import (
 )
 from ray.data._internal.logical.operators import Write
 from ray.data._internal.planner.plan_write_op import (
+    PENDING_CHECKPOINTS_KWARG_NAME,
+    WRITE_UUID_KWARG_NAME,
     _plan_write_op_internal,
     generate_collect_write_stats_fn,
 )
 from ray.data.block import Block, BlockAccessor
-from ray.data.checkpoint.checkpoint_writer import CheckpointWriter
+from ray.data.checkpoint.checkpoint_writer import (
+    CheckpointWriter,
+    PendingCheckpoint,
+)
 from ray.data.checkpoint.interfaces import (
     InvalidCheckpointingOperators,
 )
 from ray.data.context import DataContext
 from ray.data.datasource.datasink import Datasink
+from ray.data.datasource.file_datasink import _FileDatasink
+from ray.data.datasource.filename_provider import _split_base_and_ext
+
+
+def _validate_id_column_exists(id_column: str, block: Block) -> None:
+    """Validate that the ID column exists in the block.
+
+    Args:
+        id_column: The name of the ID column to validate.
+        block: The block to check.
+
+    Raises:
+        ValueError: If the ID column is not present in the block.
+    """
+    block_accessor = BlockAccessor.for_block(block)
+    if id_column not in block_accessor.column_names():
+        raise ValueError(
+            f"ID column {id_column} is "
+            f"absent in the block to be written. Do not drop or rename "
+            f"this column."
+        )
+
+
+def _combine_blocks(
+    blocks: Iterable[Block],
+) -> Tuple[List[Block], Block]:
+    """Combine multiple blocks into a single block.
+
+    This is used by checkpoint transforms to match the behavior of _FileDatasink.write(),
+    which combines all input blocks into one output file.
+
+    Args:
+        blocks: Iterable of blocks to combine.
+
+    Returns:
+        A tuple of (block_list, combined_block) where:
+        - block_list: The original blocks as a list (for later iteration)
+        - combined_block: A single block combining all input blocks
+    """
+    block_list = list(blocks)
+    builder = DelegatingBlockBuilder()
+    for block in block_list:
+        builder.add_block(block)
+    combined_block = builder.build()
+    return block_list, combined_block
 
 
 def plan_write_op_with_checkpoint_writer(
     op: Write, physical_children: List[PhysicalOperator], data_context: DataContext
 ) -> PhysicalOperator:
+    """Plan a write operation with checkpoint support.
+
+    For file-based datasinks (_FileDatasink):
+        Uses 2-phase commit for atomicity:
+        1. Pre-write: computes expected paths, write pending checkpoints
+        2. Write: writes data files
+        3. Post-write: commits checkpoints (renames pending -> committed)
+
+    Writing the pending checkpoint BEFORE the data file is critical: the
+    pending checkpoint is the source of truth for recovery. If failure occurs
+    after data write but before commit, recovery finds the pending checkpoint,
+    deletes the matching data files, and retries cleanly. Writing checkpoints
+    after data files would be non-atomic — if failure occurs between data
+    write and checkpoint write, there's no record of which data files are
+    uncommitted.
+
+    For non-file datasinks (SQLDatasink, etc.):
+        Falls back to post-write checkpointing:
+        1. Write: Write data to destination
+        2. Post-write: Write checkpoints
+
+    Non-file sinks (SQL, MongoDB, etc.) cannot predict a "file path" - data goes
+    to database rows or documents. So we fall back to writing data first, then
+    checkpointing. If failure occurs after data write but before checkpoint
+    write, the same data may be written again on retry without removing the
+    old data (at-least-once semantics for non-idempotent operations).
+    """
     assert data_context.checkpoint_config is not None
 
-    collect_stats_fn = generate_collect_write_stats_fn()
-    write_checkpoint_for_block_fn = _generate_checkpoint_writing_transform(
-        data_context, op
-    )
-
-    physical_op = _plan_write_op_internal(
-        op,
-        physical_children,
-        data_context,
-        extra_transformations=[
-            write_checkpoint_for_block_fn,
-            collect_stats_fn,
-        ],
-    )
-
-    return physical_op
-
-
-def _generate_checkpoint_writing_transform(
-    data_context: DataContext, logical_op: Write
-) -> BlockMapTransformFn:
-    datasink = logical_op.datasink_or_legacy_datasource
+    datasink = op.datasink_or_legacy_datasource
     if not isinstance(datasink, Datasink):
         raise InvalidCheckpointingOperators(
             f"To enable checkpointing, Write operation must use a "
@@ -55,27 +112,238 @@ def _generate_checkpoint_writing_transform(
         )
 
     checkpoint_writer = CheckpointWriter.create(data_context.checkpoint_config)
+    collect_stats_fn = generate_collect_write_stats_fn()
 
-    # MapTransformFn for writing checkpoint files after write completes.
-    def write_checkpoint_for_block(
+    if isinstance(datasink, _FileDatasink):
+        # File-based datasink: use 2-phase commit for atomicity
+        # Pre-write transform: compute expected paths and write pending checkpoints
+        prepare_checkpoint_fn = _generate_prepare_checkpoint_transform(
+            data_context, datasink, checkpoint_writer
+        )
+
+        # Post-write transform: commit checkpoints
+        commit_checkpoint_fn = _generate_commit_checkpoint_transform(checkpoint_writer)
+
+        pre_transformations = [
+            prepare_checkpoint_fn,
+        ]
+        post_transformations = [
+            commit_checkpoint_fn,
+            collect_stats_fn,
+        ]
+    else:
+        # Non-file datasink (SQL, Mongo, etc.): fall back to non-atomic checkpoint
+        # No 2-phase commit - write checkpoint after data write
+        # This might cause duplicate writes if the write operation is retried.
+        warnings.warn(
+            f"Checkpointing with non-file datasink ({type(datasink).__name__}) "
+            f"uses post-write checkpointing, which provides at-least-once "
+            f"semantics. If a failure occurs after data is written but before "
+            f"the checkpoint is saved, duplicate data may be written on retry. "
+            f"This will be addressed in a future version."
+        )
+        write_checkpoint_fn = _generate_non_atomic_write_checkpoint_transform(
+            data_context, checkpoint_writer
+        )
+        post_transformations = [
+            write_checkpoint_fn,
+            collect_stats_fn,
+        ]
+        pre_transformations = []
+
+    physical_op = _plan_write_op_internal(
+        op,
+        physical_children,
+        data_context,
+        post_transformations=post_transformations,
+        pre_transformations=pre_transformations,
+    )
+
+    return physical_op
+
+
+def _generate_base_filename(
+    datasink: _FileDatasink,
+    ctx: TaskContext,
+) -> str:
+    """Compute the base filename (without extension) for this task's data files.
+
+    This is called BEFORE writing to determine the filename prefix for data files
+    that will be written by this task. Datasinks may write multiple files (with
+    partitioning, max_rows_per_file, etc.), all sharing this base filename.
+
+    Args:
+        datasink: The file datasink being used.
+        ctx: The task context.
+
+    Returns:
+        The base filename without extension (e.g., "write_uuid_000000_000000").
+        Used both as a checkpoint ID for deterministic naming and as a prefix
+        for matching data files during recovery.
+    """
+    write_uuid = ctx.kwargs.get(WRITE_UUID_KWARG_NAME)
+    assert write_uuid is not None, "WRITE_UUID_KWARG_NAME is required"
+
+    filename = datasink.filename_provider.get_filename_for_task(
+        write_uuid, ctx.task_idx
+    )
+
+    # All file datasinks can potentially generate multiple files (e.g., with
+    # partitioning, max_rows_per_file, etc.). Use prefix matching to handle
+    # cases like "{filename}-{i}.parquet".
+    base, _ = _split_base_and_ext(filename)
+    return base
+
+
+def _generate_prepare_checkpoint_transform(
+    data_context: DataContext,
+    datasink: _FileDatasink,
+    checkpoint_writer: CheckpointWriter,
+) -> BlockMapTransformFn:
+    """Generate transform for preparing checkpoints BEFORE data write.
+
+    This transform runs BEFORE the data write to enable rollback on failure.
+    By recording the expected file path in a pending checkpoint first, we can
+    clean up orphaned data files if the task fails after writing data but
+    before committing.
+
+    Steps:
+    1. Combines all blocks (matching _FileDatasink behavior)
+    2. Computes expected data file path prefix from FilenameProvider
+    3. Writes pending checkpoint with expected path prefix as filename
+    4. Stores pending checkpoint info in ctx.kwargs for later commit
+    """
+
+    def prepare_checkpoint(
         blocks: Iterable[Block], ctx: TaskContext
     ) -> Iterable[Block]:
-        it1, it2 = itertools.tee(blocks, 2)
-        for block in it1:
-            ba = BlockAccessor.for_block(block)
-            if ba.num_rows() > 0:
-                if data_context.checkpoint_config.id_column not in ba.column_names():
-                    raise ValueError(
-                        f"ID column {data_context.checkpoint_config.id_column} is "
-                        f"absent in the block to be written. Do not drop or rename "
-                        f"this column."
-                    )
-            checkpoint_writer.write_block_checkpoint(ba)
+        # Combine all blocks to match _FileDatasink.write() behavior
+        # which combines all input blocks into one output file
+        block_list, combined_block = _combine_blocks(blocks)
+        ba = BlockAccessor.for_block(combined_block)
 
-        return list(it2)
+        if ba.num_rows() > 0:
+            # Validate ID column exists
+            id_column = data_context.checkpoint_config.id_column
+            _validate_id_column_exists(id_column, combined_block)
+
+            # Compute base filename using FilenameProvider
+            # Note: This only depends on write_uuid and task_idx, NOT block content
+            # base_filename is the filename without extension, used as checkpoint_id
+            # for deterministic naming (same on retry, enabling idempotent writes)
+            base_filename = _generate_base_filename(datasink, ctx)
+
+            # Extract ID column data for checkpoint
+            # Project to the single column first, then convert to Arrow to
+            # avoid materializing the entire block as an Arrow table.
+            id_column_data = BlockAccessor.for_block(
+                ba.select(columns=[id_column])
+            ).to_arrow()[id_column]
+
+            # Write pending checkpoint with the base filename as checkpoint_id.
+            # The checkpoint filename will be {base_filename}.pending.parquet.
+            # During recovery, the pending checkpoint basename (without
+            # .pending.parquet) is used as a prefix to match data files.
+            pending = checkpoint_writer.write_pending_checkpoint(
+                id_column_data,
+                checkpoint_id=base_filename,
+            )
+
+            # Store pending checkpoint for commit phase
+            if pending is not None:
+                if PENDING_CHECKPOINTS_KWARG_NAME not in ctx.kwargs:
+                    ctx.kwargs[PENDING_CHECKPOINTS_KWARG_NAME] = []
+                ctx.kwargs[PENDING_CHECKPOINTS_KWARG_NAME].append(pending)
+
+        # Return original blocks for the write transform
+        return iter(block_list)
 
     return BlockMapTransformFn(
-        write_checkpoint_for_block,
+        prepare_checkpoint,
+        is_udf=False,
+        disable_block_shaping=True,
+    )
+
+
+def _generate_commit_checkpoint_transform(
+    checkpoint_writer: CheckpointWriter,
+) -> BlockMapTransformFn:
+    """Generate transform for committing checkpoints AFTER data write.
+
+    This transform runs AFTER the data write succeeds, completing the 2-phase
+    commit. The commit operation (renaming pending -> committed) is the atomic
+    point: once committed, the data is considered durably written. If failure
+    occurs before this point, recovery will find the pending checkpoint and
+    can safely delete the orphaned data files using the stored path.
+
+    Steps:
+    1. Retrieves pending checkpoints from ctx.kwargs
+    2. Commits each pending checkpoint (rename pending -> committed)
+    """
+
+    def commit_checkpoints(
+        blocks: Iterable[Block], ctx: TaskContext
+    ) -> Iterable[Block]:
+        # Get pending checkpoints written in pre-write phase
+        pending_checkpoints: List[PendingCheckpoint] = ctx.kwargs.get(
+            PENDING_CHECKPOINTS_KWARG_NAME, []
+        )
+
+        # Commit each pending checkpoint
+        for pending in pending_checkpoints:
+            checkpoint_writer.commit_checkpoint(pending)
+
+        return blocks
+
+    return BlockMapTransformFn(
+        commit_checkpoints,
+        is_udf=False,
+        disable_block_shaping=True,
+    )
+
+
+def _generate_non_atomic_write_checkpoint_transform(
+    data_context: DataContext,
+    checkpoint_writer: CheckpointWriter,
+) -> BlockMapTransformFn:
+    """Generate transform for writing checkpoints AFTER data write (non-file datasinks).
+
+    This is a fallback for non-file datasinks (SQL, Mongo, etc.) that don't
+    support deletions. Unlike file-based sinks where we can delete orphaned
+    data files during recovery, these sinks have no way to undo a write once
+    data has been inserted into rows or documents.
+
+    The checkpoint is written directly after the data write completes. This
+    provides at-least-once semantics: if failure occurs after data write but
+    before checkpoint write, the same data will be written again on retry
+    without removing the old data.
+
+    For idempotent operations (upserts with unique keys), this is safe. For
+    non-idempotent operations (inserts), duplicates may result.
+
+    TODO: For datasinks that support deletions (e.g., SQL DELETE by ID), we
+    could store written IDs in pending checkpoints and delete them on recovery,
+    avoiding duplicates even for non-idempotent operations.
+    """
+
+    def write_checkpoint(blocks: Iterable[Block], ctx: TaskContext) -> Iterable[Block]:
+        # Combine all blocks
+        block_list, combined_block = _combine_blocks(blocks)
+        ba = BlockAccessor.for_block(combined_block)
+
+        if ba.num_rows() > 0:
+            # Validate ID column exists
+            id_column = data_context.checkpoint_config.id_column
+            _validate_id_column_exists(id_column, combined_block)
+
+            # Write checkpoint directly (no 2-phase commit)
+            # No data_file_path since non-file datasinks don't have file paths
+            checkpoint_writer.write_block_checkpoint(ba)
+
+        return iter(block_list)
+
+    return BlockMapTransformFn(
+        write_checkpoint,
         is_udf=False,
         # NOTE: No need for block-shaping
         disable_block_shaping=True,

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -1,6 +1,6 @@
 import itertools
 import uuid
-from typing import Callable, Iterator, List, Union
+from typing import TYPE_CHECKING, Callable, Iterator, List, Optional, Union
 
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
@@ -9,13 +9,17 @@ from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     MapTransformer,
 )
-from ray.data._internal.logical.operators import Write
 from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
 from ray.data.datasource.datasink import Datasink
 from ray.data.datasource.datasource import Datasource
 
+if TYPE_CHECKING:
+    from ray.data._internal.logical.operators import Write
+
 WRITE_UUID_KWARG_NAME = "write_uuid"
+# Key for storing pending checkpoint paths for commit phase
+PENDING_CHECKPOINTS_KWARG_NAME = "_pending_checkpoints"
 
 
 def generate_write_fn(
@@ -71,38 +75,55 @@ def generate_collect_write_stats_fn() -> BlockMapTransformFn:
 
 
 def plan_write_op(
-    op: Write,
+    op: "Write",
     physical_children: List[PhysicalOperator],
     data_context: DataContext,
 ) -> PhysicalOperator:
     collect_stats_fn = generate_collect_write_stats_fn()
 
     return _plan_write_op_internal(
-        op, physical_children, data_context, extra_transformations=[collect_stats_fn]
+        op,
+        physical_children,
+        data_context,
+        post_transformations=[collect_stats_fn],
     )
 
 
 def _plan_write_op_internal(
-    op: Write,
+    op: "Write",
     physical_children: List[PhysicalOperator],
     data_context: DataContext,
-    extra_transformations: List[BlockMapTransformFn],
+    post_transformations: List[BlockMapTransformFn],
+    pre_transformations: Optional[List[BlockMapTransformFn]] = None,
 ) -> PhysicalOperator:
+    """Plan a write operation with optional pre and post write transformations.
+
+    Args:
+        op: The write operator.
+        physical_children: The physical children operators.
+        data_context: The data context.
+        post_transformations: Transformations to run AFTER the write.
+        pre_transformations: Transformations to run BEFORE the write.
+            Useful for 2-phase commit where pending checkpoint is written first.
+
+    Returns:
+        The physical operator for the write operation.
+    """
     assert len(physical_children) == 1
     input_physical_dag = physical_children[0]
 
     datasink = op.datasink_or_legacy_datasource
     write_fn = generate_write_fn(datasink, **op.write_args)
 
-    # Create a MapTransformer for a write operator
-    transform_fns = [
-        BlockMapTransformFn(
-            write_fn,
-            is_udf=False,
-            # NOTE: No need for block-shaping
-            disable_block_shaping=True,
-        ),
-    ] + extra_transformations
+    # Build transform chain: pre_write -> write -> post_write
+    pre_transforms = pre_transformations or []
+    write_transform = BlockMapTransformFn(
+        write_fn,
+        is_udf=False,
+        # NOTE: No need for block-shaping
+        disable_block_shaping=True,
+    )
+    transform_fns = pre_transforms + [write_transform] + post_transformations
 
     map_transformer = MapTransformer(transform_fns)
 

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -1,6 +1,9 @@
 import functools
 import warnings
-from typing import Callable, Dict, List, Optional, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type, TypeVar
+
+if TYPE_CHECKING:
+    import pyarrow.fs
 
 from ray import ObjectRef
 from ray.data._internal.execution.execution_callback import add_execution_callback
@@ -55,6 +58,7 @@ from ray.data._internal.planner.plan_udf_map_op import (
 from ray.data._internal.planner.plan_write_op import plan_write_op
 from ray.data.checkpoint.load_checkpoint_callback import LoadCheckpointCallback
 from ray.data.context import DataContext
+from ray.data.datasource.file_datasink import _FileDatasink
 
 LogicalOperatorType = TypeVar("LogicalOperatorType", bound=LogicalOperator)
 PlanLogicalOpFn = Callable[
@@ -183,7 +187,10 @@ class Planner:
         ):
             self._supports_checkpointing = True
 
-            checkpoint_callback = self._create_checkpoint_callback(checkpoint_config)
+            data_file_dir, data_file_fs = self._get_data_file_info(logical_plan)
+            checkpoint_callback = self._create_checkpoint_callback(
+                checkpoint_config, data_file_dir, data_file_fs
+            )
             add_execution_callback(checkpoint_callback, logical_plan.context)
             load_checkpoint = checkpoint_callback.load_checkpoint
 
@@ -266,12 +273,35 @@ class Planner:
         op_map[physical_op] = logical_op
         return physical_op, op_map
 
-    def _create_checkpoint_callback(self, checkpoint_config) -> LoadCheckpointCallback:
+    def _create_checkpoint_callback(
+        self,
+        checkpoint_config,
+        data_file_dir=None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> LoadCheckpointCallback:
         """Factory method to create the LoadCheckpointCallback.
 
         Subclasses can override this to use a different callback implementation.
         """
-        return LoadCheckpointCallback(checkpoint_config)
+        return LoadCheckpointCallback(
+            checkpoint_config,
+            data_file_dir=data_file_dir,
+            data_file_filesystem=data_file_filesystem,
+        )
+
+    @staticmethod
+    def _get_data_file_info(logical_plan: LogicalPlan):
+        """Extract the data file directory and filesystem from the Write op's datasink.
+
+        Returns (path, filesystem) for file-based datasinks, or (None, None)
+        for non-file datasinks.
+        """
+        last_op = logical_plan.dag
+        if isinstance(last_op, Write):
+            datasink = last_op.datasink_or_legacy_datasource
+            if isinstance(datasink, _FileDatasink):
+                return datasink.unresolved_path, datasink.filesystem
+        return None, None
 
     def _get_plan_fns_for_checkpointing(
         self,

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -1,21 +1,36 @@
 import abc
 import logging
+import os
+import posixpath
 import time
 from typing import List, Optional
 
 import numpy
 import pyarrow
+from pyarrow.fs import FileSelector, FileType
 
 import ray
+from ray._common.retry import call_with_retry
 from ray.data._internal.arrow_ops import transform_pyarrow
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data.block import Block, BlockAccessor, BlockMetadata, DataBatch, Schema
 from ray.data.checkpoint import CheckpointConfig
+from ray.data.checkpoint.checkpoint_writer import PENDING_CHECKPOINT_SUFFIX
+from ray.data.checkpoint.util import build_pending_checkpoint_trie
 from ray.data.datasource import PathPartitionFilter
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.types import ObjectRef
 
 logger = logging.getLogger(__name__)
+
+# Retry configuration for checkpoint recovery operations.
+# These can be overridden via environment variables for testing or tuning.
+CHECKPOINT_RECOVERY_MAX_ATTEMPTS = int(
+    os.environ.get("RAY_DATA_CHECKPOINT_RECOVERY_MAX_ATTEMPTS", "3")
+)
+CHECKPOINT_RECOVERY_MAX_BACKOFF_S = int(
+    os.environ.get("RAY_DATA_CHECKPOINT_RECOVERY_MAX_BACKOFF_S", "8")
+)
 
 
 class CheckpointFilter(abc.ABC):
@@ -32,6 +47,84 @@ class CheckpointFilter(abc.ABC):
         self.id_column = self.ckpt_config.id_column
         self.filesystem = self.ckpt_config.filesystem
         self.filter_num_threads = self.ckpt_config.filter_num_threads
+
+
+@ray.remote(num_cpus=0)
+def _clean_pending_checkpoints_task(
+    checkpoint_path_unwrapped: str,
+    checkpoint_filesystem: pyarrow.fs.FileSystem,
+    data_file_dir_unwrapped: str,
+    data_file_filesystem: pyarrow.fs.FileSystem,
+) -> int:
+    """Delete data files that have matching pending checkpoint files, then
+    delete the pending checkpoints.
+
+    This runs as a remote task to avoid blocking the driver during potentially
+    slow filesystem operations (especially on cloud storage like S3).
+
+    Algorithm:
+    1. List all files in checkpoint dir, find those ending with .pending.parquet
+    2. Build a PrefixTrie from their basenames (strip .pending.parquet)
+    3. List all data files in data_file_dir (recursively for partitions)
+    4. For each data file, if trie.has_prefix_of(basename) -> delete it
+    5. Delete all the pending checkpoint files
+    6. Return count of pending checkpoints cleaned
+
+    Args:
+        checkpoint_path_unwrapped: The unwrapped checkpoint path.
+        checkpoint_filesystem: The filesystem for checkpoint files.
+        data_file_dir_unwrapped: The unwrapped directory where data files are
+            written (protocol prefix already stripped).
+        data_file_filesystem: The filesystem for data files. May differ from
+            checkpoint_filesystem (e.g., checkpoints on local disk, data on S3).
+
+    Returns:
+        Number of pending checkpoints cleaned.
+    """
+
+    def _clean() -> int:
+        # 1. List all files in checkpoint dir, find pending ones
+        ckpt_files = checkpoint_filesystem.get_file_info(
+            FileSelector(checkpoint_path_unwrapped, recursive=False)
+        )
+        pending_suffix = f"{PENDING_CHECKPOINT_SUFFIX}.parquet"
+        pending_file_paths = [
+            f
+            for f in ckpt_files
+            if f.type == FileType.File and f.path.endswith(pending_suffix)
+        ]
+
+        if not pending_file_paths:
+            return 0
+
+        # 2. Build prefix trie from pending checkpoint basenames
+        trie = build_pending_checkpoint_trie(pending_file_paths, pending_suffix)
+
+        # 3. List all data files (recursively for partitions)
+        data_files = data_file_filesystem.get_file_info(
+            FileSelector(data_file_dir_unwrapped, recursive=True, allow_not_found=True)
+        )
+
+        # 4. Delete data files matching a pending checkpoint prefix
+        for f in data_files:
+            if f.type != FileType.File:
+                continue
+            basename = posixpath.basename(f.path)
+            if trie.has_prefix_of(basename):
+                data_file_filesystem.delete_file(f.path)
+
+        # 5. Delete all pending checkpoint files
+        for f in pending_file_paths:
+            checkpoint_filesystem.delete_file(f.path)
+
+        return len(pending_file_paths)
+
+    return call_with_retry(
+        _clean,
+        description="clean pending checkpoints",
+        max_attempts=CHECKPOINT_RECOVERY_MAX_ATTEMPTS,
+        max_backoff_s=CHECKPOINT_RECOVERY_MAX_BACKOFF_S,
+    )
 
 
 @ray.remote(max_retries=-1)
@@ -174,12 +267,32 @@ class IdColumnCheckpointLoader(CheckpointLoader):
 class BatchBasedCheckpointFilter(CheckpointFilter):
     """CheckpointFilter for batch-based backends."""
 
-    def load_checkpoint(self) -> ObjectRef[Block]:
+    def load_checkpoint(
+        self,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> ObjectRef[Block]:
         """Load checkpointed ids as a sorted block.
+
+        This method first cleans up any pending checkpoints from incomplete
+        2-phase commits, then loads the committed checkpoint data.
+
+        Args:
+            data_file_dir: Optional directory where data files are written.
+                If provided, pending checkpoints will be used to find and
+                delete matching data files before loading.
+            data_file_filesystem: Optional filesystem for data files. If not
+                provided, defaults to the checkpoint filesystem. Should be
+                provided when data files are on a different filesystem than
+                checkpoints.
 
         Returns:
             ObjectRef[Block]: ObjectRef to the checkpointed IDs block.
         """
+        # Clean up pending checkpoints before loading (runs as a Ray task)
+        if data_file_dir is not None:
+            self._clean_pending_checkpoints(data_file_dir, data_file_filesystem)
+
         loader = IdColumnCheckpointLoader(
             checkpoint_path=self.checkpoint_path,
             filesystem=self.filesystem,
@@ -187,6 +300,41 @@ class BatchBasedCheckpointFilter(CheckpointFilter):
             checkpoint_path_partition_filter=self.ckpt_config.checkpoint_path_partition_filter,
         )
         return loader.load_checkpoint()
+
+    def _clean_pending_checkpoints(
+        self,
+        data_file_dir: str,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> None:
+        """Clean up pending checkpoints from incomplete 2-phase commits.
+
+        Finds pending checkpoint files, builds a prefix trie from their basenames,
+        deletes matching data files, then deletes the pending checkpoints.
+
+        Runs as a Ray task to avoid blocking the driver during potentially
+        slow filesystem operations (especially on cloud storage like S3).
+
+        Args:
+            data_file_dir: The directory where data files are written.
+            data_file_filesystem: The filesystem for data files. If not
+                provided, defaults to the checkpoint filesystem.
+        """
+        if data_file_filesystem is None:
+            data_file_filesystem = self.filesystem
+        try:
+            cleaned_count = ray.get(
+                _clean_pending_checkpoints_task.remote(
+                    self.checkpoint_path_unwrapped,
+                    self.filesystem,
+                    _unwrap_protocol(data_file_dir),
+                    data_file_filesystem,
+                )
+            )
+            if cleaned_count > 0:
+                logger.info(f"Cleaned up {cleaned_count} pending checkpoint(s)")
+        except ray.exceptions.RayTaskError:
+            logger.exception("Failed to clean up pending checkpoints")
+            raise
 
     def delete_checkpoint(self) -> None:
         self.filesystem.delete_dir(self.checkpoint_path_unwrapped)

--- a/python/ray/data/checkpoint/checkpoint_writer.py
+++ b/python/ray/data/checkpoint/checkpoint_writer.py
@@ -2,8 +2,14 @@ import logging
 import os
 import uuid
 from abc import abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
 
 from pyarrow import parquet as pq
+from pyarrow.fs import FileType
+
+if TYPE_CHECKING:
+    import pyarrow
 
 from ray.data._internal.util import call_with_retry
 from ray.data.block import BlockAccessor
@@ -13,12 +19,33 @@ from ray.data.datasource.path_util import _unwrap_protocol
 
 logger = logging.getLogger(__name__)
 
+# Suffix for pending checkpoint files (2-phase commit)
+PENDING_CHECKPOINT_SUFFIX = ".pending"
+
+
+@dataclass
+class PendingCheckpoint:
+    """Represents a pending checkpoint file for 2-phase commit.
+
+    Attributes:
+        pending_path: Path to the pending checkpoint file.
+        committed_path: Path where the checkpoint will be after commit.
+    """
+
+    pending_path: str
+    committed_path: str
+
 
 class CheckpointWriter:
     """Abstract class which defines the interface for writing row-level
     checkpoints based on varying backends.
 
-    Subclasses must implement `.write_block_checkpoint()`."""
+    Subclasses must implement `.write_block_checkpoint()`.
+
+    For 2-phase commit support, subclasses should also implement:
+    - `.write_pending_checkpoint()`: Write checkpoint as pending file
+    - `.commit_checkpoint()`: Rename pending to committed
+    """
 
     def __init__(self, config: CheckpointConfig):
         self.ckpt_config = config
@@ -34,8 +61,54 @@ class CheckpointWriter:
         """Write a checkpoint for all rows in a single block to the checkpoint
         output directory given by `self.checkpoint_path`.
 
+        This is used for non-file datasinks (SQL, MongoDB, etc.) where there's
+        no predictable file path to store in checkpoint metadata. For file-based
+        datasinks that need 2-phase commit with data file path tracking, use
+        `write_pending_checkpoint()` and `commit_checkpoint()` instead.
+
+        Args:
+            block: The block accessor containing the data to checkpoint.
+
         Subclasses of `CheckpointWriter` must implement this method."""
         ...
+
+    def write_pending_checkpoint(
+        self,
+        id_column_data: "pyarrow.Array",
+        checkpoint_id: str,
+    ) -> Optional[PendingCheckpoint]:
+        """Write a pending checkpoint for 2-phase commit.
+
+        This is called BEFORE the data file is written. The checkpoint filename
+        is deterministic (based on checkpoint_id), enabling idempotent writes
+        on retry. For file-based datasinks, the checkpoint filename matches
+        the data file prefix, enabling recovery to match pending checkpoints
+        to data files via prefix trie.
+
+        Args:
+            id_column_data: PyArrow array containing the ID column values.
+            checkpoint_id: Deterministic identifier for the checkpoint file,
+                derived from write_uuid and task_idx. Must be the same on retry
+                to ensure idempotent writes.
+
+        Returns:
+            PendingCheckpoint object for later commit, or None if empty.
+        """
+        raise NotImplementedError(
+            "2-phase commit not implemented for this checkpoint writer"
+        )
+
+    def commit_checkpoint(self, pending: PendingCheckpoint) -> None:
+        """Commit a pending checkpoint by renaming it to committed.
+
+        This is called AFTER the data file is successfully written.
+
+        Args:
+            pending: The PendingCheckpoint to commit.
+        """
+        raise NotImplementedError(
+            "2-phase commit not implemented for this checkpoint writer"
+        )
 
     @staticmethod
     def create(config: CheckpointConfig) -> "CheckpointWriter":
@@ -59,21 +132,49 @@ class BatchBasedCheckpointWriter(CheckpointWriter):
 
         self.filesystem.create_dir(self.checkpoint_path_unwrapped, recursive=True)
 
+    def _prepare_checkpoint_table_from_block(self, block: BlockAccessor):
+        """Prepare the checkpoint table from a block.
+
+        Args:
+            block: The block accessor containing the data to checkpoint.
+
+        Returns:
+            PyArrow table with checkpoint IDs.
+        """
+        checkpoint_ids_block = block.select(columns=[self.id_col])
+        # `pyarrow.parquet.write_parquet` requires a PyArrow table.
+        return BlockAccessor.for_block(checkpoint_ids_block).to_arrow()
+
+    def _prepare_checkpoint_table_from_id_column(self, id_column_data: "pyarrow.Array"):
+        """Prepare the checkpoint table from ID column data.
+
+        Args:
+            id_column_data: PyArrow array containing the ID column values.
+
+        Returns:
+            PyArrow table with checkpoint IDs.
+        """
+        import pyarrow as pa
+
+        return pa.table({self.id_col: id_column_data})
+
     def write_block_checkpoint(self, block: BlockAccessor):
         """Write a checkpoint for all rows in a single block to the checkpoint
         output directory given by `self.checkpoint_path`.
 
-        Subclasses of `CheckpointWriter` must implement this method."""
+        This is used for non-file datasinks (SQL, MongoDB, etc.) where there's
+        no predictable file path to store in checkpoint metadata.
+
+        Args:
+            block: The block accessor containing the data to checkpoint.
+        """
         if block.num_rows() == 0:
             return
 
         file_name = f"{uuid.uuid4()}.parquet"
         ckpt_file_path = os.path.join(self.checkpoint_path_unwrapped, file_name)
 
-        checkpoint_ids_block = block.select(columns=[self.id_col])
-        # `pyarrow.parquet.write_parquet` requires a PyArrow table. It errors if the block is
-        # a pandas DataFrame.
-        checkpoint_ids_table = BlockAccessor.for_block(checkpoint_ids_block).to_arrow()
+        checkpoint_ids_table = self._prepare_checkpoint_table_from_block(block)
 
         def _write():
             pq.write_table(
@@ -83,7 +184,7 @@ class BatchBasedCheckpointWriter(CheckpointWriter):
             )
 
         try:
-            return call_with_retry(
+            call_with_retry(
                 _write,
                 description=f"Write checkpoint file: {file_name}",
                 match=DataContext.get_current().retried_io_errors,
@@ -91,3 +192,82 @@ class BatchBasedCheckpointWriter(CheckpointWriter):
         except Exception:
             logger.exception(f"Checkpoint write failed: {file_name}")
             raise
+
+    def write_pending_checkpoint(
+        self,
+        id_column_data,
+        checkpoint_id: str,
+    ) -> Optional[PendingCheckpoint]:
+        if len(id_column_data) == 0:
+            return None
+        pending_file_name = f"{checkpoint_id}{PENDING_CHECKPOINT_SUFFIX}.parquet"
+        committed_file_name = f"{checkpoint_id}.parquet"
+
+        pending_path = os.path.join(self.checkpoint_path_unwrapped, pending_file_name)
+        committed_path = os.path.join(
+            self.checkpoint_path_unwrapped, committed_file_name
+        )
+
+        checkpoint_ids_table = self._prepare_checkpoint_table_from_id_column(
+            id_column_data
+        )
+
+        def _write():
+            pq.write_table(
+                checkpoint_ids_table,
+                pending_path,
+                filesystem=self.filesystem,
+            )
+
+        call_with_retry(
+            _write,
+            description=f"Write pending checkpoint file: {pending_file_name}",
+            match=DataContext.get_current().retried_io_errors,
+        )
+        return PendingCheckpoint(
+            pending_path=pending_path,
+            committed_path=committed_path,
+        )
+
+    def commit_checkpoint(self, pending: PendingCheckpoint) -> None:
+        """Commit a pending checkpoint by renaming it to committed.
+
+        This is called AFTER the data file is successfully written.
+
+        This operation is idempotent: if the committed file already exists
+        (and pending doesn't), it's considered already committed. This handles
+        the case where a retry happens after successful commit (e.g., network
+        timeout after move succeeded but before acknowledgment).
+
+        Args:
+            pending: The PendingCheckpoint to commit.
+        """
+
+        def _rename():
+            # Check if already committed (idempotent)
+            committed_info = self.filesystem.get_file_info(pending.committed_path)
+            pending_info = self.filesystem.get_file_info(pending.pending_path)
+
+            committed_exists = committed_info.type != FileType.NotFound
+            pending_exists = pending_info.type != FileType.NotFound
+
+            if committed_exists:
+                # Already committed. Clean up pending file if it exists.
+                if pending_exists:
+                    self.filesystem.delete_file(pending.pending_path)
+                return
+
+            if not pending_exists:
+                raise FileNotFoundError(
+                    f"Neither pending ({pending.pending_path}) nor committed "
+                    f"({pending.committed_path}) checkpoint exists"
+                )
+
+            # Normal case: move pending to committed
+            self.filesystem.move(pending.pending_path, pending.committed_path)
+
+        call_with_retry(
+            _rename,
+            description=f"Commit checkpoint: {pending.pending_path}",
+            match=DataContext.get_current().retried_io_errors,
+        )

--- a/python/ray/data/checkpoint/load_checkpoint_callback.py
+++ b/python/ray/data/checkpoint/load_checkpoint_callback.py
@@ -1,5 +1,8 @@
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    import pyarrow.fs
 
 from ray.data._internal.execution.execution_callback import (
     ExecutionCallback,
@@ -17,9 +20,16 @@ logger = logging.getLogger(__name__)
 class LoadCheckpointCallback(ExecutionCallback):
     """ExecutionCallback that handles checkpoints."""
 
-    def __init__(self, config: CheckpointConfig):
+    def __init__(
+        self,
+        config: CheckpointConfig,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ):
         assert config is not None
         self._config = config
+        self._data_file_dir = data_file_dir
+        self._data_file_filesystem = data_file_filesystem
 
         self._ckpt_filter = self._create_checkpoint_filter(config)
         self._checkpoint_ref: Optional[ObjectRef[Block]] = None
@@ -35,7 +45,10 @@ class LoadCheckpointCallback(ExecutionCallback):
 
     def _load_checkpoint_data(self) -> ObjectRef[Block]:
         """Load checkpoint data from storage (via the checkpoint filter)."""
-        return self._ckpt_filter.load_checkpoint()
+        return self._ckpt_filter.load_checkpoint(
+            data_file_dir=self._data_file_dir,
+            data_file_filesystem=self._data_file_filesystem,
+        )
 
     def before_execution_starts(self, executor: StreamingExecutor):
         assert self._config is executor._data_context.checkpoint_config

--- a/python/ray/data/checkpoint/util.py
+++ b/python/ray/data/checkpoint/util.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Iterable
+import posixpath
+from typing import Iterable, List
 
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data.block import Block, BlockAccessor, DataBatch
@@ -12,6 +13,47 @@ logger = logging.getLogger(__name__)
 
 # Checkpoint keyword argument name
 CHECKPOINTED_IDS_KWARG_NAME = "checkpointed_ids"
+
+
+class PrefixTrie:
+    """Trie for efficient prefix matching of filenames during recovery."""
+
+    def __init__(self) -> None:
+        self.children: dict[str, "PrefixTrie"] = {}
+        self.is_end: bool = False
+
+    def insert(self, word: str) -> None:
+        node = self
+        for ch in word:
+            if ch not in node.children:
+                node.children[ch] = PrefixTrie()
+            node = node.children[ch]
+        node.is_end = True
+
+    def has_prefix_of(self, word: str) -> bool:
+        """Return True if any inserted word is a prefix of `word`."""
+        node = self
+        for ch in word:
+            if node.is_end:
+                return True
+            if ch not in node.children:
+                return False
+            node = node.children[ch]
+        return node.is_end
+
+
+def build_pending_checkpoint_trie(file_paths: List, pending_suffix: str) -> PrefixTrie:
+    """Build a PrefixTrie from pending checkpoint file paths.
+
+    Strips the given pending suffix to get the data file prefix.
+    """
+    trie = PrefixTrie()
+    for f in file_paths:
+        basename = posixpath.basename(f.path)
+        if basename.endswith(pending_suffix):
+            prefix = basename[: -len(pending_suffix)]
+            trie.insert(prefix)
+    return trie
 
 
 def filter_checkpointed_rows_for_blocks(

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -18,7 +18,7 @@ from ray.data.context import DataContext
 from ray.data.datasource.datasink import Datasink, WriteResult
 from ray.data.datasource.filename_provider import (
     FilenameProvider,
-    _DefaultFilenameProvider,
+    _split_base_and_ext,
 )
 from ray.data.datasource.path_util import _resolve_paths_and_filesystem
 from ray.util.annotations import DeveloperAPI
@@ -61,7 +61,7 @@ class _FileDatasink(Datasink[None]):
             open_stream_args = {}
 
         if filename_provider is None:
-            filename_provider = _DefaultFilenameProvider(
+            filename_provider = FilenameProvider(
                 dataset_uuid=dataset_uuid, file_format=file_format
             )
 
@@ -215,14 +215,13 @@ class RowBasedFileDatasink(_FileDatasink):
         raise NotImplementedError
 
     def write_block(self, block: BlockAccessor, block_index: int, ctx: TaskContext):
+        task_filename = self.filename_provider.get_filename_for_task(
+            ctx.kwargs[WRITE_UUID_KWARG_NAME],
+            ctx.task_idx,
+        )
+        base, ext = _split_base_and_ext(task_filename)
         for row_index, row in enumerate(block.iter_rows(public_row_format=False)):
-            filename = self.filename_provider.get_filename_for_row(
-                row,
-                ctx.kwargs[WRITE_UUID_KWARG_NAME],
-                ctx.task_idx,
-                block_index,
-                row_index,
-            )
+            filename = f"{base}_{block_index:06}_{row_index:06}{ext}"
             write_path = posixpath.join(self.path, filename)
             logger.debug(f"Writing {write_path} file.")
 
@@ -273,8 +272,8 @@ class BlockBasedFileDatasink(_FileDatasink):
         raise NotImplementedError
 
     def write_block(self, block: BlockAccessor, block_index: int, ctx: TaskContext):
-        filename = self.filename_provider.get_filename_for_block(
-            block, ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx, block_index
+        filename = self.filename_provider.get_filename_for_task(
+            ctx.kwargs[WRITE_UUID_KWARG_NAME], ctx.task_idx
         )
         write_path = posixpath.join(self.path, filename)
 

--- a/python/ray/data/datasource/filename_provider.py
+++ b/python/ray/data/datasource/filename_provider.py
@@ -1,7 +1,23 @@
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Tuple
 
 from ray.data.block import Block
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import Deprecated, PublicAPI
+
+
+def _split_base_and_ext(filename: str) -> Tuple[str, str]:
+    """Split a filename into (base, extension) where extension includes the dot.
+
+    Returns (base, ext) where ext includes the leading dot (e.g., ".parquet"),
+    or is empty string if the filename has no extension.
+
+    This is the single source of truth for separating a task filename's base
+    from its extension. Used by both row-filename derivation and checkpoint
+    base-filename extraction — these MUST agree for prefix-trie recovery.
+    """
+    if "." in filename:
+        base, ext = filename.rsplit(".", 1)
+        return base, f".{ext}"
+    return filename, ""
 
 
 @PublicAPI(stability="alpha")
@@ -10,19 +26,15 @@ class FilenameProvider:
 
     Use this class to customize the filenames used when writing a Dataset.
 
-    Some methods write each row to a separate file, while others write each block to a
-    separate file. For example, :meth:`ray.data.Dataset.write_images` writes individual
-    rows, and :func:`ray.data.Dataset.write_parquet` writes blocks of data. For more
-    information about blocks, see :ref:`Data internals <datasets_scheduling>`.
-
-    If you're writing each row to a separate file, implement
-    :meth:`~FilenameProvider.get_filename_for_row`. Otherwise, implement
-    :meth:`~FilenameProvider.get_filename_for_block`.
+    Override :meth:`~FilenameProvider.get_filename_for_task` to customize filenames.
+    For row-based writes (e.g., :meth:`~ray.data.Dataset.write_images`), row filenames
+    are automatically derived by appending ``_{block_index:06}_{row_index:06}`` to the
+    task filename.
 
     Example:
 
-        This snippet shows you how to encode labels in written files. For example, if
-        `"cat"` is a label, you might write a file named `cat_000000_000000_000000.png`.
+        This snippet shows you how to customize filenames with a prefix. For example,
+        a file might be named ``images_abc123_000000.png``.
 
         .. testcode::
 
@@ -31,43 +43,93 @@ class FilenameProvider:
 
             class ImageFilenameProvider(FilenameProvider):
 
-                def __init__(self, file_format: str):
-                    self.file_format = file_format
+                def __init__(self, prefix: str, file_format: str):
+                    super().__init__(file_format=file_format)
+                    self.prefix = prefix
 
-                def get_filename_for_row(self, row, write_uuid, task_index, block_index, row_index):
-                    return (
-                        f"{row['label']}_{write_uuid}_{task_index:06}_{block_index:06}"
-                        f"_{row_index:06}.{self.file_format}"
-                    )
+                def get_filename_for_task(self, write_uuid, task_index):
+                    return f"{self.prefix}_{write_uuid}_{task_index:06}.{self.file_format}"
 
             ds = ray.data.read_parquet("s3://anonymous@ray-example-data/images.parquet")
             ds.write_images(
                 "/tmp/results",
                 column="image",
-                filename_provider=ImageFilenameProvider("png")
+                filename_provider=ImageFilenameProvider("images", "png")
             )
     """  # noqa: E501
 
+    def __init__(
+        self,
+        dataset_uuid: Optional[str] = None,
+        file_format: Optional[str] = None,
+    ) -> None:
+        self.dataset_uuid = dataset_uuid
+        self.file_format = file_format
+
+    def get_filename_for_task(self, write_uuid: str, task_index: int) -> str:
+        """Generate a filename for a write task.
+
+        Override this method to customize filenames when writing a Dataset.
+
+        .. note::
+            Filenames must be unique and deterministic for a given write UUID and
+            task index.
+
+        Args:
+            write_uuid: The UUID of the write operation.
+            task_index: The index of the write task.
+
+        Returns:
+            The generated filename string.
+        """
+        file_id = f"{write_uuid}_{task_index:06}"
+        filename = ""
+        if self.dataset_uuid is not None:
+            filename += f"{self.dataset_uuid}_"
+        filename += file_id
+        if self.file_format is not None:
+            filename += f".{self.file_format}"
+        return filename
+
+    @Deprecated(
+        message="Use get_filename_for_task() instead. The block and block_index "
+        "parameters are unused in practice because datasinks merge all blocks into "
+        "one before writing. These parameters will be removed in a future release. "
+        "Do not depend on block content or block_index in your FilenameProvider "
+        "implementation - filenames must be deterministic from (write_uuid, task_index) "
+        "alone to ensure checkpointing correctness."
+    )
     def get_filename_for_block(
-        self, block: Block, write_uuid: str, task_index: int, block_index: int
+        self, block: Optional[Block], write_uuid: str, task_index: int, block_index: int
     ) -> str:
         """Generate a filename for a block of data.
 
         .. note::
-            Filenames must be unique and deterministic for a given write UUID, and
-            task and block index.
+            Filenames must be unique and deterministic for a given write UUID and
+            task index. Do NOT depend on block content or block_index.
 
-            A block consists of multiple rows and corresponds to a single output file.
-            Each task might produce a different number of blocks.
+            Checkpointing requires predicting the output filename BEFORE writing
+            data. This enables 2-phase commit: if a write fails after creating the
+            file but before committing the checkpoint, recovery can use the
+            predicted filename to delete orphaned files and retry cleanly. If
+            filenames depend on block content, this prediction is impossible and
+            checkpointing cannot guarantee exactly-once semantics.
 
         Args:
-            block: The block that will be written to a file.
+            block: Deprecated, unused. Do not depend on block content.
             write_uuid: The UUID of the write operation.
             task_index: The index of the write task.
-            block_index: The index of the block *within* the write task.
+            block_index: Deprecated, always 0. Do not depend on this value.
         """
         raise NotImplementedError
 
+    @Deprecated(
+        message="Implement get_filename_for_task() instead. Row filenames are "
+        "automatically derived by appending _{block_index:06}_{row_index:06} to the "
+        "task filename. All files from the same task must share the task filename as "
+        "a prefix so that uncommitted data files can be identified and cleaned up "
+        "during checkpoint recovery."
+    )
     def get_filename_for_row(
         self,
         row: Dict[str, Any],
@@ -78,18 +140,10 @@ class FilenameProvider:
     ) -> str:
         """Generate a filename for a row.
 
-        .. note::
-            Filenames must be unique and deterministic for a given write UUID, and
-            task, block, and row index.
-
-            A block consists of multiple rows, and each row corresponds to a single
-            output file. Each task might produce a different number of blocks, and each
-            block might contain a different number of rows.
-
-        .. tip::
-            If you require a contiguous row index into the global dataset, use
-            :meth:`~ray.data.Dataset.iter_rows`. This method is single-threaded and
-            isn't recommended for large datasets.
+        .. deprecated::
+            Implement :meth:`get_filename_for_task` instead. Row filenames are
+            automatically derived by appending ``_{block_index:06}_{row_index:06}``
+            to the task filename.
 
         Args:
             row: The row that will be written to a file.
@@ -99,37 +153,3 @@ class FilenameProvider:
             row_index: The index of the row *within* the block.
         """
         raise NotImplementedError
-
-
-class _DefaultFilenameProvider(FilenameProvider):
-    def __init__(
-        self, dataset_uuid: Optional[str] = None, file_format: Optional[str] = None
-    ):
-        self._dataset_uuid = dataset_uuid
-        self._file_format = file_format
-
-    def get_filename_for_block(
-        self, block: Block, write_uuid: str, task_index: int, block_index: int
-    ) -> str:
-        file_id = f"{write_uuid}_{task_index:06}_{block_index:06}"
-        return self._generate_filename(file_id)
-
-    def get_filename_for_row(
-        self,
-        row: Dict[str, Any],
-        write_uuid: str,
-        task_index: int,
-        block_index: int,
-        row_index: int,
-    ) -> str:
-        file_id = f"{write_uuid}_{task_index:06}_{block_index:06}_{row_index:06}"
-        return self._generate_filename(file_id)
-
-    def _generate_filename(self, file_id: str) -> str:
-        filename = ""
-        if self._dataset_uuid is not None:
-            filename += f"{self._dataset_uuid}_"
-        filename += file_id
-        if self._file_format is not None:
-            filename += f".{self._file_format}"
-        return filename

--- a/python/ray/data/datasource/filename_provider.py
+++ b/python/ray/data/datasource/filename_provider.py
@@ -63,6 +63,16 @@ class FilenameProvider:
         dataset_uuid: Optional[str] = None,
         file_format: Optional[str] = None,
     ) -> None:
+        """Create a FilenameProvider.
+
+        Args:
+            dataset_uuid: An optional UUID to include as a prefix in generated
+                filenames. If provided, filenames will be formatted as
+                ``{dataset_uuid}_{write_uuid}_{task_index}``.
+            file_format: An optional file extension (without the leading dot)
+                to append to generated filenames, e.g. ``"parquet"`` or
+                ``"csv"``.
+        """
         self.dataset_uuid = dataset_uuid
         self.file_format = file_format
 

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -866,7 +866,7 @@ def test_parquet_write_uuid_handling_with_custom_filename_provider(
             self.filename_template = filename_template
             self.should_include_uuid = should_include_uuid
 
-        def get_filename_for_block(self, block, write_uuid, task_index, block_index):
+        def get_filename_for_task(self, write_uuid, task_index):
             if self.should_include_uuid:
                 # Replace {write_uuid} placeholder with actual write_uuid
                 return self.filename_template.format(write_uuid=write_uuid, i="{i}")

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -8,28 +8,37 @@ import pyarrow
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from pyarrow.fs import FileSelector, LocalFileSystem
+from pyarrow.fs import FileSelector, FileType, LocalFileSystem
 from pytest_lazy_fixtures import lf as lazy_fixture
 
 import ray
 from ray.data._internal.datasource.csv_datasource import CSVDatasource
 from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
+from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
 from ray.data._internal.logical.operators import Read, Write
 from ray.data._internal.logical.optimizers import get_execution_plan
+from ray.data._internal.planner.checkpoint.plan_write_op import (
+    WRITE_UUID_KWARG_NAME,
+    _generate_base_filename,
+    _generate_prepare_checkpoint_transform,
+)
 from ray.data.block import BlockAccessor
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_filter import (
     BatchBasedCheckpointFilter,
 )
 from ray.data.checkpoint.checkpoint_writer import (
+    PENDING_CHECKPOINT_SUFFIX,
     BatchBasedCheckpointWriter,
 )
 from ray.data.checkpoint.interfaces import (
     CheckpointBackend,
     InvalidCheckpointingConfig,
 )
+from ray.data.checkpoint.util import PrefixTrie
 from ray.data.context import DataContext
+from ray.data.datasource import BlockBasedFileDatasink, RowBasedFileDatasink
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
@@ -582,6 +591,510 @@ def test_manual_checkpoint_filters_ids(
 
 
 @pytest.mark.parametrize(
+    "fs,base_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+    ids=["local", "s3"],
+)
+def test_pending_checkpoint_write_and_commit(fs, base_path):
+    """Test the two-phase commit (2PC) checkpoint write and commit workflow.
+
+    This verifies that:
+    1. write_pending_checkpoint() creates a checkpoint file with PENDING suffix
+    2. The pending checkpoint exists but the committed version does not
+    3. commit_checkpoint() renames the pending file to committed (removes suffix)
+    4. After commit, the pending file no longer exists and committed file exists
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(base_path, "checkpoint")
+    fs.create_dir(_unwrap_protocol(checkpoint_path))
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+        override_filesystem=fs,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2], "col1": [0.1, 0.2]})
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+    assert fs.get_file_info(pending.pending_path).type != FileType.NotFound
+    assert fs.get_file_info(pending.committed_path).type == FileType.NotFound
+
+    writer.commit_checkpoint(pending)
+    assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
+    assert fs.get_file_info(pending.committed_path).type != FileType.NotFound
+
+    # Read back and verify contents
+    with fs.open_input_file(pending.committed_path) as f:
+        table = pq.read_table(f)
+    assert table.column(ID_COL).to_pylist() == [1, 2]
+
+
+@pytest.mark.parametrize(
+    "fs,base_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+    ids=["local", "s3"],
+)
+def test_commit_checkpoint_idempotent_already_committed(fs, base_path):
+    """Test that commit_checkpoint is idempotent when already committed.
+
+    If the committed file already exists and pending doesn't, calling
+    commit_checkpoint should succeed without error (no-op).
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(base_path, "checkpoint")
+    fs.create_dir(_unwrap_protocol(checkpoint_path))
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+        override_filesystem=fs,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2]})
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+
+    # First commit succeeds
+    writer.commit_checkpoint(pending)
+    assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
+    assert fs.get_file_info(pending.committed_path).type != FileType.NotFound
+
+    # Second commit should be idempotent (no error)
+    writer.commit_checkpoint(pending)
+    assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
+    assert fs.get_file_info(pending.committed_path).type != FileType.NotFound
+
+
+@pytest.mark.parametrize(
+    "fs,base_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+    ids=["local", "s3"],
+)
+def test_commit_checkpoint_idempotent_both_exist(fs, base_path):
+    """Test that commit_checkpoint cleans up when both files exist.
+
+    If both committed and pending files exist (edge case), the pending
+    file should be deleted and committed file preserved.
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(base_path, "checkpoint")
+    fs.create_dir(_unwrap_protocol(checkpoint_path))
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+        override_filesystem=fs,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2]})
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+
+    # Commit normally
+    writer.commit_checkpoint(pending)
+
+    # Manually recreate the pending file to simulate edge case
+    with fs.open_output_stream(pending.pending_path) as f:
+        f.write(b"dummy")
+
+    assert fs.get_file_info(pending.pending_path).type != FileType.NotFound
+    assert fs.get_file_info(pending.committed_path).type != FileType.NotFound
+
+    # Commit should clean up the pending file
+    writer.commit_checkpoint(pending)
+    assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
+    assert fs.get_file_info(pending.committed_path).type != FileType.NotFound
+
+
+@pytest.mark.parametrize(
+    "fs,base_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+    ids=["local", "s3"],
+)
+def test_commit_checkpoint_neither_exists(fs, base_path):
+    """Test that commit_checkpoint raises error when neither file exists."""
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(base_path, "checkpoint")
+    fs.create_dir(_unwrap_protocol(checkpoint_path))
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+        override_filesystem=fs,
+    )
+
+    df = pd.DataFrame({ID_COL: [1, 2]})
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+
+    # Delete the pending file to simulate missing state
+    fs.delete_file(pending.pending_path)
+    assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
+    assert fs.get_file_info(pending.committed_path).type == FileType.NotFound
+
+    # Commit should raise FileNotFoundError
+    with pytest.raises(FileNotFoundError):
+        writer.commit_checkpoint(pending)
+
+
+@pytest.mark.parametrize("data_file_exists", [True, False])
+@pytest.mark.parametrize(
+    "fs,base_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+    ids=["local", "s3"],
+)
+def test_clean_pending_checkpoint(
+    ray_start_10_cpus_shared, fs, base_path, data_file_exists
+):
+    """Test pending checkpoint cleanup removes incomplete writes.
+
+    When a write fails after creating a pending checkpoint but before commit,
+    the cleanup process must:
+    1. Find pending checkpoint files, build prefix trie from their basenames
+    2. Delete associated data files matching the prefix (if they exist)
+    3. Delete the pending checkpoint files
+
+    This test verifies cleanup works correctly whether the data file was
+    actually written (data_file_exists=True) or not (data_file_exists=False).
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(base_path, "checkpoint")
+    data_dir = os.path.join(base_path, "data")
+    for p in [checkpoint_path, data_dir]:
+        fs.create_dir(_unwrap_protocol(p))
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+        override_filesystem=fs,
+    )
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+
+    # Write a pending checkpoint (simulating pre-write phase)
+    df = pd.DataFrame({ID_COL: [0]})
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        checkpoint_id="test_000000_000000",
+    )
+    assert pending is not None
+    assert fs.get_file_info(pending.pending_path).type != FileType.NotFound
+
+    # Optionally create a data file matching the pending checkpoint prefix
+    data_file = os.path.join(_unwrap_protocol(data_dir), "test_000000_000000.csv")
+    if data_file_exists:
+        with fs.open_output_stream(data_file) as f:
+            f.write(b"id\n0\n")
+
+    filter_instance = BatchBasedCheckpointFilter(ctx.checkpoint_config)
+    filter_instance._clean_pending_checkpoints(data_dir, fs)
+
+    # Data file should be deleted (if it existed)
+    if data_file_exists:
+        assert fs.get_file_info(data_file).type == FileType.NotFound
+    # Pending checkpoint should be deleted
+    assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
+
+
+@pytest.mark.parametrize(
+    "fs,base_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+    ids=["local", "s3"],
+)
+def test_clean_pending_checkpoint_with_partitioned_data(
+    ray_start_10_cpus_shared, fs, base_path
+):
+    """Test pending checkpoint cleanup removes files in partition subdirectories.
+
+    When using ParquetDatasink with partition_cols, data files are written to
+    subdirectories like output/col=val/file.parquet. The cleanup process must
+    recursively search subdirectories to find and delete data files matching
+    pending checkpoint prefixes.
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(base_path, "checkpoint")
+    data_dir = os.path.join(base_path, "data")
+    for p in [checkpoint_path, data_dir]:
+        fs.create_dir(_unwrap_protocol(p))
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+        override_filesystem=fs,
+    )
+
+    writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+
+    # Write a pending checkpoint for "pending_task" (simulating failed write)
+    base_filename = "pending_task"
+    df = pd.DataFrame({ID_COL: [0, 1, 2]})
+    id_column_data = BlockAccessor.for_block(df).to_arrow()[ID_COL]
+    pending = writer.write_pending_checkpoint(
+        id_column_data,
+        checkpoint_id=base_filename,
+    )
+    assert pending is not None
+
+    # Create data files matching the pending checkpoint in partition subdirectories
+    partition_dirs = ["partition_col=a", "partition_col=b"]
+    pending_data_files = []
+    for partition_dir in partition_dirs:
+        partition_path = os.path.join(_unwrap_protocol(data_dir), partition_dir)
+        fs.create_dir(partition_path)
+        data_file = os.path.join(partition_path, f"{base_filename}-0.parquet")
+        with fs.open_output_stream(data_file) as f:
+            f.write(b"dummy data")
+        pending_data_files.append(data_file)
+
+    # Also create a matching file directly in base dir
+    base_data_file = os.path.join(
+        _unwrap_protocol(data_dir), f"{base_filename}-0.parquet"
+    )
+    with fs.open_output_stream(base_data_file) as f:
+        f.write(b"dummy data")
+    pending_data_files.append(base_data_file)
+
+    # Create unrelated data files that should NOT be deleted
+    unrelated_files = []
+    for partition_dir in partition_dirs:
+        partition_path = os.path.join(_unwrap_protocol(data_dir), partition_dir)
+        data_file = os.path.join(partition_path, "other_task-0.parquet")
+        with fs.open_output_stream(data_file) as f:
+            f.write(b"dummy data")
+        unrelated_files.append(data_file)
+
+    # Verify all files were created
+    for f in pending_data_files + unrelated_files:
+        assert (
+            fs.get_file_info(f).type != FileType.NotFound
+        ), f"Expected file to exist: {f}"
+
+    # Run cleanup
+    filter_instance = BatchBasedCheckpointFilter(ctx.checkpoint_config)
+    filter_instance._clean_pending_checkpoints(data_dir, fs)
+
+    # Verify data files matching pending checkpoint were deleted
+    for f in pending_data_files:
+        assert (
+            fs.get_file_info(f).type == FileType.NotFound
+        ), f"Expected pending data file to be deleted: {f}"
+
+    # Verify unrelated data files still exist
+    for f in unrelated_files:
+        assert (
+            fs.get_file_info(f).type != FileType.NotFound
+        ), f"Expected unrelated file to still exist: {f}"
+
+    # Verify pending checkpoint was also deleted
+    assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
+
+
+def test_clean_pending_checkpoints_task_failure(ray_start_10_cpus_shared, tmp_path):
+    """Test that _clean_pending_checkpoints raises when the cleanup task fails.
+
+    This verifies that:
+    1. When the underlying Ray task fails, the exception is propagated
+    2. The error is logged properly before re-raising
+    """
+    ctx = ray.data.DataContext.get_current()
+    # Use a non-existent path to trigger a failure when trying to list files
+    checkpoint_path = os.path.join(tmp_path, "nonexistent", "deeply", "nested", "path")
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    filter_instance = BatchBasedCheckpointFilter(ctx.checkpoint_config)
+
+    # The cleanup task should fail because the checkpoint directory doesn't exist
+    # and get_file_info on a non-existent path will raise an error
+    with pytest.raises(ray.exceptions.RayTaskError):
+        filter_instance._clean_pending_checkpoints("/dummy/data/path")
+
+
+def test_prepare_checkpoint_transform_writes_pending(tmp_path):
+    """Test that the pre-write checkpoint transform writes a pending checkpoint.
+
+    This verifies that:
+    1. _generate_prepare_checkpoint_transform() creates a transform that writes
+       a pending checkpoint file
+    2. The pending checkpoint filename matches the base filename with .pending suffix
+    """
+
+    class MockFileDatasink(BlockBasedFileDatasink):
+        def write_block_to_file(self, block: BlockAccessor, file: "pyarrow.NativeFile"):
+            file.write(b"")
+
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    os.makedirs(checkpoint_path, exist_ok=True)
+    data_output_path = os.path.join(tmp_path, "output")
+    os.makedirs(data_output_path, exist_ok=True)
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    datasink = MockFileDatasink(data_output_path, file_format="csv")
+    checkpoint_writer = BatchBasedCheckpointWriter(ctx.checkpoint_config)
+    transform = _generate_prepare_checkpoint_transform(ctx, datasink, checkpoint_writer)
+
+    ctx_task = TaskContext(task_idx=0, op_name="test")
+    ctx_task.kwargs[WRITE_UUID_KWARG_NAME] = "test-write-uuid"
+
+    df = pd.DataFrame({ID_COL: [0], "col1": [0.1]})
+    list(transform._apply_transform(ctx_task, [df]))
+
+    pending_files = [
+        f
+        for f in os.listdir(checkpoint_path)
+        if f.endswith(f"{PENDING_CHECKPOINT_SUFFIX}.parquet")
+    ]
+    assert len(pending_files) == 1
+
+    # Verify pending checkpoint filename matches the base filename
+    base_filename = _generate_base_filename(datasink, ctx_task)
+    assert pending_files[0] == f"{base_filename}{PENDING_CHECKPOINT_SUFFIX}.parquet"
+
+
+def test_2pc_fail_retry_cleans_pending_checkpoints(
+    ray_start_10_cpus_shared,
+    tmp_path,
+):
+    """Test end-to-end 2PC cleanup: fail during write, retry succeeds after cleanup.
+
+    This is an integration test for the full two-phase commit cleanup flow:
+    1. First write attempt: pre-write creates pending checkpoint, datasink
+       writes partial data then fails, leaving pending checkpoint files
+    2. Retry: the checkpoint filter's _clean_pending_checkpoints() detects
+       pending files, deletes them along with partial data files
+    3. Second write attempt: succeeds, writing complete data with no duplicates
+
+    Verifies that after cleanup, all pending checkpoints are removed and
+    the final output contains the correct data.
+    """
+    ctx = ray.data.DataContext.get_current()
+    ctx.raise_original_map_exception = True
+    ctx.default_hash_shuffle_parallelism = 1
+
+    checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    data_output_path = os.path.join(tmp_path, "output")
+    os.makedirs(checkpoint_path, exist_ok=True)
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+    )
+
+    @ray.remote(num_cpus=0)
+    class FailController:
+        def __init__(self):
+            self._should_fail = True
+
+        def should_fail(self):
+            return self._should_fail
+
+        def disable_failure(self):
+            self._should_fail = False
+
+    controller = FailController.remote()
+
+    class FailOnceCSVDatasink(BlockBasedFileDatasink):
+        def __init__(self, path: str, controller):
+            super().__init__(path, file_format="csv")
+            self._controller = controller
+
+        def write_block_to_file(self, block: BlockAccessor, file: "pyarrow.NativeFile"):
+            if ray.get(self._controller.should_fail.remote()):
+                # Write a partial file and then fail to simulate incomplete write.
+                file.write(b"id\n0\n")
+                raise RuntimeError("Simulated write failure")
+            block.to_pandas().to_csv(file, index=False)
+
+    datasink = FailOnceCSVDatasink(data_output_path, controller)
+    ds = ray.data.range(SAMPLE_DATA_NUM_ROWS, override_num_blocks=1)
+
+    with pytest.raises(RuntimeError, match="Simulated write failure"):
+        ds.write_datasink(datasink, ray_remote_args={"max_retries": 0})
+
+    # After failure, there should be pending checkpoint files (written in
+    # pre-write phase, before the data write failed)
+    pending_files = [
+        f
+        for f in os.listdir(checkpoint_path)
+        if f.endswith(f"{PENDING_CHECKPOINT_SUFFIX}.parquet")
+    ]
+    assert pending_files, "Expected pending checkpoint files after failed write."
+
+    ray.get(controller.disable_failure.remote())
+    ds.write_datasink(datasink, ray_remote_args={"max_retries": 0})
+
+    # After successful retry, pending checkpoints should be cleaned up
+    pending_files_after = [
+        f
+        for f in os.listdir(checkpoint_path)
+        if f.endswith(f"{PENDING_CHECKPOINT_SUFFIX}.parquet")
+    ]
+    assert pending_files_after == []
+
+    ctx.checkpoint_config = None
+    ds_readback = ray.data.read_csv(data_output_path)
+    actual_output = sorted([row[ID_COL] for row in ds_readback.iter_rows()])
+    expected_output = sorted(range(SAMPLE_DATA_NUM_ROWS))
+    assert actual_output == expected_output
+
+
+@pytest.mark.parametrize(
     "backend,fs,data_path",
     [
         (CheckpointBackend.FILE_STORAGE, None, lazy_fixture("local_path")),
@@ -823,6 +1336,421 @@ def test_checkpoint_restore_after_full_execution(
     assert (
         num_rows_second == 0  # No rows should be written
     ), f"Expected 0 rows, got {num_rows_second}"
+
+
+class FailAfterWriteParquetDatasink(ParquetDatasink):
+    """Test helper: ParquetDatasink that fails AFTER writing data (simulates post-write crash).
+
+    This simulates the failure scenario where:
+    - Data is successfully written to the output file
+    - But the process crashes/fails before the checkpoint can be committed
+    This is the critical case that 2PC is designed to handle - the data file
+    exists but is "uncommitted" and should be cleaned up on recovery.
+    """
+
+    def __init__(self, path: str, fail_threshold: int = 100, **kwargs):
+        super().__init__(path, **kwargs)
+        self._fail_threshold = fail_threshold
+
+    def write(self, blocks, ctx):
+        blocks_list = list(blocks)
+
+        # Check if any block has id > threshold
+        should_fail = False
+        for block in blocks_list:
+            accessor = BlockAccessor.for_block(block)
+            df = accessor.to_pandas()
+            if ID_COL in df.columns and df[ID_COL].max() > self._fail_threshold:
+                should_fail = True
+                break
+
+        # First, write the blocks normally
+        result = super().write(iter(blocks_list), ctx)
+
+        # Then fail if threshold exceeded (simulates post-write failure)
+        if should_fail:
+            raise RuntimeError(
+                f"Simulated failure: block contains {ID_COL} > {self._fail_threshold}"
+            )
+
+        return result
+
+
+def test_partial_failure_no_duplicates(
+    ray_start_10_cpus_shared,
+    tmp_path,
+):
+    """Test checkpoint deduplication: partial failure + retry produces no duplicate rows.
+
+    This is the key correctness test for the checkpoint deduplication feature.
+    It verifies that when a write pipeline fails partway through:
+    1. Already-committed rows (from successful blocks before failure) are tracked
+    2. Uncommitted rows (from blocks that failed after writing data) are cleaned up
+    3. On retry, only uncommitted rows are re-written
+    4. Final output has exactly the expected rows with NO duplicates
+
+    The test uses run_tag to verify which rows came from which run, confirming
+    that committed rows from run 1 are preserved and not re-written in run 2.
+
+    Note: This test requires ray.shutdown() + ray.init() mid-test to flush
+    in-flight checkpoint writes, which is incompatible with mock S3 (pyarrow's
+    S3 subsystem gets finalized during shutdown). The checkpoint storage layer
+    is already tested with S3 in other parameterized tests.
+    """
+    num_rows = 1000
+    fail_threshold = 100
+
+    # Create paths
+    input_path = tmp_path / "input"
+    output_path = tmp_path / "output"
+    checkpoint_path_dir = tmp_path / "checkpoint"
+    for path in [input_path, output_path, checkpoint_path_dir]:
+        path.mkdir(exist_ok=True)
+
+    # Create sample data (1000 rows with unique IDs)
+    df = pd.DataFrame(
+        {ID_COL: range(num_rows), "value": [f"row_{i}" for i in range(num_rows)]}
+    )
+    df.to_parquet(input_path / "data.parquet", index=False)
+
+    # Configure checkpointing
+    ctx = DataContext.get_current()
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=str(checkpoint_path_dir),
+        delete_checkpoint_on_success=False,
+    )
+
+    def add_run_tag(batch, run_tag):
+        """Add a run_tag column to identify which run wrote the data."""
+        batch["run_tag"] = [run_tag] * len(batch[ID_COL])
+        return batch
+
+    # Run 1: Use the failing datasink - should write some blocks then fail
+    with pytest.raises(RuntimeError, match="Simulated failure"):
+        ds = ray.data.read_parquet(str(input_path))
+        ds = ds.repartition(200)  # 200 blocks
+        ds = ds.map_batches(lambda b: add_run_tag(b, "first"), batch_size=None)
+        failing_datasink = FailAfterWriteParquetDatasink(
+            str(output_path), fail_threshold=fail_threshold
+        )
+        ds.write_datasink(failing_datasink, ray_remote_args={"max_retries": 0})
+
+    # Shutdown Ray to ensure all in-flight tasks complete before checking state.
+    # This addresses the race condition where background tasks may still be writing
+    # checkpoint files after the exception is raised.
+    ray.shutdown()
+    ray.init()
+
+    # Run 2: Use regular write_parquet - should resume from checkpoint
+    ds2 = ray.data.read_parquet(str(input_path))
+    ds2 = ds2.repartition(200)
+    ds2 = ds2.map_batches(lambda b: add_run_tag(b, "second"), batch_size=None)
+    ds2.write_parquet(str(output_path))
+
+    result = ray.data.read_parquet(str(output_path)).to_pandas()
+
+    assert len(result) == num_rows, f"Expected {num_rows} rows, got {len(result)}"
+
+    # Check for duplicates
+    assert result[ID_COL].is_unique, (
+        f"Duplicate IDs found: "
+        f"{sorted(result[result.duplicated(ID_COL, keep=False)][ID_COL].unique().tolist())}"
+    )
+
+    # Verify that some rows came from first run (before failure) and rest from second
+    run_tag_counts = result["run_tag"].value_counts()
+    assert "first" in run_tag_counts.index, "Expected some rows from first run"
+    assert "second" in run_tag_counts.index, "Expected some rows from second run"
+
+
+def test_partial_failure_no_duplicates_partitioned(
+    ray_start_10_cpus_shared,
+    tmp_path,
+):
+    """Test checkpoint deduplication with multi-level partitioned parquet output.
+
+    Same as test_partial_failure_no_duplicates, but writes partitioned output
+    using 3 partition columns, creating deeply nested subdirectories
+    (e.g., output/region=us/category=x/tier=1/file.parquet). This exercises
+    the recovery path where data files must be found via recursive search
+    using the data_file_dir passed through the call chain.
+
+    Note: This test requires ray.shutdown() + ray.init() mid-test to flush
+    in-flight checkpoint writes, which is incompatible with mock S3 (pyarrow's
+    S3 subsystem gets finalized during shutdown). The checkpoint storage layer
+    is already tested with S3 in other parameterized tests.
+    """
+    num_rows = 1000
+    fail_threshold = 100
+
+    # Create paths
+    input_path = tmp_path / "input"
+    output_path = tmp_path / "output"
+    checkpoint_path_dir = tmp_path / "checkpoint"
+    for path in [input_path, output_path, checkpoint_path_dir]:
+        path.mkdir(exist_ok=True)
+
+    # Create sample data with 3 partition columns for deeply nested output
+    # (e.g., output/region=us/category=x/tier=1/file.parquet)
+    regions = ["us", "eu"]
+    categories = ["x", "y", "z"]
+    tiers = [1, 2]
+    df = pd.DataFrame(
+        {
+            ID_COL: range(num_rows),
+            "value": [f"row_{i}" for i in range(num_rows)],
+            "region": [regions[i % len(regions)] for i in range(num_rows)],
+            "category": [categories[i % len(categories)] for i in range(num_rows)],
+            "tier": [tiers[i % len(tiers)] for i in range(num_rows)],
+        }
+    )
+    df.to_parquet(input_path / "data.parquet", index=False)
+
+    # Configure checkpointing
+    ctx = DataContext.get_current()
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=str(checkpoint_path_dir),
+        delete_checkpoint_on_success=False,
+    )
+
+    def add_run_tag(batch, run_tag):
+        """Add a run_tag column to identify which run wrote the data."""
+        batch["run_tag"] = [run_tag] * len(batch[ID_COL])
+        return batch
+
+    partition_cols = ["region", "category", "tier"]
+
+    # Run 1: Use the failing datasink with partition_cols
+    with pytest.raises(RuntimeError, match="Simulated failure"):
+        ds = ray.data.read_parquet(str(input_path))
+        ds = ds.repartition(200)
+        ds = ds.map_batches(lambda b: add_run_tag(b, "first"), batch_size=None)
+        failing_datasink = FailAfterWriteParquetDatasink(
+            str(output_path),
+            fail_threshold=fail_threshold,
+            partition_cols=partition_cols,
+        )
+        ds.write_datasink(failing_datasink, ray_remote_args={"max_retries": 0})
+
+    # Shutdown Ray to ensure all in-flight tasks complete before checking state.
+    ray.shutdown()
+    ray.init()
+
+    # Run 2: Use regular write_parquet with partition_cols - should resume
+    ds2 = ray.data.read_parquet(str(input_path))
+    ds2 = ds2.repartition(200)
+    ds2 = ds2.map_batches(lambda b: add_run_tag(b, "second"), batch_size=None)
+    ds2.write_parquet(str(output_path), partition_cols=partition_cols)
+
+    result = ray.data.read_parquet(str(output_path)).to_pandas()
+
+    assert len(result) == num_rows, f"Expected {num_rows} rows, got {len(result)}"
+
+    # Check for duplicates
+    assert result[ID_COL].is_unique, (
+        f"Duplicate IDs found: "
+        f"{sorted(result[result.duplicated(ID_COL, keep=False)][ID_COL].unique().tolist())}"
+    )
+
+    # Verify that some rows came from first run (before failure) and rest from second
+    run_tag_counts = result["run_tag"].value_counts()
+    assert "first" in run_tag_counts.index, "Expected some rows from first run"
+    assert "second" in run_tag_counts.index, "Expected some rows from second run"
+
+    # Verify partitioned output structure: partition subdirectories should exist
+    output_subdirs = [
+        d for d in os.listdir(str(output_path)) if os.path.isdir(output_path / d)
+    ]
+    assert len(output_subdirs) > 0, "Expected partition subdirectories in output"
+
+
+class TextRowDatasink(RowBasedFileDatasink):
+    """Test helper: RowBasedFileDatasink that writes each row as a text file."""
+
+    def __init__(self, path: str, **kwargs):
+        super().__init__(path, file_format="txt", **kwargs)
+
+    def write_row_to_file(self, row, file):
+        file.write(f"{row[ID_COL]},{row['value']}".encode())
+
+
+class FailAfterWriteTextRowDatasink(TextRowDatasink):
+    """Test helper: TextRowDatasink that fails AFTER writing data."""
+
+    def __init__(self, path: str, fail_threshold: int = 100, **kwargs):
+        super().__init__(path, **kwargs)
+        self._fail_threshold = fail_threshold
+
+    def write(self, blocks, ctx):
+        blocks_list = list(blocks)
+
+        should_fail = False
+        for block in blocks_list:
+            accessor = BlockAccessor.for_block(block)
+            df = accessor.to_pandas()
+            if ID_COL in df.columns and df[ID_COL].max() > self._fail_threshold:
+                should_fail = True
+                break
+
+        result = super().write(iter(blocks_list), ctx)
+
+        if should_fail:
+            raise RuntimeError(
+                f"Simulated failure: block contains {ID_COL} > {self._fail_threshold}"
+            )
+
+        return result
+
+
+def test_partial_failure_no_duplicates_row_based(
+    ray_start_10_cpus_shared,
+    tmp_path,
+):
+    """Test checkpoint deduplication with row-based datasink (one file per row).
+
+    Row-based datasinks write multiple files per task, e.g.:
+      write_uuid_000000_000000_000000.txt
+      write_uuid_000000_000000_000001.txt
+    Recovery must match all of them via the checkpoint prefix (write_uuid_000000).
+    This validates the PrefixTrie-based matching works for row-based writes.
+    """
+    num_rows = 1000
+    fail_threshold = 100
+
+    # Create paths
+    input_path = tmp_path / "input"
+    output_path = tmp_path / "output"
+    checkpoint_path_dir = tmp_path / "checkpoint"
+    for path in [input_path, output_path, checkpoint_path_dir]:
+        path.mkdir(exist_ok=True)
+
+    # Create sample data
+    df = pd.DataFrame(
+        {ID_COL: range(num_rows), "value": [f"row_{i}" for i in range(num_rows)]}
+    )
+    df.to_parquet(input_path / "data.parquet", index=False)
+
+    # Configure checkpointing
+    ctx = DataContext.get_current()
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=str(checkpoint_path_dir),
+        delete_checkpoint_on_success=False,
+    )
+
+    def add_run_tag(batch, run_tag):
+        batch["run_tag"] = [run_tag] * len(batch[ID_COL])
+        return batch
+
+    # Run 1: Use the failing row-based datasink
+    with pytest.raises(RuntimeError, match="Simulated failure"):
+        ds = ray.data.read_parquet(str(input_path))
+        ds = ds.repartition(200)
+        ds = ds.map_batches(lambda b: add_run_tag(b, "first"), batch_size=None)
+        failing_datasink = FailAfterWriteTextRowDatasink(
+            str(output_path), fail_threshold=fail_threshold
+        )
+        ds.write_datasink(failing_datasink, ray_remote_args={"max_retries": 0})
+
+    ray.shutdown()
+    ray.init()
+
+    # Run 2: Use the same row-based datasink (non-failing) to resume
+    ds2 = ray.data.read_parquet(str(input_path))
+    ds2 = ds2.repartition(200)
+    ds2 = ds2.map_batches(lambda b: add_run_tag(b, "second"), batch_size=None)
+    ds2.write_datasink(TextRowDatasink(str(output_path)))
+
+    # Read all output text files and parse them
+    output_files = [f for f in os.listdir(str(output_path)) if f.endswith(".txt")]
+    rows = []
+    for fname in output_files:
+        with open(os.path.join(str(output_path), fname)) as f:
+            content = f.read()
+            id_val, value = content.split(",", 1)
+            rows.append({ID_COL: int(id_val), "value": value})
+
+    result = pd.DataFrame(rows)
+
+    assert len(result) == num_rows, f"Expected {num_rows} rows, got {len(result)}"
+
+    # Check for duplicates
+    assert result[ID_COL].is_unique, (
+        f"Duplicate IDs found: "
+        f"{sorted(result[result.duplicated(ID_COL, keep=False)][ID_COL].unique().tolist())}"
+    )
+
+
+def test_prefix_trie():
+    """Test PrefixTrie insert and has_prefix_of operations."""
+    trie = PrefixTrie()
+    trie.insert("abc")
+    trie.insert("def")
+    trie.insert("ab")
+
+    # "ab" is a prefix of "abc", "abcd", "ab"
+    assert trie.has_prefix_of("abc")
+    assert trie.has_prefix_of("abcd")
+    assert trie.has_prefix_of("ab")
+    assert trie.has_prefix_of("abxyz")
+    assert trie.has_prefix_of("def")
+    assert trie.has_prefix_of("defgh")
+
+    # No prefix matches for these
+    assert not trie.has_prefix_of("a")
+    assert not trie.has_prefix_of("xyz")
+    assert not trie.has_prefix_of("d")
+    assert not trie.has_prefix_of("de")
+    assert not trie.has_prefix_of("")
+
+
+def test_prefix_trie_empty():
+    """Test that an empty PrefixTrie returns False for all queries."""
+    trie = PrefixTrie()
+    assert not trie.has_prefix_of("")
+    assert not trie.has_prefix_of("abc")
+    assert not trie.has_prefix_of("anything")
+
+
+@pytest.mark.parametrize(
+    "fs,base_path",
+    [
+        (lazy_fixture("local_fs"), lazy_fixture("local_path")),
+        (lazy_fixture("s3_fs"), lazy_fixture("s3_path")),
+    ],
+    ids=["local", "s3"],
+)
+def test_clean_pending_checkpoints_no_pending(ray_start_10_cpus_shared, fs, base_path):
+    """Test that cleanup is a no-op when there are no pending checkpoint files.
+
+    With no pending checkpoints, no data files should be deleted. This is the
+    normal case after a successful write where all checkpoints were committed.
+    """
+    ctx = ray.data.DataContext.get_current()
+    checkpoint_path = os.path.join(base_path, "checkpoint")
+    fs.create_dir(_unwrap_protocol(checkpoint_path))
+
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=checkpoint_path,
+        delete_checkpoint_on_success=False,
+        override_filesystem=fs,
+    )
+
+    # Create data files but no pending checkpoints
+    data_dir = os.path.join(base_path, "data")
+    fs.create_dir(_unwrap_protocol(data_dir))
+    data_file = os.path.join(_unwrap_protocol(data_dir), "some_data.parquet")
+    with fs.open_output_stream(data_file) as f:
+        f.write(b"dummy")
+
+    filter_instance = BatchBasedCheckpointFilter(ctx.checkpoint_config)
+    filter_instance._clean_pending_checkpoints(data_dir, fs)
+
+    # Data file should still exist (no pending checkpoints means nothing to clean)
+    assert fs.get_file_info(data_file).type != FileType.NotFound
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/test_filename_provider.py
+++ b/python/ray/data/tests/unit/test_filename_provider.py
@@ -1,65 +1,62 @@
-import pandas as pd
 import pytest
 
-from ray.data.datasource.filename_provider import _DefaultFilenameProvider
+from ray.data.datasource.filename_provider import FilenameProvider
 
 
 @pytest.fixture(params=["csv", None])
 def filename_provider(request):
-    yield _DefaultFilenameProvider(dataset_uuid="", file_format=request.param)
+    yield FilenameProvider(dataset_uuid="", file_format=request.param)
 
 
-def test_default_filename_for_row_is_deterministic(filename_provider):
-    row = {}
-
-    first_filename = filename_provider.get_filename_for_row(
-        row, write_uuid="spam", task_index=0, block_index=0, row_index=0
+def test_default_filename_for_task_includes_task_index(filename_provider):
+    filename_0 = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=0
     )
-    second_filename = filename_provider.get_filename_for_row(
-        row, write_uuid="spam", task_index=0, block_index=0, row_index=0
+    filename_1 = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=1
     )
+    assert filename_0 != filename_1
+    assert "000000" in filename_0
+    assert "000001" in filename_1
+
+
+def test_default_get_filename_for_task_is_deterministic(filename_provider):
+    """Test the new get_filename_for_task() method is deterministic."""
+
+    first_filename = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=0
+    )
+    second_filename = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=0
+    )
+
     assert first_filename == second_filename
 
 
-def test_default_filename_for_block_is_deterministic(filename_provider):
-    block = pd.DataFrame()
-
-    first_filename = filename_provider.get_filename_for_block(
-        block, write_uuid="spam", task_index=0, block_index=0
+def test_default_row_filenames_derived_from_task_are_unique(filename_provider):
+    """Row filenames derived from task filename with block/row index are unique."""
+    task_filename = filename_provider.get_filename_for_task(
+        write_uuid="spam", task_index=0
     )
-    second_filename = filename_provider.get_filename_for_block(
-        block, write_uuid="spam", task_index=0, block_index=0
-    )
-
-    assert first_filename == second_filename
-
-
-def test_default_filename_for_row_is_unique(filename_provider):
-    filenames = [
-        filename_provider.get_filename_for_row(
-            {},
-            write_uuid="spam",
-            task_index=task_index,
-            block_index=block_index,
-            row_index=row_index,
-        )
-        for task_index in range(2)
-        for block_index in range(2)
-        for row_index in range(2)
-    ]
+    filenames = []
+    for block_index in range(2):
+        for row_index in range(4):
+            if "." in task_filename:
+                base, ext = task_filename.rsplit(".", 1)
+                filenames.append(f"{base}_{block_index:06}_{row_index:06}.{ext}")
+            else:
+                filenames.append(f"{task_filename}_{block_index:06}_{row_index:06}")
     assert len(set(filenames)) == len(filenames)
 
 
-def test_default_filename_for_block_is_unique(filename_provider):
+def test_default_get_filename_for_task_is_unique(filename_provider):
+    """Test the new get_filename_for_task() method generates unique filenames."""
     filenames = [
-        filename_provider.get_filename_for_block(
-            pd.DataFrame(),
+        filename_provider.get_filename_for_task(
             write_uuid="spam",
             task_index=task_index,
-            block_index=block_index,
         )
-        for task_index in range(2)
-        for block_index in range(2)
+        for task_index in range(4)
     ]
     assert len(set(filenames)) == len(filenames)
 


### PR DESCRIPTION
## Summary

This PR introduces **2-phase commit (2PC) for Ray Data checkpointing** and then **simplifies the recovery algorithm** using a prefix trie. Together these changes eliminate duplicate data files on failure recovery and provide exactly-once write semantics for file-based datasinks.

### Part 1: 2-phase commit for checkpointing to avoid duplicates

Previously, checkpoints were written *after* data files. If a task failed between writing data and writing the checkpoint, recovery would re-write the same data — producing duplicates. 2PC fixes this:

1. **Pre-write**: Write a *pending* checkpoint (`.pending.parquet`) containing the expected data file prefix
2. **Write**: Write the actual data file
3. **Post-write**: *Commit* the checkpoint (rename `.pending.parquet` → `.parquet`)

On recovery, pending checkpoints identify uncommitted data files that should be deleted before retrying.

For non-file datasinks (SQL, MongoDB, etc.), falls back to post-write checkpointing with at-least-once semantics (with warning).

### Part 2: Simplify recovery with prefix trie

Removes metadata storage in checkpoint parquet files (`DATA_FILE_DIR_METADATA_KEY`, `DATA_FILE_PREFIX_METADATA_KEY`) and replaces per-checkpoint metadata-based recovery with a simpler algorithm:

1. List pending checkpoint files, build a `PrefixTrie` from their basenames (strip `.pending.parquet`)
2. List all data files recursively (handles partitioned output)
3. Delete data files whose basename matches a trie prefix
4. Delete the pending checkpoint files

### Other changes

- **Plumb `data_file_dir` / `data_file_filesystem`** through `Planner → LoadCheckpointCallback → BatchBasedCheckpointFilter` so recovery can locate data files without reading checkpoint metadata
- **Add deterministic `FilenameProvider.get_filename_for_task()`** so checkpoint ID matches data file prefix. Deprecate `get_filename_for_block()` and `get_filename_for_row()`
- **Simplify `write_pending_checkpoint()` signature**: takes only `(id_column_data, checkpoint_id)` instead of also requiring `data_file_dir` and `data_file_prefix`
- **Row-based datasinks** (`RowBasedFileDatasink`) derive per-row filenames from the task filename via `_split_base_and_ext`, ensuring all files from one task share a common prefix for recovery

### Why write checkpoint before data?

`pq.write_table` is not atomic — if the process is killed mid-write, the file may exist on disk but be corrupted. Writing the pending checkpoint first and renaming it after the data write succeeds ensures we can always detect and clean up incomplete writes.

## Test plan

- [x] New 2PC unit tests: pending checkpoint write/commit, idempotent commit, recovery with prefix trie, partitioned data cleanup
- [x] Non-file datasink warning test
- [x] S3 parametrization for all recovery tests (via moto mock server)
- [x] Updated `test_filename_provider.py` for new `get_filename_for_task()` API
- [x] Row-based dedupe coverage for `RowBasedFileDatasink`
- [x] Existing checkpoint tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)