### PR TITLE
[Data] Support rapidsmpf 26.2 in gpu shuffle

### DIFF
--- a/python/ray/data/_internal/gpu_shuffle/rapidsmpf_backend.py
+++ b/python/ray/data/_internal/gpu_shuffle/rapidsmpf_backend.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from packaging.version import parse as parse_version
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -53,8 +54,7 @@ def lazy_load() -> type[Any]:
     """
     import cudf
     import rmm.mr
-    from rapidsmpf.buffer.buffer import MemoryType
-    from rapidsmpf.buffer.resource import BufferResource, LimitAvailableMemory
+    import rapidsmpf
     from rapidsmpf.integrations.cudf.partition import (
         partition_and_pack,
         unpack_and_concat,
@@ -64,6 +64,14 @@ def lazy_load() -> type[Any]:
     from rapidsmpf.statistics import Statistics
     from rapidsmpf.utils.cudf import cudf_to_pylibcudf_table
     from rapidsmpf.utils.ray_utils import BaseShufflingActor
+
+    if parse_version(rapidsmpf.__version__) >= parse_version("26.2.0"):
+        from rapidsmpf.memory.buffer import MemoryType
+        from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
+    else:
+        from rapidsmpf.buffer.buffer import MemoryType
+        from rapidsmpf.buffer.resource import BufferResource, LimitAvailableMemory
+
 
     # Exempt this class from coverage is it's indirectly tested by the ShuffleStage which coverage tools don't pick up.
     class BulkRapidsMPFShuffler(BaseShufflingActor):  # pragma: no cover

--- a/python/ray/data/_internal/gpu_shuffle/rapidsmpf_backend.py
+++ b/python/ray/data/_internal/gpu_shuffle/rapidsmpf_backend.py
@@ -16,8 +16,9 @@
 
 from __future__ import annotations
 
-from packaging.version import parse as parse_version
 from typing import TYPE_CHECKING, Any, Literal
+
+from packaging.version import parse as parse_version
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -53,8 +54,8 @@ def lazy_load() -> type[Any]:
     This is necessary because the BulkRapidsMPFShuffler inherits from BaseShufflingActor.
     """
     import cudf
-    import rmm.mr
     import rapidsmpf
+    import rmm.mr
     from rapidsmpf.integrations.cudf.partition import (
         partition_and_pack,
         unpack_and_concat,
@@ -67,11 +68,13 @@ def lazy_load() -> type[Any]:
 
     if parse_version(rapidsmpf.__version__) >= parse_version("26.2.0"):
         from rapidsmpf.memory.buffer import MemoryType
-        from rapidsmpf.memory.buffer_resource import BufferResource, LimitAvailableMemory
+        from rapidsmpf.memory.buffer_resource import (
+            BufferResource,
+            LimitAvailableMemory,
+        )
     else:
         from rapidsmpf.buffer.buffer import MemoryType
         from rapidsmpf.buffer.resource import BufferResource, LimitAvailableMemory
-
 
     # Exempt this class from coverage is it's indirectly tested by the ShuffleStage which coverage tools don't pick up.
     class BulkRapidsMPFShuffler(BaseShufflingActor):  # pragma: no cover


### PR DESCRIPTION
## Description
This PR adds support for rapidsmpf 26.02, which had a breaking API change.

## Related issues
Related to #61371 
