### PR TITLE
[serve] fix: guard against None autoscaling_config in enable_custom_autoscaling_metrics

### DIFF
--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -718,7 +718,8 @@ class ReplicaMetricsManager:
         if custom_metrics_enabled:
             self._custom_metrics_enabled = custom_metrics_enabled
             self._record_autoscaling_stats_fn = record_autoscaling_stats_fn
-            self.start_metrics_pusher()
+            if self._autoscaling_config is not None:
+                self.start_metrics_pusher()
 
     def inc_num_ongoing_requests(self, request_metadata: RequestMetadata) -> int:
         self._num_ongoing_requests += 1


### PR DESCRIPTION
## Why are these changes needed?

Fixes #62122

When a Ray Serve deployment defines `record_autoscaling_stats()` but uses a fixed `num_replicas` (no `autoscaling_config`), the replica crashes on startup with:

```
AttributeError: 'NoneType' object has no attribute 'metrics_interval_s'
```

Root cause:
1. `enable_custom_autoscaling_metrics()` detects `record_autoscaling_stats` on the user class and sets `custom_metrics_enabled=True`
2. This unconditionally calls `self.start_metrics_pusher()`
3. `start_metrics_pusher()` accesses `self._autoscaling_config.metrics_interval_s` — but `_autoscaling_config` is `None` for fixed-replica deployments

Fix: add `if self._autoscaling_config is not None:` guard before calling `start_metrics_pusher()`. Custom autoscaling metric *collection* is independent of the autoscaling *policy* — the pusher only needs to run when the controller is actively autoscaling.

## Related issues / PRs

Fixes #62122

## Checks

- [x] I've signed off all commits (DCO)
- [x] I have read the [contributor guidelines](https://docs.ray.io/en/master/ray-contribute/getting-involved.html)
