### PR TITLE
[data][llm] Fix SGLangEngineProcessor telemetry for trust_remote_code models

### DIFF
--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -235,13 +235,15 @@ def build_sglang_engine_processor(
             model_path_or_id,
             trust_remote_code=trust_remote_code,
         )
-    except Exception:
+    except OSError as e:
         # Failed to retrieve HuggingFace config for telemetry purposes.
         # This is non-fatal: we fall back to DEFAULT_MODEL_ARCHITECTURE for telemetry.
         # The actual model loading happens later in SGLang, which may support models
         # that aren't available via HuggingFace's AutoConfig.
         logger.warning(
-            f"Failed to retrieve HuggingFace config for {config.model_source}"
+            "Failed to retrieve HuggingFace config for %s: %s",
+            config.model_source,
+            e,
         )
         hf_config = None
 

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -222,7 +222,7 @@ def build_sglang_engine_processor(
         if trust_remote_code
         else NodeModelDownloadable.TOKENIZER_ONLY
     )
-    model_path = download_model_files(
+    model_path_or_id = download_model_files(
         model_id=config.model_source,
         mirror_config=None,
         download_model=download_mode,
@@ -231,7 +231,7 @@ def build_sglang_engine_processor(
 
     try:
         hf_config = transformers.AutoConfig.from_pretrained(
-            model_path,
+            model_path_or_id,
             trust_remote_code=trust_remote_code,
         )
         architectures = getattr(hf_config, "architectures", [])

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -37,6 +37,10 @@ from ray.llm._internal.batch.stages.configs import (
     resolve_stage_config,
 )
 from ray.llm._internal.common.observability.telemetry_utils import DEFAULT_GPU_TYPE
+from ray.llm._internal.common.utils.download_utils import (
+    NodeModelDownloadable,
+    download_model_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -211,8 +215,36 @@ def build_sglang_engine_processor(
             )
         )
 
-    hf_config = transformers.AutoConfig.from_pretrained(config.model_source)
-    architecture = getattr(hf_config, "architectures", [DEFAULT_MODEL_ARCHITECTURE])[0]
+    # Download model files first if trust_remote_code is enabled,
+    # so that custom architecture .py config files are available locally.
+    download_mode = (
+        NodeModelDownloadable.EXCLUDE_SAFETENSORS
+        if trust_remote_code
+        else NodeModelDownloadable.TOKENIZER_ONLY
+    )
+    model_path = download_model_files(
+        model_id=config.model_source,
+        mirror_config=None,
+        download_model=download_mode,
+        download_extra_files=False,
+    )
+
+    try:
+        hf_config = transformers.AutoConfig.from_pretrained(
+            model_path,
+            trust_remote_code=trust_remote_code,
+        )
+        architectures = getattr(hf_config, "architectures", [])
+        architecture = architectures[0] if architectures else DEFAULT_MODEL_ARCHITECTURE
+    except Exception:
+        # Failed to retrieve HuggingFace config for telemetry purposes.
+        # This is non-fatal: we fall back to DEFAULT_MODEL_ARCHITECTURE for telemetry.
+        # The actual model loading happens later in SGLang, which may support models
+        # that aren't available via HuggingFace's AutoConfig.
+        logger.warning(
+            f"Failed to retrieve HuggingFace config for {config.model_source}"
+        )
+        architecture = DEFAULT_MODEL_ARCHITECTURE
 
     telemetry_agent = get_or_create_telemetry_agent()
     telemetry_agent.push_telemetry_report(

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -218,19 +218,19 @@ def build_sglang_engine_processor(
     # Download model files for telemetry before engine init.
     # Use EXCLUDE_SAFETENSORS for trust_remote_code models so custom .py config
     # files are available locally.
-    download_mode = (
-        NodeModelDownloadable.EXCLUDE_SAFETENSORS
-        if trust_remote_code
-        else NodeModelDownloadable.TOKENIZER_ONLY
-    )
-    model_path_or_id = download_model_files(
-        model_id=config.model_source,
-        mirror_config=None,
-        download_model=download_mode,
-        download_extra_files=False,
-    )
-
     try:
+        download_mode = (
+            NodeModelDownloadable.EXCLUDE_SAFETENSORS
+            if trust_remote_code
+            else NodeModelDownloadable.TOKENIZER_ONLY
+        )
+        model_path_or_id = download_model_files(
+            model_id=config.model_source,
+            mirror_config=None,
+            download_model=download_mode,
+            download_extra_files=False,
+        )
+
         hf_config = transformers.AutoConfig.from_pretrained(
             model_path_or_id,
             trust_remote_code=trust_remote_code,

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -215,8 +215,9 @@ def build_sglang_engine_processor(
             )
         )
 
-    # Download model files first if trust_remote_code is enabled,
-    # so that custom architecture .py config files are available locally.
+    # Download model files for telemetry before engine init.
+    # Use EXCLUDE_SAFETENSORS for trust_remote_code models so custom .py config
+    # files are available locally.
     download_mode = (
         NodeModelDownloadable.EXCLUDE_SAFETENSORS
         if trust_remote_code
@@ -234,8 +235,6 @@ def build_sglang_engine_processor(
             model_path_or_id,
             trust_remote_code=trust_remote_code,
         )
-        architectures = getattr(hf_config, "architectures", [])
-        architecture = architectures[0] if architectures else DEFAULT_MODEL_ARCHITECTURE
     except Exception:
         # Failed to retrieve HuggingFace config for telemetry purposes.
         # This is non-fatal: we fall back to DEFAULT_MODEL_ARCHITECTURE for telemetry.
@@ -244,7 +243,10 @@ def build_sglang_engine_processor(
         logger.warning(
             f"Failed to retrieve HuggingFace config for {config.model_source}"
         )
-        architecture = DEFAULT_MODEL_ARCHITECTURE
+        hf_config = None
+
+    architectures = getattr(hf_config, "architectures", [])
+    architecture = architectures[0] if architectures else DEFAULT_MODEL_ARCHITECTURE
 
     telemetry_agent = get_or_create_telemetry_agent()
     telemetry_agent.push_telemetry_report(

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -235,7 +235,7 @@ def build_sglang_engine_processor(
             model_path_or_id,
             trust_remote_code=trust_remote_code,
         )
-    except OSError as e:
+    except Exception as e:
         # Failed to retrieve HuggingFace config for telemetry purposes.
         # This is non-fatal: we fall back to DEFAULT_MODEL_ARCHITECTURE for telemetry.
         # The actual model loading happens later in SGLang, which may support models

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -74,6 +74,7 @@ def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):
         "num_gpus": 4,  # Based on tp_size=2, dp_size=2 in engine_kwargs
     }
 
+
 class TestSGLangEngineProcessorConfig:
     @pytest.mark.parametrize(
         "experimental_config",
@@ -117,6 +118,7 @@ class TestSGLangEngineProcessorConfig:
 
         processor = build_sglang_engine_processor(config)
         assert processor is not None
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -1,4 +1,5 @@
 """This test suite does not need sglang to be installed."""
+
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -110,6 +111,140 @@ class TestSGLangEngineProcessorConfig:
                     call_kwargs["max_tasks_in_flight_per_actor"]
                     == DEFAULT_MAX_TASKS_IN_FLIGHT
                 )
+
+
+class TestSGLangTelemetryTrustRemoteCode:
+    """Tests for SGLang telemetry initialization with trust_remote_code support.
+
+    Covers the fix for https://github.com/ray-project/ray/issues/62075:
+    when trust_remote_code=True is set in engine_kwargs, telemetry should
+    still initialise correctly rather than raising an exception.
+    """
+
+    _MODULE = "ray.llm._internal.batch.processor.sglang_engine_proc"
+
+    def _build_config(self, trust_remote_code: bool = False):
+        return SGLangEngineProcessorConfig(
+            model_source="unsloth/Llama-3.2-1B-Instruct",
+            engine_kwargs={"trust_remote_code": trust_remote_code},
+        )
+
+    def test_download_model_files_called_with_exclude_safetensors_when_trust_remote_code(
+        self,
+    ):
+        """download_model_files should use EXCLUDE_SAFETENSORS mode when
+        trust_remote_code=True so that custom architecture .py files are
+        available locally before AutoConfig.from_pretrained is called."""
+        from ray.llm._internal.common.utils.download_utils import NodeModelDownloadable
+
+        with (
+            patch(f"{self._MODULE}.download_model_files") as mock_download,
+            patch(f"{self._MODULE}.transformers") as mock_transformers,
+            patch(f"{self._MODULE}.get_or_create_telemetry_agent"),
+        ):
+            mock_download.return_value = "/tmp/fake_model"
+            mock_hf_config = MagicMock()
+            mock_hf_config.architectures = ["MiniMaxM2ForCausalLM"]
+            mock_transformers.AutoConfig.from_pretrained.return_value = mock_hf_config
+
+            config = self._build_config(trust_remote_code=True)
+            from ray.llm._internal.batch.processor.sglang_engine_proc import (
+                build_sglang_engine_processor,
+            )
+
+            build_sglang_engine_processor(config)
+
+            mock_download.assert_called_once()
+            call_kwargs = mock_download.call_args[1]
+            assert (
+                call_kwargs["download_model"]
+                == NodeModelDownloadable.EXCLUDE_SAFETENSORS
+            )
+
+    def test_download_model_files_called_with_tokenizer_only_when_no_trust_remote_code(
+        self,
+    ):
+        """download_model_files should use TOKENIZER_ONLY mode when
+        trust_remote_code=False (the default)."""
+        from ray.llm._internal.common.utils.download_utils import NodeModelDownloadable
+
+        with (
+            patch(f"{self._MODULE}.download_model_files") as mock_download,
+            patch(f"{self._MODULE}.transformers") as mock_transformers,
+            patch(f"{self._MODULE}.get_or_create_telemetry_agent"),
+        ):
+            mock_download.return_value = "unsloth/Llama-3.2-1B-Instruct"
+            mock_hf_config = MagicMock()
+            mock_hf_config.architectures = ["LlamaForCausalLM"]
+            mock_transformers.AutoConfig.from_pretrained.return_value = mock_hf_config
+
+            config = self._build_config(trust_remote_code=False)
+            from ray.llm._internal.batch.processor.sglang_engine_proc import (
+                build_sglang_engine_processor,
+            )
+
+            build_sglang_engine_processor(config)
+
+            mock_download.assert_called_once()
+            call_kwargs = mock_download.call_args[1]
+            assert call_kwargs["download_model"] == NodeModelDownloadable.TOKENIZER_ONLY
+
+    def test_trust_remote_code_passed_to_autoconfig(self):
+        """trust_remote_code from engine_kwargs must be forwarded to
+        AutoConfig.from_pretrained so that custom tokeniser/config code runs."""
+        with (
+            patch(f"{self._MODULE}.download_model_files") as mock_download,
+            patch(f"{self._MODULE}.transformers") as mock_transformers,
+            patch(f"{self._MODULE}.get_or_create_telemetry_agent"),
+        ):
+            fake_path = "/tmp/fake_trust_model"
+            mock_download.return_value = fake_path
+            mock_hf_config = MagicMock()
+            mock_hf_config.architectures = ["CustomArch"]
+            mock_transformers.AutoConfig.from_pretrained.return_value = mock_hf_config
+
+            config = self._build_config(trust_remote_code=True)
+            from ray.llm._internal.batch.processor.sglang_engine_proc import (
+                build_sglang_engine_processor,
+            )
+
+            build_sglang_engine_processor(config)
+
+            mock_transformers.AutoConfig.from_pretrained.assert_called_once_with(
+                fake_path,
+                trust_remote_code=True,
+            )
+
+    def test_telemetry_falls_back_to_default_architecture_on_autoconfig_error(
+        self,
+    ):
+        """If AutoConfig.from_pretrained raises (e.g. unsupported model), the
+        processor must still be built successfully and telemetry must record
+        DEFAULT_MODEL_ARCHITECTURE instead of propagating the exception."""
+        from ray.llm._internal.batch.processor.sglang_engine_proc import (
+            DEFAULT_MODEL_ARCHITECTURE,
+            build_sglang_engine_processor,
+        )
+
+        with (
+            patch(f"{self._MODULE}.download_model_files") as mock_download,
+            patch(f"{self._MODULE}.transformers") as mock_transformers,
+            patch(f"{self._MODULE}.get_or_create_telemetry_agent") as mock_telemetry,
+        ):
+            mock_download.return_value = "/tmp/unsupported_model"
+            mock_transformers.AutoConfig.from_pretrained.side_effect = OSError(
+                "model config not found"
+            )
+            mock_agent = MagicMock()
+            mock_telemetry.return_value = mock_agent
+
+            config = self._build_config(trust_remote_code=True)
+            # Should not raise.
+            build_sglang_engine_processor(config)
+
+            mock_agent.push_telemetry_report.assert_called_once()
+            report = mock_agent.push_telemetry_report.call_args[0][0]
+            assert report.model_architecture == DEFAULT_MODEL_ARCHITECTURE
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -109,52 +109,14 @@ class TestSGLangEngineProcessorConfig:
                     == DEFAULT_MAX_TASKS_IN_FLIGHT
                 )
 
-class TestSGLangTelemetryTrustRemoteCode:
-    """Tests for SGLang telemetry initialization with trust_remote_code support.
-
-    Covers the fix for https://github.com/ray-project/ray/issues/62075:
-    when trust_remote_code=True is set in engine_kwargs, telemetry should
-    still initialise correctly rather than raising an exception.
-    """
-
-    def _build_config(self, trust_remote_code: bool = False):
-        return SGLangEngineProcessorConfig(
-            model_source="unsloth/Llama-3.2-1B-Instruct",
-            engine_kwargs={"trust_remote_code": trust_remote_code},
-        )
-
-    def test_build_processor_autoconfig_failure(self):
-        """AutoConfig failure is non-fatal; processor builds successfully.
-        Follows vLLM pattern: no mocks, real code path with nonexistent model."""
+    def test_build_processor_autoconfig_failure_with_trust_remote_code(self):
         config = SGLangEngineProcessorConfig(
             model_source="nonexistent-org/nonexistent-model",
+            engine_kwargs={"trust_remote_code": True},
         )
+
         processor = build_sglang_engine_processor(config)
         assert processor is not None
-
-    def test_trust_remote_code_passed_to_autoconfig(self):
-        """trust_remote_code from engine_kwargs forwarded to AutoConfig."""
-        fake_path = "/tmp/fake_trust_model"
-
-        with (
-            patch(
-                "ray.llm._internal.batch.processor.sglang_engine_proc.download_model_files",
-                return_value=fake_path,
-            ),
-            patch(
-                "transformers.AutoConfig.from_pretrained",
-            ) as mock_autoconfig,
-            patch(
-                "ray.llm._internal.batch.processor.sglang_engine_proc.get_or_create_telemetry_agent",
-            ),
-        ):
-            config = self._build_config(trust_remote_code=True)
-            build_sglang_engine_processor(config)
-
-            mock_autoconfig.assert_called_once_with(
-                fake_path,
-                trust_remote_code=True,
-            )
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -119,6 +119,28 @@ class TestSGLangEngineProcessorConfig:
         processor = build_sglang_engine_processor(config)
         assert processor is not None
 
+    def test_build_processor_import_error_with_trust_remote_code(self):
+        config = SGLangEngineProcessorConfig(
+            model_source="org/model-with-custom-code",
+            engine_kwargs={"trust_remote_code": True},
+        )
+
+        with (
+            patch(
+                "ray.llm._internal.batch.processor.sglang_engine_proc."
+                "download_model_files",
+                return_value="/tmp/fake_model_dir",
+            ),
+            patch(
+                "ray.llm._internal.batch.processor.sglang_engine_proc."
+                "transformers.AutoConfig.from_pretrained",
+                side_effect=ModuleNotFoundError("custom modeling module missing"),
+            ),
+        ):
+            processor = build_sglang_engine_processor(config)
+
+        assert processor is not None
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -9,6 +9,10 @@ import ray
 from ray.data.llm import SGLangEngineProcessorConfig
 from ray.llm._internal.batch.constants import SGLangTaskType
 from ray.llm._internal.batch.processor import ProcessorBuilder
+from ray.llm._internal.batch.processor.base import DEFAULT_MAX_TASKS_IN_FLIGHT
+from ray.llm._internal.batch.processor.sglang_engine_proc import (
+    build_sglang_engine_processor,
+)
 
 
 def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):
@@ -70,7 +74,6 @@ def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):
         "num_gpus": 4,  # Based on tp_size=2, dp_size=2 in engine_kwargs
     }
 
-
 class TestSGLangEngineProcessorConfig:
     @pytest.mark.parametrize(
         "experimental_config",
@@ -83,12 +86,6 @@ class TestSGLangEngineProcessorConfig:
         self, experimental_config
     ):
         """Tests that max_tasks_in_flight_per_actor is set properly in the ActorPoolStrategy."""
-
-        from ray.llm._internal.batch.processor.base import DEFAULT_MAX_TASKS_IN_FLIGHT
-        from ray.llm._internal.batch.processor.sglang_engine_proc import (
-            SGLangEngineProcessorConfig,
-            build_sglang_engine_processor,
-        )
 
         with patch("ray.data.ActorPoolStrategy") as mock_actor_pool:
             mock_actor_pool.return_value = MagicMock()
@@ -112,7 +109,6 @@ class TestSGLangEngineProcessorConfig:
                     == DEFAULT_MAX_TASKS_IN_FLIGHT
                 )
 
-
 class TestSGLangTelemetryTrustRemoteCode:
     """Tests for SGLang telemetry initialization with trust_remote_code support.
 
@@ -121,131 +117,44 @@ class TestSGLangTelemetryTrustRemoteCode:
     still initialise correctly rather than raising an exception.
     """
 
-    _MODULE = "ray.llm._internal.batch.processor.sglang_engine_proc"
-
     def _build_config(self, trust_remote_code: bool = False):
         return SGLangEngineProcessorConfig(
             model_source="unsloth/Llama-3.2-1B-Instruct",
             engine_kwargs={"trust_remote_code": trust_remote_code},
         )
 
-    def test_download_model_files_called_with_exclude_safetensors_when_trust_remote_code(
-        self,
-    ):
-        """download_model_files should use EXCLUDE_SAFETENSORS mode when
-        trust_remote_code=True so that custom architecture .py files are
-        available locally before AutoConfig.from_pretrained is called."""
-        from ray.llm._internal.common.utils.download_utils import NodeModelDownloadable
-
-        with (
-            patch(f"{self._MODULE}.download_model_files") as mock_download,
-            patch(f"{self._MODULE}.transformers") as mock_transformers,
-            patch(f"{self._MODULE}.get_or_create_telemetry_agent"),
-        ):
-            mock_download.return_value = "/tmp/fake_model"
-            mock_hf_config = MagicMock()
-            mock_hf_config.architectures = ["MiniMaxM2ForCausalLM"]
-            mock_transformers.AutoConfig.from_pretrained.return_value = mock_hf_config
-
-            config = self._build_config(trust_remote_code=True)
-            from ray.llm._internal.batch.processor.sglang_engine_proc import (
-                build_sglang_engine_processor,
-            )
-
-            build_sglang_engine_processor(config)
-
-            mock_download.assert_called_once()
-            call_kwargs = mock_download.call_args[1]
-            assert (
-                call_kwargs["download_model"]
-                == NodeModelDownloadable.EXCLUDE_SAFETENSORS
-            )
-
-    def test_download_model_files_called_with_tokenizer_only_when_no_trust_remote_code(
-        self,
-    ):
-        """download_model_files should use TOKENIZER_ONLY mode when
-        trust_remote_code=False (the default)."""
-        from ray.llm._internal.common.utils.download_utils import NodeModelDownloadable
-
-        with (
-            patch(f"{self._MODULE}.download_model_files") as mock_download,
-            patch(f"{self._MODULE}.transformers") as mock_transformers,
-            patch(f"{self._MODULE}.get_or_create_telemetry_agent"),
-        ):
-            mock_download.return_value = "unsloth/Llama-3.2-1B-Instruct"
-            mock_hf_config = MagicMock()
-            mock_hf_config.architectures = ["LlamaForCausalLM"]
-            mock_transformers.AutoConfig.from_pretrained.return_value = mock_hf_config
-
-            config = self._build_config(trust_remote_code=False)
-            from ray.llm._internal.batch.processor.sglang_engine_proc import (
-                build_sglang_engine_processor,
-            )
-
-            build_sglang_engine_processor(config)
-
-            mock_download.assert_called_once()
-            call_kwargs = mock_download.call_args[1]
-            assert call_kwargs["download_model"] == NodeModelDownloadable.TOKENIZER_ONLY
+    def test_build_processor_autoconfig_failure(self):
+        """AutoConfig failure is non-fatal; processor builds successfully.
+        Follows vLLM pattern: no mocks, real code path with nonexistent model."""
+        config = SGLangEngineProcessorConfig(
+            model_source="nonexistent-org/nonexistent-model",
+        )
+        processor = build_sglang_engine_processor(config)
+        assert processor is not None
 
     def test_trust_remote_code_passed_to_autoconfig(self):
-        """trust_remote_code from engine_kwargs must be forwarded to
-        AutoConfig.from_pretrained so that custom tokeniser/config code runs."""
+        """trust_remote_code from engine_kwargs forwarded to AutoConfig."""
+        fake_path = "/tmp/fake_trust_model"
+
         with (
-            patch(f"{self._MODULE}.download_model_files") as mock_download,
-            patch(f"{self._MODULE}.transformers") as mock_transformers,
-            patch(f"{self._MODULE}.get_or_create_telemetry_agent"),
+            patch(
+                "ray.llm._internal.batch.processor.sglang_engine_proc.download_model_files",
+                return_value=fake_path,
+            ),
+            patch(
+                "transformers.AutoConfig.from_pretrained",
+            ) as mock_autoconfig,
+            patch(
+                "ray.llm._internal.batch.processor.sglang_engine_proc.get_or_create_telemetry_agent",
+            ),
         ):
-            fake_path = "/tmp/fake_trust_model"
-            mock_download.return_value = fake_path
-            mock_hf_config = MagicMock()
-            mock_hf_config.architectures = ["CustomArch"]
-            mock_transformers.AutoConfig.from_pretrained.return_value = mock_hf_config
-
             config = self._build_config(trust_remote_code=True)
-            from ray.llm._internal.batch.processor.sglang_engine_proc import (
-                build_sglang_engine_processor,
-            )
-
             build_sglang_engine_processor(config)
 
-            mock_transformers.AutoConfig.from_pretrained.assert_called_once_with(
+            mock_autoconfig.assert_called_once_with(
                 fake_path,
                 trust_remote_code=True,
             )
-
-    def test_telemetry_falls_back_to_default_architecture_on_autoconfig_error(
-        self,
-    ):
-        """If AutoConfig.from_pretrained raises (e.g. unsupported model), the
-        processor must still be built successfully and telemetry must record
-        DEFAULT_MODEL_ARCHITECTURE instead of propagating the exception."""
-        from ray.llm._internal.batch.processor.sglang_engine_proc import (
-            DEFAULT_MODEL_ARCHITECTURE,
-            build_sglang_engine_processor,
-        )
-
-        with (
-            patch(f"{self._MODULE}.download_model_files") as mock_download,
-            patch(f"{self._MODULE}.transformers") as mock_transformers,
-            patch(f"{self._MODULE}.get_or_create_telemetry_agent") as mock_telemetry,
-        ):
-            mock_download.return_value = "/tmp/unsupported_model"
-            mock_transformers.AutoConfig.from_pretrained.side_effect = OSError(
-                "model config not found"
-            )
-            mock_agent = MagicMock()
-            mock_telemetry.return_value = mock_agent
-
-            config = self._build_config(trust_remote_code=True)
-            # Should not raise.
-            build_sglang_engine_processor(config)
-
-            mock_agent.push_telemetry_report.assert_called_once()
-            report = mock_agent.push_telemetry_report.call_args[0][0]
-            assert report.model_architecture == DEFAULT_MODEL_ARCHITECTURE
-
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -141,6 +141,21 @@ class TestSGLangEngineProcessorConfig:
 
         assert processor is not None
 
+    def test_build_processor_download_error_with_trust_remote_code(self):
+        config = SGLangEngineProcessorConfig(
+            model_source="org/model-with-custom-code",
+            engine_kwargs={"trust_remote_code": True},
+        )
+
+        with patch(
+            "ray.llm._internal.batch.processor.sglang_engine_proc."
+            "download_model_files",
+            side_effect=RuntimeError("download failed"),
+        ):
+            processor = build_sglang_engine_processor(config)
+
+        assert processor is not None
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description
Fixes #62075

When using models with `trust_remote_code=True` (e.g., MiniMax-M2.1), the telemetry initialization fails because:
1. `AutoConfig.from_pretrained()` was not passing `trust_remote_code`
2. Model files weren't downloaded first (Python configs unavailable)
3. No error handling - failure crashed entire processor build

## Fix
1. Call `download_model_files()` before `AutoConfig.from_pretrained()`
2. Use `EXCLUDE_SAFETENSORS` mode when `trust_remote_code=True` to download custom architecture .py config files
3. Pass `trust_remote_code` from `engine_kwargs` to `AutoConfig.from_pretrained()`
4. Wrap in try/except, fall back to `DEFAULT_MODEL_ARCHITECTURE` on failure

This matches the fix applied to vLLM processor in PR #60344.

## Files Changed
- `python/ray/llm/_internal/batch/processor/sglang_engine_proc.py`

## Testing
- Code follows same pattern as vLLM processor fix (PR #60344)
- No behavioral change for non-trust_remote_code models