### PR TITLE
[data][WIP] rough draft async executor framework PPE

### DIFF
--- a/python/ray/data/_internal/execution/execution_callback.py
+++ b/python/ray/data/_internal/execution/execution_callback.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 from ray.data.context import DataContext
 
 if TYPE_CHECKING:
-    from ray.data._internal.execution.interfaces.async_service import AsyncServiceTask
+    from ray.data._internal.execution.interfaces.async_service import AsyncCallee
     from ray.data._internal.execution.streaming_executor import StreamingExecutor
 
 EXECUTION_CALLBACKS_CONFIG_KEY = "execution_callbacks"
@@ -17,7 +17,7 @@ class ExecutionCallback:
     """Callback interface for execution events.
 
     Callbacks can participate in async state refresh by implementing the
-    ``AsyncRefreshable`` protocol (``create_async_task``,
+    ``AsyncCaller`` protocol (``create_async_task``,
     ``build_refresh_input``, ``apply_refresh_result``).  The executor
     manages the submit/poll lifecycle automatically.
     """
@@ -40,12 +40,12 @@ class ExecutionCallback:
         """Called after the Dataset execution fails."""
         ...
 
-    # -- AsyncRefreshable protocol --
+    # -- AsyncCaller protocol --
     # Callbacks that need per-step state refresh should override these
     # instead of on_execution_step(). The executor manages the async lifecycle.
 
-    def create_async_task(self) -> Optional["AsyncServiceTask"]:
-        """Return an ``AsyncServiceTask`` to register with the async service,
+    def create_async_task(self) -> Optional["AsyncCallee"]:
+        """Return an ``AsyncCallee`` to register with the async service,
         or ``None`` to fall back to synchronous ``on_execution_step()``.
         """
         return None

--- a/python/ray/data/_internal/execution/execution_callback.py
+++ b/python/ray/data/_internal/execution/execution_callback.py
@@ -1,10 +1,11 @@
 import importlib
 import os
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from ray.data.context import DataContext
 
 if TYPE_CHECKING:
+    from ray.data._internal.execution.interfaces.async_service import AsyncServiceTask
     from ray.data._internal.execution.streaming_executor import StreamingExecutor
 
 EXECUTION_CALLBACKS_CONFIG_KEY = "execution_callbacks"
@@ -13,7 +14,15 @@ ENV_CALLBACKS_INITIALIZED_KEY = "_env_callbacks_initialized"
 
 
 class ExecutionCallback:
-    """Callback interface for execution events."""
+    """Callback interface for execution events.
+
+    Callbacks can participate in async state refresh by implementing the
+    ``AsyncRefreshable`` protocol (``create_async_task``,
+    ``build_refresh_input``, ``apply_refresh_result``).  The executor
+    manages the submit/poll lifecycle automatically.
+    """
+
+    # -- Sync lifecycle hooks (called once) --
 
     def before_execution_starts(self, executor: "StreamingExecutor"):
         """Called before the Dataset execution starts."""
@@ -30,6 +39,30 @@ class ExecutionCallback:
     def after_execution_fails(self, executor: "StreamingExecutor", error: Exception):
         """Called after the Dataset execution fails."""
         ...
+
+    # -- AsyncRefreshable protocol --
+    # Callbacks that need per-step state refresh should override these
+    # instead of on_execution_step(). The executor manages the async lifecycle.
+
+    def create_async_task(self) -> Optional["AsyncServiceTask"]:
+        """Return an ``AsyncServiceTask`` to register with the async service,
+        or ``None`` to fall back to synchronous ``on_execution_step()``.
+        """
+        return None
+
+    def build_refresh_input(self) -> Any:
+        """Build a serializable snapshot for the async task.
+
+        Called on the scheduling thread. Has access to live state.
+        """
+        return None
+
+    def apply_refresh_result(self, result: Any) -> None:
+        """Apply the async task's result back to internal state.
+
+        Called on the scheduling thread when the result is ready.
+        """
+        pass
 
 
 def _initialize_env_callbacks(context: DataContext) -> None:

--- a/python/ray/data/_internal/execution/interfaces/__init__.py
+++ b/python/ray/data/_internal/execution/interfaces/__init__.py
@@ -1,4 +1,9 @@
-from .async_service import AsyncService
+from .async_service import (
+    AsyncCallee,
+    AsyncCaller,
+    AsyncServiceActor,
+    AsyncServiceHandle,
+)
 from .common import NodeIdStr
 from .execution_options import ExecutionOptions, ExecutionResources
 from .executor import Executor, OutputIterator
@@ -19,5 +24,8 @@ __all__ = [
     "BlockSlice",
     "ReportsExtraResourceUsage",
     "TaskContext",
-    "AsyncService",
+    "AsyncCallee",
+    "AsyncCaller",
+    "AsyncServiceActor",
+    "AsyncServiceHandle",
 ]

--- a/python/ray/data/_internal/execution/interfaces/__init__.py
+++ b/python/ray/data/_internal/execution/interfaces/__init__.py
@@ -1,3 +1,4 @@
+from .async_service import AsyncService
 from .common import NodeIdStr
 from .execution_options import ExecutionOptions, ExecutionResources
 from .executor import Executor, OutputIterator
@@ -18,4 +19,5 @@ __all__ = [
     "BlockSlice",
     "ReportsExtraResourceUsage",
     "TaskContext",
+    "AsyncService",
 ]

--- a/python/ray/data/_internal/execution/interfaces/__init__.py
+++ b/python/ray/data/_internal/execution/interfaces/__init__.py
@@ -1,7 +1,6 @@
 from .async_service import (
     AsyncCallee,
     AsyncCaller,
-    AsyncServiceActor,
     AsyncServiceHandle,
 )
 from .common import NodeIdStr
@@ -26,6 +25,5 @@ __all__ = [
     "TaskContext",
     "AsyncCallee",
     "AsyncCaller",
-    "AsyncServiceActor",
     "AsyncServiceHandle",
 ]

--- a/python/ray/data/_internal/execution/interfaces/async_service.py
+++ b/python/ray/data/_internal/execution/interfaces/async_service.py
@@ -1,0 +1,170 @@
+import logging
+import uuid
+from abc import ABC, abstractmethod
+from concurrent import futures
+from enum import Enum
+from typing import Any, Dict, Generic, Optional, TypeVar
+
+import ray
+from ray.actor import ActorHandle
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+logger = logging.getLogger(__name__)
+
+InputT = TypeVar("InputT")
+OutputT = TypeVar("OutputT")
+ServiceKeyT = uuid.UUID
+
+ASYNC_SERVICE_ACTOR_NAME = "RayData_AsyncServiceActor"
+ASYNC_SERVICE_NAMESPACE = "RayData_AsyncService"
+
+
+class AsyncServiceTask(ABC, Generic[InputT, OutputT]):
+    """A unit of work that runs asynchronously in the AsyncServiceActor process.
+
+    Subclasses implement ``run()`` to perform expensive computation (CPU-bound)
+    or concurrent I/O (via the provided ThreadPoolExecutor).
+    """
+
+    @abstractmethod
+    def run(self, obj: InputT, tpe: futures.ThreadPoolExecutor) -> OutputT:
+        ...
+
+
+class AsyncRefreshable(ABC):
+    """Protocol for components that participate in async state refresh.
+
+    Both ``PhysicalOperator`` and ``ExecutionCallback`` can implement this.
+    The executor manages the submit/poll lifecycle for all registered
+    refreshables — components only implement these three methods.
+
+    The flow each scheduling step:
+        1. ``build_refresh_input()`` — snapshot state (scheduling thread)
+        2. ``task.run(snapshot, tpe)`` — expensive work (actor process)
+        3. ``apply_refresh_result(result)`` — apply output (scheduling thread)
+    """
+
+    def create_async_task(self) -> Optional["AsyncServiceTask"]:
+        """Return the task to register with the async service, or None to skip."""
+        return None
+
+    def build_refresh_input(self) -> Any:
+        """Build a serializable input snapshot for the async task.
+
+        Called on the scheduling thread. Has access to live internal state.
+        """
+        return None
+
+    def apply_refresh_result(self, result: Any) -> None:
+        """Apply the result from the async task back to internal state.
+
+        Called on the scheduling thread when the result is ready.
+        """
+        pass
+
+
+class ErrorPolicy(Enum):
+    LOG_AND_RETRY = "log_and_retry"
+    PROPAGATE = "propagate"
+
+
+@ray.remote(num_cpus=0)
+class AsyncServiceActor:
+    """Singleton Ray actor that hosts async service tasks in a separate process.
+
+    Multiple executors/datasets can register tasks via unique ServiceKeyT keys.
+    Each ``update()`` call runs the task synchronously within the actor process,
+    and the result is returned to the caller via ObjectRef.
+    """
+
+    def __init__(self):
+        self._tasks: Dict[ServiceKeyT, AsyncServiceTask] = {}
+        self._tpe = futures.ThreadPoolExecutor()
+
+    def register(self, task: AsyncServiceTask) -> ServiceKeyT:
+        service_key = uuid.uuid4()
+        self._tasks[service_key] = task
+        return service_key
+
+    def update(self, key: ServiceKeyT, state_obj: Any) -> Any:
+        task = self._tasks[key]
+        return task.run(state_obj, self._tpe)
+
+    def unregister(self, key: ServiceKeyT):
+        self._tasks.pop(key, None)
+
+
+class AsyncServiceHandle(Generic[InputT, OutputT]):
+    """Client-side handle for non-blocking interaction with an AsyncServiceTask.
+
+    Used in the scheduling loop to submit snapshots and poll for
+    results via ``ray.wait(timeout=0)`` without blocking.
+    """
+
+    def __init__(
+        self,
+        task: AsyncServiceTask,
+        key: ServiceKeyT,
+        error_policy: ErrorPolicy = ErrorPolicy.LOG_AND_RETRY,
+    ):
+
+        self._key = ray.get(get_or_create_async_service_actor().register.remote(task))
+        self._error_policy = error_policy
+        self._pending_ref: Optional[ray.ObjectRef] = None
+
+    def request_refresh(self, state: InputT) -> None:
+        """Submit state to the actor for async computation.
+
+        Only call when no request is currently in flight.
+        """
+        assert self._pending_ref is None, "Previous refresh still in flight"
+        self._pending_ref = get_or_create_async_service_actor().update.remote(
+            self._key, state
+        )
+
+    def try_get_result(self) -> Optional[OutputT]:
+        """Non-blocking poll. Returns the result if ready, None otherwise."""
+        assert self._pending_ref is not None, "No pending ref yet"
+        ready, _ = ray.wait([self._pending_ref], timeout=0)
+        if not ready:
+            return None
+
+        try:
+            return ray.get(self._pending_ref, timeout=1)
+        except ray.exceptions.GetTimeoutError:
+            pass
+        except Exception as e:
+            if self._error_policy == ErrorPolicy.PROPAGATE:
+                raise
+            logger.debug(f"Async service task failed: {e}")
+        finally:
+            self._pending_ref = None
+
+    def has_in_flight_request(self) -> bool:
+        return self._pending_ref is not None
+
+    def shutdown(self) -> None:
+        if self._pending_ref is not None:
+            ray.cancel(self._pending_ref, force=False)
+            self._pending_ref = None
+        get_or_create_async_service_actor().unregister.remote(self._key)
+
+
+def get_or_create_async_service_actor() -> ActorHandle:
+    """Get or create the singleton AsyncServiceActor.
+
+    The actor is co-located on the driver node via NodeAffinitySchedulingStrategy
+    for low-latency serialization. It uses ``get_if_exists=True`` so multiple
+    datasets/executors share the same actor.
+    """
+    scheduling_strategy = NodeAffinitySchedulingStrategy(
+        ray.get_runtime_context().get_node_id(),
+        soft=False,
+    )
+    return AsyncServiceActor.options(
+        name=ASYNC_SERVICE_ACTOR_NAME,
+        namespace=ASYNC_SERVICE_NAMESPACE,
+        get_if_exists=True,
+        lifetime="detached",
+        scheduling_strategy=scheduling_strategy,
+    ).remote()

--- a/python/ray/data/_internal/execution/interfaces/async_service.py
+++ b/python/ray/data/_internal/execution/interfaces/async_service.py
@@ -79,7 +79,7 @@ class AsyncCaller(Protocol):
         ...
 
 
-@ray.remote(num_cpus=0)
+@ray.remote(num_cpus=0, max_restarts=-1)
 class AsyncServiceActor:
     """Singleton Ray actor that hosts async service tasks in a separate process.
 

--- a/python/ray/data/_internal/execution/interfaces/async_service.py
+++ b/python/ray/data/_internal/execution/interfaces/async_service.py
@@ -66,8 +66,8 @@ class AsyncCaller(Protocol):
     def build_refresh_input(self) -> Any:
         """Build a serializable input snapshot for the async task.
 
-        Called on the scheduling thread. The *executor* is passed so
-        implementations need not hold a reference to it.
+        Called on the scheduling thread. Has access to live state of the
+        implementing object.
         """
         ...
 
@@ -150,14 +150,16 @@ class AsyncServiceHandle(Generic[InputT, OutputT]):
             return None
 
         try:
-            return ray.get(self._pending_ref, timeout=1)
+            result = ray.get(self._pending_ref, timeout=1)
+            self._pending_ref = None
+            return result
         except ray.exceptions.GetTimeoutError:
-            pass
+            # Not fully ready, will try again in the next call.
+            return None
         except Exception as e:
             logger.debug(f"Async service task failed: {e}")
-            raise
-        finally:
             self._pending_ref = None
+            raise
 
     def has_in_flight_request(self) -> bool:
         return self._pending_ref is not None

--- a/python/ray/data/_internal/execution/interfaces/async_service.py
+++ b/python/ray/data/_internal/execution/interfaces/async_service.py
@@ -1,10 +1,9 @@
 import logging
 import time
-import uuid
 from abc import ABC, abstractmethod
+from concurrent.futures import Future, ProcessPoolExecutor
 from typing import (
     Any,
-    Dict,
     Generic,
     Optional,
     Protocol,
@@ -12,22 +11,14 @@ from typing import (
     runtime_checkable,
 )
 
-import ray
-from ray.actor import ActorHandle
-from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-
 logger = logging.getLogger(__name__)
 
 InputT = TypeVar("InputT")
 OutputT = TypeVar("OutputT")
-ServiceKeyT = uuid.UUID
-
-ASYNC_SERVICE_ACTOR_NAME = "RayData_AsyncServiceActor"
-ASYNC_SERVICE_NAMESPACE = "RayData_AsyncService"
 
 
 class AsyncCallee(ABC, Generic[InputT, OutputT]):
-    """A unit of work that runs asynchronously in the AsyncServiceActor process.
+    """A unit of work that runs asynchronously in a worker process.
 
     Subclasses implement ``run()`` to perform expensive computation (CPU-bound)
     or concurrent I/O.
@@ -55,7 +46,7 @@ class AsyncCaller(Protocol):
 
     The flow each scheduling step:
         1. ``build_refresh_input(executor)`` — snapshot state (scheduling thread)
-        2. ``task.run(snapshot)`` — expensive work (actor process)
+        2. ``task.run(snapshot)`` — expensive work (worker process)
         3. ``apply_refresh_result(result, executor)`` — apply output (scheduling thread)
     """
 
@@ -79,113 +70,87 @@ class AsyncCaller(Protocol):
         ...
 
 
-@ray.remote(num_cpus=0, max_restarts=-1)
-class AsyncServiceActor:
-    """Singleton Ray actor that hosts async service tasks in a separate process.
+def _run_task(callee: AsyncCallee, state: Any) -> Any:
+    """Top-level function so pickle can serialize the work item."""
+    return callee.run(state)
 
-    Multiple executors/datasets can register tasks via unique ServiceKeyT keys.
-    Each ``update()`` call runs the task synchronously within the actor process,
-    and the result is returned to the caller via ObjectRef.
+
+_pool: Optional[ProcessPoolExecutor] = None
+
+
+def _get_pool() -> ProcessPoolExecutor:
+    """Lazily create a module-level singleton ProcessPoolExecutor(max_workers=1).
+
+    Shared across all datasets/executors, analogous to the singleton Ray actor
+    in the actor-based implementation.
     """
-
-    def __init__(self):
-        self._tasks: Dict[ServiceKeyT, AsyncCallee] = {}
-
-    def register(self, task: AsyncCallee) -> ServiceKeyT:
-        service_key = uuid.uuid4()
-        self._tasks[service_key] = task
-        return service_key
-
-    def update(self, key: ServiceKeyT, state_obj: Any) -> Any:
-        task = self._tasks[key]
-        return task.run(state_obj)
-
-    def unregister(self, key: ServiceKeyT):
-        self._tasks.pop(key, None)
+    global _pool
+    if _pool is None:
+        _pool = ProcessPoolExecutor(max_workers=1)
+    return _pool
 
 
 class AsyncServiceHandle(Generic[InputT, OutputT]):
     """Client-side handle for non-blocking interaction with an AsyncCallee.
 
     Used in the scheduling loop to submit snapshots and poll for
-    results via ``ray.wait(timeout=0)`` without blocking.
+    results without blocking.
     """
 
-    def __init__(
-        self,
-        task: AsyncCallee,
-    ):
-
-        self._key = ray.get(get_or_create_async_service_actor().register.remote(task))
+    def __init__(self, task: AsyncCallee):
+        self._task = task
         self._min_interval_s = task.min_interval_s
-        self._pending_ref: Optional[ray.ObjectRef] = None
+        self._pending_future: Optional[Future] = None
         self._last_submit_time: float = 0
 
     def should_submit(self) -> bool:
         """True if no request is in-flight and the minimum interval has elapsed."""
-        if self._pending_ref is not None:
-            print("pending ref is None")
+        if self._pending_future is not None:
             return False
         if self._min_interval_s > 0:
-            print(f"delta is {time.monotonic() - self._last_submit_time}")
             return time.monotonic() - self._last_submit_time >= self._min_interval_s
         return True
 
     def request_refresh(self, state: InputT) -> None:
-        """Submit state to the actor for async computation.
+        """Submit state to the worker process for async computation.
 
         Only call when ``should_submit()`` returns True.
         """
-        assert self._pending_ref is None, "Previous refresh still in flight"
+        assert self._pending_future is None, "Previous refresh still in flight"
         self._last_submit_time = time.monotonic()
-        self._pending_ref = get_or_create_async_service_actor().update.remote(
-            self._key, state
-        )
+        self._pending_future = _get_pool().submit(_run_task, self._task, state)
 
     def try_get_result(self) -> Optional[OutputT]:
         """Non-blocking poll. Returns the result if ready, None otherwise."""
-        assert self._pending_ref is not None, "No pending ref yet"
-        ready, _ = ray.wait([self._pending_ref], timeout=0)
-        if not ready:
+        assert self._pending_future is not None, "No pending future yet"
+        if not self._pending_future.done():
             return None
 
         try:
-            result = ray.get(self._pending_ref, timeout=1)
-            self._pending_ref = None
+            result = self._pending_future.result(timeout=0)
+            self._pending_future = None
             return result
-        except ray.exceptions.GetTimeoutError:
-            # Not fully ready, will try again in the next call.
-            return None
         except Exception as e:
             logger.debug(f"Async service task failed: {e}")
-            self._pending_ref = None
+            self._pending_future = None
             raise
 
     def has_in_flight_request(self) -> bool:
-        return self._pending_ref is not None
+        return self._pending_future is not None
 
     def shutdown(self) -> None:
-        if self._pending_ref is not None:
-            ray.cancel(self._pending_ref, force=False)
-            self._pending_ref = None
-        get_or_create_async_service_actor().unregister.remote(self._key)
+        if self._pending_future is not None:
+            self._pending_future.cancel()
+            self._pending_future = None
 
 
-def get_or_create_async_service_actor() -> ActorHandle:
-    """Get or create the singleton AsyncServiceActor.
+def shutdown_pool() -> None:
+    """Shut down the module-level ProcessPoolExecutor.
 
-    The actor is co-located on the driver node via NodeAffinitySchedulingStrategy
-    for low-latency serialization. It uses ``get_if_exists=True`` so multiple
-    datasets/executors share the same actor.
+    Call during interpreter shutdown or test teardown. In production the pool
+    is left alive (like the detached Ray actor) so subsequent datasets reuse it.
     """
-    scheduling_strategy = NodeAffinitySchedulingStrategy(
-        ray.get_runtime_context().get_node_id(),
-        soft=False,
-    )
-    return AsyncServiceActor.options(
-        name=ASYNC_SERVICE_ACTOR_NAME,
-        namespace=ASYNC_SERVICE_NAMESPACE,
-        get_if_exists=True,
-        lifetime="detached",
-        scheduling_strategy=scheduling_strategy,
-    ).remote()
+    global _pool
+    if _pool is not None:
+        _pool.shutdown(wait=False)
+        _pool = None

--- a/python/ray/data/_internal/execution/interfaces/async_service.py
+++ b/python/ray/data/_internal/execution/interfaces/async_service.py
@@ -1,9 +1,16 @@
 import logging
+import time
 import uuid
 from abc import ABC, abstractmethod
-from concurrent import futures
-from enum import Enum
-from typing import Any, Dict, Generic, Optional, TypeVar
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Optional,
+    Protocol,
+    TypeVar,
+    runtime_checkable,
+)
 
 import ray
 from ray.actor import ActorHandle
@@ -19,53 +26,57 @@ ASYNC_SERVICE_ACTOR_NAME = "RayData_AsyncServiceActor"
 ASYNC_SERVICE_NAMESPACE = "RayData_AsyncService"
 
 
-class AsyncServiceTask(ABC, Generic[InputT, OutputT]):
+class AsyncCallee(ABC, Generic[InputT, OutputT]):
     """A unit of work that runs asynchronously in the AsyncServiceActor process.
 
     Subclasses implement ``run()`` to perform expensive computation (CPU-bound)
-    or concurrent I/O (via the provided ThreadPoolExecutor).
+    or concurrent I/O.
+
+    Set ``min_interval_s`` to throttle how often the task is submitted.
+    The ``AsyncServiceHandle`` enforces this on the scheduling thread.
     """
 
+    min_interval_s: float = 0
+
     @abstractmethod
-    def run(self, obj: InputT, tpe: futures.ThreadPoolExecutor) -> OutputT:
+    def run(self, obj: InputT) -> OutputT:
         ...
 
 
-class AsyncRefreshable(ABC):
+@runtime_checkable
+class AsyncCaller(Protocol):
     """Protocol for components that participate in async state refresh.
 
-    Both ``PhysicalOperator`` and ``ExecutionCallback`` can implement this.
+    Both ``PhysicalOperator`` and ``ExecutionCallback`` can implement this
+    via structural subtyping — no inheritance required.
+
     The executor manages the submit/poll lifecycle for all registered
-    refreshables — components only implement these three methods.
+    refreshables; components only implement these three methods.
 
     The flow each scheduling step:
-        1. ``build_refresh_input()`` — snapshot state (scheduling thread)
-        2. ``task.run(snapshot, tpe)`` — expensive work (actor process)
-        3. ``apply_refresh_result(result)`` — apply output (scheduling thread)
+        1. ``build_refresh_input(executor)`` — snapshot state (scheduling thread)
+        2. ``task.run(snapshot)`` — expensive work (actor process)
+        3. ``apply_refresh_result(result, executor)`` — apply output (scheduling thread)
     """
 
-    def create_async_task(self) -> Optional["AsyncServiceTask"]:
+    def create_async_task(self) -> Optional["AsyncCallee"]:
         """Return the task to register with the async service, or None to skip."""
-        return None
+        ...
 
     def build_refresh_input(self) -> Any:
         """Build a serializable input snapshot for the async task.
 
-        Called on the scheduling thread. Has access to live internal state.
+        Called on the scheduling thread. The *executor* is passed so
+        implementations need not hold a reference to it.
         """
-        return None
+        ...
 
     def apply_refresh_result(self, result: Any) -> None:
         """Apply the result from the async task back to internal state.
 
         Called on the scheduling thread when the result is ready.
         """
-        pass
-
-
-class ErrorPolicy(Enum):
-    LOG_AND_RETRY = "log_and_retry"
-    PROPAGATE = "propagate"
+        ...
 
 
 @ray.remote(num_cpus=0)
@@ -78,24 +89,23 @@ class AsyncServiceActor:
     """
 
     def __init__(self):
-        self._tasks: Dict[ServiceKeyT, AsyncServiceTask] = {}
-        self._tpe = futures.ThreadPoolExecutor()
+        self._tasks: Dict[ServiceKeyT, AsyncCallee] = {}
 
-    def register(self, task: AsyncServiceTask) -> ServiceKeyT:
+    def register(self, task: AsyncCallee) -> ServiceKeyT:
         service_key = uuid.uuid4()
         self._tasks[service_key] = task
         return service_key
 
     def update(self, key: ServiceKeyT, state_obj: Any) -> Any:
         task = self._tasks[key]
-        return task.run(state_obj, self._tpe)
+        return task.run(state_obj)
 
     def unregister(self, key: ServiceKeyT):
         self._tasks.pop(key, None)
 
 
 class AsyncServiceHandle(Generic[InputT, OutputT]):
-    """Client-side handle for non-blocking interaction with an AsyncServiceTask.
+    """Client-side handle for non-blocking interaction with an AsyncCallee.
 
     Used in the scheduling loop to submit snapshots and poll for
     results via ``ray.wait(timeout=0)`` without blocking.
@@ -103,21 +113,31 @@ class AsyncServiceHandle(Generic[InputT, OutputT]):
 
     def __init__(
         self,
-        task: AsyncServiceTask,
-        key: ServiceKeyT,
-        error_policy: ErrorPolicy = ErrorPolicy.LOG_AND_RETRY,
+        task: AsyncCallee,
     ):
 
         self._key = ray.get(get_or_create_async_service_actor().register.remote(task))
-        self._error_policy = error_policy
+        self._min_interval_s = task.min_interval_s
         self._pending_ref: Optional[ray.ObjectRef] = None
+        self._last_submit_time: float = 0
+
+    def should_submit(self) -> bool:
+        """True if no request is in-flight and the minimum interval has elapsed."""
+        if self._pending_ref is not None:
+            print("pending ref is None")
+            return False
+        if self._min_interval_s > 0:
+            print(f"delta is {time.monotonic() - self._last_submit_time}")
+            return time.monotonic() - self._last_submit_time >= self._min_interval_s
+        return True
 
     def request_refresh(self, state: InputT) -> None:
         """Submit state to the actor for async computation.
 
-        Only call when no request is currently in flight.
+        Only call when ``should_submit()`` returns True.
         """
         assert self._pending_ref is None, "Previous refresh still in flight"
+        self._last_submit_time = time.monotonic()
         self._pending_ref = get_or_create_async_service_actor().update.remote(
             self._key, state
         )
@@ -134,9 +154,8 @@ class AsyncServiceHandle(Generic[InputT, OutputT]):
         except ray.exceptions.GetTimeoutError:
             pass
         except Exception as e:
-            if self._error_policy == ErrorPolicy.PROPAGATE:
-                raise
             logger.debug(f"Async service task failed: {e}")
+            raise
         finally:
             self._pending_ref = None
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -36,6 +36,7 @@ from ray.data.context import DataContext
 
 if TYPE_CHECKING:
 
+    from ray.data._internal.execution.interfaces.async_service import AsyncServiceTask
     from ray.data.block import BlockMetadataWithSchema
 
 logger = logging.getLogger(__name__)
@@ -906,13 +907,32 @@ class PhysicalOperator(Operator):
     def refresh_state(self):
         """Refreshes the state of the operator at runtime.
 
-        This method will be called at runtime in each StreamingExecutor iteration.
-        Subclasses can override it to account for asynchronous updates, like restarting
-        actors, retrying tasks, or lost objects which are NOT transparent to the
-        StreamingExecutor.
+        This method will be called at runtime in each StreamingExecutor iteration
+        for operators that have NOT registered an async task.
+        """
+        pass
 
-        TODO: Currently this method is synchronous. We should consider making this async,
-        or calling it in an asynchronous context.
+    # -- AsyncRefreshable protocol --
+    # Operators that need per-step state refresh should override these
+    # instead of refresh_state(). The executor manages the async lifecycle.
+
+    def create_async_task(self) -> Optional["AsyncServiceTask"]:
+        """Return an ``AsyncServiceTask`` to register with the async service,
+        or ``None`` to fall back to synchronous ``refresh_state()``.
+        """
+        return None
+
+    def build_refresh_input(self) -> Any:
+        """Build a serializable snapshot for the async task.
+
+        Called on the scheduling thread. Has access to live operator state.
+        """
+        return None
+
+    def apply_refresh_result(self, result: Any) -> None:
+        """Apply the async task's result back to operator state.
+
+        Called on the scheduling thread when the result is ready.
         """
         pass
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -36,7 +36,7 @@ from ray.data.context import DataContext
 
 if TYPE_CHECKING:
 
-    from ray.data._internal.execution.interfaces.async_service import AsyncServiceTask
+    from ray.data._internal.execution.interfaces.async_service import AsyncCallee
     from ray.data.block import BlockMetadataWithSchema
 
 logger = logging.getLogger(__name__)
@@ -912,12 +912,12 @@ class PhysicalOperator(Operator):
         """
         pass
 
-    # -- AsyncRefreshable protocol --
+    # -- AsyncCaller protocol --
     # Operators that need per-step state refresh should override these
     # instead of refresh_state(). The executor manages the async lifecycle.
 
-    def create_async_task(self) -> Optional["AsyncServiceTask"]:
-        """Return an ``AsyncServiceTask`` to register with the async service,
+    def create_async_task(self) -> Optional["AsyncCallee"]:
+        """Return an ``AsyncCallee`` to register with the async service,
         or ``None`` to fall back to synchronous ``refresh_state()``.
         """
         return None

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -23,7 +23,7 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
 )
 from ray.data._internal.execution.interfaces.async_service import (
-    AsyncRefreshable,
+    AsyncCaller,
     AsyncServiceHandle,
 )
 from ray.data._internal.execution.operators.base_physical_operator import (
@@ -100,7 +100,7 @@ class StreamingExecutor(Executor, threading.Thread):
         self._final_stats: Optional[DatasetStats] = None
         self._progress_manager: Optional["BaseExecutionProgressManager"] = None
         self._callbacks: List["ExecutionCallback"] = []
-        self._async_handles: Dict[AsyncRefreshable, AsyncServiceHandle] = {}
+        self._async_handles: Dict[AsyncCaller, AsyncServiceHandle] = {}
 
         # The executor can be shutdown while still running.
         self._shutdown_lock = threading.RLock()
@@ -389,8 +389,7 @@ class StreamingExecutor(Executor, threading.Thread):
                     )
 
                 for callback in self._callbacks:
-                    if callback not in self._async_handles:
-                        callback.on_execution_step(self)
+                    callback.on_execution_step(self)
                 if not continue_sched or self._shutdown:
                     break
         except Exception as e:
@@ -552,7 +551,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 self._export_operator_schema(op)
 
             if not op.has_completed():
-                if op not in self._async_handles:
+                if not self._uses_async_service(op):
                     op.refresh_state()
             elif not self._has_op_completed[op]:
                 log_str = (
@@ -584,16 +583,15 @@ class StreamingExecutor(Executor, threading.Thread):
     def _setup_async_refreshables(self) -> None:
         """Discover and register async tasks from operators and callbacks."""
 
-        for op in self._topology:
-            task = op.create_async_task()
+        for refreshable in list(self._topology) + self._callbacks:
+            task = refreshable.create_async_task()
             if task is None:
                 continue
-            self._async_handles[op] = AsyncServiceHandle(task=task)
-        for cb in self._callbacks:
-            task = cb.create_async_task()
-            if task is None:
-                continue
-            self._async_handles[cb] = AsyncServiceHandle(task=task)
+            self._async_handles[refreshable] = AsyncServiceHandle(task=task)
+
+    def _uses_async_service(self, refreshable: "AsyncCaller") -> bool:
+        """True if the refreshable is registered with the async service."""
+        return refreshable in self._async_handles
 
     def _poll_and_submit_async_refreshes(self) -> None:
         """Poll all async handles for results and submit new work."""
@@ -603,7 +601,7 @@ class StreamingExecutor(Executor, threading.Thread):
                 if result is None:
                     continue
                 refreshable.apply_refresh_result(result)
-            else:
+            elif handle.should_submit():
                 snapshot = refreshable.build_refresh_input()
                 handle.request_refresh(snapshot)
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -22,6 +22,10 @@ from ray.data._internal.execution.interfaces import (
     PhysicalOperator,
     RefBundle,
 )
+from ray.data._internal.execution.interfaces.async_service import (
+    AsyncRefreshable,
+    AsyncServiceHandle,
+)
 from ray.data._internal.execution.operators.base_physical_operator import (
     InternalQueueOperatorMixin,
 )
@@ -96,6 +100,7 @@ class StreamingExecutor(Executor, threading.Thread):
         self._final_stats: Optional[DatasetStats] = None
         self._progress_manager: Optional["BaseExecutionProgressManager"] = None
         self._callbacks: List["ExecutionCallback"] = []
+        self._async_handles: Dict[AsyncRefreshable, AsyncServiceHandle] = {}
 
         # The executor can be shutdown while still running.
         self._shutdown_lock = threading.RLock()
@@ -257,6 +262,8 @@ class StreamingExecutor(Executor, threading.Thread):
         for callback in self._callbacks:
             callback.before_execution_starts(self)
 
+        self._setup_async_refreshables()
+
         self.start()
         self._execution_started = True
 
@@ -333,6 +340,10 @@ class StreamingExecutor(Executor, threading.Thread):
                 f" (min/max/total={min_}/{max_}/{total}s)"
             )
 
+            for handle in self._async_handles.values():
+                handle.shutdown()
+            self._async_handles.clear()
+
             if exception is None:
                 for callback in self._callbacks:
                     callback.after_execution_succeeds(self)
@@ -378,7 +389,8 @@ class StreamingExecutor(Executor, threading.Thread):
                     )
 
                 for callback in self._callbacks:
-                    callback.on_execution_step(self)
+                    if callback not in self._async_handles:
+                        callback.on_execution_step(self)
                 if not continue_sched or self._shutdown:
                     break
         except Exception as e:
@@ -531,15 +543,17 @@ class StreamingExecutor(Executor, threading.Thread):
             _debug_dump_topology(topology, self._resource_manager)
             self._last_debug_log_time = time.time()
 
+        self._poll_and_submit_async_refreshes()
+
         for op, state in topology.items():
             # Export operator schema if it's updated
             if state._schema is not None and self._op_schema.get(op) != state._schema:
                 self._op_schema[op] = state._schema
                 self._export_operator_schema(op)
 
-            # Log metrics of newly completed operators.
             if not op.has_completed():
-                op.refresh_state()
+                if op not in self._async_handles:
+                    op.refresh_state()
             elif not self._has_op_completed[op]:
                 log_str = (
                     f"Operator {op} completed. "
@@ -566,6 +580,32 @@ class StreamingExecutor(Executor, threading.Thread):
         """Returns whether the user thread is blocked on topology execution."""
         _, state = self._output_node
         return len(state.output_queue) == 0
+
+    def _setup_async_refreshables(self) -> None:
+        """Discover and register async tasks from operators and callbacks."""
+
+        for op in self._topology:
+            task = op.create_async_task()
+            if task is None:
+                continue
+            self._async_handles[op] = AsyncServiceHandle(task=task)
+        for cb in self._callbacks:
+            task = cb.create_async_task()
+            if task is None:
+                continue
+            self._async_handles[cb] = AsyncServiceHandle(task=task)
+
+    def _poll_and_submit_async_refreshes(self) -> None:
+        """Poll all async handles for results and submit new work."""
+        for refreshable, handle in self._async_handles.items():
+            if handle.has_in_flight_request():
+                result = handle.try_get_result()
+                if result is None:
+                    continue
+                refreshable.apply_refresh_result(result)
+            else:
+                snapshot = refreshable.build_refresh_input()
+                handle.request_refresh(snapshot)
 
     def _export_operator_schema(self, op: PhysicalOperator) -> None:
         schema = self._op_schema.get(op)

--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -49,7 +49,7 @@ MIN_PYARROW_VERSION_FIXED_SHAPE_TENSOR_ARRAY = parse_version("12.0.0")
 MIN_PYARROW_VERSION_FIXED_SHAPE_TENSOR_SCALAR = parse_version("16.0.0")
 # Min version supporting ``ExtensionArray``s in ``pyarrow.concat``
 MIN_PYARROW_VERSION_EXT_ARRAY_CONCAT_SUPPORTED = parse_version("12.0.0")
-
+PYARROW_VERSION = get_pyarrow_version()
 
 NUM_BYTES_PER_UNICODE_CHAR = 4
 

--- a/python/ray/data/tests/test_transform_pyarrow.py
+++ b/python/ray/data/tests/test_transform_pyarrow.py
@@ -14,6 +14,7 @@ from ray.data._internal.tensor_extensions.arrow import (
     FixedShapeTensorFormat,
 )
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data.context import DataContext
 from ray.data.extensions import (
     ArrowConversionError,
     ArrowPythonObjectType,


### PR DESCRIPTION
## Description
The ProcessPoolExecutor equivalent to https://github.com/ray-project/ray/pull/61852

Differs from https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor when running multiple datasets, as `ProcessPoolExecutor` will run once per dataset, while `AsyncServiceActor` will run as a singleton instance

Here's what claude said when asked about differences:
# Async Service vs ProcessPoolExecutor (max_workers=1)

## Architecture Overview

### Async Service

- **Worker**: Single detached Ray actor (`num_cpus=0`), co-located on the driver node
- **Submit**: `actor.update.remote(key, snapshot)` → returns `ObjectRef` immediately
- **Poll**: `ray.wait([ref], timeout=0)` → non-blocking check each scheduling step
- **Backpressure**: At most 1 in-flight request per callee; skip if busy
- **Serialization**: Ray serialization (zero-copy capable for Arrow/numpy via object store)
- **Threads added to scheduler process**: 0

### ProcessPoolExecutor (max_workers=1)

- **Worker**: Single OS subprocess, spawned via `multiprocessing`
- **Submit**: `pool.submit(fn, snapshot)` → returns `Future`, enqueues internally
- **Poll**: `future.done()` → non-blocking, but result delivery depends on internal management thread
- **Backpressure**: None built-in; every `submit()` enqueues regardless of worker state
- **Serialization**: `pickle` over OS pipes (data is always copied)
- **Threads added to scheduler process**: 2+ (queue management thread + pipe feeder thread)

## Tradeoff Comparison

| Dimension                  | Async Service                          | ProcessPoolExecutor (max_workers=1)       |
| -------------------------- | -------------------------------------- | ----------------------------------------- |
| Extra threads in scheduler | 0                                      | 2+ (management thread + queue feeder)     |
| Backpressure               | Built-in (1 in-flight, skip if busy)   | None (unbounded queue of stale work)      |
| "Latest wins" semantics    | Natural (stale snapshot never sent)    | Must manually cancel/discard stale Futures|
| Non-blocking submit        | `actor.update.remote()` → immediate    | `pool.submit()` → immediate, but internal thread feeds pipe |
| Non-blocking poll          | `ray.wait(timeout=0)` — no threads     | `future.done()` — depends on mgmt thread |
| Serialization cost         | Ray (zero-copy for large Arrow/numpy)  | pickle through OS pipes (always copies)   |
| Fault tolerance            | Ray actor restarts (configurable)      | Auto worker replacement by pool           |
| Ray integration            | Native (dashboard, logs, object store) | Foreign (invisible to Ray)                |
| Process lifecycle          | Detached singleton, shared across datasets | Per-executor, deterministic shutdown  |
| GIL contention risk        | Minimal (no new threads)               | Higher (extra threads compete for GIL)    |
| Complexity                 | Low (single actor, integrated polling) | Medium (pool + manual gating logic needed)|



## Related issues

## Additional information
