### PR TITLE
[Data] Add heterogeneous memory batch inference release test

### DIFF
--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -12,6 +12,18 @@ nodes' local object store is full. This benchmark exercises that scenario.
 
 Pipeline: range -> gen_data -> cpu_process -> gpu_inference -> write
 All UDFs are fake (sleep-based). Inference is the bottleneck.
+
+Data size:
+  - 400k rows x ~1 MB/row = ~400 GB total
+  - Per CPU task: 1024 rows x 1 MB = ~1 GB
+  - Per GPU task: 256 rows x 1 MB = ~256 MB
+
+Cluster (heterogeneous_memory_compute.yaml):
+  - 1 head node: m5.2xlarge (8 vCPUs, 32 GiB, no tasks scheduled)
+  - 10 CPU workers: m5.2xlarge (8 vCPUs, 32 GiB, ~12 GiB object store each)
+  - 2 GPU workers: r5.4xlarge (128 GiB, ~48 GiB object store each, 4 logical
+    GPUs, 0 CPUs — only GPU tasks scheduled here)
+  - Total object store: ~216 GiB (120 GiB CPU + 96 GiB GPU)
 """
 
 import argparse

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -106,8 +106,7 @@ def build_and_run_pipeline(
         concurrency=gpu_concurrency,
     )
 
-    result = ds.write_datasink(NullDatasink())
-    return result.num_rows
+    ds.write_datasink(NullDatasink())
 
 
 # ---------------------------------------------------------------------------
@@ -116,7 +115,7 @@ def build_and_run_pipeline(
 
 
 def main(args):
-    total_rows = build_and_run_pipeline(
+    build_and_run_pipeline(
         num_rows=args.num_rows,
         gen_batch_size=args.gen_batch_size,
         cpu_batch_size=args.cpu_batch_size,
@@ -125,7 +124,6 @@ def main(args):
     )
 
     return {
-        BenchmarkMetric.NUM_ROWS: int(total_rows),
         "num_rows_input": int(args.num_rows),
         "gpu_concurrency": int(args.gpu_concurrency),
     }

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -34,7 +34,6 @@ from benchmark import Benchmark, BenchmarkMetric
 
 import ray
 
-
 # ---------------------------------------------------------------------------
 # UDFs
 # ---------------------------------------------------------------------------
@@ -90,10 +89,8 @@ def build_and_run_pipeline(
     ds = ray.data.range(num_rows)
 
     ds = ds.map_batches(gen_data, batch_size=gen_batch_size)
-    ds._set_name("gen_data")
 
     ds = ds.map_batches(cpu_process, batch_size=cpu_batch_size)
-    ds._set_name("cpu_process")
 
     ds = ds.map_batches(
         FakeGPUInference,
@@ -102,10 +99,8 @@ def build_and_run_pipeline(
         num_gpus=1,
         concurrency=gpu_concurrency,
     )
-    ds._set_name("gpu_inference")
 
     ds = ds.map_batches(consume, batch_size=gpu_batch_size)
-    ds._set_name("consume")
 
     total_rows = 0
     for batch in ds.iter_batches(batch_size=None):

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -33,6 +33,8 @@ import numpy as np
 from benchmark import Benchmark, BenchmarkMetric
 
 import ray
+from ray.data._internal.execution.interfaces import TaskContext
+from ray.data.datasource import Datasink
 
 # ---------------------------------------------------------------------------
 # UDFs
@@ -69,9 +71,13 @@ class FakeGPUInference:
         return batch
 
 
-def consume(batch):
-    """Terminal op: discard data."""
-    return {"n": [len(batch["prediction"])]}
+class NullDatasink(Datasink):
+    """Datasink that discards all data."""
+
+    def write(self, blocks, ctx: TaskContext):
+        # Use this empty loop to drain the generator.
+        for _ in blocks:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -100,13 +106,8 @@ def build_and_run_pipeline(
         concurrency=gpu_concurrency,
     )
 
-    ds = ds.map_batches(consume, batch_size=gpu_batch_size)
-
-    total_rows = 0
-    for batch in ds.iter_batches(batch_size=None):
-        total_rows += sum(batch["n"])
-
-    return total_rows
+    result = ds.write_datasink(NullDatasink())
+    return result.num_rows
 
 
 # ---------------------------------------------------------------------------

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -1,0 +1,142 @@
+"""
+Heterogeneous Memory Batch Inference Benchmark
+
+Tests Ray Data memory management on a cluster with heterogeneous memory:
+- CPU nodes: small memory, run data generation and preprocessing
+- GPU nodes: large memory, run inference
+
+The global object store memory threshold is the sum of all nodes' object store
+memory. Because GPU nodes contribute a large share of that budget, CPU-only
+stages can keep producing data without triggering backpressure, even when CPU
+nodes' local object store is full. This benchmark exercises that scenario.
+
+Pipeline: range -> gen_data -> cpu_process -> gpu_inference -> write
+All UDFs are fake (sleep-based). Inference is the bottleneck.
+"""
+
+import argparse
+import time
+
+import numpy as np
+from benchmark import Benchmark, BenchmarkMetric
+
+import ray
+
+
+# ---------------------------------------------------------------------------
+# UDFs
+# ---------------------------------------------------------------------------
+
+
+ROW_SIZE = 125_000  # ~1 MB per row (125K float64 elements x 8 bytes)
+
+
+def gen_data(batch):
+    """Generate ~1 MB of data per row."""
+    n = len(batch["id"])
+    batch["data"] = [np.random.rand(ROW_SIZE) for _ in range(n)]
+    return batch
+
+
+def cpu_process(batch):
+    """Simulate CPU preprocessing. Moderately fast."""
+    time.sleep(0.05)
+    batch["processed"] = [1] * len(batch["data"])
+    return batch
+
+
+class FakeGPUInference:
+    """Simulate slow GPU inference (bottleneck)."""
+
+    def __init__(self):
+        # Simulate model loading.
+        time.sleep(2)
+
+    def __call__(self, batch):
+        time.sleep(0.5)
+        batch["prediction"] = list(range(len(batch["data"])))
+        return batch
+
+
+def consume(batch):
+    """Terminal op: discard data."""
+    return {"n": [len(batch["prediction"])]}
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+def build_and_run_pipeline(
+    num_rows: int,
+    gen_batch_size: int,
+    cpu_batch_size: int,
+    gpu_batch_size: int,
+    gpu_concurrency: int,
+):
+    ds = ray.data.range(num_rows)
+
+    ds = ds.map_batches(gen_data, batch_size=gen_batch_size)
+    ds._set_name("gen_data")
+
+    ds = ds.map_batches(cpu_process, batch_size=cpu_batch_size)
+    ds._set_name("cpu_process")
+
+    ds = ds.map_batches(
+        FakeGPUInference,
+        batch_size=gpu_batch_size,
+        num_cpus=0,
+        num_gpus=1,
+        concurrency=gpu_concurrency,
+    )
+    ds._set_name("gpu_inference")
+
+    ds = ds.map_batches(consume, batch_size=gpu_batch_size)
+    ds._set_name("consume")
+
+    total_rows = 0
+    for batch in ds.iter_batches(batch_size=None):
+        total_rows += batch["n"][0]
+
+    return total_rows
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(args):
+    total_rows = build_and_run_pipeline(
+        num_rows=args.num_rows,
+        gen_batch_size=args.gen_batch_size,
+        cpu_batch_size=args.cpu_batch_size,
+        gpu_batch_size=args.gpu_batch_size,
+        gpu_concurrency=args.gpu_concurrency,
+    )
+
+    return {
+        BenchmarkMetric.NUM_ROWS: int(total_rows),
+        "num_rows_input": int(args.num_rows),
+        "gpu_concurrency": int(args.gpu_concurrency),
+    }
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Heterogeneous memory batch inference benchmark"
+    )
+    p.add_argument("--num-rows", type=int, default=400_000)
+    p.add_argument("--gen-batch-size", type=int, default=1024)
+    p.add_argument("--cpu-batch-size", type=int, default=1024)
+    p.add_argument("--gpu-batch-size", type=int, default=256)
+    p.add_argument("--gpu-concurrency", type=int, default=8)
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    benchmark = Benchmark()
+    benchmark.run_fn("heterogeneous-memory-batch-inference", main, args)
+    benchmark.write_result()

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -30,7 +30,7 @@ import argparse
 import time
 
 import numpy as np
-from benchmark import Benchmark, BenchmarkMetric
+from benchmark import Benchmark
 
 import ray
 from ray.data._internal.execution.interfaces import TaskContext

--- a/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
+++ b/release/nightly_tests/dataset/heterogeneous_memory_batch_inference.py
@@ -104,7 +104,7 @@ def build_and_run_pipeline(
 
     total_rows = 0
     for batch in ds.iter_batches(batch_size=None):
-        total_rows += batch["n"][0]
+        total_rows += sum(batch["n"])
 
     return total_rows
 

--- a/release/nightly_tests/dataset/heterogeneous_memory_compute.yaml
+++ b/release/nightly_tests/dataset/heterogeneous_memory_compute.yaml
@@ -1,0 +1,36 @@
+# Heterogeneous cluster for testing memory management with mixed node types.
+# CPU nodes have small memory; GPU nodes have large memory.
+# GPU nodes use logical GPU resources only (no real GPUs needed).
+cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
+region: us-west-2
+
+advanced_configurations_json:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node_type:
+    name: head-node
+    instance_type: m5.2xlarge
+    resources:
+      cpu: 0
+
+worker_node_types:
+    # CPU workers: small memory nodes for CPU-bound tasks.
+    # m5.2xlarge: 8 vCPUs, 32 GiB memory (~12 GiB object store).
+    - name: cpu-worker
+      instance_type: m5.2xlarge
+      min_workers: 10
+      max_workers: 10
+      use_spot: false
+
+    # "GPU" workers: large memory nodes with logical GPU resources, no CPUs.
+    # r5.4xlarge: 16 vCPUs, 128 GiB memory (~48 GiB object store).
+    # We override resources to expose only GPU (no CPU) so that only GPU tasks
+    # are scheduled here.
+    - name: gpu-worker
+      instance_type: r5.4xlarge
+      min_workers: 2
+      max_workers: 2
+      use_spot: false
+      resources:
+        cpu: 0
+        gpu: 4

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -581,9 +581,6 @@
     timeout: 3600
     script: >
       python heterogeneous_memory_batch_inference.py
-      --num-rows 400000
-      --gpu-batch-size 256
-      --gpu-concurrency 8
 
 # 300 GB image classification parquet data up to 10 GPUs
 # 10 g4dn.12xlarge.

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -579,8 +579,7 @@
 
   run:
     timeout: 3600
-    script: >
-      python heterogeneous_memory_batch_inference.py
+    script: python heterogeneous_memory_batch_inference.py
 
 # 300 GB image classification parquet data up to 10 GPUs
 # 10 g4dn.12xlarge.

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -565,6 +565,26 @@
 # Batch inference tests
 #######################
 
+# Tests memory management on a cluster with mixed node types:
+# CPU nodes (small memory) produce data faster than GPU nodes (large memory)
+# can consume it. The global object store threshold is the sum of all nodes,
+# so CPU stages may not trigger backpressure even when CPU nodes are full.
+- name: heterogeneous_memory_batch_inference
+  python: "3.10"
+  frequency: nightly
+  group: data-batch-inference
+
+  cluster:
+    cluster_compute: heterogeneous_memory_compute.yaml
+
+  run:
+    timeout: 3600
+    script: >
+      python heterogeneous_memory_batch_inference.py
+      --num-rows 400000
+      --gpu-batch-size 256
+      --gpu-concurrency 8
+
 # 300 GB image classification parquet data up to 10 GPUs
 # 10 g4dn.12xlarge.
 - name: "image_classification_{{scaling}}"


### PR DESCRIPTION
## Summary
- Add a release test that exercises Ray Data memory management on a heterogeneous cluster (CPU nodes with small memory + GPU nodes with large memory).
- The pipeline (`range -> gen_data -> cpu_process -> gpu_inference -> consume`) uses fake UDFs with sleep to make GPU inference the bottleneck.
- ~400 GB of data flows through 10 CPU workers (32 GiB each) and 2 GPU workers (128 GiB each, logical GPUs only), exposing the issue where the global object store threshold masks per-node memory pressure on CPU nodes.

## Test plan
- [x] Submitted job on Anyscale and verified it completes successfully (~315s)
- [x] Confirmed expected behavior: CPU stages finish early, GPU inference queues up ~80 GiB, CPU nodes spill ~37 GiB each