### PR TITLE
[core][ActorPool 3/n] Add ActorPoolManager with selection, retry, and locality

### DIFF
--- a/src/ray/common/id.cc
+++ b/src/ray/common/id.cc
@@ -309,6 +309,12 @@ JobID PlacementGroupID::JobId() const {
       reinterpret_cast<const char *>(this->Data() + kUniqueBytesLength), JobID::kLength));
 }
 
+ActorPoolID ActorPoolID::FromRandom() {
+  std::string data(kLength, 0);
+  FillRandom(&data);
+  return ActorPoolID::FromBinary(data);
+}
+
 LeaseID LeaseID::FromRandom() {
   std::string data(kLength, 0);
   FillRandom(&data);
@@ -343,6 +349,7 @@ ID_OSTREAM_OPERATOR(ActorID);
 ID_OSTREAM_OPERATOR(TaskID);
 ID_OSTREAM_OPERATOR(ObjectID);
 ID_OSTREAM_OPERATOR(PlacementGroupID);
+ID_OSTREAM_OPERATOR(ActorPoolID);
 ID_OSTREAM_OPERATOR(LeaseID);
 
 const NodeID kGCSNodeID = NodeID::FromBinary(std::string(kUniqueIDSize, 0));

--- a/src/ray/common/id.h
+++ b/src/ray/common/id.h
@@ -327,6 +327,26 @@ class PlacementGroupID : public BaseID<PlacementGroupID> {
 
 typedef std::pair<PlacementGroupID, int64_t> BundleID;
 
+class ActorPoolID : public BaseID<ActorPoolID> {
+ public:
+  static constexpr size_t kLength = kUniqueIDSize;
+
+  static constexpr size_t Size() { return kLength; }
+
+  /// Creates a random `ActorPoolID`.
+  ///
+  /// \return A randomly generated `ActorPoolID`.
+  /// Warning: this can duplicate IDs after a fork() call. We assume this never happens.
+  static ActorPoolID FromRandom();
+
+  ActorPoolID() : BaseID() {}
+
+  MSGPACK_DEFINE(id_);
+
+ private:
+  uint8_t id_[kLength];
+};
+
 class LeaseID : public BaseID<LeaseID> {
  private:
   static constexpr size_t kUniqueBytesLength = 4;
@@ -370,6 +390,8 @@ static_assert(sizeof(ObjectID) == ObjectID::kLength + sizeof(size_t),
               "ObjectID size is not as expected");
 static_assert(sizeof(PlacementGroupID) == PlacementGroupID::kLength + sizeof(size_t),
               "PlacementGroupID size is not as expected");
+static_assert(sizeof(ActorPoolID) == ActorPoolID::kLength + sizeof(size_t),
+              "ActorPoolID size is not as expected");
 static_assert(sizeof(LeaseID) == LeaseID::kLength + sizeof(size_t),
               "LeaseID size is not as expected");
 
@@ -379,6 +401,7 @@ std::ostream &operator<<(std::ostream &os, const ActorID &id);
 std::ostream &operator<<(std::ostream &os, const TaskID &id);
 std::ostream &operator<<(std::ostream &os, const ObjectID &id);
 std::ostream &operator<<(std::ostream &os, const PlacementGroupID &id);
+std::ostream &operator<<(std::ostream &os, const ActorPoolID &id);
 std::ostream &operator<<(std::ostream &os, const LeaseID &id);
 
 #define DEFINE_UNIQUE_ID(type)                                                           \
@@ -613,6 +636,7 @@ DEFINE_UNIQUE_ID(ActorID);
 DEFINE_UNIQUE_ID(TaskID);
 DEFINE_UNIQUE_ID(ObjectID);
 DEFINE_UNIQUE_ID(PlacementGroupID);
+DEFINE_UNIQUE_ID(ActorPoolID);
 DEFINE_UNIQUE_ID(LeaseID);
 #include "ray/common/id_def.h"
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -1083,3 +1083,7 @@ RAY_CONFIG(bool, experimental_object_manager_enable_multiple_connections, true)
 RAY_CONFIG(int64_t,
            idle_worker_killing_memory_threshold_bytes,
            1024 * 1024 * 1024)  // 1GB
+
+// Delay in milliseconds before re-enqueuing a pool task for reconstruction when
+// no healthy actors are available in the pool.
+RAY_CONFIG(int64_t, actor_pool_retry_delay_ms, 1000)

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -290,6 +290,9 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// Whether this task is an actor task.
   bool IsActorTask() const;
 
+  /// Whether this task belongs to an actor pool.
+  bool IsPoolTask() const { return !GetMessage().actor_pool_id().empty(); }
+
   // Returns the serialized exception allowlist for this task.
   const std::string GetSerializedRetryExceptionAllowlist() const;
 

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -142,6 +142,17 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "actor_pool_work_queue",
+    srcs = ["actor_pool_work_queue.cc"],
+    hdrs = ["actor_pool_work_queue.h"],
+    deps = [
+        ":common",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+    ],
+)
+
+ray_cc_library(
     name = "reference_counter_interface",
     hdrs = ["reference_counter_interface.h"],
     deps = [

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -153,6 +153,27 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "actor_pool_manager",
+    srcs = ["actor_pool_manager.cc"],
+    hdrs = ["actor_pool_manager.h"],
+    deps = [
+        ":actor_pool_work_queue",
+        ":common",
+        ":lease_policy",
+        ":task_manager_interface",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+        "//src/ray/core_worker/actor_management:actor_manager",
+        "//src/ray/core_worker/task_submission:actor_task_submitter",
+        "//src/ray/protobuf:common_cc_proto",
+        "//src/ray/util:time",
+        "@com_google_absl//absl/container:flat_hash_map",
+        "@com_google_absl//absl/synchronization",
+        "@com_google_googletest//:gtest_prod",
+    ],
+)
+
+ray_cc_library(
     name = "reference_counter_interface",
     hdrs = ["reference_counter_interface.h"],
     deps = [

--- a/src/ray/core_worker/actor_pool_manager.cc
+++ b/src/ray/core_worker/actor_pool_manager.cc
@@ -1,0 +1,831 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/actor_pool_manager.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/asio/steady_timer.hpp"
+#include "ray/core_worker/actor_management/actor_manager.h"
+#include "ray/core_worker/lease_policy.h"
+#include "ray/core_worker/task_manager_interface.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace core {
+
+ActorPoolManager::ActorPoolManager(ActorManager &actor_manager,
+                                   ActorTaskSubmitterInterface &task_submitter,
+                                   TaskManagerInterface &task_manager)
+    : actor_manager_(actor_manager),
+      task_submitter_(task_submitter),
+      task_manager_(task_manager),
+      io_service_(nullptr),
+      submit_actor_task_fn_(nullptr) {
+  RAY_LOG(DEBUG) << "ActorPoolManager initialized (minimal mode, no callbacks)";
+}
+
+ActorPoolManager::ActorPoolManager(ActorManager &actor_manager,
+                                   ActorTaskSubmitterInterface &task_submitter,
+                                   TaskManagerInterface &task_manager,
+                                   instrumented_io_context &io_service,
+                                   SubmitActorTaskCallback submit_actor_task_fn,
+                                   LocalityDataProviderInterface *locality_data_provider)
+    : actor_manager_(actor_manager),
+      task_submitter_(task_submitter),
+      task_manager_(task_manager),
+      io_service_(&io_service),
+      submit_actor_task_fn_(std::move(submit_actor_task_fn)),
+      locality_data_provider_(locality_data_provider) {
+  RAY_LOG(DEBUG) << "ActorPoolManager initialized (full mode with CoreWorker callbacks)";
+}
+
+ActorPoolID ActorPoolManager::RegisterPool(const ActorPoolConfig &config,
+                                           const std::vector<ActorID> &initial_actors) {
+  absl::MutexLock lock(&mu_);
+
+  ActorPoolID pool_id = ActorPoolID::FromRandom();
+
+  ActorPoolInfo pool_info;
+  pool_info.config = config;
+
+  auto work_queue = std::make_unique<UnorderedPoolWorkQueue>();
+
+  for (const auto &actor_id : initial_actors) {
+    pool_info.actor_ids.push_back(actor_id);
+    pool_info.actor_states[actor_id] = ActorPoolActorState{};
+    actor_to_pool_[actor_id] = pool_id;
+  }
+
+  pools_[pool_id] = std::move(pool_info);
+  work_queues_[pool_id] = std::move(work_queue);
+
+  RAY_LOG(INFO) << "Registered actor pool " << pool_id << " with "
+                << initial_actors.size() << " actors";
+
+  return pool_id;
+}
+
+void ActorPoolManager::UnregisterPool(const ActorPoolID &pool_id) {
+  absl::MutexLock lock(&mu_);
+
+  auto it = pools_.find(pool_id);
+  if (it == pools_.end()) {
+    RAY_LOG(WARNING) << "Attempted to unregister non-existent pool: " << pool_id;
+    return;
+  }
+
+  for (const auto &actor_id : it->second.actor_ids) {
+    actor_to_pool_.erase(actor_id);
+  }
+
+  // TODO(C2): Clean up work_items_ belonging to this pool. Currently work items
+  // for unregistered pools leak (TaskArg objects held). Need to add pool_id field
+  // to PoolWorkItem or maintain a reverse index for efficient cleanup.
+
+  work_queues_.erase(pool_id);
+  pools_.erase(it);
+
+  RAY_LOG(INFO) << "Unregistered actor pool " << pool_id;
+}
+
+void ActorPoolManager::AddActorToPool(const ActorPoolID &pool_id,
+                                      const ActorID &actor_id,
+                                      const NodeID &location) {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = pools_.find(pool_id);
+  RAY_CHECK(pool_it != pools_.end()) << "Pool not found: " << pool_id;
+
+  auto &pool_info = pool_it->second;
+
+  // If actor already in pool, just update location.
+  auto state_it = pool_info.actor_states.find(actor_id);
+  if (state_it != pool_info.actor_states.end()) {
+    if (!location.IsNil()) {
+      state_it->second.location = location;
+    }
+    return;
+  }
+
+  pool_info.actor_ids.push_back(actor_id);
+  pool_info.actor_states[actor_id] = ActorPoolActorState{
+      .num_tasks_in_flight = 0, .location = location, .is_alive = true};
+  actor_to_pool_[actor_id] = pool_id;
+
+  RAY_LOG(DEBUG) << "Added actor " << actor_id << " to pool " << pool_id;
+
+  DrainWorkQueue(pool_id);
+}
+
+void ActorPoolManager::RemoveActorFromPool(const ActorPoolID &pool_id,
+                                           const ActorID &actor_id) {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    RAY_LOG(WARNING) << "Pool not found: " << pool_id;
+    return;
+  }
+
+  auto &pool_info = pool_it->second;
+
+  auto &actor_ids = pool_info.actor_ids;
+  actor_ids.erase(std::remove(actor_ids.begin(), actor_ids.end(), actor_id),
+                  actor_ids.end());
+
+  pool_info.actor_states.erase(actor_id);
+  actor_to_pool_.erase(actor_id);
+
+  RAY_LOG(DEBUG) << "Removed actor " << actor_id << " from pool " << pool_id;
+}
+
+std::vector<rpc::ObjectReference> ActorPoolManager::SubmitTaskToPool(
+    const ActorPoolID &pool_id,
+    const RayFunction &function,
+    std::vector<std::unique_ptr<TaskArg>> args,
+    const TaskOptions &task_options) {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    RAY_LOG(ERROR) << "Pool not found: " << pool_id;
+    return {};
+  }
+
+  auto &work_queue = work_queues_[pool_id];
+
+  // Work item ID is an opaque unique key for retry tracking — it is NOT the
+  // actual TaskID used for submission (SubmitActorTaskForPool creates that).
+  // The nil JobID is fine because this ID never enters the task lineage.
+  TaskID work_item_id = TaskID::FromRandom(JobID());
+  PoolWorkItem work_item;
+  work_item.work_item_id = work_item_id;
+  work_item.function = function;
+  work_item.args = std::move(args);
+  work_item.options = task_options;
+  work_item.attempt_number = 0;
+  work_item.enqueued_at_ms = current_time_ms();
+
+  // Precompute by-reference arg ObjectIDs for locality-aware scheduling.
+  // Stored once in the work item so DrainWorkQueue and RetryWorkItem
+  // can reuse them without re-serializing args.
+  for (const auto &arg : work_item.args) {
+    rpc::TaskArg arg_proto;
+    arg->ToProto(&arg_proto);
+    if (arg_proto.has_object_ref()) {
+      work_item.arg_ids.push_back(
+          ObjectID::FromBinary(arg_proto.object_ref().object_id()));
+    }
+  }
+
+  ActorID selected_actor = SelectActorFromPool(pool_id, work_item.arg_ids);
+
+  if (selected_actor.IsNil()) {
+    RAY_LOG(DEBUG) << "No actors available in pool " << pool_id
+                   << ", enqueueing work item " << work_item_id;
+    work_queue->Push(std::move(work_item));
+    return {};
+  }
+
+  return SubmitToActor(pool_id, selected_actor, std::move(work_item));
+}
+
+std::vector<ActorID> ActorPoolManager::GetPoolActors(const ActorPoolID &pool_id) const {
+  absl::MutexLock lock(&mu_);
+
+  auto it = pools_.find(pool_id);
+  if (it == pools_.end()) {
+    return {};
+  }
+
+  return it->second.actor_ids;
+}
+
+PoolStats ActorPoolManager::GetPoolStats(const ActorPoolID &pool_id) const {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    return PoolStats{};
+  }
+
+  const auto &pool_info = pool_it->second;
+  auto wq_it = work_queues_.find(pool_id);
+  if (wq_it == work_queues_.end()) {
+    return PoolStats{};
+  }
+  const auto &work_queue = wq_it->second;
+
+  PoolStats stats;
+  stats.total_tasks_submitted = pool_info.total_tasks_submitted;
+  stats.total_tasks_failed = pool_info.total_tasks_failed;
+  stats.total_tasks_retried = pool_info.total_tasks_retried;
+  stats.num_actors = static_cast<int32_t>(pool_info.actor_ids.size());
+  stats.backlog_size = work_queue->Size();
+
+  int32_t total_in_flight = 0;
+  for (const auto &[actor_id, state] : pool_info.actor_states) {
+    total_in_flight += state.num_tasks_in_flight;
+  }
+  stats.total_in_flight = total_in_flight;
+
+  return stats;
+}
+
+bool ActorPoolManager::HasPool(const ActorPoolID &pool_id) const {
+  absl::MutexLock lock(&mu_);
+  return pools_.find(pool_id) != pools_.end();
+}
+
+int64_t ActorPoolManager::GetOccupiedTaskSlots(const ActorPoolID &pool_id) const {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    return 0;
+  }
+
+  const auto &pool_info = pool_it->second;
+  int64_t total_in_flight = 0;
+  for (const auto &[actor_id, state] : pool_info.actor_states) {
+    total_in_flight += state.num_tasks_in_flight;
+  }
+
+  auto wq_it = work_queues_.find(pool_id);
+  int64_t backlog = (wq_it != work_queues_.end()) ? wq_it->second->Size() : 0;
+
+  return total_in_flight + backlog;
+}
+
+int32_t ActorPoolManager::GetNumActiveActors(const ActorPoolID &pool_id) const {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    return 0;
+  }
+
+  int32_t active = 0;
+  for (const auto &[actor_id, state] : pool_it->second.actor_states) {
+    if (state.num_tasks_in_flight > 0) {
+      active++;
+    }
+  }
+  return active;
+}
+
+ActorID ActorPoolManager::SelectActorForTask(const ActorPoolID &pool_id,
+                                             const std::vector<ObjectID> &arg_ids) {
+  absl::MutexLock lock(&mu_);
+  return SelectActorFromPool(pool_id, arg_ids);
+}
+
+void ActorPoolManager::OnPoolTaskComplete(const ActorPoolID &pool_id,
+                                          const TaskID &work_item_id,
+                                          const TaskID &task_id,
+                                          const ActorID &actor_id,
+                                          const Status &status,
+                                          const rpc::RayErrorInfo *error_info) {
+  RAY_LOG(DEBUG) << "Pool task complete: pool=" << pool_id
+                 << ", work_item=" << work_item_id << ", task=" << task_id
+                 << ", actor=" << actor_id << ", status=" << status.ToString();
+
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    RAY_LOG(DEBUG) << "Pool " << pool_id << " no longer exists, ignoring task completion";
+    return;
+  }
+
+  if (status.ok()) {
+    OnTaskSucceeded(pool_id, actor_id);
+    work_items_.erase(work_item_id);
+  } else {
+    if (error_info != nullptr) {
+      OnTaskFailed(pool_id, work_item_id, actor_id, *error_info);
+    } else {
+      rpc::RayErrorInfo generic_error;
+      generic_error.set_error_type(rpc::ErrorType::ACTOR_DIED);
+      generic_error.set_error_message("Task failed with unknown error: " +
+                                      status.ToString());
+      OnTaskFailed(pool_id, work_item_id, actor_id, generic_error);
+    }
+  }
+}
+
+void ActorPoolManager::OnActorAlive(const ActorID &actor_id, const NodeID &node_id) {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = actor_to_pool_.find(actor_id);
+  if (pool_it == actor_to_pool_.end()) {
+    return;  // Actor not in any pool.
+  }
+
+  const auto &pool_id = pool_it->second;
+  auto info_it = pools_.find(pool_id);
+  if (info_it == pools_.end()) {
+    return;
+  }
+
+  auto &pool_info = info_it->second;
+  auto state_it = pool_info.actor_states.find(actor_id);
+  if (state_it == pool_info.actor_states.end()) {
+    return;
+  }
+
+  auto &actor_state = state_it->second;
+  actor_state.is_alive = true;
+  // Reset in-flight count. Cross-actor retry redirects tasks to other actors
+  // via InternalHeartbeat, bypassing SubmitToActor (so num_tasks_in_flight is
+  // not incremented on the target). The guarded decrement in OnTaskSucceeded
+  // (num_tasks_in_flight > 0) prevents underflow. Minor load-balancing
+  // imprecision only, not a correctness issue.
+  actor_state.num_tasks_in_flight = 0;
+  if (!node_id.IsNil()) {
+    actor_state.location = node_id;
+  }
+
+  RAY_LOG(INFO) << "Actor " << actor_id << " in pool " << pool_id
+                << " is alive (possibly restarted), draining work queue";
+
+  DrainWorkQueue(pool_id);
+}
+
+void ActorPoolManager::OnActorDead(const ActorID &actor_id) {
+  absl::MutexLock lock(&mu_);
+
+  auto pool_it = actor_to_pool_.find(actor_id);
+  if (pool_it == actor_to_pool_.end()) {
+    return;
+  }
+
+  const auto &pool_id = pool_it->second;
+  auto info_it = pools_.find(pool_id);
+  if (info_it == pools_.end()) {
+    return;
+  }
+
+  auto state_it = info_it->second.actor_states.find(actor_id);
+  if (state_it == info_it->second.actor_states.end()) {
+    return;
+  }
+
+  state_it->second.is_alive = false;
+
+  RAY_LOG(INFO) << "Actor " << actor_id << " in pool " << pool_id
+                << " marked dead/restarting";
+}
+
+ActorID ActorPoolManager::SelectActorFromPool(const ActorPoolID &pool_id,
+                                              const std::vector<ObjectID> &arg_ids) {
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    RAY_LOG(WARNING) << "Pool not found: " << pool_id;
+    return ActorID::Nil();
+  }
+
+  const auto &pool_info = pool_it->second;
+
+  // Prefer alive actors with available capacity, but fall back to any alive actor.
+  // The ActorTaskSubmitter manages its own per-actor queue and always returns valid
+  // ObjectRefs, so over-submitting beyond max_tasks_in_flight_per_actor is safe.
+  std::vector<ActorID> candidates;
+  std::vector<ActorID> alive_actors;
+  for (const auto &actor_id : pool_info.actor_ids) {
+    auto state_it = pool_info.actor_states.find(actor_id);
+    if (state_it == pool_info.actor_states.end()) {
+      continue;
+    }
+
+    const auto &state = state_it->second;
+    if (!state.is_alive) {
+      continue;
+    }
+    alive_actors.push_back(actor_id);
+
+    const int32_t max_concurrency = pool_info.config.max_tasks_in_flight_per_actor;
+    if (state.num_tasks_in_flight < max_concurrency) {
+      candidates.push_back(actor_id);
+    }
+  }
+
+  // Fall back to all alive actors when none have capacity below the configured
+  // limit. This ensures callers always get valid ObjectRefs instead of empty
+  // results from SubmitTaskToPool.
+  if (candidates.empty()) {
+    candidates = std::move(alive_actors);
+  }
+
+  if (candidates.empty()) {
+    RAY_LOG(DEBUG) << "No alive actors in pool " << pool_id;
+    return ActorID::Nil();
+  }
+
+  auto node_bytes = ComputeNodeLocalityMap(arg_ids);
+
+  auto best_actor = *std::min_element(
+      candidates.begin(), candidates.end(), [&](const ActorID &a, const ActorID &b) {
+        return RankActor(a, node_bytes, pool_info) < RankActor(b, node_bytes, pool_info);
+      });
+
+  RAY_LOG(DEBUG) << "Selected actor " << best_actor << " from pool " << pool_id;
+  return best_actor;
+}
+
+std::pair<int64_t, int32_t> ActorPoolManager::RankActor(
+    const ActorID &actor_id,
+    const absl::flat_hash_map<NodeID, uint64_t> &node_bytes,
+    const ActorPoolInfo &pool_info) const {
+  auto state_it = pool_info.actor_states.find(actor_id);
+  if (state_it == pool_info.actor_states.end()) {
+    return {INT64_MAX, INT32_MAX};
+  }
+
+  const auto &state = state_it->second;
+  int32_t load = state.num_tasks_in_flight;
+
+  if (node_bytes.empty()) {
+    return {0, load};
+  }
+
+  // Rank by (-local_bytes, load): actors on nodes holding more task data rank higher.
+  auto bytes_it = node_bytes.find(state.location);
+  if (bytes_it != node_bytes.end()) {
+    return {-static_cast<int64_t>(bytes_it->second), load};
+  }
+
+  return {INT64_MAX, load};
+}
+
+absl::flat_hash_map<NodeID, uint64_t> ActorPoolManager::ComputeNodeLocalityMap(
+    const std::vector<ObjectID> &arg_ids) const {
+  absl::flat_hash_map<NodeID, uint64_t> node_bytes;
+  if (!locality_data_provider_ || arg_ids.empty()) {
+    return node_bytes;
+  }
+
+  for (const auto &arg_id : arg_ids) {
+    auto locality = locality_data_provider_->GetLocalityData(arg_id);
+    if (!locality.has_value()) {
+      continue;
+    }
+    for (const auto &node_id : locality->nodes_containing_object) {
+      node_bytes[node_id] += locality->object_size;
+    }
+  }
+
+  return node_bytes;
+}
+
+std::vector<rpc::ObjectReference> ActorPoolManager::SubmitToActor(
+    const ActorPoolID &pool_id, const ActorID &actor_id, PoolWorkItem work_item) {
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    RAY_LOG(ERROR) << "Pool not found: " << pool_id;
+    return {};
+  }
+
+  auto &pool_info = pool_it->second;
+
+  auto &actor_state = pool_info.actor_states[actor_id];
+  actor_state.num_tasks_in_flight++;
+  pool_info.total_tasks_submitted++;
+
+  TaskID work_item_id = work_item.work_item_id;
+  int32_t attempt_number = work_item.attempt_number;
+
+  RAY_LOG(DEBUG) << "Submitting work item " << work_item_id << " to actor " << actor_id
+                 << " in pool " << pool_id << " (attempt " << attempt_number << ")";
+
+  if (!submit_actor_task_fn_) {
+    RAY_LOG(WARNING) << "SubmitToActor called without submit callback (minimal mode)";
+    work_items_[work_item_id] = std::move(work_item);
+    return {};
+  }
+
+  // Clone args before moving work_item into work_items_ (we need args for submission).
+  auto args_for_submit = CloneArgs(work_item.args);
+  RayFunction function = work_item.function;
+  TaskOptions options = work_item.options;
+
+  work_items_[work_item_id] = std::move(work_item);
+
+  // Completion is NOT handled via this callback — it flows through
+  // ActorTaskSubmitter::HandlePushTaskReply() → SetPoolTaskCompletionCallback()
+  // → OnPoolTaskComplete(). We pass nullptr to avoid duplicate handling.
+  return submit_actor_task_fn_(actor_id,
+                               function,
+                               std::move(args_for_submit),
+                               options,
+                               nullptr,
+                               pool_id,
+                               work_item_id);
+}
+
+void ActorPoolManager::OnTaskFailed(const ActorPoolID &pool_id,
+                                    const TaskID &work_item_id,
+                                    const ActorID &failed_actor_id,
+                                    const rpc::RayErrorInfo &error_info) {
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    RAY_LOG(WARNING) << "Pool not found: " << pool_id;
+    return;
+  }
+
+  auto &pool_info = pool_it->second;
+
+  auto actor_state_it = pool_info.actor_states.find(failed_actor_id);
+  if (actor_state_it != pool_info.actor_states.end()) {
+    auto &actor_state = actor_state_it->second;
+    if (actor_state.num_tasks_in_flight > 0) {
+      actor_state.num_tasks_in_flight--;
+    }
+
+    // Mark actor as not alive on system errors (actor death, node death).
+    // The actor may come back via OnActorAlive when GCS notifies of a restart.
+    // Note: with max_retries=-1, actor death errors are retried by the
+    // ActorTaskSubmitter and the pool callback never fires for those, so this
+    // code path is only reached for non-retried failures. Kept as a safety net
+    // and for OnActorDead which is the primary liveness tracker.
+    if (error_info.error_type() == rpc::ErrorType::ACTOR_DIED ||
+        error_info.error_type() == rpc::ErrorType::ACTOR_UNAVAILABLE ||
+        error_info.error_type() == rpc::ErrorType::WORKER_DIED ||
+        error_info.error_type() == rpc::ErrorType::NODE_DIED) {
+      actor_state.is_alive = false;
+    }
+  }
+
+  pool_info.total_tasks_failed++;
+
+  bool should_retry = ShouldRetryTask(pool_info.config, error_info);
+
+  if (!should_retry) {
+    RAY_LOG(INFO) << "Work item " << work_item_id << " failed with non-retriable error, "
+                  << "not retrying. Error: " << error_info.error_message();
+    FailWorkItem(work_item_id, error_info);
+    return;
+  }
+
+  auto work_item_it = work_items_.find(work_item_id);
+  if (work_item_it == work_items_.end()) {
+    RAY_LOG(WARNING) << "Work item " << work_item_id << " not found for retry";
+    return;
+  }
+
+  auto work_item = std::move(work_item_it->second);
+  work_items_.erase(work_item_it);
+
+  work_item.attempt_number++;
+
+  if (pool_info.config.max_retry_attempts >= 0 &&
+      work_item.attempt_number > pool_info.config.max_retry_attempts) {
+    RAY_LOG(INFO) << "Work item " << work_item_id << " exceeded max retry attempts ("
+                  << pool_info.config.max_retry_attempts << "), failing permanently";
+    FailWorkItem(work_item_id, error_info);
+    return;
+  }
+
+  pool_info.total_tasks_retried++;
+
+  int64_t backoff_ms = CalculateBackoff(work_item.attempt_number,
+                                        pool_info.config.retry_backoff_ms,
+                                        pool_info.config.retry_backoff_multiplier,
+                                        pool_info.config.max_retry_backoff_ms);
+
+  RAY_LOG(INFO) << "Work item " << work_item_id << " failed on actor " << failed_actor_id
+                << ", retrying (attempt " << work_item.attempt_number << ") after "
+                << backoff_ms << "ms on different actor in pool " << pool_id;
+
+  ScheduleRetry(pool_id, std::move(work_item), backoff_ms);
+}
+
+void ActorPoolManager::OnTaskSucceeded(const ActorPoolID &pool_id,
+                                       const ActorID &actor_id) {
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    return;
+  }
+
+  auto state_it = pool_it->second.actor_states.find(actor_id);
+  if (state_it == pool_it->second.actor_states.end()) {
+    // Actor was removed from pool; ignore late-arriving success callback.
+    return;
+  }
+  auto &actor_state = state_it->second;
+  if (actor_state.num_tasks_in_flight > 0) {
+    actor_state.num_tasks_in_flight--;
+  }
+
+  DrainWorkQueue(pool_id);
+}
+
+void ActorPoolManager::ScheduleRetry(const ActorPoolID &pool_id,
+                                     PoolWorkItem work_item,
+                                     int64_t backoff_ms) {
+  if (backoff_ms <= 0) {
+    RetryWorkItem(pool_id, std::move(work_item));
+    return;
+  }
+
+  if (!io_service_) {
+    RAY_LOG(DEBUG) << "No io_service available, performing immediate retry for work item "
+                   << work_item.work_item_id;
+    RetryWorkItem(pool_id, std::move(work_item));
+    return;
+  }
+
+  RAY_LOG(DEBUG) << "Scheduling retry for work item " << work_item.work_item_id
+                 << " with backoff " << backoff_ms << "ms";
+
+  // shared_ptr so the timer outlives this scope until the callback fires.
+  auto timer = std::make_shared<boost::asio::steady_timer>(
+      *io_service_, std::chrono::milliseconds(backoff_ms));
+
+  // Captures `this` — safe because ActorPoolManager outlives CoreWorker's io_service.
+  timer->async_wait([this, pool_id, work_item = std::move(work_item), timer](
+                        const boost::system::error_code &ec) mutable {
+    if (ec) {
+      RAY_LOG(WARNING) << "Timer error during retry scheduling: " << ec.message();
+      return;
+    }
+    absl::MutexLock lock(&mu_);
+    RetryWorkItem(pool_id, std::move(work_item));
+  });
+}
+
+void ActorPoolManager::RetryWorkItem(const ActorPoolID &pool_id, PoolWorkItem work_item) {
+  auto pool_it = pools_.find(pool_id);
+  if (pool_it == pools_.end()) {
+    RAY_LOG(WARNING) << "Pool not found during retry: " << pool_id;
+    return;
+  }
+
+  auto &work_queue = work_queues_[pool_id];
+
+  ActorID selected_actor = SelectActorFromPool(pool_id, work_item.arg_ids);
+
+  if (selected_actor.IsNil()) {
+    RAY_LOG(DEBUG) << "No actors available for retry of work item "
+                   << work_item.work_item_id << ", re-enqueueing";
+    work_queue->Push(std::move(work_item));
+    return;
+  }
+
+  RAY_LOG(INFO) << "Retrying work item " << work_item.work_item_id << " on actor "
+                << selected_actor << " (attempt " << work_item.attempt_number << ")";
+
+  SubmitToActor(pool_id, selected_actor, std::move(work_item));
+}
+
+bool ActorPoolManager::ShouldRetryTask(const ActorPoolConfig &config,
+                                       const rpc::RayErrorInfo &error_info) const {
+  if (!config.retry_on_system_errors) {
+    return false;
+  }
+
+  switch (error_info.error_type()) {
+  case rpc::ErrorType::ACTOR_DIED:
+  case rpc::ErrorType::ACTOR_UNAVAILABLE:
+  case rpc::ErrorType::NODE_DIED:
+  case rpc::ErrorType::WORKER_DIED:
+    return true;
+
+  case rpc::ErrorType::TASK_CANCELLED:
+    return false;
+
+  case rpc::ErrorType::TASK_EXECUTION_EXCEPTION:
+  case rpc::ErrorType::RUNTIME_ENV_SETUP_FAILED:
+  case rpc::ErrorType::OUT_OF_MEMORY:
+    // Retrying OOM on a different actor is unlikely to help.
+    return false;
+
+  default:
+    RAY_LOG(WARNING) << "Unknown error type: " << error_info.error_type()
+                     << ", not retrying";
+    return false;
+  }
+}
+
+int64_t ActorPoolManager::CalculateBackoff(int32_t attempt_number,
+                                           int32_t base_backoff_ms,
+                                           float multiplier,
+                                           int32_t max_backoff_ms) const {
+  if (attempt_number <= 1) {
+    return base_backoff_ms;
+  }
+
+  // Exponential backoff: base * multiplier^(attempt-1)
+  int64_t backoff = base_backoff_ms;
+  for (int32_t i = 1; i < attempt_number; i++) {
+    backoff = static_cast<int64_t>(backoff * multiplier);
+    if (backoff > max_backoff_ms) {
+      backoff = max_backoff_ms;
+      break;
+    }
+  }
+
+  return std::min(backoff, static_cast<int64_t>(max_backoff_ms));
+}
+
+void ActorPoolManager::FailWorkItem(const TaskID &work_item_id,
+                                    const rpc::RayErrorInfo &error_info) {
+  work_items_.erase(work_item_id);
+
+  RAY_LOG(INFO) << "Work item " << work_item_id
+                << " failed permanently. Error: " << error_info.error_message();
+
+  // The actual task failure is surfaced by TaskManager via the reply callback.
+  // We only clean up pool-level tracking state here.
+}
+
+std::vector<std::unique_ptr<TaskArg>> ActorPoolManager::CloneArgs(
+    const std::vector<std::unique_ptr<TaskArg>> &args) const {
+  std::vector<std::unique_ptr<TaskArg>> cloned_args;
+  cloned_args.reserve(args.size());
+
+  for (const auto &arg : args) {
+    rpc::TaskArg arg_proto;
+    arg->ToProto(&arg_proto);
+
+    if (arg_proto.has_object_ref()) {
+      cloned_args.push_back(std::make_unique<TaskArgByReference>(
+          ObjectID::FromBinary(arg_proto.object_ref().object_id()),
+          rpc::Address(arg_proto.object_ref().owner_address()),
+          arg_proto.object_ref().call_site()));
+    } else if (!arg_proto.data().empty() || !arg_proto.metadata().empty()) {
+      // const_cast is safe: copy_data=true makes LocalMemoryBuffer deep-copy immediately.
+      std::shared_ptr<LocalMemoryBuffer> data = nullptr;
+      if (!arg_proto.data().empty()) {
+        data = std::make_shared<LocalMemoryBuffer>(
+            reinterpret_cast<uint8_t *>(const_cast<char *>(arg_proto.data().data())),
+            arg_proto.data().size(),
+            /*copy_data=*/true);
+      }
+
+      std::shared_ptr<LocalMemoryBuffer> metadata = nullptr;
+      if (!arg_proto.metadata().empty()) {
+        metadata = std::make_shared<LocalMemoryBuffer>(
+            reinterpret_cast<uint8_t *>(const_cast<char *>(arg_proto.metadata().data())),
+            arg_proto.metadata().size(),
+            /*copy_data=*/true);
+      }
+
+      std::vector<rpc::ObjectReference> nested_refs;
+      nested_refs.reserve(arg_proto.nested_inlined_refs_size());
+      for (const auto &nested_ref : arg_proto.nested_inlined_refs()) {
+        nested_refs.push_back(nested_ref);
+      }
+
+      cloned_args.push_back(std::make_unique<TaskArgByValue>(
+          std::make_shared<RayObject>(data, metadata, nested_refs, /*copy_data=*/true)));
+    }
+  }
+
+  return cloned_args;
+}
+
+void ActorPoolManager::DrainWorkQueue(const ActorPoolID &pool_id) {
+  auto wq_it = work_queues_.find(pool_id);
+  if (wq_it == work_queues_.end()) {
+    return;
+  }
+
+  auto &work_queue = wq_it->second;
+  while (work_queue->HasWork()) {
+    auto work_item = work_queue->Pop();
+    if (!work_item.has_value()) {
+      break;
+    }
+
+    ActorID actor = SelectActorFromPool(pool_id, work_item->arg_ids);
+    if (actor.IsNil()) {
+      // No actors available — push the item back and stop draining.
+      work_queue->Push(std::move(*work_item));
+      break;
+    }
+
+    RAY_LOG(DEBUG) << "Draining queued work item " << work_item->work_item_id
+                   << " to actor " << actor << " in pool " << pool_id;
+    SubmitToActor(pool_id, actor, std::move(*work_item));
+  }
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/actor_pool_manager.h
+++ b/src/ray/core_worker/actor_pool_manager.h
@@ -1,0 +1,459 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gtest/gtest_prod.h>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/synchronization/mutex.h"
+#include "ray/common/asio/instrumented_io_context.h"
+#include "ray/common/id.h"
+#include "ray/common/task/task_common.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/core_worker/actor_pool_work_queue.h"
+#include "ray/core_worker/common.h"
+#include "ray/util/time.h"
+#include "src/ray/protobuf/common.pb.h"
+
+namespace ray {
+namespace core {
+
+// Forward declarations
+class ActorManager;
+class ActorTaskSubmitterInterface;
+class LocalityDataProviderInterface;
+class TaskManagerInterface;
+
+/// Callback type for task completion (success or failure).
+/// \param status The status of the task.
+/// \param error_info Error information if the task failed (nullptr on success).
+using TaskCompletionCallback =
+    std::function<void(const Status &status, const rpc::RayErrorInfo *error_info)>;
+
+/// Callback type for submitting an actor task via CoreWorker.
+/// This allows ActorPoolManager to delegate TaskSpec building to CoreWorker.
+///
+/// \param actor_id The actor to submit the task to.
+/// \param function The function to execute.
+/// \param args The task arguments.
+/// \param task_options Task options.
+/// \param on_complete Callback to invoke when the task completes.
+/// \param pool_id The actor pool this task belongs to.
+/// \param work_item_id The work item ID for pool-level tracking.
+/// \return Object references for the task's return values.
+using SubmitActorTaskCallback = std::function<std::vector<rpc::ObjectReference>(
+    const ActorID &actor_id,
+    const RayFunction &function,
+    std::vector<std::unique_ptr<TaskArg>> args,
+    const TaskOptions &task_options,
+    TaskCompletionCallback on_complete,
+    const ActorPoolID &pool_id,
+    const TaskID &work_item_id)>;
+
+/// Configuration for an actor pool.
+struct ActorPoolConfig {
+  /// Retry configuration
+  int32_t max_retry_attempts = 3;
+  int32_t retry_backoff_ms = 1000;
+  float retry_backoff_multiplier = 2.0f;
+  int32_t max_retry_backoff_ms = 60000;
+  bool retry_on_system_errors = true;
+
+  /// Max concurrent tasks per actor (controls admission in SelectActorFromPool).
+  int32_t max_tasks_in_flight_per_actor = 1;
+};
+
+/// State of an actor within a pool.
+struct ActorPoolActorState {
+  /// Number of tasks currently in flight for this actor.
+  int32_t num_tasks_in_flight = 0;
+
+  /// Location of the actor (for locality-aware scheduling).
+  NodeID location;
+
+  /// Whether this actor is alive and can accept work.
+  bool is_alive = true;
+};
+
+/// Information about an actor pool.
+struct ActorPoolInfo {
+  /// Pool configuration.
+  ActorPoolConfig config;
+
+  /// List of actor IDs in this pool.
+  std::vector<ActorID> actor_ids;
+
+  /// State for each actor in the pool.
+  absl::flat_hash_map<ActorID, ActorPoolActorState> actor_states;
+
+  /// Total number of tasks submitted to this pool.
+  int64_t total_tasks_submitted = 0;
+
+  /// Total number of tasks that failed.
+  int64_t total_tasks_failed = 0;
+
+  /// Total number of tasks that were retried.
+  int64_t total_tasks_retried = 0;
+};
+
+/// Statistics for an actor pool.
+struct PoolStats {
+  /// Total tasks submitted to the pool.
+  int64_t total_tasks_submitted = 0;
+
+  /// Total tasks that failed.
+  int64_t total_tasks_failed = 0;
+
+  /// Total tasks that were retried.
+  int64_t total_tasks_retried = 0;
+
+  /// Current number of actors in the pool.
+  int32_t num_actors = 0;
+
+  /// Current backlog size (queued work items).
+  size_t backlog_size = 0;
+
+  /// Total in-flight tasks across all actors.
+  int32_t total_in_flight = 0;
+};
+
+/// Manages actor pools for cross-actor retry and load balancing.
+///
+/// This class provides pool-level task submission where the pool (not the caller)
+/// selects which actor to execute the task. When a task fails, the pool can retry
+/// it on a different actor, avoiding the thundering herd problem of actor-bound retries.
+///
+/// Task completion is notified via OnPoolTaskComplete(), which is called by the
+/// callback wired through ActorTaskSubmitter::SetPoolTaskCompletionCallback().
+/// This enables the cross-actor retry mechanism:
+///   1. Task submitted to actor via SubmitToActor()
+///   2. Task completes (success or failure)
+///   3. ActorTaskSubmitter::HandlePushTaskReply() detects pool task and notifies
+///   4. OnPoolTaskComplete() called, which invokes OnTaskSucceeded/OnTaskFailed
+///   5. On failure, task can be re-enqueued and retried on a different actor
+///
+/// This class is thread-safe.
+class ActorPoolManager {
+ public:
+  /// Constructor (minimal, for testing without full CoreWorker integration).
+  ///
+  /// \param actor_manager Reference to the ActorManager.
+  /// \param task_submitter Reference to the ActorTaskSubmitter.
+  /// \param task_manager Reference to the TaskManager.
+  ActorPoolManager(ActorManager &actor_manager,
+                   ActorTaskSubmitterInterface &task_submitter,
+                   TaskManagerInterface &task_manager);
+
+  /// Constructor with full CoreWorker integration.
+  ///
+  /// \param actor_manager Reference to the ActorManager.
+  /// \param task_submitter Reference to the ActorTaskSubmitter.
+  /// \param task_manager Reference to the TaskManager.
+  /// \param io_service Reference to the IO service for delayed retry scheduling.
+  /// \param submit_actor_task_fn Callback to submit actor tasks via CoreWorker.
+  /// \param locality_data_provider Provider for object locality data (nullable).
+  ActorPoolManager(ActorManager &actor_manager,
+                   ActorTaskSubmitterInterface &task_submitter,
+                   TaskManagerInterface &task_manager,
+                   instrumented_io_context &io_service,
+                   SubmitActorTaskCallback submit_actor_task_fn,
+                   LocalityDataProviderInterface *locality_data_provider = nullptr);
+
+  ~ActorPoolManager() = default;
+
+  /// Register a new actor pool.
+  ///
+  /// \param config Pool configuration (retry, ordering, autoscaling).
+  /// \param initial_actors Optional initial set of actor IDs to add to the pool.
+  /// \return The ID of the newly created pool.
+  ActorPoolID RegisterPool(const ActorPoolConfig &config,
+                           const std::vector<ActorID> &initial_actors = {});
+
+  /// Unregister an actor pool and clean up resources.
+  ///
+  /// \param pool_id The ID of the pool to unregister.
+  void UnregisterPool(const ActorPoolID &pool_id);
+
+  /// Add an actor to a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \param actor_id The ID of the actor to add.
+  /// \param location The node ID where the actor is located.
+  void AddActorToPool(const ActorPoolID &pool_id,
+                      const ActorID &actor_id,
+                      const NodeID &location);
+
+  /// Remove an actor from a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \param actor_id The ID of the actor to remove.
+  void RemoveActorFromPool(const ActorPoolID &pool_id, const ActorID &actor_id);
+
+  /// Submit a task to an actor pool.
+  /// The pool will select an appropriate actor based on load and locality.
+  ///
+  /// \param pool_id The ID of the pool to submit to.
+  /// \param function The function to execute.
+  /// \param args The task arguments.
+  /// \param task_options Task options (num_returns, resources, etc).
+  /// \return Object references for the task's return values.
+  std::vector<rpc::ObjectReference> SubmitTaskToPool(
+      const ActorPoolID &pool_id,
+      const RayFunction &function,
+      std::vector<std::unique_ptr<TaskArg>> args,
+      const TaskOptions &task_options);
+
+  /// Get all actor IDs in a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \return Vector of actor IDs in the pool.
+  std::vector<ActorID> GetPoolActors(const ActorPoolID &pool_id) const;
+
+  /// Get statistics for a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \return Pool statistics.
+  PoolStats GetPoolStats(const ActorPoolID &pool_id) const;
+
+  /// Check if a pool exists.
+  ///
+  /// \param pool_id The ID of the pool to check.
+  /// \return True if the pool exists.
+  bool HasPool(const ActorPoolID &pool_id) const;
+
+  /// Returns in_flight + backlog — single number for backpressure decisions.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \return Total occupied task slots (in-flight tasks + queued work items).
+  int64_t GetOccupiedTaskSlots(const ActorPoolID &pool_id) const;
+
+  /// Returns number of actors with num_tasks_in_flight > 0.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \return Number of actors currently processing tasks.
+  int32_t GetNumActiveActors(const ActorPoolID &pool_id) const;
+
+  /// Select an actor from the pool for task execution or reconstruction.
+  /// Thread-safe wrapper around SelectActorFromPool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \param arg_ids Object IDs of task arguments (for locality).
+  /// \return The selected actor ID, or Nil if no actors are available.
+  ActorID SelectActorForTask(const ActorPoolID &pool_id,
+                             const std::vector<ObjectID> &arg_ids = {});
+
+  /// Called when a pool task terminally completes (success or exhausted retries).
+  /// Updates num_tasks_in_flight and drains queued work on success.
+  /// Called by ActorTaskSubmitter via MaybeNotifyPoolTaskComplete.
+  ///
+  /// \param pool_id The ID of the pool the task belongs to.
+  /// \param work_item_id The ID of the work item within the pool.
+  /// \param task_id The ID of the completed task.
+  /// \param actor_id The ID of the actor that executed the task.
+  /// \param status The completion status (OK for success, error for failure).
+  /// \param error_info Error information if the task failed (nullptr on success).
+  void OnPoolTaskComplete(const ActorPoolID &pool_id,
+                          const TaskID &work_item_id,
+                          const TaskID &task_id,
+                          const ActorID &actor_id,
+                          const Status &status,
+                          const rpc::RayErrorInfo *error_info);
+
+  /// Notify that an actor has come alive (e.g. after restart).
+  /// Called from ActorManager::HandleActorStateNotification when state = ALIVE.
+  /// Marks the actor as alive and drains the work queue to dispatch queued tasks.
+  ///
+  /// \param actor_id The actor that is now alive.
+  /// \param node_id The node the actor is running on.
+  void OnActorAlive(const ActorID &actor_id, const NodeID &node_id);
+
+  /// Notify that an actor is dead or restarting.
+  /// Called from ActorManager::HandleActorStateNotification when state = RESTARTING/DEAD.
+  /// Marks the actor as not alive so SelectActorFromPool skips it.
+  ///
+  /// \param actor_id The actor that is dead or restarting.
+  void OnActorDead(const ActorID &actor_id);
+
+ private:
+  FRIEND_TEST(ActorPoolManagerLocalityTest, LocalitySelectsDataLocalActor);
+  FRIEND_TEST(ActorPoolManagerLocalityTest, LocalityTiebreakerIsLoad);
+  FRIEND_TEST(ActorPoolManagerLocalityTest, LargerDataNodeWins);
+  FRIEND_TEST(ActorPoolManagerLocalityTest, FallsBackToLoadWithoutLocalityData);
+  FRIEND_TEST(ActorPoolManagerTest, GetOccupiedTaskSlots);
+  FRIEND_TEST(ActorPoolManagerTest, GetNumActiveActors);
+  FRIEND_TEST(ActorPoolManagerTest, OnTaskFailedMarksActorDead);
+  FRIEND_TEST(ActorPoolManagerTest, OnActorAliveDrainsQueue);
+  FRIEND_TEST(ActorPoolManagerTest, OnActorDeadMarksActorNotAlive);
+
+  /// Select the best actor from a pool based on load and locality.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \param arg_ids Object IDs of task arguments (for locality).
+  /// \return The selected actor ID, or Nil if no actors are available.
+  ActorID SelectActorFromPool(const ActorPoolID &pool_id,
+                              const std::vector<ObjectID> &arg_ids)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Rank an actor for scheduling (lower is better).
+  /// Returns (locality_rank, load) pair for lexicographic comparison.
+  /// locality_rank is -total_bytes for data-local nodes, INT64_MAX for remote.
+  ///
+  /// \param actor_id The actor to rank.
+  /// \param node_bytes Pre-computed map of NodeID → total data bytes.
+  /// \param pool_info Pool information.
+  /// \return (locality_rank, load) pair.
+  std::pair<int64_t, int32_t> RankActor(
+      const ActorID &actor_id,
+      const absl::flat_hash_map<NodeID, uint64_t> &node_bytes,
+      const ActorPoolInfo &pool_info) const;
+
+  /// Compute a map of NodeID → total bytes of task arguments on that node.
+  /// Hoisted out of per-candidate loop for efficiency.
+  ///
+  /// \param arg_ids Object IDs of task arguments.
+  /// \return Map from node ID to total bytes of arguments on that node.
+  absl::flat_hash_map<NodeID, uint64_t> ComputeNodeLocalityMap(
+      const std::vector<ObjectID> &arg_ids) const;
+
+  /// Submit a work item to a specific actor.
+  ///
+  /// \param pool_id The pool ID.
+  /// \param actor_id The actor to submit to.
+  /// \param work_item The work item to submit.
+  /// \return Object references for the task's return values.
+  std::vector<rpc::ObjectReference> SubmitToActor(const ActorPoolID &pool_id,
+                                                  const ActorID &actor_id,
+                                                  PoolWorkItem work_item)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Handle a task failure and potentially retry on a different actor.
+  ///
+  /// \param pool_id The pool ID.
+  /// \param work_item_id The work item ID.
+  /// \param failed_actor_id The actor that failed.
+  /// \param error_info Error information.
+  void OnTaskFailed(const ActorPoolID &pool_id,
+                    const TaskID &work_item_id,
+                    const ActorID &failed_actor_id,
+                    const rpc::RayErrorInfo &error_info)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Handle a task success.
+  ///
+  /// \param pool_id The pool ID.
+  /// \param actor_id The actor that succeeded.
+  void OnTaskSucceeded(const ActorPoolID &pool_id, const ActorID &actor_id)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Schedule a retry for a work item with backoff.
+  ///
+  /// \param pool_id The pool ID.
+  /// \param work_item The work item to retry.
+  /// \param backoff_ms Backoff time in milliseconds.
+  void ScheduleRetry(const ActorPoolID &pool_id,
+                     PoolWorkItem work_item,
+                     int64_t backoff_ms) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Retry a work item (select actor and submit).
+  ///
+  /// \param pool_id The pool ID.
+  /// \param work_item The work item to retry.
+  void RetryWorkItem(const ActorPoolID &pool_id, PoolWorkItem work_item)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Determine if a task should be retried based on error type.
+  ///
+  /// \param config Pool configuration.
+  /// \param error_info Error information.
+  /// \return True if the task should be retried.
+  bool ShouldRetryTask(const ActorPoolConfig &config,
+                       const rpc::RayErrorInfo &error_info) const;
+
+  /// Calculate backoff time for a retry attempt.
+  ///
+  /// \param attempt_number The attempt number (1-indexed).
+  /// \param base_backoff_ms Base backoff time.
+  /// \param multiplier Backoff multiplier.
+  /// \param max_backoff_ms Maximum backoff time.
+  /// \return Backoff time in milliseconds.
+  int64_t CalculateBackoff(int32_t attempt_number,
+                           int32_t base_backoff_ms,
+                           float multiplier,
+                           int32_t max_backoff_ms) const;
+
+  /// Fail a work item permanently.
+  ///
+  /// \param work_item_id The work item ID.
+  /// \param error_info Error information.
+  void FailWorkItem(const TaskID &work_item_id, const rpc::RayErrorInfo &error_info)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Drain the work queue for a pool, submitting queued items to available actors.
+  /// Called when new capacity becomes available (task succeeded, actor added).
+  ///
+  /// \param pool_id The pool ID whose queue to drain.
+  void DrainWorkQueue(const ActorPoolID &pool_id) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
+  /// Clone task arguments for retry (since we need to keep a copy).
+  std::vector<std::unique_ptr<TaskArg>> CloneArgs(
+      const std::vector<std::unique_ptr<TaskArg>> &args) const;
+
+  /// Reference to the actor manager.
+  ActorManager &actor_manager_;
+
+  /// Reference to the actor task submitter.
+  ActorTaskSubmitterInterface &task_submitter_;
+
+  /// Reference to the task manager.
+  TaskManagerInterface &task_manager_;
+
+  /// Reference to the IO service for delayed retry scheduling.
+  /// May be nullptr if using the minimal constructor.
+  instrumented_io_context *io_service_ = nullptr;
+
+  /// Callback to submit actor tasks via CoreWorker.
+  /// May be nullptr if using the minimal constructor.
+  SubmitActorTaskCallback submit_actor_task_fn_;
+
+  /// Provider for object locality data (for locality-aware scheduling).
+  /// May be nullptr if locality data is unavailable.
+  LocalityDataProviderInterface *locality_data_provider_ = nullptr;
+
+  /// Mutex protecting all pool state.
+  mutable absl::Mutex mu_;
+
+  /// Registry of all actor pools.
+  absl::flat_hash_map<ActorPoolID, ActorPoolInfo> pools_ ABSL_GUARDED_BY(mu_);
+
+  /// Map from actor ID to pool ID (for reverse lookup).
+  absl::flat_hash_map<ActorID, ActorPoolID> actor_to_pool_ ABSL_GUARDED_BY(mu_);
+
+  /// Work queues for each pool.
+  absl::flat_hash_map<ActorPoolID, std::unique_ptr<PoolWorkQueue>> work_queues_
+      ABSL_GUARDED_BY(mu_);
+
+  /// Map from work item ID to work item (for retry tracking).
+  absl::flat_hash_map<TaskID, PoolWorkItem> work_items_ ABSL_GUARDED_BY(mu_);
+};
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/actor_pool_work_queue.cc
+++ b/src/ray/core_worker/actor_pool_work_queue.cc
@@ -1,0 +1,43 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/actor_pool_work_queue.h"
+
+#include <utility>
+
+namespace ray {
+namespace core {
+
+void UnorderedPoolWorkQueue::Push(PoolWorkItem item) {
+  queue_.push_back(std::move(item));
+}
+
+std::optional<PoolWorkItem> UnorderedPoolWorkQueue::Pop() {
+  if (queue_.empty()) {
+    return std::nullopt;
+  }
+
+  PoolWorkItem item = std::move(queue_.front());
+  queue_.pop_front();
+  return std::move(item);
+}
+
+bool UnorderedPoolWorkQueue::HasWork() const { return !queue_.empty(); }
+
+size_t UnorderedPoolWorkQueue::Size() const { return queue_.size(); }
+
+void UnorderedPoolWorkQueue::Clear() { queue_.clear(); }
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/actor_pool_work_queue.h
+++ b/src/ray/core_worker/actor_pool_work_queue.h
@@ -1,0 +1,139 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/common/task/task_util.h"
+#include "ray/core_worker/common.h"
+
+namespace ray {
+namespace core {
+
+/// Represents a work item in the actor pool queue.
+struct PoolWorkItem {
+  /// Unique ID for this work item.
+  TaskID work_item_id;
+
+  /// The function to execute.
+  RayFunction function;
+
+  /// Task arguments.
+  std::vector<std::unique_ptr<TaskArg>> args;
+
+  /// ObjectIDs of by-reference arguments, precomputed for locality-aware scheduling.
+  std::vector<ObjectID> arg_ids;
+
+  /// Task options (num_returns, resources, etc).
+  TaskOptions options;
+
+  /// Number of times this work item has been attempted.
+  int32_t attempt_number = 0;
+
+  /// Timestamp when this work item was enqueued (in milliseconds).
+  int64_t enqueued_at_ms = 0;
+
+  PoolWorkItem() = default;
+
+  /// Move constructor.
+  PoolWorkItem(PoolWorkItem &&other) noexcept
+      : work_item_id(std::move(other.work_item_id)),
+        function(std::move(other.function)),
+        args(std::move(other.args)),
+        arg_ids(std::move(other.arg_ids)),
+        options(std::move(other.options)),
+        attempt_number(other.attempt_number),
+        enqueued_at_ms(other.enqueued_at_ms) {}
+
+  /// Move assignment.
+  PoolWorkItem &operator=(PoolWorkItem &&other) noexcept {
+    if (this != &other) {
+      work_item_id = std::move(other.work_item_id);
+      function = std::move(other.function);
+      args = std::move(other.args);
+      arg_ids = std::move(other.arg_ids);
+      options = std::move(other.options);
+      attempt_number = other.attempt_number;
+      enqueued_at_ms = other.enqueued_at_ms;
+    }
+    return *this;
+  }
+
+  // Delete copy constructor and assignment
+  PoolWorkItem(const PoolWorkItem &) = delete;
+  PoolWorkItem &operator=(const PoolWorkItem &) = delete;
+};
+
+/// Abstract interface for actor pool work queues.
+/// Different implementations can provide different ordering semantics.
+class PoolWorkQueue {
+ public:
+  virtual ~PoolWorkQueue() = default;
+
+  /// Enqueue a work item.
+  ///
+  /// \param item The work item to enqueue.
+  virtual void Push(PoolWorkItem item) = 0;
+
+  /// Dequeue a work item.
+  ///
+  /// \return The work item, or nullopt if no work is available.
+  virtual std::optional<PoolWorkItem> Pop() = 0;
+
+  /// Check if any work is available.
+  ///
+  /// \return True if there is work to process.
+  virtual bool HasWork() const = 0;
+
+  /// Get the total number of items in the queue.
+  ///
+  /// \return The queue depth.
+  virtual size_t Size() const = 0;
+
+  /// Clear all work items from the queue.
+  virtual void Clear() = 0;
+};
+
+/// Unordered work queue implementation.
+/// Work items are processed in FIFO order with no ordering guarantees.
+/// This is the simplest and highest-throughput implementation.
+class UnorderedPoolWorkQueue : public PoolWorkQueue {
+ public:
+  UnorderedPoolWorkQueue() = default;
+  ~UnorderedPoolWorkQueue() override = default;
+
+  void Push(PoolWorkItem item) override;
+
+  std::optional<PoolWorkItem> Pop() override;
+
+  bool HasWork() const override;
+
+  size_t Size() const override;
+
+  void Clear() override;
+
+ private:
+  std::deque<PoolWorkItem> queue_;
+};
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -1,6 +1,49 @@
 load("//bazel:ray.bzl", "ray_cc_test")
 
 ray_cc_test(
+    name = "actor_pool_manager_test",
+    size = "medium",
+    srcs = ["actor_pool_manager_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//:ray_mock",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+        "//src/ray/common:test_utils",
+        "//src/ray/core_worker:actor_pool_manager",
+        "//src/ray/core_worker:lease_policy",
+        "//src/ray/core_worker:reference_counter",
+        "//src/ray/core_worker/actor_management:actor_manager",
+        "//src/ray/gcs_rpc_client:gcs_client",
+        "//src/ray/observability:fake_metric",
+        "//src/ray/pubsub:fake_publisher",
+        "//src/ray/pubsub:fake_subscriber",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
+    name = "actor_pool_reconstruction_test",
+    size = "medium",
+    srcs = ["actor_pool_reconstruction_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//:ray_mock",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+        "//src/ray/common:test_utils",
+        "//src/ray/core_worker:actor_pool_manager",
+        "//src/ray/core_worker:reference_counter",
+        "//src/ray/core_worker/actor_management:actor_manager",
+        "//src/ray/gcs_rpc_client:gcs_client",
+        "//src/ray/observability:fake_metric",
+        "//src/ray/pubsub:fake_publisher",
+        "//src/ray/pubsub:fake_subscriber",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
     name = "actor_pool_work_queue_test",
     size = "medium",
     srcs = ["actor_pool_work_queue_test.cc"],

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -1,6 +1,19 @@
 load("//bazel:ray.bzl", "ray_cc_test")
 
 ray_cc_test(
+    name = "actor_pool_work_queue_test",
+    size = "medium",
+    srcs = ["actor_pool_work_queue_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+        "//src/ray/core_worker:actor_pool_work_queue",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
     name = "core_worker_resubmit_queue_test",
     size = "small",
     srcs = ["core_worker_resubmit_queue_test.cc"],

--- a/src/ray/core_worker/tests/actor_pool_manager_test.cc
+++ b/src/ray/core_worker/tests/actor_pool_manager_test.cc
@@ -1,0 +1,688 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/actor_pool_manager.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mock/ray/core_worker/task_manager_interface.h"
+#include "mock/ray/gcs_client/accessors/actor_info_accessor.h"
+#include "ray/common/test_utils.h"
+#include "ray/core_worker/actor_management/actor_manager.h"
+#include "ray/core_worker/lease_policy.h"
+#include "ray/core_worker/reference_counter.h"
+#include "ray/gcs_rpc_client/gcs_client.h"
+#include "ray/observability/fake_metric.h"
+#include "ray/pubsub/fake_publisher.h"
+#include "ray/pubsub/fake_subscriber.h"
+
+namespace ray {
+namespace core {
+
+class MockActorTaskSubmitter : public ActorTaskSubmitterInterface {
+ public:
+  MockActorTaskSubmitter() = default;
+  MOCK_METHOD(void,
+              AddActorQueueIfNotExists,
+              (const ActorID &, int32_t, bool, bool, bool),
+              (override));
+  MOCK_METHOD(void,
+              ConnectActor,
+              (const ActorID &, const rpc::Address &, int64_t),
+              (override));
+  MOCK_METHOD(void,
+              DisconnectActor,
+              (const ActorID &, int64_t, bool, const rpc::ActorDeathCause &, bool),
+              (override));
+  MOCK_METHOD(void, CheckTimeoutTasks, (), (override));
+  MOCK_METHOD(void, SetPreempted, (const ActorID &), (override));
+  virtual ~MockActorTaskSubmitter() = default;
+};
+
+class MockGcsClient : public gcs::GcsClient {
+ public:
+  explicit MockGcsClient(gcs::GcsClientOptions options) : gcs::GcsClient(options) {}
+  void Init(gcs::FakeActorInfoAccessor *accessor) { actor_accessor_.reset(accessor); }
+};
+
+class MockLocalityDataProvider : public LocalityDataProviderInterface {
+ public:
+  MockLocalityDataProvider() = default;
+  explicit MockLocalityDataProvider(
+      absl::flat_hash_map<ObjectID, LocalityData> locality_data)
+      : locality_data_(std::move(locality_data)) {}
+  std::optional<LocalityData> GetLocalityData(const ObjectID &object_id) const override {
+    auto it = locality_data_.find(object_id);
+    return (it != locality_data_.end()) ? std::optional(it->second) : std::nullopt;
+  }
+  ~MockLocalityDataProvider() override = default;
+  absl::flat_hash_map<ObjectID, LocalityData> locality_data_;
+};
+
+// Base test fixture
+class ActorPoolManagerTest : public ::testing::Test {
+ protected:
+  ActorPoolManagerTest()
+      : gcs_options_("localhost",
+                     6793,
+                     ClusterID::Nil(),
+                     /*allow_cluster_id_nil=*/true,
+                     /*fetch_cluster_id_if_nil=*/false),
+        gcs_client_(std::make_shared<MockGcsClient>(gcs_options_)),
+        actor_info_accessor_(new gcs::FakeActorInfoAccessor()),
+        mock_task_submitter_(std::make_shared<MockActorTaskSubmitter>()),
+        mock_task_manager_(std::make_unique<MockTaskManagerInterface>()),
+        publisher_(std::make_unique<pubsub::FakePublisher>()),
+        subscriber_(std::make_unique<pubsub::FakeSubscriber>()),
+        reference_counter_(std::make_unique<ReferenceCounter>(
+            rpc::Address(),
+            publisher_.get(),
+            subscriber_.get(),
+            [](const NodeID &) { return true; },
+            fake_owned_object_count_gauge_,
+            fake_owned_object_size_gauge_,
+            /*lineage_pinning_enabled=*/true)) {
+    gcs_client_->Init(actor_info_accessor_);
+  }
+
+  void SetUp() override {
+    actor_manager_ = std::make_unique<ActorManager>(
+        gcs_client_, *mock_task_submitter_, *reference_counter_);
+    pool_manager_ = std::make_unique<ActorPoolManager>(
+        *actor_manager_, *mock_task_submitter_, *mock_task_manager_);
+  }
+
+  void TearDown() override {
+    pool_manager_.reset();
+    actor_manager_.reset();
+    mock_task_manager_.reset();
+  }
+
+  ActorPoolID CreateTestPool(int32_t max_retry_attempts = 3) {
+    ActorPoolConfig config;
+    config.max_retry_attempts = max_retry_attempts;
+    config.retry_backoff_ms = 100;
+    config.retry_on_system_errors = true;
+    return pool_manager_->RegisterPool(config);
+  }
+
+  ActorID CreateActorID() {
+    return ActorID::Of(JobID::FromInt(1), TaskID::FromRandom(JobID::FromInt(1)), 0);
+  }
+
+  gcs::GcsClientOptions gcs_options_;
+  std::shared_ptr<MockGcsClient> gcs_client_;
+  gcs::FakeActorInfoAccessor *actor_info_accessor_;
+  std::shared_ptr<MockActorTaskSubmitter> mock_task_submitter_;
+  std::unique_ptr<MockTaskManagerInterface> mock_task_manager_;
+  std::unique_ptr<pubsub::FakePublisher> publisher_;
+  std::unique_ptr<pubsub::FakeSubscriber> subscriber_;
+  ray::observability::FakeGauge fake_owned_object_count_gauge_;
+  ray::observability::FakeGauge fake_owned_object_size_gauge_;
+  std::unique_ptr<ReferenceCounterInterface> reference_counter_;
+  std::unique_ptr<ActorManager> actor_manager_;
+  std::unique_ptr<ActorPoolManager> pool_manager_;
+};
+
+// Locality test fixture — inherits base, defers pool_manager_ creation to each test.
+class ActorPoolManagerLocalityTest : public ActorPoolManagerTest {
+ protected:
+  void SetUp() override {
+    actor_manager_ = std::make_unique<ActorManager>(
+        gcs_client_, *mock_task_submitter_, *reference_counter_);
+  }
+
+  ActorPoolID CreateTestPool(int32_t max_tasks_in_flight = 2) {
+    ActorPoolConfig config;
+    config.max_retry_attempts = 3;
+    config.retry_backoff_ms = 100;
+    config.retry_on_system_errors = true;
+    config.max_tasks_in_flight_per_actor = max_tasks_in_flight;
+    return pool_manager_->RegisterPool(config);
+  }
+
+  std::unique_ptr<MockLocalityDataProvider> locality_provider_;
+};
+
+// =========================================================================
+// Pool Registration and Lifecycle
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, RegisterAndUnregisterPool) {
+  // Multiple pools have unique, valid IDs
+  auto pool_id1 = CreateTestPool();
+  auto pool_id2 = CreateTestPool();
+  auto pool_id3 = CreateTestPool();
+
+  EXPECT_FALSE(pool_id1.IsNil());
+  EXPECT_NE(pool_id1, pool_id2);
+  EXPECT_NE(pool_id2, pool_id3);
+  EXPECT_NE(pool_id1, pool_id3);
+  EXPECT_TRUE(pool_manager_->HasPool(pool_id1));
+  EXPECT_TRUE(pool_manager_->HasPool(pool_id2));
+  EXPECT_TRUE(pool_manager_->HasPool(pool_id3));
+
+  // Unregister removes pool and actor mappings
+  auto actor_id = CreateActorID();
+  pool_manager_->AddActorToPool(pool_id1, actor_id, NodeID::FromRandom());
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool_id1).size(), 1);
+
+  pool_manager_->UnregisterPool(pool_id1);
+  EXPECT_FALSE(pool_manager_->HasPool(pool_id1));
+  EXPECT_TRUE(pool_manager_->GetPoolActors(pool_id1).empty());
+
+  // Unregistering non-existent pool is safe
+  pool_manager_->UnregisterPool(ActorPoolID::FromRandom());
+}
+
+TEST_F(ActorPoolManagerTest, RegisterPoolWithInitialActors) {
+  ActorPoolConfig config;
+  config.max_retry_attempts = 3;
+
+  std::vector<ActorID> initial_actors = {
+      CreateActorID(), CreateActorID(), CreateActorID()};
+  auto pool_id = pool_manager_->RegisterPool(config, initial_actors);
+
+  auto actors = pool_manager_->GetPoolActors(pool_id);
+  EXPECT_EQ(actors.size(), 3);
+  for (const auto &actor_id : initial_actors) {
+    EXPECT_TRUE(std::find(actors.begin(), actors.end(), actor_id) != actors.end());
+  }
+}
+
+// =========================================================================
+// Actor Management
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, AddAndRemoveActors) {
+  auto pool_id = CreateTestPool();
+  auto actor_id1 = CreateActorID();
+  auto actor_id2 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor_id1, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, actor_id2, NodeID::FromRandom());
+
+  auto actors = pool_manager_->GetPoolActors(pool_id);
+  EXPECT_EQ(actors.size(), 2);
+  EXPECT_TRUE(std::find(actors.begin(), actors.end(), actor_id1) != actors.end());
+  EXPECT_TRUE(std::find(actors.begin(), actors.end(), actor_id2) != actors.end());
+
+  // Adding same actor twice is idempotent
+  pool_manager_->AddActorToPool(pool_id, actor_id1, NodeID::FromRandom());
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool_id).size(), 2);
+
+  // Remove one actor
+  pool_manager_->RemoveActorFromPool(pool_id, actor_id1);
+  actors = pool_manager_->GetPoolActors(pool_id);
+  EXPECT_EQ(actors.size(), 1);
+  EXPECT_EQ(actors[0], actor_id2);
+
+  // Removing non-existent actor is safe
+  pool_manager_->RemoveActorFromPool(pool_id, CreateActorID());
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool_id).size(), 1);
+}
+
+TEST_F(ActorPoolManagerTest, MultiplePoolsWithDifferentActors) {
+  auto pool_id1 = CreateTestPool();
+  auto pool_id2 = CreateTestPool();
+
+  auto actor1 = CreateActorID();
+  auto actor2 = CreateActorID();
+  auto actor3 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id1, actor1, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id1, actor2, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id2, actor3, NodeID::FromRandom());
+
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool_id1).size(), 2);
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool_id2).size(), 1);
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool_id2)[0], actor3);
+}
+
+// =========================================================================
+// Non-Existent Pool Behavior
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, NonExistentPoolReturnsSafeDefaults) {
+  auto fake_pool_id = ActorPoolID::FromRandom();
+
+  EXPECT_FALSE(pool_manager_->HasPool(fake_pool_id));
+  EXPECT_TRUE(pool_manager_->GetPoolActors(fake_pool_id).empty());
+  EXPECT_TRUE(pool_manager_->SelectActorForTask(fake_pool_id).IsNil());
+  EXPECT_EQ(pool_manager_->GetOccupiedTaskSlots(fake_pool_id), 0);
+  EXPECT_EQ(pool_manager_->GetNumActiveActors(fake_pool_id), 0);
+
+  auto stats = pool_manager_->GetPoolStats(fake_pool_id);
+  EXPECT_EQ(stats.total_tasks_submitted, 0);
+  EXPECT_EQ(stats.total_tasks_failed, 0);
+  EXPECT_EQ(stats.num_actors, 0);
+  EXPECT_EQ(stats.backlog_size, 0);
+
+  RayFunction function;
+  std::vector<std::unique_ptr<TaskArg>> args;
+  TaskOptions options;
+  EXPECT_TRUE(
+      pool_manager_->SubmitTaskToPool(fake_pool_id, function, std::move(args), options)
+          .empty());
+}
+
+// =========================================================================
+// Pool Stats
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, PoolStatsReflectState) {
+  auto pool_id = CreateTestPool();
+
+  // Empty pool
+  auto stats = pool_manager_->GetPoolStats(pool_id);
+  EXPECT_EQ(stats.total_tasks_submitted, 0);
+  EXPECT_EQ(stats.total_tasks_failed, 0);
+  EXPECT_EQ(stats.total_tasks_retried, 0);
+  EXPECT_EQ(stats.num_actors, 0);
+  EXPECT_EQ(stats.backlog_size, 0);
+  EXPECT_EQ(stats.total_in_flight, 0);
+
+  // After adding actors
+  pool_manager_->AddActorToPool(pool_id, CreateActorID(), NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, CreateActorID(), NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, CreateActorID(), NodeID::FromRandom());
+
+  stats = pool_manager_->GetPoolStats(pool_id);
+  EXPECT_EQ(stats.num_actors, 3);
+  EXPECT_EQ(stats.total_in_flight, 0);
+  EXPECT_EQ(stats.backlog_size, 0);
+}
+
+// =========================================================================
+// Task Submission
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, SubmitTaskWithNoActorsQueuesWork) {
+  auto pool_id = CreateTestPool();
+
+  RayFunction function;
+  std::vector<std::unique_ptr<TaskArg>> args;
+  TaskOptions options;
+  auto refs =
+      pool_manager_->SubmitTaskToPool(pool_id, function, std::move(args), options);
+
+  EXPECT_TRUE(refs.empty());
+  EXPECT_EQ(pool_manager_->GetPoolStats(pool_id).backlog_size, 1);
+}
+
+TEST_F(ActorPoolManagerTest, MultipleTasksQueueWhenNoActors) {
+  auto pool_id = CreateTestPool();
+
+  for (int i = 0; i < 5; i++) {
+    RayFunction function;
+    std::vector<std::unique_ptr<TaskArg>> args;
+    TaskOptions options;
+    pool_manager_->SubmitTaskToPool(pool_id, function, std::move(args), options);
+  }
+
+  auto stats = pool_manager_->GetPoolStats(pool_id);
+  EXPECT_EQ(stats.backlog_size, 5);
+  EXPECT_EQ(stats.total_in_flight, 0);
+}
+
+// =========================================================================
+// Actor Selection
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, SelectActorForTask) {
+  auto pool_id = CreateTestPool();
+
+  // Empty pool returns Nil
+  EXPECT_TRUE(pool_manager_->SelectActorForTask(pool_id).IsNil());
+
+  // With actors, returns one of them
+  auto actor1 = CreateActorID();
+  auto actor2 = CreateActorID();
+  pool_manager_->AddActorToPool(pool_id, actor1, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, actor2, NodeID::FromRandom());
+
+  auto selected = pool_manager_->SelectActorForTask(pool_id);
+  EXPECT_FALSE(selected.IsNil());
+  EXPECT_TRUE(selected == actor1 || selected == actor2);
+}
+
+// =========================================================================
+// Locality-Aware Ranking
+// =========================================================================
+
+TEST_F(ActorPoolManagerLocalityTest, LocalitySelectsDataLocalActor) {
+  NodeID local_node = NodeID::FromRandom();
+  NodeID remote_node = NodeID::FromRandom();
+
+  ObjectID obj1 = ObjectID::FromRandom();
+  LocalityData data1;
+  data1.object_size = 1000;
+  data1.nodes_containing_object = {local_node};
+
+  locality_provider_ = std::make_unique<MockLocalityDataProvider>(
+      absl::flat_hash_map<ObjectID, LocalityData>{{obj1, data1}});
+
+  pool_manager_ = std::make_unique<ActorPoolManager>(
+      *actor_manager_, *mock_task_submitter_, *mock_task_manager_);
+  pool_manager_->locality_data_provider_ = locality_provider_.get();
+
+  auto pool_id = CreateTestPool();
+  auto local_actor = CreateActorID();
+  auto remote_actor = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, local_actor, local_node);
+  pool_manager_->AddActorToPool(pool_id, remote_actor, remote_node);
+
+  EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id, {obj1}), local_actor);
+}
+
+TEST_F(ActorPoolManagerLocalityTest, LocalityTiebreakerIsLoad) {
+  NodeID node = NodeID::FromRandom();
+
+  ObjectID obj1 = ObjectID::FromRandom();
+  LocalityData data1;
+  data1.object_size = 1000;
+  data1.nodes_containing_object = {node};
+
+  locality_provider_ = std::make_unique<MockLocalityDataProvider>(
+      absl::flat_hash_map<ObjectID, LocalityData>{{obj1, data1}});
+
+  pool_manager_ = std::make_unique<ActorPoolManager>(
+      *actor_manager_, *mock_task_submitter_, *mock_task_manager_);
+  pool_manager_->locality_data_provider_ = locality_provider_.get();
+
+  auto pool_id = CreateTestPool();
+  auto actor1 = CreateActorID();
+  auto actor2 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor1, node);
+  pool_manager_->AddActorToPool(pool_id, actor2, node);
+
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    pool_manager_->pools_[pool_id].actor_states[actor1].num_tasks_in_flight = 1;
+  }
+
+  EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id, {obj1}), actor2);
+}
+
+TEST_F(ActorPoolManagerLocalityTest, LargerDataNodeWins) {
+  NodeID node_small = NodeID::FromRandom();
+  NodeID node_large = NodeID::FromRandom();
+
+  ObjectID obj1 = ObjectID::FromRandom();
+  ObjectID obj2 = ObjectID::FromRandom();
+  LocalityData data1;
+  data1.object_size = 100;
+  data1.nodes_containing_object = {node_small};
+  LocalityData data2;
+  data2.object_size = 10000;
+  data2.nodes_containing_object = {node_large};
+
+  locality_provider_ = std::make_unique<MockLocalityDataProvider>(
+      absl::flat_hash_map<ObjectID, LocalityData>{{obj1, data1}, {obj2, data2}});
+
+  pool_manager_ = std::make_unique<ActorPoolManager>(
+      *actor_manager_, *mock_task_submitter_, *mock_task_manager_);
+  pool_manager_->locality_data_provider_ = locality_provider_.get();
+
+  auto pool_id = CreateTestPool();
+  auto actor_small = CreateActorID();
+  auto actor_large = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor_small, node_small);
+  pool_manager_->AddActorToPool(pool_id, actor_large, node_large);
+
+  EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id, {obj1, obj2}), actor_large);
+}
+
+// Merges three fallback scenarios: unknown objects, empty arg_ids, null provider.
+TEST_F(ActorPoolManagerLocalityTest, FallsBackToLoadWithoutLocalityData) {
+  NodeID node1 = NodeID::FromRandom();
+  NodeID node2 = NodeID::FromRandom();
+
+  // Helper: create pool with two actors where actor1 is more loaded.
+  auto setup_pool_with_load = [&]() -> std::pair<ActorPoolID, ActorID> {
+    auto pool_id = CreateTestPool();
+    auto actor1 = CreateActorID();
+    auto actor2 = CreateActorID();
+    pool_manager_->AddActorToPool(pool_id, actor1, node1);
+    pool_manager_->AddActorToPool(pool_id, actor2, node2);
+    {
+      absl::MutexLock lock(&pool_manager_->mu_);
+      pool_manager_->pools_[pool_id].actor_states[actor1].num_tasks_in_flight = 3;
+    }
+    return {pool_id, actor2};
+  };
+
+  // Case 1: Provider has no data for the object — falls back to load
+  locality_provider_ = std::make_unique<MockLocalityDataProvider>();
+  pool_manager_ = std::make_unique<ActorPoolManager>(
+      *actor_manager_, *mock_task_submitter_, *mock_task_manager_);
+  pool_manager_->locality_data_provider_ = locality_provider_.get();
+  {
+    auto [pool_id, expected] = setup_pool_with_load();
+    EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id, {ObjectID::FromRandom()}),
+              expected);
+  }
+
+  // Case 2: Empty arg_ids — falls back to load
+  {
+    auto [pool_id, expected] = setup_pool_with_load();
+    EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id, {}), expected);
+  }
+
+  // Case 3: Null locality provider — falls back to load
+  pool_manager_ = std::make_unique<ActorPoolManager>(
+      *actor_manager_, *mock_task_submitter_, *mock_task_manager_);
+  {
+    auto [pool_id, expected] = setup_pool_with_load();
+    EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id, {ObjectID::FromRandom()}),
+              expected);
+  }
+}
+
+// =========================================================================
+// Backpressure
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, GetOccupiedTaskSlots) {
+  auto pool_id = CreateTestPool();
+  auto actor1 = CreateActorID();
+  auto actor2 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor1, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, actor2, NodeID::FromRandom());
+
+  EXPECT_EQ(pool_manager_->GetOccupiedTaskSlots(pool_id), 0);
+
+  // Simulate in-flight tasks
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    pool_manager_->pools_[pool_id].actor_states[actor1].num_tasks_in_flight = 3;
+    pool_manager_->pools_[pool_id].actor_states[actor2].num_tasks_in_flight = 2;
+  }
+  EXPECT_EQ(pool_manager_->GetOccupiedTaskSlots(pool_id), 5);
+
+  // Remove actors and submit to force queueing — verify backlog counted
+  pool_manager_->RemoveActorFromPool(pool_id, actor1);
+  pool_manager_->RemoveActorFromPool(pool_id, actor2);
+  {
+    RayFunction function;
+    std::vector<std::unique_ptr<TaskArg>> args;
+    TaskOptions options;
+    pool_manager_->SubmitTaskToPool(pool_id, function, std::move(args), options);
+  }
+  EXPECT_EQ(pool_manager_->GetOccupiedTaskSlots(pool_id), 1);
+}
+
+TEST_F(ActorPoolManagerTest, GetNumActiveActors) {
+  auto pool_id = CreateTestPool();
+  auto actor1 = CreateActorID();
+  auto actor2 = CreateActorID();
+  auto actor3 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor1, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, actor2, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, actor3, NodeID::FromRandom());
+
+  EXPECT_EQ(pool_manager_->GetNumActiveActors(pool_id), 0);
+
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    pool_manager_->pools_[pool_id].actor_states[actor1].num_tasks_in_flight = 2;
+    pool_manager_->pools_[pool_id].actor_states[actor3].num_tasks_in_flight = 1;
+  }
+  EXPECT_EQ(pool_manager_->GetNumActiveActors(pool_id), 2);
+}
+
+// =========================================================================
+// Actor Death/Restart Recovery
+// =========================================================================
+
+TEST_F(ActorPoolManagerTest, OnTaskFailedMarksActorDead) {
+  auto pool_id = CreateTestPool();
+  auto actor1 = CreateActorID();
+  auto actor2 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor1, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, actor2, NodeID::FromRandom());
+
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    pool_manager_->pools_[pool_id].actor_states[actor1].num_tasks_in_flight = 1;
+  }
+
+  // Create a work item so OnTaskFailed can find it for retry
+  TaskID work_item_id = TaskID::FromRandom(JobID());
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    PoolWorkItem work_item;
+    work_item.work_item_id = work_item_id;
+    work_item.attempt_number = 0;
+    pool_manager_->work_items_[work_item_id] = std::move(work_item);
+  }
+
+  rpc::RayErrorInfo error_info;
+  error_info.set_error_type(rpc::ErrorType::ACTOR_DIED);
+  error_info.set_error_message("Actor died");
+
+  pool_manager_->OnPoolTaskComplete(pool_id,
+                                    work_item_id,
+                                    TaskID::FromRandom(JobID()),
+                                    actor1,
+                                    Status::IOError("actor died"),
+                                    &error_info);
+
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    EXPECT_FALSE(pool_manager_->pools_[pool_id].actor_states[actor1].is_alive);
+    EXPECT_TRUE(pool_manager_->pools_[pool_id].actor_states[actor2].is_alive);
+  }
+
+  EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id), actor2);
+}
+
+TEST_F(ActorPoolManagerTest, OnActorAliveDrainsQueue) {
+  auto pool_id = CreateTestPool();
+  auto actor1 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor1, NodeID::FromRandom());
+
+  // Mark actor dead
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    pool_manager_->pools_[pool_id].actor_states[actor1].is_alive = false;
+  }
+
+  // Submit — should queue since no alive actors
+  RayFunction function;
+  std::vector<std::unique_ptr<TaskArg>> args;
+  TaskOptions options;
+  pool_manager_->SubmitTaskToPool(pool_id, function, std::move(args), options);
+  EXPECT_EQ(pool_manager_->GetPoolStats(pool_id).backlog_size, 1);
+
+  // Actor comes alive — queue should drain
+  pool_manager_->OnActorAlive(actor1, NodeID::FromRandom());
+
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    EXPECT_TRUE(pool_manager_->pools_[pool_id].actor_states[actor1].is_alive);
+  }
+
+  auto stats = pool_manager_->GetPoolStats(pool_id);
+  EXPECT_EQ(stats.total_in_flight, 1);
+  EXPECT_EQ(stats.backlog_size, 0);
+}
+
+TEST_F(ActorPoolManagerTest, OnActorDeadMarksActorNotAlive) {
+  auto pool_id = CreateTestPool();
+  auto actor1 = CreateActorID();
+  auto actor2 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor1, NodeID::FromRandom());
+  pool_manager_->AddActorToPool(pool_id, actor2, NodeID::FromRandom());
+
+  pool_manager_->OnActorDead(actor1);
+
+  {
+    absl::MutexLock lock(&pool_manager_->mu_);
+    EXPECT_FALSE(pool_manager_->pools_[pool_id].actor_states[actor1].is_alive);
+    EXPECT_TRUE(pool_manager_->pools_[pool_id].actor_states[actor2].is_alive);
+  }
+
+  EXPECT_EQ(pool_manager_->SelectActorForTask(pool_id), actor2);
+}
+
+TEST_F(ActorPoolManagerTest, NonPoolActorCallbacksAreSafe) {
+  auto actor_id = CreateActorID();
+
+  // Should not crash for actors not in any pool
+  pool_manager_->OnActorDead(actor_id);
+  pool_manager_->OnActorAlive(actor_id, NodeID::FromRandom());
+}
+
+TEST_F(ActorPoolManagerTest, FullDeathRestartRecoveryCycle) {
+  auto pool_id = CreateTestPool();
+  auto actor1 = CreateActorID();
+
+  pool_manager_->AddActorToPool(pool_id, actor1, NodeID::FromRandom());
+  pool_manager_->OnActorDead(actor1);
+
+  // Submit tasks — all should queue (actor dead)
+  for (int i = 0; i < 3; i++) {
+    RayFunction function;
+    std::vector<std::unique_ptr<TaskArg>> args;
+    TaskOptions options;
+    pool_manager_->SubmitTaskToPool(pool_id, function, std::move(args), options);
+  }
+
+  auto stats = pool_manager_->GetPoolStats(pool_id);
+  EXPECT_EQ(stats.backlog_size, 3);
+  EXPECT_EQ(stats.total_in_flight, 0);
+
+  // Actor restarts — all queued work drained
+  pool_manager_->OnActorAlive(actor1, NodeID::FromRandom());
+
+  stats = pool_manager_->GetPoolStats(pool_id);
+  EXPECT_EQ(stats.backlog_size, 0);
+  EXPECT_EQ(stats.total_in_flight, 3);
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/tests/actor_pool_reconstruction_test.cc
+++ b/src/ray/core_worker/tests/actor_pool_reconstruction_test.cc
@@ -1,0 +1,185 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "mock/ray/core_worker/task_manager_interface.h"
+#include "mock/ray/gcs_client/accessors/actor_info_accessor.h"
+#include "ray/common/test_utils.h"
+#include "ray/core_worker/actor_management/actor_manager.h"
+#include "ray/core_worker/actor_pool_manager.h"
+#include "ray/core_worker/reference_counter.h"
+#include "ray/gcs_rpc_client/gcs_client.h"
+#include "ray/observability/fake_metric.h"
+#include "ray/pubsub/fake_publisher.h"
+#include "ray/pubsub/fake_subscriber.h"
+
+namespace ray {
+namespace core {
+namespace {
+
+class MockActorTaskSubmitter : public ActorTaskSubmitterInterface {
+ public:
+  MockActorTaskSubmitter() = default;
+  MOCK_METHOD(void,
+              AddActorQueueIfNotExists,
+              (const ActorID &, int32_t, bool, bool, bool),
+              (override));
+  MOCK_METHOD(void,
+              ConnectActor,
+              (const ActorID &, const rpc::Address &, int64_t),
+              (override));
+  MOCK_METHOD(void,
+              DisconnectActor,
+              (const ActorID &, int64_t, bool, const rpc::ActorDeathCause &, bool),
+              (override));
+  MOCK_METHOD(void, CheckTimeoutTasks, (), (override));
+  MOCK_METHOD(void, SetPreempted, (const ActorID &), (override));
+};
+
+class MockGcsClient : public gcs::GcsClient {
+ public:
+  explicit MockGcsClient(gcs::GcsClientOptions options) : gcs::GcsClient(options) {}
+  void Init(gcs::FakeActorInfoAccessor *accessor) { actor_accessor_.reset(accessor); }
+};
+
+// Integration test fixture for pool-bound reconstruction.
+// Wires ActorPoolManager with real ActorManager but mock submitter/task manager.
+class PoolReconstructionTest : public ::testing::Test {
+ protected:
+  PoolReconstructionTest()
+      : gcs_options_("localhost",
+                     6793,
+                     ClusterID::Nil(),
+                     /*allow_cluster_id_nil=*/true,
+                     /*fetch_cluster_id_if_nil=*/false),
+        gcs_client_(std::make_shared<MockGcsClient>(gcs_options_)),
+        actor_info_accessor_(new gcs::FakeActorInfoAccessor()),
+        mock_task_submitter_(std::make_shared<MockActorTaskSubmitter>()),
+        mock_task_manager_(std::make_unique<MockTaskManagerInterface>()),
+        publisher_(std::make_unique<pubsub::FakePublisher>()),
+        subscriber_(std::make_unique<pubsub::FakeSubscriber>()),
+        reference_counter_(std::make_unique<ReferenceCounter>(
+            rpc::Address(),
+            publisher_.get(),
+            subscriber_.get(),
+            [](const NodeID &) { return true; },
+            fake_gauge1_,
+            fake_gauge2_,
+            /*lineage_pinning_enabled=*/true)) {
+    gcs_client_->Init(actor_info_accessor_);
+  }
+
+  void SetUp() override {
+    actor_manager_ = std::make_unique<ActorManager>(
+        gcs_client_, *mock_task_submitter_, *reference_counter_);
+
+    pool_manager_ = std::make_unique<ActorPoolManager>(
+        *actor_manager_, *mock_task_submitter_, *mock_task_manager_);
+  }
+
+  void TearDown() override {
+    pool_manager_.reset();
+    actor_manager_.reset();
+  }
+
+  ActorID MakeActorID() {
+    return ActorID::Of(JobID::FromInt(1), TaskID::FromRandom(JobID::FromInt(1)), 0);
+  }
+
+  ActorPoolID CreatePool(const std::vector<ActorID> &actors) {
+    ActorPoolConfig config;
+    config.max_retry_attempts = 3;
+    config.retry_backoff_ms = 100;
+    config.retry_on_system_errors = true;
+
+    auto pool_id = pool_manager_->RegisterPool(config, actors);
+    for (const auto &a : actors) {
+      pool_manager_->AddActorToPool(pool_id, a, NodeID::FromRandom());
+    }
+    return pool_id;
+  }
+
+  gcs::GcsClientOptions gcs_options_;
+  std::shared_ptr<MockGcsClient> gcs_client_;
+  gcs::FakeActorInfoAccessor *actor_info_accessor_;
+  std::shared_ptr<MockActorTaskSubmitter> mock_task_submitter_;
+  std::unique_ptr<MockTaskManagerInterface> mock_task_manager_;
+  std::unique_ptr<pubsub::FakePublisher> publisher_;
+  std::unique_ptr<pubsub::FakeSubscriber> subscriber_;
+  ray::observability::FakeGauge fake_gauge1_;
+  ray::observability::FakeGauge fake_gauge2_;
+  std::unique_ptr<ReferenceCounterInterface> reference_counter_;
+  std::unique_ptr<ActorManager> actor_manager_;
+  std::unique_ptr<ActorPoolManager> pool_manager_;
+};
+
+// Reconstruction should select a different actor when the original is removed.
+TEST_F(PoolReconstructionTest, SelectsDifferentActorAfterRemoval) {
+  auto actor1 = MakeActorID();
+  auto actor2 = MakeActorID();
+  auto pool_id = CreatePool({actor1, actor2});
+
+  // Simulate actor1 dying: remove from pool.
+  pool_manager_->RemoveActorFromPool(pool_id, actor1);
+
+  // Selection should only return actor2.
+  auto selected = pool_manager_->SelectActorForTask(pool_id);
+  EXPECT_EQ(selected, actor2);
+
+  // Selecting again should still return actor2 (only healthy actor).
+  selected = pool_manager_->SelectActorForTask(pool_id);
+  EXPECT_EQ(selected, actor2);
+}
+
+// Two pools: simulate cascading reconstruction where Pool1's output feeds Pool2.
+// When a Pool1 actor dies, reconstruction should redirect within Pool1.
+// When a Pool2 actor dies, reconstruction should redirect within Pool2.
+TEST_F(PoolReconstructionTest, CascadingReconstructionAcrossTwoPools) {
+  // Pool1: 3 actors
+  auto p1_a1 = MakeActorID();
+  auto p1_a2 = MakeActorID();
+  auto p1_a3 = MakeActorID();
+  auto pool1 = CreatePool({p1_a1, p1_a2, p1_a3});
+
+  // Pool2: 2 actors
+  auto p2_a1 = MakeActorID();
+  auto p2_a2 = MakeActorID();
+  auto pool2 = CreatePool({p2_a1, p2_a2});
+
+  // Simulate node failure killing p1_a1 and p2_a1 (co-located on same node).
+  pool_manager_->RemoveActorFromPool(pool1, p1_a1);
+  pool_manager_->RemoveActorFromPool(pool2, p2_a1);
+
+  // Pool1 reconstruction redirects to surviving actors.
+  auto sel1 = pool_manager_->SelectActorForTask(pool1);
+  EXPECT_TRUE(sel1 == p1_a2 || sel1 == p1_a3);
+
+  // Pool2 reconstruction redirects to the sole surviving actor.
+  auto sel2 = pool_manager_->SelectActorForTask(pool2);
+  EXPECT_EQ(sel2, p2_a2);
+
+  // Pools are independent — pool1 selection doesn't affect pool2.
+  EXPECT_TRUE(pool_manager_->HasPool(pool1));
+  EXPECT_TRUE(pool_manager_->HasPool(pool2));
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool1).size(), 2);
+  EXPECT_EQ(pool_manager_->GetPoolActors(pool2).size(), 1);
+}
+
+}  // namespace
+}  // namespace core
+}  // namespace ray

--- a/src/ray/core_worker/tests/actor_pool_work_queue_test.cc
+++ b/src/ray/core_worker/tests/actor_pool_work_queue_test.cc
@@ -1,0 +1,200 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/core_worker/actor_pool_work_queue.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace ray {
+namespace core {
+namespace {
+
+/// Helper to create a simple PoolWorkItem for testing.
+PoolWorkItem CreateTestWorkItem(int32_t attempt_number = 0) {
+  PoolWorkItem item;
+  item.work_item_id = TaskID::FromRandom(JobID());
+  item.function = RayFunction();
+  item.attempt_number = attempt_number;
+  item.enqueued_at_ms = 12345;
+  return item;
+}
+
+}  // namespace
+
+TEST(UnorderedPoolWorkQueueTest, BasicPushPop) {
+  UnorderedPoolWorkQueue queue;
+
+  // Initially empty
+  EXPECT_FALSE(queue.HasWork());
+  EXPECT_EQ(queue.Size(), 0);
+  EXPECT_FALSE(queue.Pop().has_value());
+
+  // Push one item
+  auto item1 = CreateTestWorkItem();
+  auto item1_id = item1.work_item_id;
+  queue.Push(std::move(item1));
+
+  EXPECT_TRUE(queue.HasWork());
+  EXPECT_EQ(queue.Size(), 1);
+
+  // Pop the item
+  auto popped = queue.Pop();
+  ASSERT_TRUE(popped.has_value());
+  EXPECT_EQ(popped->work_item_id, item1_id);
+
+  // Empty again
+  EXPECT_FALSE(queue.HasWork());
+  EXPECT_EQ(queue.Size(), 0);
+  EXPECT_FALSE(queue.Pop().has_value());
+}
+
+TEST(UnorderedPoolWorkQueueTest, FIFOOrdering) {
+  UnorderedPoolWorkQueue queue;
+
+  // Push multiple items
+  std::vector<TaskID> task_ids;
+  for (int i = 0; i < 5; i++) {
+    auto item = CreateTestWorkItem();
+    task_ids.push_back(item.work_item_id);
+    queue.Push(std::move(item));
+  }
+
+  EXPECT_EQ(queue.Size(), 5);
+
+  // Pop in FIFO order
+  for (int i = 0; i < 5; i++) {
+    auto popped = queue.Pop();
+    ASSERT_TRUE(popped.has_value());
+    EXPECT_EQ(popped->work_item_id, task_ids[i]);
+  }
+
+  EXPECT_EQ(queue.Size(), 0);
+  EXPECT_FALSE(queue.Pop().has_value());
+}
+
+TEST(UnorderedPoolWorkQueueTest, RetryWithIncrementedAttempt) {
+  UnorderedPoolWorkQueue queue;
+
+  // Push item with attempt_number = 0
+  auto item = CreateTestWorkItem(0);
+  auto item_id = item.work_item_id;
+  queue.Push(std::move(item));
+
+  // Pop and increment attempt number (simulating retry)
+  auto popped = queue.Pop();
+  ASSERT_TRUE(popped.has_value());
+  EXPECT_EQ(popped->attempt_number, 0);
+
+  // Re-enqueue with incremented attempt
+  popped->attempt_number++;
+  queue.Push(std::move(*popped));
+
+  // Pop again and verify attempt number increased
+  auto retry_popped = queue.Pop();
+  ASSERT_TRUE(retry_popped.has_value());
+  EXPECT_EQ(retry_popped->work_item_id, item_id);
+  EXPECT_EQ(retry_popped->attempt_number, 1);
+}
+
+TEST(UnorderedPoolWorkQueueTest, Clear) {
+  UnorderedPoolWorkQueue queue;
+
+  // Push multiple items
+  for (int i = 0; i < 10; i++) {
+    queue.Push(CreateTestWorkItem());
+  }
+
+  EXPECT_EQ(queue.Size(), 10);
+  EXPECT_TRUE(queue.HasWork());
+
+  // Clear all
+  queue.Clear();
+
+  EXPECT_EQ(queue.Size(), 0);
+  EXPECT_FALSE(queue.HasWork());
+  EXPECT_FALSE(queue.Pop().has_value());
+}
+
+TEST(UnorderedPoolWorkQueueTest, ManyItems) {
+  UnorderedPoolWorkQueue queue;
+
+  const int num_items = 1000;
+  std::vector<TaskID> task_ids;
+
+  // Push many items
+  for (int i = 0; i < num_items; i++) {
+    auto item = CreateTestWorkItem();
+    task_ids.push_back(item.work_item_id);
+    queue.Push(std::move(item));
+  }
+
+  EXPECT_EQ(queue.Size(), num_items);
+
+  // Pop all and verify order
+  for (int i = 0; i < num_items; i++) {
+    ASSERT_TRUE(queue.HasWork());
+    auto popped = queue.Pop();
+    ASSERT_TRUE(popped.has_value());
+    EXPECT_EQ(popped->work_item_id, task_ids[i]);
+  }
+
+  EXPECT_EQ(queue.Size(), 0);
+  EXPECT_FALSE(queue.HasWork());
+}
+
+TEST(UnorderedPoolWorkQueueTest, InterleavedPushPop) {
+  UnorderedPoolWorkQueue queue;
+
+  // Interleave pushes and pops
+  auto item1 = CreateTestWorkItem();
+  auto id1 = item1.work_item_id;
+  queue.Push(std::move(item1));
+
+  auto item2 = CreateTestWorkItem();
+  auto id2 = item2.work_item_id;
+  queue.Push(std::move(item2));
+
+  EXPECT_EQ(queue.Size(), 2);
+
+  // Pop first
+  auto popped1 = queue.Pop();
+  ASSERT_TRUE(popped1.has_value());
+  EXPECT_EQ(popped1->work_item_id, id1);
+  EXPECT_EQ(queue.Size(), 1);
+
+  // Push another
+  auto item3 = CreateTestWorkItem();
+  auto id3 = item3.work_item_id;
+  queue.Push(std::move(item3));
+  EXPECT_EQ(queue.Size(), 2);
+
+  // Pop remaining two
+  auto popped2 = queue.Pop();
+  ASSERT_TRUE(popped2.has_value());
+  EXPECT_EQ(popped2->work_item_id, id2);
+
+  auto popped3 = queue.Pop();
+  ASSERT_TRUE(popped3.has_value());
+  EXPECT_EQ(popped3->work_item_id, id3);
+
+  EXPECT_EQ(queue.Size(), 0);
+}
+
+}  // namespace core
+}  // namespace ray

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -620,6 +620,12 @@ message TaskSpec {
   optional string tensor_transport = 44;
   // A list of fallback options defining the fallback strategy for scheduling.
   FallbackStrategy fallback_strategy = 45;
+  // The ID of the actor pool this task belongs to, if any.
+  // This is used for cross-actor retry within a pool.
+  optional bytes actor_pool_id = 46;
+  // The ID of the work item within the actor pool.
+  // Used to track work items across retries.
+  optional bytes actor_pool_work_item_id = 47;
 }
 
 message TaskInfoEntry {


### PR DESCRIPTION
This is PR 3/n in a stacked PR series implementing a Core Actor Pool for Ray Data. The full implementation can be previewed in #61622.

Note: This is the largest PR in the stack. Recommended review order:
  1. `actor_pool_manager.h`: API surface, structs, callback types
  2. `actor_pool_manager_test.cc`: expected behavior (20 tests)
  3. `actor_pool_manager.cc`: implementation

## Summary

  - Add `ActorPoolManager`, the central component that manages actor pools in the C++ core
  - Pool CRUD: register/unregister pools, add/remove actors, track actor states (ALIVE, DEAD, RESTARTING)
  - **Locality-aware actor selection:** picks actors via `LocalityDataProviderInterface` to prefer nodes where task arguments reside
  - **Cross-actor retry with exponential backoff:** on actor failure, failed work items are re-enqueued and dispatched to a healthy actor in the same pool, with configurable backoff (`actor_pool_retry_delay_ms` from PR https://github.com/ray-project/ray/pull/61978)
  - **Error classification:** distinguishes retriable (actor death) vs non-retriable (application) errors
  - Work queue draining: pulls from `PoolWorkQueue` (from PR https://github.com/ray-project/ray/pull/61979) and submits via a callback (wired to `ActorTaskSubmitter` in the next PR 4/n)
  - Pool stats and backpressure metrics (`GetOccupiedTaskSlots`, `GetNumActiveActors`)

## Review notes

  - **Forward-looking constructor params:** `actor_manager_`, `task_submitter_`, `task_manager_` are stored but not yet called in this PR. They are wired in the next PR 4/n (CoreWorker integration). The minimal constructor exists for unit testing
  without full CoreWorker dependencies.
  - **Known gap:** `UnregisterPool` work_items_ cleanup: Work items belonging to an unregistered pool are not cleaned up (TODO in code). This is acceptable because pool unregistration only happens at shutdown in the Ray Data
  integration path.
  - **`ScheduleRetry` captures raw `this`:** Lifetime is safe because `ActorPoolManager` is owned by `CoreWorker` and outlives its `io_service`. A shared ownership pattern could be considered in a follow-up.