### PR TITLE
[Doc] RayCronJob quick start document

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started.md
+++ b/doc/source/cluster/kubernetes/getting-started.md
@@ -24,16 +24,22 @@ It offers 3 custom resource definitions (CRDs):
 
 * **RayService**: RayService is made up of two parts: a RayCluster and Ray Serve deployment graphs. RayService offers zero-downtime upgrades for RayCluster and high availability.
 
+* **RayCronJob**: RayCronJob is used to run RayJobs on a recurring schedule. It automatically creates new RayJob resources based on a cron expression, making it easy to run periodic workloads such as batch jobs or scheduled tasks.
+
 ## Which CRD should you choose?
 
 Using [RayService](kuberay-rayservice-quickstart) to serve models and using [RayCluster](kuberay-raycluster-quickstart) to develop Ray applications are no-brainer recommendations from us.
-However, if the use case is not model serving or prototyping, how do you choose between [RayCluster](kuberay-raycluster-quickstart) and [RayJob](kuberay-rayjob-quickstart)?
+However, if the use case is not model serving or prototyping, how do you choose between [RayCluster](kuberay-raycluster-quickstart), [RayJob](kuberay-rayjob-quickstart), and [RayCronJob](kuberay-raycronjob-quickstart)?
 
 ### Q: Is downtime acceptable during a cluster upgrade (e.g. Upgrade Ray version)?
 
 If not, use RayJob. RayJob can be configured to automatically delete the RayCluster once the job is completed. You can switch between Ray versions and configurations for each job submission using RayJob.
 
 If yes, use RayCluster. Ray doesn't natively support rolling upgrades; thus, you'll need to manually shut down and create a new RayCluster.
+
+### Q: Do you need to run workloads on a recurring schedule?
+
+If yes, use RayCronJob. RayCronJob automatically creates RayJob resources on a cron schedule, allowing you to run periodic workloads such as batch processing or scheduled inference.
 
 ### Q: Are you deploying on public cloud providers (e.g. AWS, GCP, Azure)?
 
@@ -42,7 +48,7 @@ If yes, use RayJob. It allows automatic deletion of the RayCluster upon job comp
 ### Q: Do you care about the latency introduced by spinning up a RayCluster?
 
 If yes, use RayCluster.
-Unlike RayJob, which creates a new RayCluster every time a job is submitted, RayCluster creates the cluster just once and can be used multiple times.
+Unlike RayJob and RayCronJob, which creates a new RayCluster every time a job is submitted, RayCluster creates the cluster just once and can be used multiple times.
 
 ## Run your first Ray application on Kubernetes!
 

--- a/doc/source/cluster/kubernetes/getting-started.md
+++ b/doc/source/cluster/kubernetes/getting-started.md
@@ -48,7 +48,7 @@ If yes, use RayJob. It allows automatic deletion of the RayCluster upon job comp
 ### Q: Do you care about the latency introduced by spinning up a RayCluster?
 
 If yes, use RayCluster.
-Unlike RayJob and RayCronJob, which creates a new RayCluster every time a job is submitted, RayCluster creates the cluster just once and can be used multiple times.
+Unlike RayJob and RayCronJob, which create a new RayCluster every time a job is submitted, RayCluster creates the cluster just once and can be used multiple times.
 
 ## Run your first Ray application on Kubernetes!
 

--- a/doc/source/cluster/kubernetes/getting-started.md
+++ b/doc/source/cluster/kubernetes/getting-started.md
@@ -9,6 +9,7 @@ getting-started/kuberay-operator-installation
 getting-started/raycluster-quick-start
 getting-started/rayjob-quick-start
 getting-started/rayservice-quick-start
+getting-started/raycronjob-quick-start
 ```
 
 
@@ -48,3 +49,4 @@ Unlike RayJob, which creates a new RayCluster every time a job is submitted, Ray
 * [RayCluster Quick Start](kuberay-raycluster-quickstart)
 * [RayJob Quick Start](kuberay-rayjob-quickstart)
 * [RayService Quick Start](kuberay-rayservice-quickstart)
+* [RayCronJob Quick Start](kuberay-raycronjob-quickstart)

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -18,7 +18,7 @@ This is particularly useful for recurring tasks such as scheduled model retraini
 
 ## RayCronJob Configuration
 
-The `RayCronJob` CRD acts as an automated scheduler specifically designed to create and manage **RayJob** custom resources on a recurring basis. It does not execute workloads directly. Instead, it acts as a controller that creates a new `RayJob` on each schedule triggers.
+The `RayCronJob` CRD acts as an automated scheduler specifically designed to create and manage **RayJob** custom resources on a recurring basis. It does not execute workloads directly. Instead, it acts as a controller that creates a new `RayJob` each time the schedule triggers.
 
 * `schedule` - The cron schedule string defining when a new Ray job should be created and run (e.g., `* * * * *` for every minute).
 * `jobTemplate` - Wraps a standard **RayJob** spec that the controller will use for each scheduled run. It supports the same fields as a RayJob spec. See the standard [RayJob Configuration](kuberay-rayjob-quickstart) documentation for the complete list of supported fields within the `jobTemplate`.

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -1,0 +1,149 @@
+(kuberay-raycronjob-quickstart)=
+
+# RayCronJob Quickstart
+
+## What is a RayCronJob?
+
+A `RayCronJob` is a KubeRay Custom Resource (CR) that allows you to run `RayJob` workloads on a recurring, time-based schedule. It is heavily inspired by the native Kubernetes `CronJob` and brings automated, scheduled execution to your distributed Ray applications. 
+
+
+This is particularly useful for recurring tasks such as scheduled model retraining, nightly batch inferences, or regular data processing pipelines.
+
+## RayCronJob Features
+
+The `RayCronJob` CRD provides standard cron-like functionality tailored for Ray workloads:
+
+* **Automated Scheduling:** Define your run schedule using standard cron format strings (e.g., `* * * * *` for every minute).
+* **Concurrency Policy (`concurrencyPolicy`):** Control what happens if a new job is scheduled to run before the previous one has finished:
+    * `Allow`: (Default) Allows concurrent jobs to run.
+    * `Forbid`: Skips the new job run if the previous one is still active.
+    * `Replace`: Cancels the currently running job and replaces it with the new one.
+* **Job History Limits:** Automatically clean up the cluster by specifying how many completed or failed `RayJob`s to keep using `successfulJobsHistoryLimit` and `failedJobsHistoryLimit`.
+* **Suspend (`suspend`):** Temporarily pause the scheduling of future jobs without deleting the `RayCronJob` resource.
+
+## How to Configure a RayCronJob
+
+Configuring a `RayCronJob` requires wrapping a standard `RayJob` specification inside a `jobTemplate`, alongside your scheduling parameters.
+
+The high-level structure looks like this:
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayCronJob
+metadata:
+  name: example-raycronjob
+spec:
+  schedule: "*/5 * * * *" # Run every 5 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    # Everything below here is a standard RayJob spec
+    spec:
+      entrypoint: python /home/ray/samples/sample_code.py
+      # ... (RayCluster spec, runtimeEnv, etc.)
+```
+
+## How to Run an Easy RayCronJob
+
+Let's deploy a simple `RayCronJob` that executes a short Python script every minute.
+
+### Prerequisites
+
+* A running Kubernetes cluster.
+* The KubeRay operator installed and running in your cluster.
+
+### Step 1: Create the RayCronJob YAML
+
+Create a file named `raycronjob-sample.yaml` with the following content. This job will simply print the current date and time in the Ray cluster every minute.
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayCronJob
+metadata:
+  name: raycronjob-sample
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    # Notice: No "spec:" wrapper here! 
+    # These are standard RayJob fields placed directly under jobTemplate
+    entrypoint: python -c "import datetime; print(f'Hello from RayCronJob! Current time is {datetime.datetime.now()}')"
+    shutdownAfterJobFinishes: true
+    ttlSecondsAfterFinished: 60
+    rayClusterSpec:
+      rayVersion: '2.52.0'
+      headGroupSpec:
+        rayStartParams:
+          dashboard-host: '0.0.0.0'
+        template:
+          spec:
+            containers:
+              - name: ray-head
+                image: rayproject/ray:2.52.0
+                resources:
+                  limits:
+                    cpu: "1"
+                    memory: "2Gi"
+                  requests:
+                    cpu: "200m"
+      workerGroupSpecs:
+        - replicas: 1
+          minReplicas: 1
+          maxReplicas: 1
+          groupName: small-group
+          rayStartParams: {}
+          template:
+            spec:
+              containers:
+                - name: ray-worker
+                  image: rayproject/ray:2.52.0
+                  resources:
+                    limits:
+                      cpu: "1"
+                      memory: "2Gi"
+                    requests:
+                      cpu: "200m"
+```
+
+### Step 2: Apply the Resource
+
+Apply the configuration to your cluster:
+
+```bash
+kubectl apply -f raycronjob-sample.yaml
+```
+
+### Step 3: Monitor the RayCronJob
+
+Check the status of your `RayCronJob`. You should see the schedule and the last time it successfully scheduled a job.
+
+```bash
+kubectl get raycronjob raycronjob-sample
+```
+
+Because our schedule is `* * * * *`, a new `RayJob` will be generated at the start of the next minute. You can watch the `RayJob` instances being created:
+
+```bash
+kubectl get rayjob -w
+```
+
+### Step 4: Verify the Output
+
+Once a generated `RayJob` completes, you can check the logs of the Ray job submitter or the head node to verify our Python script ran successfully:
+
+```bash
+# Find the specific pod running the job (usually named after the RayJob with a suffix)
+kubectl get pods -l ray.io/is-job-worker=true
+
+# Fetch the logs of the job pod
+kubectl logs <job-pod-name>
+```
+
+### Step 5: Clean Up
+
+To stop the recurring jobs and delete the resource, run:
+
+```bash
+kubectl delete -f raycronjob-sample.yaml
+```

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -25,7 +25,7 @@ The `RayCronJob` CRD acts as an automated scheduler specifically designed to cre
   * `rayClusterSpec` - Defines the RayCluster custom resource to run the Ray job on.
   * `entrypoint` - The command to execute for the job.
   * `shutdownAfterJobFinishes` - Determines whether to recycle the RayCluster after the scheduled Ray job finishes.
-  * *Note: See the standard {ref}`RayJob Configuration <kuberay-rayjob-quickstart>` documentation for the complete list of supported fields within the `jobTemplate`.*
+  * *Note: See the standard [RayJob Configuration](kuberay-rayjob-quickstart) documentation for the complete list of supported fields within the `jobTemplate`.*
 * `suspend` (Optional): If `suspend` is true, the controller suspends the scheduling of future jobs. This does not apply to or interrupt any `RayJob`s that have already been created and are currently running.
 
 ## How to Configure a RayCronJob
@@ -70,7 +70,7 @@ helm install kuberay-operator kuberay/kuberay-operator \
   --set "featureGates[0].name=RayCronJob" \
   --set "featureGates[0].enabled=true"
 ```
-For alternative installation methods, refer to {ref}`KubeRay Operator Installation <kuberay-operator-deploy>`, but ensure you append the feature gate configuration.
+For alternative installation methods, refer to [KubeRay Operator Installation](kuberay-operator-deploy), but ensure you append the feature gate configuration.
 
 ### Step 3: Install a RayCronJob
 

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -21,11 +21,7 @@ This is particularly useful for recurring tasks such as scheduled model retraini
 The `RayCronJob` CRD acts as an automated scheduler specifically designed to create and manage **RayJob** custom resources on a recurring basis. It does not execute workloads directly; instead, it acts as a factory that generates a new `RayJob` every time its schedule triggers.
 
 * `schedule` - The cron schedule string defining when a new Ray job should be created and run (e.g., `* * * * *` for every minute).
-* `jobTemplate` - Defines the exact **RayJob** blueprint that the controller will use for each scheduled run. Because it inherits the entire `RayJob` schema, it supports all standard RayJob configurations directly, including:
-  * `rayClusterSpec` - Defines the RayCluster custom resource to run the Ray job on.
-  * `entrypoint` - The command to execute for the job.
-  * `shutdownAfterJobFinishes` - Determines whether to recycle the RayCluster after the scheduled Ray job finishes.
-  * *Note: See the standard [RayJob Configuration](kuberay-rayjob-quickstart) documentation for the complete list of supported fields within the `jobTemplate`.*
+* `jobTemplate` - Wraps a standard **RayJob** spec that the controller will use for each scheduled run. It supports the same fields as a RayJob spec. See the standard [RayJob Configuration](kuberay-rayjob-quickstart) documentation for the complete list of supported fields within the `jobTemplate`.*
 * `suspend` (Optional): If `suspend` is true, the controller suspends the scheduling of future jobs. This does not apply to or interrupt any `RayJob`s that have already been created and are currently running.
 
 ## How to Configure a RayCronJob
@@ -58,7 +54,7 @@ kind create cluster --image=kindest/node:v1.26.0
 ```
 
 ### Step 2: Install the KubeRay operator
-You must install KubeRay operator version 1.6.0 (or newer) and enable the feature gate. We recommend using Helm for this:
+Install the KubeRay operator, following [these instructions](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/kuberay-operator-installation.html). The minimum version for this guide is v1.5.1. To use this feature, the `RayServiceIncrementalUpgrade` feature gate must be enabled. To enable the feature gate when installing the kuberay operator, run the following command: 
 
 ```sh
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
@@ -70,7 +66,6 @@ helm install kuberay-operator kuberay/kuberay-operator \
   --set "featureGates[0].name=RayCronJob" \
   --set "featureGates[0].enabled=true"
 ```
-For alternative installation methods, refer to [KubeRay Operator Installation](kuberay-operator-deploy), but ensure you append the feature gate configuration.
 
 ### Step 3: Install a RayCronJob
 
@@ -80,7 +75,7 @@ kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ra
 
 ### Step 4: Monitor the RayCronJob
 
-Check the status of your `RayCronJob`. You should see the schedule and the last time it successfully scheduled a job.
+Check the status of your `RayCronJob`. The `SCHEDULE` field should be visible immediately, while `LAST SCHEDULE` may be empty until the first scheduled run is triggered.
 
 ```sh
 kubectl get raycronjob raycronjob-sample
@@ -97,27 +92,11 @@ Because our schedule is `* * * * *`, a new `RayJob` will be generated at the sta
 ```shell
 kubectl get rayjob -w
 # [Example output]
-# NAME                      JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME   START TIME   END TIME   AGE
-# raycronjob-sample-l76h8                                                                               0s
-# raycronjob-sample-l76h8                                                                               0s
-# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              0s
-# raycronjob-sample-gmsnw                                                                                                      0s
-# raycronjob-sample-gmsnw                                                                                                      0s
-# raycronjob-sample-gmsnw                Initializing        raycronjob-sample-gmsnw-d6n2r   2026-04-03T05:57:00Z              0s
-# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              0s
-# raycronjob-sample-gmsnw                Initializing        raycronjob-sample-gmsnw-d6n2r   2026-04-03T05:57:00Z              0s
+# NAME                      JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME                 START TIME             END TIME   AGE
 # raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              2s
-# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              17s
-# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              21s
-# raycronjob-sample-l76h8                Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              31s
-# raycronjob-sample-l76h8   PENDING      Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              39s
 # raycronjob-sample-l76h8   RUNNING      Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              48s
-# raycronjob-sample-l76h8   SUCCEEDED    Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              57s
-# raycronjob-sample-pct47                                                                                                      0s
-# raycronjob-sample-pct47                                                                                                      0s
-# raycronjob-sample-pct47                Initializing        raycronjob-sample-pct47-bdspj   2026-04-03T05:58:00Z              0s
-# raycronjob-sample-pct47                Initializing        raycronjob-sample-pct47-bdspj   2026-04-03T05:58:00Z              0s
 # raycronjob-sample-l76h8   SUCCEEDED    Complete            raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z   2026-04-03T05:58:02Z   62s
+# raycronjob-sample-pct47                Initializing        raycronjob-sample-pct47-bdspj   2026-04-03T05:58:00Z              0s
 # (Press Ctrl+C to stop watching once the job completes)
 ```
 
@@ -188,5 +167,12 @@ kubectl logs <job-pod-name>
 To stop the recurring jobs and delete the resource, run:
 
 ```bash
-kubectl delete -f ray-cronjob.sample.yaml
+# Step 6.1: Delete the RayCronJob
+kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cronjob.sample.yaml
+
+# Step 6.2: Delete the KubeRay operator
+helm uninstall kuberay-operator
+
+# Step 6.3: Delete the Kubernetes cluster
+kind delete cluster
 ```

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -2,24 +2,31 @@
 
 # RayCronJob Quickstart
 
+## Prerequisites
+
+* This feature requires KubeRay version 1.6.0 or newer, and it's in alpha testing.
+    * A running Kubernetes cluster.
+    * The KubeRay operator installed and running in your cluster.
+
 ## What is a RayCronJob?
 
-A `RayCronJob` is a KubeRay Custom Resource (CR) that allows you to run `RayJob` workloads on a recurring, time-based schedule. It is heavily inspired by the native Kubernetes `CronJob` and brings automated, scheduled execution to your distributed Ray applications. 
+A `RayCronJob` is a Custom Resource (CR) that allows you to run `RayJob` workloads on a recurring, time-based schedule. It is heavily inspired by the native Kubernetes `CronJob` and brings automated, scheduled execution to your distributed Ray applications.
 
 
 This is particularly useful for recurring tasks such as scheduled model retraining, nightly batch inferences, or regular data processing pipelines.
 
-## RayCronJob Features
 
-The `RayCronJob` CRD provides standard cron-like functionality tailored for Ray workloads:
+## RayCronJob Configuration
 
-* **Automated Scheduling:** Define your run schedule using standard cron format strings (e.g., `* * * * *` for every minute).
-* **Concurrency Policy (`concurrencyPolicy`):** Control what happens if a new job is scheduled to run before the previous one has finished:
-    * `Allow`: (Default) Allows concurrent jobs to run.
-    * `Forbid`: Skips the new job run if the previous one is still active.
-    * `Replace`: Cancels the currently running job and replaces it with the new one.
-* **Job History Limits:** Automatically clean up the cluster by specifying how many completed or failed `RayJob`s to keep using `successfulJobsHistoryLimit` and `failedJobsHistoryLimit`.
-* **Suspend (`suspend`):** Temporarily pause the scheduling of future jobs without deleting the `RayCronJob` resource.
+The `RayCronJob` CRD acts as an automated scheduler specifically designed to create and manage **RayJob** custom resources on a recurring basis. It does not execute workloads directly; instead, it acts as a factory that generates a new `RayJob` every time its schedule triggers.
+
+* `schedule` - The cron schedule string defining when a new Ray job should be created and run (e.g., `* * * * *` for every minute).
+* `jobTemplate` - Defines the exact **RayJob** blueprint that the controller will use for each scheduled run. Because it inherits the entire `RayJob` schema, it supports all standard RayJob configurations directly, including:
+  * `rayClusterSpec` - Defines the RayCluster custom resource to run the Ray job on.
+  * `entrypoint` - The command to execute for the job.
+  * `shutdownAfterJobFinishes` - Determines whether to recycle the RayCluster after the scheduled Ray job finishes.
+  * *Note: See the standard [RayJob Configuration](#rayjob-quick-start) documentation for the complete list of supported fields within the `jobTemplate`.*
+* `suspend` (Optional): If `suspend` is true, the controller suspends the scheduling of future jobs. This does not apply to or interrupt any `RayJob`s that have already been created and are currently running.
 
 ## How to Configure a RayCronJob
 
@@ -34,92 +41,45 @@ metadata:
   name: example-raycronjob
 spec:
   schedule: "*/5 * * * *" # Run every 5 minutes
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 3
-  failedJobsHistoryLimit: 1
   jobTemplate:
     # Everything below here is a standard RayJob spec
-    spec:
-      entrypoint: python /home/ray/samples/sample_code.py
-      # ... (RayCluster spec, runtimeEnv, etc.)
+    entrypoint: python /home/ray/samples/sample_code.py
+    # ... (RayCluster spec, runtimeEnv, etc.)
 ```
 
 ## How to Run an Easy RayCronJob
 
 Let's deploy a simple `RayCronJob` that executes a short Python script every minute.
 
-### Prerequisites
+## Step 1: Create a Kubernetes cluster with Kind
 
-* A running Kubernetes cluster.
-* The KubeRay operator installed and running in your cluster.
-
-### Step 1: Create the RayCronJob YAML
-
-Create a file named `raycronjob-sample.yaml` with the following content. This job will simply print the current date and time in the Ray cluster every minute.
-
-```yaml
-apiVersion: ray.io/v1
-kind: RayCronJob
-metadata:
-  name: raycronjob-sample
-  namespace: default
-spec:
-  schedule: "* * * * *"
-  jobTemplate:
-    # Notice: No "spec:" wrapper here! 
-    # These are standard RayJob fields placed directly under jobTemplate
-    entrypoint: python -c "import datetime; print(f'Hello from RayCronJob! Current time is {datetime.datetime.now()}')"
-    shutdownAfterJobFinishes: true
-    ttlSecondsAfterFinished: 60
-    rayClusterSpec:
-      rayVersion: '2.52.0'
-      headGroupSpec:
-        rayStartParams:
-          dashboard-host: '0.0.0.0'
-        template:
-          spec:
-            containers:
-              - name: ray-head
-                image: rayproject/ray:2.52.0
-                resources:
-                  limits:
-                    cpu: "1"
-                    memory: "2Gi"
-                  requests:
-                    cpu: "200m"
-      workerGroupSpecs:
-        - replicas: 1
-          minReplicas: 1
-          maxReplicas: 1
-          groupName: small-group
-          rayStartParams: {}
-          template:
-            spec:
-              containers:
-                - name: ray-worker
-                  image: rayproject/ray:2.52.0
-                  resources:
-                    limits:
-                      cpu: "1"
-                      memory: "2Gi"
-                    requests:
-                      cpu: "200m"
+```sh
+kind create cluster --image=kindest/node:v1.26.0
 ```
 
-### Step 2: Apply the Resource
+## Step 2: Install the KubeRay operator
 
-Apply the configuration to your cluster:
+Follow the [KubeRay Operator Installation](kuberay-operator-deploy) to install the latest stable KubeRay operator by Helm repository.
+
+### Step 3: Install a RayCronJob
 
 ```bash
-kubectl apply -f raycronjob-sample.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cronjob.sample.yaml
 ```
 
-### Step 3: Monitor the RayCronJob
+### Step 4: Monitor the RayCronJob
 
 Check the status of your `RayCronJob`. You should see the schedule and the last time it successfully scheduled a job.
 
 ```bash
 kubectl get raycronjob raycronjob-sample
+```
+
+You should see output listing the RayCronJob created, for example:
+
+```
+NAME                SCHEDULE    LAST SCHEDULE   AGE   SUSPEND
+raycronjob-sample   * * * * *                   10s   
 ```
 
 Because our schedule is `* * * * *`, a new `RayJob` will be generated at the start of the next minute. You can watch the `RayJob` instances being created:
@@ -128,7 +88,7 @@ Because our schedule is `* * * * *`, a new `RayJob` will be generated at the sta
 kubectl get rayjob -w
 ```
 
-### Step 4: Verify the Output
+### Step 5: Verify the Output
 
 Once a generated `RayJob` completes, you can check the logs of the Ray job submitter or the head node to verify our Python script ran successfully:
 
@@ -140,10 +100,10 @@ kubectl get pods -l ray.io/is-job-worker=true
 kubectl logs <job-pod-name>
 ```
 
-### Step 5: Clean Up
+### Step 6: Clean Up
 
 To stop the recurring jobs and delete the resource, run:
 
 ```bash
-kubectl delete -f raycronjob-sample.yaml
+kubectl delete -f ray-cronjob.sample.yaml
 ```

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -25,7 +25,7 @@ The `RayCronJob` CRD acts as an automated scheduler specifically designed to cre
   * `rayClusterSpec` - Defines the RayCluster custom resource to run the Ray job on.
   * `entrypoint` - The command to execute for the job.
   * `shutdownAfterJobFinishes` - Determines whether to recycle the RayCluster after the scheduled Ray job finishes.
-  * *Note: See the standard [RayJob Configuration](#rayjob-quick-start) documentation for the complete list of supported fields within the `jobTemplate`.*
+  * *Note: See the standard {ref}`RayJob Configuration <kuberay-rayjob-quickstart>` documentation for the complete list of supported fields within the `jobTemplate`.*
 * `suspend` (Optional): If `suspend` is true, the controller suspends the scheduling of future jobs. This does not apply to or interrupt any `RayJob`s that have already been created and are currently running.
 
 ## How to Configure a RayCronJob
@@ -47,23 +47,34 @@ spec:
     # ... (RayCluster spec, runtimeEnv, etc.)
 ```
 
-## How to Run an Easy RayCronJob
+## How to Run an Simple RayCronJob
 
 Let's deploy a simple `RayCronJob` that executes a short Python script every minute.
 
-## Step 1: Create a Kubernetes cluster with Kind
+### Step 1: Create a Kubernetes cluster with Kind
 
 ```sh
 kind create cluster --image=kindest/node:v1.26.0
 ```
 
-## Step 2: Install the KubeRay operator
+### Step 2: Install the KubeRay operator
+You must install KubeRay operator version 1.6.0 (or newer) and enable the feature gate. We recommend using Helm for this:
 
-Follow the [KubeRay Operator Installation](kuberay-operator-deploy) to install the latest stable KubeRay operator by Helm repository.
+```sh
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+helm repo update
+
+# Install KubeRay operator v1.6.0 with the RayCronJob feature gate enabled
+helm install kuberay-operator kuberay/kuberay-operator \
+  --version 1.6.0 \
+  --set "featureGates[0].name=RayCronJob" \
+  --set "featureGates[0].enabled=true"
+```
+For alternative installation methods, refer to {ref}`KubeRay Operator Installation <kuberay-operator-deploy>`, but ensure you append the feature gate configuration.
 
 ### Step 3: Install a RayCronJob
 
-```bash
+```sh
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cronjob.sample.yaml
 ```
 
@@ -71,33 +82,105 @@ kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ra
 
 Check the status of your `RayCronJob`. You should see the schedule and the last time it successfully scheduled a job.
 
-```bash
+```sh
 kubectl get raycronjob raycronjob-sample
-```
 
-You should see output listing the RayCronJob created, for example:
+#You should see output listing the RayCronJob created
+# [Example output]
 
-```
-NAME                SCHEDULE    LAST SCHEDULE   AGE   SUSPEND
-raycronjob-sample   * * * * *                   10s   
+# NAME                SCHEDULE    LAST SCHEDULE   AGE   SUSPEND
+# raycronjob-sample   * * * * *                   10s   
 ```
 
 Because our schedule is `* * * * *`, a new `RayJob` will be generated at the start of the next minute. You can watch the `RayJob` instances being created:
 
-```bash
+```shell
 kubectl get rayjob -w
+# [Example output]
+# NAME                      JOB STATUS   DEPLOYMENT STATUS   RAY CLUSTER NAME   START TIME   END TIME   AGE
+# raycronjob-sample-l76h8                                                                               0s
+# raycronjob-sample-l76h8                                                                               0s
+# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              0s
+# raycronjob-sample-gmsnw                                                                                                      0s
+# raycronjob-sample-gmsnw                                                                                                      0s
+# raycronjob-sample-gmsnw                Initializing        raycronjob-sample-gmsnw-d6n2r   2026-04-03T05:57:00Z              0s
+# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              0s
+# raycronjob-sample-gmsnw                Initializing        raycronjob-sample-gmsnw-d6n2r   2026-04-03T05:57:00Z              0s
+# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              2s
+# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              17s
+# raycronjob-sample-l76h8                Initializing        raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              21s
+# raycronjob-sample-l76h8                Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              31s
+# raycronjob-sample-l76h8   PENDING      Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              39s
+# raycronjob-sample-l76h8   RUNNING      Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              48s
+# raycronjob-sample-l76h8   SUCCEEDED    Running             raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z              57s
+# raycronjob-sample-pct47                                                                                                      0s
+# raycronjob-sample-pct47                                                                                                      0s
+# raycronjob-sample-pct47                Initializing        raycronjob-sample-pct47-bdspj   2026-04-03T05:58:00Z              0s
+# raycronjob-sample-pct47                Initializing        raycronjob-sample-pct47-bdspj   2026-04-03T05:58:00Z              0s
+# raycronjob-sample-l76h8   SUCCEEDED    Complete            raycronjob-sample-l76h8-hjtrs   2026-04-03T05:57:00Z   2026-04-03T05:58:02Z   62s
+# (Press Ctrl+C to stop watching once the job completes)
 ```
 
 ### Step 5: Verify the Output
 
-Once a generated `RayJob` completes, you can check the logs of the Ray job submitter or the head node to verify our Python script ran successfully:
+Once a generated `RayJob` completes, you can inspect the logs of the job submitter pod to verify that the Python script ran successfully:
 
-```bash
-# Find the specific pod running the job (usually named after the RayJob with a suffix)
-kubectl get pods -l ray.io/is-job-worker=true
+```shell
+# Step 5.1: Find the specific pod running the job (usually named after the RayJob with a suffix)
+kubectl get pods
+# [Example output]
+# NAME                                                     READY   STATUS      RESTARTS      AGE
+# kuberay-operator-7fc88c69f5-n2g5k                        1/1     Running     1 (12m ago)   45h
+# raycronjob-sample-gmsnw-d6n2r-head-hdtmt                 0/1     Pending     0             61s
+# raycronjob-sample-gmsnw-d6n2r-small-group-worker-nd56f   0/1     Init:0/1    0             61s
+# raycronjob-sample-l76h8-hjtrs-head-9b568                 1/1     Running     0             61s
+# raycronjob-sample-l76h8-hjtrs-small-group-worker-zgx89   1/1     Running     0             61s
+# raycronjob-sample-l76h8-w9flp                            0/1     Completed   0             30s
+# raycronjob-sample-pct47-bdspj-head-cdwwc                 0/1     Pending     0             1s
+# raycronjob-sample-pct47-bdspj-small-group-worker-9r7cm   0/1     Init:0/1    0             1s
 
-# Fetch the logs of the job pod
+# (Optional) Quickly filter completed pods
+# kubectl get pods | grep Completed
+
+# Step 5.2: Identify the job pod
+# Look for the pod with STATUS=Completed that corresponds to your RayJob
+# (This is the Ray job submitter pod)
+# In this example:
+# job-pod-name = raycronjob-sample-l76h8-w9flp
+
+# Step 5.3: Fetch the logs of the job pod
 kubectl logs <job-pod-name>
+# Example:
+# kubectl logs raycronjob-sample-l76h8-w9flp
+
+# [Example output]
+# 2026-04-02 22:57:35,742 INFO cli.py:41 -- Job submission server address: http://raycronjob-sample-l76h8-hjtrs-head-svc.default.svc.cluster.local:8265
+# 2026-04-02 22:57:36,709 SUCC cli.py:65 -- ----------------------------------------------------------
+# 2026-04-02 22:57:36,710 SUCC cli.py:66 -- Job 'raycronjob-sample-l76h8-hmjz2' submitted successfully
+# 2026-04-02 22:57:36,710 SUCC cli.py:67 -- ----------------------------------------------------------
+# 2026-04-02 22:57:36,710 INFO cli.py:291 -- Next steps
+# 2026-04-02 22:57:36,710 INFO cli.py:292 -- Query the logs of the job:
+# 2026-04-02 22:57:36,710 INFO cli.py:294 -- ray job logs raycronjob-sample-l76h8-hmjz2
+# 2026-04-02 22:57:36,710 INFO cli.py:296 -- Query the status of the job:
+# 2026-04-02 22:57:36,710 INFO cli.py:298 -- ray job status raycronjob-sample-l76h8-hmjz2
+# 2026-04-02 22:57:36,710 INFO cli.py:300 -- Request the job to be stopped:
+# 2026-04-02 22:57:36,710 INFO cli.py:302 -- ray job stop raycronjob-sample-l76h8-hmjz2
+# 2026-04-02 22:57:38,771 INFO cli.py:41 -- Job submission server address: http://raycronjob-sample-l76h8-hjtrs-head-svc.default.svc.cluster.local:8265
+# 2026-04-02 22:57:36,400 INFO job_manager.py:568 -- Runtime env is setting up.
+# Running entrypoint for job raycronjob-sample-l76h8-hmjz2: python /home/ray/samples/sample_code.py
+# 2026-04-02 22:57:46,654 INFO worker.py:1696 -- Using address 10.244.0.39:6379 set in the environment variable RAY_ADDRESS
+# 2026-04-02 22:57:46,659 INFO worker.py:1837 -- Connecting to existing Ray cluster at address: 10.244.0.39:6379...
+# 2026-04-02 22:57:46,681 INFO worker.py:2014 -- Connected to Ray cluster. View the dashboard at 10.244.0.39:8265 
+# /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/worker.py:2062: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
+#   warnings.warn(
+# test_counter got 1
+# test_counter got 2
+# test_counter got 3
+# test_counter got 4
+# test_counter got 5
+# 2026-04-02 22:57:58,968 SUCC cli.py:65 -- ---------------------------------------------
+# 2026-04-02 22:57:58,968 SUCC cli.py:66 -- Job 'raycronjob-sample-l76h8-hmjz2' succeeded
+# 2026-04-02 22:57:58,968 SUCC cli.py:67 -- ---------------------------------------------
 ```
 
 ### Step 6: Clean Up

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -5,8 +5,8 @@
 ## Prerequisites
 
 * This feature requires KubeRay version 1.6.0 or newer, and it's in alpha testing.
-    * A running Kubernetes cluster.
-    * The KubeRay operator installed and running in your cluster.
+* A running Kubernetes cluster.
+* The KubeRay operator installed and running in your cluster.
 
 ## What is a RayCronJob?
 
@@ -18,10 +18,10 @@ This is particularly useful for recurring tasks such as scheduled model retraini
 
 ## RayCronJob Configuration
 
-The `RayCronJob` CRD acts as an automated scheduler specifically designed to create and manage **RayJob** custom resources on a recurring basis. It does not execute workloads directly; instead, it acts as a factory that generates a new `RayJob` every time its schedule triggers.
+The `RayCronJob` CRD acts as an automated scheduler specifically designed to create and manage **RayJob** custom resources on a recurring basis. It does not execute workloads directly. Instead, it acts as a controller that creates a new `RayJob` on each schedule triggers.
 
 * `schedule` - The cron schedule string defining when a new Ray job should be created and run (e.g., `* * * * *` for every minute).
-* `jobTemplate` - Wraps a standard **RayJob** spec that the controller will use for each scheduled run. It supports the same fields as a RayJob spec. See the standard [RayJob Configuration](kuberay-rayjob-quickstart) documentation for the complete list of supported fields within the `jobTemplate`.*
+* `jobTemplate` - Wraps a standard **RayJob** spec that the controller will use for each scheduled run. It supports the same fields as a RayJob spec. See the standard [RayJob Configuration](kuberay-rayjob-quickstart) documentation for the complete list of supported fields within the `jobTemplate`.
 * `suspend` (Optional): If `suspend` is true, the controller suspends the scheduling of future jobs. This does not apply to or interrupt any `RayJob`s that have already been created and are currently running.
 
 ## How to Configure a RayCronJob
@@ -43,7 +43,7 @@ spec:
     # ... (RayCluster spec, runtimeEnv, etc.)
 ```
 
-## How to Run an Simple RayCronJob
+## How to Run a Simple RayCronJob
 
 Let's deploy a simple `RayCronJob` that executes a short Python script every minute.
 
@@ -75,7 +75,7 @@ kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ra
 
 ### Step 4: Monitor the RayCronJob
 
-Check the status of your `RayCronJob`. The `SCHEDULE` field should be visible immediately, while `LAST SCHEDULE` may be empty until the first scheduled run is triggered.
+Check the status of your `RayCronJob`. The `SCHEDULE` field should be visible, while `LAST SCHEDULE` may be empty until the first run.
 
 ```sh
 kubectl get raycronjob raycronjob-sample
@@ -100,31 +100,16 @@ kubectl get rayjob -w
 # (Press Ctrl+C to stop watching once the job completes)
 ```
 
-### Step 5: Verify the Output
-
-Once a generated `RayJob` completes, you can inspect the logs of the job submitter pod to verify that the Python script ran successfully:
+### Step 5: Check the output of the RayCronJob
 
 ```shell
-kubectl logs $(kubectl get pods --no-headers | grep raycronjob-sample | grep Completed | awk '{print $1}' | head -n 1)
+# From the previous step, note the RayJob name label (e.g., raycronjob-sample-l76h8)
+# Use it to fetch the submitter pod logs directly:
+kubectl logs -l=job-name=<rayjob-name>
+# Example:
+# kubectl logs -l=job-name=raycronjob-sample-l76h8
 
 # [Example output]
-# 2026-04-02 22:57:35,742 INFO cli.py:41 -- Job submission server address: http://raycronjob-sample-l76h8-hjtrs-head-svc.default.svc.cluster.local:8265
-# 2026-04-02 22:57:36,709 SUCC cli.py:65 -- ----------------------------------------------------------
-# 2026-04-02 22:57:36,710 SUCC cli.py:66 -- Job 'raycronjob-sample-l76h8-hmjz2' submitted successfully
-# 2026-04-02 22:57:36,710 SUCC cli.py:67 -- ----------------------------------------------------------
-# 2026-04-02 22:57:36,710 INFO cli.py:291 -- Next steps
-# 2026-04-02 22:57:36,710 INFO cli.py:292 -- Query the logs of the job:
-# 2026-04-02 22:57:36,710 INFO cli.py:294 -- ray job logs raycronjob-sample-l76h8-hmjz2
-# 2026-04-02 22:57:36,710 INFO cli.py:296 -- Query the status of the job:
-# 2026-04-02 22:57:36,710 INFO cli.py:298 -- ray job status raycronjob-sample-l76h8-hmjz2
-# 2026-04-02 22:57:36,710 INFO cli.py:300 -- Request the job to be stopped:
-# 2026-04-02 22:57:36,710 INFO cli.py:302 -- ray job stop raycronjob-sample-l76h8-hmjz2
-# 2026-04-02 22:57:38,771 INFO cli.py:41 -- Job submission server address: http://raycronjob-sample-l76h8-hjtrs-head-svc.default.svc.cluster.local:8265
-# 2026-04-02 22:57:36,400 INFO job_manager.py:568 -- Runtime env is setting up.
-# Running entrypoint for job raycronjob-sample-l76h8-hmjz2: python /home/ray/samples/sample_code.py
-# 2026-04-02 22:57:46,654 INFO worker.py:1696 -- Using address 10.244.0.39:6379 set in the environment variable RAY_ADDRESS
-# 2026-04-02 22:57:46,659 INFO worker.py:1837 -- Connecting to existing Ray cluster at address: 10.244.0.39:6379...
-# 2026-04-02 22:57:46,681 INFO worker.py:2014 -- Connected to Ray cluster. View the dashboard at 10.244.0.39:8265 
 # /home/ray/anaconda3/lib/python3.10/site-packages/ray/_private/worker.py:2062: FutureWarning: Tip: In future versions of Ray, Ray will no longer override accelerator visible devices env var if num_gpus=0 or num_gpus=None (default). To enable this behavior and turn off this error message, set RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
 #   warnings.warn(
 # test_counter got 1

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -54,7 +54,7 @@ kind create cluster --image=kindest/node:v1.26.0
 ```
 
 ### Step 2: Install the KubeRay operator
-Install the KubeRay operator, following [these instructions](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/kuberay-operator-installation.html). The minimum version for this guide is v1.5.1. To use this feature, the `RayServiceIncrementalUpgrade` feature gate must be enabled. To enable the feature gate when installing the kuberay operator, run the following command: 
+Install the KubeRay operator, following [these instructions](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/kuberay-operator-installation.html). The minimum version for this guide is v1.6.0. To use this feature, the `RayCronJob` feature gate must be enabled. To enable the feature gate when installing the kuberay operator, run the following command:
 
 ```sh
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
@@ -105,32 +105,7 @@ kubectl get rayjob -w
 Once a generated `RayJob` completes, you can inspect the logs of the job submitter pod to verify that the Python script ran successfully:
 
 ```shell
-# Step 5.1: Find the specific pod running the job (usually named after the RayJob with a suffix)
-kubectl get pods
-# [Example output]
-# NAME                                                     READY   STATUS      RESTARTS      AGE
-# kuberay-operator-7fc88c69f5-n2g5k                        1/1     Running     1 (12m ago)   45h
-# raycronjob-sample-gmsnw-d6n2r-head-hdtmt                 0/1     Pending     0             61s
-# raycronjob-sample-gmsnw-d6n2r-small-group-worker-nd56f   0/1     Init:0/1    0             61s
-# raycronjob-sample-l76h8-hjtrs-head-9b568                 1/1     Running     0             61s
-# raycronjob-sample-l76h8-hjtrs-small-group-worker-zgx89   1/1     Running     0             61s
-# raycronjob-sample-l76h8-w9flp                            0/1     Completed   0             30s
-# raycronjob-sample-pct47-bdspj-head-cdwwc                 0/1     Pending     0             1s
-# raycronjob-sample-pct47-bdspj-small-group-worker-9r7cm   0/1     Init:0/1    0             1s
-
-# (Optional) Quickly filter completed pods
-# kubectl get pods | grep Completed
-
-# Step 5.2: Identify the job pod
-# Look for the pod with STATUS=Completed that corresponds to your RayJob
-# (This is the Ray job submitter pod)
-# In this example:
-# job-pod-name = raycronjob-sample-l76h8-w9flp
-
-# Step 5.3: Fetch the logs of the job pod
-kubectl logs <job-pod-name>
-# Example:
-# kubectl logs raycronjob-sample-l76h8-w9flp
+kubectl logs $(kubectl get pods --no-headers | grep raycronjob-sample | grep Completed | awk '{print $1}' | head -n 1)
 
 # [Example output]
 # 2026-04-02 22:57:35,742 INFO cli.py:41 -- Job submission server address: http://raycronjob-sample-l76h8-hjtrs-head-svc.default.svc.cluster.local:8265

--- a/doc/source/cluster/kubernetes/index.md
+++ b/doc/source/cluster/kubernetes/index.md
@@ -40,6 +40,7 @@ See [Getting Started](kuberay-quickstart) to learn the basics of KubeRay and fol
 * [RayCluster Quick Start](kuberay-raycluster-quickstart)
 * [RayJob Quick Start](kuberay-rayjob-quickstart)
 * [RayService Quick Start](kuberay-rayservice-quickstart)
+* [RayCronJob Quick Start](kuberay-raycronjob-quickstart)
 
 Additionally, [Anyscale](https://console.anyscale.com/register/ha?render_flow=ray&utm_source=ray_docs&utm_medium=docs&utm_campaign=ray-doc-upsell&utm_content=deploy-ray-on-k8s) is the managed Ray platform developed by the creators of Ray. It offers an easy path to deploy Ray clusters on your existing Kubernetes infrastructure, including EKS, GKE, AKS, or self-hosted Kubernetes.
 


### PR DESCRIPTION
## Description
Description
This PR adds the quickstart documentation for the newly introduced RayCronJob Custom Resource.

The guide is structured to align with the existing rayjob-quick-start.md and walks users through:

- What a RayCronJob is and its core features.

- How to properly configure a RayCronJob using the flattened jobTemplate schema.

 - A step-by-step tutorial to deploy, monitor, verify, and clean up a simple recurring Ray job.

## Related issues

## Additional information
docs link:
- https://anyscale-ray--62151.com.readthedocs.build/en/62151/cluster/kubernetes/getting-started/raycronjob-quick-start.html#rayjob-configuration
- https://anyscale-ray--62151.com.readthedocs.build/en/62151/cluster/kubernetes/getting-started.html
- https://anyscale-ray--62151.com.readthedocs.build/en/62151/cluster/kubernetes/index.html