### PR TITLE
[core] Fix negative RUNNING task metric

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2787,6 +2787,12 @@ Status CoreWorker::ExecuteTask(
   std::string func_name = task_spec.GetName();
   bool is_retry = task_spec.IsRetry();
 
+  // Modify the worker's per-function counters. This should be done before updating any
+  // substates (running_in_ray_get, running_in_ray_wait, getting_and_pinning_args) since
+  // the metric callback subtracts substate counts from running_total. Incrementing
+  // substates before kRunning could result in wrong values of RUNNING metric.
+  task_counter_.MovePendingToRunning(func_name, is_retry);
+
   ++num_get_pin_args_in_flight_;
   task_counter_.SetMetricStatus(
       func_name, rpc::TaskStatus::GETTING_AND_PINNING_ARGS, is_retry);
@@ -2809,9 +2815,6 @@ Status CoreWorker::ExecuteTask(
 
   task_queue_length_ -= 1;
   num_executed_tasks_ += 1;
-
-  // Modify the worker's per-function counters.
-  task_counter_.MovePendingToRunning(func_name, is_retry);
 
   worker::TaskStatusEvent::TaskStateUpdate update;
   {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2805,7 +2805,8 @@ Status CoreWorker::ExecuteTask(
     ++num_failed_get_pin_args_;
     // If this has happened, it's because we are unable to talk to our local raylet.
     // This very likely means that the raylet has shutdown before this worker
-    // unexpectedly. In whic case we'll trigger shut down.
+    // unexpectedly. In which case we'll mark the task finished and trigger shut down.
+    task_counter_.MoveRunningToFinished(func_name, task_spec.IsRetry());
     Exit(rpc::WorkerExitType::SYSTEM_ERROR,
          absl::StrCat("Worker failed to get and pin task arguments! Error message: ",
                       pin_args_request_status.message()),


### PR DESCRIPTION
Issue: `RUNNING` metric could be reported with a negative value. This is because `SetMetricStatus(GETTING_AND_PINNING_ARGS)` increments the `pending_getting_and_pinning_args_fetch_counter_` BEFORE `MovePendingToRunning()` increments the `kRunning` counter. If a metric flush happens in between, the RUNNING gauge = `running_total(0) - num_getting_pinning_args(1) = -1`. Gauge calculation logic can be found in constructor of `TaskCounter` in `core_worker.cc`. 

This can reproduced by adding a sufficient sleep in CoreWorker::ExecuteTask between SetMetricStatus(GETTING_AND_PINNING_ARGS) and MovePendingToRunning() to ensure metric flush takes place.
<img width="1159" height="716" alt="image" src="https://github.com/user-attachments/assets/a29e169b-f166-4e8d-8f69-e26a3de4212f" />

Fix: Since GETTING_AND_PINNING_ARGS is treated as a substate for kRunning, shift the MovePendingToRunning() call to before SetMetricStatus(GETTING_AND_PINNING_ARGS). 