### PR TITLE
[Data] - Align Hash Shuffle Metrics

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -365,7 +365,7 @@ def _shuffle_block(
 
         logger.debug(
             f"Shuffled block (rows={original_block_metadata.num_rows}, "
-            f"bytes={original_block_metadata.size_bytes/MiB:.1f}MB) "
+            f"bytes={original_block_metadata.size_bytes / MiB:.1f}MB) "
             f"into {len(partition_shards_stats)} partitions ("
             f"quantiles={'/'.join(map(str, quantiles))}, "
             f"rows={'/'.join(map(str, num_rows_quantiles))}, "
@@ -1020,14 +1020,16 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         self._shuffling_tasks.clear()
         self._finalizing_tasks.clear()
 
+    @property
+    def metrics(self) -> OpRuntimeMetrics:
+        # TODO figure out a better way to combine w/ finalization metrics
+        self._shuffle_metrics._extra_metrics = self._extra_metrics()
+        return self._shuffle_metrics
+
     def _extra_metrics(self):
-        shuffle_name = f"{self._name}_shuffle"
         finalize_name = f"{self._name}_finalize"
 
-        self._shuffle_metrics.as_dict()
-
         return {
-            shuffle_name: self._shuffle_metrics.as_dict(),
             finalize_name: self._reduce_metrics.as_dict(),
         }
 
@@ -1063,6 +1065,13 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                 * self._aggregator_pool._aggregator_ray_remote_args.get("memory", 0)
             ),
             object_store_memory=0,
+        )
+
+    def per_task_resource_allocation(self) -> ExecutionResources:
+        return ExecutionResources(
+            cpu=self._DEFAULT_SHUFFLE_BLOCK_NUM_CPUS,
+            object_store_memory=0,
+            gpu=0,
         )
 
     def incremental_resource_usage(self) -> ExecutionResources:
@@ -1303,7 +1312,9 @@ class HashShuffleOperator(HashShufflingOperatorBase):
 
         super().__init__(
             name_factory=(
-                lambda num_partitions: f"Shuffle(key_columns={key_columns}, num_partitions={num_partitions})"
+                lambda num_partitions: (
+                    f"Shuffle(key_columns={key_columns}, num_partitions={num_partitions})"
+                )
             ),
             input_ops=[input_op],
             data_context=data_context,
@@ -1826,7 +1837,7 @@ class HashShuffleAggregator:
                     }
 
             logger.debug(
-                f"Hash shuffle aggregator id={self._aggregator_id}, " f"state: {result}"
+                f"Hash shuffle aggregator id={self._aggregator_id}, state: {result}"
             )
 
     @staticmethod


### PR DESCRIPTION
## Description
Make finalize as an extra metric for shuffle.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
