### PR TITLE
Add a warning to job log when pending

### DIFF
--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -191,10 +191,6 @@ class JobManager:
                             job_id, timeout=None
                         )
                     if job_info is None:
-                        logger.warning(
-                            f"No job metadata for job {job_id}found in storage when "
-                            "monitoring; using monitor elapsed time for pending checks."
-                        )
                         resources_specified = False
                         pending_duration = (
                             self._timeout_check_timer.time() - monitor_start_time

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -167,30 +167,9 @@ class JobManager:
             )
         )
 
+        monitor_start_time = self._timeout_check_timer.time()
         job_status = None
-        job_info = await self._job_info_client.get_info(job_id, timeout=None)
-        has_py_executable = (
-            job_info.runtime_env is not None
-            and job_info.runtime_env.get("py_executable")
-        )
-        resources_specified = (
-            (
-                job_info.entrypoint_num_cpus is not None
-                and job_info.entrypoint_num_cpus > 0
-            )
-            or (
-                job_info.entrypoint_num_gpus is not None
-                and job_info.entrypoint_num_gpus > 0
-            )
-            or (
-                job_info.entrypoint_memory is not None
-                and job_info.entrypoint_memory > 0
-            )
-            or (
-                job_info.entrypoint_resources is not None
-                and len(job_info.entrypoint_resources) > 0
-            )
-        )
+        job_info = None
         ping_obj_ref = None
         logged_pending_warning = False
         driver_logger = self._get_job_driver_logger(job_id)
@@ -207,12 +186,39 @@ class JobManager:
                     job_id, timeout=None
                 )
                 if job_status == JobStatus.PENDING:
-                    # Compare the current time with the job start time.
-                    # If the job is still pending, we will set the status
-                    # to FAILED.
-                    pending_duration = (
-                        self._timeout_check_timer.time() - job_info.start_time / 1000
-                    )
+                    if job_info is None:
+                        job_info = await self._job_info_client.get_info(
+                            job_id, timeout=None
+                        )
+                    if job_info is None:
+                        logger.warning(
+                            f"No job metadata for job {job_id}found in storage when "
+                            "monitoring; using monitor elapsed time for pending checks."
+                        )
+                        resources_specified = False
+                        pending_duration = (
+                            self._timeout_check_timer.time() - monitor_start_time
+                        )
+                    else:
+                        resources_specified = any(
+                            [
+                                job_info.entrypoint_num_cpus is not None
+                                and job_info.entrypoint_num_cpus > 0,
+                                job_info.entrypoint_num_gpus is not None
+                                and job_info.entrypoint_num_gpus > 0,
+                                job_info.entrypoint_memory is not None
+                                and job_info.entrypoint_memory > 0,
+                                job_info.entrypoint_resources is not None
+                                and len(job_info.entrypoint_resources) > 0,
+                            ]
+                        )
+                        # Compare the current time with the job start time.
+                        # If the job is still pending, we will set the status
+                        # to FAILED.
+                        pending_duration = (
+                            self._timeout_check_timer.time()
+                            - job_info.start_time / 1000
+                        )
 
                     if pending_duration > timeout:
                         err_msg = (
@@ -231,12 +237,6 @@ class JobManager:
                                 "`ray status` and specifying fewer resources for the "
                                 "job entrypoint."
                             )
-                        if has_py_executable:
-                            err_msg += (
-                                " This may be because the runtime_env's py_executable "
-                                "is not valid. "
-                                "Try checking raylet.err for details."
-                            )
                         await self._job_info_client.put_status(
                             job_id,
                             JobStatus.FAILED,
@@ -250,22 +250,13 @@ class JobManager:
                     if (
                         not logged_pending_warning
                         and pending_duration >= self.PENDING_WARNING_THRESHOLD_S
-                        and (has_py_executable or resources_specified)
+                        and resources_specified
                     ):
-                        hints = []
-                        if resources_specified:
-                            hints.append(
-                                "Hint: The cluster may not have sufficient resources"
-                                " for the job entrypoint - try checking `ray status`."
-                            )
-                        if has_py_executable:
-                            hints.append(
-                                "Hint: The runtime_env's py_executable may not be"
-                                " valid - try checking raylet.err."
-                            )
                         driver_logger.warning(
                             f"Job {job_id} has been pending for"
-                            f" {int(pending_duration)}s.\n" + "\n".join(hints)
+                            f" {int(pending_duration)}s.\n"
+                            "Hint: The cluster may not have sufficient resources"
+                            " for the job entrypoint - try checking `ray status`."
                         )
                         logged_pending_warning = True
 

--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -70,6 +70,7 @@ class JobManager:
     # available.
     LOG_TAIL_SLEEP_S = 1
     JOB_MONITOR_LOOP_PERIOD_S = 1
+    PENDING_WARNING_THRESHOLD_S = 30
     WAIT_FOR_ACTOR_DEATH_TIMEOUT_S = 0.1
 
     def __init__(
@@ -167,8 +168,32 @@ class JobManager:
         )
 
         job_status = None
-        job_info = None
+        job_info = await self._job_info_client.get_info(job_id, timeout=None)
+        has_py_executable = (
+            job_info.runtime_env is not None
+            and job_info.runtime_env.get("py_executable")
+        )
+        resources_specified = (
+            (
+                job_info.entrypoint_num_cpus is not None
+                and job_info.entrypoint_num_cpus > 0
+            )
+            or (
+                job_info.entrypoint_num_gpus is not None
+                and job_info.entrypoint_num_gpus > 0
+            )
+            or (
+                job_info.entrypoint_memory is not None
+                and job_info.entrypoint_memory > 0
+            )
+            or (
+                job_info.entrypoint_resources is not None
+                and len(job_info.entrypoint_resources) > 0
+            )
+        )
         ping_obj_ref = None
+        logged_pending_warning = False
+        driver_logger = self._get_job_driver_logger(job_id)
 
         while True:
             try:
@@ -185,38 +210,16 @@ class JobManager:
                     # Compare the current time with the job start time.
                     # If the job is still pending, we will set the status
                     # to FAILED.
-                    if job_info is None:
-                        job_info = await self._job_info_client.get_info(
-                            job_id, timeout=None
-                        )
-
-                    if (
+                    pending_duration = (
                         self._timeout_check_timer.time() - job_info.start_time / 1000
-                        > timeout
-                    ):
+                    )
+
+                    if pending_duration > timeout:
                         err_msg = (
                             "Job supervisor actor failed to start within "
                             f"{timeout} seconds. This timeout can be "
                             f"configured by setting the environment "
                             f"variable {RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR}."
-                        )
-                        resources_specified = (
-                            (
-                                job_info.entrypoint_num_cpus is not None
-                                and job_info.entrypoint_num_cpus > 0
-                            )
-                            or (
-                                job_info.entrypoint_num_gpus is not None
-                                and job_info.entrypoint_num_gpus > 0
-                            )
-                            or (
-                                job_info.entrypoint_memory is not None
-                                and job_info.entrypoint_memory > 0
-                            )
-                            or (
-                                job_info.entrypoint_resources is not None
-                                and len(job_info.entrypoint_resources) > 0
-                            )
                         )
                         if resources_specified:
                             err_msg += (
@@ -228,6 +231,12 @@ class JobManager:
                                 "`ray status` and specifying fewer resources for the "
                                 "job entrypoint."
                             )
+                        if has_py_executable:
+                            err_msg += (
+                                " This may be because the runtime_env's py_executable "
+                                "is not valid. "
+                                "Try checking raylet.err for details."
+                            )
                         await self._job_info_client.put_status(
                             job_id,
                             JobStatus.FAILED,
@@ -237,6 +246,28 @@ class JobManager:
                         )
                         logger.error(err_msg)
                         break
+
+                    if (
+                        not logged_pending_warning
+                        and pending_duration >= self.PENDING_WARNING_THRESHOLD_S
+                        and (has_py_executable or resources_specified)
+                    ):
+                        hints = []
+                        if resources_specified:
+                            hints.append(
+                                "Hint: The cluster may not have sufficient resources"
+                                " for the job entrypoint - try checking `ray status`."
+                            )
+                        if has_py_executable:
+                            hints.append(
+                                "Hint: The runtime_env's py_executable may not be"
+                                " valid - try checking raylet.err."
+                            )
+                        driver_logger.warning(
+                            f"Job {job_id} has been pending for"
+                            f" {int(pending_duration)}s.\n" + "\n".join(hints)
+                        )
+                        logged_pending_warning = True
 
                 if job_supervisor is None:
                     job_supervisor = self._get_actor_for_job(job_id)
@@ -584,7 +615,7 @@ class JobManager:
                     f"Started a ray job {submission_id}.", submission_id=submission_id
                 )
 
-            driver_logger.info("Runtime env is setting up.")
+            driver_logger.info(f"[{submission_id}] Runtime env is setting up.")
             supervisor_options = dict(
                 lifetime="detached",
                 name=JOB_ACTOR_NAME_TEMPLATE.format(job_id=submission_id),

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1544,47 +1544,6 @@ async def test_job_timeout_lack_of_entrypoint_resources(
         "This may be because the job entrypoint's specified resources (entrypoint_num_cpus"
         in job_info.message
     )
-    assert "py_executable" not in job_info.message
-    assert job_info.driver_exit_code is None
-
-
-@pytest.mark.asyncio
-async def test_pending_timeout_with_py_executable(job_manager, monkeypatch):
-    """Test the warning and timeout for an invalid py_executable"""
-
-    monkeypatch.setenv(RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR, "2")
-    job_manager.PENDING_WARNING_THRESHOLD_S = 0.05
-
-    start_signal_actor = SignalActor.remote()
-
-    job_id = await job_manager.submit_job(
-        entrypoint="echo 'hello world'",
-        runtime_env={"py_executable": "/nonexistent/python"},
-        _start_signal_actor=start_signal_actor,
-    )
-
-    await job_manager._recover_running_jobs()
-
-    # The warning should appear in the driver log before the job times out.
-    async def check_driver_log_has_raylet_hint():
-        logs = job_manager.get_job_logs(job_id)
-        return "try checking raylet.err" in logs
-
-    await async_wait_for_condition(check_driver_log_has_raylet_hint, timeout=10)
-
-    # Wait for the job to time out.
-    await async_wait_for_condition(
-        check_job_failed,
-        job_manager=job_manager,
-        job_id=job_id,
-        expected_error_type=JobErrorType.JOB_SUPERVISOR_ACTOR_START_TIMEOUT,
-    )
-
-    job_info = await job_manager.get_job_info(job_id)
-    assert job_info.status == JobStatus.FAILED
-    assert "Job supervisor actor failed to start within" in job_info.message
-    assert "entrypoint_num_cpus" not in job_info.message
-    assert "py_executable is not valid" in job_info.message
     assert job_info.driver_exit_code is None
 
 
@@ -1620,7 +1579,6 @@ async def test_job_pending_timeout(job_manager, monkeypatch):
     assert job_info.status == JobStatus.FAILED
     assert "Job supervisor actor failed to start within" in job_info.message
     assert "entrypoint_num_cpus" not in job_info.message
-    assert "py_executable" not in job_info.message
     assert job_info.driver_exit_code is None
 
 

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -354,7 +354,7 @@ async def test_runtime_env_setup_logged_to_job_driver_logs(
     )
     with open(job_driver_log_path, "r") as f:
         logs = f.read()
-        assert "Runtime env is setting up." in logs
+        assert f"[{job_id}] Runtime env is setting up." in logs
         assert f"Running entrypoint for job {job_id}: {entrypoint}" in logs
 
 
@@ -1506,19 +1506,27 @@ async def test_monitor_job_pending(job_manager):
 async def test_job_timeout_lack_of_entrypoint_resources(
     call_ray_start, tmp_path, monkeypatch  # noqa: F811
 ):
-    """Test the timeout when there are not enough resources to schedule the supervisor actor)"""
+    """Test the warning and timeout when there are not enough resources to schedule the supervisor actor)"""
 
     monkeypatch.setenv(RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR, "1")
 
     ray.init(address=call_ray_start)
     gcs_client = ray._private.worker.global_worker.gcs_client
     job_manager = JobManager(gcs_client, tmp_path)
+    job_manager.PENDING_WARNING_THRESHOLD_S = 0.05
 
     # Submit a job with unsatisfied resource.
     job_id = await job_manager.submit_job(
         entrypoint="echo 'hello world'",
         entrypoint_num_cpus=2,
     )
+
+    # The warning should appear in the driver log before the job times out.
+    async def check_driver_log_has_resource_hint():
+        logs = job_manager.get_job_logs(job_id)
+        return "try checking `ray status`" in logs
+
+    await async_wait_for_condition(check_driver_log_has_resource_hint, timeout=10)
 
     # Wait for the job to timeout.
     await async_wait_for_condition(
@@ -1532,6 +1540,51 @@ async def test_job_timeout_lack_of_entrypoint_resources(
     job_info = await job_manager.get_job_info(job_id)
     assert job_info.status == JobStatus.FAILED
     assert "Job supervisor actor failed to start within" in job_info.message
+    assert (
+        "This may be because the job entrypoint's specified resources (entrypoint_num_cpus"
+        in job_info.message
+    )
+    assert "py_executable" not in job_info.message
+    assert job_info.driver_exit_code is None
+
+
+@pytest.mark.asyncio
+async def test_pending_timeout_with_py_executable(job_manager, monkeypatch):
+    """Test the warning and timeout for an invalid py_executable"""
+
+    monkeypatch.setenv(RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR, "1")
+    job_manager.PENDING_WARNING_THRESHOLD_S = 0.05
+
+    start_signal_actor = SignalActor.remote()
+
+    job_id = await job_manager.submit_job(
+        entrypoint="echo 'hello world'",
+        runtime_env={"py_executable": "/nonexistent/python"},
+        _start_signal_actor=start_signal_actor,
+    )
+
+    await job_manager._recover_running_jobs()
+
+    # The warning should appear in the driver log before the job times out.
+    async def check_driver_log_has_raylet_hint():
+        logs = job_manager.get_job_logs(job_id)
+        return "try checking raylet.err" in logs
+
+    await async_wait_for_condition(check_driver_log_has_raylet_hint, timeout=10)
+
+    # Wait for the job to time out.
+    await async_wait_for_condition(
+        check_job_failed,
+        job_manager=job_manager,
+        job_id=job_id,
+        expected_error_type=JobErrorType.JOB_SUPERVISOR_ACTOR_START_TIMEOUT,
+    )
+
+    job_info = await job_manager.get_job_info(job_id)
+    assert job_info.status == JobStatus.FAILED
+    assert "Job supervisor actor failed to start within" in job_info.message
+    assert "entrypoint_num_cpus" not in job_info.message
+    assert "py_executable is not valid" in job_info.message
     assert job_info.driver_exit_code is None
 
 
@@ -1566,6 +1619,8 @@ async def test_job_pending_timeout(job_manager, monkeypatch):
     job_info = await job_manager.get_job_info(job_id)
     assert job_info.status == JobStatus.FAILED
     assert "Job supervisor actor failed to start within" in job_info.message
+    assert "entrypoint_num_cpus" not in job_info.message
+    assert "py_executable" not in job_info.message
     assert job_info.driver_exit_code is None
 
 

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1508,7 +1508,7 @@ async def test_job_timeout_lack_of_entrypoint_resources(
 ):
     """Test the warning and timeout when there are not enough resources to schedule the supervisor actor)"""
 
-    monkeypatch.setenv(RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR, "1")
+    monkeypatch.setenv(RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR, "2")
 
     ray.init(address=call_ray_start)
     gcs_client = ray._private.worker.global_worker.gcs_client
@@ -1552,7 +1552,7 @@ async def test_job_timeout_lack_of_entrypoint_resources(
 async def test_pending_timeout_with_py_executable(job_manager, monkeypatch):
     """Test the warning and timeout for an invalid py_executable"""
 
-    monkeypatch.setenv(RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR, "1")
+    monkeypatch.setenv(RAY_JOB_START_TIMEOUT_SECONDS_ENV_VAR, "2")
     job_manager.PENDING_WARNING_THRESHOLD_S = 0.05
 
     start_signal_actor = SignalActor.remote()


### PR DESCRIPTION
## Description
Adds an early warning to the job driver log when a job has been stuck in PENDING for 30 seconds, with actionable hints for common causes. Previously, users had no indication of what might be wrong until the job timed out entirely.

- Adds a one-time warning after 30s of PENDING with hints for py_executable and/or insufficient entrypoint resources
- Adds a py_executable hint to the timeout failure message (previously only resources were mentioned)
- Adds the job ID to the "Runtime env is setting up" log

## Related issues

## Additional information
Sample job driver log:
```
2026-03-24 01:20:14,023 INFO job_manager.py:616 -- [raysubmit_bmUFYTxnqQ7mZFnZ] Runtime env is setting up.
2026-03-24 01:20:44,267 WARNING job_manager.py:263 -- Job raysubmit_bmUFYTxnqQ7mZFnZ has been pending for 30s.
Hint: The cluster may not have sufficient resources for the job entrypoint - try checking `ray status`.
Hint: The runtime_env's py_executable may not be valid - try checking raylet.err.
```