### PR TITLE
[core][autoscaler] Filter dead nodes from cluster_resource_state in v1 Monitor

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -37,6 +37,7 @@ from ray.autoscaler._private.prom_metrics import AutoscalerPrometheusMetrics
 from ray.autoscaler._private.util import format_readonly_node_type
 from ray.autoscaler.v2.sdk import get_cluster_resource_state
 from ray.core.generated import gcs_pb2
+from ray.core.generated.autoscaler_pb2 import NodeStatus
 from ray.core.generated.event_pb2 import Event as RayEvent
 from ray.experimental.internal_kv import (
     _initialize_internal_kv,
@@ -254,15 +255,20 @@ class Monitor:
         # from "get_cluster_resource_state"
         # ref: https://github.com/ray-project/ray/pull/48519#issuecomment-2481659346
         cluster_resource_state = get_cluster_resource_state(self.gcs_client)
-        ray_node_states = cluster_resource_state.node_states
+        # Filter out dead nodes so they don't appear as active in ray status.
+        alive_node_states = [
+            node
+            for node in cluster_resource_state.node_states
+            if node.status != NodeStatus.DEAD
+        ]
         ray_nodes_idle_duration_ms_by_id = {
-            node.node_id: node.idle_duration_ms for node in ray_node_states
+            node.node_id: node.idle_duration_ms for node in alive_node_states
         }
 
         # Tell the readonly node provider what nodes to report.
         if self.readonly_config:
             new_nodes = []
-            for msg in list(cluster_resource_state.node_states):
+            for msg in alive_node_states:
                 node_id = msg.node_id.hex()
                 new_nodes.append((node_id, msg.node_ip_address))
             self.autoscaler.provider._set_nodes(new_nodes)
@@ -276,7 +282,7 @@ class Monitor:
         )
 
         mirror_node_types = {}
-        for resource_message in cluster_resource_state.node_states:
+        for resource_message in alive_node_states:
             node_id = resource_message.node_id
             # Generate node type config based on GCS reported node list.
             if self.readonly_config:


### PR DESCRIPTION
## Description
  Filter out `NodeStatus.DEAD` nodes from `get_cluster_resource_state()` results in `Monitor.update_load_metrics()`                                                                                             
  `get_cluster_resource_state()` intentionally includes DEAD nodes. The v2 autoscaler already filters them in `get_non_terminated()` and `_parse_cluster_resource_usage()`, but this filtering was missing in v1.   
                                                                                                                                               
  Without filtering, DEAD nodes appear as active causing ghost entries in `ray status` .

## Related issues
Fixes #61834, #52198
