### PR TITLE
[docs] Remove redundant VLLM_USE_V1 env var from docs and examples

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
@@ -80,9 +80,6 @@ serveConfigV2: |
             autoscaling_config:
               min_replicas: 1
               max_replicas: 1
-          runtime_env:
-            env_vars:
-              VLLM_USE_V1: "1"
           engine_kwargs:
             tensor_parallel_size: 8
             pipeline_parallel_size: 2

--- a/doc/source/serve/tutorials/serve-deepseek.md
+++ b/doc/source/serve/tutorials/serve-deepseek.md
@@ -42,7 +42,6 @@ llm_config = LLMConfig(
     },
     # Change to the accelerator type of the node
     accelerator_type="H100",
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     # Customize engine arguments as needed (e.g. vLLM engine kwargs)
     engine_kwargs={
         "tensor_parallel_size": 8,
@@ -78,9 +77,6 @@ applications:
           autoscaling_config:
             min_replicas: 1
             max_replicas: 1
-        runtime_env:
-          env_vars:
-            VLLM_USE_V1: "1"
         engine_kwargs:
           tensor_parallel_size: 8
           pipeline_parallel_size: 2


### PR DESCRIPTION
## What does this PR do?

V1 engine has been the default in vLLM for some time. This PR removes explicit `VLLM_USE_V1=1` settings from documentation examples and a release test since they are now redundant.

## Changes

- **doc/source/serve/tutorials/serve-deepseek.md**: Removed `runtime_env` with `VLLM_USE_V1=1` from both Python and YAML configs
- **doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md**: Removed `runtime_env` section with `VLLM_USE_V1=1` from Kubernetes YAML
- **doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py**: Removed `runtime_env` parameter with `VLLM_USE_V1=1`
- **release/llm_tests/serve/test_llm_serve_fault_tolerance.py**: Removed `runtime_env` with `VLLM_USE_V1=1` since V1 is now default

## Related Issue

Fixes #61892

## Notes

- The `VLLM_USE_V1=0` reference in `entity-recognition-with-llms/README.md` is intentionally kept, as it's used to disable V1 for LoRA adapter support
- The code check in `vllm_engine.py` that warns when V0 is detected is also kept, as it serves as a guard