### PR TITLE
[Data] Make multimodal inference tests use Ray Data defaults

### DIFF
--- a/release/nightly_tests/multimodal_inference_benchmarks/audio_transcription/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/audio_transcription/ray_data_main.py
@@ -13,11 +13,9 @@ from benchmark import Benchmark
 
 
 TRANSCRIPTION_MODEL = "openai/whisper-tiny"
-NUM_GPUS = 8
 SAMPLING_RATE = 16000
 INPUT_PATH = "s3://anonymous@ray-example-data/common_voice_17/parquet/"
 OUTPUT_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
-BATCH_SIZE = 64
 
 ray.init()
 
@@ -94,13 +92,10 @@ def decoder(batch):
 
 def run_pipeline():
     ds = ray.data.read_parquet(INPUT_PATH)
-    ds = ds.repartition(target_num_rows_per_block=BATCH_SIZE)
     ds = ds.map(resample)
-    ds = ds.map_batches(whisper_preprocess, batch_size=BATCH_SIZE)
+    ds = ds.map_batches(whisper_preprocess)
     ds = ds.map_batches(
         Transcriber,
-        batch_size=BATCH_SIZE,
-        concurrency=NUM_GPUS,
         num_gpus=1,
     )
     ds = ds.map_batches(decoder)

--- a/release/nightly_tests/multimodal_inference_benchmarks/audio_transcription/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/audio_transcription/ray_data_main.py
@@ -16,6 +16,7 @@ TRANSCRIPTION_MODEL = "openai/whisper-tiny"
 SAMPLING_RATE = 16000
 INPUT_PATH = "s3://anonymous@ray-example-data/common_voice_17/parquet/"
 OUTPUT_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
+BATCH_SIZE = 64
 
 ray.init()
 
@@ -96,6 +97,7 @@ def run_pipeline():
     ds = ds.map_batches(whisper_preprocess)
     ds = ds.map_batches(
         Transcriber,
+        batch_size=BATCH_SIZE,
         num_gpus=1,
     )
     ds = ds.map_batches(decoder)

--- a/release/nightly_tests/multimodal_inference_benchmarks/document_embedding/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/document_embedding/ray_data_main.py
@@ -13,7 +13,6 @@ from benchmark import Benchmark
 
 EMBED_MODEL_ID = "sentence-transformers/all-MiniLM-L6-v2"
 EMBEDDING_DIM = 384
-NUM_GPU_NODES = 8
 INPUT_PATH = "s3://anonymous@ray-example-data/digitalcorpora/metadata/"
 OUTPUT_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
 
@@ -91,7 +90,6 @@ def run_pipeline():
         .flat_map(chunker)
         .map_batches(
             Embedder,
-            concurrency=NUM_GPU_NODES,
             num_gpus=1.0,
             batch_size=EMBEDDING_BATCH_SIZE,
         )

--- a/release/nightly_tests/multimodal_inference_benchmarks/document_embedding/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/document_embedding/ray_data_main.py
@@ -37,7 +37,9 @@ ray.get([warmup.remote() for _ in range(64)])
 
 def extract_text_from_pdf(row):
     try:
-        bs = row["bytes"]
+        # NOTE: Remove the `bytes` column since we don't need it anymore. This is done by
+        # the system automatically on Ray Data 2.51+ with the `with_column` API.
+        bs = row.pop("bytes")
         doc = pymupdf.Document(stream=bs, filetype="pdf")
         if len(doc) > MAX_PDF_PAGES:
             path = row["uploaded_pdf_path"]
@@ -57,7 +59,7 @@ def chunker(row):
     splitter = RecursiveCharacterTextSplitter(
         chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP
     )
-    page_text = row["page_text"]
+    page_text = row.pop("page_text")
     chunk_iter = splitter.split_text(page_text)
     for chunk_index, text in enumerate(chunk_iter):
         row["chunk"] = text
@@ -85,9 +87,7 @@ def run_pipeline():
         .filter(lambda row: row["file_name"].endswith(".pdf"))
         .with_column("bytes", download("uploaded_pdf_path"))
         .flat_map(extract_text_from_pdf)
-        .drop_columns(["bytes"])
         .flat_map(chunker)
-        .drop_columns(["page_text"])
         .map_batches(
             Embedder,
             num_gpus=1.0,

--- a/release/nightly_tests/multimodal_inference_benchmarks/document_embedding/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/document_embedding/ray_data_main.py
@@ -37,9 +37,7 @@ ray.get([warmup.remote() for _ in range(64)])
 
 def extract_text_from_pdf(row):
     try:
-        # NOTE: Remove the `bytes` column since we don't need it anymore. This is done by
-        # the system automatically on Ray Data 2.51+ with the `with_column` API.
-        bs = row.pop("bytes")
+        bs = row["bytes"]
         doc = pymupdf.Document(stream=bs, filetype="pdf")
         if len(doc) > MAX_PDF_PAGES:
             path = row["uploaded_pdf_path"]
@@ -59,7 +57,7 @@ def chunker(row):
     splitter = RecursiveCharacterTextSplitter(
         chunk_size=CHUNK_SIZE, chunk_overlap=CHUNK_OVERLAP
     )
-    page_text = row.pop("page_text")
+    page_text = row["page_text"]
     chunk_iter = splitter.split_text(page_text)
     for chunk_index, text in enumerate(chunk_iter):
         row["chunk"] = text
@@ -87,7 +85,9 @@ def run_pipeline():
         .filter(lambda row: row["file_name"].endswith(".pdf"))
         .with_column("bytes", download("uploaded_pdf_path"))
         .flat_map(extract_text_from_pdf)
+        .drop_columns(["bytes"])
         .flat_map(chunker)
+        .drop_columns(["page_text"])
         .map_batches(
             Embedder,
             num_gpus=1.0,

--- a/release/nightly_tests/multimodal_inference_benchmarks/image_classification/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/image_classification/ray_data_main.py
@@ -12,7 +12,6 @@ import ray
 from benchmark import Benchmark
 
 
-NUM_GPU_NODES = 8
 INPUT_PATH = "s3://anonymous@ray-example-data/imagenet/metadata_file.parquet"
 OUTPUT_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
 BATCH_SIZE = 100
@@ -86,7 +85,6 @@ def run_pipeline():
             fn=ResNetActor,
             batch_size=BATCH_SIZE,
             num_gpus=1.0,
-            concurrency=NUM_GPU_NODES,
         )
         .select_columns(["image_url", "label"])
     )

--- a/release/nightly_tests/multimodal_inference_benchmarks/large_image_embedding/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/large_image_embedding/ray_data_main.py
@@ -93,7 +93,6 @@ def run_pipeline():
             Infer,
             batch_size=BATCH_SIZE,
             num_gpus=1,
-            concurrency=40,
         )
         .write_parquet(OUTPUT_PREFIX)
     )

--- a/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
@@ -14,8 +14,7 @@ OUTPUT_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
 IMAGE_HEIGHT = 640
 IMAGE_WIDTH = 640
 # This was a change made: Alter batch size accordingly
-# batch_size = 32 for 1x large
-# batch_size = 100 for 2x, 4x, and 8x large
+# batch_size = 100 for 1x, 2x, 4x, and 8x large
 BATCH_SIZE = 100
 
 ray.init()
@@ -79,8 +78,7 @@ def crop_image(row):
     cropped_pil = pil_image.crop((x1, y1, x2, y2))
 
     buf = io.BytesIO()
-    # This was a change made: Use compress_level=2
-    cropped_pil.save(buf, format="PNG", compress_level=2)
+    cropped_pil.save(buf, format="PNG")
     cropped_pil_png = buf.getvalue()
 
     row["object"] = cropped_pil_png

--- a/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
+++ b/release/nightly_tests/multimodal_inference_benchmarks/video_object_detection/ray_data_main.py
@@ -8,7 +8,6 @@ import io
 import uuid
 from benchmark import Benchmark
 
-NUM_GPU_NODES = 8
 YOLO_MODEL = "yolo11n.pt"
 INPUT_PATH = "s3://anonymous@ray-example-data/videos/Hollywood2-actions-videos/Hollywood2/AVIClips/"
 OUTPUT_PATH = f"s3://ray-data-write-benchmark/{uuid.uuid4().hex}"
@@ -17,7 +16,7 @@ IMAGE_WIDTH = 640
 # This was a change made: Alter batch size accordingly
 # batch_size = 32 for 1x large
 # batch_size = 100 for 2x, 4x, and 8x large
-BATCH_SIZE = 32
+BATCH_SIZE = 100
 
 ray.init()
 
@@ -95,7 +94,6 @@ def run_pipeline():
         ExtractImageFeatures,
         batch_size=BATCH_SIZE,
         num_gpus=1.0,
-        concurrency=NUM_GPU_NODES,
     )
     ds = ds.flat_map(explode_features)
     ds = ds.map(crop_image)


### PR DESCRIPTION
Several of our release tests contain workarounds to mitigate OOMs or improve performance. To make sure our system works well out-of-the-box, we update the release tests to only use defaults.

The tests that have been modified to also have default variations include:
```
audio_transcription
document_embedding
large_image_embedding
image_classification
```