### PR TITLE
Replace deprecated datetime.utcnow() and utcfromtimestamp() calls

### DIFF
--- a/python/ray/_common/tls_utils.py
+++ b/python/ray/_common/tls_utils.py
@@ -50,7 +50,7 @@ def generate_self_signed_tls_certs() -> Tuple[str, str]:
             x509.DNSName("localhost"),
         ]
     )
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     cert = (
         x509.CertificateBuilder()
         .subject_name(subject)

--- a/python/ray/autoscaler/_private/log_timer.py
+++ b/python/ray/autoscaler/_private/log_timer.py
@@ -12,13 +12,13 @@ class LogTimer:
         self._show_status = show_status
 
     def __enter__(self):
-        self._start_time = datetime.datetime.utcnow()
+        self._start_time = datetime.datetime.now(datetime.timezone.utc)
 
     def __exit__(self, *error_vals):
         if cli_logger.log_style != "record":
             return
 
-        td = datetime.datetime.utcnow() - self._start_time
+        td = datetime.datetime.now(datetime.timezone.utc) - self._start_time
         status = ""
         if self._show_status:
             status = "failed" if any(error_vals) else "succeeded"

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1124,7 +1124,7 @@ class ReporterAgent(
         return mem.shared
 
     async def _async_collect_stats(self):
-        now = dashboard_utils.to_posix_time(datetime.datetime.utcnow())
+        now = dashboard_utils.to_posix_time(datetime.datetime.now(datetime.timezone.utc))
         network_stats = self._get_network_stats()
         self._network_stats_hist.append((now, network_stats))
         network_speed_stats = self._compute_speed_from_hist(self._network_stats_hist)

--- a/python/ray/dashboard/utils.py
+++ b/python/ray/dashboard/utils.py
@@ -342,6 +342,8 @@ def get_all_modules(module_type):
 
 
 def to_posix_time(dt):
+    if dt.tzinfo is not None:
+        return dt.timestamp()
     return (dt - datetime.datetime(1970, 1, 1)).total_seconds()
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -10,7 +10,7 @@ import time
 import urllib
 import urllib.parse
 import warnings
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional, Set, Tuple
 
 import click
@@ -294,7 +294,7 @@ def debug(address: str, verbose: bool):
                 ]
             ]
             for i, data in enumerate(sessions_data):
-                date = datetime.utcfromtimestamp(data["timestamp"]).strftime(
+                date = datetime.fromtimestamp(data["timestamp"], tz=timezone.utc).strftime(
                     "%Y-%m-%d %H:%M:%S"
                 )
                 table.append(
@@ -313,7 +313,7 @@ def debug(address: str, verbose: bool):
             # Non verbose mode: no IDs.
             table = [["index", "timestamp", "Ray task", "filename:lineno"]]
             for i, data in enumerate(sessions_data):
-                date = datetime.utcfromtimestamp(data["timestamp"]).strftime(
+                date = datetime.fromtimestamp(data["timestamp"], tz=timezone.utc).strftime(
                     "%Y-%m-%d %H:%M:%S"
                 )
                 table.append(


### PR DESCRIPTION
## Why are these changes needed?

`datetime.utcnow()` and `datetime.utcfromtimestamp()` have been deprecated since Python 3.12 ([cpython#103857](https://github.com/python/cpython/issues/103857)). These methods return naive datetime objects that represent UTC time but don't carry timezone info, making them error-prone. Running with `-W error::DeprecationWarning` causes failures.

## Changes

Replace with timezone-aware alternatives:
- `datetime.utcnow()` → `datetime.now(timezone.utc)`
- `datetime.utcfromtimestamp(ts)` → `datetime.fromtimestamp(ts, tz=timezone.utc)`

Also update `dashboard.utils.to_posix_time()` to handle timezone-aware datetimes using `dt.timestamp()` when `tzinfo` is present, maintaining backward compatibility with naive datetime callers.

### Files changed
- `python/ray/_common/tls_utils.py` — TLS cert generation
- `python/ray/autoscaler/_private/log_timer.py` — autoscaler log timing
- `python/ray/scripts/scripts.py` — debug CLI timestamp display
- `python/ray/dashboard/modules/reporter/reporter_agent.py` — stats collection
- `python/ray/dashboard/utils.py` — `to_posix_time` utility

## Related issue number

N/A — proactive deprecation cleanup

## Checks

- [x] I've signed the [CLA](https://docs.google.com/forms/d/e/1FAIpQLSd3qOU8MFxRHPGry0dcHOxIzRy3W_Nw81y-mMTrD4yB_pMXHA/viewform)
- [x] Changes are backward compatible
- [x] No new dependencies added