### PR TITLE
[Serve] Fix flaky test_proxy_metrics_internal_error in HAProxy metrics tests

### DIFF
--- a/python/ray/serve/tests/test_metrics_haproxy.py
+++ b/python/ray/serve/tests/test_metrics_haproxy.py
@@ -432,7 +432,7 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
                 http_error_count == 2
             ), f"Expected at least 2 HTTP 500 errors, got {http_error_count}"
             assert (
-                deployment_error_count >= 2
+                deployment_error_count == 2
             ), f"Expected at least 2 deployment 500 errors, got {deployment_error_count}"
 
         return http_error_count == 2 and deployment_error_count == 2

--- a/python/ray/serve/tests/test_metrics_haproxy.py
+++ b/python/ray/serve/tests/test_metrics_haproxy.py
@@ -388,8 +388,10 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
     app_name = "app"
     serve.run(A.bind(), name=app_name, route_prefix="/")
 
-    httpx.get("http://localhost:8000/", timeout=None)
-    httpx.get("http://localhost:8000/", timeout=None)
+    resp1 = httpx.get("http://localhost:8000/", timeout=None)
+    resp2 = httpx.get("http://localhost:8000/", timeout=None)
+    assert resp1.status_code == 500
+    assert resp2.status_code == 500
 
     # Ensure all expected metrics are present.
     try:
@@ -405,26 +407,39 @@ def test_proxy_metrics_internal_error(metrics_start_shutdown):
     def verify_error_count(do_assert=False):
         resp = httpx.get("http://127.0.0.1:9999", timeout=None).text
         resp = resp.split("\n")
+        http_error_count = 0
+        deployment_error_count = 0
+
         for metrics in resp:
             if "# HELP" in metrics or "# TYPE" in metrics:
                 continue
-            if "ray_serve_num_http_error_requests_total" in metrics:
-                # route "/" should have error count 2 (HTTP 500)
-                if do_assert:
-                    assert "2.0" in metrics
-                if "2.0" not in metrics:
-                    return False
-            elif "ray_serve_num_deployment_http_error_requests" in metrics:
-                # deployment A should have error count 2 (HTTP 500)
-                if do_assert:
-                    assert 'deployment="A"' in metrics and "2.0" in metrics
-                if 'deployment="A"' not in metrics or "2.0" not in metrics:
-                    return False
-        return True
+            if (
+                "ray_serve_num_http_error_requests_total" in metrics
+                and 'route="/"' in metrics
+                and 'error_code="500"' in metrics
+            ):
+                http_error_count += int(float(metrics.split(" ")[-1]))
+            elif (
+                "ray_serve_num_deployment_http_error_requests" in metrics
+                and 'deployment="A"' in metrics
+                and 'error_code="500"' in metrics
+            ):
+                deployment_error_count += int(float(metrics.split(" ")[-1]))
+
+        # We expect 2 requests total, both should be 500 errors
+        if do_assert:
+            assert (
+                http_error_count == 2
+            ), f"Expected at least 2 HTTP 500 errors, got {http_error_count}"
+            assert (
+                deployment_error_count >= 2
+            ), f"Expected at least 2 deployment 500 errors, got {deployment_error_count}"
+
+        return http_error_count == 2 and deployment_error_count == 2
 
     # There is a latency in updating the counter
     try:
-        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=10)
+        wait_for_condition(verify_error_count, retry_interval_ms=1000, timeout=30)
     except RuntimeError:
         verify_error_count(do_assert=True)
 


### PR DESCRIPTION
Increase the `wait_for_condition` timeout from 10s to 30s.