### PR TITLE
[Data] Fix typing mismatches in Dataset public API

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -307,7 +307,7 @@ class Dataset:
     @PublicAPI(api_group=BT_API_GROUP)
     def map(
         self,
-        fn: Callable[[Dict[str, Any]], Dict[str, Any]],
+        fn: UserDefinedFunction[Dict[str, Any], Dict[str, Any]],
         *,
         compute: Optional[ComputeStrategy] = None,
         fn_args: Optional[Iterable[Any]] = None,
@@ -2889,8 +2889,8 @@ class Dataset:
         ds: "Dataset",
         join_type: str,
         num_partitions: int,
-        on: Tuple[str] = ("id",),
-        right_on: Optional[Tuple[str]] = None,
+        on: Tuple[str, ...] = ("id",),
+        right_on: Optional[Tuple[str, ...]] = None,
         left_suffix: Optional[str] = None,
         right_suffix: Optional[str] = None,
         *,
@@ -5101,7 +5101,7 @@ class Dataset:
     def write_snowflake(
         self,
         table: str,
-        connection_parameters: str,
+        connection_parameters: Dict[str, Any],
         *,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1816,7 +1816,7 @@ class Dataset:
     def random_shuffle(
         self,
         *,
-        seed: Optional[int | RandomSeedConfig] = None,
+        seed: Optional[Union[int, RandomSeedConfig]] = None,
         num_blocks: Optional[int] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -1898,7 +1898,7 @@ class Dataset:
     def randomize_block_order(
         self,
         *,
-        seed: Optional[int | RandomSeedConfig] = None,
+        seed: Optional[Union[int, RandomSeedConfig]] = None,
     ) -> "Dataset":
         """Randomly shuffle the :ref:`blocks <dataset_concept>` of this :class:`Dataset`.
 
@@ -1948,7 +1948,7 @@ class Dataset:
 
     @PublicAPI(api_group=BT_API_GROUP)
     def random_sample(
-        self, fraction: float, *, seed: Optional[int | RandomSeedConfig] = None
+        self, fraction: float, *, seed: Optional[Union[int, RandomSeedConfig]] = None
     ) -> "Dataset":
         """Returns a new :class:`Dataset` containing a random fraction of the rows.
         In other words, this method "randomly filters" the rows of the dataset without

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1059,7 +1059,7 @@ class Dataset:
         self,
         cols: List[str],
         *,
-        compute: Optional[str] = None,
+        compute: Optional[Union[str, ComputeStrategy]] = None,
         concurrency: Optional[int] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -1120,7 +1120,7 @@ class Dataset:
         self,
         cols: Union[str, List[str]],
         *,
-        compute: Union[str, ComputeStrategy] = None,
+        compute: Optional[Union[str, ComputeStrategy]] = None,
         concurrency: Optional[int] = None,
         **ray_remote_args,
     ) -> "Dataset":
@@ -1474,7 +1474,7 @@ class Dataset:
         fn: Optional[UserDefinedFunction[Dict[str, Any], bool]] = None,
         expr: Optional[Union[str, Expr]] = None,
         *,
-        compute: Union[str, ComputeStrategy] = None,
+        compute: Optional[Union[str, ComputeStrategy]] = None,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
         fn_constructor_args: Optional[Iterable[Any]] = None,
@@ -3584,7 +3584,7 @@ class Dataset:
         self,
         key: Union[str, List[str]],
         descending: Union[bool, List[bool]] = False,
-        boundaries: List[Union[int, float]] = None,
+        boundaries: Optional[List[Union[int, float]]] = None,
     ) -> "Dataset":
         """Sort the dataset by the specified key column or key function.
         The `key` parameter must be specified (i.e., it cannot be `None`).

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -458,7 +458,7 @@ class Dataset:
     def _set_name(self, name: Optional[str]):
         self.set_name(name)
 
-    def set_name(self, name: Optional[str]):
+    def set_name(self, name: Optional[str]) -> None:
         """Set the name of the dataset.
 
         Used as a prefix for metrics tags.
@@ -1203,7 +1203,7 @@ class Dataset:
         *,
         concurrency: Optional[Union[int, Tuple[int, int], Tuple[int, int, int]]] = None,
         **ray_remote_args,
-    ):
+    ) -> "Dataset":
         """Rename columns in the dataset.
 
         Examples:
@@ -5105,7 +5105,7 @@ class Dataset:
         *,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
-    ):
+    ) -> None:
         """Write this ``Dataset`` to a Snowflake table.
 
         Examples:
@@ -6759,7 +6759,7 @@ class Dataset:
         return self.get_stats_summary().to_string()
 
     @PublicAPI(api_group=IM_API_GROUP, stability="alpha")
-    def explain(self):
+    def explain(self) -> None:
         """Show the logical plan and physical plan of the dataset.
 
         Examples:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3168,7 +3168,7 @@ class Dataset:
     @AllToAllAPI
     @ConsumptionAPI
     @PublicAPI(api_group=GGA_API_GROUP)
-    def aggregate(self, *aggs: AggregateFn) -> Union[Any, Dict[str, Any]]:
+    def aggregate(self, *aggs: AggregateFn) -> Any:
         """Aggregate values using one or more functions.
 
         Use this method to compute metrics like the product of a column.
@@ -4088,8 +4088,7 @@ class Dataset:
             80
 
         Returns:
-            The in-memory size of the dataset in bytes, or None if the
-            in-memory size is not known.
+            The in-memory size of the dataset in bytes.
         """
         # If the size is known from metadata, return it.
         if self._logical_plan.dag.infer_metadata().size_bytes is not None:


### PR DESCRIPTION
## Summary
- Fix incorrect type annotations on `Dataset` public methods (`map`, `join`, `write_snowflake`)
- Add `None` to Union types where the default value is `None` but the type excluded it (`select_columns`, `filter`, `sort`, `drop_columns`)
- Normalize mixed `Optional[int | X]` style to `Optional[Union[int, X]]` for consistency (`random_shuffle`, `randomize_block_order`, `random_sample`)
- Add missing return type annotations on `set_name`, `rename_columns`, `write_snowflake`, `explain`
- Simplify redundant `Union[Any, Dict[str, Any]]` to `Any` on `aggregate`, fix stale `size_bytes` docstring

## Test plan
- [ ] Verify no runtime behavior changes (annotation-only changes)
- [ ] Run `python -c "import ray.data"` to confirm no import errors
- [ ] Run existing Dataset unit tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)