### PR TITLE
[docs][llm] Add C/C++ binaries incompatibility workaround

### DIFF
--- a/.vale/styles/config/vocabularies/Data/accept.txt
+++ b/.vale/styles/config/vocabularies/Data/accept.txt
@@ -2,6 +2,7 @@ assess_quality
 autoscaler
 [Aa]vro
 [Bb]ackpressure
+conda
 Dask
 [Dd]ata('s)?
 [Dd]atasource(s)?

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -402,12 +402,17 @@ Then reference the remote path in your config:
 
 C/C++ runtime dependencies incompatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Ray 2.55 installs vLLM 0.18.0. Depending on the Conda environment, you may encounter incompatibilities with native runtime libraries (e.g., libstdc++, CXXABI, ICU).
-In such cases, configure ``LD_LIBRARY_PATH`` to prefer the Conda environment's libraries over system libraries.
 
-.. code-block:: shell
+.. admonition:: Known issue
 
-    export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+   Ray 2.55 installs vLLM 0.18.0. Depending on the conda environment, you may encounter
+   incompatibilities with native runtime libraries (for example, ``libstdc++``, ``CXXABI``, ``ICU``).
+
+   In such cases, configure ``LD_LIBRARY_PATH`` to prefer the conda environment's libraries over system libraries.
+
+   .. code-block:: shell
+
+      export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 .. _resiliency:
 

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -399,6 +399,16 @@ Then reference the remote path in your config:
     :start-after: __s3_config_example_start__
     :end-before: __s3_config_example_end__
 
+
+C/C++ runtime dependencies incompatibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ray 2.55 installs vLLM 0.18.0. Depending on the Conda environment, you may encounter incompatibilities with native runtime libraries (e.g., libstdc++, CXXABI, ICU).
+In such cases, configure ``LD_LIBRARY_PATH`` to prefer the Conda environment's libraries over system libraries.
+
+.. code-block:: shell
+
+    export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
 .. _resiliency:
 
 Resiliency

--- a/doc/source/serve/llm/troubleshooting.md
+++ b/doc/source/serve/llm/troubleshooting.md
@@ -77,6 +77,14 @@ app = build_openai_app({"llm_configs": [llm_config]})
 serve.run(app, blocking=True)
 ```
 
+### C/C++ runtime dependencies incompatibility
+Ray 2.55 installs vLLM 0.18.0. Depending on the Conda environment, you may encounter incompatibilities with native runtime libraries (e.g., libstdc++, CXXABI, ICU).
+In such cases, configure ``LD_LIBRARY_PATH`` to prefer the Conda environment's libraries over system libraries.
+
+```shell
+export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+```
+
 ## Get help
 
 If you encounter issues not covered in this guide:

--- a/doc/source/serve/llm/troubleshooting.md
+++ b/doc/source/serve/llm/troubleshooting.md
@@ -78,12 +78,16 @@ serve.run(app, blocking=True)
 ```
 
 ### C/C++ runtime dependencies incompatibility
-Ray 2.55 installs vLLM 0.18.0. Depending on the Conda environment, you may encounter incompatibilities with native runtime libraries (e.g., libstdc++, CXXABI, ICU).
-In such cases, configure ``LD_LIBRARY_PATH`` to prefer the Conda environment's libraries over system libraries.
+
+:::{admonition} Known issue
+Ray 2.55 installs vLLM 0.18.0. Depending on the conda environment, you may encounter incompatibilities with native runtime libraries (for example, `libstdc++`, `CXXABI`, `ICU`).
+
+In such cases, configure `LD_LIBRARY_PATH` to prefer the conda environment's libraries over system libraries.
 
 ```shell
 export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 ```
+:::
 
 ## Get help
 


### PR DESCRIPTION
## Description
Ray 2.55 is about to be released with vLLM 0.18.0, and there could be C/C++ libraries incompatibilities when users install `ray[llm]` in their conda environments. We want to make sure that the mitigation is captured in docs.

Added instructions under [Ray Data LLM](https://docs.ray.io/en/latest/data/working-with-llms.html) and [Ray Serve LLM](https://docs.ray.io/en/latest/serve/llm/troubleshooting.html) troubleshooting section:
- Ray Data LLM

<img width="1483" height="627" alt="Screenshot 2026-03-26 at 2 11 27 PM" src="https://github.com/user-attachments/assets/b2a4b9f8-f40f-4d0e-9fc3-ca54a8aed8e3" />

- Ray Serve LLM

<img width="1485" height="387" alt="Screenshot 2026-03-26 at 2 12 16 PM" src="https://github.com/user-attachments/assets/434d197e-e86a-4113-84c4-72525198ea83" />


## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.

