### PR TITLE
[Data] Add failing files to type checking exclude list

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -68,17 +68,14 @@ steps:
     tags: cibase
 
   # type check
-  # FIXME: The PR that added pyrefly was out of sync with the main branch. Since we made
-  # changes to the codebase since then, there are a few files that aren't ignored and
-  # causing the type check to fail on master.
-  # - label: ":python: pyrefly type check"
-  #   tags:
-  #     - data
-  #   instance_type: small
-  #   commands:
-  #     - bash ci/lint/pyrefly-check.sh
-  #   depends_on: data9build-multipy
-  #   job_env: data9build-py3.10
+  - label: ":python: pyrefly type check"
+    tags:
+      - data
+    instance_type: small
+    commands:
+      - bash ci/lint/pyrefly-check.sh
+    depends_on: data9build-multipy
+    job_env: data9build-py3.10
 
   # tests
   - label: ":database: data: arrow v9 tests"

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -68,14 +68,17 @@ steps:
     tags: cibase
 
   # type check
-  - label: ":python: pyrefly type check"
-    tags:
-      - data
-    instance_type: small
-    commands:
-      - bash ci/lint/pyrefly-check.sh
-    depends_on: data9build-multipy
-    job_env: data9build-py3.10
+  # FIXME: The PR that added pyrefly was out of sync with the main branch. Since we made
+  # changes to the codebase since then, there are a few files that aren't ignored and
+  # causing the type check to fail on master.
+  # - label: ":python: pyrefly type check"
+  #   tags:
+  #     - data
+  #   instance_type: small
+  #   commands:
+  #     - bash ci/lint/pyrefly-check.sh
+  #   depends_on: data9build-multipy
+  #   job_env: data9build-py3.10
 
   # tests
   - label: ":database: data: arrow v9 tests"

--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -343,3 +343,9 @@ python/ray/data/tests/util.py
 python/ray/data/util/data_batch_conversion.py
 python/ray/data/util/expression_utils.py
 python/ray/data/util/torch_utils.py
+python/ray/data/tests/test_gpu_shuffle.py
+python/ray/data/tests/datasource/test_mongo.py
+python/ray/data/tests/datasource/test_kafka.py
+python/ray/data/_internal/gpu_shuffle/rapidsmpf_backend.py
+python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
+python/ray/data/_internal/execution/bundle_queue/base.py


### PR DESCRIPTION
The PR that added pyrefly was out of sync with the main branch. Since we made changes to the codebase since then, there are a few files that aren't ignored and causing the type check to fail on master.

In this PR, I've added those failing files to the excluded list.