### PR TITLE
Fix set literal typos in GCP GPU instance definitions

### DIFF
--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -65,8 +65,8 @@ gcp_gpu_instances = {
     "n1-standard-16-nvidia-tesla-t4-1": (16, 1),
     "n1-standard-64-nvidia-tesla-t4-4": (64, 4),
     "n1-standard-32-nvidia-tesla-t4-2": (32, 2),
-    "n1-highmem-64-nvidia-tesla-v100-8": {64, 8},
-    "n1-highmem-96-nvidia-tesla-v100-8": {96, 8},
+    "n1-highmem-64-nvidia-tesla-v100-8": (64, 8),
+    "n1-highmem-96-nvidia-tesla-v100-8": (96, 8),
 }
 
 


### PR DESCRIPTION
Two entries in gcp_gpu_instances used set literals {64, 8} instead of
tuples (64, 8), causing incorrect resource calculations.

Topic: fix-gcp-set-literals
Labels: draft
Signed-off-by: sai.miduthuri <sai.miduthuri@anyscale.com>