### PR TITLE
[CI] Migrate platform-specific pipelines from matrix to array syntax

### DIFF
--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -29,89 +29,89 @@ steps:
     instance_type: builder-arm64
 
   - name: raycpubase-aarch64
-    label: "wanda: ray.py{{matrix}}.cpu.base (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cpu.base (aarch64)"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
 
   - name: raycpubaseextra-aarch64
-    label: "wanda: ray.py{{matrix}}.cpu.base-extra (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cpu.base-extra (aarch64)"
     wanda: docker/base-extra/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: "-aarch64"
     depends_on: raycpubase-aarch64
 
   - name: raycudabase-aarch64
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.base (aarch64)"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: "-aarch64"
 
   - name: raycudabaseextra-aarch64
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base-extra (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.base-extra (aarch64)"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: "-aarch64"
     depends_on: raycudabase-aarch64
@@ -131,34 +131,36 @@ steps:
     instance_type: builder-arm64
 
   - name: ray-core-build-aarch64
-    label: "wanda: core binary parts py{{matrix}} (aarch64)"
+    label: "wanda: core binary parts py{{array.python}} (aarch64)"
     wanda: ci/docker/ray-core.wanda.yaml
     env_file: rayci.env
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
       HOSTTYPE: "aarch64"
     tags: release_wheels
     instance_type: builder-arm64
 
   - name: ray-wheel-build-aarch64
-    label: "wanda: wheel py{{matrix}} (aarch64)"
+    label: "wanda: wheel py{{array.python}} (aarch64)"
     wanda: ci/docker/ray-wheel.wanda.yaml
     env_file: rayci.env
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
       HOSTTYPE: "aarch64"
     tags:
@@ -170,19 +172,20 @@ steps:
       - ray-dashboard-build-aarch64
     instance_type: builder-arm64
 
-  - label: ":arrow_up: upload: wheel py{{matrix}} (aarch64)"
+  - label: ":arrow_up: upload: wheel py{{array.python}} (aarch64)"
     key: linux_wheels_upload_aarch64
     instance_type: small  # x86_64 instance since crane is currently only x86_64
     commands:
       - bazel run //ci/ray_ci/automation:extract_wanda_wheels --
-        --wanda-image-name=ray-wheel-py{{matrix}}-aarch64
+        --wanda-image-name=ray-wheel-py{{array.python}}-aarch64
       - ./ci/build/copy_build_artifacts.sh wheel
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     depends_on:
       - ray-wheel-build-aarch64
       - forge
@@ -240,16 +243,17 @@ steps:
       - skip-on-premerge
 
   - name: ray-image-cpu-build-aarch64
-    label: "wanda: ray py{{matrix}} cpu (aarch64)"
+    label: "wanda: ray py{{array.python}} cpu (aarch64)"
     wanda: ci/docker/ray-image-cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
@@ -261,29 +265,28 @@ steps:
     instance_type: builder-arm64
 
   - name: ray-image-cuda-build-aarch64
-    label: "wanda: ray py{{matrix.python}} cu{{matrix.cuda}} (aarch64)"
+    label: "wanda: ray py{{array.python}} cu{{array.cuda}} (aarch64)"
     wanda: ci/docker/ray-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
@@ -294,13 +297,13 @@ steps:
       - raycudabase-aarch64
     instance_type: builder-arm64
 
-  - label: ":crane: publish: ray py{{matrix}} (aarch64)"
+  - label: ":crane: publish: ray py{{array.python}} (aarch64)"
     key: ray_images_push_aarch64
     instance_type: small  # x86_64 instance since crane is currently only x86_64
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cpu
         --platform cu11.7.1-cudnn8
         --platform cu11.8.0-cudnn8
@@ -313,11 +316,12 @@ steps:
         --platform cu12.9.1-cudnn
         --image-type ray
         --architecture aarch64
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     depends_on:
       - ray-image-cpu-build-aarch64
       - ray-image-cuda-build-aarch64
@@ -328,16 +332,17 @@ steps:
       - skip-on-premerge
 
   - name: ray-extra-image-cpu-build-aarch64
-    label: "wanda: ray-extra py{{matrix}} cpu (aarch64)"
+    label: "wanda: ray-extra py{{array.python}} cpu (aarch64)"
     wanda: ci/docker/ray-extra-image-cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
@@ -349,29 +354,28 @@ steps:
     instance_type: builder-arm64
 
   - name: ray-extra-image-cuda-build-aarch64
-    label: "wanda: ray-extra py{{matrix.python}} cu{{matrix.cuda}} (aarch64)"
+    label: "wanda: ray-extra py{{array.python}} cu{{array.cuda}} (aarch64)"
     wanda: ci/docker/ray-extra-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
@@ -382,13 +386,13 @@ steps:
       - raycudabaseextra-aarch64
     instance_type: builder-arm64
 
-  - label: ":crane: publish: ray-extra py{{matrix}} (aarch64)"
+  - label: ":crane: publish: ray-extra py{{array.python}} (aarch64)"
     key: ray_extra_images_push_aarch64
     instance_type: small
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cpu
         --platform cu11.7.1-cudnn8
         --platform cu11.8.0-cudnn8
@@ -401,11 +405,12 @@ steps:
         --platform cu12.9.1-cudnn
         --image-type ray-extra
         --architecture aarch64
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     depends_on:
       - ray-extra-image-cpu-build-aarch64
       - ray-extra-image-cuda-build-aarch64

--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -27,7 +27,7 @@ steps:
     if: build.env("BUILDKITE_PIPELINE_ID") == "0189942e-0876-4b8f-80a4-617f988ec59b" || build.env("BUILDKITE_PIPELINE_ID") == "018f4f1e-1b73-4906-9802-92422e3badaa"
     depends_on: []
 
-  - label: ":windows: wheel {{matrix}}"
+  - label: ":windows: wheel {{array.python}}"
     # we have linux/mac wheels tag, but do not have a windows wheels tag..
     # so using python and core_cpp here, to make sure at least it builds
     key: windows_wheels
@@ -40,11 +40,12 @@ steps:
     instance_type: windows
     commands:
       - bash ci/ray_ci/windows/install_tools.sh
-      - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{matrix}} --operating-system windows --upload
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
+      - bazel run //ci/ray_ci:build_in_docker_windows -- wheel --python-version {{array.python}} --operating-system windows --upload
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
     depends_on:
       - windowsbuild
       - block-windows-tests


### PR DESCRIPTION
Convert linux_aarch64.rayci.yml and windows.rayci.yml.

Topic: array-platform-pipelines
Relative: array-test-groups
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>