### PR TITLE
[Data] Remove `get_plan_conversion_fns`

### DIFF
--- a/python/ray/data/_internal/logical/optimizers.py
+++ b/python/ray/data/_internal/logical/optimizers.py
@@ -1,4 +1,6 @@
-from typing import TYPE_CHECKING, Callable, List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
+
+from ray.data._internal.planner import create_planner
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.execution_callback import ExecutionCallback
@@ -8,7 +10,6 @@ from ray.data._internal.logical.interfaces import (
     LogicalPlan,
     Optimizer,
     PhysicalPlan,
-    Plan,
     Rule,
 )
 from ray.data._internal.logical.rules import (
@@ -71,31 +72,6 @@ class PhysicalOptimizer(Optimizer):
         return [rule_cls() for rule_cls in get_physical_ruleset()]
 
 
-def get_plan_conversion_fns() -> Tuple[
-    Callable[[Plan], Plan],
-    Callable[[LogicalPlan], Tuple[PhysicalPlan, List["ExecutionCallback"]]],
-    Callable[[Plan], Plan],
-]:
-    """Get the list of transformation functions to convert a logical plan
-    to an optimized physical plan.
-
-    This returns the 3 transformation steps:
-    1. Logical optimization
-    2. Planning (logical -> physical operators)
-    3. Physical optimization
-
-    Returns:
-        A list of transformation functions, each taking a Plan and returning a Plan.
-    """
-    from ray.data._internal.planner import create_planner
-
-    return (
-        LogicalOptimizer().optimize,  # Logical optimization
-        create_planner().plan,  # Planning
-        PhysicalOptimizer().optimize,  # Physical optimization
-    )
-
-
 def get_execution_plan(
     logical_plan: LogicalPlan,
 ) -> Tuple[PhysicalPlan, List["ExecutionCallback"]]:
@@ -106,18 +82,14 @@ def get_execution_plan(
     (2) planning: convert logical to physical operators.
     (3) physical optimization: optimize physical operators.
     """
+    # 1. Logical -> Logical (Optimized)
+    optimized_logical_plan = LogicalOptimizer().optimize(logical_plan)
 
-    # 1. Get planning functions
-    optimize_logical, plan, optimize_physical = get_plan_conversion_fns()
-
-    # 2. Logical -> Logical (Optimized)
-    optimized_logical_plan = optimize_logical(logical_plan)
-
-    # 3. Rewire Logical -> Logical (Optimized)
+    # 2. Rewire Logical -> Logical (Optimized)
     logical_plan._dag = optimized_logical_plan.dag
 
-    # 4. Logical (Optimized) -> Physical
-    physical_plan, callbacks = plan(optimized_logical_plan)
+    # 3. Logical (Optimized) -> Physical
+    physical_plan, callbacks = create_planner().plan(optimized_logical_plan)
 
-    # 5. Physical (Optimized) -> Physical
-    return optimize_physical(physical_plan), callbacks
+    # 4. Physical (Optimized) -> Physical
+    return PhysicalOptimizer().optimize(physical_plan), callbacks

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1,7 +1,7 @@
 import copy
 import itertools
 import logging
-from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Type, Union
 
 import pyarrow
 
@@ -12,7 +12,11 @@ from ray.data._internal.logical.interfaces import SourceOperator
 from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
 from ray.data._internal.logical.interfaces.operator import Operator
 from ray.data._internal.logical.operators.one_to_one_operator import Limit
-from ray.data._internal.logical.optimizers import get_plan_conversion_fns
+from ray.data._internal.logical.optimizers import (
+    LogicalOptimizer,
+    PhysicalOptimizer,
+)
+from ray.data._internal.planner import create_planner
 from ray.data._internal.stats import DatasetStats
 from ray.data.block import _take_first_non_empty_schema
 from ray.data.context import DataContext
@@ -100,36 +104,28 @@ class ExecutionPlan:
 
     def explain(self) -> str:
         """Return a string representation of the logical and physical plan."""
-
-        convert_fns = [lambda x: x] + list(get_plan_conversion_fns())
-        titles: List[str] = [
-            "Logical Plan",
-            "Logical Plan (Optimized)",
-            "Physical Plan",
-            "Physical Plan (Optimized)",
-        ]
-
-        # 1. Set initial plan
-        plan = self._logical_plan
-
         sections = []
-        for title, convert_fn in zip(titles, convert_fns):
 
-            # 2. Convert plan to new plan
-            plan = convert_fn(plan)
-            # TODO: This loop mixes two kinds of functions: optimizers (return a Plan) and
-            # the planner (returns a (PhysicalPlan, callbacks) tuple). The isinstance check
-            # below is a workaround for that mismatch. Fix this by pulling the planner step
-            # out of the loop so each function has a uniform return type.
-            if isinstance(plan, tuple):
-                plan = plan[0]
-
-            # 3. Generate plan str from new plan.
+        def _add_section(title, plan):
             plan_str, _ = self.generate_plan_string(plan.dag, show_op_repr=True)
-
             banner = f"\n-------- {title} --------\n"
-            section = f"{banner}{plan_str}"
-            sections.append(section)
+            sections.append(f"{banner}{plan_str}")
+
+        # 1. Logical Plan
+        logical_plan = self._logical_plan
+        _add_section("Logical Plan", logical_plan)
+
+        # 2. Optimized Logical Plan
+        optimized_logical = LogicalOptimizer().optimize(logical_plan)
+        _add_section("Logical Plan (Optimized)", optimized_logical)
+
+        # 3. Physical Plan
+        physical_plan, _ = create_planner().plan(optimized_logical)
+        _add_section("Physical Plan", physical_plan)
+
+        # 4. Optimized Physical Plan
+        optimized_physical = PhysicalOptimizer().optimize(physical_plan)
+        _add_section("Physical Plan (Optimized)", optimized_physical)
 
         return "".join(sections)
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1,7 +1,7 @@
 import copy
 import itertools
 import logging
-from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Type, Union
 
 import pyarrow
 

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -1,7 +1,7 @@
 import copy
 import itertools
 import logging
-from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Iterator, List, Optional, Tuple, Type, Union
 
 import pyarrow
 


### PR DESCRIPTION
`get_plan_conversion_fns` returns a tuple of 3 callables that `ExecutionPlan.explain()` iterates over in a loop. This design forces a type mismatch workaround because the planner returns `(PhysicalPlan, callbacks)` while the optimizers return just a `Plan`. There's an existing TODO calling this out.
                                                                                                                                                                                               
In this PR, I've removed `get_plan_conversion_fns` and inlines its logic at both call sites:                                                                                                            
                                                                                                                                                                                              
  - ExecutionPlan.explain(): Replaced the loop with explicit sequential calls, eliminating the `isinstance` workaround.                                                                          
  - get_execution_plan(): Calls `LogicalOptimizer`, `create_planner`, and `PhysicalOptimizer` directly instead of unpacking them from a tuple.