### PR TITLE
Prevent torch_learner.py from crashing under some parameter-freezing edge cases.

### DIFF
--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -187,6 +187,10 @@ class TorchLearner(Learner):
             assert total_loss == 0
             return {}
 
+        # If all parameters for this module are currently frozen, we can't optimize it.
+        if total_loss.grad_fn is None:
+            return {}
+
         total_loss.backward()
         grads = {pid: p.grad for pid, p in self._params.items()}
 


### PR DESCRIPTION
## Description

When fine-tuning pretrained models, some parameters might be frozen, while others aren't. In some cases, under some algorithms, this may result in training runs where no parameters with gradients are used in a given iteration.

This fix prevents this crash by avoiding calls to `backward()` when no gradient exists on total_loss.