### PR TITLE
[Data] Fix missing PYARROW_VERSION and DataContext import

### DIFF
--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -40,6 +40,7 @@ from ray.util.common import INT32_MAX
 # First, assert Arrow version is w/in expected bounds
 _check_pyarrow_version()
 
+PYARROW_VERSION = get_pyarrow_version()
 
 # Minimum version supporting `zero_copy_only` flag in `ChunkedArray.to_numpy`
 MIN_PYARROW_VERSION_CHUNKED_ARRAY_TO_NUMPY_ZERO_COPY_ONLY = parse_version("13.0.0")

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -14,6 +14,7 @@ from ray.data._internal.tensor_extensions.arrow import (
     FixedShapeTensorFormat,
 )
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data.context import DataContext
 from ray.data.extensions import (
     ArrowConversionError,
     ArrowPythonObjectType,


### PR DESCRIPTION
## Summary
- Add missing `PYARROW_VERSION = get_pyarrow_version()` in `arrow.py` — was referenced but never defined, causing `NameError` at import time
- Add missing `from ray.data.context import DataContext` in `test_transform_pyarrow.py` — used in tests but never imported

## Test plan
- [ ] `test_transform_pyarrow.py` passes (previously failing with `NameError: name 'DataContext' is not defined`)
- [ ] Arrow tensor extension module imports without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)