### PR TITLE
[deps] Fix stale open-telemetry hashes in llm py312 lock files

### DIFF
--- a/python/deplocks/llm/rayllm_test_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cpu.lock
@@ -3289,8 +3289,8 @@ openlineage-python==1.40.0 \
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
     #   -r python/requirements/cloud-requirements.txt
 opentelemetry-api==1.39.0 \
-    --hash=sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3 \
-    --hash=sha256:b7df4cb0830d5a6c29ad0c0691dbae874d8daefa934b8b1d642de48323d32a8c
+    --hash=sha256:3c3b3ca5c5687b1b5b37e5c5027ff68eacea8675241b29f13110a8ffbb8f0459 \
+    --hash=sha256:6130644268c5ac6bdffaf660ce878f10906b3e789f7e2daa5e169b047a2933b9
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
     #   -r python/requirements.txt
@@ -3311,12 +3311,12 @@ opentelemetry-exporter-otlp-proto-common==1.39.0 \
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-grpc==1.39.0 \
-    --hash=sha256:04bb8b732b02295be79f8a86a4ad28fae3d4ddb07307a98c7aa6f331de18cca6 \
-    --hash=sha256:7c841b90caa3aafcfc4fee58487a6c71743c34c6dc1787089d8b0578bbd794dd
+    --hash=sha256:758641278050de9bb895738f35ff8840e4a47685b7e6ef4a201fe83196ba7a05 \
+    --hash=sha256:7e7bb3f436006836c0e0a42ac619097746ad5553ad7128a5bd4d3e727f37fc06
     # via opentelemetry-exporter-otlp
 opentelemetry-exporter-otlp-proto-http==1.39.0 \
-    --hash=sha256:5251f00ca85872ce50d871f6d3cc89fe203b94c3c14c964bbdc3883366c705d8 \
-    --hash=sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad
+    --hash=sha256:28d78fc0eb82d5a71ae552263d5012fa3ebad18dfd189bf8d8095ba0e65ee1ed \
+    --hash=sha256:5789cb1375a8b82653328c0ce13a054d285f774099faf9d068032a49de4c7862
     # via opentelemetry-exporter-otlp
 opentelemetry-exporter-prometheus==0.60b0 \
     --hash=sha256:4f616397040257fae4c5e5272b57b47c13372e3b7f0f2db2427fd4dbe69c60b5 \
@@ -3325,8 +3325,8 @@ opentelemetry-exporter-prometheus==0.60b0 \
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
     #   -r python/requirements.txt
 opentelemetry-proto==1.39.0 \
-    --hash=sha256:16286214e405c211fc774187f3e4bbb1351290b8dfb88e8948af209ce85b719e \
-    --hash=sha256:eb4bb5ac27f2562df2d6857fc557b3a481b5e298bc04f94cc68041f00cebcbd2
+    --hash=sha256:1e086552ac79acb501485ff0ce75533f70f3382d43d0a30728eeee594f7bf818 \
+    --hash=sha256:c1fa48678ad1a1624258698e59be73f990b7fc1f39e73e16a9d08eef65dd838c
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
     #   -r python/requirements.txt

--- a/python/deplocks/llm/rayllm_test_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cu130.lock
@@ -3373,12 +3373,12 @@ opentelemetry-exporter-otlp-proto-common==1.39.0 \
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-exporter-otlp-proto-grpc==1.39.0 \
-    --hash=sha256:04bb8b732b02295be79f8a86a4ad28fae3d4ddb07307a98c7aa6f331de18cca6 \
-    --hash=sha256:7c841b90caa3aafcfc4fee58487a6c71743c34c6dc1787089d8b0578bbd794dd
+    --hash=sha256:758641278050de9bb895738f35ff8840e4a47685b7e6ef4a201fe83196ba7a05 \
+    --hash=sha256:7e7bb3f436006836c0e0a42ac619097746ad5553ad7128a5bd4d3e727f37fc06
     # via opentelemetry-exporter-otlp
 opentelemetry-exporter-otlp-proto-http==1.39.0 \
-    --hash=sha256:5251f00ca85872ce50d871f6d3cc89fe203b94c3c14c964bbdc3883366c705d8 \
-    --hash=sha256:aaac36fdce46a8191e604dcf632e1f9380c7d5b356b27b3e0edb5610d9be28ad
+    --hash=sha256:28d78fc0eb82d5a71ae552263d5012fa3ebad18dfd189bf8d8095ba0e65ee1ed \
+    --hash=sha256:5789cb1375a8b82653328c0ce13a054d285f774099faf9d068032a49de4c7862
     # via opentelemetry-exporter-otlp
 opentelemetry-exporter-prometheus==0.60b0 \
     --hash=sha256:4f616397040257fae4c5e5272b57b47c13372e3b7f0f2db2427fd4dbe69c60b5 \
@@ -3387,8 +3387,8 @@ opentelemetry-exporter-prometheus==0.60b0 \
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
     #   -r python/requirements.txt
 opentelemetry-proto==1.39.0 \
-    --hash=sha256:16286214e405c211fc774187f3e4bbb1351290b8dfb88e8948af209ce85b719e \
-    --hash=sha256:eb4bb5ac27f2562df2d6857fc557b3a481b5e298bc04f94cc68041f00cebcbd2
+    --hash=sha256:1e086552ac79acb501485ff0ce75533f70f3382d43d0a30728eeee594f7bf818 \
+    --hash=sha256:c1fa48678ad1a1624258698e59be73f990b7fc1f39e73e16a9d08eef65dd838c
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
     #   -r python/requirements.txt


### PR DESCRIPTION
## Description
Fix stale open-telemetry hashes in llm py312 lock files missed by https://github.com/ray-project/ray/pull/61598.

## Related issues
Post-merge failures: https://buildkite.com/ray-project/postmerge/builds/16555/steps/canvas?sid=019d047c-934a-44b9-a9bd-89756bcdc297&tab=output.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.


Testing
Built locally with wanda: **export PYTHON=3.12 && export BASE_TYPE=build && export BUILD_VARIANT=build && export RAY_CUDA_CODE=cpu && wanda ci/docker/llm.build.wanda.yaml**
<details>
<summary>Click to see logs</summary>

```
2026/03/19 18:01:32 building oss-ci-base_test-py3.12 (from ci/docker/base.test.wanda.yaml)
2026/03/19 18:01:41 build input digest: sha256:18a8af74139d665a6e758968bfbde633d6378f53fc93c9e43f44d5e44079d5dd
2026/03/19 18:01:41 cache hit: sha256:5a4947e0886491051e825e5818560be5424df55fb702b0490fd80a9f3df69e42
2026/03/19 18:01:41 tag output as cr.ray.io/rayproject/oss-ci-base_test-py3.12
2026/03/19 18:01:41 tag output as localhost:5000/rayci-work:oss-ci-base_test-py3.12
2026/03/19 18:01:41 tag output as localhost:5000/rayci-work:z-18a8af74139d665a6e758968bfbde633d6378f53fc93c9e43f44d5e44079d5dd
2026/03/19 18:01:41 building oss-ci-base_build-py3.12 (from ci/docker/base.build.wanda.yaml)
2026/03/19 18:01:41 build input digest: sha256:350b089d9da1200e6ec5c1ab39401339692fec2edee96f5b1710df664e95830d
2026/03/19 18:01:41 cache hit: sha256:912c6d3aeabd7af2a8aaaa69ae4fae1b6885be3ba89d324c5fdd9802e90e13e9
2026/03/19 18:01:41 tag output as cr.ray.io/rayproject/oss-ci-base_build-py3.12
2026/03/19 18:01:41 tag output as localhost:5000/rayci-work:oss-ci-base_build-py3.12
2026/03/19 18:01:41 tag output as localhost:5000/rayci-work:z-350b089d9da1200e6ec5c1ab39401339692fec2edee96f5b1710df664e95830d
2026/03/19 18:01:41 building llmbuild (from /home/ubuntu/repos/ray/ci/docker/llm.build.wanda.yaml)
2026/03/19 18:01:41 build input digest: sha256:90b7bd4eb00b5344b3ff80a3996023a33183a922639b86e91336c95c1aaf11f3
2026/03/19 18:01:41 cache hit: sha256:75c255fb274c3b7e373735eb20834391f65a20308b53e26e052c17de7920ed5c
2026/03/19 18:01:41 tag output as cr.ray.io/rayproject/llmbuild
2026/03/19 18:01:41 tag output as localhost:5000/rayci-work:llmbuild
2026/03/19 18:01:42 tag output as localhost:5000/rayci-work:z-90b7bd4eb00b5344b3ff80a3996023a33183a922639b86e91336c95c1aaf11f3
```
</details>