### PR TITLE
[Data] rewrite `Sort` + `Limit` to `TopK`

### DIFF
--- a/python/ray/data/_internal/logical/operators/__init__.py
+++ b/python/ray/data/_internal/logical/operators/__init__.py
@@ -7,6 +7,7 @@ from ray.data._internal.logical.operators.all_to_all_operator import (
     RandomShuffle,
     Repartition,
     Sort,
+    TopK,
 )
 from ray.data._internal.logical.operators.count_operator import Count
 from ray.data._internal.logical.operators.from_operators import (
@@ -71,6 +72,7 @@ __all__ = [
     "Sort",
     "StreamingRepartition",
     "StreamingSplit",
+    "TopK",
     "Union",
     "Write",
     "Zip",

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -22,6 +22,7 @@ __all__ = [
     "RandomizeBlocks",
     "Repartition",
     "Sort",
+    "TopK",
 ]
 
 
@@ -214,6 +215,50 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Sort doesn't affect filtering correctness
+        return PredicatePassThroughBehavior.PASSTHROUGH
+
+
+class TopK(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
+    """Logical operator for TopK."""
+
+    def __init__(
+        self,
+        input_op: LogicalOperator,
+        sort_key: SortKey,
+        k: int,
+        batch_format: Optional[str] = "default",
+    ):
+        super().__init__(
+            input_op,
+            name="TopK",
+        )
+        self.sort_key = sort_key
+        self.k = k
+        self.batch_format = batch_format
+
+    def infer_metadata(self) -> "BlockMetadata":
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        input_meta = self.input_dependencies[0].infer_metadata()
+        if input_meta.num_rows is None:
+            num_rows = None
+        else:
+            num_rows = min(input_meta.num_rows, self.k)
+        return BlockMetadata(
+            num_rows=num_rows,
+            size_bytes=None,
+            input_files=input_meta.input_files,
+            exec_stats=None,
+        )
+
+    def infer_schema(
+        self,
+    ) -> Optional["Schema"]:
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        assert isinstance(self.input_dependencies[0], LogicalOperator)
+        return self.input_dependencies[0].infer_schema()
+
+    def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -8,12 +8,18 @@ from ray.data._internal.logical.operators import (
     AbstractOneToOne,
     Download,
     Limit,
+    Sort,
+    TopK,
     Union,
 )
 
 __all__ = [
     "LimitPushdownRule",
+    "SORT_LIMIT_TO_TOPK_MAX_K_CONFIG_KEY",
 ]
+
+SORT_LIMIT_TO_TOPK_MAX_K_CONFIG_KEY = "execution_optimizer.sort_limit_to_topk_max_k"
+DEFAULT_SORT_LIMIT_TO_TOPK_MAX_K = 1000
 
 
 logger = logging.getLogger(__name__)
@@ -40,6 +46,9 @@ class LimitPushdownRule(Rule):
     """
 
     def apply(self, plan: LogicalPlan) -> LogicalPlan:
+        max_k = plan.context.get_config(
+            SORT_LIMIT_TO_TOPK_MAX_K_CONFIG_KEY, DEFAULT_SORT_LIMIT_TO_TOPK_MAX_K
+        )
         # The DAG's root is the most downstream operator.
         def transform(node: LogicalOperator) -> LogicalOperator:
             if isinstance(node, Limit):
@@ -49,6 +58,20 @@ class LimitPushdownRule(Rule):
                     # Fuse consecutive Limits: Limit[n] -> Limit[m] becomes Limit[min(n,m)]
                     new_limit = min(node.limit, upstream_op.limit)
                     return Limit(upstream_op.input_dependency, new_limit)
+
+                if (
+                    isinstance(upstream_op, Sort)
+                    and node.limit > 0
+                    and isinstance(max_k, int)
+                    and max_k > 0
+                    and node.limit <= max_k
+                ):
+                    return TopK(
+                        upstream_op.input_dependencies[0],
+                        upstream_op.sort_key,
+                        node.limit,
+                        upstream_op.batch_format,
+                    )
 
                 # If no fusion, apply pushdown logic
                 if isinstance(upstream_op, Union):

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -11,12 +11,13 @@ from ray.data._internal.logical.operators import (
     RandomShuffle,
     Repartition,
     Sort,
+    TopK,
 )
 from ray.data._internal.planner.aggregate import generate_aggregate_fn
 from ray.data._internal.planner.random_shuffle import generate_random_shuffle_fn
 from ray.data._internal.planner.randomize_blocks import generate_randomize_blocks_fn
 from ray.data._internal.planner.repartition import generate_repartition_fn
-from ray.data._internal.planner.sort import generate_sort_fn
+from ray.data._internal.planner.sort import generate_sort_fn, generate_topk_fn
 from ray.data.context import DataContext, ShuffleStrategy
 
 
@@ -134,6 +135,14 @@ def plan_all_to_all_op(
             op.batch_format,
             data_context,
             debug_limit_shuffle_execution_to_num_blocks,
+        )
+
+    elif isinstance(op, TopK):
+        fn = generate_topk_fn(
+            op.sort_key,
+            op.batch_format,
+            op.k,
+            data_context,
         )
 
     elif isinstance(op, Aggregate):

--- a/python/ray/data/_internal/planner/sort.py
+++ b/python/ray/data/_internal/planner/sort.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import List, Optional, Tuple
 
+import ray
 from ray.data._internal.execution.interfaces import (
     AllToAllTransformFn,
     RefBundle,
@@ -13,8 +14,10 @@ from ray.data._internal.planner.exchange.push_based_shuffle_task_scheduler impor
     PushBasedShuffleTaskScheduler,
 )
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey, SortTaskSpec
+from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.stats import StatsDict
 from ray.data._internal.util import unify_ref_bundles_schema
+from ray.data.block import Block, BlockAccessor, BlockMetadataWithSchema
 from ray.data.context import DataContext, ShuffleStrategy
 
 
@@ -81,3 +84,64 @@ def generate_sort_fn(
     # "UnboundLocalError: local variable ... referenced before assignment",
     # because `key` and `descending` variables are reassigned in `fn()`.
     return partial(fn, sort_key)
+
+
+def generate_topk_fn(
+    sort_key: SortKey,
+    batch_format: str,
+    k: int,
+    _data_context: DataContext,
+) -> AllToAllTransformFn:
+    def fn(
+        sort_key: SortKey,
+        refs: List[RefBundle],
+        ctx: TaskContext,
+    ) -> Tuple[List[RefBundle], StatsDict]:
+        blocks: List[ray.ObjectRef[Block]] = []
+        for ref_bundle in refs:
+            blocks.extend(ref_bundle.block_refs)
+        if len(blocks) == 0 or k <= 0:
+            return ([], {})
+
+        sort_key.validate_schema(unify_ref_bundles_schema(refs))
+
+        topk_block = cached_remote_fn(_topk_sort_block)
+        topk_block_refs = [topk_block.remote(block, sort_key, k) for block in blocks]
+        topk_blocks = ray.get(topk_block_refs)
+
+        from ray.data._internal.execution.interfaces import RefBundle
+        from ray.data._internal.planner.exchange.interfaces import ExchangeTaskSpec
+        from ray.data._internal.table_block import TableBlockAccessor
+
+        target_block_type = ExchangeTaskSpec._derive_target_block_type(batch_format)
+        normalized_blocks = TableBlockAccessor.normalize_block_types(
+            topk_blocks,
+            target_block_type=target_block_type,
+        )
+        merged_block, _ = BlockAccessor.for_block(normalized_blocks[0]).merge_sorted_blocks(
+            normalized_blocks, sort_key
+        )
+        merged_accessor = BlockAccessor.for_block(merged_block)
+        result_block = merged_accessor.slice(0, min(k, merged_accessor.num_rows()), copy=False)
+
+        meta_with_schema = BlockMetadataWithSchema.from_block(result_block)
+        output = RefBundle(
+            [
+                (
+                    ray.put(result_block),
+                    meta_with_schema.metadata,
+                )
+            ],
+            owns_blocks=True,
+            schema=meta_with_schema.schema,
+        )
+        return ([output], {})
+
+    return partial(fn, sort_key)
+
+
+def _topk_sort_block(block: Block, sort_key: SortKey, k: int) -> Block:
+    accessor = BlockAccessor.for_block(block)
+    sorted_block = accessor.sort(sort_key)
+    sorted_accessor = BlockAccessor.for_block(sorted_block)
+    return sorted_accessor.slice(0, min(k, sorted_accessor.num_rows()), copy=False)

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -8,9 +8,13 @@ import ray
 from ray.data import Dataset
 from ray.data._internal.logical.interfaces import LogicalOperator, Plan
 from ray.data._internal.logical.operators import Download, Limit
-from ray.data._internal.logical.rules.limit_pushdown import LimitPushdownRule
+from ray.data._internal.logical.rules.limit_pushdown import (
+    SORT_LIMIT_TO_TOPK_MAX_K_CONFIG_KEY,
+    LimitPushdownRule,
+)
 from ray.data._internal.util import rows_same
 from ray.data.block import BlockMetadata
+from ray.data.context import DataContext
 from ray.data.datasource import Datasource
 from ray.data.datasource.datasource import ReadTask
 from ray.data.tests.conftest import *  # noqa
@@ -161,8 +165,21 @@ def test_limit_pushdown_through_project(ray_start_regular_shared_2_cpus):
     )
 
 
-def test_limit_pushdown_stops_at_sort(ray_start_regular_shared_2_cpus):
-    """Test that Limit stops at Sort operations (AllToAll)."""
+def test_sort_limit_rewritten_to_topk(ray_start_regular_shared_2_cpus):
+    """Test that Sort -> Limit is rewritten to TopK."""
+    ds = ray.data.range(100).sort("id").limit(5)
+    _check_valid_plan_and_result(
+        ds,
+        "Read[ReadRange] -> TopK[TopK]",
+        [{"id": i} for i in range(5)],
+    )
+
+
+def test_sort_limit_not_rewritten_when_k_above_threshold(
+    ray_start_regular_shared_2_cpus, restore_data_context
+):
+    ctx = DataContext.get_current()
+    ctx.set_config(SORT_LIMIT_TO_TOPK_MAX_K_CONFIG_KEY, 3)
     ds = ray.data.range(100).sort("id").limit(5)
     _check_valid_plan_and_result(
         ds,
@@ -183,8 +200,7 @@ def test_limit_pushdown_complex_interweaved_operations(ray_start_regular_shared_
     ds = ray.data.range(100).sort("id").map(f1).limit(20).sort("id").map(f2).limit(5)
     _check_valid_plan_and_result(
         ds,
-        "Read[ReadRange] -> Sort[Sort] -> Limit[limit=20] -> MapRows[Map(f1)] -> "
-        "Sort[Sort] -> Limit[limit=5] -> MapRows[Map(f2)]",
+        "Read[ReadRange] -> TopK[TopK] -> MapRows[Map(f1)] -> TopK[TopK] -> MapRows[Map(f2)]",
         [{"id": i} for i in range(5)],
     )
 
@@ -397,7 +413,7 @@ def test_limit_pushdown_union_with_maprows(ray_start_regular_shared_2_cpus):
 
 
 def test_limit_pushdown_union_with_sort(ray_start_regular_shared_2_cpus):
-    """Limit after Union + Sort: limit must NOT push through the Sort."""
+    """Limit after Union + Sort should be rewritten to TopK."""
     ds1 = ray.data.range(100, override_num_blocks=4)
     ds2 = ray.data.range(50, override_num_blocks=4).map(
         lambda x: {"id": x["id"] + 1000}
@@ -407,7 +423,7 @@ def test_limit_pushdown_union_with_sort(ray_start_regular_shared_2_cpus):
     expected_plan = (
         "Read[ReadRange], "
         "Read[ReadRange] -> MapRows[Map(<lambda>)] -> "
-        "Union[Union] -> Sort[Sort] -> Limit[limit=5]"
+        "Union[Union] -> TopK[TopK]"
     )
     _check_valid_plan_and_result(ds, expected_plan, [{"id": i} for i in range(5)])
 
@@ -471,7 +487,7 @@ def test_limit_pushdown_complex_chain(ray_start_regular_shared_2_cpus):
     expected_plan = (
         "Read[ReadRange] -> Limit[limit=10] -> Project[Project], "
         "Read[ReadRange] -> Limit[limit=10] -> MapRows[Map(<lambda>)] "
-        "-> Union[Union] -> Aggregate[Aggregate] -> Sort[Sort] -> Limit[limit=3]"
+        "-> Union[Union] -> Aggregate[Aggregate] -> TopK[TopK]"
     )
 
     # Top-3 ids are the three largest (1009, 1008, 1007) with count()==1.


### PR DESCRIPTION
## Description
This PR adds an execution optimize rule to convert consecutive `Sort` -> `Limit` into a `TopK` logical operator when the requested `k` is small enough. This avoids performing a full global sort for common “top-K” patterns and can significantly reduce shuffle and sort cost.
The rewrite is guarded by a configurable threshold to prevent negative performance impact for very large k values.

## Related issues
None

## Additional information
- Behavior change (planner/optimizer) : `ds.sort(...).limit(k)` becomes `TopK` when `k <= execution_optimizer.sort_limit_to_topk_max_k` and `k > 0` ; otherwise the plan stays as `Sort -> Limit`.
- Config key : `execution_optimizer.sort_limit_to_topk_max_k` (default: `1000` ). Set via `ray.data.DataContext.get_current().set_config(...)` before dataset creation.
- Implementation overview :
  - New logical operator: `TopK`
  - Logical rewrite added in `LimitPushdownRule`
  - Physical planning support for `TopK` and execution function added
- Tests : Added/updated unit tests to validate plan rewrite and the threshold guard.