### PR TITLE
[Data] Fix flaky test_streaming_split_invalid_iterator: replace bare asserts in _barrier() with ValueError

### DIFF
--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -366,9 +366,15 @@ class SplitCoordinator:
         # Advance to the next epoch
         self._try_start_new_epoch(starting_epoch)
 
-        assert self._output_iterator is not None
-        assert (
-            self._cur_epoch == starting_epoch + 1
-        ), f"Expected current epoch to be {starting_epoch + 1} (got {self._cur_epoch})"
+        if self._output_iterator is None:
+            raise ValueError(
+                "Invalid iterator: output iterator is not initialized. "
+                "This may indicate too many concurrent consumers."
+            )
+        if self._cur_epoch != starting_epoch + 1:
+            raise ValueError(
+                f"Invalid iterator: too many concurrent consumers detected. "
+                f"Expected epoch {starting_epoch + 1}, got {self._cur_epoch}."
+            )
 
         return self._cur_epoch


### PR DESCRIPTION
## Why

Two different invalid-consumer conditions are detected in `_barrier()` and `get()`,
but raise inconsistent error types:

```
_barrier() L369-372  ->  bare assert  ->  AssertionError   (racing through the barrier, causes flakiness)
get()      L255-258  ->  raise ValueError                  (consumer calling with a stale epoch id)
```

Both in stream_split_iterator.py. The assert in `_barrier()` fires before `get()` is 
ever reached, so `pytest.raises(ValueError)` in the test doesn't catch it and fails.

## What

Replace the two bare `assert`s in `SplitCoordinator._barrier()`
with `ValueError` to match the error type raised in `get()`.

## Related
Fixes #62119