### PR TITLE
[Data] Fix planner tests to handle tuple return from planner.plan()

### DIFF
--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -53,7 +53,8 @@ def test_random_shuffle_operator(ray_start_regular_shared_2_cpus):
         seed_config=RandomSeedConfig(seed=0),
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "RandomShuffle"
     assert isinstance(physical_op, AllToAllOperator)
@@ -85,7 +86,8 @@ def test_repartition_operator(ray_start_regular_shared_2_cpus, shuffle):
     read_op = get_parquet_read_logical_op()
     op = Repartition(read_op, num_outputs=5, shuffle=shuffle)
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "Repartition"
     assert isinstance(physical_op, AllToAllOperator)
@@ -161,7 +163,8 @@ def test_write_operator(ray_start_regular_shared_2_cpus, tmp_path):
         compute=TaskPoolStrategy(concurrency),
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "Write"
     assert isinstance(physical_op, TaskPoolMapOperator)
@@ -185,7 +188,8 @@ def test_sort_operator(
         sort_key=SortKey("col1"),
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "Sort"
     assert isinstance(physical_op, AllToAllOperator)
@@ -362,7 +366,8 @@ def test_zip_operator(ray_start_regular_shared_2_cpus):
     read_op2 = get_parquet_read_logical_op()
     op = Zip(read_op1, read_op2)
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "Zip"
     assert isinstance(physical_op, ZipOperator)

--- a/python/ray/data/tests/test_execution_optimizer_basic.py
+++ b/python/ray/data/tests/test_execution_optimizer_basic.py
@@ -44,7 +44,8 @@ def test_read_operator(ray_start_regular_shared_2_cpus):
     planner = create_planner()
     op = get_parquet_read_logical_op()
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "ReadParquet"
     assert isinstance(physical_op, MapOperator)
@@ -129,7 +130,8 @@ def test_from_operators(ray_start_regular_shared_2_cpus):
         planner = create_planner()
         op = op_cls([], [])
         plan = LogicalPlan(op, ctx)
-        physical_op = planner.plan(plan)[0].dag
+        physical_plan, _ = planner.plan(plan)
+        physical_op = physical_plan.dag
 
         assert op.name == op_cls.__name__
         assert isinstance(physical_op, InputDataBuffer)
@@ -204,7 +206,8 @@ def test_map_batches_operator(ray_start_regular_shared_2_cpus):
         lambda x: x,
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "MapBatches(<lambda>)"
     assert isinstance(physical_op, MapOperator)
@@ -232,7 +235,8 @@ def test_map_rows_operator(ray_start_regular_shared_2_cpus):
         lambda x: x,
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "Map(<lambda>)"
     assert isinstance(physical_op, MapOperator)
@@ -259,7 +263,8 @@ def test_filter_operator(ray_start_regular_shared_2_cpus):
         fn=lambda x: x,
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "Filter(<lambda>)"
     assert isinstance(physical_op, MapOperator)
@@ -335,7 +340,8 @@ def test_flat_map(ray_start_regular_shared_2_cpus):
         lambda x: x,
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "FlatMap(<lambda>)"
     assert isinstance(physical_op, MapOperator)

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -22,7 +22,8 @@ def test_randomize_blocks_operator(ray_start_regular_shared):
         seed_config=RandomSeedConfig(seed=0),
     )
     plan = LogicalPlan(op, ctx)
-    physical_op = planner.plan(plan)[0].dag
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
 
     assert op.name == "RandomizeBlockOrder"
     assert isinstance(physical_op, AllToAllOperator)


### PR DESCRIPTION
## Description

`planner.plan()` now returns a tuple `(physical_plan, callbacks)` after #61405. In this PR, I've updates the planner unit tests to unpack the tuple instead of indexing into the result.

I'm doing this to make the return type a bit more explicit and readable.

## Related issues

Related to #61405