### PR TITLE
docs(serve): fix metrics_interval_s value in autoscaling examples

### DIFF
--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -161,10 +161,14 @@ downscaling.
 
 * **[`metrics_interval_s`](../api/doc/ray.serve.config.AutoscalingConfig.metrics_interval_s.rst) [default_value=10]**: In future this deployment level
 config will be removed in favor of cross-application level global config.
-  
+
 This controls how often each replica and handle sends reports on current ongoing requests to the autoscaler.
 ::{note}
 If metrics are reported infrequently, Ray Serve can take longer to notice a change in autoscaling metrics, so scaling can start later even if your delays are short. For example, if you set `upscale_delay_s = 3` but metrics are pushed every 10 seconds, Ray Serve might not see a change until the next push, so scaling up can be limited to about once every 10 seconds.
+::
+
+::{warning}
+Setting `metrics_interval_s` to a very small value (such as `0.1`) can overload the head node controller with high-frequency metric reports and cause instability. Use the default value of `10` unless you have a specific reason to change it, and avoid values that are significantly smaller than the default.
 ::
 
 * **[`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.look_back_period_s.rst) [default_value=30]**: This is the window over which the

--- a/doc/source/serve/doc_code/autoscaling_policy.py
+++ b/doc/source/serve/doc_code/autoscaling_policy.py
@@ -161,7 +161,7 @@ from ray.serve.config import AutoscalingConfig, AutoscalingPolicy
     autoscaling_config=AutoscalingConfig(
         min_replicas=1,
         max_replicas=10,
-        metrics_interval_s=0.1,
+        metrics_interval_s=10,
         upscale_delay_s=1.0,
         downscale_delay_s=1.0,
         policy=AutoscalingPolicy(

--- a/doc/source/serve/doc_code/custom_metrics_autoscaling.py
+++ b/doc/source/serve/doc_code/custom_metrics_autoscaling.py
@@ -10,7 +10,7 @@ from ray import serve
     autoscaling_config={
         "min_replicas": 1,
         "max_replicas": 5,
-        "metrics_interval_s": 0.1,
+        "metrics_interval_s": 10,
         "policy": {
             "policy_function": "autoscaling_policy:custom_metrics_autoscaling_policy"
         },


### PR DESCRIPTION
## Why are these changes needed?

The code examples in `doc/source/serve/doc_code/` were using `metrics_interval_s=0.1`, which is too low and can overload the head node controller with high-frequency metric reports, causing instability.

This PR:
1. Updates both doc code examples to use the default value of `10`
2. Adds a warning callout in `advanced-autoscaling.md` explaining that very small values for this config can cause head node instability

Fixes #61043.

## Related issue number

Closes #61043

## Checks

- [x] I've signed off every commit
- [x] I've run linting (`ruff`, `black`) — pre-existing lint warnings in `autoscaling_policy.py` (E402) are unrelated to this change
- [x] I've tested locally against the changes
- [x] Documentation is updated (this IS the doc change)