### PR TITLE
[Data] Refactor PandasRow and ArrowsRow, avoiding per-row slicing

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -89,8 +89,11 @@ class ArrowRow(Mapping):
     Row of a tabular Dataset backed by a Arrow Table block.
     """
 
-    def __init__(self, row: Any):
-        self._row = row
+    def __init__(
+        self, batch: Union["pyarrow.Table", "pyarrow.RecordBatch"], row_idx: int
+    ):
+        self._batch = batch
+        self._row_idx = row_idx
 
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
         from ray.data.extensions import get_arrow_extension_tensor_types
@@ -98,23 +101,29 @@ class ArrowRow(Mapping):
         tensor_arrow_extension_types = get_arrow_extension_tensor_types()
 
         def get_item(keys: List[str]) -> Any:
-            schema = self._row.schema
+            schema = self._batch.schema
             if isinstance(schema.field(keys[0]).type, tensor_arrow_extension_types):
                 # Build a tensor row.
                 return tuple(
                     [
                         ArrowBlockAccessor._build_tensor_row(
-                            self._row, col_name=key, row_idx=0
+                            self._batch, col_name=key, row_idx=self._row_idx
                         )
                         for key in keys
                     ]
                 )
 
-            table = self._row.select(keys)
-            if len(table) == 0:
-                return None
+            # Pyarrow select internally creates a new table by slicing which is expensive.
+            # Instead, access the columns directly at row_idx.
+            items = []
+            for col_name in keys:
+                col_idx = schema.get_field_index(col_name)
+                if col_idx == -1:
+                    # key not found
+                    return None
+                col = self._batch.column(col_idx)
+                items.append(col[self._row_idx])
 
-            items = [col[0] for col in table.columns]
             try:
                 # Try to interpret this as a pyarrow.Scalar value.
                 return tuple([item.as_py() for item in items])
@@ -137,11 +146,11 @@ class ArrowRow(Mapping):
             return items
 
     def __iter__(self) -> Iterator:
-        for k in self._row.column_names:
+        for k in self._batch.column_names:
             yield k
 
     def __len__(self):
-        return self._row.num_columns
+        return self._batch.num_columns
 
     def as_pydict(self) -> Dict[str, Any]:
         return dict(self.items())
@@ -219,8 +228,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         self._max_chunk_size: Optional[int] = None
 
     def _get_row(self, index: int) -> ArrowRow:
-        base_row = self.slice(index, index + 1, copy=False)
-        return ArrowRow(base_row)
+        return ArrowRow(self._table, index)
 
     def column_names(self) -> List[str]:
         return self._table.column_names

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -95,6 +95,16 @@ class ArrowRow(Mapping):
         self._batch = batch
         self._row_idx = row_idx
 
+    def _select_columns(self, keys: List[str]) -> List[Any]:
+        items = []
+        for col_name in keys:
+            col_idx = self._batch.schema.get_field_index(col_name)
+            if col_idx == -1:
+                raise KeyError(col_name)
+            col = self._batch.column(col_idx)
+            items.append(col[self._row_idx])
+        return items
+
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
         from ray.data.extensions import get_arrow_extension_tensor_types
 
@@ -113,16 +123,7 @@ class ArrowRow(Mapping):
                     ]
                 )
 
-            # Pyarrow select internally creates a new table by slicing which is expensive.
-            # Instead, access the columns directly at row_idx.
-            items = []
-            for col_name in keys:
-                col_idx = schema.get_field_index(col_name)
-                if col_idx == -1:
-                    raise KeyError(col_name)
-                col = self._batch.column(col_idx)
-                items.append(col[self._row_idx])
-
+            items = self._select_columns(keys)
             try:
                 # Try to interpret this as a pyarrow.Scalar value.
                 return tuple([item.as_py() for item in items])

--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -119,8 +119,7 @@ class ArrowRow(Mapping):
             for col_name in keys:
                 col_idx = schema.get_field_index(col_name)
                 if col_idx == -1:
-                    # key not found
-                    return None
+                    raise KeyError(col_name)
                 col = self._batch.column(col_idx)
                 items.append(col[self._row_idx])
 

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -112,7 +112,7 @@ class PandasRow(Mapping):
     def as_pydict(self) -> Dict[str, Any]:
         pydict: Dict[str, Any] = {}
         for key in self:
-            value = self._batch[key].iloc[self._row_idx]
+            value = self[key]
             # Convert NA to None for consistency across block formats. `pd.isna`
             # returns True for both NA and NaN, but since we want to preserve NaN
             # values, we check for identity instead.

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -76,15 +76,13 @@ class PandasRow(Mapping):
         def get_item(keys: List[str]) -> Any:
             items = []
             for col_name in keys:
-                if col_name not in self._batch.columns:
-                    return None
                 val = self._batch[col_name].iloc[self._row_idx]
                 if isinstance(val, TensorArrayElement):
                     # Getting an item in a Pandas tensor column may return
                     # a TensorArrayElement, which we have to convert to an ndarray.
                     val = val.to_numpy()
                 items.append(val)
-                
+
             # Try to interpret this as a numpy-type value.
             # See https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types.  # noqa: E501
             try:

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -66,31 +66,31 @@ class PandasRow(Mapping):
     Row of a tabular Dataset backed by a Pandas DataFrame block.
     """
 
-    def __init__(self, row: Any):
-        self._row = row
+    def __init__(self, df: "pandas.DataFrame", row_idx: int):
+        self._batch = df
+        self._row_idx = row_idx
 
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
         from ray.data.extensions import TensorArrayElement
 
         def get_item(keys: List[str]) -> Any:
-            col = self._row[keys]
-            if len(col) == 0:
-                return None
-
-            items = col.iloc[0]
-            if isinstance(items.iloc[0], TensorArrayElement):
-                # Getting an item in a Pandas tensor column may return
-                # a TensorArrayElement, which we have to convert to an ndarray.
-                return tuple(item.to_numpy() for item in items)
-
+            items = []
+            for col_name in keys:
+                if col_name not in self._batch.columns:
+                    return None
+                val = self._batch[col_name].iloc[self._row_idx]
+                if isinstance(val, TensorArrayElement):
+                    # Getting an item in a Pandas tensor column may return
+                    # a TensorArrayElement, which we have to convert to an ndarray.
+                    val = val.to_numpy()
+                items.append(val)
+                
+            # Try to interpret this as a numpy-type value.
+            # See https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types.  # noqa: E501
             try:
-                # Try to interpret this as a numpy-type value.
-                # See https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types.  # noqa: E501
                 return tuple(item for item in items)
-
             except (AttributeError, ValueError) as e:
                 logger.warning(f"Failed to convert {items} to a tuple", exc_info=e)
-
                 # Fallback to the original form.
                 return items
 
@@ -102,21 +102,19 @@ class PandasRow(Mapping):
         if items is None:
             return None
 
-        elif is_single_item:
-            return items[0]
-        else:
-            return items
+        return items[0] if is_single_item else items
 
     def __iter__(self) -> Iterator:
-        for k in self._row.columns:
+        for k in self._batch.columns:
             yield k
 
     def __len__(self):
-        return self._row.shape[1]
+        return self._batch.shape[1]
 
     def as_pydict(self) -> Dict[str, Any]:
         pydict: Dict[str, Any] = {}
-        for key, value in self.items():
+        for key in self:
+            value = self._batch[key].iloc[self._row_idx]
             # Convert NA to None for consistency across block formats. `pd.isna`
             # returns True for both NA and NaN, but since we want to preserve NaN
             # values, we check for identity instead.
@@ -365,8 +363,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         super().__init__(table)
 
     def _get_row(self, index: int) -> PandasRow:
-        base_row = self.slice(index, index + 1, copy=False)
-        return PandasRow(base_row)
+        return PandasRow(self._table, index)
 
     def column_names(self) -> List[str]:
         return self._table.columns.tolist()


### PR DESCRIPTION
## Description
For each ArrowRow/PandasRow, store a reference to the full batch + row index instead of pre-slicing a 1-row container on construction, eliminating table.slice()/df.iloc[[i]] overhead on every row iteration. `__getitem__` accesses columns directly by index (`schema.get_field_index` then`col[row_idx]` for Arrow, `series.iloc[row_idx]` for Pandas)

## Additional information
As we plan to deprecate Pandas as the internal block format, we will remove references to PandasRow. Left in for now as proof of concept