### PR TITLE
[serve] Eliminate gang autoscaling oscillation & stabilize flaky gang tests

### DIFF
--- a/python/ray/serve/_private/gang_scheduling_autoscaling_policy.py
+++ b/python/ray/serve/_private/gang_scheduling_autoscaling_policy.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, Callable, Dict, Tuple
 
 from ray.serve.config import AutoscalingContext
@@ -9,10 +10,13 @@ class GangSchedulingAutoscalingPolicy:
     When gang scheduling is enabled, the number of replicas must always be a
     multiple of gang_size so that complete gangs can be scheduled or released
     atomically. This policy wraps a base scaling policy (e.g.
-    replica_queue_length_autoscaling_policy or user's custom policy) and snaps
-    its decision to the nearest gang-aligned value.
+    replica_queue_length_autoscaling_policy or user's custom policy) and rounds
+    up to the next gang-aligned multiple.
 
-    Ties are broken toward the lower value to be conservative about resource usage.
+    Always rounding up ensures the deployment never operates below the capacity
+    the base policy requested, avoiding capacity deficits. The result is
+    deterministic — the same desired count always produces the same output
+    regardless of the current replica count, which prevents oscillation.
 
     This class is not intended to be configured directly by users. It is
     automatically injected with a gang-scheduled deployment with autoscaling
@@ -27,12 +31,6 @@ class GangSchedulingAutoscalingPolicy:
         num_replicas, policy_state = self._base_scaling_policy(ctx)
 
         if self._gang_size > 1 and num_replicas > 0:
-            lower = (num_replicas // self._gang_size) * self._gang_size
-            upper = lower + self._gang_size
-
-            if upper - num_replicas < num_replicas - lower:
-                num_replicas = upper
-            else:
-                num_replicas = lower
+            num_replicas = math.ceil(num_replicas / self._gang_size) * self._gang_size
 
         return num_replicas, policy_state

--- a/python/ray/serve/_private/gang_scheduling_autoscaling_policy.py
+++ b/python/ray/serve/_private/gang_scheduling_autoscaling_policy.py
@@ -1,4 +1,3 @@
-import math
 from typing import Any, Callable, Dict, Tuple
 
 from ray.serve.config import AutoscalingContext
@@ -11,12 +10,9 @@ class GangSchedulingAutoscalingPolicy:
     multiple of gang_size so that complete gangs can be scheduled or released
     atomically. This policy wraps a base scaling policy (e.g.
     replica_queue_length_autoscaling_policy or user's custom policy) and snaps
-    its decision to the nearest gang-aligned value:
+    its decision to the nearest gang-aligned value.
 
-    - Scaling up (desired >= current): Rounds up to the next multiple
-      so the deployment has enough capacity.
-    - Scaling down (desired < current): Rounds down to release only
-      complete gangs.
+    Ties are broken toward the lower value to be conservative about resource usage.
 
     This class is not intended to be configured directly by users. It is
     automatically injected with a gang-scheduled deployment with autoscaling
@@ -31,14 +27,12 @@ class GangSchedulingAutoscalingPolicy:
         num_replicas, policy_state = self._base_scaling_policy(ctx)
 
         if self._gang_size > 1 and num_replicas > 0:
-            current = ctx.current_num_replicas
-            if num_replicas >= current:
-                # Scaling up: round up so we have enough capacity
-                num_replicas = (
-                    math.ceil(num_replicas / self._gang_size) * self._gang_size
-                )
+            lower = (num_replicas // self._gang_size) * self._gang_size
+            upper = lower + self._gang_size
+
+            if upper - num_replicas < num_replicas - lower:
+                num_replicas = upper
             else:
-                # Scaling down: round down to release complete gangs
-                num_replicas = (num_replicas // self._gang_size) * self._gang_size
+                num_replicas = lower
 
         return num_replicas, policy_state

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -205,7 +205,6 @@ py_test_module_list(
         "test_autoscaling_policy.py",
         "test_deploy.py",
         "test_fastapi.py",
-        "test_gang_scheduling.py",
         "test_grpc.py",
         "test_logging.py",
         "test_logging_2.py",
@@ -218,6 +217,24 @@ py_test_module_list(
     ],
     tags = [
         "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
+# Don't run gang scheduling tests on Windows
+py_test_module_list(
+    size = "enormous",
+    files = [
+        "test_gang_scheduling.py",
+    ],
+    tags = [
+        "exclusive",
+        "no_windows",
         "team:serve",
     ],
     deps = [

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -1424,7 +1424,12 @@ class TestGangNodeFailure:
         wait_for_condition(fully_recovered, timeout=60)
         recovered.set()
 
-        time.sleep(1)
+        # Wait for at least one post-recovery success
+        successes_at_recovery = len(successes)
+        wait_for_condition(
+            lambda: len(successes) > successes_at_recovery,
+            timeout=10,
+        )
         stop.set()
         sender.join(timeout=5)
 
@@ -1434,15 +1439,6 @@ class TestGangNodeFailure:
         # After full recovery, no errors should occur.
         assert len(errors_after_recovery) == 0
         assert len(successes) > 0
-
-        # Verify no leaked PGs (already checked in fully_recovered, but
-        # assert here for a clear failure message).
-        gang_pg_names = [
-            n
-            for n in get_all_live_placement_group_names()
-            if n.startswith(GANG_PG_NAME_PREFIX)
-        ]
-        assert len(gang_pg_names) == expected_num_pgs
 
         wait_for_condition(check_apps_running, apps=[app_name])
 
@@ -1816,7 +1812,7 @@ class TestGangAutoscaling:
 
         # Send 9 blocking requests. With target_ongoing_requests=2:
         # desired = ceil(9/2) = 5 (unaligned).
-        # Gang policy rounds up: ceil(5/3)*3 = 6.
+        # Gang policy rounds to nearest: nearest(5, 3) = 6.
         results = [handle.remote() for _ in range(9)]
 
         def upscaled_and_aligned():
@@ -1869,7 +1865,9 @@ class TestGangAutoscaling:
                 "initial_replicas": 9,
                 "metrics_interval_s": 0.5,
                 "upscale_delay_s": 5,
-                "downscale_delay_s": 3,
+                # Must be long enough for all 9 gang-scheduled replicas to
+                # start before the autoscaler can trigger a downscale.
+                "downscale_delay_s": 20,
                 "look_back_period_s": 1,
                 "target_ongoing_requests": 2,
             },
@@ -1893,7 +1891,7 @@ class TestGangAutoscaling:
 
         # Send 13 blocking requests. With target_ongoing_requests=2:
         # desired = ceil(13/2) = 7 (unaligned).
-        # Gang policy rounds down: 7 // 3 * 3 = 6.
+        # Gang policy rounds to nearest: nearest(7, 3) = 6.
         results = [handle.remote() for _ in range(13)]
 
         # Wait for downscale from 9 to 6.

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -1812,7 +1812,7 @@ class TestGangAutoscaling:
 
         # Send 9 blocking requests. With target_ongoing_requests=2:
         # desired = ceil(9/2) = 5 (unaligned).
-        # Gang policy rounds to nearest: nearest(5, 3) = 6.
+        # Gang policy rounds up: ceil(5/3)*3 = 6.
         results = [handle.remote() for _ in range(9)]
 
         def upscaled_and_aligned():
@@ -1889,10 +1889,10 @@ class TestGangAutoscaling:
             timeout=60,
         )
 
-        # Send 13 blocking requests. With target_ongoing_requests=2:
-        # desired = ceil(13/2) = 7 (unaligned).
-        # Gang policy rounds to nearest: nearest(7, 3) = 6.
-        results = [handle.remote() for _ in range(13)]
+        # Send 10 blocking requests. With target_ongoing_requests=2:
+        # desired = ceil(10/2) = 5 (unaligned).
+        # Gang policy rounds up: ceil(5/3)*3 = 6.
+        results = [handle.remote() for _ in range(10)]
 
         # Wait for downscale from 9 to 6.
         def downscaled_and_aligned():

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1210,16 +1210,20 @@ class TestGangSchedulingAutoscalingPolicy:
             total_pending_async_requests=0,
         )
 
-    @pytest.mark.parametrize("raw_autoscaling_decision,expected", [(5, 8), (8, 8)])
-    def test_scale_up_rounds_up(self, raw_autoscaling_decision, expected):
-        ctx = self._make_ctx(current_num_replicas=4)
+    @pytest.mark.parametrize(
+        "raw_autoscaling_decision,expected",
+        [
+            (5, 4),  # closer to 4 than 8
+            (7, 8),  # closer to 8 than 4
+            (8, 8),  # already aligned
+            (6, 4),  # equidistant (4 and 8) — tie goes to lower
+        ],
+    )
+    def test_rounds_to_nearest(self, raw_autoscaling_decision, expected):
+        """Round-to-nearest is independent of current replica count."""
+        current_num_replicas = 4
         policy = self._make_policy(gang_size=4, inner_result=raw_autoscaling_decision)
-        assert policy(ctx)[0] == expected
-
-    @pytest.mark.parametrize("raw_autoscaling_decision,expected", [(10, 8), (8, 8)])
-    def test_scale_down_rounds_down(self, raw_autoscaling_decision, expected):
-        ctx = self._make_ctx(current_num_replicas=12)
-        policy = self._make_policy(gang_size=4, inner_result=raw_autoscaling_decision)
+        ctx = self._make_ctx(current_num_replicas=current_num_replicas)
         assert policy(ctx)[0] == expected
 
     def test_zero_replicas_unchanged(self):
@@ -1278,11 +1282,11 @@ class TestGangSchedulingAutoscalingPolicy:
         assert not isinstance(state._policy, GangSchedulingAutoscalingPolicy)
 
     def test_integration_scale_up_respects_max(self):
-        """Gang alignment rounds up, but apply_bounds clips to max_replicas."""
+        """Gang alignment rounds to nearest, but apply_bounds clips to max."""
         state = self._create_state(
             gang_size=4, min_replicas=4, max_replicas=8, running=4
         )
-        # GangSchedulingAutoscalingPolicy rounds up to 12
+        # nearest(9, gang_size=4) = 8, clipped to max_replicas=8
         state._policy = GangSchedulingAutoscalingPolicy(
             lambda ctx: (9, {}), gang_size=4
         )
@@ -1290,11 +1294,11 @@ class TestGangSchedulingAutoscalingPolicy:
         assert decision == 8
 
     def test_integration_scale_down_respects_min(self):
-        """Gang alignment rounds down, but apply_bounds clips to min_replicas."""
+        """Gang alignment rounds to nearest, but apply_bounds clips to min."""
         state = self._create_state(
             gang_size=4, min_replicas=4, max_replicas=16, running=8
         )
-        # GangSchedulingAutoscalingPolicy rounds down to 0
+        # nearest(1, gang_size=4) = 0, clipped to min_replicas=4
         state._policy = GangSchedulingAutoscalingPolicy(
             lambda ctx: (1, {}), gang_size=4
         )

--- a/python/ray/serve/tests/unit/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_policy.py
@@ -1213,18 +1213,18 @@ class TestGangSchedulingAutoscalingPolicy:
     @pytest.mark.parametrize(
         "raw_autoscaling_decision,expected",
         [
-            (5, 4),  # closer to 4 than 8
-            (7, 8),  # closer to 8 than 4
+            (5, 8),  # ceil(5/4)*4 = 8
+            (7, 8),  # ceil(7/4)*4 = 8
             (8, 8),  # already aligned
-            (6, 4),  # equidistant (4 and 8) — tie goes to lower
+            (9, 12),  # ceil(9/4)*4 = 12
         ],
     )
-    def test_rounds_to_nearest(self, raw_autoscaling_decision, expected):
-        """Round-to-nearest is independent of current replica count."""
-        current_num_replicas = 4
+    def test_rounds_up(self, raw_autoscaling_decision, expected):
+        """Always rounds up, independent of current replica count."""
         policy = self._make_policy(gang_size=4, inner_result=raw_autoscaling_decision)
-        ctx = self._make_ctx(current_num_replicas=current_num_replicas)
-        assert policy(ctx)[0] == expected
+        for current in [4, 12]:
+            ctx = self._make_ctx(current_num_replicas=current)
+            assert policy(ctx)[0] == expected
 
     def test_zero_replicas_unchanged(self):
         ctx = self._make_ctx(current_num_replicas=4)
@@ -1282,11 +1282,11 @@ class TestGangSchedulingAutoscalingPolicy:
         assert not isinstance(state._policy, GangSchedulingAutoscalingPolicy)
 
     def test_integration_scale_up_respects_max(self):
-        """Gang alignment rounds to nearest, but apply_bounds clips to max."""
+        """Gang alignment rounds up, but apply_bounds clips to max."""
         state = self._create_state(
             gang_size=4, min_replicas=4, max_replicas=8, running=4
         )
-        # nearest(9, gang_size=4) = 8, clipped to max_replicas=8
+        # ceil(9/4)*4 = 12, clipped to max_replicas=8
         state._policy = GangSchedulingAutoscalingPolicy(
             lambda ctx: (9, {}), gang_size=4
         )
@@ -1294,11 +1294,11 @@ class TestGangSchedulingAutoscalingPolicy:
         assert decision == 8
 
     def test_integration_scale_down_respects_min(self):
-        """Gang alignment rounds to nearest, but apply_bounds clips to min."""
+        """Gang alignment rounds up, but apply_bounds clips to min."""
         state = self._create_state(
             gang_size=4, min_replicas=4, max_replicas=16, running=8
         )
-        # nearest(1, gang_size=4) = 0, clipped to min_replicas=4
+        # ceil(1/4)*4 = 4, clipped to min_replicas=4
         state._policy = GangSchedulingAutoscalingPolicy(
             lambda ctx: (1, {}), gang_size=4
         )


### PR DESCRIPTION
## Description
Fix gang scheduling autoscaling oscillation and flaky tests.

- Adjust `GangSchedulingAutoscalingPolicy` to round to the nearest gang-aligned boundary instead of rounding based on scaling direction. This eliminates oscillation where the same desired replica count (e.g. 7 with gang_size=3) would round down to 6 when current=9 but round up to 9 when current=6, causing the system to endlessly cycle between the two.
- Fix `test_gang_autoscaling_unaligned_downscale` startup race: increase `downscale_delay_s` from 3 to 20 so the autoscaler cannot downscale before all 9 initial gang-scheduled replicas finish starting.
- Fix `test_worker_node_failure_restarts_gang` flakiness: remove redundant PG count assertion that raced with async PG cleanup (already verified inside `fully_recovered()`), and replace `time.sleep(1)` with a deterministic `wait_for_condition` for post-recovery success.
- Disable `test_gang_scheduling.py` on Windows (no_windows tag). We don't foresee any gang scheduling use cases on Windows.

## Test
Ran the flaky tests `TestGangAutoscaling::test_gang_autoscaling_unaligned_downscale` and `TestGangNodeFailure:: test_worker_node_failure_restarts_gang` 20 times locally and verify that they pass reliably.

## Related issues
Flaky postmerge tests:
- Linux & Windows: `test_gang_autoscaling_unaligned_downscale`: https://buildkite.com/ray-project/postmerge/builds/16676/steps/canvas?jid=019d288c-9fda-4115-9be4-c865772e26eb&tab=output. We're disabling Windows tests anyways.
- Linux only: `test_worker_node_failure_restarts_gang`: https://buildkite.com/ray-project/postmerge/builds/16678/steps/canvas?jid=019d2aee-783f-4559-8949-8049f82062b6&tab=output

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
