### PR TITLE
[Data] Fix pyrefly type errors in batcher.py

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -2,7 +2,6 @@ python/ray/data/_internal/arrow_block.py
 python/ray/data/_internal/arrow_ops/transform_polars.py
 python/ray/data/_internal/arrow_ops/transform_pyarrow.py
 python/ray/data/_internal/arrow_utils.py
-python/ray/data/_internal/batcher.py
 python/ray/data/_internal/block_batching/iter_batches.py
 python/ray/data/_internal/block_batching/util.py
 python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -26,7 +26,7 @@ class BatcherInterface:
         """
         raise NotImplementedError()
 
-    def done_adding(self) -> bool:
+    def done_adding(self) -> None:
         """Indicate to the batcher that no more blocks will be added to the buffer."""
         raise NotImplementedError()
 
@@ -84,7 +84,7 @@ class Batcher(BatcherInterface):
             self._buffer.append(block)
             self._buffer_size += BlockAccessor.for_block(block).num_rows()
 
-    def done_adding(self) -> bool:
+    def done_adding(self) -> None:
         """Indicate to the batcher that no more blocks will be added to the batcher."""
         self._done_adding = True
 
@@ -269,7 +269,7 @@ class ShufflingBatcher(BatcherInterface):
 
         return self._average_row_nbytes * self._min_rows_to_trigger_compaction
 
-    def done_adding(self) -> bool:
+    def done_adding(self) -> None:
         """Indicate to the batcher that no more blocks will be added to the batcher.
 
         No more blocks should be added to the batcher after calling this.


### PR DESCRIPTION
## Why are these changes needed?

This PR fixes pyrefly type check errors in `python/ray/data/_internal/batcher.py` and removes it from the exclusion list.

## Changes

**Type fix:**
- `BatcherInterface.done_adding()`: `bool` → `None`
- `Batcher.done_adding()`: `bool` → `None`
- `ShufflingBatcher.done_adding()`: `bool` → `None`

The `done_adding()` method sets an internal `_done_adding` flag and does not return anything. The return type annotation was incorrectly declared as `bool`. No callers depend on a return value.

**Exclusion list:**
- Removed `python/ray/data/_internal/batcher.py` from `ci/lint/pyrefly-excluded-files.txt`

## Verification

```bash
$ pyrefly check python/ray/data/_internal/batcher.py
 INFO 0 errors
```

## Related issue

Contributes to https://github.com/ray-project/ray/issues/61933

## Checks

- [x] pyrefly check passes with 0 errors
- [x] File removed from exclusion list