### PR TITLE
[Core] Print subprocess log tails with exit codes on unexpected exit

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -92,8 +92,8 @@ def _log_unexpected_subprocess_exit_details(
             exit_codes_by_process_type.setdefault(str(process_type), set()).add(rc_str)
             lines_for_file.append(f"  {process_type} [exit code={rc_str}]")
     try:
-        file_msg = (
-            "Some Ray subprocesses exited unexpectedly:\n" + "\n".join(lines_for_file)
+        file_msg = "Some Ray subprocesses exited unexpectedly:\n" + "\n".join(
+            lines_for_file
         )
         process_exit_logger.error("%s", file_msg)
     except Exception as e:

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -99,12 +99,13 @@ def _log_unexpected_subprocess_exit_details(
     except Exception as e:
         cli_logger.warning("Failed to write process exit log: {}", e)
 
-    try:
-        process_types = sorted({str(t) for t, _p in unexpected_deceased})
-        for process_type in process_types:
-            exit_codes = sorted(exit_codes_by_process_type[process_type])
-            exit_codes_display = ", ".join(exit_codes)
-            for fname in (f"{process_type}.err", f"{process_type}.out"):
+    process_types = sorted({str(t) for t, _p in unexpected_deceased})
+    for process_type in process_types:
+        exit_codes = sorted(exit_codes_by_process_type[process_type])
+        exit_codes_display = ", ".join(exit_codes)
+        for fname in (f"{process_type}.err", f"{process_type}.out"):
+            began_tail_output = False
+            try:
                 fpath = os.path.join(logs_dir, fname)
                 if not os.path.exists(fpath) or os.path.getsize(fpath) == 0:
                     continue
@@ -114,16 +115,19 @@ def _log_unexpected_subprocess_exit_details(
                     fname,
                     exit_codes_display,
                 )
+                began_tail_output = True
                 cli_logger.newline()
                 cli_logger.error("{}", _tail_file(fpath))
-                cli_logger.newline()
-                cli_logger.error(
-                    "----- END {} tail (exit code(s)={}) -----",
-                    fname,
-                    exit_codes_display,
-                )
-    except Exception as e:
-        cli_logger.error("Failed to tail process logs: {}", e)
+            except Exception as e:
+                cli_logger.error("Failed to tail process log {}: {}", fname, e)
+            finally:
+                if began_tail_output:
+                    cli_logger.newline()
+                    cli_logger.error(
+                        "----- END {} tail (exit code(s)={}) -----",
+                        fname,
+                        exit_codes_display,
+                    )
 
 
 def _check_ray_version(gcs_client):

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -10,6 +10,7 @@ import time
 import urllib
 import urllib.parse
 import warnings
+from collections import deque
 from datetime import datetime
 from typing import List, Optional, Set, Tuple
 
@@ -66,6 +67,63 @@ from ray.util.check_open_ports import check_open_ports
 import psutil
 
 logger = logging.getLogger(__name__)
+
+
+def _tail_file(path: str, max_lines: int = 200) -> str:
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return "".join(deque(f, maxlen=max_lines))
+
+
+def _log_unexpected_subprocess_exit_details(
+    unexpected_deceased, logs_dir: str, process_exit_logger
+) -> None:
+    """Log unexpected subprocess exits to both structured and console outputs."""
+    lines_for_file = []
+    exit_codes_by_process_type = {}
+    with cli_logger.indented():
+        for process_type, process in unexpected_deceased:
+            cli_logger.error(
+                "{}",
+                cf.bold(str(process_type)),
+                _tags={"exit code": str(process.returncode)},
+            )
+            rc = getattr(process, "returncode", None)
+            rc_str = format_returncode(rc)
+            exit_codes_by_process_type.setdefault(str(process_type), set()).add(rc_str)
+            lines_for_file.append(f"  {process_type} [exit code={rc_str}]")
+    try:
+        file_msg = (
+            "Some Ray subprocesses exited unexpectedly:\n" + "\n".join(lines_for_file)
+        )
+        process_exit_logger.error("%s", file_msg)
+    except Exception as e:
+        cli_logger.warning("Failed to write process exit log: {}", e)
+
+    try:
+        process_types = sorted({str(t) for t, _p in unexpected_deceased})
+        for process_type in process_types:
+            exit_codes = sorted(exit_codes_by_process_type[process_type])
+            exit_codes_display = ", ".join(exit_codes)
+            for fname in (f"{process_type}.err", f"{process_type}.out"):
+                fpath = os.path.join(logs_dir, fname)
+                if not os.path.exists(fpath) or os.path.getsize(fpath) == 0:
+                    continue
+                cli_logger.newline()
+                cli_logger.error(
+                    "----- BEGIN {} tail (exit code(s)={}) -----",
+                    fname,
+                    exit_codes_display,
+                )
+                cli_logger.newline()
+                cli_logger.error("{}", _tail_file(fpath))
+                cli_logger.newline()
+                cli_logger.error(
+                    "----- END {} tail (exit code(s)={}) -----",
+                    fname,
+                    exit_codes_display,
+                )
+    except Exception as e:
+        cli_logger.error("Failed to tail process logs: {}", e)
 
 
 def _check_ray_version(gcs_client):
@@ -1199,29 +1257,15 @@ def start(
             if len(unexpected_deceased) > 0:
                 cli_logger.newline()
                 cli_logger.error("Some Ray subprocesses exited unexpectedly:")
-
-                lines_for_file = []
-                with cli_logger.indented():
-                    for process_type, process in unexpected_deceased:
-                        cli_logger.error(
-                            "{}",
-                            cf.bold(str(process_type)),
-                            _tags={"exit code": str(process.returncode)},
-                        )
-                        rc = getattr(process, "returncode", None)
-                        rc_str = format_returncode(rc)
-                        lines_for_file.append(f"  {process_type} [exit code={rc_str}]")
-                try:
-                    file_msg = (
-                        "Some Ray subprocesses exited unexpectedly:\n"
-                        + "\n".join(lines_for_file)
-                    )
-                    process_exit_logger.error("%s", file_msg)
-                except Exception as e:
-                    cli_logger.warning("Failed to write process exit log: {}", e)
+                _log_unexpected_subprocess_exit_details(
+                    unexpected_deceased,
+                    logs_dir,
+                    process_exit_logger,
+                )
 
                 cli_logger.newline()
                 cli_logger.error("Remaining processes will be killed.")
+                cli_logger.flush()
 
                 # explicitly kill all processes since atexit handlers
                 # will not exit with errors.

--- a/python/ray/tests/test_cli.py
+++ b/python/ray/tests/test_cli.py
@@ -186,6 +186,50 @@ def _die_on_error(result):
     _fail_if_false(result.exit_code == 0, result.output)
 
 
+def test_log_unexpected_subprocess_exit_details(monkeypatch, tmp_path):
+    logs_dir = tmp_path
+    (logs_dir / "gcs_server.err").write_text("sentinel_tail_line\n", encoding="utf-8")
+
+    emitted_errors = []
+
+    class _IndentedContext:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def _render_message(message, args):
+        try:
+            return str(message).format(*args)
+        except Exception:
+            return f"{message} {' '.join(map(str, args))}"
+
+    def _capture_error(message, *args, **kwargs):
+        emitted_errors.append(_render_message(message, args))
+
+    monkeypatch.setattr(scripts.cli_logger, "indented", lambda: _IndentedContext())
+    monkeypatch.setattr(scripts.cli_logger, "error", _capture_error)
+    monkeypatch.setattr(scripts.cli_logger, "warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(scripts.cli_logger, "newline", lambda *args, **kwargs: None)
+
+    process_exit_logger = MagicMock()
+    fake_process = MagicMock(returncode=137)
+
+    scripts._log_unexpected_subprocess_exit_details(
+        [("gcs_server", fake_process)],
+        str(logs_dir),
+        process_exit_logger,
+    )
+
+    process_exit_logger.error.assert_called_once()
+    logged_message = process_exit_logger.error.call_args.args[1]
+    assert "Some Ray subprocesses exited unexpectedly:" in logged_message
+    assert "gcs_server [exit code=" in logged_message
+    assert any("BEGIN gcs_server.err tail (exit code(s)=" in x for x in emitted_errors)
+    assert any("sentinel_tail_line" in x for x in emitted_errors)
+
+
 def _debug_check_line_by_line(result, expected_lines):
     """Print the result and expected output line-by-line."""
     output_lines = result.output.split("\n")


### PR DESCRIPTION
## Description
Failure details are primarily written to on-disk logs inside the container, while observability commonly relies on `stdout/stderr`.
After a head-container restart, previous-container failure context is often unavailable.
This PR emits key diagnostics (last 200 log lines and exit codes) to `stdout/stderr` on unexpected subprocess exit, so they are visible in both centralized logging pipelines and direct `kubectl logs` inspection.

## Additional information
- Scope: `python/ray/scripts/scripts.py`
- Behavior: only tails logs for unexpectedly exited subprocesses; skips missing/empty files.

