### PR TITLE
[deps] rayllm: updating stale hashes

### DIFF
--- a/python/deplocks/llm/rayllm_test_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cu130.lock
@@ -3396,8 +3396,8 @@ opentelemetry-proto==1.39.0 \
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
 opentelemetry-sdk==1.39.0 \
-    --hash=sha256:308effad4059562f1d92163c61c8141df649da24ce361827812c40abb2a1e96e \
-    --hash=sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d
+    --hash=sha256:90cfb07600dfc0d2de26120cebc0c8f27e69bf77cd80ef96645232372709a514 \
+    --hash=sha256:c22204f12a0529e07aa4d985f1bca9d6b0e7b29fe7f03e923548ae52e0e15dde
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
     #   -r python/requirements.txt


### PR DESCRIPTION
updating rayllm stale hashes for opentelemetry-sdk in `python/deplocks/llm/rayllm_test_py312_cu130.lock`

failing postmerge build: https://buildkite.com/ray-project/postmerge/builds/16575#_

Successful local build logs
```
environment instead: https://pip.pypa.io/warnings/venv. Use the --root-user-action option if you know what you are doing and want to suppress this warning.
#10 DONE 395.9s

#11 exporting to image
#11 exporting layers
#11 exporting layers 84.0s done
#11 writing image sha256:38cfb1ceb9d5b48e3c6c51560401e9a184958fc272a942fe76dc0728947aed94 done
#11 naming to cr.ray.io/rayproject/llmgpubuild-py312 done
#11 naming to localhost:5000/rayci-work:llmgpubuild-py312 done
#11 naming to localhost:5000/rayci-work:z-bf8e5fafc62f806191b7a3827b333416d8ec7b169807dde435a970317846c6af done
#11 DONE 84.1s
```