### PR TITLE
[Core] Replace deprecated threading APIs (getName/setDaemon) with modern equivalents

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -699,7 +699,7 @@ def check_oversized_function(
 
 
 def is_main_thread():
-    return threading.current_thread().getName() == "MainThread"
+    return threading.current_thread().name == "MainThread"
 
 
 def detect_fate_sharing_support_win32():

--- a/python/ray/autoscaler/_private/spark/spark_job_server.py
+++ b/python/ray/autoscaler/_private/spark/spark_job_server.py
@@ -238,8 +238,7 @@ def _start_spark_job_server(host, port, spark, ray_node_custom_env):
     def run_server():
         server.serve_forever()
 
-    server_thread = threading.Thread(target=run_server)
-    server_thread.setDaemon(True)
+    server_thread = threading.Thread(target=run_server, daemon=True)
     server_thread.start()
 
     return server


### PR DESCRIPTION
Replace deprecated threading APIs (getName/setDaemon) with modern equivalents

- threading.current_thread().getName() -> threading.current_thread().name
- threading.Thread.setDaemon(True) -> threading.Thread(daemon=True)

These APIs were deprecated since Python 3.10, and Ray requires python_requires>='3.10'. The .name property and daemon constructor parameter have been available since Python 3.x and are the recommended replacements per the official documentation.

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
