### PR TITLE
fix(serve/metrics): drop per-replica labels at write time for OTel counter/sum to prevent unbounded memory growth

### DIFF
--- a/python/ray/_private/telemetry/metric_cardinality.py
+++ b/python/ray/_private/telemetry/metric_cardinality.py
@@ -8,6 +8,11 @@ from ray._private.telemetry.metric_types import MetricType
 WORKER_ID_TAG_KEY = "WorkerId"
 # Keep in sync with the NameKey in src/ray/stats/tag_defs.cc
 TASK_OR_ACTOR_NAME_TAG_KEY = "Name"
+# Keep in sync with REPLICA_TAG in python/ray/serve/metrics.py
+SERVE_REPLICA_TAG_KEY = "replica"
+# actor_id is a per-handle-instance label used in Serve router metrics
+SERVE_ACTOR_ID_TAG_KEY = "actor_id"
+
 # Aggregation functions for high-cardinality gauge metrics when labels are dropped.
 # Counter and Sum metrics always use sum() aggregation.
 HIGH_CARDINALITY_GAUGE_AGGREGATION: Dict[str, Callable[[List[float]], float]] = {
@@ -15,8 +20,20 @@ HIGH_CARDINALITY_GAUGE_AGGREGATION: Dict[str, Callable[[List[float]], float]] = 
     "actors": sum,
 }
 
+# Per-instance labels that cause unbounded cardinality growth in cumulative metrics
+# (Counter, Sum). Unlike gauges which clear after each scrape, cumulative metrics
+# retain one entry per unique tag combination forever. These labels are unique per
+# actor/replica/worker instance, so they must be dropped at write time.
+# Dropped when RAY_metric_cardinality_level >= "recommended" (the default).
+_CUMULATIVE_METRIC_HIGH_CARDINALITY_LABELS = (
+    WORKER_ID_TAG_KEY,
+    SERVE_REPLICA_TAG_KEY,
+    SERVE_ACTOR_ID_TAG_KEY,
+)
+
 _CARDINALITY_LEVEL = None
 _HIGH_CARDINALITY_LABELS: Dict[str, List[str]] = {}
+_CUMULATIVE_HIGH_CARDINALITY_LABELS_CACHE: Dict[str, List[str]] = {}
 
 
 class MetricCardinality(str, Enum):
@@ -27,8 +44,9 @@ class MetricCardinality(str, Enum):
 
     - LEGACY: Keep all labels. This is the default behavior.
     - RECOMMENDED: Drop high cardinality labels. The set of high cardinality labels
-    are determined internally by Ray and not exposed to users. Currently, this includes
-    the following labels: WorkerId
+    are determined internally by Ray and not exposed to users. For gauge metrics,
+    this currently includes WorkerId. For cumulative metrics (Counter, Sum), this
+    includes WorkerId, replica, and actor_id to prevent unbounded memory growth.
     - LOW: Same as RECOMMENDED, but also drop the Name label for tasks and actors.
     """
 
@@ -99,3 +117,26 @@ class MetricCardinality(str, Enum):
         ]:
             _HIGH_CARDINALITY_LABELS[metric_name].append(TASK_OR_ACTOR_NAME_TAG_KEY)
         return _HIGH_CARDINALITY_LABELS[metric_name]
+
+    @staticmethod
+    def get_cumulative_metric_labels_to_drop(metric_name: str) -> List[str]:
+        """Get per-instance labels to drop at write time for cumulative metrics.
+
+        Cumulative metrics (Counter, Sum) are never cleared, so every unique tag
+        combination creates a permanent entry. This returns labels to strip so
+        observations collapse to a bounded number of entries.
+
+        Returns an empty list at LEGACY cardinality level.
+        """
+        if metric_name in _CUMULATIVE_HIGH_CARDINALITY_LABELS_CACHE:
+            return _CUMULATIVE_HIGH_CARDINALITY_LABELS_CACHE[metric_name]
+
+        cardinality_level = MetricCardinality.get_cardinality_level()
+        if cardinality_level == MetricCardinality.LEGACY:
+            _CUMULATIVE_HIGH_CARDINALITY_LABELS_CACHE[metric_name] = []
+            return []
+
+        _CUMULATIVE_HIGH_CARDINALITY_LABELS_CACHE[metric_name] = list(
+            _CUMULATIVE_METRIC_HIGH_CARDINALITY_LABELS
+        )
+        return _CUMULATIVE_HIGH_CARDINALITY_LABELS_CACHE[metric_name]

--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -213,6 +213,28 @@ class OpenTelemetryMetricRecorder:
         """
         return self._histogram_bucket_midpoints[name]
 
+    def _accumulate_cumulative_metric(
+        self,
+        store: dict,
+        name: str,
+        tags: dict,
+        tag_key: frozenset,
+        value: float,
+    ) -> None:
+        """Accumulate a value for a cumulative metric (Counter or Sum).
+
+        Drops high-cardinality per-instance labels at write time so the dict
+        stays bounded. Without this, every unique tag combination creates a
+        permanent entry that is never cleared.
+        """
+        labels_to_drop = MetricCardinality.get_cumulative_metric_labels_to_drop(name)
+        storage_key = (
+            frozenset((k, v) for k, v in tags.items() if k not in labels_to_drop)
+            if labels_to_drop
+            else tag_key
+        )
+        store[storage_key] = store.get(storage_key, 0) + value
+
     def set_metric_value(self, name: str, tags: dict, value: float):
         """
         Set the value of a metric with the given name and tags.
@@ -233,14 +255,15 @@ class OpenTelemetryMetricRecorder:
                 # Gauge - store the most recent value for the given tags.
                 self._gauge_observations_by_name[name][tag_key] = value
             elif name in self._counter_observations_by_name:
-                # Counter - increment the value for the given tags.
-                self._counter_observations_by_name[name][tag_key] = (
-                    self._counter_observations_by_name[name].get(tag_key, 0) + value
+                # Counter - accumulate with high-cardinality labels dropped
+                # at write time to keep the dict bounded (cumulative semantics).
+                self._accumulate_cumulative_metric(
+                    self._counter_observations_by_name[name], name, tags, tag_key, value
                 )
             elif name in self._sum_observations_by_name:
-                # Sum - add the value for the given tags.
-                self._sum_observations_by_name[name][tag_key] = (
-                    self._sum_observations_by_name[name].get(tag_key, 0) + value
+                # Sum - same write-time label-drop as Counter.
+                self._accumulate_cumulative_metric(
+                    self._sum_observations_by_name[name], name, tags, tag_key, value
                 )
             else:
                 # Histogram - record the value synchronously.

--- a/python/ray/tests/test_open_telemetry_metric_recorder.py
+++ b/python/ray/tests/test_open_telemetry_metric_recorder.py
@@ -5,6 +5,7 @@ import pytest
 from opentelemetry.metrics import NoOpHistogram
 
 from ray._private.metrics_agent import Gauge, Record
+from ray._private.telemetry import metric_cardinality as _mc_module
 from ray._private.telemetry.open_telemetry_metric_recorder import (
     OpenTelemetryMetricRecorder,
 )
@@ -300,6 +301,139 @@ def test_record_histogram_aggregated_batch(
 
     # No warnings should be logged for registered histogram
     mock_logger_warning.assert_not_called()
+
+
+def _reset_cardinality_cache():
+    """Reset module-level caches between cardinality tests."""
+    _mc_module._CARDINALITY_LEVEL = None
+    _mc_module._HIGH_CARDINALITY_LABELS.clear()
+    _mc_module._CUMULATIVE_HIGH_CARDINALITY_LABELS_CACHE.clear()
+
+
+@patch("opentelemetry.metrics.set_meter_provider")
+@patch("opentelemetry.metrics.get_meter")
+def test_counter_write_time_label_drop_recommended(
+    mock_get_meter, mock_set_meter_provider
+):
+    """Counter collapses per-instance labels at write time under RECOMMENDED."""
+    mock_get_meter.return_value = MagicMock()
+
+    try:
+        with patch.object(_mc_module, "RAY_METRIC_CARDINALITY_LEVEL", "recommended"):
+            _reset_cardinality_cache()
+            recorder = OpenTelemetryMetricRecorder()
+            recorder.register_counter_metric(
+                name="serve_num_router_requests", description="Router requests"
+            )
+
+            for replica_id, actor_id in [
+                ("app_MyDeployment#abc123", "a1b2c3"),
+                ("app_MyDeployment#def456", "d4e5f6"),
+                ("app_MyDeployment#ghi789", "g7h8i9"),
+            ]:
+                recorder.set_metric_value(
+                    name="serve_num_router_requests",
+                    tags={
+                        "deployment": "MyDeployment",
+                        "application": "app",
+                        "route": "/predict",
+                        "handle": "default",
+                        "replica": replica_id,
+                        "actor_id": actor_id,
+                    },
+                    value=10.0,
+                )
+
+            observations = recorder._counter_observations_by_name[
+                "serve_num_router_requests"
+            ]
+
+            # All three replicas should collapse to a single entry
+            assert len(observations) == 1, (
+                f"Expected 1 collapsed entry, got {len(observations)}"
+            )
+            assert list(observations.values())[0] == 30.0
+            stored_key_dict = dict(list(observations.keys())[0])
+            assert "replica" not in stored_key_dict
+            assert "actor_id" not in stored_key_dict
+            assert stored_key_dict["deployment"] == "MyDeployment"
+            assert stored_key_dict["route"] == "/predict"
+    finally:
+        _reset_cardinality_cache()
+
+
+@patch("opentelemetry.metrics.set_meter_provider")
+@patch("opentelemetry.metrics.get_meter")
+def test_counter_write_time_label_drop_legacy_preserves_full_tags(
+    mock_get_meter, mock_set_meter_provider
+):
+    """At LEGACY cardinality level, full tag combinations are preserved."""
+    mock_get_meter.return_value = MagicMock()
+
+    try:
+        with patch.object(_mc_module, "RAY_METRIC_CARDINALITY_LEVEL", "legacy"):
+            _reset_cardinality_cache()
+            recorder = OpenTelemetryMetricRecorder()
+            recorder.register_counter_metric(
+                name="serve_num_router_requests", description="Router requests"
+            )
+
+            for replica_id in ["replica#aaa", "replica#bbb"]:
+                recorder.set_metric_value(
+                    name="serve_num_router_requests",
+                    tags={
+                        "deployment": "MyDeployment",
+                        "replica": replica_id,
+                    },
+                    value=5.0,
+                )
+
+            observations = recorder._counter_observations_by_name[
+                "serve_num_router_requests"
+            ]
+            assert len(observations) == 2
+    finally:
+        _reset_cardinality_cache()
+
+
+@patch("opentelemetry.metrics.set_meter_provider")
+@patch("opentelemetry.metrics.get_meter")
+def test_sum_write_time_label_drop_recommended(mock_get_meter, mock_set_meter_provider):
+    """Sum collapses per-instance labels at write time under RECOMMENDED."""
+    mock_get_meter.return_value = MagicMock()
+
+    try:
+        with patch.object(_mc_module, "RAY_METRIC_CARDINALITY_LEVEL", "recommended"):
+            _reset_cardinality_cache()
+            recorder = OpenTelemetryMetricRecorder()
+            recorder.register_sum_metric(
+                name="serve_deployment_queued_queries", description="Queued queries"
+            )
+
+            for actor_id in ["actor#111", "actor#222", "actor#333"]:
+                recorder.set_metric_value(
+                    name="serve_deployment_queued_queries",
+                    tags={
+                        "deployment": "MyDeployment",
+                        "application": "app",
+                        "handle": "default",
+                        "actor_id": actor_id,
+                    },
+                    value=3.0,
+                )
+
+            observations = recorder._sum_observations_by_name[
+                "serve_deployment_queued_queries"
+            ]
+
+            assert len(observations) == 1, (
+                f"Expected 1 entry after write-time label drop, got {len(observations)}"
+            )
+            assert list(observations.values())[0] == 9.0
+            stored_key_dict = dict(list(observations.keys())[0])
+            assert "actor_id" not in stored_key_dict
+    finally:
+        _reset_cardinality_cache()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

**Root cause**: `OpenTelemetryMetricRecorder._counter_observations_by_name` and
`_sum_observations_by_name` grow without bound in long-running clusters using Ray Serve at scale.

Counters and sums retain one dict entry per unique `frozenset(tags.items())` indefinitely (cumulative
semantics — they are never cleared). Serve metrics include per-instance labels such as:
- `replica` — value is `replica_id.unique_id`, globally unique per replica lifetime
- `actor_id` — unique per handle/router instance

With thousands of Serve replicas created and destroyed over time, these dicts accumulate millions of
entries. We observed **2.4 GB RSS** in a production DashboardAgent running ~700 Serve replicas, with
the agent event loop eventually blocking job submissions.

The existing read-time label-dropping in `_create_observable_callback` correctly collapses observations
during export but does **not** reduce storage: it reads N distinct entries and emits M < N aggregated
Prometheus series, but N keeps growing as replicas come and go.

**Fix**: Drop high-cardinality per-instance labels (`WorkerId`, `replica`, `actor_id`) at **write time**
when storing counter and sum observations — consistent with how histograms already filter tags before
calling `instrument.record()`.

This bounds storage to the number of unique `deployment/application/route` combinations (O(tens))
rather than the number of unique replica instances (O(thousands+)).

The filtering is gated on `RAY_metric_cardinality_level >= recommended` (the default). `LEGACY` mode
preserves the previous behavior.

**Before:**
```
# _counter_observations_by_name["serve_num_router_requests"] grows forever:
{frozenset({("deployment","D"),("replica","app#replica-aaa"),("actor_id","a1"),...}): 100.0,
 frozenset({("deployment","D"),("replica","app#replica-bbb"),("actor_id","a2"),...}): 200.0,
 # ... one entry per dead replica, never cleaned up
 frozenset({("deployment","D"),("replica","app#replica-zzz"),("actor_id","aN"),...}): 50.0}
```

**After (RECOMMENDED, the default):**
```
# Collapsed to one entry per deployment×route combination:
{frozenset({("deployment","D"),("application","app"),("route","/predict")}): 350.0}
```

## Changes

- **`metric_cardinality.py`**: Add `SERVE_REPLICA_TAG_KEY` / `SERVE_ACTOR_ID_TAG_KEY` constants.
  Add `MetricCardinality.get_cumulative_metric_labels_to_drop(metric_name)` — returns the per-instance
  labels to strip for Counter/Sum at `RECOMMENDED`+ level; returns `[]` at `LEGACY`.

- **`open_telemetry_metric_recorder.py`**: In `set_metric_value`, compute the storage key for Counter
  and Sum after stripping the cumulative high-cardinality labels returned by the new method. The
  `_create_observable_callback` read path is unchanged (it already handles label aggregation correctly
  and will now simply iterate over a much smaller, already-filtered dict).

- **`test_open_telemetry_metric_recorder.py`**: Three new unit tests:
  1. `test_counter_write_time_label_drop_recommended` — N unique replica/actor_id tag combos collapse
     to 1 entry with correct aggregated value under RECOMMENDED.
  2. `test_counter_write_time_label_drop_legacy_preserves_full_tags` — LEGACY preserves all tag
     combinations (backward-compat).
  3. `test_sum_write_time_label_drop_recommended` — Sum metric collapses N unique actor_id values.

## Related issues

Related to the general problem of unbounded OTel metric cardinality at scale with Ray Serve.