### PR TITLE
[Data] Remove dataset_state.py from pyrefly exclusion list

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -50,7 +50,6 @@ python/ray/data/_internal/execution/bundle_queue/fifo.py
 python/ray/data/_internal/execution/bundle_queue/hash_link.py
 python/ray/data/_internal/execution/bundle_queue/reordering.py
 python/ray/data/_internal/execution/callbacks/insert_issue_detectors.py
-python/ray/data/_internal/execution/dataset_state.py
 python/ray/data/_internal/execution/interfaces/common.py
 python/ray/data/_internal/execution/interfaces/execution_options.py
 python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py


### PR DESCRIPTION
## Why are these changes needed?

This file now passes `pyrefly check` with 0 errors.

## File removed

- `python/ray/data/_internal/execution/dataset_state.py`

## Verification

```bash
$ pyrefly check python/ray/data/_internal/execution/dataset_state.py
 INFO 0 errors
```

## Related issue

Contributes to #61933