### PR TITLE
[jax][tpu] Simplify elastic TPU scaling to use simplier slice counting

### DIFF
--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -19,6 +19,7 @@ Utility
    ray.util.tpu.get_tpu_slice_name_from_node
    ray.util.tpu.get_tpu_nodes_for_slice
    ray.util.tpu.get_num_ready_tpu_slices
+   ray.util.tpu.get_num_intact_tpu_slices
    ray.util.tpu.get_tpu_num_slices_for_workers
    ray.util.tpu.get_tpu_version_from_type
    ray.util.tpu.get_tpu_worker_resources

--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -19,7 +19,6 @@ Utility
    ray.util.tpu.get_tpu_slice_name_from_node
    ray.util.tpu.get_tpu_nodes_for_slice
    ray.util.tpu.get_num_ready_tpu_slices
-   ray.util.tpu.get_num_intact_tpu_slices
    ray.util.tpu.get_tpu_num_slices_for_workers
    ray.util.tpu.get_tpu_version_from_type
    ray.util.tpu.get_tpu_worker_resources

--- a/python/ray/tests/test_tpu.py
+++ b/python/ray/tests/test_tpu.py
@@ -599,6 +599,115 @@ def test_get_num_ready_tpu_slices_calculation(
     assert actual_ready == expected_ready
 
 
+@pytest.mark.parametrize(
+    "topology, accelerator_type, mock_nodes, expected_intact",
+    [
+        # 1 fully intact v4 slice (2 physical hosts).
+        (
+            "2x2x2",
+            "v4",
+            [
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 0, node_id="A"),
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 1, node_id="B"),
+            ],
+            1,
+        ),
+        # Intact slice counts even if TPUs are in use (no idle check).
+        (
+            "2x2x2",
+            "v4",
+            [
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 0, node_id="A"),
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 1, node_id="B"),
+            ],
+            1,
+        ),
+        # Fractured slice (missing a physical host) -> 0 intact slices.
+        (
+            "2x2x2",
+            "v4",
+            [
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 0, node_id="A"),
+            ],
+            0,
+        ),
+        # Missing head node (rank 0) -> 0 intact slices.
+        (
+            "2x2x2",
+            "v4",
+            [
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 1, node_id="A"),
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 2, node_id="B"),
+            ],
+            0,
+        ),
+        # One physical host is dead -> 0 intact slices.
+        (
+            "2x2x2",
+            "v4",
+            [
+                _make_mock_tpu_node(True, "v4-16", "slice-1", 0, node_id="A"),
+                _make_mock_tpu_node(False, "v4-16", "slice-1", 1, node_id="B"),
+            ],
+            0,
+        ),
+        # 2 slices: one intact, one fractured -> 1 intact slice.
+        (
+            "2x2x2",
+            "v4",
+            [
+                _make_mock_tpu_node(True, "v4-16", "slice-A", 0, node_id="A0"),
+                _make_mock_tpu_node(True, "v4-16", "slice-A", 1, node_id="A1"),
+                _make_mock_tpu_node(True, "v4-16", "slice-B", 0, node_id="B0"),
+            ],
+            1,
+        ),
+        # 2 fully intact v6e slices.
+        (
+            "4x4",
+            "v6e",
+            [
+                _make_mock_tpu_node(True, "v6e-16", "slice-1", 0, node_id="S1_0"),
+                _make_mock_tpu_node(True, "v6e-16", "slice-1", 1, node_id="S1_1"),
+                _make_mock_tpu_node(True, "v6e-16", "slice-1", 2, node_id="S1_2"),
+                _make_mock_tpu_node(True, "v6e-16", "slice-1", 3, node_id="S1_3"),
+                _make_mock_tpu_node(True, "v6e-16", "slice-2", 0, node_id="S2_0"),
+                _make_mock_tpu_node(True, "v6e-16", "slice-2", 1, node_id="S2_1"),
+                _make_mock_tpu_node(True, "v6e-16", "slice-2", 2, node_id="S2_2"),
+                _make_mock_tpu_node(True, "v6e-16", "slice-2", 3, node_id="S2_3"),
+            ],
+            2,
+        ),
+    ],
+)
+@patch("ray.is_initialized", return_value=True)
+@patch("ray.nodes")
+def test_get_num_intact_tpu_slices_calculation(
+    mock_nodes_call,
+    mock_is_initialized,
+    topology,
+    accelerator_type,
+    mock_nodes,
+    expected_intact,
+):
+    """Test that the intact TPU slice utility counts slices based purely on
+    physical integrity (all hosts alive, correct chip count) without checking
+    whether they are idle."""
+    mock_nodes_call.return_value = mock_nodes
+
+    actual_intact = ray.util.tpu.get_num_intact_tpu_slices(
+        topology=topology,
+        accelerator_type=accelerator_type,
+    )
+    assert actual_intact == expected_intact
+
+
+@patch("ray.is_initialized", return_value=False)
+def test_get_num_intact_tpu_slices_uninitialized(mock_is_initialized):
+    """Test that the utility gracefully handles an uninitialized Ray context."""
+    assert ray.util.tpu.get_num_intact_tpu_slices("2x2x2", "v4") == 0
+
+
 def test_get_num_ready_tpu_slices(ray_tpu_cluster):
     """
     Tests the get_num_ready_tpu_slices utility against a real Ray cluster.

--- a/python/ray/tests/test_tpu.py
+++ b/python/ray/tests/test_tpu.py
@@ -672,7 +672,7 @@ def test_get_num_ready_tpu_slices_calculation(
 )
 @patch("ray.is_initialized", return_value=True)
 @patch("ray.nodes")
-def test_get_num_intact_tpu_slices_calculation(
+def test_get_num_tpu_slices_calculation(
     mock_nodes_call,
     mock_is_initialized,
     topology,
@@ -685,7 +685,7 @@ def test_get_num_intact_tpu_slices_calculation(
     whether they are idle."""
     mock_nodes_call.return_value = mock_nodes
 
-    actual_intact = ray.util.tpu.get_num_intact_tpu_slices(
+    actual_intact = ray.util.tpu.get_num_tpu_slices(
         topology=topology,
         accelerator_type=accelerator_type,
     )
@@ -693,9 +693,9 @@ def test_get_num_intact_tpu_slices_calculation(
 
 
 @patch("ray.is_initialized", return_value=False)
-def test_get_num_intact_tpu_slices_uninitialized(mock_is_initialized):
+def test_get_num_tpu_slices_uninitialized(mock_is_initialized):
     """Test that the utility gracefully handles an uninitialized Ray context."""
-    assert ray.util.tpu.get_num_intact_tpu_slices("2x2x2", "v4") == 0
+    assert ray.util.tpu.get_num_tpu_slices("2x2x2", "v4") == 0
 
 
 def test_get_num_ready_tpu_slices(ray_tpu_cluster):

--- a/python/ray/tests/test_tpu.py
+++ b/python/ray/tests/test_tpu.py
@@ -612,16 +612,6 @@ def test_get_num_ready_tpu_slices_calculation(
             ],
             1,
         ),
-        # Intact slice counts even if TPUs are in use (no idle check).
-        (
-            "2x2x2",
-            "v4",
-            [
-                _make_mock_tpu_node(True, "v4-16", "slice-1", 0, node_id="A"),
-                _make_mock_tpu_node(True, "v4-16", "slice-1", 1, node_id="B"),
-            ],
-            1,
-        ),
         # Fractured slice (missing a physical host) -> 0 intact slices.
         (
             "2x2x2",

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -493,12 +493,6 @@ class TrainController:
         Returns:
             TrainControllerLoopIterationResult with the appropriate next state
         """
-        # If we are in a non-running state we should ensure the old worker group
-        # is shut down and its resources before we ask the scaling policy to
-        # calculate newly available resources.
-        if self._worker_group:
-            self._shutdown_worker_group()
-
         scaling_decision = (
             self._scaling_policy.make_decision_for_non_running_worker_group()
         )

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -113,7 +113,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         Returns:
             The number of workers aligned to fully intact TPU slices.
         """
-        from ray.util.tpu import get_num_intact_tpu_slices, get_tpu_worker_resources
+        from ray.util.tpu import get_num_tpu_slices, get_tpu_worker_resources
 
         single_worker_resources = self.scaling_config._resources_per_worker_not_none
 
@@ -134,7 +134,7 @@ class ElasticScalingPolicy(ScalingPolicy):
 
             if num_slices_from_resources > 0:
                 try:
-                    num_intact_slices = get_num_intact_tpu_slices(
+                    num_intact_slices = get_num_tpu_slices(
                         topology=self.scaling_config.topology,
                         accelerator_type=self.scaling_config.accelerator_type,
                     )

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -126,6 +126,8 @@ class ElasticScalingPolicy(ScalingPolicy):
             )
 
             if workers_per_slice == 0:
+                # A single worker requires more resources than exist in a
+                # full slice — impossible scheduling configuration for TPU.
                 return 0
 
             num_slices_from_resources = total_num_workers // workers_per_slice

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -45,16 +45,18 @@ class ElasticScalingPolicy(ScalingPolicy):
         return self.scaling_config.max_workers
 
     def _count_possible_workers(
-        self, allocated_resources: List[Dict[str, float]], current_num_workers: int = 0
+        self, allocated_resources: List[Dict[str, float]]
     ) -> int:
         """Count the number of workers that can be started/restarted with the given
         the list of node resources. The returned number is capped at the maximum
         number of workers.
 
+        For GPUs, this divides raw allocated resources by per-worker requirements.
+        For TPUs, an additional check ensures workers align with physically intact
+        TPU slices (see ``_get_strict_tpu_worker_count``).
+
         Args:
             allocated_resources: The resources currently allocated by the AutoscalingCoordinator.
-            current_num_workers: The number of healthy workers currently running.
-                This should only be passed when evaluating a running worker group.
 
         Returns:
             The number of workers that can be started/restarted with the current resources.
@@ -87,32 +89,60 @@ class ElasticScalingPolicy(ScalingPolicy):
         ):
             total_num_workers = self._get_strict_tpu_worker_count(
                 total_num_workers=total_num_workers,
-                current_num_workers=current_num_workers,
             )
 
         return total_num_workers
 
-    def _get_strict_tpu_worker_count(
-        self, total_num_workers: int, current_num_workers: int = 0
-    ) -> int:
+    def _get_strict_tpu_worker_count(self, total_num_workers: int) -> int:
         """Calculate the number of workers that can run on intact TPU slices.
 
-        The Autoscaler's allocated resources might overestimate the number of schedulable
-        TPU workers because it counts raw resources. TPUs require atomic, interconnected
-        slices. This function strictly checks the cluster for physically intact slices
-        to prevent scaling up onto fractional/broken topologies.
+        The Autoscaler's allocated resources might overestimate the number of
+        schedulable TPU workers because it counts raw resources. TPUs require
+        atomic, interconnected slices. This function checks the cluster for
+        physically intact slices to prevent scaling onto fractional/broken
+        topologies.
+
+        Unlike GPUs where we simply divide total resources by per-worker need,
+        TPU workers must be scheduled on complete slices. A slice with any
+        dead host is unusable even if some hosts in it are still alive.
+
+        How TPU worker count is calculated
+        -----------------------------------
+
+        Example: 2 x (2x4 TPU V5E) slices, each with 2 hosts
+
+            Cluster: 4 hosts across 2 slices
+            ┌─────────────────────┐  ┌─────────────────────┐
+            │  Slice A  (2x4)     │  │  Slice B  (2x4)     │
+            │  ┌──────┐ ┌──────┐  │  │  ┌──────┐ ┌──────┐  │
+            │  │Host 0│ │Host 1│  │  │  │Host 0│ │Host 1│  │
+            │  │4 chip│ │4 chip│  │  │  │4 chip│ │4 chip│  │
+            │  └──────┘ └──────┘  │  │  └──────┘ └──────┘  │
+            └─────────────────────┘  └─────────────────────┘
+            workers_per_slice = 2 (one per host)
+
+            If Host 1 in Slice B goes down:
+            ┌─────────────────────┐  ┌─────────────────────┐
+            │  Slice A  (intact)  │  │  Slice B  (broken)   │
+            │  ┌──────┐ ┌──────┐  │  │  ┌──────┐ ┌──────┐  │
+            │  │Host 0│ │Host 1│  │  │  │Host 0│ │  ██  │  │
+            │  │4 chip│ │4 chip│  │  │  │4 chip│ │ DEAD │  │
+            │  └──────┘ └──────┘  │  │  └──────┘ └──────┘  │
+            └─────────────────────┘  └─────────────────────┘
+
+            Step 1: Autoscaler allocated resources → 3 hosts → 3 raw workers
+            Step 2: workers_per_slice=2 → 3//2 = 1 slice from resources
+            Step 3: get_num_ready_tpu_slices → 1 intact slice (Slice A)
+            Step 4: min(1, 1) = 1 usable slice → 1 * 2 = 2 workers
 
         Args:
-            total_num_workers: The initial estimate of workers based on raw allocated resources.
-            current_num_workers: The number of healthy workers currently running.
-                For TPUs, this implies the slices for the existing workload are physically
-                intact, allowing us to safely add them to the count of newly available
-                idle slices.
+            total_num_workers: The initial estimate of workers based on raw
+                allocated resources.
 
         Returns:
-            The precise number of workers that align with fully intact TPU slices.
+            The number of workers aligned to fully intact TPU slices.
         """
-        from ray.util.tpu import get_num_ready_tpu_slices, get_tpu_worker_resources
+        from ray.util.tpu import get_num_intact_tpu_slices, get_tpu_worker_resources
 
         single_worker_resources = self.scaling_config._resources_per_worker_not_none
 
@@ -125,36 +155,25 @@ class ElasticScalingPolicy(ScalingPolicy):
             )
 
             if workers_per_slice == 0:
-                # A single worker requires more resources than exist in a full slice.
-                # This is an impossible scheduling configuration for TPU.
                 return 0
 
-            num_available_slices = total_num_workers // workers_per_slice
+            num_slices_from_resources = total_num_workers // workers_per_slice
 
-            # If there are enough TPU workers in the cluster for a full slice,
-            # check the cluster to validate there are alive, complete TPU
-            # slices available.
-            if num_available_slices > 0:
+            if num_slices_from_resources > 0:
                 try:
-                    # This strictly finds physically intact slices that are fully available
-                    # for scheduling.
-                    num_ready_slices = get_num_ready_tpu_slices(
+                    num_intact_slices = get_num_intact_tpu_slices(
                         topology=self.scaling_config.topology,
                         accelerator_type=self.scaling_config.accelerator_type,
                     )
-                    # Add back the slices we already own and are currently running
-                    running_slices = current_num_workers // workers_per_slice
-                    alive_slices = num_ready_slices + running_slices
-
-                    num_available_slices = min(num_available_slices, alive_slices)
+                    num_slices_from_resources = min(
+                        num_slices_from_resources, num_intact_slices
+                    )
                 except Exception as e:
                     logger.warning(
-                        f"Failed to check cluster state for ready TPU slices: {e}"
+                        f"Failed to check cluster state for intact TPU slices: {e}"
                     )
 
-            # The number of workers scaled should be a multiple of the number of
-            # workers that fit on a TPU slice.
-            return num_available_slices * workers_per_slice
+            return num_slices_from_resources * workers_per_slice
 
         except Exception as e:
             logger.warning(
@@ -162,7 +181,6 @@ class ElasticScalingPolicy(ScalingPolicy):
                 "Worker counts may not align with TPU topology."
             )
 
-        # Return 0 if we're not able to detect any available TPU slice for scheduling.
         return 0
 
     def _get_resize_decision(self, num_workers: int) -> ResizeDecision:
@@ -239,9 +257,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         if allocated_resources is None:
             return NoopDecision()
 
-        num_workers = self._count_possible_workers(
-            allocated_resources, current_num_workers=worker_group_state.num_workers
-        )
+        num_workers = self._count_possible_workers(allocated_resources)
 
         if num_workers == worker_group_state.num_workers:
             logger.info(

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -102,38 +102,9 @@ class ElasticScalingPolicy(ScalingPolicy):
         physically intact slices to prevent scaling onto fractional/broken
         topologies.
 
-        Unlike GPUs where we simply divide total resources by per-worker need,
-        TPU workers must be scheduled on complete slices. A slice with any
-        dead host is unusable even if some hosts in it are still alive.
-
-        How TPU worker count is calculated
-        -----------------------------------
-
-        Example: 2 x (2x4 TPU V5E) slices, each with 2 hosts
-
-            Cluster: 4 hosts across 2 slices
-            ┌─────────────────────┐  ┌─────────────────────┐
-            │  Slice A  (2x4)     │  │  Slice B  (2x4)     │
-            │  ┌──────┐ ┌──────┐  │  │  ┌──────┐ ┌──────┐  │
-            │  │Host 0│ │Host 1│  │  │  │Host 0│ │Host 1│  │
-            │  │4 chip│ │4 chip│  │  │  │4 chip│ │4 chip│  │
-            │  └──────┘ └──────┘  │  │  └──────┘ └──────┘  │
-            └─────────────────────┘  └─────────────────────┘
-            workers_per_slice = 2 (one per host)
-
-            If Host 1 in Slice B goes down:
-            ┌─────────────────────┐  ┌─────────────────────┐
-            │  Slice A  (intact)  │  │  Slice B  (broken)   │
-            │  ┌──────┐ ┌──────┐  │  │  ┌──────┐ ┌──────┐  │
-            │  │Host 0│ │Host 1│  │  │  │Host 0│ │  ██  │  │
-            │  │4 chip│ │4 chip│  │  │  │4 chip│ │ DEAD │  │
-            │  └──────┘ └──────┘  │  │  └──────┘ └──────┘  │
-            └─────────────────────┘  └─────────────────────┘
-
-            Step 1: Autoscaler allocated resources → 3 hosts → 3 raw workers
-            Step 2: workers_per_slice=2 → 3//2 = 1 slice from resources
-            Step 3: get_num_ready_tpu_slices → 1 intact slice (Slice A)
-            Step 4: min(1, 1) = 1 usable slice → 1 * 2 = 2 workers
+        The worker count is: min(resource_based_slices, intact_slices) *
+        workers_per_slice, where resource_based_slices =
+        total_num_workers // workers_per_slice.
 
         Args:
             total_num_workers: The initial estimate of workers based on raw

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -443,7 +443,7 @@ def test_request_and_clear():
         (12, 3, 12),
     ],
 )
-@patch("ray.util.tpu.get_num_intact_tpu_slices")
+@patch("ray.util.tpu.get_num_tpu_slices")
 def test_count_possible_workers_tpu_slice_rounding(
     mock_get_intact_slices,
     num_autoscaler_nodes,

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -426,24 +426,36 @@ def test_request_and_clear():
 
 
 @pytest.mark.parametrize(
-    "num_autoscaler_nodes, mock_gcs_ready_slices, expected_workers",
+    "num_autoscaler_nodes, mock_gcs_intact_slices, expected_workers",
     [
         # No resources -> 0 workers
         (0, 0, 0),
         # Autoscaler sees 3 nodes but slice requires 4 -> rounds to 0 workers
         (3, 0, 0),
-        # Autoscaler sees 4 nodes and determines 1 full slice is ready -> 4 workers
+        # Autoscaler sees 4 nodes and 1 intact slice -> 4 workers
         (4, 1, 4),
+        # Autoscaler sees 8 nodes (2 slices worth) but only 1 slice is intact
+        # (e.g. 1 host down in the other slice) -> capped at 4 workers
+        (8, 1, 4),
+        # Autoscaler sees 8 nodes and both slices are intact -> 8 workers
+        (8, 2, 8),
+        # Autoscaler sees 12 nodes (3 slices), all 3 intact -> 12 workers (max)
+        (12, 3, 12),
     ],
 )
-@patch("ray.util.tpu.get_num_ready_tpu_slices")
+@patch("ray.util.tpu.get_num_intact_tpu_slices")
 def test_count_possible_workers_tpu_slice_rounding(
-    mock_get_ready_slices, num_autoscaler_nodes, mock_gcs_ready_slices, expected_workers
+    mock_get_intact_slices,
+    num_autoscaler_nodes,
+    mock_gcs_intact_slices,
+    expected_workers,
 ):
     """
-    Test that TPU scaling correctly floors to the nearest complete TPU slice.
+    Test that TPU scaling correctly floors to the nearest complete, physically
+    intact TPU slice. Intact slices are counted regardless of whether they are
+    currently idle or in use.
     """
-    mock_get_ready_slices.return_value = mock_gcs_ready_slices
+    mock_get_intact_slices.return_value = mock_gcs_intact_slices
 
     # Scaling config for TPU v6e 4x4 between 1 and 3 slices.
     scaling_config = ScalingConfig(

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -375,15 +375,12 @@ def get_num_intact_tpu_slices(
 
     try:
         pod_type = infer_tpu_pod_type_from_topology(topology, accelerator_type)
-        if not pod_type:
-            return 0
-
         total_chips_expected = get_num_chips_from_topology(topology)
-        if total_chips_expected <= 0:
-            return 0
-
     except Exception as e:
         logger.warning(f"Failed to parse TPU topology for integrity check: {e}")
+        return 0
+
+    if not pod_type or total_chips_expected <= 0:
         return 0
 
     slice_to_nodes = {}
@@ -398,18 +395,12 @@ def get_num_intact_tpu_slices(
     intact_slices = 0
     for slice_name, nodes in slice_to_nodes.items():
         slice_tpu_chips = sum(node.get("Resources", {}).get("TPU", 0) for node in nodes)
-
-        if slice_tpu_chips != total_chips_expected:
-            continue
-
         has_head = any(
             n.get("Labels", {}).get(ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY) == "0"
             for n in nodes
         )
-        if not has_head:
-            continue
-
-        intact_slices += 1
+        if slice_tpu_chips == total_chips_expected and has_head:
+            intact_slices += 1
 
     return intact_slices
 

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -348,6 +348,73 @@ def get_num_ready_tpu_slices(
 
 
 @PublicAPI(stability="alpha")
+def get_num_intact_tpu_slices(
+    topology: str,
+    accelerator_type: str,
+) -> int:
+    """
+    Checks the cluster state to determine how many full TPU slices of the
+    specified topology are physically intact (all hosts alive with the
+    expected chip count).
+
+    Unlike ``get_num_ready_tpu_slices``, this does NOT check whether the
+    slices are idle. A slice is counted as long as every host in it is alive
+    and the total chip count matches the topology. This avoids requiring the
+    old worker group to be fully shut down before querying for available
+    slices during elastic scaling.
+
+    Args:
+        topology: The TPU topology string (e.g. "2x4").
+        accelerator_type: The accelerator type string (e.g. "TPU-V6E").
+
+    Returns:
+        The integer count of physically intact TPU slices.
+    """
+    if not ray.is_initialized():
+        return 0
+
+    try:
+        pod_type = infer_tpu_pod_type_from_topology(topology, accelerator_type)
+        if not pod_type:
+            return 0
+
+        total_chips_expected = get_num_chips_from_topology(topology)
+        if total_chips_expected <= 0:
+            return 0
+
+    except Exception as e:
+        logger.warning(f"Failed to parse TPU topology for integrity check: {e}")
+        return 0
+
+    slice_to_nodes = {}
+    for node in ray.nodes():
+        if node.get("Alive"):
+            labels = node.get("Labels", {})
+            if labels.get(ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY) == pod_type:
+                slice_name = get_tpu_slice_name_from_node(node)
+                if slice_name:
+                    slice_to_nodes.setdefault(slice_name, []).append(node)
+
+    intact_slices = 0
+    for slice_name, nodes in slice_to_nodes.items():
+        slice_tpu_chips = sum(node.get("Resources", {}).get("TPU", 0) for node in nodes)
+
+        if slice_tpu_chips != total_chips_expected:
+            continue
+
+        has_head = any(
+            n.get("Labels", {}).get(ray._raylet.RAY_NODE_TPU_WORKER_ID_KEY) == "0"
+            for n in nodes
+        )
+        if not has_head:
+            continue
+
+        intact_slices += 1
+
+    return intact_slices
+
+
+@PublicAPI(stability="alpha")
 class SlicePlacementGroup:
     """
     A handle to a placement group reservation for a TPU slice.

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -12,7 +12,7 @@ from ray._private.accelerators.tpu import (
     reserve_tpu_slice,
 )
 from ray._private.client_mode_hook import client_mode_wrap
-from ray.util.annotations import PublicAPI
+from ray.util.annotations import DeveloperAPI, PublicAPI
 from ray.util.placement_group import (
     PlacementGroup,
     placement_group,
@@ -347,8 +347,8 @@ def get_num_ready_tpu_slices(
     return ready_and_available_slices
 
 
-@PublicAPI(stability="alpha")
-def get_num_intact_tpu_slices(
+@DeveloperAPI
+def get_num_tpu_slices(
     topology: str,
     accelerator_type: str,
 ) -> int:
@@ -357,11 +357,9 @@ def get_num_intact_tpu_slices(
     specified topology are physically intact (all hosts alive with the
     expected chip count).
 
-    Unlike ``get_num_ready_tpu_slices``, this does NOT check whether the
+    Unlike :func:`get_num_ready_tpu_slices`, this does NOT check whether the
     slices are idle. A slice is counted as long as every host in it is alive
-    and the total chip count matches the topology. This avoids requiring the
-    old worker group to be fully shut down before querying for available
-    slices during elastic scaling.
+    and the total chip count matches the topology.
 
     Args:
         topology: The TPU topology string (e.g. "2x4").


### PR DESCRIPTION
## Description
1. Introduces `get_num_tpu_slices` in ray.util.tpu, which counts physically intact TPU slices (all hosts alive, correct chip count) without requiring them to be idle. This replaces the use of `get_num_ready_tpu_slices` during elastic scaling, removing the need to fully shut down the old worker group before querying for available slices.
2. Simplifies ElasticScalingPolicy by removing the current_num_workers bookkeeping. Previously, the policy had to track running workers and add back "owned" slices to the ready count. With intact-slice counting, this workaround is no longer needed — the formula is simply min(resource_based_slices, intact_slices) * workers_per_slice.
3. Removes the eager `_shutdown_worker_group` call from the controller's non-running state handler, since the scaling policy no longer requires workers to be stopped before it can accurately count available slices.


