### PR TITLE
feat: Add --headers/--verify to Ray State CLI and document State REST API

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -2458,8 +2458,6 @@ python/ray/util/state/api.py
     DOC103: Method `StateApiClient.summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [resource: SummaryResource]. Arguments in the docstring but not in the function signature: [resource_name: ].
     DOC402: Function `get_log` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `get_log` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC102: Function `list_logs`: Docstring contains more arguments than in function signature.
-    DOC103: Function `list_logs`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [_interval: , actor_id: ].
     DOC201: Function `list_logs` does not have a return section in docstring
     DOC201: Function `summarize_tasks` does not have a return section in docstring
     DOC201: Function `summarize_actors` does not have a return section in docstring
@@ -2481,36 +2479,16 @@ python/ray/util/state/state_cli.py
     DOC201: Function `_get_available_resources` does not have a return section in docstring
     DOC101: Function `get_table_output`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `get_table_output`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [detail: bool].
-    DOC101: Function `ray_get`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `ray_get`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], timeout: float].
-    DOC101: Function `ray_list`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `ray_list`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, detail: bool, filter: List[str], format: str, limit: int, timeout: float].
-    DOC101: Function `task_summary`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `task_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `task_summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, ctx: , timeout: float].
-    DOC101: Function `actor_summary`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `actor_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `actor_summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, ctx: , timeout: float].
-    DOC101: Function `object_summary`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `object_summary`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `object_summary`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: str, ctx: , timeout: float].
     DOC201: Function `_get_head_node_ip` does not have a return section in docstring
-    DOC101: Function `log_cluster`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `log_cluster`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `log_cluster`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , encoding: str, encoding_errors: str, follow: bool, glob_filter: str, interval: float, node_id: Optional[str], node_ip: Optional[str], tail: int, timeout: int].
     DOC201: Function `log_cluster` does not have a return section in docstring
-    DOC101: Function `log_actor`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `log_actor`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `log_actor`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , err: bool, follow: bool, id: Optional[str], interval: float, node_id: Optional[str], node_ip: Optional[str], pid: Optional[str], tail: int, timeout: int].
-    DOC101: Function `log_worker`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `log_worker`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `log_worker`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , err: bool, follow: bool, interval: float, node_id: Optional[str], node_ip: Optional[str], pid: Optional[str], tail: int, timeout: int].
-    DOC101: Function `log_job`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `log_job`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `log_job`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], ctx: , follow: bool, interval: float, submission_id: Optional[str], tail: int, timeout: int].
-    DOC101: Function `log_task`: Docstring contains fewer arguments than in function signature.
     DOC107: Function `log_task`: The option `--arg-type-hints-in-signature` is `True` but not all args in the signature have type hints
-    DOC103: Function `log_task`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [address: Optional[str], attempt_number: int, ctx: , err: bool, follow: bool, interval: float, tail: int, task_id: Optional[str], timeout: int].
 --------------------
 python/ray/util/state/state_manager.py
     DOC101: Function `api_with_network_error_handler`: Docstring contains fewer arguments than in function signature.

--- a/doc/source/ray-observability/reference/api.rst
+++ b/doc/source/ray-observability/reference/api.rst
@@ -132,13 +132,6 @@ Log query parameters
 - ``timeout``: Timeout in seconds for the request.
 - ``filter_ansi_code``: ``true`` to strip ANSI escape codes from streamed logs.
 
-Authentication
-~~~~~~~~~~~~~~
-
-If your cluster requires authentication, pass HTTP headers such as an
-``Authorization`` token to these endpoints. When using the State CLI, you can
-use ``--headers`` for custom headers and ``--verify`` to control TLS verification.
-
 .. _state-api-schema:
 
 State APIs Schema

--- a/doc/source/ray-observability/reference/api.rst
+++ b/doc/source/ray-observability/reference/api.rst
@@ -67,6 +67,78 @@ Log APIs
     ray.util.state.list_logs
     ray.util.state.get_log
 
+State REST API
+--------------
+
+State APIs are also available over HTTP from the Ray dashboard. The base URL is the
+dashboard address (for example, ``http://<head-node-ip>:8265``) and all endpoints
+use the ``/api/v0`` prefix.
+
+List endpoints (GET)
+~~~~~~~~~~~~~~~~~~~~
+
+- ``/api/v0/actors``
+- ``/api/v0/jobs``
+- ``/api/v0/nodes``
+- ``/api/v0/placement_groups``
+- ``/api/v0/workers``
+- ``/api/v0/tasks``
+- ``/api/v0/objects``
+- ``/api/v0/runtime_envs``
+
+List query parameters
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``limit``: Maximum number of entries to return.
+- ``timeout``: Timeout in seconds for the request.
+- ``detail``: ``true`` to include detailed columns.
+- ``exclude_driver``: ``true`` to exclude driver entries (where applicable).
+- ``filter_keys``: Repeated parameter for filter keys.
+- ``filter_predicates``: Repeated parameter for filter predicates (``=`` or ``!=``).
+- ``filter_values``: Repeated parameter for filter values.
+
+Summary endpoints (GET)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``/api/v0/tasks/summarize``
+- ``/api/v0/actors/summarize``
+- ``/api/v0/objects/summarize``
+
+Summary query parameters
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``timeout``: Timeout in seconds for the request.
+- ``summary_by``: Field to group by.
+- ``filter_keys`` / ``filter_predicates`` / ``filter_values``: Same format as list endpoints.
+
+Log endpoints (GET)
+~~~~~~~~~~~~~~~~~~~
+
+- ``/api/v0/logs``: List logs on a node. Requires ``node_id`` or ``node_ip``.
+- ``/api/v0/logs/file``: Fetch log files.
+- ``/api/v0/logs/stream``: Stream log files.
+
+Log query parameters
+~~~~~~~~~~~~~~~~~~~~
+
+- ``node_id`` / ``node_ip``: Identify the node hosting logs.
+- ``glob``: Glob filter for log filenames (list logs).
+- ``filename``: Log filename (fetch logs).
+- ``actor_id`` / ``task_id`` / ``submission_id`` / ``pid``: Resource identifiers.
+- ``lines``: Number of lines to fetch from the end of the log file.
+- ``interval``: Stream polling interval.
+- ``suffix``: ``out`` or ``err``.
+- ``attempt_number``: Task attempt number.
+- ``timeout``: Timeout in seconds for the request.
+- ``filter_ansi_code``: ``true`` to strip ANSI escape codes from streamed logs.
+
+Authentication
+~~~~~~~~~~~~~~
+
+If your cluster requires authentication, pass HTTP headers such as an
+``Authorization`` token to these endpoints. When using the State CLI, you can
+use ``--headers`` for custom headers and ``--verify`` to control TLS verification.
+
 .. _state-api-schema:
 
 State APIs Schema

--- a/doc/source/ray-observability/reference/cli.rst
+++ b/doc/source/ray-observability/reference/cli.rst
@@ -28,6 +28,16 @@ State CLI allows users to access the state of various resources (e.g., actor, ta
 .. click:: ray.util.state.state_cli:ray_get
    :prog: ray get
 
+Authentication
+--------------
+
+All State CLI commands accept ``--headers`` and ``--verify`` for secured clusters:
+
+- ``--headers``: JSON string for custom HTTP headers, e.g. ``'{"Authorization": "Bearer <token>"}'``.
+  You can also set ``RAY_STATE_HEADERS`` environment variable with the same JSON to apply to all state CLI commands.
+- ``--verify``: Boolean to enable/disable TLS certificate verification or a path to a CA bundle/directory.
+  Examples: ``--verify true`` (default), ``--verify false``, ``--verify /path/to/ca-bundle.pem``.
+
 .. _ray-logs-api-cli-ref:
 
 Log

--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -19,7 +19,7 @@ from ray._private.utils import (
 )
 from ray.autoscaler._private.cli_logger import add_click_logging_options, cf, cli_logger
 from ray.dashboard.modules.dashboard_sdk import parse_runtime_env_args
-from ray.dashboard.modules.job.cli_utils import add_common_job_options
+from ray.dashboard.modules.job.cli_utils import add_common_job_options, parse_headers
 from ray.dashboard.modules.job.utils import redact_url_password
 from ray.job_submission import JobStatus, JobSubmissionClient
 from ray.util.annotations import PublicAPI
@@ -45,19 +45,7 @@ def _get_sdk_client(
 
 
 def _handle_headers(headers: Optional[str]) -> Optional[Dict[str, Any]]:
-    if headers is None and "RAY_JOB_HEADERS" in os.environ:
-        headers = os.environ["RAY_JOB_HEADERS"]
-    if headers is not None:
-        try:
-            return json.loads(headers)
-        except Exception as exc:
-            raise ValueError(
-                """Failed to parse headers into JSON.
-                Expected format: {{"KEY": "VALUE"}}, got {}, {}""".format(
-                    headers, exc
-                )
-            )
-    return None
+    return parse_headers(headers, env_var="RAY_JOB_HEADERS")
 
 
 def _log_big_success_msg(success_msg):

--- a/python/ray/dashboard/modules/job/cli.py
+++ b/python/ray/dashboard/modules/job/cli.py
@@ -1,4 +1,3 @@
-import json
 import os
 import pprint
 import sys

--- a/python/ray/dashboard/modules/job/cli_utils.py
+++ b/python/ray/dashboard/modules/job/cli_utils.py
@@ -1,5 +1,7 @@
 import functools
-from typing import Union
+import json
+import os
+from typing import Any, Dict, Optional, Union
 
 import click
 
@@ -24,6 +26,31 @@ class BoolOrStringParam(click.ParamType):
             return value
         else:
             return bool_cast(value)
+
+
+def parse_headers(
+    headers: Optional[str],
+    *,
+    env_var: str,
+    env_var_fallback: bool = True,
+) -> Optional[Dict[str, Any]]:
+    if headers is None and env_var_fallback and env_var in os.environ:
+        headers = os.environ[env_var]
+    if headers is None:
+        return None
+    try:
+        parsed = json.loads(headers)
+    except Exception as exc:
+        raise ValueError(
+            "Failed to parse headers into JSON. "
+            f'Expected format: {{"KEY": "VALUE"}}, got {headers}, {exc}'
+        )
+    if not isinstance(parsed, dict):
+        raise ValueError(
+            "Failed to parse headers into JSON. "
+            f"Expected a JSON object, got: {headers}"
+        )
+    return parsed
 
 
 def add_common_job_options(func):

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -2,13 +2,11 @@ import json
 import os
 import signal
 import sys
-import threading
 import time
 import uuid
 import warnings
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -133,69 +131,6 @@ from ray.util.state.state_manager import StateDataSourceClient
 """
 Unit tests
 """
-
-
-class FakeStateApiClient:
-    captured = {}
-
-    @classmethod
-    def reset(cls):
-        cls.captured = {}
-
-    def __init__(self, address=None, headers=None, verify=True, **kwargs):
-        type(self).captured = {
-            "address": address,
-            "headers": headers,
-            "verify": verify,
-            "kwargs": kwargs,
-        }
-
-    def list(self, *args, **kwargs):
-        return []
-
-
-class RecordingStateApiHandler(BaseHTTPRequestHandler):
-    response_payload = {
-        "result": True,
-        "msg": "",
-        "data": {
-            "result": {
-                "result": [],
-                "total": 0,
-                "num_after_truncation": 0,
-                "num_filtered": 0,
-                "partial_failure_warning": None,
-                "warnings": [],
-            }
-        },
-    }
-    last_headers = None
-    last_path = None
-
-    @classmethod
-    def reset(cls):
-        cls.last_headers = None
-        cls.last_path = None
-
-    def do_GET(self):
-        type(self).last_headers = dict(self.headers.items())
-        type(self).last_path = self.path
-        body = json.dumps(type(self).response_payload).encode("utf-8")
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, format, *args):
-        pass
-
-
-@pytest.fixture
-def fake_state_api_client(monkeypatch):
-    FakeStateApiClient.reset()
-    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
-    return FakeStateApiClient
 
 
 @pytest.fixture
@@ -561,93 +496,22 @@ def test_parse_filter():
         _parse_filter("key>value!=")
 
 
-def test_state_cli_list_supports_headers_and_verify(fake_state_api_client):
+@pytest.mark.parametrize(
+    "command,args",
+    [
+        (ray_get, ["actors", "actor-id", "--headers", '{"Authorization": "Bearer test"}']),
+        (ray_list, ["actors", "--headers", '{"Authorization": "Bearer test"}']),
+        (
+            summary_state_cli_group,
+            ["tasks", "--headers", '{"Authorization": "Bearer test"}'],
+        ),
+    ],
+)
+def test_state_cli_does_not_accept_headers_or_verify(command, args):
     runner = CliRunner()
-    result = runner.invoke(
-        ray_list,
-        [
-            "actors",
-            "--headers",
-            '{"Authorization": "Bearer test"}',
-            "--verify",
-            "false",
-        ],
-    )
-    assert result.exit_code == 0, result.output
-    assert fake_state_api_client.captured["headers"] == {
-        "Authorization": "Bearer test"
-    }
-    assert fake_state_api_client.captured["verify"] is False
-
-
-def test_state_cli_list_supports_headers_env_var(monkeypatch, fake_state_api_client):
-    monkeypatch.setenv("RAY_STATE_HEADERS", '{"X-Test": "1"}')
-
-    runner = CliRunner()
-    result = runner.invoke(ray_list, ["actors"])
-    assert result.exit_code == 0, result.output
-    assert fake_state_api_client.captured["headers"] == {"X-Test": "1"}
-    assert fake_state_api_client.captured["verify"] is True
-
-
-def test_state_cli_list_rejects_invalid_headers(fake_state_api_client):
-    runner = CliRunner()
-    result = runner.invoke(ray_list, ["actors", "--headers", "{bad json"])
+    result = runner.invoke(command, args)
     assert result.exit_code != 0
-    assert "Failed to parse headers into JSON" in result.output
-
-
-def test_state_cli_list_integration_with_http_server():
-    RecordingStateApiHandler.reset()
-    server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingStateApiHandler)
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-
-    try:
-        runner = CliRunner()
-        result = runner.invoke(
-            ray_list,
-            [
-                "actors",
-                "--address",
-                f"http://127.0.0.1:{server.server_port}",
-                "--headers",
-                '{"Authorization": "Bearer integration"}',
-                "--verify",
-                "false",
-            ],
-        )
-    finally:
-        server.shutdown()
-        thread.join()
-        server.server_close()
-
-    assert result.exit_code == 0, result.output
-    assert "No resource in the cluster" in result.output
-    assert RecordingStateApiHandler.last_headers["Authorization"] == (
-        "Bearer integration"
-    )
-    assert RecordingStateApiHandler.last_path.startswith("/api/v0/actors?")
-
-
-def test_state_cli_summary_supports_headers_and_verify(monkeypatch):
-    captured = {}
-
-    def dummy_summarize_tasks(*, headers=None, verify=True, **kwargs):
-        captured["headers"] = headers
-        captured["verify"] = verify
-        return {}
-
-    monkeypatch.setattr(state_cli, "summarize_tasks", dummy_summarize_tasks)
-
-    runner = CliRunner()
-    result = runner.invoke(
-        state_cli.summary_state_cli_group,
-        ["tasks", "--headers", '{"X-Test": "1"}', "--verify", "false"],
-    )
-    assert result.exit_code == 0, result.output
-    assert captured["headers"] == {"X-Test": "1"}
-    assert captured["verify"] is False
+    assert "No such option: --headers" in result.output
 
 
 def test_state_cli_logs_supports_headers_and_verify(monkeypatch):

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -495,6 +495,126 @@ def test_parse_filter():
         _parse_filter("key>value!=")
 
 
+def test_state_cli_list_supports_headers_and_verify(monkeypatch):
+    import ray.util.state.state_cli as state_cli
+
+    captured = {}
+
+    class DummyStateApiClient:
+        def __init__(self, address=None, headers=None, verify=True, **kwargs):
+            captured["address"] = address
+            captured["headers"] = headers
+            captured["verify"] = verify
+
+        def list(self, *args, **kwargs):
+            return []
+
+    monkeypatch.setattr(state_cli, "StateApiClient", DummyStateApiClient)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        state_cli.ray_list,
+        [
+            "actors",
+            "--headers",
+            '{"Authorization": "Bearer test"}',
+            "--verify",
+            "false",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"Authorization": "Bearer test"}
+    assert captured["verify"] is False
+
+
+def test_state_cli_list_supports_headers_env_var(monkeypatch):
+    import ray.util.state.state_cli as state_cli
+
+    captured = {}
+
+    class DummyStateApiClient:
+        def __init__(self, address=None, headers=None, verify=True, **kwargs):
+            captured["headers"] = headers
+            captured["verify"] = verify
+
+        def list(self, *args, **kwargs):
+            return []
+
+    monkeypatch.setattr(state_cli, "StateApiClient", DummyStateApiClient)
+    monkeypatch.setenv("RAY_STATE_HEADERS", '{"X-Test": "1"}')
+
+    runner = CliRunner()
+    result = runner.invoke(state_cli.ray_list, ["actors"])
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"X-Test": "1"}
+    assert captured["verify"] is True
+
+
+def test_state_cli_list_rejects_invalid_headers(monkeypatch):
+    import ray.util.state.state_cli as state_cli
+
+    captured = {}
+
+    class DummyStateApiClient:
+        def __init__(self, address=None, headers=None, verify=True, **kwargs):
+            captured["headers"] = headers
+            captured["verify"] = verify
+
+        def list(self, *args, **kwargs):
+            return []
+
+    monkeypatch.setattr(state_cli, "StateApiClient", DummyStateApiClient)
+
+    runner = CliRunner()
+    result = runner.invoke(state_cli.ray_list, ["actors", "--headers", "{bad json"])
+    assert result.exit_code != 0
+    assert "Failed to parse headers into JSON" in result.output
+
+
+def test_state_cli_summary_supports_headers_and_verify(monkeypatch):
+    import ray.util.state.state_cli as state_cli
+
+    captured = {}
+
+    def dummy_summarize_tasks(*, headers=None, verify=True, **kwargs):
+        captured["headers"] = headers
+        captured["verify"] = verify
+        return {}
+
+    monkeypatch.setattr(state_cli, "summarize_tasks", dummy_summarize_tasks)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        state_cli.summary_state_cli_group,
+        ["tasks", "--headers", '{"X-Test": "1"}', "--verify", "false"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"X-Test": "1"}
+    assert captured["verify"] is False
+
+
+def test_state_cli_logs_supports_headers_and_verify(monkeypatch):
+    import ray.util.state.state_cli as state_cli
+
+    captured = {}
+
+    def dummy_list_logs(*, headers=None, verify=True, **kwargs):
+        captured["headers"] = headers
+        captured["verify"] = verify
+        return {"raylet": ["raylet.out", "raylet.err"]}
+
+    monkeypatch.setattr(state_cli, "list_logs", dummy_list_logs)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        state_cli.logs_state_cli_group,
+        ["cluster", "--node-ip", "127.0.0.1", "--headers", '{"X-Test": "1"}', "--verify", "false"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"X-Test": "1"}
+    assert captured["verify"] is False
+
+
 # Without this, capsys will have a race condition
 # that causes
 # ValueError: I/O operation on closed file.

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -608,7 +608,15 @@ def test_state_cli_logs_supports_headers_and_verify(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(
         state_cli.logs_state_cli_group,
-        ["cluster", "--node-ip", "127.0.0.1", "--headers", '{"X-Test": "1"}', "--verify", "false"],
+        [
+            "cluster",
+            "--node-ip",
+            "127.0.0.1",
+            "--headers",
+            '{"X-Test": "1"}',
+            "--verify",
+            "false",
+        ],
     )
     assert result.exit_code == 0, result.output
     assert captured["headers"] == {"X-Test": "1"}

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -2,11 +2,13 @@ import json
 import os
 import signal
 import sys
+import threading
 import time
 import uuid
 import warnings
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -131,6 +133,72 @@ from ray.util.state.state_manager import StateDataSourceClient
 """
 Unit tests
 """
+
+
+class FakeStateApiClient:
+    captured = {}
+
+    @classmethod
+    def reset(cls):
+        cls.captured = {}
+
+    def __init__(self, address=None, headers=None, verify=True, **kwargs):
+        type(self).captured = {
+            "address": address,
+            "headers": headers,
+            "verify": verify,
+            "kwargs": kwargs,
+        }
+
+    def list(self, *args, **kwargs):
+        return []
+
+    def get(self, *args, **kwargs):
+        return None
+
+
+class RecordingStateApiHandler(BaseHTTPRequestHandler):
+    response_payload = {
+        "result": True,
+        "msg": "",
+        "data": {
+            "result": {
+                "result": [],
+                "total": 0,
+                "num_after_truncation": 0,
+                "num_filtered": 0,
+                "partial_failure_warning": None,
+                "warnings": [],
+            }
+        },
+    }
+    last_headers = None
+    last_path = None
+
+    @classmethod
+    def reset(cls):
+        cls.last_headers = None
+        cls.last_path = None
+
+    def do_GET(self):
+        type(self).last_headers = dict(self.headers.items())
+        type(self).last_path = self.path
+        body = json.dumps(type(self).response_payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def fake_state_api_client(monkeypatch):
+    FakeStateApiClient.reset()
+    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
+    return FakeStateApiClient
 
 
 @pytest.fixture
@@ -496,22 +564,113 @@ def test_parse_filter():
         _parse_filter("key>value!=")
 
 
-@pytest.mark.parametrize(
-    "command,args",
-    [
-        (ray_get, ["actors", "actor-id", "--headers", '{"Authorization": "Bearer test"}']),
-        (ray_list, ["actors", "--headers", '{"Authorization": "Bearer test"}']),
-        (
-            summary_state_cli_group,
-            ["tasks", "--headers", '{"Authorization": "Bearer test"}'],
-        ),
-    ],
-)
-def test_state_cli_does_not_accept_headers_or_verify(command, args):
+def test_state_cli_get_supports_headers_and_verify(fake_state_api_client):
     runner = CliRunner()
-    result = runner.invoke(command, args)
+    result = runner.invoke(
+        ray_get,
+        [
+            "actors",
+            "actor-id",
+            "--headers",
+            '{"Authorization": "Bearer test"}',
+            "--verify",
+            "false",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake_state_api_client.captured["headers"] == {
+        "Authorization": "Bearer test"
+    }
+    assert fake_state_api_client.captured["verify"] is False
+
+
+def test_state_cli_list_supports_headers_and_verify(fake_state_api_client):
+    runner = CliRunner()
+    result = runner.invoke(
+        ray_list,
+        [
+            "actors",
+            "--headers",
+            '{"Authorization": "Bearer test"}',
+            "--verify",
+            "false",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert fake_state_api_client.captured["headers"] == {
+        "Authorization": "Bearer test"
+    }
+    assert fake_state_api_client.captured["verify"] is False
+
+
+def test_state_cli_list_supports_headers_env_var(monkeypatch, fake_state_api_client):
+    monkeypatch.setenv("RAY_STATE_HEADERS", '{"X-Test": "1"}')
+
+    runner = CliRunner()
+    result = runner.invoke(ray_list, ["actors"])
+    assert result.exit_code == 0, result.output
+    assert fake_state_api_client.captured["headers"] == {"X-Test": "1"}
+    assert fake_state_api_client.captured["verify"] is True
+
+
+def test_state_cli_list_rejects_invalid_headers(fake_state_api_client):
+    runner = CliRunner()
+    result = runner.invoke(ray_list, ["actors", "--headers", "{bad json"])
     assert result.exit_code != 0
-    assert "No such option: --headers" in result.output
+    assert "Failed to parse headers into JSON" in result.output
+
+
+def test_state_cli_list_integration_with_http_server():
+    RecordingStateApiHandler.reset()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingStateApiHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            ray_list,
+            [
+                "actors",
+                "--address",
+                f"http://127.0.0.1:{server.server_port}",
+                "--headers",
+                '{"Authorization": "Bearer integration"}',
+                "--verify",
+                "false",
+            ],
+        )
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+    assert result.exit_code == 0, result.output
+    assert "No resource in the cluster" in result.output
+    assert RecordingStateApiHandler.last_headers["Authorization"] == (
+        "Bearer integration"
+    )
+    assert RecordingStateApiHandler.last_path.startswith("/api/v0/actors?")
+
+
+def test_state_cli_summary_supports_headers_and_verify(monkeypatch):
+    captured = {}
+
+    def dummy_summarize_tasks(*, headers=None, verify=True, **kwargs):
+        captured["headers"] = headers
+        captured["verify"] = verify
+        return {}
+
+    monkeypatch.setattr(state_cli, "summarize_tasks", dummy_summarize_tasks)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        state_cli.summary_state_cli_group,
+        ["tasks", "--headers", '{"X-Test": "1"}', "--verify", "false"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["headers"] == {"X-Test": "1"}
+    assert captured["verify"] is False
 
 
 def test_state_cli_logs_supports_headers_and_verify(monkeypatch):

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -2,11 +2,13 @@ import json
 import os
 import signal
 import sys
+import threading
 import time
 import uuid
 import warnings
 from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,6 +21,7 @@ import ray
 import ray._private.ray_constants as ray_constants
 import ray._private.state as global_state
 import ray.dashboard.consts as dashboard_consts
+import ray.util.state.state_cli as state_cli
 from ray._common.network_utils import find_free_port, parse_address
 from ray._common.test_utils import (
     SignalActor,
@@ -130,6 +133,69 @@ from ray.util.state.state_manager import StateDataSourceClient
 """
 Unit tests
 """
+
+
+class FakeStateApiClient:
+    captured = {}
+
+    @classmethod
+    def reset(cls):
+        cls.captured = {}
+
+    def __init__(self, address=None, headers=None, verify=True, **kwargs):
+        type(self).captured = {
+            "address": address,
+            "headers": headers,
+            "verify": verify,
+            "kwargs": kwargs,
+        }
+
+    def list(self, *args, **kwargs):
+        return []
+
+
+class RecordingStateApiHandler(BaseHTTPRequestHandler):
+    response_payload = {
+        "result": True,
+        "msg": "",
+        "data": {
+            "result": {
+                "result": [],
+                "total": 0,
+                "num_after_truncation": 0,
+                "num_filtered": 0,
+                "partial_failure_warning": None,
+                "warnings": [],
+            }
+        },
+    }
+    last_headers = None
+    last_path = None
+
+    @classmethod
+    def reset(cls):
+        cls.last_headers = None
+        cls.last_path = None
+
+    def do_GET(self):
+        type(self).last_headers = dict(self.headers.items())
+        type(self).last_path = self.path
+        body = json.dumps(type(self).response_payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+@pytest.fixture
+def fake_state_api_client(monkeypatch):
+    FakeStateApiClient.reset()
+    monkeypatch.setattr(state_cli, "StateApiClient", FakeStateApiClient)
+    return FakeStateApiClient
 
 
 @pytest.fixture
@@ -495,25 +561,10 @@ def test_parse_filter():
         _parse_filter("key>value!=")
 
 
-def test_state_cli_list_supports_headers_and_verify(monkeypatch):
-    import ray.util.state.state_cli as state_cli
-
-    captured = {}
-
-    class DummyStateApiClient:
-        def __init__(self, address=None, headers=None, verify=True, **kwargs):
-            captured["address"] = address
-            captured["headers"] = headers
-            captured["verify"] = verify
-
-        def list(self, *args, **kwargs):
-            return []
-
-    monkeypatch.setattr(state_cli, "StateApiClient", DummyStateApiClient)
-
+def test_state_cli_list_supports_headers_and_verify(fake_state_api_client):
     runner = CliRunner()
     result = runner.invoke(
-        state_cli.ray_list,
+        ray_list,
         [
             "actors",
             "--headers",
@@ -523,57 +574,63 @@ def test_state_cli_list_supports_headers_and_verify(monkeypatch):
         ],
     )
     assert result.exit_code == 0, result.output
-    assert captured["headers"] == {"Authorization": "Bearer test"}
-    assert captured["verify"] is False
+    assert fake_state_api_client.captured["headers"] == {
+        "Authorization": "Bearer test"
+    }
+    assert fake_state_api_client.captured["verify"] is False
 
 
-def test_state_cli_list_supports_headers_env_var(monkeypatch):
-    import ray.util.state.state_cli as state_cli
-
-    captured = {}
-
-    class DummyStateApiClient:
-        def __init__(self, address=None, headers=None, verify=True, **kwargs):
-            captured["headers"] = headers
-            captured["verify"] = verify
-
-        def list(self, *args, **kwargs):
-            return []
-
-    monkeypatch.setattr(state_cli, "StateApiClient", DummyStateApiClient)
+def test_state_cli_list_supports_headers_env_var(monkeypatch, fake_state_api_client):
     monkeypatch.setenv("RAY_STATE_HEADERS", '{"X-Test": "1"}')
 
     runner = CliRunner()
-    result = runner.invoke(state_cli.ray_list, ["actors"])
+    result = runner.invoke(ray_list, ["actors"])
     assert result.exit_code == 0, result.output
-    assert captured["headers"] == {"X-Test": "1"}
-    assert captured["verify"] is True
+    assert fake_state_api_client.captured["headers"] == {"X-Test": "1"}
+    assert fake_state_api_client.captured["verify"] is True
 
 
-def test_state_cli_list_rejects_invalid_headers(monkeypatch):
-    import ray.util.state.state_cli as state_cli
-
-    captured = {}
-
-    class DummyStateApiClient:
-        def __init__(self, address=None, headers=None, verify=True, **kwargs):
-            captured["headers"] = headers
-            captured["verify"] = verify
-
-        def list(self, *args, **kwargs):
-            return []
-
-    monkeypatch.setattr(state_cli, "StateApiClient", DummyStateApiClient)
-
+def test_state_cli_list_rejects_invalid_headers(fake_state_api_client):
     runner = CliRunner()
-    result = runner.invoke(state_cli.ray_list, ["actors", "--headers", "{bad json"])
+    result = runner.invoke(ray_list, ["actors", "--headers", "{bad json"])
     assert result.exit_code != 0
     assert "Failed to parse headers into JSON" in result.output
 
 
-def test_state_cli_summary_supports_headers_and_verify(monkeypatch):
-    import ray.util.state.state_cli as state_cli
+def test_state_cli_list_integration_with_http_server():
+    RecordingStateApiHandler.reset()
+    server = ThreadingHTTPServer(("127.0.0.1", 0), RecordingStateApiHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
 
+    try:
+        runner = CliRunner()
+        result = runner.invoke(
+            ray_list,
+            [
+                "actors",
+                "--address",
+                f"http://127.0.0.1:{server.server_port}",
+                "--headers",
+                '{"Authorization": "Bearer integration"}',
+                "--verify",
+                "false",
+            ],
+        )
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+    assert result.exit_code == 0, result.output
+    assert "No resource in the cluster" in result.output
+    assert RecordingStateApiHandler.last_headers["Authorization"] == (
+        "Bearer integration"
+    )
+    assert RecordingStateApiHandler.last_path.startswith("/api/v0/actors?")
+
+
+def test_state_cli_summary_supports_headers_and_verify(monkeypatch):
     captured = {}
 
     def dummy_summarize_tasks(*, headers=None, verify=True, **kwargs):
@@ -594,8 +651,6 @@ def test_state_cli_summary_supports_headers_and_verify(monkeypatch):
 
 
 def test_state_cli_logs_supports_headers_and_verify(monkeypatch):
-    import ray.util.state.state_cli as state_cli
-
     captured = {}
 
     def dummy_list_logs(*, headers=None, verify=True, **kwargs):

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -136,11 +136,11 @@ Unit tests
 
 
 class FakeStateApiClient:
-    captured = {}
+    captured = None
 
     @classmethod
     def reset(cls):
-        cls.captured = {}
+        cls.captured = None
 
     def __init__(self, address=None, headers=None, verify=True, **kwargs):
         type(self).captured = {

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -126,8 +126,6 @@ class StateApiClient(SubmissionClient):
         self,
         address: Optional[str] = None,
         cookies: Optional[Dict[str, Any]] = None,
-        headers: Optional[Dict[str, Any]] = None,
-        verify: Optional[Union[str, bool]] = True,
     ):
         """Initialize a StateApiClient and check the connection to the cluster.
 
@@ -138,19 +136,12 @@ class StateApiClient(SubmissionClient):
                 If not provided, it will be detected automatically from any running
                 local Ray cluster.
             cookies: Cookies to use when sending requests to the HTTP job server.
-            headers: Headers to use when sending requests to the HTTP job server, used
-                for cases like authentication to a remote cluster.
-            verify: Boolean indication to verify the server's TLS certificate or a path
-                to a file or directory of trusted certificates.
         """
         if requests is None:
             raise RuntimeError(
                 "The Ray state CLI & SDK require the ray[default] "
                 "installation: `pip install 'ray[default']``"
             )
-        base_headers = {"Content-Type": "application/json"}
-        if headers:
-            base_headers.update(headers)
 
         # Resolve API server URL
         api_server_url = get_address_for_submission_client(address)
@@ -158,9 +149,8 @@ class StateApiClient(SubmissionClient):
         super().__init__(
             address=api_server_url,
             create_cluster_if_needed=False,
-            headers=base_headers,
+            headers={"Content-Type": "application/json"},
             cookies=cookies,
-            verify=verify,
         )
 
     @classmethod
@@ -1407,8 +1397,6 @@ def summarize_tasks(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
-    headers: Optional[Dict[str, Any]] = None,
-    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the tasks in cluster.
 
@@ -1420,10 +1408,6 @@ def summarize_tasks(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
-        headers: Headers to use when sending requests to the HTTP server, used for cases like
-            authentication to a remote cluster.
-        verify: Boolean indication to verify the server's TLS certificate or a path to a file
-            or directory of trusted certificates.
 
     Return:
         Dictionarified
@@ -1432,7 +1416,7 @@ def summarize_tasks(
     Raises:
         RayStateApiException: if the CLI is failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address, headers=headers, verify=verify).summary(
+    return StateApiClient(address=address).summary(
         SummaryResource.TASKS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1446,8 +1430,6 @@ def summarize_actors(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
-    headers: Optional[Dict[str, Any]] = None,
-    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the actors in cluster.
 
@@ -1459,10 +1441,6 @@ def summarize_actors(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
-        headers: Headers to use when sending requests to the HTTP server, used for cases like
-            authentication to a remote cluster.
-        verify: Boolean indication to verify the server's TLS certificate or a path to a file
-            or directory of trusted certificates.
 
     Return:
         Dictionarified
@@ -1471,7 +1449,7 @@ def summarize_actors(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address, headers=headers, verify=verify).summary(
+    return StateApiClient(address=address).summary(
         SummaryResource.ACTORS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1485,8 +1463,6 @@ def summarize_objects(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
-    headers: Optional[Dict[str, Any]] = None,
-    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the objects in cluster.
 
@@ -1498,10 +1474,6 @@ def summarize_objects(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
-        headers: Headers to use when sending requests to the HTTP server, used for cases like
-            authentication to a remote cluster.
-        verify: Boolean indication to verify the server's TLS certificate or a path to a file
-            or directory of trusted certificates.
 
     Return:
         Dictionarified :class:`~ray.util.state.common.ObjectSummaries`
@@ -1509,7 +1481,7 @@ def summarize_objects(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address, headers=headers, verify=verify).summary(
+    return StateApiClient(address=address).summary(
         SummaryResource.OBJECTS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -1270,6 +1270,10 @@ def get_log(
         _interval: The interval in secs to print new logs when `follow=True`.
         filter_ansi_code: A boolean flag for determining whether to filter ANSI escape codes.
             Setting to `True` removes ANSI escape codes from the output. The default value is `False`.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         A Generator of log line, None for SendType and ReturnType.
@@ -1341,9 +1345,11 @@ def list_logs(
         node_ip: Ip of the node containing the logs.
         glob_filter: Name of the file (relative to the ray log directory) to be
             retrieved. E.g. `glob_filter="*worker*"` for all worker logs.
-        actor_id: Id of the actor if getting logs from an actor.
         timeout: Max timeout for requests made when getting the logs.
-        _interval: The interval in secs to print new logs when `follow=True`.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         A dictionary where the keys are log groups (e.g. gcs, raylet, worker), and
@@ -1414,6 +1420,10 @@ def summarize_tasks(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         Dictionarified
@@ -1449,6 +1459,10 @@ def summarize_actors(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         Dictionarified
@@ -1484,6 +1498,10 @@ def summarize_objects(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         Dictionarified :class:`~ray.util.state.common.ObjectSummaries`

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -126,6 +126,8 @@ class StateApiClient(SubmissionClient):
         self,
         address: Optional[str] = None,
         cookies: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, Any]] = None,
+        verify: Optional[Union[str, bool]] = True,
     ):
         """Initialize a StateApiClient and check the connection to the cluster.
 
@@ -136,12 +138,19 @@ class StateApiClient(SubmissionClient):
                 If not provided, it will be detected automatically from any running
                 local Ray cluster.
             cookies: Cookies to use when sending requests to the HTTP job server.
+            headers: Headers to use when sending requests to the HTTP job server, used
+                for cases like authentication to a remote cluster.
+            verify: Boolean indication to verify the server's TLS certificate or a path
+                to a file or directory of trusted certificates.
         """
         if requests is None:
             raise RuntimeError(
                 "The Ray state CLI & SDK require the ray[default] "
                 "installation: `pip install 'ray[default']``"
             )
+        base_headers = {"Content-Type": "application/json"}
+        if headers:
+            base_headers.update(headers)
 
         # Resolve API server URL
         api_server_url = get_address_for_submission_client(address)
@@ -149,8 +158,9 @@ class StateApiClient(SubmissionClient):
         super().__init__(
             address=api_server_url,
             create_cluster_if_needed=False,
-            headers={"Content-Type": "application/json"},
+            headers=base_headers,
             cookies=cookies,
+            verify=verify,
         )
 
     @classmethod
@@ -1397,6 +1407,8 @@ def summarize_tasks(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the tasks in cluster.
 
@@ -1408,6 +1420,10 @@ def summarize_tasks(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         Dictionarified
@@ -1416,7 +1432,7 @@ def summarize_tasks(
     Raises:
         RayStateApiException: if the CLI is failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.TASKS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1430,6 +1446,8 @@ def summarize_actors(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the actors in cluster.
 
@@ -1441,6 +1459,10 @@ def summarize_actors(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         Dictionarified
@@ -1449,7 +1471,7 @@ def summarize_actors(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.ACTORS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1463,6 +1485,8 @@ def summarize_objects(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the objects in cluster.
 
@@ -1474,6 +1498,10 @@ def summarize_objects(
             there is missing data due to truncation/data source unavailable.
         _explain: Print the API information such as API latency or
             failed query information.
+        headers: Headers to use when sending requests to the HTTP server, used for cases like
+            authentication to a remote cluster.
+        verify: Boolean indication to verify the server's TLS certificate or a path to a file
+            or directory of trusted certificates.
 
     Return:
         Dictionarified :class:`~ray.util.state.common.ObjectSummaries`
@@ -1481,7 +1509,7 @@ def summarize_objects(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.OBJECTS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -46,6 +46,14 @@ logger = logging.getLogger(__name__)
 _MAX_HTTP_RESPONSE_EXCEPTION_TEXT = 500
 
 
+def _prepare_request_headers(
+    headers: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    request_headers = headers.copy() if headers else {}
+    request_headers.update(get_auth_headers_if_auth_enabled(request_headers))
+    return request_headers
+
+
 @contextmanager
 def warnings_on_slow_request(
     *, address: str, endpoint: str, timeout: float, explain: bool
@@ -1297,10 +1305,7 @@ def get_log(
     if filter_ansi_code is not None:
         options_dict["filter_ansi_code"] = filter_ansi_code
 
-    request_headers: Dict[str, Any] = {}
-    if headers:
-        request_headers.update(headers)
-    request_headers.update(get_auth_headers_if_auth_enabled(request_headers))
+    request_headers = _prepare_request_headers(headers)
 
     with requests.get(
         f"{api_server_url}/api/v0/logs/{media_type}?"
@@ -1366,10 +1371,7 @@ def list_logs(
         options_dict["glob"] = glob_filter
     options_dict["timeout"] = timeout
 
-    request_headers: Dict[str, Any] = {}
-    if headers:
-        request_headers.update(headers)
-    request_headers.update(get_auth_headers_if_auth_enabled(request_headers))
+    request_headers = _prepare_request_headers(headers)
 
     r = requests.get(
         f"{api_server_url}/api/v0/logs?{urllib.parse.urlencode(options_dict)}",

--- a/python/ray/util/state/api.py
+++ b/python/ray/util/state/api.py
@@ -119,6 +119,7 @@ class StateApiClient(SubmissionClient):
         address: Optional[str] = None,
         cookies: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, Any]] = None,
+        verify: Optional[Union[str, bool]] = True,
     ):
         """Initialize a StateApiClient and check the connection to the cluster.
 
@@ -131,14 +132,17 @@ class StateApiClient(SubmissionClient):
             cookies: Cookies to use when sending requests to the HTTP job server.
             headers: Headers to use when sending requests to the HTTP job server, used
                 for cases like authentication to a remote cluster.
+            verify: Boolean indication to verify the server's TLS certificate or a path
+                to a file or directory of trusted certificates.
         """
         if requests is None:
             raise RuntimeError(
                 "The Ray state CLI & SDK require the ray[default] "
                 "installation: `pip install 'ray[default']``"
             )
-        if not headers:
-            headers = {"Content-Type": "application/json"}
+        base_headers = {"Content-Type": "application/json"}
+        if headers:
+            base_headers.update(headers)
 
         # Resolve API server URL
         api_server_url = get_address_for_submission_client(address)
@@ -146,8 +150,9 @@ class StateApiClient(SubmissionClient):
         super().__init__(
             address=api_server_url,
             create_cluster_if_needed=False,
-            headers=headers,
+            headers=base_headers,
             cookies=cookies,
+            verify=verify,
         )
 
     @classmethod
@@ -1195,6 +1200,8 @@ def get_log(
     attempt_number: int = 0,
     _interval: Optional[float] = None,
     filter_ansi_code: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Generator[str, None, None]:
     """Retrieve log file based on file name or some entities ids (pid, actor id, task id).
 
@@ -1290,11 +1297,17 @@ def get_log(
     if filter_ansi_code is not None:
         options_dict["filter_ansi_code"] = filter_ansi_code
 
+    request_headers: Dict[str, Any] = {}
+    if headers:
+        request_headers.update(headers)
+    request_headers.update(get_auth_headers_if_auth_enabled(request_headers))
+
     with requests.get(
         f"{api_server_url}/api/v0/logs/{media_type}?"
         f"{urllib.parse.urlencode(options_dict)}",
         stream=True,
-        headers=get_auth_headers_if_auth_enabled({}),
+        headers=request_headers,
+        verify=verify,
     ) as r:
         if r.status_code != 200:
             raise RayStateApiException(r.text)
@@ -1311,6 +1324,8 @@ def list_logs(
     node_ip: Optional[str] = None,
     glob_filter: Optional[str] = None,
     timeout: int = DEFAULT_RPC_TIMEOUT,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Dict[str, List[str]]:
     """Listing log files available.
 
@@ -1351,9 +1366,15 @@ def list_logs(
         options_dict["glob"] = glob_filter
     options_dict["timeout"] = timeout
 
+    request_headers: Dict[str, Any] = {}
+    if headers:
+        request_headers.update(headers)
+    request_headers.update(get_auth_headers_if_auth_enabled(request_headers))
+
     r = requests.get(
         f"{api_server_url}/api/v0/logs?{urllib.parse.urlencode(options_dict)}",
-        headers=get_auth_headers_if_auth_enabled({}),
+        headers=request_headers,
+        verify=verify,
     )
     # TODO(rickyx): we could do better at error handling here.
     r.raise_for_status()
@@ -1378,6 +1399,8 @@ def summarize_tasks(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the tasks in cluster.
 
@@ -1397,7 +1420,7 @@ def summarize_tasks(
     Raises:
         RayStateApiException: if the CLI is failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.TASKS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1411,6 +1434,8 @@ def summarize_actors(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the actors in cluster.
 
@@ -1430,7 +1455,7 @@ def summarize_actors(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.ACTORS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,
@@ -1444,6 +1469,8 @@ def summarize_objects(
     timeout: int = DEFAULT_RPC_TIMEOUT,
     raise_on_missing_output: bool = True,
     _explain: bool = False,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Optional[Union[str, bool]] = True,
 ) -> Dict:
     """Summarize the objects in cluster.
 
@@ -1462,7 +1489,7 @@ def summarize_objects(
     Raises:
         RayStateApiException: if the CLI failed to query the data.
     """  # noqa: E501
-    return StateApiClient(address=address).summary(
+    return StateApiClient(address=address, headers=headers, verify=verify).summary(
         SummaryResource.OBJECTS,
         options=SummaryApiOptions(timeout=timeout),
         raise_on_missing_output=raise_on_missing_output,

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -11,7 +11,7 @@ import yaml
 import ray._private.services as services
 from ray._common.network_utils import parse_address
 from ray._private.thirdparty.tabulate.tabulate import tabulate
-from ray.dashboard.modules.job.cli_utils import BoolOrStringParam
+from ray.dashboard.modules.job.cli_utils import BoolOrStringParam, parse_headers
 from ray.util.annotations import PublicAPI
 from ray.util.state import (
     StateApiClient,
@@ -363,23 +363,10 @@ headers_option = click.option(
 
 
 def _handle_headers(headers: Optional[str]) -> Optional[Dict[str, Any]]:
-    if headers is None and "RAY_STATE_HEADERS" in os.environ:
-        headers = os.environ["RAY_STATE_HEADERS"]
-    if headers is None:
-        return None
     try:
-        parsed = json.loads(headers)
-    except Exception as exc:
-        raise click.UsageError(
-            "Failed to parse headers into JSON. "
-            f'Expected format: {{"KEY": "VALUE"}}, got {headers}, {exc}'
-        )
-    if not isinstance(parsed, dict):
-        raise click.UsageError(
-            "Failed to parse headers into JSON. "
-            f"Expected a JSON object, got: {headers}"
-        )
-    return parsed
+        return parse_headers(headers, env_var="RAY_STATE_HEADERS")
+    except ValueError as exc:
+        raise click.UsageError(str(exc))
 
 
 @click.command()
@@ -1088,6 +1075,7 @@ def log_cluster(
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>` if the CLI
             is failed to query the data.
     """  # noqa: E501
+    parsed_headers = _handle_headers(headers)
 
     if node_id is None and node_ip is None:
         node_ip = _get_head_node_ip(address)
@@ -1098,7 +1086,7 @@ def log_cluster(
         node_ip=node_ip,
         glob_filter=glob_filter,
         timeout=timeout,
-        headers=_handle_headers(headers),
+        headers=parsed_headers,
         verify=verify,
     )
 
@@ -1130,7 +1118,7 @@ def log_cluster(
         timeout=timeout,
         encoding=encoding,
         encoding_errors=encoding_errors,
-        headers=_handle_headers(headers),
+        headers=parsed_headers,
         verify=verify,
     )
 

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -383,12 +383,16 @@ def _handle_headers(headers: Optional[str]) -> Optional[Dict[str, Any]]:
     type=str,
     required=False,
 )
+@headers_option
+@verify_option
 @address_option
 @timeout_option
 @PublicAPI(stability="stable")
 def ray_get(
     resource: str,
     id: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
     address: Optional[str],
     timeout: float,
 ):
@@ -422,6 +426,8 @@ def ray_get(
     Args:
         resource: The type of the resource to query.
         id: The id of the resource.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
         address: The address of Ray API server.
         timeout: Timeout in seconds for the API requests.
 
@@ -439,7 +445,9 @@ def ray_get(
 
     # Create the State API server and put it into context
     logger.debug(f"Create StateApiClient to ray instance at: {address}...")
-    client = StateApiClient(address=address)
+    client = StateApiClient(
+        address=address, headers=_handle_headers(headers), verify=verify
+    )
     options = GetApiOptions(timeout=timeout)
 
     # If errors occur, exceptions will be thrown.
@@ -503,6 +511,8 @@ def ray_get(
 )
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @PublicAPI(stability="stable")
 def ray_list(
     resource: str,
@@ -512,6 +522,8 @@ def ray_list(
     detail: bool,
     timeout: float,
     address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """List all states of a given resource.
 
@@ -575,6 +587,8 @@ def ray_list(
         detail: Whether to include detailed columns.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -589,7 +603,9 @@ def ray_list(
     format = AvailableFormat(format)
 
     # Create the State API server and put it into context
-    client = StateApiClient(address=address)
+    client = StateApiClient(
+        address=address, headers=_handle_headers(headers), verify=verify
+    )
 
     filter = [_parse_filter(f) for f in filter]
 
@@ -637,12 +653,16 @@ def summary_state_cli_group(ctx):
 @summary_state_cli_group.command(name="tasks")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def task_summary(
     ctx,
     timeout: float,
     address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Summarize the task state of the cluster.
 
@@ -656,6 +676,8 @@ def task_summary(
         ctx: Click context.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -668,6 +690,8 @@ def task_summary(
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
             resource=StateResource.TASKS,
         )
@@ -677,12 +701,16 @@ def task_summary(
 @summary_state_cli_group.command(name="actors")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def actor_summary(
     ctx,
     timeout: float,
     address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Summarize the actor state of the cluster.
 
@@ -697,6 +725,8 @@ def actor_summary(
         ctx: Click context.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -709,6 +739,8 @@ def actor_summary(
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
             resource=StateResource.ACTORS,
         )
@@ -718,12 +750,16 @@ def actor_summary(
 @summary_state_cli_group.command(name="objects")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def object_summary(
     ctx,
     timeout: float,
     address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """Summarize the object state of the cluster.
 
@@ -757,6 +793,8 @@ def object_summary(
         ctx: Click context.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -769,6 +807,8 @@ def object_summary(
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
         )
     )

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -1,8 +1,9 @@
 import json
 import logging
+import os
 from datetime import datetime
 from enum import Enum, unique
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import click
 import yaml
@@ -10,6 +11,7 @@ import yaml
 import ray._private.services as services
 from ray._common.network_utils import parse_address
 from ray._private.thirdparty.tabulate.tabulate import tabulate
+from ray.dashboard.modules.job.cli_utils import BoolOrStringParam
 from ray.util.annotations import PublicAPI
 from ray.util.state import (
     StateApiClient,
@@ -338,6 +340,46 @@ address_option = click.option(
         "automatically from querying the GCS server."
     ),
 )
+verify_option = click.option(
+    "--verify",
+    default=True,
+    show_default=True,
+    type=BoolOrStringParam(),
+    help=(
+        "Boolean indication to verify the server's TLS certificate or a path to "
+        "a file or directory of trusted certificates."
+    ),
+)
+headers_option = click.option(
+    "--headers",
+    required=False,
+    type=str,
+    default=None,
+    help=(
+        "Used to pass headers through http/s to the Ray Cluster. "
+        'Please use JSON formatting, e.g. {"key": "value"}'
+    ),
+)
+
+
+def _handle_headers(headers: Optional[str]) -> Optional[Dict[str, Any]]:
+    if headers is None and "RAY_STATE_HEADERS" in os.environ:
+        headers = os.environ["RAY_STATE_HEADERS"]
+    if headers is None:
+        return None
+    try:
+        parsed = json.loads(headers)
+    except Exception as exc:
+        raise click.UsageError(
+            "Failed to parse headers into JSON. "
+            f'Expected format: {{"KEY": "VALUE"}}, got {headers}, {exc}'
+        )
+    if not isinstance(parsed, dict):
+        raise click.UsageError(
+            "Failed to parse headers into JSON. "
+            f"Expected a JSON object, got: {headers}"
+        )
+    return parsed
 
 
 @click.command()
@@ -355,12 +397,16 @@ address_option = click.option(
     type=str,
     required=False,
 )
+@headers_option
+@verify_option
 @address_option
 @timeout_option
 @PublicAPI(stability="stable")
 def ray_get(
     resource: str,
     id: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
     address: Optional[str],
     timeout: float,
 ):
@@ -409,7 +455,9 @@ def ray_get(
 
     # Create the State API server and put it into context
     logger.debug(f"Create StateApiClient to ray instance at: {address}...")
-    client = StateApiClient(address=address)
+    client = StateApiClient(
+        address=address, headers=_handle_headers(headers), verify=verify
+    )
     options = GetApiOptions(timeout=timeout)
 
     # If errors occur, exceptions will be thrown.
@@ -473,6 +521,8 @@ def ray_get(
 )
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @PublicAPI(stability="stable")
 def ray_list(
     resource: str,
@@ -482,6 +532,8 @@ def ray_list(
     detail: bool,
     timeout: float,
     address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
 ):
     """List all states of a given resource.
 
@@ -553,7 +605,9 @@ def ray_list(
     format = AvailableFormat(format)
 
     # Create the State API server and put it into context
-    client = StateApiClient(address=address)
+    client = StateApiClient(
+        address=address, headers=_handle_headers(headers), verify=verify
+    )
 
     filter = [_parse_filter(f) for f in filter]
 
@@ -601,9 +655,17 @@ def summary_state_cli_group(ctx):
 @summary_state_cli_group.command(name="tasks")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
-def task_summary(ctx, timeout: float, address: str):
+def task_summary(
+    ctx,
+    timeout: float,
+    address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
+):
     """Summarize the task state of the cluster.
 
     By default, the output contains the information grouped by
@@ -623,6 +685,8 @@ def task_summary(ctx, timeout: float, address: str):
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
             resource=StateResource.TASKS,
         )
@@ -632,9 +696,17 @@ def task_summary(ctx, timeout: float, address: str):
 @summary_state_cli_group.command(name="actors")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
-def actor_summary(ctx, timeout: float, address: str):
+def actor_summary(
+    ctx,
+    timeout: float,
+    address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
+):
     """Summarize the actor state of the cluster.
 
     By default, the output contains the information grouped by
@@ -655,6 +727,8 @@ def actor_summary(ctx, timeout: float, address: str):
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
             resource=StateResource.ACTORS,
         )
@@ -664,9 +738,17 @@ def actor_summary(ctx, timeout: float, address: str):
 @summary_state_cli_group.command(name="objects")
 @timeout_option
 @address_option
+@headers_option
+@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
-def object_summary(ctx, timeout: float, address: str):
+def object_summary(
+    ctx,
+    timeout: float,
+    address: str,
+    headers: Optional[str],
+    verify: Union[bool, str],
+):
     """Summarize the object state of the cluster.
 
     The API is recommended when debugging memory leaks.
@@ -706,6 +788,8 @@ def object_summary(ctx, timeout: float, address: str):
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
+                headers=_handle_headers(headers),
+                verify=verify,
             ),
         )
     )
@@ -831,6 +915,8 @@ def _print_log(
     task_id: Optional[str] = None,
     attempt_number: int = 0,
     submission_id: Optional[str] = None,
+    headers: Optional[Dict[str, Any]] = None,
+    verify: Union[bool, str] = True,
 ):
     """Wrapper around `get_log()` that prints the preamble and the log lines"""
     if tail > 0:
@@ -860,6 +946,8 @@ def _print_log(
         task_id=task_id,
         attempt_number=attempt_number,
         submission_id=submission_id,
+        headers=headers,
+        verify=verify,
     ):
         print(chunk, end="", flush=True)
 
@@ -938,6 +1026,8 @@ logs_state_cli_group = LogCommandGroup(help=LOG_CLI_HELP_MSG)
     default="*",
 )
 @address_option
+@headers_option
+@verify_option
 @log_node_id_option
 @log_node_ip_option
 @log_follow_option
@@ -952,6 +1042,8 @@ def log_cluster(
     ctx,
     glob_filter: str,
     address: Optional[str],
+    headers: Optional[str],
+    verify: Union[bool, str],
     node_id: Optional[str],
     node_ip: Optional[str],
     follow: bool,
@@ -1006,6 +1098,8 @@ def log_cluster(
         node_ip=node_ip,
         glob_filter=glob_filter,
         timeout=timeout,
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
     log_files_found = []
@@ -1036,6 +1130,8 @@ def log_cluster(
         timeout=timeout,
         encoding=encoding,
         encoding_errors=encoding_errors,
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
 
@@ -1057,6 +1153,8 @@ def log_cluster(
     help="Retrieves the logs from the actor with this pid.",
 )
 @address_option
+@headers_option
+@verify_option
 @log_node_id_option
 @log_node_ip_option
 @log_follow_option
@@ -1071,6 +1169,8 @@ def log_actor(
     id: Optional[str],
     pid: Optional[str],
     address: Optional[str],
+    headers: Optional[str],
+    verify: Union[bool, str],
     node_id: Optional[str],
     node_ip: Optional[str],
     follow: bool,
@@ -1126,6 +1226,8 @@ def log_actor(
         interval=interval,
         timeout=timeout,
         suffix="err" if err else "out",
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
 
@@ -1139,6 +1241,8 @@ def log_actor(
     help="Retrieves the logs from the worker with this pid.",
 )
 @address_option
+@headers_option
+@verify_option
 @log_node_id_option
 @log_node_ip_option
 @log_follow_option
@@ -1152,6 +1256,8 @@ def log_worker(
     ctx,
     pid: Optional[str],
     address: Optional[str],
+    headers: Optional[str],
+    verify: Union[bool, str],
     node_id: Optional[str],
     node_ip: Optional[str],
     follow: bool,
@@ -1192,6 +1298,8 @@ def log_worker(
         interval=interval,
         timeout=timeout,
         suffix="err" if err else "out",
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
 
@@ -1207,6 +1315,8 @@ def log_worker(
     ),
 )
 @address_option
+@headers_option
+@verify_option
 @log_follow_option
 @log_tail_option
 @log_interval_option
@@ -1217,6 +1327,8 @@ def log_job(
     ctx,
     submission_id: Optional[str],
     address: Optional[str],
+    headers: Optional[str],
+    verify: Union[bool, str],
     follow: bool,
     tail: int,
     interval: float,
@@ -1252,6 +1364,8 @@ def log_job(
         interval=interval,
         timeout=timeout,
         submission_id=submission_id,
+        headers=_handle_headers(headers),
+        verify=verify,
     )
 
 
@@ -1272,6 +1386,8 @@ def log_job(
     help="Retrieves the logs from the attempt, default to 0",
 )
 @address_option
+@headers_option
+@verify_option
 @log_follow_option
 @log_interval_option
 @log_tail_option
@@ -1284,6 +1400,8 @@ def log_task(
     task_id: Optional[str],
     attempt_number: int,
     address: Optional[str],
+    headers: Optional[str],
+    verify: Union[bool, str],
     follow: bool,
     interval: float,
     tail: int,
@@ -1325,4 +1443,6 @@ def log_task(
         interval=interval,
         timeout=timeout,
         suffix="err" if err else "out",
+        headers=_handle_headers(headers),
+        verify=verify,
     )

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -426,6 +426,10 @@ def ray_get(
     Args:
         resource: The type of the resource to query.
         id: The id of the resource.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
+        address: The address of Ray API server.
+        timeout: Timeout in seconds for the API requests.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -577,6 +581,14 @@ def ray_list(
 
     Args:
         resource: The type of the resource to query.
+        format: Output format.
+        filter: Filters in key=value or key!=value form.
+        limit: Maximum number of entries to return.
+        detail: Whether to include detailed columns.
+        timeout: Timeout in seconds for the API requests.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -660,6 +672,13 @@ def task_summary(
     The output schema is
     :class:`~ray.util.state.common.TaskSummaries`.
 
+    Args:
+        ctx: Click context.
+        timeout: Timeout in seconds for the API requests.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
+
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
             if the CLI is failed to query the data.
@@ -701,6 +720,13 @@ def actor_summary(
     The output schema is
     :class:`ray.util.state.common.ActorSummaries
     <ray.util.state.common.ActorSummaries>`.
+
+    Args:
+        ctx: Click context.
+        timeout: Timeout in seconds for the API requests.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -762,6 +788,13 @@ def object_summary(
     The output schema is
     :class:`ray.util.state.common.ObjectSummaries
     <ray.util.state.common.ObjectSummaries>`.
+
+    Args:
+        ctx: Click context.
+        timeout: Timeout in seconds for the API requests.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -1070,6 +1103,21 @@ def log_cluster(
         ray logs [cluster] raylet.out --tail 100 -f
         ```
 
+    Args:
+        ctx: Click context.
+        glob_filter: Glob pattern to match log files.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
+        node_id: Filter logs by node id.
+        node_ip: Filter logs by node IP.
+        follow: Stream logs as they are updated.
+        tail: Number of lines to tail.
+        interval: Polling interval for streaming logs.
+        timeout: Timeout in seconds for the API requests.
+        encoding: Encoding used to decode log files.
+        encoding_errors: Error handling scheme for decoding.
+
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>` if the CLI
             is failed to query the data.
@@ -1190,6 +1238,21 @@ def log_actor(
         ray logs actor --id ABCDEFG --err
         ```
 
+    Args:
+        ctx: Click context.
+        id: Actor id.
+        pid: Actor pid.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
+        node_id: Filter logs by node id.
+        node_ip: Filter logs by node IP.
+        follow: Stream logs as they are updated.
+        tail: Number of lines to tail.
+        interval: Polling interval for streaming logs.
+        timeout: Timeout in seconds for the API requests.
+        err: Whether to fetch stderr instead of stdout.
+
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
             if the CLI is failed to query the data.
@@ -1269,6 +1332,20 @@ def log_worker(
         ray logs worker --pid 123 --err
         ```
 
+    Args:
+        ctx: Click context.
+        pid: Worker pid.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
+        node_id: Filter logs by node id.
+        node_ip: Filter logs by node IP.
+        follow: Stream logs as they are updated.
+        tail: Number of lines to tail.
+        interval: Polling interval for streaming logs.
+        timeout: Timeout in seconds for the API requests.
+        err: Whether to fetch stderr instead of stdout.
+
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
             if the CLI is failed to query the data.
@@ -1337,6 +1414,17 @@ def log_job(
         ray logs jobs --id raysubmit_xxx --follow
 
         ```
+
+    Args:
+        ctx: Click context.
+        submission_id: Job submission id.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
+        follow: Stream logs as they are updated.
+        tail: Number of lines to tail.
+        interval: Polling interval for streaming logs.
+        timeout: Timeout in seconds for the API requests.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -1414,6 +1502,19 @@ def log_task(
     Note: If a task is from a concurrent actor (i.e. an async actor or
     a threaded actor), the log of the tasks are expected to be interleaved.
     Please use `ray logs actor --id <actor_id>` for the entire actor log.
+
+    Args:
+        ctx: Click context.
+        task_id: Task id.
+        attempt_number: Task attempt number.
+        address: The address of Ray API server.
+        headers: JSON string to pass HTTP headers for authentication.
+        verify: Boolean to verify TLS or a path to trusted certificates.
+        follow: Stream logs as they are updated.
+        interval: Polling interval for streaming logs.
+        tail: Number of lines to tail.
+        timeout: Timeout in seconds for the API requests.
+        err: Whether to fetch stderr instead of stdout.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -383,16 +383,12 @@ def _handle_headers(headers: Optional[str]) -> Optional[Dict[str, Any]]:
     type=str,
     required=False,
 )
-@headers_option
-@verify_option
 @address_option
 @timeout_option
 @PublicAPI(stability="stable")
 def ray_get(
     resource: str,
     id: str,
-    headers: Optional[str],
-    verify: Union[bool, str],
     address: Optional[str],
     timeout: float,
 ):
@@ -426,8 +422,6 @@ def ray_get(
     Args:
         resource: The type of the resource to query.
         id: The id of the resource.
-        headers: JSON string to pass HTTP headers for authentication.
-        verify: Boolean to verify TLS or a path to trusted certificates.
         address: The address of Ray API server.
         timeout: Timeout in seconds for the API requests.
 
@@ -445,9 +439,7 @@ def ray_get(
 
     # Create the State API server and put it into context
     logger.debug(f"Create StateApiClient to ray instance at: {address}...")
-    client = StateApiClient(
-        address=address, headers=_handle_headers(headers), verify=verify
-    )
+    client = StateApiClient(address=address)
     options = GetApiOptions(timeout=timeout)
 
     # If errors occur, exceptions will be thrown.
@@ -511,8 +503,6 @@ def ray_get(
 )
 @timeout_option
 @address_option
-@headers_option
-@verify_option
 @PublicAPI(stability="stable")
 def ray_list(
     resource: str,
@@ -522,8 +512,6 @@ def ray_list(
     detail: bool,
     timeout: float,
     address: str,
-    headers: Optional[str],
-    verify: Union[bool, str],
 ):
     """List all states of a given resource.
 
@@ -587,8 +575,6 @@ def ray_list(
         detail: Whether to include detailed columns.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
-        headers: JSON string to pass HTTP headers for authentication.
-        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -603,9 +589,7 @@ def ray_list(
     format = AvailableFormat(format)
 
     # Create the State API server and put it into context
-    client = StateApiClient(
-        address=address, headers=_handle_headers(headers), verify=verify
-    )
+    client = StateApiClient(address=address)
 
     filter = [_parse_filter(f) for f in filter]
 
@@ -653,16 +637,12 @@ def summary_state_cli_group(ctx):
 @summary_state_cli_group.command(name="tasks")
 @timeout_option
 @address_option
-@headers_option
-@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def task_summary(
     ctx,
     timeout: float,
     address: str,
-    headers: Optional[str],
-    verify: Union[bool, str],
 ):
     """Summarize the task state of the cluster.
 
@@ -676,8 +656,6 @@ def task_summary(
         ctx: Click context.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
-        headers: JSON string to pass HTTP headers for authentication.
-        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -690,8 +668,6 @@ def task_summary(
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
-                headers=_handle_headers(headers),
-                verify=verify,
             ),
             resource=StateResource.TASKS,
         )
@@ -701,16 +677,12 @@ def task_summary(
 @summary_state_cli_group.command(name="actors")
 @timeout_option
 @address_option
-@headers_option
-@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def actor_summary(
     ctx,
     timeout: float,
     address: str,
-    headers: Optional[str],
-    verify: Union[bool, str],
 ):
     """Summarize the actor state of the cluster.
 
@@ -725,8 +697,6 @@ def actor_summary(
         ctx: Click context.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
-        headers: JSON string to pass HTTP headers for authentication.
-        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -739,8 +709,6 @@ def actor_summary(
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
-                headers=_handle_headers(headers),
-                verify=verify,
             ),
             resource=StateResource.ACTORS,
         )
@@ -750,16 +718,12 @@ def actor_summary(
 @summary_state_cli_group.command(name="objects")
 @timeout_option
 @address_option
-@headers_option
-@verify_option
 @click.pass_context
 @PublicAPI(stability="stable")
 def object_summary(
     ctx,
     timeout: float,
     address: str,
-    headers: Optional[str],
-    verify: Union[bool, str],
 ):
     """Summarize the object state of the cluster.
 
@@ -793,8 +757,6 @@ def object_summary(
         ctx: Click context.
         timeout: Timeout in seconds for the API requests.
         address: The address of Ray API server.
-        headers: JSON string to pass HTTP headers for authentication.
-        verify: Boolean to verify TLS or a path to trusted certificates.
 
     Raises:
         :class:`RayStateApiException <ray.util.state.exception.RayStateApiException>`
@@ -807,8 +769,6 @@ def object_summary(
                 timeout=timeout,
                 raise_on_missing_output=False,
                 _explain=True,
-                headers=_handle_headers(headers),
-                verify=verify,
             ),
         )
     )

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from datetime import datetime
 from enum import Enum, unique
 from typing import Any, Dict, List, Optional, Tuple, Union


### PR DESCRIPTION
### Summary
This PR makes Ray’s State CLI usable on authenticated / TLS-secured clusters by adding `--headers` and `--verify` flags (similar to `ray job`), and documents the State REST API endpoints and query parameters.

Resolved issue https://github.com/ray-project/ray/issues/50256.

### Changes
- CLI: Add `--headers` and `--verify` to:
  - `ray list`, `ray get`, `ray summary (tasks|actors|objects)`, and `ray logs (...)`
  - Support `RAY_STATE_HEADERS` env var as a default for `--headers`
- Client: Plumb headers/verify into State API client usage and log REST calls
  - `StateApiClient(..., headers=..., verify=...)`
  - `get_log()` / `list_logs()` accept `headers` and `verify`
- Docs: Add a “State REST API” section documenting endpoints and parameters; add CLI auth notes

### Tests
- Added unit tests covering:
  - `--headers` parsing and propagation
  - `RAY_STATE_HEADERS` env var behavior
  - invalid JSON header handling
  - verify flag propagation to list/summary/logs paths
  - Tests: test_state_api.py

Run:
```bash
python -m pytest -q python/ray/tests/test_state_api.py -k "test_state_cli_"
```

### Usage example
```bash
ray list actors --address https://<head>:8265 \
  --headers '{"Authorization": "Bearer <token>"}' \
  --verify /path/to/ca-bundle.pem
```