### PR TITLE
[dashboard] Forward **kwargs through JobSubmissionClient to cluster info resolvers

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -830,7 +830,7 @@ python/ray/dashboard/head.py
 --------------------
 python/ray/dashboard/modules/dashboard_sdk.py
     DOC101: Function `get_job_submission_client_cluster_info`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `get_job_submission_client_cluster_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_use_tls: Optional[bool], cookies: Optional[Dict[str, Any]], headers: Optional[Dict[str, Any]], metadata: Optional[Dict[str, Any]]].
+    DOC103: Function `get_job_submission_client_cluster_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , _use_tls: Optional[bool], cookies: Optional[Dict[str, Any]], headers: Optional[Dict[str, Any]], metadata: Optional[Dict[str, Any]]].
 --------------------
 python/ray/dashboard/modules/event/event_head.py
     DOC101: Function `_list_cluster_events_impl`: Docstring contains fewer arguments than in function signature.

--- a/python/ray/dashboard/modules/dashboard_sdk.py
+++ b/python/ray/dashboard/modules/dashboard_sdk.py
@@ -97,6 +97,7 @@ def get_job_submission_client_cluster_info(
     metadata: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, Any]] = None,
     _use_tls: Optional[bool] = False,
+    **kwargs,
 ) -> ClusterInfo:
     """Get address, cookies, and metadata used for SubmissionClient.
 
@@ -131,6 +132,7 @@ def parse_cluster_info(
     cookies: Optional[Dict[str, Any]] = None,
     metadata: Optional[Dict[str, Any]] = None,
     headers: Optional[Dict[str, Any]] = None,
+    **kwargs,
 ) -> ClusterInfo:
     """Create a cluster if needed and return its address, cookies, and metadata."""
     if address is None:
@@ -176,6 +178,7 @@ def parse_cluster_info(
             metadata=metadata,
             headers=headers,
             _use_tls=(module_string == "https"),
+            **kwargs,
         )
     # Try to dynamically import the function to get cluster info.
     else:
@@ -198,6 +201,7 @@ def parse_cluster_info(
             cookies=cookies,
             metadata=metadata,
             headers=headers,
+            **kwargs,
         )
 
 
@@ -210,6 +214,7 @@ class SubmissionClient:
         metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
         verify: Optional[Union[str, bool]] = True,
+        **kwargs,
     ):
         # Remove any trailing slashes
         if address is not None and address.endswith("/"):
@@ -220,7 +225,7 @@ class SubmissionClient:
             )
 
         cluster_info = parse_cluster_info(
-            address, create_cluster_if_needed, cookies, metadata, headers
+            address, create_cluster_if_needed, cookies, metadata, headers, **kwargs
         )
         self._address = cluster_info.address
         self._cookies = cluster_info.cookies

--- a/python/ray/dashboard/modules/job/sdk.py
+++ b/python/ray/dashboard/modules/job/sdk.py
@@ -58,6 +58,10 @@ class JobSubmissionClient(SubmissionClient):
             for cases like authentication to a remote cluster.
         verify: Boolean indication to verify the server's TLS certificate or a path to
             a file or directory of trusted certificates. Default: True.
+        **kwargs: Additional keyword arguments forwarded to the cluster info
+            resolution function. For external module addresses (e.g.,
+            ``anyscale://``), these are passed through to the module's
+            ``get_job_submission_client_cluster_info()`` implementation.
     """
 
     def __init__(
@@ -68,6 +72,7 @@ class JobSubmissionClient(SubmissionClient):
         metadata: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
         verify: Optional[Union[str, bool]] = True,
+        **kwargs,
     ):
         self._client_ray_version = ray.__version__
         """Initialize a JobSubmissionClient and check the connection to the cluster."""
@@ -102,6 +107,7 @@ class JobSubmissionClient(SubmissionClient):
             metadata=metadata,
             headers=headers,
             verify=verify,
+            **kwargs,
         )
         self._check_connection_and_version(
             min_version="1.9",

--- a/python/ray/dashboard/modules/job/tests/test_sdk.py
+++ b/python/ray/dashboard/modules/job/tests/test_sdk.py
@@ -65,12 +65,14 @@ def check_internal_kv_gced():
 @pytest.mark.parametrize("cookies", [None, {"test_cookie_key": "test_cookie_val"}])
 @pytest.mark.parametrize("metadata", [None, {"test_metadata_key": "test_metadata_val"}])
 @pytest.mark.parametrize("headers", [None, {"test_headers_key": "test_headers_val"}])
+@pytest.mark.parametrize("extra_kwargs", [{}, {"cloud": "my-cloud"}])
 def test_parse_cluster_info(
     address_param: Tuple[str, str, str],
     create_cluster_if_needed: bool,
     cookies: Optional[Dict[str, str]],
     metadata: Optional[Dict[str, str]],
     headers: Optional[Dict[str, str]],
+    extra_kwargs: Dict[str, str],
 ):
     """
     Test ray.dashboard.modules.dashboard_sdk.parse_cluster_info for different
@@ -100,6 +102,7 @@ def test_parse_cluster_info(
                     cookies=cookies,
                     metadata=metadata,
                     headers=headers,
+                    **extra_kwargs,
                 )
         elif module_string == "other_module":
             assert (
@@ -109,6 +112,7 @@ def test_parse_cluster_info(
                     cookies=cookies,
                     metadata=metadata,
                     headers=headers,
+                    **extra_kwargs,
                 )
                 == "Other module ClusterInfo"
             )
@@ -119,6 +123,7 @@ def test_parse_cluster_info(
                 cookies=cookies,
                 metadata=metadata,
                 headers=headers,
+                **extra_kwargs,
             )
 
 

--- a/python/ray/dashboard/modules/tests/test_dashboard_sdk.py
+++ b/python/ray/dashboard/modules/tests/test_dashboard_sdk.py
@@ -93,5 +93,11 @@ def test_parse_cluster_address_validation():
         parse_cluster_info(f"{scheme}://localhost:10001")
 
 
+def test_parse_cluster_info_ignores_extra_kwargs():
+    """Test that parse_cluster_info with http:// gracefully ignores extra kwargs."""
+    result = parse_cluster_info("http://localhost:8265", cloud="test")
+    assert result.address == "http://localhost:8265"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

External module addresses (e.g. `anyscale://`) need to accept additional parameters like cloud name, but the call chain from `JobSubmissionClient` through `parse_cluster_info` to `get_job_submission_client_cluster_info` dropped any extra keyword arguments.

This PR threads `**kwargs` through the entire chain so that external modules can receive additional parameters passed by the caller.

## Related issue number

N/A

## Checks

- [x] I've signed the [CLA](http://ray.io/cla).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` under the corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests