### PR TITLE
[train] Add missing `@pytest.mark.asyncio` to async def tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,6 @@ filterwarnings =
 
 # Default to 3 min timeout for all individual pytest.
 timeout = 180
+
+# Automatically decorate any async pytest function with `@pytest.mark.asyncio`
+asyncio_mode = auto

--- a/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
+++ b/python/ray/llm/tests/batch/cpu/stages/test_chat_template_stage.py
@@ -89,7 +89,6 @@ async def test_chat_template_udf_multiple_messages(mock_tokenizer_setup):
     assert mock_tokenizer.apply_chat_template.call_count == 2
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "chat_template_kwargs, expected_prompt",
     [
@@ -102,6 +101,7 @@ async def test_chat_template_udf_multiple_messages(mock_tokenizer_setup):
         ),
     ],
 )
+@pytest.mark.asyncio
 async def test_chat_template_udf_chat_template_kwargs(
     mock_tokenizer_setup, chat_template_kwargs, expected_prompt
 ):

--- a/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
@@ -27,7 +27,6 @@ def mock_serve_deployment_handle():
         yield mock_handle
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "method,test_data",
     [
@@ -61,6 +60,7 @@ def mock_serve_deployment_handle():
         ),
     ],
 )
+@pytest.mark.asyncio
 async def test_serve_deployment_udf_methods(
     mock_serve_deployment_handle, method, test_data
 ):
@@ -141,10 +141,10 @@ async def test_serve_deployment_invalid_method(mock_serve_deployment_handle):
             pass
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "dtype_mapping", [None, {"ChatCompletionRequest": ChatCompletionRequest}]
 )
+@pytest.mark.asyncio
 async def test_serve_deployment_missing_dtype(
     mock_serve_deployment_handle, dtype_mapping
 ):
@@ -327,7 +327,6 @@ async def test_serve_udf_mixed_success_and_error(mock_serve_deployment_handle):
     assert "ValueError" in errors[0]["__inference_error__"]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "fatal_error",
     [
@@ -338,6 +337,7 @@ async def test_serve_udf_mixed_success_and_error(mock_serve_deployment_handle):
         ),
     ],
 )
+@pytest.mark.asyncio
 async def test_serve_udf_fatal_errors_always_propagate(
     mock_serve_deployment_handle, fatal_error
 ):

--- a/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
@@ -197,8 +197,8 @@ async def test_sglang_engine_udf_basic(mock_sglang_wrapper, model_llama_3_2_216M
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("max_pending_requests,batch_size", [(2, 10), (-1, 5)])
+@pytest.mark.asyncio
 async def test_sglang_wrapper(
     mock_sgl_engine, model_llama_3_2_216M, max_pending_requests, batch_size
 ):

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -343,7 +343,6 @@ async def test_vllm_wrapper_embed(model_opt_125m):
     wrapper.shutdown()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "pooling_params,tokenization_kwargs,expect_same_output",
     [
@@ -354,6 +353,7 @@ async def test_vllm_wrapper_embed(model_opt_125m):
         (None, {"truncation": True, "max_length": 3}, False),
     ],
 )
+@pytest.mark.asyncio
 async def test_vllm_wrapper_embed_pooling_params(
     model_opt_125m, pooling_params, tokenization_kwargs, expect_same_output
 ):
@@ -408,7 +408,6 @@ async def test_vllm_wrapper_embed_pooling_params(
     wrapper.shutdown()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "pooling_params,tokenization_kwargs",
     [
@@ -419,6 +418,7 @@ async def test_vllm_wrapper_embed_pooling_params(
     ],
     ids=["truncate_prompt_tokens_compat", "tokenization_kwargs"],
 )
+@pytest.mark.asyncio
 async def test_vllm_wrapper_embed_long_prompt(
     model_opt_125m, pooling_params, tokenization_kwargs
 ):
@@ -507,8 +507,8 @@ async def test_vllm_wrapper_lora(model_llama_3_2_216M, model_llama_3_2_216M_lora
     wrapper.shutdown()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("param_key", ["guided_decoding", "structured_outputs"])
+@pytest.mark.asyncio
 async def test_vllm_wrapper_json(model_llama_3_2_1B_instruct, param_key):
     """Test the JSON output with xgrammar backend.
 

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -56,9 +56,9 @@ def create_oai_client(llm_config: LLMConfig):
 
 
 class TestOpenAiIngress:
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("stream_batching_interval_ms", [None, 0, 10000])
     @pytest.mark.parametrize("stream", [True, False])
+    @pytest.mark.asyncio
     async def test_chat(self, stream_batching_interval_ms, client, stream):
         """Tests chat streaming with different stream_batching_interval_ms values.
 
@@ -92,9 +92,9 @@ class TestOpenAiIngress:
         assert role == "assistant"
         assert text.strip() == " ".join([f"test_{i}" for i in range(n_tokens)])
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("stream_batching_interval_ms", [None, 0, 10000])
     @pytest.mark.parametrize("stream", [True, False])
+    @pytest.mark.asyncio
     async def test_completion(self, stream_batching_interval_ms, client, stream):
         """Tests text completions streaming with different stream_batching_interval_ms values."""
 
@@ -119,8 +119,8 @@ class TestOpenAiIngress:
         expected_text = " ".join([f"test_{i}" for i in range(n_tokens)])
         assert text.strip() == expected_text
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("stream", [True, False])
+    @pytest.mark.asyncio
     async def test_tool_call(self, client, stream):
         response = client.chat.completions.create(
             model="llm_model_id",

--- a/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
@@ -129,10 +129,10 @@ class TestPow2FallbackBehavior:
             chosen = await prefix_request_router._choose_replica_for_request(req)
             assert chosen == r1
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "prefix_request_router", [{"imbalanced_threshold": 2}], indirect=True
     )
+    @pytest.mark.asyncio
     async def test_fallback_when_imbalanced(self, prefix_request_router):
         """If load is imbalanced beyond threshold, prefix matching is skipped."""
         r1 = FakeRunningReplica("r1")
@@ -257,7 +257,6 @@ class TestPrefixAwareLogic:
 class TestEvictionBehavior:
     """Tests for prefix tree eviction behavior."""
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "prefix_request_router",
         [
@@ -270,6 +269,7 @@ class TestEvictionBehavior:
         ],
         indirect=True,
     )
+    @pytest.mark.asyncio
     async def test_eviction_task_creation(self, prefix_request_router):
         """Test that eviction task is only created after update_replicas."""
         # Before update_replicas
@@ -352,7 +352,6 @@ class TestPromptNormalization:
         with pytest.raises(ValueError):
             _ = prefix_request_router._extract_text_from_request(fake_pending_request())
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "prefix_request_router",
         [
@@ -365,6 +364,7 @@ class TestPromptNormalization:
         ],
         indirect=True,
     )
+    @pytest.mark.asyncio
     async def test_eviction_threshold_behavior(self, prefix_request_router):
         """Test that eviction reduces tree size below threshold after interval."""
         r1 = FakeRunningReplica("r1")

--- a/python/ray/train/v2/tests/test_checkpoint_manager.py
+++ b/python/ray/train/v2/tests/test_checkpoint_manager.py
@@ -78,7 +78,6 @@ def _checkpoint_managers_equal(cm1: CheckpointManager, cm2: CheckpointManager) -
     return True
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "checkpoint_config",
     [
@@ -90,6 +89,7 @@ def _checkpoint_managers_equal(cm1: CheckpointManager, cm2: CheckpointManager) -
         ),
     ],
 )
+@pytest.mark.asyncio
 async def test_save_load_state_equivalence(
     monkeypatch, tmp_path, checkpoint_config: CheckpointConfig
 ):

--- a/python/ray/train/v2/tests/test_checkpoint_manager.py
+++ b/python/ray/train/v2/tests/test_checkpoint_manager.py
@@ -78,6 +78,7 @@ def _checkpoint_managers_equal(cm1: CheckpointManager, cm2: CheckpointManager) -
     return True
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "checkpoint_config",
     [
@@ -161,6 +162,7 @@ def test_load_state_error(tmp_path, json_state, match):
         checkpoint_manager._load_state(json_state)
 
 
+@pytest.mark.asyncio
 async def test_before_init_train_context(tmp_path):
 
     storage_context = StorageContext(
@@ -188,6 +190,7 @@ async def test_before_init_train_context(tmp_path):
     }
 
 
+@pytest.mark.asyncio
 async def test_pending_checkpoint_management(tmp_path):
     storage_context = StorageContext(
         storage_path=tmp_path,
@@ -241,6 +244,7 @@ async def test_pending_checkpoint_management(tmp_path):
     ]
 
 
+@pytest.mark.asyncio
 async def test_pending_checkpoint_management_break_ties_by_report_index(tmp_path):
     storage_context = StorageContext(
         storage_path=tmp_path,
@@ -279,6 +283,7 @@ async def test_pending_checkpoint_management_break_ties_by_report_index(tmp_path
     ]
 
 
+@pytest.mark.asyncio
 async def test_pending_checkpoint_management_finalized_checkpoint(tmp_path):
     storage_context = StorageContext(
         storage_path=tmp_path,

--- a/python/ray/train/v2/tests/test_report_handler.py
+++ b/python/ray/train/v2/tests/test_report_handler.py
@@ -54,7 +54,6 @@ def generate_worker_group_poll_status(num_workers, num_ckpt, num_dummy, num_none
     return WorkerGroupPollStatus(dict(enumerate(worker_statuses)))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "num_workers, num_ckpt, num_dummy, num_none, expected",
     [
@@ -63,6 +62,7 @@ def generate_worker_group_poll_status(num_workers, num_ckpt, num_dummy, num_none
         (10, 1, 8, 1, 0),  # one worker with checkpoint, one worker with None
     ],
 )
+@pytest.mark.asyncio
 async def test_report_handler(
     tmp_path, num_workers, num_ckpt, num_dummy, num_none, expected
 ):

--- a/python/ray/train/v2/tests/test_report_handler.py
+++ b/python/ray/train/v2/tests/test_report_handler.py
@@ -54,6 +54,7 @@ def generate_worker_group_poll_status(num_workers, num_ckpt, num_dummy, num_none
     return WorkerGroupPollStatus(dict(enumerate(worker_statuses)))
 
 
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "num_workers, num_ckpt, num_dummy, num_none, expected",
     [


### PR DESCRIPTION
## Description
In running the train test suite, I found that some of the tests were being skipped as they needed an `pytest.mark.asyncio` decorator.
This PR adds the decorator and I did a search all the whole repo for all `async def test_*` function and checked if they had the decorator by hand. 

Gemini code review warned that 
> The `@pytest.mark.asyncio` decorator should be placed directly above the async def test function, inside any `@pytest.mark.parametrize` decorators.

Therefore, I've re-reviewed all the "async def test_*` tests on their decorator ordered and fixed any that don't implement this. 