### PR TITLE
[serve] 1/4: Add multi-turn benchmark scaffold with smoke mode

### DIFF
--- a/python/ray/llm/_internal/serve/benchmark/__main__.py
+++ b/python/ray/llm/_internal/serve/benchmark/__main__.py
@@ -1,3 +1,7 @@
+"""CLI entry point for the multi-turn OpenAI-compatible HTTP benchmark.
+
+Example: python -m ray.llm._internal.serve.benchmark --help
+"""
 from ray.llm._internal.serve.benchmark.cli import main
 
 main()

--- a/python/ray/llm/_internal/serve/benchmark/__main__.py
+++ b/python/ray/llm/_internal/serve/benchmark/__main__.py
@@ -1,0 +1,3 @@
+from ray.llm._internal.serve.benchmark.cli import main
+
+main()

--- a/python/ray/llm/_internal/serve/benchmark/cli.py
+++ b/python/ray/llm/_internal/serve/benchmark/cli.py
@@ -49,6 +49,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="HuggingFace tokenizer name/path (default: same as --model)",
     )
+    server.add_argument(
+        "--api-key",
+        default=None,
+        help="API key for Authorization header (default: None)",
+    )
 
     ## Workload ##
     workload = parser.add_argument_group("workload")
@@ -89,7 +94,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Simulated user think-time between turns in seconds (default: %(default)s)",
     )
     workload.add_argument(
-        "--chunk-size",
+        "--first-chunk-threshold",
         type=int,
         default=16,
         help="Number of content chunks before recording first-chunk latency (default: %(default)s)",

--- a/python/ray/llm/_internal/serve/benchmark/cli.py
+++ b/python/ray/llm/_internal/serve/benchmark/cli.py
@@ -1,0 +1,204 @@
+"""CLI entry point for the multi-turn OpenAI-compatible HTTP benchmark."""
+
+import argparse
+import sys
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Multi-turn OpenAI-compatible HTTP benchmark",
+    )
+
+    # ── Mode flags ──────────────────────────────────────────────────────
+    mode = parser.add_argument_group("mode")
+    mode.add_argument(
+        "-s", "--smoke",
+        action="store_true",
+        help="Smoke test (single request, exit)",
+    )
+    mode.add_argument(
+        "-i", "--interactive",
+        action="store_true",
+        help="Interactive mode (server by default)",
+    )
+    mode.add_argument(
+        "--client",
+        action="store_true",
+        help="Interactive client mode (used with -i)",
+    )
+
+    # ── Server / API ────────────────────────────────────────────────────
+    server = parser.add_argument_group("server/API")
+    server.add_argument(
+        "-u", "--base-url",
+        default="http://127.0.0.1:8000",
+        help="Base URL of the OpenAI-compatible API (default: %(default)s)",
+    )
+    server.add_argument(
+        "-m", "--model",
+        default="test-model",
+        help="Model name to send in requests (default: %(default)s)",
+    )
+    server.add_argument(
+        "--tokenizer",
+        default=None,
+        help="HuggingFace tokenizer name/path (default: same as --model)",
+    )
+
+    # ── Workload (simple mode) ──────────────────────────────────────────
+    workload = parser.add_argument_group("workload")
+    workload.add_argument(
+        "--isl",
+        type=int,
+        default=None,
+        help="Average input sequence length",
+    )
+    workload.add_argument(
+        "--hit-rate",
+        type=float,
+        default=None,
+        help="Prefix cache hit rate [0, 1]",
+    )
+    workload.add_argument(
+        "--num-turns",
+        type=int,
+        default=None,
+        help="Number of turns per session",
+    )
+    workload.add_argument(
+        "--osl",
+        type=int,
+        default=None,
+        help="Output tokens per turn",
+    )
+    workload.add_argument(
+        "--cross-sharing",
+        type=float,
+        default=1.0,
+        help="Cross-session prefix sharing factor (default: %(default)s)",
+    )
+    workload.add_argument(
+        "--think-time",
+        type=float,
+        default=0.0,
+        help="Simulated user think-time between turns in seconds (default: %(default)s)",
+    )
+    workload.add_argument(
+        "--chunk-size",
+        type=int,
+        default=16,
+        help="Number of content chunks before recording first-chunk latency (default: %(default)s)",
+    )
+
+    # ── Traffic ──────────────────────────────────────────────────────────
+    traffic = parser.add_argument_group("traffic")
+    traffic.add_argument(
+        "--concurrency",
+        type=int,
+        default=None,
+        help="Number of concurrent sessions",
+    )
+    traffic.add_argument(
+        "--request-rate",
+        type=float,
+        default=None,
+        help="Request rate (requests per second)",
+    )
+    traffic.add_argument(
+        "--duration",
+        type=float,
+        default=None,
+        help="Duration in seconds",
+    )
+    traffic.add_argument(
+        "--num-sessions",
+        type=int,
+        default=None,
+        help="Total number of sessions to run",
+    )
+    traffic.add_argument(
+        "--warm-up",
+        type=float,
+        default=0,
+        help="Warm-up period in seconds (default: %(default)s)",
+    )
+    traffic.add_argument(
+        "--ramp-interval",
+        type=float,
+        default=-1,
+        help="Ramp interval in seconds (default: %(default)s)",
+    )
+
+    # ── Interactive-only ─────────────────────────────────────────────────
+    interactive = parser.add_argument_group("interactive-only")
+    interactive.add_argument(
+        "--status-interval",
+        type=int,
+        default=5,
+        help="Status reporting interval in seconds (default: %(default)s)",
+    )
+    interactive.add_argument(
+        "--cmd",
+        type=str,
+        default=None,
+        help="Command to send in interactive client mode",
+    )
+    interactive.add_argument(
+        "--log-failures",
+        action="store_true",
+        help="Log individual request failures",
+    )
+    interactive.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility",
+    )
+    interactive.add_argument(
+        "--save-result",
+        type=str,
+        default=None,
+        help="Filename to save results",
+    )
+    interactive.add_argument(
+        "--save-dir",
+        type=str,
+        default=None,
+        help="Directory to save results",
+    )
+    interactive.add_argument(
+        "--num-workers",
+        type=int,
+        default=None,
+        help="Number of worker tasks",
+    )
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.smoke:
+        from ray.llm._internal.serve.benchmark.multiturn_bench import run_smoke
+
+        sys.exit(run_smoke(args))
+    elif args.interactive and args.client:
+        print(
+            "Interactive client mode is not implemented yet.", file=sys.stderr
+        )
+        sys.exit(1)
+    elif args.interactive:
+        print(
+            "Interactive server mode is not implemented yet.", file=sys.stderr
+        )
+        sys.exit(1)
+    elif args.concurrency or args.request_rate:
+        print(
+            "Direct benchmark mode is not implemented yet.", file=sys.stderr
+        )
+        sys.exit(1)
+    else:
+        parser.print_help()
+        sys.exit(1)

--- a/python/ray/llm/_internal/serve/benchmark/cli.py
+++ b/python/ray/llm/_internal/serve/benchmark/cli.py
@@ -94,6 +94,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Simulated user think-time between turns in seconds (default: %(default)s)",
     )
     workload.add_argument(
+        "-fc",
         "--first-chunk-threshold",
         type=int,
         default=16,

--- a/python/ray/llm/_internal/serve/benchmark/cli.py
+++ b/python/ray/llm/_internal/serve/benchmark/cli.py
@@ -13,12 +13,14 @@ def build_parser() -> argparse.ArgumentParser:
     ## Mode flags ##
     mode = parser.add_argument_group("mode")
     mode.add_argument(
-        "-s", "--smoke",
+        "-s",
+        "--smoke",
         action="store_true",
         help="Smoke test (single request, exit)",
     )
     mode.add_argument(
-        "-i", "--interactive",
+        "-i",
+        "--interactive",
         action="store_true",
         help="Interactive mode (server by default)",
     )
@@ -31,12 +33,14 @@ def build_parser() -> argparse.ArgumentParser:
     ## Server / API ##
     server = parser.add_argument_group("server/API")
     server.add_argument(
-        "-u", "--base-url",
+        "-u",
+        "--base-url",
         default="http://127.0.0.1:8000",
         help="Base URL of the OpenAI-compatible API (default: %(default)s)",
     )
     server.add_argument(
-        "-m", "--model",
+        "-m",
+        "--model",
         default="test-model",
         help="Model name to send in requests (default: %(default)s)",
     )
@@ -186,19 +190,13 @@ def main() -> None:
 
         sys.exit(run_smoke(args))
     elif args.interactive and args.client:
-        print(
-            "Interactive client mode is not implemented yet.", file=sys.stderr
-        )
+        print("Interactive client mode is not implemented yet.", file=sys.stderr)
         sys.exit(1)
     elif args.interactive:
-        print(
-            "Interactive server mode is not implemented yet.", file=sys.stderr
-        )
+        print("Interactive server mode is not implemented yet.", file=sys.stderr)
         sys.exit(1)
     elif args.concurrency or args.request_rate:
-        print(
-            "Direct benchmark mode is not implemented yet.", file=sys.stderr
-        )
+        print("Direct benchmark mode is not implemented yet.", file=sys.stderr)
         sys.exit(1)
     else:
         parser.print_help()

--- a/python/ray/llm/_internal/serve/benchmark/cli.py
+++ b/python/ray/llm/_internal/serve/benchmark/cli.py
@@ -6,10 +6,11 @@ import sys
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
+        prog="python -m ray.llm._internal.serve.benchmark",
         description="Multi-turn OpenAI-compatible HTTP benchmark",
     )
 
-    # ── Mode flags ──────────────────────────────────────────────────────
+    ## Mode flags ##
     mode = parser.add_argument_group("mode")
     mode.add_argument(
         "-s", "--smoke",
@@ -27,7 +28,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Interactive client mode (used with -i)",
     )
 
-    # ── Server / API ────────────────────────────────────────────────────
+    ## Server / API ##
     server = parser.add_argument_group("server/API")
     server.add_argument(
         "-u", "--base-url",
@@ -45,7 +46,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="HuggingFace tokenizer name/path (default: same as --model)",
     )
 
-    # ── Workload (simple mode) ──────────────────────────────────────────
+    ## Workload ##
     workload = parser.add_argument_group("workload")
     workload.add_argument(
         "--isl",
@@ -90,7 +91,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Number of content chunks before recording first-chunk latency (default: %(default)s)",
     )
 
-    # ── Traffic ──────────────────────────────────────────────────────────
+    ## Traffic ##
     traffic = parser.add_argument_group("traffic")
     traffic.add_argument(
         "--concurrency",
@@ -129,7 +130,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Ramp interval in seconds (default: %(default)s)",
     )
 
-    # ── Interactive-only ─────────────────────────────────────────────────
+    ## Interactive-only ##
     interactive = parser.add_argument_group("interactive-only")
     interactive.add_argument(
         "--status-interval",

--- a/python/ray/llm/_internal/serve/benchmark/multiturn_bench.py
+++ b/python/ray/llm/_internal/serve/benchmark/multiturn_bench.py
@@ -1,0 +1,168 @@
+"""Minimal multi-turn benchmark engine — Phase 1 (smoke mode only)."""
+
+import asyncio
+import json
+import logging
+import time
+from dataclasses import dataclass
+from statistics import mean
+from typing import Optional
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TurnResult:
+    """Result of a single turn's HTTP request."""
+
+    ttft_ms: float  # time to first token
+    fc_ms: float  # first-chunk latency (time to N-th content chunk)
+    tpot_ms: float  # average time per output token (decode phase)
+    latency_ms: float  # total request latency
+    input_tokens: int  # reported by server (usage.prompt_tokens)
+    output_tokens: int  # reported by server (usage.completion_tokens)
+    generated_text: str  # generated text
+
+
+async def send_chat_completion(
+    session: aiohttp.ClientSession,
+    base_url: str,
+    model: str,
+    messages: list[dict[str, str]],
+    session_id: str = "",
+    max_tokens: int = 256,
+    chunk_size: int = 16,
+    timeout_sec: int = 300,
+) -> TurnResult:
+    """Send a streaming chat completion request and collect metrics."""
+    url = f"{base_url}/v1/chat/completions"
+    payload = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "temperature": 0.0,
+    }
+
+    headers = {
+        "Content-Type": "application/json",
+    }
+    if session_id:
+        headers["X-Session-Id"] = session_id
+
+    timeout = aiohttp.ClientTimeout(total=timeout_sec)
+
+    start_ns = time.perf_counter_ns()
+    ttft_ns: Optional[int] = None
+    fc_ns: Optional[int] = None
+    content_chunk_count = 0
+    chunk_times: list[int] = []
+    generated_text = ""
+    input_tokens = 0
+    output_tokens = 0
+    prev_ts = start_ns
+
+    async with session.post(
+        url, json=payload, headers=headers, timeout=timeout
+    ) as resp:
+        if resp.status != 200:
+            body = await resp.text()
+            raise RuntimeError(f"HTTP {resp.status}: {body[:500]}")
+
+        async for raw_line in resp.content:
+            line = raw_line.strip()
+            if not line:
+                continue
+            text = line.decode("utf-8", errors="replace")
+            if not text.startswith("data: "):
+                continue
+            data_str = text[6:]
+            if data_str == "[DONE]":
+                continue
+
+            try:
+                data = json.loads(data_str)
+            except json.JSONDecodeError:
+                continue
+
+            # Check for usage in the chunk
+            usage = data.get("usage")
+            if usage:
+                input_tokens = usage.get("prompt_tokens", input_tokens)
+                output_tokens = usage.get("completion_tokens", output_tokens)
+
+            choices = data.get("choices", [])
+            if not choices:
+                continue
+
+            delta = choices[0].get("delta", {})
+            content = delta.get("content") or delta.get("reasoning")
+            if content:
+                now_ns = time.perf_counter_ns()
+                content_chunk_count += 1
+                if ttft_ns is None:
+                    ttft_ns = now_ns - start_ns
+                else:
+                    chunk_times.append(now_ns - prev_ts)
+                if fc_ns is None and content_chunk_count >= chunk_size:
+                    fc_ns = now_ns - start_ns
+                prev_ts = now_ns
+                generated_text += content
+
+    end_ns = time.perf_counter_ns()
+    latency_ns = end_ns - start_ns
+
+    if ttft_ns is None:
+        ttft_ns = latency_ns
+
+    if fc_ns is None:
+        fc_ns = latency_ns
+
+    tpot_ns = mean(chunk_times) if chunk_times else 0.0
+
+    return TurnResult(
+        ttft_ms=ttft_ns / 1e6,
+        fc_ms=fc_ns / 1e6,
+        tpot_ms=tpot_ns / 1e6,
+        latency_ms=latency_ns / 1e6,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        generated_text=generated_text,
+    )
+
+
+async def _run_smoke_async(args) -> dict:
+    """Run a single smoke-test request and return metrics."""
+    messages = [
+        {"role": "user", "content": "Say 'this is a test' and nothing else."}
+    ]
+    async with aiohttp.ClientSession() as session:
+        result = await send_chat_completion(
+            session=session,
+            base_url=args.base_url,
+            model=args.model,
+            messages=messages,
+            chunk_size=args.chunk_size,
+        )
+    return {
+        "ttft_ms": round(result.ttft_ms, 2),
+        "fc_ms": round(result.fc_ms, 2),
+        "tpot_ms": round(result.tpot_ms, 2),
+        "latency_ms": round(result.latency_ms, 2),
+        "input_tokens": result.input_tokens,
+        "output_tokens": result.output_tokens,
+    }
+
+
+def run_smoke(args) -> int:
+    """Run smoke test synchronously, return exit code."""
+    try:
+        result = asyncio.run(_run_smoke_async(args))
+        print(json.dumps(result, indent=2))
+        return 0
+    except Exception as e:
+        logger.error(f"Smoke test failed: {e}")
+        return 1

--- a/python/ray/llm/_internal/serve/benchmark/multiturn_bench.py
+++ b/python/ray/llm/_internal/serve/benchmark/multiturn_bench.py
@@ -33,8 +33,9 @@ async def send_chat_completion(
     messages: list[dict[str, str]],
     session_id: str = "",
     max_tokens: int = 256,
-    chunk_size: int = 16,
+    first_chunk_threshold: int = 16,
     timeout_sec: int = 300,
+    api_key: Optional[str] = None,
 ) -> TurnResult:
     """Send a streaming chat completion request and collect metrics."""
     url = f"{base_url}/v1/chat/completions"
@@ -50,6 +51,8 @@ async def send_chat_completion(
     headers = {
         "Content-Type": "application/json",
     }
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     if session_id:
         headers["X-Session-Id"] = session_id
 
@@ -107,7 +110,7 @@ async def send_chat_completion(
                     ttft_ns = now_ns - start_ns
                 else:
                     chunk_times.append(now_ns - prev_ts)
-                if fc_ns is None and content_chunk_count >= chunk_size:
+                if fc_ns is None and content_chunk_count >= first_chunk_threshold:
                     fc_ns = now_ns - start_ns
                 prev_ts = now_ns
                 generated_text += content
@@ -143,7 +146,8 @@ async def _run_smoke_async(args) -> dict:
             base_url=args.base_url,
             model=args.model,
             messages=messages,
-            chunk_size=args.chunk_size,
+            first_chunk_threshold=args.first_chunk_threshold,
+            api_key=getattr(args, "api_key", None),
         )
     return {
         "ttft_ms": round(result.ttft_ms, 2),

--- a/python/ray/llm/_internal/serve/benchmark/multiturn_bench.py
+++ b/python/ray/llm/_internal/serve/benchmark/multiturn_bench.py
@@ -136,9 +136,7 @@ async def send_chat_completion(
 
 async def _run_smoke_async(args) -> dict:
     """Run a single smoke-test request and return metrics."""
-    messages = [
-        {"role": "user", "content": "Say 'this is a test' and nothing else."}
-    ]
+    messages = [{"role": "user", "content": "Say 'this is a test' and nothing else."}]
     async with aiohttp.ClientSession() as session:
         result = await send_chat_completion(
             session=session,

--- a/python/ray/llm/tests/serve/benchmark/conftest.py
+++ b/python/ray/llm/tests/serve/benchmark/conftest.py
@@ -1,0 +1,123 @@
+"""Shared fixtures for benchmark tests."""
+
+import asyncio
+import json
+import socket
+import threading
+from collections.abc import Generator
+from typing import Any
+
+import aiohttp.web
+import pytest
+
+
+@pytest.fixture()
+def free_port() -> int:
+    """Find and return a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def make_sse_chunk(data: dict[str, Any]) -> bytes:
+    """Encode a dict as an SSE data line."""
+    return f"data: {json.dumps(data)}\n\n".encode()
+
+
+async def mock_chat_handler(
+    request: aiohttp.web.Request,
+) -> aiohttp.web.StreamResponse:
+    """Mock OpenAI streaming chat completions endpoint."""
+    body = await request.json()
+    assert body["model"] is not None
+    assert body["stream"] is True
+
+    resp = aiohttp.web.StreamResponse(
+        status=200,
+        headers={"Content-Type": "text/event-stream"},
+    )
+    await resp.prepare(request)
+
+    words = ["this", " is", " a", " test"]
+    for word in words:
+        chunk = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": word},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        await resp.write(make_sse_chunk(chunk))
+
+    finish_chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    await resp.write(make_sse_chunk(finish_chunk))
+
+    usage_chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 4,
+            "total_tokens": 14,
+        },
+    }
+    await resp.write(make_sse_chunk(usage_chunk))
+
+    await resp.write(b"data: [DONE]\n\n")
+
+    return resp
+
+
+def _run_server(
+    loop: asyncio.AbstractEventLoop,
+    runner: aiohttp.web.AppRunner,
+    port: int,
+    started: threading.Event,
+) -> None:
+    asyncio.set_event_loop(loop)
+    site = aiohttp.web.TCPSite(runner, "127.0.0.1", port)
+    loop.run_until_complete(site.start())
+    started.set()
+    loop.run_forever()
+
+
+@pytest.fixture()
+def mock_server(free_port: int) -> Generator[str, None, None]:
+    """Start a mock SSE server in a background thread and yield its base URL."""
+    port = free_port
+    app = aiohttp.web.Application()
+    app.router.add_post("/v1/chat/completions", mock_chat_handler)
+
+    loop = asyncio.new_event_loop()
+    runner = aiohttp.web.AppRunner(app)
+    loop.run_until_complete(runner.setup())
+
+    started = threading.Event()
+    thread = threading.Thread(
+        target=_run_server, args=(loop, runner, port, started), daemon=True
+    )
+    thread.start()
+    assert started.wait(timeout=5), "Mock server failed to start"
+
+    base_url = f"http://127.0.0.1:{port}"
+    yield base_url
+
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.run_until_complete(runner.cleanup())
+    loop.close()

--- a/python/ray/llm/tests/serve/benchmark/test_smoke.py
+++ b/python/ray/llm/tests/serve/benchmark/test_smoke.py
@@ -22,7 +22,7 @@ async def test_send_chat_completion(mock_server: str) -> None:
             base_url=mock_server,
             model="test-model",
             messages=messages,
-            chunk_size=2,
+            first_chunk_threshold=2,
         )
 
     assert isinstance(result, TurnResult)
@@ -40,7 +40,7 @@ def test_run_smoke(mock_server: str) -> None:
     args = types.SimpleNamespace(
         base_url=mock_server,
         model="test-model",
-        chunk_size=2,
+        first_chunk_threshold=2,
     )
     exit_code = run_smoke(args)
     assert exit_code == 0
@@ -51,7 +51,7 @@ def test_run_smoke_connection_error(free_port: int) -> None:
     args = types.SimpleNamespace(
         base_url=f"http://127.0.0.1:{free_port}",
         model="test-model",
-        chunk_size=16,
+        first_chunk_threshold=16,
     )
     exit_code = run_smoke(args)
     assert exit_code == 1

--- a/python/ray/llm/tests/serve/benchmark/test_smoke.py
+++ b/python/ray/llm/tests/serve/benchmark/test_smoke.py
@@ -1,0 +1,169 @@
+"""Tests for benchmark smoke mode."""
+
+import asyncio
+import json
+import socket
+import threading
+import types
+
+import aiohttp
+import aiohttp.web
+import pytest
+
+from ray.llm._internal.serve.benchmark.multiturn_bench import (
+    TurnResult,
+    send_chat_completion,
+    run_smoke,
+)
+
+
+def _find_free_port() -> int:
+    """Find and return a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _make_sse_chunk(data: dict) -> bytes:
+    """Encode a dict as an SSE data line."""
+    return f"data: {json.dumps(data)}\n\n".encode()
+
+
+async def _mock_chat_handler(
+    request: aiohttp.web.Request,
+) -> aiohttp.web.StreamResponse:
+    """Mock OpenAI streaming chat completions endpoint."""
+    body = await request.json()
+    assert body["model"] is not None
+    assert body["stream"] is True
+
+    resp = aiohttp.web.StreamResponse(
+        status=200,
+        headers={"Content-Type": "text/event-stream"},
+    )
+    await resp.prepare(request)
+
+    # Send several content chunks
+    words = ["this", " is", " a", " test"]
+    for word in words:
+        chunk = {
+            "id": "chatcmpl-test",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": word},
+                    "finish_reason": None,
+                }
+            ],
+        }
+        await resp.write(_make_sse_chunk(chunk))
+
+    # Send finish chunk (no content)
+    finish_chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+    await resp.write(_make_sse_chunk(finish_chunk))
+
+    # Send usage chunk
+    usage_chunk = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 4,
+            "total_tokens": 14,
+        },
+    }
+    await resp.write(_make_sse_chunk(usage_chunk))
+
+    # Send [DONE]
+    await resp.write(b"data: [DONE]\n\n")
+
+    return resp
+
+
+def _run_server(loop: asyncio.AbstractEventLoop, runner, port: int) -> None:
+    """Run the aiohttp server in a background thread."""
+    asyncio.set_event_loop(loop)
+    site = aiohttp.web.TCPSite(runner, "127.0.0.1", port)
+    loop.run_until_complete(site.start())
+    loop.run_forever()
+
+
+@pytest.fixture()
+def mock_server():
+    """Start a mock SSE server in a background thread and yield its base URL."""
+    port = _find_free_port()
+    app = aiohttp.web.Application()
+    app.router.add_post("/v1/chat/completions", _mock_chat_handler)
+
+    loop = asyncio.new_event_loop()
+    runner = aiohttp.web.AppRunner(app)
+    loop.run_until_complete(runner.setup())
+
+    thread = threading.Thread(target=_run_server, args=(loop, runner, port), daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    yield base_url
+
+    loop.call_soon_threadsafe(loop.stop)
+    thread.join(timeout=5)
+    loop.run_until_complete(runner.cleanup())
+    loop.close()
+
+
+@pytest.mark.asyncio
+async def test_send_chat_completion(mock_server: str) -> None:
+    """send_chat_completion should parse SSE stream and return correct TurnResult."""
+    messages = [{"role": "user", "content": "hello"}]
+    async with aiohttp.ClientSession() as session:
+        result = await send_chat_completion(
+            session=session,
+            base_url=mock_server,
+            model="test-model",
+            messages=messages,
+            chunk_size=2,
+        )
+
+    assert isinstance(result, TurnResult)
+    assert result.generated_text == "this is a test"
+    assert result.input_tokens == 10
+    assert result.output_tokens == 4
+    assert result.ttft_ms > 0
+    assert result.latency_ms > 0
+    assert result.fc_ms > 0
+    assert isinstance(result.tpot_ms, float)
+
+
+def test_run_smoke(mock_server: str) -> None:
+    """run_smoke should return 0 and print JSON metrics."""
+    args = types.SimpleNamespace(
+        base_url=mock_server,
+        model="test-model",
+        chunk_size=2,
+    )
+    exit_code = run_smoke(args)
+    assert exit_code == 0
+
+
+def test_run_smoke_connection_error() -> None:
+    """run_smoke should return 1 when the server is unreachable."""
+    port = _find_free_port()
+    args = types.SimpleNamespace(
+        base_url=f"http://127.0.0.1:{port}",
+        model="test-model",
+        chunk_size=16,
+    )
+    exit_code = run_smoke(args)
+    assert exit_code == 1

--- a/python/ray/llm/tests/serve/benchmark/test_smoke.py
+++ b/python/ray/llm/tests/serve/benchmark/test_smoke.py
@@ -1,126 +1,15 @@
 """Tests for benchmark smoke mode."""
 
-import asyncio
-import json
-import socket
-import threading
 import types
 
 import aiohttp
-import aiohttp.web
 import pytest
 
 from ray.llm._internal.serve.benchmark.multiturn_bench import (
     TurnResult,
-    send_chat_completion,
     run_smoke,
+    send_chat_completion,
 )
-
-
-def _find_free_port() -> int:
-    """Find and return a free TCP port on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def _make_sse_chunk(data: dict) -> bytes:
-    """Encode a dict as an SSE data line."""
-    return f"data: {json.dumps(data)}\n\n".encode()
-
-
-async def _mock_chat_handler(
-    request: aiohttp.web.Request,
-) -> aiohttp.web.StreamResponse:
-    """Mock OpenAI streaming chat completions endpoint."""
-    body = await request.json()
-    assert body["model"] is not None
-    assert body["stream"] is True
-
-    resp = aiohttp.web.StreamResponse(
-        status=200,
-        headers={"Content-Type": "text/event-stream"},
-    )
-    await resp.prepare(request)
-
-    # Send several content chunks
-    words = ["this", " is", " a", " test"]
-    for word in words:
-        chunk = {
-            "id": "chatcmpl-test",
-            "object": "chat.completion.chunk",
-            "choices": [
-                {
-                    "index": 0,
-                    "delta": {"content": word},
-                    "finish_reason": None,
-                }
-            ],
-        }
-        await resp.write(_make_sse_chunk(chunk))
-
-    # Send finish chunk (no content)
-    finish_chunk = {
-        "id": "chatcmpl-test",
-        "object": "chat.completion.chunk",
-        "choices": [
-            {
-                "index": 0,
-                "delta": {},
-                "finish_reason": "stop",
-            }
-        ],
-    }
-    await resp.write(_make_sse_chunk(finish_chunk))
-
-    # Send usage chunk
-    usage_chunk = {
-        "id": "chatcmpl-test",
-        "object": "chat.completion.chunk",
-        "choices": [],
-        "usage": {
-            "prompt_tokens": 10,
-            "completion_tokens": 4,
-            "total_tokens": 14,
-        },
-    }
-    await resp.write(_make_sse_chunk(usage_chunk))
-
-    # Send [DONE]
-    await resp.write(b"data: [DONE]\n\n")
-
-    return resp
-
-
-def _run_server(loop: asyncio.AbstractEventLoop, runner, port: int) -> None:
-    """Run the aiohttp server in a background thread."""
-    asyncio.set_event_loop(loop)
-    site = aiohttp.web.TCPSite(runner, "127.0.0.1", port)
-    loop.run_until_complete(site.start())
-    loop.run_forever()
-
-
-@pytest.fixture()
-def mock_server():
-    """Start a mock SSE server in a background thread and yield its base URL."""
-    port = _find_free_port()
-    app = aiohttp.web.Application()
-    app.router.add_post("/v1/chat/completions", _mock_chat_handler)
-
-    loop = asyncio.new_event_loop()
-    runner = aiohttp.web.AppRunner(app)
-    loop.run_until_complete(runner.setup())
-
-    thread = threading.Thread(target=_run_server, args=(loop, runner, port), daemon=True)
-    thread.start()
-
-    base_url = f"http://127.0.0.1:{port}"
-    yield base_url
-
-    loop.call_soon_threadsafe(loop.stop)
-    thread.join(timeout=5)
-    loop.run_until_complete(runner.cleanup())
-    loop.close()
 
 
 @pytest.mark.asyncio
@@ -157,11 +46,10 @@ def test_run_smoke(mock_server: str) -> None:
     assert exit_code == 0
 
 
-def test_run_smoke_connection_error() -> None:
+def test_run_smoke_connection_error(free_port: int) -> None:
     """run_smoke should return 1 when the server is unreachable."""
-    port = _find_free_port()
     args = types.SimpleNamespace(
-        base_url=f"http://127.0.0.1:{port}",
+        base_url=f"http://127.0.0.1:{free_port}",
         model="test-model",
         chunk_size=16,
     )


### PR DESCRIPTION
## Summary
- Create the benchmark package at `ray/llm/_internal/serve/benchmark/` with CLI entry point (`python -m ray.llm._internal.serve.benchmark.cli`)
- Define full argparse with all flags (workload, traffic, interactive) so the CLI signature is stable from day one
- Implement smoke mode (`-s`): single streaming chat completion request with TTFT/FC/TPOT metrics
- `send_chat_completion`: SSE streaming parser collecting time-to-first-token, first-chunk latency, and time-per-output-token

## Test plan
- `test_smoke.py`: mock SSE server validates `send_chat_completion` metrics and end-to-end `run_smoke` exit code
- Connection error test verifies graceful failure (exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)