### PR TITLE
fix: guard against empty alive_vec in GCS liveness check

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -462,18 +462,29 @@ void NodeManager::RegisterGcs() {
             // capture checking ptr here because vs17 fail to compile
             [this, checking_ptr = &checking](const auto &status,
                                              const auto &alive_vec) mutable {
+              // When the RPC fails (timeout, network error, etc.), accessor calls
+              // callback(status, {}). Do not access alive_vec[0] when empty.
+              if (!status.ok()) {
+                if (status.IsUnauthenticated()) {
+                  RAY_LOG(FATAL)
+                      << "GCS returned an authentication error. This may happen when "
+                      << "GCS is not backed by a DB and restarted or there is data loss "
+                      << "in the DB. Local cluster ID: " << gcs_client_.GetClusterId();
+                }
+                *checking_ptr = false;
+                return;
+              }
+              if (alive_vec.empty()) {
+                *checking_ptr = false;
+                return;
+              }
               bool alive = alive_vec[0];
-              if ((status.ok() && !alive)) {
+              if (!alive) {
                 // GCS think this raylet is dead. Fail the node
                 RAY_LOG(FATAL)
                     << "GCS consider this node to be dead. This may happen when "
                     << "GCS is not backed by a DB and restarted or there is data loss "
                     << "in the DB.";
-              } else if (status.IsUnauthenticated()) {
-                RAY_LOG(FATAL)
-                    << "GCS returned an authentication error. This may happen when "
-                    << "GCS is not backed by a DB and restarted or there is data loss "
-                    << "in the DB. Local cluster ID: " << gcs_client_.GetClusterId();
               }
               *checking_ptr = false;
             });


### PR DESCRIPTION
## Summary
Fixes #61787.
**Root cause:** The GCS liveness check callback accessed `alive_vec[0]` without checking if the vector was empty. When the RPC failed and returned an empty vector, this caused a SIGSEGV (out-of-bounds access).
**Fix:** Added an empty check for `alive_vec` before accessing its elements, and handle non-OK status before touching the vector.
## Changes
- Added `alive_vec.empty()` guard in the GCS liveness check callback
- Handle `!status.ok()` first to avoid accessing alive_vec on RPC failure
## Testing
- Verified fix addresses reported SIGSEGV scenario
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)