### PR TITLE
[Autoscaler][v2] Fix instance_type_name in autoscaling state

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/config.py
+++ b/python/ray/autoscaler/v2/instance_manager/config.py
@@ -309,7 +309,9 @@ class AutoscalingConfig:
 
     def get_provider_instance_type(self, ray_node_type: NodeType) -> str:
         provider = self.provider
-        node_config = self.get_node_type_specific_config(ray_node_type, "node_config")
+        node_config = (
+            self.get_node_type_specific_config(ray_node_type, "node_config") or {}
+        )
         if provider in [Provider.AWS, Provider.ALIYUN]:
             return node_config.get("InstanceType", "")
         elif provider == Provider.AZURE:

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -307,7 +307,9 @@ class Reconciler:
             )
 
         Reconciler._fill_autoscaling_state(
-            instance_manager=instance_manager, autoscaling_state=autoscaling_state
+            instance_manager=instance_manager,
+            autoscaling_state=autoscaling_state,
+            autoscaling_config=autoscaling_config,
         )
 
     #######################################################
@@ -1313,7 +1315,16 @@ class Reconciler:
     def _fill_autoscaling_state(
         instance_manager: InstanceManager,
         autoscaling_state: AutoscalingState,
+        autoscaling_config: AutoscalingConfig,
     ) -> None:
+        provider_instance_type_map: Dict[str, str] = {}
+
+        def get_provider_instance_type(instance_type: str) -> str:
+            if instance_type not in provider_instance_type_map:
+                provider_instance_type_map[
+                    instance_type
+                ] = autoscaling_config.get_provider_instance_type(instance_type)
+            return provider_instance_type_map[instance_type]
 
         # Use the IM instance version for the autoscaler_state_version
         instances, version = Reconciler._get_im_instances(instance_manager)
@@ -1351,6 +1362,7 @@ class Reconciler:
             for instance_type, count in num_instances_by_type.items():
                 autoscaling_state.pending_instance_requests.append(
                     PendingInstanceRequest(
+                        instance_type_name=get_provider_instance_type(instance_type),
                         ray_node_type_name=instance_type,
                         count=int(count),
                         request_ts=int(request_time_ns // 1e9),
@@ -1362,13 +1374,15 @@ class Reconciler:
             instances_by_status[IMInstance.ALLOCATED]
             + instances_by_status[IMInstance.RAY_INSTALLING]
         ):
-
             status_history = sorted(
                 instance.status_history, key=lambda x: x.timestamp_ns, reverse=True
             )
             autoscaling_state.pending_instances.append(
                 PendingInstance(
                     instance_id=instance.instance_id,
+                    instance_type_name=get_provider_instance_type(
+                        instance.instance_type
+                    ),
                     ray_node_type_name=instance.instance_type,
                     details=status_history[0].details,
                 )
@@ -1390,6 +1404,9 @@ class Reconciler:
             )
             autoscaling_state.failed_instance_requests.append(
                 FailedInstanceRequest(
+                    instance_type_name=get_provider_instance_type(
+                        instance.instance_type
+                    ),
                     ray_node_type_name=instance.instance_type,
                     start_ts=int(request_time // 1e9),
                     failed_ts=int(

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -1317,14 +1317,8 @@ class Reconciler:
         autoscaling_state: AutoscalingState,
         autoscaling_config: AutoscalingConfig,
     ) -> None:
-        provider_instance_type_map: Dict[str, str] = {}
-
         def get_provider_instance_type(instance_type: str) -> str:
-            if instance_type not in provider_instance_type_map:
-                provider_instance_type_map[
-                    instance_type
-                ] = autoscaling_config.get_provider_instance_type(instance_type)
-            return provider_instance_type_map[instance_type]
+            return autoscaling_config.get_provider_instance_type(instance_type)
 
         # Use the IM instance version for the autoscaler_state_version
         instances, version = Reconciler._get_im_instances(instance_manager)

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -83,9 +83,12 @@ class MockAutoscalingConfig:
     def get_idle_timeout_s(self):
         return self._configs.get("idle_timeout_s", 999)
 
+    def get_provider_instance_type(self, ray_node_type):
+        return self._configs.get("provider_instance_types", {}).get(ray_node_type, "")
+
     @property
     def provider(self):
-        return Provider.UNKNOWN
+        return self._configs.get("provider", Provider.UNKNOWN)
 
 
 class MockScheduler(IResourceScheduler):
@@ -1441,6 +1444,13 @@ class TestReconciler:
             autoscaling_config=MockAutoscalingConfig(
                 configs={
                     "max_concurrent_launches": 0,  # don't launch anything.
+                    "provider_instance_types": {
+                        "type-1": "m5.large",
+                        "type-2": "m5.xlarge",
+                        "type-3": "c5.large",
+                        "type-4": "g5.xlarge",
+                        "type-5": "r5.large",
+                    },
                 }
             ),
         )
@@ -1449,16 +1459,29 @@ class TestReconciler:
         assert len(autoscaling_state.infeasible_gang_resource_requests) == 1
         assert len(autoscaling_state.infeasible_resource_requests) == 1
         assert len(autoscaling_state.pending_instances) == 2
-        pending_instances = {i.instance_id for i in autoscaling_state.pending_instances}
-        assert pending_instances == {"i-1", "i-5"}
+        pending_instances = {
+            (i.instance_id, i.instance_type_name, i.ray_node_type_name)
+            for i in autoscaling_state.pending_instances
+        }
+        assert pending_instances == {
+            ("i-1", "m5.large", "type-1"),
+            ("i-5", "r5.large", "type-5"),
+        }
         pending_instance_requests = defaultdict(int)
         for r in autoscaling_state.pending_instance_requests:
-            pending_instance_requests[r.ray_node_type_name] += r.count
+            pending_instance_requests[
+                (r.instance_type_name, r.ray_node_type_name)
+            ] += r.count
         failed_instance_requests = defaultdict(int)
         for r in autoscaling_state.failed_instance_requests:
-            failed_instance_requests[r.ray_node_type_name] += r.count
-        assert pending_instance_requests == {"type-2": 1, "type-3": 1}
-        assert failed_instance_requests == {"type-4": 1}
+            failed_instance_requests[
+                (r.instance_type_name, r.ray_node_type_name)
+            ] += r.count
+        assert pending_instance_requests == {
+            ("m5.xlarge", "type-2"): 1,
+            ("c5.large", "type-3"): 1,
+        }
+        assert failed_instance_requests == {("g5.xlarge", "type-4"): 1}
 
     @staticmethod
     def test_extra_cloud_instances_cloud_provider(setup):


### PR DESCRIPTION
## Description
Populate `instance_type_name` in the autoscaling state generated by the v2 reconciler.

Previously `_fill_autoscaling_state()` only populated `ray_node_type_name` for pending instance requests, pending instances, and failed instance requests. As a result, downstream consumers could observe empty provider instance types in parsed autoscaler status.

Use `autoscaling_config.get_provider_instance_type()` to fill `instance_type_name`.


## Related issues
https://github.com/ray-project/ray/issues/62100

