### PR TITLE
[ci] Remove LD_LIBRARY_PATH override from general ray release images

### DIFF
--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -65,3 +65,7 @@ sudo rm -rf /var/lib/apt/lists/*
 sudo apt-get clean
 
 EOF
+
+# vLLM 0.17.0 eagerly imports xgrammar -> ICU 78 -> CXXABI_1.3.15.
+# System libstdc++ only has 1.3.13; prepend conda's newer copy.
+ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}

--- a/release/ray_release/byod/byod.Dockerfile
+++ b/release/ray_release/byod/byod.Dockerfile
@@ -68,11 +68,7 @@ EOF
 #
 # RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE=1
 #   To make ray data compatible across multiple pyarrow versions.
-# Conda's libstdc++ provides CXXABI_1.3.15 needed by ICU 78 and other
-# C++ libraries pulled in by vLLM 0.17.0. Place it before the system copy
-# so the dynamic linker finds it first.
 ENV \
-  LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}} \
   RAY_BACKEND_LOG_JSON=1 \
   RAY_DATA_LOG_INTERNAL_STACK_TRACE_TO_STDOUT=1 \
   RAY_DATA_AUTOLOAD_PYEXTENSIONTYPE=1

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2326,6 +2326,9 @@
       runtime_env: # env vars for nixl
         - UCX_TLS=all
         - UCX_NET_DEVICES=all
+        # vLLM 0.17.0 eagerly imports xgrammar -> ICU 78 -> CXXABI_1.3.15.
+        # System libstdc++ only has 1.3.13; prepend conda's newer copy.
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: experimental/compute_a100_gpu.yaml
 
   run:
@@ -3979,6 +3982,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4000,6 +4005,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4022,6 +4029,7 @@
       type: llm-cu128
       runtime_env:
         - RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY=1 # For test_llm_serve_prefill_decode_with_data_parallelism
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4039,6 +4047,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4056,6 +4066,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_g5-4xlarge.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4077,6 +4089,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4097,6 +4111,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4117,6 +4133,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4136,6 +4154,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4155,6 +4175,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4175,6 +4197,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4195,6 +4219,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4215,6 +4241,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4235,6 +4263,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4255,6 +4285,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_llm_lmcache_test.sh
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
@@ -4278,6 +4310,7 @@
       type: llm-cu128
       runtime_env:
         - RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_llm_sglang_test.sh
     cluster_compute: llm_four_L4_gpu_head_node.yaml
 
@@ -4299,6 +4332,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_4xl4.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4319,6 +4354,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_llm_sglang_test.sh
     cluster_compute: llm_4xl4.yaml
 
@@ -4338,6 +4375,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4356,6 +4395,7 @@
     byod:
       runtime_env:
         - VLLM_DISABLE_COMPILE_CACHE=1
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       type: llm-cu128
       post_build_script: byod_llm_single_node_baseline_benchmark.sh
       python_depset: llm_batch/llm_batch_single_node_benchmark_py311_cu128.lock
@@ -4376,6 +4416,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: dataset/{{scaling}}_gpu_g6e_2xl_aws.yaml
 
   matrix:
@@ -4399,6 +4441,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
     cluster_compute: dataset/{{scaling}}_gpu_g6e_2xl_aws.yaml
 
   matrix:
@@ -4460,6 +4504,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_llm_ner.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4485,6 +4531,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_mcp-ray-serve.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4510,6 +4558,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_langchain_agent_ray_serve.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4536,6 +4586,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_multi_agent_a2a.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4813,6 +4865,8 @@
   cluster:
     byod:
       type: llm-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_e2e_audio.sh
     cluster_compute: ci/aws.yaml
 
@@ -4887,6 +4941,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_object_detection.sh # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4913,6 +4969,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_e2e_rag.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4963,6 +5021,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_llamafactory_llm_fine_tune.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4988,6 +5048,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_ray_train_workloads.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5013,6 +5075,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_tune_pytorch_asha.sh
     cluster_compute: ci/aws.yaml
 
@@ -5038,6 +5102,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_llm_batch_inference_text.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5064,6 +5130,8 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
+      runtime_env:
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
       post_build_script: byod_llm_batch_inference_vision.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2328,7 +2328,7 @@
         - UCX_NET_DEVICES=all
         # vLLM 0.17.0 eagerly imports xgrammar -> ICU 78 -> CXXABI_1.3.15.
         # System libstdc++ only has 1.3.13; prepend conda's newer copy.
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: experimental/compute_a100_gpu.yaml
 
   run:
@@ -3983,7 +3983,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4006,7 +4006,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4029,7 +4029,7 @@
       type: llm-cu128
       runtime_env:
         - RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY=1 # For test_llm_serve_prefill_decode_with_data_parallelism
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4048,7 +4048,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4067,7 +4067,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_g5-4xlarge.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4090,7 +4090,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4112,7 +4112,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4134,7 +4134,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4155,7 +4155,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4176,7 +4176,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4198,7 +4198,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4220,7 +4220,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4242,7 +4242,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4264,7 +4264,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4286,7 +4286,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_lmcache_test.sh
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
@@ -4310,7 +4310,7 @@
       type: llm-cu128
       runtime_env:
         - RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_sglang_test.sh
     cluster_compute: llm_four_L4_gpu_head_node.yaml
 
@@ -4333,7 +4333,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_4xl4.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4355,7 +4355,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_sglang_test.sh
     cluster_compute: llm_4xl4.yaml
 
@@ -4376,7 +4376,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4395,7 +4395,7 @@
     byod:
       runtime_env:
         - VLLM_DISABLE_COMPILE_CACHE=1
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       type: llm-cu128
       post_build_script: byod_llm_single_node_baseline_benchmark.sh
       python_depset: llm_batch/llm_batch_single_node_benchmark_py311_cu128.lock
@@ -4417,7 +4417,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: dataset/{{scaling}}_gpu_g6e_2xl_aws.yaml
 
   matrix:
@@ -4442,7 +4442,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: dataset/{{scaling}}_gpu_g6e_2xl_aws.yaml
 
   matrix:
@@ -4505,7 +4505,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_ner.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4532,7 +4532,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_mcp-ray-serve.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4559,7 +4559,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_langchain_agent_ray_serve.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4587,7 +4587,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_multi_agent_a2a.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4866,7 +4866,7 @@
     byod:
       type: llm-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_e2e_audio.sh
     cluster_compute: ci/aws.yaml
 
@@ -4942,7 +4942,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_object_detection.sh # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4970,7 +4970,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_e2e_rag.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5022,7 +5022,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llamafactory_llm_fine_tune.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5049,7 +5049,7 @@
     byod:
       type: llm-cu128  # anyscale/ray:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_ray_train_workloads.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5076,7 +5076,7 @@
     byod:
       type: llm-cu128  # anyscale/ray:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_tune_pytorch_asha.sh
     cluster_compute: ci/aws.yaml
 
@@ -5103,7 +5103,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_batch_inference_text.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5131,7 +5131,7 @@
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
       runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_batch_inference_vision.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2326,9 +2326,6 @@
       runtime_env: # env vars for nixl
         - UCX_TLS=all
         - UCX_NET_DEVICES=all
-        # vLLM 0.17.0 eagerly imports xgrammar -> ICU 78 -> CXXABI_1.3.15.
-        # System libstdc++ only has 1.3.13; prepend conda's newer copy.
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: experimental/compute_a100_gpu.yaml
 
   run:
@@ -3982,8 +3979,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4005,8 +4000,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4029,7 +4022,6 @@
       type: llm-cu128
       runtime_env:
         - RAY_SERVE_USE_COMPACT_SCHEDULING_STRATEGY=1 # For test_llm_serve_prefill_decode_with_data_parallelism
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4047,8 +4039,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4066,8 +4056,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_g5-4xlarge.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4089,8 +4077,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4111,8 +4097,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4133,8 +4117,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4154,8 +4136,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4175,8 +4155,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4197,8 +4175,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4219,8 +4195,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_four_L4_gpu_head_node.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4241,8 +4215,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4263,8 +4235,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4285,8 +4255,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_lmcache_test.sh
     cluster_compute: llm_auto_select_worker.yaml
     # NOTE: Important for getting the correct secrets
@@ -4310,7 +4278,6 @@
       type: llm-cu128
       runtime_env:
         - RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_sglang_test.sh
     cluster_compute: llm_four_L4_gpu_head_node.yaml
 
@@ -4332,8 +4299,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_4xl4.yaml
     # NOTE: Important for getting the correct secrets
     cloud_id: cld_wy5a6nhazplvu32526ams61d98
@@ -4354,8 +4319,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_sglang_test.sh
     cluster_compute: llm_4xl4.yaml
 
@@ -4375,8 +4338,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: llm_2x_4xl4.yaml
 
   run:
@@ -4395,7 +4356,6 @@
     byod:
       runtime_env:
         - VLLM_DISABLE_COMPILE_CACHE=1
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       type: llm-cu128
       post_build_script: byod_llm_single_node_baseline_benchmark.sh
       python_depset: llm_batch/llm_batch_single_node_benchmark_py311_cu128.lock
@@ -4416,8 +4376,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: dataset/{{scaling}}_gpu_g6e_2xl_aws.yaml
 
   matrix:
@@ -4441,8 +4399,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
     cluster_compute: dataset/{{scaling}}_gpu_g6e_2xl_aws.yaml
 
   matrix:
@@ -4504,8 +4460,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_ner.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4531,8 +4485,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_mcp-ray-serve.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4558,8 +4510,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_langchain_agent_ray_serve.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4586,8 +4536,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_multi_agent_a2a.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4865,8 +4813,6 @@
   cluster:
     byod:
       type: llm-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_e2e_audio.sh
     cluster_compute: ci/aws.yaml
 
@@ -4941,8 +4887,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_object_detection.sh # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -4969,8 +4913,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_e2e_rag.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5021,8 +4963,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llamafactory_llm_fine_tune.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5048,8 +4988,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_ray_train_workloads.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5075,8 +5013,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_tune_pytorch_asha.sh
     cluster_compute: ci/aws.yaml
 
@@ -5102,8 +5038,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_batch_inference_text.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
@@ -5130,8 +5064,6 @@
   cluster:
     byod:
       type: llm-cu128  # anyscale/ray-llm:<PR_RAY_VERSION>-py311-cu128
-      runtime_env:
-        - LD_LIBRARY_PATH=/home/ray/anaconda3/lib
       post_build_script: byod_llm_batch_inference_vision.sh  # release/ray_release/byod/
     cluster_compute: ci/aws.yaml  # relative to working_dir
 


### PR DESCRIPTION
## Description
We shouldn't hijack `LD_LIBRARY_PATH` in general Ray release images introduced by https://github.com/ray-project/ray/pull/61598.

#### Why can't we remove `LD_LIBRARY_PATH` override entirely?
[Sample failure log](https://console.anyscale-staging.com/cld_wy5a6nhazplvu32526ams61d98/prj_lhlrf1u5yv8qz9qg3xzw8fkiiq/jobs/prodjob_flsttgr66j688ckr4mgfxzb32l?job-logs-section-tabs=application_logs&job-tab=overview)

```
Traceback (most recent call last):
  File "/home/ray/anaconda3/bin/vllm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/entrypoints/cli/main.py", line 21, in main
    import vllm.entrypoints.cli.serve
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/entrypoints/cli/serve.py", line 12, in <module>
    from vllm.entrypoints.openai.api_server import (
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/entrypoints/openai/api_server.py", line 25, in <module>
    from vllm.engine.protocol import EngineClient
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/engine/protocol.py", line 23, in <module>
    from vllm.v1.engine.input_processor import InputProcessor
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/engine/input_processor.py", line 20, in <module>
    from vllm.multimodal.encoder_budget import MultiModalBudget
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/multimodal/encoder_budget.py", line 10, in <module>
    from vllm.v1.core.encoder_cache_manager import compute_mm_encoder_budget
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/core/encoder_cache_manager.py", line 9, in <module>
    from vllm.v1.request import Request
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/request.py", line 24, in <module>
    from vllm.v1.structured_output.request import StructuredOutputRequest
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/structured_output/__init__.py", line 19, in <module>
    from vllm.v1.structured_output.backend_xgrammar import XgrammarBackend
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/structured_output/backend_xgrammar.py", line 20, in <module>
    from vllm.v1.structured_output.utils import (
  File "/home/ray/anaconda3/lib/python3.11/site-packages/vllm/v1/structured_output/utils.py", line 15, in <module>
    from diskcache import Cache
  File "/home/ray/anaconda3/lib/python3.11/site-packages/diskcache/__init__.py", line 8, in <module>
    from .core import (
  File "/home/ray/anaconda3/lib/python3.11/site-packages/diskcache/core.py", line 14, in <module>
    import sqlite3
  File "/home/ray/anaconda3/lib/python3.11/sqlite3/__init__.py", line 57, in <module>
    from sqlite3.dbapi2 import *
  File "/home/ray/anaconda3/lib/python3.11/sqlite3/dbapi2.py", line 27, in <module>
    from _sqlite3 import *
ImportError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `CXXABI_1.3.15' not found (required by /home/ray/anaconda3/lib/python3.11/lib-dynload/../.././libicui18n.so.78)
```

<img width="1002" height="351" alt="Screenshot 2026-03-20 at 4 44 45 PM" src="https://github.com/user-attachments/assets/6641c774-3e55-4020-9d49-8435a12bec7c" />

## Related issues
Fixes https://buildkite.com/ray-project/release/builds/85094#019d09c4-f0c6-4eaa-890e-986829d3046b.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
