### PR TITLE
[Data] Deprecate Pandas as internal blocks format using types_mapper conversion

### DIFF
--- a/python/ray/_private/arrow_serialization.py
+++ b/python/ray/_private/arrow_serialization.py
@@ -266,7 +266,9 @@ def _array_payload_to_array(payload: "PicklableArrayPayload") -> "pyarrow.Array"
         # Array.from_buffers() doesn't work for DictionaryArrays.
         assert len(children) == 2, len(children)
         indices, dictionary = children
-        return pa.DictionaryArray.from_arrays(indices, dictionary)
+        return pa.DictionaryArray.from_arrays(
+            indices, dictionary, ordered=payload.type.ordered
+        )
     elif pa.types.is_map(payload.type) and len(children) > 1:
         # In pyarrow<7.0.0, the underlying map child array is not exposed, so we work
         # with the key and item arrays.

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -280,7 +280,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         #   return None, falling back to their own to_pandas_dtype() hooks which
         #   produce TensorDtype / PythonObjectDtype as appropriate.
         def _types_mapper(t):
-            if isinstance(t, pyarrow.ExtensionType):
+            if isinstance(t, pyarrow.ExtensionType) or pyarrow.types.is_dictionary(t):
                 return None
             return pd.ArrowDtype(t)
 

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -271,6 +271,8 @@ class ArrowBlockAccessor(TableBlockAccessor):
     def to_pandas(self) -> "pandas.DataFrame":
         import pandas as pd
 
+        from ray.data.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
+
         ctx = DataContext.get_current()
 
         # types_mapper preserves Arrow dtypes through the pandas round-trip:
@@ -284,10 +286,13 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 return None
             return pd.ArrowDtype(t)
 
-        return self._table.to_pandas(
+        df = self._table.to_pandas(
             ignore_metadata=ctx.pandas_block_ignore_metadata,
             types_mapper=_types_mapper,
         )
+        if ctx.enable_tensor_extension_casting:
+            df = _cast_tensor_columns_to_ndarrays(df, arrow_schema=self._table.schema)
+        return df
 
     def to_numpy(
         self, columns: Optional[Union[str, List[str]]] = None

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -269,15 +269,25 @@ class ArrowBlockAccessor(TableBlockAccessor):
         return self._table.schema
 
     def to_pandas(self) -> "pandas.DataFrame":
-        from ray.data.util.data_batch_conversion import _cast_tensor_columns_to_ndarrays
+        import pandas as pd
 
-        # We specify ignore_metadata=True because pyarrow will use the metadata
-        # to build the Table. This is handled incorrectly for older pyarrow versions
         ctx = DataContext.get_current()
-        df = self._table.to_pandas(ignore_metadata=ctx.pandas_block_ignore_metadata)
-        if ctx.enable_tensor_extension_casting:
-            df = _cast_tensor_columns_to_ndarrays(df, arrow_schema=self._table.schema)
-        return df
+
+        # types_mapper preserves Arrow dtypes through the pandas round-trip:
+        # - Standard Arrow types become pd.ArrowDtype, so pa.Table.from_pandas()
+        #   can reconstruct them exactly without lossy numpy conversion.
+        # - Ray extension types (ArrowTensorType, ArrowPythonObjectType, etc.)
+        #   return None, falling back to their own to_pandas_dtype() hooks which
+        #   produce TensorDtype / PythonObjectDtype as appropriate.
+        def _types_mapper(t):
+            if isinstance(t, pyarrow.ExtensionType):
+                return None
+            return pd.ArrowDtype(t)
+
+        return self._table.to_pandas(
+            ignore_metadata=ctx.pandas_block_ignore_metadata,
+            types_mapper=_types_mapper,
+        )
 
     def to_numpy(
         self, columns: Optional[Union[str, List[str]]] = None

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -42,6 +42,7 @@ def batch_blocks(
         ),
         batch_format=batch_format,
         stats=stats,
+        ensure_copy=ensure_copy,
     )
 
     if collate_fn is not None:

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -192,6 +192,7 @@ class BatchIterator:
             batch_format=self._batch_format,
             collate_fn=self._collate_fn,
             num_threadpool_workers=num_threadpool_workers,
+            ensure_copy=self._ensure_copy,
         )
 
     def _finalize_batches(
@@ -312,6 +313,7 @@ def _format_in_threadpool(
     batch_format: Optional[str],
     collate_fn: Optional[Callable[[DataBatch], Any]],
     num_threadpool_workers: int,
+    ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Executes the batching, formatting, and collation logic in a threadpool.
 
@@ -326,6 +328,8 @@ def _format_in_threadpool(
             as batches.
         collate_fn: A function to apply to each data batch before returning it.
         num_threadpool_workers: The number of threads to use in the threadpool.
+        ensure_copy: Whether batches are always copied from the underlying base
+            blocks (not zero-copy views).
     """
 
     def threadpool_computations_format_collate(
@@ -333,7 +337,7 @@ def _format_in_threadpool(
     ) -> Iterator[Batch]:
         # Step 4a: Format the batches.
         formatted_batch_iter = format_batches(
-            batch_iter, batch_format=batch_format, stats=stats
+            batch_iter, batch_format=batch_format, stats=stats, ensure_copy=ensure_copy
         )
 
         # Step 4b: Apply the collate function if applicable.

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -189,15 +189,39 @@ class _BatchingIterator(Iterator[Batch]):
                 raise StopIteration
 
 
+def _make_batch_writable(batch):
+    """Return a writable copy of batch where needed.
+
+    ``pa.Array.to_numpy()`` returns read-only views by default, so when
+    ``ensure_copy=True`` (i.e. ``zero_copy_batch=False``) and the block is
+    Arrow, numpy-format batches must be explicitly copied to give UDFs
+    writable arrays.
+    """
+    import numpy as np
+
+    if isinstance(batch, dict):
+        return {
+            k: v.copy() if (isinstance(v, np.ndarray) and not v.flags.writeable) else v
+            for k, v in batch.items()
+        }
+    elif isinstance(batch, np.ndarray) and not batch.flags.writeable:
+        return batch.copy()
+    # pandas DataFrames are writable by default; Arrow tables are immutable by design.
+    return batch
+
+
 def _format_batch(
     batch: Batch,
     batch_format: Optional[str],
     stats: Optional[DatasetStats],
+    ensure_copy: bool = False,
 ) -> Batch:
     with stats.iter_format_batch_s.timer() if stats else nullcontext():
         formatted_data = BlockAccessor.for_block(batch.data).to_batch_format(
             batch_format
         )
+        if ensure_copy:
+            formatted_data = _make_batch_writable(formatted_data)
     return dataclasses.replace(batch, data=formatted_data)
 
 
@@ -205,11 +229,17 @@ def format_batches(
     batch_iter: Iterator[Batch],
     batch_format: Optional[str],
     stats: Optional[DatasetStats] = None,
+    ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Given an iterator of batches, returns an iterator of formatted batches."""
     return _MappingIterator(
         batch_iter,
-        functools.partial(_format_batch, batch_format=batch_format, stats=stats),
+        functools.partial(
+            _format_batch,
+            batch_format=batch_format,
+            stats=stats,
+            ensure_copy=ensure_copy,
+        ),
     )
 
 

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -61,6 +61,46 @@ def lazy_import_pandas():
     return _pandas
 
 
+def _safe_from_pandas(df: "pandas.DataFrame") -> "pyarrow.Table":
+    """Convert a pandas DataFrame to an Arrow table, handling object-dtype columns.
+
+    ``pa.Table.from_pandas`` infers Arrow types for object-dtype columns by inspecting
+    the first Python value, then calls ``pa.array()`` on the whole column. This fails
+    for values that PyArrow cannot convert natively — e.g. multi-dimensional numpy
+    arrays, PIL images, or mixed list/scalar content.
+
+    This function routes object-dtype columns through ``convert_to_pyarrow_array``,
+    which produces ``ArrowTensorArray`` for ndarray elements and falls back to
+    ``ArrowPythonObjectArray`` (pickle) for arbitrary Python objects. All other columns
+    go through ``pa.array(col, from_pandas=True)`` which handles nullable dtypes and
+    extension types via ``__arrow_array__``.
+    """
+    import pyarrow as pa
+
+    from ray.data._internal.tensor_extensions.arrow import convert_to_pyarrow_array
+
+    # If no object-dtype columns, use fast path with regular from_pandas()
+    if not any(is_object_dtype(df[col].dtype) for col in df.columns):
+        # Set `preserve_index=False` so that Arrow doesn't add a '__index_level_0__'
+        return pa.Table.from_pandas(df, preserve_index=False)
+
+    # Convert column by column: object-dtype columns go through
+    # convert_to_pyarrow_array (handles tensors, PIL images, arbitrary objects),
+    # all others go through pa.array() with from_pandas=True.
+    arrays = []
+    fields = []
+    for col_name in df.columns:
+        col = df[col_name]
+        if is_object_dtype(col.dtype):
+            arr = convert_to_pyarrow_array(col.values, col_name)
+        else:
+            arr = pa.array(col, from_pandas=True)
+        arrays.append(arr)
+        fields.append(pa.field(col_name, arr.type))
+
+    return pa.table(dict(zip(df.columns, arrays)), schema=pa.schema(fields))
+
+
 class PandasRow(Mapping):
     """
     Row of a tabular Dataset backed by a Pandas DataFrame block.
@@ -479,9 +519,9 @@ class PandasBlockAccessor(TableBlockAccessor):
 
         from ray.data._internal.tensor_extensions.pandas import TensorDtype
 
-        # Set `preserve_index=False` so that Arrow doesn't add a '__index_level_0__'
-        # column to the resulting table.
-        arrow_table = pa.Table.from_pandas(self._table, preserve_index=False)
+        # _safe_from_pandas handles object-dtype columns that pa.Table.from_pandas
+        # cannot convert (e.g. multi-dimensional numpy arrays, PIL images).
+        arrow_table = _safe_from_pandas(self._table)
 
         # NOTE: Pandas by default coerces all-null column types (including None,
         #       NaN, etc) into "double" type by default, which is incorrect in a

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1601,16 +1601,22 @@ def is_nan(value) -> bool:
 
 
 def is_null(value: Any) -> bool:
-    """This generalization of ``is_nan`` util qualifying both None and np.nan
-    as null values"""
-    return value is None or is_nan(value)
+    """This generalization of ``is_nan`` util qualifying both None, np.nan,
+    and pd.NA as null values"""
+    return value is None or is_nan(value) or value is pd.NA
 
 
 def keys_equal(keys1, keys2):
     if len(keys1) != len(keys2):
         return False
     for k1, k2 in zip(keys1, keys2):
-        if not ((is_nan(k1) and is_nan(k2)) or k1 == k2):
+        k1_null = is_null(k1)
+        k2_null = is_null(k2)
+        if k1_null and k2_null:
+            continue
+        if k1_null or k2_null:
+            return False
+        if k1 != k2:
             return False
     return True
 

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -23,6 +23,7 @@ import pyarrow as pa
 
 import ray
 from ray.data._internal.util import _check_pyarrow_version, _truncated_repr
+from ray.data.context import DataContext
 from ray.types import ObjectRef
 from ray.util import log_once
 from ray.util.annotations import DeveloperAPI
@@ -529,6 +530,7 @@ class BlockAccessor:
         block_type: Optional[BlockType] = None,
     ) -> Block:
         """Create a block from user-facing data formats."""
+        import pandas
 
         if isinstance(batch, np.ndarray):
             raise ValueError(
@@ -543,6 +545,13 @@ class BlockAccessor:
         # to_arrow() instead of the slow column-by-column Mapping path.
         elif _is_cudf_dataframe(batch):
             return batch.to_arrow()
+
+        elif isinstance(batch, pandas.DataFrame):
+            if (block_type == BlockType.ARROW) or (
+                block_type is None
+                and DataContext.get_current().batch_to_block_arrow_format
+            ):
+                return cls.for_block(batch).to_arrow()
 
         elif isinstance(batch, collections.abc.Mapping):
             if block_type is None or block_type == BlockType.ARROW:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -71,6 +71,10 @@ DEFAULT_PANDAS_BLOCK_IGNORE_METADATA = env_bool(
     "RAY_DATA_PANDAS_BLOCK_IGNORE_METADATA", False
 )
 
+DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
+    "RAY_DATA_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT", True
+)
+
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
@@ -578,6 +582,9 @@ class DataContext:
         gpu_shuffle_setup_timeout_s: Maximum time in seconds to wait for UCXX
             communicator setup (actor creation + root/worker init) before raising
             a ``TimeoutError``. Defaults to 120 seconds.
+        batch_to_block_arrow_format: Whether to convert pandas DataFrame batches
+            returned by UDFs into Arrow blocks by default, keeping Arrow as the
+            internal block format throughout the pipeline.
     """
 
     # `None` means the block size is infinite.
@@ -745,6 +752,8 @@ class DataContext:
     enforce_schemas: bool = DEFAULT_ENFORCE_SCHEMAS
 
     pandas_block_ignore_metadata: bool = DEFAULT_PANDAS_BLOCK_IGNORE_METADATA
+
+    batch_to_block_arrow_format: bool = DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT
 
     _checkpoint_config: Optional[CheckpointConfig] = None
 

--- a/python/ray/data/tests/block_batching/test_block_batching.py
+++ b/python/ray/data/tests/block_batching/test_block_batching.py
@@ -25,8 +25,18 @@ class TestBatchBlocks:
         if batch_format == "pandas":
             assert isinstance(batches[0], pd.DataFrame)
             assert isinstance(batches[1], pd.DataFrame)
-            pd.testing.assert_frame_equal(batches[0], pd.DataFrame({"foo": [0, 1, 2]}))
-            pd.testing.assert_frame_equal(batches[1], pd.DataFrame({"foo": [3, 4, 5]}))
+            pd.testing.assert_frame_equal(
+                batches[0],
+                pd.DataFrame({"foo": [0, 1, 2]}).convert_dtypes(
+                    dtype_backend="pyarrow"
+                ),
+            )
+            pd.testing.assert_frame_equal(
+                batches[1],
+                pd.DataFrame({"foo": [3, 4, 5]}).convert_dtypes(
+                    dtype_backend="pyarrow"
+                ),
+            )
         elif batch_format == "numpy":
             assert isinstance(batches[0], dict)
             assert isinstance(batches[1], dict)

--- a/python/ray/data/tests/datasource/test_tfrecords.py
+++ b/python/ray/data/tests/datasource/test_tfrecords.py
@@ -5,8 +5,8 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import numpy as np
+import pyarrow as pa
 import pytest
-from pandas.api.types import is_float_dtype, is_int64_dtype, is_object_dtype
 
 import ray
 from ray.data._internal.datasource.tfrecords_datasource import TFXReadOptions
@@ -390,35 +390,42 @@ def test_read_tfrecords(
     )
 
     df = ds.to_pandas()
+    dtypes = dict(df.dtypes)
     # Protobuf serializes features in a non-deterministic order.
     if with_tf_schema:
-        assert is_object_dtype(dict(df.dtypes)["int_item"])
+        assert dtypes["int_item"] == pd.ArrowDtype(pa.list_(pa.int64()))
     else:
-        assert is_int64_dtype(dict(df.dtypes)["int_item"])
-    assert is_object_dtype(dict(df.dtypes)["int_list"])
-    assert is_object_dtype(dict(df.dtypes)["int_partial"])
-    assert is_object_dtype(dict(df.dtypes)["int_empty"])
+        assert dtypes["int_item"] == pd.ArrowDtype(pa.int64())
+    assert dtypes["int_list"] == pd.ArrowDtype(pa.list_(pa.int64()))
+    assert dtypes["int_partial"] == pd.ArrowDtype(pa.list_(pa.null()))
+    assert dtypes["int_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
     if with_tf_schema:
-        assert is_object_dtype(dict(df.dtypes)["float_item"])
-        assert is_object_dtype(dict(df.dtypes)["float_partial"])
+        assert dtypes["float_item"] == pd.ArrowDtype(pa.list_(pa.float32()))
+        assert dtypes["float_partial"] == pd.ArrowDtype(pa.list_(pa.float32()))
     else:
-        assert is_float_dtype(dict(df.dtypes)["float_item"])
-        assert is_float_dtype(dict(df.dtypes)["float_partial"])
-    assert is_object_dtype(dict(df.dtypes)["float_list"])
-    assert is_object_dtype(dict(df.dtypes)["float_empty"])
+        assert dtypes["float_item"] == pd.ArrowDtype(pa.float32())
+        assert dtypes["float_partial"] == pd.ArrowDtype(pa.float32())
+    assert dtypes["float_list"] == pd.ArrowDtype(pa.list_(pa.float32()))
+    assert dtypes["float_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
-    # In both cases, bytes are of `object` dtype in pandas
-    assert is_object_dtype(dict(df.dtypes)["bytes_item"])
-    assert is_object_dtype(dict(df.dtypes)["bytes_partial"])
-    assert is_object_dtype(dict(df.dtypes)["bytes_list"])
-    assert is_object_dtype(dict(df.dtypes)["bytes_empty"])
+    # bytes columns: scalar when schema=False (single value unwrapped), list when schema=True
+    if with_tf_schema:
+        assert dtypes["bytes_item"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    else:
+        assert dtypes["bytes_item"] == pd.ArrowDtype(pa.binary())
+    assert dtypes["bytes_partial"] == pd.ArrowDtype(pa.list_(pa.null()))
+    assert dtypes["bytes_list"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    assert dtypes["bytes_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
-    # strings are of `object` dtype in pandas
-    assert is_object_dtype(dict(df.dtypes)["string_item"])
-    assert is_object_dtype(dict(df.dtypes)["string_partial"])
-    assert is_object_dtype(dict(df.dtypes)["string_list"])
-    assert is_object_dtype(dict(df.dtypes)["string_empty"])
+    # string columns (stored as bytes in TF): same pattern as bytes
+    if with_tf_schema:
+        assert dtypes["string_item"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    else:
+        assert dtypes["string_item"] == pd.ArrowDtype(pa.binary())
+    assert dtypes["string_partial"] == pd.ArrowDtype(pa.list_(pa.null()))
+    assert dtypes["string_list"] == pd.ArrowDtype(pa.list_(pa.binary()))
+    assert dtypes["string_empty"] == pd.ArrowDtype(pa.list_(pa.null()))
 
     # If the schema is specified, we should not perform the
     # automatic unwrapping of single-element lists.

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -471,8 +471,8 @@ def test_groupby_tabular_sum(
 
     expected = pd.DataFrame(
         {
-            "A": [0, 1, 2],
-            "sum(B)": pd.Series([None, None, None], dtype="object"),
+            "A": pd.array([0, 1, 2], dtype=pd.ArrowDtype(pa.int64())),
+            "sum(B)": pd.array([None, None, None], dtype=pd.ArrowDtype(pa.null())),
         },
     )
     result = nan_agg_ds.sort("A").to_pandas()
@@ -652,6 +652,7 @@ def test_groupby_arrow_multi_agg(
 
     agg_df["unique(B)"] = _sort_series_of_lists_elements(agg_df["unique(B)"])
     expected_df["unique(B)"] = _sort_series_of_lists_elements(expected_df["unique(B)"])
+    expected_df = expected_df.convert_dtypes(dtype_backend="pyarrow")
 
     print(f"Expected: {expected_df}")
     print(f"Result: {agg_df}")
@@ -1003,7 +1004,11 @@ def test_groupby_map_groups_for_pandas(
     # aggregate rows, so we still have 3 rows.
     assert mapped.count() == 3
     expected = pd.DataFrame(
-        {"A": ["a", "a", "b"], "B": [0.5, 0.5, 1.000000], "C": [0.4, 0.6, 1.0]}
+        {
+            "A": pd.array(["a", "a", "b"], dtype=pd.ArrowDtype(pa.string())),
+            "B": pd.array([0.5, 0.5, 1.000000], dtype=pd.ArrowDtype(pa.float64())),
+            "C": pd.array([0.4, 0.6, 1.0], dtype=pd.ArrowDtype(pa.float64())),
+        }
     )
 
     result = mapped.sort(["A", "C"]).to_pandas()

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -14,7 +14,7 @@ from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.planner.plan_udf_map_op import (
     _generate_transform_fn_for_map_batches,
 )
-from ray.data.block import DataBatch
+from ray.data.block import BlockAccessor, DataBatch
 
 
 def _create_chained_transformer(udf, n):
@@ -22,6 +22,7 @@ def _create_chained_transformer(udf, n):
     transform_fns = [
         BatchMapTransformFn(
             _generate_transform_fn_for_map_batches(udf),
+            batch_format="pandas",
             batch_size=1,
             output_block_size_option=OutputBlockSizeOption.of(target_max_block_size=1),
         )
@@ -66,8 +67,16 @@ def test_chained_transforms_release_intermediates_between_batches():
         result = next(result_iter)
         assert result is not None
 
+        # apply_transform returns Arrow blocks, convert to pandas to test the correctness of the result
         pd.testing.assert_frame_equal(
-            result, pd.DataFrame({"id": [(i + 1) * 2**NUM_CHAINED_TRANSFORMS]})
+            BlockAccessor.for_block(result).to_pandas(),
+            pd.DataFrame(
+                {
+                    "id": pd.array(
+                        [(i + 1) * 2**NUM_CHAINED_TRANSFORMS], dtype="int64[pyarrow]"
+                    )
+                }
+            ),
         )
 
         # Trigger GC

--- a/python/ray/data/tests/test_strict_mode.py
+++ b/python/ray/data/tests/test_strict_mode.py
@@ -9,7 +9,6 @@ import ray
 from ray.data._internal.tensor_extensions.arrow import (
     create_arrow_fixed_shape_tensor_type,
 )
-from ray.data._internal.tensor_extensions.pandas import TensorDtype
 from ray.data.context import DataContext
 from ray.data.dataset import Schema
 from ray.data.tests.conftest import *  # noqa
@@ -191,7 +190,6 @@ def test_strict_compute(ray_start_regular_shared_2_cpus):
 def test_strict_schema(ray_start_regular_shared_2_cpus, tensor_format_context):
     import pyarrow as pa
 
-    from ray.data._internal.pandas_block import PandasBlockSchema
     from ray.data.extensions.object_extension import (
         ArrowPythonObjectType,
     )
@@ -235,9 +233,8 @@ def test_strict_schema(ray_start_regular_shared_2_cpus, tensor_format_context):
 
     schema = ds.map_batches(_id, batch_format="pandas").schema()
 
-    assert isinstance(schema.base_schema, PandasBlockSchema)
+    assert isinstance(schema.base_schema, pa.lib.Schema)
     assert schema.names == ["data"]
-    assert schema.base_schema.types == (TensorDtype(shape=(10,), dtype=pa.float64()),)
     # NOTE: Schema by default returns Arrow types
     assert schema.types == [expected_arrow_ext_type]
 

--- a/python/ray/data/tests/test_tensor.py
+++ b/python/ray/data/tests/test_tensor.py
@@ -619,6 +619,7 @@ def test_tensors_in_tables_pandas_roundtrip_variable_shaped(
         expected_df["two"] = _create_possibly_ragged_ndarray(
             expected_df["two"].to_numpy()
         )
+    expected_df["one"] = expected_df["one"].astype("int64[pyarrow]")
     pd.testing.assert_frame_equal(ds_df, expected_df)
 
 

--- a/python/ray/data/util/data_batch_conversion.py
+++ b/python/ray/data/util/data_batch_conversion.py
@@ -329,8 +329,11 @@ def _cast_tensor_columns_to_ndarrays(
         for field in arrow_schema:
             if _is_native_tensor_type(field.type) and field.name in df.columns:
                 shape = tuple(field.type.shape)
+                # np.asarray handles both flat numpy arrays (zero-copy) and Python
+                # lists. We need to handle lists as when types_mapper returns None for FixedShapeTensorType,
+                # PyArrow's extension to_pandas_dtype() yields lists not arrays).
                 df[field.name] = [
-                    arr.reshape(shape) if arr is not None else None
+                    np.asarray(arr).reshape(shape) if arr is not None else None
                     for arr in df[field.name]
                 ]
 


### PR DESCRIPTION

## Description                                                                                                      
                                                                                                                        
 When a UDF returns a `pd.DataFrame` or dict batch, Ray Data previously stored it as a Pandas block in the object    
store. This PR changes that behavior: UDF output is now immediately converted to an Arrow block before being stored, making Arrow the single internal block format