### PR TITLE
[Serve] Configurable rolling update percentage + reconfigure blocking (#54509)

### DIFF
--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -221,7 +221,7 @@ class DeploymentConfig(BaseModel):
 
     rolling_update_percentage: float = Field(
         default=0.2,
-        ge=0.0,
+        gt=0.0,
         le=1.0,
         update_type=DeploymentOptionUpdateType.LightWeight,
     )

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -219,6 +219,18 @@ class DeploymentConfig(BaseModel):
         update_type=DeploymentOptionUpdateType.HeavyWeight,
     )
 
+    rolling_update_percentage: float = Field(
+        default=0.2,
+        ge=0.0,
+        le=1.0,
+        update_type=DeploymentOptionUpdateType.LightWeight,
+    )
+
+    blocking_reconfigure: bool = Field(
+        default=True,
+        update_type=DeploymentOptionUpdateType.LightWeight,
+    )
+
     # Contains the names of deployment options manually set by the user
     user_configured_option_names: Set[str] = set()
 

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -324,6 +324,9 @@ class DeploymentConfig(BaseModel):
 
     def to_proto(self):
         data = self.model_dump()
+        # Use a sentinel field to distinguish "blocking_reconfigure=False"
+        # from "not set" since proto3 defaults bool to false.
+        data["has_blocking_reconfigure"] = True
         if data.get("user_config") is not None:
             if self.needs_pickle():
                 data["user_config"] = cloudpickle.dumps(data["user_config"])
@@ -548,6 +551,15 @@ class DeploymentConfig(BaseModel):
             data["deployment_actors"] = deployment_actors
         else:
             data.pop("deployment_actors", None)
+
+        # Handle proto3 zero-value defaults for rolling update fields.
+        # During rolling upgrades, older controllers send configs without
+        # these fields; proto3 defaults double to 0.0 and bool to false.
+        if not data.get("rolling_update_percentage"):
+            data.pop("rolling_update_percentage", None)
+        # Use the sentinel to distinguish explicit False from proto3 default.
+        if not data.pop("has_blocking_reconfigure", False):
+            data.pop("blocking_reconfigure", None)
 
         return cls(**data)
 

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4248,9 +4248,7 @@ class DeploymentState:
             try:
                 latency_s = replica._actor.check_pending_nonblocking_reconfigure()
                 if latency_s is not None:
-                    self.replica_reconfigure_latency_histogram.observe(
-                        latency_s * 1000
-                    )
+                    self.replica_reconfigure_latency_histogram.observe(latency_s * 1000)
             except Exception:
                 # Re-enter transition so the controller retries reconfigure
                 # on the next loop (the version was reverted, so the replica

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4252,6 +4252,10 @@ class DeploymentState:
                         latency_s * 1000
                     )
             except Exception:
+                # Re-enter transition so the controller retries reconfigure
+                # on the next loop (the version was reverted, so the replica
+                # will be detected as outdated).
+                self._in_transition = True
                 logger.warning(
                     f"Non-blocking reconfigure failed for {replica.replica_id}. "
                     "The replica will continue serving with its previous config.",

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3408,7 +3408,10 @@ class DeploymentState:
                 actor_updating = replica.reconfigure(
                     self._target_state.version, rank=current_rank.rank
                 )
-                if actor_updating:
+                blocking_reconfigure = (
+                    self._target_state.info.deployment_config.blocking_reconfigure
+                )
+                if actor_updating and blocking_reconfigure:
                     self._replicas.add(ReplicaState.UPDATING, replica)
                 else:
                     self._replicas.add(ReplicaState.RUNNING, replica)
@@ -3484,7 +3487,12 @@ class DeploymentState:
         # Maximum number of replicas that can be updating at any given time.
         # There should never be more than rollout_size old replicas stopping
         # or rollout_size new replicas starting.
-        rollout_size = max(int(0.2 * self._target_state.target_num_replicas), 1)
+        rolling_update_percentage = (
+            self._target_state.info.deployment_config.rolling_update_percentage
+        )
+        rollout_size = max(
+            int(rolling_update_percentage * self._target_state.target_num_replicas), 1
+        )
 
         # For gang deployments, ensure rollout_size is at least a multiple of
         # gang_size so that we always stop and start complete gangs.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4248,9 +4248,8 @@ class DeploymentState:
             try:
                 latency_s = replica._actor.check_pending_nonblocking_reconfigure()
                 if latency_s is not None:
-                    metric_tags = {"replica": replica.replica_id.unique_id}
                     self.replica_reconfigure_latency_histogram.observe(
-                        latency_s * 1000, tags=metric_tags
+                        latency_s * 1000
                     )
             except Exception:
                 logger.warning(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -579,6 +579,10 @@ class ActorReplicaWrapper:
         self._last_health_check_failed: Optional[bool] = None
         self._initialization_latency_s: Optional[float] = None
         self._reconfigure_start_time: Optional[float] = None
+        # Tracks a pending non-blocking reconfigure obj ref so we can
+        # detect failures and record latency even when the replica stays
+        # in RUNNING state.
+        self._pending_nonblocking_reconfigure_ref: Optional[ObjectRef] = None
         self._internal_grpc_port: Optional[int] = None
         self._docs_path: Optional[str] = None
         self._route_patterns: Optional[List[str]] = None
@@ -822,6 +826,38 @@ class ActorReplicaWrapper:
         Returns None if no reconfigure operation has started.
         """
         return self._reconfigure_start_time
+
+    def set_pending_nonblocking_reconfigure(self):
+        """Mark the current _ready_obj_ref as a non-blocking reconfigure ref."""
+        self._pending_nonblocking_reconfigure_ref = self._ready_obj_ref
+
+    def check_pending_nonblocking_reconfigure(self) -> Optional[float]:
+        """Check if a pending non-blocking reconfigure has completed.
+
+        Returns:
+            The reconfigure latency in seconds if completed successfully,
+            None if still pending or no pending reconfigure.
+
+        Raises:
+            RuntimeError: if the reconfigure failed on the actor.
+        """
+        if self._pending_nonblocking_reconfigure_ref is None:
+            return None
+
+        if not check_obj_ref_ready_nowait(self._pending_nonblocking_reconfigure_ref):
+            return None
+
+        # Completed — clear the ref and compute latency.
+        try:
+            ray.get(self._pending_nonblocking_reconfigure_ref)
+        except Exception:
+            self._pending_nonblocking_reconfigure_ref = None
+            raise
+
+        self._pending_nonblocking_reconfigure_ref = None
+        if self._reconfigure_start_time is not None:
+            return time.time() - self._reconfigure_start_time
+        return 0.0
 
     @property
     def last_health_check_latency_ms(self) -> Optional[float]:
@@ -3413,6 +3449,11 @@ class DeploymentState:
                 )
                 if actor_updating and blocking_reconfigure:
                     self._replicas.add(ReplicaState.UPDATING, replica)
+                elif actor_updating and not blocking_reconfigure:
+                    # Non-blocking: keep serving but track the obj ref so
+                    # we can detect failures and record latency.
+                    replica._actor.set_pending_nonblocking_reconfigure()
+                    self._replicas.add(ReplicaState.RUNNING, replica)
                 else:
                     self._replicas.add(ReplicaState.RUNNING, replica)
             # We don't allow going from STARTING, PENDING_MIGRATION to UPDATING.
@@ -4183,6 +4224,24 @@ class DeploymentState:
         for replica in self._replicas.pop(
             states=[ReplicaState.RUNNING, ReplicaState.PENDING_MIGRATION]
         ):
+            # Check for completed non-blocking reconfigure operations.
+            # When blocking_reconfigure=False, replicas stay in RUNNING while
+            # reconfigure runs on the actor. We need to detect failures and
+            # record latency metrics here since _check_startup_replicas won't.
+            try:
+                latency_s = replica._actor.check_pending_nonblocking_reconfigure()
+                if latency_s is not None:
+                    metric_tags = {"replica": replica.replica_id.unique_id}
+                    self.replica_reconfigure_latency_histogram.observe(
+                        latency_s * 1000, tags=metric_tags
+                    )
+            except Exception:
+                logger.warning(
+                    f"Non-blocking reconfigure failed for {replica.replica_id}. "
+                    "The replica will continue serving with its previous config.",
+                    exc_info=True,
+                )
+
             is_healthy = replica.check_health()
 
             # Record health check latency and failure metrics.

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -583,6 +583,9 @@ class ActorReplicaWrapper:
         # detect failures and record latency even when the replica stays
         # in RUNNING state.
         self._pending_nonblocking_reconfigure_ref: Optional[ObjectRef] = None
+        # The version before a non-blocking reconfigure was started, used to
+        # revert on failure so the controller retries on the next loop.
+        self._pre_nonblocking_reconfigure_version: Optional[DeploymentVersion] = None
         self._internal_grpc_port: Optional[int] = None
         self._docs_path: Optional[str] = None
         self._route_patterns: Optional[List[str]] = None
@@ -827,9 +830,14 @@ class ActorReplicaWrapper:
         """
         return self._reconfigure_start_time
 
-    def set_pending_nonblocking_reconfigure(self):
-        """Mark the current _ready_obj_ref as a non-blocking reconfigure ref."""
+    def set_pending_nonblocking_reconfigure(self, old_version: DeploymentVersion):
+        """Mark the current _ready_obj_ref as a non-blocking reconfigure ref.
+
+        Args:
+            old_version: The version before reconfigure, used to revert on failure.
+        """
         self._pending_nonblocking_reconfigure_ref = self._ready_obj_ref
+        self._pre_nonblocking_reconfigure_version = old_version
 
     def check_pending_nonblocking_reconfigure(self) -> Optional[float]:
         """Check if a pending non-blocking reconfigure has completed.
@@ -851,10 +859,16 @@ class ActorReplicaWrapper:
         try:
             ray.get(self._pending_nonblocking_reconfigure_ref)
         except Exception:
+            # Revert version so the controller detects this replica as
+            # outdated and retries reconfigure on the next control loop.
+            if self._pre_nonblocking_reconfigure_version is not None:
+                self._version = self._pre_nonblocking_reconfigure_version
             self._pending_nonblocking_reconfigure_ref = None
+            self._pre_nonblocking_reconfigure_version = None
             raise
 
         self._pending_nonblocking_reconfigure_ref = None
+        self._pre_nonblocking_reconfigure_version = None
         if self._reconfigure_start_time is not None:
             return time.time() - self._reconfigure_start_time
         return 0.0
@@ -3441,6 +3455,9 @@ class DeploymentState:
                 current_rank = self._rank_manager.get_replica_rank(
                     replica.replica_id.unique_id
                 )
+                # Save old version before reconfigure updates it eagerly,
+                # so we can revert on failure for non-blocking reconfigure.
+                old_version = replica.version
                 actor_updating = replica.reconfigure(
                     self._target_state.version, rank=current_rank.rank
                 )
@@ -3452,7 +3469,7 @@ class DeploymentState:
                 elif actor_updating and not blocking_reconfigure:
                     # Non-blocking: keep serving but track the obj ref so
                     # we can detect failures and record latency.
-                    replica._actor.set_pending_nonblocking_reconfigure()
+                    replica._actor.set_pending_nonblocking_reconfigure(old_version)
                     self._replicas.add(ReplicaState.RUNNING, replica)
                 else:
                     self._replicas.add(ReplicaState.RUNNING, replica)

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -461,6 +461,14 @@ class MockReplicaActorWrapper:
     def reconfigure_start_time(self) -> Optional[float]:
         return None
 
+    def set_pending_nonblocking_reconfigure(self, old_version=None):
+        """No-op for mock: non-blocking reconfigure tracking."""
+        pass
+
+    def check_pending_nonblocking_reconfigure(self) -> Optional[float]:
+        """No-op for mock: always returns None (no pending reconfigure)."""
+        return None
+
     @property
     def last_health_check_latency_ms(self) -> Optional[float]:
         return None

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -467,7 +467,7 @@ class DeploymentSchema(BaseModel):
         default=DEFAULT.VALUE,
         description=(
             "The percentage of replicas to update at a time during a "
-            "rolling update. Must be between 0.0 and 1.0 (exclusive of 0). "
+            "rolling update. Must be in the range (0.0, 1.0]. "
             "Defaults to 0.2 (20%)."
         ),
         gt=0.0,

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -463,6 +463,25 @@ class DeploymentSchema(BaseModel):
             "init_kwargs, and actor_options."
         ),
     )
+    rolling_update_percentage: float = Field(
+        default=DEFAULT.VALUE,
+        description=(
+            "The percentage of replicas to update at a time during a "
+            "rolling update. Must be between 0.0 and 1.0 (exclusive of 0). "
+            "Defaults to 0.2 (20%)."
+        ),
+        gt=0.0,
+        le=1.0,
+    )
+    blocking_reconfigure: bool = Field(
+        default=DEFAULT.VALUE,
+        description=(
+            "Whether replicas should stop serving traffic while "
+            "reconfiguring (i.e., while the reconfigure method is running). "
+            "If False, replicas continue serving traffic during reconfiguration. "
+            "Defaults to True."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -666,6 +666,8 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
         health_check_timeout_s=info.deployment_config.health_check_timeout_s,
         ray_actor_options=info.replica_config.ray_actor_options,
         request_router_config=info.deployment_config.request_router_config,
+        rolling_update_percentage=info.deployment_config.rolling_update_percentage,
+        blocking_reconfigure=info.deployment_config.blocking_reconfigure,
     )
 
     if info.deployment_config.autoscaling_config is not None:

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -212,6 +212,8 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy_nam
                                     "backoff_multiplier": 2.0,
                                     "max_backoff_s": 0.5,
                                 },
+                                "rolling_update_percentage": 0.2,
+                                "blocking_reconfigure": True,
                             },
                             "target_num_replicas": 1,
                             "required_resources": {"CPU": 1},

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -2435,6 +2435,8 @@ def test_get_serve_instance_details_json_serializable(
                                     "backoff_multiplier": 2.0,
                                     "max_backoff_s": 0.5,
                                 },
+                                "rolling_update_percentage": 0.2,
+                                "blocking_reconfigure": True,
                             },
                             "target_num_replicas": 1,
                             "required_resources": {"CPU": 1},

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1619,6 +1619,114 @@ def test_reconfigure_throttling(mock_deployment_state_manager):
     )
 
 
+def test_rolling_update_percentage_configurable(mock_deployment_state_manager):
+    """Test that rolling_update_percentage controls how many replicas update per wave.
+
+    With 10 replicas and rolling_update_percentage=0.5, 5 replicas should update
+    at a time instead of the default 2 (20%).
+    """
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(
+        num_replicas=10, version="1", rolling_update_percentage=0.5
+    )
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    for replica in ds._replicas.get():
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=10, by_state=[(ReplicaState.RUNNING, 10, v1)])
+
+    # Deploy new version. With rolling_update_percentage=0.5, rollout_size should
+    # be max(int(0.5 * 10), 1) = 5, so 5 replicas should be stopped at once.
+    b_info_2, v2 = deployment_info(
+        num_replicas=10, version="2", rolling_update_percentage=0.5
+    )
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    dsm.update()
+
+    # 5 old replicas should be stopping, 5 still running.
+    check_counts(
+        ds,
+        total=10,
+        by_state=[(ReplicaState.RUNNING, 5, v1), (ReplicaState.STOPPING, 5, v1)],
+    )
+
+
+def test_nonblocking_reconfigure(mock_deployment_state_manager):
+    """Test that blocking_reconfigure=False keeps replicas in RUNNING during reconfigure.
+
+    When user_config changes and blocking_reconfigure=False, replicas should stay
+    in RUNNING state (serving traffic) instead of transitioning to UPDATING.
+    """
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(
+        num_replicas=2,
+        version="1",
+        user_config="1",
+        blocking_reconfigure=False,
+    )
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    for replica in ds._replicas.get():
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
+
+    # Deploy new user_config with blocking_reconfigure=False.
+    b_info_2, v2 = deployment_info(
+        num_replicas=2,
+        version="1",
+        user_config="2",
+        blocking_reconfigure=False,
+    )
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    dsm.update()
+
+    # With blocking_reconfigure=False, replicas should stay RUNNING (not UPDATING).
+    # The reconfigure remote call is still fired, but the replica keeps serving.
+    assert ds._replicas.count(states=[ReplicaState.UPDATING]) == 0
+    assert ds._replicas.count(states=[ReplicaState.RUNNING]) == 2
+
+
+def test_blocking_reconfigure_default(mock_deployment_state_manager):
+    """Test that blocking_reconfigure=True (default) transitions replicas to UPDATING.
+
+    This verifies the default behavior is preserved.
+    """
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    b_info_1, v1 = deployment_info(num_replicas=2, version="1", user_config="1")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    for replica in ds._replicas.get():
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=2, by_state=[(ReplicaState.RUNNING, 2, v1)])
+
+    # Deploy new user_config with default blocking_reconfigure=True.
+    b_info_2, v2 = deployment_info(num_replicas=2, version="1", user_config="2")
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
+    dsm.update()
+
+    # With default blocking_reconfigure=True, one replica should be UPDATING.
+    check_counts(
+        ds,
+        total=2,
+        by_state=[(ReplicaState.RUNNING, 1, v1), (ReplicaState.UPDATING, 1, v2)],
+    )
+
+
 def test_new_version_and_scale_down(mock_deployment_state_manager):
     # Test the case when we reduce the number of replicas and change the
     # version at the same time. First the number of replicas should be

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1648,11 +1648,15 @@ def test_rolling_update_percentage_configurable(mock_deployment_state_manager):
     assert dsm.deploy(TEST_DEPLOYMENT_ID, b_info_2)
     dsm.update()
 
-    # 5 old replicas should be stopping, 5 still running.
+    # 5 old replicas should be stopping, 5 still running, and 5 new starting.
     check_counts(
         ds,
-        total=10,
-        by_state=[(ReplicaState.RUNNING, 5, v1), (ReplicaState.STOPPING, 5, v1)],
+        total=15,
+        by_state=[
+            (ReplicaState.RUNNING, 5, v1),
+            (ReplicaState.STOPPING, 5, v1),
+            (ReplicaState.STARTING, 5, v2),
+        ],
     )
 
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -268,7 +268,7 @@ def test_worker_thread_count(monkeypatch, shutdown_only):
         ray.get(actor.get_thread_count.remote())
     # Lowering these numbers in this assert should be celebrated,
     # increasing these numbers should be scrutinized
-    assert ray.get(actor.get_thread_count.remote()) in {21, 22, 23}
+    assert ray.get(actor.get_thread_count.remote()) in {20, 21, 22, 23}
 
 
 # https://github.com/ray-project/ray/issues/7287

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -243,6 +243,19 @@ message DeploymentConfig {
 
   // Deployment-scoped actors managed by the controller.
   repeated DeploymentActorConfig deployment_actors = 22;
+
+  // The percentage of replicas to update at a time during a rolling update.
+  // Defaults to 0.2 (20%). A value of 0.0 in proto means "use default".
+  double rolling_update_percentage = 23;
+
+  // Whether replicas should stop serving traffic while reconfiguring.
+  // NOTE: proto3 defaults bool to false. We use a wrapper to distinguish
+  // "explicitly set to false" from "not set". See has_blocking_reconfigure.
+  bool blocking_reconfigure = 24;
+
+  // Whether blocking_reconfigure was explicitly set. Needed because proto3
+  // cannot distinguish false from unset for bool fields.
+  bool has_blocking_reconfigure = 25;
 }
 
 // Deployment language.


### PR DESCRIPTION
Add two new deployment config options:

- `rolling_update_percentage` (float, default 0.2): Controls what fraction of replicas are updated at a time during a rolling update. Previously hardcoded to 20%.

- `blocking_reconfigure` (bool, default True): Controls whether replicas stop serving traffic while the reconfigure method runs. When False, replicas remain in RUNNING state during reconfiguration, avoiding capacity loss for slow reconfigure operations (e.g., model downloads).

Both options are exposed through DeploymentConfig (internal), DeploymentSchema (REST API / config YAML), and preserve existing default behavior.

Added these test cases in order to this fix:

1. New unit test: `test_rolling_update_percentage_configurable`: 10 replicas with 50% rollout stops 5 per wave
2. New unit test: `test_nonblocking_reconfigure`: replicas stay RUNNING with `blocking_reconfigure=False`
3. New unit test: `test_blocking_reconfigure_default`: default behavior preserved (replicas go to UPDATING)
4. Existing `test_reconfigure_throttling` passes unchanged (defaults matches old behavior)
5. Existing `test_multi_gang_stop_per_wave` passes unchanged
6. Existing `test_recover_during_rolling_update` passes unchanged

**NOTE**: There is no explicit synchronization between reconfigure() and request handling. Users should design their reconfigure() to be safe for concurrent access (e.g., atomic model swap via self.model = new_model).