### PR TITLE
[CI] Migrate misc pipelines from matrix to array syntax

### DIFF
--- a/.buildkite/base.rayci.yml
+++ b/.buildkite/base.rayci.yml
@@ -1,26 +1,28 @@
 group: base
 steps:
   - name: oss-ci-base_test-multipy
-    label: "wanda: oss-ci-base_test-py{{matrix}}"
+    label: "wanda: oss-ci-base_test-py{{array.python}}"
     wanda: ci/docker/base.test.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
 
   - name: oss-ci-base_build-multipy
-    label: "wanda: oss-ci-base_build-py{{matrix}}"
+    label: "wanda: oss-ci-base_build-py{{array.python}}"
     wanda: ci/docker/base.build.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     depends_on: oss-ci-base_test-multipy
     tags: cibase
 
@@ -36,25 +38,27 @@ steps:
     instance_type: builder-arm64
 
   - name: oss-ci-base_ml-multipy
-    label: "wanda: oss-ci-base_ml-py{{matrix}}"
+    label: "wanda: oss-ci-base_ml-py{{array.python}}"
     wanda: ci/docker/base.ml.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     depends_on: oss-ci-base_test-multipy
 
   - name: oss-ci-base_gpu-multipy
-    label: "wanda: oss-ci-base_gpu-py{{matrix}}"
+    label: "wanda: oss-ci-base_gpu-py{{array.python}}"
     wanda: ci/docker/base.gpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     tags: cibase
 
   - name: oss-ci-base_cu128-multipy
@@ -64,10 +68,11 @@ steps:
       PYTHON: "3.11"
 
   - name: oss-ci-base_cu130-multipy
-    label: "wanda: oss-ci-base_cu130-py{{matrix}}"
+    label: "wanda: oss-ci-base_cu130-py{{array.python}}"
     wanda: ci/docker/base.cu130.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -1,17 +1,18 @@
 group: doc
 steps:
   - name: docbuild
-    label: "wanda: docbuild-py{{matrix}}"
+    label: "wanda: docbuild-py{{array.python}}"
     wanda: ci/docker/doc.build.wanda.yaml
     depends_on:
       - oss-ci-base_build-multipy
       - ray-core-build
       - ray-dashboard-build
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
     env:
-      PYTHON: "{{matrix}}"
-      REQUIREMENTS_FILE: "python/deplocks/docs/docbuild_depset_py{{matrix}}.lock"
+      PYTHON: "{{array.python}}"
+      REQUIREMENTS_FILE: "python/deplocks/docs/docbuild_depset_py{{array.python}}.lock"
     tags: cibase
 
   - name: docgpubuild

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -22,7 +22,7 @@ steps:
       - ray-core-build
       - ray-dashboard-build
 
-  - label: ":kubernetes: chaos {{matrix.workload}} under {{matrix.fault}}"
+  - label: ":kubernetes: chaos {{array.workload}} under {{array.fault}}"
     key: kuberay_tests
     tags:
       - python
@@ -31,18 +31,17 @@ steps:
       - skip-on-premerge
     instance_type: medium
     commands:
-      - bash ci/k8s/run-chaos-test.sh {{matrix.fault}} {{matrix.workload}}
+      - bash ci/k8s/run-chaos-test.sh {{array.fault}} {{array.workload}}
     docker_network: "host"
-    matrix:
-      setup:
-        fault:
-          - "no_fault"
-          - "chaos_network_delay"
-          - "chaos_network_bandwidth"
-        workload:
-          - "test_potato_passer"
-          - "test_streaming_llm"
-          - "test_many_job_submissions"
+    array:
+      fault:
+        - "no_fault"
+        - "chaos_network_delay"
+        - "chaos_network_bandwidth"
+      workload:
+        - "test_potato_passer"
+        - "test_streaming_llm"
+        - "test_many_job_submissions"
     depends_on:
       - manylinux-x86_64
       - forge

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -1,6 +1,6 @@
 group: lint
 steps:
-  - label: ":lint-roller: lint: {{matrix}}"
+  - label: ":lint-roller: lint: {{array.check}}"
     key: lint-small
     tags:
       - lint
@@ -8,20 +8,21 @@ steps:
     depends_on:
       - forge
     commands:
-      - ./ci/lint/lint.sh {{matrix}}
-    matrix:
-      - clang_format
-      - pre_commit
-      - semgrep_lint
-      - banned_words
-      - doc_readme
-      - dashboard_format
-      - copyright_format
-      - bazel_team
-      - bazel_buildifier
-      - pytest_format
-      - test_coverage
-      - documentation_style
+      - ./ci/lint/lint.sh {{array.check}}
+    array:
+      check:
+        - clang_format
+        - pre_commit
+        - semgrep_lint
+        - banned_words
+        - doc_readme
+        - dashboard_format
+        - copyright_format
+        - bazel_team
+        - bazel_buildifier
+        - pytest_format
+        - test_coverage
+        - documentation_style
 
   - label: ":lint-roller: pre-commit pydoclint"
     key: pydoclint-small

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -49,24 +49,25 @@ steps:
     commands:
       - bazel run //ci/ray_ci/automation:weekly_green_metric -- --production
 
-  - label: ":robot_face: {{matrix}} microcheck test coverage"
+  - label: ":robot_face: {{array.team}} microcheck test coverage"
     tags:
       - skip-on-premerge
       - oss
     if: build.branch == "master"
     instance_type: small
     commands:
-      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 100 --test-prefix linux:__ --production
+      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{array.team}} 100 --test-prefix linux:__ --production
       # we use master branch to determine microcheck tests for darwin and windows, because darwin and windows tests do not run on premerge branches
-      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 100 --test-prefix darwin:__ --consider-master-branch --production
-      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{matrix}} 100 --test-prefix windows:__ --consider-master-branch --production
-    matrix:
-      - "core"
-      - "serve"
-      - "data"
-      - "ml"
-      - "rllib"
-      - "ci"
+      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{array.team}} 100 --test-prefix darwin:__ --consider-master-branch --production
+      - bazel run //ci/ray_ci/automation:determine_microcheck_tests -- {{array.team}} 100 --test-prefix windows:__ --consider-master-branch --production
+    array:
+      team:
+        - "core"
+        - "serve"
+        - "data"
+        - "ml"
+        - "rllib"
+        - "ci"
 
   - name: fossa-base
     wanda: ci/docker/fossa.wanda.yaml


### PR DESCRIPTION
Convert base.rayci.yml, lint.rayci.yml, doc.rayci.yml, others.rayci.yml, and kuberay.rayci.yml.

Topic: array-misc-pipelines
Relative: array-platform-pipelines
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>