### PR TITLE
[serve] Fix start_metrics_pusher crash when deployment has record_autoscaling_stats but no autoscaling config

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -717,7 +717,8 @@ class ReplicaMetricsManager:
         if custom_metrics_enabled:
             self._custom_metrics_enabled = custom_metrics_enabled
             self._record_autoscaling_stats_fn = record_autoscaling_stats_fn
-            self.start_metrics_pusher()
+            if self._autoscaling_config:
+                self.start_metrics_pusher()
 
     def inc_num_ongoing_requests(self, request_metadata: RequestMetadata) -> int:
         self._num_ongoing_requests += 1

--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -308,7 +308,6 @@ class TestCustomServeMetrics:
     def test_record_autoscaling_stats_without_autoscaling_config(self, serve_instance):
         """Test that record_autoscaling_stats doesn't crash when using num_replicas instead of autoscaling_config.
 
-        Regression test for: https://github.com/ray-project/ray/issues/XXXXX
         When a deployment defines record_autoscaling_stats but uses fixed num_replicas,
         the replica should start successfully without crashing.
         """

--- a/python/ray/serve/tests/test_custom_autoscaling_metrics.py
+++ b/python/ray/serve/tests/test_custom_autoscaling_metrics.py
@@ -305,6 +305,32 @@ class TestCustomServeMetrics:
 
         signal.send.remote()
 
+    def test_record_autoscaling_stats_without_autoscaling_config(self, serve_instance):
+        """Test that record_autoscaling_stats doesn't crash when using num_replicas instead of autoscaling_config.
+
+        Regression test for: https://github.com/ray-project/ray/issues/XXXXX
+        When a deployment defines record_autoscaling_stats but uses fixed num_replicas,
+        the replica should start successfully without crashing.
+        """
+
+        @serve.deployment(num_replicas=1)
+        class DeploymentWithCustomMetricsNoAutoscaling:
+            async def record_autoscaling_stats(self) -> Dict[str, float]:
+                return {"qps": 1.0}
+
+            async def __call__(self):
+                return "ok"
+
+        app_name = "test_custom_metrics_no_autoscaling"
+        handle = serve.run(
+            DeploymentWithCustomMetricsNoAutoscaling.bind(),
+            name=app_name,
+            route_prefix="/test_no_autoscaling",
+        )
+
+        response = handle.remote().result()
+        assert response == "ok"
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Fixes a crash when a deployment defines `record_autoscaling_stats()` for custom autoscaling metrics but uses fixed `num_replicas` instead of `autoscaling_config`. Previously, the replica would crash on startup with:

```
AttributeError: 'NoneType' object has no attribute 'metrics_interval_s'
```

The issue was in `enable_custom_autoscaling_metrics()` which called `start_metrics_pusher()` unconditionally when `custom_metrics_enabled=True`, but `start_metrics_pusher()` accesses `_autoscaling_config` attributes (like `metrics_interval_s` and `look_back_period_s`) without checking if it's `None`.

This fix adds a guard to check if `_autoscaling_config` exists before calling `start_metrics_pusher()`, matching the pattern already used in `set_autoscaling_config()`.

## Related issues

Fixes the issue described in this PR.

## Additional information

### Root cause

In `ray/serve/_private/replica.py`:

1. During replica init, Ray detects `record_autoscaling_stats` on the user callable and calls `enable_custom_autoscaling_metrics(custom_metrics_enabled=True, ...)`
2. `enable_custom_autoscaling_metrics()` calls `self.start_metrics_pusher()` **unconditionally** when `custom_metrics_enabled=True`
3. `start_metrics_pusher()` accesses `self._autoscaling_config.metrics_interval_s` without a None check
4. When the deployment uses `num_replicas=N` (no autoscaling), `_autoscaling_config` is `None` → crash

### The fix

Added a guard in `enable_custom_autoscaling_metrics()`:

```python
def enable_custom_autoscaling_metrics(self, custom_metrics_enabled, record_autoscaling_stats_fn):
    if custom_metrics_enabled:
        self._custom_metrics_enabled = custom_metrics_enabled
        self._record_autoscaling_stats_fn = record_autoscaling_stats_fn
        if self._autoscaling_config:  # <-- added guard
            self.start_metrics_pusher()
```

### Test added

Added a regression test that verifies deployments with `record_autoscaling_stats()` can start successfully when using `num_replicas` instead of `autoscaling_config`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ab070a1-20c6-45c9-9d80-7935c1807579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ab070a1-20c6-45c9-9d80-7935c1807579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

