### PR TITLE
[core] Fix GPU fractional scheduling by tracking per-instance availability

### DIFF
--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -20,25 +20,25 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
     # when the test was written.
     resource_quantity = num_pgs
     num_nodes = 5
-    custom_resources = {"pg_custom": resource_quantity}
-    # Create pg that uses 1 resource of cpu & custom resource.
+    custom_resources = {
+        "custom_resource": resource_quantity,
+        "pg_custom": resource_quantity,
+    }
     num_pg = resource_quantity
 
     # TODO(sang): Cluster setup. Remove when running in real clusters.
     nodes = []
     for _ in range(num_nodes):
-        nodes.append(
-            cluster.add_node(num_cpus=resource_quantity + 3, resources=custom_resources)
-        )
+        nodes.append(cluster.add_node(num_cpus=3, resources=custom_resources))
     cluster.wait_for_nodes()
     num_nodes = len(nodes)
 
     ray.init(address=cluster.address)
     while not ray.is_initialized():
         time.sleep(0.1)
-    bundles = [{"CPU": 1, "pg_custom": 1}] * num_nodes
+    bundles = [{"custom_resource": 1, "pg_custom": 1}] * num_nodes
 
-    @ray.remote(num_cpus=1, max_calls=0)
+    @ray.remote(num_cpus=0, resources={"custom_resource": 1}, max_calls=0)
     def mock_task():
         time.sleep(0.1)
         return True

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -28,9 +28,7 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
     nodes = []
     for _ in range(num_nodes):
         nodes.append(
-            cluster.add_node(
-                num_cpus=3, num_gpus=resource_quantity, resources=custom_resources
-            )
+            cluster.add_node(num_cpus=resource_quantity + 3, resources=custom_resources)
         )
     cluster.wait_for_nodes()
     num_nodes = len(nodes)
@@ -38,9 +36,9 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
     ray.init(address=cluster.address)
     while not ray.is_initialized():
         time.sleep(0.1)
-    bundles = [{"GPU": 1, "pg_custom": 1}] * num_nodes
+    bundles = [{"CPU": 1, "pg_custom": 1}] * num_nodes
 
-    @ray.remote(num_cpus=0, num_gpus=1, max_calls=0)
+    @ray.remote(num_cpus=1, max_calls=0)
     def mock_task():
         time.sleep(0.1)
         return True

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -20,10 +20,7 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
     # when the test was written.
     resource_quantity = num_pgs
     num_nodes = 5
-    custom_resources = {
-        "custom_resource": resource_quantity,
-        "pg_custom": resource_quantity,
-    }
+    custom_resources = {"pg_custom": resource_quantity}
     num_pg = resource_quantity
 
     # TODO(sang): Cluster setup. Remove when running in real clusters.
@@ -36,9 +33,9 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
     ray.init(address=cluster.address)
     while not ray.is_initialized():
         time.sleep(0.1)
-    bundles = [{"custom_resource": 1, "pg_custom": 1}] * num_nodes
+    bundles = [{"pg_custom": 1}] * num_nodes
 
-    @ray.remote(num_cpus=0, resources={"custom_resource": 1}, max_calls=0)
+    @ray.remote(num_cpus=0, resources={"pg_custom": 1}, max_calls=0)
     def mock_task():
         time.sleep(0.1)
         return True

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -48,7 +48,6 @@ ResourceRequest ResourceMapToResourceRequest(
 /// \param resource_map_available: Available capacities of resources we want to convert.
 ///
 /// \request Conversion result to a ResourceRequest data structure.
-/// Callers must pass integer values for available unit instance resources.
 NodeResources ResourceMapToNodeResources(
     const absl::flat_hash_map<std::string, double> &resource_map_total,
     const absl::flat_hash_map<std::string, double> &resource_map_available,

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -54,7 +54,8 @@ NodeResources ResourceMapToNodeResources(
     const absl::flat_hash_map<std::string, std::string> &node_labels) {
   NodeResources node_resources;
   node_resources.total = NodeResourceSet(resource_map_total);
-  node_resources.available = NodeResourceSet(resource_map_available);
+  node_resources.available =
+      NodeResourceInstanceSet(NodeResourceSet(resource_map_available));
   node_resources.labels = node_labels;
   return node_resources;
 }
@@ -66,7 +67,7 @@ float NodeResources::CalculateCriticalResourceUtilization() const {
     if (cur_total == 0) {
       continue;
     }
-    auto cur_available = this->available.Get(ResourceID(i)).Double();
+    auto cur_available = this->available.Sum(ResourceID(i)).Double();
     float utilization = 1 - (cur_available / cur_total.Double());
     if (utilization > highest) {
       highest = utilization;
@@ -88,7 +89,7 @@ bool NodeResources::IsAvailable(const ResourceRequest &resource_request,
     return false;
   }
 
-  return this->available >= resource_request.GetResourceSet();
+  return this->available.CanAllocate(resource_request.GetResourceSet());
 }
 
 bool NodeResources::IsFeasible(const ResourceRequest &resource_request) const {

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -48,6 +48,7 @@ ResourceRequest ResourceMapToResourceRequest(
 /// \param resource_map_available: Available capacities of resources we want to convert.
 ///
 /// \request Conversion result to a ResourceRequest data structure.
+/// Callers must pass integer values for available unit instance resources.
 NodeResources ResourceMapToNodeResources(
     const absl::flat_hash_map<std::string, double> &resource_map_total,
     const absl::flat_hash_map<std::string, double> &resource_map_available,

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -311,7 +311,7 @@ class NodeResources {
   explicit NodeResources(const NodeResourceSet &resources)
       : total(resources), available(resources) {}
   NodeResourceSet total;
-  NodeResourceSet available;
+  NodeResourceInstanceSet available;
   /// Only used by light resource report.
   ResourceSet load;
 
@@ -339,11 +339,9 @@ class NodeResources {
   /// of each resource and return the highest.
   float CalculateCriticalResourceUtilization() const;
   /// Returns true if the node has the available resources to run the task.
-  /// Note: This doesn't account for the binpacking of unit resources.
   bool IsAvailable(const ResourceRequest &resource_request,
                    bool ignore_at_capacity = false) const;
   /// Returns true if the node's total resources are enough to run the task.
-  /// Note: This doesn't account for the binpacking of unit resources.
   bool IsFeasible(const ResourceRequest &resource_request) const;
   // Returns true if the node's labels satisfy the label selector requirement.
   bool HasRequiredLabels(const LabelSelector &label_selector) const;

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -155,10 +155,6 @@ NodeResourceInstanceSet::ComputeAllocation(const std::vector<FixedPoint> &availa
     return std::nullopt;
   }
 
-  // Multiple instances, each with total capacity of 1.
-  // Allocate full unit-capacity instances first until the remaining demand becomes
-  // fractional, then best-fit the fractional part: pick the instance whose available
-  // capacity is >= remaining demand and leaves the smallest leftover.
   std::vector<FixedPoint> allocation(available.size(), FixedPoint(0));
   std::vector<FixedPoint> remaining_available = available;
   FixedPoint remaining_demand = demand;
@@ -184,12 +180,12 @@ NodeResourceInstanceSet::ComputeAllocation(const std::vector<FixedPoint> &availa
   // Remaining demand is fractional. Find the best fit, if one exists.
   if (remaining_demand > 0.) {
     int64_t idx_best_fit = -1;
-    FixedPoint remaining_best_fit = 1.;
+    FixedPoint available_best_fit = 1.;
     for (size_t i = 0; i < remaining_available.size(); i++) {
       if (remaining_available[i] >= remaining_demand) {
         if (idx_best_fit == -1 ||
-            (remaining_available[i] - remaining_demand < remaining_best_fit)) {
-          remaining_best_fit = remaining_available[i] - remaining_demand;
+            (remaining_available[i] - remaining_demand < available_best_fit)) {
+          available_best_fit = remaining_available[i] - remaining_demand;
           idx_best_fit = static_cast<int64_t>(i);
         }
       }
@@ -414,26 +410,6 @@ void NodeResourceInstanceSet::Free(ResourceID resource_id,
   }
 
   Set(resource_id, std::move(available));
-}
-
-void NodeResourceInstanceSet::CapResourceAtTotal(ResourceID resource_id,
-                                                 const NodeResourceSet &total) {
-  auto it = resources_.find(resource_id);
-  if (it == resources_.end()) {
-    return;
-  }
-  auto &instances = it->second;
-  if (resource_id.IsUnitInstanceResource()) {
-    for (auto &val : instances) {
-      val = std::min(val, FixedPoint(1.0));
-    }
-  } else if (instances.size() == 1) {
-    instances[0] = std::min(instances[0], total.Get(resource_id));
-  } else {
-    RAY_LOG(DEBUG) << "CapResourceAtTotal: non-unit resource " << resource_id.Binary()
-                   << " has " << instances.size()
-                   << " instances; skipping cap (syncer will correct).";
-  }
 }
 
 void NodeResourceInstanceSet::Add(ResourceID resource_id,

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -155,6 +155,13 @@ NodeResourceInstanceSet::ComputeAllocation(const std::vector<FixedPoint> &availa
     return std::nullopt;
   }
 
+  // If resources has multiple instances, each instance has total capacity of 1.
+  //
+  // As long as remaining_demand is greater than 1.,
+  // allocate full unit-capacity instances until the remaining_demand becomes fractional.
+  // Then try to find the best fit for the fractional remaining_demand. Best fit means
+  // allocating the resource instance with the smallest available capacity greater than
+  // remaining_demand.
   std::vector<FixedPoint> allocation(available.size(), FixedPoint(0));
   std::vector<FixedPoint> remaining_available = available;
   FixedPoint remaining_demand = demand;

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -14,6 +14,7 @@
 
 #include "ray/common/scheduling/resource_instance_set.h"
 
+#include <algorithm>
 #include <cmath>
 #include <sstream>
 #include <string>
@@ -26,19 +27,32 @@
 
 namespace ray {
 
+/*static*/ std::vector<FixedPoint> NodeResourceInstanceSet::MakeInstances(
+    ResourceID resource_id, FixedPoint total) {
+  std::vector<FixedPoint> instances;
+  if (total <= 0) {
+    // Zero or negative total: return single zero-element to satisfy Set()'s
+    // non-empty invariant. The resource will effectively be unavailable.
+    instances.push_back(FixedPoint(0));
+  } else if (resource_id.IsUnitInstanceResource()) {
+    size_t num = static_cast<size_t>(total.Double());
+    for (size_t i = 0; i < num; i++) {
+      instances.push_back(FixedPoint(1.0));
+    }
+    // Fractional remainder (e.g., total=2.5 → [1.0, 1.0, 0.5]).
+    FixedPoint remainder = total - FixedPoint(static_cast<double>(num));
+    if (remainder > 0) {
+      instances.push_back(remainder);
+    }
+  } else {
+    instances.push_back(total);
+  }
+  return instances;
+}
+
 NodeResourceInstanceSet::NodeResourceInstanceSet(const NodeResourceSet &total) {
   for (auto &resource_id : total.ExplicitResourceIds()) {
-    std::vector<FixedPoint> instances;
-    auto value = total.Get(resource_id);
-    if (resource_id.IsUnitInstanceResource()) {
-      size_t num_instances = static_cast<size_t>(value.Double());
-      for (size_t i = 0; i < num_instances; i++) {
-        instances.push_back(1.0);
-      };
-    } else {
-      instances.push_back(value);
-    }
-    Set(resource_id, instances);
+    Set(resource_id, MakeInstances(resource_id, total.Get(resource_id)));
   }
 }
 
@@ -134,6 +148,71 @@ FixedPoint NodeResourceInstanceSet::Sum(ResourceID resource_id) const {
 
 bool NodeResourceInstanceSet::operator==(const NodeResourceInstanceSet &other) const {
   return this->resources_ == other.resources_;
+}
+
+/*static*/ std::optional<std::vector<FixedPoint>>
+NodeResourceInstanceSet::ComputeAllocation(const std::vector<FixedPoint> &available,
+                                           FixedPoint demand) {
+  if (available.empty()) {
+    return std::nullopt;
+  }
+
+  if (available.size() == 1) {
+    if (available[0] >= demand) {
+      return std::vector<FixedPoint>{demand};
+    }
+    return std::nullopt;
+  }
+
+  std::vector<FixedPoint> allocation(available.size(), FixedPoint(0));
+  std::vector<FixedPoint> remaining_available = available;
+  FixedPoint remaining_demand = demand;
+
+  if (remaining_demand >= 1.) {
+    for (size_t i = 0; i < remaining_available.size(); i++) {
+      if (remaining_available[i] == 1.) {
+        allocation[i] = 1.;
+        remaining_available[i] = 0;
+        remaining_demand -= 1.;
+      }
+      if (remaining_demand < 1.) {
+        break;
+      }
+    }
+  }
+
+  if (remaining_demand >= 1.) {
+    return std::nullopt;
+  }
+
+  if (remaining_demand > 0.) {
+    int64_t idx_best_fit = -1;
+    FixedPoint remaining_best_fit = 1.;
+    for (size_t i = 0; i < remaining_available.size(); i++) {
+      if (remaining_available[i] >= remaining_demand) {
+        if (idx_best_fit == -1 ||
+            (remaining_available[i] - remaining_demand < remaining_best_fit)) {
+          remaining_best_fit = remaining_available[i] - remaining_demand;
+          idx_best_fit = static_cast<int64_t>(i);
+        }
+      }
+    }
+    if (idx_best_fit == -1) {
+      return std::nullopt;
+    }
+    allocation[idx_best_fit] = remaining_demand;
+  }
+
+  return allocation;
+}
+
+bool NodeResourceInstanceSet::CanAllocate(const ResourceSet &resource_demands) const {
+  for (const auto &[resource_id, demand] : resource_demands.Resources()) {
+    if (!ComputeAllocation(Get(resource_id), demand).has_value()) {
+      return false;
+    }
+  }
+  return true;
 }
 
 std::optional<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>
@@ -295,75 +374,16 @@ NodeResourceInstanceSet::TryAllocate(const ResourceSet &resource_demands) {
 std::optional<std::vector<FixedPoint>> NodeResourceInstanceSet::TryAllocate(
     ResourceID resource_id, FixedPoint demand) {
   std::vector<FixedPoint> available = Get(resource_id);
-  if (available.empty()) {
+  auto allocation = ComputeAllocation(available, demand);
+  if (!allocation) {
     return std::nullopt;
   }
 
-  std::vector<FixedPoint> allocation(available.size());
-  FixedPoint remaining_demand = demand;
-
-  if (available.size() == 1) {
-    // This resource has just one instance.
-    if (available[0] >= remaining_demand) {
-      available[0] -= remaining_demand;
-      allocation[0] = remaining_demand;
-      Set(resource_id, std::move(available));
-      return std::make_optional<std::vector<FixedPoint>>(std::move(allocation));
-    } else {
-      // Not enough capacity.
-      return std::nullopt;
-    }
+  for (size_t i = 0; i < available.size(); i++) {
+    available[i] -= (*allocation)[i];
   }
-
-  // If resources has multiple instances, each instance has total capacity of 1.
-  //
-  // As long as remaining_demand is greater than 1.,
-  // allocate full unit-capacity instances until the remaining_demand becomes fractional.
-  // Then try to find the best fit for the fractional remaining_resources. Best fit means
-  // allocating the resource instance with the smallest available capacity greater than
-  // remaining_demand
-  if (remaining_demand >= 1.) {
-    for (size_t i = 0; i < available.size(); i++) {
-      if (available[i] == 1.) {
-        // Allocate a full unit-capacity instance.
-        allocation[i] = 1.;
-        available[i] = 0;
-        remaining_demand -= 1.;
-      }
-      if (remaining_demand < 1.) {
-        break;
-      }
-    }
-  }
-
-  if (remaining_demand >= 1.) {
-    // Cannot satisfy a demand greater than one if no unit capacity resource is available.
-    return std::nullopt;
-  }
-
-  // Remaining demand is fractional. Find the best fit, if exists.
-  if (remaining_demand > 0.) {
-    int64_t idx_best_fit = -1;
-    FixedPoint available_best_fit = 1.;
-    for (size_t i = 0; i < available.size(); i++) {
-      if (available[i] >= remaining_demand) {
-        if (idx_best_fit == -1 ||
-            (available[i] - remaining_demand < available_best_fit)) {
-          available_best_fit = available[i] - remaining_demand;
-          idx_best_fit = static_cast<int64_t>(i);
-        }
-      }
-    }
-    if (idx_best_fit == -1) {
-      return std::nullopt;
-    } else {
-      allocation[idx_best_fit] = remaining_demand;
-      available[idx_best_fit] -= remaining_demand;
-    }
-  }
-
   Set(resource_id, std::move(available));
-  return std::make_optional<std::vector<FixedPoint>>(std::move(allocation));
+  return allocation;
 }
 
 void NodeResourceInstanceSet::AllocateWithReference(
@@ -397,6 +417,26 @@ void NodeResourceInstanceSet::Free(ResourceID resource_id,
   }
 
   Set(resource_id, std::move(available));
+}
+
+void NodeResourceInstanceSet::CapResourceAtTotal(ResourceID resource_id,
+                                                 const NodeResourceSet &total) {
+  auto it = resources_.find(resource_id);
+  if (it == resources_.end()) {
+    return;
+  }
+  auto &instances = it->second;
+  if (resource_id.IsUnitInstanceResource()) {
+    for (auto &val : instances) {
+      val = std::min(val, FixedPoint(1.0));
+    }
+  } else if (instances.size() == 1) {
+    instances[0] = std::min(instances[0], total.Get(resource_id));
+  } else {
+    RAY_LOG(DEBUG) << "CapResourceAtTotal: non-unit resource " << resource_id.Binary()
+                   << " has " << instances.size()
+                   << " instances; skipping cap (syncer will correct).";
+  }
 }
 
 void NodeResourceInstanceSet::Add(ResourceID resource_id,

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -102,7 +102,7 @@ NodeResourceInstanceSet &NodeResourceInstanceSet::Set(ResourceID resource_id,
     resources_[resource_id] = std::move(instances);
 
     if (track_pg_index_) {
-      // Popluate the pg_indexed_resources_map_
+      // Populate the pg_indexed_resources_map_
       // TODO(myan): The parsing of the resource_id String can be costly and impact the
       // task creation throughput if the parting is required every time we allocate
       // resources for a task and updating the available resources. The current benchmark
@@ -187,12 +187,12 @@ NodeResourceInstanceSet::ComputeAllocation(const std::vector<FixedPoint> &availa
   // Remaining demand is fractional. Find the best fit, if one exists.
   if (remaining_demand > 0.) {
     int64_t idx_best_fit = -1;
-    FixedPoint available_best_fit = 1.;
+    FixedPoint remaining_after_fit = 1.;
     for (size_t i = 0; i < remaining_available.size(); i++) {
       if (remaining_available[i] >= remaining_demand) {
         if (idx_best_fit == -1 ||
-            (remaining_available[i] - remaining_demand < available_best_fit)) {
-          available_best_fit = remaining_available[i] - remaining_demand;
+            (remaining_available[i] - remaining_demand < remaining_after_fit)) {
+          remaining_after_fit = remaining_available[i] - remaining_demand;
           idx_best_fit = static_cast<int64_t>(i);
         }
       }

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -27,32 +27,19 @@
 
 namespace ray {
 
-/*static*/ std::vector<FixedPoint> NodeResourceInstanceSet::MakeInstances(
-    ResourceID resource_id, FixedPoint total) {
-  std::vector<FixedPoint> instances;
-  if (total <= 0) {
-    // Zero or negative total: return single zero-element to satisfy Set()'s
-    // non-empty invariant. The resource will effectively be unavailable.
-    instances.push_back(FixedPoint(0));
-  } else if (resource_id.IsUnitInstanceResource()) {
-    size_t num = static_cast<size_t>(total.Double());
-    for (size_t i = 0; i < num; i++) {
-      instances.push_back(FixedPoint(1.0));
-    }
-    // Fractional remainder (e.g., total=2.5 → [1.0, 1.0, 0.5]).
-    FixedPoint remainder = total - FixedPoint(static_cast<double>(num));
-    if (remainder > 0) {
-      instances.push_back(remainder);
-    }
-  } else {
-    instances.push_back(total);
-  }
-  return instances;
-}
-
 NodeResourceInstanceSet::NodeResourceInstanceSet(const NodeResourceSet &total) {
   for (auto &resource_id : total.ExplicitResourceIds()) {
-    Set(resource_id, MakeInstances(resource_id, total.Get(resource_id)));
+    std::vector<FixedPoint> instances;
+    auto value = total.Get(resource_id);
+    if (resource_id.IsUnitInstanceResource()) {
+      size_t num_instances = static_cast<size_t>(value.Double());
+      for (size_t i = 0; i < num_instances; i++) {
+        instances.push_back(1.0);
+      };
+    } else {
+      instances.push_back(value);
+    }
+    Set(resource_id, instances);
   }
 }
 
@@ -63,24 +50,26 @@ bool NodeResourceInstanceSet::Has(ResourceID resource_id) const {
 void NodeResourceInstanceSet::Remove(ResourceID resource_id) {
   resources_.erase(resource_id);
 
-  // Remove from the pg_indexed_resources_ as well
-  auto data = ParsePgFormattedResource(resource_id.Binary(),
-                                       /*for_wildcard_resource=*/false,
-                                       /*for_indexed_resource=*/true);
-  if (data) {
-    ResourceID original_resource_id(data->original_resource);
+  if (track_pg_index_) {
+    // Remove from the pg_indexed_resources_ as well
+    auto data = ParsePgFormattedResource(resource_id.Binary(),
+                                         /*for_wildcard_resource=*/false,
+                                         /*for_indexed_resource=*/true);
+    if (data) {
+      ResourceID original_resource_id(data->original_resource);
 
-    auto pg_resource_map_it = pg_indexed_resources_.find(original_resource_id);
-    if (pg_resource_map_it != pg_indexed_resources_.end()) {
-      auto resource_set_it = pg_resource_map_it->second.find(data->group_id);
+      auto pg_resource_map_it = pg_indexed_resources_.find(original_resource_id);
+      if (pg_resource_map_it != pg_indexed_resources_.end()) {
+        auto resource_set_it = pg_resource_map_it->second.find(data->group_id);
 
-      if (resource_set_it != pg_resource_map_it->second.end()) {
-        resource_set_it->second.erase(resource_id);
-        if (resource_set_it->second.empty()) {
-          pg_resource_map_it->second.erase(data->group_id);
-        }
-        if (pg_resource_map_it->second.empty()) {
-          pg_indexed_resources_.erase(original_resource_id);
+        if (resource_set_it != pg_resource_map_it->second.end()) {
+          resource_set_it->second.erase(resource_id);
+          if (resource_set_it->second.empty()) {
+            pg_resource_map_it->second.erase(data->group_id);
+          }
+          if (pg_resource_map_it->second.empty()) {
+            pg_indexed_resources_.erase(original_resource_id);
+          }
         }
       }
     }
@@ -112,22 +101,24 @@ NodeResourceInstanceSet &NodeResourceInstanceSet::Set(ResourceID resource_id,
   } else {
     resources_[resource_id] = std::move(instances);
 
-    // Popluate the pg_indexed_resources_map_
-    // TODO(myan): The parsing of the resource_id String can be costly and impact the
-    // task creation throughput if the parting is required every time we allocate
-    // resources for a task and updating the available resources. The current benchmark
-    // shows no observable impact for now. But in the future, ideas of improvement are:
-    // (1) to add the placement group id as well as the bundle index inside the
-    // ResourceID class. And instead of parse the String, leveraging the fields in the
-    // ResourceID class directly; (2) to update the pg resource id format to start with
-    // a special prefix so that we can do "startwith" instead of regex match which is
-    // less costly
-    auto data = ParsePgFormattedResource(resource_id.Binary(),
-                                         /*for_wildcard_resource=*/false,
-                                         /*for_indexed_resource=*/true);
-    if (data) {
-      pg_indexed_resources_[ResourceID(data->original_resource)][data->group_id].emplace(
-          resource_id);
+    if (track_pg_index_) {
+      // Popluate the pg_indexed_resources_map_
+      // TODO(myan): The parsing of the resource_id String can be costly and impact the
+      // task creation throughput if the parting is required every time we allocate
+      // resources for a task and updating the available resources. The current benchmark
+      // shows no observable impact for now. But in the future, ideas of improvement are:
+      // (1) to add the placement group id as well as the bundle index inside the
+      // ResourceID class. And instead of parse the String, leveraging the fields in the
+      // ResourceID class directly; (2) to update the pg resource id format to start with
+      // a special prefix so that we can do "startwith" instead of regex match which is
+      // less costly
+      auto data = ParsePgFormattedResource(resource_id.Binary(),
+                                           /*for_wildcard_resource=*/false,
+                                           /*for_indexed_resource=*/true);
+      if (data) {
+        pg_indexed_resources_[ResourceID(data->original_resource)][data->group_id]
+            .emplace(resource_id);
+      }
     }
   }
   return *this;
@@ -164,6 +155,10 @@ NodeResourceInstanceSet::ComputeAllocation(const std::vector<FixedPoint> &availa
     return std::nullopt;
   }
 
+  // Multiple instances, each with total capacity of 1.
+  // Allocate full unit-capacity instances first until the remaining demand becomes
+  // fractional, then best-fit the fractional part: pick the instance whose available
+  // capacity is >= remaining demand and leaves the smallest leftover.
   std::vector<FixedPoint> allocation(available.size(), FixedPoint(0));
   std::vector<FixedPoint> remaining_available = available;
   FixedPoint remaining_demand = demand;
@@ -182,9 +177,11 @@ NodeResourceInstanceSet::ComputeAllocation(const std::vector<FixedPoint> &availa
   }
 
   if (remaining_demand >= 1.) {
+    // Not enough full-capacity instances to cover the integer part.
     return std::nullopt;
   }
 
+  // Remaining demand is fractional. Find the best fit, if one exists.
   if (remaining_demand > 0.) {
     int64_t idx_best_fit = -1;
     FixedPoint remaining_best_fit = 1.;

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -25,16 +25,15 @@
 
 namespace ray {
 
-/// Maps each resource to the per-instance amounts that were allocated (or should
-/// be freed). Enables precise speculative deduction and rollback at the cluster
-/// level, and carries allocation details through the PG Acquire->Commit flow.
 using ResourceAllocation = absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>;
 
 /// Represents a node resource set that contains the per-instance resource values.
 class NodeResourceInstanceSet {
  public:
-  /// \param track_pg_index If true, maintain the pg_indexed_resources_ index
-  /// for PG cross-bundle allocation. The raylet needs this; the GCS does not.
+  /// \param track_pg_index If true, parse resource names on every Set/Remove
+  /// to build a lookup table for PG bundle resources. The raylet uses this to
+  /// find which bundle can satisfy a PG resource request. The GCS passes false
+  /// because it never does local PG allocation, and the parsing overhead is large.
   explicit NodeResourceInstanceSet(bool track_pg_index = true)
       : track_pg_index_(track_pg_index){};
 
@@ -111,24 +110,13 @@ class NodeResourceInstanceSet {
   /// Convert to node resource set with summed per-instance values.
   NodeResourceSet ToNodeResourceSet() const;
 
-  /// Cap a single resource's available instances at the corresponding total.
-  /// For unit-instance resources, per-instance cap is 1.0.
-  /// For non-unit single-instance resources, cap is the aggregate total.
-  void CapResourceAtTotal(ResourceID resource_id, const NodeResourceSet &total);
-
-  /// Access the underlying resource map. Used by the syncer to serialize
-  /// per-instance state and by UpdateNode to rebuild available from proto.
   const absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> &Resources() const {
     return resources_;
   }
 
-  /// Allocate a single resource using ComputeAllocation, then update internal state.
-  /// Public because SubtractNodeAvailableResources uses per-resource allocation
-  /// (deliberately avoiding the multi-resource TryAllocate's PG cross-bundle logic).
-  ///
   /// \param resource_id: The id of the resource to be allocated.
   /// \param demand: The resource amount to be allocated.
-  /// \return the allocated instances, or nullopt if demand cannot be satisfied.
+  /// \return the allocated instances, if allocation successful. Else, return nullopt.
   std::optional<std::vector<FixedPoint>> TryAllocate(ResourceID resource_id,
                                                      FixedPoint demand);
 
@@ -156,7 +144,6 @@ class NodeResourceInstanceSet {
   /// pd id. The key of the map is the original resource id. The value is a map of pg id
   /// to the corresponding placement group indexed resource ids. This map should always
   /// be consistent with the resources_ map.
-  /// Only populated when track_pg_index_ is true.
   absl::flat_hash_map<ResourceID,
                       absl::flat_hash_map<std::string, absl::flat_hash_set<ResourceID>>>
       pg_indexed_resources_;

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -25,15 +25,18 @@
 
 namespace ray {
 
-/// Per-instance allocation result: maps each resource to its per-instance allocation
-/// vector. Used by SubtractNodeAvailableResources and AddNodeAvailableResources for
-/// precise speculative deduction and rollback.
+/// Maps each resource to the per-instance amounts that were allocated (or should
+/// be freed). Enables precise speculative deduction and rollback at the cluster
+/// level, and carries allocation details through the PG Acquire->Commit flow.
 using ResourceAllocation = absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>;
 
 /// Represents a node resource set that contains the per-instance resource values.
 class NodeResourceInstanceSet {
  public:
-  NodeResourceInstanceSet(){};
+  /// \param track_pg_index If true, maintain the pg_indexed_resources_ index
+  /// for PG cross-bundle allocation. The raylet needs this; the GCS does not.
+  explicit NodeResourceInstanceSet(bool track_pg_index = true)
+      : track_pg_index_(track_pg_index){};
 
   /// Construct a NodeResourceInstanceSet from a node total resources.
   explicit NodeResourceInstanceSet(const NodeResourceSet &total);
@@ -60,10 +63,6 @@ class NodeResourceInstanceSet {
   bool operator==(const NodeResourceInstanceSet &other) const;
 
   std::string DebugString() const;
-
-  /// Create per-instance vector for a resource from a scalar total. Unit-instance
-  /// resources (GPU etc.) get N x 1.0 instances; others get a single-element vector.
-  static std::vector<FixedPoint> MakeInstances(ResourceID resource_id, FixedPoint total);
 
   /// Compute the per-instance allocation for a single resource without modifying state.
   ///
@@ -117,6 +116,8 @@ class NodeResourceInstanceSet {
   /// For non-unit single-instance resources, cap is the aggregate total.
   void CapResourceAtTotal(ResourceID resource_id, const NodeResourceSet &total);
 
+  /// Access the underlying resource map. Used by the syncer to serialize
+  /// per-instance state and by UpdateNode to rebuild available from proto.
   const absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> &Resources() const {
     return resources_;
   }
@@ -145,6 +146,8 @@ class NodeResourceInstanceSet {
   void AllocateWithReference(const std::vector<FixedPoint> &ref_allocation,
                              ResourceID resource_id);
 
+  bool track_pg_index_ = true;
+
   /// Map from the resource IDs to the resource instance values.
   absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> resources_;
 
@@ -153,6 +156,7 @@ class NodeResourceInstanceSet {
   /// pd id. The key of the map is the original resource id. The value is a map of pg id
   /// to the corresponding placement group indexed resource ids. This map should always
   /// be consistent with the resources_ map.
+  /// Only populated when track_pg_index_ is true.
   absl::flat_hash_map<ResourceID,
                       absl::flat_hash_map<std::string, absl::flat_hash_set<ResourceID>>>
       pg_indexed_resources_;

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -25,6 +25,11 @@
 
 namespace ray {
 
+/// Per-instance allocation result: maps each resource to its per-instance allocation
+/// vector. Used by SubtractNodeAvailableResources and AddNodeAvailableResources for
+/// precise speculative deduction and rollback.
+using ResourceAllocation = absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>;
+
 /// Represents a node resource set that contains the per-instance resource values.
 class NodeResourceInstanceSet {
  public:
@@ -56,6 +61,27 @@ class NodeResourceInstanceSet {
 
   std::string DebugString() const;
 
+  /// Create per-instance vector for a resource from a scalar total. Unit-instance
+  /// resources (GPU etc.) get N x 1.0 instances; others get a single-element vector.
+  static std::vector<FixedPoint> MakeInstances(ResourceID resource_id, FixedPoint total);
+
+  /// Compute the per-instance allocation for a single resource without modifying state.
+  ///
+  /// Allocates full unit-capacity instances first (for the integer part of demand),
+  /// then uses best-fit for the fractional remainder: picks the instance with the
+  /// smallest available capacity that can still satisfy the remaining demand.
+  ///
+  /// Example: available = (1., 1., .7, 0.5), demand = 1.2
+  ///   -> allocate one full instance, then 0.2 from the 0.5 instance (best fit).
+  ///   -> returns (1., 0., 0., 0.2)
+  ///
+  /// Returns the allocation vector, or std::nullopt if the demand cannot be satisfied.
+  static std::optional<std::vector<FixedPoint>> ComputeAllocation(
+      const std::vector<FixedPoint> &available, FixedPoint demand);
+
+  /// Returns true if `resource_demands` can be satisfied without modifying state.
+  bool CanAllocate(const ResourceSet &resource_demands) const;
+
   /// Try to allocate resources specified by `resource_demands`.
   /// This operation is all or nothing meaning that if any single resource
   /// cannot be allocated, the entire allocation fails and std::nullopt is returned.
@@ -86,70 +112,26 @@ class NodeResourceInstanceSet {
   /// Convert to node resource set with summed per-instance values.
   NodeResourceSet ToNodeResourceSet() const;
 
-  /// Only for testing.
+  /// Cap a single resource's available instances at the corresponding total.
+  /// For unit-instance resources, per-instance cap is 1.0.
+  /// For non-unit single-instance resources, cap is the aggregate total.
+  void CapResourceAtTotal(ResourceID resource_id, const NodeResourceSet &total);
+
   const absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> &Resources() const {
     return resources_;
   }
 
- private:
-  /// Allocate enough capacity across the instances of a resource to satisfy "demand".
-  ///
-  /// Allocate full unit-capacity instances until
-  /// demand becomes fractional, and then satisfy the fractional demand using the
-  /// instance with the smallest available capacity that can satisfy the fractional
-  /// demand. For example, assume a resource conisting of 4 instances, with available
-  /// capacities: (1., 1., .7, 0.5) and deman of 1.2. Then we allocate one full
-  /// instance and then allocate 0.2 of the 0.5 instance (as this is the instance
-  /// with the smalest available capacity that can satisfy the remaining demand of 0.2).
-  /// As a result remaining available capacities will be (0., 1., .7, .3).
-  /// Thus, we will allocate a bunch of full instances and
-  /// at most a fractional instance.
-  ///
-  /// During resource allocation with a placement group, no matter whether the
-  /// allocation requirement specifies a bundle index, we generate the
-  /// allocation on both the wildcard resource and the indexed resource. The
-  /// resource_demand won't be assigned across bundles. And If no bundle index is
-  /// specified, we will iterate through the bundles and find the first bundle that can
-  /// fit the required resources. In addition, for unit resources, we make sure
-  /// that the allocation on the wildcard resource and the indexed resource are
-  /// consistent, meaning the same instance ids should be allocated.
-  ///
-  /// For example, considering the GPU resource on a host. Assuming the host has 3 GPUs
-  /// and 1 placement group with 2 bundles. The bundle with index 1 contains 1 GPU and
-  /// the bundle with index 2 contains 2 GPU.
-  ///
-  /// The current node resource can be as follows:
-  /// resource id: total, available
-  /// GPU: [1, 1, 1], [0, 0, 0]
-  /// GPU_<pg_id>: [1, 1, 1], [1, 1, 1]
-  /// GPU_1_<pg_id>: [1, 0, 0], [1, 0, 0]
-  /// GPU_2_<pg_id>: [0, 1, 1], [0, 1, 1]
-  ///
-  /// Now, we want to allocate a task with 2 GPUs and in the placement group <pg_id>,
-  /// reflecting in the following resource demand:
-  /// GPU_<pg_id> : 2
-  ///
-  /// We will iterate though all the bundles in the placement group and bundle with
-  /// index=2 has the required capacity. So we will allocate the task to the 2 GPUs in
-  /// bundle 2 in placement group <pg_id> and the same allocation should be reflected in
-  /// the wildcard GPU resource. So the allocation will be:
-  /// GPU_<pg_id> : [0, 1, 1]
-  /// GPU_2_<pg_id> : [0, 1, 1]
-  ///
-  /// And as a result, after the allocation, current node resource will be:
-  /// resource id: total, available
-  /// GPU: [1, 1, 1], [0, 0, 0]
-  /// GPU_<pg_id>: [1, 1, 1], [1, 0, 0]
-  /// GPU_1_<pg_id>: [1, 0, 0], [1, 0, 0]
-  /// GPU_2_<pg_id>: [0, 1, 1], [0, 0, 0]
+  /// Allocate a single resource using ComputeAllocation, then update internal state.
+  /// Public because SubtractNodeAvailableResources uses per-resource allocation
+  /// (deliberately avoiding the multi-resource TryAllocate's PG cross-bundle logic).
   ///
   /// \param resource_id: The id of the resource to be allocated.
   /// \param demand: The resource amount to be allocated.
-  ///
-  /// \return the allocated instances, if allocation successful. Else, return nullopt.
+  /// \return the allocated instances, or nullopt if demand cannot be satisfied.
   std::optional<std::vector<FixedPoint>> TryAllocate(ResourceID resource_id,
                                                      FixedPoint demand);
 
+ private:
   /// Allocate resource to the resource_id based on a provided reference allocation.
   /// The function is used for placement group allocation. Making the allocation of
   /// the wildcard resource be identical to the indexed resource allocation.

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -114,6 +114,47 @@ class NodeResourceInstanceSet {
     return resources_;
   }
 
+  /// Allocate enough capacity across the instances of a resource to satisfy "demand".
+  /// Uses ComputeAllocation for the best-fit algorithm.
+  ///
+  /// During resource allocation with a placement group, no matter whether the
+  /// allocation requirement specifies a bundle index, we generate the
+  /// allocation on both the wildcard resource and the indexed resource. The
+  /// resource_demand won't be assigned across bundles. And If no bundle index is
+  /// specified, we will iterate through the bundles and find the first bundle that can
+  /// fit the required resources. In addition, for unit resources, we make sure
+  /// that the allocation on the wildcard resource and the indexed resource are
+  /// consistent, meaning the same instance ids should be allocated.
+  ///
+  /// For example, considering the GPU resource on a host. Assuming the host has 3 GPUs
+  /// and 1 placement group with 2 bundles. The bundle with index 1 contains 1 GPU and
+  /// the bundle with index 2 contains 2 GPU.
+  ///
+  /// The current node resource can be as follows:
+  /// resource id: total, available
+  /// GPU: [1, 1, 1], [0, 0, 0]
+  /// GPU_<pg_id>: [1, 1, 1], [1, 1, 1]
+  /// GPU_1_<pg_id>: [1, 0, 0], [1, 0, 0]
+  /// GPU_2_<pg_id>: [0, 1, 1], [0, 1, 1]
+  ///
+  /// Now, we want to allocate a task with 2 GPUs and in the placement group <pg_id>,
+  /// reflecting in the following resource demand:
+  /// GPU_<pg_id> : 2
+  ///
+  /// We will iterate though all the bundles in the placement group and bundle with
+  /// index=2 has the required capacity. So we will allocate the task to the 2 GPUs in
+  /// bundle 2 in placement group <pg_id> and the same allocation should be reflected in
+  /// the wildcard GPU resource. So the allocation will be:
+  /// GPU_<pg_id> : [0, 1, 1]
+  /// GPU_2_<pg_id> : [0, 1, 1]
+  ///
+  /// And as a result, after the allocation, current node resource will be:
+  /// resource id: total, available
+  /// GPU: [1, 1, 1], [0, 0, 0]
+  /// GPU_<pg_id>: [1, 1, 1], [1, 0, 0]
+  /// GPU_1_<pg_id>: [1, 0, 0], [1, 0, 0]
+  /// GPU_2_<pg_id>: [0, 1, 1], [0, 0, 0]
+  ///
   /// \param resource_id: The id of the resource to be allocated.
   /// \param demand: The resource amount to be allocated.
   /// \return the allocated instances, if allocation successful. Else, return nullopt.

--- a/src/ray/common/scheduling/tests/resource_instance_set_test.cc
+++ b/src/ray/common/scheduling/tests/resource_instance_set_test.cc
@@ -984,32 +984,4 @@ TEST_F(NodeResourceInstanceSetTest, TestToNodeResourceSet) {
   ASSERT_EQ(r1.ToNodeResourceSet(), NodeResourceSet({{"CPU", 2}, {"GPU", 2}}));
 }
 
-TEST_F(NodeResourceInstanceSetTest, CanAllocateGpuFragmentation) {
-  // Core bug scenario (#52133): two GPUs each with 0.4 remaining,
-  // aggregate 0.8. Per-instance check must reject 0.5 (no single GPU has it).
-  NodeResourceInstanceSet r;
-  r.Set(ResourceID("GPU"), {FixedPoint(0.4), FixedPoint(0.4)});
-
-  ASSERT_FALSE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.5)}})));
-  ASSERT_TRUE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.4)}})));
-  ASSERT_TRUE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.3)}})));
-  ASSERT_FALSE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.8)}})));
-}
-
-TEST_F(NodeResourceInstanceSetTest, CanAllocateConsistentWithTryAllocate) {
-  // CanAllocate and TryAllocate must agree for non-PG resources.
-  NodeResourceInstanceSet r1;
-  r1.Set(ResourceID("GPU"), {FixedPoint(0.4), FixedPoint(0.8)});
-  NodeResourceInstanceSet r2 = r1;
-
-  ASSERT_TRUE(r1.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.5)}})));
-  auto alloc = r2.TryAllocate(ResourceSet({{"GPU", FixedPoint(0.5)}}));
-  ASSERT_TRUE(alloc.has_value());
-
-  NodeResourceInstanceSet r3 = r1;
-  ASSERT_FALSE(r1.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.9)}})));
-  auto alloc2 = r3.TryAllocate(ResourceSet({{"GPU", FixedPoint(0.9)}}));
-  ASSERT_FALSE(alloc2.has_value());
-}
-
 }  // namespace ray

--- a/src/ray/common/scheduling/tests/resource_instance_set_test.cc
+++ b/src/ray/common/scheduling/tests/resource_instance_set_test.cc
@@ -984,4 +984,32 @@ TEST_F(NodeResourceInstanceSetTest, TestToNodeResourceSet) {
   ASSERT_EQ(r1.ToNodeResourceSet(), NodeResourceSet({{"CPU", 2}, {"GPU", 2}}));
 }
 
+TEST_F(NodeResourceInstanceSetTest, CanAllocateGpuFragmentation) {
+  // Core bug scenario (#52133): two GPUs each with 0.4 remaining,
+  // aggregate 0.8. Per-instance check must reject 0.5 (no single GPU has it).
+  NodeResourceInstanceSet r;
+  r.Set(ResourceID("GPU"), {FixedPoint(0.4), FixedPoint(0.4)});
+
+  ASSERT_FALSE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.5)}})));
+  ASSERT_TRUE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.4)}})));
+  ASSERT_TRUE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.3)}})));
+  ASSERT_FALSE(r.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.8)}})));
+}
+
+TEST_F(NodeResourceInstanceSetTest, CanAllocateConsistentWithTryAllocate) {
+  // CanAllocate and TryAllocate must agree for non-PG resources.
+  NodeResourceInstanceSet r1;
+  r1.Set(ResourceID("GPU"), {FixedPoint(0.4), FixedPoint(0.8)});
+  NodeResourceInstanceSet r2 = r1;
+
+  ASSERT_TRUE(r1.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.5)}})));
+  auto alloc = r2.TryAllocate(ResourceSet({{"GPU", FixedPoint(0.5)}}));
+  ASSERT_TRUE(alloc.has_value());
+
+  NodeResourceInstanceSet r3 = r1;
+  ASSERT_FALSE(r1.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.9)}})));
+  auto alloc2 = r3.TryAllocate(ResourceSet({{"GPU", FixedPoint(0.9)}}));
+  ASSERT_FALSE(alloc2.has_value());
+}
+
 }  // namespace ray

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -807,7 +807,7 @@ bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
   }
 
   for (const auto &[resource_name, capacity] : wildcard_resources) {
-    if (capacity == 0) {
+    if (capacity <= 0) {
       bundle_resource_ids.emplace_back(scheduling::ResourceID(resource_name));
     } else {
       cluster_resource_manager.UpdateResourceCapacity(

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -305,7 +305,7 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
     DestroyPlacementGroupCommittedBundleResources(
         lease_status_tracker->GetPlacementGroup()->GetPlacementGroupID());
     ReturnBundleResources(lease_status_tracker->GetBundleLocations(),
-                          lease_status_tracker.get());
+                          lease_status_tracker);
     schedule_failure_handler(lease_status_tracker->GetPlacementGroup(),
                              /*is_feasible=*/true);
     return;
@@ -386,7 +386,7 @@ void GcsPlacementGroupScheduler::OnAllBundlePrepareRequestReturned(
     RAY_CHECK(it != placement_group_leasing_in_progress_.end());
     placement_group_leasing_in_progress_.erase(it);
     ReturnBundleResources(lease_status_tracker->GetBundleLocations(),
-                          lease_status_tracker.get());
+                          lease_status_tracker);
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -441,7 +441,7 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
   if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
     DestroyPlacementGroupCommittedBundleResources(placement_group_id);
     ReturnBundleResources(lease_status_tracker->GetBundleLocations(),
-                          lease_status_tracker.get());
+                          lease_status_tracker);
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -455,7 +455,7 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
       placement_group->GetMutableBundle(bundle.first.second)->clear_node_id();
     }
     placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
-    ReturnBundleResources(uncommitted_bundle_locations, lease_status_tracker.get());
+    ReturnBundleResources(uncommitted_bundle_locations, lease_status_tracker);
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
   } else {
     schedule_success_handler(placement_group);
@@ -715,9 +715,6 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
       auto resource_id = scheduling::ResourceID(resource_name);
       auto original_name = GetOriginalResourceName(resource_name);
 
-      // Use the per-instance allocation from AcquireBundleResources if available
-      // for this original resource. Synthetic resources like bundle_group won't
-      // be in the allocation and fall through to the single-element path.
       if (bundle_alloc != nullptr) {
         auto alloc_it = bundle_alloc->find(scheduling::ResourceID(original_name));
         if (alloc_it != bundle_alloc->end()) {
@@ -726,8 +723,9 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
           continue;
         }
       }
-      // No saved allocation (e.g. GCS restart recovery). Single-element vector
-      // may not match actual per-instance layout; syncer corrects within ~100ms.
+      // Two cases reach here:
+      // 1. Synthetic resources like bundle_group have no physical allocation.
+      // 2. GCS restart loses the in-memory tracker; syncer corrects within ~100ms.
       cluster_resource_manager.AddResourceInstances(
           node_id, resource_id, {FixedPoint(capacity)});
     }
@@ -740,10 +738,19 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
 
 void GcsPlacementGroupScheduler::ReturnBundleResources(
     const std::shared_ptr<BundleLocations> &bundle_locations,
-    const LeaseStatusTracker *lease_status_tracker) {
-  // If a tracker is provided, restore the original resources that were
-  // speculatively deducted by AcquireBundleResources, using the saved
-  // per-instance allocation.
+    const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker) {
+  // 1. Remove PG-formatted resources (GPU_group_xxx, etc.) from nodes.
+  // 2. Add original resources (GPU, CPU) back to nodes if has a tracker.
+  //    Without a tracker (e.g. PG remove, where it was destroyed after commit)
+  //    we don't know which instances were allocated, and recomputing is not a
+  //    good idea since the topology may have changed. Prefer relying on syncer
+  //    which delivers the real state within ~100ms.
+  for (auto &bundle : *bundle_locations) {
+    if (!TryReleasingBundleResources(bundle.second)) {
+      waiting_removed_bundles_.push_back(bundle.second);
+    }
+  }
+
   if (lease_status_tracker) {
     auto &crm = cluster_resource_scheduler_.GetClusterResourceManager();
     for (const auto &[bundle_id, location] : *bundle_locations) {
@@ -752,13 +759,6 @@ void GcsPlacementGroupScheduler::ReturnBundleResources(
         crm.AddNodeAvailableResources(scheduling::NodeID(location.first.Binary()),
                                       *alloc);
       }
-    }
-  }
-
-  // Clean up PG-formatted resources (wildcard + indexed).
-  for (auto &bundle : *bundle_locations) {
-    if (!TryReleasingBundleResources(bundle.second)) {
-      waiting_removed_bundles_.push_back(bundle.second);
     }
   }
 
@@ -818,8 +818,6 @@ bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
   // It will affect nothing if the resource_id to be deleted does not exist in the
   // cluster_resource_manager_.
   cluster_resource_manager.DeleteResources(node_id, bundle_resource_ids);
-  // Original resources are restored by the caller (ReturnBundleResources)
-  // when a LeaseStatusTracker is available, or by syncer otherwise.
   return true;
 }
 

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "ray/common/asio/asio_util.h"
+#include "ray/common/bundle_spec.h"
 
 namespace ray {
 namespace gcs {
@@ -110,9 +111,8 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
                 .emplace(placement_group->GetPlacementGroupID(), lease_status_tracker)
                 .second);
 
-  // Acquire resources from gcs resources manager to reserve bundle resources.
   const auto &bundle_locations = lease_status_tracker->GetBundleLocations();
-  AcquireBundleResources(bundle_locations);
+  AcquireBundleResources(bundle_locations, lease_status_tracker);
 
   // Convert to a set of bundle specifications grouped by the node.
   std::unordered_map<NodeID, std::vector<std::shared_ptr<const BundleSpecification>>>
@@ -344,7 +344,7 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
         // Commit the bundle resources on the remote node to the cluster resources.
         // If status is not OK, no need to call ReturnBundleResources because the
         // OnAllBundleCommitRequestReturned function calls it.
-        CommitBundleResources(commited_bundle_locations);
+        CommitBundleResources(commited_bundle_locations, lease_status_tracker);
       }
 
       if (lease_status_tracker->AllCommitRequestReturned()) {
@@ -638,15 +638,30 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
   }
 }
 
+void LeaseStatusTracker::SetBundleAllocation(const BundleID &bundle_id,
+                                             ResourceAllocation allocation) {
+  acquired_resource_allocations_[bundle_id] = std::move(allocation);
+}
+
+const ResourceAllocation *LeaseStatusTracker::GetBundleAllocation(
+    const BundleID &bundle_id) const {
+  auto it = acquired_resource_allocations_.find(bundle_id);
+  return it != acquired_resource_allocations_.end() ? &it->second : nullptr;
+}
+
 void GcsPlacementGroupScheduler::AcquireBundleResources(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
+    const std::shared_ptr<BundleLocations> &bundle_locations,
+    const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker) {
   // Acquire bundle resources from gcs resources manager.
   auto &cluster_resource_manager =
       cluster_resource_scheduler_.GetClusterResourceManager();
   for (auto &bundle : *bundle_locations) {
-    cluster_resource_manager.SubtractNodeAvailableResources(
+    auto allocation = cluster_resource_manager.SubtractNodeAvailableResources(
         scheduling::NodeID(bundle.second.first.Binary()),
         bundle.second.second->GetRequiredResources());
+    if (allocation.has_value() && lease_status_tracker) {
+      lease_status_tracker->SetBundleAllocation(bundle.first, std::move(*allocation));
+    }
   }
 }
 
@@ -682,29 +697,35 @@ bool GcsPlacementGroupScheduler::IsPlacementGroupWildcardResource(
 }
 
 void GcsPlacementGroupScheduler::CommitBundleResources(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
-  // Acquire bundle resources from gcs resources manager.
+    const std::shared_ptr<BundleLocations> &bundle_locations,
+    const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker) {
   auto &cluster_resource_manager =
       cluster_resource_scheduler_.GetClusterResourceManager();
-  auto node_bundle_resources_map = ToNodeBundleResourcesMap(bundle_locations);
-  for (const auto &[node_id, node_bundle_resources] : node_bundle_resources_map) {
-    for (const auto &resource_id : node_bundle_resources.ResourceIds()) {
-      // A placement group's wildcard resource has to be the sum of all related bundles.
-      // Even though `ToNodeBundleResourcesMap` has already considered this,
-      // it misses the scenario in which single (or subset of) bundle is rescheduled.
-      // When commiting this single bundle, its wildcard resource would wrongly overwrite
-      // the existing value, unless using the following additive operation.
-      auto capacity = node_bundle_resources.Get(resource_id);
-      if (IsPlacementGroupWildcardResource(resource_id.Binary())) {
-        auto new_capacity =
-            capacity +
-            cluster_resource_manager.GetNodeResources(node_id).total.Get(resource_id);
-        cluster_resource_manager.UpdateResourceCapacity(
-            node_id, resource_id, new_capacity.Double());
-      } else {
-        cluster_resource_manager.UpdateResourceCapacity(
-            node_id, resource_id, capacity.Double());
+
+  for (const auto &[bundle_id, location] : *bundle_locations) {
+    const auto &node_id = scheduling::NodeID(location.first.Binary());
+    const auto &bundle_spec = *location.second;
+
+    const auto *bundle_alloc = lease_status_tracker->GetBundleAllocation(bundle_id);
+
+    const auto &resources = bundle_spec.GetFormattedResources();
+    for (const auto &[resource_name, capacity] : resources) {
+      auto resource_id = scheduling::ResourceID(resource_name);
+      auto original_name = GetOriginalResourceName(resource_name);
+
+      // Use the per-instance allocation from AcquireBundleResources if available
+      // (GPU, CPU, etc.). Synthetic resources like bundle_group won't be in the
+      // allocation and fall through to the single-element path.
+      if (bundle_alloc != nullptr) {
+        auto phys_it = bundle_alloc->find(scheduling::ResourceID(original_name));
+        if (phys_it != bundle_alloc->end()) {
+          cluster_resource_manager.AddResourceInstances(
+              node_id, resource_id, phys_it->second);
+          continue;
+        }
       }
+      cluster_resource_manager.AddResourceInstances(
+          node_id, resource_id, {FixedPoint(capacity)});
     }
   }
 
@@ -780,9 +801,8 @@ bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
   // It will affect nothing if the resource_id to be deleted does not exist in the
   // cluster_resource_manager_.
   cluster_resource_manager.DeleteResources(node_id, bundle_resource_ids);
-  // Add reserved bundle resources back to the node.
-  cluster_resource_manager.AddNodeAvailableResources(
-      node_id, bundle_spec->GetRequiredResources().GetResourceSet());
+  // Original resources are restored when the node broadcasts its updated
+  // state via syncer, not here.
   return true;
 }
 

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -304,7 +304,8 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
   if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
     DestroyPlacementGroupCommittedBundleResources(
         lease_status_tracker->GetPlacementGroup()->GetPlacementGroupID());
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
+    ReturnBundleResources(lease_status_tracker->GetBundleLocations(),
+                          lease_status_tracker.get());
     schedule_failure_handler(lease_status_tracker->GetPlacementGroup(),
                              /*is_feasible=*/true);
     return;
@@ -384,7 +385,8 @@ void GcsPlacementGroupScheduler::OnAllBundlePrepareRequestReturned(
     auto it = placement_group_leasing_in_progress_.find(placement_group_id);
     RAY_CHECK(it != placement_group_leasing_in_progress_.end());
     placement_group_leasing_in_progress_.erase(it);
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
+    ReturnBundleResources(lease_status_tracker->GetBundleLocations(),
+                          lease_status_tracker.get());
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -438,7 +440,8 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
   // to destroy them separately.
   if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
     DestroyPlacementGroupCommittedBundleResources(placement_group_id);
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
+    ReturnBundleResources(lease_status_tracker->GetBundleLocations(),
+                          lease_status_tracker.get());
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -452,7 +455,7 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
       placement_group->GetMutableBundle(bundle.first.second)->clear_node_id();
     }
     placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
-    ReturnBundleResources(uncommitted_bundle_locations);
+    ReturnBundleResources(uncommitted_bundle_locations, lease_status_tracker.get());
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
   } else {
     schedule_success_handler(placement_group);
@@ -736,10 +739,23 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
 }
 
 void GcsPlacementGroupScheduler::ReturnBundleResources(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
-  // Return bundle resources to gcs resources manager should contains the following steps.
-  // 1. Remove related bundle resources from nodes.
-  // 2. Add resources allocated for bundles back to nodes.
+    const std::shared_ptr<BundleLocations> &bundle_locations,
+    const LeaseStatusTracker *lease_status_tracker) {
+  // If a tracker is provided, restore the original resources that were
+  // speculatively deducted by AcquireBundleResources, using the saved
+  // per-instance allocation.
+  if (lease_status_tracker) {
+    auto &crm = cluster_resource_scheduler_.GetClusterResourceManager();
+    for (const auto &[bundle_id, location] : *bundle_locations) {
+      const auto *alloc = lease_status_tracker->GetBundleAllocation(bundle_id);
+      if (alloc) {
+        crm.AddNodeAvailableResources(scheduling::NodeID(location.first.Binary()),
+                                      *alloc);
+      }
+    }
+  }
+
+  // Clean up PG-formatted resources (wildcard + indexed).
   for (auto &bundle : *bundle_locations) {
     if (!TryReleasingBundleResources(bundle.second)) {
       waiting_removed_bundles_.push_back(bundle.second);
@@ -802,8 +818,8 @@ bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
   // It will affect nothing if the resource_id to be deleted does not exist in the
   // cluster_resource_manager_.
   cluster_resource_manager.DeleteResources(node_id, bundle_resource_ids);
-  // Original resources are restored when the node broadcasts its updated
-  // state via syncer, not here.
+  // Original resources are restored by the caller (ReturnBundleResources)
+  // when a LeaseStatusTracker is available, or by syncer otherwise.
   return true;
 }
 

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -652,7 +652,6 @@ const ResourceAllocation *LeaseStatusTracker::GetBundleAllocation(
 void GcsPlacementGroupScheduler::AcquireBundleResources(
     const std::shared_ptr<BundleLocations> &bundle_locations,
     const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker) {
-  // Acquire bundle resources from gcs resources manager.
   auto &cluster_resource_manager =
       cluster_resource_scheduler_.GetClusterResourceManager();
   for (auto &bundle : *bundle_locations) {
@@ -714,16 +713,18 @@ void GcsPlacementGroupScheduler::CommitBundleResources(
       auto original_name = GetOriginalResourceName(resource_name);
 
       // Use the per-instance allocation from AcquireBundleResources if available
-      // (GPU, CPU, etc.). Synthetic resources like bundle_group won't be in the
-      // allocation and fall through to the single-element path.
+      // for this original resource. Synthetic resources like bundle_group won't
+      // be in the allocation and fall through to the single-element path.
       if (bundle_alloc != nullptr) {
-        auto phys_it = bundle_alloc->find(scheduling::ResourceID(original_name));
-        if (phys_it != bundle_alloc->end()) {
+        auto alloc_it = bundle_alloc->find(scheduling::ResourceID(original_name));
+        if (alloc_it != bundle_alloc->end()) {
           cluster_resource_manager.AddResourceInstances(
-              node_id, resource_id, phys_it->second);
+              node_id, resource_id, alloc_it->second);
           continue;
         }
       }
+      // No saved allocation (e.g. GCS restart recovery). Single-element vector
+      // may not match actual per-instance layout; syncer corrects within ~100ms.
       cluster_resource_manager.AddResourceInstances(
           node_id, resource_id, {FixedPoint(capacity)});
     }

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -228,7 +228,7 @@ class LeaseStatusTracker {
   /// status tracker anymore.
   void MarkCommitPhaseStarted();
 
-  /// Save the per-instance physical allocation for a bundle (from
+  /// Save the per-instance allocation for a bundle (from
   /// AcquireBundleResources).
   void SetBundleAllocation(const BundleID &bundle_id, ResourceAllocation allocation);
 
@@ -279,9 +279,9 @@ class LeaseStatusTracker {
   /// Bundles to schedule.
   std::vector<std::shared_ptr<const BundleSpecification>> bundles_to_schedule_;
 
-  /// Per-bundle physical resource allocations from AcquireBundleResources.
-  /// Used by CommitBundleResources to create PG resources with the correct
-  /// per-instance distribution, matching the raylet's allocation.
+  /// Per-bundle resource allocations (original resources, not PG-formatted)
+  /// from AcquireBundleResources. Used by CommitBundleResources to create
+  /// PG-formatted resources with the correct per-instance distribution.
   absl::flat_hash_map<BundleID, ResourceAllocation, pair_hash>
       acquired_resource_allocations_;
 
@@ -468,7 +468,7 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker);
 
   /// Return the bundle resources to the cluster resources.
-  /// Removes PG-specific resources (wildcard + indexed). Physical resources
+  /// Removes PG-formatted resources (wildcard + indexed). Original resources
   /// are NOT added back here; syncer delivers the real state.
   void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
 

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -228,6 +228,13 @@ class LeaseStatusTracker {
   /// status tracker anymore.
   void MarkCommitPhaseStarted();
 
+  /// Save the per-instance physical allocation for a bundle (from
+  /// AcquireBundleResources).
+  void SetBundleAllocation(const BundleID &bundle_id, ResourceAllocation allocation);
+
+  /// Retrieve the saved allocation. Returns nullptr if not found.
+  const ResourceAllocation *GetBundleAllocation(const BundleID &bundle_id) const;
+
  private:
   /// Method to update leasing states.
   ///
@@ -271,6 +278,12 @@ class LeaseStatusTracker {
 
   /// Bundles to schedule.
   std::vector<std::shared_ptr<const BundleSpecification>> bundles_to_schedule_;
+
+  /// Per-bundle physical resource allocations from AcquireBundleResources.
+  /// Used by CommitBundleResources to create PG resources with the correct
+  /// per-instance distribution, matching the raylet's allocation.
+  absl::flat_hash_map<BundleID, ResourceAllocation, pair_hash>
+      acquired_resource_allocations_;
 
   /// Location of bundles.
   std::shared_ptr<BundleLocations> bundle_locations_;
@@ -445,13 +458,18 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const PlacementGroupID &placement_group_id);
 
   /// Acquire the bundle resources from the cluster resources.
-  void AcquireBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
+  void AcquireBundleResources(
+      const std::shared_ptr<BundleLocations> &bundle_locations,
+      const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker);
 
   /// Commit the bundle resources to the cluster resources.
-  void CommitBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
+  void CommitBundleResources(
+      const std::shared_ptr<BundleLocations> &bundle_locations,
+      const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker);
 
   /// Return the bundle resources to the cluster resources.
-  /// It will remove bundle resources AND also add original resources back.
+  /// Removes PG-specific resources (wildcard + indexed). Physical resources
+  /// are NOT added back here; syncer delivers the real state.
   void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
 
   /// Create scheduling context.

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -228,11 +228,9 @@ class LeaseStatusTracker {
   /// status tracker anymore.
   void MarkCommitPhaseStarted();
 
-  /// Save the per-instance allocation for a bundle (from
-  /// AcquireBundleResources).
   void SetBundleAllocation(const BundleID &bundle_id, ResourceAllocation allocation);
 
-  /// Retrieve the saved allocation. Returns nullptr if not found.
+  /// Returns nullptr if not found.
   const ResourceAllocation *GetBundleAllocation(const BundleID &bundle_id) const;
 
  private:
@@ -279,9 +277,8 @@ class LeaseStatusTracker {
   /// Bundles to schedule.
   std::vector<std::shared_ptr<const BundleSpecification>> bundles_to_schedule_;
 
-  /// Per-bundle resource allocations (original resources, not PG-formatted)
-  /// from AcquireBundleResources. Used by CommitBundleResources to create
-  /// PG-formatted resources with the correct per-instance distribution.
+  /// Per-bundle per-instance resource allocations (original resources, not
+  /// PG-formatted), e.g. {GPU: [0, 1, 0, 0]} meaning GPU instance 1 was used.
   absl::flat_hash_map<BundleID, ResourceAllocation, pair_hash>
       acquired_resource_allocations_;
 
@@ -468,11 +465,11 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker);
 
   /// Return the bundle resources to the cluster resources.
-  /// Removes PG-formatted resources (wildcard + indexed). If a LeaseStatusTracker
-  /// is provided, also restores original resources using the saved per-instance
-  /// allocation from AcquireBundleResources.
-  void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations,
-                             const LeaseStatusTracker *lease_status_tracker = nullptr);
+  /// Removes PG-formatted resources and restores original resources if a
+  /// LeaseStatusTracker with saved per-instance allocation is provided.
+  void ReturnBundleResources(
+      const std::shared_ptr<BundleLocations> &bundle_locations,
+      const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker = nullptr);
 
   /// Create scheduling context.
   std::unique_ptr<BundleSchedulingContext> CreateSchedulingContext(

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -468,9 +468,11 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const std::shared_ptr<LeaseStatusTracker> &lease_status_tracker);
 
   /// Return the bundle resources to the cluster resources.
-  /// Removes PG-formatted resources (wildcard + indexed). Original resources
-  /// are NOT added back here; syncer delivers the real state.
-  void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
+  /// Removes PG-formatted resources (wildcard + indexed). If a LeaseStatusTracker
+  /// is provided, also restores original resources using the saved per-instance
+  /// allocation from AcquireBundleResources.
+  void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations,
+                             const LeaseStatusTracker *lease_status_tracker = nullptr);
 
   /// Create scheduling context.
   std::unique_ptr<BundleSchedulingContext> CreateSchedulingContext(

--- a/src/ray/gcs/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_resource_manager.cc
@@ -90,9 +90,10 @@ void GcsResourceManager::HandleGetAllAvailableResources(
     rpc::AvailableResources resource;
     resource.set_node_id(node_resources_entry.first.Binary());
     const auto &node_resources = node_resources_entry.second.GetLocalView();
-    for (const auto &resource_id : node_resources.available.ExplicitResourceIds()) {
+    auto available_set = node_resources.available.ToNodeResourceSet();
+    for (const auto &resource_id : available_set.ExplicitResourceIds()) {
       const auto &resource_name = resource_id.Binary();
-      const auto &resource_value = node_resources.available.Get(resource_id);
+      const auto &resource_value = available_set.Get(resource_id);
       resource.mutable_resources_available()->insert(
           {resource_name, resource_value.Double()});
     }
@@ -223,8 +224,15 @@ void GcsResourceManager::UpdateNodeResourceUsage(
         resource_view_sync_message.resources_total();
   }
 
-  (*iter->second.mutable_resources_available()) =
-      resource_view_sync_message.resources_available();
+  iter->second.mutable_resources_available()->clear();
+  for (const auto &[name, instances] :
+       resource_view_sync_message.resources_available_instances()) {
+    double sum = 0;
+    for (double v : instances.values()) {
+      sum += v;
+    }
+    (*iter->second.mutable_resources_available())[name] = sum;
+  }
 }
 
 void GcsResourceManager::Initialize(const GcsInitData &gcs_init_data) {

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -143,6 +143,23 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     gcs_resource_manager_->OnNodeAdd(*node);
   }
 
+  // Simulate a syncer update (available = total) so tests see resources restored.
+  void SimulateSyncerUpdate(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
+    auto node_id = NodeID::FromBinary(node->node_id());
+    syncer::ResourceViewSyncMessage msg;
+    for (const auto &[name, value] : node->resources_total()) {
+      (*msg.mutable_resources_total())[name] = value;
+      rpc::syncer::ResourceInstances instances;
+      auto resource_id = scheduling::ResourceID(name);
+      for (const auto &v :
+           NodeResourceInstanceSet::MakeInstances(resource_id, FixedPoint(value))) {
+        instances.add_values(v.Double());
+      }
+      (*msg.mutable_resources_available_instances())[name] = instances;
+    }
+    gcs_resource_manager_->UpdateFromResourceView(node_id, msg);
+  }
+
   void RemoveNode(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
     rpc::NodeDeathInfo death_info;
     gcs_node_manager_->RemoveNode(
@@ -237,10 +254,10 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   }
 
   void AddTwoNodes() {
-    auto node0 = GenNodeInfo(0);
-    auto node1 = GenNodeInfo(1);
-    AddNode(node0);
-    AddNode(node1);
+    node0_ = GenNodeInfo(0);
+    node1_ = GenNodeInfo(1);
+    AddNode(node0_);
+    AddNode(node1_);
   }
 
   bool EnsureClusterResourcesAreNotInUse() {
@@ -249,7 +266,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     auto resource_view_before_scheduling = cluster_resource_manager.GetResourceView();
     // Make sure the resources are not used.
     for (const auto &[node_id, node] : resource_view_before_scheduling) {
-      if (node.GetLocalView().total != node.GetLocalView().available) {
+      if (node.GetLocalView().total !=
+          node.GetLocalView().available.ToNodeResourceSet()) {
         return false;
       }
     }
@@ -299,6 +317,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   std::shared_ptr<InMemoryStoreClient> store_client_;
 
   std::vector<std::shared_ptr<rpc::FakeRayletClient>> raylet_clients_;
+  std::shared_ptr<rpc::GcsNodeInfo> node0_;
+  std::shared_ptr<rpc::GcsNodeInfo> node1_;
   std::shared_ptr<GcsResourceManager> gcs_resource_manager_;
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
@@ -1303,6 +1323,10 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPrepareFromDeadNodes) {
   GrantPrepareBundleResources(/*grant0=*/{true, Status::OK()},
                               /*grant1=*/{false, Status::IOError("")});
 
+  // Syncer delivers real state after bundle release.
+  SimulateSyncerUpdate(node0_);
+  SimulateSyncerUpdate(node1_);
+
   // Make sure the resources are returned to the cluster_resource_manager at the GCS
   // side.
   ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
@@ -1330,6 +1354,9 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPrepareFromNodeWithInsufficientResour
   // node1 grants the schedule request with success=false and status=Status::OK()
   GrantPrepareBundleResources(/*grant0=*/{true, Status::OK()},
                               /*grant1=*/{false, Status::OK()});
+
+  SimulateSyncerUpdate(node0_);
+  SimulateSyncerUpdate(node1_);
 
   // Make sure the resources are returned to the cluster_resource_manager at the GCS
   // side.
@@ -1363,6 +1390,9 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestCommitToDeadNodes) {
   // node0 grants the schedule request status=Status::IOError("")
   // node1 grants the schedule request status=Status::IOError("")
   GrantCommitBundleResources(Status::IOError(""), Status::IOError(""));
+
+  SimulateSyncerUpdate(node0_);
+  SimulateSyncerUpdate(node1_);
 
   // Make sure the resources are returned to the cluster_resource_manager at the GCS
   // side.

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -143,27 +143,6 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     gcs_resource_manager_->OnNodeAdd(*node);
   }
 
-  // Simulate a syncer update (available = total) so tests see resources restored.
-  void SimulateSyncerUpdate(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
-    auto node_id = NodeID::FromBinary(node->node_id());
-    syncer::ResourceViewSyncMessage msg;
-    for (const auto &[name, value] : node->resources_total()) {
-      (*msg.mutable_resources_total())[name] = value;
-      rpc::syncer::ResourceInstances instances;
-      auto resource_id = scheduling::ResourceID(name);
-      if (resource_id.IsUnitInstanceResource()) {
-        size_t num = static_cast<size_t>(value);
-        for (size_t i = 0; i < num; i++) {
-          instances.add_values(1.0);
-        }
-      } else {
-        instances.add_values(value);
-      }
-      (*msg.mutable_resources_available_instances())[name] = instances;
-    }
-    gcs_resource_manager_->UpdateFromResourceView(node_id, msg);
-  }
-
   void RemoveNode(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
     rpc::NodeDeathInfo death_info;
     gcs_node_manager_->RemoveNode(
@@ -258,10 +237,10 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   }
 
   void AddTwoNodes() {
-    node0_ = GenNodeInfo(0);
-    node1_ = GenNodeInfo(1);
-    AddNode(node0_);
-    AddNode(node1_);
+    auto node0 = GenNodeInfo(0);
+    auto node1 = GenNodeInfo(1);
+    AddNode(node0);
+    AddNode(node1);
   }
 
   bool EnsureClusterResourcesAreNotInUse() {
@@ -321,8 +300,6 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
   std::shared_ptr<InMemoryStoreClient> store_client_;
 
   std::vector<std::shared_ptr<rpc::FakeRayletClient>> raylet_clients_;
-  std::shared_ptr<rpc::GcsNodeInfo> node0_;
-  std::shared_ptr<rpc::GcsNodeInfo> node1_;
   std::shared_ptr<GcsResourceManager> gcs_resource_manager_;
   std::shared_ptr<ClusterResourceScheduler> cluster_resource_scheduler_;
   std::shared_ptr<GcsNodeManager> gcs_node_manager_;
@@ -1327,10 +1304,6 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPrepareFromDeadNodes) {
   GrantPrepareBundleResources(/*grant0=*/{true, Status::OK()},
                               /*grant1=*/{false, Status::IOError("")});
 
-  // Syncer delivers real state after bundle release.
-  SimulateSyncerUpdate(node0_);
-  SimulateSyncerUpdate(node1_);
-
   // Make sure the resources are returned to the cluster_resource_manager at the GCS
   // side.
   ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
@@ -1358,9 +1331,6 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPrepareFromNodeWithInsufficientResour
   // node1 grants the schedule request with success=false and status=Status::OK()
   GrantPrepareBundleResources(/*grant0=*/{true, Status::OK()},
                               /*grant1=*/{false, Status::OK()});
-
-  SimulateSyncerUpdate(node0_);
-  SimulateSyncerUpdate(node1_);
 
   // Make sure the resources are returned to the cluster_resource_manager at the GCS
   // side.
@@ -1394,9 +1364,6 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestCommitToDeadNodes) {
   // node0 grants the schedule request status=Status::IOError("")
   // node1 grants the schedule request status=Status::IOError("")
   GrantCommitBundleResources(Status::IOError(""), Status::IOError(""));
-
-  SimulateSyncerUpdate(node0_);
-  SimulateSyncerUpdate(node1_);
 
   // Make sure the resources are returned to the cluster_resource_manager at the GCS
   // side.

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -143,6 +143,15 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     gcs_resource_manager_->OnNodeAdd(*node);
   }
 
+  void AddNodeWithGpu(const std::shared_ptr<rpc::GcsNodeInfo> &node,
+                      int cpu_num = 4,
+                      int gpu_num = 2) {
+    (*node->mutable_resources_total())["CPU"] = cpu_num;
+    (*node->mutable_resources_total())["GPU"] = gpu_num;
+    gcs_node_manager_->AddNode(node);
+    gcs_resource_manager_->OnNodeAdd(*node);
+  }
+
   void RemoveNode(const std::shared_ptr<rpc::GcsNodeInfo> &node) {
     rpc::NodeDeathInfo death_info;
     gcs_node_manager_->RemoveNode(
@@ -249,8 +258,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     auto resource_view_before_scheduling = cluster_resource_manager.GetResourceView();
     // Make sure the resources are not used.
     for (const auto &[node_id, node] : resource_view_before_scheduling) {
-      if (node.GetLocalView().total !=
-          node.GetLocalView().available.ToNodeResourceSet()) {
+      if (!(node.GetLocalView().available ==
+            NodeResourceInstanceSet(node.GetLocalView().total))) {
         return false;
       }
     }
@@ -1425,6 +1434,59 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestBundlesRemovedWhenNodeDead) {
   // There shouldn't be any remaining bundles to be removed since the node is
   // already removed. The bundles are already removed when the node is removed.
   ASSERT_EQ(scheduler_->waiting_removed_bundles_.size(), 0);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestGpuPgPrepareFailureRollback) {
+  // Add a node with 4 CPUs and 2 GPUs.
+  auto node = GenNodeInfo(0);
+  AddNodeWithGpu(node, /*cpu_num=*/4, /*gpu_num=*/2);
+
+  scheduling::NodeID scheduling_node_id(node->node_id());
+  const auto &view =
+      cluster_resource_scheduler_->GetClusterResourceManager().GetResourceView();
+
+  // Verify GPU per-instance: 2 instances, each 1.0.
+  auto gpu_before = view.at(scheduling_node_id)
+                        .GetLocalView()
+                        .available.Get(scheduling::ResourceID("GPU"));
+  ASSERT_EQ(gpu_before.size(), 2);
+  ASSERT_EQ(gpu_before[0], FixedPoint(1.0));
+  ASSERT_EQ(gpu_before[1], FixedPoint(1.0));
+
+  // Create a PG with 1 bundle requiring 1 GPU (using GenCreatePlacementGroupRequest
+  // with cpu_num=0, then manually add GPU to the bundle spec is hard, so we create
+  // the request with 1 CPU per bundle and rely on the node having both).
+  auto request = GenCreatePlacementGroupRequest(
+      /*name=*/"",
+      /*strategy=*/rpc::PlacementStrategy::SPREAD,
+      /*bundles_count=*/1,
+      /*cpu_num=*/1.0);
+  // Add GPU to the bundle.
+  auto *bundle = request.mutable_placement_group_spec()->mutable_bundles(0);
+  (*bundle->mutable_unit_resources())["GPU"] = 1.0;
+
+  auto pg = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+  ScheduleUnplacedBundles(pg);
+
+  // After speculative deduction: 1 GPU instance should be deducted.
+  auto gpu_after = view.at(scheduling_node_id)
+                       .GetLocalView()
+                       .available.Get(scheduling::ResourceID("GPU"));
+  ASSERT_EQ(gpu_after.size(), 2);
+  ASSERT_EQ(gpu_after[0] + gpu_after[1], FixedPoint(1.0));
+
+  // Prepare fails → rollback should restore per-instance GPU state.
+  ASSERT_TRUE(
+      raylet_clients_[0]->GrantPrepareBundleResources(/*success=*/false, Status::OK()));
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
+
+  ASSERT_TRUE(EnsureClusterResourcesAreNotInUse());
+  auto gpu_restored = view.at(scheduling_node_id)
+                          .GetLocalView()
+                          .available.Get(scheduling::ResourceID("GPU"));
+  ASSERT_EQ(gpu_restored.size(), 2);
+  ASSERT_EQ(gpu_restored[0], FixedPoint(1.0));
+  ASSERT_EQ(gpu_restored[1], FixedPoint(1.0));
 }
 
 }  // namespace gcs

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -151,9 +151,13 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
       (*msg.mutable_resources_total())[name] = value;
       rpc::syncer::ResourceInstances instances;
       auto resource_id = scheduling::ResourceID(name);
-      for (const auto &v :
-           NodeResourceInstanceSet::MakeInstances(resource_id, FixedPoint(value))) {
-        instances.add_values(v.Double());
+      if (resource_id.IsUnitInstanceResource()) {
+        size_t num = static_cast<size_t>(value);
+        for (size_t i = 0; i < num; i++) {
+          instances.add_values(1.0);
+        }
+      } else {
+        instances.add_values(value);
       }
       (*msg.mutable_resources_available_instances())[name] = instances;
     }

--- a/src/ray/gcs/tests/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_resource_manager_test.cc
@@ -47,7 +47,15 @@ class GcsResourceManagerTest : public ::testing::Test {
     syncer::ResourceViewSyncMessage resource_view_sync_message;
     for (const auto &resource : available_resources) {
       rpc::syncer::ResourceInstances instances;
-      instances.add_values(resource.second);
+      auto resource_id = scheduling::ResourceID(resource.first);
+      if (resource_id.IsUnitInstanceResource()) {
+        size_t num = static_cast<size_t>(resource.second);
+        for (size_t i = 0; i < num; i++) {
+          instances.add_values(1.0);
+        }
+      } else {
+        instances.add_values(resource.second);
+      }
       (*resource_view_sync_message
             .mutable_resources_available_instances())[resource.first] = instances;
     }
@@ -103,6 +111,55 @@ TEST_F(GcsResourceManagerTest, TestBasic) {
   // Test `ReleaseResources`.
   ASSERT_TRUE(cluster_resource_manager_.AddNodeAvailableResources(scheduling_node_id,
                                                                   allocation.value()));
+}
+
+TEST_F(GcsResourceManagerTest, TestPerInstanceGpuResources) {
+  auto node = GenNodeInfo();
+  node->mutable_resources_total()->insert({{"GPU", 4}});
+  gcs_resource_manager_->OnNodeAdd(*node);
+
+  auto node_id = NodeID::FromBinary(node->node_id());
+  scheduling::NodeID scheduling_node_id(node->node_id());
+
+  // Syncer reports 4 GPUs, each with 1.0 capacity.
+  UpdateFromResourceViewSync(node_id, {{"GPU", 4}}, {{"GPU", 4}});
+
+  // Verify per-instance: 4 instances, each 1.0.
+  const auto &view = cluster_resource_manager_.GetResourceView();
+  const auto &available = view.at(scheduling_node_id).GetLocalView().available;
+  auto gpu_instances = available.Get(scheduling::ResourceID("GPU"));
+  ASSERT_EQ(gpu_instances.size(), 4);
+  for (const auto &inst : gpu_instances) {
+    ASSERT_EQ(inst, FixedPoint(1.0));
+  }
+
+  // Allocate 0.5 GPU (should take from one instance).
+  absl::flat_hash_map<std::string, double> demand_map = {{"GPU", 0.5}};
+  auto request =
+      ResourceMapToResourceRequest(demand_map, /*requires_object_store_memory=*/false);
+  auto alloc = cluster_resource_manager_.SubtractNodeAvailableResources(
+      scheduling_node_id, request);
+  ASSERT_TRUE(alloc.has_value());
+
+  // One instance should have 0.5 remaining, others still 1.0.
+  const auto &after_alloc = view.at(scheduling_node_id).GetLocalView().available;
+  auto gpu_after = after_alloc.Get(scheduling::ResourceID("GPU"));
+  ASSERT_EQ(gpu_after.size(), 4);
+  FixedPoint sum(0);
+  for (const auto &inst : gpu_after) {
+    sum += inst;
+  }
+  ASSERT_EQ(sum, FixedPoint(3.5));
+
+  // Free it back.
+  ASSERT_TRUE(cluster_resource_manager_.AddNodeAvailableResources(scheduling_node_id,
+                                                                  alloc.value()));
+  auto gpu_freed = view.at(scheduling_node_id)
+                       .GetLocalView()
+                       .available.Get(scheduling::ResourceID("GPU"));
+  for (const auto &inst : gpu_freed) {
+    ASSERT_EQ(inst, FixedPoint(1.0));
+  }
 }
 
 TEST_F(GcsResourceManagerTest, TestResourceUsageAPI) {

--- a/src/ray/gcs/tests/gcs_resource_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_resource_manager_test.cc
@@ -46,8 +46,10 @@ class GcsResourceManagerTest : public ::testing::Test {
       int64_t draining_deadline_timestamp_ms = -1) {
     syncer::ResourceViewSyncMessage resource_view_sync_message;
     for (const auto &resource : available_resources) {
-      (*resource_view_sync_message.mutable_resources_available())[resource.first] =
-          resource.second;
+      rpc::syncer::ResourceInstances instances;
+      instances.add_values(resource.second);
+      (*resource_view_sync_message
+            .mutable_resources_available_instances())[resource.first] = instances;
     }
     for (const auto &resource : total_resources) {
       (*resource_view_sync_message.mutable_resources_total())[resource.first] =
@@ -90,16 +92,17 @@ TEST_F(GcsResourceManagerTest, TestBasic) {
       scheduling_node_id,
       resource_request,
       /*ignore_object_store_memory_requirement=*/true));
-  ASSERT_TRUE(cluster_resource_manager_.SubtractNodeAvailableResources(scheduling_node_id,
-                                                                       resource_request));
+  auto allocation = cluster_resource_manager_.SubtractNodeAvailableResources(
+      scheduling_node_id, resource_request);
+  ASSERT_TRUE(allocation.has_value());
   ASSERT_FALSE(cluster_resource_manager_.HasAvailableResources(
       scheduling_node_id,
       resource_request,
       /*ignore_object_store_memory_requirement=*/true));
 
   // Test `ReleaseResources`.
-  ASSERT_TRUE(cluster_resource_manager_.AddNodeAvailableResources(
-      scheduling_node_id, resource_request.GetResourceSet()));
+  ASSERT_TRUE(cluster_resource_manager_.AddNodeAvailableResources(scheduling_node_id,
+                                                                  allocation.value()));
 }
 
 TEST_F(GcsResourceManagerTest, TestResourceUsageAPI) {
@@ -117,7 +120,6 @@ TEST_F(GcsResourceManagerTest, TestResourceUsageAPI) {
   gcs_resource_manager_->OnNodeAdd(*node);
 
   syncer::ResourceViewSyncMessage resource_view_sync_message;
-  (*resource_view_sync_message.mutable_resources_available())["CPU"] = 2;
   (*resource_view_sync_message.mutable_resources_total())["CPU"] = 2;
   gcs_resource_manager_->UpdateNodeResourceUsage(node_id, resource_view_sync_message);
 
@@ -146,9 +148,10 @@ TEST_F(GcsResourceManagerTest, TestResourceUsageFromDifferentSyncMsgs) {
 
   syncer::ResourceViewSyncMessage resource_view_sync_message;
   resource_view_sync_message.mutable_resources_total()->insert({"CPU", 5});
-  resource_view_sync_message.mutable_resources_available()->insert({"CPU", 5});
+  rpc::syncer::ResourceInstances cpu_inst;
+  cpu_inst.add_values(5);
+  (*resource_view_sync_message.mutable_resources_available_instances())["CPU"] = cpu_inst;
 
-  // Update resource usage from resource view.
   gcs_resource_manager_->UpdateFromResourceView(NodeID::FromBinary(node->node_id()),
                                                 resource_view_sync_message);
   ASSERT_EQ(
@@ -171,7 +174,10 @@ TEST_F(GcsResourceManagerTest, TestSetAvailableResourcesWhenNodeDead) {
 
   syncer::ResourceViewSyncMessage resource_view_sync_message;
   resource_view_sync_message.mutable_resources_total()->insert({"CPU", 5});
-  resource_view_sync_message.mutable_resources_available()->insert({"CPU", 5});
+  rpc::syncer::ResourceInstances cpu_inst2;
+  cpu_inst2.add_values(5);
+  (*resource_view_sync_message.mutable_resources_available_instances())["CPU"] =
+      cpu_inst2;
   gcs_resource_manager_->UpdateFromResourceView(node_id, resource_view_sync_message);
   ASSERT_EQ(cluster_resource_manager_.GetResourceView().size(), 0);
 }

--- a/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
@@ -689,7 +689,9 @@ TEST_P(GcsClientTest, TestGetAllAvailableResources) {
   rpc::syncer::ResourceInstances cpu_instances;
   cpu_instances.add_values(1.0);
   rpc::syncer::ResourceInstances gpu_instances;
-  gpu_instances.add_values(10.0);
+  for (int i = 0; i < 10; i++) {
+    gpu_instances.add_values(1.0);
+  }
   (*resource.mutable_resources_available_instances())["CPU"] = cpu_instances;
   (*resource.mutable_resources_available_instances())["GPU"] = gpu_instances;
   (*resource.mutable_resources_total())["CPU"] = 1.0;

--- a/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
@@ -686,8 +686,12 @@ TEST_P(GcsClientTest, TestGetAllAvailableResources) {
   NodeID node_id = NodeID::FromBinary(node_info->node_id());
   syncer::ResourceViewSyncMessage resource;
   // Set this flag to indicate resources has changed.
-  (*resource.mutable_resources_available())["CPU"] = 1.0;
-  (*resource.mutable_resources_available())["GPU"] = 10.0;
+  rpc::syncer::ResourceInstances cpu_instances;
+  cpu_instances.add_values(1.0);
+  rpc::syncer::ResourceInstances gpu_instances;
+  gpu_instances.add_values(10.0);
+  (*resource.mutable_resources_available_instances())["CPU"] = cpu_instances;
+  (*resource.mutable_resources_available_instances())["GPU"] = gpu_instances;
   (*resource.mutable_resources_total())["CPU"] = 1.0;
   (*resource.mutable_resources_total())["GPU"] = 10.0;
   gcs_server_->UpdateGcsResourceManagerInTest(node_id, resource);

--- a/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
+++ b/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
@@ -294,8 +294,12 @@ TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   syncer::ResourceViewSyncMessage resources2;
   (*resources2.mutable_resources_total())["CPU"] = 1;
   (*resources2.mutable_resources_total())["GPU"] = 10;
-  (*resources2.mutable_resources_available())["CPU"] = 1;
-  (*resources2.mutable_resources_available())["GPU"] = 5;
+  rpc::syncer::ResourceInstances cpu_instances2;
+  cpu_instances2.add_values(1.0);
+  (*resources2.mutable_resources_available_instances())["CPU"] = cpu_instances2;
+  rpc::syncer::ResourceInstances gpu_instances2;
+  gpu_instances2.add_values(5.0);
+  (*resources2.mutable_resources_available_instances())["GPU"] = gpu_instances2;
   gcs_server_->UpdateGcsResourceManagerInTest(
       NodeID::FromBinary(node_table_data->node_id()), resources2);
 

--- a/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
+++ b/src/ray/gcs_rpc_client/tests/global_state_accessor_test.cc
@@ -298,7 +298,12 @@ TEST_P(GlobalStateAccessorTest, TestGetAllResourceUsage) {
   cpu_instances2.add_values(1.0);
   (*resources2.mutable_resources_available_instances())["CPU"] = cpu_instances2;
   rpc::syncer::ResourceInstances gpu_instances2;
-  gpu_instances2.add_values(5.0);
+  for (int i = 0; i < 5; i++) {
+    gpu_instances2.add_values(1.0);
+  }
+  for (int i = 0; i < 5; i++) {
+    gpu_instances2.add_values(0.0);
+  }
   (*resources2.mutable_resources_available_instances())["GPU"] = gpu_instances2;
   gcs_server_->UpdateGcsResourceManagerInTest(
       NodeID::FromBinary(node_table_data->node_id()), resources2);

--- a/src/ray/protobuf/ray_syncer.proto
+++ b/src/ray/protobuf/ray_syncer.proto
@@ -25,6 +25,8 @@ message CommandsSyncMessage {
   bool should_global_gc = 1;
 }
 
+// Per-instance available values for a single resource (e.g., [0.4, 0.6] for
+// a 2-GPU node where GPU 0 has 0.4 free and GPU 1 has 0.6 free).
 message ResourceInstances {
   repeated double values = 1;
 }
@@ -47,6 +49,10 @@ message ResourceViewSyncMessage {
   repeated string node_activity = 7;
   // The key-value labels of this node.
   map<string, string> labels = 8;
+  // Per-instance available resources for this node. For unit-instance resources
+  // like GPU, each element corresponds to one instance (e.g., one GPU card).
+  // For non-unit resources like CPU, the vector has a single element with the
+  // aggregate value. Replaces the old scalar resources_available (field 1).
   map<string, ResourceInstances> resources_available_instances = 9;
 }
 

--- a/src/ray/protobuf/ray_syncer.proto
+++ b/src/ray/protobuf/ray_syncer.proto
@@ -49,10 +49,10 @@ message ResourceViewSyncMessage {
   repeated string node_activity = 7;
   // The key-value labels of this node.
   map<string, string> labels = 8;
-  // Per-instance available resources for this node. For unit-instance resources
-  // like GPU, each element corresponds to one instance (e.g., one GPU card).
-  // For non-unit resources like CPU, the vector has a single element with the
-  // aggregate value. Replaces the old scalar resources_available (field 1).
+  // Per-instance available resources. For unit instance resources like GPU,
+  // each element is one instance (e.g., {"GPU": [0.4, 0.6]} means
+  // GPU 0 has 0.4 free, GPU 1 has 0.6 free). For scalar resources like CPU,
+  // a single element with the aggregate value (e.g., {"CPU": [8.0]}).
   map<string, ResourceInstances> resources_available_instances = 9;
 }
 

--- a/src/ray/protobuf/ray_syncer.proto
+++ b/src/ray/protobuf/ray_syncer.proto
@@ -25,9 +25,11 @@ message CommandsSyncMessage {
   bool should_global_gc = 1;
 }
 
+message ResourceInstances {
+  repeated double values = 1;
+}
+
 message ResourceViewSyncMessage {
-  // Resource capacity currently available on this node manager.
-  map<string, double> resources_available = 1;
   // Total resource capacity configured for this node manager.
   map<string, double> resources_total = 2;
   // Whether this node has object pulls queued. This can happen if
@@ -45,6 +47,7 @@ message ResourceViewSyncMessage {
   repeated string node_activity = 7;
   // The key-value labels of this node.
   map<string, string> labels = 8;
+  map<string, ResourceInstances> resources_available_instances = 9;
 }
 
 message RaySyncMessage {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2039,10 +2039,16 @@ void NodeManager::HandleResizeLocalResourceInstances(
     }
   }
 
+  // Convert the delta resource map to NodeResourceInstanceSet and apply
   if (!delta_resource_map.empty()) {
-    for (const auto &[resource_name, delta_value] : delta_resource_map) {
+    NodeResourceSet delta_resources(delta_resource_map);
+    NodeResourceInstanceSet delta_instances(delta_resources);
+
+    // Apply deltas for each resource
+    for (const auto &resource_id : delta_resources.ExplicitResourceIds()) {
+      const auto &instances = delta_instances.Get(resource_id);
       cluster_resource_scheduler_.GetLocalResourceManager().AddLocalResourceInstances(
-          scheduling::ResourceID(resource_name), {FixedPoint(delta_value)});
+          resource_id, instances);
     }
   }
 

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2039,8 +2039,6 @@ void NodeManager::HandleResizeLocalResourceInstances(
     }
   }
 
-  // Apply deltas directly. Don't use NodeResourceInstanceSet constructor
-  // because MakeInstances clamps negative values to zero, losing the delta.
   if (!delta_resource_map.empty()) {
     for (const auto &[resource_name, delta_value] : delta_resource_map) {
       cluster_resource_scheduler_.GetLocalResourceManager().AddLocalResourceInstances(

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2039,16 +2039,12 @@ void NodeManager::HandleResizeLocalResourceInstances(
     }
   }
 
-  // Convert the delta resource map to NodeResourceInstanceSet and apply
+  // Apply deltas directly. Don't use NodeResourceInstanceSet constructor
+  // because MakeInstances clamps negative values to zero, losing the delta.
   if (!delta_resource_map.empty()) {
-    NodeResourceSet delta_resources(delta_resource_map);
-    NodeResourceInstanceSet delta_instances(delta_resources);
-
-    // Apply deltas for each resource
-    for (const auto &resource_id : delta_resources.ExplicitResourceIds()) {
-      const auto &instances = delta_instances.Get(resource_id);
+    for (const auto &[resource_name, delta_value] : delta_resource_map) {
       cluster_resource_scheduler_.GetLocalResourceManager().AddLocalResourceInstances(
-          resource_id, instances);
+          scheduling::ResourceID(resource_name), {FixedPoint(delta_value)});
     }
   }
 

--- a/src/ray/raylet/scheduling/cluster_lease_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_lease_manager.cc
@@ -353,8 +353,14 @@ void ClusterLeaseManager::FillResourceUsage(rpc::ResourcesData &data) {
       resource_view_sync_message);
   (*data.mutable_resources_total()) =
       std::move(*resource_view_sync_message.mutable_resources_total());
-  (*data.mutable_resources_available()) =
-      std::move(*resource_view_sync_message.mutable_resources_available());
+  for (const auto &[name, instances] :
+       resource_view_sync_message.resources_available_instances()) {
+    double sum = 0;
+    for (double v : instances.values()) {
+      sum += v;
+    }
+    (*data.mutable_resources_available())[name] = sum;
+  }
   data.set_object_pulls_queued(resource_view_sync_message.object_pulls_queued());
   data.set_idle_duration_ms(resource_view_sync_message.idle_duration_ms());
   data.set_is_draining(resource_view_sync_message.is_draining());

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -14,6 +14,8 @@
 
 #include "ray/raylet/scheduling/cluster_resource_manager.h"
 
+#include <algorithm>
+#include <cmath>
 #include <string>
 #include <utility>
 #include <vector>
@@ -82,16 +84,24 @@ bool ClusterResourceManager::UpdateNode(
 
   const auto resources_total =
       MapFromProtobuf(resource_view_sync_message.resources_total());
-  const auto resources_available =
-      MapFromProtobuf(resource_view_sync_message.resources_available());
   auto node_labels = MapFromProtobuf(resource_view_sync_message.labels());
-  NodeResources node_resources =
-      ResourceMapToNodeResources(resources_total, resources_available);
+
   NodeResources local_view;
   RAY_CHECK(GetNodeResources(node_id, &local_view));
 
-  local_view.total = std::move(node_resources.total);
-  local_view.available = std::move(node_resources.available);
+  local_view.total = NodeResourceSet(resources_total);
+
+  const auto &instances_map = resource_view_sync_message.resources_available_instances();
+  NodeResourceInstanceSet new_available;
+  for (const auto &[resource_name, resource_instances] : instances_map) {
+    std::vector<FixedPoint> instances;
+    for (const auto &value : resource_instances.values()) {
+      instances.push_back(FixedPoint(value));
+    }
+    new_available.Set(ResourceID(resource_name), std::move(instances));
+  }
+  local_view.available = std::move(new_available);
+
   local_view.labels = std::move(node_labels);
   local_view.object_pulls_queued = resource_view_sync_message.object_pulls_queued();
 
@@ -161,25 +171,32 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
                                                     double resource_total) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
-    NodeResources node_resources;
-    it = nodes_.emplace(node_id, node_resources).first;
+    it = nodes_.emplace(node_id, NodeResources{}).first;
   }
 
-  auto local_view = it->second.GetMutableLocalView();
-  FixedPoint resource_total_fp(resource_total);
-  auto local_total = local_view->total.Get(resource_id);
-  auto local_available = local_view->available.Get(resource_id);
-  auto diff_capacity = resource_total_fp - local_total;
-  auto total = local_total + diff_capacity;
-  auto available = local_available + diff_capacity;
-  if (total < 0) {
-    total = 0;
+  auto *local_view = it->second.GetMutableLocalView();
+  FixedPoint new_total = std::max(FixedPoint(resource_total), FixedPoint(0));
+  local_view->total.Set(resource_id, new_total);
+
+  // Only init available for new resources. Existing resources' available can't be
+  // correctly adjusted from a scalar total (don't know which instances to update).
+  if (!local_view->available.Has(resource_id)) {
+    local_view->available.Set(
+        resource_id, NodeResourceInstanceSet::MakeInstances(resource_id, new_total));
   }
-  if (available < 0) {
-    available = 0;
-  }
-  local_view->total.Set(resource_id, total);
-  local_view->available.Set(resource_id, available);
+}
+
+void ClusterResourceManager::AddResourceInstances(
+    scheduling::NodeID node_id,
+    scheduling::ResourceID resource_id,
+    const std::vector<FixedPoint> &instances) {
+  auto it = nodes_.find(node_id);
+  RAY_CHECK(it != nodes_.end()) << "Node " << node_id.ToInt() << " not found.";
+
+  auto *local_view = it->second.GetMutableLocalView();
+  auto total_add = FixedPoint::Sum(instances);
+  local_view->total.Set(resource_id, local_view->total.Get(resource_id) + total_add);
+  local_view->available.Add(resource_id, instances);
 }
 
 bool ClusterResourceManager::DeleteResources(
@@ -192,7 +209,7 @@ bool ClusterResourceManager::DeleteResources(
   auto local_view = it->second.GetMutableLocalView();
   for (const auto &resource_id : resource_ids) {
     local_view->total.Set(resource_id, 0);
-    local_view->available.Set(resource_id, 0);
+    local_view->available.Remove(resource_id);
   }
   return true;
 }
@@ -208,23 +225,37 @@ const absl::flat_hash_map<scheduling::NodeID, Node>
   return nodes_;
 }
 
-bool ClusterResourceManager::SubtractNodeAvailableResources(
+std::optional<ResourceAllocation> ClusterResourceManager::SubtractNodeAvailableResources(
     scheduling::NodeID node_id, const ResourceRequest &resource_request) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
-    return false;
+    return std::nullopt;
   }
 
   NodeResources *resources = it->second.GetMutableLocalView();
 
-  resources->available -= resource_request.GetResourceSet();
-  resources->available.RemoveNegative();
+  // Use single-resource TryAllocate (not the multi-resource variant) because the
+  // multi-resource version has PG cross-bundle logic that only applies to local
+  // allocation, not speculative remote deduction.
+  ResourceAllocation allocation;
+  for (const auto &[resource_id, demand] :
+       resource_request.GetResourceSet().Resources()) {
+    auto alloc = resources->available.TryAllocate(resource_id, demand);
+    if (!alloc.has_value()) {
+      // Rollback already applied allocations.
+      for (const auto &[rid, instances] : allocation) {
+        resources->available.Free(rid, instances);
+      }
+      return std::nullopt;
+    }
+    allocation[resource_id] = std::move(*alloc);
+  }
 
   // TODO(swang): We should also subtract object store memory if the task has
   // arguments. Right now we do not modify object_pulls_queued in case of
   // performance regressions in spillback.
 
-  return true;
+  return allocation;
 }
 
 bool ClusterResourceManager::HasFeasibleResources(
@@ -250,24 +281,19 @@ bool ClusterResourceManager::HasAvailableResources(
                                                ignore_object_store_memory_requirement);
 }
 
-bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_id,
-                                                       const ResourceSet &resource_set) {
+bool ClusterResourceManager::AddNodeAvailableResources(
+    scheduling::NodeID node_id, const ResourceAllocation &allocation) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     return false;
   }
 
   auto node_resources = it->second.GetMutableLocalView();
-  for (auto &resource_id : resource_set.ResourceIds()) {
-    if (node_resources->total.Has(resource_id)) {
-      auto available = node_resources->available.Get(resource_id);
-      auto total = node_resources->total.Get(resource_id);
-      auto new_available = available + resource_set.Get(resource_id);
-      if (new_available > total) {
-        new_available = total;
-      }
-      node_resources->available.Set(resource_id, new_available);
-    }
+  for (const auto &[resource_id, instances] : allocation) {
+    node_resources->available.Free(resource_id, instances);
+    // Cap at total to match master behavior. Only cap the freed resource,
+    // not the entire node (avoids O(all_resources) on every rollback).
+    node_resources->available.CapResourceAtTotal(resource_id, node_resources->total);
   }
   return true;
 }

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -303,9 +303,6 @@ bool ClusterResourceManager::AddNodeAvailableResources(
   auto node_resources = it->second.GetMutableLocalView();
   for (const auto &[resource_id, instances] : allocation) {
     node_resources->available.Free(resource_id, instances);
-    // Cap at total to match master behavior. Only cap the freed resource,
-    // not the entire node (avoids O(all_resources) on every rollback).
-    node_resources->available.CapResourceAtTotal(resource_id, node_resources->total);
   }
   return true;
 }

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -92,7 +92,7 @@ bool ClusterResourceManager::UpdateNode(
   local_view.total = NodeResourceSet(resources_total);
 
   const auto &instances_map = resource_view_sync_message.resources_available_instances();
-  NodeResourceInstanceSet new_available;
+  NodeResourceInstanceSet new_available(/*track_pg_index=*/false);
   for (const auto &[resource_name, resource_instances] : instances_map) {
     std::vector<FixedPoint> instances;
     for (const auto &value : resource_instances.values()) {
@@ -181,8 +181,20 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
   // Only init available for new resources. Existing resources' available can't be
   // correctly adjusted from a scalar total (don't know which instances to update).
   if (!local_view->available.Has(resource_id)) {
-    local_view->available.Set(
-        resource_id, NodeResourceInstanceSet::MakeInstances(resource_id, new_total));
+    // Build per-instance vector: unit-instance resources get N x 1.0, others
+    // get a single element.
+    std::vector<FixedPoint> instances;
+    if (resource_id.IsUnitInstanceResource()) {
+      size_t num = static_cast<size_t>(std::max(new_total.Double(), 0.0));
+      for (size_t i = 0; i < num; i++) {
+        instances.push_back(FixedPoint(1.0));
+      }
+    } else {
+      instances.push_back(std::max(new_total, FixedPoint(0)));
+    }
+    if (!instances.empty()) {
+      local_view->available.Set(resource_id, std::move(instances));
+    }
   }
 }
 

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -79,9 +79,7 @@ class ClusterResourceManager {
                               double resource_total);
 
   /// Add per-instance capacity to a resource. Updates both total (scalar sum
-  /// of instances added) and available (element-wise addition). Used by
-  /// CommitBundleResources to create PG-formatted resources with the correct
-  /// per-instance distribution from AcquireBundleResources.
+  /// of instances added) and available (element-wise addition).
   void AddResourceInstances(scheduling::NodeID node_id,
                             scheduling::ResourceID resource_id,
                             const std::vector<FixedPoint> &instances);

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -78,9 +78,9 @@ class ClusterResourceManager {
                               scheduling::ResourceID resource_id,
                               double resource_total);
 
-  /// Add per-instance capacity to a resource (both total and available).
-  /// Element-wise addition, matching the raylet's AddLocalResourceInstances.
-  /// Used by CommitBundleResources to create PG resources with the correct
+  /// Add per-instance capacity to a resource. Updates both total (scalar sum
+  /// of instances added) and available (element-wise addition). Used by
+  /// CommitBundleResources to create PG-formatted resources with the correct
   /// per-instance distribution from AcquireBundleResources.
   void AddResourceInstances(scheduling::NodeID node_id,
                             scheduling::ResourceID resource_id,

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -70,14 +70,21 @@ class ClusterResourceManager {
   /// Get number of nodes in the cluster.
   int64_t NumNodes() const;
 
-  /// Update total capacity of a given resource of a given node.
-  ///
-  /// \param node_id: Node whose resource we want to update.
-  /// \param resource_id: Resource which we want to update.
-  /// \param resource_total: New capacity of the resource.
+  /// Update the total capacity of a resource on a node. Only sets total; for
+  /// resources that don't yet exist in available, initializes available = total.
+  /// Existing resources' available is untouched -- a scalar total change can't be
+  /// correctly distributed across per-instance available.
   void UpdateResourceCapacity(scheduling::NodeID node_id,
                               scheduling::ResourceID resource_id,
                               double resource_total);
+
+  /// Add per-instance capacity to a resource (both total and available).
+  /// Element-wise addition, matching the raylet's AddLocalResourceInstances.
+  /// Used by CommitBundleResources to create PG resources with the correct
+  /// per-instance distribution from AcquireBundleResources.
+  void AddResourceInstances(scheduling::NodeID node_id,
+                            scheduling::ResourceID resource_id,
+                            const std::vector<FixedPoint> &instances);
 
   /// Delete a given resource from a given node.
   ///
@@ -94,9 +101,9 @@ class ClusterResourceManager {
   const NodeResources &GetNodeResources(scheduling::NodeID node_id) const;
 
   /// Subtract available resource from a given node.
-  /// Return false if such node doesn't exist.
-  bool SubtractNodeAvailableResources(scheduling::NodeID node_id,
-                                      const ResourceRequest &resource_request);
+  /// Return std::nullopt if such node doesn't exist or allocation fails.
+  std::optional<ResourceAllocation> SubtractNodeAvailableResources(
+      scheduling::NodeID node_id, const ResourceRequest &resource_request);
 
   /// Check if we have available resources to fullfill resource request for an given node.
   ///
@@ -111,10 +118,10 @@ class ClusterResourceManager {
   bool HasFeasibleResources(scheduling::NodeID node_id,
                             const ResourceRequest &resource_request) const;
 
-  /// Add available resource to a given node.
-  /// Return false if such node doesn't exist.
+  /// Restore previously subtracted resources using a precise per-instance allocation.
+  /// Returns false if the node doesn't exist.
   bool AddNodeAvailableResources(scheduling::NodeID node_id,
-                                 const ResourceSet &resource_set);
+                                 const ResourceAllocation &allocation);
 
   /// Return if the node is tracked.
   bool HasNode(const scheduling::NodeID &node_id) const {

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -255,8 +255,6 @@ bool ClusterResourceScheduler::SubtractRemoteNodeAvailableResources(
   if (!IsSchedulable(resource_request, node_id)) {
     return false;
   }
-  // The per-instance allocation is discarded; the actual allocation happens
-  // on the remote node and its real state syncs back via RaySyncer.
   return cluster_resource_manager_
       ->SubtractNodeAvailableResources(node_id, resource_request)
       .has_value();

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -255,8 +255,11 @@ bool ClusterResourceScheduler::SubtractRemoteNodeAvailableResources(
   if (!IsSchedulable(resource_request, node_id)) {
     return false;
   }
-  return cluster_resource_manager_->SubtractNodeAvailableResources(node_id,
-                                                                   resource_request);
+  // The per-instance allocation is discarded; the actual allocation happens
+  // on the remote node and its real state syncs back via RaySyncer.
+  return cluster_resource_manager_
+      ->SubtractNodeAvailableResources(node_id, resource_request)
+      .has_value();
 }
 
 std::string ClusterResourceScheduler::DebugString(void) const {

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -44,7 +44,7 @@ LocalResourceManager::LocalResourceManager(
       shutdown_raylet_gracefully_(shutdown_raylet_gracefully),
       resource_change_subscriber_(resource_change_subscriber),
       resource_usage_gauge_(resource_usage_gauge) {
-  RAY_CHECK(node_resources.total == node_resources.available);
+  RAY_CHECK(node_resources.total == node_resources.available.ToNodeResourceSet());
   local_resources_.available = NodeResourceInstanceSet(node_resources.total);
   local_resources_.total = NodeResourceInstanceSet(node_resources.total);
   local_resources_.labels = node_resources.labels;
@@ -317,7 +317,7 @@ void LocalResourceManager::ReleaseWorkerResources(
 
 NodeResources LocalResourceManager::ToNodeResources() const {
   NodeResources node_resources;
-  node_resources.available = local_resources_.available.ToNodeResourceSet();
+  node_resources.available = local_resources_.available;
   node_resources.total = local_resources_.total.ToNodeResourceSet();
   node_resources.labels = local_resources_.labels;
   node_resources.is_draining = IsLocalNodeDraining();
@@ -374,14 +374,19 @@ void LocalResourceManager::PopulateResourceViewSyncMessage(
   resource_view_sync_message.mutable_resources_total()->insert(total.begin(),
                                                                total.end());
 
-  for (const auto &[resource_name, available] : resources.available.GetResourceMap()) {
-    // Resource availability can be negative locally but treat it as 0
-    // when we broadcast to others since other parts of the
-    // system assume resource availability cannot be negative and
-    // there is no difference between negative and zero from other nodes
-    // and gcs's point of view.
-    (*resource_view_sync_message.mutable_resources_available())[resource_name] =
-        std::max(available, 0.0);
+  // Resource availability can be negative locally but treat it as 0
+  // when we broadcast to others since other parts of the
+  // system assume resource availability cannot be negative and
+  // there is no difference between negative and zero from other nodes
+  // and gcs's point of view.
+  for (const auto &[resource_id, instances] : resources.available.Resources()) {
+    rpc::syncer::ResourceInstances resource_instances;
+    for (const auto &value : instances) {
+      resource_instances.add_values(std::max(value.Double(), 0.0));
+    }
+    (*resource_view_sync_message
+          .mutable_resources_available_instances())[resource_id.Binary()] =
+        std::move(resource_instances);
   }
 
   if (get_pull_manager_at_capacity_ != nullptr) {

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -362,26 +362,20 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
   // where per-instance CanAllocate rejects a summed demand that could be
   // satisfied by distributing across instances.
   auto try_allocate_all_bundles = [&](scheduling::NodeID node_id) -> bool {
-    std::vector<std::optional<ResourceAllocation>> allocs;
+    std::vector<ResourceAllocation> allocs;
     for (const auto *request : resource_request_list) {
       auto alloc =
           cluster_resource_manager_.SubtractNodeAvailableResources(node_id, *request);
       if (!alloc.has_value()) {
-        // Rollback all previous allocations on this node.
         for (auto &prev : allocs) {
-          if (prev.has_value()) {
-            cluster_resource_manager_.AddNodeAvailableResources(node_id, *prev);
-          }
+          cluster_resource_manager_.AddNodeAvailableResources(node_id, prev);
         }
         return false;
       }
-      allocs.push_back(std::move(alloc));
+      allocs.push_back(std::move(*alloc));
     }
-    // Rollback -- we're only checking feasibility, not committing.
     for (auto &a : allocs) {
-      if (a.has_value()) {
-        cluster_resource_manager_.AddNodeAvailableResources(node_id, *a);
-      }
+      cluster_resource_manager_.AddNodeAvailableResources(node_id, a);
     }
     return true;
   };

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -177,6 +177,8 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
 
   std::vector<scheduling::NodeID> result_nodes;
   result_nodes.resize(sorted_resource_request_list.size());
+  std::vector<std::optional<ResourceAllocation>> allocations;
+  allocations.resize(sorted_resource_request_list.size());
   std::list<std::pair<int, const ResourceRequest *>> required_resources_list_copy;
   int index = 0;
   for (const auto &resource_request : sorted_resource_request_list) {
@@ -194,8 +196,10 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
 
     const auto &node_resources = best_node.second->GetLocalView();
 
-    RAY_CHECK(cluster_resource_manager_.SubtractNodeAvailableResources(
-        best_node.first, *required_resources));
+    auto allocation = cluster_resource_manager_.SubtractNodeAvailableResources(
+        best_node.first, *required_resources);
+    RAY_CHECK(allocation.has_value());
+    allocations[required_resources_index] = std::move(allocation);
     result_nodes[required_resources_index] = best_node.first;
     required_resources_list_copy.pop_front();
 
@@ -204,8 +208,10 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
          iter != required_resources_list_copy.end();) {
       // If the node has sufficient resources, allocate it.
       if (node_resources.IsAvailable(*iter->second)) {
-        RAY_CHECK(cluster_resource_manager_.SubtractNodeAvailableResources(
-            best_node.first, *iter->second));
+        auto iter_allocation = cluster_resource_manager_.SubtractNodeAvailableResources(
+            best_node.first, *iter->second);
+        RAY_CHECK(iter_allocation.has_value());
+        allocations[iter->first] = std::move(iter_allocation);
         result_nodes[iter->first] = best_node.first;
         required_resources_list_copy.erase(iter++);
       } else {
@@ -219,10 +225,9 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
   // Releasing the resources temporarily deducted from `cluster_resource_manager_`.
   for (size_t res_node_idx = 0; res_node_idx < result_nodes.size(); res_node_idx++) {
     // If `PackSchedule` fails, the id of some nodes may be nil.
-    if (!result_nodes[res_node_idx].IsNil()) {
+    if (!result_nodes[res_node_idx].IsNil() && allocations[res_node_idx].has_value()) {
       RAY_CHECK(cluster_resource_manager_.AddNodeAvailableResources(
-          result_nodes[res_node_idx],
-          (*sorted_resource_request_list[res_node_idx]).GetResourceSet()));
+          result_nodes[res_node_idx], allocations[res_node_idx].value()));
     }
   }
 
@@ -258,6 +263,7 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
   }
 
   std::vector<scheduling::NodeID> result_nodes;
+  std::vector<std::optional<ResourceAllocation>> allocations;
   absl::flat_hash_map<scheduling::NodeID, const Node *> selected_nodes;
   for (const auto &resource_request : sorted_resource_request_list) {
     // Score and sort nodes.
@@ -266,8 +272,10 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
     // There are nodes to meet the scheduling requirements.
     if (!best_node.first.IsNil()) {
       result_nodes.emplace_back(best_node.first);
-      RAY_CHECK(cluster_resource_manager_.SubtractNodeAvailableResources(
-          best_node.first, *resource_request));
+      auto allocation = cluster_resource_manager_.SubtractNodeAvailableResources(
+          best_node.first, *resource_request);
+      RAY_CHECK(allocation.has_value());
+      allocations.emplace_back(std::move(allocation));
       candidate_nodes.erase(result_nodes.back());
       selected_nodes.emplace(best_node);
     } else {
@@ -275,8 +283,10 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
       best_node = GetBestNode(*resource_request, selected_nodes, options);
       if (!best_node.first.IsNil()) {
         result_nodes.emplace_back(best_node.first);
-        RAY_CHECK(cluster_resource_manager_.SubtractNodeAvailableResources(
-            best_node.first, *resource_request));
+        auto allocation = cluster_resource_manager_.SubtractNodeAvailableResources(
+            best_node.first, *resource_request);
+        RAY_CHECK(allocation.has_value());
+        allocations.emplace_back(std::move(allocation));
       } else {
         break;
       }
@@ -285,10 +295,10 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
 
   // Releasing the resources temporarily deducted from `cluster_resource_manager_`.
   for (size_t index = 0; index < result_nodes.size(); index++) {
-    // If `PackSchedule` fails, the id of some nodes may be nil.
-    if (!result_nodes[index].IsNil()) {
+    // If `SpreadSchedule` fails, the id of some nodes may be nil.
+    if (!result_nodes[index].IsNil() && allocations[index].has_value()) {
       RAY_CHECK(cluster_resource_manager_.AddNodeAvailableResources(
-          result_nodes[index], (*sorted_resource_request_list[index]).GetResourceSet()));
+          result_nodes[index], allocations[index].value()));
     }
   }
 
@@ -347,32 +357,69 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
     return SchedulingResult::Infeasible();
   }
 
-  std::pair<scheduling::NodeID, const Node *> best_node(scheduling::NodeID::Nil(),
-                                                        nullptr);
+  // Try each candidate node by allocating bundles one by one (per-bundle
+  // SubtractNodeAvailableResources). This avoids the aggregated-request problem
+  // where per-instance CanAllocate rejects a summed demand that could be
+  // satisfied by distributing across instances.
+  auto try_allocate_all_bundles = [&](scheduling::NodeID node_id) -> bool {
+    std::vector<std::optional<ResourceAllocation>> allocs;
+    for (const auto *request : resource_request_list) {
+      auto alloc =
+          cluster_resource_manager_.SubtractNodeAvailableResources(node_id, *request);
+      if (!alloc.has_value()) {
+        // Rollback all previous allocations on this node.
+        for (auto &prev : allocs) {
+          if (prev.has_value()) {
+            cluster_resource_manager_.AddNodeAvailableResources(node_id, *prev);
+          }
+        }
+        return false;
+      }
+      allocs.push_back(std::move(alloc));
+    }
+    // Rollback -- we're only checking feasibility, not committing.
+    for (auto &a : allocs) {
+      if (a.has_value()) {
+        cluster_resource_manager_.AddNodeAvailableResources(node_id, *a);
+      }
+    }
+    return true;
+  };
+
+  // Prefer the soft target node if specified and viable.
+  scheduling::NodeID best_node_id = scheduling::NodeID::Nil();
   if (!options.bundle_strict_pack_soft_target_node_id_.IsNil()) {
-    if (candidate_nodes.contains(options.bundle_strict_pack_soft_target_node_id_)) {
-      best_node = GetBestNode(
-          aggregated_resource_request,
-          absl::flat_hash_map<scheduling::NodeID, const ray::Node *>{
-              {options.bundle_strict_pack_soft_target_node_id_,
-               candidate_nodes[options.bundle_strict_pack_soft_target_node_id_]}},
-          options);
+    if (candidate_nodes.contains(options.bundle_strict_pack_soft_target_node_id_) &&
+        try_allocate_all_bundles(options.bundle_strict_pack_soft_target_node_id_)) {
+      best_node_id = options.bundle_strict_pack_soft_target_node_id_;
     }
   }
 
-  if (best_node.first.IsNil()) {
-    best_node = GetBestNode(aggregated_resource_request, candidate_nodes, options);
+  if (best_node_id.IsNil()) {
+    // Score viable candidates per-bundle using the existing scorer.
+    // try_allocate_all_bundles already verified all bundles fit, so each
+    // individual Score(bundle) will pass IsAvailable.
+    double best_score = -1;
+    for (const auto &[node_id, node] : candidate_nodes) {
+      if (!try_allocate_all_bundles(node_id)) {
+        continue;
+      }
+      double score = 0;
+      for (const auto *request : resource_request_list) {
+        score += node_scorer_->Score(*request, node->GetLocalView());
+      }
+      if (best_node_id.IsNil() || score > best_score) {
+        best_score = score;
+        best_node_id = node_id;
+      }
+    }
   }
 
-  // Select the node with the highest score.
-  // `StrictPackSchedule` does not need to consider the scheduling context, because it
-  // only schedules to a node and triggers rescheduling when node dead.
   std::vector<scheduling::NodeID> result_nodes;
-  if (!best_node.first.IsNil()) {
-    result_nodes.resize(resource_request_list.size(), best_node.first);
+  if (!best_node_id.IsNil()) {
+    result_nodes.resize(resource_request_list.size(), best_node_id);
   }
   if (result_nodes.empty()) {
-    // Can't meet the scheduling requirements temporarily.
     return SchedulingResult::Failed();
   }
 

--- a/src/ray/raylet/scheduling/policy/scorer.cc
+++ b/src/ray/raylet/scheduling/policy/scorer.cc
@@ -26,7 +26,7 @@ double LeastResourceScorer::Score(const ResourceRequest &required_resources,
   double node_score = 0.;
   for (auto &resource_id : required_resources.ResourceIds()) {
     const auto &request_resource = required_resources.Get(resource_id);
-    const auto &node_available_resource = node_resources.available.Get(resource_id);
+    auto node_available_resource = node_resources.available.Sum(resource_id);
     node_score += Calculate(request_resource, node_available_resource);
   }
   return node_score;

--- a/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
@@ -32,9 +32,21 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double available_gpu,
                                   double total_gpu) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu)
-      .Set(ResourceID::Memory(), available_memory)
-      .Set(ResourceID::GPU(), available_gpu);
+  resources.available.Set(ResourceID::CPU(), {FixedPoint(available_cpu)})
+      .Set(ResourceID::Memory(), {FixedPoint(available_memory)});
+  size_t num_gpu = static_cast<size_t>(total_gpu);
+  if (num_gpu > 0) {
+    std::vector<FixedPoint> gpu_instances;
+    double remaining_avail = available_gpu;
+    for (size_t i = 0; i < num_gpu; i++) {
+      double per_instance = std::min(remaining_avail, 1.0);
+      gpu_instances.push_back(FixedPoint(std::max(per_instance, 0.0)));
+      remaining_avail -= per_instance;
+    }
+    resources.available.Set(ResourceID::GPU(), std::move(gpu_instances));
+  } else if (available_gpu > 0) {
+    resources.available.Set(ResourceID::GPU(), {FixedPoint(available_gpu)});
+  }
   resources.total.Set(ResourceID::CPU(), total_cpu)
       .Set(ResourceID::Memory(), total_memory)
       .Set(ResourceID::GPU(), total_gpu);

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -577,6 +577,27 @@ TEST_F(SchedulingPolicyTest, StrictPackBundleSchedulingTest) {
   ASSERT_EQ(to_schedule.selected_nodes[0], local_node);
 }
 
+TEST_F(SchedulingPolicyTest, StrictPackFractionalUnitResourceTest) {
+  NodeResources fragmented;
+  fragmented.available.Set(ResourceID::CPU(), {FixedPoint(10)});
+  fragmented.available.Set(ResourceID::GPU(), {FixedPoint(0.7), FixedPoint(0.3)});
+  fragmented.total.Set(ResourceID::CPU(), 10);
+  fragmented.total.Set(ResourceID::GPU(), 2.0);
+  nodes.emplace(local_node, fragmented);
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"GPU", 0.5}}, false);
+  std::vector<const ResourceRequest *> two_bundles(2, &req);
+
+  auto op = SchedulingOptions::BundleStrictPack(scheduling::NodeID::Nil());
+  auto result = raylet_scheduling_policy::BundleStrictPackSchedulingPolicy(
+                    *cluster_resource_manager, [](auto) { return true; })
+                    .Schedule(two_bundles, op);
+  // bundle1 takes 0.5 from the 0.7 instance -> [0.2, 0.3].
+  // bundle2 needs 0.5 but max available is 0.3 -> rejected.
+  ASSERT_FALSE(result.status.IsSuccess());
+}
+
 TEST_F(SchedulingPolicyTest, StrictPackBundleLabelSelectorSuccessTest) {
   nodes.emplace(local_node, CreateNodeResourcesWithLabels(10, 10, {{"zone", "us-east"}}));
   nodes.emplace(remote_node,

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -30,9 +30,21 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double available_gpu,
                                   double total_gpu) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu)
-      .Set(ResourceID::Memory(), available_memory)
-      .Set(ResourceID::GPU(), available_gpu);
+  resources.available.Set(ResourceID::CPU(), {FixedPoint(available_cpu)})
+      .Set(ResourceID::Memory(), {FixedPoint(available_memory)});
+  size_t num_gpu = static_cast<size_t>(total_gpu);
+  if (num_gpu > 0) {
+    std::vector<FixedPoint> gpu_instances;
+    double remaining_avail = available_gpu;
+    for (size_t i = 0; i < num_gpu; i++) {
+      double per_instance = std::min(remaining_avail, 1.0);
+      gpu_instances.push_back(FixedPoint(std::max(per_instance, 0.0)));
+      remaining_avail -= per_instance;
+    }
+    resources.available.Set(ResourceID::GPU(), std::move(gpu_instances));
+  } else if (available_gpu > 0) {
+    resources.available.Set(ResourceID::GPU(), {FixedPoint(available_gpu)});
+  }
   resources.total.Set(ResourceID::CPU(), total_cpu)
       .Set(ResourceID::Memory(), total_memory)
       .Set(ResourceID::GPU(), total_gpu);
@@ -232,7 +244,7 @@ TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
   auto task_req2 = ResourceMapToResourceRequest({{"CPU", 1}}, false);
 
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), 2.0);
+  resources.available.Set(ResourceID::CPU(), {FixedPoint(2.0)});
   resources.total.Set(ResourceID::CPU(), 2.0);
   ASSERT_FALSE(resources.IsAvailable(task_req1));
   ASSERT_TRUE(resources.IsAvailable(task_req2));
@@ -241,17 +253,17 @@ TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
 TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {
   {
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0);
+    resources.available.Set(ResourceID::CPU(), {FixedPoint(1.0)});
     resources.total.Set(ResourceID::CPU(), 2.0);
     ASSERT_EQ(resources.CalculateCriticalResourceUtilization(), 0.5);
   }
   {
     // Basic test of max
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0)
-        .Set(ResourceID::Memory(), 0.25)
-        .Set(ResourceID::GPU(), 1)
-        .Set(ResourceID::ObjectStoreMemory(), 50);
+    resources.available.Set(ResourceID::CPU(), {FixedPoint(1.0)})
+        .Set(ResourceID::Memory(), {FixedPoint(0.25)})
+        .Set(ResourceID::GPU(), {FixedPoint(1), FixedPoint(0)})
+        .Set(ResourceID::ObjectStoreMemory(), {FixedPoint(50)});
     resources.total.Set(ResourceID::CPU(), 2.0)
         .Set(ResourceID::Memory(), 1)
         .Set(ResourceID::GPU(), 2)
@@ -262,10 +274,10 @@ TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {
   {
     // Skip GPU
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0)
-        .Set(ResourceID::Memory(), 0.25)
-        .Set(ResourceID::GPU(), 0)
-        .Set(ResourceID::ObjectStoreMemory(), 50);
+    resources.available.Set(ResourceID::CPU(), {FixedPoint(1.0)})
+        .Set(ResourceID::Memory(), {FixedPoint(0.25)})
+        .Set(ResourceID::GPU(), {FixedPoint(0), FixedPoint(0)})
+        .Set(ResourceID::ObjectStoreMemory(), {FixedPoint(50)});
     resources.total.Set(ResourceID::CPU(), 2.0)
         .Set(ResourceID::Memory(), 1)
         .Set(ResourceID::GPU(), 2)

--- a/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
@@ -2288,18 +2288,18 @@ TEST_F(ClusterLeaseManagerTest, NegativePlacementGroupCpuResources) {
 
   // ray.get() returns and worker1 acquires the CPU resource again
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_1_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_0_aaa")), -1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_1_aaa")), 1);
 
   auto worker3 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 7678);
   allocated_instances = std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
       {{"CPU_group_aaa", 1.}, {"CPU_group_1_aaa", 1.}}, allocated_instances));
   worker3->SetAllocatedInstances(allocated_instances);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_1_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_aaa")), -1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_0_aaa")), -1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_1_aaa")), 0);
 }
 
 TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources) {
@@ -2316,8 +2316,8 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   const NodeResources &node_resources =
       scheduler_->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(id_.Binary()));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 4);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::GPU()), 4);
 
   auto worker1 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
   auto worker2 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 5678);
@@ -2347,24 +2347,24 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   worker2->SetAllocatedInstances(allocated_instances);
 
   // Check that the resources are allocated successfully.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are released successfully.
   ASSERT_TRUE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
   ASSERT_TRUE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
 
   // Check that only cpu resources are released.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as blocked.
   worker1->MarkBlocked();
@@ -2373,24 +2373,24 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   ASSERT_FALSE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
   ASSERT_FALSE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
   // Check nothing will be changed.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are returned back to worker successfully.
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
 
   // Check that only cpu resources are returned back to the worker.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as unblocked.
   worker1->MarkUnblocked();
@@ -2398,12 +2398,12 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   ASSERT_FALSE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
   ASSERT_FALSE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
   // Check nothing will be changed.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 }
 
 TEST_F(ClusterLeaseManagerTest, TestSpillWaitingLeases) {

--- a/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
@@ -192,8 +192,7 @@ TEST_F(ClusterResourceManagerTest, SubtractAndAddNodeAvailableResources) {
   ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 1);
 }
 
-TEST_F(ClusterResourceManagerTest, GpuFragmentationBlocksScheduling) {
-  // Regression test for #52133/#54729: GPU fragmentation must block scheduling.
+TEST_F(ClusterResourceManagerTest, FractionalUnitResourceRejectsFragmentedNode) {
   NodeResources gpu_node;
   gpu_node.available.Set(ResourceID::GPU(), {FixedPoint(1.0), FixedPoint(1.0)});
   gpu_node.total.Set(ResourceID::GPU(), 2.0);
@@ -211,7 +210,6 @@ TEST_F(ClusterResourceManagerTest, GpuFragmentationBlocksScheduling) {
                                    /*requires_object_store_memory=*/false));
   ASSERT_TRUE(a2.has_value());
 
-  // [0.4, 0.4]: no single GPU has 0.5, so scheduling must fail.
   ASSERT_FALSE(manager->HasAvailableResources(
       gpu_id,
       ResourceMapToResourceRequest({{"GPU", 0.5}},

--- a/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
@@ -26,9 +26,10 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double total_custom_resource = 0,
                                   bool object_pulls_queued = false) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu);
+  resources.available.Set(ResourceID::CPU(), {FixedPoint(available_cpu)});
   resources.total.Set(ResourceID::CPU(), total_cpu);
-  resources.available.Set(scheduling::ResourceID("CUSTOM"), available_custom_resource);
+  resources.available.Set(scheduling::ResourceID("CUSTOM"),
+                          {FixedPoint(available_custom_resource)});
   resources.total.Set(scheduling::ResourceID("CUSTOM"), total_custom_resource);
   resources.object_pulls_queued = object_pulls_queued;
   return resources;
@@ -53,6 +54,9 @@ struct ClusterResourceManagerTest : public ::testing::Test {
                                                  /*total_custom*/ 1,
                                                  /*object_pulls_queued*/ true));
   }
+  void AddNode(scheduling::NodeID node_id, const NodeResources &resources) {
+    manager->AddOrUpdateNode(node_id, resources);
+  }
   scheduling::NodeID node0 = scheduling::NodeID(0);
   scheduling::NodeID node1 = scheduling::NodeID(1);
   scheduling::NodeID node2 = scheduling::NodeID(2);
@@ -64,7 +68,9 @@ TEST_F(ClusterResourceManagerTest, UpdateNode) {
   // Prepare a sync message with updated totals/available, labels and flags.
   syncer::ResourceViewSyncMessage payload;
   payload.mutable_resources_total()->insert({"CPU", 10.0});
-  payload.mutable_resources_available()->insert({"CPU", 5.0});
+  rpc::syncer::ResourceInstances cpu_instances;
+  cpu_instances.add_values(5.0);
+  (*payload.mutable_resources_available_instances())["CPU"] = cpu_instances;
   payload.mutable_labels()->insert({"zone", "us-east-1a"});
   payload.set_object_pulls_queued(true);
   payload.set_idle_duration_ms(42);
@@ -76,7 +82,7 @@ TEST_F(ClusterResourceManagerTest, UpdateNode) {
 
   const auto &node_resources = manager->GetNodeResources(node0);
   ASSERT_EQ(node_resources.total.Get(scheduling::ResourceID("CPU")), 10);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU")), 5);
+  ASSERT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU")), 5);
   ASSERT_EQ(node_resources.labels.at("zone"), "us-east-1a");
   ASSERT_TRUE(node_resources.object_pulls_queued);
   ASSERT_EQ(node_resources.idle_resource_duration_ms, 42);
@@ -115,10 +121,13 @@ TEST_F(ClusterResourceManagerTest, HasFeasibleResourcesTest) {
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false)));
-  manager->SubtractNodeAvailableResources(
-      node0,
-      ResourceMapToResourceRequest({{"CPU", 1}},
-                                   /*requires_object_store_memory=*/false));
+  ASSERT_TRUE(
+      manager
+          ->SubtractNodeAvailableResources(
+              node0,
+              ResourceMapToResourceRequest({{"CPU", 1}},
+                                           /*requires_object_store_memory=*/false))
+          .has_value());
   // node0 has no available CPU resource but it's still feasible.
   ASSERT_TRUE(manager->HasFeasibleResources(
       node0,
@@ -163,26 +172,63 @@ TEST_F(ClusterResourceManagerTest, HasAvailableResourcesTest) {
 
 TEST_F(ClusterResourceManagerTest, SubtractAndAddNodeAvailableResources) {
   const auto &node_resources = manager->GetNodeResources(node0);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 1);
 
-  manager->SubtractNodeAvailableResources(
+  auto allocation = manager->SubtractNodeAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 0);
-  // Subtract again and make sure the available == 0.
-  manager->SubtractNodeAvailableResources(
+  ASSERT_TRUE(allocation.has_value());
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 0);
+
+  auto allocation2 = manager->SubtractNodeAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 0);
+  ASSERT_FALSE(allocation2.has_value());
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 0);
 
-  // Add resources back.
-  manager->AddNodeAvailableResources(node0, ResourceSet({{"CPU", FixedPoint(1)}}));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
-  // Add again and make sure the available == 1 (<= total).
-  manager->AddNodeAvailableResources(node0, ResourceSet({{"CPU", FixedPoint(1)}}));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  manager->AddNodeAvailableResources(node0, allocation.value());
+  ASSERT_EQ(node_resources.available.Sum(ResourceID::CPU()), 1);
+}
+
+TEST_F(ClusterResourceManagerTest, GpuFragmentationBlocksScheduling) {
+  // Regression test for #52133/#54729: GPU fragmentation must block scheduling.
+  NodeResources gpu_node;
+  gpu_node.available.Set(ResourceID::GPU(), {FixedPoint(1.0), FixedPoint(1.0)});
+  gpu_node.total.Set(ResourceID::GPU(), 2.0);
+  scheduling::NodeID gpu_id = scheduling::NodeID(10);
+  AddNode(gpu_id, gpu_node);
+
+  auto a1 = manager->SubtractNodeAvailableResources(
+      gpu_id,
+      ResourceMapToResourceRequest({{"GPU", 0.6}},
+                                   /*requires_object_store_memory=*/false));
+  ASSERT_TRUE(a1.has_value());
+  auto a2 = manager->SubtractNodeAvailableResources(
+      gpu_id,
+      ResourceMapToResourceRequest({{"GPU", 0.6}},
+                                   /*requires_object_store_memory=*/false));
+  ASSERT_TRUE(a2.has_value());
+
+  // [0.4, 0.4]: no single GPU has 0.5, so scheduling must fail.
+  ASSERT_FALSE(manager->HasAvailableResources(
+      gpu_id,
+      ResourceMapToResourceRequest({{"GPU", 0.5}},
+                                   /*requires_object_store_memory=*/false),
+      /*ignore_object_store_memory_requirement=*/false));
+
+  ASSERT_TRUE(manager->HasAvailableResources(
+      gpu_id,
+      ResourceMapToResourceRequest({{"GPU", 0.4}},
+                                   /*requires_object_store_memory=*/false),
+      /*ignore_object_store_memory_requirement=*/false));
+
+  auto a3 = manager->SubtractNodeAvailableResources(
+      gpu_id,
+      ResourceMapToResourceRequest({{"GPU", 0.5}},
+                                   /*requires_object_store_memory=*/false));
+  ASSERT_FALSE(a3.has_value());
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
@@ -82,7 +82,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     auto resource_id = scheduling::ResourceID(resource_name);
 
     ASSERT_TRUE(node_resources.available.Has(resource_id));
-    ASSERT_EQ(node_resources.available.Get(resource_id).Double(), resource_value);
+    ASSERT_EQ(node_resources.available.Sum(resource_id).Double(), resource_value);
   }
 
   void TestResourceLeaks(SchedulingOptions scheduling_options) {

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
@@ -618,9 +618,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
         resource_scheduler.GetClusterResourceManager().GetNodeResources(node_id, &nr2));
 
     for (auto &resource_id : nr1.total.ExplicitResourceIds()) {
-      auto t = nr1.available.Get(resource_id) - resource_request.Get(resource_id);
+      auto t = nr1.available.Sum(resource_id) - resource_request.Get(resource_id);
       if (t < 0) t = 0;
-      ASSERT_EQ(nr2.available.Get(resource_id), t);
+      ASSERT_EQ(nr2.available.Sum(resource_id), t);
     }
   }
 }
@@ -1264,7 +1264,7 @@ TEST_F(ClusterResourceSchedulerTest,
       NodeResources nr;
       resource_scheduler.GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(0), &nr);
-      ASSERT_TRUE(nr.available.Get(ResourceID::GPU()) == 1.5);
+      ASSERT_TRUE(nr.available.Sum(ResourceID::GPU()) == 1.5);
     }
 
     {
@@ -1286,7 +1286,7 @@ TEST_F(ClusterResourceSchedulerTest,
       NodeResources nr;
       resource_scheduler.GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(0), &nr);
-      ASSERT_TRUE(nr.available.Get(ResourceID::GPU()) == 3.8);
+      ASSERT_TRUE(nr.available.Sum(ResourceID::GPU()) == 3.8);
     }
   }
 }

--- a/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
@@ -36,7 +36,7 @@ class LocalResourceManagerTest : public ::testing::Test {
       absl::flat_hash_map<ResourceID, double> resource_usage_map) {
     NodeResources resources;
     for (auto &[resource_id, total] : resource_usage_map) {
-      resources.available.Set(resource_id, total);
+      resources.available.Set(resource_id, {FixedPoint(total)});
       resources.total.Set(resource_id, total);
     }
     return resources;
@@ -407,7 +407,9 @@ TEST_F(LocalResourceManagerTest, CreateSyncMessageNegativeResourceAvailability) 
       ResourceID::CPU(), {2.0}, /*allow_going_negative=*/true);
 
   const auto &resource_view_sync_messge = GetSyncMessageForResourceReport();
-  ASSERT_EQ(resource_view_sync_messge.resources_available().at("CPU"), 0);
+  // resources_available is no longer sent; check per-instance data.
+  ASSERT_EQ(resource_view_sync_messge.resources_available_instances().at("CPU").values(0),
+            0);
 }
 
 TEST_F(LocalResourceManagerTest, PopulateResourceViewSyncMessage) {

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -709,7 +709,9 @@ TEST_F(NodeManagerTest, TestConsumeSyncMessage) {
   // Create and wrap a mock resource view sync message.
   syncer::ResourceViewSyncMessage payload;
   payload.mutable_resources_total()->insert({"CPU", kTestTotalCpuResource});
-  payload.mutable_resources_available()->insert({"CPU", kTestTotalCpuResource});
+  rpc::syncer::ResourceInstances cpu_instances;
+  cpu_instances.add_values(kTestTotalCpuResource);
+  (*payload.mutable_resources_available_instances())["CPU"] = cpu_instances;
   payload.mutable_labels()->insert({"label1", "value1"});
 
   std::string serialized;
@@ -730,7 +732,7 @@ TEST_F(NodeManagerTest, TestConsumeSyncMessage) {
   EXPECT_EQ(node_resources.labels.at("label1"), "value1");
   EXPECT_EQ(node_resources.total.Get(scheduling::ResourceID("CPU")).Double(),
             kTestTotalCpuResource);
-  EXPECT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU")).Double(),
+  EXPECT_EQ(node_resources.available.Sum(scheduling::ResourceID("CPU")).Double(),
             kTestTotalCpuResource);
 }
 

--- a/src/ray/raylet/tests/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/tests/placement_group_resource_manager_test.cc
@@ -110,7 +110,11 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
     auto local_node_resource =
         cluster_resource_scheduler_->GetClusterResourceManager().GetNodeResources(
             scheduling::NodeID("local"));
-    ASSERT_TRUE(local_node_resource == node_resources);
+    // Compare total resources and available resources (aggregated) instead of
+    // per-instance comparison, since the instance-level distribution may differ.
+    ASSERT_TRUE(local_node_resource.total == node_resources.total);
+    ASSERT_TRUE(local_node_resource.available.ToNodeResourceSet() ==
+                node_resources.available.ToNodeResourceSet());
   }
 
   // TODO(@clay4444): Remove this once we did the batch rpc request refactor!

--- a/src/ray/raylet/tests/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/tests/placement_group_resource_manager_test.cc
@@ -110,8 +110,6 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
     auto local_node_resource =
         cluster_resource_scheduler_->GetClusterResourceManager().GetNodeResources(
             scheduling::NodeID("local"));
-    // Compare total resources and available resources (aggregated) instead of
-    // per-instance comparison, since the instance-level distribution may differ.
     ASSERT_TRUE(local_node_resource.total == node_resources.total);
     ASSERT_TRUE(local_node_resource.available.ToNodeResourceSet() ==
                 node_resources.available.ToNodeResourceSet());


### PR DESCRIPTION

## Background & Problem

In short, the issue is essentially the different checking logic between scheduling (selects a node with "sufficient resources" from all nodes) and local allocation (allocates specific GPU instances on the selected node).

More specifically, for unit resources like GPU, the accurate resource usage representation needs to fully show the GPU topology. For example, `[0.6, 0.6]` represents a node with 2 GPUs, each using 0.6. So when you want to run a task with 0.8 GPUs, there is no sufficient room to fit even though the aggregate available is exactly 0.8. This is unlike CPU, where we already have lots of functionality in OS to slice CPU and can just represent it as a scalar value.

However, currently, at the scheduling level, Ray always uses scalars to represent resource usage. At the allocation level, for unit-instance resources like GPU, it uses a vector to represent GPU topology and do allocation. This inconsistency causes problems. Here is a minimal reproduction script to demonstrate (you could also see #52133 and #54729 for more details):

```python
import ray
from ray.cluster_utils import Cluster

cluster = Cluster()
head = cluster.add_node(num_cpus=4, num_gpus=2)
ray.init(address=cluster.address)
worker = cluster.add_node(num_cpus=4, num_gpus=2)
cluster.wait_for_nodes()
# Two nodes, each with 2 GPUs. Cluster total: 4 GPUs.

@ray.remote(num_gpus=0.6, num_cpus=0)
class Actor:
    def ready(self): return True

# Schedule 2 actors. Ray's hybrid scheduling prefers the local (head) node,
# so both land on head naturally, one per GPU.
# Head GPU state after: [0.4, 0.4], aggregate remaining = 0.8
# Worker still has [1.0, 1.0].
actors = [Actor.remote() for _ in range(2)]
ray.get([a.ready.remote() for a in actors])

# Schedule a 3rd actor (0.6 GPU). Worker can easily handle it, but:
# - Cluster scheduler sees head's aggregate 0.8 >= 0.6, picks head
# - Local allocator: no single GPU on head has >= 0.6, rejects
# - Spill back reruns scheduling, head aggregate still 0.8 >= 0.6, same result
# The actor is stuck pending even though the worker has 2 idle GPUs.
try:
    a3 = Actor.remote()
    ray.get(a3.ready.remote(), timeout=15)
    print("OK: scheduled on worker")
except ray.exceptions.GetTimeoutError:
    print("BUG: stuck pending despite worker having 2 free GPUs")
```

In this example, the actor gets stuck in an infinite spill back loop because the scheduler keeps picking the fragmented head node.

Actually this is also a big problem in k8s. The different logic between k8s scheduler and allocation logic in kubelet causes scheduling failures, and was an issue at my previous company since these two parts are managed by different teams. The solution is always trying to unify them and ensure no big perf regression.

If we think deeper, the root cause is that the logic in scheduling and allocation is different, and this causes a lot of problems. So this PR is essentially to make sure scheduling and allocation use the same computing logic.



## Solution

You might think this is simple! We could either:
- When local allocation fails, exclude the local node and reschedule to another node.
- Change unit resource to also use per-instance vectors, the same as allocation.

Approach 1 is not ideal. When multiple nodes are fragmented, it could cause a ping-pong infinite loop since each node passes the aggregate check but fails local allocation.

So let's focus on changing unit resources to also use per-instance vectors.

## Changes

And here I summarized the changes that needs to be aware:

1. **Unify all scheduling policies to use the same resource sufficiency check**

Ray has 8+ scheduling policies (Hybrid, Spread, NodeAffinity, PG bundle, etc.), each with its own resource checking logic. My previous PR #59278 consolidated all scheduling policies to use `NodeResources::IsAvailable()` as the single entry point. This is exactly where the root cause lies -- `IsAvailable()` uses aggregate scalars and cannot detect fragmentation.

2. **Make raylet scheduling aware of unit resource (GPU) topology**
- `NodeResources.available` changed from scalar to per-instance vector. This is the core structural change that lets the scheduler see each GPU instance's remaining capacity.
- Extracted `CanAllocate` so that scheduling checks and local allocation use the same per instance logic for each resource type. Given that syncer keeps the resource view eventually consistent, if the scheduler says a node has enough resources, the allocator is eventually guaranteed to agree, there is no infinite loop.


3. **Make RaySyncer carry unit resource (GPU) topology in sync messages**

4. **Make GCS (for PG scheduling) aware of unit resource (GPU) topology and maintain best-effort resource topology view in GCS cache**

This is the most complex part. Let me first briefly describe how PGs get scheduled:
- GCS maintains a separate resource view, periodically updated by RaySyncer.
- Acquire: GCS speculatively deducts resources (checks if the node has enough). If sufficient, sends Prepare RPC to that node and deducts resources in resource view.
- Commit: If the node replies success, creates PG formatted resources (GPU_group_xxx, etc.).
- Return: Several cases:
  - Restore resources when Prepare or Commit fails.
  - Restore resources when a PG is removed.
- Note: Between Acquire and Commit, the resource view may be overwritten by syncer.

So the difficulty is that we now need to maintain GPU topology (per-instance) in the GCS resource view as accurately as possible, making our best effort, so that we get better scheduling quality.

PG scheduling is very similar to k8s scheduling: we have centralized scheduling, optimistically estimate and speculatively deduct resources, then rely on k8s events (in Ray, this is RaySyncer) to correct any inaccurate resource estimates.

Following the same philosophy, we optimistically assume that the GCS resource view and each node's actual state are consistent. If there is any divergence, we rely on syncer to reconcile it.

Then things become simple. The changes for each PG operation:
- Acquire: When GCS speculatively deducts resources, we save the simulated allocation, e.g. GPU [1, 0].
- Commit: We optimistically assume the allocation computed during Acquire (e.g. [1, 0]) is correct, and use it to create PG formatted resources (GPU_group_xxx, etc.).
- Return on Prepare/Commit failure: Since we know how GCS deducted the resources, we should add them back the same way. So we naturally use the allocation saved during Acquire (e.g. [1, 0]) to restore. We know that RaySyncer may have overwritten the resource view in between, so the restoration may not be perfectly accurate. But this is the optimistic scheduling model.
- Return on PG removal: At this point we no longer have the Acquire allocation info -- it's gone after PG scheduling completes. So here, I chose to do nothing. We have no allocation info and can't add resources back. Recomputing is not viable because the resource view at the time of Acquire is different from now. I'd rather do nothing and let RaySyncer automatically correct the state.
- For GCS restart, since we lost all saved info, we just rely one ray syncer to corret resource view.


5. **Fix STRICT_PACK scheduling policy for per instance available**

STRICT_PACK puts all bundles on one node. Previously it aggregated all bundle
demands into one request. This aggregation is problematic: e.g. node with GPU=[0.7, 0.3], two bundles each need 0.5 GPU.
Aggregate 1.0 >= 1.0 passes (note: this aggregation happens inside the STRICT_PACK policy itself, not in the general scheduling checking logic), but actual per bundle allocation fails (no single instance has 0.5 free for the second bundle). Causes unnecessary reschedules.

We already have per instance checking logic from the previous changes. The extra work here is that for this policy, we try allocating each bundle one by one and rollback after, instead of aggregating all bundle demands into one request.

6. **Performance optimizations**

GCS rebuilds the per instance available from syncer every ~100ms. I added flags to the rebuild functions so that GCS skips building data that only the raylet needs. Based on my performance benchmark, this improves one sync from ~60ms to ~8ms under large instance vector(200) scenria.




## Performance Testing

Benchmarked 4 scheduling paths comparing branch vs master, focusing on two things:
- The impact of increasingly longer per instance vectors (8 to 200 elements) on scheduling.
- Whether the scheduling checking logic change itself introduces overhead.

Config: 200 PGs, 0.04 GPU/CPU per bundle, 5 nodes, STRICT_SPREAD.

| GPU per node | GPU (Branch/Master) | CPU control (Branch/Master) |
|----------|--------------------|-----------------------------|
| 8 | 1.01x | 0.98x |
| 16 | 1.04x | 1.00x |
| 32 | 1.13x | 0.98x |
| 64 | 1.18x | 0.94x |
| 128 | 1.24x | 0.99x |
| 200 | 1.44x | 1.04x |

No regression for all CPU cases. Since CPU is always scalar, this isolates that the scheduling checking logic change itself has no overhead.

No regression for actor in PG, regular actor, and regular task at all counts for both GPU and CPU.

For PG scheduling with GPU, the bottleneck is syncer data volume growing with longer per instance vectors, which saturates the GCS thread. Real world clusters (8 to 16 GPU) show no regression.


