### PR TITLE
[llm] Remove mention of VLLM_USE_V1 from docs

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
@@ -80,9 +80,6 @@ serveConfigV2: |
             autoscaling_config:
               min_replicas: 1
               max_replicas: 1
-          runtime_env:
-            env_vars:
-              VLLM_USE_V1: "1"
           engine_kwargs:
             tensor_parallel_size: 8
             pipeline_parallel_size: 2

--- a/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
+++ b/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
@@ -61,7 +61,6 @@ llm_config = LLMConfig(
             },
         },
     },
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
 )
 
 app = build_openai_app({"llm_configs": [llm_config]})

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
@@ -765,12 +765,6 @@ from ray.data.llm import vLLMEngineProcessorConfig
 ```python
 config = vLLMEngineProcessorConfig(
     model_source=model_source,
-    runtime_env={
-        "env_vars": {
-            "VLLM_USE_V1": "0",  # v1 doesn't support lora adapters yet
-            # "HF_TOKEN": os.environ.get("HF_TOKEN"),
-        },
-    },
     engine_kwargs={
         "enable_lora": True,
         "max_lora_rank": 8,

--- a/doc/source/serve/tutorials/serve-deepseek.md
+++ b/doc/source/serve/tutorials/serve-deepseek.md
@@ -42,7 +42,6 @@ llm_config = LLMConfig(
     },
     # Change to the accelerator type of the node
     accelerator_type="H100",
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     # Customize engine arguments as needed (e.g. vLLM engine kwargs)
     engine_kwargs={
         "tensor_parallel_size": 8,
@@ -78,9 +77,6 @@ applications:
           autoscaling_config:
             min_replicas: 1
             max_replicas: 1
-        runtime_env:
-          env_vars:
-            VLLM_USE_V1: "1"
         engine_kwargs:
           tensor_parallel_size: 8
           pipeline_parallel_size: 2


### PR DESCRIPTION
## Description

V1 engine has been the default in vLLM for some time. This PR removes all references to the VLLM_USE_V1 environment variable from documentation and examples.

## Changes

- `doc/source/serve/tutorials/serve-deepseek.md` - Removed runtime_env with VLLM_USE_V1 from both Python and YAML examples
- `doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md` - Removed runtime_env with VLLM_USE_V1 from YAML config
- `doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py` - Removed runtime_env with VLLM_USE_V1
- `doc/source/ray-overview/examples/entity-recognition-with-llms/README.md` - Removed runtime_env with VLLM_USE_V1

## Related Issue

Fixes #61892

## Checklist

- [x] Updated documentation to remove outdated environment variable references
- [x] No breaking changes to existing functionality
- [x] Changes are consistent with the issue description