### PR TITLE
[Data] Fix verbose autoscaler request log output

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -190,6 +190,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._requester_id = f"data-{execution_id}"
         self._autoscaling_coordinator = autoscaling_coordinator
         self._get_node_counts = get_node_counts
+        self._autoscaling_enabled = is_autoscaling_enabled()
 
         # Send an empty request to register ourselves as soon as possible,
         # so the first `get_total_resources` call can get the allocated resources.
@@ -248,9 +249,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         )
 
         if resource_request != active_bundles:
-            self._log_resource_request(
-                util, active_bundles, resource_request, is_autoscaling_enabled()
-            )
+            self._log_resource_request(util, active_bundles, resource_request)
 
         self._send_resource_request(resource_request)
 
@@ -259,7 +258,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         current_utilization: ExecutionResources,
         active_bundles: List[Dict[str, float]],
         resource_request: List[Dict[str, float]],
-        autoscaling_enabled: bool = True,
     ) -> None:
         message = (
             "The utilization of one or more logical resource is higher than the "
@@ -280,7 +278,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             current_count = current_node_counts.get(node_spec, 0)
             message += f" [{node_spec}: {current_count} -> {requested_count}]"
 
-        if self.RAY_DATA_DISABLE_AUTOSCALER_LOGGING or not autoscaling_enabled:
+        if self.RAY_DATA_DISABLE_AUTOSCALER_LOGGING or not self._autoscaling_enabled:
             level = logging.DEBUG
         else:
             level = logging.INFO

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -14,7 +14,7 @@ from .resource_utilization_gauge import (
     ResourceUtilizationGauge,
     RollingLogicalUtilizationGauge,
 )
-from .util import cap_resource_request_to_limits
+from .util import cap_resource_request_to_limits, is_autoscaling_enabled
 from ray._common.utils import env_bool, env_float, env_integer
 from ray.data._internal.cluster_autoscaler import ClusterAutoscaler
 from ray.data._internal.execution.interfaces.execution_options import ExecutionResources
@@ -64,6 +64,23 @@ class _NodeResourceSpec:
 
     def to_bundle(self):
         return {"CPU": self.cpu, "GPU": self.gpu, "memory": self.mem}
+
+
+def _round_and_count(bundles: List[Dict[str, Any]]) -> Counter:
+    """Count bundles by node spec, rounding memory to the nearest 0.1 GiB.
+
+    This groups nodes of the same type that report slightly different physical
+    memory (e.g. 14.9 GiB vs 14.91 GiB) into one entry for cleaner log output.
+    """
+    from ray.data._internal.util import GiB
+
+    tenth_gib = GiB // 10
+    rounded = []
+    for bundle in bundles:
+        spec = _NodeResourceSpec.from_bundle(bundle)
+        mem = round(spec.mem / tenth_gib) * tenth_gib if spec.mem > 0 else 0
+        rounded.append(_NodeResourceSpec(cpu=spec.cpu, gpu=spec.gpu, mem=mem))
+    return Counter(rounded)
 
 
 def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
@@ -244,7 +261,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             active_bundles, pending_bundles, self._resource_limits
         )
 
-        if resource_request != active_bundles:
+        if resource_request != active_bundles and is_autoscaling_enabled():
             self._log_resource_request(util, active_bundles, resource_request)
 
         self._send_resource_request(resource_request)
@@ -264,12 +281,8 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             f"Requesting {self._cluster_scaling_up_delta} node(s) of each shape:"
         )
 
-        current_node_counts = Counter(
-            [_NodeResourceSpec.from_bundle(bundle) for bundle in active_bundles]
-        )
-        requested_node_counts = Counter(
-            [_NodeResourceSpec.from_bundle(bundle) for bundle in resource_request]
-        )
+        current_node_counts = _round_and_count(active_bundles)
+        requested_node_counts = _round_and_count(resource_request)
         for node_spec, requested_count in requested_node_counts.items():
             current_count = current_node_counts.get(node_spec, 0)
             message += f" [{node_spec}: {current_count} -> {requested_count}]"

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -19,6 +19,7 @@ from ray._common.utils import env_bool, env_float, env_integer
 from ray.data._internal.cluster_autoscaler import ClusterAutoscaler
 from ray.data._internal.execution.interfaces.execution_options import ExecutionResources
 from ray.data._internal.execution.util import memory_string
+from ray.data._internal.util import GiB
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.resource_manager import ResourceManager
@@ -51,7 +52,9 @@ class _NodeResourceSpec:
     def of(cls, *, cpu=0, gpu=0, mem=0):
         cpu = math.floor(cpu)
         gpu = math.floor(gpu)
-        mem = math.floor(mem)
+        # Round memory to the nearest 0.1 GiB so that nodes of the same type
+        # with slightly different reported physical memory are grouped together.
+        mem = int(round(mem / GiB, 1) * GiB) if mem > 0 else 0
         return cls(cpu=cpu, gpu=gpu, mem=mem)
 
     @classmethod
@@ -64,23 +67,6 @@ class _NodeResourceSpec:
 
     def to_bundle(self):
         return {"CPU": self.cpu, "GPU": self.gpu, "memory": self.mem}
-
-
-def _round_and_count(bundles: List[Dict[str, Any]]) -> Counter:
-    """Count bundles by node spec, rounding memory to the nearest 0.1 GiB.
-
-    This groups nodes of the same type that report slightly different physical
-    memory (e.g. 14.9 GiB vs 14.91 GiB) into one entry for cleaner log output.
-    """
-    from ray.data._internal.util import GiB
-
-    tenth_gib = GiB // 10
-    rounded = []
-    for bundle in bundles:
-        spec = _NodeResourceSpec.from_bundle(bundle)
-        mem = round(spec.mem / tenth_gib) * tenth_gib if spec.mem > 0 else 0
-        rounded.append(_NodeResourceSpec(cpu=spec.cpu, gpu=spec.gpu, mem=mem))
-    return Counter(rounded)
 
 
 def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
@@ -261,8 +247,10 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             active_bundles, pending_bundles, self._resource_limits
         )
 
-        if resource_request != active_bundles and is_autoscaling_enabled():
-            self._log_resource_request(util, active_bundles, resource_request)
+        if resource_request != active_bundles:
+            self._log_resource_request(
+                util, active_bundles, resource_request, is_autoscaling_enabled()
+            )
 
         self._send_resource_request(resource_request)
 
@@ -271,6 +259,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         current_utilization: ExecutionResources,
         active_bundles: List[Dict[str, float]],
         resource_request: List[Dict[str, float]],
+        autoscaling_enabled: bool = True,
     ) -> None:
         message = (
             "The utilization of one or more logical resource is higher than the "
@@ -281,13 +270,17 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             f"Requesting {self._cluster_scaling_up_delta} node(s) of each shape:"
         )
 
-        current_node_counts = _round_and_count(active_bundles)
-        requested_node_counts = _round_and_count(resource_request)
+        current_node_counts = Counter(
+            [_NodeResourceSpec.from_bundle(bundle) for bundle in active_bundles]
+        )
+        requested_node_counts = Counter(
+            [_NodeResourceSpec.from_bundle(bundle) for bundle in resource_request]
+        )
         for node_spec, requested_count in requested_node_counts.items():
             current_count = current_node_counts.get(node_spec, 0)
             message += f" [{node_spec}: {current_count} -> {requested_count}]"
 
-        if self.RAY_DATA_DISABLE_AUTOSCALER_LOGGING:
+        if self.RAY_DATA_DISABLE_AUTOSCALER_LOGGING or not autoscaling_enabled:
             level = logging.DEBUG
         else:
             level = logging.INFO

--- a/python/ray/data/_internal/cluster_autoscaler/util.py
+++ b/python/ray/data/_internal/cluster_autoscaler/util.py
@@ -6,6 +6,25 @@ from ray.data._internal.execution.interfaces import ExecutionResources
 logger = logging.getLogger(__name__)
 
 
+def is_autoscaling_enabled() -> bool:
+    """Check if any node type has autoscaling enabled (can scale up).
+
+    A node type is autoscalable if max_count == -1 (unlimited) or
+    max_count > min_count. If no cluster config is available or no node type
+    is autoscalable, returns False.
+    """
+    import ray
+
+    cluster_config = ray._private.state.state.get_cluster_config()
+    if not cluster_config or not cluster_config.node_group_configs:
+        return False
+    return any(
+        ngc.max_count == -1 or ngc.max_count > ngc.min_count
+        for ngc in cluster_config.node_group_configs
+        if ngc.resources and ngc.max_count != 0
+    )
+
+
 def cap_resource_request_to_limits(
     active_bundles: List[Dict],
     pending_bundles: List[Dict],

--- a/python/ray/data/_internal/cluster_autoscaler/util.py
+++ b/python/ray/data/_internal/cluster_autoscaler/util.py
@@ -13,7 +13,7 @@ def is_autoscaling_enabled() -> bool:
     max_count > min_count. If no cluster config is available or no node type
     is autoscalable, returns False.
     """
-    import ray
+    import ray._private.state
 
     cluster_config = ray._private.state.state.get_cluster_config()
     if not cluster_config or not cluster_config.node_group_configs:

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -17,6 +17,7 @@ from ray.data._internal.cluster_autoscaler.resource_utilization_gauge import (
     ResourceUtilizationGauge,
 )
 from ray.data._internal.execution.interfaces.execution_options import ExecutionResources
+from ray.data._internal.util import GiB
 
 
 class StubUtilizationGauge(ResourceUtilizationGauge):
@@ -38,11 +39,6 @@ _IS_AUTOSCALING_ENABLED_PATH = (
 
 class TestClusterAutoscaling:
     """Tests for cluster autoscaling functions in DefaultClusterAutoscalerV2."""
-
-    @pytest.fixture(autouse=True)
-    def mock_autoscaling_enabled(self):
-        with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=True):
-            yield
 
     def setup_class(self):
         self._node_type1 = {
@@ -403,10 +399,10 @@ class TestClusterAutoscaling:
                 1,
                 2,
             ),
-            # Memory limit: 4000 allows 2 nodes (4000 mem), not 3 (6000 mem)
+            # Memory limit: 4 GiB allows 2 nodes (4 GiB), not 3 (6 GiB)
             (
-                ExecutionResources.for_limits(memory=4000),
-                _NodeResourceSpec.of(cpu=4, gpu=0, mem=2000),
+                ExecutionResources.for_limits(memory=4 * GiB),
+                _NodeResourceSpec.of(cpu=4, gpu=0, mem=2 * GiB),
                 2,
                 1,
                 2,
@@ -466,8 +462,8 @@ class TestClusterAutoscaling:
         # CPU limit of 10 allows the initial state (4 CPUs) plus room for growth
         resource_limits = ExecutionResources.for_limits(cpu=10)
 
-        large_node_spec = _NodeResourceSpec.of(cpu=8, gpu=1, mem=4000)
-        small_node_spec = _NodeResourceSpec.of(cpu=4, gpu=0, mem=2000)
+        large_node_spec = _NodeResourceSpec.of(cpu=8, gpu=1, mem=4 * GiB)
+        small_node_spec = _NodeResourceSpec.of(cpu=4, gpu=0, mem=2 * GiB)
 
         scale_up_threshold = 0.75
         utilization = ExecutionResources(cpu=0.9, gpu=0.9, object_store_memory=0.9)
@@ -511,7 +507,7 @@ class TestClusterAutoscaling:
             "Smaller bundles should be included even when larger ones exceed limits."
         )
         assert resources_allocated.gpu == 0
-        assert resources_allocated.memory == 4000
+        assert resources_allocated.memory == 4 * GiB
 
     def test_try_scale_up_existing_nodes_prioritized_over_delta(self):
         """Test that existing node bundles are prioritized over scale-up delta bundles.
@@ -580,7 +576,7 @@ class TestClusterAutoscaling:
 
     def test_try_scale_up_logs_info_message(self, propagate_logs, caplog):
         fake_coordinator = FakeAutoscalingCoordinator()
-        node_spec = _NodeResourceSpec.of(cpu=1, gpu=0, mem=8 * 1024**3)
+        node_spec = _NodeResourceSpec.of(cpu=1, gpu=0, mem=8 * GiB)
         utilization = ExecutionResources(cpu=1, gpu=1, object_store_memory=1)
         autoscaler = DefaultClusterAutoscalerV2(
             resource_manager=MagicMock(),
@@ -591,8 +587,9 @@ class TestClusterAutoscaling:
             get_node_counts=lambda: {node_spec: 1},
         )
 
-        with caplog.at_level(logging.INFO):
-            autoscaler.try_trigger_scaling()
+        with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=True):
+            with caplog.at_level(logging.INFO):
+                autoscaler.try_trigger_scaling()
 
         expected_message = (
             "The utilization of one or more logical resource is higher than the "
@@ -607,39 +604,19 @@ class TestClusterAutoscaling:
             f"Actual logs: {log_messages}"
         )
 
-    def test_log_groups_nodes_with_similar_memory(self, propagate_logs, caplog):
-        """Test that nodes with slightly different memory are grouped in the log.
+    def test_nodes_with_similar_memory_grouped(self):
+        """Test that nodes with slightly different memory are grouped together.
 
         Nodes of the same type can report slightly different physical memory
-        (e.g. 14.9 GiB vs 14.91 GiB). The log should group them into one entry.
+        (e.g. 14.85 GiB vs 14.94 GiB) due to non-deterministic physical memory
+        availability at Ray init time. They should produce the same spec.
         """
-        GiB = 1024**3
-        fake_coordinator = FakeAutoscalingCoordinator()
-        # Two specs that differ only slightly in memory
-        spec_a = _NodeResourceSpec.of(cpu=8, gpu=0, mem=int(14.9 * GiB))
-        spec_b = _NodeResourceSpec.of(cpu=8, gpu=0, mem=int(14.91 * GiB))
-        assert spec_a != spec_b, "Specs should differ at byte level"
+        spec_a = _NodeResourceSpec.of(cpu=8, gpu=0, mem=int(14.87 * GiB))
+        spec_b = _NodeResourceSpec.of(cpu=8, gpu=0, mem=int(14.93 * GiB))
+        assert spec_a == spec_b
 
-        utilization = ExecutionResources(cpu=1, gpu=1, object_store_memory=1)
-        autoscaler = DefaultClusterAutoscalerV2(
-            resource_manager=MagicMock(),
-            execution_id="test_execution_id",
-            resource_utilization_calculator=StubUtilizationGauge(utilization),
-            min_gap_between_autoscaling_requests_s=0,
-            autoscaling_coordinator=fake_coordinator,
-            get_node_counts=lambda: {spec_a: 1, spec_b: 1},
-        )
-
-        with caplog.at_level(logging.INFO):
-            autoscaler.try_trigger_scaling()
-
-        log_messages = [r.message for r in caplog.records]
-        scaling_logs = [m for m in log_messages if "Requesting" in m]
-        # Should show one node shape entry, not two separate entries.
-        assert scaling_logs[0].count("[{") == 1
-
-    def test_no_log_when_autoscaling_disabled(self, propagate_logs, caplog):
-        """Test that no autoscaling log is emitted when autoscaling is disabled."""
+    def test_debug_log_when_autoscaling_disabled(self, propagate_logs, caplog):
+        """Test that autoscaling log is at DEBUG level when autoscaling is disabled."""
         fake_coordinator = FakeAutoscalingCoordinator()
         node_spec = _NodeResourceSpec.of(cpu=8, gpu=0, mem=1000)
         utilization = ExecutionResources(cpu=1, gpu=0, object_store_memory=1)
@@ -654,12 +631,12 @@ class TestClusterAutoscaling:
         )
 
         with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=False):
-            with caplog.at_level(logging.INFO):
+            with caplog.at_level(logging.DEBUG):
                 autoscaler.try_trigger_scaling()
 
-        assert not any(
-            "Requesting" in msg for msg in [r.message for r in caplog.records]
-        )
+        scaling_records = [r for r in caplog.records if "Requesting" in r.message]
+        assert len(scaling_records) == 1
+        assert scaling_records[0].levelno == logging.DEBUG
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -578,18 +578,18 @@ class TestClusterAutoscaling:
         fake_coordinator = FakeAutoscalingCoordinator()
         node_spec = _NodeResourceSpec.of(cpu=1, gpu=0, mem=8 * GiB)
         utilization = ExecutionResources(cpu=1, gpu=1, object_store_memory=1)
-        autoscaler = DefaultClusterAutoscalerV2(
-            resource_manager=MagicMock(),
-            execution_id="test_execution_id",
-            resource_utilization_calculator=StubUtilizationGauge(utilization),
-            min_gap_between_autoscaling_requests_s=0,
-            autoscaling_coordinator=fake_coordinator,
-            get_node_counts=lambda: {node_spec: 1},
-        )
-
         with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=True):
-            with caplog.at_level(logging.INFO):
-                autoscaler.try_trigger_scaling()
+            autoscaler = DefaultClusterAutoscalerV2(
+                resource_manager=MagicMock(),
+                execution_id="test_execution_id",
+                resource_utilization_calculator=StubUtilizationGauge(utilization),
+                min_gap_between_autoscaling_requests_s=0,
+                autoscaling_coordinator=fake_coordinator,
+                get_node_counts=lambda: {node_spec: 1},
+            )
+
+        with caplog.at_level(logging.INFO):
+            autoscaler.try_trigger_scaling()
 
         expected_message = (
             "The utilization of one or more logical resource is higher than the "
@@ -621,18 +621,18 @@ class TestClusterAutoscaling:
         node_spec = _NodeResourceSpec.of(cpu=8, gpu=0, mem=1000)
         utilization = ExecutionResources(cpu=1, gpu=0, object_store_memory=1)
 
-        autoscaler = DefaultClusterAutoscalerV2(
-            resource_manager=MagicMock(),
-            execution_id="test_execution_id",
-            resource_utilization_calculator=StubUtilizationGauge(utilization),
-            min_gap_between_autoscaling_requests_s=0,
-            autoscaling_coordinator=fake_coordinator,
-            get_node_counts=lambda: {node_spec: 2},
-        )
-
         with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=False):
-            with caplog.at_level(logging.DEBUG):
-                autoscaler.try_trigger_scaling()
+            autoscaler = DefaultClusterAutoscalerV2(
+                resource_manager=MagicMock(),
+                execution_id="test_execution_id",
+                resource_utilization_calculator=StubUtilizationGauge(utilization),
+                min_gap_between_autoscaling_requests_s=0,
+                autoscaling_coordinator=fake_coordinator,
+                get_node_counts=lambda: {node_spec: 2},
+            )
+
+        with caplog.at_level(logging.DEBUG):
+            autoscaler.try_trigger_scaling()
 
         scaling_records = [r for r in caplog.records if "Requesting" in r.message]
         assert len(scaling_records) == 1

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -30,8 +30,19 @@ class StubUtilizationGauge(ResourceUtilizationGauge):
         return self._utilization
 
 
+_IS_AUTOSCALING_ENABLED_PATH = (
+    "ray.data._internal.cluster_autoscaler."
+    "default_cluster_autoscaler_v2.is_autoscaling_enabled"
+)
+
+
 class TestClusterAutoscaling:
     """Tests for cluster autoscaling functions in DefaultClusterAutoscalerV2."""
+
+    @pytest.fixture(autouse=True)
+    def mock_autoscaling_enabled(self):
+        with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=True):
+            yield
 
     def setup_class(self):
         self._node_type1 = {
@@ -594,6 +605,60 @@ class TestClusterAutoscaling:
             f"Expected log message not found.\n"
             f"Expected: {expected_message}\n"
             f"Actual logs: {log_messages}"
+        )
+
+    def test_log_groups_nodes_with_similar_memory(self, propagate_logs, caplog):
+        """Test that nodes with slightly different memory are grouped in the log.
+
+        Nodes of the same type can report slightly different physical memory
+        (e.g. 14.9 GiB vs 14.91 GiB). The log should group them into one entry.
+        """
+        GiB = 1024**3
+        fake_coordinator = FakeAutoscalingCoordinator()
+        # Two specs that differ only slightly in memory
+        spec_a = _NodeResourceSpec.of(cpu=8, gpu=0, mem=int(14.9 * GiB))
+        spec_b = _NodeResourceSpec.of(cpu=8, gpu=0, mem=int(14.91 * GiB))
+        assert spec_a != spec_b, "Specs should differ at byte level"
+
+        utilization = ExecutionResources(cpu=1, gpu=1, object_store_memory=1)
+        autoscaler = DefaultClusterAutoscalerV2(
+            resource_manager=MagicMock(),
+            execution_id="test_execution_id",
+            resource_utilization_calculator=StubUtilizationGauge(utilization),
+            min_gap_between_autoscaling_requests_s=0,
+            autoscaling_coordinator=fake_coordinator,
+            get_node_counts=lambda: {spec_a: 1, spec_b: 1},
+        )
+
+        with caplog.at_level(logging.INFO):
+            autoscaler.try_trigger_scaling()
+
+        log_messages = [r.message for r in caplog.records]
+        scaling_logs = [m for m in log_messages if "Requesting" in m]
+        # Should show one node shape entry, not two separate entries.
+        assert len(scaling_logs) == 1
+
+    def test_no_log_when_autoscaling_disabled(self, propagate_logs, caplog):
+        """Test that no autoscaling log is emitted when autoscaling is disabled."""
+        fake_coordinator = FakeAutoscalingCoordinator()
+        node_spec = _NodeResourceSpec.of(cpu=8, gpu=0, mem=1000)
+        utilization = ExecutionResources(cpu=1, gpu=0, object_store_memory=1)
+
+        autoscaler = DefaultClusterAutoscalerV2(
+            resource_manager=MagicMock(),
+            execution_id="test_execution_id",
+            resource_utilization_calculator=StubUtilizationGauge(utilization),
+            min_gap_between_autoscaling_requests_s=0,
+            autoscaling_coordinator=fake_coordinator,
+            get_node_counts=lambda: {node_spec: 2},
+        )
+
+        with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=False):
+            with caplog.at_level(logging.INFO):
+                autoscaler.try_trigger_scaling()
+
+        assert not any(
+            "Requesting" in msg for msg in [r.message for r in caplog.records]
         )
 
 

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -636,7 +636,7 @@ class TestClusterAutoscaling:
         log_messages = [r.message for r in caplog.records]
         scaling_logs = [m for m in log_messages if "Requesting" in m]
         # Should show one node shape entry, not two separate entries.
-        assert len(scaling_logs) == 1
+        assert scaling_logs[0].count("[{") == 1
 
     def test_no_log_when_autoscaling_disabled(self, propagate_logs, caplog):
         """Test that no autoscaling log is emitted when autoscaling is disabled."""


### PR DESCRIPTION
## Description

Fixes two issues with the cluster autoscaler log:

1. Nodes of the same type reporting slightly different physical memory (e.g. 14.9 GiB vs 14.91 GiB) were logged as separate node shapes, spamming the terminal with dozens of duplicate entries. Fixed by rounding memory to 0.1 GiB precision when grouping for display.
2. The autoscaling log was emitted even when autoscaling is disabled (all node types have fixed `min_count == max_count`). Now skips the log when no node type can actually scale.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
