### PR TITLE
[Data] Fix write_parquet mode='error' race condition with parallel writes

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -24,7 +24,7 @@ EXISTING_DATA_BEHAVIOR_MAP = {
     SaveMode.APPEND: "overwrite_or_ignore",
     SaveMode.OVERWRITE: "overwrite_or_ignore",  # delete_matching is not a suitable choice for parallel writes.
     SaveMode.IGNORE: "overwrite_or_ignore",
-    SaveMode.ERROR: "error",
+    SaveMode.ERROR: "overwrite_or_ignore",  # on_write_start() already checks for existing dir.
 }
 
 FILE_FORMAT = "parquet"

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -714,28 +714,20 @@ def test_parquet_write_error_save_mode(ray_start_regular_shared, local_path):
 def test_parquet_write_error_save_mode_multiple_blocks(
     ray_start_regular_shared, local_path
 ):
-    """Test that mode='error' works with multiple blocks (parallel writes).
-
-    Regression test: previously, mode='error' would pass existing_data_behavior='error'
-    to each individual PyArrow write task, causing a race condition where the first
-    task's output would cause subsequent tasks to fail with ArrowInvalid.
-    """
     data_path = local_path
     path = os.path.join(data_path, "test_parquet_dir_multi_block")
 
-    # Create a dataset with multiple blocks to trigger parallel writes
+    # multiple blocks to trigger parallel writes
     ds = ray.data.range(100, override_num_blocks=4)
 
-    # Should succeed writing to a non-existent directory
-    ds.write_parquet(path, mode="error")
+    # should write
+    ds.write_parquet(path, filesystem=None, mode="error")
+    on_disk_table = pq.read_table(path)
+    assert on_disk_table.num_rows == 100
 
-    # Verify data was written correctly
-    result = ray.data.read_parquet(path)
-    assert result.count() == 100
-
-    # Should fail writing to an existing directory
+    # should error since dir already exists
     with pytest.raises(ValueError):
-        ds.write_parquet(path, mode="error")
+        ds.write_parquet(path, filesystem=None, mode="error")
 
 
 def test_parquet_write_append_save_mode(ray_start_regular_shared, local_path):

--- a/python/ray/data/tests/test_parquet.py
+++ b/python/ray/data/tests/test_parquet.py
@@ -711,6 +711,33 @@ def test_parquet_write_error_save_mode(ray_start_regular_shared, local_path):
     assert in_memory_table.equals(on_disk_table)
 
 
+def test_parquet_write_error_save_mode_multiple_blocks(
+    ray_start_regular_shared, local_path
+):
+    """Test that mode='error' works with multiple blocks (parallel writes).
+
+    Regression test: previously, mode='error' would pass existing_data_behavior='error'
+    to each individual PyArrow write task, causing a race condition where the first
+    task's output would cause subsequent tasks to fail with ArrowInvalid.
+    """
+    data_path = local_path
+    path = os.path.join(data_path, "test_parquet_dir_multi_block")
+
+    # Create a dataset with multiple blocks to trigger parallel writes
+    ds = ray.data.range(100, override_num_blocks=4)
+
+    # Should succeed writing to a non-existent directory
+    ds.write_parquet(path, mode="error")
+
+    # Verify data was written correctly
+    result = ray.data.read_parquet(path)
+    assert result.count() == 100
+
+    # Should fail writing to an existing directory
+    with pytest.raises(ValueError):
+        ds.write_parquet(path, mode="error")
+
+
 def test_parquet_write_append_save_mode(ray_start_regular_shared, local_path):
     data_path = local_path
     path = os.path.join(data_path, "test_parquet_dir")


### PR DESCRIPTION
## Summary
- Fixed `write_parquet(mode="error")` failing with `ArrowInvalid` when writing datasets with multiple blocks (parallel writes)
- Changed per-task `existing_data_behavior` from `"error"` to `"overwrite_or_ignore"` in `EXISTING_DATA_BEHAVIOR_MAP`, since the upfront check in `on_write_start()` already enforces the "error if exists" semantics
- Added regression test with multi-block dataset to verify parallel writes succeed with `mode="error"`

Fixes https://github.com/ray-project/ray/issues/62019

## Test plan
- [x] Local verification: write 100 rows across 4 blocks with `mode="error"` to a new directory — succeeds
- [x] Local verification: writing to an existing directory correctly raises `ValueError`
- [x] Existing `test_parquet_write_error_save_mode` (single block) still passes
- [ ] CI: `test_parquet_write_error_save_mode_multiple_blocks` added as regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)