### PR TITLE
[llm] Remove VLLM_USE_V1 from docs - V1 is now default

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
@@ -80,9 +80,6 @@ serveConfigV2: |
             autoscaling_config:
               min_replicas: 1
               max_replicas: 1
-          runtime_env:
-            env_vars:
-              VLLM_USE_V1: "1"
           engine_kwargs:
             tensor_parallel_size: 8
             pipeline_parallel_size: 2

--- a/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
+++ b/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
@@ -61,7 +61,6 @@ llm_config = LLMConfig(
             },
         },
     },
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
 )
 
 app = build_openai_app({"llm_configs": [llm_config]})

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
@@ -1218,7 +1218,6 @@
     "    model_source=model_source,\n",
     "    runtime_env={\n",
     "        \"env_vars\": {\n",
-    "            \"VLLM_USE_V1\": \"0\",  # v1 doesn't support lora adapters yet\n",
     "            # \"HF_TOKEN\": os.environ.get(\"HF_TOKEN\"),\n",
     "        },\n",
     "    },\n",

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
@@ -767,7 +767,6 @@ config = vLLMEngineProcessorConfig(
     model_source=model_source,
     runtime_env={
         "env_vars": {
-            "VLLM_USE_V1": "0",  # v1 doesn't support lora adapters yet
             # "HF_TOKEN": os.environ.get("HF_TOKEN"),
         },
     },

--- a/doc/source/serve/tutorials/serve-deepseek.md
+++ b/doc/source/serve/tutorials/serve-deepseek.md
@@ -42,7 +42,6 @@ llm_config = LLMConfig(
     },
     # Change to the accelerator type of the node
     accelerator_type="H100",
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     # Customize engine arguments as needed (e.g. vLLM engine kwargs)
     engine_kwargs={
         "tensor_parallel_size": 8,
@@ -78,9 +77,6 @@ applications:
           autoscaling_config:
             min_replicas: 1
             max_replicas: 1
-        runtime_env:
-          env_vars:
-            VLLM_USE_V1: "1"
         engine_kwargs:
           tensor_parallel_size: 8
           pipeline_parallel_size: 2

--- a/release/llm_tests/serve/benchmark/benchmark_vllm.py
+++ b/release/llm_tests/serve/benchmark/benchmark_vllm.py
@@ -242,7 +242,7 @@ def main(pargs):
         "service_name": "",
         "py_version": f"py{sys.version_info.major}{sys.version_info.minor}",
         "tag": tag,
-        "vllm_engine": f"V{os.environ.get('VLLM_USE_V1', '')}",
+        "vllm_engine": "V1",  # vLLM V1 is now the default
     }
 
     # Post the results to S3

--- a/release/llm_tests/serve/test_llm_serve_fault_tolerance.py
+++ b/release/llm_tests/serve/test_llm_serve_fault_tolerance.py
@@ -27,7 +27,6 @@ def get_llm_config(
             tensor_parallel_size=tensor_parallel_size,
             enforce_eager=True,
         ),
-        runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     )
 
 


### PR DESCRIPTION
## Summary

VLLM V1 engine has been the default for some time. This PR removes outdated `VLLM_USE_V1` environment variable configurations from documentation and examples where it was used to explicitly enable V1.

## Changes

Removed `VLLM_USE_V1` from:
- `doc/source/serve/tutorials/serve-deepseek.md` (2 occurrences)
- `doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md` (1 occurrence)
- `doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py`
- `doc/source/ray-overview/examples/entity-recognition-with-llms/README.md`
- `doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb`
- `release/llm_tests/serve/test_llm_serve_fault_tolerance.py`
- `release/llm_tests/serve/benchmark/benchmark_vllm.py` (updated to always report V1)

Note: Code logic in `python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py` is intentionally kept as it handles backward compatibility.

## Test plan

- [x] Verified no VLLM_USE_V1 references remain in docs except code logic
- [ ] CI tests pass

Fixes #61892