### PR TITLE
[core][ActorPool 5/n] Add Cython bindings for ActorPoolManager

### DIFF
--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -41,6 +41,7 @@ from ray.includes.libcoreworker cimport (
 from ray.includes.unique_ids cimport (
     CObjectID,
     CActorID,
+    CActorPoolID,
     CTaskID,
 )
 from ray.includes.function_descriptor cimport (
@@ -121,6 +122,14 @@ cdef class ActorID(BaseID):
     cdef CActorID data
 
     cdef CActorID native(self)
+
+    cdef size_t hash(self)
+
+
+cdef class ActorPoolID(BaseID):
+    cdef CActorPoolID data
+
+    cdef CActorPoolID native(self)
 
     cdef size_t hash(self)
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -148,6 +148,7 @@ from ray.includes.common cimport (
 )
 from ray.includes.unique_ids cimport (
     CActorID,
+    CActorPoolID,
     CClusterID,
     CNodeID,
     CObjectID,
@@ -157,9 +158,11 @@ from ray.includes.unique_ids cimport (
 from ray.includes.libcoreworker cimport (
     ActorHandleSharedPtr,
     CActorCreationOptions,
+    CActorPoolConfig,
     CPlacementGroupCreationOptions,
     CCoreWorkerOptions,
     CCoreWorkerProcess,
+    CPoolStats,
     CTaskOptions,
     ResourceMappingType,
     CFiberEvent,
@@ -4813,6 +4816,269 @@ cdef class CoreWorker:
                     c_object_ref_and_is_ready_pair.first.object_id(),
                     c_object_ref_and_is_ready_pair.first.owner_address().SerializeAsString()), # noqa
                 c_object_ref_and_is_ready_pair.second)
+
+    def register_actor_pool(
+            self,
+            int32_t max_retry_attempts=3,
+            int32_t retry_backoff_ms=1000,
+            float retry_backoff_multiplier=2.0,
+            int32_t max_retry_backoff_ms=60000,
+            c_bool retry_on_system_errors=True,
+            int32_t max_tasks_in_flight_per_actor=1):
+        """Register a new actor pool.
+
+        Args:
+            max_retry_attempts: Maximum number of retry attempts for failed tasks.
+            retry_backoff_ms: Initial backoff in milliseconds between retries.
+            retry_backoff_multiplier: Multiplier for exponential backoff.
+            max_retry_backoff_ms: Maximum backoff in milliseconds.
+            retry_on_system_errors: Whether to retry on system errors.
+            max_tasks_in_flight_per_actor: Max concurrent tasks per actor.
+
+        Returns:
+            ActorPoolID: The ID of the newly created pool.
+        """
+        cdef:
+            CActorPoolConfig config
+            c_vector[CActorID] c_empty_actors
+            CActorPoolID c_pool_id
+
+        config.max_retry_attempts = max_retry_attempts
+        config.retry_backoff_ms = retry_backoff_ms
+        config.retry_backoff_multiplier = retry_backoff_multiplier
+        config.max_retry_backoff_ms = max_retry_backoff_ms
+        config.retry_on_system_errors = retry_on_system_errors
+        config.max_tasks_in_flight_per_actor = max_tasks_in_flight_per_actor
+
+        with nogil:
+            c_pool_id = CCoreWorkerProcess.GetCoreWorker().RegisterActorPool(
+                config, c_empty_actors)
+
+        return ActorPoolID(c_pool_id.Binary())
+
+    def unregister_actor_pool(self, ActorPoolID pool_id):
+        """Unregister an actor pool.
+
+        Args:
+            pool_id: The ID of the pool to unregister.
+        """
+        cdef CActorPoolID c_pool_id = pool_id.native()
+
+        with nogil:
+            CCoreWorkerProcess.GetCoreWorker().UnregisterActorPool(c_pool_id)
+
+    def add_actor_to_pool(self, ActorPoolID pool_id, ActorID actor_id,
+                          NodeID location=None):
+        """Add an actor to a pool.
+
+        Args:
+            pool_id: The ID of the pool.
+            actor_id: The ID of the actor to add.
+            location: Optional node ID where the actor is located.
+                If None, derived from the actor handle's owner address.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            CActorID c_actor_id = actor_id.native()
+            CNodeID c_location
+
+        if location is not None:
+            c_location = (<NodeID>location).native()
+        else:
+            c_location = CNodeID.Nil()
+
+        with nogil:
+            CCoreWorkerProcess.GetCoreWorker().AddActorToPool(
+                c_pool_id, c_actor_id, c_location)
+
+    def remove_actor_from_pool(self, ActorPoolID pool_id, ActorID actor_id):
+        """Remove an actor from a pool.
+
+        Args:
+            pool_id: The ID of the pool.
+            actor_id: The ID of the actor to remove.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            CActorID c_actor_id = actor_id.native()
+
+        with nogil:
+            CCoreWorkerProcess.GetCoreWorker().RemoveActorFromPool(
+                c_pool_id, c_actor_id)
+
+    def get_pool_actors(self, ActorPoolID pool_id):
+        """Get all actor IDs in a pool.
+
+        Args:
+            pool_id: The ID of the pool.
+
+        Returns:
+            List of ActorID in the pool.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            c_vector[CActorID] c_actors
+            c_vector[CActorID].iterator it
+
+        with nogil:
+            c_actors = CCoreWorkerProcess.GetCoreWorker().GetActorPoolActors(
+                c_pool_id)
+
+        result = []
+        it = c_actors.begin()
+        while it != c_actors.end():
+            result.append(ActorID(dereference(it).Binary()))
+            postincrement(it)
+
+        return result
+
+    def get_pool_stats(self, ActorPoolID pool_id):
+        """Get statistics for a pool.
+
+        Args:
+            pool_id: The ID of the pool.
+
+        Returns:
+            Dictionary with pool statistics.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            CPoolStats c_stats
+
+        with nogil:
+            c_stats = CCoreWorkerProcess.GetCoreWorker().GetActorPoolStats(
+                c_pool_id)
+
+        return {
+            "total_tasks_submitted": c_stats.total_tasks_submitted,
+            "total_tasks_failed": c_stats.total_tasks_failed,
+            "total_tasks_retried": c_stats.total_tasks_retried,
+            "num_actors": c_stats.num_actors,
+            "backlog_size": c_stats.backlog_size,
+            "total_in_flight": c_stats.total_in_flight,
+        }
+
+    def has_pool(self, ActorPoolID pool_id):
+        """Check if a pool exists.
+
+        Args:
+            pool_id: The ID of the pool.
+
+        Returns:
+            True if the pool exists, False otherwise.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            c_bool exists
+
+        with nogil:
+            exists = CCoreWorkerProcess.GetCoreWorker().HasActorPool(c_pool_id)
+
+        return exists
+
+    def get_occupied_task_slots(self, ActorPoolID pool_id):
+        """Get total occupied task slots (in-flight + backlog) for a pool.
+
+        Args:
+            pool_id: The ID of the pool.
+
+        Returns:
+            Total occupied task slots.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            int64_t result
+
+        with nogil:
+            result = (CCoreWorkerProcess.GetCoreWorker()
+                      .GetActorPoolOccupiedTaskSlots(c_pool_id))
+
+        return result
+
+    def get_num_active_actors(self, ActorPoolID pool_id):
+        """Get number of actors with tasks in flight for a pool.
+
+        Args:
+            pool_id: The ID of the pool.
+
+        Returns:
+            Number of active actors.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            int32_t result
+
+        with nogil:
+            result = (CCoreWorkerProcess.GetCoreWorker()
+                      .GetActorPoolNumActiveActors(c_pool_id))
+
+        return result
+
+    def submit_task_to_pool(
+            self,
+            ActorPoolID pool_id,
+            Language language,
+            FunctionDescriptor function_descriptor,
+            list args,
+            c_string name,
+            int num_returns,
+            double num_method_cpus,
+            c_string concurrency_group_name,
+            int64_t generator_backpressure_num_objects,
+            c_bool enable_task_events):
+        """Submit a task to an actor pool.
+
+        The C++ ActorPoolManager selects an actor based on load and locality.
+
+        Returns:
+            List of ObjectRefs for the task's return values.
+        """
+        cdef:
+            CActorPoolID c_pool_id = pool_id.native()
+            unordered_map[c_string, double] c_resources
+            CRayFunction ray_function
+            c_vector[unique_ptr[CTaskArg]] args_vector
+            c_vector[CObjectReference] return_refs
+            c_vector[CObjectID] incremented_put_arg_ids
+            c_string serialized_runtime_env = b"{}"
+            unordered_map[c_string, c_string] c_labels
+            CLabelSelector c_label_selector
+            c_vector[CFallbackOption] c_fallback_strategy
+            optional[c_string] c_tensor_transport = NULL_TENSOR_TRANSPORT
+
+        if num_method_cpus > 0:
+            c_resources[b"CPU"] = num_method_cpus
+        ray_function = CRayFunction(
+            language.lang, function_descriptor.descriptor)
+        prepare_args_and_increment_put_refs(
+            language, args, &args_vector, function_descriptor,
+            &incremented_put_arg_ids)
+
+        try:
+            with nogil:
+                return_refs = (
+                    CCoreWorkerProcess.GetCoreWorker().SubmitTaskToActorPool(
+                        c_pool_id,
+                        ray_function,
+                        move(args_vector),
+                        CTaskOptions(
+                            name,
+                            num_returns,
+                            c_resources,
+                            concurrency_group_name,
+                            generator_backpressure_num_objects,
+                            serialized_runtime_env,
+                            enable_task_events,
+                            c_labels,
+                            c_label_selector,
+                            c_tensor_transport,
+                            c_fallback_strategy)))
+        finally:
+            for put_arg_id in incremented_put_arg_ids:
+                CCoreWorkerProcess.GetCoreWorker().RemoveLocalReference(
+                    put_arg_id)
+
+        return VectorToObjectRefs(return_refs, skip_adding_local_ref=True)
 
 cdef void async_callback(shared_ptr[CRayObject] obj,
                          CObjectID object_ref,

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -2,7 +2,7 @@
 # distutils: language = c++
 # cython: embedsignature = True
 
-from libc.stdint cimport int64_t, uint64_t
+from libc.stdint cimport int32_t, int64_t, uint64_t
 from libcpp cimport bool as c_bool
 from libcpp.functional cimport function
 from libcpp.memory cimport shared_ptr, unique_ptr
@@ -14,6 +14,7 @@ from libcpp.vector cimport vector as c_vector
 
 from ray.includes.unique_ids cimport (
     CActorID,
+    CActorPoolID,
     CClusterID,
     CNodeID,
     CJobID,
@@ -105,6 +106,24 @@ cdef extern from "ray/core_worker/generator_waiter.h" nogil:
                 (CRayStatus() nogil) check_signals)
         CRayStatus WaitAllObjectsReported()
 
+cdef extern from "ray/core_worker/actor_pool_manager.h" namespace "ray::core" nogil:
+    cdef cppclass CActorPoolConfig "ray::core::ActorPoolConfig":
+        int32_t max_retry_attempts
+        int32_t retry_backoff_ms
+        float retry_backoff_multiplier
+        int32_t max_retry_backoff_ms
+        c_bool retry_on_system_errors
+        int32_t max_tasks_in_flight_per_actor
+
+    cdef cppclass CPoolStats "ray::core::PoolStats":
+        int64_t total_tasks_submitted
+        int64_t total_tasks_failed
+        int64_t total_tasks_retried
+        int32_t num_actors
+        size_t backlog_size
+        int32_t total_in_flight
+
+
 cdef extern from "ray/core_worker/core_worker.h" nogil:
     cdef cppclass CActorHandle "ray::core::ActorHandle":
         CActorID GetActorID() const
@@ -161,6 +180,31 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             c_string call_site,
             c_vector[CObjectReference] &task_returns,
             const CTaskID current_task_id)
+        CActorPoolID RegisterActorPool(
+            const CActorPoolConfig &config,
+            const c_vector[CActorID] &initial_actors)
+        void UnregisterActorPool(const CActorPoolID &pool_id)
+        void AddActorToPool(
+            const CActorPoolID &pool_id,
+            const CActorID &actor_id,
+            const CNodeID &location)
+        void RemoveActorFromPool(
+            const CActorPoolID &pool_id,
+            const CActorID &actor_id)
+        c_vector[CObjectReference] SubmitTaskToActorPool(
+            const CActorPoolID &pool_id,
+            const CRayFunction &function,
+            c_vector[unique_ptr[CTaskArg]] args,
+            const CTaskOptions &task_options)
+        c_vector[CActorID] GetActorPoolActors(
+            const CActorPoolID &pool_id) const
+        CPoolStats GetActorPoolStats(
+            const CActorPoolID &pool_id) const
+        c_bool HasActorPool(const CActorPoolID &pool_id) const
+        int64_t GetActorPoolOccupiedTaskSlots(
+            const CActorPoolID &pool_id) const
+        int32_t GetActorPoolNumActiveActors(
+            const CActorPoolID &pool_id) const
         CRayStatus KillActor(
             const CActorID &actor_id, c_bool force_kill,
             c_bool no_restart)

--- a/python/ray/includes/unique_ids.pxd
+++ b/python/ray/includes/unique_ids.pxd
@@ -188,4 +188,22 @@ cdef extern from "ray/common/id.h" namespace "ray" nogil:
         @staticmethod
         CPlacementGroupID Of(CJobID job_id)
 
+    cdef cppclass CActorPoolID "ray::ActorPoolID" \
+                               (CBaseID[CActorPoolID]):
+
+        @staticmethod
+        CActorPoolID FromBinary(const c_string &binary)
+
+        @staticmethod
+        CActorPoolID FromHex(const c_string &hex_str)
+
+        @staticmethod
+        CActorPoolID FromRandom()
+
+        @staticmethod
+        const CActorPoolID Nil()
+
+        @staticmethod
+        size_t Size()
+
     ctypedef uint32_t ObjectIDIndexType

--- a/python/ray/includes/unique_ids.pxi
+++ b/python/ray/includes/unique_ids.pxi
@@ -10,6 +10,7 @@ import os
 from ray.includes.unique_ids cimport (
     CActorClassID,
     CActorID,
+    CActorPoolID,
     CNodeID,
     CConfigID,
     CJobID,
@@ -422,6 +423,45 @@ cdef class PlacementGroupID(BaseID):
     @classmethod
     def size(cls):
         return CPlacementGroupID.Size()
+
+    def binary(self):
+        return self.data.Binary()
+
+    def hex(self):
+        return decode(self.data.Hex())
+
+    def is_nil(self):
+        return self.data.IsNil()
+
+    cdef size_t hash(self):
+        return self.data.Hash()
+
+
+cdef class ActorPoolID(BaseID):
+
+    def __init__(self, id):
+        check_id(id, CActorPoolID.Size())
+        self.data = CActorPoolID.FromBinary(<c_string>id)
+
+    cdef CActorPoolID native(self):
+        return <CActorPoolID>self.data
+
+    @classmethod
+    def from_random(cls):
+        return cls(CActorPoolID.FromRandom().Binary())
+
+    @classmethod
+    def from_hex(cls, hex_id):
+        binary_id = CActorPoolID.FromHex(<c_string>hex_id).Binary()
+        return cls(binary_id)
+
+    @classmethod
+    def nil(cls):
+        return cls(CActorPoolID.Nil().Binary())
+
+    @classmethod
+    def size(cls):
+        return CActorPoolID.Size()
 
     def binary(self):
         return self.data.Binary()

--- a/python/ray/includes/unique_ids.pyi
+++ b/python/ray/includes/unique_ids.pyi
@@ -144,3 +144,15 @@ class PlacementGroupID(BaseID):
 
     @classmethod
     def nil(cls: type[_PGID]) -> _PGID: ...
+
+
+_APID = TypeVar("_APID", bound=ActorPoolID)
+class ActorPoolID(BaseID):
+
+    def __init__(self, id: bytes) -> None: ...
+
+    @classmethod
+    def from_random(cls: type[_APID]) -> _APID: ...
+
+    @classmethod
+    def nil(cls: type[_APID]) -> _APID: ...

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2745,13 +2745,18 @@ void CoreWorker::UnregisterActorPool(const ActorPoolID &pool_id) {
   actor_pool_manager_->UnregisterPool(pool_id);
 }
 
-void CoreWorker::AddActorToPool(const ActorPoolID &pool_id, const ActorID &actor_id) {
+void CoreWorker::AddActorToPool(const ActorPoolID &pool_id,
+                                const ActorID &actor_id,
+                                const NodeID &location) {
   RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
-  // Get the actor's location from the owner address (best effort)
-  // The actual location will be updated when the actor reports its address
-  auto actor_handle = actor_manager_->GetActorHandle(actor_id);
-  NodeID location = NodeID::FromBinary(actor_handle->GetOwnerAddress().node_id());
-  actor_pool_manager_->AddActorToPool(pool_id, actor_id, location);
+  NodeID resolved_location = location;
+  if (resolved_location.IsNil()) {
+    // Derive from actor handle's owner address (best effort).
+    // The actual location will be updated when the actor reports its address.
+    auto actor_handle = actor_manager_->GetActorHandle(actor_id);
+    resolved_location = NodeID::FromBinary(actor_handle->GetOwnerAddress().node_id());
+  }
+  actor_pool_manager_->AddActorToPool(pool_id, actor_id, resolved_location);
 }
 
 void CoreWorker::RemoveActorFromPool(const ActorPoolID &pool_id,
@@ -2778,6 +2783,21 @@ std::vector<ActorID> CoreWorker::GetActorPoolActors(const ActorPoolID &pool_id) 
 PoolStats CoreWorker::GetActorPoolStats(const ActorPoolID &pool_id) const {
   RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
   return actor_pool_manager_->GetPoolStats(pool_id);
+}
+
+bool CoreWorker::HasActorPool(const ActorPoolID &pool_id) const {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  return actor_pool_manager_->HasPool(pool_id);
+}
+
+int64_t CoreWorker::GetActorPoolOccupiedTaskSlots(const ActorPoolID &pool_id) const {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  return actor_pool_manager_->GetOccupiedTaskSlots(pool_id);
+}
+
+int32_t CoreWorker::GetActorPoolNumActiveActors(const ActorPoolID &pool_id) const {
+  RAY_CHECK(actor_pool_manager_) << "ActorPoolManager not initialized";
+  return actor_pool_manager_->GetNumActiveActors(pool_id);
 }
 
 std::vector<rpc::ObjectReference> CoreWorker::SubmitActorTaskForPool(

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1185,7 +1185,9 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   ///
   /// \param pool_id The ID of the pool.
   /// \param actor_id The ID of the actor to add.
-  void AddActorToPool(const ActorPoolID &pool_id, const ActorID &actor_id);
+  void AddActorToPool(const ActorPoolID &pool_id,
+                      const ActorID &actor_id,
+                      const NodeID &location = NodeID::Nil());
 
   /// Remove an actor from a pool.
   ///
@@ -1218,6 +1220,15 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// \param pool_id The ID of the pool.
   /// \return Pool statistics.
   PoolStats GetActorPoolStats(const ActorPoolID &pool_id) const;
+
+  /// Check if a pool exists.
+  bool HasActorPool(const ActorPoolID &pool_id) const;
+
+  /// Returns in_flight + backlog for backpressure decisions.
+  int64_t GetActorPoolOccupiedTaskSlots(const ActorPoolID &pool_id) const;
+
+  /// Returns number of actors with tasks in flight.
+  int32_t GetActorPoolNumActiveActors(const ActorPoolID &pool_id) const;
 
  private:
   /// Submit an actor task on behalf of an actor pool.


### PR DESCRIPTION
This is PR 5/n in a stacked PR series implementing a Core Actor Pool for Ray Data. The full implementation can be previewed in #61622.

## Summary

  - Add `ActorPoolID` Cython wrapper class (follows `PlacementGroupID` pattern)
  - Add Cython declarations for `ActorPoolConfig`, `PoolStats` C++ types
  - Add CoreWorker Cython methods
  - Add CoreWorker C++ wrappers (`HasActorPool`, `GetActorPoolOccupiedTaskSlots`, `GetActorPoolNumActiveActors`) so all Cython calls route through CoreWorker uniformly, matching Ray's existing pattern where Cython never calls
  internal managers directly
  - `add_actor_to_pool` uses `CoreWorker::AddActorToPool` which derives actor location from the actor handle (consistent with CoreWorker being the single entry point)