### PR TITLE
[Data] Fix __eq__ signature in ExecutionResources for pyrefly

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -50,9 +50,7 @@ python/ray/data/_internal/execution/bundle_queue/fifo.py
 python/ray/data/_internal/execution/bundle_queue/hash_link.py
 python/ray/data/_internal/execution/bundle_queue/reordering.py
 python/ray/data/_internal/execution/callbacks/insert_issue_detectors.py
-python/ray/data/_internal/execution/dataset_state.py
 python/ray/data/_internal/execution/interfaces/common.py
-python/ray/data/_internal/execution/interfaces/execution_options.py
 python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
 python/ray/data/_internal/execution/interfaces/physical_operator.py
 python/ray/data/_internal/execution/interfaces/ref_bundle.py

--- a/python/ray/data/_internal/execution/interfaces/execution_options.py
+++ b/python/ray/data/_internal/execution/interfaces/execution_options.py
@@ -104,7 +104,9 @@ class ExecutionResources:
             f"memory={self.memory_str()})"
         )
 
-    def __eq__(self, other: "ExecutionResources") -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ExecutionResources):
+            return NotImplemented
         return (
             self.cpu == other.cpu
             and self.gpu == other.gpu


### PR DESCRIPTION
## Why are these changes needed?

Fix pyrefly type check error in `ExecutionResources.__eq__`.

## Changes

The `__eq__` method had parameter type `ExecutionResources` but should be `object` to match the parent class (`object.__eq__`) signature.

```python
# Before
def __eq__(self, other: "ExecutionResources") -> bool:

# After
def __eq__(self, other: object) -> bool:
    if not isinstance(other, ExecutionResources):
        return NotImplemented
```

This follows Python best practices for `__eq__` implementations.

## Verification

```bash
$ pyrefly check python/ray/data/_internal/execution/interfaces/execution_options.py
INFO 0 errors
```

## Related issue

Contributes to #61933