### PR TITLE
[Core][3/N] Add fallback_strategy Python API and Cython bindings

### DIFF
--- a/python/ray/_private/label_utils.py
+++ b/python/ray/_private/label_utils.py
@@ -155,10 +155,14 @@ def validate_label_selector(label_selector: Optional[Dict[str, str]]) -> Optiona
         return None
 
     for key, value in label_selector.items():
+        if not isinstance(key, str):
+            return "Label selector keys must be strings."
         possible_error_message = validate_label_key(key)
         if possible_error_message:
             return possible_error_message
         if value is not None:
+            if not isinstance(value, str):
+                return "Label selector values must be strings."
             possible_error_message = validate_label_selector_value(value)
             if possible_error_message:
                 return possible_error_message
@@ -199,7 +203,9 @@ def validate_fallback_strategy(
     if fallback_strategy is None:
         return None
 
-    # Supported options for `fallback_strategy` scheduling.
+    if not isinstance(fallback_strategy, list):
+        return "fallback_strategy must be a list"
+
     supported_options = {"label_selector"}
 
     for strategy in fallback_strategy:
@@ -209,7 +215,6 @@ def validate_fallback_strategy(
         if not strategy:
             return "Empty dictionary found in `fallback_strategy`."
 
-        # Validate `fallback_strategy` only contains supported options.
         for option in strategy:
             if option not in supported_options:
                 return (
@@ -217,14 +222,79 @@ def validate_fallback_strategy(
                     f"Only {list(supported_options)} is currently supported."
                 )
 
-        # Validate the 'label_selector' dictionary.
-        label_selector = strategy.get("label_selector")
-        if label_selector:
-            if not isinstance(label_selector, dict):
-                return 'The value of "label_selector" must be a dictionary.'
-
-            error_message = validate_label_selector(label_selector)
+        actor_label_selector = strategy.get("label_selector")
+        if actor_label_selector is not None:
+            if not isinstance(actor_label_selector, dict):
+                return "The value of 'label_selector' must be a dictionary."
+            error_message = validate_label_selector(actor_label_selector)
             if error_message:
                 return error_message
+
+    return None
+
+
+def validate_placement_group_fallback_strategy(
+    fallback_strategy: Optional[List[Dict[str, Any]]]
+) -> Optional[str]:
+    if fallback_strategy is None:
+        return None
+
+    if not isinstance(fallback_strategy, list):
+        return "fallback_strategy must be a list"
+
+    supported_options = {"bundle_label_selector", "bundles"}
+
+    for strategy in fallback_strategy:
+        if not isinstance(strategy, dict):
+            return "Each element in fallback_strategy must be a dictionary."
+
+        if not strategy:
+            return "Empty dictionary found in `fallback_strategy`."
+
+        for option in strategy:
+            if option not in supported_options:
+                return (
+                    f"Unsupported option found: '{option}'. "
+                    f"Only {list(supported_options)} is currently supported."
+                )
+
+        label_selectors = strategy.get("bundle_label_selector")
+        if label_selectors is not None:
+            if not isinstance(label_selectors, list):
+                return 'The value of "bundle_label_selector" must be a list.'
+
+            for label_selector in label_selectors:
+                if not isinstance(label_selector, dict):
+                    return "Each label selector in bundle_label_selector must be a dictionary."
+
+                error_message = validate_label_selector(label_selector)
+                if error_message:
+                    return error_message
+
+        if "bundles" not in strategy:
+            return 'Each fallback strategy option must contain a "bundles" list.'
+
+        bundles_override = strategy.get("bundles")
+
+        if not isinstance(bundles_override, list):
+            return 'The value of "bundles" must be a list.'
+
+        if len(bundles_override) == 0:
+            return 'The value of "bundles" must be a non-empty list.'
+
+        for bundle in bundles_override:
+            if not isinstance(bundle, dict):
+                return 'Each bundle in "bundles" fallback must be a dictionary.'
+            for k, v in bundle.items():
+                if not isinstance(k, str):
+                    return "Bundle resource keys must be strings."
+                if not isinstance(v, (int, float)):
+                    return "Bundle resource values must be numbers."
+            if not bundle or all(val == 0 for val in bundle.values()):
+                return "Fallback bundles cannot be empty or have all zero resources."
+
+        if label_selectors is not None:
+            if len(label_selectors) != len(bundles_override):
+                return "The length of bundle_label_selector must equal the length of bundles."
 
     return None

--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -345,21 +345,61 @@ class GlobalState:
 
         stats = placement_group_info.stats
         assert placement_group_info is not None
+
+        scheduling_options = []
+        for option_proto in placement_group_info.scheduling_options:
+            bundles_list = []
+            label_selectors_list = []
+            for bundle in option_proto.bundles:
+                bundle_dict = message_to_dict(bundle)
+                bundles_list.append(bundle_dict.get("unitResources", {}))
+                label_selectors_list.append(bundle_dict.get("labelSelector", {}))
+
+            option_dict = {
+                "bundles": bundles_list,
+                "bundle_label_selector": label_selectors_list,
+            }
+            scheduling_options.append(option_dict)
+
+        active_index = (
+            placement_group_info.active_scheduling_option_index
+            if placement_group_info.HasField("active_scheduling_option_index")
+            else -1
+        )
+        bundles_dict = {}
+        bundles_to_node_id = {}
+
+        if active_index >= 0 and len(scheduling_options) > active_index:
+            active_option_proto = placement_group_info.scheduling_options[active_index]
+            if active_option_proto.bundles:
+                bundles_dict = {
+                    i: message_to_dict(bundle).get("unitResources", {})
+                    for i, bundle in enumerate(active_option_proto.bundles)
+                }
+
+        if not bundles_dict:
+            bundles_dict = {
+                bundle.bundle_id.bundle_index: message_to_dict(bundle).get(
+                    "unitResources", {}
+                )
+                for bundle in placement_group_info.bundles
+            }
+
+        # Node IDs are always definitively tracked by the backend on the main `bundles` list.
+        bundles_to_node_id = {
+            bundle.bundle_id.bundle_index: binary_to_hex(bundle.node_id)
+            if getattr(bundle, "node_id", None)
+            else ""
+            for bundle in placement_group_info.bundles
+        }
+
         return {
             "placement_group_id": binary_to_hex(
                 placement_group_info.placement_group_id
             ),
             "name": placement_group_info.name,
-            "bundles": {
-                # The value here is needs to be dictionarified
-                # otherwise, the payload becomes unserializable.
-                bundle.bundle_id.bundle_index: message_to_dict(bundle)["unitResources"]
-                for bundle in placement_group_info.bundles
-            },
-            "bundles_to_node_id": {
-                bundle.bundle_id.bundle_index: binary_to_hex(bundle.node_id)
-                for bundle in placement_group_info.bundles
-            },
+            "bundles": bundles_dict,
+            "bundles_to_node_id": bundles_to_node_id,
             "strategy": get_strategy(placement_group_info.strategy),
             "state": get_state(placement_group_info.state),
             "stats": {
@@ -373,6 +413,8 @@ class GlobalState:
                     stats.scheduling_state
                 ].name,
             },
+            "scheduling_options": scheduling_options,
+            "active_scheduling_option_index": active_index,
         }
 
     def _nanoseconds_to_microseconds(self, time_in_nanoseconds):

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -98,6 +98,7 @@ from ray.includes.common cimport (
     CPlacementStrategy,
     CSchedulingStrategy,
     CPlacementGroupSchedulingStrategy,
+    CPlacementGroupSchedulingOption,
     CNodeAffinitySchedulingStrategy,
     CNodeLabelSchedulingStrategy,
     CLabelMatchExpressions,
@@ -660,6 +661,55 @@ cdef int prepare_fallback_strategy(
         fallback_strategy_vector.push_back(
              CFallbackOption(c_label_selector)
         )
+
+    return 0
+
+cdef int prepare_placement_group_scheduling_options(
+        list fallback_strategy,
+        c_vector[CPlacementGroupSchedulingOption] *scheduling_options_vector) except -1:
+
+    cdef list label_selectors_list
+    cdef unordered_map[c_string, double] c_bundle
+    cdef unordered_map[c_string, c_string] c_label_selector
+
+    if fallback_strategy is None:
+        return 0
+
+    for strategy_dict in fallback_strategy:
+        if not isinstance(strategy_dict, dict):
+            raise ValueError(
+                "Fallback strategy must be a list of dicts, "
+                f"but got list containing {type(strategy_dict)}")
+
+        bundles_list = strategy_dict.get("bundles")
+        label_selectors_list = strategy_dict.get("bundle_label_selector")
+
+        # Clear option for next iteration
+        c_option = CPlacementGroupSchedulingOption()
+
+        if bundles_list is not None:
+            if not isinstance(bundles_list, list):
+                raise ValueError("Invalid fallback strategy element: invalid 'bundles'.")
+            for bundle_dict in bundles_list:
+                if not isinstance(bundle_dict, dict):
+                    raise ValueError("Each bundle must be a dictionary.")
+                c_bundle.clear()
+                for k, v in bundle_dict.items():
+                    c_bundle[k] = v
+                c_option.bundles.push_back(c_bundle)
+
+        if label_selectors_list is not None:
+            if not isinstance(label_selectors_list, list):
+                raise ValueError("Invalid fallback strategy element: invalid 'bundle_label_selector'.")
+            for label_selector_dict in label_selectors_list:
+                if not isinstance(label_selector_dict, dict):
+                    raise ValueError("Each label selector must be a dictionary.")
+                c_label_selector.clear()
+                for k, v in label_selector_dict.items():
+                    c_label_selector[k] = v
+                c_option.bundle_label_selector.push_back(c_label_selector)
+
+        scheduling_options_vector.push_back(c_option)
 
     return 0
 
@@ -3697,11 +3747,13 @@ cdef class CoreWorker:
                             c_string strategy,
                             c_bool is_detached,
                             soft_target_node_id,
-                            c_vector[unordered_map[c_string, c_string]] bundle_label_selector):
+                            c_vector[unordered_map[c_string, c_string]] bundle_label_selector,
+                            fallback_strategy):
         cdef:
             CPlacementGroupID c_placement_group_id
             CPlacementStrategy c_strategy
             CNodeID c_soft_target_node_id = CNodeID.Nil()
+            c_vector[CPlacementGroupSchedulingOption] c_fallback_strategy
 
         if strategy == b"PACK":
             c_strategy = PLACEMENT_STRATEGY_PACK
@@ -3718,6 +3770,9 @@ cdef class CoreWorker:
         if soft_target_node_id is not None:
             c_soft_target_node_id = CNodeID.FromHex(soft_target_node_id)
 
+        if fallback_strategy is not None:
+             prepare_placement_group_scheduling_options(fallback_strategy, &c_fallback_strategy)
+
         with nogil:
             check_status(
                         CCoreWorkerProcess.GetCoreWorker().
@@ -3728,7 +3783,8 @@ cdef class CoreWorker:
                                 bundles,
                                 is_detached,
                                 c_soft_target_node_id,
-                                bundle_label_selector),
+                                bundle_label_selector,
+                                c_fallback_strategy),
                             &c_placement_group_id))
 
         return PlacementGroupID(c_placement_group_id.Binary())

--- a/python/ray/autoscaler/_private/load_metrics.py
+++ b/python/ray/autoscaler/_private/load_metrics.py
@@ -268,8 +268,11 @@ class LoadMetrics:
         summarized_resource_requests = freq_of_dicts(self.get_resource_requests())
 
         def placement_group_serializer(pg):
+            pg_bundles = pg.bundles
+            if not pg_bundles and pg.scheduling_options:
+                pg_bundles = pg.scheduling_options[0].bundles
             bundles = tuple(
-                frozenset(bundle.unit_resources.items()) for bundle in pg.bundles
+                frozenset(bundle.unit_resources.items()) for bundle in pg_bundles
             )
             return (bundles, pg.strategy)
 

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -288,6 +288,13 @@ cdef extern from "ray/common/scheduling/label_selector.h" namespace "ray":
         CLabelSelector() nogil except +
         void AddConstraint(const c_string& key, const c_string& value) nogil except +
 
+cdef extern from "ray/common/placement_group.h" namespace "ray":
+    cdef cppclass CPlacementGroupSchedulingOption "ray::PlacementGroupSchedulingOption":
+        c_vector[unordered_map[c_string, double]] bundles
+        c_vector[unordered_map[c_string, c_string]] bundle_label_selector
+
+        CPlacementGroupSchedulingOption() nogil except +
+
 cdef extern from "ray/common/scheduling/fallback_strategy.h" namespace "ray":
     cdef cppclass CFallbackOption "ray::FallbackOption":
         CLabelSelector label_selector
@@ -432,6 +439,7 @@ cdef extern from "ray/core_worker/common.h" nogil:
             c_bool is_detached,
             CNodeID soft_target_node_id,
             const c_vector[unordered_map[c_string, c_string]] &bundle_label_selector,
+            const c_vector[CPlacementGroupSchedulingOption] &placement_group_scheduling_options,
         )
 
     cdef cppclass CObjectLocation "ray::core::ObjectLocation":

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -70,6 +70,7 @@ py_test_module_list(
         "test_node_label_scheduling_strategy.py",
         "test_object_spilling_2.py",
         "test_placement_group.py",
+        "test_placement_group_fallback.py",
         "test_ray_event_export_task_events.py",
         "test_ray_get.py",
         "test_reference_counting_2.py",

--- a/python/ray/tests/test_get_or_create_actor.py
+++ b/python/ray/tests/test_get_or_create_actor.py
@@ -120,7 +120,7 @@ def test_get_or_create_actor_with_placement_group_validation(shutdown_only):
     # This should raise a ValueError with a clear message about resource mismatch
     with pytest.raises(
         ValueError,
-        match=r"Cannot schedule test_get_or_create_actor_with_placement_group_validation\.<locals>\.Actor with the placement group because the resource request \{'CPU': 1, 'GPU': 8\} cannot fit into any bundles for the placement group, \[\{'CPU': 1\.0\}\]\.",
+        match=r"Cannot schedule test_get_or_create_actor_with_placement_group_validation\.<locals>\.Actor with the placement group because the resource request \{'CPU': 1, 'GPU': 8\} cannot fit into any bundles across all scheduling strategies for the placement group, \[\[\{'CPU': 1\.0\}\]\]\.",
     ):
         Actor.options(
             scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg),

--- a/python/ray/tests/test_label_scheduling.py
+++ b/python/ray/tests/test_label_scheduling.py
@@ -183,5 +183,106 @@ def test_fallback_with_feasible_primary_selector(cluster_with_labeled_nodes):
     assert ray.get(label_selector_actor.get_node_id.remote(), timeout=5) == gpu_node
 
 
+def test_placement_group_fallback_strategy(cluster_with_labeled_nodes):
+    node_1, _, _ = cluster_with_labeled_nodes
+
+    # Define an unsatisfiable label selector for placement group.
+    infeasible_label_selector = {"ray.io/accelerator-type": "does-not-exist"}
+
+    # Create a fallback strategy with multiple accelerator options.
+    accelerator_fallbacks = [
+        {
+            "bundles": [{"CPU": 1.0}],
+            "bundle_label_selector": [{"ray.io/accelerator-type": "A100"}],
+        },
+        {
+            "bundles": [{"CPU": 1.0}],
+            "bundle_label_selector": [{"ray.io/accelerator-type": "TPU"}],
+        },
+    ]
+
+    from ray.util.placement_group import placement_group
+
+    # Attempt to schedule the placement group. The scheduler should fail to find a node with the
+    # primary `label_selector` and fall back to the first available option, 'A100'.
+    pg = placement_group(
+        bundles=[{"CPU": 1.0}],
+        strategy="PACK",
+        bundle_label_selector=[infeasible_label_selector],
+        fallback_strategy=accelerator_fallbacks,
+    )
+
+    ray.get(pg.ready(), timeout=5)
+
+    # Now verify where it was placed.
+    # We can create an actor on this PG and see where it lands.
+    actor = MyActor.options(
+        placement_group=pg,
+    ).remote()
+
+    assert ray.get(actor.get_node_id.remote(), timeout=5) == node_1
+
+
+def test_placement_group_fallback_strategy_multiple_options_success(
+    cluster_with_labeled_nodes,
+):
+    _, node_2, _ = cluster_with_labeled_nodes
+
+    infeasible_label_selector = {"ray.io/accelerator-type": "H100"}
+
+    accelerator_fallbacks = [
+        {
+            "bundles": [{"CPU": 1.0}],
+            "bundle_label_selector": [{"ray.io/accelerator-type": "does-not-exist"}],
+        },
+        {
+            "bundles": [{"CPU": 1.0}],
+            "bundle_label_selector": [{"ray.io/accelerator-type": "B200"}],
+        },
+    ]
+
+    from ray.util.placement_group import placement_group
+
+    pg = placement_group(
+        bundles=[{"CPU": 1.0}],
+        strategy="PACK",
+        bundle_label_selector=[infeasible_label_selector],
+        fallback_strategy=accelerator_fallbacks,
+    )
+
+    ray.get(pg.ready(), timeout=5)
+
+    actor = MyActor.options(
+        placement_group=pg,
+    ).remote()
+
+    assert ray.get(actor.get_node_id.remote(), timeout=5) == node_2
+
+
+def test_placement_group_fallback_strategy_validation():
+    from ray.util.placement_group import placement_group
+
+    # Invalid fallback_strategy type (dict instead of list)
+    with pytest.raises(ValueError, match="fallback_strategy must be a list"):
+        placement_group(
+            bundles=[{"CPU": 1.0}],
+            strategy="PACK",
+            fallback_strategy={
+                "bundles": [{"CPU": 1.0}],
+                "bundle_label_selector": [{"type": "A100"}],
+            },
+        )
+
+    # Invalid fallback_strategy option type (string instead of dict)
+    with pytest.raises(
+        ValueError, match="Each element in fallback_strategy must be a dictionary"
+    ):
+        placement_group(
+            bundles=[{"CPU": 1.0}],
+            strategy="PACK",
+            fallback_strategy=["A100"],
+        )
+
+
 if __name__ == "__main__":
-    sys.exit(pytest.main(["-sv", __file__]))
+    sys.exit(pytest.main(["-sv", "-vv", __file__]))

--- a/python/ray/tests/test_label_utils.py
+++ b/python/ray/tests/test_label_utils.py
@@ -248,6 +248,14 @@ def test_validate_label_value(value, should_raise, expected_message):
             {"valid-key": "a" * 64},
             "Invalid label selector value",
         ),  # Invalid label value syntax
+        (
+            {123: "valid-value"},
+            "Label selector keys must be strings",
+        ),  # Non-string key
+        (
+            {"valid-key": 456},
+            "Label selector values must be strings",
+        ),  # Non-string value
     ],
 )
 def test_validate_label_selector(label_selector, expected_error):
@@ -362,6 +370,35 @@ def test_validate_node_labels():
 def test_validate_fallback_strategy(fallback_strategy, expected_error):
     """Tests the validation logic for the fallback_strategy remote option."""
     result = validate_fallback_strategy(fallback_strategy)
+    if expected_error:
+        assert expected_error in result
+    else:
+        assert result is None
+
+
+@pytest.mark.parametrize(
+    "fallback_strategy, expected_error",
+    [
+        (
+            [{"bundles": None}],
+            'The value of "bundles" must be a list.',
+        ),
+        (
+            [{"bundles": [{}]}],
+            "Fallback bundles cannot be empty or have all zero resources.",
+        ),
+        (
+            [{"bundles": [{"CPU": 0.0}]}],
+            "Fallback bundles cannot be empty or have all zero resources.",
+        ),
+        ([{"bundles": [{"CPU": 1.0}]}], None),
+    ],
+    ids=["none-bundle", "empty-bundle", "zero-bundle", "valid-bundle"],
+)
+def test_validate_placement_group_fallback_strategy(fallback_strategy, expected_error):
+    from ray._private.label_utils import validate_placement_group_fallback_strategy
+
+    result = validate_placement_group_fallback_strategy(fallback_strategy)
     if expected_error:
         assert expected_error in result
     else:

--- a/python/ray/tests/test_placement_group_fallback.py
+++ b/python/ray/tests/test_placement_group_fallback.py
@@ -1,0 +1,450 @@
+import sys
+
+import pytest
+
+import ray
+from ray._private.test_utils import placement_group_assert_no_leak
+from ray.util.placement_group import (
+    placement_group,
+    placement_group_table,
+    remove_placement_group,
+)
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+
+def test_placement_group_fallback_state_exposure(ray_start_regular):
+    """Test that fallback scheduling options are exposed in placement group table."""
+    # Create a PG with fallback
+    pg = placement_group([{"CPU": 1}], fallback_strategy=[{"bundles": [{"CPU": 0.5}]}])
+
+    # Wait for it to be ready to ensure it's in GCS
+    pg.wait(timeout_seconds=5)
+
+    table = ray.util.placement_group_table(pg)
+    assert "scheduling_options" in table
+    assert "active_scheduling_option_index" in table
+
+    opts = table["scheduling_options"]
+    assert len(opts) == 2
+    assert opts[0]["bundles"][0] == {"CPU": 1.0}
+    assert opts[1]["bundles"][0] == {"CPU": 0.5}
+
+
+def test_placement_group_fallback_resources(ray_start_cluster):
+    """Test fallback based on resource bundles."""
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=4)
+    ray.init(address=cluster.address)
+
+    # Feasible fallback strategy with bundles requesting <= available CPU.
+    fallback_strategy = [{"bundles": [{"CPU": 4}]}]
+
+    pg = placement_group(
+        name="resource_fallback_pg",
+        bundles=[{"CPU": 8}],  # Infeasible initial bundle request.
+        strategy="PACK",
+        fallback_strategy=fallback_strategy,
+    )
+    # Placement group is scheduled using fallback.
+    ray.get(pg.ready(), timeout=10)
+
+    # Example task to try to schedule to used node.
+    @ray.remote(num_cpus=1)
+    def check_capacity():
+        return "ok"
+
+    # Example task times out because all CPU used by placement group.
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(check_capacity.remote(), timeout=2)
+
+    remove_placement_group(pg)
+    placement_group_assert_no_leak([pg])
+
+
+def test_placement_group_fallback_strategy_labels(ray_start_cluster):
+    """
+    Test that fallback strategy is used when primary bundles are not feasible
+    due to label constraints.
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2, labels={})  # Unlabelled node
+    cluster.add_node(num_cpus=2, labels={"region": "us-west1"})
+    ray.init(address=cluster.address)
+
+    fallback_strategy = [
+        {"bundles": [{"CPU": 2}], "bundle_label_selector": [{"region": "us-west1"}]}
+    ]
+
+    pg = placement_group(
+        name="fallback_pg",
+        bundles=[{"CPU": 2}],
+        bundle_label_selector=[{"region": "us-east1"}],  # Infeasible label
+        strategy="PACK",
+        fallback_strategy=fallback_strategy,  # Feasible fallback
+    )
+
+    # Succeeds due to fallback option
+    ray.get(pg.ready(), timeout=10)
+
+    # Verify it was scheduled on the correct node
+    table = placement_group_table(pg)
+    bundle_node_id = table["bundles_to_node_id"][0]
+
+    found = False
+    for node in ray.nodes():
+        if node["NodeID"] == bundle_node_id:
+            assert node["Alive"]
+            found = True
+            break
+    assert found, "Scheduled node not found in cluster state"
+
+    remove_placement_group(pg)
+    placement_group_assert_no_leak([pg])
+
+
+def test_placement_group_fallback_priority(ray_start_cluster):
+    """Test that the first feasible fallback option is chosen from multiple feasible fallbacks."""
+    cluster = ray_start_cluster
+    # Node has 10 CPUs
+    cluster.add_node(num_cpus=10)
+    ray.init(address=cluster.address)
+
+    fallback_strategy = [
+        {"bundles": [{"CPU": 11}]},  # Infeasible
+        {"bundles": [{"CPU": 5}]},  # Feasible
+        {"bundles": [{"CPU": 1}]},  # Feasible
+    ]
+
+    pg = placement_group(
+        name="priority_pg",
+        bundles=[{"CPU": 20}],  # Infeasible main bundles.
+        strategy="PACK",
+        fallback_strategy=fallback_strategy,
+    )
+
+    ray.get(pg.ready(), timeout=10)
+
+    # Verify we consumed 5 CPUs, not 1.
+    @ray.remote(num_cpus=6)
+    def heavy_task():
+        return "ok"
+
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(heavy_task.remote(), timeout=2)
+
+    remove_placement_group(pg)
+    placement_group_assert_no_leak([pg])
+
+
+def test_placement_group_fallback_bundle_shapes(ray_start_cluster):
+    """Test fallback works even when changing the number of bundles."""
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=1)
+    ray.init(address=cluster.address)
+
+    # Feasible fallback specifies 2 bundles with 1 CPU each (rather than 1 bundle
+    # with 2 CPU).
+    fallback_strategy = [{"bundles": [{"CPU": 1}, {"CPU": 1}]}]
+
+    pg = placement_group(
+        name="reshape_pg",
+        bundles=[{"CPU": 2}],  # Infeasible 2 CPU bundle on any node.
+        strategy="SPREAD",
+        fallback_strategy=fallback_strategy,
+    )
+
+    ray.get(pg.ready(), timeout=10)
+
+    table = placement_group_table(pg)
+    assert len(table["bundles"]) == 2
+
+    remove_placement_group(pg)
+    placement_group_assert_no_leak([pg])
+
+
+def test_multiple_placement_groups_and_fallbacks(ray_start_cluster):
+    """
+    Test that multiple placement groups with fallback strategies correctly subtract
+    from available resources in the cluster.
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=10)
+    ray.init(address=cluster.address)
+
+    # Define a fallback strategy that uses 3 CPUs.
+    fallback_strategy = [{"bundles": [{"CPU": 3}]}]
+
+    pgs = []
+    for i in range(3):
+        pg = placement_group(
+            name=f"pg_{i}",
+            bundles=[{"CPU": 100}],  # Infeasible
+            strategy="PACK",
+            fallback_strategy=fallback_strategy,
+        )
+        pgs.append(pg)
+
+    # Create 3 PGs that should all use the fallback strategy.
+    for pg in pgs:
+        ray.get(pg.ready(), timeout=10)
+
+    # Verify we can still schedule a task utilizing the last CPU (10 total - 9 used by PGs).
+    @ray.remote(num_cpus=1)
+    def small_task():
+        return "ok"
+
+    assert ray.get(small_task.remote(), timeout=5) == "ok"
+
+    # Validate PGs with fallback correctly subtract from the available cluster resources to where
+    # a task requesting more CPU than is available times out.
+    @ray.remote(num_cpus=2)
+    def large_task():
+        return "fail"
+
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(large_task.remote(), timeout=2)
+
+    for pg in pgs:
+        remove_placement_group(pg)
+    placement_group_assert_no_leak(pgs)
+
+
+def test_placement_group_fallback_validation(ray_start_cluster):
+    """
+    Verifies that PG validates resource shape with both primary and fallback bundles.
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=4, num_gpus=0)
+    ray.init(address=cluster.address)
+
+    pg = placement_group(
+        name="validation_pg",
+        bundles=[{"GPU": 1}],
+        strategy="PACK",
+        fallback_strategy=[{"bundles": [{"CPU": 1}]}],
+    )
+
+    # Task requires CPU, primary option has only GPU.
+    # The client-side validation logic should check the fallback strategy
+    # and allow this task to proceed.
+    @ray.remote(num_cpus=1)
+    def run_on_cpu():
+        return "success"
+
+    try:
+        # If client-side validation fails, this raises ValueError immediately.
+        ref = run_on_cpu.options(placement_group=pg).remote()
+        assert ray.get(ref) == "success"
+    except ValueError as e:
+        pytest.fail(f"Validation failed for fallback-compatible task: {e}")
+
+    # Verify bundle_specs returns what was specified for the active
+    # fallback strategy.
+    ray.get(pg.ready())
+    assert pg.bundle_specs[0].get("CPU") == 1
+    assert pg.bundle_specs[0].get("GPU") is None
+
+    remove_placement_group(pg)
+    placement_group_assert_no_leak([pg])
+
+
+def test_pending_placement_group_index_validation(ray_start_cluster):
+    """
+    Test that when a PG is pending, index validation allows up to the
+    maximum number of bundles across all fallback strategies.
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0, num_gpus=0)  # keep PG pending
+    ray.init(address=cluster.address)
+
+    pg = placement_group(
+        name="pending_index_pg",
+        bundles=[{"CPU": 2}],
+        strategy="PACK",
+        fallback_strategy=[{"bundles": [{"CPU": 1}, {"CPU": 1}, {"CPU": 1}]}],
+    )
+
+    @ray.remote(num_cpus=1)
+    def dummy_task():
+        return "ok"
+
+    # Requesting index 2 shouldn't raise an error because max possible is 3.
+    try:
+        dummy_task.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=2
+            )
+        ).remote()
+    except ValueError as e:
+        pytest.fail(f"Pending PG incorrectly rejected valid fallback index: {e}")
+
+    # Requesting index 3 should fail immediately since no strategy has more than 3 bundles.
+    with pytest.raises(ValueError, match="Valid placement group indexes: 0 to 2"):
+        dummy_task.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=3
+            )
+        ).remote()
+
+    remove_placement_group(pg)
+
+
+def test_scheduled_placement_group_fallback_index_validation(ray_start_cluster):
+    """
+    Test that bundle_index validation strictly respects the active
+    strategy's bundle count once the PG is scheduled.
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    ray.init(address=cluster.address)
+
+    # Infeasible primary strategy with 3 bundles, feasible fallback strategy with 1 bundle.
+    pg = placement_group(
+        name="index_validation_pg",
+        bundles=[{"CPU": 1}, {"CPU": 1}, {"CPU": 1}],
+        strategy="STRICT_PACK",
+        fallback_strategy=[{"bundles": [{"CPU": 1}]}],
+    )
+
+    # Wait for the PG to schedule using the fallback.
+    ray.get(pg.ready(), timeout=10)
+
+    # Wait for state to propagate to GCS table
+    import time
+
+    success = False
+    for _ in range(50):
+        table = ray.util.placement_group_table(pg)
+        if table.get("active_scheduling_option_index") in (1, -1):
+            success = True
+            break
+        time.sleep(0.1)
+    assert (
+        success
+    ), f"Timed out waiting for active_scheduling_option_index to become 1. Current table: {table}"
+
+    @ray.remote(num_cpus=1)
+    def dummy_task():
+        return "ok"
+
+    # Requesting bundle_index=0 should work.
+    ref = dummy_task.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_bundle_index=0
+        )
+    ).remote()
+    assert ray.get(ref) == "ok"
+
+    # bundle_index=1 passes permissive client validation (within max fallback bounds)
+    # but hangs in scheduling because it doesn't match the active strategy.
+    ref_invalid = dummy_task.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(
+            placement_group=pg, placement_group_bundle_index=1
+        )
+    ).remote()
+
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(ref_invalid, timeout=3)
+
+    remove_placement_group(pg)
+    placement_group_assert_no_leak([pg])
+
+
+def test_pending_placement_group_shape_validation(ray_start_cluster):
+    """
+    Test that when a PG is pending, resource shape validation allows tasks that fit
+    into any of the possible scheduling strategies (primary or fallback).
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0, num_gpus=0)  # keep PG pending
+    ray.init(address=cluster.address)
+
+    pg = placement_group(
+        name="pending_shape_pg",
+        bundles=[{"CPU": 2}],
+        strategy="PACK",
+        fallback_strategy=[{"bundles": [{"GPU": 1}]}],
+    )
+
+    @ray.remote(num_cpus=1)
+    def needs_cpu():
+        return "ok"
+
+    @ray.remote(num_cpus=0, num_gpus=1)
+    def needs_gpu():
+        return "ok"
+
+    @ray.remote(num_cpus=3)
+    def needs_too_much_cpu():
+        return "ok"
+
+    # First task fits in primary option and should pass validation
+    try:
+        needs_cpu.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+    except ValueError as e:
+        pytest.fail(f"Pending PG incorrectly rejected valid primary shape: {e}")
+
+    # Second task fits in fallback option and should pass validation
+    try:
+        needs_gpu.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+    except ValueError as e:
+        pytest.fail(f"Pending PG incorrectly rejected valid fallback shape: {e}")
+
+    # Third task fits doesn't fit in any scheduling option
+    with pytest.raises(
+        ValueError, match="cannot fit into any bundles across all scheduling strategies"
+    ):
+        needs_too_much_cpu.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+        ).remote()
+
+    remove_placement_group(pg)
+
+
+def test_scheduled_placement_group_strict_shape_validation(ray_start_cluster):
+    """
+    Test that once a PG is scheduled, tasks are validated against the active
+    strategy, preventing tasks from hanging by requesting a shape from a fallback.
+    """
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=2)
+    ray.init(address=cluster.address)
+
+    # Feasible primary strategy uses CPU, infeasible
+    # fallback strategy uses GPU.
+    pg = placement_group(
+        name="strict_shape_pg",
+        bundles=[{"CPU": 1}],
+        strategy="PACK",
+        fallback_strategy=[{"bundles": [{"GPU": 1}]}],
+    )
+
+    # Wait for the PG to schedule using the primary strategy.
+    ray.get(pg.ready(), timeout=10)
+
+    @ray.remote(num_cpus=0, num_gpus=1)
+    def needs_gpu():
+        return "ok"
+
+    # The task requests a GPU. This passes the permissive client check because
+    # the fallback strategy has a GPU, but because the active strategy is CPU only,
+    # it will hang on the backend. This is intended because fallback strategies can
+    # reschedule.
+    ref_invalid = needs_gpu.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg)
+    ).remote()
+
+    with pytest.raises(ray.exceptions.GetTimeoutError):
+        ray.get(ref_invalid, timeout=3)
+
+    remove_placement_group(pg)
+    placement_group_assert_no_leak([pg])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/util/placement_group.py
+++ b/python/ray/util/placement_group.py
@@ -5,7 +5,10 @@ import ray
 from ray._common.utils import PLACEMENT_GROUP_BUNDLE_RESOURCE_NAME, hex_to_binary
 from ray._private.auto_init_hook import auto_init_ray
 from ray._private.client_mode_hook import client_mode_should_convert, client_mode_wrap
-from ray._private.label_utils import validate_label_selector
+from ray._private.label_utils import (
+    validate_label_selector,
+    validate_placement_group_fallback_strategy,
+)
 from ray._private.utils import get_ray_doc_version
 from ray._raylet import PlacementGroupID
 from ray.util.annotations import DeveloperAPI, PublicAPI
@@ -33,6 +36,8 @@ class PlacementGroup:
     ):
         self.id = id
         self.bundle_cache = bundle_cache
+        self._scheduling_options_cache = None
+        self._active_strategy_index_cache = None
 
     @property
     def is_empty(self):
@@ -85,6 +90,42 @@ class PlacementGroup:
         if not self.bundle_cache:
             self.bundle_cache = _get_bundle_cache(self.id)
 
+    def _get_scheduling_options_bundles(self) -> List[List[Dict]]:
+        """Return all possible bundles across primary and fallback options
+        as a nested list of strategies.
+        """
+        self._fill_scheduling_options_cache_if_needed()
+        return self._scheduling_options_cache or []
+
+    def _fill_scheduling_options_cache_if_needed(self) -> None:
+        if not self._scheduling_options_cache:
+            options = _get_all_scheduling_options(self.id)
+            if options:
+                self._scheduling_options_cache = options
+
+    def _get_active_strategy_index(self) -> int:
+        """Returns the active scheduling strategy index.
+        Caches the result while the placement group is ready.
+        If the placement group reschedules, the cache is invalidated.
+        """
+        is_ready = self.wait(timeout_seconds=0)
+
+        if not is_ready:
+            self._active_strategy_index_cache = None
+            return -1
+
+        if self._active_strategy_index_cache is not None:
+            return self._active_strategy_index_cache
+
+        table = ray._private.state.state.placement_group_table(self.id)
+        if table:
+            active_index = table.get("active_scheduling_option_index", -1)
+            if active_index != -1:
+                self._active_strategy_index_cache = active_index
+            return active_index
+
+        return -1
+
     def __eq__(self, other):
         if not isinstance(other, PlacementGroup):
             return False
@@ -116,9 +157,38 @@ def _get_bundle_cache(pg_id: PlacementGroupID) -> List[Dict]:
     worker = ray._private.worker.global_worker
     worker.check_connected()
 
-    return list(
-        ray._private.state.state.placement_group_table(pg_id)["bundles"].values()
-    )
+    table = ray._private.state.state.placement_group_table(pg_id)
+
+    # Fetch from all scheduling options from proto field
+    options_list = table.get("scheduling_options", [])
+    if options_list:
+        active_index = table.get("active_scheduling_option_index", -1)
+        if active_index >= 0 and active_index < len(options_list):
+            return options_list[active_index].get("bundles", [])
+        return options_list[0].get("bundles", [])
+
+    # Fallback for PGs that don't have scheduling options defined
+    bundles_dict = table.get("bundles", {})
+    return list(bundles_dict.values())
+
+
+@client_mode_wrap
+def _get_all_scheduling_options(pg_id: PlacementGroupID) -> List[List[Dict]]:
+    worker = ray._private.worker.global_worker
+    worker.check_connected()
+
+    table = ray._private.state.state.placement_group_table(pg_id)
+
+    all_options = []
+    options_list = table.get("scheduling_options", [])
+    if options_list:
+        for option in options_list:
+            all_options.append(option.get("bundles", []))
+    else:
+        bundles_dict = table.get("bundles", {})
+        all_options.append(list(bundles_dict.values()))
+
+    return all_options
 
 
 @PublicAPI
@@ -130,6 +200,7 @@ def placement_group(
     lifetime: Optional[str] = None,
     _soft_target_node_id: Optional[str] = None,
     bundle_label_selector: List[Dict[str, str]] = None,
+    fallback_strategy: List[Dict] = None,
 ) -> PlacementGroup:
     """Asynchronously creates a PlacementGroup.
 
@@ -157,6 +228,8 @@ def placement_group(
             This currently only works with STRICT_PACK pg.
         bundle_label_selector: A list of label selectors to apply to a
             placement group on a per-bundle level.
+        fallback_strategy: A list of fallback scheduling strategies to try
+            if the primary strategy cannot be satisfied.
 
     Raises:
         ValueError: if bundle type is not a list.
@@ -175,6 +248,7 @@ def placement_group(
         lifetime=lifetime,
         _soft_target_node_id=_soft_target_node_id,
         bundle_label_selector=bundle_label_selector,
+        fallback_strategy=fallback_strategy,
     )
 
     if bundle_label_selector is None:
@@ -192,9 +266,16 @@ def placement_group(
         detached,
         _soft_target_node_id,
         bundle_label_selector,
+        fallback_strategy,
     )
 
-    return PlacementGroup(placement_group_id)
+    pg = PlacementGroup(placement_group_id)
+    all_options = [bundles]
+    if fallback_strategy:
+        for opt in fallback_strategy:
+            all_options.append(opt.get("bundles", []))
+    pg._scheduling_options_cache = all_options
+    return pg
 
 
 @PublicAPI
@@ -297,7 +378,14 @@ def get_current_placement_group() -> Optional[PlacementGroup]:
     pg_id = worker.placement_group_id
     if pg_id.is_nil():
         return None
-    return PlacementGroup(pg_id)
+
+    # Cache the PlacementGroup instance on the worker.
+    # This prevents creating a new instance on every inherited child task submission.
+    cached_pg = getattr(worker, "_current_placement_group", None)
+    if cached_pg is None or cached_pg.id != pg_id:
+        worker._current_placement_group = PlacementGroup(pg_id)
+
+    return worker._current_placement_group
 
 
 def check_placement_group_index(
@@ -310,12 +398,20 @@ def check_placement_group_index(
                 "If placement group is not set, "
                 "the value of bundle index must be -1."
             )
-    elif bundle_index >= placement_group.bundle_count or bundle_index < -1:
-        raise ValueError(
-            f"placement group bundle index {bundle_index} "
-            f"is invalid. Valid placement group indexes: "
-            f"0-{placement_group.bundle_count}"
-        )
+    else:
+        all_bundles = placement_group._get_scheduling_options_bundles()
+        if not all_bundles:
+            all_bundles = [placement_group.bundle_specs]
+
+        # Validate against the maximum possible bounds across all strategies.
+        valid_len = max(len(strategy_bundles) for strategy_bundles in all_bundles)
+
+        if bundle_index >= valid_len or bundle_index < -1:
+            raise ValueError(
+                f"placement group bundle index {bundle_index} "
+                f"is invalid. Valid placement group indexes: "
+                f"0 to {valid_len - 1}."
+            )
 
 
 def validate_placement_group(
@@ -324,6 +420,7 @@ def validate_placement_group(
     lifetime: Optional[str] = None,
     _soft_target_node_id: Optional[str] = None,
     bundle_label_selector: List[Dict[str, str]] = None,
+    fallback_strategy: List[Dict] = None,
 ) -> bool:
     """Validates inputs for placement_group.
 
@@ -349,6 +446,11 @@ def validate_placement_group(
                 f"The length of `bundle_label_selector` should equal the length of `bundles`."
             )
         _validate_bundle_label_selector(bundle_label_selector)
+
+    if fallback_strategy is not None:
+        error_msg = validate_placement_group_fallback_strategy(fallback_strategy)
+        if error_msg:
+            raise ValueError(error_msg)
 
     if strategy not in VALID_PLACEMENT_GROUP_STRATEGIES:
         raise ValueError(
@@ -484,16 +586,26 @@ def _valid_resource_shape(resources, bundle_specs):
 def _validate_resource_shape(
     placement_group, resources, placement_resources, task_or_actor_repr
 ):
-    bundles = placement_group.bundle_specs
-    resources_valid = _valid_resource_shape(resources, bundles)
-    placement_resources_valid = _valid_resource_shape(placement_resources, bundles)
+    strategies = placement_group._get_scheduling_options_bundles()
+
+    if not strategies:
+        strategies = [placement_group.bundle_specs]
+
+    # Validate that the shape fits any of the strategies.
+    # We do not check against the active strategy here because it can be dynamically re-scheduled.
+    resources_valid = any(
+        _valid_resource_shape(resources, strategy) for strategy in strategies
+    )
+    placement_resources_valid = any(
+        _valid_resource_shape(placement_resources, strategy) for strategy in strategies
+    )
 
     if not resources_valid:
         raise ValueError(
             f"Cannot schedule {task_or_actor_repr} with "
             "the placement group because the resource request "
-            f"{resources} cannot fit into any bundles for "
-            f"the placement group, {bundles}."
+            f"{resources} cannot fit into any bundles across all scheduling strategies for "
+            f"the placement group, {strategies}."
         )
     if not placement_resources_valid:
         # Happens for the default actor case.
@@ -504,8 +616,8 @@ def _validate_resource_shape(
             "the placement group because the actor requires "
             f"{placement_resources.get('CPU', 0)} CPU for "
             "creation, but it cannot "
-            f"fit into any bundles for the placement group, "
-            f"{bundles}. Consider "
+            f"fit into any bundles across all scheduling strategies for the placement group, "
+            f"{strategies}. Consider "
             "creating a placement group with CPU resources."
         )
 

--- a/src/ray/common/placement_group.h
+++ b/src/ray/common/placement_group.h
@@ -69,6 +69,11 @@ class PlacementGroupSpecification : public MessageWrapper<rpc::PlacementGroupSpe
   std::vector<BundleSpecification> bundles_;
 };
 
+struct PlacementGroupSchedulingOption {
+  std::vector<std::unordered_map<std::string, double>> bundles;
+  std::vector<std::unordered_map<std::string, std::string>> bundle_label_selector;
+};
+
 class PlacementGroupSpecBuilder {
  public:
   PlacementGroupSpecBuilder() : message_(std::make_shared<rpc::PlacementGroupSpec>()) {}
@@ -88,7 +93,8 @@ class PlacementGroupSpecBuilder {
       const ActorID &creator_actor_id,
       bool is_creator_detached_actor,
       const std::vector<std::unordered_map<std::string, std::string>>
-          &bundle_label_selector = {}) {
+          &bundle_label_selector = {},
+      const std::vector<PlacementGroupSchedulingOption> &fallback_strategy = {}) {
     message_->set_placement_group_id(placement_group_id.Binary());
     message_->set_name(name);
     message_->set_strategy(strategy);
@@ -129,6 +135,35 @@ class PlacementGroupSpecBuilder {
         }
       }
     }
+
+    if (!fallback_strategy.empty()) {
+      for (const auto &option : fallback_strategy) {
+        auto *message_option = message_->add_fallback_strategy();
+
+        // Set bundles for scheduling option (primary and fallbacks).
+        for (size_t i = 0; i < option.bundles.size(); i++) {
+          const auto &resources = option.bundles[i];
+          auto *message_bundle = message_option->add_bundles();
+          auto *mutable_bundle_id = message_bundle->mutable_bundle_id();
+          mutable_bundle_id->set_bundle_index(i);
+          mutable_bundle_id->set_placement_group_id(placement_group_id.Binary());
+          auto *mutable_unit_resources = message_bundle->mutable_unit_resources();
+          for (const auto &pair : resources) {
+            if (pair.second > 0) {
+              mutable_unit_resources->insert({pair.first, pair.second});
+            }
+          }
+
+          if (option.bundle_label_selector.size() > i) {
+            auto *mutable_label_selector = message_bundle->mutable_label_selector();
+            for (const auto &pair : option.bundle_label_selector[i]) {
+              (*mutable_label_selector)[pair.first] = pair.second;
+            }
+          }
+        }
+      }
+    }
+
     return *this;
   }
 

--- a/src/ray/common/scheduling/label_selector.h
+++ b/src/ray/common/scheduling/label_selector.h
@@ -154,4 +154,11 @@ inline std::optional<absl::flat_hash_set<std::string>> GetHardNodeAffinityValues
   return std::nullopt;
 }
 
+inline bool IsGpuAcceleratorConstraint(const LabelConstraint &constraint) {
+  return constraint.GetLabelKey() == kLabelKeyNodeAcceleratorType &&
+         constraint.GetOperator() == LabelSelectorOperator::LABEL_IN &&
+         (constraint.GetLabelValues().contains(kGB300) ||
+          constraint.GetLabelValues().contains(kGB200));
+}
+
 }  // namespace ray

--- a/src/ray/common/tests/BUILD.bazel
+++ b/src/ray/common/tests/BUILD.bazel
@@ -58,6 +58,16 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "placement_group_spec_test",
+    srcs = ["placement_group_spec_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:placement_group",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
     name = "bundle_location_index_test",
     srcs = [
         "bundle_location_index_test.cc",

--- a/src/ray/common/tests/placement_group_spec_test.cc
+++ b/src/ray/common/tests/placement_group_spec_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "ray/common/placement_group.h"
+
+namespace ray {
+
+TEST(PlacementGroupSpecTest, TestPlacementGroupSpecBuilderSchedulingOptions) {
+  PlacementGroupSpecBuilder builder;
+
+  std::vector<PlacementGroupSchedulingOption> scheduling_options;
+
+  // Option 1
+  PlacementGroupSchedulingOption option1;
+  option1.bundles = {{{"CPU", 1.0}}};
+  scheduling_options.push_back(option1);
+
+  // Option 2
+  PlacementGroupSchedulingOption option2;
+  option2.bundles = {{{"CPU", 2.0}}};
+  scheduling_options.push_back(option2);
+
+  PlacementGroupID pg_id = PlacementGroupID::Of(JobID::FromInt(1));
+  std::vector<std::unordered_map<std::string, double>> bundles = {{{"CPU", 1.0}}};
+
+  builder.SetPlacementGroupSpec(pg_id,
+                                "test_pg",
+                                bundles,
+                                rpc::PlacementStrategy::PACK,
+                                /*is_detached=*/false,
+                                /*soft_target_node_id=*/NodeID::Nil(),
+                                /*job_id=*/JobID::FromInt(1),
+                                /*creator_actor_id=*/ActorID::Nil(),
+                                /*is_creator_detached_actor=*/false,
+                                /*bundle_label_selector=*/{},
+                                scheduling_options);
+
+  PlacementGroupSpecification spec = builder.Build();
+
+  // Verify that the proto message has the expected fields.
+  const auto &proto = spec.GetMessage();
+
+  ASSERT_EQ(proto.fallback_strategy_size(), 2);
+
+  const auto &p_option1 = proto.fallback_strategy(0);
+  ASSERT_EQ(p_option1.bundles_size(), 1);
+  ASSERT_EQ(p_option1.bundles(0).unit_resources().at("CPU"), 1.0);
+
+  const auto &p_option2 = proto.fallback_strategy(1);
+  ASSERT_EQ(p_option2.bundles_size(), 1);
+  ASSERT_EQ(p_option2.bundles(0).unit_resources().at("CPU"), 2.0);
+}
+
+}  // namespace ray

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -119,6 +119,7 @@ ray_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         "//src/ray/common:id",
+        "//src/ray/common:placement_group",
         "//src/ray/common:ray_object",
         "//src/ray/common:task_common",
         "//src/ray/util:process",
@@ -320,6 +321,7 @@ ray_cc_library(
     hdrs = ["generator_waiter.h"],
     deps = [
         ":common",
+        "//src/ray/common:placement_group",
         "@com_google_absl//absl/synchronization",
     ],
 )

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "ray/common/id.h"
+#include "ray/common/placement_group.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/scheduling/fallback_strategy.h"
 #include "ray/common/scheduling/label_selector.h"
@@ -232,13 +233,15 @@ struct PlacementGroupCreationOptions {
       bool is_detached_p,
       NodeID soft_target_node_id = NodeID::Nil(),
       std::vector<std::unordered_map<std::string, std::string>> bundle_label_selector =
-          {})
+          {},
+      std::vector<PlacementGroupSchedulingOption> fallback_strategy = {})
       : name_(std::move(name)),
         strategy_(strategy),
         bundles_(std::move(bundles)),
         is_detached_(is_detached_p),
         soft_target_node_id_(soft_target_node_id),
-        bundle_label_selector_(std::move(bundle_label_selector)) {
+        bundle_label_selector_(std::move(bundle_label_selector)),
+        fallback_strategy_(std::move(fallback_strategy)) {
     RAY_CHECK(soft_target_node_id_.IsNil() || strategy_ == PlacementStrategy::STRICT_PACK)
         << "soft_target_node_id only works with STRICT_PACK now";
   }
@@ -259,6 +262,8 @@ struct PlacementGroupCreationOptions {
   const NodeID soft_target_node_id_;
   /// The label selectors to apply per-bundle in this placement group.
   const std::vector<std::unordered_map<std::string, std::string>> bundle_label_selector_;
+  /// A list of scheduling options defining fallback strategies for scheduling.
+  const std::vector<PlacementGroupSchedulingOption> fallback_strategy_;
 };
 
 class ObjectLocation {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2255,6 +2255,20 @@ Status CoreWorker::CreatePlacementGroup(
       }
     }
   }
+
+  for (const auto &option : placement_group_creation_options.fallback_strategy_) {
+    for (const auto &bundle : option.bundles) {
+      for (const auto &resource : bundle) {
+        if (resource.first == kBundle_ResourceLabel) {
+          std::ostringstream stream;
+          stream << kBundle_ResourceLabel
+                 << " is a system reserved resource, which is not "
+                 << "allowed to be used in placement group fallback options. ";
+          return Status::Invalid(stream.str());
+        }
+      }
+    }
+  }
   const PlacementGroupID placement_group_id = PlacementGroupID::Of(GetCurrentJobId());
   PlacementGroupSpecBuilder builder;
   builder.SetPlacementGroupSpec(placement_group_id,
@@ -2266,7 +2280,8 @@ Status CoreWorker::CreatePlacementGroup(
                                 worker_context_->GetCurrentJobID(),
                                 worker_context_->GetCurrentActorID(),
                                 worker_context_->CurrentActorDetached(),
-                                placement_group_creation_options.bundle_label_selector_);
+                                placement_group_creation_options.bundle_label_selector_,
+                                placement_group_creation_options.fallback_strategy_);
   PlacementGroupSpecification placement_group_spec = builder.Build();
   *return_placement_group_id = placement_group_id;
   RAY_LOG(INFO).WithField(placement_group_id)

--- a/src/ray/gcs/gcs_autoscaler_state_manager.cc
+++ b/src/ray/gcs/gcs_autoscaler_state_manager.cc
@@ -222,7 +222,12 @@ void GcsAutoscalerStateManager::GetPendingGangResourceRequests(
     auto *bundle_selector = gang_resource_req->add_bundle_selectors();
 
     // Copy the PG's bundles to the request.
-    for (auto &&bundle : std::move(*pg_data.mutable_bundles())) {
+    const auto &bundles_to_use = (pg_state == rpc::PlacementGroupTableData::PENDING &&
+                                  pg_data.scheduling_options().size() > 0)
+                                     ? pg_data.scheduling_options()[0].bundles()
+                                     : pg_data.bundles();
+
+    for (const auto &bundle : bundles_to_use) {
       if (!NodeID::FromBinary(bundle.node_id()).IsNil()) {
         // We will be skipping **placed** bundle (which has node id associated with it).
         // This is to avoid double counting the bundles that are already placed when

--- a/src/ray/gcs/gcs_placement_group.cc
+++ b/src/ray/gcs/gcs_placement_group.cc
@@ -61,7 +61,6 @@ std::string GcsPlacementGroup::GetRayNamespace() const {
 
 std::vector<std::shared_ptr<const BundleSpecification>> &GcsPlacementGroup::GetBundles()
     const {
-  // Fill the cache if it wasn't.
   if (cached_bundle_specs_.empty()) {
     const auto &bundles = placement_group_table_data_.bundles();
     for (const auto &bundle : bundles) {
@@ -164,10 +163,7 @@ void GcsPlacementGroup::ComputeLabelDomainKey() {
   const LabelSelector &label_selector =
       first_bundle.GetRequiredResources().GetLabelSelector();
   for (const LabelConstraint &constraint : label_selector.GetConstraints()) {
-    if (constraint.GetLabelKey() == kLabelKeyNodeAcceleratorType &&
-        constraint.GetOperator() == LabelSelectorOperator::LABEL_IN &&
-        (constraint.GetLabelValues().contains(kGB300) ||
-         constraint.GetLabelValues().contains(kGB200))) {
+    if (IsGpuAcceleratorConstraint(constraint)) {
       placement_group_table_data_.set_label_domain_key(kGpuDomainLabelKey);
       return;
     }
@@ -194,5 +190,40 @@ void GcsPlacementGroup::ClearLabelDomainAssignments() {
   placement_group_table_data_.mutable_label_domain_assignments()->clear();
 }
 
+const google::protobuf::RepeatedPtrField<rpc::PlacementGroupSchedulingOption>
+    &GcsPlacementGroup::GetPlacementGroupSchedulingOptions() const {
+  return placement_group_table_data_.scheduling_options();
+}
+
+int32_t GcsPlacementGroup::GetActiveSchedulingOptionIndex() const {
+  if (placement_group_table_data_.has_active_scheduling_option_index()) {
+    return placement_group_table_data_.active_scheduling_option_index();
+  }
+  return -1;  // pending PG
+}
+
+void GcsPlacementGroup::UpdateActiveSchedulingOptionIndex(int32_t index) {
+  if (!placement_group_table_data_.has_active_scheduling_option_index() ||
+      index != placement_group_table_data_.active_scheduling_option_index()) {
+    placement_group_table_data_.set_active_scheduling_option_index(index);
+    cached_bundle_specs_.clear();
+
+    const auto &options = GetPlacementGroupSchedulingOptions();
+    if (index >= 0 && index < options.size()) {
+      const auto &active_option = options.Get(index);
+      if (active_option.bundles_size() > 0) {
+        placement_group_table_data_.mutable_bundles()->CopyFrom(active_option.bundles());
+
+        // Ensure all bundle IDs are properly populated with the PG ID and index
+        for (int i = 0; i < placement_group_table_data_.bundles_size(); i++) {
+          auto *bundle = placement_group_table_data_.mutable_bundles(i);
+          bundle->mutable_bundle_id()->set_placement_group_id(
+              placement_group_table_data_.placement_group_id());
+          bundle->mutable_bundle_id()->set_bundle_index(i);
+        }
+      }
+    }
+  }
+}
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_placement_group.h
+++ b/src/ray/gcs/gcs_placement_group.h
@@ -76,6 +76,14 @@ class GcsPlacementGroup {
     placement_group_table_data_.set_soft_target_node_id(
         placement_group_spec.soft_target_node_id());
     placement_group_table_data_.set_ray_namespace(ray_namespace);
+    // Index 0: primary strategy.
+    auto *primary_option = placement_group_table_data_.add_scheduling_options();
+    *primary_option->mutable_bundles() = placement_group_spec.bundles();
+
+    // Index 1..N: fallback strategies.
+    for (const auto &fb : placement_group_spec.fallback_strategy()) {
+      *placement_group_table_data_.add_scheduling_options() = fb;
+    }
     placement_group_table_data_.set_placement_group_creation_timestamp_ms(
         current_sys_time_ms());
     ComputeLabelDomainKey();
@@ -155,6 +163,9 @@ class GcsPlacementGroup {
 
   const rpc::PlacementGroupStats &GetStats() const;
 
+  const google::protobuf::RepeatedPtrField<rpc::PlacementGroupSchedulingOption>
+      &GetPlacementGroupSchedulingOptions() const;
+
   rpc::PlacementGroupStats *GetMutableStats();
 
   /// Get the node label key used for label-domain-aware scheduling (e.g.
@@ -171,6 +182,10 @@ class GcsPlacementGroup {
   /// Clear all label domain assignments (used when all bundles for label-domain PGs are
   /// unplaced).
   void ClearLabelDomainAssignments();
+
+  int32_t GetActiveSchedulingOptionIndex() const;
+
+  void UpdateActiveSchedulingOptionIndex(int32_t index);
 
  private:
   // XXX.

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -39,6 +39,70 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
       cluster_resource_scheduler_(cluster_resource_scheduler),
       raylet_client_pool_(raylet_client_pool) {}
 
+class ScopedResourceMasker {
+ public:
+  ScopedResourceMasker(
+      ClusterResourceScheduler &scheduler,
+      const std::vector<
+          std::pair<ray::NodeID, std::shared_ptr<const BundleSpecification>>>
+          &committed_bundle_pairs)
+      : scheduler_(scheduler) {
+    auto &manager = scheduler_.GetClusterResourceManager();
+    for (const auto &pair : committed_bundle_pairs) {
+      auto node_id = scheduling::NodeID(pair.first.Binary());
+
+      if (!manager.HasNode(node_id)) {
+        // Check if node still exists
+        continue;
+      }
+
+      auto bundle = pair.second;
+      absl::flat_hash_map<std::string, double> effective_resources;
+      const auto &node_resources = manager.GetNodeResources(node_id);
+      auto required_resource_map =
+          bundle->GetRequiredResources().GetResourceSet().GetResourceMap();
+
+      for (const auto &entry : required_resource_map) {
+        auto resource_id = scheduling::ResourceID(entry.first);
+        double total = node_resources.total.Get(resource_id).Double();
+        double available = node_resources.available.Get(resource_id).Double();
+        double requested = entry.second;
+
+        // The amount of resources we can effectively add without
+        // exceeding the node's total capacity.
+        double room = std::max(0.0, total - available);
+        double effective_add = std::min(requested, room);
+
+        if (effective_add > 0.0) {
+          effective_resources[entry.first] = effective_add;
+        }
+      }
+
+      auto effective_request = ResourceMapToResourceRequest(
+          effective_resources, /*requires_object_store_memory=*/false);
+
+      manager.AddNodeAvailableResources(node_id, effective_request.GetResourceSet());
+      masked_nodes_.push_back(node_id);
+      masked_resources_.push_back(effective_request);
+    }
+  }
+
+  ~ScopedResourceMasker() {
+    for (size_t i = 0; i < masked_nodes_.size(); ++i) {
+      scheduler_.GetClusterResourceManager().SubtractNodeAvailableResources(
+          masked_nodes_[i], masked_resources_[i]);
+    }
+  }
+
+  ScopedResourceMasker(const ScopedResourceMasker &) = delete;
+  ScopedResourceMasker &operator=(const ScopedResourceMasker &) = delete;
+
+ private:
+  ClusterResourceScheduler &scheduler_;
+  std::vector<scheduling::NodeID> masked_nodes_;
+  std::vector<ResourceRequest> masked_resources_;
+};
+
 void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     const SchedulePgRequest &request) {
   const auto &placement_group = request.placement_group;
@@ -57,24 +121,19 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
   const auto &bundles = placement_group->GetUnplacedBundles();
   const auto &strategy = placement_group->GetStrategy();
+  const auto &all_bundles = placement_group->GetBundles();
+  bool is_scheduling_all_bundles = (bundles.size() == all_bundles.size());
 
   // For label-domain PGs: if ALL bundles are unplaced (total failure), clear the
   // domain assignment so a new domain can be selected. If only some bundles are
   // unplaced (partial failure), we attempt to reschedule the bundles on the same domain.
-  if (placement_group->GetLabelDomainKey().has_value()) {
-    const std::vector<std::shared_ptr<const BundleSpecification>> &all_bundles =
-        placement_group->GetBundles();
-    bool is_total_failure = (bundles.size() == all_bundles.size());
-    if (is_total_failure) {
-      placement_group->ClearLabelDomainAssignments();
-      RAY_LOG(INFO) << "All bundles for pg " << placement_group->GetPlacementGroupID()
-                    << " are unplaced, rescheduling on a new label domain";
-    }
+  if (is_scheduling_all_bundles) {
+    placement_group->ClearLabelDomainAssignments();
   }
 
-  RAY_LOG(DEBUG) << "Scheduling placement group " << placement_group->GetName()
-                 << ", id: " << placement_group->GetPlacementGroupID()
-                 << ", bundles size = " << bundles.size();
+  RAY_LOG(INFO) << "Scheduling placement group " << placement_group->GetName()
+                << ", id: " << placement_group->GetPlacementGroupID()
+                << ", bundles size = " << bundles.size();
 
   std::vector<const ResourceRequest *> resource_request_list;
   resource_request_list.reserve(bundles.size());
@@ -82,9 +141,122 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     resource_request_list.emplace_back(&bundle->GetRequiredResources());
   }
 
-  auto scheduling_options = CreateSchedulingOptions(*placement_group, strategy);
-  auto scheduling_result = cluster_resource_scheduler_.SchedulePlacementGroup(
-      resource_request_list, scheduling_options);
+  const auto &placement_group_scheduling_options =
+      placement_group->GetPlacementGroupSchedulingOptions();
+
+  int start_index = placement_group->GetActiveSchedulingOptionIndex();
+  if (start_index < 0 || is_scheduling_all_bundles) {
+    start_index = 0;  // Reset to primary strategy
+  }
+
+  SchedulingResult scheduling_result;
+  int used_index = start_index;
+  bool is_feasible = false;
+
+  // If we reset to the primary strategy during a full reschedule, reconstruct the primary
+  // resource requests to avoid scheduling with stale shapes.
+  std::vector<ResourceRequest> primary_requests;
+  std::vector<const ResourceRequest *> primary_request_ptrs;
+
+  if (is_scheduling_all_bundles &&
+      placement_group->GetActiveSchedulingOptionIndex() > 0 &&
+      placement_group_scheduling_options.size() > 0) {
+    for (const auto &b : placement_group_scheduling_options.Get(0).bundles()) {
+      BundleSpecification bundle_spec(b);
+      primary_requests.push_back(bundle_spec.GetRequiredResources());
+    }
+    for (size_t j = 0; j < primary_requests.size(); ++j) {
+      primary_request_ptrs.push_back(&primary_requests[j]);
+    }
+  } else {
+    // Otherwise, use the in-memory bundles.
+    primary_request_ptrs = resource_request_list;
+  }
+
+  // Track currently committed bundles so that we can accurately evaluate freed
+  // resources during a reschedule.
+  std::vector<std::pair<ray::NodeID, std::shared_ptr<const BundleSpecification>>>
+      committed_bundle_pairs;
+  auto maybe_committed = committed_bundle_location_index_.GetBundleLocations(
+      placement_group->GetPlacementGroupID());
+  if (maybe_committed.has_value()) {
+    for (const auto &entry : *maybe_committed.value()) {
+      committed_bundle_pairs.emplace_back(entry.second.first, entry.second.second);
+    }
+  }
+
+  // Mask for the primary attempt only if it is a full reschedule.
+  // This prevents resource state corruption during partial reschedules.
+  std::optional<ScopedResourceMasker> resource_masker;
+  if (is_scheduling_all_bundles && !committed_bundle_pairs.empty()) {
+    resource_masker.emplace(cluster_resource_scheduler_, committed_bundle_pairs);
+  }
+
+  scheduling_result = cluster_resource_scheduler_.SchedulePlacementGroup(
+      primary_request_ptrs,
+      CreateSchedulingOptions(*placement_group, strategy, primary_request_ptrs));
+
+  is_feasible = is_feasible || !scheduling_result.status.IsInfeasible();
+
+  bool needs_full_reschedule = false;
+
+  if (!scheduling_result.status.IsSuccess() &&
+      placement_group_scheduling_options.size() > 1) {
+    // When falling back to more scheduling options, utilize the resource masker
+    // to evaluate accurate resource usage for the current scheduling attempt.
+    if (!resource_masker.has_value() && !committed_bundle_pairs.empty()) {
+      resource_masker.emplace(cluster_resource_scheduler_, committed_bundle_pairs);
+    }
+
+    for (int i = 0; i < placement_group_scheduling_options.size(); ++i) {
+      if (i == start_index) {
+        continue;
+      }
+
+      const auto &option = placement_group_scheduling_options.Get(i);
+      std::vector<ResourceRequest> fallback_requests;
+      std::vector<const ResourceRequest *> fallback_request_ptrs;
+
+      if (option.bundles_size() > 0) {
+        for (const auto &b : option.bundles()) {
+          BundleSpecification bundle_spec(b);
+          fallback_requests.push_back(bundle_spec.GetRequiredResources());
+        }
+      } else {
+        continue;
+      }
+
+      for (size_t j = 0; j < fallback_requests.size(); ++j) {
+        fallback_request_ptrs.push_back(&fallback_requests[j]);
+      }
+
+      auto fallback_result = cluster_resource_scheduler_.SchedulePlacementGroup(
+          fallback_request_ptrs,
+          CreateSchedulingOptions(*placement_group, strategy, fallback_request_ptrs));
+
+      is_feasible = is_feasible || !fallback_result.status.IsInfeasible();
+
+      if (fallback_result.status.IsSuccess()) {
+        scheduling_result = fallback_result;
+        used_index = i;
+        needs_full_reschedule = true;
+        break;
+      }
+    }
+  }
+
+  // If the primary or fallback strategy succeeds during a full reschedule,
+  // clean up any lingering stale resources from the old shape.
+  if (needs_full_reschedule ||
+      (is_scheduling_all_bundles && scheduling_result.status.IsSuccess())) {
+    resource_masker.reset();
+    DestroyPlacementGroupBundleResourcesIfExists(placement_group->GetPlacementGroupID());
+    is_scheduling_all_bundles = true;
+  }
+
+  if (scheduling_result.status.IsSuccess()) {
+    placement_group->UpdateActiveSchedulingOptionIndex(used_index);
+  }
 
   auto result_status = scheduling_result.status;
   const auto &selected_nodes = scheduling_result.selected_nodes;
@@ -94,12 +266,11 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
         << "Failed to schedule placement group " << placement_group->GetName()
         << ", id: " << placement_group->GetPlacementGroupID()
         << ", because current resources can't satisfy the required resource. IsFailed: "
-        << result_status.IsFailed() << " IsInfeasible: " << result_status.IsInfeasible()
+        << result_status.IsFailed() << " IsInfeasible: " << !is_feasible
         << " IsPartialSuccess: " << result_status.IsPartialSuccess();
-    bool infeasible = result_status.IsInfeasible();
     // If the placement group creation has failed,
     // but if it is not infeasible, it is retryable to create.
-    failure_callback(placement_group, /*is_feasible*/ !infeasible);
+    failure_callback(placement_group, is_feasible);
     return;
   }
 
@@ -107,7 +278,13 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
                  << placement_group->GetPlacementGroupID()
                  << ". Selected node size: " << selected_nodes.size();
 
-  RAY_CHECK(bundles.size() == selected_nodes.size());
+  std::vector<std::shared_ptr<const BundleSpecification>> current_bundles;
+  if (is_scheduling_all_bundles) {
+    current_bundles = placement_group->GetBundles();
+  } else {
+    current_bundles = bundles;
+  }
+  RAY_CHECK(current_bundles.size() == selected_nodes.size());
 
   if (scheduling_result.selected_label_domain.has_value()) {
     const auto &[label_domain_key, label_domain_value] =
@@ -121,12 +298,12 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
   // Covert to a map of bundle to node.
   ScheduleMap bundle_to_node;
   for (size_t i = 0; i < selected_nodes.size(); ++i) {
-    bundle_to_node[bundles[i]->BundleId()] =
+    bundle_to_node[current_bundles[i]->BundleId()] =
         NodeID::FromBinary(selected_nodes[i].Binary());
   }
 
-  auto lease_status_tracker =
-      std::make_shared<LeaseStatusTracker>(placement_group, bundles, bundle_to_node);
+  auto lease_status_tracker = std::make_shared<LeaseStatusTracker>(
+      placement_group, current_bundles, bundle_to_node);
   RAY_CHECK(placement_group_leasing_in_progress_
                 .emplace(placement_group->GetPlacementGroupID(), lease_status_tracker)
                 .second);
@@ -140,7 +317,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
       node_to_bundles;
   for (size_t i = 0; i < selected_nodes.size(); ++i) {
     node_to_bundles[NodeID::FromBinary(selected_nodes[i].Binary())].emplace_back(
-        bundles[i]);
+        current_bundles[i]);
   }
 
   for (const auto &entry : node_to_bundles) {
@@ -175,7 +352,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
 void GcsPlacementGroupScheduler::DestroyPlacementGroupBundleResourcesIfExists(
     const PlacementGroupID &placement_group_id) {
-  auto &bundle_locations =
+  auto bundle_locations =
       committed_bundle_location_index_.GetBundleLocations(placement_group_id);
   if (bundle_locations.has_value()) {
     // There could be leasing bundles and committed bundles at the same time if placement
@@ -490,10 +667,33 @@ GcsPlacementGroupScheduler::CreateSchedulingContext(
   return std::make_unique<BundleSchedulingContext>(std::move(bundle_locations));
 }
 
+namespace {
+// Extract the label domain from the given scheduling requests.
+// Label domains are currently only injected for GPU accelerator labels.
+std::optional<std::string> ExtractImplicitLabelDomain(
+    const std::vector<const ResourceRequest *> &active_requests) {
+  if (active_requests.empty()) {
+    return std::nullopt;
+  }
+
+  const auto &selector = active_requests.front()->GetLabelSelector();
+  for (const auto &constraint : selector.GetConstraints()) {
+    if (IsGpuAcceleratorConstraint(constraint)) {
+      return kGpuDomainLabelKey;
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace
+
 SchedulingOptions GcsPlacementGroupScheduler::CreateSchedulingOptions(
-    const GcsPlacementGroup &placement_group, rpc::PlacementStrategy strategy) {
+    const GcsPlacementGroup &placement_group,
+    rpc::PlacementStrategy strategy,
+    const std::vector<const ResourceRequest *> &active_requests) {
   std::optional<std::pair<std::string, std::optional<std::string>>> target_label_domain;
-  std::optional<std::string> label_domain = placement_group.GetLabelDomainKey();
+
+  std::optional<std::string> label_domain = ExtractImplicitLabelDomain(active_requests);
+
   if (label_domain.has_value()) {
     const std::string &label_domain_key = label_domain.value();
     std::optional<std::string> label_value =
@@ -648,7 +848,7 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupPreparedBundleResources(
 void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
     const PlacementGroupID &placement_group_id) {
   // Get the locations of committed bundles.
-  const auto &maybe_bundle_locations =
+  auto maybe_bundle_locations =
       committed_bundle_location_index_.GetBundleLocations(placement_group_id);
   if (maybe_bundle_locations.has_value()) {
     const auto &committed_bundle_locations = maybe_bundle_locations.value();

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -15,6 +15,7 @@
 
 #include <list>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -459,8 +460,10 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const PlacementGroupID &placement_group_id);
 
   /// Create scheduling options.
-  SchedulingOptions CreateSchedulingOptions(const GcsPlacementGroup &placement_group,
-                                            rpc::PlacementStrategy strategy);
+  SchedulingOptions CreateSchedulingOptions(
+      const GcsPlacementGroup &placement_group,
+      rpc::PlacementStrategy strategy,
+      const std::vector<const ResourceRequest *> &active_requests);
 
   /// Try to release bundle resource to cluster resource manager.
   ///

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -1426,5 +1426,412 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestBundlesRemovedWhenNodeDead) {
   ASSERT_EQ(scheduler_->waiting_removed_bundles_.size(), 0);
 }
 
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategySuccess) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  // Set an unsatisfiable primary label selector for the first bundle
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Option 0: Primary
+  spec->add_fallback_strategy();
+
+  // Option 1: Satisfiable fallback strategy
+  auto *option = spec->add_fallback_strategy();
+  auto *fallback_bundle1 = option->add_bundles();
+  (*fallback_bundle1->mutable_unit_resources())["CPU"] = 1.0;
+  auto *fallback_bundle2 = option->add_bundles();
+  (*fallback_bundle2->mutable_unit_resources())["CPU"] = 1.0;
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(1, raylet_clients_[0]->num_lease_requested);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategyFailure) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  // Set an unsatisfiable primary label selector for the first bundle
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Option 0: Primary
+  spec->add_fallback_strategy();
+
+  // Option 1: Unsatisfiable fallback strategy
+  auto *option = spec->add_fallback_strategy();
+  auto *fallback_bundle1 = option->add_bundles();
+  (*fallback_bundle1->mutable_unit_resources())["CPU"] = 1.0;
+  auto *selector = fallback_bundle1->mutable_label_selector();
+  (*selector)["type"] = "B200";
+  auto *fallback_bundle2 = option->add_bundles();
+  (*fallback_bundle2->mutable_unit_resources())["CPU"] = 1.0;
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(0, raylet_clients_[0]->num_lease_requested);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestPlacementGroupFallbackStrategyMultipleOptionsSuccess) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  // Set an unsatisfiable primary label selector for the first bundle
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Option 1: Unsatisfiable (B200)
+  {
+    auto *option = spec->add_fallback_strategy();
+    auto *fallback_bundle = option->add_bundles();
+    (*fallback_bundle->mutable_unit_resources())["CPU"] = 1.0;
+
+    auto *selector = fallback_bundle->mutable_label_selector();
+    (*selector)["type"] = "B200";
+  }
+
+  // Option 2: Satisfiable (A100)
+  {
+    auto *option = spec->add_fallback_strategy();
+    auto *fallback_bundle = option->add_bundles();
+    (*fallback_bundle->mutable_unit_resources())["CPU"] = 1.0;
+
+    auto *selector = fallback_bundle->mutable_label_selector();
+    (*selector)["type"] = "A100";
+  }
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(1, raylet_clients_[0]->num_lease_requested);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategyEmptyOptions) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Create an empty option. It will fall back to the primary bundles (which fail).
+  spec->add_fallback_strategy();
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(0, raylet_clients_[0]->num_lease_requested);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestPlacementGroupSchedulingOptionsBundleOverrideSuccess) {
+  // Add a node with 2 CPUs
+  auto node = GenNodeInfo();
+  AddNode(node, 2);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  // Request a PG with 3 bundles of 1 CPU each (requires 3 CPUs total)
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 3);
+  auto *spec = request.mutable_placement_group_spec();
+
+  for (int i = 0; i < 3; ++i) {
+    auto *bundle = spec->mutable_bundles(i);
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  // Set a fallback strategy that overrides bundles to 2 bundles of 1 CPU each.
+  // Option 0: Primary attempt
+  spec->add_fallback_strategy();
+
+  // Option 1: Fallback attempt (2 bundles override)
+  auto *option1 = spec->add_fallback_strategy();
+
+  // Create 2 override bundles
+  for (int i = 0; i < 2; ++i) {
+    auto *bundle = option1->add_bundles();
+    auto *bundle_id = bundle->mutable_bundle_id();
+    bundle_id->set_bundle_index(i);
+    bundle_id->set_placement_group_id(spec->placement_group_id());
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  // The first attempt (3 bundles) fails because node only has 2 CPUs.
+  // The second attempt (2 bundles) succeeds.
+  ASSERT_EQ(1, raylet_clients_[0]->num_lease_requested);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(0, GcsPlacementGroupStatus::FAILURE);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  // Verify that the active index is 1 (the fallback option)
+  ASSERT_EQ(2, placement_group->GetActiveSchedulingOptionIndex());
+
+  // Verify that the bundles list in PG is updated to the override bundles (size 2)
+  ASSERT_EQ(2, placement_group->GetBundles().size());
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupRescheduleResetsToPrimary) {
+  auto node1 = GenNodeInfo(0);
+  AddNode(node1, 2);
+  auto failure_handler = [this](std::shared_ptr<GcsPlacementGroup> placement_group,
+                                bool is_infeasible) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 3);
+  auto *spec = request.mutable_placement_group_spec();
+  spec->add_fallback_strategy();                  // Option 0 (Primary)
+  auto *option1 = spec->add_fallback_strategy();  // Option 1
+  for (int i = 0; i < 2; ++i) {
+    auto *bundle = option1->add_bundles();
+    auto *bundle_id = bundle->mutable_bundle_id();
+    bundle_id->set_bundle_index(i);
+    bundle_id->set_placement_group_id(spec->placement_group_id());
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  ASSERT_EQ(2, placement_group->GetActiveSchedulingOptionIndex());
+  ASSERT_EQ(2, placement_group->GetBundles().size());
+
+  // Add a second node with 3 CPUs (so primary now fits)
+  auto node2 = GenNodeInfo(1);
+  AddNode(node2, 3);
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  // Simulate node death rescheduling by resetting index to 0 manually
+  placement_group->UpdateActiveSchedulingOptionIndex(0);
+
+  // Clear node id of first bundle to trigger rescheduling of it
+  placement_group->GetMutableBundle(0)->clear_node_id();
+
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  // Scheduler should try and succeed with primary option.
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(2, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestScopedResourceMaskerUsesBaseResourcesDuringReschedule) {
+  // Add a single node with 2 CPUs.
+  auto node = GenNodeInfo();
+  AddNode(node, 2);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  // Create a PG requiring 2 CPUs total
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 2);
+  auto *spec = request.mutable_placement_group_spec();
+  for (int i = 0; i < 2; ++i) {
+    (*spec->mutable_bundles(i)->mutable_unit_resources())["CPU"] = 1.0;
+  }
+  spec->add_fallback_strategy();  // Option 0 (Primary)
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  auto failure_handler = [this](std::shared_ptr<GcsPlacementGroup> pg, bool) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    failure_placement_groups_.emplace_back(std::move(pg));
+  };
+  auto success_handler = [this](std::shared_ptr<GcsPlacementGroup> pg) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.emplace_back(std::move(pg));
+  };
+
+  // Initial schedule succeeds and uses both CPUs on the node
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  success_placement_groups_.clear();
+  raylet_clients_[0]->commit_callbacks.clear();
+
+  // Simulate a reschedule scenario where the bundles are unplaced
+  placement_group->GetMutableBundle(0)->clear_node_id();
+  placement_group->GetMutableBundle(1)->clear_node_id();
+
+  // Try to schedule again, resource masker should successfully simulate freeing
+  // the resources from the previous run and schedule on the same node.
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  // Verify it successfully schedules instead of immediately failing
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST(LabelSelectorTest, TestIsGpuAcceleratorConstraint) {
+  // GB300
+  LabelConstraint c1(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_IN, {kGB300});
+  ASSERT_TRUE(IsGpuAcceleratorConstraint(c1));
+
+  // GB200
+  LabelConstraint c2(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_IN, {kGB200});
+  ASSERT_TRUE(IsGpuAcceleratorConstraint(c2));
+
+  // Wrong Key
+  LabelConstraint c3("wrong-key", LabelSelectorOperator::LABEL_IN, {kGB300});
+  ASSERT_FALSE(IsGpuAcceleratorConstraint(c3));
+
+  // Wrong Operator
+  LabelConstraint c4(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_NOT_IN, {kGB300});
+  ASSERT_FALSE(IsGpuAcceleratorConstraint(c4));
+
+  // Non-GPU value
+  LabelConstraint c5(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_IN, {"N2D"});
+  ASSERT_FALSE(IsGpuAcceleratorConstraint(c5));
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestFallbackImplicitLabelDomainAssigned) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())[kLabelKeyNodeAcceleratorType] = kGB300;
+  (*node->mutable_labels())[kGpuDomainLabelKey] = "domain-1";
+  AddNode(node, 2);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 1);
+  auto *spec = request.mutable_placement_group_spec();
+  (*spec->mutable_bundles(0)->mutable_unit_resources())["CPU"] = 1.0;
+  (*spec->mutable_bundles(0)->mutable_unit_resources())["TPU"] = 1.0;
+
+  auto *fallback = spec->add_fallback_strategy();
+  auto *fallback_bundle = fallback->add_bundles();
+  (*fallback_bundle->mutable_unit_resources())["CPU"] = 1.0;
+  (*fallback_bundle->mutable_label_selector())[kLabelKeyNodeAcceleratorType] = kGB300;
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  auto failure_handler = [this](std::shared_ptr<GcsPlacementGroup> pg, bool) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    failure_placement_groups_.emplace_back(std::move(pg));
+  };
+  auto success_handler = [this](std::shared_ptr<GcsPlacementGroup> pg) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.emplace_back(std::move(pg));
+  };
+
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -709,6 +709,9 @@ message PlacementGroupSpec {
   // Otherwise, the bundles can be placed elsewhere.
   // This only applies to STRICT_PACK pg.
   bytes soft_target_node_id = 11;
+  // The list of fallback options to try if the primary resource request cannot be
+  // scheduled.
+  repeated PlacementGroupSchedulingOption fallback_strategy = 12;
 }
 
 message ObjectReference {
@@ -1110,6 +1113,14 @@ message FallbackOption {
 // node.
 message FallbackStrategy {
   repeated FallbackOption options = 1;
+}
+
+// A single fallback option for a Placement Group. Defines requirements for a Placement
+// Group to use for scheduling, including bundle overrides.
+message PlacementGroupSchedulingOption {
+  // Overrides the entire bundles list for this attempt.
+  // Bundles includes the per-bundle label selectors if specified.
+  repeated Bundle bundles = 1;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -648,7 +648,9 @@ message PlacementGroupTableData {
   bytes placement_group_id = 1;
   // The name of the placement group.
   string name = 2;
-  // The array of the bundle in Placement Group.
+  // The currently active bundles for this placement group.
+  // If scheduled via a fallback strategy, this contains the fallback's bundles.
+  // This is empty for pending placement groups.
   repeated Bundle bundles = 3;
   // The schedule strategy of this Placement Group.
   PlacementStrategy strategy = 4;
@@ -688,6 +690,10 @@ message PlacementGroupTableData {
   // The node label key that identifies the label domain for this placement group
   // (e.g. "ray.io/gpu-domain"). Empty if the PG does not use label-domain scheduling.
   string label_domain_key = 18;
+  // The primary and fallback scheduling options for this placement group.
+  repeated PlacementGroupSchedulingOption scheduling_options = 19;
+  // The index in placement_group_scheduling_options that is currently being used.
+  optional int32 active_scheduling_option_index = 20;
 }
 
 message JobTableData {


### PR DESCRIPTION
## Description
This final PR builds off of https://github.com/ray-project/ray/pull/62423 to add the python API for fallback strategy and pass it through the Cython. It adds the Python API, Cython changes, and validation logic so that fallback strategies can now be used by the scheduler logic we added.

- Updated ray.util.placement_group to accept the `fallback_strategy` argument and added comprehensive validation logic for the input format. This PR does not contain the semantic change for the `bundles` field.

- Updated _raylet.pyx and common.pxd to parse Python lists/dicts and cleanly convert them into C++ `CLabelSelector` and `CPlacementGroupSchedulingOption` vectors.

- Updated `PlacementGroupCreationOptions` in core_worker/common.h to accept the new `LabelSelector` and `fallback_strategy` arguments

- Updated `PlacementGroupSpecBuilder` in placement_group.h to directly use the `LabelSelector` objects and added the loop to populate fallback strategy bundles into the protobuf message.

- Added new unit tests in test_placement_group_fallback.py to verify validation logic and ensure the Python API correctly passes fallback strategy to the C++.

## Related issues
https://github.com/ray-project/ray/issues/51564

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
