### PR TITLE
[Data] Disable hanging issue detection

### DIFF
--- a/python/ray/data/_internal/issue_detection/issue_detector_configuration.py
+++ b/python/ray/data/_internal/issue_detection/issue_detector_configuration.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from typing import List, Type
 
 from ray.data._internal.issue_detection.detectors import (
-    HangingExecutionIssueDetector,
     HangingExecutionIssueDetectorConfig,
     HashShuffleAggregatorIssueDetector,
     HashShuffleAggregatorIssueDetectorConfig,
@@ -25,7 +24,9 @@ class IssueDetectorsConfiguration:
     )
     detectors: List[Type[IssueDetector]] = field(
         default_factory=lambda: [
-            HangingExecutionIssueDetector,
+            # FIXME: The hanging detector is disabled because it can block the
+            # scheduling loop.
+            # HangingExecutionIssueDetector,
             HashShuffleAggregatorIssueDetector,
             HighMemoryIssueDetector,
         ]

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -113,6 +113,7 @@ class TestHangingExecutionIssueDetector:
 
         # Set a short issue detection interval for testing
         ctx = DataContext.get_current()
+        ctx.issue_detectors_config.detectors = [HangingExecutionIssueDetector]
         detector_cfg = ctx.issue_detectors_config.hanging_detector_config
         detector_cfg.detection_time_interval_s = 0.00
 


### PR DESCRIPTION
The hanging issue detector makes blocking calls to the Ray State API. This can cause the scheduling loop to block and severely degrade pipeline performance.

Since we haven't fixed the blocking calls yet, I'm disabling the detector for this patch release.