### PR TITLE
Implement RandomSeedConfig for dataset iterators

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -262,7 +262,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
             view = transform_pyarrow.combine_chunks(view, copy)
         return view
 
-    def random_shuffle(self, random_seed: Optional[int]) -> "pyarrow.Table":
+    def random_shuffle(self, random_seed: tuple[int, ...] | None) -> "pyarrow.Table":
         return shuffle(self._table, random_seed)
 
     def schema(self) -> "pyarrow.lib.Schema":

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -659,15 +659,26 @@ def _align_struct_fields(
     return aligned_blocks
 
 
-def shuffle(block: "pyarrow.Table", seed: Optional[int] = None) -> "pyarrow.Table":
-    """Shuffles provided Arrow table"""
+def shuffle(
+    block: "pyarrow.Table", seed: tuple[int, ...] | None = None
+) -> "pyarrow.Table":
+    """Shuffles provided Arrow table.
 
+    Args:
+        block: The Arrow table to shuffle.
+        seed: A tuple of integers to seed ``np.random.default_rng()``,
+            or None for non-deterministic shuffling.
+
+    Returns:
+        A new ``pyarrow.Table`` with rows permuted; the input table is returned
+        unchanged when it has zero rows.
+    """
     if len(block) == 0:
         return block
 
     indices = np.arange(block.num_rows)
-    # Shuffle indices
-    np.random.RandomState(seed).shuffle(indices)
+    rng = np.random.default_rng(seed)
+    rng.shuffle(indices)
 
     return take_table(block, indices)
 

--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -8,8 +8,10 @@ from ray.data._internal.arrow_ops import transform_pyarrow
 from ray.data._internal.arrow_ops.transform_pyarrow import try_combine_chunked_columns
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.util import memory_string
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data._internal.util import get_total_obj_store_mem_on_node
 from ray.data.block import Block, BlockAccessor
+from ray.data.context import DataContext
 from ray.util import log_once
 
 # Delay compaction until the shuffle buffer has reached this ratio over the min
@@ -195,7 +197,7 @@ class ShufflingBatcher(BatcherInterface):
         self,
         batch_size: Optional[int],
         shuffle_buffer_min_size: int,
-        shuffle_seed: Optional[int] = None,
+        shuffle_seed: RandomSeedConfig | None = None,
     ):
         """Constructs a random-shuffling block batcher.
 
@@ -208,12 +210,15 @@ class ShufflingBatcher(BatcherInterface):
                 and the final batch may have less than ``batch_size`` rows. Increasing
                 this will improve the randomness of the shuffle but may increase the
                 latency to the first batch.
-            shuffle_seed: The seed to use for the local random shuffle.
+            shuffle_seed: The seed configuration for the local random shuffle.
+                Use :meth:`RandomSeedConfig.create_with_split_index` to create
+                a config with the split index set for multi-worker scenarios.
         """
         if batch_size is None:
             raise ValueError("Must specify a batch_size if using a local shuffle.")
         self._batch_size = batch_size
-        self._rng = np.random.default_rng(shuffle_seed)
+        self._shuffle_seed = shuffle_seed
+        self._compaction_idx = 0
         if shuffle_buffer_min_size < batch_size:
             # Round it up internally to `batch_size` since our algorithm requires it.
             # This is harmless since it only offers extra randomization.
@@ -341,8 +346,37 @@ class ShufflingBatcher(BatcherInterface):
             self._done_adding
             or self._num_compacted_rows() <= self._min_rows_to_yield_batch
         ):
-            if self._shuffle_buffer is not None and self._batch_head < len(
-                self._shuffled_indices
+            if self._shuffle_buffer is not None:
+                if self._batch_head > 0:
+                    # Compact the materialized shuffle buffer.
+                    block = BlockAccessor.for_block(self._shuffle_buffer)
+                    self._shuffle_buffer = block.slice(
+                        self._batch_head, block.num_rows()
+                    )
+                # Add the unyielded rows from the existing shuffle buffer.
+                self._builder.add_block(self._shuffle_buffer)
+            # Build the new shuffle buffer.
+            self._shuffle_buffer = self._builder.build()
+            # Build a hierarchical seed (least-variable → most-variable):
+            #   base_seed, [split_index,] [execution_idx,] compaction_idx
+            # Materialized (reversed) for np.random.default_rng():
+            #   (compaction_idx, [execution_idx,] [split_index,] base_seed)
+            shuffle_seed_tuple: tuple[int, ...] | None = None
+            if self._shuffle_seed is not None:
+                seed = self._shuffle_seed.make_base_seed()
+                if seed is not None:
+                    seed = self._shuffle_seed.apply_execution_idx(
+                        seed, data_context=DataContext.get_current()
+                    )
+                    seed = seed.spawn(self._compaction_idx)
+                    shuffle_seed_tuple = seed.as_rng_seed()
+            self._shuffle_buffer = BlockAccessor.for_block(
+                self._shuffle_buffer
+            ).random_shuffle(shuffle_seed_tuple)
+            self._compaction_idx += 1
+
+            if isinstance(
+                BlockAccessor.for_block(self._shuffle_buffer), ArrowBlockAccessor
             ):
                 remaining_indices = self._shuffled_indices[self._batch_head :]
                 remaining_block = BlockAccessor.for_block(self._shuffle_buffer).take(

--- a/python/ray/data/_internal/block_batching/block_batching.py
+++ b/python/ray/data/_internal/block_batching/block_batching.py
@@ -6,6 +6,7 @@ from ray.data._internal.block_batching.util import (
     collate,
     format_batches,
 )
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data._internal.stats import DatasetStats
 from ray.data.block import Block, DataBatch
 
@@ -21,7 +22,7 @@ def batch_blocks(
     drop_last: bool = False,
     collate_fn: Optional[Callable[[DataBatch], DataBatch]] = None,
     shuffle_buffer_min_size: Optional[int] = None,
-    shuffle_seed: Optional[int] = None,
+    shuffle_seed: RandomSeedConfig | None = None,
     ensure_copy: bool = False,
 ) -> Iterator[DataBatch]:
     """Create formatted batches of data from 1 or more blocks.

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -17,6 +17,7 @@ from ray.data._internal.block_batching.util import (
 )
 from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data._internal.memory_tracing import trace_deallocation
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data._internal.stats import DatasetStats, _StatsManager
 from ray.data._internal.util import make_async_gen
 from ray.data.block import Block, DataBatch
@@ -88,7 +89,9 @@ class BatchIterator:
             local in-memory shuffle buffer, and this value will serve as the minimum
             number of rows that must be in the local in-memory shuffle buffer in order
             to yield a batch.
-        shuffle_seed: The seed to use for the local random shuffle.
+        shuffle_seed: The seed configuration for the local shuffle. Use
+            :meth:`RandomSeedConfig.create_with_split_index` to create a config
+            with the split index set for multi-worker scenarios.
         ensure_copy: Whether batches are always copied from the underlying base
             blocks (not zero-copy views).
         prefetch_batches: The number of batches to fetch ahead of the current batch to
@@ -115,7 +118,7 @@ class BatchIterator:
         collate_fn: Optional[Callable[[DataBatch], Any]] = None,
         finalize_fn: Optional[Callable[[Any], Any]] = None,
         shuffle_buffer_min_size: Optional[int] = None,
-        shuffle_seed: Optional[int] = None,
+        shuffle_seed: RandomSeedConfig | None = None,
         ensure_copy: bool = False,
         prefetch_batches: int = 1,
         prefetch_bytes_callback: Optional[Callable[[int], None]] = None,

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -14,6 +14,7 @@ from ray.data._internal.block_batching.interfaces import (
     BlockPrefetcher,
     CollatedBatch,
 )
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data._internal.stats import DatasetStats
 from ray.data.block import Block, BlockAccessor, DataBatch
 from ray.types import ObjectRef
@@ -99,7 +100,7 @@ def blocks_to_batches(
     batch_size: Optional[int] = None,
     drop_last: bool = False,
     shuffle_buffer_min_size: Optional[int] = None,
-    shuffle_seed: Optional[int] = None,
+    shuffle_seed: RandomSeedConfig | None = None,
     ensure_copy: bool = False,
 ) -> Iterator[Batch]:
     """Given an iterator over blocks, returns an iterator over batches."""
@@ -128,7 +129,7 @@ class _BatchingIterator(Iterator[Batch]):
         batch_size: Optional[int] = None,
         drop_last: bool = False,
         shuffle_buffer_min_size: Optional[int] = None,
-        shuffle_seed: Optional[int] = None,
+        shuffle_seed: RandomSeedConfig | None = None,
         ensure_copy: bool = False,
     ):
         self._block_iter = block_iter

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -145,6 +145,13 @@ class StreamSplitDataIterator(DataIterator):
     def _get_dataset_tag(self):
         return ray.get(self._coord_actor.get_dataset_tag.remote(self._output_split_idx))
 
+    def _get_split_index(self) -> int:
+        """Return the split index for this iterator.
+
+        Used to derive unique seeds for local shuffle in multi-worker scenarios.
+        """
+        return self._output_split_idx
+
 
 @ray.remote(num_cpus=0)
 class SplitCoordinator:

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -453,8 +453,20 @@ class PandasBlockAccessor(TableBlockAccessor):
 
         return self._table.assign(**{column_name: column_data})
 
-    def random_shuffle(self, random_seed: Optional[int]) -> "pandas.DataFrame":
-        table = self._table.sample(frac=1, random_state=random_seed)
+    def random_shuffle(self, random_seed: tuple[int, ...] | None) -> "pandas.DataFrame":
+        """Randomly shuffle this block.
+
+        Args:
+            random_seed: A tuple of integers to seed ``np.random.default_rng()``,
+                or None for non-deterministic shuffling.
+
+        Returns:
+            A new ``pandas.DataFrame`` with rows in random order.
+        """
+        import numpy as np
+
+        rng = np.random.default_rng(random_seed)
+        table = self._table.sample(frac=1, random_state=rng)
         table.reset_index(drop=True, inplace=True)
         return table
 

--- a/python/ray/data/_internal/random_config.py
+++ b/python/ray/data/_internal/random_config.py
@@ -13,29 +13,39 @@ NUMPY_RNG_SEED_MAX = 2**32
 
 @dataclass(frozen=True)
 class SeedTuple:
-    """A seed for random number generation, optionally including execution index for reseeding.
+    """A hierarchical seed for ``np.random.default_rng()``.
 
-    Args:
-        seed: The base seed.
-        execution_idx: The execution index. If None, the seed is not reseeded after execution.
+    Levels are stored internally from least-variable (base seed) to
+    most-variable (e.g., task index, compaction index).  When materialized
+    via :meth:`as_rng_seed`, the order is reversed so the most-variable
+    index appears first, matching NumPy's ``SeedSequence`` convention for
+    optimal entropy mixing.
 
+    Use :meth:`create` to start a new seed hierarchy, and :meth:`spawn` to
+    derive child seeds at each successive level.
+
+    Example::
+
+        >>> import numpy as np
+        >>> execution_idx, task_idx = 0, 1
+        >>> seed = SeedTuple.create(42).spawn(execution_idx).spawn(task_idx)
+        >>> rng = np.random.default_rng(seed.as_rng_seed())
     """
 
-    seed: int
-    execution_idx: Optional[int] = None
+    _levels: tuple[int, ...]
 
-    def to_rng_args(self, task_idx: int) -> tuple[int, ...]:
-        """Return seed parts for np.random.default_rng((task_idx, ...)).
+    @staticmethod
+    def create(base_seed: int) -> "SeedTuple":
+        """Create a root seed with just the base value."""
+        return SeedTuple(_levels=(base_seed,))
 
-        Args:
-            task_idx: The task index.
+    def spawn(self, index: int) -> "SeedTuple":
+        """Derive a child seed by appending a more-variable level."""
+        return SeedTuple(_levels=(*self._levels, index))
 
-        Returns:
-            A tuple of seed parts.
-        """
-        if self.execution_idx is None:
-            return (task_idx, self.seed)
-        return (task_idx, self.execution_idx, self.seed)
+    def as_rng_seed(self) -> tuple[int, ...]:
+        """Materialize for ``np.random.default_rng()`` (most-variable first)."""
+        return self._levels[::-1]
 
 
 @DeveloperAPI
@@ -43,7 +53,8 @@ class SeedTuple:
 class RandomSeedConfig:
     """This configuration object controls the random seed behavior for operations
     such as :meth:`~Dataset.random_shuffle`, :meth:`~Dataset.randomize_block_order`,
-    and :meth:`~Dataset.random_sample`. The random seed behavior is determined by
+    :meth:`~Dataset.random_sample`, and local shuffling in :meth:`~Dataset.iter_batches`
+    (and related iterators). The random seed behavior is determined by
     the combination of the base seed ``seed`` and the ``reseed_after_execution`` parameter:
 
     - If ``seed`` is None, the random seed is always None (non-deterministic shuffling).
@@ -77,35 +88,71 @@ class RandomSeedConfig:
     seed: Optional[int] = None
     reseed_after_execution: bool = True
     use_timestamp_as_default: bool = False
+    # Internal field set via create_with_split_index().
+    # Used by iteration APIs to differentiate parallel workers/shards.
+    _split_index: Optional[int] = None
 
     def __post_init__(self):
         """Ensure that the seed is either None or an integer."""
         if self.seed is not None and not isinstance(self.seed, int):
             raise ValueError("Seed must be an integer or None.")
 
-    def get_seed_tuple(
+    def make_base_seed(self) -> SeedTuple | None:
+        """Create a :class:`SeedTuple` with the base seed and split index.
+
+        Returns ``None`` when ``seed`` is ``None`` (non-deterministic mode).
+        The split index is included when set (i.e., for iteration APIs
+        with multiple workers/shards).
+        """
+        if self.seed is None:
+            return None
+        seed = SeedTuple.create(self.seed)
+        if self._split_index is not None:
+            seed = seed.spawn(self._split_index)
+        return seed
+
+    def apply_execution_idx(
+        self,
+        seed: SeedTuple,
+        *,
+        data_context: DataContext,
+    ) -> SeedTuple:
+        """Append ``execution_idx`` to *seed* if reseeding is enabled.
+
+        When ``reseed_after_execution`` is ``False`` the seed is returned
+        unchanged.
+
+        Args:
+            seed: The seed to extend.
+            data_context: Used to read the current execution index.
+
+        Returns:
+            The (possibly extended) seed.
+        """
+        if self.reseed_after_execution:
+            return seed.spawn(data_context._execution_idx)
+        return seed
+
+    def make_seed(
         self,
         *,
         data_context: DataContext,
     ) -> SeedTuple | None:
-        """Return a seed for random number generation.
+        """Convenience: ``make_base_seed()`` + ``apply_execution_idx()``.
+
+        Use when no caller-specific levels need to sit between the base seed
+        and the execution index (e.g., dataset-level operations).
 
         Args:
-            data_context: A DataContext object for extracting the
-                execution index.
+            data_context: Used to read the current execution index.
 
         Returns:
-            A SeedTuple, or None for non-deterministic behavior.
+            A :class:`SeedTuple`, or ``None`` for non-deterministic behavior.
         """
-        if self.seed is None:
-            return None
-        elif self.reseed_after_execution:
-            return SeedTuple(
-                seed=self.seed,
-                execution_idx=data_context._execution_idx,
-            )
-        else:
-            return SeedTuple(seed=self.seed, execution_idx=None)
+        seed = self.make_base_seed()
+        if seed is not None:
+            seed = self.apply_execution_idx(seed, data_context=data_context)
+        return seed
 
     @classmethod
     def create_seed_config(
@@ -113,6 +160,7 @@ class RandomSeedConfig:
         seed: int | RandomSeedConfig | None,
         *,
         use_timestamp_as_default: bool = False,
+        split_index: Optional[int] = None,
     ) -> RandomSeedConfig:
         """Create a ``RandomSeedConfig`` object from the ``seed`` argument in Ray Data public random APIs.
 
@@ -128,6 +176,8 @@ class RandomSeedConfig:
                 produce identical output. When ``seed`` is an existing
                 ``RandomSeedConfig``, this value overrides its
                 ``use_timestamp_as_default`` field.
+            split_index: The index of this split/worker. Used by iteration APIs
+                to differentiate parallel workers/shards. Defaults to None.
 
         Returns:
             A ``RandomSeedConfig`` object.
@@ -137,15 +187,42 @@ class RandomSeedConfig:
                 seed=seed,
                 reseed_after_execution=False,
                 use_timestamp_as_default=use_timestamp_as_default,
+                _split_index=split_index,
             )
         elif isinstance(seed, RandomSeedConfig):
             return cls(
                 seed=seed.seed,
                 reseed_after_execution=seed.reseed_after_execution,
                 use_timestamp_as_default=use_timestamp_as_default,
+                _split_index=split_index
+                if split_index is not None
+                else seed._split_index,
             )
 
         raise ValueError(f"Invalid seed type: {type(seed)}")
+
+    @classmethod
+    def create_with_split_index(
+        cls,
+        seed: int | RandomSeedConfig | None,
+        split_index: int,
+    ) -> RandomSeedConfig | None:
+        """Create a ``RandomSeedConfig`` for iteration APIs with split index set.
+
+        This is a convenience method for iteration APIs (``iter_batches``, etc.)
+        that normalizes the seed and sets the split index in one step. Returns
+        ``None`` when ``seed`` is ``None`` (no shuffling configured).
+
+        Args:
+            seed: An integer, ``RandomSeedConfig``, or None.
+            split_index: The index of this split/worker.
+
+        Returns:
+            A ``RandomSeedConfig`` with split index set, or None if seed is None.
+        """
+        if seed is None:
+            return None
+        return cls.create_seed_config(seed, split_index=split_index)
 
 
 def get_timestamp_seed() -> int:
@@ -169,16 +246,18 @@ def get_single_integer_random_seed(
     Returns:
         A single integer random seed, or None for non-deterministic behavior.
     """
-    seed_result = seed_config.get_seed_tuple(data_context=data_context)
+    seed = seed_config.make_seed(data_context=data_context)
 
-    if seed_result is None:
+    if seed is None:
         # This is a legacy behavior for some random operations.
         return get_timestamp_seed() if seed_config.use_timestamp_as_default else None
-    elif seed_result.execution_idx is None:
-        return seed_result.seed
+
+    rng_seed = seed.as_rng_seed()
+    if len(rng_seed) == 1:
+        return rng_seed[0]
 
     # The modulo is only needed because some random implementations are using the
     # older type RandomState or np.random.seed(). Otherwise, the seed can be
     # as large as 128-bit integer. See
     # https://blog.scientific-python.org/numpy/numpy-rng/
-    return hash(seed_result) % NUMPY_RNG_SEED_MAX
+    return hash(rng_seed) % NUMPY_RNG_SEED_MAX

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -428,8 +428,16 @@ class BlockAccessor:
         """
         raise NotImplementedError()
 
-    def random_shuffle(self, random_seed: Optional[int]) -> Block:
-        """Randomly shuffle this block."""
+    def random_shuffle(self, random_seed: tuple[int, ...] | None) -> Block:
+        """Randomly shuffle this block.
+
+        Args:
+            random_seed: A tuple of integers to seed ``np.random.default_rng()``,
+                or None for non-deterministic shuffling.
+
+        Returns:
+            A new block with rows in random order.
+        """
         raise NotImplementedError
 
     def to_pandas(self) -> "pandas.DataFrame":

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2012,15 +2012,15 @@ class Dataset:
         ):
             ctx = TaskContext.get_current()
 
-            seed_result = seed_config.get_seed_tuple(data_context=data_context)
+            seed = seed_config.make_seed(data_context=data_context)
 
             if "rng" in ctx.kwargs:
                 rng = ctx.kwargs["rng"]
-            elif seed_result is None:
+            elif seed is None:
                 rng = np.random.default_rng()
                 ctx.kwargs["rng"] = rng
             else:
-                rng = np.random.default_rng(seed_result.to_rng_args(ctx.task_idx))
+                rng = np.random.default_rng(seed.spawn(ctx.task_idx).as_rng_seed())
                 ctx.kwargs["rng"] = rng
 
             mask_idx = np.where(rng.random(len(batch)) < fraction)[0]
@@ -5829,7 +5829,7 @@ class Dataset:
         batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
         _collate_fn: Optional[Callable[[DataBatch], CollatedData]] = None,
     ) -> Iterable[DataBatch]:
         """Return an iterable over batches of data.
@@ -5876,7 +5876,11 @@ class Dataset:
                 minimum number of rows that must be in the local in-memory shuffle
                 buffer in order to yield a batch. When there are no more rows to add to
                 the buffer, the remaining rows in the buffer are drained.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`RandomSeedConfig`. If an integer is provided, it
+                defaults to the same order across iterator runs
+                (``reseed_after_execution=False``). If ``None``, the shuffle is
+                non-deterministic. See :class:`RandomSeedConfig` for details.
             _collate_fn: A custom function to collate each batch of data.
 
         Returns:
@@ -5905,7 +5909,7 @@ class Dataset:
         collate_fn: Optional[Callable[[Dict[str, np.ndarray]], CollatedData]] = None,
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
         pin_memory: bool = False,
     ) -> Iterable[TorchBatchType]:
         """Return an iterable over batches of data represented as Torch tensors.
@@ -5981,7 +5985,9 @@ class Dataset:
                 buffer in order to yield a batch. When there are no more rows to add to
                 the buffer, the remaining rows in the buffer are drained.
                 ``batch_size`` must also be specified when using local shuffling.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`RandomSeedConfig`. See :meth:`Dataset.iter_batches`
+                for semantics.
             pin_memory: [Alpha] If True, copies the tensor to pinned memory. Note that
                 `pin_memory` is only supported when using `DefaultCollateFn`.
 
@@ -6128,7 +6134,7 @@ class Dataset:
         ] = None,  # noqa: F821
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
     ) -> Iterable[TensorFlowTensorBatchType]:
         """Return an iterable over batches of data represented as TensorFlow tensors.
 
@@ -6183,7 +6189,9 @@ class Dataset:
                 buffer in order to yield a batch. When there are no more rows to add to
                 the buffer, the remaining rows in the buffer are drained.
                 ``batch_size`` must also be specified when using local shuffling.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`RandomSeedConfig`. See :meth:`Dataset.iter_batches`
+                for semantics.
 
         Returns:
             An iterable over TensorFlow Tensor batches.
@@ -6218,7 +6226,7 @@ class Dataset:
         batch_size: int = 1,
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
         feature_type_spec: Union["tf.TypeSpec", Dict[str, "tf.TypeSpec"]] = None,
         label_type_spec: Union["tf.TypeSpec", Dict[str, "tf.TypeSpec"]] = None,
         additional_type_spec: Union["tf.TypeSpec", Dict[str, "tf.TypeSpec"]] = None,
@@ -6317,7 +6325,9 @@ class Dataset:
                 buffer size must be greater than or equal to ``batch_size``, and
                 therefore ``batch_size`` must also be specified when using local
                 shuffling.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`RandomSeedConfig`. See :meth:`Dataset.iter_batches`
+                for semantics.
             feature_type_spec: The `tf.TypeSpec` of `feature_columns`. If there is
                 only one column, specify a `tf.TypeSpec`. If there are multiple columns,
                 specify a ``dict`` that maps column names to their `tf.TypeSpec`.

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -23,6 +23,7 @@ from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators import InputData
 from ray.data._internal.plan import ExecutionPlan
+from ray.data._internal.random_config import RandomSeedConfig
 from ray.data._internal.stats import DatasetStats
 from ray.data.block import BlockAccessor, DataBatch, _apply_batch_format
 from ray.data.collate_fn import (
@@ -129,7 +130,7 @@ class DataIterator(abc.ABC):
         batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
     ) -> Iterable[DataBatch]:
         """Return a batched iterable over the dataset.
 
@@ -163,7 +164,11 @@ class DataIterator(abc.ABC):
                 minimum number of rows that must be in the local in-memory shuffle
                 buffer in order to yield a batch. When there are no more rows to add to
                 the buffer, the remaining rows in the buffer will be drained.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`~ray.data.RandomSeedConfig`. If an integer is
+                provided, it defaults to the same order across iterator runs
+                (``reseed_after_execution=False``). If ``None``, the shuffle is
+                non-deterministic. See :class:`~ray.data.RandomSeedConfig` for details.
 
         Returns:
             An iterable over record batches.
@@ -197,11 +202,16 @@ class DataIterator(abc.ABC):
         batch_format: Optional[str] = "default",
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
         _collate_fn: Optional[Callable[[DataBatch], "CollatedData"]] = None,
         _finalize_fn: Optional[Callable[[Any], Any]] = None,
     ) -> Iterable[DataBatch]:
         batch_format = _apply_batch_format(batch_format)
+
+        # Normalize seed to RandomSeedConfig at public boundary and set split index
+        shuffle_seed_config = RandomSeedConfig.create_with_split_index(
+            local_shuffle_seed, self._get_split_index()
+        )
 
         def _create_iterator() -> Iterator[DataBatch]:
             time_start = time.perf_counter()
@@ -245,7 +255,7 @@ class DataIterator(abc.ABC):
                 collate_fn=_collate_fn,
                 finalize_fn=_finalize_fn,
                 shuffle_buffer_min_size=local_shuffle_buffer_size,
-                shuffle_seed=local_shuffle_seed,
+                shuffle_seed=shuffle_seed_config,
                 prefetch_batches=prefetch_batches,
                 prefetch_bytes_callback=prefetch_bytes_callback,
             )
@@ -262,6 +272,14 @@ class DataIterator(abc.ABC):
 
     def _get_dataset_tag(self) -> str:
         return "unknown_dataset"
+
+    def _get_split_index(self) -> int:
+        """Return the split index for this iterator.
+
+        For regular iterators, this is 0. For split iterators (e.g., in Ray Train),
+        this is the index of the split/worker, used for deriving per-worker seeds.
+        """
+        return 0
 
     @PublicAPI
     def iter_rows(self) -> Iterable[Dict[str, Any]]:
@@ -322,7 +340,7 @@ class DataIterator(abc.ABC):
         ] = None,
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
         pin_memory: bool = False,
     ) -> Iterable["TorchBatchType"]:
         """Return a batched iterable of Torch Tensors over the dataset.
@@ -443,7 +461,9 @@ class DataIterator(abc.ABC):
                 buffer size must be greater than or equal to ``batch_size``, and
                 therefore ``batch_size`` must also be specified when using local
                 shuffling.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`~ray.data.RandomSeedConfig`. See
+                :meth:`iter_batches` for semantics.
             pin_memory: [Alpha] If True, copies the tensor to pinned memory. Note that
                 `pin_memory` is only supported when using `DefaultCollateFn`.
 
@@ -550,7 +570,7 @@ class DataIterator(abc.ABC):
         dtypes: Optional[Union["tf.dtypes.DType", Dict[str, "tf.dtypes.DType"]]] = None,
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
     ) -> Iterable["TensorFlowTensorBatchType"]:
         """Return a batched iterable of TensorFlow Tensors over the dataset.
 
@@ -595,7 +615,9 @@ class DataIterator(abc.ABC):
                 buffer size must be greater than or equal to ``batch_size``, and
                 therefore ``batch_size`` must also be specified when using local
                 shuffling.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`~ray.data.RandomSeedConfig`. See
+                :meth:`iter_batches` for semantics.
 
         Returns:
             An iterator over TensorFlow Tensor batches.
@@ -758,7 +780,7 @@ class DataIterator(abc.ABC):
         prefetch_batches: int = 1,
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
         unsqueeze_label_tensor: bool = True,
         unsqueeze_feature_tensors: bool = True,
     ) -> "torch.utils.data.IterableDataset":
@@ -837,7 +859,9 @@ class DataIterator(abc.ABC):
                 buffer size must be greater than or equal to ``batch_size``, and
                 therefore ``batch_size`` must also be specified when using local
                 shuffling.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`~ray.data.RandomSeedConfig`. See
+                :meth:`iter_batches` for semantics.
             unsqueeze_label_tensor: If set to True, the label tensor
                 will be unsqueezed (reshaped to (N, 1)). Otherwise, it will
                 be left as is, that is (N, ). In general, regression loss
@@ -953,7 +977,7 @@ class DataIterator(abc.ABC):
         batch_size: int = 1,
         drop_last: bool = False,
         local_shuffle_buffer_size: Optional[int] = None,
-        local_shuffle_seed: Optional[int] = None,
+        local_shuffle_seed: int | RandomSeedConfig | None = None,
         feature_type_spec: Union["tf.TypeSpec", Dict[str, "tf.TypeSpec"]] = None,
         label_type_spec: Union["tf.TypeSpec", Dict[str, "tf.TypeSpec"]] = None,
         additional_type_spec: Union[
@@ -1053,7 +1077,9 @@ class DataIterator(abc.ABC):
                 buffer size must be greater than or equal to ``batch_size``, and
                 therefore ``batch_size`` must also be specified when using local
                 shuffling.
-            local_shuffle_seed: The seed to use for the local random shuffle.
+            local_shuffle_seed: An optional random seed for the local shuffle. Can be
+                an integer or a :class:`~ray.data.RandomSeedConfig`. See
+                :meth:`iter_batches` for semantics.
             feature_type_spec: The `tf.TypeSpec` of `feature_columns`. If there is
                 only one column, specify a `tf.TypeSpec`. If there are multiple columns,
                 specify a ``dict`` that maps column names to their `tf.TypeSpec`.

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -66,6 +66,13 @@ def data_context_override(request):
 
 
 @pytest.fixture(scope="module")
+def ray_start_1_cpu_shared(request):
+    param = getattr(request, "param", {})
+    with _ray_start(num_cpus=1, **param) as res:
+        yield res
+
+
+@pytest.fixture(scope="module")
 def ray_start_2_cpus_shared(request):
     param = getattr(request, "param", {})
     with _ray_start(num_cpus=2, **param) as res:

--- a/python/ray/data/tests/test_batcher.py
+++ b/python/ray/data/tests/test_batcher.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data import RandomSeedConfig
 from ray.data._internal.arrow_block import ArrowBlockAccessor
 from ray.data._internal.arrow_ops.transform_pyarrow import try_combine_chunked_columns
 from ray.data._internal.batcher import (
@@ -19,7 +20,7 @@ def gen_block(num_rows):
     return pa.table({"foo": [1] * num_rows})
 
 
-def test_shuffling_batcher():
+def test_shuffling_batcher(ray_start_1_cpu_shared):
     batch_size = 5
     buffer_size = 20
 
@@ -131,7 +132,7 @@ def test_shuffling_batcher():
     assert not batcher.has_any()
 
 
-def test_batching_pyarrow_table_with_many_chunks():
+def test_batching_pyarrow_table_with_many_chunks(ray_start_1_cpu_shared):
     """Make sure batching a pyarrow table with many chunks is fast.
 
     See https://github.com/ray-project/ray/issues/31108 for more details.
@@ -173,7 +174,9 @@ def test_batching_pyarrow_table_with_many_chunks():
     "batch_size,local_shuffle_buffer_size",
     [(1, 1), (10, 1), (1, 10), (10, 1000), (1000, 10)],
 )
-def test_shuffling_batcher_grid(batch_size, local_shuffle_buffer_size):
+def test_shuffling_batcher_grid(
+    batch_size, local_shuffle_buffer_size, ray_start_1_cpu_shared
+):
     ds = ray.data.range_tensor(10000, shape=(130,))
     start = time.time()
     count = 0
@@ -189,10 +192,9 @@ def test_shuffling_batcher_grid(batch_size, local_shuffle_buffer_size):
     "batch_size,local_shuffle_buffer_size",
     [(1, 1), (10, 1), (1, 10), (10, 100), (100, 10)],
 )
-def test_local_shuffle_determinism(batch_size, local_shuffle_buffer_size):
-    # Preserve order so that the blocks are in the same order prior to shuffling.
-    ctx = ray.data.DataContext.get_current()
-    ctx.execution_options.preserve_order = True
+def test_local_shuffle_determinism(
+    batch_size, local_shuffle_buffer_size, ray_start_1_cpu_shared
+):
     TEST_ITERATIONS = 10
 
     ds = ray.data.range(1000)
@@ -208,6 +210,82 @@ def test_local_shuffle_determinism(batch_size, local_shuffle_buffer_size):
             else:
                 # Check that batch is the same as the first dataset's batch
                 assert all(batch_map[batch["id"][0]]["id"] == batch["id"])
+
+
+def test_local_shuffle_random_seed_config_matches_int_seed(ray_start_1_cpu_shared):
+    ds = ray.data.range(100)
+    kwargs = dict(batch_size=10, local_shuffle_buffer_size=25)
+    batches_int = list(ds.iter_batches(local_shuffle_seed=0, **kwargs))
+    batches_cfg = list(
+        ds.iter_batches(
+            local_shuffle_seed=RandomSeedConfig(seed=0, reseed_after_execution=False),
+            **kwargs,
+        )
+    )
+    assert len(batches_int) == len(batches_cfg)
+    for a, b in zip(batches_int, batches_cfg):
+        assert all(a["id"] == b["id"])
+
+
+def test_reseed_after_execution_produces_different_iterations(ray_start_1_cpu_shared):
+    """With reseed_after_execution=True, each iteration over the same iterable
+    should yield a different shuffle order (mimicking different training epochs).
+    """
+    ds = ray.data.range(1000)
+    it = ds.iter_batches(
+        batch_size=50,
+        local_shuffle_buffer_size=100,
+        local_shuffle_seed=RandomSeedConfig(seed=42, reseed_after_execution=True),
+    )
+
+    iterations = []
+    for _ in range(3):
+        ids = [x for batch in it for x in batch["id"].tolist()]
+        iterations.append(ids)
+
+    for ids in iterations:
+        assert sorted(ids) == list(range(1000))
+
+    # Different epochs must differ in ordering.
+    assert iterations[0] != iterations[1]
+    assert iterations[1] != iterations[2]
+
+
+def test_reseed_after_execution_is_reproducible(ray_start_1_cpu_shared):
+    """Two independent iterables with the same seed must produce the same
+    per-epoch results (simulating two script runs)."""
+    ds = ray.data.range(1000)
+    seed_cfg = RandomSeedConfig(seed=42, reseed_after_execution=True)
+    kwargs = dict(batch_size=50, local_shuffle_buffer_size=100)
+
+    runs = []
+    for _ in range(2):
+        # Reset execution index to simulate a fresh process/script run.
+        ray.data.DataContext.get_current()._execution_idx = 0
+        it = ds.iter_batches(local_shuffle_seed=seed_cfg, **kwargs)
+        epoch_results = []
+        for _ in range(3):
+            ids = [x for batch in it for x in batch["id"].tolist()]
+            epoch_results.append(ids)
+        runs.append(epoch_results)
+
+    for epoch_idx in range(3):
+        assert runs[0][epoch_idx] == runs[1][epoch_idx]
+
+
+def test_no_reseed_produces_same_iterations(ray_start_1_cpu_shared):
+    """With reseed_after_execution=False, every iteration should yield the
+    same shuffle order."""
+    ds = ray.data.range(1000)
+    it = ds.iter_batches(
+        batch_size=50,
+        local_shuffle_buffer_size=100,
+        local_shuffle_seed=RandomSeedConfig(seed=42, reseed_after_execution=False),
+    )
+
+    first_ids = [x for batch in it for x in batch["id"].tolist()]
+    second_ids = [x for batch in it for x in batch["id"].tolist()]
+    assert first_ids == second_ids
 
 
 def test_local_shuffle_buffer_warns_if_too_large(shutdown_only):

--- a/python/ray/data/tests/unit/test_transform_pyarrow.py
+++ b/python/ray/data/tests/unit/test_transform_pyarrow.py
@@ -228,7 +228,7 @@ def test_shuffle():
     shuffled = shuffle(t, seed=0xDEED)
 
     assert shuffled == pa.Table.from_pydict(
-        {"index": pa.array([4, 3, 6, 8, 7, 1, 5, 2, 9, 0])}
+        {"index": pa.array([9, 2, 7, 0, 6, 8, 3, 5, 4, 1])}
     )
 
 


### PR DESCRIPTION
## Description

This PR plumbs `RandomSeedConfig` through the `DataIterator` APIs (`iter_batches`, `iter_torch_batches`, `iter_tf_batches`, `to_torch`, `to_tf`). Together with `RandomSeedConfig` on `random_shuffle`/`randomize_block_order`/`random_sample` and `FileShuffleConfig` on read APIs, users can now build **fully reproducible multi-epoch training pipelines** (parallelism-induced ordering aside).

All iterator APIs accept either an `int` (same behavior as before: same shuffle order every epoch) or a `RandomSeedConfig` (new: `reseed_after_execution=True` gives a different-but-reproducible order per epoch).

```python
ds.iter_batches(
    local_shuffle_seed=RandomSeedConfig(seed=42, reseed_after_execution=True),
)
```

## Why each change is needed

The user-facing feature (accepting `RandomSeedConfig` on iterators) forces a few internal changes because the seed hierarchy gets deeper than before.

### 1. `SeedTuple`: fixed shape → variadic levels
Previously `SeedTuple` was hard-coded to `(seed, execution_idx)` plus a `task_idx` argument on materialization — at most 3 levels. With this PR, call-sites need up to **4 levels**:

```
base_seed → split_index → execution_idx → compaction_idx   (ShufflingBatcher)
base_seed → execution_idx → task_idx                       (random_sample)
```

The old shape literally can't express the batcher case. `SeedTuple` is now a variadic `_levels` tuple with `create()` / `spawn()` / `as_rng_seed()` — mirroring NumPy's `SeedSequence` hierarchical-seeding convention (most-variable level first on materialization for optimal entropy mixing).

### 2. `RandomSeedConfig._split_index` + `create_with_split_index()`
Iterators can be split across N workers (Ray Train). Each worker must derive a distinct seed from the same user-provided seed. A new `_split_index` field on the config (set via `create_with_split_index`) is injected between the base seed and the execution index. `DataIterator._get_split_index()` is the single hook subclasses override; `StreamSplitDataIterator` returns `self._output_split_idx`.

Normalization `int | RandomSeedConfig | None → RandomSeedConfig | None` happens exactly once, at the public iterator boundary.

### 3. `ShufflingBatcher`: per-compaction RNG keyed by `compaction_idx`
The old implementation built one `np.random.default_rng(seed)` in `__init__` and reused it across compactions. That made the shuffle order impossible to cleanly re-seed per epoch and coupled successive compactions to a single stateful stream.

Now a fresh RNG is built for every compaction, with `compaction_idx` spawned as the most-variable seed level. This gives both independence across compactions *and* reproducibility across runs.

### 4. Block-level `random_shuffle`: `Optional[int]` → `int | tuple[int, ...] | None`
`BlockAccessor.random_shuffle`, `ArrowBlockAccessor.random_shuffle`, `PandasBlockAccessor.random_shuffle`, and `transform_pyarrow.shuffle` now accept a materialized seed tuple (in addition to the existing `int`/`None`). Callers in this PR pass `SeedTuple.as_rng_seed()`, which is a tuple. Also switched from legacy `np.random.RandomState` (scalar-only) to `np.random.default_rng`, which accepts both scalars and tuples via `SeedSequence` — so third-party `BlockAccessor` subclasses that still pass an `int` continue to work unchanged.

### 5. Test additions
`test_batcher.py` gains end-to-end tests for the three public semantics:
- int seed and equivalent `RandomSeedConfig(reseed_after_execution=False)` produce identical shuffles
- `reseed_after_execution=True` produces *different* per-epoch shuffles that are *reproducible* across script runs
- `reseed_after_execution=False` produces the same shuffle every epoch

## Related issues
<!-- Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234". -->

## Additional information

**Typical usage in model training:** `iter_batches` is the per-worker data loader (e.g., for DDP). With `reseed_after_execution=True`, each epoch sees a different shuffle while remaining reproducible across runs.
