### PR TITLE
[Core] Orphaned processes on worker version mismatch

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -382,6 +382,13 @@ class Node:
                     gcs_server_port=int(gcs_server_port) if gcs_server_port else 0
                 )
 
+        # For worker nodes, check version compatibility before spawning
+        # any processes (including the reaper). If the check fails (e.g.
+        # Ray / Python version mismatch) we raise immediately rather than
+        # leave orphaned child processes behind.
+        if not head and not connect_only:
+            self.check_version_info()
+
         if not connect_only and spawn_reaper and not self.kernel_fate_share:
             self.start_reaper_process()
         if not connect_only:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1127,10 +1127,10 @@ def start(
         try:
             node.check_version_info()
         except RuntimeError:
-            # Version mismatch detected after the node has already started.
-            # Kill all node processes to unregister the raylet from the
-            # cluster before propagating the error.
-            node.kill_all_processes(check_alive=False, allow_graceful=True, wait=True)
+            try:
+                node.kill_all_processes(check_alive=False, allow_graceful=True, wait=True)
+            except Exception as e:
+                cli_logger.warning(f"Failed to clean up processes on version mismatch: {e}")
             raise
 
         cli_logger.newline()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1123,9 +1123,15 @@ def start(
         )
         temp_dir = node.get_temp_dir_path()
 
-        # Ray and Python versions should probably be checked before
-        # initializing Node.
-        node.check_version_info()
+        # Check version compatibility and clean up node processes on mismatch.
+        try:
+            node.check_version_info()
+        except RuntimeError:
+            # Version mismatch detected after the node has already started.
+            # Kill all node processes to unregister the raylet from the
+            # cluster before propagating the error.
+            node.kill_all_processes(check_alive=False, allow_graceful=True, wait=True)
+            raise
 
         cli_logger.newline()
         startup_msg = "Ray runtime started."

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1119,19 +1119,13 @@ def start(
         ensure_token_if_auth_enabled(system_config, create_token_if_missing=False)
 
         node = ray._private.node.Node(
-            ray_params, head=False, shutdown_at_exit=block, spawn_reaper=block
+            ray_params,
+            head=False,
+            shutdown_at_exit=block,
+            spawn_reaper=block,
+            connect_only=False,
         )
         temp_dir = node.get_temp_dir_path()
-
-        # Check version compatibility and clean up node processes on mismatch.
-        try:
-            node.check_version_info()
-        except RuntimeError:
-            try:
-                node.kill_all_processes(check_alive=False, allow_graceful=True, wait=True)
-            except Exception as e:
-                cli_logger.warning(f"Failed to clean up processes on version mismatch: {e}")
-            raise
 
         cli_logger.newline()
         startup_msg = "Ray runtime started."


### PR DESCRIPTION
##  Description                                                                                                                                                        
Move `check_version_info()` into `Node.__init__()` before any process spawning (including the reaper) for worker nodes. Previously, `Node.__init__()` spawned processes before `check_version_info()` ran in scripts.py. 
If a version mismatch was detected, the RuntimeError propagated without cleaning up already-started processes, leaving orphans registered as alive.
                                                                                                                                                                     
##  Changes         
- `node.py`: Add version check before `start_reaper_process()` and `start_ray_processes()` for worker nodes (`not head and not connect_only`)                              
- `scripts.py`: Remove the now-redundant post-init `check_version_info()` call. Added explicit `connect_only=False` to make it clear the `__init__ `check is always reached from this path.                                                                                                                                                   
                                                                                                                                                                                       
## Related issues                                                                                                                                                     
Fixes #61836  
