### PR TITLE
Revert "[Data] Remove obsolete PyArrow 9.0 version checks (#61483)"

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -10,6 +10,7 @@ from ray._common.utils import env_integer
 from ray._private.utils import INT32_MAX
 from ray.data._internal.tensor_extensions.arrow import (
     MIN_PYARROW_VERSION_CHUNKED_ARRAY_TO_NUMPY_ZERO_COPY_ONLY,
+    PYARROW_VERSION,
     get_arrow_extension_fixed_shape_tensor_types,
     get_arrow_extension_tensor_types,
     unify_tensor_arrays,
@@ -27,8 +28,6 @@ except ImportError:
 MIN_PYARROW_VERSION_VIEW_TYPES = parse_version("16.0.0")
 MIN_PYARROW_VERSION_RUN_END_ENCODED_TYPES = parse_version("12.0.0")
 MIN_PYARROW_VERSION_TYPE_PROMOTION = parse_version("14.0.0")
-
-PYARROW_VERSION = get_pyarrow_version()
 
 
 # pyarrow.Table.slice is slow when the table has many chunks

--- a/python/ray/data/_internal/object_extensions/arrow.py
+++ b/python/ray/data/_internal/object_extensions/arrow.py
@@ -3,14 +3,31 @@ import typing
 
 import numpy as np
 import pyarrow as pa
+from packaging.version import parse as parse_version
 
 import ray.data._internal.object_extensions.pandas
 from ray._common.serialization import pickle_dumps
-from ray.data._internal.utils.arrow_utils import _check_pyarrow_version
+from ray.data._internal.utils.arrow_utils import (
+    _check_pyarrow_version,
+    get_pyarrow_version,
+)
 from ray.util.annotations import PublicAPI
 
 # First, assert Arrow version is w/in expected bounds
 _check_pyarrow_version()
+
+
+MIN_PYARROW_VERSION_SCALAR_SUBCLASS = parse_version("9.0.0")
+
+PYARROW_VERSION = get_pyarrow_version()
+
+
+# TODO delete, since min supported pyarrow >= 9.0
+def _object_extension_type_allowed() -> bool:
+    return (
+        PYARROW_VERSION is not None
+        and PYARROW_VERSION >= MIN_PYARROW_VERSION_SCALAR_SUBCLASS
+    )
 
 
 # Please see https://arrow.apache.org/docs/python/extending_types.html for more info

--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -21,7 +21,11 @@ from ray.data._internal.numpy_support import (
     _convert_datetime_to_np_datetime,
     convert_to_numpy,
 )
-from ray.data._internal.object_extensions.arrow import ArrowPythonObjectArray
+from ray.data._internal.object_extensions.arrow import (
+    MIN_PYARROW_VERSION_SCALAR_SUBCLASS,
+    ArrowPythonObjectArray,
+    _object_extension_type_allowed,
+)
 from ray.data._internal.tensor_extensions.utils import (
     ArrayLike,
     _is_ndarray_variable_shaped_tensor,
@@ -41,6 +45,9 @@ from ray.util.common import INT32_MAX
 _check_pyarrow_version()
 
 PYARROW_VERSION = get_pyarrow_version()
+
+PYARROW_VERSION = get_pyarrow_version()
+
 
 # Minimum version supporting `zero_copy_only` flag in `ChunkedArray.to_numpy`
 MIN_PYARROW_VERSION_CHUNKED_ARRAY_TO_NUMPY_ZERO_COPY_ONLY = parse_version("13.0.0")
@@ -296,29 +303,38 @@ def convert_to_pyarrow_array(
             bool
         ] = DataContext.get_current().enable_fallback_to_arrow_object_ext_type
 
-        # NOTE: By default setting is unset which (for compatibility reasons)
-        #       is allowing the fallback
-        object_ext_type_fallback_allowed = (
-            enable_fallback_config is None or enable_fallback_config
-        )
-
-        if object_ext_type_fallback_allowed:
+        if not _object_extension_type_allowed():
+            object_ext_type_fallback_allowed = False
             object_ext_type_detail = (
-                "falling back to serialize as pickled python objects"
+                "skipping fallback to serialize as pickled python"
+                f" objects (due to unsupported Arrow version {PYARROW_VERSION}, "
+                f"min required version is {MIN_PYARROW_VERSION_SCALAR_SUBCLASS})"
             )
         else:
-            object_ext_type_detail = (
-                "skipping fallback to serialize as pickled python objects "
-                "(due to DataContext.enable_fallback_to_arrow_object_ext_type "
-                "= False)"
+            # NOTE: By default setting is unset which (for compatibility reasons)
+            #       is allowing the fallback
+            object_ext_type_fallback_allowed = (
+                enable_fallback_config is None or enable_fallback_config
             )
+
+            if object_ext_type_fallback_allowed:
+                object_ext_type_detail = (
+                    "falling back to serialize as pickled python objects"
+                )
+            else:
+                object_ext_type_detail = (
+                    "skipping fallback to serialize as pickled python objects "
+                    "(due to DataContext.enable_fallback_to_arrow_object_ext_type "
+                    "= False)"
+                )
 
         # To avoid logging following warning for every block it's
         # only going to be logged in following cases
         #   - It's being logged for the first time, and
         #   - When config enabling fallback is not set explicitly (in this case
         #       fallback will still occur by default for compatibility reasons), or
-        #   - Fallback is disallowed (explicitly)
+        #   - Fallback is disallowed (either explicitly or due to use of incompatible
+        #       Pyarrow version)
         if (
             enable_fallback_config is None or not object_ext_type_fallback_allowed
         ) and log_once("_fallback_to_arrow_object_extension_type_warning"):

--- a/python/ray/data/extensions/__init__.py
+++ b/python/ray/data/extensions/__init__.py
@@ -11,6 +11,7 @@ from ray.data.extensions.object_extension import (
     ArrowPythonObjectType,
     PythonObjectArray,
     PythonObjectDtype,
+    _object_extension_type_allowed,
 )
 from ray.data.extensions.tensor_extension import (
     ArrowConversionError,
@@ -45,5 +46,6 @@ __all__ = [
     "ArrowPythonObjectScalar",
     "PythonObjectArray",
     "PythonObjectDtype",
+    "_object_extension_type_allowed",
     "get_arrow_extension_tensor_types",
 ]

--- a/python/ray/data/extensions/object_extension.py
+++ b/python/ray/data/extensions/object_extension.py
@@ -2,6 +2,7 @@ from ray.data._internal.object_extensions.arrow import (  # noqa: F401
     ArrowPythonObjectArray,
     ArrowPythonObjectScalar,
     ArrowPythonObjectType,
+    _object_extension_type_allowed,
 )
 from ray.data._internal.object_extensions.pandas import (  # noqa: F401
     PythonObjectArray,

--- a/python/ray/data/tests/test_arrow_block.py
+++ b/python/ray/data/tests/test_arrow_block.py
@@ -20,6 +20,7 @@ from ray.data._internal.arrow_ops.transform_pyarrow import combine_chunked_array
 from ray.data._internal.util import GiB, MiB
 from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
+from ray.data.extensions.object_extension import _object_extension_type_allowed
 
 
 def test_combine_chunked_fixed_width_array_large():
@@ -214,6 +215,9 @@ assert str(schema) == \"\"\"{1}\"\"\"
     run_string_as_driver(driver_script)
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension type not supported."
+)
 def test_dict_doesnt_fallback_to_pandas_block(ray_start_regular_shared):
     # If the UDF returns a column with dict, previously, we would
     # fall back to pandas, because we couldn't convert it to

--- a/python/ray/data/tests/test_arrow_serialization.py
+++ b/python/ray/data/tests/test_arrow_serialization.py
@@ -27,6 +27,7 @@ from ray._private.arrow_serialization import (
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
 from ray.data.extensions.object_extension import (
     ArrowPythonObjectArray,
+    _object_extension_type_allowed,
 )
 from ray.data.extensions.tensor_extension import (
     ArrowTensorArray,
@@ -415,9 +416,13 @@ pytest_custom_serialization_arrays = [
     (lazy_fixture("list_of_empty_struct_array"), 0.1),
     # Complex nested array
     (lazy_fixture("complex_nested_array"), 0.1),
-    # Array of pickled objects
-    (lazy_fixture("pickled_objects_array"), 0.1),
 ]
+
+if _object_extension_type_allowed():
+    pytest_custom_serialization_arrays.append(
+        # Array of pickled objects
+        (lazy_fixture("pickled_objects_array"), 0.1),
+    )
 
 
 @pytest.mark.parametrize("data,cap_mult", pytest_custom_serialization_arrays)
@@ -539,6 +544,9 @@ def test_arrow_scalar_conversion(ray_start_regular_shared):
     assert res == [{"id": 1}], res
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_arrow_object_and_array_support(ray_start_regular_shared):
     obj = types.SimpleNamespace(some_attribute="test")
 

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -15,7 +15,7 @@ from ray.data._internal.pandas_block import (
     PandasBlockColumnAccessor,
 )
 from ray.data._internal.util import is_null
-from ray.data.context import DataContext
+from ray.data.extensions.object_extension import _object_extension_type_allowed
 
 # Set seed for the test for size as it related to sampling
 np.random.seed(42)
@@ -201,20 +201,24 @@ def test_pandas_block_timestamp_ns(ray_start_regular_shared):
         ), "Timestamp mismatch in PandasBlockBuilder output"
 
 
-def test_dict_and_none_use_arrow_block(ray_start_regular_shared, restore_data_context):
-    # Dicts are represented as Arrow struct types, so the block should remain Arrow
-    # even if object-extension fallback is disabled.
-    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
-
+@pytest.mark.skipif(
+    _object_extension_type_allowed(), reason="Objects can be put into Arrow"
+)
+def test_dict_fallback_to_pandas_block(ray_start_regular_shared):
+    # If the UDF returns a column with dict, this throws
+    # an error during block construction because we cannot cast dicts
+    # to a supported arrow type. This test checks that the block
+    # construction falls back to pandas and still succeeds.
     def fn(batch):
         batch["data_dict"] = [{"data": 0} for _ in range(len(batch["id"]))]
         return batch
 
     ds = ray.data.range(10).map_batches(fn)
     ds = ds.materialize()
-    block = ray.get(next(ds.iter_internal_ref_bundles()).block_refs[0])
-    assert isinstance(block, pa.Table)
-    assert block.schema.field("data_dict").type == pa.struct([("data", pa.int64())])
+    block = ray.get(ds.get_internal_block_refs()[0])
+    # TODO: Once we support converting dict to a supported arrow type,
+    # the block type should be Arrow.
+    assert isinstance(block, pd.DataFrame)
 
     def fn2(batch):
         batch["data_none"] = [None for _ in range(len(batch["id"]))]
@@ -222,8 +226,8 @@ def test_dict_and_none_use_arrow_block(ray_start_regular_shared, restore_data_co
 
     ds2 = ray.data.range(10).map_batches(fn2)
     ds2 = ds2.materialize()
-    block = ray.get(next(ds2.iter_internal_ref_bundles()).block_refs[0])
-    assert isinstance(block, pa.Table)
+    block = ray.get(ds2.get_internal_block_refs()[0])
+    assert isinstance(block, pd.DataFrame)
 
 
 class TestSizeBytes:

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -194,6 +194,7 @@ def test_strict_schema(ray_start_regular_shared_2_cpus, tensor_format_context):
     from ray.data._internal.pandas_block import PandasBlockSchema
     from ray.data.extensions.object_extension import (
         ArrowPythonObjectType,
+        _object_extension_type_allowed,
     )
 
     ds = ray.data.from_items([{"x": 2}])
@@ -210,13 +211,21 @@ def test_strict_schema(ray_start_regular_shared_2_cpus, tensor_format_context):
 
     ds = ray.data.from_items([{"x": 2, "y": object(), "z": [1, 2]}])
     schema = ds.schema()
-    assert isinstance(schema.base_schema, pa.lib.Schema)
-    assert schema.names == ["x", "y", "z"]
-    assert schema.types == [
-        pa.int64(),
-        ArrowPythonObjectType(),
-        pa.list_(pa.int64()),
-    ]
+    if _object_extension_type_allowed():
+        assert isinstance(schema.base_schema, pa.lib.Schema)
+        assert schema.names == ["x", "y", "z"]
+        assert schema.types == [
+            pa.int64(),
+            ArrowPythonObjectType(),
+            pa.list_(pa.int64()),
+        ]
+    else:
+        assert schema.names == ["x", "y", "z"]
+        assert schema.types == [
+            pa.int64(),
+            object,
+            object,
+        ]
 
     ds = ray.data.from_numpy(np.ones((100, 10)))
     schema = ds.schema()

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -16,10 +16,10 @@ from ray.data._internal.tensor_extensions.arrow import (
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
 from ray.data.context import DataContext
 from ray.data.extensions import (
-    ArrowConversionError,
     ArrowPythonObjectType,
     ArrowTensorArray,
     ArrowTensorType,
+    _object_extension_type_allowed,
 )
 
 
@@ -46,6 +46,10 @@ def test_pyarrow(ray_start_regular_shared):
     assert ds.filter(lambda x: x["id"] == 0).flat_map(
         lambda x: [{"b": x["id"] + 2}, {"b": x["id"] + 20}]
     ).take() == [{"b": 2}, {"b": 20}]
+
+
+class UnsupportedType:
+    pass
 
 
 def _create_dataset(op, data):
@@ -78,38 +82,29 @@ def _create_dataset(op, data):
     return ds
 
 
-def test_map_batches_fallback_to_pandas_on_incompatible_data(
+@pytest.mark.skipif(
+    _object_extension_type_allowed(), reason="Arrow table supports pickled objects"
+)
+@pytest.mark.parametrize(
+    "op, data",
+    [
+        ("map", [UnsupportedType(), 1]),
+        ("map_batches", [None, 1]),
+        ("map_batches", [{"a": 1}, {"a": 2}]),
+    ],
+)
+def test_fallback_to_pandas_on_incompatible_data(
+    op,
+    data,
     ray_start_regular_shared,
-    restore_data_context,
 ):
-    # For map_batches, if the first UDF output is incompatible with Arrow,
+    # Test if the first UDF output is incompatible with Arrow,
     # Ray Data will fall back to using Pandas.
-    class UnsupportedType:
-        pass
-
-    data = [UnsupportedType(), 1]
-    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
-    ds = _create_dataset("map_batches", data)
+    ds = _create_dataset(op, data)
     ds = ds.materialize()
     bundles = ds.iter_internal_ref_bundles()
     block = ray.get(next(bundles).block_refs[0])
     assert isinstance(block, pd.DataFrame)
-
-
-def test_map_raises_on_incompatible_data(
-    ray_start_regular_shared,
-    restore_data_context,
-):
-    # For row-based map, the output buffer builds Arrow blocks eagerly, so
-    # incompatible data raises ArrowConversionError when object fallback is disabled.
-    class UnsupportedType:
-        pass
-
-    data = [UnsupportedType(), 1]
-    DataContext.get_current().enable_fallback_to_arrow_object_ext_type = False
-    ds = _create_dataset("map", data)
-    with pytest.raises(ArrowConversionError):
-        ds.materialize()
 
 
 _PYARROW_SUPPORTS_TYPE_PROMOTION = (

--- a/python/ray/data/tests/unit/test_object_extension.py
+++ b/python/ray/data/tests/unit/test_object_extension.py
@@ -8,10 +8,14 @@ import pytest
 from ray.data._internal.object_extensions.arrow import (
     ArrowPythonObjectArray,
     ArrowPythonObjectType,
+    _object_extension_type_allowed,
 )
 from ray.data._internal.object_extensions.pandas import PythonObjectArray
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_object_array_validation():
     # Test unknown input type raises TypeError.
     with pytest.raises(TypeError):
@@ -21,6 +25,9 @@ def test_object_array_validation():
     PythonObjectArray([object(), object()])
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_arrow_scalar_object_array_roundtrip():
     arr = np.array(
         ["test", 20, False, {"some": "value"}, None, np.zeros((10, 10))], dtype=object
@@ -34,6 +41,9 @@ def test_arrow_scalar_object_array_roundtrip():
     assert np.all(out[-1] == arr[-1])
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_arrow_python_object_array_slice():
     arr = np.array(["test", 20, "test2", 40, "test3", 60], dtype=object)
     ata = ArrowPythonObjectArray.from_objects(arr)
@@ -41,6 +51,9 @@ def test_arrow_python_object_array_slice():
     assert ata[2:4].to_pylist() == ["test2", 40]
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_arrow_pandas_roundtrip():
     obj = types.SimpleNamespace(a=1, b="test")
     t1 = pa.table({"a": ArrowPythonObjectArray.from_objects([obj, obj]), "b": [0, 1]})
@@ -48,12 +61,18 @@ def test_arrow_pandas_roundtrip():
     assert t1.equals(t2)
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_pandas_python_object_isna():
     arr = np.array([1, np.nan, 3, 4, 5, np.nan, 7, 8, 9], dtype=object)
     ta = PythonObjectArray(arr)
     np.testing.assert_array_equal(ta.isna(), pd.isna(arr))
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_pandas_python_object_take():
     arr = np.array([1, 2, 3, 4, 5], dtype=object)
     ta = PythonObjectArray(arr)
@@ -66,6 +85,9 @@ def test_pandas_python_object_take():
     )
 
 
+@pytest.mark.skipif(
+    not _object_extension_type_allowed(), reason="Object extension not supported."
+)
 def test_pandas_python_object_concat():
     arr1 = np.array([1, 2, 3, 4, 5], dtype=object)
     arr2 = np.array([6, 7, 8, 9, 10], dtype=object)


### PR DESCRIPTION
## Description
This reverts commit 8b561dde6e1ccb6c3be7cef31fa08eb4e98d2530.

## Related issues
Reverts #61483.

## Additional information

Example failure: https://buildkite.com/ray-project/postmerge/builds/16548/steps/canvas?jid=019d03b9-2179-4c49-864a-7ed95f94f71f&tab=output

```
2026-03-19T01:44:06Z] Traceback (most recent call last):
--
[2026-03-19T01:44:06Z]   File "/root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/bin/python/ray/data/test_transform_pyarrow.runfiles/io_ray/python/ray/data/tests/test_transform_pyarrow.py", line 9, in <module>
[2026-03-19T01:44:06Z]     from ray.data._internal.arrow_ops.transform_pyarrow import (
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/__init__.py", line 8, in <module>
[2026-03-19T01:44:06Z]     from ray.data._internal.compute import ActorPoolStrategy, TaskPoolStrategy
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/compute.py", line 4, in <module>
[2026-03-19T01:44:06Z]     from ray.data._internal.execution.interfaces import TaskContext
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/execution/__init__.py", line 6, in <module>
[2026-03-19T01:44:06Z]     from .ranker import DefaultRanker, Ranker
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/execution/ranker.py", line 6, in <module>
[2026-03-19T01:44:06Z]     from ray.data._internal.execution.interfaces import PhysicalOperator
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/execution/interfaces/__init__.py", line 3, in <module>
[2026-03-19T01:44:06Z]     from .executor import Executor, OutputIterator
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/execution/interfaces/executor.py", line 5, in <module>
[2026-03-19T01:44:06Z]     from .physical_operator import PhysicalOperator
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/execution/interfaces/physical_operator.py", line 31, in <module>
[2026-03-19T01:44:06Z]     from ray.data._internal.logical.interfaces import LogicalOperator, Operator
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/logical/interfaces/__init__.py", line 1, in <module>
[2026-03-19T01:44:06Z]     from .logical_operator import (
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/logical/interfaces/logical_operator.py", line 7, in <module>
[2026-03-19T01:44:06Z]     from ray.data.expressions import Expr
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/expressions.py", line 26, in <module>
[2026-03-19T01:44:06Z]     from ray.data.datatype import DataType
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/datatype.py", line 8, in <module>
[2026-03-19T01:44:06Z]     from ray.data._internal.tensor_extensions.arrow import (
[2026-03-19T01:44:06Z]   File "/rayci/python/ray/data/_internal/tensor_extensions/arrow.py", line 75, in <module>
[2026-03-19T01:44:06Z]     PYARROW_VERSION is None
[2026-03-19T01:44:06Z] NameError: name 'PYARROW_VERSION' is not defined
```

