### PR TITLE
[Data] Assert no dead nodes in Data release tests

### DIFF
--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -53,8 +53,9 @@ class Benchmark:
         {"short": {"time": 1.0, "sleep_s": 1}, "long": {"time": 10.0 "sleep_s": 10}}
     """
 
-    def __init__(self):
+    def __init__(self, assert_no_dead_nodes: bool = True):
         self.result = {}
+        self.assert_no_dead_nodes = assert_no_dead_nodes
 
     def run_fn(
         self,
@@ -97,6 +98,10 @@ class Benchmark:
 
         self.result[name] = curr_case_metrics
         print(f"Result of case {name}: {curr_case_metrics}")
+
+        if self.assert_no_dead_nodes:
+            dead_nodes = [node["NodeID"] for node in ray.nodes() if not node["Alive"]]
+            assert not dead_nodes, f"Unexpected dead nodes: {dead_nodes}"
 
     def write_result(self):
         """Write all results to the appropriate JSON file.

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -158,6 +158,6 @@ def main(args):
 if __name__ == "__main__":
     args = parse_args()
 
-    benchmark = Benchmark()
+    benchmark = Benchmark(assert_no_dead_nodes=not args.chaos_test)
     benchmark.run_fn("batch-inference", main, args)
     benchmark.write_result()

--- a/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
+++ b/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
@@ -54,7 +54,7 @@ def parse_args():
 
 
 def main(args: argparse.Namespace):
-    benchmark = Benchmark()
+    benchmark = Benchmark(assert_no_dead_nodes=not args.chaos)
 
     if args.chaos:
         start_chaos()

--- a/release/nightly_tests/dataset/image_embedding_from_uris/main.py
+++ b/release/nightly_tests/dataset/image_embedding_from_uris/main.py
@@ -190,7 +190,7 @@ class FakeEmbedPatches:
 
 
 def main(args: argparse.Namespace):
-    benchmark = Benchmark()
+    benchmark = Benchmark(assert_no_dead_nodes=not args.chaos)
 
     if args.chaos:
         start_chaos()

--- a/release/nightly_tests/dataset/multi_node_train_benchmark.py
+++ b/release/nightly_tests/dataset/multi_node_train_benchmark.py
@@ -190,6 +190,12 @@ def parse_args():
         default=False,
         help="Whether to cache output dataset (after preprocessing).",
     )
+    parser.add_argument(
+        "--chaos",
+        action="store_true",
+        default=False,
+        help="Whether this benchmark is running in chaos mode.",
+    )
     args = parser.parse_args()
 
     ray.init(
@@ -763,6 +769,6 @@ if __name__ == "__main__":
     else:
         case_name = "cache-none"
 
-    benchmark = Benchmark()
+    benchmark = Benchmark(assert_no_dead_nodes=not args.chaos)
     benchmark.run_fn(case_name, benchmark_code, args=args)
     benchmark.write_result()

--- a/release/nightly_tests/dataset/sort_benchmark.py
+++ b/release/nightly_tests/dataset/sort_benchmark.py
@@ -101,6 +101,7 @@ if __name__ == "__main__":
         default=100,
         type=int,
     )
+    parser.add_argument("--chaos", action="store_true")
     parser.add_argument("--use-polars-sort", action="store_true")
     parser.add_argument("--limit-num-blocks", type=int, default=None)
 
@@ -183,7 +184,7 @@ if __name__ == "__main__":
 
         return results
 
-    benchmark = Benchmark()
+    benchmark = Benchmark(assert_no_dead_nodes=not args.chaos)
     benchmark.run_fn("main", run_benchmark, args)
     benchmark.write_result()
 

--- a/release/nightly_tests/dataset/text_embedding/main.py
+++ b/release/nightly_tests/dataset/text_embedding/main.py
@@ -78,7 +78,7 @@ def parse_args():
 
 
 def main(args: argparse.Namespace):
-    benchmark = Benchmark()
+    benchmark = Benchmark(assert_no_dead_nodes=not args.chaos)
 
     if args.chaos:
         start_chaos()

--- a/release/nightly_tests/dataset/text_embeddings_benchmark.py
+++ b/release/nightly_tests/dataset/text_embeddings_benchmark.py
@@ -191,6 +191,6 @@ def main(args):
 if __name__ == "__main__":
     args = parse_args()
     print(f"Writing to {WRITE_PATH}")
-    benchmark = Benchmark()
+    benchmark = Benchmark(assert_no_dead_nodes=not args.chaos_test)
     benchmark.run_fn("text-embeddings-benchmark", main, args)
     benchmark.write_result()

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -320,6 +320,9 @@
         prepare: >
           python setup_chaos.py --kill-interval 200 --max-to-kill 1 --task-names
           "_RayTrainWorker__execute.get_next"
+        script: >
+          python dataset/multi_node_train_benchmark.py --num-workers 16 --file-type parquet
+          --target-worker-gb 50 --use-gpu --chaos
 
 - name: training_ingest_benchmark
   python: "3.10"
@@ -511,7 +514,7 @@
       --max-to-kill 2
     script: >
       python dataset/sort_benchmark.py --num-partitions=1000 --partition-size=1e9
-      --shuffle
+      --shuffle --chaos
 
 
 - name: "sort_{{scaling}}"
@@ -545,7 +548,9 @@
     prepare: >
       python setup_chaos.py --chaos TerminateEC2Instance --kill-interval 900
       --max-to-kill 3
-    script: python dataset/sort_benchmark.py --num-partitions=1000 --partition-size=1e9
+    script: >
+      python dataset/sort_benchmark.py --num-partitions=1000 --partition-size=1e9
+      --chaos
 
 
 #######################


### PR DESCRIPTION
To ensure nodes don't unexpectedly die in our release tests, I've added a `assert_no_dead_nodes` to the `Benchmark` utility. It's set to true unless we're running a chaos test.

The motivation is to make sure we're capturing stability issues proactively.