### PR TITLE
[7/n] catalog ray serve env vars

### DIFF
--- a/doc/source/serve/model-multiplexing.md
+++ b/doc/source/serve/model-multiplexing.md
@@ -85,6 +85,20 @@ When using model composition, you can send requests from an upstream deployment 
 :end-before: __serve_model_composition_example_end__
 ```
 
+## Configuring model ID matching timeout
+
+When a request arrives with a `serve_multiplexed_model_id`, the Serve router attempts to match it to a replica that already has the model loaded. If no matching replica becomes available within the timeout, the request falls back to the default routing strategy and is sent to any available replica, which then loads the model on demand.
+
+You can configure this timeout using the `RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S` environment variable:
+
+```bash
+export RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S=2.0
+```
+
+**Default**: `1.0` second. To avoid thundering herd problems when many clients subscribe at the same time, the actual timeout is randomized between this value and `value * 2` (for example, 1.0–2.0 seconds by default).
+
+Increase this timeout if your models take a long time to load and you prefer to wait for a replica that already has the model loaded. Decrease it if you prefer faster fallback to any available replica.
+
 ## Using model multiplexing with batching
 
 You can combine model multiplexing with the `@serve.batch` decorator for efficient batched inference. When you use both features together, Ray Serve automatically splits batches by model ID to ensure each batch contains only requests for the same model. This prevents issues where a single batch would contain requests targeting different models.

--- a/doc/source/serve/model-multiplexing.md
+++ b/doc/source/serve/model-multiplexing.md
@@ -95,7 +95,7 @@ You can configure this timeout using the `RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHIN
 export RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S=2.0
 ```
 
-**Default**: `1.0` second. To avoid thundering herd problems when many clients subscribe at the same time, the actual timeout is randomized between this value and `value * 2` (for example, 1.0–2.0 seconds by default).
+**Default**: `1.0` second. To avoid thundering herd problems when many requests for the same unloaded model arrive concurrently, the actual timeout is randomized between this value and `value * 2` (for example, 1.0–2.0 seconds by default).
 
 Increase this timeout if your models take a long time to load and you prefer to wait for a replica that already has the model loaded. Decrease it if you prefer faster fallback to any available replica.
 

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -573,15 +573,21 @@ For accurate percentile calculations, configure bucket boundaries that closely m
 
 ### Metrics export interval
 
-By default, Ray Serve batches metric exports to reduce overhead. You can configure the export interval using the `RAY_SERVE_METRICS_EXPORT_INTERVAL_MS` environment variable:
+By default, Ray Serve batches its in-process metric updates (counters, gauges, histograms recorded by the router and replica) to reduce per-request overhead. You can configure how often Serve flushes these batched updates to the Ray metrics API using the `RAY_SERVE_METRICS_EXPORT_INTERVAL_MS` environment variable:
 
 ```bash
 export RAY_SERVE_METRICS_EXPORT_INTERVAL_MS=500
 ```
 
-**Default**: `100` milliseconds. Set to `0` to disable metric caching entirely and export all metrics eagerly. This interval applies to both the router and replica metric pipelines.
+**Default**: `100` milliseconds. Set to `0` to disable batching entirely and record every metric update eagerly. This interval applies to both the router and replica metric pipelines.
 
-Increasing this value reduces metric export overhead at the cost of less frequent metric updates. Decreasing it provides more up-to-date metrics but increases export frequency.
+Increasing this value reduces the overhead of recording metrics at the cost of less frequent updates. Decreasing it provides more up-to-date values but increases recording frequency.
+
+:::{note}
+`RAY_SERVE_METRICS_EXPORT_INTERVAL_MS` only controls Serve-side batching; it does **not** change how often Ray exports metrics to the Prometheus scrape endpoint. That is controlled separately by Ray Core's `metrics_report_interval_ms` system config (default `10000` ms), which determines how often each Ray process pushes its metrics to the metrics agent that Prometheus scrapes.
+
+The two settings compose: a Serve metric update is first buffered in the router/replica for up to `RAY_SERVE_METRICS_EXPORT_INTERVAL_MS`, then made available at the Prometheus endpoint on the next Ray Core export tick (`metrics_report_interval_ms`). Lowering only `RAY_SERVE_METRICS_EXPORT_INTERVAL_MS` without also lowering `metrics_report_interval_ms` does not make metrics appear in Prometheus any sooner. To change the Ray Core interval, pass it via system config when starting Ray, e.g. `ray start --head --system-config='{"metrics_report_interval_ms": 1000}'`.
+:::
 
 ### Request lifecycle and metrics
 

--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -571,6 +571,18 @@ Prometheus histograms aggregate data into predefined buckets, which can affect t
 For accurate percentile calculations, configure bucket boundaries that closely match your expected latency distribution. For example, if most requests complete in 10-100ms, use finer-grained buckets in that range.
 :::
 
+### Metrics export interval
+
+By default, Ray Serve batches metric exports to reduce overhead. You can configure the export interval using the `RAY_SERVE_METRICS_EXPORT_INTERVAL_MS` environment variable:
+
+```bash
+export RAY_SERVE_METRICS_EXPORT_INTERVAL_MS=500
+```
+
+**Default**: `100` milliseconds. Set to `0` to disable metric caching entirely and export all metrics eagerly. This interval applies to both the router and replica metric pipelines.
+
+Increasing this value reduces metric export overhead at the cost of less frequent metric updates. Decreasing it provides more up-to-date metrics but increases export frequency.
+
 ### Request lifecycle and metrics
 
 The following diagram shows where metrics are captured along the request path:

--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -694,7 +694,7 @@ These environment variables control fault tolerance-related behavior. Set them b
 
 **Default**: None (no timeout)
 
-Ray Serve persists deployment configurations and state in the [Global Control Store (GCS)](gcs-server) using its internal KV interface. Each read and write to the GCS KV store uses this timeout. By default, no timeout is set and these operations block until the GCS responds. If the GCS becomes unavailable (for example, during a head node restart), Serve operations that depend on the KV store — such as fetching or updating deployment configs — hang until the GCS recovers.
+Ray Serve persists deployment configurations and state in the Global Control Store (GCS) using its internal KV interface. Each read and write to the GCS KV store uses this timeout. By default, no timeout is set and these operations block until the GCS responds. If the GCS becomes unavailable (for example, during a head node restart), Serve operations that depend on the KV store — such as fetching or updating deployment configs — hang until the GCS recovers.
 
 Setting this value causes those operations to fail fast with a timeout error instead of blocking indefinitely, allowing Serve to detect GCS failures and trigger recovery sooner.
 

--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -686,5 +686,34 @@ Table:
 
 Note that the PID for the first ProxyActor has changed, indicating that it restarted.
 
+## Environment variables
+
+These environment variables control fault tolerance-related behavior. Set them before starting Ray.
+
+### `RAY_SERVE_KV_TIMEOUT_S`
+
+**Default**: None (no timeout)
+
+Ray Serve persists deployment configurations and state in the [Global Control Store (GCS)](gcs-server) using its internal KV interface. Each read and write to the GCS KV store uses this timeout. By default, no timeout is set and these operations block until the GCS responds. If the GCS becomes unavailable (for example, during a head node restart), Serve operations that depend on the KV store — such as fetching or updating deployment configs — hang until the GCS recovers.
+
+Setting this value causes those operations to fail fast with a timeout error instead of blocking indefinitely, allowing Serve to detect GCS failures and trigger recovery sooner.
+
+```bash
+export RAY_SERVE_KV_TIMEOUT_S=5
+```
+
+### `LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_LOWER_BOUND` / `LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_UPPER_BOUND`
+
+**Defaults**: `30` / `60` seconds
+
+Ray Serve uses a long-polling mechanism for replicas and proxies to receive configuration updates from the controller. Each long-poll request uses a random timeout between the lower and upper bounds to avoid thundering herd problems when many clients poll simultaneously.
+
+```bash
+export LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_LOWER_BOUND=10
+export LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_UPPER_BOUND=30
+```
+
+Decreasing these values makes replicas and proxies detect controller changes faster, which can speed up recovery after controller restarts. Increasing them reduces the frequency of long-poll requests to the controller.
+
 [KubeRay]: kuberay-index
 [external storage namespace]: kuberay-external-storage-namespace


### PR DESCRIPTION
## Summary
- Document 4 Ray Serve environment variables that were previously only defined in source code with no user-facing documentation
- Each env var is placed in the doc page most relevant to its purpose:
  - `RAY_SERVE_MULTIPLEXED_MODEL_ID_MATCHING_TIMEOUT_S` → `model-multiplexing.md`
  - `RAY_SERVE_METRICS_EXPORT_INTERVAL_MS` → `monitoring.md`
  - `RAY_SERVE_KV_TIMEOUT_S` → `fault-tolerance.md`
  - `LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_LOWER_BOUND` / `UPPER_BOUND` → `fault-tolerance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)