### PR TITLE
[Serve] Remove redundant replica bounds clamping from policy wrapper …

### DIFF
--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -109,17 +109,6 @@ def _apply_delay_logic(
     return decision_num_replicas, policy_state
 
 
-def _apply_bounds(
-    num_replicas: int,
-    capacity_adjusted_min_replicas: int,
-    capacity_adjusted_max_replicas: int,
-) -> int:
-    """Clip replica count to be within capacity-adjusted min/max bounds."""
-    return max(
-        capacity_adjusted_min_replicas,
-        min(capacity_adjusted_max_replicas, num_replicas),
-    )
-
 
 def _apply_default_params(
     desired_num_replicas: Union[int, float],

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -109,7 +109,6 @@ def _apply_delay_logic(
     return decision_num_replicas, policy_state
 
 
-
 def _apply_default_params(
     desired_num_replicas: Union[int, float],
     ctx: AutoscalingContext,

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -131,22 +131,16 @@ def _apply_default_params(
     desired_num_replicas = _apply_scaling_factors(
         desired_num_replicas, ctx.current_num_replicas, ctx.config
     )
-    # Apply bounds
-    bounded_num_replicas = _apply_bounds(
-        desired_num_replicas,
-        ctx.capacity_adjusted_min_replicas,
-        ctx.capacity_adjusted_max_replicas,
-    )
 
     # If curr num replicas is 0 and the policy wants to scale up (e.g. based on internal
     # signals like queue length), bypass the delay logic for immediate scale-up.
-    if ctx.current_num_replicas == 0 and bounded_num_replicas > 0:
-        return bounded_num_replicas, policy_state
+    if ctx.current_num_replicas == 0 and desired_num_replicas > 0:
+        return desired_num_replicas, policy_state
 
     # Apply delay logic
     # Only send the internal state here to avoid overwriting the custom policy state.
     final_num_replicas, updated_state = _apply_delay_logic(
-        bounded_num_replicas, ctx.target_num_replicas, ctx.config, policy_state
+        desired_num_replicas, ctx.target_num_replicas, ctx.config, policy_state
     )
 
     return final_num_replicas, updated_state

--- a/python/ray/serve/autoscaling_policy.py
+++ b/python/ray/serve/autoscaling_policy.py
@@ -140,7 +140,7 @@ def _apply_default_params(
     # Apply delay logic
     # Only send the internal state here to avoid overwriting the custom policy state.
     final_num_replicas, updated_state = _apply_delay_logic(
-        desired_num_replicas, ctx.target_num_replicas, ctx.config, policy_state
+        max(0, desired_num_replicas), ctx.target_num_replicas, ctx.config, policy_state
     )
 
     return final_num_replicas, updated_state

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -443,7 +443,12 @@ class TestReplicaQueueLengthPolicy:
             downscale_to_zero_delay_s=downscale_to_zero_delay_s,
         )
 
-        overload_requests = 100
+        # Use overload_requests that naturally produce the desired upscale_target
+        # without depending on bounds clamping (bounds are applied at a higher
+        # level in get_decision_num_replicas, not in the policy wrapper).
+        # desired = start_replicas * (overload_requests / target_ongoing_requests)
+        #         = 1 * (2 / 1) = 2
+        overload_requests = 2
 
         ctx = AutoscalingContext(
             config=config,

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -12,7 +12,6 @@ from ray.serve._private.gang_scheduling_autoscaling_policy import (
 from ray.serve.autoscaling_policy import (
     _apply_app_level_autoscaling_config,
     _apply_autoscaling_config,
-    _apply_bounds,
     _apply_delay_logic,
     _apply_scaling_factors,
     replica_queue_length_autoscaling_policy,
@@ -790,16 +789,6 @@ class TestAutoscalingConfigParameters:
         )
         # Expected: 10 - 0.5 * (10 - 9) = 9.5 = ceil(9.5) = 10. The logic then adjusts it to 9.
         assert result == 9
-
-    def test_apply_bounds(self):
-        num_replicas = 5
-        capacity_adjusted_min_replicas = 1
-        capacity_adjusted_max_replicas = 10
-        result = _apply_bounds(
-            num_replicas, capacity_adjusted_min_replicas, capacity_adjusted_max_replicas
-        )
-        # Expected: max(1, min(10, 5)) = 5
-        assert result == 5
 
     def test_apply_delay_logic_upscale(self):
         """Test upscale delay requires consecutive periods."""


### PR DESCRIPTION
…(#60613)

Replica bounds were applied twice in the autoscaling flow: once in the policy wrapper (`_apply_default_params`) and again in the autoscaling state (`apply_bounds`). This is idempotent but adds redundant computation and makes the control flow harder to reason about.

## Description
Remove the bounds clamping from the policy wrapper and keep it in the autoscaling state, which is the final gatekeeper before the controller acts on the decision.


## Related issues
[60613](https://github.com/ray-project/ray/issues/60613)
