### PR TITLE
[data] Add a refresh_state interface + use it

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -903,12 +903,16 @@ class PhysicalOperator(Operator):
         """Returns ```True``` if this operator can be fused with other operators."""
         return False
 
-    def update_resource_usage(self) -> None:
-        """Updates resource usage of this operator at runtime.
+    def refresh_state(self):
+        """Refreshes the state of the operator at runtime.
 
         This method will be called at runtime in each StreamingExecutor iteration.
-        Subclasses can override it to account for dynamic resource usage updates due to
-        restarting actors, retrying tasks, lost objects, etc.
+        Subclasses can override it to account for asynchronous updates, like restarting
+        actors, retrying tasks, or lost objects which are NOT transparent to the
+        StreamingExecutor.
+
+        TODO: Currently this method is synchronous. We should consider making this async,
+        or calling it in an asynchronous context.
         """
         pass
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -608,7 +608,7 @@ class ActorPoolMapOperator(MapOperator):
     def min_scheduling_resources(self) -> ExecutionResources:
         return self._actor_pool.per_actor_resource_usage()
 
-    def update_resource_usage(self) -> None:
+    def refresh_state(self):
         """Updates internal state"""
 
         # Trigger Actor Pool's state refresh

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -210,7 +210,6 @@ class ResourceManager:
         for op, state in reversed(self._topology.items()):
             # Update `self._op_usages`, `self._op_running_usages`,
             # and `self._op_pending_usages`.
-            op.update_resource_usage()
             op_usage = op.current_logical_usage()
             op_running_usage = op.running_logical_usage()
             op_pending_usage = op.pending_logical_usage()

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -538,7 +538,9 @@ class StreamingExecutor(Executor, threading.Thread):
                 self._export_operator_schema(op)
 
             # Log metrics of newly completed operators.
-            if op.has_completed() and not self._has_op_completed[op]:
+            if not op.has_completed():
+                op.refresh_state()
+            elif not self._has_op_completed[op]:
                 log_str = (
                     f"Operator {op} completed. "
                     f"Operator Metrics:\n{op._metrics.as_dict(skip_internal_metrics=True)}"

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -238,7 +238,6 @@ class TestResourceManager:
         }
 
         for op in [o1, o2, o3]:
-            op.update_resource_usage = MagicMock()
             op.current_logical_usage = MagicMock(
                 return_value=ExecutionResources(cpu=mock_cpu[op], gpu=0, memory=0)
             )


### PR DESCRIPTION
## Description
Currently, we don't have a great way of refreshing operate state that can be updated asynchronously (ie, actor restarts). This PR adds an interface for that in the base `PhysicalOperator`, and also uses it for `ActorPoolMapOperator`

It also `refresh_state` once per execution cycle, as opposed once every time resources are updated

## Related issues

## Additional information
