### PR TITLE
[1/4][Serve] Add TracingConfig class for first-class tracing configuration

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1384,10 +1384,12 @@ python/ray/scripts/scripts.py
 python/ray/serve/_private/api.py
     DOC101: Function `serve_start`: Docstring contains fewer arguments than in function signature.
     DOC111: Function `serve_start`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
-    DOC103: Function `serve_start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , global_logging_config: Union[None, dict, LoggingConfig]].
+    DOC103: Function `serve_start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , global_logging_config: Union[None, dict, LoggingConfig], global_tracing_config: Union[None, dict, 'TracingConfig']].
     DOC201: Function `serve_start` does not have a return section in docstring
 --------------------
 python/ray/serve/_private/application_state.py
+    DOC101: Method `ApplicationState.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ApplicationState.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tracing_config: Optional['TracingConfig']].
     DOC103: Method `ApplicationStateManager.deploy_app`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_args: List[Dict]]. Arguments in the docstring but not in the function signature: [deployment_args_list: ].
     DOC102: Function `override_deployment_info`: Docstring contains more arguments than in function signature.
     DOC103: Function `override_deployment_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [app_name: ].

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -473,6 +473,7 @@ Content-Type: application/json
    :template: autosummary/autopydantic.rst
 
    schema.LoggingConfig
+   schema.TracingConfig
 ```
 
 (serve-llm-api)=

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -26,6 +26,7 @@ try:
     )
     from ray.serve.batching import batch
     from ray.serve.config import HTTPOptions
+    from ray.serve.schema import TracingConfig
     from ray.serve.utils import get_trace_context
 
 except ModuleNotFoundError as e:
@@ -48,6 +49,7 @@ __all__ = [
     "batch",
     "start",
     "HTTPOptions",
+    "TracingConfig",
     "get_replica_context",
     "get_deployment_actor",
     "get_trace_context",

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -30,8 +30,11 @@ from ray.serve._private.constants import (
     DEFAULT_CONSUMER_CONCURRENCY,
     DEFAULT_GRPC_PORT,
     DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
     DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S,
     RAY_SERVE_LOG_ENCODING,
+    RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+    RAY_SERVE_TRACING_SAMPLING_RATIO,
     SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
@@ -215,6 +218,71 @@ class LoggingConfig(BaseModel):
         if not isinstance(other, LoggingConfig):
             return False
         return self._compute_hash() == other._compute_hash()
+
+
+@PublicAPI(stability="alpha")
+class TracingConfig(BaseModel):
+    """Tracing config for configuring OpenTelemetry tracing in Serve.
+
+    This config is global (cluster-level only) and static (set once at
+    ``serve.start()`` or via the YAML ``ServeDeploySchema``).  Changes
+    require a Serve restart.
+
+    Example:
+
+        .. code-block:: python
+
+            from ray import serve
+            from ray.serve.schema import TracingConfig
+
+            serve.start(
+                tracing_config=TracingConfig(
+                    enabled=True,
+                    exporter_import_path="my_module:my_exporter",
+                    sampling_ratio=0.05,
+                )
+            )
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default_factory=lambda: bool(RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH),
+        description=(
+            "Enable OpenTelemetry tracing. Defaults to True if the "
+            "RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH env var is set."
+        ),
+    )
+    exporter_import_path: str = Field(
+        default_factory=lambda: RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+        description=(
+            "Import path to a span exporter factory that returns "
+            "List[SpanProcessor]. When enabled=True and this field is unset, "
+            "the built-in file exporter is used automatically."
+        ),
+    )
+    sampling_ratio: float = Field(
+        default_factory=lambda: RAY_SERVE_TRACING_SAMPLING_RATIO,
+        description=(
+            "Trace sampling ratio (0.0-1.0). Defaults to the "
+            "RAY_SERVE_TRACING_SAMPLING_RATIO env var (default 0.01)."
+        ),
+    )
+
+    @field_validator("sampling_ratio")
+    @classmethod
+    def valid_sampling_ratio(cls, v):
+        if not 0.0 <= v <= 1.0:
+            raise ValueError(
+                f"Got {v} for sampling_ratio. Must be between 0.0 and 1.0."
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _fill_default_exporter(self) -> "TracingConfig":
+        if self.enabled and not self.exporter_import_path:
+            self.exporter_import_path = DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+        return self
 
 
 @PublicAPI(stability="stable")
@@ -999,6 +1067,10 @@ class ServeDeploySchema(BaseModel):
     logging_config: Optional[LoggingConfig] = Field(
         default=None,
         description="Logging config for configuring serve components logs.",
+    )
+    tracing_config: Optional[TracingConfig] = Field(
+        default=None,
+        description="Tracing config for all Serve components (proxies and replicas).",
     )
     applications: List[ServeApplicationSchema] = Field(
         ..., description="The set of applications to run on the Ray cluster."

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -27,6 +27,7 @@ from ray.serve.schema import (
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
+    TracingConfig,
 )
 from ray.serve.tests.common.remote_uris import (
     TEST_DEPLOY_GROUP_PINNED_URI,
@@ -1052,6 +1053,152 @@ class TestLoggingConfig:
             {"additional_log_standard_attrs": ["name", "name"]}
         )
         assert schema.additional_log_standard_attrs == ["name"]
+
+
+class TestTracingConfig:
+    def test_default_values(self):
+        """TracingConfig() defaults should come from the module-level constants."""
+        from ray.serve._private.constants import (
+            RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+            RAY_SERVE_TRACING_SAMPLING_RATIO,
+        )
+
+        config = TracingConfig()
+        assert config.enabled == bool(RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH)
+        assert config.exporter_import_path == RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH
+        assert config.sampling_ratio == RAY_SERVE_TRACING_SAMPLING_RATIO
+
+    def test_explicit_enabled(self):
+        """Explicitly setting enabled=True/False overrides the default."""
+        config = TracingConfig(enabled=True)
+        assert config.enabled is True
+
+        config = TracingConfig(enabled=False)
+        assert config.enabled is False
+
+    def test_parse_dict(self):
+        config = TracingConfig.model_validate(
+            {
+                "enabled": True,
+                "exporter_import_path": "my_module:my_exporter",
+                "sampling_ratio": 0.5,
+            }
+        )
+        assert config.enabled is True
+        assert config.exporter_import_path == "my_module:my_exporter"
+        assert config.sampling_ratio == 0.5
+
+    def test_parse_empty_dict(self):
+        """Empty dict should produce the same result as TracingConfig()."""
+        config = TracingConfig.model_validate({})
+        default = TracingConfig()
+        assert config.enabled == default.enabled
+        assert config.exporter_import_path == default.exporter_import_path
+        assert config.sampling_ratio == default.sampling_ratio
+
+    def test_enabled_true_fills_default_exporter(self):
+        """enabled=True with empty exporter should auto-fill the built-in exporter."""
+        config = TracingConfig(enabled=True, exporter_import_path="")
+        assert config.exporter_import_path == (
+            "ray.serve._private.tracing_utils:default_tracing_exporter"
+        )
+
+    def test_enabled_true_custom_exporter_not_overwritten(self):
+        """enabled=True with a custom exporter should not overwrite it."""
+        config = TracingConfig(
+            enabled=True,
+            exporter_import_path="custom:exporter",
+        )
+        assert config.exporter_import_path == "custom:exporter"
+
+    def test_enabled_false_no_exporter_fill(self):
+        """enabled=False should not auto-fill the exporter."""
+        config = TracingConfig(enabled=False)
+        assert config.exporter_import_path == ""
+
+    def test_sampling_ratio_bounds(self):
+        # Valid boundary values
+        assert TracingConfig(sampling_ratio=0.0).sampling_ratio == 0.0
+        assert TracingConfig(sampling_ratio=1.0).sampling_ratio == 1.0
+        assert TracingConfig(sampling_ratio=0.5).sampling_ratio == 0.5
+
+    def test_sampling_ratio_out_of_range(self):
+        with pytest.raises(ValidationError, match="sampling_ratio"):
+            TracingConfig(sampling_ratio=-0.1)
+        with pytest.raises(ValidationError, match="sampling_ratio"):
+            TracingConfig(sampling_ratio=1.1)
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            TracingConfig.model_validate({"unknown_field": "value"})
+
+    def test_dict_roundtrip(self):
+        config = TracingConfig(
+            enabled=True,
+            exporter_import_path="my_module:exporter",
+            sampling_ratio=0.1,
+        )
+        d = config.model_dump()
+        restored = TracingConfig.model_validate(d)
+        assert restored.enabled == config.enabled
+        assert restored.exporter_import_path == config.exporter_import_path
+        assert restored.sampling_ratio == config.sampling_ratio
+
+    def test_serve_deploy_schema_with_tracing_config(self):
+        """TracingConfig in ServeDeploySchema should parse correctly."""
+        deploy_config = ServeDeploySchema.model_validate(
+            {
+                "tracing_config": {
+                    "enabled": True,
+                    "exporter_import_path": "my_module:my_exporter",
+                    "sampling_ratio": 0.1,
+                },
+                "applications": [
+                    {
+                        "name": "app1",
+                        "route_prefix": "/app1",
+                        "import_path": "module.graph",
+                    }
+                ],
+            }
+        )
+        assert deploy_config.tracing_config is not None
+        assert deploy_config.tracing_config.enabled is True
+        assert deploy_config.tracing_config.exporter_import_path == (
+            "my_module:my_exporter"
+        )
+        assert deploy_config.tracing_config.sampling_ratio == 0.1
+
+    def test_serve_deploy_schema_without_tracing_config(self):
+        """Omitting tracing_config should default to None."""
+        deploy_config = ServeDeploySchema.model_validate(
+            {
+                "applications": [
+                    {
+                        "name": "app1",
+                        "route_prefix": "/app1",
+                        "import_path": "module.graph",
+                    }
+                ],
+            }
+        )
+        assert deploy_config.tracing_config is None
+
+    def test_serve_deploy_schema_invalid_tracing_config(self):
+        """Invalid tracing_config should raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ServeDeploySchema.model_validate(
+                {
+                    "tracing_config": {"sampling_ratio": 2.0},
+                    "applications": [
+                        {
+                            "name": "app1",
+                            "route_prefix": "/app1",
+                            "import_path": "module.graph",
+                        }
+                    ],
+                }
+            )
 
 
 # This function is defined globally to be accessible via import path


### PR DESCRIPTION
Adds a TracingConfig pydantic model with enabled, exporter_import_path, and sampling_ratio fields. Defaults from existing env vars for backward compatibility. Added to ServeDeploySchema for YAML/REST API support.

This is part 1 of the TracingConfig integration (issue #61788):
- TracingConfig class with validation
- ServeDeploySchema.tracing_config field
- Public API export
- API doc entry
- 13 unit tests