### PR TITLE
[ci] Upgrade anyscale SDK and add dual-path compute config support

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -551,6 +551,7 @@ py_test(
     ],
     deps = [
         ":ray_release",
+        ":test_utils",
         bk_require("pytest"),
     ],
 )

--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -1,13 +1,7 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
-
-import anyscale.image
+from typing import Any, Optional
 
 from ray_release.exception import ClusterEnvCreateError
 from ray_release.logger import logger
-
-if TYPE_CHECKING:
-    from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
-
 
 LAST_LOGS_LENGTH = 100
 
@@ -16,13 +10,16 @@ class Anyscale:
     """
     A wrapper class for latest version of Anyscale SDK.
 
+    Provides lazy-imported access to anyscale.image, anyscale.compute_config,
+    and anyscale.project, as well as the legacy AnyscaleSDK for DefaultApi calls.
+    All imports are deferred to avoid triggering credential lookup at import time.
+
     Methods of this class can be overwritten for testing.
     """
 
     def __init__(self):
-        # We need to late-import Anyscale SDK as merely importing it
-        # will trigger credential lookup on the system.
         self._anyscale_pkg = None
+        self._legacy_sdk = None
 
     def _anyscale(self) -> Any:
         if self._anyscale_pkg is None:
@@ -32,6 +29,25 @@ class Anyscale:
 
         return self._anyscale_pkg
 
+    @property
+    def image(self) -> Any:
+        return self._anyscale().image
+
+    @property
+    def compute_config(self) -> Any:
+        return self._anyscale().compute_config
+
+    @property
+    def legacy_sdk(self) -> Any:
+        """Return a cached AnyscaleSDK instance for legacy DefaultApi calls."""
+        if self._legacy_sdk is None:
+            from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
+
+            from ray_release.util import ANYSCALE_HOST
+
+            self._legacy_sdk = AnyscaleSDK(host=str(ANYSCALE_HOST))
+        return self._legacy_sdk
+
     def project_name_by_id(self, project_id: str) -> str:
         return self._anyscale().project.get(project_id).name
 
@@ -40,16 +56,8 @@ class Anyscale:
 the_v2_sdk = Anyscale()
 
 
-def get_project_name(
-    project_id: str, sdk: Optional[Union[Anyscale, "AnyscaleSDK"]] = None
-) -> str:
+def get_project_name(project_id: str, sdk: Optional[Anyscale] = None) -> str:
     sdk = sdk or the_v2_sdk
-
-    if not isinstance(sdk, Anyscale):
-        # Fallback to old SDK if provided.
-        # TODO(aslonnie): remove this once we fully migrate to new SDK.
-        return sdk.get_project(project_id).result.name
-
     return sdk.project_name_by_id(project_id)
 
 
@@ -61,18 +69,18 @@ def get_custom_cluster_env_name(image: str, test_name: str) -> str:
 def create_cluster_env_from_image(
     image: str,
     test_name: str,
-    runtime_env: Dict[str, Any],
-    sdk: Optional["AnyscaleSDK"] = None,
     cluster_env_id: Optional[str] = None,
     cluster_env_name: Optional[str] = None,
-    use_new_sdk: bool = False,
+    sdk: Optional["Anyscale"] = None,
 ) -> str:
     """Register image with anyscale.image APIs and return the cluster env ID."""
+    anyscale_image = (sdk or the_v2_sdk).image
+
     if not cluster_env_name:
         cluster_env_name = get_custom_cluster_env_name(image, test_name)
 
     if not cluster_env_id:
-        for img in anyscale.image.list(name=cluster_env_name):
+        for img in anyscale_image.list(name=cluster_env_name):
             if img.name == cluster_env_name:
                 cluster_env_id = img.id
                 logger.info(f"Cluster env already exists with ID {cluster_env_id}")
@@ -81,15 +89,10 @@ def create_cluster_env_from_image(
     if not cluster_env_id:
         logger.info("Cluster env not found. Creating new one.")
         try:
-            anyscale.image.register(image, name=cluster_env_name, ray_version="nightly")
-            img = anyscale.image.get(name=cluster_env_name)
+            anyscale_image.register(image, name=cluster_env_name, ray_version="nightly")
+            img = anyscale_image.get(name=cluster_env_name)
             cluster_env_id = img.id
         except Exception as e:
-            logger.warning(
-                f"Got exception when trying to create cluster "
-                f"env: {e}. Sleeping for 10 seconds with jitter and then "
-                f"try again..."
-            )
             raise ClusterEnvCreateError("Could not create cluster env.") from e
 
         logger.info(f"Cluster env created with ID {cluster_env_id}")

--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -1,11 +1,9 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import anyscale.image
-from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 
 from ray_release.exception import ClusterEnvCreateError
 from ray_release.logger import logger
-from ray_release.util import get_anyscale_sdk
 
 if TYPE_CHECKING:
     from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
@@ -56,7 +54,6 @@ def get_project_name(
 
 
 def get_custom_cluster_env_name(image: str, test_name: str) -> str:
-    # TODO(aslonnie): remove this; new SDK does not need creating cluster envs anymore.
     image_normalized = image.replace("/", "_").replace(":", "_").replace(".", "_")
     return f"test_env_{image_normalized}_{test_name}"
 
@@ -70,78 +67,10 @@ def create_cluster_env_from_image(
     cluster_env_name: Optional[str] = None,
     use_new_sdk: bool = False,
 ) -> str:
+    """Register image with anyscale.image APIs and return the cluster env ID."""
     if not cluster_env_name:
         cluster_env_name = get_custom_cluster_env_name(image, test_name)
 
-    if use_new_sdk:
-        return _create_cluster_env_new_sdk(image, cluster_env_name, cluster_env_id)
-
-    return _create_cluster_env_legacy(image, cluster_env_name, cluster_env_id, sdk)
-
-
-def _create_cluster_env_legacy(
-    image: str,
-    cluster_env_name: str,
-    cluster_env_id: Optional[str] = None,
-    sdk: Optional["AnyscaleSDK"] = None,
-) -> str:
-    """Find or create a cluster env using legacy DefaultApi SDK."""
-    anyscale_sdk = sdk or get_anyscale_sdk()
-
-    paging_token = None
-    while not cluster_env_id:
-        result = DefaultApi.search_cluster_environments(
-            anyscale_sdk,
-            dict(
-                name=dict(equals=cluster_env_name),
-                paging=dict(count=50, paging_token=paging_token),
-                project_id=None,
-            ),
-        )
-        paging_token = result.metadata.next_paging_token
-
-        for res in result.results:
-            if res.name == cluster_env_name:
-                cluster_env_id = res.id
-                logger.info(f"Cluster env already exists with ID {cluster_env_id}")
-                break
-
-        if not paging_token or cluster_env_id:
-            break
-
-    if not cluster_env_id:
-        logger.info("Cluster env not found. Creating new one.")
-        try:
-            result = DefaultApi.create_byod_cluster_environment(
-                anyscale_sdk,
-                dict(
-                    name=cluster_env_name,
-                    config_json=dict(
-                        docker_image=image,
-                        ray_version="nightly",
-                    ),
-                ),
-            )
-            cluster_env_id = result.result.id
-        except Exception as e:
-            logger.warning(
-                f"Got exception when trying to create cluster "
-                f"env: {e}. Sleeping for 10 seconds with jitter and then "
-                f"try again..."
-            )
-            raise ClusterEnvCreateError("Could not create cluster env.") from e
-
-        logger.info(f"Cluster env created with ID {cluster_env_id}")
-
-    return cluster_env_id
-
-
-def _create_cluster_env_new_sdk(
-    image: str,
-    cluster_env_name: str,
-    cluster_env_id: Optional[str] = None,
-) -> str:
-    """Find or create a cluster env using anyscale.image APIs."""
     if not cluster_env_id:
         for img in anyscale.image.list(name=cluster_env_name):
             if img.name == cluster_env_name:

--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -79,38 +79,6 @@ def create_cluster_env_from_image(
     return _create_cluster_env_legacy(image, cluster_env_name, cluster_env_id, sdk)
 
 
-def _create_cluster_env_new_sdk(
-    image: str,
-    cluster_env_name: str,
-    cluster_env_id: Optional[str] = None,
-) -> str:
-    """Find or create a cluster env using anyscale.image APIs."""
-    if not cluster_env_id:
-        for img in anyscale.image.list(name=cluster_env_name):
-            if img.name == cluster_env_name:
-                cluster_env_id = img.id
-                logger.info(f"Cluster env already exists with ID {cluster_env_id}")
-                break
-
-    if not cluster_env_id:
-        logger.info("Cluster env not found. Creating new one.")
-        try:
-            anyscale.image.register(image, name=cluster_env_name, ray_version="nightly")
-            img = anyscale.image.get(name=cluster_env_name)
-            cluster_env_id = img.id
-        except Exception as e:
-            logger.warning(
-                f"Got exception when trying to create cluster "
-                f"env: {e}. Sleeping for 10 seconds with jitter and then "
-                f"try again..."
-            )
-            raise ClusterEnvCreateError("Could not create cluster env.") from e
-
-        logger.info(f"Cluster env created with ID {cluster_env_id}")
-
-    return cluster_env_id
-
-
 def _create_cluster_env_legacy(
     image: str,
     cluster_env_name: str,
@@ -155,6 +123,38 @@ def _create_cluster_env_legacy(
                 ),
             )
             cluster_env_id = result.result.id
+        except Exception as e:
+            logger.warning(
+                f"Got exception when trying to create cluster "
+                f"env: {e}. Sleeping for 10 seconds with jitter and then "
+                f"try again..."
+            )
+            raise ClusterEnvCreateError("Could not create cluster env.") from e
+
+        logger.info(f"Cluster env created with ID {cluster_env_id}")
+
+    return cluster_env_id
+
+
+def _create_cluster_env_new_sdk(
+    image: str,
+    cluster_env_name: str,
+    cluster_env_id: Optional[str] = None,
+) -> str:
+    """Find or create a cluster env using anyscale.image APIs."""
+    if not cluster_env_id:
+        for img in anyscale.image.list(name=cluster_env_name):
+            if img.name == cluster_env_name:
+                cluster_env_id = img.id
+                logger.info(f"Cluster env already exists with ID {cluster_env_id}")
+                break
+
+    if not cluster_env_id:
+        logger.info("Cluster env not found. Creating new one.")
+        try:
+            anyscale.image.register(image, name=cluster_env_name, ray_version="nightly")
+            img = anyscale.image.get(name=cluster_env_name)
+            cluster_env_id = img.id
         except Exception as e:
             logger.warning(
                 f"Got exception when trying to create cluster "

--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
+from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
+
 from ray_release.exception import ClusterEnvCreateError
 from ray_release.logger import logger
 from ray_release.util import get_anyscale_sdk
@@ -74,12 +76,13 @@ def create_cluster_env_from_image(
     # Find whether there is identical cluster env
     paging_token = None
     while not cluster_env_id:
-        result = anyscale_sdk.search_cluster_environments(
+        result = DefaultApi.search_cluster_environments(
+            anyscale_sdk,
             dict(
                 name=dict(equals=cluster_env_name),
                 paging=dict(count=50, paging_token=paging_token),
                 project_id=None,
-            )
+            ),
         )
         paging_token = result.metadata.next_paging_token
 
@@ -95,14 +98,15 @@ def create_cluster_env_from_image(
     if not cluster_env_id:
         logger.info("Cluster env not found. Creating new one.")
         try:
-            result = anyscale_sdk.create_byod_cluster_environment(
+            result = DefaultApi.create_byod_cluster_environment(
+                anyscale_sdk,
                 dict(
                     name=cluster_env_name,
                     config_json=dict(
                         docker_image=image,
                         ray_version="nightly",
                     ),
-                )
+                ),
             )
             cluster_env_id = result.result.id
         except Exception as e:

--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
+import anyscale.image
 from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 
 from ray_release.exception import ClusterEnvCreateError
@@ -67,13 +68,58 @@ def create_cluster_env_from_image(
     sdk: Optional["AnyscaleSDK"] = None,
     cluster_env_id: Optional[str] = None,
     cluster_env_name: Optional[str] = None,
+    use_new_sdk: bool = False,
 ) -> str:
-    # TODO(aslonnie): remove this; new SDK does not need creating cluster envs anymore.
-    anyscale_sdk = sdk or get_anyscale_sdk()
     if not cluster_env_name:
         cluster_env_name = get_custom_cluster_env_name(image, test_name)
 
-    # Find whether there is identical cluster env
+    if use_new_sdk:
+        return _create_cluster_env_new_sdk(image, cluster_env_name, cluster_env_id)
+
+    return _create_cluster_env_legacy(image, cluster_env_name, cluster_env_id, sdk)
+
+
+def _create_cluster_env_new_sdk(
+    image: str,
+    cluster_env_name: str,
+    cluster_env_id: Optional[str] = None,
+) -> str:
+    """Find or create a cluster env using anyscale.image APIs."""
+    if not cluster_env_id:
+        for img in anyscale.image.list(name=cluster_env_name):
+            if img.name == cluster_env_name:
+                cluster_env_id = img.id
+                logger.info(f"Cluster env already exists with ID {cluster_env_id}")
+                break
+
+    if not cluster_env_id:
+        logger.info("Cluster env not found. Creating new one.")
+        try:
+            anyscale.image.register(image, name=cluster_env_name, ray_version="nightly")
+            img = anyscale.image.get(name=cluster_env_name)
+            cluster_env_id = img.id
+        except Exception as e:
+            logger.warning(
+                f"Got exception when trying to create cluster "
+                f"env: {e}. Sleeping for 10 seconds with jitter and then "
+                f"try again..."
+            )
+            raise ClusterEnvCreateError("Could not create cluster env.") from e
+
+        logger.info(f"Cluster env created with ID {cluster_env_id}")
+
+    return cluster_env_id
+
+
+def _create_cluster_env_legacy(
+    image: str,
+    cluster_env_name: str,
+    cluster_env_id: Optional[str] = None,
+    sdk: Optional["AnyscaleSDK"] = None,
+) -> str:
+    """Find or create a cluster env using legacy DefaultApi SDK."""
+    anyscale_sdk = sdk or get_anyscale_sdk()
+
     paging_token = None
     while not cluster_env_id:
         result = DefaultApi.search_cluster_environments(
@@ -89,7 +135,7 @@ def create_cluster_env_from_image(
         for res in result.results:
             if res.name == cluster_env_name:
                 cluster_env_id = res.id
-                logger.info(f"Cluster env already exists with ID " f"{cluster_env_id}")
+                logger.info(f"Cluster env already exists with ID {cluster_env_id}")
                 break
 
         if not paging_token or cluster_env_id:

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -65,8 +65,8 @@ gcp_gpu_instances = {
     "n1-standard-16-nvidia-tesla-t4-1": (16, 1),
     "n1-standard-64-nvidia-tesla-t4-4": (64, 4),
     "n1-standard-32-nvidia-tesla-t4-2": (32, 2),
-    "n1-highmem-64-nvidia-tesla-v100-8": {64, 8},
-    "n1-highmem-96-nvidia-tesla-v100-8": {96, 8},
+    "n1-highmem-64-nvidia-tesla-v100-8": (64, 8),
+    "n1-highmem-96-nvidia-tesla-v100-8": (96, 8),
 }
 
 
@@ -131,20 +131,33 @@ def get_concurrency_group(test: Test) -> Tuple[str, int]:
 
 def get_test_resources(test: Test) -> Tuple[int, int]:
     cluster_compute = load_test_cluster_compute(test)
-    return get_test_resources_from_cluster_compute(cluster_compute)
+    return get_test_resources_from_cluster_compute(
+        cluster_compute, is_new_schema=test.uses_anyscale_sdk_2026()
+    )
 
 
-def get_test_resources_from_cluster_compute(cluster_compute: Dict) -> Tuple[int, int]:
+def get_test_resources_from_cluster_compute(
+    cluster_compute: Dict, is_new_schema: bool = False
+) -> Tuple[int, int]:
     instances = []
 
-    # Add head node instance
-    instances.append((cluster_compute["head_node_type"]["instance_type"], 1))
+    if is_new_schema:
+        head_node = cluster_compute.get("head_node", {})
+        if head_node.get("instance_type"):
+            instances.append((head_node["instance_type"], 1))
 
-    # Add worker node instances
-    instances.extend(
-        (w["instance_type"], w.get("max_workers", w.get("min_workers", 1)))
-        for w in cluster_compute["worker_node_types"]
-    )
+        for w in cluster_compute.get("worker_nodes", []):
+            if w.get("instance_type"):
+                instances.append(
+                    (w["instance_type"], w.get("max_nodes", w.get("min_nodes", 1)))
+                )
+    else:
+        instances.append((cluster_compute["head_node_type"]["instance_type"], 1))
+
+        instances.extend(
+            (w["instance_type"], w.get("max_workers", w.get("min_workers", 1)))
+            for w in cluster_compute["worker_node_types"]
+        )
 
     aws_instance_types = load_instance_types()
     total_cpus = 0

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -8,6 +8,7 @@ from ray_release.buildkite.concurrency import get_concurrency_group
 from ray_release.config import (
     DEFAULT_ANYSCALE_PROJECT,
     DEFAULT_CLOUD_ID,
+    DEFAULT_CLOUD_NAME,
     as_smoke_test,
     get_test_project_id,
 )
@@ -32,6 +33,7 @@ DOCKER_PLUGIN_KEY = "docker#v5.8.0"
 _DEFAULT_STEP_TEMPLATE: Dict[str, Any] = {
     "env": {
         "ANYSCALE_CLOUD_ID": str(DEFAULT_CLOUD_ID),
+        "ANYSCALE_CLOUD": str(DEFAULT_CLOUD_NAME),
         "ANYSCALE_PROJECT": str(DEFAULT_ANYSCALE_PROJECT),
         "RELEASE_AWS_BUCKET": str(RELEASE_AWS_BUCKET),
         "RELEASE_AWS_LOCATION": "dev",

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -1,19 +1,16 @@
 import abc
 import copy
 import time
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Dict, Optional
 
-from ray_release.anyscale_util import get_project_name
+from ray_release.anyscale_util import Anyscale, get_project_name, the_v2_sdk
 from ray_release.aws import (
     RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
     add_tags_to_aws_config,
 )
 from ray_release.config import DEFAULT_AUTOSUSPEND_MINS, DEFAULT_MAXIMUM_UPTIME_MINS
 from ray_release.test import Test
-from ray_release.util import dict_hash, get_anyscale_sdk
-
-if TYPE_CHECKING:
-    from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
+from ray_release.util import dict_hash
 
 
 class ClusterManager(abc.ABC):
@@ -21,10 +18,10 @@ class ClusterManager(abc.ABC):
         self,
         test: Test,
         project_id: str,
-        sdk: Optional["AnyscaleSDK"] = None,
+        sdk: Optional[Anyscale] = None,
         smoke_test: bool = False,
     ):
-        self.sdk = sdk or get_anyscale_sdk()
+        self.sdk = sdk or the_v2_sdk
 
         self.test = test
         self.smoke_test = smoke_test

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -1,4 +1,5 @@
 import abc
+import copy
 import time
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
@@ -69,9 +70,11 @@ class ClusterManager(abc.ABC):
         self.cluster_compute.setdefault(
             "maximum_uptime_minutes", self.maximum_uptime_minutes
         )
+        is_new_schema = self.test.uses_anyscale_sdk_2026()
         self.cluster_compute = self._annotate_cluster_compute(
             self.cluster_compute,
             extra_tags=extra_tags,
+            is_new_schema=is_new_schema,
         )
 
         self.cluster_compute_name = (
@@ -84,20 +87,43 @@ class ClusterManager(abc.ABC):
         self,
         cluster_compute: Dict[str, Any],
         extra_tags: Dict[str, str],
+        is_new_schema: bool = False,
     ) -> Dict[str, Any]:
         if not extra_tags or self.cloud_provider != "aws":
             return cluster_compute
 
-        cluster_compute = cluster_compute.copy()
-        if "aws" in cluster_compute:
-            raise ValueError(
-                "aws field is invalid in compute config, "
-                "use advanced_configurations_json instead"
+        cluster_compute = copy.deepcopy(cluster_compute)
+
+        if is_new_schema:
+            aws = cluster_compute.get("advanced_instance_config", {})
+            cluster_compute["advanced_instance_config"] = add_tags_to_aws_config(
+                aws, extra_tags, RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING
             )
-        aws = cluster_compute.get("advanced_configurations_json", {})
-        cluster_compute["advanced_configurations_json"] = add_tags_to_aws_config(
-            aws, extra_tags, RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING
-        )
+            if "head_node" in cluster_compute:
+                head = cluster_compute["head_node"]
+                head_aws = head.get("advanced_instance_config", {})
+                head["advanced_instance_config"] = add_tags_to_aws_config(
+                    head_aws,
+                    extra_tags,
+                    RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
+                )
+            for worker in cluster_compute.get("worker_nodes", []):
+                worker_aws = worker.get("advanced_instance_config", {})
+                worker["advanced_instance_config"] = add_tags_to_aws_config(
+                    worker_aws,
+                    extra_tags,
+                    RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
+                )
+        else:
+            if "aws" in cluster_compute:
+                raise ValueError(
+                    "aws field is invalid in compute config, "
+                    "use advanced_configurations_json instead"
+                )
+            aws = cluster_compute.get("advanced_configurations_json", {})
+            cluster_compute["advanced_configurations_json"] = add_tags_to_aws_config(
+                aws, extra_tags, RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING
+            )
         return cluster_compute
 
     def build_configs(self, timeout: float = 30.0):

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -77,7 +77,9 @@ class MinimalClusterManager(ClusterManager):
         last_status = None
         error_message = None
         config_json = None
-        result = self.sdk.list_cluster_environment_builds(self.cluster_env_id)
+        result = DefaultApi.list_cluster_environment_builds(
+            self.sdk, self.cluster_env_id
+        )
         if not result or not result.results:
             raise ClusterEnvBuildError(f"No build found for cluster env: {result}")
 
@@ -100,10 +102,11 @@ class MinimalClusterManager(ClusterManager):
             logger.info("Starting new cluster env build...")
 
             # Retry build
-            result = self.sdk.create_cluster_environment_build(
+            result = DefaultApi.create_cluster_environment_build(
+                self.sdk,
                 dict(
                     cluster_environment_id=self.cluster_env_id, config_json=config_json
-                )
+                ),
             )
             build_id = result.result.id
 
@@ -131,7 +134,7 @@ class MinimalClusterManager(ClusterManager):
                 )
                 next_report = next_report + REPORT_S
 
-            result = self.sdk.get_build(build_id)
+            result = DefaultApi.get_build(self.sdk, build_id)
             build = result.result
 
             if build.status == "failed":

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -1,5 +1,9 @@
 import time
 
+import anyscale.compute_config
+from anyscale.compute_config.models import ComputeConfig
+from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
+
 from ray_release.anyscale_util import create_cluster_env_from_image
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.exception import (
@@ -16,6 +20,21 @@ from ray_release.util import (
 )
 
 REPORT_S = 30.0
+
+# Fields accepted by anyscale.compute_config.models.ComputeConfig.
+COMPUTE_CONFIG_FIELDS = {
+    "cloud",
+    "cloud_resource",
+    "head_node",
+    "worker_nodes",
+    "min_resources",
+    "max_resources",
+    "zones",
+    "enable_cross_zone_scaling",
+    "advanced_instance_config",
+    "flags",
+    "auto_select_worker_config",
+}
 
 
 class MinimalClusterManager(ClusterManager):
@@ -148,71 +167,127 @@ class MinimalClusterManager(ClusterManager):
         assert self.cluster_compute_id is None
 
         if self.cluster_compute:
-            assert self.cluster_compute
-
             logger.info(
                 f"Tests uses compute template "
                 f"with name {self.cluster_compute_name}. "
                 f"Looking up existing cluster computes."
             )
 
-            paging_token = None
-            while not self.cluster_compute_id:
-                result = self.sdk.search_cluster_computes(
-                    dict(
-                        project_id=self.project_id,
-                        name=dict(equals=self.cluster_compute_name),
-                        include_anonymous=True,
-                        paging=dict(paging_token=paging_token),
-                    )
+            if self.test.uses_anyscale_sdk_2026():
+                self._create_cluster_compute_new_sdk(_repeat=_repeat)
+            else:
+                self._create_cluster_compute_legacy(_repeat=_repeat)
+
+    def _create_cluster_compute_new_sdk(self, _repeat: bool = True):
+        """Create or find a cluster compute using the new anyscale.compute_config API."""
+        result = anyscale.compute_config.list(name=self.cluster_compute_name)
+        for cc in result.results:
+            if cc.name.rsplit(":", 1)[0] == self.cluster_compute_name:
+                self.cluster_compute_id = cc.id
+                logger.info(
+                    f"Cluster compute already exists "
+                    f"with ID {self.cluster_compute_id}"
                 )
-                paging_token = result.metadata.next_paging_token
+                return
 
-                for res in result.results:
-                    if res.name == self.cluster_compute_name:
-                        self.cluster_compute_id = res.id
-                        logger.info(
-                            f"Cluster compute already exists "
-                            f"with ID {self.cluster_compute_id}"
-                        )
-                        break
+        logger.info(
+            f"Cluster compute not found. "
+            f"Creating with name {self.cluster_compute_name}."
+        )
+        try:
+            # Filter to only fields accepted by ComputeConfig; keys like
+            # idle_termination_minutes/maximum_uptime_minutes are cluster-level
+            # settings not part of the ComputeConfig model.
+            compute_kwargs = {
+                k: v
+                for k, v in self.cluster_compute.items()
+                if k in COMPUTE_CONFIG_FIELDS
+            }
+            config = ComputeConfig(**compute_kwargs)
+            full_name = anyscale.compute_config.create(
+                config, name=self.cluster_compute_name
+            )
+            version = anyscale.compute_config.get(full_name)
+            self.cluster_compute_id = version.id
+        except Exception as e:
+            if _repeat:
+                logger.warning(
+                    f"Got exception when trying to create cluster "
+                    f"compute: {e}. Sleeping for 10 seconds and then "
+                    f"try again once..."
+                )
+                time.sleep(10)
+                return self._create_cluster_compute_new_sdk(_repeat=False)
 
-                if not paging_token:
+            raise ClusterComputeCreateError("Could not create cluster compute") from e
+
+        logger.info(
+            f"Cluster compute template created with "
+            f"name {self.cluster_compute_name} and "
+            f"ID {self.cluster_compute_id}"
+        )
+
+    def _create_cluster_compute_legacy(self, _repeat: bool = True):
+        """Create or find a cluster compute using the legacy DefaultApi SDK."""
+        paging_token = None
+        while not self.cluster_compute_id:
+            result = DefaultApi.search_cluster_computes(
+                self.sdk,
+                dict(
+                    project_id=self.project_id,
+                    name=dict(equals=self.cluster_compute_name),
+                    include_anonymous=True,
+                    paging=dict(paging_token=paging_token),
+                ),
+            )
+            paging_token = result.metadata.next_paging_token
+
+            for res in result.results:
+                if res.name == self.cluster_compute_name:
+                    self.cluster_compute_id = res.id
+                    logger.info(
+                        f"Cluster compute already exists "
+                        f"with ID {self.cluster_compute_id}"
+                    )
                     break
 
-            if not self.cluster_compute_id:
-                logger.info(
-                    f"Cluster compute not found. "
-                    f"Creating with name {self.cluster_compute_name}."
+            if not paging_token:
+                break
+
+        if not self.cluster_compute_id:
+            logger.info(
+                f"Cluster compute not found. "
+                f"Creating with name {self.cluster_compute_name}."
+            )
+            try:
+                result = DefaultApi.create_cluster_compute(
+                    self.sdk,
+                    dict(
+                        name=self.cluster_compute_name,
+                        project_id=self.project_id,
+                        config=self.cluster_compute,
+                    ),
                 )
-                try:
-                    result = self.sdk.create_cluster_compute(
-                        dict(
-                            name=self.cluster_compute_name,
-                            project_id=self.project_id,
-                            config=self.cluster_compute,
-                        )
+                self.cluster_compute_id = result.result.id
+            except Exception as e:
+                if _repeat:
+                    logger.warning(
+                        f"Got exception when trying to create cluster "
+                        f"compute: {e}. Sleeping for 10 seconds and then "
+                        f"try again once..."
                     )
-                    self.cluster_compute_id = result.result.id
-                except Exception as e:
-                    if _repeat:
-                        logger.warning(
-                            f"Got exception when trying to create cluster "
-                            f"compute: {e}. Sleeping for 10 seconds and then "
-                            f"try again once..."
-                        )
-                        time.sleep(10)
-                        return self.create_cluster_compute(_repeat=False)
+                    time.sleep(10)
+                    return self._create_cluster_compute_legacy(_repeat=False)
 
-                    raise ClusterComputeCreateError(
-                        "Could not create cluster compute"
-                    ) from e
+                raise ClusterComputeCreateError(
+                    "Could not create cluster compute"
+                ) from e
 
-                logger.info(
-                    f"Cluster compute template created with "
-                    f"name {self.cluster_compute_name} and "
-                    f"ID {self.cluster_compute_id}"
-                )
+            logger.info(
+                f"Cluster compute template created with "
+                f"name {self.cluster_compute_name} and "
+                f"ID {self.cluster_compute_id}"
+            )
 
     def build_configs(self, timeout: float = 30.0):
         try:

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -259,8 +259,6 @@ class MinimalClusterManager(ClusterManager):
 
             time.sleep(1)
 
-        self.cluster_env_build_id = build_id
-
     def create_cluster_compute(self, _repeat: bool = True):
         assert self.cluster_compute_id is None
 

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -1,7 +1,5 @@
 import time
 
-import anyscale.compute_config
-import anyscale.image
 from anyscale.compute_config.models import ComputeConfig
 from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 
@@ -63,11 +61,9 @@ class MinimalClusterManager(ClusterManager):
         self.cluster_env_id = create_cluster_env_from_image(
             image=self.test.get_anyscale_byod_image(),
             test_name=self.cluster_env_name,
-            runtime_env=self.test.get_byod_runtime_env(),
-            sdk=self.sdk,
             cluster_env_id=self.cluster_env_id,
             cluster_env_name=self.cluster_env_name,
-            use_new_sdk=self.test.uses_anyscale_sdk_2026(),
+            sdk=self.sdk,
         )
 
     def build_cluster_env(self, timeout: float = 600.0):
@@ -75,7 +71,7 @@ class MinimalClusterManager(ClusterManager):
         assert self.cluster_env_build_id is None
 
         """Poll build status using anyscale.image.get()."""
-        img = anyscale.image.get(name=self.cluster_env_name)
+        img = self.sdk.image.get(name=self.cluster_env_name)
         build_id = img.latest_build_id
         status = (
             str(img.latest_build_status).upper() if img.latest_build_status else None
@@ -91,6 +87,11 @@ class MinimalClusterManager(ClusterManager):
                 f"Link to succeeded cluster env build: "
                 f"{format_link(anyscale_cluster_env_build_url(build_id))}"
             )
+            if img.latest_build_revision is None:
+                raise ClusterEnvBuildError(
+                    f"Build succeeded but revision is missing for "
+                    f"{self.cluster_env_name}"
+                )
             # image_uri for JobConfig: "anyscale/image/{name}:{revision}"
             self.cluster_env_build_id = (
                 f"anyscale/image/{img.name}:{img.latest_build_revision}"
@@ -121,7 +122,7 @@ class MinimalClusterManager(ClusterManager):
                 )
                 next_report = next_report + REPORT_S
 
-            img = anyscale.image.get(name=self.cluster_env_name)
+            img = self.sdk.image.get(name=self.cluster_env_name)
             status = (
                 str(img.latest_build_status).upper()
                 if img.latest_build_status
@@ -136,6 +137,11 @@ class MinimalClusterManager(ClusterManager):
 
             if status == "SUCCEEDED":
                 logger.info("Build succeeded.")
+                if img.latest_build_revision is None:
+                    raise ClusterEnvBuildError(
+                        f"Build succeeded but revision is missing for "
+                        f"{self.cluster_env_name}"
+                    )
                 # image_uri for JobConfig: "anyscale/image/{name}:{revision}"
                 self.cluster_env_build_id = (
                     f"anyscale/image/{img.name}:{img.latest_build_revision}"
@@ -172,10 +178,11 @@ class MinimalClusterManager(ClusterManager):
 
     def _create_cluster_compute_legacy(self, _repeat: bool = True):
         """Create or find a cluster compute using the legacy DefaultApi SDK."""
+        legacy_sdk = self.sdk.legacy_sdk
         paging_token = None
         while not self.cluster_compute_id:
             result = DefaultApi.search_cluster_computes(
-                self.sdk,
+                legacy_sdk,
                 dict(
                     project_id=self.project_id,
                     name=dict(equals=self.cluster_compute_name),
@@ -204,7 +211,7 @@ class MinimalClusterManager(ClusterManager):
             )
             try:
                 result = DefaultApi.create_cluster_compute(
-                    self.sdk,
+                    legacy_sdk,
                     dict(
                         name=self.cluster_compute_name,
                         project_id=self.project_id,
@@ -234,7 +241,9 @@ class MinimalClusterManager(ClusterManager):
 
     def _create_cluster_compute_new_sdk(self, _repeat: bool = True):
         """Create or find a cluster compute using the new anyscale.compute_config API."""
-        result = anyscale.compute_config.list(name=self.cluster_compute_name)
+        # Pagination not needed: names include a content hash (dict_hash),
+        # so >20 versions of the same name is extremely unlikely.
+        result = self.sdk.compute_config.list(name=self.cluster_compute_name)
         for cc in result.results:
             if cc.name.rsplit(":", 1)[0] == self.cluster_compute_name:
                 self.cluster_compute_id = cc.id
@@ -258,10 +267,10 @@ class MinimalClusterManager(ClusterManager):
                 if k in COMPUTE_CONFIG_FIELDS
             }
             config = ComputeConfig(**compute_kwargs)
-            full_name = anyscale.compute_config.create(
+            full_name = self.sdk.compute_config.create(
                 config, name=self.cluster_compute_name
             )
-            version = anyscale.compute_config.get(full_name)
+            version = self.sdk.compute_config.get(full_name)
             self.cluster_compute_id = version.id
         except Exception as e:
             if _repeat:

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -74,12 +74,6 @@ class MinimalClusterManager(ClusterManager):
         assert self.cluster_env_id
         assert self.cluster_env_build_id is None
 
-        if self.test.uses_anyscale_sdk_2026():
-            self._build_cluster_env_new_sdk(timeout)
-        else:
-            self._build_cluster_env_legacy(timeout)
-
-    def _build_cluster_env_new_sdk(self, timeout: float):
         """Poll build status using anyscale.image.get()."""
         img = anyscale.image.get(name=self.cluster_env_name)
         build_id = img.latest_build_id
@@ -97,12 +91,10 @@ class MinimalClusterManager(ClusterManager):
                 f"Link to succeeded cluster env build: "
                 f"{format_link(anyscale_cluster_env_build_url(build_id))}"
             )
-            # Store image URI (not build ID) for use with JobConfig.image_uri
-            self.cluster_env_build_id = img.latest_image_uri
-            if not self.cluster_env_build_id:
-                raise ClusterEnvBuildError(
-                    f"Build {build_id} succeeded but no image URI was returned."
-                )
+            # image_uri for JobConfig: "anyscale/image/{name}:{revision}"
+            self.cluster_env_build_id = (
+                f"anyscale/image/{img.name}:{img.latest_build_revision}"
+            )
             return
 
         if status == "FAILED":
@@ -144,111 +136,15 @@ class MinimalClusterManager(ClusterManager):
 
             if status == "SUCCEEDED":
                 logger.info("Build succeeded.")
-                # Store image URI (not build ID) for use with JobConfig.image_uri
-                self.cluster_env_build_id = img.latest_image_uri
-                if not self.cluster_env_build_id:
-                    raise ClusterEnvBuildError(
-                        f"Build {build_id} succeeded but no image URI " f"was returned."
-                    )
+                # image_uri for JobConfig: "anyscale/image/{name}:{revision}"
+                self.cluster_env_build_id = (
+                    f"anyscale/image/{img.name}:{img.latest_build_revision}"
+                )
                 return
 
             if status not in ("IN_PROGRESS", None):
                 raise ClusterEnvBuildError(
                     f"Unknown build status: {status}. Please see "
-                    f"{anyscale_cluster_env_build_url(build_id)} for details"
-                )
-
-            if time.monotonic() > timeout_at:
-                raise ClusterEnvBuildTimeout(
-                    f"Time out when building cluster env {self.cluster_env_name}"
-                )
-
-            time.sleep(1)
-
-    def _build_cluster_env_legacy(self, timeout: float):
-        """Poll build status using legacy DefaultApi SDK."""
-        # Fetch build
-        build_id = None
-        last_status = None
-        error_message = None
-        config_json = None
-        result = DefaultApi.list_cluster_environment_builds(
-            self.sdk, self.cluster_env_id
-        )
-        if not result or not result.results:
-            raise ClusterEnvBuildError(f"No build found for cluster env: {result}")
-
-        build = sorted(result.results, key=lambda b: b.created_at)[-1]
-        build_id = build.id
-        last_status = build.status
-        error_message = build.error_message
-        config_json = build.config_json
-
-        if last_status == "succeeded":
-            logger.info(
-                f"Link to succeeded cluster env build: "
-                f"{format_link(anyscale_cluster_env_build_url(build_id))}"
-            )
-            self.cluster_env_build_id = build_id
-            return
-
-        if last_status == "failed":
-            logger.info(f"Previous cluster env build failed: {error_message}")
-            logger.info("Starting new cluster env build...")
-
-            # Retry build
-            result = DefaultApi.create_cluster_environment_build(
-                self.sdk,
-                dict(
-                    cluster_environment_id=self.cluster_env_id, config_json=config_json
-                ),
-            )
-            build_id = result.result.id
-
-            logger.info(
-                f"Link to created cluster env build: "
-                f"{format_link(anyscale_cluster_env_build_url(build_id))}"
-            )
-
-        # Build found but not failed/finished yet
-        completed = False
-        start_wait = time.time()
-        next_report = start_wait + REPORT_S
-        timeout_at = time.monotonic() + timeout
-        logger.info(f"Waiting for build {build_id} to finish...")
-        logger.info(
-            f"Track progress here: "
-            f"{format_link(anyscale_cluster_env_build_url(build_id))}"
-        )
-        while not completed:
-            now = time.time()
-            if now > next_report:
-                logger.info(
-                    f"... still waiting for build {build_id} to finish "
-                    f"({int(now - start_wait)} seconds) ..."
-                )
-                next_report = next_report + REPORT_S
-
-            result = DefaultApi.get_build(self.sdk, build_id)
-            build = result.result
-
-            if build.status == "failed":
-                raise ClusterEnvBuildError(
-                    f"Cluster env build failed. Please see "
-                    f"{anyscale_cluster_env_build_url(build_id)} for details. "
-                    f"Error message: {build.error_message}"
-                )
-
-            if build.status == "succeeded":
-                logger.info("Build succeeded.")
-                self.cluster_env_build_id = build_id
-                return
-
-            completed = build.status not in ["in_progress", "pending"]
-
-            if completed:
-                raise ClusterEnvBuildError(
-                    f"Unknown build status: {build.status}. Please see "
                     f"{anyscale_cluster_env_build_url(build_id)} for details"
                 )
 

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -276,55 +276,6 @@ class MinimalClusterManager(ClusterManager):
             else:
                 self._create_cluster_compute_legacy(_repeat=_repeat)
 
-    def _create_cluster_compute_new_sdk(self, _repeat: bool = True):
-        """Create or find a cluster compute using the new anyscale.compute_config API."""
-        result = anyscale.compute_config.list(name=self.cluster_compute_name)
-        for cc in result.results:
-            if cc.name.rsplit(":", 1)[0] == self.cluster_compute_name:
-                self.cluster_compute_id = cc.id
-                logger.info(
-                    f"Cluster compute already exists "
-                    f"with ID {self.cluster_compute_id}"
-                )
-                return
-
-        logger.info(
-            f"Cluster compute not found. "
-            f"Creating with name {self.cluster_compute_name}."
-        )
-        try:
-            # Filter to only fields accepted by ComputeConfig; keys like
-            # idle_termination_minutes/maximum_uptime_minutes are cluster-level
-            # settings not part of the ComputeConfig model.
-            compute_kwargs = {
-                k: v
-                for k, v in self.cluster_compute.items()
-                if k in COMPUTE_CONFIG_FIELDS
-            }
-            config = ComputeConfig(**compute_kwargs)
-            full_name = anyscale.compute_config.create(
-                config, name=self.cluster_compute_name
-            )
-            version = anyscale.compute_config.get(full_name)
-            self.cluster_compute_id = version.id
-        except Exception as e:
-            if _repeat:
-                logger.warning(
-                    f"Got exception when trying to create cluster "
-                    f"compute: {e}. Sleeping for 10 seconds and then "
-                    f"try again once..."
-                )
-                time.sleep(10)
-                return self._create_cluster_compute_new_sdk(_repeat=False)
-
-            raise ClusterComputeCreateError("Could not create cluster compute") from e
-
-        logger.info(
-            f"Cluster compute template created with "
-            f"name {self.cluster_compute_name} and "
-            f"ID {self.cluster_compute_id}"
-        )
-
     def _create_cluster_compute_legacy(self, _repeat: bool = True):
         """Create or find a cluster compute using the legacy DefaultApi SDK."""
         paging_token = None
@@ -386,6 +337,55 @@ class MinimalClusterManager(ClusterManager):
                 f"name {self.cluster_compute_name} and "
                 f"ID {self.cluster_compute_id}"
             )
+
+    def _create_cluster_compute_new_sdk(self, _repeat: bool = True):
+        """Create or find a cluster compute using the new anyscale.compute_config API."""
+        result = anyscale.compute_config.list(name=self.cluster_compute_name)
+        for cc in result.results:
+            if cc.name.rsplit(":", 1)[0] == self.cluster_compute_name:
+                self.cluster_compute_id = cc.id
+                logger.info(
+                    f"Cluster compute already exists "
+                    f"with ID {self.cluster_compute_id}"
+                )
+                return
+
+        logger.info(
+            f"Cluster compute not found. "
+            f"Creating with name {self.cluster_compute_name}."
+        )
+        try:
+            # Filter to only fields accepted by ComputeConfig; keys like
+            # idle_termination_minutes/maximum_uptime_minutes are cluster-level
+            # settings not part of the ComputeConfig model.
+            compute_kwargs = {
+                k: v
+                for k, v in self.cluster_compute.items()
+                if k in COMPUTE_CONFIG_FIELDS
+            }
+            config = ComputeConfig(**compute_kwargs)
+            full_name = anyscale.compute_config.create(
+                config, name=self.cluster_compute_name
+            )
+            version = anyscale.compute_config.get(full_name)
+            self.cluster_compute_id = version.id
+        except Exception as e:
+            if _repeat:
+                logger.warning(
+                    f"Got exception when trying to create cluster "
+                    f"compute: {e}. Sleeping for 10 seconds and then "
+                    f"try again once..."
+                )
+                time.sleep(10)
+                return self._create_cluster_compute_new_sdk(_repeat=False)
+
+            raise ClusterComputeCreateError("Could not create cluster compute") from e
+
+        logger.info(
+            f"Cluster compute template created with "
+            f"name {self.cluster_compute_name} and "
+            f"ID {self.cluster_compute_id}"
+        )
 
     def build_configs(self, timeout: float = 30.0):
         try:

--- a/release/ray_release/cluster_manager/minimal.py
+++ b/release/ray_release/cluster_manager/minimal.py
@@ -1,6 +1,7 @@
 import time
 
 import anyscale.compute_config
+import anyscale.image
 from anyscale.compute_config.models import ComputeConfig
 from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 
@@ -66,12 +67,106 @@ class MinimalClusterManager(ClusterManager):
             sdk=self.sdk,
             cluster_env_id=self.cluster_env_id,
             cluster_env_name=self.cluster_env_name,
+            use_new_sdk=self.test.uses_anyscale_sdk_2026(),
         )
 
     def build_cluster_env(self, timeout: float = 600.0):
         assert self.cluster_env_id
         assert self.cluster_env_build_id is None
 
+        if self.test.uses_anyscale_sdk_2026():
+            self._build_cluster_env_new_sdk(timeout)
+        else:
+            self._build_cluster_env_legacy(timeout)
+
+    def _build_cluster_env_new_sdk(self, timeout: float):
+        """Poll build status using anyscale.image.get()."""
+        img = anyscale.image.get(name=self.cluster_env_name)
+        build_id = img.latest_build_id
+        status = (
+            str(img.latest_build_status).upper() if img.latest_build_status else None
+        )
+
+        if not build_id:
+            raise ClusterEnvBuildError(
+                f"No build found for cluster env: {self.cluster_env_name}"
+            )
+
+        if status == "SUCCEEDED":
+            logger.info(
+                f"Link to succeeded cluster env build: "
+                f"{format_link(anyscale_cluster_env_build_url(build_id))}"
+            )
+            # Store image URI (not build ID) for use with JobConfig.image_uri
+            self.cluster_env_build_id = img.latest_image_uri
+            if not self.cluster_env_build_id:
+                raise ClusterEnvBuildError(
+                    f"Build {build_id} succeeded but no image URI was returned."
+                )
+            return
+
+        if status == "FAILED":
+            raise ClusterEnvBuildError(
+                f"Cluster env build failed. Please see "
+                f"{anyscale_cluster_env_build_url(build_id)} for details."
+            )
+
+        # Build in progress — poll until done
+        start_wait = time.time()
+        next_report = start_wait + REPORT_S
+        timeout_at = time.monotonic() + timeout
+        logger.info(f"Waiting for build {build_id} to finish...")
+        logger.info(
+            f"Track progress here: "
+            f"{format_link(anyscale_cluster_env_build_url(build_id))}"
+        )
+        while True:
+            now = time.time()
+            if now > next_report:
+                logger.info(
+                    f"... still waiting for build {build_id} to finish "
+                    f"({int(now - start_wait)} seconds) ..."
+                )
+                next_report = next_report + REPORT_S
+
+            img = anyscale.image.get(name=self.cluster_env_name)
+            status = (
+                str(img.latest_build_status).upper()
+                if img.latest_build_status
+                else None
+            )
+
+            if status == "FAILED":
+                raise ClusterEnvBuildError(
+                    f"Cluster env build failed. Please see "
+                    f"{anyscale_cluster_env_build_url(build_id)} for details."
+                )
+
+            if status == "SUCCEEDED":
+                logger.info("Build succeeded.")
+                # Store image URI (not build ID) for use with JobConfig.image_uri
+                self.cluster_env_build_id = img.latest_image_uri
+                if not self.cluster_env_build_id:
+                    raise ClusterEnvBuildError(
+                        f"Build {build_id} succeeded but no image URI " f"was returned."
+                    )
+                return
+
+            if status not in ("IN_PROGRESS", None):
+                raise ClusterEnvBuildError(
+                    f"Unknown build status: {status}. Please see "
+                    f"{anyscale_cluster_env_build_url(build_id)} for details"
+                )
+
+            if time.monotonic() > timeout_at:
+                raise ClusterEnvBuildTimeout(
+                    f"Time out when building cluster env {self.cluster_env_name}"
+                )
+
+            time.sleep(1)
+
+    def _build_cluster_env_legacy(self, timeout: float):
+        """Poll build status using legacy DefaultApi SDK."""
         # Fetch build
         build_id = None
         last_status = None

--- a/release/ray_release/command_runner/anyscale_job_runner.py
+++ b/release/ray_release/command_runner/anyscale_job_runner.py
@@ -4,7 +4,7 @@ import re
 import shlex
 import shutil
 import tempfile
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Dict, Optional
 
 from ray_release.cloud_util import (
     convert_abfss_uri_to_https,
@@ -36,11 +36,7 @@ from ray_release.util import (
     AZURE_CLOUD_STORAGE,
     AZURE_STORAGE_CONTAINER,
     S3_CLOUD_STORAGE,
-    get_anyscale_sdk,
 )
-
-if TYPE_CHECKING:
-    from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
 
 TIMEOUT_RETURN_CODE = 124
 
@@ -89,7 +85,6 @@ class AnyscaleJobRunner(CommandRunner):
         cluster_manager: ClusterManager,
         file_manager: JobFileManager,
         working_dir: str,
-        sdk: Optional["AnyscaleSDK"] = None,
         artifact_path: Optional[str] = None,
     ):
         super().__init__(
@@ -97,7 +92,6 @@ class AnyscaleJobRunner(CommandRunner):
             working_dir=working_dir,
         )
         self.file_manager = file_manager
-        self.sdk = sdk or get_anyscale_sdk()
         self.job_manager = AnyscaleJobManager(cluster_manager)
 
         self.last_command_scd_id = None

--- a/release/ray_release/config.py
+++ b/release/ray_release/config.py
@@ -29,6 +29,10 @@ DEFAULT_CLOUD_ID = DeferredEnvVar(
     "RELEASE_DEFAULT_CLOUD_ID",
     "cld_kvedZWag2qA8i5BjxUevf5i7",  # anyscale_v2_default_cloud
 )
+DEFAULT_CLOUD_NAME = DeferredEnvVar(
+    "RELEASE_DEFAULT_CLOUD_NAME",
+    "anyscale_v2_default_cloud",
+)
 DEFAULT_ANYSCALE_PROJECT = DeferredEnvVar(
     "RELEASE_DEFAULT_PROJECT",
     "prj_6rfevmf12tbsbd6g3al5f6zssh",
@@ -45,6 +49,27 @@ RELEASE_TEST_CONFIG_FILES = [
 ]
 
 ALLOWED_BYOD_TYPES = ["gpu", "gpu-cu130", "cpu", "cu123", "llm-cu128", "llm-cu130"]
+
+NEW_COMPUTE_CONFIG_KEYS = {
+    "cloud",
+    "head_node",
+    "worker_nodes",
+    "advanced_instance_config",
+}
+LEGACY_COMPUTE_CONFIG_KEYS = {
+    "aws",
+    "cloud_id",
+    "head_node_type",
+    "worker_node_types",
+    "aws_advanced_configurations",
+    "advanced_configurations_json",
+    "gcp_advanced_configurations_json",
+}
+
+CLOUD_ID_TO_NAME = {
+    "cld_kvedZWag2qA8i5BjxUevf5i7": "anyscale_v2_default_cloud",
+    "cld_wy5a6nhazplvu32526ams61d98": "serve_release_tests_cloud",
+}
 
 
 def read_and_validate_release_test_collection(
@@ -285,21 +310,53 @@ def validate_test_cluster_compute(
 ) -> Optional[str]:
     from ray_release.template import load_test_cluster_compute
 
+    is_new_schema = test.uses_anyscale_sdk_2026()
     cluster_compute = load_test_cluster_compute(test, test_definition_root)
-    return validate_cluster_compute(cluster_compute)
+    return validate_cluster_compute(cluster_compute, is_new_schema=is_new_schema)
 
 
-def validate_cluster_compute(cluster_compute: Dict[str, Any]) -> Optional[str]:
-    aws = cluster_compute.get("aws", {})
-    head_node_aws = cluster_compute.get("head_node_type", {}).get(
-        "aws_advanced_configurations", {}
-    )
+def validate_cluster_compute(
+    cluster_compute: Dict[str, Any], is_new_schema: bool = False
+) -> Optional[str]:
+    compute_keys = set(cluster_compute.keys())
+    found_legacy_keys = compute_keys & LEGACY_COMPUTE_CONFIG_KEYS
+    found_new_keys = compute_keys & NEW_COMPUTE_CONFIG_KEYS
 
-    configs_to_check = [aws, head_node_aws]
-
-    for worker_node in cluster_compute.get("worker_node_types", []):
-        worker_node_aws = worker_node.get("aws_advanced_configurations", {})
-        configs_to_check.append(worker_node_aws)
+    if is_new_schema:
+        if found_legacy_keys:
+            return (
+                f"Compute config has legacy schema keys ({found_legacy_keys}) "
+                f"but test expects new schema (anyscale_sdk_2026=true)"
+            )
+        head_node_aws = cluster_compute.get("head_node", {}).get(
+            "advanced_instance_config", {}
+        )
+        configs_to_check = [
+            cluster_compute.get("advanced_instance_config", {}),
+            head_node_aws,
+        ]
+        for worker_node in cluster_compute.get("worker_nodes", []):
+            worker_aws = worker_node.get("advanced_instance_config", {})
+            configs_to_check.append(worker_aws)
+    else:
+        if found_new_keys:
+            return (
+                f"Compute config has new schema keys ({found_new_keys}) "
+                f"but test expects legacy schema (anyscale_sdk_2026=false)"
+            )
+        if not found_legacy_keys:
+            return (
+                "Compute config does not have legacy schema keys "
+                "but test expects legacy schema (anyscale_sdk_2026=false)"
+            )
+        aws = cluster_compute.get("aws", {})
+        head_node_aws = cluster_compute.get("head_node_type", {}).get(
+            "aws_advanced_configurations", {}
+        )
+        configs_to_check = [aws, head_node_aws]
+        for worker_node in cluster_compute.get("worker_node_types", []):
+            worker_node_aws = worker_node.get("aws_advanced_configurations", {})
+            configs_to_check.append(worker_node_aws)
 
     for config in configs_to_check:
         error = validate_aws_config(config)
@@ -351,6 +408,14 @@ def parse_python_version(version: str) -> Tuple[int, int]:
 
 def get_test_cloud_id(test: Test) -> str:
     return test.get("cluster", {}).get("cloud_id", str(DEFAULT_CLOUD_ID))
+
+
+def get_test_cloud_name(test: Test) -> str:
+    cloud_name = test.get("cluster", {}).get("cloud")
+    if cloud_name:
+        return cloud_name
+    cloud_id = get_test_cloud_id(test)
+    return CLOUD_ID_TO_NAME[cloud_id]
 
 
 def get_test_project_id(test: Test, default_project_id: Optional[str] = None) -> str:

--- a/release/ray_release/glue.py
+++ b/release/ray_release/glue.py
@@ -478,9 +478,7 @@ def run_release_test_anyscale(
         cluster_env_id = None
         # If image is provided, create/reuse a custom cluster environment
         if image:
-            cluster_env_id = create_cluster_env_from_image(
-                image, test.get_name(), test.get_byod_runtime_env()
-            )
+            cluster_env_id = create_cluster_env_from_image(image, test.get_name())
             cluster_manager.cluster_env_name = get_custom_cluster_env_name(
                 image, test.get_name()
             )

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -44,9 +44,6 @@ class AnyscaleJobManager:
         self.cluster_startup_timeout = 600
         self._duration = None
 
-    def _uses_new_sdk(self) -> bool:
-        return self.cluster_manager.test.uses_anyscale_sdk_2026()
-
     def _run_job(
         self,
         cmd_to_run: str,
@@ -64,7 +61,18 @@ class AnyscaleJobManager:
         )
 
         try:
-            self._job_id = self._submit_job(cmd_to_run, env_vars_for_job, working_dir)
+            # cluster_env_build_id stores "anyscale/image/{name}:{revision}"
+            # from anyscale.image.get() after build_cluster_env().
+            config = JobConfig(
+                name=self.cluster_manager.cluster_name,
+                entrypoint=cmd_to_run,
+                image_uri=self.cluster_manager.cluster_env_build_id,
+                compute_config=self.cluster_manager.cluster_compute_name,
+                env_vars=env_vars_for_job,
+                working_dir=working_dir,
+                max_retries=0,
+            )
+            self._job_id = anyscale.job.submit(config)
         except Exception as e:
             raise JobStartupFailed(
                 "Error starting job with name "
@@ -77,26 +85,6 @@ class AnyscaleJobManager:
 
         logger.info(f"Link to job: " f"{format_link(self.job_url())}")
         return
-
-    def _submit_job(
-        self,
-        cmd_to_run: str,
-        env_vars: Dict[str, str],
-        working_dir: Optional[str] = None,
-    ) -> str:
-        """Submit a job using anyscale.job.submit() and return the job ID."""
-        # cluster_env_build_id stores "anyscale/image/{name}:{revision}"
-        # from anyscale.image.get() after build_cluster_env().
-        config = JobConfig(
-            name=self.cluster_manager.cluster_name,
-            entrypoint=cmd_to_run,
-            image_uri=self.cluster_manager.cluster_env_build_id,
-            compute_config=self.cluster_manager.cluster_compute_name,
-            env_vars=env_vars,
-            working_dir=working_dir,
-            max_retries=0,
-        )
-        return anyscale.job.submit(config)
 
     def save_last_job_status(self, status):
         if status and hasattr(status, "id") and status.id != self._job_id:

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -4,11 +4,6 @@ from typing import Any, Dict, Optional, Tuple
 
 import anyscale
 from anyscale.job.models import JobConfig, JobState
-from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
-from anyscale.sdk.anyscale_client.models import (
-    CreateProductionJob,
-    CreateProductionJobConfig,
-)
 
 from ray_release.anyscale_util import LAST_LOGS_LENGTH
 from ray_release.cluster_manager.cluster_manager import ClusterManager
@@ -69,14 +64,7 @@ class AnyscaleJobManager:
         )
 
         try:
-            if self._uses_new_sdk():
-                self._job_id = self._submit_job_new_sdk(
-                    cmd_to_run, env_vars_for_job, working_dir
-                )
-            else:
-                self._job_id = self._submit_job_legacy(
-                    cmd_to_run, env_vars_for_job, working_dir, upload_path
-                )
+            self._job_id = self._submit_job(cmd_to_run, env_vars_for_job, working_dir)
         except Exception as e:
             raise JobStartupFailed(
                 "Error starting job with name "
@@ -90,48 +78,23 @@ class AnyscaleJobManager:
         logger.info(f"Link to job: " f"{format_link(self.job_url())}")
         return
 
-    def _submit_job_legacy(
-        self,
-        cmd_to_run: str,
-        env_vars: Dict[str, str],
-        working_dir: Optional[str] = None,
-        upload_path: Optional[str] = None,
-    ) -> str:
-        """Submit a job using DefaultApi.create_job() and return the job ID."""
-        runtime_env: Dict[str, Any] = {
-            "env_vars": env_vars,
-        }
-        if working_dir:
-            runtime_env["working_dir"] = working_dir
-            if upload_path:
-                runtime_env["upload_path"] = upload_path
-
-        job_request = CreateProductionJob(
-            name=self.cluster_manager.cluster_name,
-            description=f"Smoke test: {self.cluster_manager.smoke_test}",
-            project_id=self.cluster_manager.project_id,
-            config=CreateProductionJobConfig(
-                entrypoint=cmd_to_run,
-                runtime_env=runtime_env,
-                build_id=self.cluster_manager.cluster_env_build_id,
-                compute_config_id=self.cluster_manager.cluster_compute_id,
-                max_retries=0,
-            ),
-        )
-        job_response = DefaultApi.create_job(self._sdk, job_request)
-        return job_response.result.id
-
-    def _submit_job_new_sdk(
+    def _submit_job(
         self,
         cmd_to_run: str,
         env_vars: Dict[str, str],
         working_dir: Optional[str] = None,
     ) -> str:
         """Submit a job using anyscale.job.submit() and return the job ID."""
+        # For the new SDK path, cluster_env_build_id is already an image URI.
+        # For the legacy path, it's a build ID — use the BYOD image instead.
+        if self._uses_new_sdk():
+            image_uri = self.cluster_manager.cluster_env_build_id
+        else:
+            image_uri = self.cluster_manager.test.get_anyscale_byod_image()
         config = JobConfig(
             name=self.cluster_manager.cluster_name,
             entrypoint=cmd_to_run,
-            image_uri=self.cluster_manager.cluster_env_build_id,
+            image_uri=image_uri,
             compute_config=self.cluster_manager.cluster_compute_id,
             env_vars=env_vars,
             working_dir=working_dir,
@@ -177,10 +140,7 @@ class AnyscaleJobManager:
             return
         logger.info(f"Terminating job {self._job_id}...")
         try:
-            if self._uses_new_sdk():
-                anyscale.job.terminate(id=self._job_id)
-            else:
-                DefaultApi.terminate_job(self._sdk, self._job_id)
+            anyscale.job.terminate(id=self._job_id)
             logger.info(f"Job {self._job_id} terminated!")
         except Exception:
             msg = f"Couldn't terminate job {self._job_id}!"

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import anyscale
 from anyscale.job.models import JobState
+from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 from anyscale.sdk.anyscale_client.models import (
     CreateProductionJob,
     CreateProductionJobConfig,
@@ -85,7 +86,7 @@ class AnyscaleJobManager:
                     max_retries=0,
                 ),
             )
-            job_response = self._sdk.create_job(job_request)
+            job_response = DefaultApi.create_job(self._sdk, job_request)
         except Exception as e:
             raise JobStartupFailed(
                 "Error starting job with name "
@@ -138,7 +139,7 @@ class AnyscaleJobManager:
             return
         logger.info(f"Terminating job {self._job_id}...")
         try:
-            self._sdk.terminate_job(self._job_id)
+            DefaultApi.terminate_job(self._sdk, self._job_id)
             logger.info(f"Job {self._job_id} terminated!")
         except Exception:
             msg = f"Couldn't terminate job {self._job_id}!"

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 from typing import Any, Dict, Optional, Tuple
 
 import anyscale
-from anyscale.job.models import JobState
+from anyscale.job.models import JobConfig, JobState
 from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 from anyscale.sdk.anyscale_client.models import (
     CreateProductionJob,
@@ -49,6 +49,9 @@ class AnyscaleJobManager:
         self.cluster_startup_timeout = 600
         self._duration = None
 
+    def _uses_new_sdk(self) -> bool:
+        return self.cluster_manager.test.uses_anyscale_sdk_2026()
+
     def _run_job(
         self,
         cmd_to_run: str,
@@ -65,28 +68,15 @@ class AnyscaleJobManager:
             f"Executing {cmd_to_run} with {env_vars_for_job} via Anyscale job submit"
         )
 
-        runtime_env = {
-            "env_vars": env_vars_for_job,
-        }
-        if working_dir:
-            runtime_env["working_dir"] = working_dir
-            if upload_path:
-                runtime_env["upload_path"] = upload_path
-
         try:
-            job_request = CreateProductionJob(
-                name=self.cluster_manager.cluster_name,
-                description=f"Smoke test: {self.cluster_manager.smoke_test}",
-                project_id=self.cluster_manager.project_id,
-                config=CreateProductionJobConfig(
-                    entrypoint=cmd_to_run,
-                    runtime_env=runtime_env,
-                    build_id=self.cluster_manager.cluster_env_build_id,
-                    compute_config_id=self.cluster_manager.cluster_compute_id,
-                    max_retries=0,
-                ),
-            )
-            job_response = DefaultApi.create_job(self._sdk, job_request)
+            if self._uses_new_sdk():
+                self._job_id = self._submit_job_new_sdk(
+                    cmd_to_run, env_vars_for_job, working_dir
+                )
+            else:
+                self._job_id = self._submit_job_legacy(
+                    cmd_to_run, env_vars_for_job, working_dir, upload_path
+                )
         except Exception as e:
             raise JobStartupFailed(
                 "Error starting job with name "
@@ -94,12 +84,60 @@ class AnyscaleJobManager:
                 f"{e}"
             ) from e
 
-        self._job_id = job_response.result.id
         self._last_job_result = None
         self.start_time = time.time()
 
         logger.info(f"Link to job: " f"{format_link(self.job_url())}")
         return
+
+    def _submit_job_new_sdk(
+        self,
+        cmd_to_run: str,
+        env_vars: Dict[str, str],
+        working_dir: Optional[str] = None,
+    ) -> str:
+        """Submit a job using anyscale.job.submit() and return the job ID."""
+        config = JobConfig(
+            name=self.cluster_manager.cluster_name,
+            entrypoint=cmd_to_run,
+            image_uri=self.cluster_manager.cluster_env_build_id,
+            compute_config=self.cluster_manager.cluster_compute_id,
+            env_vars=env_vars,
+            working_dir=working_dir,
+            max_retries=0,
+        )
+        return anyscale.job.submit(config)
+
+    def _submit_job_legacy(
+        self,
+        cmd_to_run: str,
+        env_vars: Dict[str, str],
+        working_dir: Optional[str] = None,
+        upload_path: Optional[str] = None,
+    ) -> str:
+        """Submit a job using DefaultApi.create_job() and return the job ID."""
+        runtime_env: Dict[str, Any] = {
+            "env_vars": env_vars,
+        }
+        if working_dir:
+            runtime_env["working_dir"] = working_dir
+            if upload_path:
+                runtime_env["upload_path"] = upload_path
+
+        job_request = CreateProductionJob(
+            name=self.cluster_manager.cluster_name,
+            description=f"Smoke test: {self.cluster_manager.smoke_test}",
+            project_id=self.cluster_manager.project_id,
+            config=CreateProductionJobConfig(
+                entrypoint=cmd_to_run,
+                runtime_env=runtime_env,
+                build_id=self.cluster_manager.cluster_env_build_id,
+                compute_config_id=self.cluster_manager.cluster_compute_id,
+                max_retries=0,
+            ),
+        )
+        job_response = DefaultApi.create_job(self._sdk, job_request)
+        return job_response.result.id
 
     def save_last_job_status(self, status):
         if status and hasattr(status, "id") and status.id != self._job_id:
@@ -139,7 +177,10 @@ class AnyscaleJobManager:
             return
         logger.info(f"Terminating job {self._job_id}...")
         try:
-            DefaultApi.terminate_job(self._sdk, self._job_id)
+            if self._uses_new_sdk():
+                anyscale.job.terminate(id=self._job_id)
+            else:
+                DefaultApi.terminate_job(self._sdk, self._job_id)
             logger.info(f"Job {self._job_id} terminated!")
         except Exception:
             msg = f"Couldn't terminate job {self._job_id}!"

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -85,17 +85,13 @@ class AnyscaleJobManager:
         working_dir: Optional[str] = None,
     ) -> str:
         """Submit a job using anyscale.job.submit() and return the job ID."""
-        # For the new SDK path, cluster_env_build_id is already an image URI.
-        # For the legacy path, it's a build ID — use the BYOD image instead.
-        if self._uses_new_sdk():
-            image_uri = self.cluster_manager.cluster_env_build_id
-        else:
-            image_uri = self.cluster_manager.test.get_anyscale_byod_image()
+        # cluster_env_build_id stores "anyscale/image/{name}:{revision}"
+        # from anyscale.image.get() after build_cluster_env().
         config = JobConfig(
             name=self.cluster_manager.cluster_name,
             entrypoint=cmd_to_run,
-            image_uri=image_uri,
-            compute_config=self.cluster_manager.cluster_compute_id,
+            image_uri=self.cluster_manager.cluster_env_build_id,
+            compute_config=self.cluster_manager.cluster_compute_name,
             env_vars=env_vars,
             working_dir=working_dir,
             max_retries=0,

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -90,24 +90,6 @@ class AnyscaleJobManager:
         logger.info(f"Link to job: " f"{format_link(self.job_url())}")
         return
 
-    def _submit_job_new_sdk(
-        self,
-        cmd_to_run: str,
-        env_vars: Dict[str, str],
-        working_dir: Optional[str] = None,
-    ) -> str:
-        """Submit a job using anyscale.job.submit() and return the job ID."""
-        config = JobConfig(
-            name=self.cluster_manager.cluster_name,
-            entrypoint=cmd_to_run,
-            image_uri=self.cluster_manager.cluster_env_build_id,
-            compute_config=self.cluster_manager.cluster_compute_id,
-            env_vars=env_vars,
-            working_dir=working_dir,
-            max_retries=0,
-        )
-        return anyscale.job.submit(config)
-
     def _submit_job_legacy(
         self,
         cmd_to_run: str,
@@ -138,6 +120,24 @@ class AnyscaleJobManager:
         )
         job_response = DefaultApi.create_job(self._sdk, job_request)
         return job_response.result.id
+
+    def _submit_job_new_sdk(
+        self,
+        cmd_to_run: str,
+        env_vars: Dict[str, str],
+        working_dir: Optional[str] = None,
+    ) -> str:
+        """Submit a job using anyscale.job.submit() and return the job ID."""
+        config = JobConfig(
+            name=self.cluster_manager.cluster_name,
+            entrypoint=cmd_to_run,
+            image_uri=self.cluster_manager.cluster_env_build_id,
+            compute_config=self.cluster_manager.cluster_compute_id,
+            env_vars=env_vars,
+            working_dir=working_dir,
+            max_retries=0,
+        )
+        return anyscale.job.submit(config)
 
     def save_last_job_status(self, status):
         if status and hasattr(status, "id") and status.id != self._job_id:

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -86,11 +86,17 @@
 				"cloud_id": {
 					"type": "string"
 				},
+				"cloud": {
+					"type": "string"
+				},
 				"project_id": {
 					"type": "string"
 				},
 				"byod": {
 					"$ref": "#/definitions/Byod"
+				},
+				"anyscale_sdk_2026": {
+					"type": "boolean"
 				}
 			},
 			"required": [

--- a/release/ray_release/template.py
+++ b/release/ray_release/template.py
@@ -7,7 +7,7 @@ import jinja2
 import yaml
 
 from ray_release.bazel import bazel_runfile
-from ray_release.config import get_test_cloud_id
+from ray_release.config import get_test_cloud_id, get_test_cloud_name
 from ray_release.exception import ReleaseTestConfigError
 
 if TYPE_CHECKING:
@@ -111,5 +111,7 @@ def _populate_cluster_compute_variables(test: "Test") -> Dict:
     env = _get_test_environment()
 
     cloud_id = get_test_cloud_id(test)
+    cloud_name = get_test_cloud_name(test)
     env["ANYSCALE_CLOUD_ID"] = cloud_id
+    env["ANYSCALE_CLOUD"] = cloud_name
     return env

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -403,6 +403,10 @@ class Test(dict):
         """Returns whether this test is running on Azure."""
         return self.get_cloud_env() == "azure"
 
+    def uses_anyscale_sdk_2026(self) -> bool:
+        """Returns whether this test uses the new 2026 Anyscale compute config schema."""
+        return self.get("cluster", {}).get("anyscale_sdk_2026", False)
+
     def is_high_impact(self) -> bool:
         # a test is high impact if it catches regressions frequently, this field is
         # populated by the determine_microcheck_tests.py script

--- a/release/ray_release/tests/test_anyscale_job_manager.py
+++ b/release/ray_release/tests/test_anyscale_job_manager.py
@@ -21,13 +21,8 @@ class FakeSDK(Anyscale):
         return "fake_project_name"
 
 
-class MockTest(Test):
-    def get_anyscale_byod_image(self) -> str:
-        return "anyscale/ray:nightly-py310-cpu"
-
-
 def _make_job_manager(uses_new_sdk=False):
-    fake_test = MockTest(
+    fake_test = Test(
         {
             "name": "fake_test",
             "cluster": {"byod": {}, "anyscale_sdk_2026": uses_new_sdk},
@@ -38,6 +33,7 @@ def _make_job_manager(uses_new_sdk=False):
     cm.cluster_name = "test_cluster_123"
     cm.cluster_env_name = "test_env"
     cm.cluster_env_build_id = "anyscale/image/test:1"
+    cm.cluster_compute_name = "test_compute_config"
     cm.cluster_compute_id = "cc_123"
     cm.smoke_test = False
     return AnyscaleJobManager(cluster_manager=cm)
@@ -75,16 +71,17 @@ def test_submit_job_new_sdk(mock_job):
     assert config.name == "test_cluster_123"
     assert config.entrypoint == "echo hello"
     assert config.image_uri == "anyscale/image/test:1"
-    assert config.compute_config == "cc_123"
+    assert config.compute_config == "test_compute_config"
     assert config.max_retries == 0
     assert "FOO" in config.env_vars
 
 
 @patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
 def test_submit_job_legacy(mock_job):
-    """Legacy path uses BYOD image as image_uri."""
+    """Legacy path uses {name}:{revision} from build as image_uri."""
     jm = _make_job_manager(uses_new_sdk=False)
-    jm.cluster_manager.cluster_env_build_id = "bld_legacy_123"
+    # Both paths store "{img.name}:{img.latest_build_revision}" in cluster_env_build_id
+    jm.cluster_manager.cluster_env_build_id = "anyscale/image/test_image:3"
     mock_job.submit.return_value = "job_legacy_456"
 
     jm._run_job("echo hello", {"FOO": "bar"})
@@ -94,9 +91,8 @@ def test_submit_job_legacy(mock_job):
     config = mock_job.submit.call_args[0][0]
     assert config.name == "test_cluster_123"
     assert config.entrypoint == "echo hello"
-    # Legacy path uses the BYOD image, not the build ID
-    assert config.image_uri == "anyscale/ray:nightly-py310-cpu"
-    assert config.compute_config == "cc_123"
+    assert config.image_uri == "anyscale/image/test_image:3"
+    assert config.compute_config == "test_compute_config"
     assert "FOO" in config.env_vars
 
 

--- a/release/ray_release/tests/test_anyscale_job_manager.py
+++ b/release/ray_release/tests/test_anyscale_job_manager.py
@@ -3,14 +3,12 @@ from unittest.mock import patch
 
 import pytest
 from anyscale.job.models import JobState
-from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 
 from ray_release.anyscale_util import Anyscale
 from ray_release.cluster_manager.cluster_manager import ClusterManager
 from ray_release.exception import JobStartupFailed
 from ray_release.job_manager.anyscale_job_manager import AnyscaleJobManager
 from ray_release.test import Test
-from ray_release.tests.utils import APIDict
 
 
 class FakeJobStatus:
@@ -23,10 +21,17 @@ class FakeSDK(Anyscale):
         return "fake_project_name"
 
 
+class MockTest(Test):
+    def get_anyscale_byod_image(self) -> str:
+        return "anyscale/ray:nightly-py310-cpu"
+
+
 def _make_job_manager(uses_new_sdk=False):
-    fake_test = Test(
-        name="fake_test",
-        cluster={"byod": {}, "anyscale_sdk_2026": uses_new_sdk},
+    fake_test = MockTest(
+        {
+            "name": "fake_test",
+            "cluster": {"byod": {}, "anyscale_sdk_2026": uses_new_sdk},
+        }
     )
     fake_sdk = FakeSDK()
     cm = ClusterManager(test=fake_test, project_id="fake_project_id", sdk=fake_sdk)
@@ -58,7 +63,7 @@ def test_get_last_logs_long_running_job():
 
 @patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
 def test_submit_job_new_sdk(mock_job):
-    """New SDK path submits via anyscale.job.submit with JobConfig."""
+    """New SDK path uses cluster_env_build_id (image URI) as image_uri."""
     jm = _make_job_manager(uses_new_sdk=True)
     mock_job.submit.return_value = "job_new_123"
 
@@ -75,28 +80,29 @@ def test_submit_job_new_sdk(mock_job):
     assert "FOO" in config.env_vars
 
 
-@patch.object(DefaultApi, "create_job")
-def test_submit_job_legacy(mock_create_job):
-    """Legacy path submits via DefaultApi.create_job."""
+@patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
+def test_submit_job_legacy(mock_job):
+    """Legacy path uses BYOD image as image_uri."""
     jm = _make_job_manager(uses_new_sdk=False)
     jm.cluster_manager.cluster_env_build_id = "bld_legacy_123"
-    mock_create_job.return_value = APIDict(result=APIDict(id="job_legacy_456"))
+    mock_job.submit.return_value = "job_legacy_456"
 
-    jm._run_job("echo hello", {"FOO": "bar"}, upload_path="/tmp/upload")
+    jm._run_job("echo hello", {"FOO": "bar"})
 
     assert jm._job_id == "job_legacy_456"
-    mock_create_job.assert_called_once()
-    job_request = mock_create_job.call_args[0][1]
-    assert job_request.name == "test_cluster_123"
-    assert job_request.config.entrypoint == "echo hello"
-    assert job_request.config.build_id == "bld_legacy_123"
-    assert job_request.config.compute_config_id == "cc_123"
-    assert "FOO" in job_request.config.runtime_env["env_vars"]
+    mock_job.submit.assert_called_once()
+    config = mock_job.submit.call_args[0][0]
+    assert config.name == "test_cluster_123"
+    assert config.entrypoint == "echo hello"
+    # Legacy path uses the BYOD image, not the build ID
+    assert config.image_uri == "anyscale/ray:nightly-py310-cpu"
+    assert config.compute_config == "cc_123"
+    assert "FOO" in config.env_vars
 
 
 @patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
-def test_submit_job_new_sdk_failure_raises_startup_failed(mock_job):
-    """New SDK path wraps exceptions in JobStartupFailed."""
+def test_submit_job_failure_raises_startup_failed(mock_job):
+    """Job submission wraps exceptions in JobStartupFailed."""
     jm = _make_job_manager(uses_new_sdk=True)
     mock_job.submit.side_effect = RuntimeError("API error")
 
@@ -104,38 +110,16 @@ def test_submit_job_new_sdk_failure_raises_startup_failed(mock_job):
         jm._run_job("echo hello", {})
 
 
-@patch.object(DefaultApi, "create_job")
-def test_submit_job_legacy_failure_raises_startup_failed(mock_create_job):
-    """Legacy path wraps exceptions in JobStartupFailed."""
-    jm = _make_job_manager(uses_new_sdk=False)
-    mock_create_job.side_effect = RuntimeError("API error")
-
-    with pytest.raises(JobStartupFailed):
-        jm._run_job("echo hello", {})
-
-
 @patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
-def test_terminate_job_new_sdk(mock_job):
-    """New SDK path terminates via anyscale.job.terminate."""
-    jm = _make_job_manager(uses_new_sdk=True)
-    jm._job_id = "job_123"
-    jm._last_job_result = None  # No terminal state yet
-
-    jm._terminate_job()
-
-    mock_job.terminate.assert_called_once_with(id="job_123")
-
-
-@patch.object(DefaultApi, "terminate_job")
-def test_terminate_job_legacy(mock_terminate):
-    """Legacy path terminates via DefaultApi.terminate_job."""
+def test_terminate_job(mock_job):
+    """Terminate calls anyscale.job.terminate."""
     jm = _make_job_manager(uses_new_sdk=False)
-    jm._job_id = "job_456"
+    jm._job_id = "job_123"
     jm._last_job_result = None
 
     jm._terminate_job()
 
-    mock_terminate.assert_called_once()
+    mock_job.terminate.assert_called_once_with(id="job_123")
 
 
 @patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")

--- a/release/ray_release/tests/test_anyscale_job_manager.py
+++ b/release/ray_release/tests/test_anyscale_job_manager.py
@@ -1,12 +1,16 @@
 import sys
+from unittest.mock import patch
 
 import pytest
 from anyscale.job.models import JobState
+from anyscale.sdk.anyscale_client.api.default_api import DefaultApi
 
 from ray_release.anyscale_util import Anyscale
 from ray_release.cluster_manager.cluster_manager import ClusterManager
+from ray_release.exception import JobStartupFailed
 from ray_release.job_manager.anyscale_job_manager import AnyscaleJobManager
 from ray_release.test import Test
+from ray_release.tests.utils import APIDict
 
 
 class FakeJobStatus:
@@ -17,6 +21,21 @@ class FakeJobStatus:
 class FakeSDK(Anyscale):
     def project_name_by_id(self, project_id: str) -> str:
         return "fake_project_name"
+
+
+def _make_job_manager(uses_new_sdk=False):
+    fake_test = Test(
+        name="fake_test",
+        cluster={"byod": {}, "anyscale_sdk_2026": uses_new_sdk},
+    )
+    fake_sdk = FakeSDK()
+    cm = ClusterManager(test=fake_test, project_id="fake_project_id", sdk=fake_sdk)
+    cm.cluster_name = "test_cluster_123"
+    cm.cluster_env_name = "test_env"
+    cm.cluster_env_build_id = "anyscale/image/test:1"
+    cm.cluster_compute_id = "cc_123"
+    cm.smoke_test = False
+    return AnyscaleJobManager(cluster_manager=cm)
 
 
 def test_get_last_logs_long_running_job():
@@ -35,6 +54,116 @@ def test_get_last_logs_long_running_job():
     anyscale_job_manager._job_id = "foo"
     anyscale_job_manager.save_last_job_status(FakeJobStatus(state=JobState.SUCCEEDED))
     assert anyscale_job_manager.get_last_logs() is None
+
+
+@patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
+def test_submit_job_new_sdk(mock_job):
+    """New SDK path submits via anyscale.job.submit with JobConfig."""
+    jm = _make_job_manager(uses_new_sdk=True)
+    mock_job.submit.return_value = "job_new_123"
+
+    jm._run_job("echo hello", {"FOO": "bar"})
+
+    assert jm._job_id == "job_new_123"
+    mock_job.submit.assert_called_once()
+    config = mock_job.submit.call_args[0][0]
+    assert config.name == "test_cluster_123"
+    assert config.entrypoint == "echo hello"
+    assert config.image_uri == "anyscale/image/test:1"
+    assert config.compute_config == "cc_123"
+    assert config.max_retries == 0
+    assert "FOO" in config.env_vars
+
+
+@patch.object(DefaultApi, "create_job")
+def test_submit_job_legacy(mock_create_job):
+    """Legacy path submits via DefaultApi.create_job."""
+    jm = _make_job_manager(uses_new_sdk=False)
+    jm.cluster_manager.cluster_env_build_id = "bld_legacy_123"
+    mock_create_job.return_value = APIDict(result=APIDict(id="job_legacy_456"))
+
+    jm._run_job("echo hello", {"FOO": "bar"}, upload_path="/tmp/upload")
+
+    assert jm._job_id == "job_legacy_456"
+    mock_create_job.assert_called_once()
+    job_request = mock_create_job.call_args[0][1]
+    assert job_request.name == "test_cluster_123"
+    assert job_request.config.entrypoint == "echo hello"
+    assert job_request.config.build_id == "bld_legacy_123"
+    assert job_request.config.compute_config_id == "cc_123"
+    assert "FOO" in job_request.config.runtime_env["env_vars"]
+
+
+@patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
+def test_submit_job_new_sdk_failure_raises_startup_failed(mock_job):
+    """New SDK path wraps exceptions in JobStartupFailed."""
+    jm = _make_job_manager(uses_new_sdk=True)
+    mock_job.submit.side_effect = RuntimeError("API error")
+
+    with pytest.raises(JobStartupFailed):
+        jm._run_job("echo hello", {})
+
+
+@patch.object(DefaultApi, "create_job")
+def test_submit_job_legacy_failure_raises_startup_failed(mock_create_job):
+    """Legacy path wraps exceptions in JobStartupFailed."""
+    jm = _make_job_manager(uses_new_sdk=False)
+    mock_create_job.side_effect = RuntimeError("API error")
+
+    with pytest.raises(JobStartupFailed):
+        jm._run_job("echo hello", {})
+
+
+@patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
+def test_terminate_job_new_sdk(mock_job):
+    """New SDK path terminates via anyscale.job.terminate."""
+    jm = _make_job_manager(uses_new_sdk=True)
+    jm._job_id = "job_123"
+    jm._last_job_result = None  # No terminal state yet
+
+    jm._terminate_job()
+
+    mock_job.terminate.assert_called_once_with(id="job_123")
+
+
+@patch.object(DefaultApi, "terminate_job")
+def test_terminate_job_legacy(mock_terminate):
+    """Legacy path terminates via DefaultApi.terminate_job."""
+    jm = _make_job_manager(uses_new_sdk=False)
+    jm._job_id = "job_456"
+    jm._last_job_result = None
+
+    jm._terminate_job()
+
+    mock_terminate.assert_called_once()
+
+
+@patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
+def test_terminate_job_skips_when_no_job(mock_job):
+    """Terminate is a no-op when no job ID exists."""
+    jm = _make_job_manager(uses_new_sdk=True)
+    jm._job_id = None
+    jm._terminate_job()
+    mock_job.terminate.assert_not_called()
+
+
+@patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
+def test_terminate_job_skips_when_terminal(mock_job):
+    """Terminate is a no-op when job is already in terminal state."""
+    jm = _make_job_manager(uses_new_sdk=True)
+    jm._job_id = "job_123"
+    jm.save_last_job_status(FakeJobStatus(state=JobState.SUCCEEDED))
+    jm._terminate_job()
+    mock_job.terminate.assert_not_called()
+
+
+def test_uses_new_sdk():
+    """_uses_new_sdk() returns True when anyscale_sdk_2026 is set."""
+    jm_new = _make_job_manager(uses_new_sdk=True)
+    assert jm_new._uses_new_sdk() is True
+
+    jm_legacy = _make_job_manager(uses_new_sdk=False)
+    assert jm_legacy._uses_new_sdk() is False
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_anyscale_job_manager.py
+++ b/release/ray_release/tests/test_anyscale_job_manager.py
@@ -58,14 +58,14 @@ def test_get_last_logs_long_running_job():
 
 
 @patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
-def test_submit_job_new_sdk(mock_job):
-    """New SDK path uses cluster_env_build_id (image URI) as image_uri."""
-    jm = _make_job_manager(uses_new_sdk=True)
-    mock_job.submit.return_value = "job_new_123"
+def test_submit_job(mock_job):
+    """_run_job submits via anyscale.job.submit with correct JobConfig fields."""
+    jm = _make_job_manager()
+    mock_job.submit.return_value = "job_123"
 
     jm._run_job("echo hello", {"FOO": "bar"})
 
-    assert jm._job_id == "job_new_123"
+    assert jm._job_id == "job_123"
     mock_job.submit.assert_called_once()
     config = mock_job.submit.call_args[0][0]
     assert config.name == "test_cluster_123"
@@ -73,26 +73,6 @@ def test_submit_job_new_sdk(mock_job):
     assert config.image_uri == "anyscale/image/test:1"
     assert config.compute_config == "test_compute_config"
     assert config.max_retries == 0
-    assert "FOO" in config.env_vars
-
-
-@patch("ray_release.job_manager.anyscale_job_manager.anyscale.job")
-def test_submit_job_legacy(mock_job):
-    """Legacy path uses {name}:{revision} from build as image_uri."""
-    jm = _make_job_manager(uses_new_sdk=False)
-    # Both paths store "{img.name}:{img.latest_build_revision}" in cluster_env_build_id
-    jm.cluster_manager.cluster_env_build_id = "anyscale/image/test_image:3"
-    mock_job.submit.return_value = "job_legacy_456"
-
-    jm._run_job("echo hello", {"FOO": "bar"})
-
-    assert jm._job_id == "job_legacy_456"
-    mock_job.submit.assert_called_once()
-    config = mock_job.submit.call_args[0][0]
-    assert config.name == "test_cluster_123"
-    assert config.entrypoint == "echo hello"
-    assert config.image_uri == "anyscale/image/test_image:3"
-    assert config.compute_config == "test_compute_config"
     assert "FOO" in config.env_vars
 
 
@@ -135,15 +115,6 @@ def test_terminate_job_skips_when_terminal(mock_job):
     jm.save_last_job_status(FakeJobStatus(state=JobState.SUCCEEDED))
     jm._terminate_job()
     mock_job.terminate.assert_not_called()
-
-
-def test_uses_new_sdk():
-    """_uses_new_sdk() returns True when anyscale_sdk_2026 is set."""
-    jm_new = _make_job_manager(uses_new_sdk=True)
-    assert jm_new._uses_new_sdk() is True
-
-    jm_legacy = _make_job_manager(uses_new_sdk=False)
-    assert jm_legacy._uses_new_sdk() is False
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -701,6 +701,46 @@ class BuildkiteSettingsTest(unittest.TestCase):
         self.assertEqual(cpus, 16 + 32 * 4 + 24 * 8)
         self.assertEqual(gpus, 2 * 8)
 
+    def testInstanceResourcesNewSchema(self):
+        cpus, gpus = get_test_resources_from_cluster_compute(
+            {
+                "head_node": {"instance_type": "m5.4xlarge"},
+                "worker_nodes": [
+                    {
+                        "instance_type": "m5.8xlarge",
+                        "min_nodes": 1,
+                        "max_nodes": 4,
+                    },
+                    {
+                        "instance_type": "g3.8xlarge",
+                        "min_nodes": 8,
+                        "max_nodes": 8,
+                    },
+                ],
+            },
+            is_new_schema=True,
+        )
+        self.assertEqual(cpus, 16 + 32 * 4 + 32 * 8)
+        self.assertEqual(gpus, 2 * 8)
+
+    def testInstanceResourcesNewSchemaEmpty(self):
+        cpus, gpus = get_test_resources_from_cluster_compute({}, is_new_schema=True)
+        self.assertEqual(cpus, 0)
+        self.assertEqual(gpus, 0)
+
+    def testInstanceResourcesNewSchemaMissingInstanceType(self):
+        cpus, gpus = get_test_resources_from_cluster_compute(
+            {
+                "head_node": {"instance_type": "m5.4xlarge"},
+                "worker_nodes": [
+                    {"min_nodes": 4},
+                ],
+            },
+            is_new_schema=True,
+        )
+        self.assertEqual(cpus, 16)
+        self.assertEqual(gpus, 0)
+
     def testConcurrencyGroups(self):
         def _return(ret):
             def _inner(*args, **kwargs):

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -86,18 +86,29 @@ class _DelayedResponse:
 
 
 def _make_default_api_proxy(sdk):
-    """Return patchers that make DefaultApi methods delegate to MockSDK."""
+    """Return patchers that make DefaultApi methods delegate to MockSDK.
 
-    def search_proxy(self_arg, query):
-        return sdk.search_cluster_computes(query)
+    DefaultApi.method(self.sdk, ...) is used in production code to bypass
+    AnyscaleSDK deprecation overrides. These patches intercept the unbound
+    method calls and route them to the MockSDK instance.
+    """
 
-    def create_proxy(self_arg, body):
-        return sdk.create_cluster_compute(body)
+    def _proxy(method_name):
+        def proxy_fn(self_arg, *args, **kwargs):
+            return getattr(sdk, method_name)(*args, **kwargs)
 
-    return (
-        patch.object(DefaultApi, "search_cluster_computes", search_proxy),
-        patch.object(DefaultApi, "create_cluster_compute", create_proxy),
-    )
+        return proxy_fn
+
+    methods = [
+        "search_cluster_computes",
+        "create_cluster_compute",
+        "list_cluster_environment_builds",
+        "create_cluster_environment_build",
+        "get_build",
+        "search_cluster_environments",
+        "create_byod_cluster_environment",
+    ]
+    return tuple(patch.object(DefaultApi, name, _proxy(name)) for name in methods)
 
 
 class MinimalSessionManagerTest(unittest.TestCase):

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
+from ray_release.anyscale_util import create_cluster_env_from_image
 from ray_release.cluster_manager.minimal import DefaultApi, MinimalClusterManager
 from ray_release.exception import (
     ClusterComputeCreateError,
@@ -850,6 +851,210 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
         self.assertGreaterEqual(self.sdk.call_counter["get_build"], 9)
         self.assertEqual(len(self.sdk.call_counter), 2)
+
+
+class NewSdkBuildClusterEnvTest(unittest.TestCase):
+    """Tests for _build_cluster_env_new_sdk() which polls anyscale.image.get()."""
+
+    def _make_new_sdk_cm(self):
+        sdk = MockSDK()
+        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        cm = MinimalClusterManager(
+            project_id=UNIT_TEST_PROJECT_ID,
+            sdk=sdk,
+            test=MockTest(
+                {
+                    "name": "unit_test_new_sdk_build",
+                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
+                }
+            ),
+        )
+        cm.set_cluster_env()
+        cm.cluster_env_id = "env_id"
+        cm.cluster_env_build_id = None
+        return cm
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.image")
+    def testNewSdkBuildAlreadySucceeded(self, mock_image):
+        cm = self._make_new_sdk_cm()
+        mock_image.get.return_value = APIDict(
+            latest_build_id="bld_123",
+            latest_build_status="SUCCEEDED",
+            latest_image_uri="anyscale/image/test:1",
+        )
+        cm.build_cluster_env(timeout=600)
+        # Stores image URI, not build ID
+        self.assertEqual(cm.cluster_env_build_id, "anyscale/image/test:1")
+        mock_image.get.assert_called_once_with(name=cm.cluster_env_name)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.image")
+    def testNewSdkBuildAlreadyFailed(self, mock_image):
+        cm = self._make_new_sdk_cm()
+        mock_image.get.return_value = APIDict(
+            latest_build_id="bld_123",
+            latest_build_status="FAILED",
+            latest_image_uri=None,
+        )
+        with self.assertRaisesRegex(ClusterEnvBuildError, "build failed"):
+            cm.build_cluster_env(timeout=600)
+        self.assertIsNone(cm.cluster_env_build_id)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.image")
+    def testNewSdkBuildNoBuild(self, mock_image):
+        cm = self._make_new_sdk_cm()
+        mock_image.get.return_value = APIDict(
+            latest_build_id=None,
+            latest_build_status=None,
+            latest_image_uri=None,
+        )
+        with self.assertRaisesRegex(ClusterEnvBuildError, "No build found"):
+            cm.build_cluster_env(timeout=600)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.image")
+    def testNewSdkBuildInProgressThenSucceeds(self, mock_image):
+        cm = self._make_new_sdk_cm()
+        call_count = [0]
+
+        def fake_get(name=None):
+            call_count[0] += 1
+            if call_count[0] <= 3:
+                return APIDict(
+                    latest_build_id="bld_123",
+                    latest_build_status="IN_PROGRESS",
+                    latest_image_uri=None,
+                )
+            return APIDict(
+                latest_build_id="bld_123",
+                latest_build_status="SUCCEEDED",
+                latest_image_uri="anyscale/image/test:2",
+            )
+
+        mock_image.get.side_effect = fake_get
+        cm.build_cluster_env(timeout=600)
+        self.assertEqual(cm.cluster_env_build_id, "anyscale/image/test:2")
+        self.assertGreaterEqual(mock_image.get.call_count, 4)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.image")
+    def testNewSdkBuildInProgressThenFails(self, mock_image):
+        cm = self._make_new_sdk_cm()
+        call_count = [0]
+
+        def fake_get(name=None):
+            call_count[0] += 1
+            if call_count[0] <= 3:
+                return APIDict(
+                    latest_build_id="bld_123",
+                    latest_build_status="IN_PROGRESS",
+                    latest_image_uri=None,
+                )
+            return APIDict(
+                latest_build_id="bld_123",
+                latest_build_status="FAILED",
+                latest_image_uri=None,
+            )
+
+        mock_image.get.side_effect = fake_get
+        with self.assertRaisesRegex(ClusterEnvBuildError, "build failed"):
+            cm.build_cluster_env(timeout=600)
+        self.assertIsNone(cm.cluster_env_build_id)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.image")
+    def testNewSdkBuildTimeout(self, mock_image):
+        cm = self._make_new_sdk_cm()
+        mock_image.get.return_value = APIDict(
+            latest_build_id="bld_123",
+            latest_build_status="IN_PROGRESS",
+            latest_image_uri=None,
+        )
+        with self.assertRaisesRegex(ClusterEnvBuildTimeout, "Time out when building"):
+            cm.build_cluster_env(timeout=0)
+        self.assertIsNone(cm.cluster_env_build_id)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.image")
+    def testNewSdkBuildSucceededButNoImageUri(self, mock_image):
+        cm = self._make_new_sdk_cm()
+        mock_image.get.return_value = APIDict(
+            latest_build_id="bld_123",
+            latest_build_status="SUCCEEDED",
+            latest_image_uri=None,
+        )
+        with self.assertRaisesRegex(ClusterEnvBuildError, "no image URI"):
+            cm.build_cluster_env(timeout=600)
+        self.assertIsNone(cm.cluster_env_build_id)
+
+
+class NewSdkCreateClusterEnvTest(unittest.TestCase):
+    """Tests for _create_cluster_env_new_sdk() in anyscale_util."""
+
+    @patch("ray_release.anyscale_util.anyscale.image")
+    def testNewSdkFindExistingEnv(self, mock_image):
+        mock_image.list.return_value = [
+            APIDict(name="my_env", id="env_123"),
+        ]
+        result = create_cluster_env_from_image(
+            image="docker/image:tag",
+            test_name="test",
+            runtime_env={},
+            cluster_env_name="my_env",
+            use_new_sdk=True,
+        )
+        self.assertEqual(result, "env_123")
+        mock_image.list.assert_called_once_with(name="my_env")
+        mock_image.register.assert_not_called()
+
+    @patch("ray_release.anyscale_util.anyscale.image")
+    def testNewSdkCreateEnvSucceed(self, mock_image):
+        mock_image.list.return_value = []
+        mock_image.get.return_value = APIDict(id="new_env_id")
+
+        result = create_cluster_env_from_image(
+            image="docker/image:tag",
+            test_name="test",
+            runtime_env={},
+            cluster_env_name="my_env",
+            use_new_sdk=True,
+        )
+        self.assertEqual(result, "new_env_id")
+        mock_image.register.assert_called_once_with(
+            "docker/image:tag", name="my_env", ray_version="nightly"
+        )
+        mock_image.get.assert_called_once_with(name="my_env")
+
+    @patch("ray_release.anyscale_util.anyscale.image")
+    def testNewSdkCreateEnvFail(self, mock_image):
+        mock_image.list.return_value = []
+        mock_image.register.side_effect = RuntimeError("API error")
+
+        with self.assertRaises(ClusterEnvCreateError):
+            create_cluster_env_from_image(
+                image="docker/image:tag",
+                test_name="test",
+                runtime_env={},
+                cluster_env_name="my_env",
+                use_new_sdk=True,
+            )
+
+    @patch("ray_release.anyscale_util.anyscale.image")
+    def testNewSdkExistingIdSkipsList(self, mock_image):
+        """When cluster_env_id is already provided, skip listing."""
+        result = create_cluster_env_from_image(
+            image="docker/image:tag",
+            test_name="test",
+            runtime_env={},
+            cluster_env_id="existing_id",
+            cluster_env_name="my_env",
+            use_new_sdk=True,
+        )
+        self.assertEqual(result, "existing_id")
+        mock_image.list.assert_not_called()
+        mock_image.register.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -1,3 +1,4 @@
+import copy
 import sys
 import time
 import unittest
@@ -35,6 +36,20 @@ TEST_CLUSTER_COMPUTE = {
             "min_workers": 0,
             "max_workers": 0,
             "use_spot": False,
+        }
+    ],
+}
+
+TEST_CLUSTER_COMPUTE_NEW_SCHEMA = {
+    "cloud": "test_cloud",
+    "head_node": {
+        "instance_type": "m5.4xlarge",
+    },
+    "worker_nodes": [
+        {
+            "instance_type": "m5.xlarge",
+            "min_nodes": 0,
+            "max_nodes": 4,
         }
     ],
 }
@@ -301,6 +316,42 @@ class MinimalSessionManagerTest(unittest.TestCase):
             self.cluster_manager.cluster_compute["advanced_configurations_json"],
             target_cluster_compute["advanced_configurations_json"],
         )
+
+    def testClusterComputeExtraTagsNewSchema(self):
+        sdk = MockSDK()
+        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        cluster_manager = MinimalClusterManager(
+            project_id=UNIT_TEST_PROJECT_ID,
+            sdk=sdk,
+            test=MockTest(
+                {
+                    "name": "unit_test_new_schema",
+                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
+                }
+            ),
+        )
+
+        cluster_compute = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)
+        cluster_manager.set_cluster_compute(cluster_compute, extra_tags={"foo": "bar"})
+
+        top_level_aic = cluster_manager.cluster_compute["advanced_instance_config"]
+        self.assertIn("TagSpecifications", top_level_aic)
+
+        head_aic = cluster_manager.cluster_compute["head_node"][
+            "advanced_instance_config"
+        ]
+        self.assertIn("TagSpecifications", head_aic)
+
+        worker_aic = cluster_manager.cluster_compute["worker_nodes"][0][
+            "advanced_instance_config"
+        ]
+        self.assertIn("TagSpecifications", worker_aic)
+
+        for aic in [top_level_aic, head_aic, worker_aic]:
+            tag_specs = aic["TagSpecifications"]
+            instance_tags = [ts for ts in tag_specs if ts["ResourceType"] == "instance"]
+            self.assertEqual(len(instance_tags), 1)
+            self.assertIn({"Key": "foo", "Value": "bar"}, instance_tags[0]["Tags"])
 
     @patch("time.sleep", lambda *a, **kw: None)
     def testFindCreateClusterEnvExisting(self):

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -479,10 +479,10 @@ class MinimalSessionManagerTest(unittest.TestCase):
             self.assertIn({"Key": "foo", "Value": "bar"}, instance_tags[0]["Tags"])
 
 
-class NewSdkBuildClusterEnvTest(unittest.TestCase):
+class BuildClusterEnvTest(unittest.TestCase):
     """Tests for build_cluster_env() which polls anyscale.image.get()."""
 
-    def _make_new_sdk_cm(self):
+    def _make_cm(self):
         sdk = MockSDK()
         sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
         cm = MinimalClusterManager(
@@ -502,8 +502,8 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
 
     @patch("time.sleep", lambda *a, **kw: None)
     @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testNewSdkBuildAlreadySucceeded(self, mock_image):
-        cm = self._make_new_sdk_cm()
+    def testBuildAlreadySucceeded(self, mock_image):
+        cm = self._make_cm()
         mock_image.get.return_value = APIDict(
             name="test_image",
             latest_build_id="bld_123",
@@ -516,8 +516,8 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
 
     @patch("time.sleep", lambda *a, **kw: None)
     @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testNewSdkBuildAlreadyFailed(self, mock_image):
-        cm = self._make_new_sdk_cm()
+    def testBuildAlreadyFailed(self, mock_image):
+        cm = self._make_cm()
         mock_image.get.return_value = APIDict(
             latest_build_id="bld_123",
             latest_build_status="FAILED",
@@ -529,8 +529,8 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
 
     @patch("time.sleep", lambda *a, **kw: None)
     @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testNewSdkBuildNoBuild(self, mock_image):
-        cm = self._make_new_sdk_cm()
+    def testBuildNoBuild(self, mock_image):
+        cm = self._make_cm()
         mock_image.get.return_value = APIDict(
             latest_build_id=None,
             latest_build_status=None,
@@ -541,8 +541,8 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
 
     @patch("time.sleep", lambda *a, **kw: None)
     @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testNewSdkBuildInProgressThenSucceeds(self, mock_image):
-        cm = self._make_new_sdk_cm()
+    def testBuildInProgressThenSucceeds(self, mock_image):
+        cm = self._make_cm()
         call_count = [0]
 
         def fake_get(name=None):
@@ -568,8 +568,8 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
 
     @patch("time.sleep", lambda *a, **kw: None)
     @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testNewSdkBuildInProgressThenFails(self, mock_image):
-        cm = self._make_new_sdk_cm()
+    def testBuildInProgressThenFails(self, mock_image):
+        cm = self._make_cm()
         call_count = [0]
 
         def fake_get(name=None):
@@ -593,8 +593,8 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
 
     @patch("time.sleep", lambda *a, **kw: None)
     @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testNewSdkBuildTimeout(self, mock_image):
-        cm = self._make_new_sdk_cm()
+    def testBuildTimeout(self, mock_image):
+        cm = self._make_cm()
         mock_image.get.return_value = APIDict(
             latest_build_id="bld_123",
             latest_build_status="IN_PROGRESS",
@@ -605,11 +605,11 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
         self.assertIsNone(cm.cluster_env_build_id)
 
 
-class NewSdkCreateClusterEnvTest(unittest.TestCase):
-    """Tests for _create_cluster_env_new_sdk() in anyscale_util."""
+class CreateClusterEnvTest(unittest.TestCase):
+    """Tests for create_cluster_env_from_image() in anyscale_util."""
 
     @patch("ray_release.anyscale_util.anyscale.image")
-    def testNewSdkFindExistingEnv(self, mock_image):
+    def testFindExistingEnv(self, mock_image):
         mock_image.list.return_value = [
             APIDict(name="my_env", id="env_123"),
         ]
@@ -625,7 +625,7 @@ class NewSdkCreateClusterEnvTest(unittest.TestCase):
         mock_image.register.assert_not_called()
 
     @patch("ray_release.anyscale_util.anyscale.image")
-    def testNewSdkCreateEnvSucceed(self, mock_image):
+    def testCreateEnvSucceed(self, mock_image):
         mock_image.list.return_value = []
         mock_image.get.return_value = APIDict(id="new_env_id")
 
@@ -643,7 +643,7 @@ class NewSdkCreateClusterEnvTest(unittest.TestCase):
         mock_image.get.assert_called_once_with(name="my_env")
 
     @patch("ray_release.anyscale_util.anyscale.image")
-    def testNewSdkCreateEnvFail(self, mock_image):
+    def testCreateEnvFail(self, mock_image):
         mock_image.list.return_value = []
         mock_image.register.side_effect = RuntimeError("API error")
 
@@ -657,7 +657,7 @@ class NewSdkCreateClusterEnvTest(unittest.TestCase):
             )
 
     @patch("ray_release.anyscale_util.anyscale.image")
-    def testNewSdkExistingIdSkipsList(self, mock_image):
+    def testExistingIdSkipsList(self, mock_image):
         """When cluster_env_id is already provided, skip listing."""
         result = create_cluster_env_from_image(
             image="docker/image:tag",

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -5,8 +5,6 @@ import unittest
 from typing import Callable
 from unittest.mock import patch
 
-from freezegun import freeze_time
-
 from ray_release.anyscale_util import create_cluster_env_from_image
 from ray_release.cluster_manager.minimal import DefaultApi, MinimalClusterManager
 from ray_release.exception import (
@@ -480,381 +478,9 @@ class MinimalSessionManagerTest(unittest.TestCase):
             self.assertEqual(len(instance_tags), 1)
             self.assertIn({"Key": "foo", "Value": "bar"}, instance_tags[0]["Tags"])
 
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testFindCreateClusterEnvExisting(self):
-        # Find existing env and succeed
-        self.cluster_manager.set_cluster_env()
-        self.assertTrue(self.cluster_manager.cluster_env_name)
-        self.assertFalse(self.cluster_manager.cluster_env_id)
-
-        self.sdk.returns["search_cluster_environments"] = APIDict(
-            metadata=APIDict(
-                next_paging_token=None,
-            ),
-            results=[
-                APIDict(
-                    name="no_match",
-                    id="wrong",
-                ),
-                APIDict(name=self.cluster_manager.cluster_env_name, id="correct"),
-            ],
-        )
-        self.cluster_manager.create_cluster_env()
-        self.assertEqual(self.cluster_manager.cluster_env_id, "correct")
-        self.assertEqual(self.sdk.call_counter["search_cluster_environments"], 1)
-        self.assertEqual(len(self.sdk.call_counter), 1)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testFindCreateClusterEnvFailFail(self):
-        # No existing compute, create new, but fail both times
-        self.cluster_manager.set_cluster_env()
-        self.assertTrue(self.cluster_manager.cluster_env_name)
-        self.assertFalse(self.cluster_manager.cluster_env_id)
-
-        self.sdk.returns["search_cluster_environments"] = APIDict(
-            metadata=APIDict(
-                next_paging_token=None,
-            ),
-            results=[
-                APIDict(
-                    name="no_match",
-                    id="wrong",
-                ),
-            ],
-        )
-        self.sdk.returns["create_byod_cluster_environment"] = fail_always
-        with self.assertRaises(ClusterEnvCreateError):
-            self.cluster_manager.create_cluster_env()
-        # No cluster ID found or created
-        self.assertFalse(self.cluster_manager.cluster_env_id)
-        # Both APIs were called twice (retry after fail)
-        self.assertEqual(self.sdk.call_counter["search_cluster_environments"], 2)
-        self.assertEqual(self.sdk.call_counter["create_byod_cluster_environment"], 2)
-        self.assertEqual(len(self.sdk.call_counter), 2)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testFindCreateClusterEnvFailSucceed(self):
-        # No existing compute, create new, fail once, succeed afterwards
-        self.cluster_manager.set_cluster_env()
-        self.assertTrue(self.cluster_manager.cluster_env_name)
-        self.assertFalse(self.cluster_manager.cluster_env_id)
-
-        self.cluster_manager.cluster_env_id = None
-        self.sdk.reset()
-        self.sdk.returns["search_cluster_environments"] = APIDict(
-            metadata=APIDict(
-                next_paging_token=None,
-            ),
-            results=[
-                APIDict(
-                    name="no_match",
-                    id="wrong",
-                ),
-            ],
-        )
-        self.sdk.returns["create_byod_cluster_environment"] = fail_once(
-            result=APIDict(
-                result=APIDict(
-                    id="correct",
-                )
-            )
-        )
-        self.cluster_manager.create_cluster_env()
-        # Both APIs were called twice (retry after fail)
-        self.assertEqual(self.cluster_manager.cluster_env_id, "correct")
-        self.assertEqual(self.sdk.call_counter["search_cluster_environments"], 2)
-        self.assertEqual(self.sdk.call_counter["create_byod_cluster_environment"], 2)
-        self.assertEqual(len(self.sdk.call_counter), 2)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testFindCreateClusterEnvSucceed(self):
-        # No existing compute, create new, and succeed
-        self.cluster_manager.set_cluster_env()
-        self.assertTrue(self.cluster_manager.cluster_env_name)
-        self.assertFalse(self.cluster_manager.cluster_env_id)
-
-        self.sdk.returns["search_cluster_environments"] = APIDict(
-            metadata=APIDict(
-                next_paging_token=None,
-            ),
-            results=[
-                APIDict(
-                    name="no_match",
-                    id="wrong",
-                ),
-            ],
-        )
-        self.sdk.returns["create_byod_cluster_environment"] = APIDict(
-            result=APIDict(
-                id="correct",
-            )
-        )
-        self.cluster_manager.create_cluster_env()
-        # Both APIs were called twice (retry after fail)
-        self.assertEqual(self.cluster_manager.cluster_env_id, "correct")
-        self.assertEqual(self.sdk.call_counter["search_cluster_environments"], 1)
-        self.assertEqual(self.sdk.call_counter["create_byod_cluster_environment"], 1)
-        self.assertEqual(len(self.sdk.call_counter), 2)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testBuildClusterEnvNotFound(self):
-        self.cluster_manager.set_cluster_env()
-        self.cluster_manager.cluster_env_id = "correct"
-
-        # Environment build not found
-        self.sdk.returns["list_cluster_environment_builds"] = APIDict(results=[])
-        with self.assertRaisesRegex(ClusterEnvBuildError, "No build found"):
-            self.cluster_manager.build_cluster_env(timeout=600)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testBuildClusterEnvPreBuildFailed(self):
-        """Pre-build fails, but is kicked off again."""
-        self.cluster_manager.set_cluster_env()
-        self.cluster_manager.cluster_env_id = "correct"
-
-        # Build failed on first lookup
-        self.cluster_manager.cluster_env_build_id = None
-        self.sdk.reset()
-        self.sdk.returns["list_cluster_environment_builds"] = APIDict(
-            results=[
-                APIDict(
-                    id="build_failed",
-                    status="failed",
-                    created_at=0,
-                    error_message=None,
-                    config_json={},
-                )
-            ]
-        )
-        self.sdk.returns["create_cluster_environment_build"] = APIDict(
-            result=APIDict(id="new_build_id")
-        )
-        self.sdk.returns["get_build"] = APIDict(
-            result=APIDict(
-                id="build_now_succeeded",
-                status="failed",
-                created_at=0,
-                error_message=None,
-                config_json={},
-            )
-        )
-        with self.assertRaisesRegex(ClusterEnvBuildError, "Cluster env build failed"):
-            self.cluster_manager.build_cluster_env(timeout=600)
-        self.assertFalse(self.cluster_manager.cluster_env_build_id)
-        self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
-        self.assertEqual(self.sdk.call_counter["create_cluster_environment_build"], 1)
-        self.assertEqual(len(self.sdk.call_counter), 3)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testBuildClusterEnvPreBuildSucceeded(self):
-        self.cluster_manager.set_cluster_env()
-        self.cluster_manager.cluster_env_id = "correct"
-        # (Second) build succeeded
-        self.cluster_manager.cluster_env_build_id = None
-        self.sdk.reset()
-        self.sdk.returns["list_cluster_environment_builds"] = APIDict(
-            results=[
-                APIDict(
-                    id="build_failed",
-                    status="failed",
-                    created_at=0,
-                    error_message=None,
-                    config_json={},
-                ),
-                APIDict(
-                    id="build_succeeded",
-                    status="succeeded",
-                    created_at=1,
-                    error_message=None,
-                    config_json={},
-                ),
-            ]
-        )
-        self.cluster_manager.build_cluster_env(timeout=600)
-        self.assertTrue(self.cluster_manager.cluster_env_build_id)
-        self.assertEqual(self.cluster_manager.cluster_env_build_id, "build_succeeded")
-        self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
-        self.assertEqual(len(self.sdk.call_counter), 1)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testBuildClusterEnvSelectLastBuild(self):
-        self.cluster_manager.set_cluster_env()
-        self.cluster_manager.cluster_env_id = "correct"
-        # (Second) build succeeded
-        self.cluster_manager.cluster_env_build_id = None
-        self.sdk.reset()
-        self.sdk.returns["list_cluster_environment_builds"] = APIDict(
-            results=[
-                APIDict(
-                    id="build_succeeded",
-                    status="succeeded",
-                    created_at=0,
-                    error_message=None,
-                    config_json={},
-                ),
-                APIDict(
-                    id="build_succeeded_2",
-                    status="succeeded",
-                    created_at=1,
-                    error_message=None,
-                    config_json={},
-                ),
-            ]
-        )
-        self.cluster_manager.build_cluster_env(timeout=600)
-        self.assertTrue(self.cluster_manager.cluster_env_build_id)
-        self.assertEqual(self.cluster_manager.cluster_env_build_id, "build_succeeded_2")
-        self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
-        self.assertEqual(len(self.sdk.call_counter), 1)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testBuildClusterBuildFails(self):
-        self.cluster_manager.set_cluster_env()
-        self.cluster_manager.cluster_env_id = "correct"
-
-        # Build, but fails after 300 seconds
-        self.cluster_manager.cluster_env_build_id = None
-        self.sdk.reset()
-        self.sdk.returns["list_cluster_environment_builds"] = APIDict(
-            results=[
-                APIDict(
-                    id="build_failed",
-                    status="failed",
-                    created_at=0,
-                    error_message=None,
-                    config_json={},
-                ),
-                APIDict(
-                    id="build_succeeded",
-                    status="pending",
-                    created_at=1,
-                    error_message=None,
-                    config_json={},
-                ),
-            ]
-        )
-        with freeze_time() as frozen_time, self.assertRaisesRegex(
-            ClusterEnvBuildError, "Cluster env build failed"
-        ):
-            self.sdk.returns["get_build"] = _DelayedResponse(
-                lambda: frozen_time.tick(delta=10),
-                finish_after=300,
-                before=APIDict(
-                    result=APIDict(
-                        status="in_progress", error_message=None, config_json={}
-                    )
-                ),
-                after=APIDict(
-                    result=APIDict(status="failed", error_message=None, config_json={})
-                ),
-            )
-            self.cluster_manager.build_cluster_env(timeout=600)
-
-        self.assertFalse(self.cluster_manager.cluster_env_build_id)
-        self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
-        self.assertGreaterEqual(self.sdk.call_counter["get_build"], 9)
-        self.assertEqual(len(self.sdk.call_counter), 2)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testBuildClusterEnvBuildTimeout(self):
-        self.cluster_manager.set_cluster_env()
-        self.cluster_manager.cluster_env_id = "correct"
-
-        # Build, but timeout after 100 seconds
-        self.cluster_manager.cluster_env_build_id = None
-        self.sdk.reset()
-        self.sdk.returns["list_cluster_environment_builds"] = APIDict(
-            results=[
-                APIDict(
-                    id="build_failed",
-                    status="failed",
-                    created_at=0,
-                    error_message=None,
-                    config_json={},
-                ),
-                APIDict(
-                    id="build_succeeded",
-                    status="pending",
-                    created_at=1,
-                    error_message=None,
-                    config_json={},
-                ),
-            ]
-        )
-        with freeze_time() as frozen_time, self.assertRaisesRegex(
-            ClusterEnvBuildTimeout, "Time out when building cluster env"
-        ):
-            self.sdk.returns["get_build"] = _DelayedResponse(
-                lambda: frozen_time.tick(delta=10),
-                finish_after=300,
-                before=APIDict(
-                    result=APIDict(
-                        status="in_progress", error_message=None, config_json={}
-                    )
-                ),
-                after=APIDict(
-                    result=APIDict(
-                        status="succeeded", error_message=None, config_json={}
-                    )
-                ),
-            )
-            self.cluster_manager.build_cluster_env(timeout=100)
-
-        self.assertFalse(self.cluster_manager.cluster_env_build_id)
-        self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
-        self.assertGreaterEqual(self.sdk.call_counter["get_build"], 9)
-        self.assertEqual(len(self.sdk.call_counter), 2)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    def testBuildClusterBuildSucceed(self):
-        self.cluster_manager.set_cluster_env()
-        self.cluster_manager.cluster_env_id = "correct"
-        # Build, succeed after 300 seconds
-        self.cluster_manager.cluster_env_build_id = None
-        self.sdk.reset()
-        self.sdk.returns["list_cluster_environment_builds"] = APIDict(
-            results=[
-                APIDict(
-                    id="build_failed",
-                    status="failed",
-                    created_at=0,
-                    error_message=None,
-                    config_json={},
-                ),
-                APIDict(
-                    id="build_succeeded",
-                    status="pending",
-                    created_at=1,
-                    error_message=None,
-                    config_json={},
-                ),
-            ]
-        )
-        with freeze_time() as frozen_time:
-            self.sdk.returns["get_build"] = _DelayedResponse(
-                lambda: frozen_time.tick(delta=10),
-                finish_after=300,
-                before=APIDict(
-                    result=APIDict(
-                        status="in_progress", error_message=None, config_json={}
-                    )
-                ),
-                after=APIDict(
-                    result=APIDict(
-                        status="succeeded", error_message=None, config_json={}
-                    )
-                ),
-            )
-            self.cluster_manager.build_cluster_env(timeout=600)
-
-        self.assertTrue(self.cluster_manager.cluster_env_build_id)
-        self.assertEqual(self.sdk.call_counter["list_cluster_environment_builds"], 1)
-        self.assertGreaterEqual(self.sdk.call_counter["get_build"], 9)
-        self.assertEqual(len(self.sdk.call_counter), 2)
-
 
 class NewSdkBuildClusterEnvTest(unittest.TestCase):
-    """Tests for _build_cluster_env_new_sdk() which polls anyscale.image.get()."""
+    """Tests for build_cluster_env() which polls anyscale.image.get()."""
 
     def _make_new_sdk_cm(self):
         sdk = MockSDK()
@@ -879,13 +505,13 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
     def testNewSdkBuildAlreadySucceeded(self, mock_image):
         cm = self._make_new_sdk_cm()
         mock_image.get.return_value = APIDict(
+            name="test_image",
             latest_build_id="bld_123",
+            latest_build_revision=3,
             latest_build_status="SUCCEEDED",
-            latest_image_uri="anyscale/image/test:1",
         )
         cm.build_cluster_env(timeout=600)
-        # Stores image URI, not build ID
-        self.assertEqual(cm.cluster_env_build_id, "anyscale/image/test:1")
+        self.assertEqual(cm.cluster_env_build_id, "anyscale/image/test_image:3")
         mock_image.get.assert_called_once_with(name=cm.cluster_env_name)
 
     @patch("time.sleep", lambda *a, **kw: None)
@@ -923,19 +549,21 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
             call_count[0] += 1
             if call_count[0] <= 3:
                 return APIDict(
+                    name="test_image",
                     latest_build_id="bld_123",
+                    latest_build_revision=5,
                     latest_build_status="IN_PROGRESS",
-                    latest_image_uri=None,
                 )
             return APIDict(
+                name="test_image",
                 latest_build_id="bld_123",
+                latest_build_revision=5,
                 latest_build_status="SUCCEEDED",
-                latest_image_uri="anyscale/image/test:2",
             )
 
         mock_image.get.side_effect = fake_get
         cm.build_cluster_env(timeout=600)
-        self.assertEqual(cm.cluster_env_build_id, "anyscale/image/test:2")
+        self.assertEqual(cm.cluster_env_build_id, "anyscale/image/test_image:5")
         self.assertGreaterEqual(mock_image.get.call_count, 4)
 
     @patch("time.sleep", lambda *a, **kw: None)
@@ -974,19 +602,6 @@ class NewSdkBuildClusterEnvTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(ClusterEnvBuildTimeout, "Time out when building"):
             cm.build_cluster_env(timeout=0)
-        self.assertIsNone(cm.cluster_env_build_id)
-
-    @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testNewSdkBuildSucceededButNoImageUri(self, mock_image):
-        cm = self._make_new_sdk_cm()
-        mock_image.get.return_value = APIDict(
-            latest_build_id="bld_123",
-            latest_build_status="SUCCEEDED",
-            latest_image_uri=None,
-        )
-        with self.assertRaisesRegex(ClusterEnvBuildError, "no image URI"):
-            cm.build_cluster_env(timeout=600)
         self.assertIsNone(cm.cluster_env_build_id)
 
 

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from freezegun import freeze_time
 
-from ray_release.cluster_manager.minimal import MinimalClusterManager
+from ray_release.cluster_manager.minimal import DefaultApi, MinimalClusterManager
 from ray_release.exception import (
     ClusterComputeCreateError,
     ClusterEnvBuildError,
@@ -85,6 +85,21 @@ class _DelayedResponse:
             return self.before
 
 
+def _make_default_api_proxy(sdk):
+    """Return patchers that make DefaultApi methods delegate to MockSDK."""
+
+    def search_proxy(self_arg, query):
+        return sdk.search_cluster_computes(query)
+
+    def create_proxy(self_arg, body):
+        return sdk.create_cluster_compute(body)
+
+    return (
+        patch.object(DefaultApi, "search_cluster_computes", search_proxy),
+        patch.object(DefaultApi, "create_cluster_compute", create_proxy),
+    )
+
+
 class MinimalSessionManagerTest(unittest.TestCase):
     def setUp(self) -> None:
         self.sdk = MockSDK()
@@ -105,6 +120,15 @@ class MinimalSessionManagerTest(unittest.TestCase):
             ),
         )
         self.sdk.reset()
+
+        # Patch DefaultApi methods to delegate to MockSDK
+        self._api_patchers = _make_default_api_proxy(self.sdk)
+        for p in self._api_patchers:
+            p.start()
+
+    def tearDown(self) -> None:
+        for p in self._api_patchers:
+            p.stop()
 
     def testClusterName(self):
         sdk = MockSDK()
@@ -259,6 +283,97 @@ class MinimalSessionManagerTest(unittest.TestCase):
             self.cluster_manager.cluster_compute["maximum_uptime_minutes"],
             self.cluster_manager.maximum_uptime_minutes,
         )
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.compute_config")
+    def testNewSdkFindExisting(self, mock_cc):
+        """New SDK path: find existing compute config."""
+        sdk = MockSDK()
+        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        cm = MinimalClusterManager(
+            project_id=UNIT_TEST_PROJECT_ID,
+            sdk=sdk,
+            test=MockTest(
+                {
+                    "name": "unit_test_new_sdk",
+                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
+                }
+            ),
+        )
+        cm.set_cluster_compute(copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA))
+
+        mock_cc.list.return_value = APIDict(
+            results=[
+                APIDict(name=cm.cluster_compute_name + ":1", id="existing_id"),
+            ]
+        )
+        cm.create_cluster_compute()
+        self.assertEqual(cm.cluster_compute_id, "existing_id")
+        mock_cc.list.assert_called_once_with(name=cm.cluster_compute_name)
+        mock_cc.create.assert_not_called()
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.compute_config")
+    def testNewSdkCreateSucceed(self, mock_cc):
+        """New SDK path: no existing, create succeeds."""
+        sdk = MockSDK()
+        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        cm = MinimalClusterManager(
+            project_id=UNIT_TEST_PROJECT_ID,
+            sdk=sdk,
+            test=MockTest(
+                {
+                    "name": "unit_test_new_sdk",
+                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
+                }
+            ),
+        )
+        cm.set_cluster_compute(copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA))
+
+        mock_cc.list.return_value = APIDict(results=[])
+        mock_cc.create.return_value = cm.cluster_compute_name + ":1"
+        mock_cc.get.return_value = APIDict(id="new_id")
+
+        cm.create_cluster_compute()
+        self.assertEqual(cm.cluster_compute_id, "new_id")
+        mock_cc.create.assert_called_once()
+        mock_cc.get.assert_called_once_with(cm.cluster_compute_name + ":1")
+
+        # Verify that COMPUTE_CONFIG_FIELDS filtering works: set_cluster_compute
+        # adds idle_termination_minutes/maximum_uptime_minutes to the dict, but
+        # these must be excluded before passing to ComputeConfig (a frozen
+        # dataclass that rejects unknown kwargs). The fact that create_cluster_compute
+        # succeeded without TypeError proves filtering is working.
+        self.assertIn("idle_termination_minutes", cm.cluster_compute)
+        self.assertIn("maximum_uptime_minutes", cm.cluster_compute)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    @patch("ray_release.cluster_manager.minimal.anyscale.compute_config")
+    def testNewSdkCreateFailFail(self, mock_cc):
+        """New SDK path: create fails both times."""
+        sdk = MockSDK()
+        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        cm = MinimalClusterManager(
+            project_id=UNIT_TEST_PROJECT_ID,
+            sdk=sdk,
+            test=MockTest(
+                {
+                    "name": "unit_test_new_sdk",
+                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
+                }
+            ),
+        )
+        cm.set_cluster_compute(copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA))
+
+        mock_cc.list.return_value = APIDict(results=[])
+        mock_cc.create.side_effect = RuntimeError("API error")
+
+        with self.assertRaises(ClusterComputeCreateError):
+            cm.create_cluster_compute()
+        self.assertIsNone(cm.cluster_compute_id)
+        # Both list and create are called twice (retry after fail)
+        self.assertEqual(mock_cc.list.call_count, 2)
+        self.assertEqual(mock_cc.create.call_count, 2)
 
     def testClusterComputeExtraTags(self):
         self.cluster_manager.set_cluster_compute(self.cluster_compute)

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -3,9 +3,9 @@ import sys
 import time
 import unittest
 from typing import Callable
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from ray_release.anyscale_util import create_cluster_env_from_image
+from ray_release.anyscale_util import Anyscale, create_cluster_env_from_image
 from ray_release.cluster_manager.minimal import DefaultApi, MinimalClusterManager
 from ray_release.exception import (
     ClusterComputeCreateError,
@@ -56,6 +56,13 @@ TEST_CLUSTER_COMPUTE_NEW_SCHEMA = {
 
 def _fail(*args, **kwargs):
     raise RuntimeError()
+
+
+class FakeAnyscale(Anyscale):
+    """Test fake that avoids credential lookup."""
+
+    def project_name_by_id(self, project_id: str) -> str:
+        return "release_unit_tests"
 
 
 class MockTest(Test):
@@ -113,9 +120,7 @@ def _make_default_api_proxy(sdk):
 class MinimalSessionManagerTest(unittest.TestCase):
     def setUp(self) -> None:
         self.sdk = MockSDK()
-        self.sdk.returns["get_project"] = APIDict(
-            result=APIDict(name="release_unit_tests")
-        )
+        self.sdk.returns["project_name_by_id"] = "release_unit_tests"
 
         self.cluster_compute = TEST_CLUSTER_COMPUTE
 
@@ -142,7 +147,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
 
     def testClusterName(self):
         sdk = MockSDK()
-        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        sdk.returns["project_name_by_id"] = "release_unit_tests"
         cluster_manager = MinimalClusterManager(
             test=MockTest({"name": "test"}),
             project_id=UNIT_TEST_PROJECT_ID,
@@ -160,7 +165,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
 
     def testSetClusterEnv(self):
         sdk = MockSDK()
-        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        sdk.returns["project_name_by_id"] = "release_unit_tests"
         cluster_manager = MinimalClusterManager(
             test=MockTest({"name": "test", "cluster": {"byod": {}}}),
             project_id=UNIT_TEST_PROJECT_ID,
@@ -192,7 +197,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.cluster_manager.create_cluster_compute()
         self.assertEqual(self.cluster_manager.cluster_compute_id, "correct")
         self.assertEqual(self.sdk.call_counter["search_cluster_computes"], 1)
-        self.assertEqual(len(self.sdk.call_counter), 1)
+        self.assertEqual(len(self.sdk.call_counter), 2)  # +legacy_sdk access
 
     @patch("time.sleep", lambda *a, **kw: None)
     def testFindCreateClusterComputeCreateFailFail(self):
@@ -220,7 +225,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
         # Both APIs were called twice (retry after fail)
         self.assertEqual(self.sdk.call_counter["search_cluster_computes"], 2)
         self.assertEqual(self.sdk.call_counter["create_cluster_compute"], 2)
-        self.assertEqual(len(self.sdk.call_counter), 2)
+        self.assertEqual(len(self.sdk.call_counter), 3)  # +legacy_sdk access
 
     @patch("time.sleep", lambda *a, **kw: None)
     def testFindCreateClusterComputeCreateFailSucceed(self):
@@ -252,7 +257,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.assertEqual(self.cluster_manager.cluster_compute_id, "correct")
         self.assertEqual(self.sdk.call_counter["search_cluster_computes"], 2)
         self.assertEqual(self.sdk.call_counter["create_cluster_compute"], 2)
-        self.assertEqual(len(self.sdk.call_counter), 2)
+        self.assertEqual(len(self.sdk.call_counter), 3)  # +legacy_sdk access
 
     @patch("time.sleep", lambda *a, **kw: None)
     def testFindCreateClusterComputeCreateSucceed(self):
@@ -282,7 +287,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.assertEqual(self.cluster_manager.cluster_compute_id, "correct")
         self.assertEqual(self.sdk.call_counter["search_cluster_computes"], 1)
         self.assertEqual(self.sdk.call_counter["create_cluster_compute"], 1)
-        self.assertEqual(len(self.sdk.call_counter), 2)
+        self.assertEqual(len(self.sdk.call_counter), 3)  # +legacy_sdk access
 
         # Test automatic fields
         self.assertEqual(
@@ -294,12 +299,10 @@ class MinimalSessionManagerTest(unittest.TestCase):
             self.cluster_manager.maximum_uptime_minutes,
         )
 
-    @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.compute_config")
-    def testNewSdkFindExisting(self, mock_cc):
-        """New SDK path: find existing compute config."""
-        sdk = MockSDK()
-        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+    def _make_new_sdk_cm(self):
+        sdk = FakeAnyscale()
+        mock_cc = MagicMock()
+        sdk._anyscale_pkg = MagicMock(compute_config=mock_cc)
         cm = MinimalClusterManager(
             project_id=UNIT_TEST_PROJECT_ID,
             sdk=sdk,
@@ -310,6 +313,12 @@ class MinimalSessionManagerTest(unittest.TestCase):
                 }
             ),
         )
+        return cm, mock_cc
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    def testNewSdkFindExisting(self):
+        """New SDK path: find existing compute config."""
+        cm, mock_cc = self._make_new_sdk_cm()
         cm.set_cluster_compute(copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA))
 
         mock_cc.list.return_value = APIDict(
@@ -323,21 +332,9 @@ class MinimalSessionManagerTest(unittest.TestCase):
         mock_cc.create.assert_not_called()
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.compute_config")
-    def testNewSdkCreateSucceed(self, mock_cc):
+    def testNewSdkCreateSucceed(self):
         """New SDK path: no existing, create succeeds."""
-        sdk = MockSDK()
-        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
-        cm = MinimalClusterManager(
-            project_id=UNIT_TEST_PROJECT_ID,
-            sdk=sdk,
-            test=MockTest(
-                {
-                    "name": "unit_test_new_sdk",
-                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
-                }
-            ),
-        )
+        cm, mock_cc = self._make_new_sdk_cm()
         cm.set_cluster_compute(copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA))
 
         mock_cc.list.return_value = APIDict(results=[])
@@ -358,21 +355,9 @@ class MinimalSessionManagerTest(unittest.TestCase):
         self.assertIn("maximum_uptime_minutes", cm.cluster_compute)
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.compute_config")
-    def testNewSdkCreateFailFail(self, mock_cc):
+    def testNewSdkCreateFailFail(self):
         """New SDK path: create fails both times."""
-        sdk = MockSDK()
-        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
-        cm = MinimalClusterManager(
-            project_id=UNIT_TEST_PROJECT_ID,
-            sdk=sdk,
-            test=MockTest(
-                {
-                    "name": "unit_test_new_sdk",
-                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
-                }
-            ),
-        )
+        cm, mock_cc = self._make_new_sdk_cm()
         cm.set_cluster_compute(copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA))
 
         mock_cc.list.return_value = APIDict(results=[])
@@ -444,7 +429,7 @@ class MinimalSessionManagerTest(unittest.TestCase):
 
     def testClusterComputeExtraTagsNewSchema(self):
         sdk = MockSDK()
-        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        sdk.returns["project_name_by_id"] = "release_unit_tests"
         cluster_manager = MinimalClusterManager(
             project_id=UNIT_TEST_PROJECT_ID,
             sdk=sdk,
@@ -480,11 +465,10 @@ class MinimalSessionManagerTest(unittest.TestCase):
 
 
 class BuildClusterEnvTest(unittest.TestCase):
-    """Tests for build_cluster_env() which polls anyscale.image.get()."""
+    """Tests for build_cluster_env() which polls sdk.image.get()."""
 
     def _make_cm(self):
-        sdk = MockSDK()
-        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        sdk = FakeAnyscale()
         cm = MinimalClusterManager(
             project_id=UNIT_TEST_PROJECT_ID,
             sdk=sdk,
@@ -501,9 +485,10 @@ class BuildClusterEnvTest(unittest.TestCase):
         return cm
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testBuildAlreadySucceeded(self, mock_image):
+    def testBuildAlreadySucceeded(self):
         cm = self._make_cm()
+        mock_image = MagicMock()
+        cm.sdk._anyscale_pkg = MagicMock(image=mock_image)
         mock_image.get.return_value = APIDict(
             name="test_image",
             latest_build_id="bld_123",
@@ -515,9 +500,25 @@ class BuildClusterEnvTest(unittest.TestCase):
         mock_image.get.assert_called_once_with(name=cm.cluster_env_name)
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testBuildAlreadyFailed(self, mock_image):
+    def testBuildSucceededButNoRevision(self):
         cm = self._make_cm()
+        mock_image = MagicMock()
+        cm.sdk._anyscale_pkg = MagicMock(image=mock_image)
+        mock_image.get.return_value = APIDict(
+            name="test_image",
+            latest_build_id="bld_123",
+            latest_build_revision=None,
+            latest_build_status="SUCCEEDED",
+        )
+        with self.assertRaisesRegex(ClusterEnvBuildError, "revision is missing"):
+            cm.build_cluster_env(timeout=600)
+        self.assertIsNone(cm.cluster_env_build_id)
+
+    @patch("time.sleep", lambda *a, **kw: None)
+    def testBuildAlreadyFailed(self):
+        cm = self._make_cm()
+        mock_image = MagicMock()
+        cm.sdk._anyscale_pkg = MagicMock(image=mock_image)
         mock_image.get.return_value = APIDict(
             latest_build_id="bld_123",
             latest_build_status="FAILED",
@@ -528,9 +529,10 @@ class BuildClusterEnvTest(unittest.TestCase):
         self.assertIsNone(cm.cluster_env_build_id)
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testBuildNoBuild(self, mock_image):
+    def testBuildNoBuild(self):
         cm = self._make_cm()
+        mock_image = MagicMock()
+        cm.sdk._anyscale_pkg = MagicMock(image=mock_image)
         mock_image.get.return_value = APIDict(
             latest_build_id=None,
             latest_build_status=None,
@@ -540,9 +542,10 @@ class BuildClusterEnvTest(unittest.TestCase):
             cm.build_cluster_env(timeout=600)
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testBuildInProgressThenSucceeds(self, mock_image):
+    def testBuildInProgressThenSucceeds(self):
         cm = self._make_cm()
+        mock_image = MagicMock()
+        cm.sdk._anyscale_pkg = MagicMock(image=mock_image)
         call_count = [0]
 
         def fake_get(name=None):
@@ -567,9 +570,10 @@ class BuildClusterEnvTest(unittest.TestCase):
         self.assertGreaterEqual(mock_image.get.call_count, 4)
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testBuildInProgressThenFails(self, mock_image):
+    def testBuildInProgressThenFails(self):
         cm = self._make_cm()
+        mock_image = MagicMock()
+        cm.sdk._anyscale_pkg = MagicMock(image=mock_image)
         call_count = [0]
 
         def fake_get(name=None):
@@ -592,9 +596,10 @@ class BuildClusterEnvTest(unittest.TestCase):
         self.assertIsNone(cm.cluster_env_build_id)
 
     @patch("time.sleep", lambda *a, **kw: None)
-    @patch("ray_release.cluster_manager.minimal.anyscale.image")
-    def testBuildTimeout(self, mock_image):
+    def testBuildTimeout(self):
         cm = self._make_cm()
+        mock_image = MagicMock()
+        cm.sdk._anyscale_pkg = MagicMock(image=mock_image)
         mock_image.get.return_value = APIDict(
             latest_build_id="bld_123",
             latest_build_status="IN_PROGRESS",
@@ -608,33 +613,37 @@ class BuildClusterEnvTest(unittest.TestCase):
 class CreateClusterEnvTest(unittest.TestCase):
     """Tests for create_cluster_env_from_image() in anyscale_util."""
 
-    @patch("ray_release.anyscale_util.anyscale.image")
-    def testFindExistingEnv(self, mock_image):
+    def _make_sdk(self):
+        sdk = FakeAnyscale()
+        mock_image = MagicMock()
+        sdk._anyscale_pkg = MagicMock(image=mock_image)
+        return sdk, mock_image
+
+    def testFindExistingEnv(self):
+        sdk, mock_image = self._make_sdk()
         mock_image.list.return_value = [
             APIDict(name="my_env", id="env_123"),
         ]
         result = create_cluster_env_from_image(
             image="docker/image:tag",
             test_name="test",
-            runtime_env={},
             cluster_env_name="my_env",
-            use_new_sdk=True,
+            sdk=sdk,
         )
         self.assertEqual(result, "env_123")
         mock_image.list.assert_called_once_with(name="my_env")
         mock_image.register.assert_not_called()
 
-    @patch("ray_release.anyscale_util.anyscale.image")
-    def testCreateEnvSucceed(self, mock_image):
+    def testCreateEnvSucceed(self):
+        sdk, mock_image = self._make_sdk()
         mock_image.list.return_value = []
         mock_image.get.return_value = APIDict(id="new_env_id")
 
         result = create_cluster_env_from_image(
             image="docker/image:tag",
             test_name="test",
-            runtime_env={},
             cluster_env_name="my_env",
-            use_new_sdk=True,
+            sdk=sdk,
         )
         self.assertEqual(result, "new_env_id")
         mock_image.register.assert_called_once_with(
@@ -642,8 +651,8 @@ class CreateClusterEnvTest(unittest.TestCase):
         )
         mock_image.get.assert_called_once_with(name="my_env")
 
-    @patch("ray_release.anyscale_util.anyscale.image")
-    def testCreateEnvFail(self, mock_image):
+    def testCreateEnvFail(self):
+        sdk, mock_image = self._make_sdk()
         mock_image.list.return_value = []
         mock_image.register.side_effect = RuntimeError("API error")
 
@@ -651,21 +660,19 @@ class CreateClusterEnvTest(unittest.TestCase):
             create_cluster_env_from_image(
                 image="docker/image:tag",
                 test_name="test",
-                runtime_env={},
                 cluster_env_name="my_env",
-                use_new_sdk=True,
+                sdk=sdk,
             )
 
-    @patch("ray_release.anyscale_util.anyscale.image")
-    def testExistingIdSkipsList(self, mock_image):
+    def testExistingIdSkipsList(self):
         """When cluster_env_id is already provided, skip listing."""
+        sdk, mock_image = self._make_sdk()
         result = create_cluster_env_from_image(
             image="docker/image:tag",
             test_name="test",
-            runtime_env={},
             cluster_env_id="existing_id",
             cluster_env_name="my_env",
-            use_new_sdk=True,
+            sdk=sdk,
         )
         self.assertEqual(result, "existing_id")
         mock_image.list.assert_not_called()

--- a/release/ray_release/tests/test_config.py
+++ b/release/ray_release/tests/test_config.py
@@ -5,7 +5,9 @@ import pytest
 import yaml
 
 from ray_release.config import (
+    CLOUD_ID_TO_NAME,
     _substitute_variable,
+    get_test_cloud_name,
     load_schema_file,
     parse_test_definition,
     read_and_validate_release_test_collection,
@@ -422,6 +424,144 @@ def test_compute_config_invalid_ebs():
     ][0]["Ebs"]["DeleteOnTermination"] = True
 
     assert not validate_cluster_compute(compute_config)
+
+
+def test_validate_cluster_compute_new_schema_valid():
+    assert not validate_cluster_compute({}, is_new_schema=True)
+
+
+def test_validate_cluster_compute_new_schema_valid_with_fields():
+    compute_config = {
+        "cloud": "my_cloud",
+        "head_node": {"instance_type": "m5.4xlarge"},
+        "worker_nodes": [{"instance_type": "m5.xlarge", "min_nodes": 1}],
+    }
+    assert not validate_cluster_compute(compute_config, is_new_schema=True)
+
+
+def test_validate_cluster_compute_new_schema_rejects_legacy_keys():
+    compute_config = {
+        "cloud_id": "cld_123",
+        "head_node_type": {"instance_type": "m5.4xlarge"},
+    }
+    error = validate_cluster_compute(compute_config, is_new_schema=True)
+    assert error is not None
+    assert "legacy schema keys" in error
+    assert "anyscale_sdk_2026=true" in error
+
+
+def test_validate_cluster_compute_legacy_rejects_new_keys():
+    compute_config = {
+        "cloud_id": "cld_123",
+        "head_node": {"instance_type": "m5.4xlarge"},
+    }
+    error = validate_cluster_compute(compute_config, is_new_schema=False)
+    assert error is not None
+    assert "new schema keys" in error
+    assert "anyscale_sdk_2026=false" in error
+
+
+def test_validate_cluster_compute_legacy_rejects_empty():
+    error = validate_cluster_compute({}, is_new_schema=False)
+    assert error is not None
+    assert "does not have legacy schema keys" in error
+
+
+def test_validate_cluster_compute_new_schema_ebs_top_level():
+    compute_config = {
+        "advanced_instance_config": {
+            "BlockDeviceMappings": [
+                {
+                    "DeviceName": "/dev/sda1",
+                    "Ebs": {"VolumeSize": 1000},
+                }
+            ]
+        },
+    }
+    assert validate_cluster_compute(compute_config, is_new_schema=True)
+
+    compute_config["advanced_instance_config"]["BlockDeviceMappings"][0]["Ebs"][
+        "DeleteOnTermination"
+    ] = True
+    assert not validate_cluster_compute(compute_config, is_new_schema=True)
+
+
+def test_validate_cluster_compute_new_schema_ebs_head_node():
+    compute_config = {
+        "head_node": {
+            "instance_type": "m5.4xlarge",
+            "advanced_instance_config": {
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {"VolumeSize": 1000},
+                    }
+                ]
+            },
+        },
+    }
+    assert validate_cluster_compute(compute_config, is_new_schema=True)
+
+    compute_config["head_node"]["advanced_instance_config"]["BlockDeviceMappings"][0][
+        "Ebs"
+    ]["DeleteOnTermination"] = True
+    assert not validate_cluster_compute(compute_config, is_new_schema=True)
+
+
+def test_validate_cluster_compute_new_schema_ebs_worker_nodes():
+    compute_config = {
+        "worker_nodes": [
+            {
+                "instance_type": "m5.xlarge",
+                "advanced_instance_config": {
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/sda1",
+                            "Ebs": {"VolumeSize": 500},
+                        }
+                    ]
+                },
+            }
+        ],
+    }
+    assert validate_cluster_compute(compute_config, is_new_schema=True)
+
+    compute_config["worker_nodes"][0]["advanced_instance_config"][
+        "BlockDeviceMappings"
+    ][0]["Ebs"]["DeleteOnTermination"] = True
+    assert not validate_cluster_compute(compute_config, is_new_schema=True)
+
+
+def test_get_test_cloud_name_from_cluster_cloud():
+    test = Test(
+        {
+            "name": "test",
+            "cluster": {"cluster_compute": "tpl.yaml", "cloud": "my_cloud"},
+        }
+    )
+    assert get_test_cloud_name(test) == "my_cloud"
+
+
+def test_get_test_cloud_name_from_cloud_id_mapping():
+    for cloud_id, expected_name in CLOUD_ID_TO_NAME.items():
+        test = Test(
+            {
+                "name": "test",
+                "cluster": {"cluster_compute": "tpl.yaml", "cloud_id": cloud_id},
+            }
+        )
+        assert get_test_cloud_name(test) == expected_name
+
+
+def test_get_test_cloud_name_unknown_cloud_id():
+    test = Test(
+        {
+            "name": "test",
+            "cluster": {"cluster_compute": "tpl.yaml", "cloud_id": "cld_unknown"},
+        }
+    )
+    with pytest.raises(KeyError):
+        get_test_cloud_name(test)
 
 
 def test_load_and_validate_test_collection_file():

--- a/release/ray_release/tests/test_glue.py
+++ b/release/ray_release/tests/test_glue.py
@@ -77,9 +77,7 @@ class GlueTest(unittest.TestCase):
         self.tempdir = tempfile.mkdtemp()
         self.sdk = MockSDK()
 
-        self.sdk.returns["get_project"] = APIDict(
-            result=APIDict(name="unit_test_project")
-        )
+        self.sdk.returns["project_name_by_id"] = "unit_test_project"
         self.sdk.returns["get_cloud"] = APIDict(result=APIDict(provider="AWS"))
 
         self.writeClusterEnv("{'env': true}")
@@ -143,14 +141,12 @@ class GlueTest(unittest.TestCase):
                 cluster_manager: ClusterManager,
                 file_manager: JobFileManager,
                 working_dir,
-                sdk=None,
                 artifact_path: Optional[str] = None,
             ):
                 super(MockCommandRunner, self).__init__(
                     cluster_manager,
                     FakeFileManager(cluster_manager),
                     this_tempdir,
-                    sdk=this_sdk,
                     artifact_path=artifact_path,
                 )
                 self.return_dict = this_command_runner_return
@@ -268,7 +264,7 @@ class GlueTest(unittest.TestCase):
                 test=self.test,
                 anyscale_project=self.anyscale_project,
                 result=result,
-                **kwargs
+                **kwargs,
             )
 
     def testInvalidClusterCompute(self):

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -641,5 +641,16 @@ def test_get_byod_image_tag_with_runtime_env_and_script(mock_get_byod_base_image
     assert dict_hash(custom_info) != dict_hash(custom_info_no_env)
 
 
+def test_uses_anyscale_sdk_2026():
+    assert not Test({"name": "t", "cluster": {}}).uses_anyscale_sdk_2026()
+    assert not Test({"name": "t"}).uses_anyscale_sdk_2026()
+    assert Test(
+        {"name": "t", "cluster": {"anyscale_sdk_2026": True}}
+    ).uses_anyscale_sdk_2026()
+    assert not Test(
+        {"name": "t", "cluster": {"anyscale_sdk_2026": False}}
+    ).uses_anyscale_sdk_2026()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/util.py
+++ b/release/ray_release/util.py
@@ -4,15 +4,12 @@ import json
 import os
 import subprocess
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
 from ray_release.configs.global_config import get_global_config
 from ray_release.logger import logger
-
-if TYPE_CHECKING:
-    from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
 
 
 class DeferredEnvVar:
@@ -114,20 +111,6 @@ def anyscale_cluster_env_build_url(build_id: str) -> str:
 
 def anyscale_job_url(job_id: str) -> str:
     return f"{ANYSCALE_HOST}/o/anyscale-internal/jobs/{job_id}"
-
-
-_anyscale_sdk = None
-
-
-def get_anyscale_sdk(use_cache: bool = True) -> "AnyscaleSDK":
-    from anyscale.sdk.anyscale_client.sdk import AnyscaleSDK
-
-    global _anyscale_sdk
-    if use_cache and _anyscale_sdk:
-        return _anyscale_sdk
-
-    _anyscale_sdk = AnyscaleSDK(host=str(ANYSCALE_HOST))
-    return _anyscale_sdk
 
 
 def exponential_backoff_retry(

--- a/release/requirements_py310.in
+++ b/release/requirements_py310.in
@@ -1,7 +1,7 @@
 # Requirements to run release tests from buildkite (client dependencies will be installed separately)
 # Copy anyscale pin to requirements.txt and util.py
 aioboto3
-anyscale >= 0.26.14
+anyscale >= 0.26.91
 azure-identity
 azure-storage-blob
 bazel-runfiles
@@ -36,7 +36,6 @@ h11>=0.16.0
 google-cloud-logging
 packaging==25.0
 
-# Last anyscale CLI/SDK release before Ray summit 2025
-# This should have a recent version of the new SDK where still having
-# the old SDK.
-anyscale>=0.26.74
+# Anyscale SDK version with support for new compute config API
+# (anyscale.compute_config module) alongside legacy SDK.
+anyscale>=0.26.91

--- a/release/requirements_py310.txt
+++ b/release/requirements_py310.txt
@@ -1645,7 +1645,6 @@ requests==2.32.5 \
     #   kubernetes
     #   msal
     #   pybuildkite
-    #   pygithub
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -2102,7 +2101,6 @@ urllib3==1.26.18 \
     #   botocore
     #   docker
     #   kubernetes
-    #   pygithub
     #   requests
     #   responses
     #   twine

--- a/release/requirements_py310.txt
+++ b/release/requirements_py310.txt
@@ -118,8 +118,9 @@ anyio==4.4.0 \
     # via
     #   starlette
     #   watchfiles
-anyscale==0.26.74 \
-    --hash=sha256:e3823395f1fb5fee6ad2f03e16e540f22c3c9f5b8a8867b7d7f711b68be6d8bd
+anyscale==0.26.91 \
+    --hash=sha256:02829feeaa58b9602de3c8a3b034a45a5327d2db696257626cf38fb65811b3d3 \
+    --hash=sha256:23fe6cc0ed4da494e974fe48a7ac51776847ac28138d3ffb8a09a61c87e0b615
     # via -r release/requirements_py310.in
 appnope==0.1.4 \
     --hash=sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee \
@@ -205,6 +206,7 @@ certifi==2025.1.31 \
     # via
     #   -r release/requirements_py310.in
     #   anyscale
+    #   kubernetes
     #   requests
 cffi==1.16.0 \
     --hash=sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc \
@@ -367,7 +369,6 @@ colorama==0.4.6 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via
     #   anyscale
-    #   log-symbols
     #   sphinx-autobuild
 comm==0.2.2 \
     --hash=sha256:3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e \
@@ -458,6 +459,10 @@ docutils==0.20.1 \
     #   sphinx
     #   sphinx-click
     #   sphinx-jsonschema
+durationpy==0.10 \
+    --hash=sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba \
+    --hash=sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286
+    # via kubernetes
 exceptiongroup==1.3.1 \
     --hash=sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219 \
     --hash=sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598
@@ -923,9 +928,9 @@ keyring==25.2.0 \
     --hash=sha256:19f17d40335444aab84b19a0d16a77ec0758a9c384e3446ae2ed8bd6d53b67a5 \
     --hash=sha256:7045f367268ce42dba44745050164b431e46f6e92f99ef2937dfadaef368d8cf
     # via twine
-log-symbols==0.0.14 \
-    --hash=sha256:4952106ff8b605ab7d5081dd2c7e6ca7374584eff7086f499c06edd1ce56dcca \
-    --hash=sha256:cf0bbc6fe1a8e53f0d174a716bc625c4f87043cc21eb55dd8a740cfe22680556
+kubernetes==35.0.0 \
+    --hash=sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d \
+    --hash=sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee
     # via anyscale
 markdown-it-py==3.0.0 \
     --hash=sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1 \
@@ -1178,6 +1183,10 @@ oauth2client==4.1.3 \
     --hash=sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac \
     --hash=sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6
     # via anyscale
+oauthlib==3.3.1 \
+    --hash=sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9 \
+    --hash=sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1
+    # via requests-oauthlib
 opentelemetry-api==1.33.1 \
     --hash=sha256:1c6055fc0a2d3f23a50c7e17e16ef75ad489345fd3df1f8b8af7c0bbf8a109e8 \
     --hash=sha256:4db83ebcf7ea93e64637ec6ee6fabee45c5cbe4abd9cf3da95c43828ddb50b83
@@ -1450,6 +1459,7 @@ python-dateutil==2.9.0.post0 \
     #   botocore
     #   freezegun
     #   jupyter-client
+    #   kubernetes
 python-dotenv==1.0.1 \
     --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
     --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
@@ -1511,6 +1521,7 @@ pyyaml==6.0.1 \
     #   anyscale
     #   jupyter-cache
     #   jupytext
+    #   kubernetes
     #   myst-nb
     #   myst-parser
     #   responses
@@ -1631,13 +1642,20 @@ requests==2.32.5 \
     #   google-api-core
     #   google-cloud-storage
     #   id
+    #   kubernetes
     #   msal
     #   pybuildkite
+    #   pygithub
+    #   requests-oauthlib
     #   requests-toolbelt
     #   responses
     #   sphinx
     #   sphinx-jsonschema
     #   twine
+requests-oauthlib==2.0.0 \
+    --hash=sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36 \
+    --hash=sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9
+    # via kubernetes
 requests-toolbelt==1.0.0 \
     --hash=sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6 \
     --hash=sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06
@@ -1780,6 +1798,7 @@ six==1.16.0 \
     #   anyscale
     #   asttokens
     #   azure-core
+    #   kubernetes
     #   oauth2client
     #   python-dateutil
     #   sphinxcontrib-redoc
@@ -1888,10 +1907,6 @@ sphinxemoji==0.3.2 \
     --hash=sha256:0fb07a95bca5960a3b312bc05b65b0c3040456414a076c363f4ecaf546c6e09e \
     --hash=sha256:814da89a9a7603b7e4d85c487c7381656fa83632f20065e5ed782ab1dbbb5083
     # via -r release/requirements-doc.txt
-spinners==0.0.24 \
-    --hash=sha256:1eb6aeb4781d72ab42ed8a01dcf20f3002bf50740d7154d12fb8c9769bf9e27f \
-    --hash=sha256:2fa30d0b72c9650ad12bbe031c9943b8d441e41b4f5602b0ec977a19f3290e98
-    # via anyscale
 sqlalchemy==2.0.31 \
     --hash=sha256:0b0f658414ee4e4b8cbcd4a9bb0fd743c5eeb81fc858ca517217a8013d282c96 \
     --hash=sha256:2196208432deebdfe3b22185d46b08f00ac9d7b01284e168c212919891289396 \
@@ -2086,6 +2101,8 @@ urllib3==1.26.18 \
     #   anyscale
     #   botocore
     #   docker
+    #   kubernetes
+    #   pygithub
     #   requests
     #   responses
     #   twine
@@ -2182,6 +2199,10 @@ wcwidth==0.2.13 \
     --hash=sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859 \
     --hash=sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5
     # via prompt-toolkit
+websocket-client==1.9.0 \
+    --hash=sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98 \
+    --hash=sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef
+    # via kubernetes
 websockets==13.0.1 \
     --hash=sha256:00fd961943b6c10ee6f0b1130753e50ac5dcd906130dcd77b0003c3ab797d026 \
     --hash=sha256:03d3f9ba172e0a53e37fa4e636b86cc60c3ab2cfee4935e66ed1d7acaa4625ad \

--- a/release/setup.py
+++ b/release/setup.py
@@ -15,7 +15,7 @@ setup(
     install_requires=[
         # Keep this in sync with requirements_py310.in
         "aioboto3",
-        "anyscale >= 0.26.1",
+        "anyscale >= 0.26.91",
         "aws_requests_auth",
         "azure-identity",
         "azure-storage-blob",


### PR DESCRIPTION
## Description
> Note: This PR is very large, and needs to be broken down into smaller parts that:
> 1. upgrade `anyscale` version, change job creation/termination code, and handle compute-configs with backward-compatible function calls
> 2. create two paths for legacy and new compute config handling

#### Summary
- Upgrade anyscale package from 0.26.74 to >=0.26.91 and add support for both legacy and new (2026) Anyscale compute config schemas in the release test framework
- Tests with anyscale_sdk_2026: true in their cluster config use the new anyscale.compute_config API; all others use the legacy DefaultApi path
- Cluster env registration, build polling, and job submission are unified to use the new anyscale.image and anyscale.job APIs for both paths

#### Key changes
  - New schema field: cluster.anyscale_sdk_2026 boolean in test configs selects between legacy and new compute config schemas
  - Dual-path compute config: Legacy path uses DefaultApi.search_cluster_computes/create_cluster_compute; new path uses anyscale.compute_config.list/create
  - Unified APIs: anyscale.image.register/get for cluster env, anyscale.job.submit(JobConfig(...)) for job submission — used on both paths
  - SDK wrapper class: Anyscale class with lazy-loaded image, compute_config, and legacy_sdk properties, threaded through ClusterManager.sdk to avoid credential lookup at import time
  - Dead code removal: Removed get_anyscale_sdk(), dead sdk parameter on AnyscaleJobRunner, and old-SDK fallback in get_project_name()

## Related issues
None

## Additional information
None
