### PR TITLE
[llm][serve] Decouple Ray Serve LLM ingress from vLLM protocol models

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
+++ b/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
@@ -64,9 +64,6 @@ except ImportError:
             ScoringResponse as _ScoreResponse,
             TokenizeRequest as _TokenizeCompletionRequest,
             TokenizeResponse as _TokenizeResponse,
-            TranscriptionRequest as _TranscriptionRequest,
-            TranscriptionResponse as _TranscriptionResponse,
-            TranscriptionStreamResponse as _TranscriptionStreamResponse,
         )
     except ImportError:
         raise ImportError(
@@ -74,6 +71,29 @@ except ImportError:
             "for Ray Serve LLM protocol models. Install with: "
             "`pip install ray[llm]` or `pip install sglang[all]`"
         )
+
+    def _unsupported_model(name: str, feature: str = ""):
+        """Create a BaseModel stub that raises NotImplementedError on instantiation."""
+        msg = f"{name} is not supported with the current backend." + (
+            f" {feature}" if feature else ""
+        )
+
+        class _Stub(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+
+            def __init__(self, **kwargs):
+                raise NotImplementedError(msg)
+
+        _Stub.__name__ = _Stub.__qualname__ = name
+        return _Stub
+
+    # SGLang does not provide transcription protocol models.
+    _vllm_hint = "Install vLLM to use transcription endpoints."
+    _TranscriptionRequest = _unsupported_model("TranscriptionRequest", _vllm_hint)
+    _TranscriptionResponse = _unsupported_model("TranscriptionResponse", _vllm_hint)
+    _TranscriptionStreamResponse = _unsupported_model(
+        "TranscriptionStreamResponse", _vllm_hint
+    )
 
     # SGLang has no equivalent to vLLM's nested ErrorResponse.error -> ErrorInfo
     # pattern, so we define our own.

--- a/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
+++ b/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
@@ -1,104 +1,153 @@
-"""This module contains the wrapper classes for vLLM's OpenAI implementation.
+"""This module contains wrapper classes for OpenAI-compatible protocol models.
 
-If there are any major differences in the interface, the expectation is that
-they will be upstreamed to vLLM.
+Supports both vLLM and SGLang as the underlying engine. vLLM is tried first;
+on ImportError, SGLang models are imported as a fallback. If neither is
+installed, an ImportError is raised at import time.
 """
 
+import uuid
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
-from vllm.entrypoints.openai.chat_completion.protocol import (
-    ChatCompletionRequest as vLLMChatCompletionRequest,
-    ChatCompletionResponse as vLLMChatCompletionResponse,
-    ChatCompletionStreamResponse as vLLMChatCompletionStreamResponse,
-)
-from vllm.entrypoints.openai.completion.protocol import (
-    CompletionRequest as vLLMCompletionRequest,
-    CompletionResponse as vLLMCompletionResponse,
-    CompletionStreamResponse as vLLMCompletionStreamResponse,
-)
-from vllm.entrypoints.openai.engine.protocol import (
-    ErrorInfo as vLLMErrorInfo,
-    ErrorResponse as vLLMErrorResponse,
-)
-from vllm.entrypoints.openai.speech_to_text.protocol import (
-    TranscriptionRequest as vLLMTranscriptionRequest,
-    TranscriptionResponse as vLLMTranscriptionResponse,
-    TranscriptionStreamResponse as vLLMTranscriptionStreamResponse,
-)
-from vllm.entrypoints.pooling.embed.protocol import (
-    EmbeddingChatRequest as vLLMEmbeddingChatRequest,
-    EmbeddingCompletionRequest as vLLMEmbeddingCompletionRequest,
-    EmbeddingResponse as vLLMEmbeddingResponse,
-)
-from vllm.entrypoints.pooling.score.protocol import (
-    ScoreResponse as vLLMScoreResponse,
-    ScoreTextRequest as vLLMScoreTextRequest,
-)
-from vllm.entrypoints.serve.tokenize.protocol import (
-    DetokenizeRequest as vLLMDetokenizeRequest,
-    DetokenizeResponse as vLLMDetokenizeResponse,
-    TokenizeChatRequest as vLLMTokenizeChatRequest,
-    TokenizeCompletionRequest as vLLMTokenizeCompletionRequest,
-    TokenizeResponse as vLLMTokenizeResponse,
-)
-from vllm.utils import random_uuid
+
+try:
+    from vllm.entrypoints.openai.chat_completion.protocol import (
+        ChatCompletionRequest as _ChatCompletionRequest,
+        ChatCompletionResponse as _ChatCompletionResponse,
+        ChatCompletionStreamResponse as _ChatCompletionStreamResponse,
+    )
+    from vllm.entrypoints.openai.completion.protocol import (
+        CompletionRequest as _CompletionRequest,
+        CompletionResponse as _CompletionResponse,
+        CompletionStreamResponse as _CompletionStreamResponse,
+    )
+    from vllm.entrypoints.openai.engine.protocol import (
+        ErrorInfo as _ErrorInfo,
+        ErrorResponse as _ErrorResponse,
+    )
+    from vllm.entrypoints.openai.speech_to_text.protocol import (
+        TranscriptionRequest as _TranscriptionRequest,
+        TranscriptionResponse as _TranscriptionResponse,
+        TranscriptionStreamResponse as _TranscriptionStreamResponse,
+    )
+    from vllm.entrypoints.pooling.embed.protocol import (
+        EmbeddingChatRequest as _EmbeddingChatRequest,
+        EmbeddingCompletionRequest as _EmbeddingCompletionRequest,
+        EmbeddingResponse as _EmbeddingResponse,
+    )
+    from vllm.entrypoints.pooling.score.protocol import (
+        ScoreResponse as _ScoreResponse,
+        ScoreTextRequest as _ScoreTextRequest,
+    )
+    from vllm.entrypoints.serve.tokenize.protocol import (
+        DetokenizeRequest as _DetokenizeRequest,
+        DetokenizeResponse as _DetokenizeResponse,
+        TokenizeChatRequest as _TokenizeChatRequest,
+        TokenizeCompletionRequest as _TokenizeCompletionRequest,
+        TokenizeResponse as _TokenizeResponse,
+    )
+
+except ImportError:
+    try:
+        from sglang.srt.entrypoints.openai.protocol import (
+            ChatCompletionRequest as _ChatCompletionRequest,
+            ChatCompletionResponse as _ChatCompletionResponse,
+            ChatCompletionStreamResponse as _ChatCompletionStreamResponse,
+            CompletionRequest as _CompletionRequest,
+            CompletionResponse as _CompletionResponse,
+            CompletionStreamResponse as _CompletionStreamResponse,
+            DetokenizeRequest as _DetokenizeRequest,
+            DetokenizeResponse as _DetokenizeResponse,
+            EmbeddingRequest as _EmbeddingCompletionRequest,
+            EmbeddingResponse as _EmbeddingResponse,
+            ScoringRequest as _ScoreTextRequest,
+            ScoringResponse as _ScoreResponse,
+            TokenizeRequest as _TokenizeCompletionRequest,
+            TokenizeResponse as _TokenizeResponse,
+            TranscriptionRequest as _TranscriptionRequest,
+            TranscriptionResponse as _TranscriptionResponse,
+            TranscriptionStreamResponse as _TranscriptionStreamResponse,
+        )
+    except ImportError:
+        raise ImportError(
+            "Neither vLLM nor SGLang is installed. At least one is required "
+            "for Ray Serve LLM protocol models. Install with: "
+            "`pip install ray[llm]` or `pip install sglang[all]`"
+        )
+
+    # SGLang has no equivalent to vLLM's nested ErrorResponse.error -> ErrorInfo
+    # pattern, so we define our own.
+
+    class _ErrorInfo(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        message: str
+        type: str
+        param: Optional[str] = None
+        code: int
+
+    class _ErrorResponse(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+        error: _ErrorInfo
+
+    _EmbeddingChatRequest = _EmbeddingCompletionRequest
+    _TokenizeChatRequest = _TokenizeCompletionRequest
+
 
 if TYPE_CHECKING:
     from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 
 
-class ChatCompletionRequest(vLLMChatCompletionRequest):
+class ChatCompletionRequest(_ChatCompletionRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class ChatCompletionResponse(vLLMChatCompletionResponse):
+class ChatCompletionResponse(_ChatCompletionResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class ChatCompletionStreamResponse(vLLMChatCompletionStreamResponse):
+class ChatCompletionStreamResponse(_ChatCompletionStreamResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class ErrorInfo(vLLMErrorInfo):
+class ErrorInfo(_ErrorInfo):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class ErrorResponse(vLLMErrorResponse):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-# TODO (Kourosh): Upstream
-class CompletionRequest(vLLMCompletionRequest):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-class CompletionResponse(vLLMCompletionResponse):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-
-class CompletionStreamResponse(vLLMCompletionStreamResponse):
+class ErrorResponse(_ErrorResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 # TODO (Kourosh): Upstream
-class EmbeddingCompletionRequest(vLLMEmbeddingCompletionRequest):
+class CompletionRequest(_CompletionRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class EmbeddingChatRequest(vLLMEmbeddingChatRequest):
+class CompletionResponse(_CompletionResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class EmbeddingResponse(vLLMEmbeddingResponse):
+class CompletionStreamResponse(_CompletionStreamResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class TranscriptionRequest(vLLMTranscriptionRequest):
+# TODO (Kourosh): Upstream
+class EmbeddingCompletionRequest(_EmbeddingCompletionRequest):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class EmbeddingChatRequest(_EmbeddingChatRequest):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class EmbeddingResponse(_EmbeddingResponse):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class TranscriptionRequest(_TranscriptionRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     request_id: str = Field(
-        default_factory=lambda: f"{random_uuid()}",
+        default_factory=lambda: str(uuid.uuid4()),
         description=(
             "The request_id related to this request. If the caller does "
             "not set it, a random_uuid will be generated. This id is used "
@@ -107,39 +156,39 @@ class TranscriptionRequest(vLLMTranscriptionRequest):
     )
 
 
-class TranscriptionResponse(vLLMTranscriptionResponse):
+class TranscriptionResponse(_TranscriptionResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class TranscriptionStreamResponse(vLLMTranscriptionStreamResponse):
+class TranscriptionStreamResponse(_TranscriptionStreamResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class ScoreRequest(vLLMScoreTextRequest):
+class ScoreRequest(_ScoreTextRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class ScoreResponse(vLLMScoreResponse):
+class ScoreResponse(_ScoreResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class TokenizeCompletionRequest(vLLMTokenizeCompletionRequest):
+class TokenizeCompletionRequest(_TokenizeCompletionRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class TokenizeChatRequest(vLLMTokenizeChatRequest):
+class TokenizeChatRequest(_TokenizeChatRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class TokenizeResponse(vLLMTokenizeResponse):
+class TokenizeResponse(_TokenizeResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class DetokenizeRequest(vLLMDetokenizeRequest):
+class DetokenizeRequest(_DetokenizeRequest):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
-class DetokenizeResponse(vLLMDetokenizeResponse):
+class DetokenizeResponse(_DetokenizeResponse):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -137,17 +137,28 @@ def _sanitize_chat_completion_request(
     This addresses a known Pydantic bug where tool_calls fields become ValidatorIterator
     objects that cannot be pickled for Ray remote calls.
 
-    References:
-    - vLLM PR that introduces the workaround: https://github.com/vllm-project/vllm/pull/9951
+    Workaround logic adapted from vLLM (credits: @gcalmettes):
+    - vLLM PR: https://github.com/vllm-project/vllm/pull/9951
     - Pydantic Issue: https://github.com/pydantic/pydantic/issues/9467
     - Related Issue: https://github.com/pydantic/pydantic/issues/9541
     - Official Workaround: https://github.com/pydantic/pydantic/issues/9467#issuecomment-2442097291
 
     TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix.
     """
-    from vllm.tokenizers.mistral import maybe_serialize_tool_calls
+    for i, message in enumerate(request.messages):
+        if message.get("role") == "assistant":
+            if (tool_calls_validator := message.get("tool_calls", None)) is not None:
+                try:
+                    validated_tool_calls = list(tool_calls_validator)
+                except (TypeError, ValueError) as e:
+                    raise ValueError(
+                        "Validating messages' `tool_calls` raised an error. "
+                        "Please ensure `tool_calls` are iterable of tool calls."
+                    ) from e
+            else:
+                validated_tool_calls = []
 
-    maybe_serialize_tool_calls(request)
+            request.messages[i]["tool_calls"] = validated_tool_calls
 
     return request
 
@@ -705,9 +716,9 @@ class OpenAiIngress(DeploymentProtocol):
             result = await results.__anext__()
             if isinstance(result, ErrorResponse):
                 raise OpenAIHTTPException(
-                    message=result.message,
-                    status_code=result.code,
-                    type=result.type,
+                    message=result.error.message,
+                    status_code=result.error.code,
+                    type=result.error.type,
                 )
 
             if isinstance(result, ScoreResponse):

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -152,18 +152,15 @@ def _sanitize_chat_completion_request(
             request.messages[i] = message = message.model_dump()
 
         if message.get("role") == "assistant":
-            if (tool_calls_validator := message.get("tool_calls", None)) is not None:
+            tool_calls_val = message.get("tool_calls")
+            if tool_calls_val is not None:
                 try:
-                    validated_tool_calls = list(tool_calls_validator)
+                    request.messages[i]["tool_calls"] = list(tool_calls_val)
                 except (TypeError, ValueError) as e:
                     raise ValueError(
                         "Validating messages' `tool_calls` raised an error. "
                         "Please ensure `tool_calls` are iterable of tool calls."
                     ) from e
-            else:
-                validated_tool_calls = []
-
-            request.messages[i]["tool_calls"] = validated_tool_calls
 
     return request
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -146,6 +146,11 @@ def _sanitize_chat_completion_request(
     TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix.
     """
     for i, message in enumerate(request.messages):
+        # SGLang messages are Pydantic BaseModels (no .get()); convert to dicts
+        # so the same logic works for both vLLM (TypedDict) and SGLang.
+        if not isinstance(message, dict):
+            request.messages[i] = message = message.model_dump()
+
         if message.get("role") == "assistant":
             if (tool_calls_validator := message.get("tool_calls", None)) is not None:
                 try:

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -28,7 +28,6 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 )
 from ray.llm._internal.serve.core.engine.protocol import LLMEngine
 from ray.llm._internal.serve.core.protocol import LLMServerProtocol, RawRequestInfo
-from ray.llm._internal.serve.engines.vllm.vllm_engine import VLLMEngine
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.llm._internal.serve.observability.usage_telemetry.usage import (
     push_telemetry_report_for_all_models,
@@ -126,7 +125,7 @@ class LLMServer(LLMServerProtocol):
         deployment = serve.deployment(LLMServer).bind(llm_config)
     """
 
-    _default_engine_cls = VLLMEngine
+    _default_engine_cls = None
 
     async def __init__(
         self,
@@ -229,12 +228,17 @@ class LLMServer(LLMServerProtocol):
     def _get_default_engine_class(self) -> Type[LLMEngine]:
         """Helper to load the engine class from the environment variable.
         This is used for testing or escape-hatch for patching purposes.
-        If env variable is not set, it will fallback to the default engine class.
+        If env variable is not set, it will fallback to the default engine class
+        (VLLMEngine, imported lazily to avoid a hard module-level dependency).
         """
         engine_cls_path = os.environ.get(RAYLLM_VLLM_ENGINE_CLS_ENV)
         if engine_cls_path:
             return import_attr(engine_cls_path)
-        return self._default_engine_cls
+        if self._default_engine_cls is not None:
+            return self._default_engine_cls
+        from ray.llm._internal.serve.engines.vllm.vllm_engine import VLLMEngine
+
+        return VLLMEngine
 
     async def _start_engine(self):
         if self.engine is None:

--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -519,7 +519,7 @@ class SGLangServer:
             )
         prompt = tokenizer.decode(request.tokens)
 
-        yield DetokenizeResponse(prompt=prompt)
+        yield DetokenizeResponse(text=prompt)
 
     async def llm_config(self) -> Optional[LLMConfig]:
         return self._llm_config

--- a/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
@@ -127,6 +127,12 @@ class TestSanitizeChatCompletionRequest:
 
         result = _sanitize_chat_completion_request(request)
         assert result is request
+        # Sanitizer must not inject tool_calls onto messages that never had them.
+        assistant_msg = result.messages[1]
+        if isinstance(assistant_msg, dict):
+            assert assistant_msg.get("tool_calls") is None
+        else:
+            assert getattr(assistant_msg, "tool_calls", None) is None
 
 
 class TestLLMServerLazyImport:

--- a/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
@@ -1,0 +1,144 @@
+"""Tests for openai_api_models.py engine-agnostic import behaviour.
+
+SGLang fallback tests live in the llm_serve_sglang_e2e release test.
+"""
+
+import importlib
+import sys
+
+import pytest
+
+_OAI_MODELS_MOD = "ray.llm._internal.serve.core.configs.openai_api_models"
+
+
+class _VLLMImportBlocker:
+    """Meta-path finder that makes every ``vllm.*`` import raise."""
+
+    def find_module(self, fullname, path=None):
+        if fullname == "vllm" or fullname.startswith("vllm."):
+            return self
+        return None
+
+    def load_module(self, fullname):
+        raise ImportError(f"Mocked: {fullname} is not installed")
+
+
+class TestVLLMBackend:
+    def test_wrapper_classes_inherit_from_vllm(self):
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            ChatCompletionRequest,
+            CompletionRequest,
+            ErrorInfo,
+            ErrorResponse,
+        )
+
+        assert "vllm" in ChatCompletionRequest.__mro__[1].__module__
+        assert "vllm" in CompletionRequest.__mro__[1].__module__
+        assert "vllm" in ErrorInfo.__mro__[1].__module__
+        assert "vllm" in ErrorResponse.__mro__[1].__module__
+
+    def test_error_response_round_trip(self):
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            ErrorInfo,
+            ErrorResponse,
+        )
+
+        info = ErrorInfo(message="something broke", code=500, type="InternalError")
+        resp = ErrorResponse(error=info)
+        assert resp.error.message == "something broke"
+        assert resp.error.code == 500
+        assert resp.error.type == "InternalError"
+
+        dumped = resp.model_dump()
+        assert dumped["error"]["message"] == "something broke"
+
+    def test_transcription_request_has_request_id(self):
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            TranscriptionRequest,
+        )
+
+        assert "request_id" in TranscriptionRequest.model_fields
+
+    def test_import_error_when_vllm_blocked(self):
+        """SGLang is not installed here either, so blocking vLLM means neither
+        backend is available."""
+        blocker = _VLLMImportBlocker()
+        saved = {
+            k: sys.modules.pop(k)
+            for k in list(sys.modules)
+            if k == "vllm" or k.startswith("vllm.")
+        }
+        sys.modules.pop(_OAI_MODELS_MOD, None)
+        sys.meta_path.insert(0, blocker)
+        try:
+            with pytest.raises(ImportError, match="Neither vLLM nor SGLang"):
+                importlib.import_module(_OAI_MODELS_MOD)
+        finally:
+            sys.meta_path.remove(blocker)
+            sys.modules.pop(_OAI_MODELS_MOD, None)
+            sys.modules.update(saved)
+
+
+class TestSanitizeChatCompletionRequest:
+    def test_serializes_tool_calls_iterator(self):
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            ChatCompletionRequest,
+        )
+        from ray.llm._internal.serve.core.ingress.ingress import (
+            _sanitize_chat_completion_request,
+        )
+
+        tool_calls = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "f", "arguments": "{}"},
+            },
+        ]
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": None, "tool_calls": iter(tool_calls)},
+            ],
+        )
+
+        result = _sanitize_chat_completion_request(request)
+        assistant_msg = result.messages[1]
+        assert isinstance(assistant_msg["tool_calls"], list)
+        assert len(assistant_msg["tool_calls"]) == 1
+
+    def test_handles_no_tool_calls(self):
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            ChatCompletionRequest,
+        )
+        from ray.llm._internal.serve.core.ingress.ingress import (
+            _sanitize_chat_completion_request,
+        )
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "world"},
+            ],
+        )
+
+        result = _sanitize_chat_completion_request(request)
+        assert result is request
+
+
+class TestLLMServerLazyImport:
+    def test_default_engine_cls_is_none(self):
+        mod_name = "ray.llm._internal.serve.core.server.llm_server"
+        old_mod = sys.modules.pop(mod_name, None)
+        try:
+            mod = importlib.import_module(mod_name)
+            assert mod.LLMServer._default_engine_cls is None
+        finally:
+            if old_mod is not None:
+                sys.modules[mod_name] = old_mod
+
+    def test_ray_serve_llm_importable(self):
+        import ray.serve.llm  # noqa: F401

--- a/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
@@ -142,3 +142,7 @@ class TestLLMServerLazyImport:
 
     def test_ray_serve_llm_importable(self):
         import ray.serve.llm  # noqa: F401
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/llm_tests/serve/test_llm_serve_sglang.py
+++ b/release/llm_tests/serve/test_llm_serve_sglang.py
@@ -226,5 +226,42 @@ def test_sglang_embeddings(sglang_embedding_client):
     assert emb_batch_resp.data[1].embedding
 
 
+# ---------------------------------------------------------------------------
+# Protocol decoupling tests — verify modules are importable without vLLM
+# and that SGLang protocol models are wired correctly.
+# ---------------------------------------------------------------------------
+
+
+class TestSGLangProtocolDecoupling:
+    """Verify modules are importable without vLLM and SGLang models are wired."""
+
+    def test_modules_importable_without_vllm(self):
+        """openai_api_models, ingress, llm_server, and ray.serve.llm should
+        all import without vLLM installed."""
+        from ray.llm._internal.serve.core.configs import openai_api_models  # noqa: F401
+        from ray.llm._internal.serve.core.ingress import ingress  # noqa: F401
+        from ray.llm._internal.serve.core.server.llm_server import LLMServer
+        import ray.serve.llm  # noqa: F401
+
+        assert LLMServer._default_engine_cls is None
+
+    def test_error_response_round_trip(self):
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            ErrorInfo,
+            ErrorResponse,
+        )
+
+        resp = ErrorResponse(error=ErrorInfo(message="bad", code=400, type="Invalid"))
+        assert resp.error.message == "bad"
+        assert resp.error.code == 400
+        assert resp.model_dump()["error"]["message"] == "bad"
+
+    def test_score_request_is_sglang_scoring_request(self):
+        from sglang.srt.entrypoints.openai.protocol import ScoringRequest
+        from ray.llm._internal.serve.core.configs.openai_api_models import ScoreRequest
+
+        assert issubclass(ScoreRequest, ScoringRequest)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-xvs", __file__]))

--- a/release/llm_tests/serve/test_llm_serve_sglang.py
+++ b/release/llm_tests/serve/test_llm_serve_sglang.py
@@ -166,8 +166,8 @@ def test_sglang_detokenize(sglang_client):
     )
     assert detok_resp.status_code == 200
     data = detok_resp.json()
-    assert "prompt" in data
-    assert "Hello world" in data["prompt"]
+    assert "text" in data
+    assert "Hello world" in data["text"]
 
 
 @pytest.fixture(scope="module")

--- a/release/ray_release/byod/byod_llm_sglang_test.sh
+++ b/release/ray_release/byod/byod_llm_sglang_test.sh
@@ -3,5 +3,5 @@
 # to run the llm sglang release tests
 
 set -exo pipefail
-
+pip3 uninstall -y vllm
 pip3 install "sglang[all]==0.5.6.post1"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4275,7 +4275,7 @@
 
   cluster:
     byod:
-      type: cu128
+      type: gpu-cu130
       runtime_env:
         - RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
       post_build_script: byod_llm_sglang_test.sh

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4268,14 +4268,14 @@
 
 - name: llm_serve_sglang_e2e
   frequency: manual
-  python: "3.12"
+  python: "3.11"
   group: llm-serve
   team: llm
   working_dir: llm_tests/serve
 
   cluster:
     byod:
-      type: gpu-cu130
+      type: llm-cu128
       runtime_env:
         - RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
       post_build_script: byod_llm_sglang_test.sh

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4268,7 +4268,7 @@
 
 - name: llm_serve_sglang_e2e
   frequency: manual
-  python: "3.11"
+  python: "3.12"
   group: llm-serve
   team: llm
   working_dir: llm_tests/serve

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4275,7 +4275,7 @@
 
   cluster:
     byod:
-      type: llm-cu128
+      type: cu128
       runtime_env:
         - RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
       post_build_script: byod_llm_sglang_test.sh


### PR DESCRIPTION
Part of https://github.com/ray-project/ray/issues/61114

## Decouple Ray Serve LLM ingress from vLLM protocol models

`OpenAiIngress` had a hard dependency on vLLM's OpenAI protocol classes for request parsing. This made it impossible to run `SGLangServer` without vLLM installed, which is often not feasible due to PyTorch ABI conflicts between the two engines.

### Changes

**`openai_api_models.py`** — Replace unconditional vLLM imports with try/except fallback to `sglang.srt.entrypoints.openai.protocol`. Wrapper classes inherit from whichever engine resolved. SGLang lacks vLLM's nested `ErrorResponse.error -> ErrorInfo` pattern, so we define a standalone `ErrorInfo`/`ErrorResponse` pair. Also fixes a latent bug in `score()` where `ErrorResponse` fields were accessed flat (`result.message`) instead of nested (`result.error.message`) like every other endpoint.

**`ingress.py`** — Inline the `maybe_serialize_tool_calls` workaround (was a lazy vLLM import). The Pydantic `ValidatorIterator` bug affects both engines.

**`llm_server.py`** — Set `_default_engine_cls = None`, lazy-import `VLLMEngine` inside `_get_default_engine_class`. Breaks the import chain from `ray.serve.llm` -> `LLMServer` -> `vllm`.

### Test plan

**CPU (vLLM-only env)**:
- Wrapper classes inherit from vLLM bases
- Blocking vLLM in `sys.modules` raises `ImportError("Neither vLLM nor SGLang")`
- Tool call sanitization works without vLLM import
- `LLMServer._default_engine_cls is None` after import

**`llm_serve_sglang_e2e` (SGLang-only env, BYOD changed to `gpu-cu130`)**:
- `openai_api_models`, `ingress`, `llm_server`, `ray.serve.llm` all importable without vLLM
- `ErrorResponse` round-trips through nested access and `model_dump()`
- `ScoreRequest` is a subclass of SGLang's `ScoringRequest`
- Existing e2e tests (chat, completions, tokenize, embeddings) pass unchanged
