### PR TITLE
[Data] Make `image_classification` release test more realistic

### DIFF
--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -1,5 +1,6 @@
 import argparse
 import time
+import uuid
 from typing import Dict
 
 import numpy as np
@@ -9,6 +10,8 @@ from torchvision.models import ResNet50_Weights, resnet50
 
 import ray
 from ray.data import ActorPoolStrategy
+
+WRITE_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
 
 
 def parse_args():
@@ -48,11 +51,6 @@ def main(args):
 
     print(f"Running GPU batch prediction with data from {data_url}")
 
-    # The preprocessing UDF converts images from uint8 to float64, which increases
-    # memory usage 8x. Each processed image is about 1.5 MiB (256×256×3×8 bytes). Since
-    # our target block size is 128 MiB, we set the batch size to around 90 images (128
-    # MiB / 1.5) to avoid running out of memory.
-    PREPROCESS_BATCH_SIZE = 90
     # Largest batch that can fit on a T4.
     INFERENCE_BATCH_SIZE = 900
 
@@ -85,6 +83,8 @@ def main(args):
         transformed_batch = transform(tensor_batch).numpy()
         return {"image": transformed_batch}
 
+    # Take advantage of vectorization
+    # Keep memory low
     class Predictor:
         def __init__(self, model):
             self.model = ray.get(model)
@@ -102,41 +102,27 @@ def main(args):
         compute = ActorPoolStrategy(size=4)
         num_gpus = 0
     else:
-        compute = ActorPoolStrategy(min_size=1, max_size=10)
+        compute = None
         num_gpus = 1
-    ds = ds.map_batches(preprocess, batch_size=PREPROCESS_BATCH_SIZE)
+    ds = ds.map_batches(preprocess)
     ds = ds.map_batches(
         Predictor,
         batch_size=INFERENCE_BATCH_SIZE,
         compute=compute,
         num_gpus=num_gpus,
         fn_constructor_kwargs={"model": model_ref},
-        max_concurrency=2,
     )
 
-    total_images = 0
-
-    # NOTE: We're iterating over ref-bundles to avoid pulling blocks into the
-    #       driver, therefore making it a factor impacting benchmark performance
-    for bundle in ds.iter_internal_ref_bundles():
-        total_images += bundle.num_rows()
+    ds.write_parquet(WRITE_PATH)
 
     end_time = time.time()
 
     total_time = end_time - start_time
-    throughput = total_images / (total_time)
     total_time_without_metadata_fetch = end_time - start_time_without_metadata_fetching
-    throughput_without_metadata_fetch = total_images / (
-        total_time_without_metadata_fetch
-    )
 
     print("Total time (sec): ", total_time)
-    print("Throughput (img/sec): ", throughput)
     print("Total time w/o metadata fetching (sec): ", total_time_without_metadata_fetch)
-    print(
-        "Throughput w/o metadata fetching (img/sec): ",
-        throughput_without_metadata_fetch,
-    )
+
     if chaos_test:
         dead_nodes = [node["NodeID"] for node in ray.nodes() if not node["Alive"]]
         assert dead_nodes
@@ -145,11 +131,9 @@ def main(args):
     # For structured output integration with internal tooling
     results = {
         BenchmarkMetric.RUNTIME: total_time,
-        BenchmarkMetric.THROUGHPUT: throughput,
         "data_directory": data_directory,
         "data_format": data_format,
         "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
-        "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
     }
 
     return results

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -83,8 +83,6 @@ def main(args):
         transformed_batch = transform(tensor_batch).numpy()
         return {"image": transformed_batch}
 
-    # Take advantage of vectorization
-    # Keep memory low
     class Predictor:
         def __init__(self, model):
             self.model = ray.get(model)

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -110,7 +110,6 @@ def main(args):
         num_gpus=num_gpus,
         fn_constructor_kwargs={"model": model_ref},
     )
-
     ds.write_parquet(WRITE_PATH)
 
     end_time = time.time()

--- a/release/nightly_tests/dataset/gpu_batch_inference.py
+++ b/release/nightly_tests/dataset/gpu_batch_inference.py
@@ -1,6 +1,5 @@
 import argparse
 import time
-import uuid
 from typing import Dict
 
 import numpy as np
@@ -10,8 +9,6 @@ from torchvision.models import ResNet50_Weights, resnet50
 
 import ray
 from ray.data import ActorPoolStrategy
-
-WRITE_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
 
 
 def parse_args():
@@ -51,6 +48,11 @@ def main(args):
 
     print(f"Running GPU batch prediction with data from {data_url}")
 
+    # The preprocessing UDF converts images from uint8 to float64, which increases
+    # memory usage 8x. Each processed image is about 1.5 MiB (256×256×3×8 bytes). Since
+    # our target block size is 128 MiB, we set the batch size to around 90 images (128
+    # MiB / 1.5) to avoid running out of memory.
+    PREPROCESS_BATCH_SIZE = 90
     # Largest batch that can fit on a T4.
     INFERENCE_BATCH_SIZE = 900
 
@@ -100,26 +102,41 @@ def main(args):
         compute = ActorPoolStrategy(size=4)
         num_gpus = 0
     else:
-        compute = None
+        compute = ActorPoolStrategy(min_size=1, max_size=10)
         num_gpus = 1
-    ds = ds.map_batches(preprocess)
+    ds = ds.map_batches(preprocess, batch_size=PREPROCESS_BATCH_SIZE)
     ds = ds.map_batches(
         Predictor,
         batch_size=INFERENCE_BATCH_SIZE,
         compute=compute,
         num_gpus=num_gpus,
         fn_constructor_kwargs={"model": model_ref},
+        max_concurrency=2,
     )
-    ds.write_parquet(WRITE_PATH)
+
+    total_images = 0
+
+    # NOTE: We're iterating over ref-bundles to avoid pulling blocks into the
+    #       driver, therefore making it a factor impacting benchmark performance
+    for bundle in ds.iter_internal_ref_bundles():
+        total_images += bundle.num_rows()
 
     end_time = time.time()
 
     total_time = end_time - start_time
+    throughput = total_images / (total_time)
     total_time_without_metadata_fetch = end_time - start_time_without_metadata_fetching
+    throughput_without_metadata_fetch = total_images / (
+        total_time_without_metadata_fetch
+    )
 
     print("Total time (sec): ", total_time)
+    print("Throughput (img/sec): ", throughput)
     print("Total time w/o metadata fetching (sec): ", total_time_without_metadata_fetch)
-
+    print(
+        "Throughput w/o metadata fetching (img/sec): ",
+        throughput_without_metadata_fetch,
+    )
     if chaos_test:
         dead_nodes = [node["NodeID"] for node in ray.nodes() if not node["Alive"]]
         assert dead_nodes
@@ -128,9 +145,11 @@ def main(args):
     # For structured output integration with internal tooling
     results = {
         BenchmarkMetric.RUNTIME: total_time,
+        BenchmarkMetric.THROUGHPUT: throughput,
         "data_directory": data_directory,
         "data_format": data_format,
         "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
+        "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
     }
 
     return results

--- a/release/nightly_tests/dataset/image_classification_from_parquet/main.py
+++ b/release/nightly_tests/dataset/image_classification_from_parquet/main.py
@@ -1,0 +1,163 @@
+import argparse
+import time
+from typing import Dict
+
+import numpy as np
+import torch
+from benchmark import Benchmark, BenchmarkMetric
+from torchvision.models import ResNet50_Weights, resnet50
+
+import ray
+from ray.data import ActorPoolStrategy
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--data-directory",
+        help=(
+            "Name of the S3 directory in the air-example-data-2 "
+            "bucket to load data from."
+        ),
+    )
+    parser.add_argument(
+        "--data-format",
+        choices=["parquet", "raw"],
+        help="The format of the data. Can be either parquet or raw.",
+    )
+    parser.add_argument(
+        "--smoke-test",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--chaos-test",
+        action="store_true",
+        default=False,
+    )
+    return parser.parse_args()
+
+
+def main(args):
+    data_directory: str = args.data_directory
+    data_format: str = args.data_format
+    smoke_test: bool = args.smoke_test
+    chaos_test: bool = args.chaos_test
+    data_url = f"s3://anonymous@air-example-data-2/{data_directory}"
+
+    print(f"Running GPU batch prediction with data from {data_url}")
+
+    # The preprocessing UDF converts images from uint8 to float64, which increases
+    # memory usage 8x. Each processed image is about 1.5 MiB (256×256×3×8 bytes). Since
+    # our target block size is 128 MiB, we set the batch size to around 90 images (128
+    # MiB / 1.5) to avoid running out of memory.
+    PREPROCESS_BATCH_SIZE = 90
+    # Largest batch that can fit on a T4.
+    INFERENCE_BATCH_SIZE = 900
+
+    device = "cpu" if smoke_test else "cuda"
+
+    weights = ResNet50_Weights.DEFAULT
+    model = resnet50(weights=weights)
+    model_ref = ray.put(model)
+
+    # Get the preprocessing transforms from the pre-trained weights.
+    transform = weights.transforms()
+
+    start_time = time.time()
+
+    if data_format == "raw":
+        if smoke_test:
+            data_url += "/dog_1.jpg"
+        ds = ray.data.read_images(data_url, size=(256, 256))
+    elif data_format == "parquet":
+        if smoke_test:
+            data_url += "/8cc8856e16c343829ef320fef4b353b1_000000.parquet"
+        ds = ray.data.read_parquet(data_url)
+
+    # Preprocess the images using standard preprocessing
+    def preprocess(image_batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+        tensor_batch = torch.as_tensor(image_batch["image"], dtype=torch.float)
+        # (B, H, W, C) -> (B, C, H, W). This is required for the torchvision transform.
+        # https://pytorch.org/vision/main/models/generated/torchvision.models.resnet50.html#torchvision.models.ResNet50_Weights  # noqa
+        tensor_batch = tensor_batch.permute(0, 3, 1, 2)
+        transformed_batch = transform(tensor_batch).numpy()
+        return {"image": transformed_batch}
+
+    class Predictor:
+        def __init__(self, model):
+            self.model = ray.get(model)
+            self.model.eval()
+            self.model.to(device)
+
+        def __call__(self, batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+            with torch.inference_mode():
+                output = self.model(torch.as_tensor(batch["image"], device=device))
+                return {"predictions": output.cpu().numpy()}
+
+    start_time_without_metadata_fetching = time.time()
+
+    if smoke_test:
+        compute = ActorPoolStrategy(size=4)
+        num_gpus = 0
+    else:
+        compute = ActorPoolStrategy(min_size=1, max_size=10)
+        num_gpus = 1
+    ds = ds.map_batches(preprocess, batch_size=PREPROCESS_BATCH_SIZE)
+    ds = ds.map_batches(
+        Predictor,
+        batch_size=INFERENCE_BATCH_SIZE,
+        compute=compute,
+        num_gpus=num_gpus,
+        fn_constructor_kwargs={"model": model_ref},
+        max_concurrency=2,
+    )
+
+    total_images = 0
+
+    # NOTE: We're iterating over ref-bundles to avoid pulling blocks into the
+    #       driver, therefore making it a factor impacting benchmark performance
+    for bundle in ds.iter_internal_ref_bundles():
+        total_images += bundle.num_rows()
+
+    end_time = time.time()
+
+    total_time = end_time - start_time
+    throughput = total_images / (total_time)
+    total_time_without_metadata_fetch = end_time - start_time_without_metadata_fetching
+    throughput_without_metadata_fetch = total_images / (
+        total_time_without_metadata_fetch
+    )
+
+    print("Total time (sec): ", total_time)
+    print("Throughput (img/sec): ", throughput)
+    print("Total time w/o metadata fetching (sec): ", total_time_without_metadata_fetch)
+    print(
+        "Throughput w/o metadata fetching (img/sec): ",
+        throughput_without_metadata_fetch,
+    )
+    if chaos_test:
+        dead_nodes = [node["NodeID"] for node in ray.nodes() if not node["Alive"]]
+        assert dead_nodes
+        print(f"Total chaos killed: {dead_nodes}")
+
+    # For structured output integration with internal tooling
+    results = {
+        BenchmarkMetric.RUNTIME: total_time,
+        BenchmarkMetric.THROUGHPUT: throughput,
+        "data_directory": data_directory,
+        "data_format": data_format,
+        "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
+        "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
+    }
+
+    return results
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    benchmark = Benchmark()
+    benchmark.run_fn("batch-inference", main, args)
+    benchmark.write_result()

--- a/release/nightly_tests/dataset/image_classification_from_parquet/main.py
+++ b/release/nightly_tests/dataset/image_classification_from_parquet/main.py
@@ -1,5 +1,6 @@
 import argparse
 import time
+import uuid
 from typing import Dict
 
 import numpy as np
@@ -9,6 +10,8 @@ from torchvision.models import ResNet50_Weights, resnet50
 
 import ray
 from ray.data import ActorPoolStrategy
+
+WRITE_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
 
 
 def parse_args():
@@ -48,11 +51,6 @@ def main(args):
 
     print(f"Running GPU batch prediction with data from {data_url}")
 
-    # The preprocessing UDF converts images from uint8 to float64, which increases
-    # memory usage 8x. Each processed image is about 1.5 MiB (256×256×3×8 bytes). Since
-    # our target block size is 128 MiB, we set the batch size to around 90 images (128
-    # MiB / 1.5) to avoid running out of memory.
-    PREPROCESS_BATCH_SIZE = 90
     # Largest batch that can fit on a T4.
     INFERENCE_BATCH_SIZE = 900
 
@@ -102,41 +100,26 @@ def main(args):
         compute = ActorPoolStrategy(size=4)
         num_gpus = 0
     else:
-        compute = ActorPoolStrategy(min_size=1, max_size=10)
+        compute = None
         num_gpus = 1
-    ds = ds.map_batches(preprocess, batch_size=PREPROCESS_BATCH_SIZE)
+    ds = ds.map_batches(preprocess)
     ds = ds.map_batches(
         Predictor,
         batch_size=INFERENCE_BATCH_SIZE,
         compute=compute,
         num_gpus=num_gpus,
         fn_constructor_kwargs={"model": model_ref},
-        max_concurrency=2,
     )
-
-    total_images = 0
-
-    # NOTE: We're iterating over ref-bundles to avoid pulling blocks into the
-    #       driver, therefore making it a factor impacting benchmark performance
-    for bundle in ds.iter_internal_ref_bundles():
-        total_images += bundle.num_rows()
+    ds.write_parquet(WRITE_PATH)
 
     end_time = time.time()
 
     total_time = end_time - start_time
-    throughput = total_images / (total_time)
     total_time_without_metadata_fetch = end_time - start_time_without_metadata_fetching
-    throughput_without_metadata_fetch = total_images / (
-        total_time_without_metadata_fetch
-    )
 
     print("Total time (sec): ", total_time)
-    print("Throughput (img/sec): ", throughput)
     print("Total time w/o metadata fetching (sec): ", total_time_without_metadata_fetch)
-    print(
-        "Throughput w/o metadata fetching (img/sec): ",
-        throughput_without_metadata_fetch,
-    )
+
     if chaos_test:
         dead_nodes = [node["NodeID"] for node in ray.nodes() if not node["Alive"]]
         assert dead_nodes
@@ -145,11 +128,9 @@ def main(args):
     # For structured output integration with internal tooling
     results = {
         BenchmarkMetric.RUNTIME: total_time,
-        BenchmarkMetric.THROUGHPUT: throughput,
         "data_directory": data_directory,
         "data_format": data_format,
         "total_time_s_wo_metadata_fetch": total_time_without_metadata_fetch,
-        "throughput_images_s_wo_metadata_fetch": throughput_without_metadata_fetch,
     }
 
     return results

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -611,6 +611,32 @@
       python dataset/gpu_batch_inference.py
       --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet --chaos-test
 
+# 300 GB image classification parquet data up to 10 GPUs
+# 10 g4dn.12xlarge.
+# NOTE: This is almost identical to the `image_classification` test except it removes
+# non-default configurations and writes to cloud storage. After some period of time,
+# we should remove the legacy `image_classification` test and only keep this one.
+- name: "image_classification_from_parquet_{{scaling}}"
+  python: "3.10"
+  group: data-batch-inference
+
+  cluster:
+    byod:
+      # NOTE: Image classification have to pin Pyarrow to 19.0 due to dataset using
+      #       previous tensor extension type inheriting from ``pyarrow.PyExtensionType``
+      #       that is removed in Pyarrow 21.0
+      python_depset: image_classification_py3.10.lock
+    cluster_compute: "{{scaling}}_gpu_compute.yaml"
+
+  matrix:
+    setup:
+      scaling: [fixed_size, autoscaling]
+
+  run:
+    timeout: 1800
+    script: >
+      python image_classification_from_parquet/main.py
+      --data-directory 300G-image-data-synthetic-raw-parquet --data-format parquet
 
 - name: image_embedding_from_uris_{{case}}
   python: "3.10"


### PR DESCRIPTION
The `image_classification` contains some workarounds and non-default patterns.

In this PR, I've updated it to make it more realistic. Here's what I changed:
* Removed the low-level `max_concurrency` configuration
* Removed the preprocessing batch size that was originally added to avoid OOMs
* Updated the pipeline to write instead of iterate. Users don't usually iterate over batch inference results.
* Replaced the `compute` parameter with `None` (default).