### PR TITLE
[Serve] Strengthen leaked PG recovery test assertions

### DIFF
--- a/python/ray/serve/tests/test_replica_placement_group.py
+++ b/python/ray/serve/tests/test_replica_placement_group.py
@@ -305,6 +305,8 @@ def test_leaked_gang_pg_removed_on_controller_recovery(serve_instance):
     assert len(survivor_pg) == 1
     assert len(victim_pg) == 1
     original_survivor_pg_name = survivor_pg[0]
+    original_victim_pg_name = victim_pg[0]
+    prev_per_replica_pg_name = non_gang_pgs[0]
 
     # Kill the controller
     ray.kill(_get_global_client()._controller, no_restart=False)
@@ -331,10 +333,12 @@ def test_leaked_gang_pg_removed_on_controller_recovery(serve_instance):
         except Exception:
             return False
 
+        current_pg_names = get_all_live_placement_group_names()
         current_gang_pgs = [
-            n
-            for n in get_all_live_placement_group_names()
-            if n.startswith(GANG_PG_NAME_PREFIX)
+            n for n in current_pg_names if n.startswith(GANG_PG_NAME_PREFIX)
+        ]
+        current_non_gang_pgs = [
+            n for n in current_pg_names if not n.startswith(GANG_PG_NAME_PREFIX)
         ]
 
         # The survivor's *original* PG must still exist (not removed).
@@ -345,6 +349,14 @@ def test_leaked_gang_pg_removed_on_controller_recovery(serve_instance):
         # Victim should have recovered with a new PG (old one was removed).
         victim_pgs = [n for n in current_gang_pgs if "victim_app" in n]
         if len(victim_pgs) != 1:
+            return False
+        if victim_pgs[0] == original_victim_pg_name:
+            return False
+
+        # The old per-replica PG must be removed, not leaked alongside the new one.
+        if len(current_non_gang_pgs) != 1:
+            return False
+        if current_non_gang_pgs[0] == prev_per_replica_pg_name:
             return False
 
         # Per-replica app should have recovered with a new PG.


### PR DESCRIPTION

## Description
`test_leaked_gang_pg_removed_on_controller_recovery` did not fully verify that the old per-replica placement group was removed after controller recovery.

Before this change, the test only checked that the recovered deployment returned a different placement group object. That could still pass if the old placement group leaked and Serve created a new one for the replacement replica.

## Related issues
https://github.com/ray-project/ray/issues/61935

## Additional information

Tighten the recovery checks by recording the original per-replica placement group name before controller restart and asserting that after recovery:
- exactly one non-gang placement group remains
- the remaining non-gang placement group is not the original one

Keep the existing placement group object comparison as an extra sanity check that the deployment recovered onto a new placement group.
