### PR TITLE
[Data] Fix autoscaler logging: move traceback to debug level

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -132,7 +132,10 @@ def handle_timeout_errors(
                     ) from exc
 
                 logger.warning(msg)
-                logger.debug(f"Traceback for {operation_name} failure for {requester_id}:", exc_info=True)
+                logger.debug(
+                    f"Traceback for {operation_name} failure for {requester_id}:",
+                    exc_info=True,
+                )
 
                 # Return value on error if callback provided
                 if on_error_return is not None:

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -132,7 +132,7 @@ def handle_timeout_errors(
                     ) from exc
 
                 logger.warning(msg)
-                logger.debug("Traceback for the above error:", exc_info=True)
+                logger.debug(f"Traceback for {operation_name} failure for {requester_id}:", exc_info=True)
 
                 # Return value on error if callback provided
                 if on_error_return is not None:

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -131,7 +131,8 @@ def handle_timeout_errors(
                         f"after {failure_counter} consecutive failures."
                     ) from exc
 
-                logger.warning(msg, exc_info=True)
+                logger.warning(msg)
+                logger.debug("Traceback for the above error:", exc_info=True)
 
                 # Return value on error if callback provided
                 if on_error_return is not None:


### PR DESCRIPTION
The original code passed `exc_info=True` to `logger.warning`, which included the full traceback on every transient timeout error. This is noisy for errors that are retried. This PR splits the log into a warning (message only) and a debug log (with traceback), so operators can still access the traceback when needed by setting the log level to DEBUG.