### PR TITLE
[serve] Add env var to specify haproxy lb algo

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -721,6 +721,11 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
     "RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER", "250ms"
 )
 
+# The balancing algorithm to use in HAProxy backends. Default is leastconn.
+RAY_SERVE_HAPROXY_BALANCE_ALGORITHM = get_env_str(
+    "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", "leastconn"
+)
+
 RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT = int(
     os.environ.get("RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT", "30000")
 )

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -391,13 +391,7 @@ class HAProxyConfig:
 
     syslog_port: int = RAY_SERVE_HAPROXY_SYSLOG_PORT
 
-    @property
-    def balance_algorithm(self) -> str:
-        lb_algo = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()
-        if not HAPROXY_BALANCE_ALGORITHM_PATTERN.match(lb_algo):
-            lb_algo = "leastconn"
-
-        return lb_algo
+    balance_algorithm: str = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()
 
     @property
     def frontend_host(self) -> str:
@@ -726,13 +720,6 @@ class HAProxyApi(ProxyApi):
                 # Set initial reload ID if header injection is enabled and ID is not set
                 if self.cfg.inject_process_id_header and self.cfg.reload_id is None:
                     self.cfg.reload_id = f"initial-{int(time.time() * 1000)}"
-
-                if not HAPROXY_BALANCE_ALGORITHM_PATTERN.match(
-                    RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()
-                ):
-                    logger.warning(
-                        f"'{RAY_SERVE_HAPROXY_BALANCE_ALGORITHM}' isn't a valid balancing algorithm. HAProxy will use leastconn instead. Valid algorithms match: leastconn, roundrobin, random, random(<draws>)"
-                    )
 
                 self._generate_config_file_internal()
                 logger.info("Successfully generated HAProxy config file.")

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -27,6 +27,7 @@ from ray.serve._private.constants import (
     NO_ROUTES_MESSAGE,
     PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_HAPROXY_OPTIMIZED_CONFIG,
+    RAY_SERVE_HAPROXY_BALANCE_ALGORITHM,
     RAY_SERVE_HAPROXY_CONFIG_FILE_LOC,
     RAY_SERVE_HAPROXY_HARD_STOP_AFTER_S,
     RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER,
@@ -64,6 +65,11 @@ from ray.serve.schema import (
 )
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+HAPROXY_BALANCE_ALGORITHM_PATTERN = re.compile(
+    r"^(leastconn|roundrobin|random(\(\d+\))?)$"
+)
 
 
 @dataclass
@@ -384,6 +390,14 @@ class HAProxyConfig:
     http_options: HTTPOptions = field(default_factory=HTTPOptions)
 
     syslog_port: int = RAY_SERVE_HAPROXY_SYSLOG_PORT
+
+    @property
+    def balance_algorithm(self) -> str:
+        lb_algo = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()
+        if not HAPROXY_BALANCE_ALGORITHM_PATTERN.match(lb_algo):
+            lb_algo = "leastconn"
+
+        return lb_algo
 
     @property
     def frontend_host(self) -> str:
@@ -712,6 +726,9 @@ class HAProxyApi(ProxyApi):
                 # Set initial reload ID if header injection is enabled and ID is not set
                 if self.cfg.inject_process_id_header and self.cfg.reload_id is None:
                     self.cfg.reload_id = f"initial-{int(time.time() * 1000)}"
+
+                if not HAPROXY_BALANCE_ALGORITHM_PATTERN.match(RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()):
+                    logger.warning(f"'{RAY_SERVE_HAPROXY_BALANCE_ALGORITHM}' isn't a valid balancing algorithm. HAProxy will use leastconn instead. Valid algorithms match: leastconn, roundrobin, random, random(<draws>)")
 
                 self._generate_config_file_internal()
                 logger.info("Successfully generated HAProxy config file.")

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -67,11 +67,6 @@ from ray.serve.schema import (
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
-HAPROXY_BALANCE_ALGORITHM_PATTERN = re.compile(
-    r"^(leastconn|roundrobin|random(\(\d+\))?)$"
-)
-
-
 @dataclass
 class ServerStats:
     """Server statistics from HAProxy."""

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -727,8 +727,12 @@ class HAProxyApi(ProxyApi):
                 if self.cfg.inject_process_id_header and self.cfg.reload_id is None:
                     self.cfg.reload_id = f"initial-{int(time.time() * 1000)}"
 
-                if not HAPROXY_BALANCE_ALGORITHM_PATTERN.match(RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()):
-                    logger.warning(f"'{RAY_SERVE_HAPROXY_BALANCE_ALGORITHM}' isn't a valid balancing algorithm. HAProxy will use leastconn instead. Valid algorithms match: leastconn, roundrobin, random, random(<draws>)")
+                if not HAPROXY_BALANCE_ALGORITHM_PATTERN.match(
+                    RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()
+                ):
+                    logger.warning(
+                        f"'{RAY_SERVE_HAPROXY_BALANCE_ALGORITHM}' isn't a valid balancing algorithm. HAProxy will use leastconn instead. Valid algorithms match: leastconn, roundrobin, random, random(<draws>)"
+                    )
 
                 self._generate_config_file_internal()
                 logger.info("Successfully generated HAProxy config file.")

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -386,7 +386,7 @@ class HAProxyConfig:
 
     syslog_port: int = RAY_SERVE_HAPROXY_SYSLOG_PORT
 
-    balance_algorithm: str = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM.lower()
+    balance_algorithm: str = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM
 
     @property
     def frontend_host(self) -> str:

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -60,6 +60,7 @@ defaults
     {%- if config.enable_hap_optimization %}
     load-server-state-from-file global
     {%- endif %}
+    balance {{ config.balance_algorithm }}
 frontend prometheus
     bind :{{ config.metrics_port }}
     mode http
@@ -90,7 +91,6 @@ backend default_backend
 {%- set hc = item.health_config %}
 backend {{ backend.name or 'unknown' }}
     log global
-    balance leastconn
     # Enable HTTP connection reuse for better performance
     http-reuse always
     # Set backend-specific timeouts, overriding defaults if specified

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -20,7 +20,6 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_HA_PROXY,
 )
 from ray.serve._private.haproxy import (
-    HAPROXY_BALANCE_ALGORITHM_PATTERN,
     BackendConfig,
     HAProxyApi,
     HAProxyConfig,

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -20,6 +20,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_HA_PROXY,
 )
 from ray.serve._private.haproxy import (
+    HAPROXY_BALANCE_ALGORITHM_PATTERN,
     BackendConfig,
     HAProxyApi,
     HAProxyConfig,
@@ -290,6 +291,7 @@ defaults
     errorfile 502 {temp_dir}/500.http
     errorfile 504 {temp_dir}/500.http
     load-server-state-from-file global
+    balance leastconn
 frontend prometheus
     bind :9101
     mode http
@@ -323,7 +325,6 @@ backend default_backend
     http-request return status 404 content-type text/plain lf-string "Path \'%[path]\' not found. Ping http://.../-/routes for available routes."
 backend api_backend
     log global
-    balance leastconn
     # Enable HTTP connection reuse for better performance
     http-reuse always
     # Set backend-specific timeouts, overriding defaults if specified
@@ -342,7 +343,6 @@ backend api_backend
     server api_fallback_server 127.0.0.1:8500 check backup
 backend web_backend
     log global
-    balance leastconn
     # Enable HTTP connection reuse for better performance
     http-reuse always
     # Set backend-specific timeouts, overriding defaults if specified
@@ -1660,6 +1660,32 @@ async def test_start_with_tcp_nodelay(haproxy_api_cleanup):
             ), "Config should contain 'option http-no-delay' when tcp_nodelay=True"
 
         await api.stop()
+
+
+@pytest.mark.parametrize(
+    "env_value,expected",
+    [
+        ("leastconn", "leastconn"),
+        ("roundrobin", "roundrobin"),
+        ("random", "random"),
+        ("random(2)", "random(2)"),
+        ("random(10)", "random(10)"),
+        ("LEASTCONN", "leastconn"),
+        ("Random(3)", "random(3)"),
+        ("rando", "leastconn"),
+        ("random(abc)", "leastconn"),
+        ("test", "leastconn"),
+        ("", "leastconn"),
+    ],
+)
+def test_balance_algorithm_validation(env_value, expected):
+    """Test that HAProxyConfig.balance_algorithm returns the env var value
+    when valid, and falls back to leastconn when invalid."""
+    with mock.patch(
+        "ray.serve._private.haproxy.RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", env_value
+    ):
+        config = HAProxyConfig()
+        assert config.balance_algorithm == expected
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -252,6 +252,8 @@ def test_generate_config_file_internal(haproxy_api_cleanup):
                 config_file_path=config_file_path,
             )
 
+            api.cfg.balance_algorithm = "random(2)"
+
             try:
                 api._generate_config_file_internal()
 
@@ -290,7 +292,7 @@ defaults
     errorfile 502 {temp_dir}/500.http
     errorfile 504 {temp_dir}/500.http
     load-server-state-from-file global
-    balance leastconn
+    balance random(2)
 frontend prometheus
     bind :9101
     mode http
@@ -1659,32 +1661,6 @@ async def test_start_with_tcp_nodelay(haproxy_api_cleanup):
             ), "Config should contain 'option http-no-delay' when tcp_nodelay=True"
 
         await api.stop()
-
-
-@pytest.mark.parametrize(
-    "env_value,expected",
-    [
-        ("leastconn", "leastconn"),
-        ("roundrobin", "roundrobin"),
-        ("random", "random"),
-        ("random(2)", "random(2)"),
-        ("random(10)", "random(10)"),
-        ("LEASTCONN", "leastconn"),
-        ("Random(3)", "random(3)"),
-        ("rando", "leastconn"),
-        ("random(abc)", "leastconn"),
-        ("test", "leastconn"),
-        ("", "leastconn"),
-    ],
-)
-def test_balance_algorithm_validation(env_value, expected):
-    """Test that HAProxyConfig.balance_algorithm returns the env var value
-    when valid, and falls back to leastconn when invalid."""
-    with mock.patch(
-        "ray.serve._private.haproxy.RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", env_value
-    ):
-        config = HAProxyConfig()
-        assert config.balance_algorithm == expected
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allow configuring the haproxy lb algo via env var `RAY_SERVE_HAPROXY_BALANCE_ALGORITHM`

available algos:
1. leastconn
2. roundrobin
3. random(n)

if empty or not set to one of the above, leastconn will be used