### PR TITLE
fix(core): break ActorMethod.options() reference cycle (#61922)

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -921,8 +921,6 @@ class ActorMethod:
             >>> actor.my_method.options(name="foo", num_returns=2).remote(x, y)
         """
 
-        func_cls = self
-
         tensor_transport = options.get("tensor_transport", None)
         if tensor_transport is not None:
             from ray.experimental.rdt.util import (
@@ -932,15 +930,7 @@ class ActorMethod:
             tensor_transport = normalize_and_validate_tensor_transport(tensor_transport)
             options["tensor_transport"] = tensor_transport
 
-        class FuncWrapper:
-            def remote(self, *args, **kwargs):
-                return func_cls._remote(args=args, kwargs=kwargs, **options)
-
-            @DeveloperAPI
-            def bind(self, *args, **kwargs):
-                return func_cls._bind(args=args, kwargs=kwargs, **options)
-
-        return FuncWrapper()
+        return _ActorMethodOptionsWrapper(self, options)
 
     @wrap_auto_init
     @_tracing_actor_method_invocation
@@ -1151,6 +1141,29 @@ class ActorMethod:
             state["decorator"],
             state["_tensor_transport"],
         )
+
+
+class _ActorMethodOptionsWrapper:
+    """Wraps an ActorMethod with pre-set options for .remote() and .bind().
+
+    Defined at module scope to avoid the reference cycle that occurs when a
+    class is defined inside a closure (CPython's implicit ``__class__`` cell
+    keeps the enclosing closure alive, which keeps the ActorMethod — and
+    therefore its ActorHandle — alive until the cyclic GC runs).
+
+    See https://github.com/ray-project/ray/issues/61922.
+    """
+
+    def __init__(self, actor_method, options):
+        self._actor_method = actor_method
+        self._options = options
+
+    def remote(self, *args, **kwargs):
+        return self._actor_method._remote(args=args, kwargs=kwargs, **self._options)
+
+    @DeveloperAPI
+    def bind(self, *args, **kwargs):
+        return self._actor_method._bind(args=args, kwargs=kwargs, **self._options)
 
 
 class _ActorClassMethodMetadata(object):

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -922,6 +922,53 @@ def test_options_name(ray_start_regular_shared):
     ray.get(f.method.options(name="bar").remote("bar"))
 
 
+def test_options_no_actor_handle_ref_cycle(ray_start_regular_shared):
+    """ActorMethod.options() must not create a reference cycle.
+
+    The old implementation defined FuncWrapper inside the options() closure,
+    capturing ``self`` (the ActorMethod) via ``func_cls = self``.  CPython's
+    implicit ``__class__`` cell in a nested class definition also kept the
+    closure alive.  Together they formed a cycle:
+
+        FuncWrapper  →  closure cell  →  ActorMethod  →  ActorHandle
+
+    This cycle prevented the reference-count from dropping to zero, so the
+    ActorHandle was only freed after a full cyclic-GC pass instead of
+    immediately when the last user reference was dropped.
+
+    Regression test for https://github.com/ray-project/ray/issues/61922.
+    """
+    import gc
+    import weakref
+
+    @ray.remote
+    class MyActor:
+        def task(self, x):
+            return x
+
+    # Disable the cyclic GC so that only reference-counting drives collection.
+    gc.disable()
+    try:
+        actor = MyActor.remote()
+        weak = weakref.ref(actor)
+
+        # Call via .options().remote() — this is what triggered the cycle.
+        ref = actor.task.options(num_returns=1).remote(42)
+        assert ray.get(ref) == 42
+
+        # Drop the strong references.  With the fix the handle should be freed
+        # immediately by reference counting (no gc.collect() needed).
+        del ref
+        del actor
+
+        assert weak() is None, (
+            "ActorHandle still alive after del — reference cycle was not broken. "
+            "See https://github.com/ray-project/ray/issues/61922"
+        )
+    finally:
+        gc.enable()
+
+
 def test_define_actor(ray_start_regular_shared):
     @ray.remote
     class Test:


### PR DESCRIPTION
## Why

`ActorMethod.options()` defined `FuncWrapper` as a nested class inside the method body. This caused two overlapping reference cycles:

1. `func_cls = self` explicitly captured the `ActorMethod` (which holds a strong reference to `ActorHandle`) in the enclosing closure.
2. CPython adds an implicit `__class__` cell to every nested class definition; this cell also keeps the enclosing closure frame alive.

Together they formed the chain:

```
FuncWrapper instance
  -> FuncWrapper.__class__ cell
    -> options() closure
      -> func_cls (ActorMethod)
        -> ActorMethod._actor (ActorHandle)
```

Because CPython's reference counter cannot break cycles, the `ActorHandle` was only freed after a full cyclic-GC pass rather than immediately when the last user reference was dropped. This delayed `__ray_shutdown__` and caused actor resource leaks.

## What changed

- Removed `func_cls = self` and the inline `FuncWrapper` class from `ActorMethod.options()`.
- Added a module-level `_ActorMethodOptionsWrapper` class that accepts `actor_method` and `options` as constructor arguments.
- `options()` now returns `_ActorMethodOptionsWrapper(self, options)` — a plain attribute reference with no closure, so no cycle is formed.

## Test

Added `test_options_no_actor_handle_ref_cycle` in `python/ray/tests/test_actor.py`.
The test disables the cyclic GC (`gc.disable()`), calls `.options().remote()`, drops all strong references, and asserts the `weakref` becomes `None` immediately — proving the fix works by reference-counting alone.

Fixes #61922

## Checklist

- [x] Added a regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)