### PR TITLE
[Data] fix the lint error on DefaultResizingPolicy

### DIFF
--- a/python/ray/data/_internal/actor_autoscaler/__init__.py
+++ b/python/ray/data/_internal/actor_autoscaler/__init__.py
@@ -26,7 +26,6 @@ __all__ = [
     "ActorAutoscaler",
     "ActorPoolScalingRequest",
     "AutoscalingActorPool",
-    "DefaultResizingPolicy",
     "create_actor_autoscaler",
     "_get_max_scale_up",
 ]


### PR DESCRIPTION
## Description
We are seeing this lint error:
```
ERROR Name `DefaultResizingPolicy` is listed in `__all__` but is not defined in the module [bad-dunder-all]
--
[2026-03-20T17:32:42Z]   --> python/ray/data/_internal/actor_autoscaler/__init__.py:29:5
[2026-03-20T17:32:42Z]    \|
[2026-03-20T17:32:42Z] 29 \|     "DefaultResizingPolicy",
[2026-03-20T17:32:42Z]    \|     ^^^^^^^^^^^^^^^^^^^^^^^
[2026-03-20T17:32:42Z]    \|
[2026-03-20T17:32:42Z]  INFO 1 error
[2026-03-20T17:32:42Z] 🚨 Error: The command exited with status 123

```

<img width="1559" height="189" alt="image" src="https://github.com/user-attachments/assets/868bd4ee-0a60-4685-9307-574fd9c3a53f" />

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
