### PR TITLE
Adding py314 to linux wheel verification

### DIFF
--- a/ci/ray_ci/automation/ray_wheels_lib.py
+++ b/ci/ray_ci/automation/ray_wheels_lib.py
@@ -12,6 +12,7 @@ PYTHON_VERSIONS = [
     "cp311-cp311",
     "cp312-cp312",
     "cp313-cp313",
+    "cp314-cp314",
 ]
 ALL_PLATFORMS = [
     "manylinux2014_x86_64",
@@ -51,7 +52,10 @@ def _get_wheel_names(ray_version: str) -> List[str]:
 
     for python_version in PYTHON_VERSIONS:
         for platform in ALL_PLATFORMS:
-            if python_version == "cp313-cp313" and platform == "win_amd64":
+            if (
+                python_version in ("cp313-cp313", "cp314-cp314")
+                and platform == "win_amd64"
+            ):
                 continue
             wheel_name = f"ray-{ray_version}-{python_version}-{platform}"
             wheel_names.append(wheel_name)

--- a/ci/ray_ci/automation/test_ray_wheels_lib.py
+++ b/ci/ray_ci/automation/test_ray_wheels_lib.py
@@ -31,8 +31,8 @@ def test_get_wheel_names():
 
     assert (
         len(wheel_names)
-        == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) + len(ALL_PLATFORMS) - 1
-    )  # Except for the win_amd64 wheel for cp313
+        == len(PYTHON_VERSIONS) * len(ALL_PLATFORMS) + len(ALL_PLATFORMS) - 2
+    )  # Except for the win_amd64 wheel for cp313 and cp314
     python_versions = list(PYTHON_VERSIONS) + ["py3-none"]
 
     for wheel_name in wheel_names:


### PR DESCRIPTION
  - Add cp314-cp314 to the PYTHON_VERSIONS list in ray_wheels_lib.py for wheel building  
  and validation                                                                         
  - Exclude cp314 win_amd64 wheels (same as cp313)                                       
  - Update test assertion to account for the additional win_amd64 exclusion              
                                                                                         
  Test plan                                                                              
                                                                                         
  - Verify test_ray_wheels_lib.py tests pass with updated wheel count expectation        
  - Confirm py314 wheels are built and validated in Linux x86_64 and arm64 CI pipelines