### PR TITLE
docs: remove VLLM_USE_V1 environment variable references

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
@@ -81,8 +81,7 @@ serveConfigV2: |
               min_replicas: 1
               max_replicas: 1
           runtime_env:
-            env_vars:
-              VLLM_USE_V1: "1"
+            env_vars: {}
           engine_kwargs:
             tensor_parallel_size: 8
             pipeline_parallel_size: 2

--- a/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
+++ b/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
@@ -61,7 +61,6 @@ llm_config = LLMConfig(
             },
         },
     },
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
 )
 
 app = build_openai_app({"llm_configs": [llm_config]})

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
@@ -767,7 +767,6 @@ config = vLLMEngineProcessorConfig(
     model_source=model_source,
     runtime_env={
         "env_vars": {
-            "VLLM_USE_V1": "0",  # v1 doesn't support lora adapters yet
             # "HF_TOKEN": os.environ.get("HF_TOKEN"),
         },
     },

--- a/doc/source/serve/tutorials/serve-deepseek.md
+++ b/doc/source/serve/tutorials/serve-deepseek.md
@@ -42,7 +42,6 @@ llm_config = LLMConfig(
     },
     # Change to the accelerator type of the node
     accelerator_type="H100",
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     # Customize engine arguments as needed (e.g. vLLM engine kwargs)
     engine_kwargs={
         "tensor_parallel_size": 8,


### PR DESCRIPTION
## Description
V1 engine is now the default in vLLM and no longer needs to be explicitly set through environment variables.

## Changes
Removes VLLM_USE_V1 from documentation and examples:
- rayserve-deepseek-example.md
- prefix_aware_example.py  
- entity-recognition-with-llms README.md
- serve-deepseek.md tutorial

## Fixes
Closes #61892