### PR TITLE
fix(dashboard): add missing http:// scheme in EventAgent dashboard URL

### DIFF
--- a/bazel/ray_deps_setup.bzl
+++ b/bazel/ray_deps_setup.bzl
@@ -230,6 +230,13 @@ def ray_deps_setup():
         name = "io_opentelemetry_cpp",
         url = "https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.19.0.zip",
         sha256 = "8ef0a63f4959d5dfc3d8190d62229ef018ce41eef36e1f3198312d47ab2de05a",
+        # Enable mTLS support for OTLP gRPC exporter.
+        # This is required because Ray's gRPC servers require client certificates when TLS is enabled.
+        # See https://github.com/ray-project/ray/issues/59968
+        patches = [
+            "@io_ray//thirdparty/patches:opentelemetry-cpp-enable-mtls.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     auto_http_archive(

--- a/ci/ray_ci/utils.py
+++ b/ci/ray_ci/utils.py
@@ -19,7 +19,7 @@ from ray_release.test import Test, TestState
 GLOBAL_CONFIG_FILE = (
     os.environ.get("RAYCI_GLOBAL_CONFIG") or "ci/ray_ci/oss_config.yaml"
 )
-RAY_VERSION = "3.0.0.dev0"
+RAY_VERSION = "2.54.0"
 
 
 def ci_init() -> None:

--- a/ci/raydepsets/configs/docs.depsets.yaml
+++ b/ci/raydepsets/configs/docs.depsets.yaml
@@ -18,3 +18,4 @@ depsets:
       - --unsafe-package ray
     build_arg_sets:
       - py310
+    include_setuptools: true

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -1,7 +1,7 @@
 # Production requirements. This is what readthedocs.com picks up
 
 # Required to build the docs on 3.12 due to pkg_resources deprecation
-setuptools>=70.0.0
+setuptools==80.9.0
 
 # Syntax highlighting
 Pygments==2.16.1

--- a/doc/source/serve/tutorials/video-analysis/jobs/generate_text_embeddings.py
+++ b/doc/source/serve/tutorials/video-analysis/jobs/generate_text_embeddings.py
@@ -54,12 +54,15 @@ def compute_text_embeddings(
         # Get embeddings
         with torch.no_grad():
             outputs = model.get_text_features(**inputs)
-        
-        # L2 normalize
-        embeddings = outputs.cpu().numpy()
+
+        # Handle case where outputs is a model output object vs raw tensor
+        if hasattr(outputs, 'pooler_output'):
+            embeddings = outputs.pooler_output.cpu().numpy()
+        else:
+            embeddings = outputs.cpu().numpy()
         embeddings = embeddings / np.linalg.norm(embeddings, axis=1, keepdims=True)
         all_embeddings.append(embeddings)
-    
+
     return np.vstack(all_embeddings).astype(np.float32)
 
 

--- a/java/api/pom_template.xml
+++ b/java/api/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.54.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/performance_test/pom_template.xml
+++ b/java/performance_test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.54.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.ray</groupId>
   <artifactId>ray-superpom</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.54.0</version>
   <packaging>pom</packaging>
   <name>Ray Project Parent POM</name>
   <description>An open source framework that provides a simple, universal API for building distributed applications.
@@ -63,7 +63,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.version>2.0.0-SNAPSHOT</project.version>
+    <project.version>2.54.0</project.version>
   </properties>
 
   <dependencyManagement>

--- a/java/runtime/pom_template.xml
+++ b/java/runtime/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.54.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/serve/pom_template.xml
+++ b/java/serve/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.54.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/test/pom_template.xml
+++ b/java/test/pom_template.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.ray</groupId>
     <artifactId>ray-superpom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.54.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -1063,6 +1063,10 @@ s3transfer==0.10.4 \
     --hash=sha256:244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e \
     --hash=sha256:29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7
     # via boto3
+setuptools==80.9.0 \
+    --hash=sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922 \
+    --hash=sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c
+    # via -r doc/requirements-doc.txt
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -1523,6 +1527,3 @@ zipp==3.23.0 \
     --hash=sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e \
     --hash=sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166
     # via importlib-metadata
-
-# The following packages were excluded from the output:
-# setuptools

--- a/python/ray/_version.py
+++ b/python/ray/_version.py
@@ -1,6 +1,6 @@
 # Replaced with the current commit when building the wheels.
 commit = "{{RAY_COMMIT_SHA}}"
-version = "3.0.0.dev0"
+version = "2.54.0"
 
 if __name__ == "__main__":
     print("%s %s" % (version, commit))

--- a/python/ray/dashboard/modules/event/event_agent.py
+++ b/python/ray/dashboard/modules/event/event_agent.py
@@ -66,7 +66,12 @@ class EventAgent(dashboard_utils.DashboardAgentModule):
                 )
                 if not dashboard_http_address:
                     raise ValueError("Dashboard http address not found in InternalKV.")
-                self._dashboard_http_address = dashboard_http_address.decode()
+                # GCS KV stores the address without scheme (e.g. "host:port").
+                # Prepend http:// so aiohttp can use it as a valid URL, consistent
+                # with how other callers (e.g. dashboard/utils.py) handle this value.
+                self._dashboard_http_address = (
+                    f"http://{dashboard_http_address.decode()}"
+                )
                 return self._dashboard_http_address
             except Exception:
                 logger.exception("Get dashboard http address failed.")

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -510,7 +510,7 @@ class PhysicalOperator(Operator):
         For regular tasks, this is the resources required to schedule a task. For actor
         tasks, this is the resources required to schedule an actor.
         """
-        return ExecutionResources.zero()
+        return self.incremental_resource_usage()
 
     def progress_str(self) -> str:
         """Return any extra status to be displayed in the operator progress bar.

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -1047,6 +1047,9 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
             gpu=0,
         )
 
+    def min_scheduling_resources(self) -> ExecutionResources:
+        return self.incremental_resource_usage()
+
     def has_completed(self) -> bool:
         # TODO separate marking as completed from the check
         return self._is_finalized() and super().has_completed()

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -967,12 +967,12 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         for i, op in enumerate(reversed(eligible_ops)):
             # By default, divide the remaining shared resources equally.
             op_shared = remaining_shared.scale(1.0 / (len(eligible_ops) - i))
-            # But if the op's budget is less than `incremental_resource_usage`,
+            # But if the op's budget is less than `min_scheduling_resources`,
             # it will be useless. So we'll let the downstream operator
             # borrow some resources from the upstream operator, if remaining_shared
             # is still enough.
             to_borrow = (
-                op.incremental_resource_usage()
+                op.min_scheduling_resources()
                 .subtract(self._op_budgets[op].add(op_shared))
                 .max(ExecutionResources.zero())
             )

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -692,12 +692,14 @@ class OpResourceAllocator(ABC):
     def _should_unblock_streaming_output_backpressure(
         self, op: PhysicalOperator
     ) -> bool:
+        downstream_eligible_ops = list(self._get_downstream_eligible_ops(op))
+
         # NOTE: If this operator is a terminal one, extracting outputs from it
         #       should not be throttled
-        if not op.output_dependencies:
+        if not downstream_eligible_ops:
             return True
 
-        for downstream_op in self._get_downstream_eligible_ops(op):
+        for downstream_op in downstream_eligible_ops:
             # To maintain liveness of the pipeline, we relax output backpressure
             # in one of the following cases
             if downstream_op.num_active_tasks() == 0:

--- a/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/hanging_detector.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 
 import ray
 from ray.data._internal.issue_detection.issue_detector import (
@@ -35,7 +35,6 @@ logger = logging.getLogger(__name__)
 class HangingExecutionState:
     operator_id: str
     task_idx: int
-    task_id: ray.TaskID
     task_state: Optional[TaskState]
     bytes_output: int
     start_time_hanging: float
@@ -113,7 +112,7 @@ class HangingExecutionIssueDetector(IssueDetector):
                     attempt_number = state.task_state.attempt_number
 
                 message = (
-                    f"A task (task_id={state.task_id}) of operator {op_name} (pid={pid}, node_id={node_id}, attempt={attempt_number}) has been running for {duration:.2f}s, which is longer"
+                    f"A task of operator {op_name} (pid={pid}, node_id={node_id}, attempt={attempt_number}) has been running for {duration:.2f}s, which is longer"
                     f" than the average task duration of this operator ({avg_duration:.2f}s)."
                     f" If this message persists, please check the stack trace of the "
                     "task for potential hanging issues."
@@ -154,11 +153,29 @@ class HangingExecutionIssueDetector(IssueDetector):
                         prev_state_value is None
                         or bytes_output != prev_state_value.bytes_output
                     ):
+                        task_state = None
+                        try:
+                            task_state: Union[
+                                TaskState, List[TaskState]
+                            ] = ray.util.state.get_task(
+                                task_info.task_id.hex(),
+                                timeout=1.0,
+                                _explain=True,
+                            )
+                            if isinstance(task_state, list):
+                                # get the latest task
+                                task_state = max(
+                                    task_state, key=lambda ts: ts.attempt_number
+                                )
+                        except Exception as e:
+                            logger.debug(
+                                f"Failed to grab task state with task_index={task_idx}, task_id={task_info.task_id}: {e}"
+                            )
+                            pass
                         self._state_map[operator.id][task_idx] = HangingExecutionState(
                             operator_id=operator.id,
                             task_idx=task_idx,
-                            task_id=task_info.task_id,
-                            task_state=None,
+                            task_state=task_state,
                             bytes_output=bytes_output,
                             start_time_hanging=time.perf_counter(),
                         )
@@ -177,10 +194,6 @@ class HangingExecutionIssueDetector(IssueDetector):
             for task_idx, state_value in op_state_values.items():
                 curr_time = time.perf_counter() - state_value.start_time_hanging
                 if op_task_stats.count() >= self._op_task_stats_min_count:
-                    if state_value.task_state is None:
-                        state_value.task_state = get_latest_state_for_task(
-                            state_value.task_id
-                        )
                     mean = op_task_stats.mean()
                     stddev = op_task_stats.stddev()
                     threshold = mean + self._op_task_stats_std_factor_threshold * stddev
@@ -198,20 +211,3 @@ class HangingExecutionIssueDetector(IssueDetector):
 
     def detection_time_interval_s(self) -> float:
         return self._detector_cfg.detection_time_interval_s
-
-
-def get_latest_state_for_task(task_id: ray.TaskID) -> TaskState | None:
-    try:
-        task_state: TaskState | List[TaskState] | None = ray.util.state.get_task(
-            task_id.hex(),
-            timeout=1.0,
-            _explain=True,
-        )
-        if isinstance(task_state, list):
-            # get the latest task
-            task_state = max(task_state, key=lambda ts: ts.attempt_number)
-        return task_state
-    except Exception as e:
-        logger.debug(f"Failed to grab task state with task_id={task_id}: {e}")
-        pass
-    return None

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -303,7 +303,7 @@ class GroupedData:
             num_gpus=num_gpus,
             memory=memory,
             concurrency=concurrency,
-            udf_modifying_row_count=False,
+            udf_modifying_row_count=True,
             ray_remote_args_fn=ray_remote_args_fn,
             **ray_remote_args,
         )

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -615,5 +615,17 @@ def test_does_not_pushdown_limit_past_map_batches_by_default(
     assert num_rows == 1, num_rows
 
 
+def test_does_not_pushdown_limit_past_map_groups_by_default(
+    ray_start_regular_shared_2_cpus,
+):
+    def duplicate_id(batch):
+        yield {"data": list(batch["id"]) * 2}
+
+    # If the optimizer incorrectly pushes the limit past the map operator, then the
+    # returned count is 2.
+    num_rows = ray.data.range(1).groupby("id").map_groups(duplicate_id).limit(1).count()
+    assert num_rows == 1, num_rows
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -123,7 +123,7 @@ class TestHangingExecutionIssueDetector:
         _ = ray.data.range(1).map(f1).materialize()
 
         log_output = log_capture.getvalue()
-        warn_msg = r"A task \(task_id=.+\) .+ \(pid=.+, node_id=.+, attempt=.+\) has been running for [\d\.]+s"
+        warn_msg = r"A task of operator .+ \(pid=.+, node_id=.+, attempt=.+\) has been running for [\d\.]+s"
         assert re.search(warn_msg, log_output) is None, log_output
 
         # # test hanging does log hanging warning

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -38,7 +38,6 @@ def mock_map_op(
     input_op: PhysicalOperator,
     ray_remote_args: Optional[Dict[str, Any]] = None,
     compute_strategy: Optional[ComputeStrategy] = None,
-    incremental_resource_usage: Optional[ExecutionResources] = None,
     name="Map",
 ):
     op = MapOperator.create(
@@ -50,34 +49,19 @@ def mock_map_op(
         name=name,
     )
     op.start(ExecutionOptions())
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 
-def mock_union_op(
-    input_ops,
-    incremental_resource_usage=None,
-):
+def mock_union_op(input_ops):
     op = UnionOperator(
         DataContext.get_current(),
         *input_ops,
     )
     op.start = MagicMock(side_effect=lambda _: None)
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 
-def mock_join_op(
-    left_input_op,
-    right_input_op,
-    incremental_resource_usage=None,
-):
+def mock_join_op(left_input_op, right_input_op):
     left_input_op._logical_operators = [(MagicMock())]
     right_input_op._logical_operators = [(MagicMock())]
 
@@ -98,10 +82,6 @@ def mock_join_op(
         )
 
     op.start = MagicMock(side_effect=lambda _: None)
-    if incremental_resource_usage is not None:
-        op.incremental_resource_usage = MagicMock(
-            return_value=incremental_resource_usage
-        )
     return op
 
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -590,6 +590,8 @@ RAY_SERVE_DIRECT_INGRESS_PORT_RETRY_COUNT = int(
     os.environ.get("RAY_SERVE_DIRECT_INGRESS_PORT_RETRY_COUNT", "100")
 )
 # The minimum drain period for a HTTP proxy.
+# If RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS is set to 1,
+# then the minimum draining period is 0.
 RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S = float(
     os.environ.get("RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S", "30")
 )

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -37,6 +37,8 @@ from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.constants import (
     DEFAULT_LATENCY_BUCKET_MS,
     MAX_PER_REPLICA_RETRY_COUNT,
+    RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S,
+    RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_TASK_EVENTS,
     RAY_SERVE_FAIL_ON_RANK_ERROR,
     RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS,
@@ -251,11 +253,6 @@ SLOW_STARTUP_WARNING_PERIOD_S = int(
 
 ALL_REPLICA_STATES = list(ReplicaState)
 _SCALING_LOG_ENABLED = os.environ.get("SERVE_ENABLE_SCALING_LOG", "0") != "0"
-# Feature flag to disable forcibly shutting down replicas.
-RAY_SERVE_DISABLE_SHUTTING_DOWN_INGRESS_REPLICAS_FORCEFULLY = (
-    os.environ.get("RAY_SERVE_DISABLE_SHUTTING_DOWN_INGRESS_REPLICAS_FORCEFULLY", "0")
-    == "1"
-)
 
 
 def print_verbose_scaling_log():
@@ -758,7 +755,7 @@ class ActorReplicaWrapper:
         self._rank = rank
         return updating
 
-    def recover(self) -> bool:
+    def recover(self, ingress: bool = False) -> bool:
         """Recover replica version from a live replica actor.
 
         When controller dies, the deployment state loses the info on the version that's
@@ -767,12 +764,17 @@ class ActorReplicaWrapper:
 
         Also confirm that actor is allocated and initialized before marking as running.
 
-        Returns: False if the replica actor is no longer alive; the
+        Args:
+            ingress: Whether this replica is an ingress replica.
+
+        Returns:
+            False if the replica actor is no longer alive; the
             actor could have been killed in the time between when the
             controller fetching all Serve actors in the cluster and when
             the controller tries to recover it. Otherwise, return True.
         """
         logger.info(f"Recovering {self.replica_id}.")
+        self._ingress = ingress
         try:
             self._actor_handle = ray.get_actor(
                 self._actor_name, namespace=SERVE_NAMESPACE
@@ -1189,20 +1191,8 @@ class ActorReplicaWrapper:
 
         return self._routing_stats
 
-    def force_stop(self, log_shutdown_message: bool = False):
+    def force_stop(self):
         """Force the actor to exit without shutting down gracefully."""
-        if (
-            self._ingress
-            and RAY_SERVE_DISABLE_SHUTTING_DOWN_INGRESS_REPLICAS_FORCEFULLY
-        ):
-            if log_shutdown_message:
-                logger.info(
-                    f"{self.replica_id} did not shut down because it had not finished draining requests. "
-                    "Going to wait until the draining is complete. You can force-stop the replica by "
-                    "setting RAY_SERVE_DISABLE_SHUTTING_DOWN_INGRESS_REPLICAS_FORCEFULLY to 0."
-                )
-            return
-
         try:
             ray.kill(ray.get_actor(self._actor_name, namespace=SERVE_NAMESPACE))
         except ValueError:
@@ -1235,7 +1225,6 @@ class DeploymentReplica:
         )
         self._multiplexed_model_ids: List[str] = []
         self._routing_stats: Dict[str, Any] = {}
-        self._logged_shutdown_message = False
 
     def get_running_replica_info(
         self, cluster_node_info_cache: ClusterNodeInfoCache
@@ -1366,7 +1355,6 @@ class DeploymentReplica:
             deployment_info, assign_rank_callback=assign_rank_callback
         )
         self._start_time = time.time()
-        self._logged_shutdown_message = False
         self.update_actor_details(start_time_s=self._start_time)
         return replica_scheduling_request
 
@@ -1383,16 +1371,20 @@ class DeploymentReplica:
         """
         return self._actor.reconfigure(version, rank=rank)
 
-    def recover(self) -> bool:
+    def recover(self, deployment_info: DeploymentInfo) -> bool:
         """
         Recover states in DeploymentReplica instance by fetching running actor
         status
 
-        Returns: False if the replica is no longer alive at the time
-            when this method is called.
+        Args:
+            deployment_info: The deployment info for this replica.
+
+        Returns:
+            True if the replica actor is alive and recovered successfully.
+            False if the replica actor is no longer alive.
         """
         # If replica is no longer alive
-        if not self._actor.recover():
+        if not self._actor.recover(ingress=deployment_info.ingress):
             return False
 
         self._start_time = time.time()
@@ -1442,6 +1434,11 @@ class DeploymentReplica:
         timeout_s = self._actor.graceful_stop()
         if not graceful:
             timeout_s = 0
+        elif self._actor._ingress and RAY_SERVE_ENABLE_DIRECT_INGRESS:
+            # In direct ingress mode, ensure we wait at least
+            # RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S to give external
+            # load balancers (e.g., ALB) time to deregister the replica.
+            timeout_s = max(timeout_s, RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S)
         self._shutdown_deadline = time.time() + timeout_s
 
     def check_stopped(self) -> bool:
@@ -1451,19 +1448,11 @@ class DeploymentReplica:
 
         timeout_passed = time.time() >= self._shutdown_deadline
         if timeout_passed:
-            if (
-                not self._logged_shutdown_message
-                and not RAY_SERVE_DISABLE_SHUTTING_DOWN_INGRESS_REPLICAS_FORCEFULLY
-            ):
-                logger.info(
-                    f"{self.replica_id} did not shut down after grace "
-                    "period, force-killing it. "
-                )
-
-            self._actor.force_stop(
-                log_shutdown_message=not self._logged_shutdown_message
+            logger.info(
+                f"{self.replica_id} did not shut down after grace "
+                "period, force-killing it."
             )
-            self._logged_shutdown_message = True
+            self._actor.force_stop()
         return False
 
     def check_health(self) -> bool:
@@ -2342,7 +2331,7 @@ class DeploymentState:
             )
             # If replica is no longer alive, simply don't add it to the
             # deployment state manager to track.
-            if not new_deployment_replica.recover():
+            if not new_deployment_replica.recover(self._target_state.info):
                 logger.warning(f"{replica_id} died before controller could recover it.")
                 continue
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2311,38 +2311,23 @@ class Replica(ReplicaBase):
                 raise asyncio.CancelledError
 
     async def perform_graceful_shutdown(self):
-        if not RAY_SERVE_ENABLE_DIRECT_INGRESS or not self._ingress:
-            # if direct ingress is not enabled or the replica is not an ingress replica,
-            # we can just call the super method to perform the graceful shutdown.
-            await super().perform_graceful_shutdown()
-            return
-
-        # set the shutting down flag to True to signal ALBs with failing health checks
-        # to stop sending traffic to this replica.
-        self._shutting_down = True
-
-        # If the replica was never initialized it never served traffic, so we
-        # can skip the wait period.
-        if self._user_callable_initialized:
-            # in order to gracefully shutdown the replica, we need to wait for the
-            # requests to drain and for PROXY_MIN_DRAINING_PERIOD_S to pass.
-            # this is necessary because we want to give ALB time to update its
-            # target group to remove the replica from it and to mark this replica
-            # as unhealthy.
-            # TODO(abrar): the code below assumes that once ALB marks a replica target
-            # as unhealthy, it will not send traffic to it. This is not true because
-            # ALB can send traffic to a replica if all targets are unhealthy.
-            # The correct way to handle is this we start the cooldown period since
-            # the last request finished and wait for the cooldown period to pass.
+        if (
+            RAY_SERVE_ENABLE_DIRECT_INGRESS
+            and self._ingress
+            and self._user_callable_initialized
+        ):
+            # In direct ingress mode, we need to wait at least
+            # RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S to give external load
+            # balancers (e.g., ALB) time to deregister the replica, in addition to
+            # waiting for requests to drain.
             await asyncio.gather(
                 asyncio.sleep(RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S),
-                self._drain_ongoing_requests(),
+                super().perform_graceful_shutdown(),
             )
-            logger.info(
-                f"Replica {self._replica_id} successfully drained ongoing requests."
-            )
+        else:
+            await super().perform_graceful_shutdown()
 
-        await self.shutdown()
+        # Cancel direct ingress HTTP/gRPC server tasks if they exist.
         if self._direct_ingress_http_server_task:
             self._direct_ingress_http_server_task.cancel()
         if self._direct_ingress_grpc_server_task:

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -2037,8 +2037,9 @@ def test_shutdown_replica_only_after_draining_requests(
     """Test that the replica is shutdown correctly when the deployment is shutdown."""
     signal = SignalActor.remote()
 
-    # Increase graceful_shutdown_timeout_s to ensure replicas aren't force-killed
-    # before requests complete when RAY_SERVE_DISABLE_SHUTTING_DOWN_INGRESS_REPLICAS_FORCEFULLY=0
+    # In direct ingress mode, graceful_shutdown_timeout_s is automatically bumped to
+    # max(graceful_shutdown_timeout_s, RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S)
+    # to give external load balancers time to deregister the replica.
     @serve.deployment(name="replica-shutdown-deployment", graceful_shutdown_timeout_s=5)
     class ReplicaShutdownTest:
         async def __call__(self):
@@ -2437,6 +2438,89 @@ def test_get_deployment_config(_skip_if_ff_not_enabled, serve_instance):
     )
     # After the deployment is created, the config should be DeploymentConfig.
     assert isinstance(deployment_config, DeploymentConfig)
+
+
+def test_stuck_requests_are_force_killed(_skip_if_ff_not_enabled, serve_instance):
+    """This test is really slow, because it waits for the ports to be released from TIME_WAIT state.
+    The ports are in TIME_WAIT state because the replicas are force-killed and the ports are not
+    released immediately."""
+    import socket
+
+    def _can_bind_to_port(port):
+        """Check if we can bind to the port (not just if nothing is listening)."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("0.0.0.0", port))
+            sock.close()
+            return True
+        except OSError:
+            sock.close()
+            return False
+
+    signal = SignalActor.remote()
+
+    @serve.deployment(
+        name="stuck-requests-deployment",
+        graceful_shutdown_timeout_s=1,
+    )
+    class StuckRequestsTest:
+        async def __call__(self):
+            # This request will never complete - it waits forever
+            await signal.wait.remote()
+            return "ok"
+
+    serve.run(
+        StuckRequestsTest.bind(),
+        name="stuck-requests-deployment",
+        route_prefix="/stuck-requests-deployment",
+    )
+
+    # Collect all ports used by the application before deleting it
+    http_ports = get_http_ports(route_prefix="/stuck-requests-deployment")
+    grpc_ports = get_grpc_ports(route_prefix="/stuck-requests-deployment")
+
+    http_url = get_application_url("HTTP", app_name="stuck-requests-deployment")
+
+    with ThreadPoolExecutor() as executor:
+        # Send requests that will hang forever (signal is never sent)
+        futures = [executor.submit(httpx.get, http_url, timeout=60) for _ in range(2)]
+
+        # Wait for requests to be received by the replica
+        wait_for_condition(
+            lambda: ray.get(signal.cur_num_waiters.remote()) == 2, timeout=10
+        )
+
+        # Delete the deployment - requests are still stuck
+        serve.delete("stuck-requests-deployment", _blocking=False)
+
+        # Verify the application is eventually deleted (replica was force-killed).
+        # This should complete within graceful_shutdown_timeout_s (35s) + buffer.
+        wait_for_condition(
+            lambda: "stuck-requests-deployment" not in serve.status().applications,
+            timeout=10,
+        )
+
+        # The stuck requests should fail (connection closed or similar)
+        for future in futures:
+            try:
+                result = future.result(timeout=5)
+                # If we get a response, it should be an error (not 200)
+                assert result.status_code != 200
+            except Exception:
+                # Expected - request failed due to force-kill
+                pass
+
+    # Wait until all ports can be bound (not just until nothing is listening).
+    # This ensures the ports are fully released from TIME_WAIT state.
+    def all_ports_can_be_bound():
+        for port in http_ports + grpc_ports:
+            if not _can_bind_to_port(port):
+                return False
+        return True
+
+    # TIME_WAIT can last up to 60s on Linux, so use a generous timeout
+    wait_for_condition(all_ports_can_be_bound, timeout=120)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -109,6 +109,7 @@ class MockReplicaActorWrapper:
         self._docs_path = None
         self._rank = replica_rank_context.get(replica_id.unique_id, None)
         self._assign_rank_callback = None
+        self._ingress = False
 
     @property
     def is_cross_language(self) -> bool:
@@ -280,10 +281,11 @@ class MockReplicaActorWrapper:
         replica_rank_context[self._replica_id.unique_id] = rank
         return updating
 
-    def recover(self):
+    def recover(self, ingress: bool = False):
         if self.replica_id in dead_replicas_context:
             return False
 
+        self._ingress = ingress
         self.recovering = True
         self.started = False
         self._rank = replica_rank_context.get(self._replica_id.unique_id, None)

--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -246,7 +246,12 @@ def test_failed_task_runtime_env_setup(shutdown_only):
     def f():
         pass
 
-    bad_env = RuntimeEnv(conda={"dependencies": ["_this_does_not_exist"]})
+    bad_env = RuntimeEnv(
+        conda={
+            "channels": ["defaults"],
+            "dependencies": ["_this_does_not_exist"],
+        }
+    )
     with pytest.raises(
         RuntimeEnvSetupError,
     ):

--- a/python/ray/tests/test_tls_auth.py
+++ b/python/ray/tests/test_tls_auth.py
@@ -150,5 +150,89 @@ assert ray.is_initialized()
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason=("Cryptography (TLS dependency) doesn't install in Mac build pipeline"),
+)
+@pytest.mark.parametrize("use_tls", [True], indirect=True)
+def test_metrics_export_with_tls(use_tls):
+    """Test that metrics can be exported when TLS is enabled.
+
+    This verifies that the OpenTelemetry metric exporter correctly configures
+    TLS/mTLS credentials to communicate with the dashboard agent's gRPC server.
+    See https://github.com/ray-project/ray/issues/59968
+    """
+    # Enable OpenTelemetry metrics along with TLS
+    env = build_env()
+    env["RAY_enable_open_telemetry"] = "true"
+
+    run_string_as_driver(
+        """
+import ray
+import time
+import requests
+
+# Configure faster metrics reporting
+ray.init(_system_config={"metrics_report_interval_ms": 1000})
+try:
+    # Run a simple task to generate activity and trigger metrics
+    @ray.remote
+    def dummy_task():
+        return 1
+    ray.get(dummy_task.remote())
+
+    # Wait for metrics to be available
+    node_info = ray.nodes()[0]
+    metrics_port = node_info["MetricsExportPort"]
+    assert metrics_port > 0, f"Expected valid metrics port, got {metrics_port}"
+
+    # Try to fetch metrics from the Prometheus endpoint
+    metrics_url = f"http://127.0.0.1:{metrics_port}"
+
+    # C++ component metrics that only appear when the OpenTelemetry gRPC exporter
+    # successfully connects with TLS. Python metrics (~26) are exported even when
+    # TLS is broken, but C++ metrics (~87 total) require working TLS configuration.
+    cpp_metric_prefixes = ["ray_gcs_", "ray_object_directory_", "ray_grpc_"]
+
+    # Give the metrics agent time to start and export C++ metrics
+    # Use longer timeout since metrics may take time to be collected and exported
+    for i in range(60):
+        try:
+            response = requests.get(metrics_url, timeout=2)
+            if response.status_code == 200:
+                # Check for C++ component metrics (proves TLS is working)
+                has_cpp_metrics = any(
+                    prefix in response.text for prefix in cpp_metric_prefixes
+                )
+                if has_cpp_metrics:
+                    print(f"Found C++ metrics after {i+1} attempts")
+                    break
+                elif i % 10 == 0:
+                    # Debug: show how many metrics we have
+                    metric_lines = [l for l in response.text.split('\\n') if l.startswith('ray_')]
+                    print(f"Attempt {i+1}: {len(metric_lines)} ray metrics found, waiting for C++ metrics...")
+        except requests.exceptions.RequestException as e:
+            if i % 10 == 0:
+                print(f"Attempt {i+1}: request failed: {e}")
+        time.sleep(1)
+    else:
+        # On failure, print what metrics we do have for debugging
+        try:
+            response = requests.get(metrics_url, timeout=2)
+            metric_lines = [l for l in response.text.split('\\n') if l.startswith('ray_')]
+            print(f"Final metrics ({len(metric_lines)}): {metric_lines[:10]}...")
+        except Exception:
+            pass
+        raise AssertionError(
+            "Failed to fetch C++ component metrics within timeout. "
+            "This indicates TLS configuration may not be working correctly."
+        )
+finally:
+    ray.shutdown()
+    """,
+        env=env,
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -471,7 +471,8 @@
   group: Tune tests
   working_dir: ml_user_tests
 
-  frequency: nightly-3x
+  # TODO(rllib): https://github.com/anyscale/ray/issues/581
+  frequency: manual
   team: ml
 
   cluster:
@@ -843,7 +844,8 @@
   group: Long running tests
   working_dir: long_running_tests
 
-  frequency: weekly
+  # TODO(rllib): https://github.com/anyscale/ray/issues/568
+  frequency: manual
   team: rllib
 
   cluster:
@@ -855,7 +857,7 @@
     long_running: true
 
   smoke_test:
-    frequency: nightly
+    frequency: manual
 
     run:
       timeout: 3600
@@ -959,7 +961,8 @@
   group: Long running tests
   working_dir: long_running_tests
 
-  frequency: weekly
+  # TODO(rllib): https://github.com/anyscale/ray/issues/571
+  frequency: manual
   team: ml
 
   cluster:
@@ -977,7 +980,7 @@
 
 
   smoke_test:
-    frequency: nightly
+    frequency: manual
 
     run:
       timeout: 3600

--- a/rllib/evaluation/postprocessing.py
+++ b/rllib/evaluation/postprocessing.py
@@ -1,7 +1,6 @@
 from typing import Dict, Optional
 
 import numpy as np
-import scipy.signal
 
 from ray.rllib.policy.policy import Policy
 from ray.rllib.policy.sample_batch import SampleBatch
@@ -325,4 +324,7 @@ def discount_cumsum(x: np.ndarray, gamma: float) -> np.ndarray:
                2.0 + 0.9*3.0,
                3.0])
     """
+    # Import scipy here to avoid import error when framework is tensorflow.
+    import scipy
+
     return scipy.signal.lfilter([1], [1, float(-gamma)], x[::-1], axis=0)[::-1]

--- a/rllib/offline/offline_policy_evaluation_runner.py
+++ b/rllib/offline/offline_policy_evaluation_runner.py
@@ -15,9 +15,6 @@ import numpy
 
 import ray
 from ray.data.iterator import DataIterator
-from ray.data.util.torch_utils import (
-    convert_ndarray_batch_to_torch_tensor_batch,
-)
 from ray.rllib.connectors.env_to_module import EnvToModulePipeline
 from ray.rllib.core import (
     ALL_MODULES,
@@ -116,6 +113,12 @@ class MiniBatchEpisodeRayDataIterator(MiniBatchRayDataIterator):
         _batch: Dict[EpisodeID, Dict[str, numpy.ndarray]],
     ) -> Dict[EpisodeID, Dict[str, TensorType]]:
         """Converts a batch of episodes to torch tensors."""
+        # Avoid torch import error when framework is tensorflow.
+        # Note (artur): This can be removed when we remove tf support.
+        from ray.data.util.torch_utils import (
+            convert_ndarray_batch_to_torch_tensor_batch,
+        )
+
         return [
             convert_ndarray_batch_to_torch_tensor_batch(
                 episode, device=self._device, dtypes=torch.float32

--- a/src/ray/common/constants.h
+++ b/src/ray/common/constants.h
@@ -74,7 +74,7 @@ constexpr char kDashboardAgentListenPortName[] = "dashboard_agent_listen_port";
 constexpr char kGcsServerPortName[] = "gcs_server_port";
 
 /// The version of Ray
-constexpr char kRayVersion[] = "3.0.0.dev0";
+constexpr char kRayVersion[] = "2.54.0";
 
 /*****************************/
 /* ENV labels for autoscaler */

--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -8,9 +8,14 @@ ray_cc_library(
     hdrs = [
         "open_telemetry_metric_recorder.h",
     ],
+    # Enable mTLS support for OpenTelemetry OTLP gRPC exporter.
+    # This must match the define used when building io_opentelemetry_cpp.
+    # See https://github.com/ray-project/ray/issues/59968
+    copts = ["-DENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW"],
     deps = [
         "//src/ray/common:constants",
         "//src/ray/common:ray_config",
+        "//src/ray/rpc:common",
         "//src/ray/rpc/authentication:authentication_mode",
         "//src/ray/rpc/authentication:authentication_token_loader",
         "//src/ray/util:logging",

--- a/src/ray/observability/open_telemetry_metric_recorder.cc
+++ b/src/ray/observability/open_telemetry_metric_recorder.cc
@@ -32,6 +32,7 @@
 #include "ray/common/constants.h"
 #include "ray/rpc/authentication/authentication_mode.h"
 #include "ray/rpc/authentication/authentication_token_loader.h"
+#include "ray/rpc/common.h"
 #include "ray/util/logging.h"
 
 // Anonymous namespace that contains the private callback functions for the
@@ -103,6 +104,59 @@ void OpenTelemetryMetricRecorder::Start(const std::string &endpoint,
       exporter_options.metadata.insert(
           {std::string(kAuthTokenKey), token->ToAuthorizationHeaderValue()});
     }
+  }
+  // Configure TLS/SSL credentials to match how Ray's gRPC servers are configured.
+  // When USE_TLS is enabled, the dashboard agent's gRPC server uses SSL, so the
+  // OpenTelemetry exporter must also use SSL to connect successfully.
+  // See https://github.com/ray-project/ray/issues/59968
+  if (RayConfig::instance().USE_TLS()) {
+    exporter_options.use_ssl_credentials = true;
+
+    // Load CA certificate for server verification.
+    // Reuse ReadCert from ray/rpc/common.h for consistency with other TLS code paths.
+    std::string ca_cert_file = std::string(RayConfig::instance().TLS_CA_CERT());
+    if (!ca_cert_file.empty()) {
+      std::string ca_cert = rpc::ReadCert(ca_cert_file);
+      RAY_CHECK(!ca_cert.empty())
+          << "Failed to read CA certificate file: " << ca_cert_file;
+      exporter_options.ssl_credentials_cacert_as_string = std::move(ca_cert);
+    }
+
+#ifdef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
+    // Load client certificate and key for mutual TLS (mTLS).
+    // Ray's gRPC server requires client authentication when CA cert is configured.
+    // Note: mTLS support requires the OpenTelemetry SDK to be built with
+    // ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW defined.
+    //
+    // We reuse TLS_SERVER_CERT and TLS_SERVER_KEY for the client certificate because
+    // Ray components (raylet, gcs_server, etc.) act as both servers and clients,
+    // using the same certificate for bidirectional mTLS communication. This is
+    // consistent with how other Ray gRPC clients are configured.
+    std::string client_cert_file = std::string(RayConfig::instance().TLS_SERVER_CERT());
+    std::string client_key_file = std::string(RayConfig::instance().TLS_SERVER_KEY());
+    if (!client_cert_file.empty()) {
+      std::string client_cert = rpc::ReadCert(client_cert_file);
+      RAY_CHECK(!client_cert.empty())
+          << "Failed to read client certificate file: " << client_cert_file;
+      exporter_options.ssl_client_cert_string = std::move(client_cert);
+    }
+    if (!client_key_file.empty()) {
+      std::string client_key = rpc::ReadCert(client_key_file);
+      RAY_CHECK(!client_key.empty())
+          << "Failed to read client key file: " << client_key_file;
+      exporter_options.ssl_client_key_string = std::move(client_key);
+    }
+    RAY_LOG(INFO) << "OpenTelemetry metric exporter configured with TLS and mTLS enabled";
+#else
+    // Ray's gRPC server requires client certificates (mTLS) when TLS is enabled.
+    // Without mTLS support, the OpenTelemetry exporter will fail to connect.
+    // This is a fatal error because metric export will silently fail otherwise.
+    RAY_LOG(FATAL)
+        << "OpenTelemetry metric exporter cannot be configured: TLS is enabled "
+        << "but mTLS support is not available (SDK built without "
+        << "ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW). Ray's gRPC servers require "
+        << "client certificates when TLS is enabled.";
+#endif
   }
   auto exporter = std::make_unique<OpenTelemetryMetricExporter>(exporter_options);
 

--- a/src/ray/rpc/BUILD.bazel
+++ b/src/ray/rpc/BUILD.bazel
@@ -4,7 +4,10 @@ ray_cc_library(
     name = "common",
     srcs = ["common.cc"],
     hdrs = ["common.h"],
-    visibility = ["//visibility:private"],
+    visibility = [
+        "//src/ray/observability:__pkg__",
+        "//src/ray/rpc:__pkg__",
+    ],
 )
 
 ray_cc_library(

--- a/thirdparty/patches/opentelemetry-cpp-enable-mtls.patch
+++ b/thirdparty/patches/opentelemetry-cpp-enable-mtls.patch
@@ -1,0 +1,14 @@
+diff --git a/exporters/otlp/BUILD b/exporters/otlp/BUILD
+index 1234567..abcdefg 100644
+--- a/exporters/otlp/BUILD
++++ b/exporters/otlp/BUILD
+@@ -42,6 +42,9 @@ cc_library(
+         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
+         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
+     ],
++    defines = [
++        "ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW",
++    ],
+     strip_include_prefix = "include",
+     tags = [
+         "otlp",


### PR DESCRIPTION
## Description

`EventAgent._get_dashboard_http_address()` reads the dashboard address from GCS internal KV and uses it directly to construct the `report_events` URL. However, GCS KV stores the address as `host:port` **without** an HTTP scheme — for example `10.19.92.13:8266`.

This causes `aiohttp` to raise `NonHttpUrlClientError` on every `report_events()` POST:

```
NonHttpUrlClientError: 10.19.92.13:8266/report_events
```

The result is a continuous retry loop (10 retries per report cycle) producing spurious `WARNING`/`ERROR` log spam and adding unnecessary CPU pressure on the DashboardAgent asyncio event loop.

**Root cause:** Every other consumer of `DASHBOARD_ADDRESS` from GCS KV already prepends `http://` manually. For example, `dashboard/utils.py:694`:

```python
api_server_url = f"http://{api_server_url.decode()}"
```

`event_agent.py` was missing this step.

**Fix:** Prepend `http://` when caching the address from GCS KV in `_get_dashboard_http_address()`, consistent with all other callers.

```python
# Before
self._dashboard_http_address = dashboard_http_address.decode()

# After
self._dashboard_http_address = f"http://{dashboard_http_address.decode()}"
```

## Related issues

None (discovered via log monitoring on a production Ray 2.54 cluster).

## Additional information

- Affects all Ray versions where `EventAgent` uses `async_internal_kv_get` for the dashboard address
- No behaviour change other than fixing the URL — events that were previously silently dropped will now be delivered correctly
- 1-line logic change, no API surface affected
