### PR TITLE
[serve][llm] Refactor Serve LLM dashboard panels for more visible insights

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -14,8 +14,8 @@ from ray.dashboard.modules.metrics.dashboards.common import (
 # ---------------------------------------------------------------------------
 # WorkerId join: attaches deployment + replica labels to vLLM-only metrics
 _WORKER_JOIN = (
-    '\n* on(WorkerId) group_left(deployment, replica)'
-    '\nmax by(WorkerId, deployment, replica) ('
+    "\n* on(WorkerId) group_left(deployment, replica)"
+    "\nmax by(WorkerId, deployment, replica) ("
     'ray_serve_deployment_request_counter_total{{{global_filters}, deployment=~"$deployment"}} * 0 + 1)'
 )
 
@@ -32,50 +32,45 @@ _DEP_REPLICA = "{{deployment}}: {{replica}}"
 def _mean_with_join(metric_base: str) -> str:
     """Mean = sum(_sum) / sum(_count) with NaN guard + WorkerId join."""
     return (
-        '(\n'
-        '  (\n'
-        f'    sum by(WorkerId) (rate({metric_base}_sum{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
-        '    /\n'
-        f'    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
-        '  )\n'
-        '  and on(WorkerId)\n'
-        '  (\n'
-        f'    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n'
-        '  )\n'
-        ')'
-        + _WORKER_JOIN
+        "(\n"
+        "  (\n"
+        f"    sum by(WorkerId) (rate({metric_base}_sum{{{{{_VLLM_FILTER}}}}}[$interval]))\n"
+        "    /\n"
+        f"    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval]))\n"
+        "  )\n"
+        "  and on(WorkerId)\n"
+        "  (\n"
+        f"    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n"
+        "  )\n"
+        ")" + _WORKER_JOIN
     )
 
 
 def _percentile_with_join(metric_base: str, quantile: float) -> str:
     """histogram_quantile with NaN guard + WorkerId join."""
     return (
-        '(\n'
-        '  histogram_quantile(\n'
-        f'    {quantile},\n'
-        f'    sum by (le, WorkerId) (rate({metric_base}_bucket{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
-        '  )\n'
-        '  and on(WorkerId)\n'
-        '  (\n'
-        f'    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n'
-        '  )\n'
-        ')'
-        + _WORKER_JOIN
+        "(\n"
+        "  histogram_quantile(\n"
+        f"    {quantile},\n"
+        f"    sum by (le, WorkerId) (rate({metric_base}_bucket{{{{{_VLLM_FILTER}}}}}[$interval]))\n"
+        "  )\n"
+        "  and on(WorkerId)\n"
+        "  (\n"
+        f"    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n"
+        "  )\n"
+        ")" + _WORKER_JOIN
     )
 
 
 def _gauge_with_join(metric: str) -> str:
     """Simple gauge metric with WorkerId join (no rate, no guard)."""
-    return (
-        f'sum by(WorkerId) ({metric}{{{{{_VLLM_FILTER}}}}})'
-        + _WORKER_JOIN
-    )
+    return f"sum by(WorkerId) ({metric}{{{{{_VLLM_FILTER}}}}})" + _WORKER_JOIN
 
 
 def _rate_with_join(metric: str, agg_fn: str = "rate") -> str:
     """rate() or increase() of a metric summed by WorkerId, with join."""
     return (
-        f'sum by(WorkerId) ({agg_fn}({metric}{{{{{_VLLM_FILTER}}}}}[$interval]))'
+        f"sum by(WorkerId) ({agg_fn}({metric}{{{{{_VLLM_FILTER}}}}}[$interval]))"
         + _WORKER_JOIN
     )
 
@@ -93,19 +88,18 @@ def _ratio_with_join_and_guard(
     """
     guard = guard_metric or denominator_metric
     return (
-        '(\n'
-        '  (\n'
-        f'    sum by(WorkerId) (rate({numerator_metric}{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
-        '    /\n'
-        f'    sum by(WorkerId) (rate({denominator_metric}{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
-        + (f'    {scale}\n' if scale else '')
-        + '  )\n'
-        '  and on(WorkerId)\n'
-        '  (\n'
-        f'    sum by(WorkerId) (rate({guard}{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n'
-        '  )\n'
-        ')'
-        + _WORKER_JOIN
+        "(\n"
+        "  (\n"
+        f"    sum by(WorkerId) (rate({numerator_metric}{{{{{_VLLM_FILTER}}}}}[$interval]))\n"
+        "    /\n"
+        f"    sum by(WorkerId) (rate({denominator_metric}{{{{{_VLLM_FILTER}}}}}[$interval]))\n"
+        + (f"    {scale}\n" if scale else "")
+        + "  )\n"
+        "  and on(WorkerId)\n"
+        "  (\n"
+        f"    sum by(WorkerId) (rate({guard}{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n"
+        "  )\n"
+        ")" + _WORKER_JOIN
     )
 
 
@@ -127,7 +121,9 @@ def _latency_panels(
             description=description,
             unit="s",
             targets=[Target(expr=_mean_with_join(metric_base), legend=_DEP_REPLICA)],
-            fill=1, linewidth=2, stack=False,
+            fill=1,
+            linewidth=2,
+            stack=False,
             grid_pos=GridPos(0, y, 8, 8),
         ),
         Panel(
@@ -135,8 +131,14 @@ def _latency_panels(
             title=f"{label} -- P50",
             description=description,
             unit="s",
-            targets=[Target(expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA)],
-            fill=1, linewidth=2, stack=False,
+            targets=[
+                Target(
+                    expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA
+                )
+            ],
+            fill=1,
+            linewidth=2,
+            stack=False,
             grid_pos=GridPos(8, y, 8, 8),
         ),
         Panel(
@@ -144,8 +146,14 @@ def _latency_panels(
             title=f"{label} -- P90",
             description=description,
             unit="s",
-            targets=[Target(expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA)],
-            fill=1, linewidth=2, stack=False,
+            targets=[
+                Target(
+                    expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA
+                )
+            ],
+            fill=1,
+            linewidth=2,
+            stack=False,
             grid_pos=GridPos(16, y, 8, 8),
         ),
     ]
@@ -168,7 +176,9 @@ def _length_panels(
             description="",
             unit="short",
             targets=[Target(expr=_mean_with_join(metric_base), legend=_DEP_REPLICA)],
-            fill=1, linewidth=1, stack=False,
+            fill=1,
+            linewidth=1,
+            stack=False,
             grid_pos=GridPos(0, y, 8, 8),
         ),
         Panel(
@@ -176,8 +186,14 @@ def _length_panels(
             title=f"{label} -- P50",
             description="",
             unit="short",
-            targets=[Target(expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA)],
-            fill=1, linewidth=1, stack=False,
+            targets=[
+                Target(
+                    expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA
+                )
+            ],
+            fill=1,
+            linewidth=1,
+            stack=False,
             grid_pos=GridPos(8, y, 8, 8),
         ),
         Panel(
@@ -185,8 +201,14 @@ def _length_panels(
             title=f"{label} -- P90",
             description="",
             unit="short",
-            targets=[Target(expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA)],
-            fill=1, linewidth=1, stack=False,
+            targets=[
+                Target(
+                    expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA
+                )
+            ],
+            fill=1,
+            linewidth=1,
+            stack=False,
             grid_pos=GridPos(16, y, 8, 8),
         ),
     ]
@@ -203,15 +225,17 @@ _throughput_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))',
+                expr=f"sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))",
                 legend=_DEP_REPLICA,
             ),
             Target(
-                expr=f'sum(rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))',
+                expr=f"sum(rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))",
                 legend="Total QPS",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 1, 8, 8),
     ),
     Panel(
@@ -225,11 +249,13 @@ _throughput_panels = [
                 legend=_DEP_REPLICA,
             ),
             Target(
-                expr=f'sum(rate(ray_vllm_request_prompt_tokens_sum{{{{{_VLLM_FILTER}}}}}[$interval]))',
+                expr=f"sum(rate(ray_vllm_request_prompt_tokens_sum{{{{{_VLLM_FILTER}}}}}[$interval]))",
                 legend="Total",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(8, 1, 8, 8),
     ),
     Panel(
@@ -243,11 +269,13 @@ _throughput_panels = [
                 legend=_DEP_REPLICA,
             ),
             Target(
-                expr=f'sum(rate(ray_vllm_generation_tokens_total{{{{{_VLLM_FILTER}}}}}[$interval]))',
+                expr=f"sum(rate(ray_vllm_generation_tokens_total{{{{{_VLLM_FILTER}}}}}[$interval]))",
                 legend="Total",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(16, 1, 8, 8),
     ),
 ]
@@ -256,9 +284,17 @@ _throughput_panels = [
 # Row 2: Latency (3x3 grid)
 # ===================================================================
 _latency_panels_list = [
-    *_latency_panels("ray_vllm_request_time_per_output_token_seconds", "TPOT", (6, 7, 8), 10),
+    *_latency_panels(
+        "ray_vllm_request_time_per_output_token_seconds", "TPOT", (6, 7, 8), 10
+    ),
     *_latency_panels("ray_vllm_time_to_first_token_seconds", "TTFT", (9, 10, 11), 18),
-    *_latency_panels("ray_vllm_e2e_request_latency_seconds", "Request Latency", (12, 13, 14), 26, description="Latency from request start to first token returned (in seconds)."),
+    *_latency_panels(
+        "ray_vllm_e2e_request_latency_seconds",
+        "Request Latency",
+        (12, 13, 14),
+        26,
+        description="Latency from request start to first token returned (in seconds).",
+    ),
 ]
 
 # ===================================================================
@@ -276,7 +312,9 @@ _cache_panels = [
                 legend=_DEP_REPLICA,
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 35, 12, 8),
     ),
     Panel(
@@ -287,31 +325,33 @@ _cache_panels = [
         targets=[
             Target(
                 expr=(
-                    f'100 * ('
-                    f'(sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) '
-                    f'/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval])))'
-                    f' and on(WorkerId) '
-                    f'(sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval])) > 0))'
+                    f"100 * ("
+                    f"(sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) "
+                    f"/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval])))"
+                    f" and on(WorkerId) "
+                    f"(sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval])) > 0))"
                     + _WORKER_JOIN
                 ),
                 legend=_DEP_REPLICA,
             ),
             Target(
                 expr=(
-                    f'max(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) '
-                    f'/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))'
+                    f"max(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) "
+                    f"/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))"
                 ),
                 legend="Max Hit Rate",
             ),
             Target(
                 expr=(
-                    f'min(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) '
-                    f'/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))'
+                    f"min(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) "
+                    f"/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))"
                 ),
                 legend="Min Hit Rate",
             ),
         ],
-        fill=1, linewidth=1, stack=False,
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(12, 35, 12, 8),
     ),
 ]
@@ -320,8 +360,12 @@ _cache_panels = [
 # Row 4: Request Length
 # ===================================================================
 _request_length_panels = [
-    *_length_panels("ray_vllm_request_prompt_tokens", "Prompt Length", (19, 20, 21), 44),
-    *_length_panels("ray_vllm_request_generation_tokens", "Generation Length", (22, 23, 24), 52),
+    *_length_panels(
+        "ray_vllm_request_prompt_tokens", "Prompt Length", (19, 20, 21), 44
+    ),
+    *_length_panels(
+        "ray_vllm_request_generation_tokens", "Generation Length", (22, 23, 24), 52
+    ),
 ]
 
 # ===================================================================
@@ -333,8 +377,15 @@ _scheduler_panels = [
         title="Scheduler: Running",
         description="",
         unit="short",
-        targets=[Target(expr=_gauge_with_join("ray_vllm_num_requests_running"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_gauge_with_join("ray_vllm_num_requests_running"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(0, 61, 8, 8),
     ),
     Panel(
@@ -342,8 +393,15 @@ _scheduler_panels = [
         title="Scheduler: Swapped",
         description="",
         unit="short",
-        targets=[Target(expr=_gauge_with_join("ray_vllm_num_requests_swapped"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_gauge_with_join("ray_vllm_num_requests_swapped"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(8, 61, 8, 8),
     ),
     Panel(
@@ -351,8 +409,15 @@ _scheduler_panels = [
         title="Scheduler: Waiting",
         description="",
         unit="short",
-        targets=[Target(expr=_gauge_with_join("ray_vllm_num_requests_waiting"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_gauge_with_join("ray_vllm_num_requests_waiting"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(16, 61, 8, 8),
     ),
     Panel(
@@ -363,13 +428,15 @@ _scheduler_panels = [
         targets=[
             Target(
                 expr=(
-                    f'sum by(finished_reason, WorkerId) (increase(ray_vllm_request_success_total{{{{{_VLLM_FILTER}}}}}[$interval]))'
+                    f"sum by(finished_reason, WorkerId) (increase(ray_vllm_request_success_total{{{{{_VLLM_FILTER}}}}}[$interval]))"
                     + _WORKER_JOIN
                 ),
                 legend="{{finished_reason}} \u2014 {{deployment}}: {{replica}}",
             ),
         ],
-        fill=1, linewidth=1, stack=False,
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(0, 69, 12, 8),
     ),
     Panel(
@@ -377,8 +444,15 @@ _scheduler_panels = [
         title="Queue Time",
         description="",
         unit="s",
-        targets=[Target(expr=_rate_with_join("ray_vllm_request_queue_time_seconds_sum"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_rate_with_join("ray_vllm_request_queue_time_seconds_sum"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(12, 69, 12, 8),
     ),
     Panel(
@@ -386,8 +460,15 @@ _scheduler_panels = [
         title="Prefill Time",
         description="",
         unit="s",
-        targets=[Target(expr=_rate_with_join("ray_vllm_request_prefill_time_seconds_sum"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_rate_with_join("ray_vllm_request_prefill_time_seconds_sum"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(0, 77, 12, 8),
     ),
     Panel(
@@ -395,8 +476,15 @@ _scheduler_panels = [
         title="Decode Time",
         description="",
         unit="s",
-        targets=[Target(expr=_rate_with_join("ray_vllm_request_decode_time_seconds_sum"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_rate_with_join("ray_vllm_request_decode_time_seconds_sum"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(12, 77, 12, 8),
     ),
 ]
@@ -420,7 +508,9 @@ _nixl_panels = [
                 legend=_DEP_REPLICA,
             ),
         ],
-        fill=1, linewidth=1, stack=False,
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(0, 86, 8, 8),
     ),
     Panel(
@@ -439,7 +529,9 @@ _nixl_panels = [
                 legend=_DEP_REPLICA,
             ),
         ],
-        fill=1, linewidth=1, stack=False,
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(8, 86, 8, 8),
     ),
     Panel(
@@ -447,8 +539,15 @@ _nixl_panels = [
         title="NIXL: Transfer Rate",
         description="Number of NIXL KV cache transfers per second.",
         unit="ops",
-        targets=[Target(expr=_rate_with_join("ray_vllm_nixl_xfer_time_seconds_count"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_rate_with_join("ray_vllm_nixl_xfer_time_seconds_count"),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(16, 86, 8, 8),
     ),
     Panel(
@@ -466,7 +565,9 @@ _nixl_panels = [
                 legend=_DEP_REPLICA,
             ),
         ],
-        fill=1, linewidth=1, stack=False,
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(0, 94, 8, 8),
     ),
     Panel(
@@ -474,8 +575,17 @@ _nixl_panels = [
         title="NIXL: KV Transfer Failures",
         description="Number of failed NIXL KV cache transfers.",
         unit="short",
-        targets=[Target(expr=_rate_with_join("ray_vllm_nixl_num_failed_transfers", agg_fn="increase"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_rate_with_join(
+                    "ray_vllm_nixl_num_failed_transfers", agg_fn="increase"
+                ),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(8, 94, 8, 8),
     ),
     Panel(
@@ -483,8 +593,17 @@ _nixl_panels = [
         title="NIXL: KV Expired Requests",
         description="Number of requests whose KV blocks expired before decode consumed them.",
         unit="short",
-        targets=[Target(expr=_rate_with_join("ray_vllm_nixl_num_kv_expired_reqs_total", agg_fn="increase"), legend=_DEP_REPLICA)],
-        fill=1, linewidth=1, stack=False,
+        targets=[
+            Target(
+                expr=_rate_with_join(
+                    "ray_vllm_nixl_num_kv_expired_reqs_total", agg_fn="increase"
+                ),
+                legend=_DEP_REPLICA,
+            )
+        ],
+        fill=1,
+        linewidth=1,
+        stack=False,
         grid_pos=GridPos(16, 94, 8, 8),
     ),
 ]
@@ -502,15 +621,17 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])))',
+                expr=f"(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])))",
                 legend="Input: {{model_name}}",
             ),
             Target(
-                expr=f'(sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])))',
+                expr=f"(sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])))",
                 legend="Generated: {{model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 103, 12, 8),
         template=PanelTemplate.STAT,
     ),
@@ -521,15 +642,17 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])',
+                expr=f"delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])",
                 legend="Input: {{model_name}}",
             ),
             Target(
-                expr=f'delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])',
+                expr=f"delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])",
                 legend="Generated: {{model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(12, 103, 12, 8),
         template=PanelTemplate.STAT,
     ),
@@ -540,11 +663,13 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])) / sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])) / sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d]))",
                 legend="{{model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 111, 12, 8),
         template=PanelTemplate.STAT,
     ),
@@ -555,11 +680,13 @@ _token_distribution_panels = [
         unit="Requests",
         targets=[
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1d]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1d]))",
                 legend="{{model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(12, 111, 12, 8),
         template=PanelTemplate.PIE_CHART,
     ),
@@ -570,11 +697,13 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'max_over_time(sum by (model_name) (rate(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[2m]))[24h:1m])',
+                expr=f"max_over_time(sum by (model_name) (rate(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[2m]))[24h:1m])",
                 legend="{{model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 119, 12, 8),
         template=PanelTemplate.STAT,
     ),
@@ -585,11 +714,13 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d]))",
                 legend="{{model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(12, 119, 12, 8),
         template=PanelTemplate.STAT,
     ),
@@ -601,14 +732,16 @@ _token_distribution_panels = [
         targets=[
             Target(
                 expr=(
-                    f'(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) +\n'
-                    f'sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])))'
-                    f' / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))'
+                    f"(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) +\n"
+                    f"sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])))"
+                    f" / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))"
                 ),
                 legend="{{ model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 127, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
@@ -619,11 +752,13 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))",
                 legend="{{ model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(12, 127, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
@@ -634,15 +769,17 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w]))",
                 legend="In: {{ model_name}}",
             ),
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w]))",
                 legend="Out: {{ model_name }}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 135, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
@@ -654,14 +791,16 @@ _token_distribution_panels = [
         targets=[
             Target(
                 expr=(
-                    f'(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) '
-                    f'+ sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])))'
-                    f'/ sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))'
+                    f"(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) "
+                    f"+ sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])))"
+                    f"/ sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))"
                 ),
                 legend="{{ model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(12, 135, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
@@ -672,15 +811,17 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))",
                 legend="In: {{ model_name}}",
             ),
             Target(
-                expr=f'sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
+                expr=f"sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))",
                 legend="Out: {{ model_name}}",
             ),
         ],
-        fill=1, linewidth=2, stack=False,
+        fill=1,
+        linewidth=2,
+        stack=False,
         grid_pos=GridPos(0, 143, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
@@ -696,16 +837,19 @@ _ALL_ROWS = [
     Row(title="Request Length", id=504, panels=_request_length_panels),
     Row(title="Scheduler", id=505, panels=_scheduler_panels),
     Row(title="NIXL", id=506, panels=_nixl_panels),
-    Row(title="Token Distribution", id=507, collapsed=True, panels=_token_distribution_panels),
+    Row(
+        title="Token Distribution",
+        id=507,
+        collapsed=True,
+        panels=_token_distribution_panels,
+    ),
 ]
 
 # Validate uniqueness of panel IDs across all rows
-_all_ids = sorted(
-    panel.id for row in _ALL_ROWS for panel in row.panels
-)
-assert len(_all_ids) == len(set(_all_ids)), (
-    f"Duplicated id found. Use unique id for each panel. {_all_ids}"
-)
+_all_ids = sorted(panel.id for row in _ALL_ROWS for panel in row.panels)
+assert len(_all_ids) == len(
+    set(_all_ids)
+), f"Duplicated id found. Use unique id for each panel. {_all_ids}"
 
 serve_llm_dashboard_config = DashboardConfig(
     name="SERVE_LLM",

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -5,646 +5,713 @@ from ray.dashboard.modules.metrics.dashboards.common import (
     GridPos,
     Panel,
     PanelTemplate,
+    Row,
     Target,
 )
 
-SERVE_LLM_GRAFANA_PANELS = [
+# ---------------------------------------------------------------------------
+# Reusable PromQL fragments
+# ---------------------------------------------------------------------------
+# WorkerId join: attaches deployment + replica labels to vLLM-only metrics
+_WORKER_JOIN = (
+    '\n* on(WorkerId) group_left(deployment, replica)'
+    '\nmax by(WorkerId, deployment, replica) ('
+    'ray_serve_deployment_request_counter_total{{{global_filters}, deployment=~"$deployment"}} * 0 + 1)'
+)
+
+# Standard vLLM metric filter
+_VLLM_FILTER = 'model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}'
+
+# Deployment-scoped filter (for ray_serve metrics)
+_SERVE_FILTER = 'model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}, deployment=~"$deployment"'
+
+# Legend used by most per-worker panels
+_DEP_REPLICA = "{{deployment}}: {{replica}}"
+
+
+def _mean_with_join(metric_base: str) -> str:
+    """Mean = sum(_sum) / sum(_count) with NaN guard + WorkerId join."""
+    return (
+        '(\n'
+        '  (\n'
+        f'    sum by(WorkerId) (rate({metric_base}_sum{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
+        '    /\n'
+        f'    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
+        '  )\n'
+        '  and on(WorkerId)\n'
+        '  (\n'
+        f'    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n'
+        '  )\n'
+        ')'
+        + _WORKER_JOIN
+    )
+
+
+def _percentile_with_join(metric_base: str, quantile: float) -> str:
+    """histogram_quantile with NaN guard + WorkerId join."""
+    return (
+        '(\n'
+        '  histogram_quantile(\n'
+        f'    {quantile},\n'
+        f'    sum by (le, WorkerId) (rate({metric_base}_bucket{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
+        '  )\n'
+        '  and on(WorkerId)\n'
+        '  (\n'
+        f'    sum by(WorkerId) (rate({metric_base}_count{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n'
+        '  )\n'
+        ')'
+        + _WORKER_JOIN
+    )
+
+
+def _gauge_with_join(metric: str) -> str:
+    """Simple gauge metric with WorkerId join (no rate, no guard)."""
+    return (
+        f'sum by(WorkerId) ({metric}{{{{{_VLLM_FILTER}}}}})'
+        + _WORKER_JOIN
+    )
+
+
+def _rate_with_join(metric: str, agg_fn: str = "rate") -> str:
+    """rate() or increase() of a metric summed by WorkerId, with join."""
+    return (
+        f'sum by(WorkerId) ({agg_fn}({metric}{{{{{_VLLM_FILTER}}}}}[$interval]))'
+        + _WORKER_JOIN
+    )
+
+
+def _ratio_with_join_and_guard(
+    numerator_metric: str,
+    denominator_metric: str,
+    *,
+    scale: str = "",
+    guard_metric: str | None = None,
+) -> str:
+    """Ratio of two rate metrics with NaN guard + WorkerId join.
+
+    Optionally applies a scale factor (e.g. '* 1000' or '/ 1024 / 1024 / 1024').
+    """
+    guard = guard_metric or denominator_metric
+    return (
+        '(\n'
+        '  (\n'
+        f'    sum by(WorkerId) (rate({numerator_metric}{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
+        '    /\n'
+        f'    sum by(WorkerId) (rate({denominator_metric}{{{{{_VLLM_FILTER}}}}}[$interval]))\n'
+        + (f'    {scale}\n' if scale else '')
+        + '  )\n'
+        '  and on(WorkerId)\n'
+        '  (\n'
+        f'    sum by(WorkerId) (rate({guard}{{{{{_VLLM_FILTER}}}}}[$interval])) > 0\n'
+        '  )\n'
+        ')'
+        + _WORKER_JOIN
+    )
+
+
+# ---------------------------------------------------------------------------
+# Latency helper: generates Mean / P50 / P90 panels for a given metric
+# ---------------------------------------------------------------------------
+def _latency_panels(
+    metric_base: str,
+    label: str,
+    ids: tuple,
+    y: int,
+    description: str = "",
+) -> list:
+    """Return [Mean, P50, P90] panels for a histogram metric."""
+    return [
+        Panel(
+            id=ids[0],
+            title=f"{label} -- Mean",
+            description=description,
+            unit="s",
+            targets=[Target(expr=_mean_with_join(metric_base), legend=_DEP_REPLICA)],
+            fill=1, linewidth=2, stack=False,
+            grid_pos=GridPos(0, y, 8, 8),
+        ),
+        Panel(
+            id=ids[1],
+            title=f"{label} -- P50",
+            description=description,
+            unit="s",
+            targets=[Target(expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA)],
+            fill=1, linewidth=2, stack=False,
+            grid_pos=GridPos(8, y, 8, 8),
+        ),
+        Panel(
+            id=ids[2],
+            title=f"{label} -- P90",
+            description=description,
+            unit="s",
+            targets=[Target(expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA)],
+            fill=1, linewidth=2, stack=False,
+            grid_pos=GridPos(16, y, 8, 8),
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Request Length helper: Mean / P50 / P90 for token-count histograms
+# ---------------------------------------------------------------------------
+def _length_panels(
+    metric_base: str,
+    label: str,
+    ids: tuple,
+    y: int,
+) -> list:
+    """Return [Mean, P50, P90] panels for a token-count histogram metric."""
+    return [
+        Panel(
+            id=ids[0],
+            title=f"{label} -- Mean",
+            description="",
+            unit="short",
+            targets=[Target(expr=_mean_with_join(metric_base), legend=_DEP_REPLICA)],
+            fill=1, linewidth=1, stack=False,
+            grid_pos=GridPos(0, y, 8, 8),
+        ),
+        Panel(
+            id=ids[1],
+            title=f"{label} -- P50",
+            description="",
+            unit="short",
+            targets=[Target(expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA)],
+            fill=1, linewidth=1, stack=False,
+            grid_pos=GridPos(8, y, 8, 8),
+        ),
+        Panel(
+            id=ids[2],
+            title=f"{label} -- P90",
+            description="",
+            unit="short",
+            targets=[Target(expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA)],
+            fill=1, linewidth=1, stack=False,
+            grid_pos=GridPos(16, y, 8, 8),
+        ),
+    ]
+
+
+# ===================================================================
+# Row 1: Throughput
+# ===================================================================
+_throughput_panels = [
     Panel(
-        id=29,
-        title="QPS per vLLM worker",
+        id=2,
+        title="Requests / s",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='sum by (model_name, WorkerId, replica) (rate(ray_serve_deployment_request_counter_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}, deployment=~"$deployment"}}[$interval]))',
-                legend="replica {{replica}}, worker {{WorkerId}}",
+                expr=f'sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))',
+                legend=_DEP_REPLICA,
             ),
             Target(
-                expr='sum(rate(ray_serve_deployment_request_counter_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}, deployment=~"$deployment"}}[$interval]))',
+                expr=f'sum(rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))',
                 legend="Total QPS",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 0, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 1, 8, 8),
     ),
     Panel(
-        id=2,
-        title="vLLM: Time Per Output Token Latency",
-        description="",
-        unit="s",
-        targets=[
-            Target(
-                expr='histogram_quantile(0.99, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P99 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.95, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P95 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.9, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P90 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.5, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P50 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='(sum by(model_name, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_request_time_per_output_token_seconds_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="Mean - {{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 0, 12, 8),
-    ),
-    Panel(
-        id=1,
-        title="vLLM: Token Throughput",
+        id=3,
+        title="Prompt Tokens/s",
         description="Number of tokens processed per second",
         unit="tokens/s",
         targets=[
             Target(
-                expr='sum by (model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="Prompt Tokens/Sec - {{model_name}} - {{WorkerId}}",
+                expr=_rate_with_join("ray_vllm_request_prompt_tokens_sum"),
+                legend=_DEP_REPLICA,
             ),
             Target(
-                expr='sum by (model_name, WorkerId) (rate(ray_vllm_generation_tokens_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="Generation Tokens/Sec - {{model_name}} - {{WorkerId}}",
+                expr=f'sum(rate(ray_vllm_request_prompt_tokens_sum{{{{{_VLLM_FILTER}}}}}[$interval]))',
+                legend="Total",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 8, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(8, 1, 8, 8),
     ),
     Panel(
-        id=5,
-        title="vLLM: Time To First Token Latency",
-        description="P50, P90, P95, and P99 TTFT latency",
-        unit="s",
+        id=4,
+        title="Generation Tokens/s",
+        description="Number of tokens processed per second",
+        unit="tokens/s",
         targets=[
             Target(
-                expr='(sum by(model_name, WorkerId) (rate(ray_vllm_time_to_first_token_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_time_to_first_token_seconds_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="Average - {{model_name}} - {{WorkerId}}",
+                expr=_rate_with_join("ray_vllm_generation_tokens_total"),
+                legend=_DEP_REPLICA,
             ),
             Target(
-                expr='histogram_quantile(0.5, sum by(le, model_name, WorkerId)(rate(ray_vllm_time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P50 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.9, sum by(le, model_name, WorkerId)(rate(ray_vllm_time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P90 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.95, sum by(le, model_name, WorkerId) (rate(ray_vllm_time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P95 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.99, sum by(le, model_name, WorkerId)(rate(ray_vllm_time_to_first_token_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P99 - {{model_name}} - {{WorkerId}}",
+                expr=f'sum(rate(ray_vllm_generation_tokens_total{{{{{_VLLM_FILTER}}}}}[$interval]))',
+                legend="Total",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 8, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(16, 1, 8, 8),
     ),
+]
+
+# ===================================================================
+# Row 2: Latency (3x3 grid)
+# ===================================================================
+_latency_panels_list = [
+    *_latency_panels("ray_vllm_request_time_per_output_token_seconds", "TPOT", (6, 7, 8), 10),
+    *_latency_panels("ray_vllm_time_to_first_token_seconds", "TTFT", (9, 10, 11), 18),
+    *_latency_panels("ray_vllm_e2e_request_latency_seconds", "Request Latency", (12, 13, 14), 26, description="Latency from request start to first token returned (in seconds)."),
+]
+
+# ===================================================================
+# Row 3: Cache
+# ===================================================================
+_cache_panels = [
     Panel(
-        id=3,
-        title="vLLM: Cache Utilization",
+        id=16,
+        title="Cache Utilization",
         description="Percentage of used cache blocks by vLLM.",
         unit="percentunit",
         targets=[
             Target(
-                expr='sum by (WorkerId) (ray_vllm_kv_cache_usage_perc{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}})',
-                legend="GPU Cache Usage - {{WorkerId}}",
+                expr=_gauge_with_join("ray_vllm_kv_cache_usage_perc"),
+                legend=_DEP_REPLICA,
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 16, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 35, 12, 8),
     ),
     Panel(
-        id=31,
-        title="vLLM: KV Cache Hit Rate",
+        id=17,
+        title="GPU KV Cache Hit Rate",
         description="",
         unit="percent",
         targets=[
             Target(
-                expr='max(100 * (sum by (WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])) / sum by (WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))))',
-                legend="Max Hit Rate",
-            ),
-            Target(
-                expr='min(100 * (sum by (WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])) / sum by (WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))))',
-                legend="Min Hit Rate",
-            ),
-            Target(
-                expr='100 * (sum by (WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])) / sum by (WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="Hit Rate: worker {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=1,
-        stack=False,
-        grid_pos=GridPos(12, 16, 12, 8),
-    ),
-    Panel(
-        id=6,
-        title="vLLM: E2E Request Latency",
-        description="Latency from request start to first token returned (in seconds).",
-        unit="s",
-        targets=[
-            Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="Average - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.5, sum by(le, model_name, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P50 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.9, sum by(le, model_name, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P90 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.95, sum by(le, model_name, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P95 - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.99, sum by(le, model_name, WorkerId) (rate(ray_vllm_e2e_request_latency_seconds_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P99 - {{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 24, 12, 8),
-    ),
-    Panel(
-        id=7,
-        title="vLLM: Scheduler State",
-        description="Number of requests in RUNNING, WAITING, and SWAPPED state",
-        unit="Requests",
-        targets=[
-            Target(
-                expr='ray_vllm_num_requests_running{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}',
-                legend="Num Running - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='ray_vllm_num_requests_swapped{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}',
-                legend="Num Swapped - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='ray_vllm_num_requests_waiting{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}',
-                legend="Num Waiting - {{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 24, 12, 8),
-    ),
-    Panel(
-        id=33,
-        title="vLLM: Prompt Length",
-        description="",
-        unit="short",
-        targets=[
-            Target(
-                expr='histogram_quantile(0.5, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P50-{{model_name}}-{{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.90, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P90-{{model_name}}-{{WorkerId}}",
-            ),
-            Target(
-                expr='(sum by(model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_request_prompt_tokens_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="Average-{{model_name}}-{{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=1,
-        stack=False,
-        grid_pos=GridPos(0, 32, 12, 8),
-    ),
-    Panel(
-        id=35,
-        title="vLLM: Generation Length",
-        description="",
-        unit="short",
-        targets=[
-            Target(
-                expr='histogram_quantile(0.50, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_generation_tokens_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P50-{{model_name}}-{{WorkerId}}",
-            ),
-            Target(
-                expr='histogram_quantile(0.90, sum by(le, model_name, WorkerId) (rate(ray_vllm_request_generation_tokens_bucket{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))',
-                legend="P90-{{model_name}}-{{WorkerId}}",
+                expr=(
+                    f'100 * ('
+                    f'(sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) '
+                    f'/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval])))'
+                    f' and on(WorkerId) '
+                    f'(sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval])) > 0))'
+                    + _WORKER_JOIN
+                ),
+                legend=_DEP_REPLICA,
             ),
             Target(
                 expr=(
-                    '(sum by(model_name, WorkerId) (rate(ray_vllm_request_generation_tokens_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))'
-                    "\n/\n"
-                    '(sum by(model_name, WorkerId) (rate(ray_vllm_request_generation_tokens_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval])))'
+                    f'max(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) '
+                    f'/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))'
                 ),
-                legend="Average-{{model_name}}-{{WorkerId}}",
+                legend="Max Hit Rate",
+            ),
+            Target(
+                expr=(
+                    f'min(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) '
+                    f'/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))'
+                ),
+                legend="Min Hit Rate",
             ),
         ],
-        fill=1,
-        linewidth=1,
-        stack=False,
-        grid_pos=GridPos(12, 32, 12, 8),
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(12, 35, 12, 8),
+    ),
+]
+
+# ===================================================================
+# Row 4: Request Length
+# ===================================================================
+_request_length_panels = [
+    *_length_panels("ray_vllm_request_prompt_tokens", "Prompt Length", (19, 20, 21), 44),
+    *_length_panels("ray_vllm_request_generation_tokens", "Generation Length", (22, 23, 24), 52),
+]
+
+# ===================================================================
+# Row 5: Scheduler
+# ===================================================================
+_scheduler_panels = [
+    Panel(
+        id=26,
+        title="Scheduler: Running",
+        description="",
+        unit="short",
+        targets=[Target(expr=_gauge_with_join("ray_vllm_num_requests_running"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(0, 61, 8, 8),
     ),
     Panel(
-        id=10,
-        title="vLLM: Finish Reason",
-        description="Number of finished requests by their finish reason: either an EOS token was generated or the max sequence length was reached.",
-        unit="Requests",
+        id=27,
+        title="Scheduler: Swapped",
+        description="",
+        unit="short",
+        targets=[Target(expr=_gauge_with_join("ray_vllm_num_requests_swapped"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(8, 61, 8, 8),
+    ),
+    Panel(
+        id=28,
+        title="Scheduler: Waiting",
+        description="",
+        unit="short",
+        targets=[Target(expr=_gauge_with_join("ray_vllm_num_requests_waiting"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(16, 61, 8, 8),
+    ),
+    Panel(
+        id=29,
+        title="Finish Reason",
+        description="Number of finished requests by their finish reason.",
+        unit="short",
         targets=[
             Target(
-                expr='sum by(finished_reason, model_name, WorkerId) (increase(ray_vllm_request_success_total{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="{{finished_reason}} - {{model_name}} - {{WorkerId}}",
+                expr=(
+                    f'sum by(finished_reason, WorkerId) (increase(ray_vllm_request_success_total{{{{{_VLLM_FILTER}}}}}[$interval]))'
+                    + _WORKER_JOIN
+                ),
+                legend="{{finished_reason}} \u2014 {{deployment}}: {{replica}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 48, 12, 8),
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(0, 69, 12, 8),
     ),
     Panel(
-        id=11,
-        title="vLLM: Queue Time",
+        id=30,
+        title="Queue Time",
         description="",
         unit="s",
-        targets=[
-            Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_request_queue_time_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="{{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 48, 12, 8),
+        targets=[Target(expr=_rate_with_join("ray_vllm_request_queue_time_seconds_sum"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(12, 69, 12, 8),
     ),
     Panel(
-        id=12,
-        title="vLLM: Requests Prefill and Decode Time",
+        id=31,
+        title="Prefill Time",
         description="",
         unit="s",
-        targets=[
-            Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_request_decode_time_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="Decode - {{model_name}} - {{WorkerId}}",
-            ),
-            Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_request_prefill_time_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="Prefill - {{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 56, 12, 8),
+        targets=[Target(expr=_rate_with_join("ray_vllm_request_prefill_time_seconds_sum"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(0, 77, 12, 8),
     ),
     Panel(
-        id=13,
-        title="vLLM: Max Generation Token in Sequence Group",
+        id=32,
+        title="Decode Time",
         description="",
-        unit="none",
-        targets=[
-            Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_request_max_num_generation_tokens_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="{{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 56, 12, 8),
+        unit="s",
+        targets=[Target(expr=_rate_with_join("ray_vllm_request_decode_time_seconds_sum"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(12, 77, 12, 8),
     ),
+]
+
+# ===================================================================
+# Row 6: NIXL
+# ===================================================================
+_nixl_panels = [
     Panel(
-        id=40,
+        id=34,
         title="NIXL: Transfer Latency",
         description="Average NIXL KV cache transfer latency in milliseconds.",
         unit="ms",
         targets=[
             Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n* 1000',
-                legend="Avg Latency - {{model_name}} - {{WorkerId}}",
+                expr=_ratio_with_join_and_guard(
+                    "ray_vllm_nixl_xfer_time_seconds_sum",
+                    "ray_vllm_nixl_xfer_time_seconds_count",
+                    scale="* 1000",
+                ),
+                legend=_DEP_REPLICA,
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 64, 12, 8),
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(0, 86, 8, 8),
     ),
     Panel(
-        id=41,
+        id=35,
         title="NIXL: Transfer Throughput",
-        description="NIXL KV cache transfer throughput in GB/s (bytes transferred / transfer time).",
+        description="NIXL KV cache transfer throughput in GB/s.",
         unit="GBs",
         targets=[
             Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_nixl_bytes_transferred_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/ 1024 / 1024 / 1024',
-                legend="Throughput - {{model_name}} - {{WorkerId}}",
+                expr=_ratio_with_join_and_guard(
+                    "ray_vllm_nixl_bytes_transferred_sum",
+                    "ray_vllm_nixl_xfer_time_seconds_sum",
+                    scale="/ 1024 / 1024 / 1024",
+                    guard_metric="ray_vllm_nixl_xfer_time_seconds_sum",
+                ),
+                legend=_DEP_REPLICA,
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 64, 12, 8),
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(8, 86, 8, 8),
     ),
     Panel(
-        id=42,
+        id=36,
         title="NIXL: Transfer Rate",
         description="Number of NIXL KV cache transfers per second.",
         unit="ops",
-        targets=[
-            Target(
-                expr='sum by (model_name, WorkerId) (rate(ray_vllm_nixl_xfer_time_seconds_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="Transfers/s - {{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 72, 12, 8),
+        targets=[Target(expr=_rate_with_join("ray_vllm_nixl_xfer_time_seconds_count"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(16, 86, 8, 8),
     ),
     Panel(
-        id=43,
+        id=37,
         title="NIXL: Avg Post Time",
         description="Average time to post/initiate a NIXL transfer in milliseconds.",
         unit="ms",
         targets=[
             Target(
-                expr='sum by(model_name, WorkerId) (rate(ray_vllm_nixl_post_time_seconds_sum{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n/\nsum by(model_name, WorkerId) (rate(ray_vllm_nixl_post_time_seconds_count{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))\n* 1000',
-                legend="Avg Post Time - {{model_name}} - {{WorkerId}}",
+                expr=_ratio_with_join_and_guard(
+                    "ray_vllm_nixl_post_time_seconds_sum",
+                    "ray_vllm_nixl_post_time_seconds_count",
+                    scale="* 1000",
+                ),
+                legend=_DEP_REPLICA,
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 72, 12, 8),
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(0, 94, 8, 8),
     ),
     Panel(
-        id=44,
+        id=38,
         title="NIXL: KV Transfer Failures",
-        description="Number of failed NIXL KV cache transfers. Any non-zero value is concerning and indicates RDMA transfer errors.",
+        description="Number of failed NIXL KV cache transfers.",
         unit="short",
-        targets=[
-            Target(
-                expr='sum by (model_name, WorkerId) (increase(ray_vllm_nixl_num_failed_transfers{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="Failed Transfers - {{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 80, 12, 8),
+        targets=[Target(expr=_rate_with_join("ray_vllm_nixl_num_failed_transfers", agg_fn="increase"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(8, 94, 8, 8),
     ),
     Panel(
-        id=45,
+        id=39,
         title="NIXL: KV Expired Requests",
-        description="Number of requests whose KV blocks expired before decode consumed them. Spikes indicate prefill is outrunning decode or the timeout is too short.",
+        description="Number of requests whose KV blocks expired before decode consumed them.",
         unit="short",
-        targets=[
-            Target(
-                expr='sum by (model_name, WorkerId) (increase(ray_vllm_nixl_num_kv_expired_reqs{{model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}}}[$interval]))',
-                legend="KV Expired - {{model_name}} - {{WorkerId}}",
-            ),
-        ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 80, 12, 8),
+        targets=[Target(expr=_rate_with_join("ray_vllm_nixl_num_kv_expired_reqs_total", agg_fn="increase"), legend=_DEP_REPLICA)],
+        fill=1, linewidth=1, stack=False,
+        grid_pos=GridPos(16, 94, 8, 8),
     ),
+]
+
+# ===================================================================
+# Row 7: Token Distribution (collapsed)
+# ===================================================================
+_WORKERID_FILTER = 'WorkerId=~"$workerid", {global_filters}'
+
+_token_distribution_panels = [
     Panel(
-        id=14,
+        id=41,
         title="Tokens Last 24 Hours",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])))',
+                expr=f'(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])))',
                 legend="Input: {{model_name}}",
             ),
             Target(
-                expr='(sum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])))',
+                expr=f'(sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])))',
                 legend="Generated: {{model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 88, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 103, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
-        id=15,
+        id=42,
         title="Tokens Last Hour",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1h]))',
+                expr=f'delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])',
                 legend="Input: {{model_name}}",
             ),
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1h]))',
+                expr=f'delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])',
                 legend="Generated: {{model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 88, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(12, 103, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
-        id=18,
+        id=43,
         title="Ratio Input:Generated Tokens Last 24 Hours",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])) / sum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])) / sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d]))',
                 legend="{{model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 96, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 111, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
-        id=16,
+        id=44,
         title="Distribution of Requests Per Model Last 24 Hours",
         description="",
         unit="Requests",
         targets=[
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1d]))',
                 legend="{{model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 96, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(12, 111, 12, 8),
         template=PanelTemplate.PIE_CHART,
     ),
     Panel(
-        id=21,
+        id=45,
         title="Peak Tokens Per Second Per Model Last 24 Hours",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='max_over_time(sum by (model_name) (rate(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[2m]))[24h:1m])',
+                expr=f'max_over_time(sum by (model_name) (rate(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[2m]))[24h:1m])',
                 legend="{{model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 104, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 119, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
-        id=19,
+        id=46,
         title="Tokens Per Model Last 24 Hours",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1d]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1d]))',
                 legend="{{model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 104, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(12, 119, 12, 8),
         template=PanelTemplate.STAT,
     ),
     Panel(
-        id=24,
+        id=47,
         title="Avg Total Tokens Per Request Last 7 Days",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) +\nsum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))) / sum by (model_name) (delta(ray_vllm_request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                expr=(
+                    f'(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) +\n'
+                    f'sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])))'
+                    f' / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))'
+                ),
                 legend="{{ model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 112, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 127, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
-        id=23,
+        id=48,
         title="Requests Per Model Last Week",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
                 legend="{{ model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 112, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(12, 127, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
-        id=26,
+        id=49,
         title="Tokens Per Model Last 7 Days",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
                 legend="In: {{ model_name}}",
             ),
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
                 legend="Out: {{ model_name }}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(0, 120, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 135, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
-        id=25,
+        id=50,
         title="Avg Total Tokens Per Request Per Model Last 7 Days",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) + sum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])))/ sum by (model_name) (delta(ray_vllm_request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                expr=(
+                    f'(sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) '
+                    f'+ sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])))'
+                    f'/ sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))'
+                ),
                 legend="{{ model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 120, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(12, 135, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
     Panel(
-        id=27,
+        id=51,
         title="Tokens Per Request Per Model Last 7 Days",
         description="",
         unit="short",
         targets=[
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
                 legend="In: {{ model_name}}",
             ),
             Target(
-                expr='sum by (model_name) (delta(ray_vllm_generation_tokens_total{{WorkerId=~"$workerid", {global_filters}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{WorkerId=~"$workerid", {global_filters}}}[1w]))',
+                expr=f'sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1w])) / sum by (model_name) (delta(ray_vllm_request_success_total{{{{{_WORKERID_FILTER}}}}}[1w]))',
                 legend="Out: {{ model_name}}",
             ),
         ],
-        fill=1,
-        linewidth=2,
-        stack=False,
-        grid_pos=GridPos(12, 128, 12, 8),
+        fill=1, linewidth=2, stack=False,
+        grid_pos=GridPos(0, 143, 12, 8),
         template=PanelTemplate.GAUGE,
     ),
 ]
 
-ids = []
-for panel in SERVE_LLM_GRAFANA_PANELS:
-    ids.append(panel.id)
+# ===================================================================
+# Assemble rows and config
+# ===================================================================
+_ALL_ROWS = [
+    Row(title="Throughput", id=501, panels=_throughput_panels),
+    Row(title="Latency", id=502, panels=_latency_panels_list),
+    Row(title="Cache", id=503, panels=_cache_panels),
+    Row(title="Request Length", id=504, panels=_request_length_panels),
+    Row(title="Scheduler", id=505, panels=_scheduler_panels),
+    Row(title="NIXL", id=506, panels=_nixl_panels),
+    Row(title="Token Distribution", id=507, collapsed=True, panels=_token_distribution_panels),
+]
 
-ids.sort()
-
-assert len(ids) == len(
-    set(ids)
-), f"Duplicated id found. Use unique id for each panel. {ids}"
+# Validate uniqueness of panel IDs across all rows
+_all_ids = sorted(
+    panel.id for row in _ALL_ROWS for panel in row.panels
+)
+assert len(_all_ids) == len(set(_all_ids)), (
+    f"Duplicated id found. Use unique id for each panel. {_all_ids}"
+)
 
 serve_llm_dashboard_config = DashboardConfig(
     name="SERVE_LLM",
     default_uid="rayServeLlmDashboard",
-    panels=SERVE_LLM_GRAFANA_PANELS,
     standard_global_filters=[],
-    # Base Grafana dashboard template that is injected with panels from this file
     base_json_file_name="serve_llm_grafana_dashboard_base.json",
+    panels=[],
+    rows=_ALL_ROWS,
 )

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -12,7 +12,10 @@ from ray.dashboard.modules.metrics.dashboards.common import (
 # ---------------------------------------------------------------------------
 # Reusable PromQL fragments
 # ---------------------------------------------------------------------------
-# WorkerId join: attaches deployment + replica labels to vLLM-only metrics
+# WorkerId join: attaches deployment + replica labels to vLLM-only metrics.
+# The `* 0 + 1` trick turns the counter into a constant-1 lookup table keyed
+# by WorkerId so the join resolves deployment + replica labels without
+# affecting the numeric value of the left-hand side.
 _WORKER_JOIN = (
     "\n* on(WorkerId) group_left(deployment, replica)"
     "\nmax by(WorkerId, deployment, replica) ("
@@ -22,8 +25,9 @@ _WORKER_JOIN = (
 # Standard vLLM metric filter
 _VLLM_FILTER = 'model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}'
 
-# Deployment-scoped filter (for ray_serve metrics)
-_SERVE_FILTER = 'model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}, deployment=~"$deployment"'
+# vLLM filter scoped to a specific deployment (used for ray_serve_* metrics
+# that also carry model_name / WorkerId labels).
+_VLLM_DEPLOYMENT_FILTER = 'model_name=~"$vllm_model_name", WorkerId=~"$workerid", {global_filters}, deployment=~"$deployment"'
 
 # Legend used by most per-worker panels
 _DEP_REPLICA = "{{deployment}}: {{replica}}"
@@ -104,13 +108,15 @@ def _ratio_with_join_and_guard(
 
 
 # ---------------------------------------------------------------------------
-# Latency helper: generates Mean / P50 / P90 panels for a given metric
+# Histogram helper: generates Mean / P50 / P90 panels for a given metric
 # ---------------------------------------------------------------------------
-def _latency_panels(
+def _histogram_panels(
     metric_base: str,
     label: str,
     ids: tuple,
     y: int,
+    unit: str = "s",
+    linewidth: int = 2,
     description: str = "",
 ) -> list:
     """Return [Mean, P50, P90] panels for a histogram metric."""
@@ -119,10 +125,10 @@ def _latency_panels(
             id=ids[0],
             title=f"{label} -- Mean",
             description=description,
-            unit="s",
+            unit=unit,
             targets=[Target(expr=_mean_with_join(metric_base), legend=_DEP_REPLICA)],
             fill=1,
-            linewidth=2,
+            linewidth=linewidth,
             stack=False,
             grid_pos=GridPos(0, y, 8, 8),
         ),
@@ -130,14 +136,14 @@ def _latency_panels(
             id=ids[1],
             title=f"{label} -- P50",
             description=description,
-            unit="s",
+            unit=unit,
             targets=[
                 Target(
                     expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA
                 )
             ],
             fill=1,
-            linewidth=2,
+            linewidth=linewidth,
             stack=False,
             grid_pos=GridPos(8, y, 8, 8),
         ),
@@ -145,69 +151,14 @@ def _latency_panels(
             id=ids[2],
             title=f"{label} -- P90",
             description=description,
-            unit="s",
+            unit=unit,
             targets=[
                 Target(
                     expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA
                 )
             ],
             fill=1,
-            linewidth=2,
-            stack=False,
-            grid_pos=GridPos(16, y, 8, 8),
-        ),
-    ]
-
-
-# ---------------------------------------------------------------------------
-# Request Length helper: Mean / P50 / P90 for token-count histograms
-# ---------------------------------------------------------------------------
-def _length_panels(
-    metric_base: str,
-    label: str,
-    ids: tuple,
-    y: int,
-) -> list:
-    """Return [Mean, P50, P90] panels for a token-count histogram metric."""
-    return [
-        Panel(
-            id=ids[0],
-            title=f"{label} -- Mean",
-            description="",
-            unit="short",
-            targets=[Target(expr=_mean_with_join(metric_base), legend=_DEP_REPLICA)],
-            fill=1,
-            linewidth=1,
-            stack=False,
-            grid_pos=GridPos(0, y, 8, 8),
-        ),
-        Panel(
-            id=ids[1],
-            title=f"{label} -- P50",
-            description="",
-            unit="short",
-            targets=[
-                Target(
-                    expr=_percentile_with_join(metric_base, 0.5), legend=_DEP_REPLICA
-                )
-            ],
-            fill=1,
-            linewidth=1,
-            stack=False,
-            grid_pos=GridPos(8, y, 8, 8),
-        ),
-        Panel(
-            id=ids[2],
-            title=f"{label} -- P90",
-            description="",
-            unit="short",
-            targets=[
-                Target(
-                    expr=_percentile_with_join(metric_base, 0.9), legend=_DEP_REPLICA
-                )
-            ],
-            fill=1,
-            linewidth=1,
+            linewidth=linewidth,
             stack=False,
             grid_pos=GridPos(16, y, 8, 8),
         ),
@@ -225,11 +176,11 @@ _throughput_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f"sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))",
+                expr=f"sum by (deployment, replica) (rate(ray_serve_deployment_request_counter_total{{{{{_VLLM_DEPLOYMENT_FILTER}}}}}[$interval]))",
                 legend=_DEP_REPLICA,
             ),
             Target(
-                expr=f"sum(rate(ray_serve_deployment_request_counter_total{{{{{_SERVE_FILTER}}}}}[$interval]))",
+                expr=f"sum(rate(ray_serve_deployment_request_counter_total{{{{{_VLLM_DEPLOYMENT_FILTER}}}}}[$interval]))",
                 legend="Total QPS",
             ),
         ],
@@ -284,11 +235,13 @@ _throughput_panels = [
 # Row 2: Latency (3x3 grid)
 # ===================================================================
 _latency_panels_list = [
-    *_latency_panels(
+    *_histogram_panels(
         "ray_vllm_request_time_per_output_token_seconds", "TPOT", (6, 7, 8), 10
     ),
-    *_latency_panels("ray_vllm_time_to_first_token_seconds", "TTFT", (9, 10, 11), 18),
-    *_latency_panels(
+    *_histogram_panels(
+        "ray_vllm_time_to_first_token_seconds", "TTFT", (9, 10, 11), 18
+    ),
+    *_histogram_panels(
         "ray_vllm_e2e_request_latency_seconds",
         "Request Latency",
         (12, 13, 14),
@@ -334,20 +287,6 @@ _cache_panels = [
                 ),
                 legend=_DEP_REPLICA,
             ),
-            Target(
-                expr=(
-                    f"max(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) "
-                    f"/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))"
-                ),
-                legend="Max Hit Rate",
-            ),
-            Target(
-                expr=(
-                    f"min(100 * (sum by(WorkerId) (rate(ray_vllm_prefix_cache_hits_total{{{{{_VLLM_FILTER}}}}}[$interval])) "
-                    f"/ sum by(WorkerId) (rate(ray_vllm_prefix_cache_queries_total{{{{{_VLLM_FILTER}}}}}[$interval]))))"
-                ),
-                legend="Min Hit Rate",
-            ),
         ],
         fill=1,
         linewidth=1,
@@ -360,11 +299,21 @@ _cache_panels = [
 # Row 4: Request Length
 # ===================================================================
 _request_length_panels = [
-    *_length_panels(
-        "ray_vllm_request_prompt_tokens", "Prompt Length", (19, 20, 21), 44
+    *_histogram_panels(
+        "ray_vllm_request_prompt_tokens",
+        "Prompt Length",
+        (19, 20, 21),
+        44,
+        unit="short",
+        linewidth=1,
     ),
-    *_length_panels(
-        "ray_vllm_request_generation_tokens", "Generation Length", (22, 23, 24), 52
+    *_histogram_panels(
+        "ray_vllm_request_generation_tokens",
+        "Generation Length",
+        (22, 23, 24),
+        52,
+        unit="short",
+        linewidth=1,
     ),
 ]
 
@@ -524,7 +473,6 @@ _nixl_panels = [
                     "ray_vllm_nixl_bytes_transferred_sum",
                     "ray_vllm_nixl_xfer_time_seconds_sum",
                     scale="/ 1024 / 1024 / 1024",
-                    guard_metric="ray_vllm_nixl_xfer_time_seconds_sum",
                 ),
                 legend=_DEP_REPLICA,
             ),
@@ -573,7 +521,7 @@ _nixl_panels = [
     Panel(
         id=38,
         title="NIXL: KV Transfer Failures",
-        description="Number of failed NIXL KV cache transfers.",
+        description="Number of failed NIXL KV cache transfers. Any non-zero value is concerning and indicates RDMA transfer errors.",
         unit="short",
         targets=[
             Target(
@@ -591,7 +539,7 @@ _nixl_panels = [
     Panel(
         id=39,
         title="NIXL: KV Expired Requests",
-        description="Number of requests whose KV blocks expired before decode consumed them.",
+        description="Number of requests whose KV blocks expired before decode consumed them. Spikes indicate prefill is outrunning decode or the timeout is too short.",
         unit="short",
         targets=[
             Target(
@@ -642,11 +590,11 @@ _token_distribution_panels = [
         unit="short",
         targets=[
             Target(
-                expr=f"delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])",
+                expr=f"sum by (model_name) (delta(ray_vllm_prompt_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h]))",
                 legend="Input: {{model_name}}",
             ),
             Target(
-                expr=f"delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h])",
+                expr=f"sum by (model_name) (delta(ray_vllm_generation_tokens_total{{{{{_WORKERID_FILTER}}}}}[1h]))",
                 legend="Generated: {{model_name}}",
             ),
         ],
@@ -856,6 +804,5 @@ serve_llm_dashboard_config = DashboardConfig(
     default_uid="rayServeLlmDashboard",
     standard_global_filters=[],
     base_json_file_name="serve_llm_grafana_dashboard_base.json",
-    panels=[],
     rows=_ALL_ROWS,
 )

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_dashboard_panels.py
@@ -238,9 +238,7 @@ _latency_panels_list = [
     *_histogram_panels(
         "ray_vllm_request_time_per_output_token_seconds", "TPOT", (6, 7, 8), 10
     ),
-    *_histogram_panels(
-        "ray_vllm_time_to_first_token_seconds", "TTFT", (9, 10, 11), 18
-    ),
+    *_histogram_panels("ray_vllm_time_to_first_token_seconds", "TTFT", (9, 10, 11), 18),
     *_histogram_panels(
         "ray_vllm_e2e_request_latency_seconds",
         "Request Latency",

--- a/python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_llm_grafana_dashboard_base.json
@@ -102,8 +102,8 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "includeAll": false,
-        "multi": false,
+        "includeAll": true,
+        "multi": true,
         "allValue": ".*",
         "current": {
           "selected": true,

--- a/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
+++ b/python/ray/dashboard/modules/metrics/grafana_dashboard_factory.py
@@ -476,8 +476,16 @@ def _generate_grafana_panels(
             else:
                 panels.append(panel_template)
 
-        # Update y position for next row
-        current_y_position += _calculate_panel_heights(len(row.panels))
+        # Update y position for next row based on actual panel positions
+        # when explicit grid_pos is used, or fallback to calculated height.
+        if any(p.grid_pos for p in row.panels):
+            max_y_bottom = max(
+                (p.grid_pos.y + p.grid_pos.h for p in row.panels if p.grid_pos),
+                default=current_y_position,
+            )
+            current_y_position = max_y_bottom
+        else:
+            current_y_position += _calculate_panel_heights(len(row.panels))
 
     return panels
 


### PR DESCRIPTION
## Summary
- Rewrites `serve_llm_dashboard_panels.py` from a flat 29-panel list to 7 rows with 44 panels.
- Switches to 3-column (8-unit) layout for most sections, with WorkerId join pattern for `deployment:replica` legends on vLLM-only metrics
- Adds NaN guards on all mean/ratio queries and helper functions to reduce PromQL repetition
- Fixes `deployment` variable in base template (`includeAll=true, multi=true`) so "All" resolves to `.*` instead of empty string

### New panel structure
| Row | Panels | Description |
|-----|--------|-------------|
| Throughput | 3 | Requests/s, Prompt Tokens/s, Generation Tokens/s |
| Latency | 9 | TPOT/TTFT/Request Latency with Mean/P50/P90 |
| Cache | 2 | Cache Utilization, GPU KV Cache Hit Rate |
| Request Length | 6 | Prompt/Generation Length with Mean/P50/P90 |
| Scheduler | 7 | Running/Swapped/Waiting, Finish Reason, Queue/Prefill/Decode Time |
| NIXL | 6 | Transfer Latency/Throughput/Rate, Avg Post Time, Failures, Expired |
| Token Distribution (collapsed) | 11 | Usage stats over 1h/24h/7d |

### Screenshots

Rows:

<img width="1911" height="375" alt="image" src="https://github.com/user-attachments/assets/c21a8d73-4d04-40cc-913c-e6ecba76fdce" />


Throughput:

<img width="1896" height="376" alt="image" src="https://github.com/user-attachments/assets/b7c0d575-3fe4-43dd-a0e6-bccc0afd956a" />

Latency:

<img width="1884" height="861" alt="image" src="https://github.com/user-attachments/assets/2988bdd7-0c17-4ec6-911c-bcf662844db5" />

Cache:

<img width="1894" height="374" alt="image" src="https://github.com/user-attachments/assets/46ef5ef2-556b-412a-b268-c2139a3c226a" />


Request:

<img width="1893" height="705" alt="image" src="https://github.com/user-attachments/assets/06823da7-3b65-4403-8441-ead55cd696e6" />

Scheduler:

<img width="1905" height="767" alt="image" src="https://github.com/user-attachments/assets/a32ee4f4-27a7-4e0a-a70e-bd1f7b27d4c1" />

NIXL:

<img width="1902" height="509" alt="image" src="https://github.com/user-attachments/assets/8280bf61-e1da-4a42-a2d5-b4c3d6b8d565" />


## Test plan
- [x] Tier 1: Generated JSON locally via `grafana_dashboard_factory.py` — verified 7 rows + 44 content panels, all PromQL expressions pass `.format(global_filters=...)`, no hardcoded ClusterId
- [x] Tier 1: Loaded generated JSON on Anyscale workspace — all panels render correctly with live data
- [ ] Tier 5: Build custom Ray image and verify end-to-end on Anyscale service

🤖 Generated with [Claude Code](https://claude.com/claude-code)