### PR TITLE
[Data] Update exclude_resources docs to reflect Train autoscaling coordinator changes

### DIFF
--- a/doc/source/data/execution-configurations.rst
+++ b/doc/source/data/execution-configurations.rst
@@ -31,7 +31,7 @@ To use it, modify the attributes in the current :class:`~ray.data.DataContext` o
 * `resource_limits`: Set a soft limit on the resource usage during execution. For example, if there are other parts of the code which require some minimum amount of resources, you may want to limit the amount of resources that Ray Data uses. Auto-detected by default.
 * `exclude_resources`: Amount of resources to exclude from Ray Data. Set this if you have other workloads running on the same cluster. Note:
 
-  * If you're using Ray Data with Ray Train, training resources are automatically excluded. Otherwise, off by default.
+  * If you're using Ray Data with Ray Train, training resources are automatically reserved and you don't need to set ``exclude_resources`` for them. Otherwise, off by default.
   * For each resource type, you can't set both ``resource_limits`` and ``exclude_resources``.
 
 * `preserve_order`: Set this to preserve the ordering between blocks processed by operators under the streaming executor. Off by default.

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -298,8 +298,9 @@ class ExecutionOptions:
         exclude_resources: Amount of resources to exclude from Ray Data.
             Set this if you have other workloads running on the same cluster.
             Note,
-            - If using Ray Data with Ray Train, training resources will be
-            automatically excluded.
+            - If using Ray Data with Ray Train, training resources are
+            automatically reserved and you don't need to set exclude_resources
+            for them.
             - For each resource type, resource_limits and exclude_resources can
             not be both set.
         preserve_order: Set this to preserve the ordering between blocks processed by


### PR DESCRIPTION
## Summary

After #61703, Ray Train no longer adds training resources to `exclude_resources`. Instead, training resources are registered directly with the `AutoscalingCoordinator`. The docs still said training resources are "automatically excluded," which is misleading. This updates the wording to reflect the new behavior.

## Changes

- Update `exclude_resources` note in `doc/source/data/execution-configurations.rst` and `ExecutionOptions` docstring in `execution_options.py` to clarify that training resources are automatically reserved without needing `exclude_resources`.

## Tests

Doc-only change — no new tests needed.