### PR TITLE
[Core] Avoid reentrant locking in worker context to prevent absl mutex debug complaint

### DIFF
--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -231,22 +231,24 @@ const TaskID &WorkerContext::GetCurrentInternalTaskId() const {
 }
 
 PlacementGroupID WorkerContext::GetCurrentPlacementGroupId() const {
+  PlacementGroupID placement_group_id = GetThreadContext().GetCurrentPlacementGroupId();
   absl::ReaderMutexLock lock(&mutex_);
   // If the worker is an actor, we should return the actor's placement group id.
   if (current_actor_id_ != ActorID::Nil()) {
     return current_actor_placement_group_id_;
   } else {
-    return GetThreadContext().GetCurrentPlacementGroupId();
+    return placement_group_id;
   }
 }
 
 bool WorkerContext::ShouldCaptureChildTasksInPlacementGroup() const {
+  bool should_capture_child_tasks = GetThreadContext().PlacementGroupCaptureChildTasks();
   absl::ReaderMutexLock lock(&mutex_);
   // If the worker is an actor, we should return the actor's placement group id.
   if (current_actor_id_ != ActorID::Nil()) {
     return placement_group_capture_child_tasks_;
   } else {
-    return GetThreadContext().PlacementGroupCaptureChildTasks();
+    return should_capture_child_tasks;
   }
 }
 


### PR DESCRIPTION
## Description
We were observing that task submission on a separate thread when running ray built from source with `dbg` option would trigger an absl `Potential Mutex deadlock` error. This was because absl Mutex locks do not naturally support reentrant locking. Even though we are only using read locks here, because we locking the same mutex on the same thread multiple times, the absl debug deadlock check still triggers. 

This PR resolves this issue for submitting task on separate threads for ray built with `dbg` option by separating the nested read lock from the outer lock. 

Example message:
```
  warnings.warn(
[mutex.cc : 1384] RAW: Potential Mutex deadlock: 
        @ 0x14b66fee30db absl::lts_20230802::DebugOnlyDeadlockCheck()
        @ 0x14b66fee34d2 absl::lts_20230802::Mutex::ReaderLock()
        @ 0x14b66e5c6805 absl::lts_20230802::ReaderMutexLock::ReaderMutexLock()
        @ 0x14b66e8679d6 ray::core::WorkerContext::GetThreadContext()
        @ 0x14b66e8660d7 ray::core::WorkerContext::ShouldCaptureChildTasksInPlacementGroup()
        @ 0x14b66e42391c ray::core::CoreWorker::ShouldCaptureChildTasksInPlacementGroup()
        @ 0x14b66e2e6754 __pyx_pf_3ray_7_raylet_10CoreWorker_30should_capture_child_tasks_in_placement_group()
        @ 0x14b66e2e66ff __pyx_pw_3ray_7_raylet_10CoreWorker_31should_capture_child_tasks_in_placement_group()
        @ 0x14b66e3fb260 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS()
        @ 0x555dc11aa72e PyObject_Vectorcall

[mutex.cc : 1394] RAW: Acquiring absl::Mutex 0x555dc36d5258 while holding  0x555dc36d5258; a cycle in the historical lock ordering graph has been observed
[mutex.cc : 1398] RAW: Cycle: 
[mutex.cc : 1412] RAW: mutex@0x555dc36d5258 stack: 
        @ 0x14b66fee30db absl::lts_20230802::DebugOnlyDeadlockCheck()
        @ 0x14b66fee34d2 absl::lts_20230802::Mutex::ReaderLock()
        @ 0x14b66e5c6805 absl::lts_20230802::ReaderMutexLock::ReaderMutexLock()
        @ 0x14b66e8679d6 ray::core::WorkerContext::GetThreadContext()
        @ 0x14b66e8660d7 ray::core::WorkerContext::ShouldCaptureChildTasksInPlacementGroup()
        @ 0x14b66e42391c ray::core::CoreWorker::ShouldCaptureChildTasksInPlacementGroup()
        @ 0x14b66e2e6754 __pyx_pf_3ray_7_raylet_10CoreWorker_30should_capture_child_tasks_in_placement_group()
        @ 0x14b66e2e66ff __pyx_pw_3ray_7_raylet_10CoreWorker_31should_capture_child_tasks_in_placement_group()
        @ 0x14b66e3fb260 __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS()
        @ 0x555dc11aa72e PyObject_Vectorcall

[mutex.cc : 1420] RAW: dying due to potential deadlock
*** SIGABRT received at time=1773144724 on cpu 7 ***
PC: @     0x14b67f0f3005  (unknown)  raise
    @     0x14b66fea2822         64  absl::lts_20230802::WriteFailureInfo()
    @     0x14b66fea2a3f         96  absl::lts_20230802::AbslFailureSignalHandler()
    @     0x14b67f3e0c70       6960  (unknown)
    @     0x14b66ff3082f        256  absl::lts_20230802::raw_log_internal::RawLog()
    @     0x14b66fee3005        240  absl::lts_20230802::DeadlockCheck()
    @     0x14b66fee30db         32  absl::lts_20230802::DebugOnlyDeadlockCheck()
    @     0x14b66fee34d2         96  absl::lts_20230802::Mutex::ReaderLock()
    @     0x14b66e5c6805         32  absl::lts_20230802::ReaderMutexLock::ReaderMutexLock()
    @     0x14b66e8679d6       1232  ray::core::WorkerContext::GetThreadContext()
    @     0x14b66e8660d7         64  ray::core::WorkerContext::ShouldCaptureChildTasksInPlacementGroup()
    @     0x14b66e42391c         32  ray::core::CoreWorker::ShouldCaptureChildTasksInPlacementGroup()
    @     0x14b66e2e6754         64  __pyx_pf_3ray_7_raylet_10CoreWorker_30should_capture_child_tasks_in_placement_group()
    @     0x14b66e2e66ff         64  __pyx_pw_3ray_7_raylet_10CoreWorker_31should_capture_child_tasks_in_placement_group()
    @     0x14b66e3fb260         80  __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS()
    @     0x555dc11aa72e  (unknown)  PyObject_Vectorcall
    @     0x555dc4b2f530  (unknown)  (unknown)
[2026-03-10 20:12:04,743 E 949184 951574] logging.cc:474: *** SIGABRT received at time=1773144724 on cpu 7 ***
[2026-03-10 20:12:04,743 E 949184 951574] logging.cc:474: PC: @     0x14b67f0f3005  (unknown)  raise
[2026-03-10 20:12:04,743 E 949184 951574] logging.cc:474:     @     0x14b66fea2822         64  absl::lts_20230802::WriteFailureInfo()
[2026-03-10 20:12:04,770 E 949184 951574] logging.cc:474:     @     0x14b66fea2a63         96  absl::lts_20230802::AbslFailureSignalHandler()
[2026-03-10 20:12:04,770 E 949184 951574] logging.cc:474:     @     0x14b67f3e0c70       6960  (unknown)
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66ff3082f        256  absl::lts_20230802::raw_log_internal::RawLog()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66fee3005        240  absl::lts_20230802::DeadlockCheck()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66fee30db         32  absl::lts_20230802::DebugOnlyDeadlockCheck()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66fee34d2         96  absl::lts_20230802::Mutex::ReaderLock()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66e5c6805         32  absl::lts_20230802::ReaderMutexLock::ReaderMutexLock()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66e8679d6       1232  ray::core::WorkerContext::GetThreadContext()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66e8660d7         64  ray::core::WorkerContext::ShouldCaptureChildTasksInPlacementGroup()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66e42391c         32  ray::core::CoreWorker::ShouldCaptureChildTasksInPlacementGroup()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66e2e6754         64  __pyx_pf_3ray_7_raylet_10CoreWorker_30should_capture_child_tasks_in_placement_group()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66e2e66ff         64  __pyx_pw_3ray_7_raylet_10CoreWorker_31should_capture_child_tasks_in_placement_group()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x14b66e3fb260         80  __Pyx_CyFunction_Vectorcall_FASTCALL_KEYWORDS()
[2026-03-10 20:12:04,771 E 949184 951574] logging.cc:474:     @     0x555dc11aa72e  (unknown)  PyObject_Vectorcall
[2026-03-10 20:12:04,775 E 949184 951574] logging.cc:474:     @     0x555dc4b2f530  (unknown)  (unknown)
Fatal Python error: Aborted

Stack (most recent call first):
  File "/ray/python/ray/_private/worker.py", line 594 in should_capture_child_tasks_in_placement_group
  File "/ray/python/ray/remote_function.py", line 449 in _remote
  File "/ray/python/ray/util/tracing/tracing_helper.py", line 310 in _invocation_remote_span
  File "/ray/python/ray/_private/auto_init_hook.py", line 22 in auto_init_wrapper
  File "/ray/python/ray/remote_function.py", line 164 in _remote_proxy

Extension modules: msgpack._cmsgpack, psutil._psutil_linux, google._upb._message, charset_normalizer.md, charset_normalizer.cd, requests.packages.charset_normalizer.md, requests.packages.chardet.md, requests.packages.charset_normalizer.cd, requests.packages.chardet.cd, yaml._yaml, ray._raylet, multidict._multidict, yarl._quoting_c, propcache._helpers_c, aiohttp._http_writer, aiohttp._http_parser, aiohttp._websocket.mask, aiohttp._websocket.reader_c, frozenlist._frozenlist, grpc._cython.cygrpc, numpy._core._multiarray_umath, numpy.linalg._umath_linalg, pyarrow.lib, pyarrow._json (total: 24)
Aborted (core dumped)/
```

## Related issues
This PR fixes: https://github.com/ray-project/ray/issues/61678

## Additional information

