### PR TITLE
docs(llm): remove deprecated VLLM_USE_V1 env var from examples

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
@@ -80,9 +80,6 @@ serveConfigV2: |
             autoscaling_config:
               min_replicas: 1
               max_replicas: 1
-          runtime_env:
-            env_vars:
-              VLLM_USE_V1: "1"
           engine_kwargs:
             tensor_parallel_size: 8
             pipeline_parallel_size: 2

--- a/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
+++ b/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
@@ -61,7 +61,6 @@ llm_config = LLMConfig(
             },
         },
     },
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
 )
 
 app = build_openai_app({"llm_configs": [llm_config]})

--- a/doc/source/serve/tutorials/serve-deepseek.md
+++ b/doc/source/serve/tutorials/serve-deepseek.md
@@ -42,7 +42,6 @@ llm_config = LLMConfig(
     },
     # Change to the accelerator type of the node
     accelerator_type="H100",
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     # Customize engine arguments as needed (e.g. vLLM engine kwargs)
     engine_kwargs={
         "tensor_parallel_size": 8,
@@ -78,9 +77,6 @@ applications:
           autoscaling_config:
             min_replicas: 1
             max_replicas: 1
-        runtime_env:
-          env_vars:
-            VLLM_USE_V1: "1"
         engine_kwargs:
           tensor_parallel_size: 8
           pipeline_parallel_size: 2


### PR DESCRIPTION
## Why are these changes needed?

vLLM v2 engine has been the default for some time. The `VLLM_USE_V1` environment variable is no longer needed in documentation and code examples.

This PR removes `VLLM_USE_V1: "1"` references from:
- `doc/source/serve/tutorials/serve-deepseek.md`
- `doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md`
- `doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py`

**Note:** `doc/source/ray-overview/examples/entity-recognition-with-llms/README.md` retains `VLLM_USE_V1=0` as the comment explains LoRA adapter support in V1 is still pending — that is a separate concern.

Fixes #61892.

## Related issue number

Closes #61892

## Checks

- [x] I've signed off every commit
- [x] I've run linting — no new lint issues introduced
- [x] I've tested locally against the changes
- [x] Documentation is updated (this IS the doc change)