### PR TITLE
[RLlib] Toggle eval/train mode in TorchRLModule forward passes

### DIFF
--- a/rllib/core/rl_module/multi_rl_module.py
+++ b/rllib/core/rl_module/multi_rl_module.py
@@ -192,7 +192,7 @@ class MultiRLModule(RLModule):
         By default, this calls the generic `self._forward()` method.
         """
         return {
-            mid: self._rl_modules[mid]._forward_inference(batch[mid], **kwargs)
+            mid: self._rl_modules[mid].forward_inference(batch[mid], **kwargs)
             for mid in batch.keys()
             if mid in self
         }
@@ -210,7 +210,7 @@ class MultiRLModule(RLModule):
         By default, this calls the generic `self._forward()` method.
         """
         return {
-            mid: self._rl_modules[mid]._forward_exploration(batch[mid], **kwargs)
+            mid: self._rl_modules[mid].forward_exploration(batch[mid], **kwargs)
             for mid in batch.keys()
             if mid in self
         }
@@ -228,7 +228,7 @@ class MultiRLModule(RLModule):
         By default, this calls the generic `self._forward()` method.
         """
         return {
-            mid: self._rl_modules[mid]._forward_train(batch[mid], **kwargs)
+            mid: self._rl_modules[mid].forward_train(batch[mid], **kwargs)
             for mid in batch.keys()
             if mid in self
         }

--- a/rllib/core/rl_module/torch/tests/test_torch_rl_module.py
+++ b/rllib/core/rl_module/torch/tests/test_torch_rl_module.py
@@ -73,6 +73,34 @@ class TestRLModule(unittest.TestCase):
         module.forward_inference({"obs": obs})
         module.forward_exploration({"obs": obs})
 
+    def test_training_mode_toggling(self):
+        """Test that eval mode is set during inference/exploration and restored after."""
+
+        env = gym.make("CartPole-v1")
+        module = VPGTorchRLModule(
+            observation_space=env.observation_space,
+            action_space=env.action_space,
+            model_config={"hidden_dim": 32},
+        )
+
+        obs_shape = env.observation_space.shape
+        obs = torch.randn((1,) + obs_shape)
+
+        # Module starts in training mode.
+        self.assertTrue(module.training)
+
+        # forward_inference should set eval mode internally and restore train mode.
+        module.forward_inference({"obs": obs})
+        self.assertTrue(module.training)
+
+        # forward_exploration should also set eval mode and restore train mode.
+        module.forward_exploration({"obs": obs})
+        self.assertTrue(module.training)
+
+        # forward_train should keep train mode.
+        module.forward_train({"obs": obs})
+        self.assertTrue(module.training)
+
     def test_get_set_state(self):
 
         env = gym.make("CartPole-v1")

--- a/rllib/core/rl_module/torch/torch_rl_module.py
+++ b/rllib/core/rl_module/torch/torch_rl_module.py
@@ -83,30 +83,28 @@ class TorchRLModule(nn.Module, RLModule):
 
     @override(RLModule)
     def forward_inference(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        was_training = self.training
         self.eval()
         try:
             return self._forward_inference(batch, **kwargs)
         finally:
-            self.train()
+            if was_training:
+                self.train()
 
     @override(RLModule)
     def forward_exploration(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        was_training = self.training
         self.eval()
         try:
             return self._forward_exploration(batch, **kwargs)
         finally:
-            self.train()
+            if was_training:
+                self.train()
 
     @override(RLModule)
     def forward_train(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
-        if self.inference_only:
-            raise RuntimeError(
-                "Calling `forward_train` on an inference_only module is not allowed! "
-                "Set the `inference_only=False` flag in the RLModuleSpec (or the "
-                "RLModule's constructor)."
-            )
         self.train()
-        return self._forward_train(batch, **kwargs)
+        return super().forward_train(batch, **kwargs)
 
     @OverrideToImplementCustomLogic
     def _forward_inference(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:

--- a/rllib/core/rl_module/torch/torch_rl_module.py
+++ b/rllib/core/rl_module/torch/torch_rl_module.py
@@ -99,6 +99,12 @@ class TorchRLModule(nn.Module, RLModule):
 
     @override(RLModule)
     def forward_train(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        if self.inference_only:
+            raise RuntimeError(
+                "Calling `forward_train` on an inference_only module is not allowed! "
+                "Set the `inference_only=False` flag in the RLModuleSpec (or the "
+                "RLModule's constructor)."
+            )
         self.train()
         return self._forward_train(batch, **kwargs)
 

--- a/rllib/core/rl_module/torch/torch_rl_module.py
+++ b/rllib/core/rl_module/torch/torch_rl_module.py
@@ -81,6 +81,27 @@ class TorchRLModule(nn.Module, RLModule):
         """
         return compile_wrapper(self, compile_config)
 
+    @override(RLModule)
+    def forward_inference(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        self.eval()
+        try:
+            return self._forward_inference(batch, **kwargs)
+        finally:
+            self.train()
+
+    @override(RLModule)
+    def forward_exploration(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        self.eval()
+        try:
+            return self._forward_exploration(batch, **kwargs)
+        finally:
+            self.train()
+
+    @override(RLModule)
+    def forward_train(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        self.train()
+        return self._forward_train(batch, **kwargs)
+
     @OverrideToImplementCustomLogic
     def _forward_inference(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
         # By default, calls the generic `_forward()` method, but with a no-grad context


### PR DESCRIPTION
## Why are these changes needed?

Fixes #61961

`TorchRLModule` extends `nn.Module` but never calls `self.eval()` during inference or exploration forward passes, so `self.training` stays `True`. This affects layers like `Dropout` and `BatchNorm` that behave differently based on the training flag.

The old API stack handled this correctly in `torch_policy_v2.py` (calling `model.eval()` before action computation and `model.train()` before learning), but the new API stack missed it.

## Changes

Override `forward_inference` and `forward_exploration` in `TorchRLModule` to call `self.eval()` before the forward pass and `self.train()` in a `finally` block. Also override `forward_train` to explicitly set train mode for symmetry.

## Related issue number

Fixes #61961