### PR TITLE
[Data] Remove progress/__init__.py from pyrefly exclusion list

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -131,7 +131,6 @@ python/ray/data/_internal/planner/random_shuffle.py
 python/ray/data/_internal/planner/randomize_blocks.py
 python/ray/data/_internal/planner/repartition.py
 python/ray/data/_internal/planner/sort.py
-python/ray/data/_internal/progress/__init__.py
 python/ray/data/_internal/progress/base_progress.py
 python/ray/data/_internal/progress/rich_progress.py
 python/ray/data/_internal/remote_fn.py


### PR DESCRIPTION
## Why are these changes needed?

This file now passes `pyrefly check` with 0 errors.

## File removed

- `python/ray/data/_internal/progress/__init__.py`

## Verification

```bash
$ pyrefly check python/ray/data/_internal/progress/__init__.py
 INFO 0 errors
```

## Related issue

Contributes to #61933