### PR TITLE
[llm] Validate `accelerator_type` against CPU-only configurations

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -468,6 +468,38 @@ class LLMConfig(BaseModelExtended):
 
         return self
 
+    @model_validator(mode="after")
+    def _validate_accelerator_type_with_gpu_mode(self):
+        """Validate that accelerator_type is not set when use_gpu would resolve to False.
+
+        This catches the case where accelerator_type would be silently ignored because
+        the configuration resolves to CPU-only mode (via use_cpu=True or
+        placement_group_config with no GPUs).
+        """
+        if not self.accelerator_type:
+            return self
+
+        # Check if use_cpu is explicitly True
+        if self.use_cpu is True:
+            raise ValueError(
+                f"accelerator_type='{self.accelerator_type}' cannot be used with "
+                "use_cpu=True. Either remove accelerator_type or set use_cpu=False."
+            )
+
+        # Check if placement_group_config has bundles with no GPUs
+        if self.placement_group_config:
+            bundles = self.placement_group_config.get("bundles", [])
+            if bundles:
+                has_gpu = any(bundle.get("GPU", 0) > 0 for bundle in bundles)
+                if not has_gpu:
+                    raise ValueError(
+                        f"accelerator_type='{self.accelerator_type}' cannot be used with "
+                        "placement_group_config that contains no GPUs. Either remove "
+                        "accelerator_type or add GPUs to the placement group bundles."
+                    )
+
+        return self
+
     def multiplex_config(self) -> ServeMultiplexConfig:
         multiplex_config = None
         if self.lora_config:

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -422,7 +422,9 @@ class LLMConfig(BaseModelExtended):
     @property
     def use_gpu(self) -> bool:
         """Returns True if configured to use GPU resources."""
-        return _compute_use_gpu(self.use_cpu, self.placement_group_config, self.accelerator_type)
+        return _compute_use_gpu(
+            self.use_cpu, self.placement_group_config, self.accelerator_type
+        )
 
     @field_validator("accelerator_type")
     def validate_accelerator_type(cls, value: Optional[str]):

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -488,15 +488,18 @@ class LLMConfig(BaseModelExtended):
 
         # Check if placement_group_config has bundles with no GPUs
         if self.placement_group_config:
-            bundles = self.placement_group_config.get("bundles", [])
-            if bundles:
+            bundle_per_worker = self.placement_group_config.get("bundle_per_worker")
+            if bundle_per_worker:
+                has_gpu = bundle_per_worker.get("GPU", 0) > 0
+            else:
+                bundles = self.placement_group_config.get("bundles", [])
                 has_gpu = any(bundle.get("GPU", 0) > 0 for bundle in bundles)
-                if not has_gpu:
-                    raise ValueError(
-                        f"accelerator_type='{self.accelerator_type}' cannot be used with "
-                        "placement_group_config that contains no GPUs. Either remove "
-                        "accelerator_type or add GPUs to the placement group bundles."
-                    )
+            if not has_gpu:
+                raise ValueError(
+                    f"accelerator_type='{self.accelerator_type}' cannot be used with "
+                    "placement_group_config that contains no GPUs. Either remove "
+                    "accelerator_type or add GPUs to the placement group bundles."
+                )
 
         return self
 

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -49,6 +49,55 @@ GPUType = Enum("GPUType", vars(accelerators))
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 
+def _compute_use_gpu(
+    use_cpu: Optional[bool],
+    placement_group_config: Optional[Dict[str, Any]],
+    accelerator_type: Optional[str],
+) -> bool:
+    """Returns True if the configuration resolves to GPU usage.
+
+    Priority order:
+    1. Explicit use_cpu flag
+    2. placement_group_config GPU bundles
+    3. accelerator_type (known GPU types default to True, else True)
+    """
+    # Explicit use_cpu setting takes precedence over all other configurations
+    if isinstance(use_cpu, bool):
+        return not use_cpu
+
+    # Check placement_group_config for explicit GPU specification
+    if placement_group_config:
+        bundle_per_worker = placement_group_config.get("bundle_per_worker")
+        if bundle_per_worker:
+            return bundle_per_worker.get("GPU", 0) > 0
+
+        # Check bundles list (empty list → no GPUs → CPU-only)
+        bundles = placement_group_config.get("bundles")
+        if bundles is not None:
+            return any(bundle.get("GPU", 0) > 0 for bundle in bundles)
+
+    # Default behavior based on accelerator_type
+    if not accelerator_type:
+        return True
+
+    return accelerator_type in (
+        GPUType.NVIDIA_TESLA_V100.value,
+        GPUType.NVIDIA_TESLA_P100.value,
+        GPUType.NVIDIA_TESLA_T4.value,
+        GPUType.NVIDIA_TESLA_P4.value,
+        GPUType.NVIDIA_TESLA_K80.value,
+        GPUType.NVIDIA_TESLA_A10G.value,
+        GPUType.NVIDIA_L4.value,
+        GPUType.NVIDIA_L40S.value,
+        GPUType.NVIDIA_A100.value,
+        GPUType.NVIDIA_H100.value,
+        GPUType.NVIDIA_H200.value,
+        GPUType.NVIDIA_H20.value,
+        GPUType.NVIDIA_A100_40G.value,
+        GPUType.NVIDIA_A100_80G.value,
+    )
+
+
 logger = get_logger(__name__)
 
 
@@ -370,6 +419,11 @@ class LLMConfig(BaseModelExtended):
     def max_request_context_length(self) -> Optional[int]:
         return self.engine_kwargs.get("max_model_len")
 
+    @property
+    def use_gpu(self) -> bool:
+        """Returns True if configured to use GPU resources."""
+        return _compute_use_gpu(self.use_cpu, self.placement_group_config, self.accelerator_type)
+
     @field_validator("accelerator_type")
     def validate_accelerator_type(cls, value: Optional[str]):
         if value is None:
@@ -470,37 +524,18 @@ class LLMConfig(BaseModelExtended):
 
     @model_validator(mode="after")
     def _validate_accelerator_type_with_gpu_mode(self):
-        """Validate that accelerator_type is not set when use_gpu would resolve to False.
+        """Validate that accelerator_type is not set when use_gpu resolves to False.
 
         This catches the case where accelerator_type would be silently ignored because
         the configuration resolves to CPU-only mode (via use_cpu=True or
         placement_group_config with no GPUs).
         """
-        if not self.accelerator_type:
-            return self
-
-        # Check if use_cpu is explicitly True
-        if self.use_cpu is True:
+        if self.accelerator_type and not self.use_gpu:
             raise ValueError(
                 f"accelerator_type='{self.accelerator_type}' cannot be used with "
-                "use_cpu=True. Either remove accelerator_type or set use_cpu=False."
+                "CPU-only configurations. Either remove accelerator_type, set "
+                "use_cpu=False, or ensure placement_group_config bundles include GPUs."
             )
-
-        # Check if placement_group_config has bundles with no GPUs
-        if self.placement_group_config:
-            bundle_per_worker = self.placement_group_config.get("bundle_per_worker")
-            if bundle_per_worker:
-                has_gpu = bundle_per_worker.get("GPU", 0) > 0
-            else:
-                bundles = self.placement_group_config.get("bundles", [])
-                has_gpu = any(bundle.get("GPU", 0) > 0 for bundle in bundles)
-            if not has_gpu:
-                raise ValueError(
-                    f"accelerator_type='{self.accelerator_type}' cannot be used with "
-                    "placement_group_config that contains no GPUs. Either remove "
-                    "accelerator_type or add GPUs to the placement group bundles."
-                )
-
         return self
 
     def multiplex_config(self) -> ServeMultiplexConfig:

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -59,7 +59,7 @@ def _compute_use_gpu(
     Priority order:
     1. Explicit use_cpu flag
     2. placement_group_config GPU bundles
-    3. accelerator_type (known GPU types default to True, else True)
+    3. Default to True — any accelerator_type implies GPU-capable hardware
     """
     # Explicit use_cpu setting takes precedence over all other configurations
     if isinstance(use_cpu, bool):
@@ -76,26 +76,8 @@ def _compute_use_gpu(
         if bundles is not None:
             return any(bundle.get("GPU", 0) > 0 for bundle in bundles)
 
-    # Default behavior based on accelerator_type
-    if not accelerator_type:
-        return True
-
-    return accelerator_type in (
-        GPUType.NVIDIA_TESLA_V100.value,
-        GPUType.NVIDIA_TESLA_P100.value,
-        GPUType.NVIDIA_TESLA_T4.value,
-        GPUType.NVIDIA_TESLA_P4.value,
-        GPUType.NVIDIA_TESLA_K80.value,
-        GPUType.NVIDIA_TESLA_A10G.value,
-        GPUType.NVIDIA_L4.value,
-        GPUType.NVIDIA_L40S.value,
-        GPUType.NVIDIA_A100.value,
-        GPUType.NVIDIA_H100.value,
-        GPUType.NVIDIA_H200.value,
-        GPUType.NVIDIA_H20.value,
-        GPUType.NVIDIA_A100_40G.value,
-        GPUType.NVIDIA_A100_80G.value,
-    )
+    # All supported accelerator types are GPU-capable; default to GPU.
+    return True
 
 
 logger = get_logger(__name__)

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -52,14 +52,13 @@ ModelT = TypeVar("ModelT", bound=BaseModel)
 def _compute_use_gpu(
     use_cpu: Optional[bool],
     placement_group_config: Optional[Dict[str, Any]],
-    accelerator_type: Optional[str],
 ) -> bool:
     """Returns True if the configuration resolves to GPU usage.
 
     Priority order:
     1. Explicit use_cpu flag
     2. placement_group_config GPU bundles
-    3. Default to True — any accelerator_type implies GPU-capable hardware
+    3. Default to True — all supported accelerator types are GPU-capable
     """
     # Explicit use_cpu setting takes precedence over all other configurations
     if isinstance(use_cpu, bool):
@@ -404,9 +403,7 @@ class LLMConfig(BaseModelExtended):
     @property
     def use_gpu(self) -> bool:
         """Returns True if configured to use GPU resources."""
-        return _compute_use_gpu(
-            self.use_cpu, self.placement_group_config, self.accelerator_type
-        )
+        return _compute_use_gpu(self.use_cpu, self.placement_group_config)
 
     @field_validator("accelerator_type")
     def validate_accelerator_type(cls, value: Optional[str]):

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -3,7 +3,7 @@ import dataclasses
 import os
 from typing import Any, Dict, List, Optional
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.openai.cli_args import FrontendArgs
 
@@ -284,10 +284,9 @@ class VLLMEngineConfig(BaseModelExtended):
             if bundle_per_worker:
                 return bundle_per_worker.get("GPU", 0) > 0
 
-            # Check bundles list
-            bundles = self.placement_group_config.get("bundles", [])
-            if bundles:
-                # If any bundle has GPU > 0, we use GPU
+            # Check bundles list (empty list → no GPUs → CPU-only)
+            bundles = self.placement_group_config.get("bundles")
+            if bundles is not None:
                 return any(bundle.get("GPU", 0) > 0 for bundle in bundles)
 
         # Default behavior based on accelerator_type

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -274,7 +274,9 @@ class VLLMEngineConfig(BaseModelExtended):
     @property
     def use_gpu(self) -> bool:
         """Returns True if vLLM is configured to use GPU resources."""
-        return _compute_use_gpu(self.use_cpu, self.placement_group_config, self.accelerator_type)
+        return _compute_use_gpu(
+            self.use_cpu, self.placement_group_config, self.accelerator_type
+        )
 
     def get_or_create_pg(self) -> PlacementGroup:
         """Gets or a creates a placement group.

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -77,6 +77,22 @@ class VLLMEngineConfig(BaseModelExtended):
         validated = PlacementGroupConfig(**value)
         return validated.model_dump()
 
+    @model_validator(mode="after")
+    def _validate_accelerator_type_with_gpu_mode(self):
+        """Validate that accelerator_type is not set when use_gpu resolves to False.
+
+        This catches the case where accelerator_type is silently ignored because
+        the configuration resolves to CPU-only mode (via use_cpu=True or
+        placement_group_config with no GPUs).
+        """
+        if self.accelerator_type and not self.use_gpu:
+            raise ValueError(
+                f"accelerator_type='{self.accelerator_type}' cannot be used with "
+                "CPU-only configurations. Either remove accelerator_type, set "
+                "use_cpu=False, or ensure placement_group_config bundles include GPUs."
+            )
+        return self
+
     runtime_env: Optional[Dict[str, Any]] = None
     engine_kwargs: Dict[str, Any] = {}
     frontend_kwargs: Dict[str, Any] = {}

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -18,6 +18,7 @@ from ray.llm._internal.serve.constants import (
 from ray.llm._internal.serve.core.configs.llm_config import (
     GPUType,
     LLMConfig,
+    _compute_use_gpu,
 )
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.util.placement_group import (
@@ -273,43 +274,7 @@ class VLLMEngineConfig(BaseModelExtended):
     @property
     def use_gpu(self) -> bool:
         """Returns True if vLLM is configured to use GPU resources."""
-        # Explicit use_cpu setting takes precedence over all other configurations
-        if isinstance(self.use_cpu, bool):
-            return not self.use_cpu
-
-        # Check placement_group_config for explicit GPU specification
-        if self.placement_group_config:
-            # Check bundle_per_worker inside placement_group_config
-            bundle_per_worker = self.placement_group_config.get("bundle_per_worker")
-            if bundle_per_worker:
-                return bundle_per_worker.get("GPU", 0) > 0
-
-            # Check bundles list (empty list → no GPUs → CPU-only)
-            bundles = self.placement_group_config.get("bundles")
-            if bundles is not None:
-                return any(bundle.get("GPU", 0) > 0 for bundle in bundles)
-
-        # Default behavior based on accelerator_type
-        if not self.accelerator_type:
-            # Default to GPU when no accelerator_type is specified
-            return True
-
-        return self.accelerator_type in (
-            GPUType.NVIDIA_TESLA_V100.value,
-            GPUType.NVIDIA_TESLA_P100.value,
-            GPUType.NVIDIA_TESLA_T4.value,
-            GPUType.NVIDIA_TESLA_P4.value,
-            GPUType.NVIDIA_TESLA_K80.value,
-            GPUType.NVIDIA_TESLA_A10G.value,
-            GPUType.NVIDIA_L4.value,
-            GPUType.NVIDIA_L40S.value,
-            GPUType.NVIDIA_A100.value,
-            GPUType.NVIDIA_H100.value,
-            GPUType.NVIDIA_H200.value,
-            GPUType.NVIDIA_H20.value,
-            GPUType.NVIDIA_A100_40G.value,
-            GPUType.NVIDIA_A100_80G.value,
-        )
+        return _compute_use_gpu(self.use_cpu, self.placement_group_config, self.accelerator_type)
 
     def get_or_create_pg(self) -> PlacementGroup:
         """Gets or a creates a placement group.

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -274,9 +274,7 @@ class VLLMEngineConfig(BaseModelExtended):
     @property
     def use_gpu(self) -> bool:
         """Returns True if vLLM is configured to use GPU resources."""
-        return _compute_use_gpu(
-            self.use_cpu, self.placement_group_config, self.accelerator_type
-        )
+        return _compute_use_gpu(self.use_cpu, self.placement_group_config)
 
     def get_or_create_pg(self) -> PlacementGroup:
         """Gets or a creates a placement group.

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -316,16 +316,51 @@ class TestUseCpuLogic:
         engine_config_gpu = llm_config_gpu.get_engine_config()
         assert engine_config_gpu.use_gpu is True
 
-    def test_use_cpu_precedence_over_accelerator_type(self):
-        """Test that explicit use_cpu setting takes precedence over accelerator_type."""
-        # use_cpu=True should override GPU accelerator_type
-        llm_config_cpu_override = LLMConfig(
+    def test_accelerator_type_with_use_cpu_raises_error(self):
+        """Test that accelerator_type with use_cpu=True raises a validation error."""
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="accelerator_type='L4' cannot be used with use_cpu=True",
+        ):
+            LLMConfig(
+                model_loading_config=ModelLoadingConfig(model_id="test_model"),
+                use_cpu=True,
+                accelerator_type="L4",
+            )
+
+    def test_accelerator_type_with_cpu_only_placement_group_raises_error(self):
+        """Test that accelerator_type with CPU-only placement_group_config raises error."""
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="accelerator_type='L4' cannot be used with placement_group_config that contains no GPUs",
+        ):
+            LLMConfig(
+                model_loading_config=ModelLoadingConfig(model_id="test_model"),
+                accelerator_type="L4",
+                placement_group_config={"bundles": [{"CPU": 4}]},
+            )
+
+    def test_accelerator_type_with_gpu_placement_group_succeeds(self):
+        """Test that accelerator_type with GPU-containing placement_group_config succeeds."""
+        llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test_model"),
-            use_cpu=True,
-            accelerator_type="L4",  # GPU type but use_cpu=True should take precedence
+            accelerator_type="L4",
+            placement_group_config={"bundles": [{"GPU": 1, "CPU": 4}]},
         )
-        engine_config = llm_config_cpu_override.get_engine_config()
-        assert engine_config.use_gpu is False  # use_cpu=True takes precedence
+        assert llm_config.accelerator_type == "L4"
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.use_gpu is True
+
+    def test_accelerator_type_with_use_cpu_false_succeeds(self):
+        """Test that accelerator_type with use_cpu=False succeeds."""
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test_model"),
+            accelerator_type="L4",
+            use_cpu=False,
+        )
+        assert llm_config.accelerator_type == "L4"
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.use_gpu is True
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -332,12 +332,26 @@ class TestUseCpuLogic:
         """Test that accelerator_type with CPU-only placement_group_config raises error."""
         with pytest.raises(
             pydantic.ValidationError,
-            match="accelerator_type='L4' cannot be used with placement_group_config that contains no GPUs",
+            match="accelerator_type='L4' cannot be used with "
+            "placement_group_config that contains no GPUs",
         ):
             LLMConfig(
                 model_loading_config=ModelLoadingConfig(model_id="test_model"),
                 accelerator_type="L4",
                 placement_group_config={"bundles": [{"CPU": 4}]},
+            )
+
+    def test_accelerator_type_with_empty_bundles_raises_error(self):
+        """Test that accelerator_type with empty bundles list raises error."""
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="accelerator_type='L4' cannot be used with "
+            "placement_group_config that contains no GPUs",
+        ):
+            LLMConfig(
+                model_loading_config=ModelLoadingConfig(model_id="test_model"),
+                accelerator_type="L4",
+                placement_group_config={"bundles": []},
             )
 
     def test_accelerator_type_with_gpu_placement_group_succeeds(self):

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -304,6 +304,7 @@ class TestUseCpuLogic:
             use_cpu=True,
         )
         assert llm_config_cpu.use_cpu is True
+        assert llm_config_cpu.use_gpu is False
         engine_config = llm_config_cpu.get_engine_config()
         assert engine_config.use_gpu is False
 
@@ -313,6 +314,7 @@ class TestUseCpuLogic:
             use_cpu=False,
         )
         assert llm_config_gpu.use_cpu is False
+        assert llm_config_gpu.use_gpu is True
         engine_config_gpu = llm_config_gpu.get_engine_config()
         assert engine_config_gpu.use_gpu is True
 
@@ -320,7 +322,7 @@ class TestUseCpuLogic:
         """Test that accelerator_type with use_cpu=True raises a validation error."""
         with pytest.raises(
             pydantic.ValidationError,
-            match="accelerator_type='L4' cannot be used with use_cpu=True",
+            match="accelerator_type='L4' cannot be used with CPU-only configurations",
         ):
             LLMConfig(
                 model_loading_config=ModelLoadingConfig(model_id="test_model"),
@@ -332,8 +334,7 @@ class TestUseCpuLogic:
         """Test that accelerator_type with CPU-only placement_group_config raises error."""
         with pytest.raises(
             pydantic.ValidationError,
-            match="accelerator_type='L4' cannot be used with "
-            "placement_group_config that contains no GPUs",
+            match="accelerator_type='L4' cannot be used with CPU-only configurations",
         ):
             LLMConfig(
                 model_loading_config=ModelLoadingConfig(model_id="test_model"),
@@ -345,8 +346,7 @@ class TestUseCpuLogic:
         """Test that accelerator_type with empty bundles list raises error."""
         with pytest.raises(
             pydantic.ValidationError,
-            match="accelerator_type='L4' cannot be used with "
-            "placement_group_config that contains no GPUs",
+            match="accelerator_type='L4' cannot be used with CPU-only configurations",
         ):
             LLMConfig(
                 model_loading_config=ModelLoadingConfig(model_id="test_model"),

--- a/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
@@ -410,7 +410,7 @@ class TestAcceleratorTypeValidation:
     """Test accelerator_type validation with CPU-only configurations."""
 
     def test_vllm_engine_config_accelerator_type_with_use_cpu_raises_error(self):
-        """Test that VLLMEngineConfig raises error when accelerator_type is set with use_cpu=True."""
+        """VLLMEngineConfig raises error with accelerator_type and use_cpu=True."""
         with pytest.raises(
             ValueError,
             match="accelerator_type='L4' cannot be used with CPU-only configurations",
@@ -424,7 +424,7 @@ class TestAcceleratorTypeValidation:
     def test_vllm_engine_config_accelerator_type_with_cpu_only_bundles_raises_error(
         self,
     ):
-        """Test that VLLMEngineConfig raises error when accelerator_type is set with CPU-only bundles."""
+        """VLLMEngineConfig raises error with accelerator_type and CPU-only bundles."""
         with pytest.raises(
             ValueError,
             match="accelerator_type='L4' cannot be used with CPU-only configurations",
@@ -433,6 +433,20 @@ class TestAcceleratorTypeValidation:
                 model_id="test_model",
                 accelerator_type="L4",
                 placement_group_config={"bundles": [{"CPU": 4}]},
+            )
+
+    def test_vllm_engine_config_accelerator_type_with_empty_bundles_raises_error(
+        self,
+    ):
+        """VLLMEngineConfig raises error with accelerator_type and empty bundles."""
+        with pytest.raises(
+            ValueError,
+            match="accelerator_type='L4' cannot be used with CPU-only configurations",
+        ):
+            VLLMEngineConfig(
+                model_id="test_model",
+                accelerator_type="L4",
+                placement_group_config={"bundles": []},
             )
 
     def test_vllm_engine_config_accelerator_type_with_gpu_bundles_succeeds(self):

--- a/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
@@ -481,7 +481,7 @@ class TestAcceleratorTypeValidation:
                 accelerator_type="L4",
                 use_cpu=True,
             )
-        assert "accelerator_type='L4' cannot be used with use_cpu=True" in str(
+        assert "accelerator_type='L4' cannot be used with CPU-only configurations" in str(
             exc_info.value
         )
 

--- a/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
@@ -406,5 +406,71 @@ def test_bundle_per_worker_non_fractional_gpu_no_env_var():
     assert "VLLM_RAY_PER_WORKER_GPUS" not in runtime_env.get("env_vars", {})
 
 
+class TestAcceleratorTypeValidation:
+    """Test accelerator_type validation with CPU-only configurations."""
+
+    def test_vllm_engine_config_accelerator_type_with_use_cpu_raises_error(self):
+        """Test that VLLMEngineConfig raises error when accelerator_type is set with use_cpu=True."""
+        with pytest.raises(
+            ValueError,
+            match="accelerator_type='L4' cannot be used with CPU-only configurations",
+        ):
+            VLLMEngineConfig(
+                model_id="test_model",
+                accelerator_type="L4",
+                use_cpu=True,
+            )
+
+    def test_vllm_engine_config_accelerator_type_with_cpu_only_bundles_raises_error(
+        self,
+    ):
+        """Test that VLLMEngineConfig raises error when accelerator_type is set with CPU-only bundles."""
+        with pytest.raises(
+            ValueError,
+            match="accelerator_type='L4' cannot be used with CPU-only configurations",
+        ):
+            VLLMEngineConfig(
+                model_id="test_model",
+                accelerator_type="L4",
+                placement_group_config={"bundles": [{"CPU": 4}]},
+            )
+
+    def test_vllm_engine_config_accelerator_type_with_gpu_bundles_succeeds(self):
+        """Test that VLLMEngineConfig succeeds when accelerator_type is set with GPU bundles."""
+        config = VLLMEngineConfig(
+            model_id="test_model",
+            accelerator_type="L4",
+            placement_group_config={"bundles": [{"GPU": 1, "CPU": 4}]},
+        )
+        assert config.accelerator_type == "L4"
+        assert config.use_gpu is True
+
+    def test_vllm_engine_config_accelerator_type_default_uses_gpu(self):
+        """Test that VLLMEngineConfig with accelerator_type and no use_cpu defaults to GPU."""
+        config = VLLMEngineConfig(
+            model_id="test_model",
+            accelerator_type="L4",
+        )
+        assert config.accelerator_type == "L4"
+        assert config.use_gpu is True
+
+    def test_llm_config_accelerator_type_validation_propagates_to_engine_config(self):
+        """Test that LLMConfig's validation catches the error before VLLMEngineConfig."""
+        # This should raise at LLMConfig level, not at VLLMEngineConfig level
+        import pydantic
+
+        with pytest.raises(pydantic.ValidationError) as exc_info:
+            LLMConfig(
+                model_loading_config=ModelLoadingConfig(
+                    model_id="test_model",
+                ),
+                accelerator_type="L4",
+                use_cpu=True,
+            )
+        assert "accelerator_type='L4' cannot be used with use_cpu=True" in str(
+            exc_info.value
+        )
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_multi_node_placement_groups.py
@@ -481,8 +481,9 @@ class TestAcceleratorTypeValidation:
                 accelerator_type="L4",
                 use_cpu=True,
             )
-        assert "accelerator_type='L4' cannot be used with CPU-only configurations" in str(
-            exc_info.value
+        assert (
+            "accelerator_type='L4' cannot be used with CPU-only configurations"
+            in str(exc_info.value)
         )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR adds validation to raise a `ValueError` when `accelerator_type` is set but the configuration resolves to CPU-only mode. Previously, the `accelerator_type` hint was silently ignored in these cases.

### Changes

1. **`VLLMEngineConfig`**: Added a `model_validator(mode="after")` that checks if `accelerator_type` is set but `use_gpu` resolves to `False`. This validates the final resolved state.

2. **`LLMConfig`**: Added a `model_validator(mode="after")` that catches the issue earlier at config construction time by checking:
   - If `use_cpu=True` is explicitly set alongside `accelerator_type`
   - If `placement_group_config` bundles contain no GPUs alongside `accelerator_type`

### Error Messages

```python
# When use_cpu=True is set
LLMConfig(accelerator_type="L4", use_cpu=True, ...)
# ValueError: accelerator_type='L4' cannot be used with use_cpu=True. 
#             Either remove accelerator_type or set use_cpu=False.

# When placement_group_config has no GPUs
LLMConfig(accelerator_type="L4", placement_group_config={"bundles": [{"CPU": 4}]}, ...)
# ValueError: accelerator_type='L4' cannot be used with placement_group_config 
#             that contains no GPUs. Either remove accelerator_type or add GPUs 
#             to the placement group bundles.
```

## Related issues

Fixes the issue flagged in https://github.com/ray-project/ray/pull/59903#discussion_r2977527955

## Additional information

- Tests have been added to both `test_models.py` and `test_multi_node_placement_groups.py` to cover the new validation logic
- The `LLMConfig` validation catches issues early at construction time
- The `VLLMEngineConfig` validation provides a second layer of validation for cases where the config is created directly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a86c8c1d-86b0-4207-b77d-dbedc5bdece1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a86c8c1d-86b0-4207-b77d-dbedc5bdece1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

