### PR TITLE
[ci] use conda ssh instead of system ssh to avoid using system ssh but with a mismatched conda openssl

### DIFF
--- a/release/ray_release/byod/byod.Dockerfile
+++ b/release/ray_release/byod/byod.Dockerfile
@@ -57,6 +57,11 @@ rm -rf /tmp/wrk
 
 "$HOME/anaconda3/bin/pip" install --no-cache-dir -r extra-test-requirements.txt
 
+# Use conda's ssh (not the OS one): LD_LIBRARY_PATH below points at conda's libs,
+# and /usr/bin/ssh would pick up the wrong OpenSSL and error. Therefore, we install
+# conda's ssh.
+"$HOME/anaconda3/bin/conda" install -y -c conda-forge openssh
+
 EOF
 
 # RAY_BACKEND_LOG_JSON=1


### PR DESCRIPTION

## Description
> Briefly describe what this PR accomplishes and why it's needed.

Fixes the `ssh` loaded with a mismatched OpenSSL lib.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

https://buildkite.com/ray-project/release/builds/85094#019d09c4-f0c6-4eaa-890e-986829d3046b

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
