### PR TITLE
[core][ActorPool 4/n] Wire ActorPoolManager into CoreWorker, TaskManager, and ActorTaskSubmitter

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -14,6 +14,7 @@ ray_cc_library(
         "core_worker_shutdown_executor.h",
     ],
     deps = [
+        ":actor_pool_manager",
         ":common",
         ":core_worker_context",
         ":core_worker_options",

--- a/src/ray/core_worker/actor_management/actor_manager.cc
+++ b/src/ray/core_worker/actor_management/actor_manager.cc
@@ -228,6 +228,10 @@ void ActorManager::WaitForActorRefDeleted(
   }
 }
 
+void ActorManager::SetActorPoolStateCallback(ActorPoolStateCallback callback) {
+  actor_pool_state_callback_ = std::move(callback);
+}
+
 void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
                                                 const rpc::ActorTableData &actor_data) {
   const auto &actor_state = rpc::ActorTableData::ActorState_Name(actor_data.state());
@@ -249,6 +253,9 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
                                           /*dead=*/false,
                                           actor_data.death_cause(),
                                           /*is_restartable=*/true);
+    if (actor_pool_state_callback_) {
+      actor_pool_state_callback_(actor_id, /*is_alive=*/false, NodeID::Nil());
+    }
   } else if (actor_data.state() == rpc::ActorTableData::DEAD) {
     OnActorKilled(actor_id);
     actor_task_submitter_.DisconnectActor(actor_id,
@@ -256,12 +263,18 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
                                           /*dead=*/true,
                                           actor_data.death_cause(),
                                           gcs::IsActorRestartable(actor_data));
+    if (actor_pool_state_callback_) {
+      actor_pool_state_callback_(actor_id, /*is_alive=*/false, NodeID::Nil());
+    }
     // We cannot erase the actor handle here because clients can still
     // submit tasks to dead actors. This also means we defer unsubscription,
     // otherwise we crash when bulk unsubscribing all actor handles.
   } else if (actor_data.state() == rpc::ActorTableData::ALIVE) {
     actor_task_submitter_.ConnectActor(
         actor_id, actor_data.address(), actor_data.num_restarts());
+    if (actor_pool_state_callback_) {
+      actor_pool_state_callback_(actor_id, /*is_alive=*/true, node_id);
+    }
   } else {
     // The actor is being created and not yet ready, just ignore!
   }

--- a/src/ray/core_worker/actor_management/actor_manager.h
+++ b/src/ray/core_worker/actor_management/actor_manager.h
@@ -148,6 +148,17 @@ class ActorManager {
   /// Returns the actor handle if it exists, nullptr otherwise.
   std::shared_ptr<ActorHandle> GetActorHandleIfExists(const ActorID &actor_id);
 
+  /// Callback type for notifying actor pool state changes.
+  /// \param actor_id The actor whose state changed.
+  /// \param is_alive True if the actor is alive, false if dead/restarting.
+  /// \param node_id The node the actor is on (only meaningful when is_alive=true).
+  using ActorPoolStateCallback =
+      std::function<void(const ActorID &actor_id, bool is_alive, const NodeID &node_id)>;
+
+  /// Set callback for notifying the ActorPoolManager of actor state changes.
+  /// Called once during CoreWorker initialization.
+  void SetActorPoolStateCallback(ActorPoolStateCallback callback);
+
  private:
   /// Give this worker a handle to an actor.
   ///
@@ -223,6 +234,9 @@ class ActorManager {
   /// id -> is_killed_or_out_of_scope
   /// The state of actor is true When the actor is out of scope or is killed
   absl::flat_hash_map<ActorID, bool> subscribed_actors_ ABSL_GUARDED_BY(cache_mutex_);
+
+  /// Callback to notify ActorPoolManager of actor state changes.
+  ActorPoolStateCallback actor_pool_state_callback_;
 
   FRIEND_TEST(ActorManagerTest, TestNamedActorIsKilledAfterSubscribeFinished);
   FRIEND_TEST(ActorManagerTest, TestNamedActorIsKilledBeforeSubscribeFinished);

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "ray/core_worker/core_worker_shutdown_executor.h"
+#include "ray/core_worker/lease_policy.h"
 #include "ray/core_worker/shutdown_coordinator.h"
 
 #ifndef _WIN32
@@ -395,6 +396,61 @@ CoreWorker::CoreWorker(
                                                     *actor_task_execution_arg_waiter_,
                                                     options_.initialize_thread_callback);
   }
+
+  // Initialize the actor pool manager for cross-actor retry support.
+  // We use the full constructor with io_service and submit callback for:
+  // 1. Delayed retry scheduling via io_service_
+  // 2. Delegating TaskSpec building to CoreWorker via submit callback
+  actor_pool_manager_ = std::make_unique<ActorPoolManager>(
+      *actor_manager_,
+      *actor_task_submitter_,
+      *task_manager_,
+      io_service_,
+      [this](const ActorID &actor_id,
+             const RayFunction &function,
+             std::vector<std::unique_ptr<TaskArg>> args,
+             const TaskOptions &task_options,
+             TaskCompletionCallback on_complete,
+             const ActorPoolID &pool_id,
+             const TaskID &work_item_id) {
+        return this->SubmitActorTaskForPool(actor_id,
+                                            function,
+                                            std::move(args),
+                                            task_options,
+                                            std::move(on_complete),
+                                            pool_id,
+                                            work_item_id);
+      },
+      dynamic_cast<LocalityDataProviderInterface *>(reference_counter_.get()));
+
+  // Wire pool task completion callback from ActorTaskSubmitter to ActorPoolManager.
+  // This enables cross-actor retry by notifying the pool when tasks complete.
+  actor_task_submitter_->SetPoolTaskCompletionCallback(
+      [this](const ActorPoolID &pool_id,
+             const TaskID &work_item_id,
+             const TaskID &task_id,
+             const ActorID &actor_id,
+             const Status &status,
+             const rpc::RayErrorInfo *error_info) {
+        // Route completion to ActorPoolManager if the pool exists
+        if (actor_pool_manager_->HasPool(pool_id)) {
+          actor_pool_manager_->OnPoolTaskComplete(
+              pool_id, work_item_id, task_id, actor_id, status, error_info);
+        }
+      });
+
+  // Wire actor state notifications from GCS to ActorPoolManager.
+  // When a pool actor restarts (ALIVE), this triggers DrainWorkQueue to
+  // dispatch queued tasks. When it dies (RESTARTING/DEAD), the actor is
+  // marked not alive so SelectActorFromPool skips it.
+  actor_manager_->SetActorPoolStateCallback(
+      [this](const ActorID &actor_id, bool is_alive, const NodeID &node_id) {
+        if (is_alive) {
+          actor_pool_manager_->OnActorAlive(actor_id, node_id);
+        } else {
+          actor_pool_manager_->OnActorDead(actor_id);
+        }
+      });
 
   RegisterToGcs(options_.worker_launch_time_ms, options_.worker_launched_time_ms);
 
@@ -807,6 +863,29 @@ void CoreWorker::InternalHeartbeat() {
   for (auto &task_to_retry : tasks_to_resubmit) {
     auto &spec = task_to_retry.task_spec;
     if (spec.IsActorTask()) {
+      // Pool tasks: redirect to a healthy actor chosen by the pool.
+      if (spec.IsPoolTask()) {
+        const auto &pool_id_bin = spec.GetMessage().actor_pool_id();
+        ActorPoolID pool_id = ActorPoolID::FromBinary(pool_id_bin);
+        if (actor_pool_manager_->HasPool(pool_id)) {
+          ActorID new_actor_id = actor_pool_manager_->SelectActorForTask(pool_id);
+          if (new_actor_id.IsNil()) {
+            // No healthy actors — re-enqueue with a short delay.
+            absl::MutexLock lock(&mutex_);
+            task_to_retry.execution_time_ms =
+                current_time_ms() + RayConfig::instance().actor_pool_retry_delay_ms();
+            to_resubmit_.push(task_to_retry);
+            continue;
+          }
+          // Redirect the task to the selected actor.
+          auto *mutable_actor_spec = spec.GetMutableMessage().mutable_actor_task_spec();
+          mutable_actor_spec->set_actor_id(new_actor_id.Binary());
+          const TaskID creation_task_id = TaskID::ForActorCreationTask(new_actor_id);
+          const ObjectID dummy_obj_id =
+              ObjectID::FromIndex(creation_task_id, /*index=*/1);
+          mutable_actor_spec->set_actor_creation_dummy_object_id(dummy_obj_id.Binary());
+        }
+      }
       auto actor_handle = actor_manager_->GetActorHandle(spec.ActorId());
       actor_handle->SetResubmittedActorTaskSpec(spec);
       actor_task_submitter_->SubmitTask(spec);
@@ -2653,6 +2732,167 @@ CoreWorker::ListNamedActors(bool all_namespaces) {
     return std::make_pair(std::move(actors), Status::TimedOut(stream.str()));
   }
   return std::make_pair(std::move(actors), std::move(status));
+}
+
+ActorPoolID CoreWorker::RegisterActorPool(const ActorPoolConfig &config,
+                                          const std::vector<ActorID> &initial_actors) {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  return actor_pool_manager_->RegisterPool(config, initial_actors);
+}
+
+void CoreWorker::UnregisterActorPool(const ActorPoolID &pool_id) {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  actor_pool_manager_->UnregisterPool(pool_id);
+}
+
+void CoreWorker::AddActorToPool(const ActorPoolID &pool_id, const ActorID &actor_id) {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  // Get the actor's location from the owner address (best effort)
+  // The actual location will be updated when the actor reports its address
+  auto actor_handle = actor_manager_->GetActorHandle(actor_id);
+  NodeID location = NodeID::FromBinary(actor_handle->GetOwnerAddress().node_id());
+  actor_pool_manager_->AddActorToPool(pool_id, actor_id, location);
+}
+
+void CoreWorker::RemoveActorFromPool(const ActorPoolID &pool_id,
+                                     const ActorID &actor_id) {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  actor_pool_manager_->RemoveActorFromPool(pool_id, actor_id);
+}
+
+std::vector<rpc::ObjectReference> CoreWorker::SubmitTaskToActorPool(
+    const ActorPoolID &pool_id,
+    const RayFunction &function,
+    std::vector<std::unique_ptr<TaskArg>> args,
+    const TaskOptions &task_options) {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  return actor_pool_manager_->SubmitTaskToPool(
+      pool_id, function, std::move(args), task_options);
+}
+
+std::vector<ActorID> CoreWorker::GetActorPoolActors(const ActorPoolID &pool_id) const {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  return actor_pool_manager_->GetPoolActors(pool_id);
+}
+
+PoolStats CoreWorker::GetActorPoolStats(const ActorPoolID &pool_id) const {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  return actor_pool_manager_->GetPoolStats(pool_id);
+}
+
+std::vector<rpc::ObjectReference> CoreWorker::SubmitActorTaskForPool(
+    const ActorID &actor_id,
+    const RayFunction &function,
+    std::vector<std::unique_ptr<TaskArg>> args,
+    const TaskOptions &task_options,
+    TaskCompletionCallback on_complete,
+    const ActorPoolID &pool_id,
+    const TaskID &work_item_id) {
+  absl::ReleasableMutexLock lock(&actor_task_mutex_);
+
+  if (!actor_task_submitter_->CheckActorExists(actor_id)) {
+    RAY_LOG(WARNING) << "Actor " << actor_id << " not found for pool task submission";
+    if (on_complete) {
+      rpc::RayErrorInfo error_info;
+      error_info.set_error_type(rpc::ErrorType::ACTOR_DIED);
+      error_info.set_error_message("Actor not found");
+      on_complete(Status::NotFound("Actor not found"), &error_info);
+    }
+    return {};
+  }
+
+  auto actor_handle = actor_manager_->GetActorHandle(actor_id);
+
+  // Subscribe to actor state updates so that ActorTaskSubmitter learns the
+  // actor's address (via ConnectActor) when it becomes ALIVE.  Without this,
+  // the task sits queued in the submitter forever because it doesn't know
+  // where to send it.  The method is idempotent.
+  actor_manager_->SubscribeActorState(actor_id);
+
+  // Build TaskSpec
+  TaskSpecBuilder builder;
+  const auto next_task_index = worker_context_->GetNextTaskIndex();
+  const TaskID actor_task_id =
+      TaskID::ForActorTask(worker_context_->GetCurrentJobID(),
+                           worker_context_->GetCurrentInternalTaskId(),
+                           next_task_index,
+                           actor_handle->GetActorID());
+
+  const std::unordered_map<std::string, double> required_resources;
+  const auto task_name = task_options.name.empty()
+                             ? function.GetFunctionDescriptor()->DefaultTaskName()
+                             : task_options.name;
+
+  int64_t depth = worker_context_->GetTaskDepth() + 1;
+
+  BuildCommonTaskSpec(builder,
+                      actor_handle->CreationJobID(),
+                      actor_task_id,
+                      task_name,
+                      worker_context_->GetCurrentTaskID(),
+                      next_task_index,
+                      GetCallerId(),
+                      rpc_address_,
+                      function,
+                      args,
+                      task_options.num_returns,
+                      task_options.resources,
+                      required_resources,
+                      /*debugger_breakpoint=*/"",
+                      depth,
+                      /*serialized_runtime_env_info=*/"{}",
+                      CurrentCallSite(),
+                      worker_context_->GetMainThreadOrActorCreationTaskID(),
+                      task_options.concurrency_group_name,
+                      /*include_job_config=*/false,
+                      task_options.generator_backpressure_num_objects,
+                      task_options.enable_task_events,
+                      /*labels=*/{},
+                      /*label_selector=*/{},
+                      /*fallback_strategy=*/{});
+
+  // Set actor task spec with max_retries=-1 (infinite retries).
+  // Keeps the ObjectRef pending through failures, enabling cross-actor retry
+  // via InternalHeartbeat redirect.
+  actor_handle->SetActorTaskSpec(builder,
+                                 ObjectID::Nil(),
+                                 /*max_retries=*/-1,
+                                 /*retry_exceptions=*/false,
+                                 /*serialized_retry_exception_allowlist=*/"",
+                                 task_options.concurrency_group_name,
+                                 task_options.tensor_transport);
+
+  TaskSpecification task_spec = std::move(builder).ConsumeAndBuild();
+
+  // Tag the task with pool metadata so downstream components (TaskManager,
+  // ActorTaskSubmitter) can identify it as a pool task for lineage pinning
+  // and cross-actor retry routing.
+  if (!pool_id.IsNil()) {
+    task_spec.GetMutableMessage().set_actor_pool_id(pool_id.Binary());
+    task_spec.GetMutableMessage().set_actor_pool_work_item_id(work_item_id.Binary());
+  }
+
+  RAY_LOG(DEBUG) << "Submitting pool actor task " << task_spec.DebugString();
+
+  // Add pending task and get return refs
+  auto returned_refs = task_manager_->AddPendingTask(
+      rpc_address_, task_spec, CurrentCallSite(), /*max_retries=*/-1);
+
+  // Note: The on_complete callback passed here is NOT directly invoked by TaskManager
+  // because TaskManager doesn't support completion callbacks. Instead, task completion
+  // is wired through ActorTaskSubmitter::HandlePushTaskReply(), which detects pool
+  // tasks via task_spec.has_actor_pool_id() and notifies via the callback set in
+  // SetPoolTaskCompletionCallback(). That callback routes to OnPoolTaskComplete()
+  // which handles success/failure and triggers cross-actor retry if needed.
+  //
+  // The on_complete parameter here is intentionally unused - ActorPoolManager now
+  // passes nullptr since completion is handled via the ActorTaskSubmitter path.
+  (void)on_complete;
+
+  // Submit the task
+  actor_task_submitter_->SubmitTask(task_spec);
+
+  return returned_refs;
 }
 
 std::string CoreWorker::GetActorName() const {

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -31,6 +31,7 @@
 #include "ray/common/buffer.h"
 #include "ray/core_worker/actor_management/actor_handle.h"
 #include "ray/core_worker/actor_management/actor_manager.h"
+#include "ray/core_worker/actor_pool_manager.h"
 #include "ray/core_worker/common.h"
 #include "ray/core_worker/context.h"
 #include "ray/core_worker/core_worker_options.h"
@@ -280,6 +281,8 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   }
 
   WorkerContext &GetWorkerContext() { return *worker_context_; }
+
+  ActorPoolManager &GetActorPoolManager() { return *actor_pool_manager_; }
 
   const TaskID &GetCurrentTaskId() const { return worker_context_->GetCurrentTaskID(); }
 
@@ -1161,6 +1164,76 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   std::pair<std::vector<std::pair<std::string, std::string>>, Status> ListNamedActors(
       bool all_namespaces);
 
+  ///
+  /// Actor Pool methods (for cross-actor retry).
+  ///
+
+  /// Register a new actor pool.
+  ///
+  /// \param config Pool configuration (retry, ordering, autoscaling).
+  /// \param initial_actors Optional initial set of actor IDs to add to the pool.
+  /// \return The ID of the newly created pool.
+  ActorPoolID RegisterActorPool(const ActorPoolConfig &config,
+                                const std::vector<ActorID> &initial_actors = {});
+
+  /// Unregister an actor pool and clean up resources.
+  ///
+  /// \param pool_id The ID of the pool to unregister.
+  void UnregisterActorPool(const ActorPoolID &pool_id);
+
+  /// Add an actor to a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \param actor_id The ID of the actor to add.
+  void AddActorToPool(const ActorPoolID &pool_id, const ActorID &actor_id);
+
+  /// Remove an actor from a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \param actor_id The ID of the actor to remove.
+  void RemoveActorFromPool(const ActorPoolID &pool_id, const ActorID &actor_id);
+
+  /// Submit a task to an actor pool.
+  /// The pool will select an appropriate actor based on load and locality.
+  ///
+  /// \param pool_id The ID of the pool to submit to.
+  /// \param function The function to execute.
+  /// \param args The task arguments.
+  /// \param task_options Task options (num_returns, resources, etc).
+  /// \return Object references for the task's return values.
+  std::vector<rpc::ObjectReference> SubmitTaskToActorPool(
+      const ActorPoolID &pool_id,
+      const RayFunction &function,
+      std::vector<std::unique_ptr<TaskArg>> args,
+      const TaskOptions &task_options);
+
+  /// Get all actor IDs in a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \return Vector of actor IDs in the pool.
+  std::vector<ActorID> GetActorPoolActors(const ActorPoolID &pool_id) const;
+
+  /// Get statistics for a pool.
+  ///
+  /// \param pool_id The ID of the pool.
+  /// \return Pool statistics.
+  PoolStats GetActorPoolStats(const ActorPoolID &pool_id) const;
+
+ private:
+  /// Submit an actor task on behalf of an actor pool.
+  /// This is used by ActorPoolManager to delegate TaskSpec building to CoreWorker.
+  /// The task is submitted with max_retries=-1 (infinite) to keep the ObjectRef
+  /// alive through actor failures; cross-actor retry is handled by the pool.
+  std::vector<rpc::ObjectReference> SubmitActorTaskForPool(
+      const ActorID &actor_id,
+      const RayFunction &function,
+      std::vector<std::unique_ptr<TaskArg>> args,
+      const TaskOptions &task_options,
+      TaskCompletionCallback on_complete,
+      const ActorPoolID &pool_id = ActorPoolID::Nil(),
+      const TaskID &work_item_id = TaskID::Nil());
+
+ public:
   /// Get the expected return ids of the next task.
   std::vector<ObjectID> GetCurrentReturnIds(int num_returns,
                                             const ActorID &callee_actor_id);
@@ -1819,6 +1892,9 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   /// Interface to manage actor handles.
   std::unique_ptr<ActorManager> actor_manager_;
+
+  /// Interface to manage actor pools (for cross-actor retry).
+  std::unique_ptr<ActorPoolManager> actor_pool_manager_;
 
   ///
   /// Fields related to task execution.

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -431,6 +431,9 @@ void TaskManager::SetupTaskEntryForResubmit(TaskEntry &task_entry) {
 
   if (task_entry.num_retries_left_ > 0) {
     task_entry.num_retries_left_--;
+  } else if (task_entry.spec_.IsPoolTask()) {
+    // Pool tasks use pool-bound reconstruction; retries are managed by
+    // ActorPoolManager, so num_retries_left_ stays at 0.
   } else {
     RAY_CHECK(task_entry.num_retries_left_ == -1);
   }
@@ -1056,8 +1059,10 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
 
     // A finished task can only be re-executed if it has some number of
     // retries left and returned at least one object that is still in use and
-    // stored in plasma.
-    bool task_retryable = it->second.num_retries_left_ != 0 &&
+    // stored in plasma. Pool tasks are always retryable via pool-bound
+    // reconstruction regardless of num_retries_left_.
+    bool is_pool_task = it->second.spec_.IsPoolTask();
+    bool task_retryable = (it->second.num_retries_left_ != 0 || is_pool_task) &&
                           !it->second.reconstructable_return_ids_.empty();
     if (task_retryable) {
       // Pin the task spec if it may be retried again.

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -27,6 +27,38 @@
 namespace ray {
 namespace core {
 
+namespace {
+
+// Helper to notify ActorPoolManager when a pool task completes.
+void MaybeNotifyPoolTaskComplete(const PoolTaskCompletionCallback &callback,
+                                 const TaskSpecification &task_spec,
+                                 const Status &status,
+                                 const rpc::RayErrorInfo *error_info) {
+  if (!callback) {
+    return;
+  }
+
+  // Check if this task belongs to an actor pool
+  if (!task_spec.IsPoolTask()) {
+    return;
+  }
+
+  const auto &msg = task_spec.GetMessage();
+  auto pool_id = ActorPoolID::FromBinary(msg.actor_pool_id());
+  TaskID work_item_id = TaskID::Nil();
+  if (msg.has_actor_pool_work_item_id() && !msg.actor_pool_work_item_id().empty()) {
+    work_item_id = TaskID::FromBinary(msg.actor_pool_work_item_id());
+  }
+
+  RAY_LOG(DEBUG) << "Notifying pool " << pool_id << " of task completion for work item "
+                 << work_item_id << ", status: " << status.ToString();
+
+  callback(
+      pool_id, work_item_id, task_spec.TaskId(), task_spec.ActorId(), status, error_info);
+}
+
+}  // namespace
+
 void ActorTaskSubmitter::NotifyGCSWhenActorOutOfScope(
     const ActorID &actor_id, uint64_t num_restarts_due_to_lineage_reconstruction) {
   const auto actor_creation_return_id = ObjectID::ForActorHandle(actor_id);
@@ -475,6 +507,9 @@ void ActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
       for (auto &task : wait_for_death_info_tasks) {
         task_manager_.FailPendingTask(
             task->task_spec_.TaskId(), error_type, &task->status_, &error_info);
+        // Notify pool of failure for tasks that were waiting for death info
+        MaybeNotifyPoolTaskComplete(
+            pool_task_completion_callback_, task->task_spec_, task->status_, &error_info);
       }
     }
   }
@@ -503,6 +538,9 @@ void ActorTaskSubmitter::FailTaskWithError(const PendingTaskWaitingForDeathInfo 
   }
   task_manager_.FailPendingTask(
       task.task_spec_.TaskId(), error_info.error_type(), &task.status_, &error_info);
+  // Notify pool of failure for timed-out tasks
+  MaybeNotifyPoolTaskComplete(
+      pool_task_completion_callback_, task.task_spec_, task.status_, &error_info);
 }
 
 void ActorTaskSubmitter::CheckTimeoutTasks() {
@@ -672,6 +710,11 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
   if ((status.ok() && reply.was_cancelled_before_running()) ||
       status.IsSchedulingCancelled()) {
     HandleTaskCancelledBeforeExecution(status, reply, task_spec);
+    // Notify pool of cancellation
+    MaybeNotifyPoolTaskComplete(pool_task_completion_callback_,
+                                task_spec,
+                                Status::SchedulingCancelled("Task cancelled"),
+                                nullptr);
   } else if (status.ok() && !is_retryable_exception) {
     // status.ok() means the worker completed the reply, either succeeded or with a
     // retryable failure (e.g. user exceptions). We complete only on non-retryable case.
@@ -692,9 +735,15 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
       error_info.set_error_type(rpc::ErrorType::TASK_CANCELLED);
       task_manager_.FailPendingTask(
           task_id, rpc::ErrorType::TASK_CANCELLED, nullptr, &error_info);
+      // Notify pool of failure
+      MaybeNotifyPoolTaskComplete(
+          pool_task_completion_callback_, task_spec, status, &error_info);
     } else {
       task_manager_.CompletePendingTask(
           task_id, reply, addr, reply.is_application_error());
+      // Notify pool of success
+      MaybeNotifyPoolTaskComplete(
+          pool_task_completion_callback_, task_spec, Status::OK(), nullptr);
     }
   } else {
     bool is_actor_dead = false;
@@ -748,6 +797,15 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
                                              &error_info,
                                              /*mark_task_object_failed*/ is_actor_dead,
                                              fail_immediately);
+
+    // With max_retries=-1 (pool default), will_retry is always true for
+    // actor death, so this branch is not taken. Kept for safety if
+    // max_retries is changed to a finite value in the future.
+    if (is_actor_dead && !will_retry) {
+      MaybeNotifyPoolTaskComplete(
+          pool_task_completion_callback_, task_spec, status, &error_info);
+    }
+
     if (!is_actor_dead && !will_retry) {
       // Ran out of retries, last failure = either user exception or actor death.
       if (status.ok()) {
@@ -756,6 +814,9 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
 
         task_manager_.CompletePendingTask(
             task_id, reply, addr, reply.is_application_error());
+        // Notify pool of user exception failure
+        MaybeNotifyPoolTaskComplete(
+            pool_task_completion_callback_, task_spec, status, &error_info);
 
       } else if (RayConfig::instance().timeout_ms_task_wait_for_death_info() != 0) {
         // last failure = Actor death, but we still see the actor "alive" so we
@@ -785,6 +846,9 @@ void ActorTaskSubmitter::HandlePushTaskReply(const Status &status,
         }
         task_manager_.FailPendingTask(
             task_spec.TaskId(), error_info.error_type(), &status, &error_info);
+        // Notify pool of failure
+        MaybeNotifyPoolTaskComplete(
+            pool_task_completion_callback_, task_spec, status, &error_info);
       }
     }
   }

--- a/src/ray/core_worker/task_submission/actor_task_submitter.h
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.h
@@ -38,6 +38,23 @@
 namespace ray {
 namespace core {
 
+/// Callback type for notifying ActorPoolManager when a pool task completes.
+/// This enables cross-actor retry by allowing the pool to re-enqueue failed tasks.
+///
+/// \param pool_id The ID of the actor pool.
+/// \param work_item_id The ID of the work item within the pool.
+/// \param task_id The ID of the completed task.
+/// \param actor_id The ID of the actor that executed the task.
+/// \param status The completion status (OK for success, error for failure).
+/// \param error_info Error information if the task failed (nullptr on success).
+using PoolTaskCompletionCallback =
+    std::function<void(const ActorPoolID &pool_id,
+                       const TaskID &work_item_id,
+                       const TaskID &task_id,
+                       const ActorID &actor_id,
+                       const Status &status,
+                       const rpc::RayErrorInfo *error_info)>;
+
 // Interface for testing.
 class ActorTaskSubmitterInterface {
  public:
@@ -184,6 +201,15 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
   /// \param[in] actor_id The actor ID.
   /// \return Whether this actor is alive.
   bool IsActorAlive(const ActorID &actor_id) const;
+
+  /// Set the callback for pool task completion notifications.
+  /// This is used to notify ActorPoolManager when tasks that belong to an
+  /// actor pool complete, enabling cross-actor retry.
+  ///
+  /// \param[in] callback The callback to invoke when a pool task completes.
+  void SetPoolTaskCompletionCallback(PoolTaskCompletionCallback callback) {
+    pool_task_completion_callback_ = std::move(callback);
+  }
 
   /// Get the given actor id's address.
   /// It returns nullopt if the actor's address is not reported.
@@ -456,6 +482,12 @@ class ActorTaskSubmitter : public ActorTaskSubmitterInterface {
   instrumented_io_context &io_service_;
 
   std::shared_ptr<ReferenceCounterInterface> reference_counter_;
+
+  /// Callback for notifying ActorPoolManager when pool tasks complete.
+  /// This enables cross-actor retry by allowing the pool to re-enqueue failed tasks.
+  /// Set once during CoreWorker construction via SetPoolTaskCompletionCallback()
+  /// before any concurrent access; immutable thereafter.
+  PoolTaskCompletionCallback pool_task_completion_callback_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -825,6 +825,203 @@ TEST_F(TaskManagerLineageTest, TestActorLineagePinned) {
   ASSERT_FALSE(reference_counter_->HasReference(return_id));
 }
 
+// Pool tasks (max_retries=0 but actor_pool_id set) should have lineage pinned
+// for reconstruction via the pool.
+TEST_F(TaskManagerLineageTest, TestPoolTaskLineagePinned) {
+  rpc::Address caller_address;
+  ActorID actor_id = ActorID::FromHex("f4ce02420592ca68c1738a0d01000000");
+  const ObjectID actor_creation_dummy_object_id =
+      ObjectID::FromIndex(TaskID::ForActorCreationTask(actor_id), /*index=*/1);
+
+  TaskSpecBuilder builder;
+  builder.SetCommonTaskSpec(
+      TaskID::ForActorTask(JobID::Nil(), TaskID::Nil(), 0, actor_id),
+      "pool_actor_task",
+      Language::PYTHON,
+      FunctionDescriptorBuilder::BuildPython("a", "", "", ""),
+      JobID::Nil(),
+      rpc::JobConfig(),
+      TaskID::Nil(),
+      0,
+      TaskID::Nil(),
+      rpc::Address(),
+      1,
+      false,
+      false,
+      -1,
+      {},
+      {},
+      "",
+      0,
+      TaskID::Nil(),
+      "");
+  builder.SetActorTaskSpec(actor_id,
+                           actor_creation_dummy_object_id,
+                           /*max_retries=*/0,
+                           false,
+                           "",
+                           0,
+                           std::nullopt);
+  TaskSpecification spec = std::move(builder).ConsumeAndBuild();
+
+  // Tag as pool task.
+  ActorPoolID pool_id = ActorPoolID::FromRandom();
+  spec.GetMutableMessage().set_actor_pool_id(pool_id.Binary());
+  spec.GetMutableMessage().set_actor_pool_work_item_id(
+      TaskID::FromRandom(JobID::Nil()).Binary());
+
+  manager_.AddPendingTask(caller_address, spec, "", /*max_retries=*/0);
+  auto return_id = spec.ReturnId(0);
+  ASSERT_TRUE(manager_.IsTaskPending(spec.TaskId()));
+
+  // Complete with plasma return.
+  rpc::PushTaskReply reply;
+  auto return_object = reply.add_return_objects();
+  return_object->set_object_id(return_id.Binary());
+  auto data = GenerateRandomBuffer();
+  return_object->set_data(data->Data(), data->Size());
+  return_object->set_in_plasma(true);
+  manager_.CompletePendingTask(spec.TaskId(), reply, rpc::Address(), false);
+
+  // Despite max_retries=0, lineage should be pinned because it's a pool task.
+  ASSERT_TRUE(manager_.IsTaskSubmissible(spec.TaskId()));
+  ASSERT_TRUE(reference_counter_->HasReference(return_id));
+
+  // Releasing the return object should free lineage.
+  reference_counter_->RemoveLocalReference(return_id, nullptr);
+  ASSERT_FALSE(manager_.IsTaskSubmissible(spec.TaskId()));
+}
+
+// Non-pool actor tasks with max_retries=0 should NOT have lineage pinned.
+TEST_F(TaskManagerLineageTest, TestNonPoolTaskNotPinned) {
+  rpc::Address caller_address;
+  ActorID actor_id = ActorID::FromHex("f4ce02420592ca68c1738a0d01000000");
+  const ObjectID actor_creation_dummy_object_id =
+      ObjectID::FromIndex(TaskID::ForActorCreationTask(actor_id), /*index=*/1);
+
+  TaskSpecBuilder builder;
+  builder.SetCommonTaskSpec(
+      TaskID::ForActorTask(JobID::Nil(), TaskID::Nil(), 0, actor_id),
+      "non_pool_actor_task",
+      Language::PYTHON,
+      FunctionDescriptorBuilder::BuildPython("a", "", "", ""),
+      JobID::Nil(),
+      rpc::JobConfig(),
+      TaskID::Nil(),
+      0,
+      TaskID::Nil(),
+      rpc::Address(),
+      1,
+      false,
+      false,
+      -1,
+      {},
+      {},
+      "",
+      0,
+      TaskID::Nil(),
+      "");
+  builder.SetActorTaskSpec(actor_id,
+                           actor_creation_dummy_object_id,
+                           /*max_retries=*/0,
+                           false,
+                           "",
+                           0,
+                           std::nullopt);
+  TaskSpecification spec = std::move(builder).ConsumeAndBuild();
+
+  // No pool_id set — this is a normal actor task with 0 retries.
+  manager_.AddPendingTask(caller_address, spec, "", /*max_retries=*/0);
+  auto return_id = spec.ReturnId(0);
+
+  rpc::PushTaskReply reply;
+  auto return_object = reply.add_return_objects();
+  return_object->set_object_id(return_id.Binary());
+  auto data = GenerateRandomBuffer();
+  return_object->set_data(data->Data(), data->Size());
+  return_object->set_in_plasma(true);
+  manager_.CompletePendingTask(spec.TaskId(), reply, rpc::Address(), false);
+
+  // Lineage should NOT be pinned since max_retries=0 and no pool.
+  ASSERT_FALSE(manager_.IsTaskSubmissible(spec.TaskId()));
+
+  // Clean up return reference.
+  reference_counter_->RemoveLocalReference(return_id, nullptr);
+}
+
+// Pool task resubmission should succeed even with num_retries_left=0.
+TEST_F(TaskManagerLineageTest, TestPoolTaskResubmitSucceeds) {
+  rpc::Address caller_address;
+  ActorID actor_id = ActorID::FromHex("f4ce02420592ca68c1738a0d01000000");
+  const ObjectID actor_creation_dummy_object_id =
+      ObjectID::FromIndex(TaskID::ForActorCreationTask(actor_id), /*index=*/1);
+
+  TaskSpecBuilder builder;
+  builder.SetCommonTaskSpec(
+      TaskID::ForActorTask(JobID::Nil(), TaskID::Nil(), 0, actor_id),
+      "pool_resubmit_task",
+      Language::PYTHON,
+      FunctionDescriptorBuilder::BuildPython("a", "", "", ""),
+      JobID::Nil(),
+      rpc::JobConfig(),
+      TaskID::Nil(),
+      0,
+      TaskID::Nil(),
+      rpc::Address(),
+      1,
+      false,
+      false,
+      -1,
+      {},
+      {},
+      "",
+      0,
+      TaskID::Nil(),
+      "");
+  builder.SetActorTaskSpec(actor_id,
+                           actor_creation_dummy_object_id,
+                           /*max_retries=*/0,
+                           false,
+                           "",
+                           0,
+                           std::nullopt);
+  TaskSpecification spec = std::move(builder).ConsumeAndBuild();
+
+  ActorPoolID pool_id = ActorPoolID::FromRandom();
+  spec.GetMutableMessage().set_actor_pool_id(pool_id.Binary());
+
+  manager_.AddPendingTask(caller_address, spec, "", /*max_retries=*/0);
+  auto return_id = spec.ReturnId(0);
+
+  // Complete with plasma return so lineage is pinned.
+  rpc::PushTaskReply reply;
+  auto return_object = reply.add_return_objects();
+  return_object->set_object_id(return_id.Binary());
+  auto data = GenerateRandomBuffer();
+  return_object->set_data(data->Data(), data->Size());
+  return_object->set_in_plasma(true);
+  manager_.CompletePendingTask(spec.TaskId(), reply, rpc::Address(), false);
+  ASSERT_TRUE(manager_.IsTaskSubmissible(spec.TaskId()));
+
+  // Simulate object loss — resubmit should work for pool tasks.
+  std::vector<ObjectID> task_deps;
+  auto error = manager_.ResubmitTask(spec.TaskId(), &task_deps);
+  ASSERT_FALSE(error.has_value());
+  num_retries_++;
+  ASSERT_TRUE(manager_.IsTaskPending(spec.TaskId()));
+
+  // Clean up: complete again and release reference.
+  rpc::PushTaskReply reply2;
+  auto return_object2 = reply2.add_return_objects();
+  return_object2->set_object_id(return_id.Binary());
+  auto data2 = GenerateRandomBuffer();
+  return_object2->set_data(data2->Data(), data2->Size());
+  return_object2->set_in_plasma(true);
+  manager_.CompletePendingTask(spec.TaskId(), reply2, rpc::Address(), false);
+  reference_counter_->RemoveLocalReference(return_id, nullptr);
+  ASSERT_FALSE(manager_.IsTaskSubmissible(spec.TaskId()));
+}
+
 // Test to make sure that the task spec and dependencies for an object are
 // pinned when lineage pinning is enabled in the ReferenceCounter.
 TEST_F(TaskManagerLineageTest, TestLineagePinned) {


### PR DESCRIPTION
This is PR 4/n in a stacked PR series implementing a Core Actor Pool for Ray Data. The full implementation can be previewed in #61622.

This PR wires the `ActorPoolManager` into the CoreWorker subsystem, enabling end-to-end cross-actor retry for pool tasks.

  **CoreWorker integration:**
  - Initialize `ActorPoolManager` with `io_service`, submit callback (delegates TaskSpec building), and locality provider (`ReferenceCounter` via `dynamic_cast`)
  - Wire `SetPoolTaskCompletionCallback` from `ActorTaskSubmitter` --> `ActorPoolManager::OnPoolTaskComplete`
  - Wire `SetActorPoolStateCallback` from `ActorManager` --> `ActorPoolManager::OnActorAlive/OnActorDead`
  - `SubmitActorTaskForPool`: builds TaskSpec with `max_retries=-1` (keeps ObjectRef alive through failures), tags with `actor_pool_id`/`actor_pool_work_item_id`
  - `InternalHeartbeat`: pool tasks are redirected to a healthy actor via `SelectActorForTask` instead of resubmitting to the original actor

  **TaskManager lineage pinning:**
  - Pool tasks (`IsPoolTask()`) are treated as retryable regardless of `num_retries_left`, enabling pool-bound reconstruction via `InternalHeartbeat`

Note: The `SetupTaskEntryForResubmit` pool task branch is defensive with max_retries=-1, pool tasks already take the infinite-retries path. The branch provides safety if max_retries is ever
  changed to a finite value. The `CompletePendingTask` pool task check is similarly defensive but validates the intended behavior (pool tasks remain retryable regardless of retry count).

  **ActorTaskSubmitter completion notifications:**
  - `MaybeNotifyPoolTaskComplete` helper called at 7 completion/failure paths: success, cancellation, timeout, actor death (with/without retry), user exception, death-info wait

  **ActorManager state notifications:**
  - ALIVE --> `OnActorAlive` (triggers `DrainWorkQueue`)
  - RESTARTING/DEAD --> `OnActorDead` (marks actor not alive)