### PR TITLE
[serve] Increment backoff metric when router actually backs off

### DIFF
--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -1196,14 +1196,14 @@ class RequestRouter(ABC):
                 ):
                     continue
 
+                # Only backoff after the first retry.
                 if not entered_backoff:
                     entered_backoff = True
+                else:
                     self.num_routing_tasks_in_backoff += 1
                     self.num_routing_tasks_in_backoff_gauge.set(
                         self.num_routing_tasks_in_backoff
                     )
-                else:
-                    # Only backoff after the first retry.
                     await self._backoff(attempt)
                     attempt += 1
         finally:


### PR DESCRIPTION
Before we were incrementing the gauge even if the router didn't actually backoff.