### PR TITLE
[RLlib] Fix TorchRLModule.self.training always True during evaluation

### DIFF
--- a/rllib/core/rl_module/torch/tests/test_torch_rl_module.py
+++ b/rllib/core/rl_module/torch/tests/test_torch_rl_module.py
@@ -73,33 +73,66 @@ class TestRLModule(unittest.TestCase):
         module.forward_inference({"obs": obs})
         module.forward_exploration({"obs": obs})
 
-    def test_training_mode_toggling(self):
-        """Test that eval mode is set during inference/exploration and restored after."""
+    def test_training_mode_during_forward_passes(self):
+        """Test that self.training is correctly set during each forward pass.
+
+        Regression test for https://github.com/ray-project/ray/issues/61961:
+        RLModule.self.training was True even during evaluation because
+        model.eval() was never called before forward_inference / forward_exploration.
+        """
+
+        training_flags: dict = {}
+
+        class TrainingFlagCapture(VPGTorchRLModule):
+            def _forward_inference(self, batch, **kwargs):
+                training_flags["inference"] = self.training
+                return super()._forward_inference(batch, **kwargs)
+
+            def _forward_exploration(self, batch, **kwargs):
+                training_flags["exploration"] = self.training
+                return super()._forward_exploration(batch, **kwargs)
+
+            def _forward_train(self, batch, **kwargs):
+                training_flags["train"] = self.training
+                return super()._forward_train(batch, **kwargs)
 
         env = gym.make("CartPole-v1")
-        module = VPGTorchRLModule(
+        module = TrainingFlagCapture(
             observation_space=env.observation_space,
             action_space=env.action_space,
             model_config={"hidden_dim": 32},
         )
 
-        obs_shape = env.observation_space.shape
-        obs = torch.randn((1,) + obs_shape)
+        obs = torch.randn((1,) + env.observation_space.shape)
+        batch = {"obs": obs}
 
-        # Module starts in training mode.
-        self.assertTrue(module.training)
+        # forward_inference must run with self.training == False (eval mode).
+        module.forward_inference(batch)
+        self.assertFalse(
+            training_flags["inference"],
+            "self.training should be False inside _forward_inference (eval mode)",
+        )
 
-        # forward_inference should set eval mode internally and restore train mode.
-        module.forward_inference({"obs": obs})
-        self.assertTrue(module.training)
+        # forward_exploration must also run with self.training == False (eval mode).
+        module.forward_exploration(batch)
+        self.assertFalse(
+            training_flags["exploration"],
+            "self.training should be False inside _forward_exploration (eval mode)",
+        )
 
-        # forward_exploration should also set eval mode and restore train mode.
-        module.forward_exploration({"obs": obs})
-        self.assertTrue(module.training)
+        # forward_train must run with self.training == True (train mode).
+        module.forward_train(batch)
+        self.assertTrue(
+            training_flags["train"],
+            "self.training should be True inside _forward_train (train mode)",
+        )
 
-        # forward_train should keep train mode.
-        module.forward_train({"obs": obs})
-        self.assertTrue(module.training)
+        # After all forward passes, the module should be back in train mode
+        # (the default PyTorch state).
+        self.assertTrue(
+            module.training,
+            "Module should be restored to train mode after forward passes complete",
+        )
 
     def test_get_set_state(self):
 

--- a/rllib/core/rl_module/torch/torch_rl_module.py
+++ b/rllib/core/rl_module/torch/torch_rl_module.py
@@ -83,26 +83,46 @@ class TorchRLModule(nn.Module, RLModule):
 
     @override(RLModule)
     def forward_inference(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
-        was_training = self.training
+        """Forward-pass during evaluation/inference with eval mode set.
+
+        Sets the module to ``eval`` mode (``self.training == False``) before
+        delegating to the parent implementation and restores ``train`` mode
+        afterwards.  This ensures that layers such as ``BatchNorm`` and
+        ``Dropout`` behave correctly during evaluation and that
+        ``self.training`` reads ``False`` inside any user-defined
+        ``_forward_inference`` override.
+        """
         self.eval()
         try:
-            return self._forward_inference(batch, **kwargs)
+            return super().forward_inference(batch, **kwargs)
         finally:
-            if was_training:
-                self.train()
+            self.train()
 
     @override(RLModule)
     def forward_exploration(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
-        was_training = self.training
+        """Forward-pass during sample collection with eval mode set.
+
+        Sets the module to ``eval`` mode before delegating to the parent
+        implementation and restores ``train`` mode afterwards.  During
+        exploration the agent collects environment data; gradient-dependent
+        layers (``BatchNorm``, ``Dropout``) should still run in inference mode
+        to avoid contaminating running statistics with exploratory noise.
+        """
         self.eval()
         try:
-            return self._forward_exploration(batch, **kwargs)
+            return super().forward_exploration(batch, **kwargs)
         finally:
-            if was_training:
-                self.train()
+            self.train()
 
     @override(RLModule)
     def forward_train(self, batch: Dict[str, Any], **kwargs) -> Dict[str, Any]:
+        """Forward-pass for loss computation with train mode explicitly set.
+
+        Ensures ``self.training == True`` is set before the forward pass so
+        that the behaviour is well-defined even when the module was previously
+        used for inference on the same process (e.g. a local EnvRunner that
+        also runs learning updates).
+        """
         self.train()
         return super().forward_train(batch, **kwargs)
 


### PR DESCRIPTION
## Why are these changes needed?

Fixes #61961.

`algo.evaluate()` never called `model.eval()` on the `RLModule`, so
`self.training` was always `True` even during evaluation. This caused:

- `BatchNorm` running-statistics to be updated during evaluation rollouts (incorrect)
- `Dropout` layers remaining active during evaluation (incorrect)
- User code inside `_forward_inference` / `_forward_exploration` unable to
  distinguish between training and inference contexts via `self.training`

The old API stack (`TorchPolicyV2`) already handled this correctly by calling
`self.model.eval()` in `_compute_action_helper`. The new RLModule API stack
was missing the equivalent.

## What changes were made?

`TorchRLModule` now overrides the three public forward methods to bracket each
call with the correct PyTorch training-mode flag:

| Method | Training mode inside call | Restored to |
|---|---|---|
| `forward_inference` | `eval` (`self.training == False`) | `train` |
| `forward_exploration` | `eval` (`self.training == False`) | `train` |
| `forward_train` | `train` (`self.training == True`) | — |

A `try/finally` guard in `forward_inference` and `forward_exploration` ensures
`train` mode is restored even when the forward pass raises an exception.

The `_forward_inference` / `_forward_exploration` private overrides (which
users are encouraged to customise) are unchanged — they continue to wrap the
call in `torch.no_grad()` for performance.

## Tests

Added `TestRLModule.test_training_mode_during_forward_passes` in
`rllib/core/rl_module/torch/tests/test_torch_rl_module.py`.

The test subclasses `VPGTorchRLModule`, captures `self.training` inside each
`_forward_*` hook, and asserts:

- `self.training == False` during `_forward_inference`
- `self.training == False` during `_forward_exploration`
- `self.training == True` during `_forward_train`
- Module is back in `train` mode after all forward passes complete

## Checklist

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR
- [x] I've run `scripts/format.sh` to lint the changes in this PR
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/
- [x] I've added any new APIs to the API stability tags.  For fixes to broken tests, skip this step.
- [x] I've made sure existing tests are not broken.
- [x] Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(