### PR TITLE
Fix orphaned processes on worker version mismatch

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -387,6 +387,13 @@ class Node:
         if not connect_only:
             self._ray_params.update_pre_selected_port()
 
+        # For worker nodes, check version compatibility before spawning
+        # any processes.  If the check fails (e.g. Ray / Python version
+        # mismatch) we want to raise immediately rather than leave orphaned
+        # child processes behind.  See: https://github.com/ray-project/ray/issues/61836
+        if not head and not connect_only:
+            self.check_version_info()
+
         # Start processes.
         if head:
             self.start_head_processes()

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -1123,8 +1123,10 @@ def start(
         )
         temp_dir = node.get_temp_dir_path()
 
-        # Ray and Python versions should probably be checked before
-        # initializing Node.
+        # Version check now runs inside Node.__init__ before spawning
+        # processes (see https://github.com/ray-project/ray/issues/61836).
+        # Kept here as a defense-in-depth check for any code paths that
+        # may bypass __init__'s early check.
         node.check_version_info()
 
         cli_logger.newline()


### PR DESCRIPTION
## Why are these changes needed?

When starting a worker node with `ray start --address=...`, `Node.__init__()` spawns child processes (raylet, log monitor, etc.) via `start_ray_processes()` **before** `check_version_info()` is called. If a Ray or Python version mismatch is detected, a `RuntimeError` is raised but the already-spawned processes are never cleaned up, leaving orphaned processes on the machine.

## Changes

- **`python/ray/_private/node.py`**: Call `self.check_version_info()` for non-head, non-connect-only nodes **before** `start_ray_processes()` in `Node.__init__`. This ensures version compatibility is validated before any child processes are spawned.
- **`python/ray/scripts/scripts.py`**: Updated comment to reflect that the primary version check now happens inside `Node.__init__`. The existing call is kept as defense-in-depth.

The existing comment in `scripts.py` (line 1126) already noted: *"Ray and Python versions should probably be checked before initializing Node"* — this PR implements exactly that.

## Related issue number

Fixes #61836

## Checks

- [x] I've signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLSfAepRkkqAFcMbQ-6PGFhiFQCDA0VEGKFv7H8QLNE3bJCJiKQ/viewform)
- [x] Changes are **backward compatible**
- [x] This PR is **small enough** to review easily