### PR TITLE
[core] Rename cluster scheduler Schedule -> SchedulePlacementGroup 

### DIFF
--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -71,8 +71,8 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
       CreateSchedulingOptions(placement_group->GetPlacementGroupID(),
                               strategy,
                               placement_group->GetSoftTargetNodeID());
-  auto scheduling_result =
-      cluster_resource_scheduler_.SchedulePlacementGroup(resource_request_list, scheduling_options);
+  auto scheduling_result = cluster_resource_scheduler_.SchedulePlacementGroup(
+      resource_request_list, scheduling_options);
 
   auto result_status = scheduling_result.status;
   const auto &selected_nodes = scheduling_result.selected_nodes;

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -72,7 +72,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
                               strategy,
                               placement_group->GetSoftTargetNodeID());
   auto scheduling_result =
-      cluster_resource_scheduler_.Schedule(resource_request_list, scheduling_options);
+      cluster_resource_scheduler_.SchedulePlacementGroup(resource_request_list, scheduling_options);
 
   auto result_status = scheduling_result.status;
   const auto &selected_nodes = scheduling_result.selected_nodes;

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -394,7 +394,7 @@ scheduling::NodeID ClusterResourceScheduler::GetBestSchedulableNode(
   return highest_priority_unavailable_node;
 }
 
-SchedulingResult ClusterResourceScheduler::Schedule(
+SchedulingResult ClusterResourceScheduler::SchedulePlacementGroup(
     const std::vector<const ResourceRequest *> &resource_request_list,
     SchedulingOptions options) {
   return bundle_scheduling_policy_->Schedule(resource_request_list, options);

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -70,7 +70,7 @@ class ClusterResourceScheduler {
           nullptr,
       const absl::flat_hash_map<std::string, std::string> &local_node_labels = {});
 
-  /// Schedule the specified resources to the cluster nodes.
+  /// Schedule a placement group with the specified resources to the cluster nodes.
   ///
   /// \param resource_request_list The resource request list we're attempting to schedule.
   /// \param options: scheduling options.
@@ -79,7 +79,7 @@ class ClusterResourceScheduler {
   /// \return `SchedulingResult`, including the
   /// selected nodes if schedule successful, otherwise, it will return an empty vector and
   /// a flag to indicate whether this request can be retry or not.
-  SchedulingResult Schedule(
+  SchedulingResult SchedulePlacementGroup(
       const std::vector<const ResourceRequest *> &resource_request_list,
       SchedulingOptions options);
 

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
@@ -105,8 +105,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     for (auto &request : requests) {
       resource_request_list.emplace_back(&request);
     }
-    const auto &result1 =
-        cluster_resource_scheduler_->SchedulePlacementGroup(resource_request_list, scheduling_options);
+    const auto &result1 = cluster_resource_scheduler_->SchedulePlacementGroup(
+        resource_request_list, scheduling_options);
     ASSERT_TRUE(result1.status.IsSuccess());
     ASSERT_EQ(result1.selected_nodes.size(), 3);
 
@@ -123,8 +123,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     for (auto &request : requests) {
       resource_request_list.emplace_back(&request);
     }
-    const auto &result2 =
-        cluster_resource_scheduler_->SchedulePlacementGroup(resource_request_list, scheduling_options);
+    const auto &result2 = cluster_resource_scheduler_->SchedulePlacementGroup(
+        resource_request_list, scheduling_options);
     ASSERT_TRUE(result2.status.IsFailed());
     ASSERT_EQ(result2.selected_nodes.size(), 0);
 
@@ -178,8 +178,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     for (auto &request : requests) {
       resource_request_list.emplace_back(&request);
     }
-    auto result =
-        cluster_resource_scheduler_->SchedulePlacementGroup(resource_request_list, scheduling_options);
+    auto result = cluster_resource_scheduler_->SchedulePlacementGroup(
+        resource_request_list, scheduling_options);
     ASSERT_TRUE(result.status.IsSuccess());
     ASSERT_EQ(result.selected_nodes.size(), resources_list.size());
   }

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
@@ -106,7 +106,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
       resource_request_list.emplace_back(&request);
     }
     const auto &result1 =
-        cluster_resource_scheduler_->Schedule(resource_request_list, scheduling_options);
+        cluster_resource_scheduler_->SchedulePlacementGroup(resource_request_list, scheduling_options);
     ASSERT_TRUE(result1.status.IsSuccess());
     ASSERT_EQ(result1.selected_nodes.size(), 3);
 
@@ -124,7 +124,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
       resource_request_list.emplace_back(&request);
     }
     const auto &result2 =
-        cluster_resource_scheduler_->Schedule(resource_request_list, scheduling_options);
+        cluster_resource_scheduler_->SchedulePlacementGroup(resource_request_list, scheduling_options);
     ASSERT_TRUE(result2.status.IsFailed());
     ASSERT_EQ(result2.selected_nodes.size(), 0);
 
@@ -179,7 +179,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
       resource_request_list.emplace_back(&request);
     }
     auto result =
-        cluster_resource_scheduler_->Schedule(resource_request_list, scheduling_options);
+        cluster_resource_scheduler_->SchedulePlacementGroup(resource_request_list, scheduling_options);
     ASSERT_TRUE(result.status.IsSuccess());
     ASSERT_EQ(result.selected_nodes.size(), resources_list.size());
   }
@@ -229,7 +229,7 @@ TEST_F(GcsResourceSchedulerTest, TestNodeFilter) {
   auto bundle_locations = std::make_shared<BundleLocations>();
   BundleID bundle_id{PlacementGroupID::Of(JobID::FromInt(1)), 0};
   bundle_locations->emplace(bundle_id, std::make_pair(node_id, nullptr));
-  auto result1 = cluster_resource_scheduler_->Schedule(
+  auto result1 = cluster_resource_scheduler_->SchedulePlacementGroup(
       resource_request_list,
       SchedulingOptions::BundleStrictSpread(
           std::make_unique<BundleSchedulingContext>(bundle_locations)));
@@ -237,7 +237,7 @@ TEST_F(GcsResourceSchedulerTest, TestNodeFilter) {
   ASSERT_EQ(result1.selected_nodes.size(), 0);
 
   // Scheduling succeeded.
-  auto result2 = cluster_resource_scheduler_->Schedule(
+  auto result2 = cluster_resource_scheduler_->SchedulePlacementGroup(
       resource_request_list,
       SchedulingOptions::BundleStrictSpread(
           std::make_unique<BundleSchedulingContext>(nullptr)));
@@ -266,7 +266,7 @@ TEST_F(GcsResourceSchedulerTest, TestSchedulingResultStatusForStrictStrategy) {
   for (auto &request : requests) {
     resource_request_list.emplace_back(&request);
   }
-  auto result1 = cluster_resource_scheduler_->Schedule(
+  auto result1 = cluster_resource_scheduler_->SchedulePlacementGroup(
       resource_request_list, SchedulingOptions::BundleStrictSpread());
   ASSERT_TRUE(result1.status.IsInfeasible());
   ASSERT_EQ(result1.selected_nodes.size(), 0);
@@ -287,7 +287,7 @@ TEST_F(GcsResourceSchedulerTest, TestSchedulingResultStatusForStrictStrategy) {
   for (auto &request : requests) {
     resource_request_list.emplace_back(&request);
   }
-  const auto &result2 = cluster_resource_scheduler_->Schedule(
+  const auto &result2 = cluster_resource_scheduler_->SchedulePlacementGroup(
       resource_request_list, SchedulingOptions::BundleStrictPack());
   ASSERT_TRUE(result2.status.IsInfeasible());
   ASSERT_EQ(result2.selected_nodes.size(), 0);


### PR DESCRIPTION
## Description
Renames cluster_resource_scheduler's Schedule method -> SchedulePlacementGroup method, since its only use case is to schedule a placement group

## Additional information
<img width="813" height="381" alt="image" src="https://github.com/user-attachments/assets/2442c164-284b-40c9-847b-3d8e5d7f4aef" />
In the references for the header file above, we can see a duplicate reference for the header file, the implementation, and then the only call to the function within gcs_placement_group_scheduler. This is called within the ScheduleUnplacedBundles function, where bundles are scheduled using the cluster resource scheduler. Thus, this is only used for the purpose of scheduling bundles within placement groups.