### PR TITLE
fix(serve): Fix Ray Serve LLM embeddings endpoint for pooling models

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -1,6 +1,7 @@
 import argparse
 import dataclasses
 import inspect
+import json
 import typing
 from typing import TYPE_CHECKING, Any, AsyncGenerator, List, Optional, Tuple, Union
 
@@ -329,7 +330,7 @@ class VLLMEngine(LLMEngine):
         self._oai_models = getattr(state, "openai_serving_models", None)
         self._oai_serving_chat = getattr(state, "openai_serving_chat", None)
         self._oai_serving_completion = getattr(state, "openai_serving_completion", None)
-        self._oai_serving_embedding = getattr(state, "openai_serving_embedding", None)
+        self._oai_serving_embedding = getattr(state, "serving_embedding", None)
         self._oai_serving_transcription = getattr(
             state, "openai_serving_transcription", None
         )
@@ -579,7 +580,8 @@ class VLLMEngine(LLMEngine):
         raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
             raw_request_info
         )
-        embedding_response = await self._oai_serving_embedding.create_embedding(  # type: ignore[attr-defined]
+        # vLLM's ServingEmbedding is a callable, not a class with create_embedding
+        embedding_response = await self._oai_serving_embedding(
             request,
             raw_request=raw_request,
         )
@@ -588,8 +590,14 @@ class VLLMEngine(LLMEngine):
             yield ErrorResponse(
                 error=ErrorInfo(**embedding_response.error.model_dump())
             )
+            return
+
+        # vLLM returns a Starlette Response object, extract the JSON content
+        if hasattr(embedding_response, 'body'):
+            content = json.loads(embedding_response.body)
+            yield EmbeddingResponse(**content)
         else:
-            yield EmbeddingResponse(**embedding_response.model_dump())
+            yield embedding_response
 
     async def transcriptions(
         self,


### PR DESCRIPTION
## Summary
Fixes two issues preventing embedding models from working with Ray Serve LLM:

1. **Attribute name mismatch**: vLLM sets \`state.serving_embedding\` but Ray was looking for \`state.openai_serving_embedding\`, causing the endpoint to fail with \"This model does not support the 'embed' task\".

2. **API mismatch**: vLLM's \`ServingEmbedding\` is a callable class, not a class with a \`create_embedding\` method. Updated to call the instance directly and handle the Starlette Response return type properly.

## Changes
- Updated attribute lookup from \`openai_serving_embedding\` to \`serving_embedding\` to match vLLM's naming
- Changed from calling \`create_embedding()\` to calling \`__call__()\` directly
- Added handling for Starlette Response objects returned by vLLM

## Testing
Tested with \`Qwen3-8B-emb\` model using \`runner="pooling"\` and \`convert="embed"\` configuration.

## Related
Fixes compatibility issue between Ray Serve LLM and vLLM's pooling/embedding API.