### PR TITLE
[train] Fix StateManagerCallback to accept datasets explicitly

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/state_manager.py
+++ b/python/ray/train/v2/_internal/callbacks/state_manager.py
@@ -1,6 +1,9 @@
 import importlib
 import logging
-from typing import Optional
+from typing import TYPE_CHECKING, Dict, Optional
+
+if TYPE_CHECKING:
+    from ray.data import Dataset
 
 import ray
 from ray.train.v2._internal.execution.callback import (
@@ -66,6 +69,9 @@ def _get_framework_version(framework: Optional[TrainingFramework]):
 
 
 class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
+    def __init__(self, datasets: Dict[str, "Dataset"]):
+        self._datasets = datasets
+
     def after_controller_start(self, train_run_context: TrainRunContext):
         self._state_manager = TrainStateManager()
         self._run_name = train_run_context.get_run_config().name
@@ -88,7 +94,7 @@ class StateManagerCallback(ControllerCallback, WorkerGroupCallback):
             train_loop_config=train_run_context.train_loop_config,
             scaling_config=train_run_context.scaling_config,
             backend_config=train_run_context.backend_config,
-            datasets=train_run_context.datasets,
+            datasets=self._datasets,
             dataset_config=train_run_context.dataset_config,
         )
 

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -231,7 +231,7 @@ class DataParallelTrainer:
             callbacks.append(WorkerMetricsCallback(self.train_run_context))
 
         if env_bool(RAY_TRAIN_ENABLE_STATE_TRACKING, False):
-            callbacks.append(StateManagerCallback())
+            callbacks.append(StateManagerCallback(datasets=self.datasets))
 
         run_config_callbacks = (
             self.run_config.callbacks if self.run_config.callbacks is not None else []

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -170,7 +170,7 @@ def callback(monkeypatch):
         lambda: expected_controller_log_path,
     )
 
-    callback = StateManagerCallback()
+    callback = StateManagerCallback(datasets={})
     callback.after_controller_start(train_run_context=create_dummy_run_context())
     return callback
 
@@ -784,7 +784,7 @@ def test_callback_log_file_paths(
     )
 
     # Create the callback
-    callback = StateManagerCallback()
+    callback = StateManagerCallback(datasets={})
 
     # Initialize the callback
     callback.after_controller_start(train_run_context=create_dummy_run_context())


### PR DESCRIPTION
# Summary

This change allows the callback to track datasets without depending on `TrainRunContext` state. 

## Changes

- Added `__init__` method to `StateManagerCallback` to accept `datasets` as a required parameter.
- Updated `StateManagerCallback` to use the explicitly passed datasets instead of relying on `train_run_context.datasets`.
- Modified `DataParallelTrainer` to pass `datasets=self.datasets` when instantiating `StateManagerCallback`.

## Related

Tracking was introduced in #59186.
Datasets were removed from the `TrainRunContext` in #61953.