### PR TITLE
[CI] Migrate test group pipelines from matrix to array syntax

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -6,57 +6,61 @@ depends_on:
 steps:
   # builds
   - name: corebuild-multipy
-    label: "wanda: corebuild-py{{matrix}}"
+    label: "wanda: corebuild-py{{array.python}}"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "build"
       BUILD_VARIANT: "build"
     depends_on: oss-ci-base_build-multipy
 
   - name: coregpubuild-multipy
-    label: "wanda: coregpubuild-py{{matrix}}"
+    label: "wanda: coregpubuild-py{{array.python}}"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
     depends_on: oss-ci-base_gpu-multipy
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "gpu"
       BUILD_VARIANT: "gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
 
   - name: coregpu-cu130-build-multipy
-    label: "wanda: coregpu-cu130-build-py{{matrix}}"
+    label: "wanda: coregpu-cu130-build-py{{array.python}}"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
     depends_on: oss-ci-base_cu130-multipy
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "cu130"
       BUILD_VARIANT: "gpu-cu130-build"
       RAYCI_IS_GPU_BUILD: "true"
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
 
   - name: minbuild-core
-    label: "wanda: minbuild-core-py{{matrix}}"
+    label: "wanda: minbuild-core-py{{array.python}}"
     wanda: ci/docker/min.build.wanda.yaml
     depends_on: oss-ci-base_test-multipy
     tags: cibase
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       EXTRA_DEPENDENCY: core
 
   - wait: ~
@@ -78,7 +82,7 @@ steps:
         --except-tags custom_setup
         --install-mask all-ray-libraries
 
-  - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":ray: core: python {{array.python}} tests ({{array.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - python
@@ -87,14 +91,13 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
-        --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
-        --python-version {{matrix.python}} --build-name corebuild-py{{matrix.python}}
+        --workers 4 --worker-id "{{array.worker_id}}" --parallelism-per-worker 3
+        --python-version {{array.python}} --build-name corebuild-py{{array.python}}
         --except-tags custom_setup
     depends_on: corebuild-multipy
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1", "2", "3"]
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1", "2", "3"]
 
   - label: ":ray: core: ray client tests"
     tags:
@@ -271,7 +274,7 @@ steps:
       - forge
       - ray-wheel-build
 
-  - label: ":ray: core: minimal tests {{matrix}}"
+  - label: ":ray: core: minimal tests {{array.python}}"
     tags:
       - python
       - dashboard
@@ -284,49 +287,50 @@ steps:
       # core tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
-        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --test-env=EXPECTED_PYTHON_VERSION={{array.python}}
         --only-tags minimal
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --except-tags basic_test,manual,cgroup
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
-        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --test-env=EXPECTED_PYTHON_VERSION={{array.python}}
         --only-tags minimal
         --except-tags no_basic_test,manual
         --skip-ray-installation
       # core redis tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
         --test-env=TEST_EXTERNAL_REDIS=1
-        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --test-env=EXPECTED_PYTHON_VERSION={{array.python}}
         --only-tags minimal
         --except-tags no_basic_test,manual
         --skip-ray-installation
       # serve tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... serve
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
         --only-tags minimal
         --skip-ray-installation
     depends_on:
       - minbuild-core
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
 
   - label: ":ray: core: cgroup tests"
     tags:

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -7,28 +7,31 @@ depends_on:
 steps:
   # builds
   - name: data9build-multipy
-    label: "wanda: data9build-py{{matrix}}"
+    label: "wanda: data9build-py{{array.python}}"
     wanda: ci/docker/data9.build.wanda.yaml
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     tags: cibase
 
   - name: datalbuild-multipy
-    label: "wanda: datalbuild-py{{matrix}}"
+    label: "wanda: datalbuild-py{{array.python}}"
     wanda: ci/docker/datal.build.wanda.yaml
-    matrix: ["3.10", "3.12"]
+    array:
+      python: ["3.10", "3.12"]
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     tags: cibase
 
   - name: databuild-multipy
-    label: "wanda: databuild-py{{matrix}}"
+    label: "wanda: databuild-py{{array.python}}"
     wanda: ci/docker/data.build.wanda.yaml
-    matrix: ["3.10", "3.12"]
+    array:
+      python: ["3.10", "3.12"]
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     tags: cibase
 
   - name: datanbuild-multipy
@@ -148,7 +151,7 @@ steps:
         --except-tags data_non_parallel_postmerge_only,cudf
     depends_on: datalbuild-multipy
 
-  - label: ":database: data: arrow v23 py{{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":database: data: arrow v23 py{{array.python}} tests ({{array.worker_id}})"
     key: datal_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
@@ -156,16 +159,15 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
-        --build-name datalbuild-py{{matrix.python}} --python-version {{matrix.python}}
+        --workers 2 --worker-id {{array.worker_id}} --parallelism-per-worker 3
+        --build-name datalbuild-py{{array.python}} --python-version {{array.python}}
         --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
     depends_on: datalbuild-multipy
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1"]
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1"]
 
-  - label: ":database: data: arrow v23 py{{matrix.python}} tests (data_non_parallel)"
+  - label: ":database: data: arrow v23 py{{array.python}} tests (data_non_parallel)"
     key: datal_python_non_parallel_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
@@ -173,13 +175,12 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
-        --build-name datalbuild-py{{matrix.python}} --python-version {{matrix.python}}
+        --build-name datalbuild-py{{array.python}} --python-version {{array.python}}
         --only-tags data_non_parallel
         --except-tags data_non_parallel_postmerge_only,cudf
     depends_on: datalbuild-multipy
-    matrix:
-      setup:
-        python: ["3.12"]
+    array:
+      python: ["3.12"]
 
   - label: ":database: data: arrow nightly tests"
     tags:

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -6,28 +6,30 @@ depends_on:
 steps:
   # builds
   - name: minbuild-ml
-    label: "wanda: minbuild-ml-py{{matrix}}"
+    label: "wanda: minbuild-ml-py{{array.python}}"
     wanda: ci/docker/min.build.wanda.yaml
     depends_on: oss-ci-base_test-multipy
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       EXTRA_DEPENDENCY: ml
     tags: cibase
 
   - name: mlbuild-multipy
-    label: "wanda: mlbuild-py{{matrix}}"
+    label: "wanda: mlbuild-py{{array.python}}"
     wanda: ci/docker/ml.build.wanda.yaml
     depends_on: oss-ci-base_ml-multipy
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "ml"
       BUILD_VARIANT: "build"
       RAYCI_IS_GPU_BUILD: "false"
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     tags: cibase
 
   - name: mllightning2gpubuild
@@ -35,17 +37,18 @@ steps:
     depends_on: oss-ci-base_gpu-multipy
 
   - name: mlgpubuild-multipy
-    label: "wanda: mlgpubuild-py{{matrix}}"
+    label: "wanda: mlgpubuild-py{{array.python}}"
     wanda: ci/docker/ml.build.wanda.yaml
     depends_on: oss-ci-base_gpu-multipy
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "gpu"
       BUILD_VARIANT: "gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     tags: cibase
 
   # tests
@@ -85,7 +88,7 @@ steps:
         --except-tags data_integration
     depends_on: [ "mlgpubuild-multipy", "forge" ]
 
-  - label: ":bullettrain_front: :python: ml: train v2 {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":bullettrain_front: :python: ml: train v2 {{array.python}} tests ({{array.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - train
@@ -95,14 +98,13 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --python-version {{matrix.python}} --build-name mlbuild-py{{matrix.python}}
+        --python-version {{array.python}} --build-name mlbuild-py{{array.python}}
         --only-tags train_v2
         --except-tags needs_credentials
     depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1"]
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1"]
 
   - label: ":train: ml: train v1 gpu tests"
     tags:
@@ -129,7 +131,7 @@ steps:
         --only-tags data_integration
     depends_on: [ "mlgpubuild-multipy", "forge" ]
 
-  - label: ":bullettrain_front: :python: ml: train v2 gpu {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":bullettrain_front: :python: ml: train v2 gpu {{array.python}} tests ({{array.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - train_gpu
@@ -137,16 +139,15 @@ steps:
     instance_type: gpu-large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... //python/ray/air/... //doc/... ml
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 2
-        --python-version {{matrix.python}}
-        --build-name mlgpubuild-py{{matrix.python}}
+        --workers 2 --worker-id {{array.worker_id}} --parallelism-per-worker 2
+        --python-version {{array.python}}
+        --build-name mlgpubuild-py{{array.python}}
         --only-tags train_v2_gpu
         --except-tags doctest,data_integration
     depends_on: [ "mlgpubuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1"]
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1"]
 
   - label: ":train: ml: train authentication tests"
     tags:
@@ -174,19 +175,18 @@ steps:
         --except-tags doctest,soft_imports,rllib
     depends_on: [ "mlbuild-multipy", "forge" ]
 
-  - label: ":bullettrain_front: :python: ml: tune {{matrix.python}} tests"
+  - label: ":bullettrain_front: :python: ml: tune {{array.python}} tests"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags: tune
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tune/... ml
         --parallelism-per-worker 3
-        --python-version {{matrix.python}} --build-name mlbuild-py{{matrix.python}}
+        --python-version {{array.python}} --build-name mlbuild-py{{array.python}}
         --except-tags doctest,soft_imports,rllib
     depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.12"]
+    array:
+      python: ["3.12"]
 
   - label: ":train: ml: tune soft import tests"
     tags: tune

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -7,13 +7,14 @@ depends_on:
 steps:
   # builds
   - name: servebuild-multipy
-    label: "wanda: servebuild-py{{matrix}}"
+    label: "wanda: servebuild-py{{array.python}}"
     wanda: ci/docker/serve.build.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     tags: cibase
 
 
@@ -21,16 +22,15 @@ steps:
     wanda: ci/docker/servetracing.build.wanda.yaml
 
   - name: minbuild-serve
-    label: "wanda: minbuild-{{matrix.extra}}-py{{matrix.python}}"
+    label: "wanda: minbuild-{{array.extra}}-py{{array.python}}"
     wanda: ci/docker/min.build.wanda.yaml
     depends_on: oss-ci-base_test-multipy
-    matrix:
-      setup:
-        python: ["3.10"]
-        extra: ["serve", "default"]
+    array:
+      python: ["3.10"]
+      extra: ["serve", "default"]
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      EXTRA_DEPENDENCY: "{{matrix.extra}}"
+      PYTHON_VERSION: "{{array.python}}"
+      EXTRA_DEPENDENCY: "{{array.extra}}"
     tags: cibase
 
   # tests
@@ -77,7 +77,7 @@ steps:
         --python-version 3.10
     depends_on: servebuild-multipy
 
-  - label: ":ray-serve: serve: python {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":ray-serve: serve: python {{array.python}} tests ({{array.worker_id}})"
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - serve
@@ -86,14 +86,13 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/serve/... //python/ray/tests/...  serve
         --except-tags post_wheel_build,gpu,ha_integration,serve_tracing,direct_ingress,haproxy
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
-        --python-version {{matrix.python}}
-        --test-env=EXPECTED_PYTHON_VERSION={{matrix.python}}
+        --workers 2 --worker-id {{array.worker_id}} --parallelism-per-worker 3
+        --python-version {{array.python}}
+        --test-env=EXPECTED_PYTHON_VERSION={{array.python}}
     depends_on: servebuild-multipy
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1"]
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1"]
 
   - label: ":ray-serve: serve: release tests"
     tags:


### PR DESCRIPTION
Convert core.rayci.yml, data.rayci.yml, ml.rayci.yml, and serve.rayci.yml.

Topic: array-test-groups
Relative: array-build-pipelines
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>