### PR TITLE
Add anyscale_sdk_2026 schema flag and Anyscale wrapper properties

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -424,6 +424,7 @@ py_library(
     imports = ["."],
     visibility = ["//ci/ray_ci:__pkg__"],
     deps = [
+        ":anyscale_util",
         ":aws",
         ":github_client",
         ":global_config",

--- a/release/ray_release/anyscale_util.py
+++ b/release/ray_release/anyscale_util.py
@@ -1,3 +1,4 @@
+from types import ModuleType
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from ray_release.exception import ClusterEnvCreateError
@@ -30,6 +31,14 @@ class Anyscale:
             self._anyscale_pkg = anyscale
 
         return self._anyscale_pkg
+
+    @property
+    def compute_config(self) -> ModuleType:
+        return self._anyscale().compute_config
+
+    @property
+    def cloud(self) -> ModuleType:
+        return self._anyscale().cloud
 
     def project_name_by_id(self, project_id: str) -> str:
         return self._anyscale().project.get(project_id).name

--- a/release/ray_release/buildkite/concurrency.py
+++ b/release/ray_release/buildkite/concurrency.py
@@ -65,8 +65,8 @@ gcp_gpu_instances = {
     "n1-standard-16-nvidia-tesla-t4-1": (16, 1),
     "n1-standard-64-nvidia-tesla-t4-4": (64, 4),
     "n1-standard-32-nvidia-tesla-t4-2": (32, 2),
-    "n1-highmem-64-nvidia-tesla-v100-8": {64, 8},
-    "n1-highmem-96-nvidia-tesla-v100-8": {96, 8},
+    "n1-highmem-64-nvidia-tesla-v100-8": (64, 8),
+    "n1-highmem-96-nvidia-tesla-v100-8": (96, 8),
 }
 
 

--- a/release/ray_release/schema.json
+++ b/release/ray_release/schema.json
@@ -86,11 +86,17 @@
 				"cloud_id": {
 					"type": "string"
 				},
+				"cloud": {
+					"type": "string"
+				},
 				"project_id": {
 					"type": "string"
 				},
 				"byod": {
 					"$ref": "#/definitions/Byod"
+				},
+				"anyscale_sdk_2026": {
+					"type": "boolean"
 				}
 			},
 			"required": [

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -17,6 +17,7 @@ from botocore.exceptions import ClientError
 if TYPE_CHECKING:
     from ray_release.github_client import GitHubRepo
 
+from ray_release.anyscale_util import Anyscale
 from ray_release.aws import s3_put_rayci_test_data
 from ray_release.configs.global_config import get_global_config
 from ray_release.logger import logger
@@ -168,6 +169,7 @@ class Test(dict):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.test_results = None
+        self.anyscale = Anyscale()
 
     @classmethod
     def from_bazel_event(cls, event: dict, team: str):
@@ -402,6 +404,10 @@ class Test(dict):
     def is_azure(self) -> bool:
         """Returns whether this test is running on Azure."""
         return self.get_cloud_env() == "azure"
+
+    def uses_anyscale_sdk_2026(self) -> bool:
+        """Returns whether this test uses the 2026 Anyscale compute config schema."""
+        return self.get("cluster", {}).get("anyscale_sdk_2026", False)
 
     def is_high_impact(self) -> bool:
         # a test is high impact if it catches regressions frequently, this field is

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -641,5 +641,16 @@ def test_get_byod_image_tag_with_runtime_env_and_script(mock_get_byod_base_image
     assert dict_hash(custom_info) != dict_hash(custom_info_no_env)
 
 
+def test_uses_anyscale_sdk_2026():
+    assert not Test({"name": "t", "cluster": {}}).uses_anyscale_sdk_2026()
+    assert not Test({"name": "t"}).uses_anyscale_sdk_2026()
+    assert Test(
+        {"name": "t", "cluster": {"anyscale_sdk_2026": True}}
+    ).uses_anyscale_sdk_2026()
+    assert not Test(
+        {"name": "t", "cluster": {"anyscale_sdk_2026": False}}
+    ).uses_anyscale_sdk_2026()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
Add a cluster.anyscale_sdk_2026 boolean flag to the release test schema
so tests can opt into the new 2026 Anyscale compute config format. Also
expose compute_config and cloud properties on the Anyscale wrapper to
support the new SDK API.

Topic: sdk-2026-schema-flag
Relative: fix-gcp-set-literals
Labels: draft
Signed-off-by: sai.miduthuri <sai.miduthuri@anyscale.com>