### PR TITLE
[Data] Revisiting hashing method of Pyarrow schemas to improve perf

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -12,7 +12,6 @@ from ray.data.block import (
     BlockAccessor,
     BlockMetadata,
     Schema,
-    _make_hashable_schema,
 )
 from ray.data.context import DataContext
 from ray.types import ObjectRef

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -377,7 +377,8 @@ class RefBundle:
     def __hash__(self) -> int:
         return hash(
             (
-                *self.blocks,
+                # Only hash block refs
+                *[b for b, _ in self.blocks],
                 *self.slices,
                 # Check out comment in ``__eq__``
                 id(self.schema),

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -365,10 +365,12 @@ class RefBundle:
         return (
             self.blocks == other.blocks
             and self.slices == other.slices
-            and (
-                (self.schema is None and other.schema is None) or
-                (self.schema is not None and other.schema is not None and self.schema.equals(other.schema, check_metadata=False))
-            )
+            # NOTE: We're establishing a requirement of schemas for `RefBundle`
+            #       to be exactly the same object for it to be considered equal.
+            #
+            #       This is necessary to avoid a full schema equality check that
+            #       is computationally intensive.
+            and self.schema is other.schema
             and self.owns_blocks == other.owns_blocks
             and self.output_split_idx == other.output_split_idx
         )
@@ -378,7 +380,8 @@ class RefBundle:
             (
                 *self.blocks,
                 *self.slices,
-                _make_hashable_schema(self.schema) if self.schema is not None else None,
+                # Check out comment in ``__eq__``
+                id(self.schema),
                 self.owns_blocks,
                 self.output_split_idx,
             )

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -365,7 +365,7 @@ class RefBundle:
         return (
             self.blocks == other.blocks
             and self.slices == other.slices
-            and self.schema == other.schema
+            and ((self.schema is None and other.schema is None) or self.schema.equals(other, check_metadata=False))
             and self.owns_blocks == other.owns_blocks
             and self.output_split_idx == other.output_split_idx
         )

--- a/python/ray/data/_internal/execution/interfaces/ref_bundle.py
+++ b/python/ray/data/_internal/execution/interfaces/ref_bundle.py
@@ -365,7 +365,10 @@ class RefBundle:
         return (
             self.blocks == other.blocks
             and self.slices == other.slices
-            and ((self.schema is None and other.schema is None) or self.schema.equals(other, check_metadata=False))
+            and (
+                (self.schema is None and other.schema is None) or
+                (self.schema is not None and other.schema is not None and self.schema.equals(other.schema, check_metadata=False))
+            )
             and self.owns_blocks == other.owns_blocks
             and self.output_split_idx == other.output_split_idx
         )

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -346,7 +346,7 @@ class PandasBlockBuilder(TableBlockBuilder):
         return BlockType.PANDAS
 
 
-# NOTE: This has to be compatible with pyarrow.lib.schema
+# NOTE: This has to be compatible with Pyarrow ``Schema``
 @dataclass(frozen=True, init=False)
 class PandasBlockSchema:
     # Stored as tuples for hash-ability.
@@ -356,6 +356,12 @@ class PandasBlockSchema:
     def __init__(self, names, types):
         object.__setattr__(self, "names", tuple(names))
         object.__setattr__(self, "types", tuple(types))
+
+    def equals(self, other, check_metadata: bool = False):
+        """NOTE: This method exists for sole purpose of making it compatible
+                 with Pyarrow's ``Schema``
+        """
+        return self == other
 
 
 class PandasBlockAccessor(TableBlockAccessor):

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -357,12 +357,6 @@ class PandasBlockSchema:
         object.__setattr__(self, "names", tuple(names))
         object.__setattr__(self, "types", tuple(types))
 
-    def equals(self, other, check_metadata: bool = False):
-        """NOTE: This method exists for sole purpose of making it compatible
-                 with Pyarrow's ``Schema``
-        """
-        return self == other
-
 
 class PandasBlockAccessor(TableBlockAccessor):
     ROW_TYPE = PandasRow

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -79,6 +79,18 @@ class ExecutionPlan:
 
         self._context = data_context
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        # Flush execution cache before serialization
+        state.pop("_cache", None)
+        return state
+
+    def __setstate__(self, state):
+        from ray.data.dataset import _ExecutionCache
+
+        self.__dict__.update(state)
+        self._cache = _ExecutionCache()
+
     def get_dataset_id(self) -> str:
         """Unique ID of the dataset, including the dataset name,
         UUID, and current execution index.

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -303,28 +303,10 @@ class BlockMetadata(BlockStats):
         )
 
 
-def _make_hashable_schema(schema: Schema) -> Tuple[Tuple[str, ...], Tuple]:
-    # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
-    #       isn't hashable. Therefore we simply drop metadata when trying
-    #       to hash the schemas
-    if isinstance(schema, pa.Schema):
-        return schema.remove_metadata()
-
-    return schema
-
-
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True)
 class BlockMetadataWithSchema(BlockMetadata):
     schema: Optional[Schema] = None
-
-    def __hash__(self):
-        return hash(
-            (
-                BlockMetadata.__hash__(self),
-                _make_hashable_schema(self.schema) if self.schema is not None else None,
-            )
-        )
 
     @staticmethod
     def from_metadata(

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -307,7 +307,10 @@ def _make_hashable_schema(schema: Schema) -> Tuple[Tuple[str, ...], Tuple]:
     # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
     #       isn't hashable. Therefore we simply drop metadata when trying
     #       to hash the schemas
-    return schema.remove_metadata()
+    if isinstance(schema, pa.Schema):
+        return schema.remove_metadata()
+
+    return schema
 
 
 @DeveloperAPI(stability="alpha")

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -305,8 +305,9 @@ class BlockMetadata(BlockStats):
 
 def _make_hashable_schema(schema: Schema) -> Tuple[Tuple[str, ...], Tuple]:
     # NOTE: Pyarrow < 23 schemas metadata contains dicts and therefore
-    #       isn't hashable
-    return (tuple(schema.names), tuple(schema.types))
+    #       isn't hashable. Therefore we simply drop metadata when trying
+    #       to hash the schemas
+    return schema.remove_metadata()
 
 
 @DeveloperAPI(stability="alpha")

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import warnings
 from datetime import datetime
+from dataclasses import replace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -501,7 +502,15 @@ def read_datasource(
     read_tasks = datasource_or_legacy_reader.get_read_tasks(requested_parallelism)
 
     stats = DatasetStats(
-        metadata={"Read": [read_task.metadata for read_task in read_tasks]},
+        metadata={
+            "Read": [
+                # NOTE: We're truncating `input_files` from metadata as it could
+                #       be carrying 1000s of input files (for `ImageDatasource` for ex)
+                #       and isn't useful inside `DatasetStats`
+                replace(read_task.metadata, input_files=None)
+                for read_task in read_tasks
+            ]
+        },
         parent=None,
     )
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1,8 +1,8 @@
 import collections
 import logging
 import warnings
-from datetime import datetime
 from dataclasses import replace
+from datetime import datetime
 from typing import (
     TYPE_CHECKING,
     Any,


### PR DESCRIPTION
## Description

This change is aiming to address following issues

 - Avoiding invoking equality/hashing on `Schema`s in `RefBundle` to reduce impact on large schemas
 - Avoid wiring `input_files` into `DatasetStats` to avoid carrying potentially large # of strings of input files (for ex, in cases of image datasets)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
