### PR TITLE
[Serve][2/4] Wire TracingConfig through serve.start() to proxies

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1384,10 +1384,12 @@ python/ray/scripts/scripts.py
 python/ray/serve/_private/api.py
     DOC101: Function `serve_start`: Docstring contains fewer arguments than in function signature.
     DOC111: Function `serve_start`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
-    DOC103: Function `serve_start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , global_logging_config: Union[None, dict, LoggingConfig]].
+    DOC103: Function `serve_start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , global_logging_config: Union[None, dict, LoggingConfig], global_tracing_config: Union[None, dict, 'TracingConfig']].
     DOC201: Function `serve_start` does not have a return section in docstring
 --------------------
 python/ray/serve/_private/application_state.py
+    DOC101: Method `ApplicationState.__init__`: Docstring contains fewer arguments than in function signature.
+    DOC103: Method `ApplicationState.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [tracing_config: Optional['TracingConfig']].
     DOC103: Method `ApplicationStateManager.deploy_app`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [deployment_args: List[Dict]]. Arguments in the docstring but not in the function signature: [deployment_args_list: ].
     DOC102: Function `override_deployment_info`: Docstring contains more arguments than in function signature.
     DOC103: Function `override_deployment_info`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the docstring but not in the function signature: [app_name: ].

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -473,6 +473,7 @@ Content-Type: application/json
    :template: autosummary/autopydantic.rst
 
    schema.LoggingConfig
+   schema.TracingConfig
 ```
 
 (serve-llm-api)=

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -26,6 +26,7 @@ try:
     )
     from ray.serve.batching import batch
     from ray.serve.config import HTTPOptions
+    from ray.serve.schema import TracingConfig
     from ray.serve.utils import get_trace_context
 
 except ModuleNotFoundError as e:
@@ -48,6 +49,7 @@ __all__ = [
     "batch",
     "start",
     "HTTPOptions",
+    "TracingConfig",
     "get_replica_context",
     "get_deployment_actor",
     "get_trace_context",

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -19,7 +19,7 @@ from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.context import _get_global_client, _set_global_client
 from ray.serve.deployment import Application
 from ray.serve.exceptions import RayServeException
-from ray.serve.schema import LoggingConfig
+from ray.serve.schema import LoggingConfig, TracingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -52,6 +52,7 @@ def _start_controller(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, "TracingConfig"] = None,
     **kwargs,
 ) -> ActorHandle:
     """Start Ray Serve controller.
@@ -91,11 +92,17 @@ def _start_controller(
     elif isinstance(global_logging_config, dict):
         global_logging_config = LoggingConfig(**global_logging_config)
 
+    if global_tracing_config is None:
+        global_tracing_config = TracingConfig()
+    elif isinstance(global_tracing_config, dict):
+        global_tracing_config = TracingConfig(**global_tracing_config)
+
     controller_impl = get_controller_impl()
     controller = controller_impl.remote(
         http_options=http_options,
         grpc_options=grpc_options,
         global_logging_config=global_logging_config,
+        global_tracing_config=global_tracing_config,
     )
 
     proxy_handles = ray.get(controller.get_proxies.remote())
@@ -116,6 +123,7 @@ async def serve_start_async(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, "TracingConfig"] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance asynchronously.
@@ -145,7 +153,13 @@ async def serve_start_async(
     controller = (
         await ray.remote(_start_controller)
         .options(num_cpus=0)
-        .remote(http_options, grpc_options, global_logging_config, **kwargs)
+        .remote(
+            http_options,
+            grpc_options,
+            global_logging_config,
+            global_tracing_config,
+            **kwargs,
+        )
     )
 
     client = ServeControllerClient(
@@ -160,6 +174,7 @@ def serve_start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, "TracingConfig"] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance.
@@ -217,7 +232,11 @@ def serve_start(
         pass
 
     controller = _start_controller(
-        http_options, grpc_options, global_logging_config, **kwargs
+        http_options,
+        grpc_options,
+        global_logging_config,
+        global_tracing_config,
+        **kwargs,
     )
 
     client = ServeControllerClient(

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -104,6 +104,7 @@ from ray.serve.schema import (
     ServeInstanceDetails,
     Target,
     TargetGroup,
+    TracingConfig,
     gRPCOptionsSchema,
 )
 from ray.util import metrics
@@ -148,6 +149,7 @@ class ServeController:
         *,
         http_options: HTTPOptions,
         global_logging_config: LoggingConfig,
+        global_tracing_config: Optional[TracingConfig] = None,
         grpc_options: Optional[gRPCOptions] = None,
     ):
         self._controller_node_id = ray.get_runtime_context().get_node_id()
@@ -171,6 +173,11 @@ class ServeController:
         if log_config_checkpoint is not None:
             global_logging_config = pickle.loads(log_config_checkpoint)
         self.reconfigure_global_logging_config(global_logging_config)
+
+        # Tracing config is static — no checkpoint, no long-poll.
+        if global_tracing_config is None:
+            global_tracing_config = TracingConfig()
+        self.global_tracing_config = global_tracing_config
 
         configure_component_memory_profiler(
             component_name="controller", component_id=str(os.getpid())
@@ -208,6 +215,7 @@ class ServeController:
             head_node_id=self._controller_node_id,
             cluster_node_info_cache=self.cluster_node_info_cache,
             logging_config=self.global_logging_config,
+            tracing_config=self.global_tracing_config,
             grpc_options=set_proxy_default_grpc_options(grpc_options),
             proxy_actor_class=get_proxy_actor_class(),
             running_native_proxies=self._ha_proxy_enabled,

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -934,12 +934,14 @@ class HAProxyManager(ProxyActorInterface):
         node_id: NodeId,
         node_ip_address: str,
         logging_config: LoggingConfig,
+        tracing_config=None,
         long_poll_client: Optional[LongPollClient] = None,
     ):  # noqa: F821
         super().__init__(
             node_id=node_id,
             node_ip_address=node_ip_address,
             logging_config=logging_config,
+            tracing_config=tracing_config,
             # HAProxyManager is not on the request path, so we can disable
             # the buffer to ensure logs are immediately flushed.
             log_buffer_size=1,

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -100,7 +100,7 @@ from ray.serve._private.utils import (
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.generated.serve_pb2 import HealthzResponse, ListApplicationsResponse
 from ray.serve.handle import DeploymentHandle
-from ray.serve.schema import EncodingType, LoggingConfig
+from ray.serve.schema import EncodingType, LoggingConfig, TracingConfig
 from ray.util import metrics
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -1465,6 +1465,7 @@ class ProxyActorInterface(ABC):
         node_id: NodeId,
         node_ip_address: str,
         logging_config: LoggingConfig,
+        tracing_config: Optional["TracingConfig"] = None,
         log_buffer_size: int = RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     ):
         """Initialize the proxy actor.
@@ -1473,11 +1474,13 @@ class ProxyActorInterface(ABC):
             node_id: ID of the node this proxy is running on
             node_ip_address: IP address of the node
             logging_config: Logging configuration
+            tracing_config: Tracing configuration
             log_buffer_size: Size of the log buffer
         """
         self._node_id = node_id
         self._node_ip_address = node_ip_address
         self._logging_config = logging_config
+        self._tracing_config = tracing_config
         self._log_buffer_size = log_buffer_size
 
         self._update_logging_config(logging_config)
@@ -1611,12 +1614,14 @@ class ProxyActor(ProxyActorInterface):
         node_id: NodeId,
         node_ip_address: str,
         logging_config: LoggingConfig,
+        tracing_config: Optional["TracingConfig"] = None,
         long_poll_client: Optional[LongPollClient] = None,
     ):  # noqa: F821
         super().__init__(
             node_id=node_id,
             node_ip_address=node_ip_address,
             logging_config=logging_config,
+            tracing_config=tracing_config,
         )
 
         self._grpc_options = grpc_options
@@ -1633,8 +1638,20 @@ class ProxyActor(ProxyActorInterface):
         )
 
         try:
+            tracing_kwargs = {}
+            if self._tracing_config is not None:
+                tracing_kwargs["tracing_exporter_import_path"] = (
+                    self._tracing_config.exporter_import_path
+                    if self._tracing_config.enabled
+                    else ""
+                )
+                tracing_kwargs[
+                    "tracing_sampling_ratio"
+                ] = self._tracing_config.sampling_ratio
             is_tracing_setup_successful = setup_tracing(
-                component_name="proxy", component_id=node_ip_address
+                component_name="proxy",
+                component_id=node_ip_address,
+                **tracing_kwargs,
             )
             if is_tracing_setup_successful:
                 logger.info("Successfully set up tracing for proxy")

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -40,6 +40,7 @@ from ray.serve.schema import (
     ProxyDetails,
     ProxyStatus,
     Target,
+    TracingConfig,
 )
 from ray.util import metrics
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
@@ -111,6 +112,7 @@ class ActorProxyWrapper(ProxyWrapper):
     def __init__(
         self,
         logging_config: LoggingConfig,
+        tracing_config: Optional["TracingConfig"] = None,
         actor_handle: Optional[ActorHandle] = None,
         http_options: Optional[HTTPOptions] = None,
         grpc_options: Optional[gRPCOptions] = None,
@@ -130,6 +132,7 @@ class ActorProxyWrapper(ProxyWrapper):
             port=port,
             proxy_actor_class=proxy_actor_class,
             logging_config=logging_config,
+            tracing_config=tracing_config,
         )
         self._ready_check_future = None
         self._health_check_future = None
@@ -151,6 +154,7 @@ class ActorProxyWrapper(ProxyWrapper):
         node_ip_address: str,
         port: int,
         logging_config: LoggingConfig,
+        tracing_config: Optional["TracingConfig"] = None,
         proxy_actor_class: Type[ProxyActor] = ProxyActor,
     ) -> ProxyWrapper:
         """Helper to start or reuse existing proxy.
@@ -183,6 +187,7 @@ class ActorProxyWrapper(ProxyWrapper):
             node_id=node_id,
             node_ip_address=node_ip_address,
             logging_config=logging_config,
+            tracing_config=tracing_config,
         )
 
     @property
@@ -598,6 +603,7 @@ class ProxyStateManager:
         head_node_id: str,
         cluster_node_info_cache: ClusterNodeInfoCache,
         logging_config: LoggingConfig,
+        tracing_config: Optional["TracingConfig"] = None,
         grpc_options: Optional[gRPCOptions] = None,
         proxy_actor_class: Type[ProxyActor] = ProxyActor,
         actor_proxy_wrapper_class: Type[ProxyWrapper] = ActorProxyWrapper,
@@ -605,6 +611,7 @@ class ProxyStateManager:
         running_native_proxies: bool = False,
     ):
         self.logging_config = logging_config
+        self.tracing_config = tracing_config
         self._http_options = http_options or HTTPOptions()
         self._grpc_options = grpc_options or gRPCOptions()
         self._proxy_states: Dict[NodeId, ProxyState] = dict()
@@ -855,6 +862,7 @@ class ProxyStateManager:
 
         return self._actor_proxy_wrapper_class(
             logging_config=self.logging_config,
+            tracing_config=self.tracing_config,
             http_options=http_options,
             grpc_options=grpc_options,
             name=name,

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -59,7 +59,12 @@ from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import DeploymentHandle
 from ray.serve.multiplex import _ModelMultiplexWrapper
-from ray.serve.schema import LoggingConfig, ServeInstanceDetails, ServeStatus
+from ray.serve.schema import (
+    LoggingConfig,
+    ServeInstanceDetails,
+    ServeStatus,
+    TracingConfig,
+)
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 from ray.serve._private import api as _private_api  # isort:skip
@@ -74,6 +79,7 @@ def start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     logging_config: Union[None, dict, LoggingConfig] = None,
+    tracing_config: Union[None, dict, "TracingConfig"] = None,
     **kwargs,
 ):
     """Start Serve on the cluster.
@@ -99,12 +105,16 @@ def start(
           class See `gRPCOptions` for supported options.
         logging_config: logging config options for the serve component (
             controller & proxy).
+        tracing_config: [EXPERIMENTAL] Tracing config for OpenTelemetry tracing
+            across all Serve components. Can be passed as a dictionary or
+            ``TracingConfig`` object.
     """
     http_options = prepare_imperative_http_options(proxy_location, http_options)
     _private_api.serve_start(
         http_options=http_options,
         grpc_options=grpc_options,
         global_logging_config=logging_config,
+        global_tracing_config=tracing_config,
         **kwargs,
     )
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -30,8 +30,11 @@ from ray.serve._private.constants import (
     DEFAULT_CONSUMER_CONCURRENCY,
     DEFAULT_GRPC_PORT,
     DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
     DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S,
     RAY_SERVE_LOG_ENCODING,
+    RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+    RAY_SERVE_TRACING_SAMPLING_RATIO,
     SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
@@ -215,6 +218,71 @@ class LoggingConfig(BaseModel):
         if not isinstance(other, LoggingConfig):
             return False
         return self._compute_hash() == other._compute_hash()
+
+
+@PublicAPI(stability="alpha")
+class TracingConfig(BaseModel):
+    """Tracing config for configuring OpenTelemetry tracing in Serve.
+
+    This config is global (cluster-level only) and static (set once at
+    ``serve.start()`` or via the YAML ``ServeDeploySchema``).  Changes
+    require a Serve restart.
+
+    Example:
+
+        .. code-block:: python
+
+            from ray import serve
+            from ray.serve.schema import TracingConfig
+
+            serve.start(
+                tracing_config=TracingConfig(
+                    enabled=True,
+                    exporter_import_path="my_module:my_exporter",
+                    sampling_ratio=0.05,
+                )
+            )
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default_factory=lambda: bool(RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH),
+        description=(
+            "Enable OpenTelemetry tracing. Defaults to True if the "
+            "RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH env var is set."
+        ),
+    )
+    exporter_import_path: str = Field(
+        default_factory=lambda: RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+        description=(
+            "Import path to a span exporter factory that returns "
+            "List[SpanProcessor]. When enabled=True and this field is unset, "
+            "the built-in file exporter is used automatically."
+        ),
+    )
+    sampling_ratio: float = Field(
+        default_factory=lambda: RAY_SERVE_TRACING_SAMPLING_RATIO,
+        description=(
+            "Trace sampling ratio (0.0-1.0). Defaults to the "
+            "RAY_SERVE_TRACING_SAMPLING_RATIO env var (default 0.01)."
+        ),
+    )
+
+    @field_validator("sampling_ratio")
+    @classmethod
+    def valid_sampling_ratio(cls, v):
+        if not 0.0 <= v <= 1.0:
+            raise ValueError(
+                f"Got {v} for sampling_ratio. Must be between 0.0 and 1.0."
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _fill_default_exporter(self) -> "TracingConfig":
+        if self.enabled and not self.exporter_import_path:
+            self.exporter_import_path = DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+        return self
 
 
 @PublicAPI(stability="stable")
@@ -999,6 +1067,10 @@ class ServeDeploySchema(BaseModel):
     logging_config: Optional[LoggingConfig] = Field(
         default=None,
         description="Logging config for configuring serve components logs.",
+    )
+    tracing_config: Optional[TracingConfig] = Field(
+        default=None,
+        description="Tracing config for all Serve components (proxies and replicas).",
     )
     applications: List[ServeApplicationSchema] = Field(
         ..., description="The set of applications to run on the Ray cluster."

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -27,6 +27,7 @@ from ray.serve.schema import (
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
+    TracingConfig,
 )
 from ray.serve.tests.common.remote_uris import (
     TEST_DEPLOY_GROUP_PINNED_URI,
@@ -1052,6 +1053,152 @@ class TestLoggingConfig:
             {"additional_log_standard_attrs": ["name", "name"]}
         )
         assert schema.additional_log_standard_attrs == ["name"]
+
+
+class TestTracingConfig:
+    def test_default_values(self):
+        """TracingConfig() defaults should come from the module-level constants."""
+        from ray.serve._private.constants import (
+            RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+            RAY_SERVE_TRACING_SAMPLING_RATIO,
+        )
+
+        config = TracingConfig()
+        assert config.enabled == bool(RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH)
+        assert config.exporter_import_path == RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH
+        assert config.sampling_ratio == RAY_SERVE_TRACING_SAMPLING_RATIO
+
+    def test_explicit_enabled(self):
+        """Explicitly setting enabled=True/False overrides the default."""
+        config = TracingConfig(enabled=True)
+        assert config.enabled is True
+
+        config = TracingConfig(enabled=False)
+        assert config.enabled is False
+
+    def test_parse_dict(self):
+        config = TracingConfig.model_validate(
+            {
+                "enabled": True,
+                "exporter_import_path": "my_module:my_exporter",
+                "sampling_ratio": 0.5,
+            }
+        )
+        assert config.enabled is True
+        assert config.exporter_import_path == "my_module:my_exporter"
+        assert config.sampling_ratio == 0.5
+
+    def test_parse_empty_dict(self):
+        """Empty dict should produce the same result as TracingConfig()."""
+        config = TracingConfig.model_validate({})
+        default = TracingConfig()
+        assert config.enabled == default.enabled
+        assert config.exporter_import_path == default.exporter_import_path
+        assert config.sampling_ratio == default.sampling_ratio
+
+    def test_enabled_true_fills_default_exporter(self):
+        """enabled=True with empty exporter should auto-fill the built-in exporter."""
+        config = TracingConfig(enabled=True, exporter_import_path="")
+        assert config.exporter_import_path == (
+            "ray.serve._private.tracing_utils:default_tracing_exporter"
+        )
+
+    def test_enabled_true_custom_exporter_not_overwritten(self):
+        """enabled=True with a custom exporter should not overwrite it."""
+        config = TracingConfig(
+            enabled=True,
+            exporter_import_path="custom:exporter",
+        )
+        assert config.exporter_import_path == "custom:exporter"
+
+    def test_enabled_false_no_exporter_fill(self):
+        """enabled=False should not auto-fill the exporter."""
+        config = TracingConfig(enabled=False)
+        assert config.exporter_import_path == ""
+
+    def test_sampling_ratio_bounds(self):
+        # Valid boundary values
+        assert TracingConfig(sampling_ratio=0.0).sampling_ratio == 0.0
+        assert TracingConfig(sampling_ratio=1.0).sampling_ratio == 1.0
+        assert TracingConfig(sampling_ratio=0.5).sampling_ratio == 0.5
+
+    def test_sampling_ratio_out_of_range(self):
+        with pytest.raises(ValidationError, match="sampling_ratio"):
+            TracingConfig(sampling_ratio=-0.1)
+        with pytest.raises(ValidationError, match="sampling_ratio"):
+            TracingConfig(sampling_ratio=1.1)
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValidationError):
+            TracingConfig.model_validate({"unknown_field": "value"})
+
+    def test_dict_roundtrip(self):
+        config = TracingConfig(
+            enabled=True,
+            exporter_import_path="my_module:exporter",
+            sampling_ratio=0.1,
+        )
+        d = config.model_dump()
+        restored = TracingConfig.model_validate(d)
+        assert restored.enabled == config.enabled
+        assert restored.exporter_import_path == config.exporter_import_path
+        assert restored.sampling_ratio == config.sampling_ratio
+
+    def test_serve_deploy_schema_with_tracing_config(self):
+        """TracingConfig in ServeDeploySchema should parse correctly."""
+        deploy_config = ServeDeploySchema.model_validate(
+            {
+                "tracing_config": {
+                    "enabled": True,
+                    "exporter_import_path": "my_module:my_exporter",
+                    "sampling_ratio": 0.1,
+                },
+                "applications": [
+                    {
+                        "name": "app1",
+                        "route_prefix": "/app1",
+                        "import_path": "module.graph",
+                    }
+                ],
+            }
+        )
+        assert deploy_config.tracing_config is not None
+        assert deploy_config.tracing_config.enabled is True
+        assert deploy_config.tracing_config.exporter_import_path == (
+            "my_module:my_exporter"
+        )
+        assert deploy_config.tracing_config.sampling_ratio == 0.1
+
+    def test_serve_deploy_schema_without_tracing_config(self):
+        """Omitting tracing_config should default to None."""
+        deploy_config = ServeDeploySchema.model_validate(
+            {
+                "applications": [
+                    {
+                        "name": "app1",
+                        "route_prefix": "/app1",
+                        "import_path": "module.graph",
+                    }
+                ],
+            }
+        )
+        assert deploy_config.tracing_config is None
+
+    def test_serve_deploy_schema_invalid_tracing_config(self):
+        """Invalid tracing_config should raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ServeDeploySchema.model_validate(
+                {
+                    "tracing_config": {"sampling_ratio": 2.0},
+                    "applications": [
+                        {
+                            "name": "app1",
+                            "route_prefix": "/app1",
+                            "import_path": "module.graph",
+                        }
+                    ],
+                }
+            )
 
 
 # This function is defined globally to be accessible via import path


### PR DESCRIPTION
  ## Summary

  Adds `tracing_config` parameter to `serve.start()` and wires it through to proxy actors.

  Part 2 of 4 for issue #61788. Depends on PR 1.

  ### Changes
  - `serve.start(tracing_config=...)` parameter
  - Normalization in `_start_controller()` (None/dict → TracingConfig)
  - Controller accepts, stores, forwards to ProxyStateManager
  - ProxyStateManager passes to ProxyActor and HAProxyManager
  - ProxyActor uses config in `setup_tracing()`
  - Falls back to env var defaults when `tracing_config` is None

  ## Test plan
  - [x] Existing proxy tests pass