### PR TITLE
[raydepsets] adding errors for invalid configs

### DIFF
--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -169,6 +169,9 @@ class DependencySetManager:
 
     def _build(self, build_all_configs: Optional[bool] = False):
         """Build the dependency graph from config depsets."""
+        # First pass: add all depset nodes so we can validate edges
+        depset_names = {depset.name for depset in self.config.depsets}
+
         for depset in self.config.depsets:
             if depset.operation == "compile":
                 self.build_graph.add_node(
@@ -179,6 +182,11 @@ class DependencySetManager:
                     config_name=depset.config_name,
                 )
             elif depset.operation == "subset":
+                if depset.source_depset not in depset_names:
+                    raise ValueError(
+                        f"Depset '{depset.name}' references source_depset '{depset.source_depset}' which does not exist. "
+                        f"Available depsets: {sorted(depset_names)}"
+                    )
                 self.build_graph.add_node(
                     depset.name,
                     operation="subset",
@@ -188,6 +196,12 @@ class DependencySetManager:
                 )
                 self.build_graph.add_edge(depset.source_depset, depset.name)
             elif depset.operation == "expand":
+                for dep_name in depset.depsets:
+                    if dep_name not in depset_names:
+                        raise ValueError(
+                            f"Depset '{depset.name}' references depset '{dep_name}' which does not exist. "
+                            f"Available depsets: {sorted(depset_names)}"
+                        )
                 self.build_graph.add_node(
                     depset.name,
                     operation="expand",
@@ -198,6 +212,11 @@ class DependencySetManager:
                 for depset_name in depset.depsets:
                     self.build_graph.add_edge(depset_name, depset.name)
             elif depset.operation == "relax":
+                if depset.source_depset not in depset_names:
+                    raise ValueError(
+                        f"Depset '{depset.name}' references source_depset '{depset.source_depset}' which does not exist. "
+                        f"Available depsets: {sorted(depset_names)}"
+                    )
                 self.build_graph.add_node(
                     depset.name,
                     operation="relax",

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -244,7 +244,7 @@ class TestCli(unittest.TestCase):
 
     def test_subset_with_expanded_depsettest_subset_with_expanded_depset(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            copy_data_to_tmpdir(tmpdir)
+            copy_data_to_tmpdir(tmpdir, ignore_patterns="test2.depsets.yaml")
             compile_depset = Depset(
                 name="compile_depset",
                 operation="compile",
@@ -497,6 +497,57 @@ class TestCli(unittest.TestCase):
                 "Invalid operation: invalid_op for depset invalid_op_depset in config test.depsets.yaml"
                 in str(e.exception)
             )
+
+    def test_build_graph_subset_missing_source_depset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir, ignore_patterns="test2.depsets.yaml")
+            depset = Depset(
+                name="bad_subset",
+                operation="subset",
+                source_depset="nonexistent_depset",
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled_bad_subset.txt",
+                config_name="test.depsets.yaml",
+            )
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
+            with self.assertRaises(ValueError) as e:
+                _create_test_manager(tmpdir)
+            assert "nonexistent_depset" in str(e.exception)
+            assert "does not exist" in str(e.exception)
+
+    def test_build_graph_expand_missing_depset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir, ignore_patterns="test2.depsets.yaml")
+            depset = Depset(
+                name="bad_expand",
+                operation="expand",
+                depsets=["nonexistent_depset"],
+                requirements=["requirements_test.txt"],
+                output="requirements_compiled_bad_expand.txt",
+                config_name="test.depsets.yaml",
+            )
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
+            with self.assertRaises(ValueError) as e:
+                _create_test_manager(tmpdir)
+            assert "nonexistent_depset" in str(e.exception)
+            assert "does not exist" in str(e.exception)
+
+    def test_build_graph_relax_missing_source_depset(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            copy_data_to_tmpdir(tmpdir, ignore_patterns="test2.depsets.yaml")
+            depset = Depset(
+                name="bad_relax",
+                operation="relax",
+                source_depset="nonexistent_depset",
+                packages=["emoji"],
+                output="requirements_compiled_bad_relax.txt",
+                config_name="test.depsets.yaml",
+            )
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
+            with self.assertRaises(ValueError) as e:
+                _create_test_manager(tmpdir)
+            assert "nonexistent_depset" in str(e.exception)
+            assert "does not exist" in str(e.exception)
 
     def test_execute(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
adding errors messages when referenced depsets do not exist during build graph generation
ex.
```
depsets:
  - name: ray_img_depset_${PYTHON_SHORT}
    requirements:
      - req1.in
    output: python/deplocks/depset1.lock
    operation: compile
    build_arg_sets:
      - py310

  - name: ray_base_extra_testdeps_${PYTHON_SHORT}
    operation: expand
    requirements:
      - req2.in
    depsets:
      - ray_img_invalid_depset_${PYTHON_SHORT}
    output: python/deplocks/depset2.lock
    build_arg_sets:
      - py310
```

invalid depset that doesn't exist:
    **depsets:
      - ray_img_invalid_depset_${PYTHON_SHORT}**