### PR TITLE
[Data] Preserve schema from empty Arrow tables in from_arrow_refs

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -809,15 +809,16 @@ def unify_block_metadata_schema(
         A unified schema of the input list of schemas, or None if no valid schemas
         are provided.
     """
-    # Some blocks could be empty, in which case we cannot get their schema.
     # TODO(ekl) validate schema is the same across different blocks.
 
-    # First check if there are blocks with computed schemas, then unify
-    # valid schemas from all such blocks.
+    # Collect schemas from all blocks that have a valid schema.
+    # Empty blocks (num_rows == 0) can still carry a valid schema (e.g. an
+    # empty PyArrow table preserves its column names and types), so we must
+    # not skip them.  Only blocks whose schema is None are excluded.
 
     schemas_to_unify = []
     for m in block_metadata_with_schemas:
-        if m.schema is not None and (m.num_rows is None or m.num_rows > 0):
+        if m.schema is not None:
             schemas_to_unify.append(m.schema)
     return unify_schemas_with_validation(schemas_to_unify)
 
@@ -847,9 +848,7 @@ def unify_ref_bundles_schema(
 ) -> Optional["Schema"]:
     schemas_to_unify = []
     for bundle in ref_bundles:
-        if bundle.schema is not None and (
-            bundle.num_rows() is None or bundle.num_rows() > 0
-        ):
+        if bundle.schema is not None:
             schemas_to_unify.append(bundle.schema)
     return unify_schemas_with_validation(schemas_to_unify)
 

--- a/python/ray/data/tests/datasource/test_arrow.py
+++ b/python/ray/data/tests/datasource/test_arrow.py
@@ -128,6 +128,19 @@ def test_to_arrow_refs(ray_start_regular_shared):
     assert df.equals(dfds)
 
 
+def test_from_arrow_refs_empty_table_preserves_schema(ray_start_regular_shared):
+    """Regression test: empty Arrow tables should preserve column names and types.
+
+    See https://github.com/ray-project/ray/issues/59946
+    """
+    empty_array = pa.array([], pa.int32())
+    empty_ref = ray.put(pa.table([empty_array], ["apples"]))
+    ds = ray.data.from_arrow_refs([empty_ref])
+    result = ds.to_pandas()
+    assert list(result.columns) == ["apples"], list(result.columns)
+    assert len(result) == 0
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?

`from_arrow_refs` currently drops column information when all input tables are
empty (0 rows). For example:

```python
import pyarrow as pa
import ray

empty_ref = ray.put(pa.table([pa.array([], pa.int32())], ["apples"]))
ds = ray.data.from_arrow_refs([empty_ref])
print(ds.to_pandas().columns)  # Empty — expected ["apples"]
```

**Root cause:** `unify_block_metadata_schema` and `unify_ref_bundles_schema` in
`util.py` skip blocks where `num_rows == 0`, assuming empty blocks have no
schema. That assumption is wrong for PyArrow tables — an empty table retains its
full schema (column names + types). When every block is empty, no schema survives
unification, so the dataset loses all column metadata.

**Fix:** Remove the `num_rows > 0` guard. Only skip blocks whose `schema` is
actually `None`.

Fixes #59946

## Related issue number

https://github.com/ray-project/ray/issues/59946

## Checks

- [x] I've signed off every commit (for DCO purposes).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed.
- [x] I've added any new tests.
- [x] I've made sure the tests are passing.