### PR TITLE
[CI] Migrate automation pipelines from matrix to array syntax

### DIFF
--- a/.buildkite/cicd-cron/cicd-cron.rayci.yml
+++ b/.buildkite/cicd-cron/cicd-cron.rayci.yml
@@ -45,7 +45,7 @@ steps:
       ARCH_SUFFIX: "aarch64"
       HOSTTYPE: "aarch64"
 
-  - label: ":docker: push: Push manylinux-cibase{{matrix.jdk_suffix}}{{matrix.host_suffix}} to Docker Hub"
+  - label: ":docker: push: Push manylinux-cibase{{array.jdk_suffix}}{{array.host_suffix}} to Docker Hub"
     depends_on:
       - manylinux-cibase-x86_64
       - manylinux-cibase-aarch64
@@ -53,18 +53,17 @@ steps:
       - manylinux-cibase-jdk-aarch64
       - forge
     job_env: forge
-    matrix:
-      setup:
-        host_suffix:
-          - "-x86_64"
-          - "-aarch64"
-        jdk_suffix:
-          - ""
-          - "-jdk"
+    array:
+      host_suffix:
+        - "-x86_64"
+        - "-aarch64"
+      jdk_suffix:
+        - ""
+        - "-jdk"
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:copy_wanda_image --
-        --wanda-image-name manylinux-cibase{{matrix.jdk_suffix}}{{matrix.host_suffix}}
+        --wanda-image-name manylinux-cibase{{array.jdk_suffix}}{{array.host_suffix}}
         --destination-repository rayproject/manylinux2014
-        --tag-suffix {{matrix.jdk_suffix}}{{matrix.host_suffix}}
+        --tag-suffix {{array.jdk_suffix}}{{array.host_suffix}}
         --upload

--- a/.buildkite/release-automation/wheels.rayci.yml
+++ b/.buildkite/release-automation/wheels.rayci.yml
@@ -24,45 +24,47 @@ steps:
     depends_on:
       - forge
 
-  - label: "Linux x86_64 Python {{matrix}}"
+  - label: "Linux x86_64 Python {{array.python}}"
     key: validate-linux-x86_64-wheels
     job_env: forge
     depends_on:
       - block-validate-linux-x86_64-wheels
     commands:
-      - export PYTHON_VERSION={{matrix}}
+      - export PYTHON_VERSION={{array.python}}
       - export RAY_VERSION="$RAY_VERSION"
       - export RAY_COMMIT="$RAY_COMMIT"
       - bash -i .buildkite/release-automation/verify-linux-wheels.sh
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
 
   - block: "Download & validate Ray wheels from TestPyPI Linux arm64"
     key: block-validate-linux-arm64-wheels
     depends_on:
       - forge-arm64
 
-  - label: "Linux arm64 Python {{matrix}}"
+  - label: "Linux arm64 Python {{array.python}}"
     key: validate-linux-arm64-wheels
     instance_type: medium-arm64
     job_env: forge-arm64
     depends_on:
       - block-validate-linux-arm64-wheels
     commands:
-      - export PYTHON_VERSION={{matrix}}
+      - export PYTHON_VERSION={{array.python}}
       - export RAY_VERSION="$RAY_VERSION"
       - export RAY_COMMIT="$RAY_COMMIT"
       - bash -i .buildkite/release-automation/verify-linux-wheels.sh
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
 
   - block: "Download & validate Ray wheels from TestPyPI Mac"
     key: block-validate-macos-wheels


### PR DESCRIPTION
Convert release-automation/wheels.rayci.yml and cicd-cron/cicd-cron.rayci.yml.

Topic: array-automation-pipelines
Relative: array-misc-pipelines
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>