### PR TITLE
Disable lazy remote cache downloads to fix eviction race

### DIFF
--- a/ci/build/build-manylinux-forge.sh
+++ b/ci/build/build-manylinux-forge.sh
@@ -82,5 +82,6 @@ sudo ln -sf /usr/local/bin/python3.10 /usr/local/bin/python3
   echo "build --announce_rc"
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
     echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
+    echo "build:ci --remote_download_minimal=false"
   fi
 } > "$HOME"/.bazelrc

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -47,6 +47,8 @@ apt-get update
 apt-get install -y docker-ce-cli
 
 echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> /root/.bazelrc
+echo "build --remote_download_minimal=false" >> /root/.bazelrc
+
 
 EOF
 

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -139,6 +139,7 @@ set -euo pipefail
   echo "build --config=ci"
   echo "build --announce_rc"
   echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
+  echo "build --remote_download_minimal=false"
 } > ~/.bazelrc
 
 EOF

--- a/ci/docker/manylinux-retag.Dockerfile
+++ b/ci/docker/manylinux-retag.Dockerfile
@@ -22,6 +22,7 @@ set -euo pipefail
   echo "build --announce_rc"
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
     echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
+    echo "build:ci --remote_download_minimal=false"
   fi
 } > "$HOME"/.bazelrc
 

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -46,6 +46,7 @@ set -euo pipefail
   echo "build --announce_rc"
   if [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
     echo "build:ci --remote_cache=${BUILDKITE_BAZEL_CACHE_URL:-}"
+    echo "build:ci --remote_download_minimal=false"
   fi
 } > "$HOME"/.bazelrc
 

--- a/ci/docker/ray-core.Dockerfile
+++ b/ci/docker/ray-core.Dockerfile
@@ -58,6 +58,7 @@ fi
 
 bazelisk --output_base=$BAZEL_CACHE build --config=ci \
     --repository_cache=$REPOSITORY_CACHE \
+    --remote_download_minimal=false \
     $BAZEL_CACHE_ARGS \
     $BAZEL_RESOURCE_FLAGS \
     //:ray_pkg_zip //:ray_py_proto_zip

--- a/ci/docker/ray-cpp-core.Dockerfile
+++ b/ci/docker/ray-cpp-core.Dockerfile
@@ -55,6 +55,7 @@ fi
 
 bazelisk --output_base=$BAZEL_CACHE build --config=ci \
     --repository_cache=$REPOSITORY_CACHE \
+    --remote_download_minimal=false \
     $BAZEL_CACHE_ARGS \
     //cpp:ray_cpp_pkg_zip
 

--- a/ci/docker/ray-java.Dockerfile
+++ b/ci/docker/ray-java.Dockerfile
@@ -52,6 +52,7 @@ fi
 
 bazelisk --output_base=$BAZEL_CACHE run --config=ci \
     --repository_cache=$REPOSITORY_CACHE \
+    --remote_download_minimal=false \
     $BAZEL_CACHE_ARGS \
     $BAZEL_RESOURCE_FLAGS \
     //java:gen_ray_java_pkg

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -116,6 +116,7 @@ if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then
     echo "build --repository_cache=/tmp/bazel-repo-cache" >> ~/.bazelrc
   elif [[ "${BUILDKITE_BAZEL_CACHE_URL:-}" != "" ]]; then
     echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> ~/.bazelrc
+    echo "build --remote_download_minimal=false" >> ~/.bazelrc
     if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then
       echo "build --remote_upload_local_results=false" >> ~/.bazelrc
     fi

--- a/ci/ray_ci/windows/build_ray.sh
+++ b/ci/ray_ci/windows/build_ray.sh
@@ -14,6 +14,7 @@ cd /c/rayci
   # Set a shorter output_base to avoid long file paths that Windows can't handle.
   echo "startup --output_base=c:/bzl";
   echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}";
+  echo "build --remote_download_minimal=false";
 } >> ~/.bazelrc
 
 if [[ "${BUILDKITE_CACHE_READONLY:-}" == "true" ]]; then


### PR DESCRIPTION
  - Bazel builds using the S3 remote cache               
  (bazel-cache-dev) are intermittently failing with exit 
  code 39 (REMOTE_CACHE_EVICTED) because cached blob     
  metadata is validated early in the build but the actual
   blob content is evicted by the time Bazel lazily
  fetches it
  - Added --remote_download_minimal=false across all 10
  locations where --remote_cache is configured, forcing  
  Bazel to eagerly download blobs on cache hit instead of
   deferring the fetch                                   
  - This closes the race window between cache metadata 
  lookup and blob download that was causing              
  //java:gen_ray_java_pkg (and potentially other targets)
   to fail mid-build                                     
                                                       
  Test plan

  - Verify jar build (//java:gen_ray_java_pkg) completes 
  without exit code 39
  - Verify wheel build via build-manylinux-ray.sh path   
  succeeds                                               
  - Monitor CI for any increase in build time or disk
  usage from eager downloads 