### PR TITLE
[Train] Decouple datasets field from TrainRunContext

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -23,7 +23,7 @@ from ray.train.v2._internal.execution.worker_group.worker_group import (
 from ray.types import ObjectRef
 
 if TYPE_CHECKING:
-    from ray.data import DataIterator
+    from ray.data import DataIterator, Dataset
     from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
@@ -50,8 +50,12 @@ class RayDatasetShardProvider:
 class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
     """A callback for managing Ray Datasets for the worker group."""
 
-    def __init__(self, train_run_context: TrainRunContext):
-        self._datasets = train_run_context.datasets
+    def __init__(
+        self,
+        train_run_context: TrainRunContext,
+        datasets: Dict[str, "Dataset"],
+    ):
+        self._datasets = datasets
         self._data_config = copy.deepcopy(train_run_context.dataset_config)
         self._scaling_config = train_run_context.scaling_config
         self._coordinator_actors: List[ActorHandle] = []

--- a/python/ray/train/v2/_internal/execution/context.py
+++ b/python/ray/train/v2/_internal/execution/context.py
@@ -28,7 +28,7 @@ from ray.train.v2.api.report_config import (
 from ray.train.v2.api.validation_config import ValidationTaskConfig
 
 if TYPE_CHECKING:
-    from ray.data import DataIterator, Dataset
+    from ray.data import DataIterator
     from ray.train import BackendConfig, Checkpoint, DataConfig
     from ray.train.v2._internal.data_integration.interfaces import (
         DatasetShardMetadata,
@@ -64,9 +64,6 @@ class TrainRunContext:
 
     # The configuration for the training backend (e.g., PyTorch, XGBoost).
     backend_config: "BackendConfig"
-
-    # The datasets used in the current training run.
-    datasets: Dict[str, "Dataset"]
 
     # The configuration for dataset ingestion and sharding.
     dataset_config: "DataConfig"

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -103,7 +103,6 @@ class DataParallelTrainer:
             train_loop_config=self.train_loop_config,
             scaling_config=self.scaling_config,
             backend_config=self.backend_config,
-            datasets=self.datasets,
             dataset_config=self.data_config,
         )
 
@@ -210,7 +209,10 @@ class DataParallelTrainer:
             self.backend_config, self.scaling_config
         )
         backend_setup_callback = BackendSetupCallback(self.backend_config)
-        datasets_callback = DatasetsCallback(train_run_context=self.train_run_context)
+        datasets_callback = DatasetsCallback(
+            train_run_context=self.train_run_context,
+            datasets=self.datasets,
+        )
         placement_group_cleaner_callback = PlacementGroupCleanerCallback()
         callbacks.extend(
             [

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -112,7 +112,6 @@ def test_datasets_callback(ray_start_4_cpus):
         resources_per_worker=scaling_config.resources_per_worker,
     )
     train_run_context = create_dummy_run_context(
-        datasets={"train": train_ds, "valid": valid_ds},
         dataset_config=data_config,
         scaling_config=scaling_config,
     )
@@ -122,7 +121,10 @@ def test_datasets_callback(ray_start_4_cpus):
     )
     worker_group._start()
 
-    callback = DatasetsCallback(train_run_context)
+    callback = DatasetsCallback(
+        train_run_context=train_run_context,
+        datasets={"train": train_ds, "valid": valid_ds},
+    )
     dataset_manager_for_each_worker = callback.before_init_train_context(
         worker_group.get_workers()
     )["dataset_shard_provider"]
@@ -637,7 +639,6 @@ def test_datasets_callback_v1_uses_exclude_resources(ray_start_4_cpus, monkeypat
         resources_per_worker=scaling_config.resources_per_worker,
     )
     train_run_context = create_dummy_run_context(
-        datasets={"train": train_ds, "valid": valid_ds},
         dataset_config=data_config,
         scaling_config=scaling_config,
     )
@@ -647,7 +648,10 @@ def test_datasets_callback_v1_uses_exclude_resources(ray_start_4_cpus, monkeypat
     )
     worker_group._start()
 
-    callback = DatasetsCallback(train_run_context)
+    callback = DatasetsCallback(
+        train_run_context=train_run_context,
+        datasets={"train": train_ds, "valid": valid_ds},
+    )
     dataset_manager_for_each_worker = callback.before_init_train_context(
         worker_group.get_workers()
     )["dataset_shard_provider"]
@@ -697,7 +701,6 @@ def test_v2_no_negative_exclude_resources(ray_start_4_cpus):
         resources_per_worker=scaling_config.resources_per_worker,
     )
     train_run_context = create_dummy_run_context(
-        datasets={"train": train_ds, "valid": valid_ds},
         dataset_config=data_config,
         scaling_config=scaling_config,
     )
@@ -707,7 +710,10 @@ def test_v2_no_negative_exclude_resources(ray_start_4_cpus):
     )
     worker_group._start()
 
-    callback = DatasetsCallback(train_run_context)
+    callback = DatasetsCallback(
+        train_run_context=train_run_context,
+        datasets={"train": train_ds, "valid": valid_ds},
+    )
     dataset_manager_for_each_worker = callback.before_init_train_context(
         worker_group.get_workers()
     )["dataset_shard_provider"]

--- a/python/ray/train/v2/tests/test_data_resource_cleanup.py
+++ b/python/ray/train/v2/tests/test_data_resource_cleanup.py
@@ -44,11 +44,12 @@ def test_datasets_callback_multiple_datasets(ray_start_4_cpus):
         "unsharded": ray.data.range(NUM_ROWS),
     }
     dataset_config = ray.train.DataConfig(datasets_to_split=["sharded_1", "sharded_2"])
-    train_run_context = create_dummy_run_context(
-        datasets=datasets, dataset_config=dataset_config
-    )
+    train_run_context = create_dummy_run_context(dataset_config=dataset_config)
 
-    callback = DatasetsCallback(train_run_context)
+    callback = DatasetsCallback(
+        train_run_context=train_run_context,
+        datasets=datasets,
+    )
     callback.before_init_train_context(wg.get_workers())
 
     # Two coordinator actors, one for each sharded dataset
@@ -57,7 +58,10 @@ def test_datasets_callback_multiple_datasets(ray_start_4_cpus):
 
 
 def test_after_worker_group_abort():
-    callback = DatasetsCallback(create_dummy_run_context())
+    callback = DatasetsCallback(
+        train_run_context=create_dummy_run_context(),
+        datasets={},
+    )
 
     # Mock SplitCoordinator shutdown_executor method
     coord_mock = create_autospec(SplitCoordinator)
@@ -78,7 +82,10 @@ def test_after_worker_group_abort():
 
 
 def test_after_worker_group_shutdown():
-    callback = DatasetsCallback(create_dummy_run_context())
+    callback = DatasetsCallback(
+        train_run_context=create_dummy_run_context(),
+        datasets={},
+    )
 
     # Mock SplitCoordinator shutdown_executor method
     coord_mock = create_autospec(SplitCoordinator)

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -243,7 +243,6 @@ def create_dummy_run_context(**kwargs: dict) -> TrainRunContext:
         train_loop_config={},
         scaling_config=ScalingConfig(num_workers=1),
         backend_config=BackendConfig(),
-        datasets={},
         dataset_config=DataConfig(),
     )
     config.update(kwargs)


### PR DESCRIPTION
## Summary

`TrainRunContext` previously held a direct reference to the `datasets` dict, which contains full `Dataset` objects. Because `TrainRunContext` is serialized and sent to every training worker during `init_train_context`, this caused head node object store usage to scale linearly with the number of workers. At scale, this contributed to head node OOMs and training ingest instability.

This is a companion change to https://github.com/ray-project/ray/pull/61607, which addressed the same serialization issue in `StreamSplitDataIterator`. Together, these two PRs ensure that `Dataset` objects are no longer serialized to train workers, eliminating a class of memory pressure that scales with worker count during training ingest.

## Changes

- Remove the `datasets` field from `TrainRunContext` in `context.py`, so the `Dataset` objects are no longer part of the serialized context
- Update `DatasetsCallback.__init__` in `datasets.py` to accept `datasets` as a separate argument instead of extracting it from `TrainRunContext`
- Update `DataParallelTrainer._create_default_callbacks()` in `data_parallel_trainer.py` to pass `self.datasets` directly to `DatasetsCallback`
- Update `create_dummy_run_context` test utility and all affected tests

## Tests

- Existing tests in `test_data_resource_cleanup.py` and `test_data_integration.py` updated to use the new `DatasetsCallback` signature
- All 7 affected tests pass: `test_datasets_callback`, `test_datasets_callback_v1_uses_exclude_resources`, `test_v2_no_negative_exclude_resources`, `test_datasets_callback_multiple_datasets`, `test_after_worker_group_abort`, `test_after_worker_group_shutdown`, `test_split_coordinator_shutdown_executor`