### PR TITLE
[data][ActorPool 7/n] CoreActorPoolAdapter and Ray Data integration

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -223,6 +223,20 @@ py_test(
 )
 
 py_test(
+    name = "test_actor_pool_reconstruction",
+    size = "medium",
+    srcs = ["tests/test_actor_pool_reconstruction.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_arrow_serialization",
     size = "small",
     srcs = ["tests/test_arrow_serialization.py"],

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -64,10 +64,25 @@ from ray.data.context import (
 from ray.types import ObjectRef
 from ray.util.common import INT32_MAX
 
+# Lazy import to avoid circular dependencies
+_CoreActorPoolAdapter = None
+
 logger = logging.getLogger(__name__)
 
 # Type alias for the logical identifier of an actor (used in labels and actor-to-id maps).
 LogicalActorId = str
+
+
+def _get_core_actor_pool_adapter():
+    """Lazy import of CoreActorPoolAdapter to avoid circular imports."""
+    global _CoreActorPoolAdapter
+    if _CoreActorPoolAdapter is None:
+        from ray.data._internal.execution.operators.core_actor_pool_adapter import (
+            CoreActorPoolAdapter,
+        )
+
+        _CoreActorPoolAdapter = CoreActorPoolAdapter
+    return _CoreActorPoolAdapter
 
 
 class ActorPoolMapOperator(MapOperator):
@@ -166,6 +181,13 @@ class ActorPoolMapOperator(MapOperator):
         # class per operator with a unique name.
         self._map_worker_cls = type(map_worker_cls_name, (_MapWorker,), {})
 
+        # Use new Core Actor Pool if feature flag is enabled.
+        # Fall back to legacy path when ray_remote_args_fn is set, because the
+        # Core pool creates actors with static options baked in at construction
+        # time and has no hook for per-actor dynamic arg generation.
+        self._use_core_pool = (
+            data_context.use_core_actor_pool and not self._ray_remote_args_fn
+        )
         self._actor_pool = self._create_actor_pool(compute_strategy)
         # A queue of bundles awaiting dispatch to actors.
         self._bundle_queue = create_bundle_queue()
@@ -181,6 +203,33 @@ class ActorPoolMapOperator(MapOperator):
         self, compute_strategy: ActorPoolStrategy
     ) -> "AutoscalingActorPool":
         config = self._create_actor_pool_config(compute_strategy)
+        if self._use_core_pool:
+            Adapter = _get_core_actor_pool_adapter()
+            pool = Adapter(
+                actor_cls=self._map_worker_cls,
+                per_actor_resource_usage=config.per_actor_resource_usage,
+                min_size=config.min_size,
+                max_size=config.max_size,
+                initial_size=config.initial_size,
+                max_actor_concurrency=config.max_actor_concurrency,
+                max_tasks_in_flight_per_actor=config.max_tasks_in_flight_per_actor,
+                actor_kwargs={
+                    "ctx": self.data_context,
+                    "src_fn_name": self.name,
+                    "map_transformer": self._map_transformer,
+                    "actor_location_tracker": get_or_create_actor_location_tracker(),
+                },
+                actor_options=self._ray_remote_args,
+                operator_id=self.id,
+                _enable_actor_pool_on_exit_hook=getattr(
+                    self.data_context, "_enable_actor_pool_on_exit_hook", False
+                ),
+            )
+            logger.debug(
+                f"Using CoreActorPoolAdapter for operator {self.name} "
+                f"(min={config.min_size}, max={config.max_size})"
+            )
+            return pool
         return _ActorPool(
             create_actor_fn=self._start_actor,
             config=config,
@@ -196,7 +245,7 @@ class ActorPoolMapOperator(MapOperator):
             memory=self._ray_remote_args.get("memory"),
         )
         max_actor_concurrency = self._ray_remote_args.get("max_concurrency", 1)
-        config = AutoscalingActorConfig(
+        return AutoscalingActorConfig(
             min_size=compute_strategy.min_size,
             max_size=compute_strategy.max_size,
             initial_size=compute_strategy.initial_size,
@@ -207,7 +256,6 @@ class ActorPoolMapOperator(MapOperator):
             max_actor_concurrency=max_actor_concurrency,
             per_actor_resource_usage=per_actor_resource_usage,
         )
-        return config
 
     @staticmethod
     def _apply_default_actor_task_remote_args(
@@ -264,6 +312,11 @@ class ActorPoolMapOperator(MapOperator):
             )
         )
 
+        # For CoreActorPoolAdapter, register callbacks for pending refs
+        # to transition actors from pending to running when ready
+        if self._use_core_pool:
+            self._register_pending_actor_callbacks()
+
         # If `wait_for_min_actors_s` is specified and is positive, then
         # Actor Pool will block until min number of actors is provisioned.
         #
@@ -297,6 +350,8 @@ class ActorPoolMapOperator(MapOperator):
             should be able to launch a task.
 
         """
+        if getattr(self._actor_pool, "supports_pool_submission", False):
+            return self._actor_pool.num_free_task_slots() > 0
         return self._actor_pool.can_schedule_task()
 
     def _start_actor(
@@ -342,6 +397,27 @@ class ActorPoolMapOperator(MapOperator):
         )
         return actor, res_ref
 
+    def _register_pending_actor_callbacks(self):
+        """Register callbacks for pending actors in CoreActorPoolAdapter.
+
+        When using the class-based adapter, actors are created by the adapter's
+        internal ActorPool. We need to register callbacks so that when actors
+        become ready (get_location returns), we transition them from pending
+        to running state.
+        """
+        pending_refs = self._actor_pool.get_pending_actor_refs()
+        for res_ref in pending_refs:
+
+            def _task_done_callback(ref):
+                has_actor = self._actor_pool.pending_to_running(ref)
+                if not has_actor:
+                    return
+
+            self._submit_metadata_task(
+                res_ref,
+                lambda ref=res_ref: _task_done_callback(ref),
+            )
+
     def _try_schedule_task(self, bundle: RefBundle, strict: bool):
         # Notify first input for deferred initialization (e.g., Iceberg schema evolution).
         self._notify_first_input(bundle)
@@ -366,6 +442,9 @@ class ActorPoolMapOperator(MapOperator):
 
     def _try_schedule_tasks_internal(self) -> int:
         """Try to dispatch tasks from the internal queue. Returns the # of tasks submitted"""
+
+        if getattr(self._actor_pool, "supports_pool_submission", False):
+            return self._try_schedule_via_pool()
 
         num_submitted_tasks = 0
         while self._bundle_queue.has_next():
@@ -426,6 +505,46 @@ class ActorPoolMapOperator(MapOperator):
                 self._locality_misses += 1
 
         return num_submitted_tasks
+
+    def _try_schedule_via_pool(self) -> int:
+        """Submit tasks through the C++ ActorPoolManager.
+
+        Actor selection, load balancing, and fault tolerance are handled by C++.
+        """
+        num_submitted = 0
+        while self._bundle_queue and self._actor_pool.num_free_task_slots() > 0:
+            bundle = self._bundle_queue.get_next()
+            self._metrics.on_input_dequeued(bundle, input_index=0)
+            input_blocks = [block for block, _ in bundle.blocks]
+
+            ctx = TaskContext(
+                task_idx=self._next_data_task_idx,
+                op_name=self.name,
+                target_max_block_size_override=self.target_max_block_size_override,
+            )
+
+            gen, _ = self._actor_pool.submit_task(
+                method_name="submit",
+                args=(
+                    self.data_context,
+                    ctx,
+                    *input_blocks,
+                ),
+                kwargs=dict(
+                    slices=bundle.slices,
+                    **self.get_map_task_kwargs(),
+                ),
+                num_returns="streaming",
+                remote_args=self._ray_actor_task_remote_args,
+            )
+
+            def _task_done_callback():
+                self._actor_pool.on_task_completed()
+
+            self._submit_data_task(gen, bundle, _task_done_callback)
+            num_submitted += 1
+
+        return num_submitted
 
     def _refresh_actor_cls(self):
         """When `self._ray_remote_args_fn` is specified, this method should
@@ -632,6 +751,9 @@ class ActorPoolMapOperator(MapOperator):
 class _MapWorker:
     """An actor worker for MapOperator."""
 
+    # Label key for logical actor ID (shared with ActorPool and _ActorPool)
+    _LOGICAL_ACTOR_ID_LABEL_KEY = "__ray_data_logical_actor_id"
+
     def __init__(
         self,
         ctx: DataContext,
@@ -647,10 +769,16 @@ class _MapWorker:
         DataContext._set_current(ctx)
         # Initialize state for this actor with retry logic for UDF init failures.
         self._init_udf_with_retries(ctx)
-        self._logical_actor_id = logical_actor_id
-        actor_location_tracker.update_actor_location.remote(
-            self._logical_actor_id, ray.get_runtime_context().get_node_id()
-        )
+
+        # Logical actor ID is either passed explicitly (callback-based path)
+        # or injected via actor_kwargs by ActorPool (class-based path)
+        # If neither, use empty string as a fallback
+        self._logical_actor_id = logical_actor_id or ""
+
+        if actor_location_tracker is not None:
+            actor_location_tracker.update_actor_location.remote(
+                self._logical_actor_id, ray.get_runtime_context().get_node_id()
+            )
 
     def _init_udf_with_retries(self, ctx: DataContext) -> None:
         """Initialize the UDF with retry logic for transient failures."""

--- a/python/ray/data/_internal/execution/operators/core_actor_pool_adapter.py
+++ b/python/ray/data/_internal/execution/operators/core_actor_pool_adapter.py
@@ -1,0 +1,615 @@
+"""Adapter to integrate ray.experimental.actor_pool.ActorPool with Ray Data.
+
+This module provides CoreActorPoolAdapter, which implements the
+AutoscalingActorPool interface expected by Ray Data's ActorPoolMapOperator,
+using the Core-backed ActorPool with actor_cls directly.
+
+The class-based adapter enables Ray Data to benefit from:
+- Core-backed pool management
+- Cross-actor retry on failures and reconstruction
+- Unified ActorPool API across Ray
+
+Note: This class is NOT thread-safe. All methods should be called from the
+same thread (the operator's execution thread).
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Type
+
+import ray
+from ray.actor import ActorHandle
+from ray.core.generated import gcs_pb2
+from ray.data._internal.actor_autoscaler import AutoscalingActorPool
+from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import (
+    ActorPoolInfo,
+    ActorPoolScalingRequest,
+)
+from ray.data._internal.execution.interfaces import ExecutionResources
+from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
+from ray.types import ObjectRef
+
+logger = logging.getLogger(__name__)
+
+# Cache protobuf enum values at module level to avoid repeated descriptor lookups.
+_ACTOR_STATE_DEAD = gcs_pb2.ActorTableData.ActorState.DEAD
+_ACTOR_STATE_ALIVE = gcs_pb2.ActorTableData.ActorState.ALIVE
+
+
+@dataclass
+class _ActorState:
+    """Per-actor state for Ray Data compatibility."""
+
+    num_tasks_in_flight: int
+    actor_location: str
+    is_restarting: bool
+
+
+class CoreActorPoolAdapter(AutoscalingActorPool):
+    """Core ActorPool adapter using ray.experimental.actor_pool.ActorPool.
+
+    This adapter implements the AutoscalingActorPool interface expected by
+    ActorPoolMapOperator, using the new C++-backed ActorPool.
+
+    Key features:
+    - Creates ActorPool internally which handles actor lifecycle
+    - ActorPool generates logical IDs and sets labels automatically
+    - Maintains Python-side state tracking for Ray Data compatibility
+    """
+
+    _ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S = 10
+    _ACTOR_POOL_GRACEFUL_SHUTDOWN_TIMEOUT_S = 30
+    _ACTOR_STARTUP_TIMEOUT_S = 30
+    _LOGICAL_ACTOR_ID_LABEL_KEY = "__ray_data_logical_actor_id"
+
+    def __init__(
+        self,
+        actor_cls: Type,
+        per_actor_resource_usage: ExecutionResources,
+        *,
+        min_size: int,
+        max_size: int,
+        initial_size: int,
+        max_actor_concurrency: int,
+        max_tasks_in_flight_per_actor: int,
+        actor_kwargs: Optional[Dict[str, Any]] = None,
+        actor_options: Optional[Dict[str, Any]] = None,
+        operator_id: Optional[str] = None,
+        _enable_actor_pool_on_exit_hook: bool = False,
+    ):
+        """Initialize the adapter.
+
+        Args:
+            actor_cls: The actor class (e.g., _MapWorker) to instantiate.
+            per_actor_resource_usage: Resource usage per actor.
+            min_size: Minimum pool size.
+            max_size: Maximum pool size.
+            initial_size: Initial pool size.
+            max_actor_concurrency: Max concurrent tasks per actor.
+            max_tasks_in_flight_per_actor: Max tasks that can be queued per actor.
+            actor_kwargs: Keyword arguments for actor constructor.
+            actor_options: Options for ray.remote() (num_cpus, num_gpus, etc.).
+            operator_id: Operator ID for labeling actors.
+            _enable_actor_pool_on_exit_hook: Enable actor cleanup hook.
+        """
+        from ray.experimental.actor_pool import ActorPool
+
+        self._min_size = min_size
+        self._max_size = max_size
+        self._initial_size = initial_size
+        self._max_actor_concurrency = max_actor_concurrency
+        self._max_tasks_in_flight = max_tasks_in_flight_per_actor
+        self._per_actor_resource_usage = per_actor_resource_usage
+        self._enable_actor_pool_on_exit_hook = _enable_actor_pool_on_exit_hook
+
+        if self._min_size < 1:
+            raise ValueError(f"min_size must be >= 1, got {self._min_size}")
+        if self._max_size < self._min_size:
+            raise ValueError(
+                f"max_size ({self._max_size}) must be >= min_size ({self._min_size})"
+            )
+        if self._initial_size > self._max_size:
+            raise ValueError(
+                f"initial_size ({self._initial_size}) must be <= max_size ({self._max_size})"
+            )
+        if self._initial_size < self._min_size:
+            raise ValueError(
+                f"initial_size ({self._initial_size}) must be >= min_size ({self._min_size})"
+            )
+        if self._max_tasks_in_flight < 1:
+            raise ValueError(
+                f"max_tasks_in_flight must be >= 1, got {self._max_tasks_in_flight}"
+            )
+
+        # Build static labels for operator tracking
+        static_labels = {}
+        if operator_id:
+            static_labels["__ray_data_operator_id"] = operator_id
+
+        # Create the ActorPool (this creates initial_size=0 actors initially)
+        # We set initial_size=0 because Ray Data's ActorPoolMapOperator calls
+        # scale() explicitly after start() to create actors
+        self._pool = ActorPool(
+            actor_cls=actor_cls,
+            min_size=min_size,
+            max_size=max_size,
+            initial_size=0,  # Don't create actors yet
+            actor_kwargs=actor_kwargs or {},
+            actor_options=actor_options or {},
+            max_tasks_in_flight_per_actor=self._max_tasks_in_flight,
+            logical_id_label_key=self._LOGICAL_ACTOR_ID_LABEL_KEY,
+            logical_id_kwarg_name="logical_actor_id",
+            static_labels=static_labels,
+        )
+
+        # Scale down debouncing
+        self._last_upscaled_at: Optional[float] = None
+        self._last_downscaling_debounce_warning_ts: Optional[float] = None
+
+        # Actor tracking (Python-side for Ray Data compatibility)
+        self._running_actors: Dict[ActorHandle, _ActorState] = {}
+        self._pending_actors: Dict[ObjectRef, ActorHandle] = {}
+
+        # Cached counts
+        self._num_restarting_actors: int = 0
+
+        # Cache worker reference for C++ pool queries
+        self._worker = None
+
+    # =========================================================================
+    # AutoscalingActorPool Interface Implementation
+    # =========================================================================
+
+    def min_size(self) -> int:
+        return self._min_size
+
+    def max_size(self) -> int:
+        return self._max_size
+
+    def current_size(self) -> int:
+        return self.num_pending_actors() + self.num_running_actors()
+
+    def num_running_actors(self) -> int:
+        return len(self._running_actors)
+
+    def num_active_actors(self) -> int:
+        return self._get_worker().core_worker.get_num_active_actors(self._pool.pool_id)
+
+    def num_pending_actors(self) -> int:
+        return len(self._pending_actors)
+
+    def num_restarting_actors(self) -> int:
+        return self._num_restarting_actors
+
+    def num_alive_actors(self) -> int:
+        return len(self._running_actors) - self._num_restarting_actors
+
+    def max_tasks_in_flight_per_actor(self) -> int:
+        return self._max_tasks_in_flight
+
+    def max_actor_concurrency(self) -> int:
+        return self._max_actor_concurrency
+
+    def num_tasks_in_flight(self) -> int:
+        return self._get_worker().core_worker.get_occupied_task_slots(
+            self._pool.pool_id
+        )
+
+    def initial_size(self) -> int:
+        return self._initial_size
+
+    def per_actor_resource_usage(self) -> ExecutionResources:
+        return self._per_actor_resource_usage
+
+    def get_pool_util(self) -> float:
+        if self.num_running_actors() == 0:
+            return 0.0
+        return self.num_tasks_in_flight() / (
+            self._max_actor_concurrency * self.num_running_actors()
+        )
+
+    def num_free_task_slots(self) -> int:
+        """Number of free task slots across all running actors."""
+        occupied = self._get_worker().core_worker.get_occupied_task_slots(
+            self._pool.pool_id
+        )
+        capacity = self._max_tasks_in_flight * self.num_running_actors()
+        return max(0, capacity - occupied)
+
+    def scale(self, req: ActorPoolScalingRequest) -> Optional[int]:
+        """Apply scaling request."""
+        if not self._can_apply(req):
+            return 0
+
+        if req.delta > 0:
+            target_num_actors = req.delta
+            logger.debug(
+                f"Scaling up actor pool by {target_num_actors} "
+                f"(reason={req.reason}, {self.get_actor_info()})"
+            )
+
+            self._pool.scale(target_num_actors)
+
+            # Get the newly created actors and track them as pending
+            # ActorPool creates actors synchronously, but we need to track
+            # their readiness via get_location.remote()
+            for actor in self._pool.actors[-target_num_actors:]:
+                ready_ref = actor.get_location.remote()
+                self._pending_actors[ready_ref] = actor
+
+            self._last_upscaled_at = time.time()
+            return target_num_actors
+
+        elif req.delta < 0:
+            num_released = 0
+            target_num_actors = abs(req.delta)
+
+            for _ in range(target_num_actors):
+                if self._remove_inactive_actor():
+                    num_released += 1
+
+            if num_released > 0:
+                logger.debug(
+                    f"Scaled down actor pool by {num_released} "
+                    f"(reason={req.reason}; {self.get_actor_info()})"
+                )
+
+            return -num_released
+
+        return None
+
+    def _can_apply(self, config: ActorPoolScalingRequest) -> bool:
+        """Check if scaling request can be applied (with debouncing)."""
+        if config.delta < 0:
+            if (
+                not config.force
+                and self._last_upscaled_at is not None
+                and (
+                    time.time()
+                    <= self._last_upscaled_at
+                    + self._ACTOR_POOL_SCALE_DOWN_DEBOUNCE_PERIOD_S
+                )
+            ):
+                if self._last_upscaled_at != self._last_downscaling_debounce_warning_ts:
+                    logger.debug(
+                        f"Ignoring scaling down request (request={config}; "
+                        f"reason=debounced from scaling up at {self._last_upscaled_at})"
+                    )
+                    self._last_downscaling_debounce_warning_ts = self._last_upscaled_at
+                return False
+        return True
+
+    # =========================================================================
+    # Actor Lifecycle Management
+    # =========================================================================
+
+    def pending_to_running(self, ready_ref: ObjectRef) -> bool:
+        """Move actor from pending to running state.
+
+        Args:
+            ready_ref: The ObjectRef that signals the actor is ready.
+
+        Returns:
+            True if actor was moved, False if it was already removed.
+        """
+        if ready_ref not in self._pending_actors:
+            return False
+
+        actor = self._pending_actors.pop(ready_ref)
+        # Use ray.wait() with timeout to avoid blocking indefinitely
+        # if the actor crashes during startup.
+        ready, _ = ray.wait([ready_ref], timeout=self._ACTOR_STARTUP_TIMEOUT_S)
+        if not ready:
+            logger.warning(
+                "Timed out waiting for actor location after %ds. "
+                "Returning actor to pending state.",
+                self._ACTOR_STARTUP_TIMEOUT_S,
+            )
+            self._pending_actors[ready_ref] = actor
+            return False
+
+        actor_location = ray.get(ready[0])
+
+        self._running_actors[actor] = _ActorState(
+            num_tasks_in_flight=0,
+            actor_location=actor_location,
+            is_restarting=False,
+        )
+
+        # Update the C++ pool with the actor's node location for
+        # locality-aware scheduling. The actor was already added during
+        # scale() without a location; this call updates it in-place.
+        if actor_location:
+            from ray._raylet import NodeID
+
+            node_id = NodeID.from_hex(actor_location)
+            import ray._private.worker as worker_module
+
+            worker = worker_module.global_worker
+            worker.core_worker.add_actor_to_pool(
+                self._pool.pool_id,
+                actor._actor_id,
+                location=node_id,
+            )
+
+        return True
+
+    def running_actors(self) -> Dict[ActorHandle, _ActorState]:
+        """Get running actors with their state."""
+        return self._running_actors
+
+    def get_pending_actor_refs(self) -> List[ObjectRef]:
+        """Get refs for pending actors."""
+        return list(self._pending_actors.keys())
+
+    def get_running_actor_refs(self) -> List[ActorHandle]:
+        """Get refs for running actors."""
+        return list(self._running_actors.keys())
+
+    def get_logical_ids(self) -> List[str]:
+        """Get logical IDs for all actors."""
+        return self._pool.get_logical_ids()
+
+    def get_logical_id_label_key(self) -> str:
+        """Get the label key for logical actor ID."""
+        return self._LOGICAL_ACTOR_ID_LABEL_KEY
+
+    # =========================================================================
+    # C++ Pool Task Submission
+    # =========================================================================
+
+    def submit_task(
+        self,
+        method_name: str,
+        args: tuple,
+        kwargs: dict,
+        num_returns,
+        remote_args: Optional[Dict[str, Any]] = None,
+    ):
+        """Submit a task via the C++ ActorPoolManager.
+
+        The C++ pool handles actor selection, load balancing, and fault tolerance.
+        Returns (ObjectRefGenerator or ObjectRef list, None) — the actor is unknown
+        to Python since C++ chose it.
+        """
+        import ray._private.worker as worker_module
+        from ray._common.signature import flatten_args
+        from ray._raylet import STREAMING_GENERATOR_RETURN, ObjectRefGenerator
+
+        worker = worker_module.global_worker
+        remote_args = remote_args or {}
+
+        if not self._running_actors:
+            raise RuntimeError(
+                "Cannot submit task to C++ ActorPool: no running actors. "
+                "Ensure actors have been scaled up and moved to running state "
+                "before submitting tasks."
+            )
+
+        actor = next(iter(self._running_actors))
+        language = actor._ray_actor_language
+        fn_signature = actor._ray_method_signatures[method_name]
+        fn_descriptor = actor._ray_function_descriptor[method_name]
+        list_args = flatten_args(fn_signature, args, kwargs)
+
+        actual_num_returns = num_returns
+        if num_returns == "streaming":
+            actual_num_returns = STREAMING_GENERATOR_RETURN
+        elif num_returns == "dynamic":
+            actual_num_returns = -1
+
+        num_cpus = remote_args.get("num_cpus", 0)
+        concurrency_group = remote_args.get("concurrency_group_name", b"")
+        if isinstance(concurrency_group, str):
+            concurrency_group = concurrency_group.encode()
+        backpressure = remote_args.get("_generator_backpressure_num_objects", -1)
+
+        object_refs = worker.core_worker.submit_task_to_pool(
+            self._pool.pool_id,
+            language,
+            fn_descriptor,
+            list_args,
+            name=fn_descriptor.function_name.encode(),
+            num_returns=actual_num_returns,
+            num_method_cpus=num_cpus,
+            concurrency_group_name=concurrency_group,
+            generator_backpressure_num_objects=backpressure,
+            enable_task_events=True,
+        )
+        if not object_refs:
+            raise RuntimeError(
+                "C++ ActorPoolManager returned no refs — pool has no actors "
+                "with available capacity. This indicates a mismatch between "
+                "Python num_free_task_slots() and C++ max_tasks_in_flight_per_actor."
+            )
+
+        # C++ tracks in-flight counts authoritatively via SubmitToActor().
+        # No Python-side increment needed.
+
+        if actual_num_returns == STREAMING_GENERATOR_RETURN:
+            return ObjectRefGenerator(object_refs[0], worker), None
+
+        if len(object_refs) == 1:
+            return object_refs[0], None
+        return object_refs, None
+
+    @property
+    def supports_pool_submission(self) -> bool:
+        return True
+
+    # =========================================================================
+    # Task Tracking (Python-side for Ray Data compatibility)
+    # =========================================================================
+
+    def on_task_submitted(self, actor: ActorHandle):
+        """Called when a task is submitted to an actor (legacy direct-submission path).
+
+        For pool-submitted tasks, C++ tracks counts authoritatively.
+        This method only updates the per-actor Python state for the legacy path.
+        """
+        if actor not in self._running_actors:
+            return
+        state = self._running_actors[actor]
+        state.num_tasks_in_flight += 1
+
+    def on_task_completed(self, actor: Optional[ActorHandle] = None):
+        """Called when a task completes.
+
+        Args:
+            actor: The actor that ran the task. None for pool-submitted tasks
+                   where C++ selected the actor.
+        """
+        # For pool-submitted tasks (actor=None), C++ handles decrement
+        # via OnTaskSucceeded(). Only update per-actor Python state for
+        # the legacy direct-submission path.
+        if actor is not None and actor in self._running_actors:
+            state = self._running_actors[actor]
+            if state.num_tasks_in_flight > 0:
+                state.num_tasks_in_flight -= 1
+
+    def select_actors(
+        self,
+        bundle: Optional[RefBundle] = None,
+        actor_locality_enabled: bool = False,
+    ) -> Optional[ActorHandle]:
+        if self.num_free_task_slots() <= 0:
+            return None
+        for actor, state in self._running_actors.items():
+            if not state.is_restarting:
+                return actor
+        return None
+
+    def get_actor_location(self, actor: ActorHandle) -> str:
+        if actor in self._running_actors:
+            return self._running_actors[actor].actor_location
+        return ""
+
+    def refresh_actor_state(self):
+        """Refresh actor states from GCS (alive vs restarting)."""
+        for actor in self.get_running_actor_refs():
+            actor_state = actor._get_local_state()
+            if actor_state in (None, _ACTOR_STATE_DEAD):
+                continue
+            elif actor_state != _ACTOR_STATE_ALIVE:
+                self.update_running_actor_state(actor, is_restarting=True)
+            else:
+                self.update_running_actor_state(actor, is_restarting=False)
+
+    def update_running_actor_state(self, actor: ActorHandle, is_restarting: bool):
+        """Update actor's restarting state."""
+        if actor not in self._running_actors:
+            return
+        if self._running_actors[actor].is_restarting == is_restarting:
+            return
+
+        self._running_actors[actor].is_restarting = is_restarting
+        if is_restarting:
+            self._num_restarting_actors += 1
+        else:
+            self._num_restarting_actors -= 1
+
+    # =========================================================================
+    # Pool Management
+    # =========================================================================
+
+    def _get_worker(self):
+        """Get cached worker reference."""
+        if self._worker is None:
+            import ray._private.worker as worker_module
+
+            self._worker = worker_module.global_worker
+        return self._worker
+
+    def num_idle_actors(self) -> int:
+        """Number of idle actors (no tasks in flight)."""
+        return len(self._running_actors) - self.num_active_actors()
+
+    def _remove_inactive_actor(self) -> bool:
+        """Remove a pending or idle actor."""
+        released = self._try_remove_pending_actor()
+        if not released:
+            released = self._try_remove_idle_actor()
+        return released
+
+    def _try_remove_pending_actor(self) -> bool:
+        """Try to remove a pending actor."""
+        if self._pending_actors:
+            ready_ref = next(iter(self._pending_actors.keys()))
+            actor = self._pending_actors.pop(ready_ref)
+            self._pool.remove_actor(actor, kill=True)
+            return True
+        return False
+
+    def _try_remove_idle_actor(self) -> bool:
+        """Try to remove an idle running actor."""
+        for actor, state in list(self._running_actors.items()):
+            if state.num_tasks_in_flight == 0:
+                self._release_running_actor(actor)
+                return True
+        return False
+
+    def shutdown(self, force: bool = False):
+        """Shutdown the pool."""
+        self._release_pending_actors(force=force)
+        self._release_running_actors(force=force)
+        # Shutdown the underlying ActorPool
+        self._pool.shutdown(force=force)
+
+    def _release_pending_actors(self, force: bool):
+        """Release all pending actors."""
+        self._pending_actors.clear()
+
+    def _release_running_actors(self, force: bool):
+        """Release all running actors."""
+        running = list(self._running_actors.keys())
+        on_exit_refs = []
+
+        for actor in running:
+            ref = self._release_running_actor(actor)
+            if ref:
+                on_exit_refs.append(ref)
+
+        if on_exit_refs:
+            ray.wait(on_exit_refs, timeout=self._ACTOR_POOL_GRACEFUL_SHUTDOWN_TIMEOUT_S)
+
+        # Kill actors after on_exit hooks have completed/timed out.
+        # _release_running_actor calls remove_actor(kill=False), so
+        # _pool.shutdown() won't find them — we must kill them here.
+        for actor in running:
+            try:
+                ray.kill(actor)
+            except Exception:
+                pass
+
+    def _release_running_actor(self, actor: ActorHandle) -> Optional[ObjectRef]:
+        """Release a single running actor."""
+        if actor not in self._running_actors:
+            return None
+
+        actor_state = self._running_actors[actor]
+
+        if actor_state.is_restarting:
+            self._num_restarting_actors -= 1
+
+        # Remove from underlying ActorPool (Python + C++ tracking).
+        # kill=False because the caller handles killing after on_exit hooks.
+        self._pool.remove_actor(actor, kill=False)
+
+        ref = None
+        if self._enable_actor_pool_on_exit_hook:
+            try:
+                ref = actor.on_exit.remote()
+            except Exception:
+                pass
+
+        del self._running_actors[actor]
+        return ref
+
+    def get_actor_info(self) -> ActorPoolInfo:
+        """Get actor pool info for metrics."""
+        return ActorPoolInfo(
+            running=self.num_alive_actors(),
+            pending=self.num_pending_actors(),
+            restarting=self.num_restarting_actors(),
+        )

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -212,6 +212,11 @@ DEFAULT_ENABLE_OP_RESOURCE_RESERVATION = env_bool(
     "RAY_DATA_ENABLE_OP_RESOURCE_RESERVATION", True
 )
 
+# Feature flag to use the new C++-backed Core Actor Pool instead of the internal
+# Python actor pool. This enables cross-actor retry and improved performance.
+# Set RAY_DATA_USE_CORE_ACTOR_POOL=1 to enable.
+DEFAULT_USE_CORE_ACTOR_POOL = env_bool("RAY_DATA_USE_CORE_ACTOR_POOL", False)
+
 DEFAULT_OP_RESOURCE_RESERVATION_RATIO = float(
     os.environ.get("RAY_DATA_OP_RESERVATION_RATIO", "0.5")
 )
@@ -697,6 +702,8 @@ class DataContext:
     ] = DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
     actor_init_retry_on_errors: bool = DEFAULT_ACTOR_INIT_RETRY_ON_ERRORS
     actor_init_max_retries: int = DEFAULT_ACTOR_INIT_MAX_RETRIES
+    # Use new C++-backed Core Actor Pool for improved performance and cross-actor retry
+    use_core_actor_pool: bool = DEFAULT_USE_CORE_ACTOR_POOL
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
     op_resource_reservation_ratio: float = DEFAULT_OP_RESOURCE_RESERVATION_RATIO
     max_errored_blocks: int = DEFAULT_MAX_ERRORED_BLOCKS

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -1172,10 +1172,16 @@ def test_completed_when_downstream_op_has_finished_execution(ray_start_regular_s
     assert actor_pool_map_op.has_completed()
 
 
-def test_actor_pool_fault_tolerance_e2e(ray_start_cluster, restore_data_context):
+@pytest.mark.parametrize("use_core_actor_pool", [False, True])
+def test_actor_pool_fault_tolerance_e2e(
+    ray_start_cluster, restore_data_context, use_core_actor_pool
+):
     """Test that a dataset with actor pools can finish, when
     all nodes in the cluster are removed and added back."""
     ray.shutdown()
+
+    ctx = restore_data_context
+    ctx.use_core_actor_pool = use_core_actor_pool
 
     cluster = ray_start_cluster
     cluster.add_node(num_cpus=0)
@@ -1530,6 +1536,98 @@ def test_map_worker_repr_handles_uninitialized_src_fn_name():
     # Also verify that when src_fn_name IS set, __repr__ returns it correctly
     worker.src_fn_name = "TestFunction"
     assert repr(worker) == "MapWorker(TestFunction)"
+
+
+# =============================================================================
+# Parity Tests for CoreActorPoolAdapter
+# =============================================================================
+# These tests verify that CoreActorPoolAdapter (via use_core_actor_pool flag)
+# works correctly through the full ActorPoolMapOperator integration.
+
+
+@pytest.mark.parametrize("use_core_actor_pool", [False, True])
+def test_actor_pool_map_operator_parity(
+    ray_start_regular_shared, restore_data_context, use_core_actor_pool
+):
+    """Test that ActorPoolMapOperator works with both pool implementations."""
+    ctx = restore_data_context
+    ctx.use_core_actor_pool = use_core_actor_pool
+
+    class SimpleMapper:
+        def __call__(self, batch):
+            batch["value"] = batch["id"] * 2
+            return batch
+
+    ds = ray.data.range(100)
+    ds = ds.map_batches(
+        SimpleMapper,
+        batch_size=10,
+        # Use num_cpus=0 to avoid resource contention with ReadRange tasks
+        compute=ray.data.ActorPoolStrategy(size=1),
+        num_cpus=0,
+    )
+    result = ds.take_all()
+
+    assert len(result) == 100
+    for row in result:
+        assert row["value"] == row["id"] * 2
+
+
+@pytest.mark.parametrize("use_core_actor_pool", [False, True])
+def test_actor_pool_scaling_parity(
+    ray_start_regular_shared, restore_data_context, use_core_actor_pool
+):
+    """Test that scaling works with both pool implementations."""
+    ctx = restore_data_context
+    ctx.use_core_actor_pool = use_core_actor_pool
+
+    class SlowMapper:
+        def __call__(self, batch):
+            import time
+
+            time.sleep(0.01)
+            return batch
+
+    ds = ray.data.range(50)
+    ds = ds.map_batches(
+        SlowMapper,
+        batch_size=5,
+        # Use num_cpus=0 to avoid resource contention with ReadRange tasks
+        compute=ray.data.ActorPoolStrategy(min_size=1, max_size=1),
+        num_cpus=0,
+    )
+    result = ds.take_all()
+
+    assert len(result) == 50
+
+
+@pytest.mark.parametrize("use_core_actor_pool", [False, True])
+def test_actor_pool_stats_parity(
+    ray_start_regular_shared, restore_data_context, use_core_actor_pool
+):
+    """Test that ActorPoolMapOperator reports correct stats with both implementations."""
+    ctx = restore_data_context
+    ctx.use_core_actor_pool = use_core_actor_pool
+
+    class CountingMapper:
+        def __init__(self):
+            self.count = 0
+
+        def __call__(self, batch):
+            self.count += 1
+            return batch
+
+    ds = ray.data.range(20)
+    ds = ds.map_batches(
+        CountingMapper,
+        batch_size=2,
+        # Use num_cpus=0 to avoid resource contention with ReadRange tasks
+        compute=ray.data.ActorPoolStrategy(size=1),
+        num_cpus=0,
+    )
+    result = ds.take_all()
+
+    assert len(result) == 20
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_actor_pool_reconstruction.py
+++ b/python/ray/data/tests/test_actor_pool_reconstruction.py
@@ -1,0 +1,152 @@
+"""End-to-end tests for pool-bound lineage reconstruction with Ray Data.
+
+These tests validate that when a node dies mid-pipeline, Ray Data pipelines
+using actor pool-based map_batches can recover through pool-bound reconstruction:
+the pool selects a healthy actor and re-executes the lost lineage.
+"""
+
+import numpy as np
+import pytest
+
+import ray
+
+
+@pytest.fixture
+def enable_core_actor_pool(restore_data_context):
+    """Enable Core actor pool for reconstruction tests.
+
+    Uses the shared restore_data_context fixture from conftest.py to ensure
+    full DataContext restoration after each test.
+    """
+    restore_data_context.use_core_actor_pool = True
+    yield restore_data_context
+
+
+def test_pool_reconstruction_no_data_loss(ray_start_cluster, enable_core_actor_pool):
+    """map_batches(pool) -> collect: kill a worker node, verify all rows present."""
+    ray.shutdown()
+
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=3)
+    victim = cluster.add_node(num_cpus=2)
+    ray.init()
+
+    n_rows = 200
+
+    class Identity:
+        def __call__(self, batch):
+            return batch
+
+    ds = ray.data.range(n_rows)
+    ds = ds.map_batches(
+        Identity,
+        batch_size=10,
+        concurrency=2,
+    )
+    cluster.remove_node(victim)
+
+    result = ds.take_all()
+    assert len(result) == n_rows, f"Expected {n_rows} rows, got {len(result)}"
+
+
+def test_cascading_pool_reconstruction_with_sort(
+    ray_start_cluster, enable_core_actor_pool
+):
+    """map_batches(pool1) -> sort -> map_batches(pool2): kill node, verify results.
+
+    This exercises the cascading reconstruction path:
+    1. Pool1 outputs are lost when a node dies.
+    2. Pool-bound reconstruction re-executes Pool1 tasks on surviving actors.
+    3. The sort (AllToAll) operator consumes the reconstructed outputs.
+    4. Pool2 processes the sorted data.
+    """
+    ray.shutdown()
+
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=4)
+    victim = cluster.add_node(num_cpus=2)
+    ray.init()
+
+    n_rows = 500
+
+    class DoubleId:
+        def __call__(self, batch):
+            return {"val": batch["id"] * 2}
+
+    class IncrementVal:
+        def __call__(self, batch):
+            return {"result": batch["val"] + 1}
+
+    ds = ray.data.range(n_rows)
+
+    ds = ds.map_batches(
+        DoubleId,
+        batch_size=50,
+        concurrency=2,
+    )
+
+    ds = ds.sort("val")
+
+    ds = ds.map_batches(
+        IncrementVal,
+        batch_size=50,
+        concurrency=2,
+    )
+
+    cluster.remove_node(victim)
+
+    result = ds.take_all()
+    assert len(result) == n_rows, f"Expected {n_rows} rows, got {len(result)}"
+
+    expected = sorted([i * 2 + 1 for i in range(n_rows)])
+    actual = sorted([r["result"] for r in result])
+    np.testing.assert_array_equal(actual, expected)
+
+
+def test_map_batches_to_map_batches_reconstruction_no_sort(
+    ray_start_cluster, enable_core_actor_pool
+):
+    """map_batches(pool1) -> map_batches(pool2): kill node, verify results.
+
+    Unlike test_cascading_pool_reconstruction_with_sort, there is no sort
+    (AllToAll barrier) between the two pool stages. Both pools must handle
+    reconstruction when a node is lost.
+    """
+    ray.shutdown()
+
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    cluster.add_node(num_cpus=3)
+    victim = cluster.add_node(num_cpus=2)
+    ray.init()
+
+    n_rows = 300
+
+    class MultiplyById:
+        def __call__(self, batch):
+            return {"val": batch["id"] * 3}
+
+    class AddOffset:
+        def __call__(self, batch):
+            return {"result": batch["val"] + 10}
+
+    ds = ray.data.range(n_rows)
+    ds = ds.map_batches(MultiplyById, batch_size=25, concurrency=2)
+    ds = ds.map_batches(AddOffset, batch_size=25, concurrency=2)
+
+    cluster.remove_node(victim)
+
+    result = ds.take_all()
+    assert len(result) == n_rows, f"Expected {n_rows} rows, got {len(result)}"
+
+    expected = sorted([i * 3 + 10 for i in range(n_rows)])
+    actual = sorted([r["result"] for r in result])
+    np.testing.assert_array_equal(actual, expected)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
This is PR 7/n in a stacked PR series implementing a Core Actor Pool for Ray Data. The full implementation can be previewed in #61622.

## Integration pattern

The adapter wraps `ray.experimental.actor_pool.ActorPool` (https://github.com/ray-project/ray/pull/62007) and implements Ray Data's `AutoscalingActorPool` interface. Task submission routes through C++ `SubmitTaskToActorPool` where the `ActorPoolManager` handles actor selection, while Python-side state (`_running_actors`, `_pending_actors`) is maintained for Data's scheduling loop compatibility (e.g., `num_free_task_slots`, `pending_to_running` transitions).

**Why this pattern:** The alternative was to call `ActorPoolManager` methods directly from `ActorPoolMapOperator`, bypassing the Python `ActorPool` class entirely. We chose the adapter-over-ActorPool pattern because: 
1. It reuses `ActorPool`'s actor lifecycle management (creation with `max_restarts=-1`, label injection, logical IDs) instead of duplicating it. 
2. It keeps `ActorPool` as the single public API surface; Data is just another consumer, and 
3. It allows non-Data users to use the same `ActorPool` class directly without any Data dependencies.

A second alternative was modifying `_ActorPool` (the existing legacy pool) to optionally delegate to C++. This was rejected because `_ActorPool` is tightly coupled to callback-based actor creation (`_start_actor` returns `(actor, res_ref)`), and retrofitting C++ pool semantics into that interface would have been more invasive than a clean adapter.

## Summary

  - Add `CoreActorPoolAdapter` implementing `AutoscalingActorPool` for Ray Data's `ActorPoolMapOperator`
  - Feature flag: `DataContext.use_core_actor_pool` / `RAY_DATA_USE_CORE_ACTOR_POOL=1` (default off)
  - **State tracking**: Python-side `_running_actors`/`_pending_actors` for Data compatibility, Core tracks authoritative in-flight counts
  - **`submit_task`**: Routes through Core `SubmitTaskToActorPool` with streaming generator support
  - **Backpressure**: Reads from Core `GetOccupiedTaskSlots`/`GetNumActiveActors` for unified backpressure
  - **`refresh_actor_state`**: Uses GCS protobuf to detect actor restarts/deaths
  - **Actor lifecycle**: `pending_to_running` updates Core pool with actor location for locality-aware scheduling
  - Modify `ActorPoolMapOperator`: `_use_core_pool` flag, `_create_actor_pool` core pool branch, `_register_pending_actor_callbacks`, `_try_schedule_via_pool`, `can_add_input` core pool path
  - Modify `_MapWorker`: `logical_actor_id` optional with fallback, None-guard `actor_location_tracker`
  - E2E reconstruction tests (node kill with single pool, cascading with sort, cascading without sort)
  - parity tests in `test_actor_pool_map_operator.py`

  ## Implementation notes

  - **Falls back to legacy path** when `ray_remote_args_fn` is set (dynamic per-actor args not supported by Core pool)
  - **Core authoritative counts**: `on_task_submitted`/`on_task_completed` in the adapter are no-ops for pool-submitted tasks since C++ manages `num_tasks_in_flight`