### PR TITLE
[Serve] drop replica label from controller histogram metrics

### DIFF
--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -693,16 +693,20 @@ These metrics track proxy health and lifecycle.
 
 These metrics track replica health, restarts, and lifecycle timing.
 
+:::{note}
+These lifecycle **histograms** use `deployment` and `application` labels only—no `replica` label—so Prometheus cardinality stays manageable at scale.
+:::
+
 | Metric | Type | Tags | Description |
 |--------|------|------|-------------|
 | `ray_serve_deployment_replica_healthy` | Gauge | `deployment`, `replica`, `application` | Health status of the replica: `1` = healthy, `0` = unhealthy. |
 | `ray_serve_deployment_replica_starts_total` | Counter | `deployment`, `replica`, `application` | Total number of times the replica has started (including restarts due to failure). |
-| `ray_serve_replica_startup_latency_ms` | Histogram | `deployment`, `replica`, `application` | Total time from replica creation to ready state in milliseconds. Includes node provisioning (if needed on VM or Kubernetes), runtime environment bootstrap (pip install, Docker image pull, etc.), Ray actor scheduling, and actor constructor execution. Useful for debugging slow cold starts. |
-| `ray_serve_replica_initialization_latency_ms` | Histogram | `deployment`, `replica`, `application` | Time for the actor constructor to run in milliseconds. This is a subset of `ray_serve_replica_startup_latency_ms`. |
-| `ray_serve_replica_reconfigure_latency_ms` | Histogram | `deployment`, `replica`, `application` | Time in milliseconds for a replica to complete reconfiguration. Includes both reconfigure time and one control-loop iteration, so very low values may be unreliable. |
-| `ray_serve_health_check_latency_ms` | Histogram | `deployment`, `replica`, `application` | Duration of health check calls in milliseconds. Useful for identifying slow health checks blocking scaling. |
+| `ray_serve_replica_startup_latency_ms` | Histogram | `deployment`, `application` | Total time from replica creation to ready state in milliseconds. Includes node provisioning (if needed on VM or Kubernetes), runtime environment bootstrap (pip install, Docker image pull, etc.), Ray actor scheduling, and actor constructor execution. Useful for debugging slow cold starts. |
+| `ray_serve_replica_initialization_latency_ms` | Histogram | `deployment`, `application` | Time for the actor constructor to run in milliseconds. This is a subset of `ray_serve_replica_startup_latency_ms`. |
+| `ray_serve_replica_reconfigure_latency_ms` | Histogram | `deployment`, `application` | Time in milliseconds for a replica to complete reconfiguration. Includes both reconfigure time and one control-loop iteration, so very low values may be unreliable. |
+| `ray_serve_health_check_latency_ms` | Histogram | `deployment`, `application` | Duration of health check calls in milliseconds. Useful for identifying slow health checks blocking scaling. |
 | `ray_serve_health_check_failures_total` | Counter | `deployment`, `replica`, `application` | Total number of failed health checks. Provides early warning before replica is marked unhealthy. |
-| `ray_serve_replica_shutdown_duration_ms` | Histogram | `deployment`, `replica`, `application` | Time from shutdown signal to replica fully stopped in milliseconds. Useful for debugging slow draining during scale-down or rolling updates. |
+| `ray_serve_replica_shutdown_duration_ms` | Histogram | `deployment`, `application` | Time from shutdown signal to replica fully stopped in milliseconds. Useful for debugging slow draining during scale-down or rolling updates. |
 
 ### Autoscaling metrics
 
@@ -742,8 +746,8 @@ These metrics track the Serve controller's performance. Useful for debugging con
 |--------|------|------|-------------|
 | `ray_serve_controller_control_loop_duration_s` | Gauge | — | Duration of the last control loop iteration in seconds. |
 | `ray_serve_controller_num_control_loops` | Gauge | `actor_id` | Total number of control loop iterations. Increases monotonically. |
-| `ray_serve_routing_stats_delay_ms` | Histogram | `deployment`, `replica`, `application` | Time taken for routing stats to propagate from replica to controller in milliseconds. |
-| `ray_serve_routing_stats_error_total` | Counter | `deployment`, `replica`, `application`, `error_type` | Total number of errors when getting routing stats from replicas. `error_type` is `exception` (replica raised an error) or `timeout` (replica didn't respond in time). |
+| `ray_serve_routing_stats_delay_ms` | Histogram | `deployment`, `application` | Time taken for routing stats to propagate from replica to controller in milliseconds. |
+| `ray_serve_routing_stats_error_total` | Counter | `deployment`, `replica`, `application`, `error_type` | Total number of errors when getting routing stats from replicas. `error_type` is `exception` (replica raised an error) or `timeout` (replica didn't respond in time). Includes `replica` so you can pinpoint which replica failed. |
 | `ray_serve_long_poll_host_transmission_counter_total` **[†]** | Counter | `namespace_or_state` | Total number of long poll updates transmitted to clients. |
 | `ray_serve_deployment_status` | Gauge | `deployment`, `application` | Numeric status of deployment: `0` = UNKNOWN, `1` = DEPLOY_FAILED, `2` = UNHEALTHY, `3` = UPDATING, `4` = UPSCALING, `5` = DOWNSCALING, `6` = HEALTHY. Use for state timeline visualization and lifecycle debugging. |
 | `ray_serve_application_status` | Gauge | `application` | Numeric status of application: `0` = UNKNOWN, `1` = DEPLOY_FAILED, `2` = UNHEALTHY, `3` = NOT_STARTED, `4` = DELETING, `5` = DEPLOYING, `6` = RUNNING. Use for state timeline visualization and lifecycle debugging. |

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -621,12 +621,11 @@ class ActorReplicaWrapper:
                 "from replica to controller."
             ),
             boundaries=DEFAULT_LATENCY_BUCKET_MS,
-            tag_keys=("deployment", "replica", "application"),
+            tag_keys=("deployment", "application"),
         )
         self._routing_stats_delay_histogram.set_default_tags(
             {
                 "deployment": self._deployment_id.name,
-                "replica": self._replica_id.unique_id,
                 "application": self._deployment_id.app_name,
             }
         )
@@ -2617,7 +2616,7 @@ class DeploymentState:
             "serve_replica_startup_latency_ms",
             description=("Time from replica creation to ready state in milliseconds."),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "replica", "application"),
+            tag_keys=("deployment", "application"),
         )
         self.replica_startup_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2628,7 +2627,7 @@ class DeploymentState:
             "serve_replica_initialization_latency_ms",
             description=("Time for replica to initialize in milliseconds."),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "replica", "application"),
+            tag_keys=("deployment", "application"),
         )
         self.replica_initialization_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2640,7 +2639,7 @@ class DeploymentState:
             "serve_replica_reconfigure_latency_ms",
             description=("Time for replica to complete reconfigure in milliseconds."),
             boundaries=REQUEST_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "replica", "application"),
+            tag_keys=("deployment", "application"),
         )
         self.replica_reconfigure_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2651,7 +2650,7 @@ class DeploymentState:
             "serve_health_check_latency_ms",
             description=("Duration of health check calls in milliseconds."),
             boundaries=REQUEST_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "replica", "application"),
+            tag_keys=("deployment", "application"),
         )
         self.health_check_latency_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -2674,7 +2673,7 @@ class DeploymentState:
                 "Time from shutdown signal to replica fully stopped in milliseconds."
             ),
             boundaries=REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
-            tag_keys=("deployment", "replica", "application"),
+            tag_keys=("deployment", "application"),
         )
         self.replica_shutdown_duration_histogram.set_default_tags(
             {"deployment": self._id.name, "application": self._id.app_name}
@@ -3884,16 +3883,13 @@ class DeploymentState:
                 logger.info(replica_startup_message, extra={"log_to_stderr": False})
 
                 # Record startup or reconfigure latency metrics.
-                metric_tags = {
-                    "replica": replica.replica_id.unique_id,
-                }
                 if original_state == ReplicaState.STARTING:
                     # Record replica startup latency (end-to-end from creation to ready).
                     # This includes the time taken from starting a node, scheduling the replica,
                     # and the replica constructor.
                     e2e_replica_start_latency_ms = e2e_replica_start_latency * 1000
                     self.replica_startup_latency_histogram.observe(
-                        e2e_replica_start_latency_ms, tags=metric_tags
+                        e2e_replica_start_latency_ms
                     )
                     # Record replica initialization latency.
                     if replica.initialization_latency_s is not None:
@@ -3901,7 +3897,7 @@ class DeploymentState:
                             replica.initialization_latency_s * 1000
                         )
                         self.replica_initialization_latency_histogram.observe(
-                            initialization_latency_ms, tags=metric_tags
+                            initialization_latency_ms
                         )
                 elif original_state == ReplicaState.UPDATING:
                     # Record replica reconfigure latency.
@@ -3910,7 +3906,7 @@ class DeploymentState:
                             time.time() - replica.reconfigure_start_time
                         ) * 1000
                         self.replica_reconfigure_latency_histogram.observe(
-                            reconfigure_latency_ms, tags=metric_tags
+                            reconfigure_latency_ms
                         )
 
             elif start_status == ReplicaStartupStatus.FAILED:
@@ -4173,15 +4169,14 @@ class DeploymentState:
             is_healthy = replica.check_health()
 
             # Record health check latency and failure metrics.
-            metric_tags = {
-                "replica": replica.replica_id.unique_id,
-            }
             if replica.last_health_check_latency_ms is not None:
                 self.health_check_latency_histogram.observe(
-                    replica.last_health_check_latency_ms, tags=metric_tags
+                    replica.last_health_check_latency_ms
                 )
             if replica.last_health_check_failed:
-                self.health_check_failures_counter.inc(tags=metric_tags)
+                self.health_check_failures_counter.inc(
+                    tags={"replica": replica.replica_id.unique_id}
+                )
 
             if is_healthy:
                 healthy_replicas.append(replica)
@@ -4335,10 +4330,7 @@ class DeploymentState:
                         time.time() - replica.shutdown_start_time
                     ) * 1000
                     self.replica_shutdown_duration_histogram.observe(
-                        shutdown_duration_ms,
-                        tags={
-                            "replica": replica.replica_id.unique_id,
-                        },
+                        shutdown_duration_ms
                     )
 
                 # Release rank only after replica is successfully stopped

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -1285,11 +1285,11 @@ def test_routing_stats_delay_metric(metrics_start_shutdown):
         )
         if not metrics:
             return False
-        # Check that at least one metric has expected tags
+        # Check that at least one metric has expected tags (no per-replica label)
         for metric in metrics:
             assert metric["deployment"] == "Model"
             assert metric["application"] == "app"
-            assert "replica" in metric
+            assert "replica" not in metric
             return True
         return False
 

--- a/python/ray/serve/tests/test_metrics_3.py
+++ b/python/ray/serve/tests/test_metrics_3.py
@@ -149,21 +149,21 @@ def test_replica_startup_and_initialization_latency_metrics(metrics_start_shutdo
     url = get_application_url("HTTP", "app")
     assert "hello" == httpx.get(url).text
 
-    # Verify startup latency metric count is exactly 1 (one replica started)
+    # Verify startup latency: two replicas aggregate into one time series (_count == 2).
     wait_for_condition(
         check_metric_float_eq,
         timeout=20,
         metric="ray_serve_replica_startup_latency_ms_count",
-        expected=1,
+        expected=2,
         expected_tags={"deployment": "MyDeployment", "application": "app"},
     )
 
-    # Verify initialization latency metric count is exactly 1
+    # Verify initialization latency _count matches (one observation per replica).
     wait_for_condition(
         check_metric_float_eq,
         timeout=20,
         metric="ray_serve_replica_initialization_latency_ms_count",
-        expected=1,
+        expected=2,
         expected_tags={"deployment": "MyDeployment", "application": "app"},
     )
 
@@ -180,25 +180,19 @@ def test_replica_startup_and_initialization_latency_metrics(metrics_start_shutdo
 
     wait_for_condition(check_initialization_latency_value, timeout=20)
 
-    # Assert that 2 metrics are recorded (one per replica)
-    def check_metrics_count():
+    # One aggregated time series per deployment (no per-replica label).
+    def check_single_series_no_replica_label():
         metrics = get_metric_dictionaries(
             "ray_serve_replica_initialization_latency_ms_count",
             wait=False,
         )
-        assert len(metrics) == 2, f"Expected 2 metrics, got {len(metrics)}"
-        # All metrics should have same deployment and application
-        for metric in metrics:
-            assert metric["deployment"] == "MyDeployment"
-            assert metric["application"] == "app"
-        # Each replica should have a unique replica tag
-        replica_ids = {metric["replica"] for metric in metrics}
-        assert (
-            len(replica_ids) == 2
-        ), f"Expected 2 unique replica IDs, got {replica_ids}"
+        assert len(metrics) == 1, f"Expected 1 metric series, got {len(metrics)}"
+        assert metrics[0]["deployment"] == "MyDeployment"
+        assert metrics[0]["application"] == "app"
+        assert "replica" not in metrics[0]
         return True
 
-    wait_for_condition(check_metrics_count, timeout=20)
+    wait_for_condition(check_single_series_no_replica_label, timeout=20)
 
 
 def test_replica_reconfigure_latency_metrics(metrics_start_shutdown):


### PR DESCRIPTION
Ray Serve’s controller was exporting several **histograms** with a **`replica` label**. Each replica multiplies histogram bucket series, which drove **very large** `/metrics` payloads and slow scrapes (e.g. timeouts at ~5s) on busy clusters.

## Changes

- **Remove the `replica` label** from these controller-side histograms so they aggregate by **`deployment`** and **`application`** only:
  - `serve_routing_stats_delay_ms`
  - `serve_replica_startup_latency_ms`
  - `serve_replica_initialization_latency_ms`
  - `serve_replica_reconfigure_latency_ms`
  - `serve_health_check_latency_ms`
  - `serve_replica_shutdown_duration_ms`
- **Keep `replica`** on `serve_routing_stats_error` (counter) and **`serve_health_check_failures_total`** so failures stay attributable per replica without ballooning histogram cardinality.
- **Docs:** Update `doc/source/serve/monitoring.md` (tag tables + a short note on cardinality and which metrics still include `replica`).