### PR TITLE
[Data] Relaxing `DefaultActorAutoscaler` constraint to keep autoscaling 

### DIFF
--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -85,18 +85,10 @@ class DefaultActorAutoscaler(ActorAutoscaler):
         util = actor_pool.get_pool_util()
 
         if util >= self._actor_pool_scaling_up_threshold:
-            # Skip scaling up if the current free task slots can handle all pending work.
-            if _estimate_expected_tasks(
-                op_state
-            ) <= _estimate_total_available_task_slots(actor_pool):
-                return ActorPoolScalingRequest.no_op(
-                    reason="enough free task slots to consume the existing inputs"
-                )
-
             # Do not scale up if either
             #   - Actor Pool is at max size already
             #   - Op is throttled (ie exceeding allocated resource quota)
-            elif actor_pool.current_size() >= actor_pool.max_size():
+            if actor_pool.current_size() >= actor_pool.max_size():
                 return ActorPoolScalingRequest.no_op(reason="reached max size")
             if not op_state._scheduling_status.under_resource_limits:
                 return ActorPoolScalingRequest.no_op(

--- a/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
+++ b/python/ray/data/_internal/actor_autoscaler/default_actor_autoscaler.py
@@ -244,18 +244,6 @@ def _estimate_total_available_task_slots(actor_pool: "AutoscalingActorPool") -> 
     )
 
 
-def _estimate_expected_tasks(
-    op_state: OpState,
-) -> float:
-    # Each task consumes `average_num_inputs_per_task` input blocks on average,
-    # so the total expected number of tasks:
-    #
-    #   ceil(num enqueued blocks / avg_inputs_per_task)
-    #
-    avg_input_blocks_per_task = op_state.op.metrics.average_num_inputs_per_task or 1
-    return math.ceil(op_state.total_enqueued_input_blocks() / avg_input_blocks_per_task)
-
-
 def _get_max_scale_up(
     actor_pool: AutoscalingActorPool,
     budget: ExecutionResources,

--- a/python/ray/data/tests/test_autoscaler.py
+++ b/python/ray/data/tests/test_autoscaler.py
@@ -175,10 +175,11 @@ def test_actor_pool_scaling():
                     expected_reason="consumed all inputs",
                 )
 
-            # Should be no-op since the op has enough free task slots to consume the existing inputs (which is 0).
+            # With no enqueued inputs but inputs not being complete still,
+            # the autoscaler should still scale up based on utilization
             assert_autoscaling_action(
-                delta=0,
-                expected_reason="enough free task slots to consume the existing inputs",
+                delta=5,
+                expected_reason="utilization of 1.5 >= 1.0",
             )
 
     # Should be no-op since the op doesn't have enough resources.


### PR DESCRIPTION
## Description

Currently, `DefaultActorAutoscaler` limits autoscaling if current number of task slots in the pool (ie `actor-pool-size x max_tasks_in_flight_per_actor`) are more than the pending inputs available.

This is unnecessarily limiting autoscaling:

 - We want to increase actual concurrency, which is measured by actor pool utilization. This check is outdated and is rudimentary to the new Autoscaler architecture.

Case in point: If you increase `max_tasks_in_flight_per_actor` to improve locality then you essentially disabling ability to autoscale.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
