### PR TITLE
[Serve] Fix Java long poll timeout serialization

### DIFF
--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -438,8 +438,14 @@ class LongPollHost:
             self._parse_xlang_key(xlang_key): snapshot_id
             for xlang_key, snapshot_id in request_proto.keys_to_snapshot_ids.items()
         }
-        keys_to_updated_objects = await self.listen_for_change(keys_to_snapshot_ids)
-        return self._listen_result_to_proto_bytes(keys_to_updated_objects)
+        result = await self.listen_for_change(keys_to_snapshot_ids)
+
+        # Java long-poll protocol currently doesn't encode LongPollState.
+        # Convert timeout to an empty update payload so the Java client can retry.
+        if result is LongPollState.TIME_OUT:
+            result = {}
+
+        return self._listen_result_to_proto_bytes(result)
 
     def _parse_poll_namespace(self, name: str):
         if name == LongPollNamespace.ROUTE_TABLE.name:

--- a/python/ray/serve/tests/test_long_poll.py
+++ b/python/ray/serve/tests/test_long_poll.py
@@ -265,5 +265,33 @@ def test_listen_for_change_java(serve_instance):
     ]
 
 
+def test_listen_for_change_java_timeout_returns_empty_result(serve_instance):
+    host = ray.remote(LongPollHost).remote(
+        listen_for_change_request_timeout_s=(0.5, 0.5)
+    )
+    ray.get(host.notify_changed.remote({"key_1": 999}))
+
+    initial_result = LongPollResult.FromString(
+        ray.get(
+            host.listen_for_change_java.remote(
+                LongPollRequest(keys_to_snapshot_ids={"key_1": -1}).SerializeToString()
+            )
+        )
+    )
+    snapshot_id = initial_result.updated_objects["key_1"].snapshot_id
+
+    timeout_result = LongPollResult.FromString(
+        ray.get(
+            host.listen_for_change_java.remote(
+                LongPollRequest(
+                    keys_to_snapshot_ids={"key_1": snapshot_id}
+                ).SerializeToString()
+            )
+        )
+    )
+
+    assert len(timeout_result.updated_objects) == 0
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION

## Description
Fixes a bug in LongPollHost.listen_for_change_java() when the upstream listen_for_change() call times out.

listen_for_change() can return LongPollState.TIME_OUT, but the Java wrapper path previously forwarded that value directly to _listen_result_to_proto_bytes(), which expects a dictionary of updated objects. This could cause the Java long-poll path to fail on timeout.

This PR converts LongPollState.TIME_OUT to an empty result before serialization, so Java callers receive a valid empty LongPollResult instead.

## Related issues
https://github.com/ray-project/ray/issues/61874

## Additional information
Added a unit test to verify that listen_for_change_java() returns an empty LongPollResult on timeout.
