### PR TITLE
fix(core): correct typo in fetch_prometheus_timeseries

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -477,11 +477,11 @@ def fetch_prometheus(prom_addresses):
 
 
 def fetch_prometheus_timeseries(
-    prom_addreses: List[str],
+    prom_addresses: List[str],
     result: PrometheusTimeseries,
 ) -> PrometheusTimeseries:
     components_dict, metric_descriptors, metric_samples = fetch_prometheus(
-        prom_addreses
+        prom_addresses
     )
     for address, components in components_dict.items():
         if address not in result.components_dict:


### PR DESCRIPTION
## Why are these changes needed?

Fixes a typo in the `fetch_prometheus_timeseries` function signature. The parameter `prom_addreses` was missing one 's' and should be `prom_addresses`. The same typo was also present on the next line where the variable is used.

Fixes #60874.

## Related issue number

Closes #60874

## Checks

- [x] I've signed off every commit(as shown in the logs for each commit, the commit message ends with the name and email of the committer)
- [x] I've run linting (`ruff`, `black`) and the changes pass
- [x] I've tested locally against the changes
- [ ] I've updated the docs if required