### PR TITLE
[Core] Fix event_logger to flush all handlers, not just the first one

### DIFF
--- a/python/ray/_private/event/event_logger.py
+++ b/python/ray/_private/event/event_logger.py
@@ -100,8 +100,11 @@ class EventLoggerAdapter:
             )
         )
 
-        # Force flush so that we won't lose events
-        self.logger.handlers[0].flush()
+        # Force flush so that we won't lose events.
+        # Flush all handlers to ensure no events are lost when multiple
+        # handlers are attached (e.g., from different event sources).
+        for handler in self.logger.handlers:
+            handler.flush()
 
 
 def _build_event_file_logger(source: Event.SourceType, sink_dir: str):

--- a/python/ray/dashboard/modules/event/tests/test_event.py
+++ b/python/ray/dashboard/modules/event/tests/test_event.py
@@ -120,6 +120,49 @@ def test_python_global_event_logger(tmp_path):
             assert data["custom_fields"]["b"] == "b"
 
 
+def test_event_logger_flushes_all_handlers(tmp_path):
+    """Test that _emit flushes all handlers, not just the first one.
+
+    Regression test for https://github.com/ray-project/ray/issues/61873
+    """
+    from unittest.mock import MagicMock
+    from ray._private.event.event_logger import EventLoggerAdapter
+
+    # Create a mock logger with multiple handlers
+    mock_logger = MagicMock()
+    handlers = [MagicMock() for _ in range(3)]
+    mock_logger.handlers = handlers
+
+    # Create EventLoggerAdapter with the mock logger
+    adapter = EventLoggerAdapter(event_pb2.Event.SourceType.GCS, mock_logger)
+
+    # Emit an event
+    adapter.info("test message")
+
+    # Verify all handlers were flushed
+    for handler in handlers:
+        handler.flush.assert_called_once()
+
+
+def test_event_logger_no_handlers(tmp_path):
+    """Test that _emit handles empty handlers list gracefully.
+
+    Regression test for https://github.com/ray-project/ray/issues/61873
+    """
+    from unittest.mock import MagicMock
+    from ray._private.event.event_logger import EventLoggerAdapter
+
+    # Create a mock logger with no handlers
+    mock_logger = MagicMock()
+    mock_logger.handlers = []
+
+    # Create EventLoggerAdapter with the mock logger
+    adapter = EventLoggerAdapter(event_pb2.Event.SourceType.GCS, mock_logger)
+
+    # Emit an event - should not raise IndexError
+    adapter.info("test message")  # This would raise IndexError before the fix
+
+
 def test_event_basic(disable_aiohttp_cache, ray_start_with_dashboard):
     assert wait_until_server_available(ray_start_with_dashboard["webui_url"])
     webui_url = format_web_url(ray_start_with_dashboard["webui_url"])


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes two issues in `EventLoggerAdapter._emit()` (`python/ray/_private/event/event_logger.py`):

1. **IndexError risk**: If `self.logger.handlers` is empty, `handlers[0]` would raise `IndexError`.

2. **Partial flush**: When multiple handlers are attached to the logger (e.g., from different event sources calling `get_event_logger()`), only `handlers[0]` was being flushed. Events buffered in other handlers could be lost on crash or shutdown.

## Changes

The fix iterates over all handlers and flushes each one:

```python
# Before
self.logger.handlers[0].flush()

# After
for handler in self.logger.handlers:
    handler.flush()
```

## Related issue

Fixes https://github.com/ray-project/ray/issues/61873

## Checks

- [x] I have added tests that prove the fix works
- [x] The tests cover both the multi-handler case and the empty-handlers case
- [x] All existing tests pass