### PR TITLE
[Serve][1/2] Add TracingConfig and wire through proxy and replica paths

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1384,7 +1384,7 @@ python/ray/scripts/scripts.py
 python/ray/serve/_private/api.py
     DOC101: Function `serve_start`: Docstring contains fewer arguments than in function signature.
     DOC111: Function `serve_start`: The option `--arg-type-hints-in-docstring` is `False` but there are type hints in the docstring arg list
-    DOC103: Function `serve_start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , global_logging_config: Union[None, dict, LoggingConfig]].
+    DOC103: Function `serve_start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , global_logging_config: Union[None, dict, LoggingConfig], global_tracing_config: Union[None, dict, 'TracingConfig']].
     DOC201: Function `serve_start` does not have a return section in docstring
 --------------------
 python/ray/serve/_private/application_state.py

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -473,6 +473,7 @@ Content-Type: application/json
    :template: autosummary/autopydantic.rst
 
    schema.LoggingConfig
+   schema.TracingConfig
 ```
 
 (serve-llm-api)=

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -26,6 +26,7 @@ try:
     )
     from ray.serve.batching import batch
     from ray.serve.config import HTTPOptions
+    from ray.serve.schema import TracingConfig
     from ray.serve.utils import get_trace_context
 
 except ModuleNotFoundError as e:
@@ -66,4 +67,5 @@ __all__ = [
     "status",
     "get_app_handle",
     "get_deployment_handle",
+    "TracingConfig",
 ]

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -19,7 +19,7 @@ from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.context import _get_global_client, _set_global_client
 from ray.serve.deployment import Application
 from ray.serve.exceptions import RayServeException
-from ray.serve.schema import LoggingConfig
+from ray.serve.schema import LoggingConfig, TracingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -52,6 +52,7 @@ def _start_controller(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, "TracingConfig"] = None,
     **kwargs,
 ) -> ActorHandle:
     """Start Ray Serve controller.
@@ -91,11 +92,17 @@ def _start_controller(
     elif isinstance(global_logging_config, dict):
         global_logging_config = LoggingConfig(**global_logging_config)
 
+    if global_tracing_config is None:
+        global_tracing_config = TracingConfig()
+    elif isinstance(global_tracing_config, dict):
+        global_tracing_config = TracingConfig(**global_tracing_config)
+
     controller_impl = get_controller_impl()
     controller = controller_impl.remote(
         http_options=http_options,
         grpc_options=grpc_options,
         global_logging_config=global_logging_config,
+        global_tracing_config=global_tracing_config,
     )
 
     proxy_handles = ray.get(controller.get_proxies.remote())
@@ -116,6 +123,7 @@ async def serve_start_async(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, "TracingConfig"] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance asynchronously.
@@ -145,7 +153,13 @@ async def serve_start_async(
     controller = (
         await ray.remote(_start_controller)
         .options(num_cpus=0)
-        .remote(http_options, grpc_options, global_logging_config, **kwargs)
+        .remote(
+            http_options,
+            grpc_options,
+            global_logging_config,
+            global_tracing_config,
+            **kwargs,
+        )
     )
 
     client = ServeControllerClient(
@@ -160,6 +174,7 @@ def serve_start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, "TracingConfig"] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance.
@@ -217,7 +232,11 @@ def serve_start(
         pass
 
     controller = _start_controller(
-        http_options, grpc_options, global_logging_config, **kwargs
+        http_options,
+        grpc_options,
+        global_logging_config,
+        global_tracing_config,
+        **kwargs,
     )
 
     client = ServeControllerClient(

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -247,6 +247,7 @@ class ApplicationState:
         endpoint_state: EndpointState,
         logging_config: LoggingConfig,
         external_scaler_enabled: bool,
+        tracing_config: Optional["TracingConfig"] = None,  # noqa: F821
     ):
         """
         Initialize an ApplicationState instance.
@@ -259,6 +260,7 @@ class ApplicationState:
             logging_config: Logging configuration schema.
             external_scaler_enabled: Whether external autoscaling is enabled for
                 this application.
+            tracing_config: Tracing configuration for OpenTelemetry tracing.
         """
 
         self._name = name
@@ -287,6 +289,7 @@ class ApplicationState:
             serialized_application_autoscaling_policy_def=None,
         )
         self._logging_config = logging_config
+        self._tracing_config = tracing_config
 
     @property
     def route_prefix(self) -> Optional[str]:
@@ -452,9 +455,9 @@ class ApplicationState:
             code_version=None,
             target_config=target_config,
             deleting=False,
-            external_scaler_enabled=target_config.external_scaler_enabled
-            if target_config
-            else False,
+            external_scaler_enabled=(
+                target_config.external_scaler_enabled if target_config else False
+            ),
         )
 
     def _delete_deployment(self, name: str) -> bool:
@@ -1171,12 +1174,14 @@ class ApplicationStateManager:
         endpoint_state: EndpointState,
         kv_store: KVStoreBase,
         logging_config: LoggingConfig,
+        tracing_config: Optional["TracingConfig"] = None,  # noqa: F821
     ):
         self._deployment_state_manager = deployment_state_manager
         self._autoscaling_state_manager = autoscaling_state_manager
         self._endpoint_state = endpoint_state
         self._kv_store = kv_store
         self._logging_config = logging_config
+        self._tracing_config = tracing_config
 
         self._shutting_down = False
 
@@ -1210,6 +1215,7 @@ class ApplicationStateManager:
                     self._endpoint_state,
                     self._logging_config,
                     checkpoint_data.external_scaler_enabled,
+                    tracing_config=self._tracing_config,
                 )
                 app_state.recover_target_state_from_checkpoint(checkpoint_data)
                 self._application_states[app_name] = app_state
@@ -1265,6 +1271,7 @@ class ApplicationStateManager:
                     self._endpoint_state,
                     self._logging_config,
                     external_scaler_enabled,
+                    tracing_config=self._tracing_config,
                 )
             ServeUsageTag.NUM_APPS.record(str(len(self._application_states)))
 
@@ -1321,6 +1328,7 @@ class ApplicationStateManager:
                     endpoint_state=self._endpoint_state,
                     logging_config=self._logging_config,
                     external_scaler_enabled=app_config.external_scaler_enabled,
+                    tracing_config=self._tracing_config,
                 )
 
             self._application_states[app_config.name].apply_app_config(

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -110,6 +110,7 @@ from ray.serve.schema import (
     ServeInstanceDetails,
     Target,
     TargetGroup,
+    TracingConfig,
     gRPCOptionsSchema,
 )
 from ray.util import metrics
@@ -155,6 +156,7 @@ class ServeController:
         http_options: HTTPOptions,
         global_logging_config: LoggingConfig,
         grpc_options: Optional[gRPCOptions] = None,
+        global_tracing_config: Optional[TracingConfig] = None,
     ):
         if RAY_SERVE_THROUGHPUT_OPTIMIZED:
             self._log_throughput_opt_message()
@@ -180,6 +182,8 @@ class ServeController:
         if log_config_checkpoint is not None:
             global_logging_config = pickle.loads(log_config_checkpoint)
         self.reconfigure_global_logging_config(global_logging_config)
+
+        self.global_tracing_config = global_tracing_config
 
         configure_component_memory_profiler(
             component_name="controller", component_id=str(os.getpid())
@@ -220,6 +224,7 @@ class ServeController:
             grpc_options=set_proxy_default_grpc_options(grpc_options),
             proxy_actor_class=get_proxy_actor_class(),
             running_native_proxies=self._ha_proxy_enabled,
+            tracing_config=self.global_tracing_config,
         )
         # We modify the HTTP and gRPC options above, so delete them to avoid
         del http_options, grpc_options
@@ -243,6 +248,7 @@ class ServeController:
             get_all_live_placement_group_names(),
             self.cluster_node_info_cache,
             self.autoscaling_state_manager,
+            tracing_config=self.global_tracing_config,
         )
 
         # Manage all applications' state
@@ -252,6 +258,7 @@ class ServeController:
             self.endpoint_state,
             self.kv_store,
             self.global_logging_config,
+            tracing_config=self.global_tracing_config,
         )
 
         # Controller actor details

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -555,10 +555,12 @@ class ActorReplicaWrapper:
         self,
         replica_id: ReplicaID,
         version: DeploymentVersion,
+        tracing_config=None,
     ):
         self._replica_id = replica_id
         self._deployment_id = replica_id.deployment_id
         self._actor_name = replica_id.to_full_id_str()
+        self._tracing_config = tracing_config
 
         # Populated in either self.start() or self.recover()
         self._allocated_obj_ref: ObjectRef = None
@@ -898,17 +900,22 @@ class ActorReplicaWrapper:
                 )
             init_args = (
                 self.replica_id,
-                cloudpickle.dumps(deployment_info.replica_config.deployment_def)
-                if self._deployment_is_cross_language
-                else deployment_info.replica_config.serialized_deployment_def,
+                (
+                    cloudpickle.dumps(deployment_info.replica_config.deployment_def)
+                    if self._deployment_is_cross_language
+                    else deployment_info.replica_config.serialized_deployment_def
+                ),
                 serialized_init_args,
-                deployment_info.replica_config.serialized_init_kwargs
-                if deployment_info.replica_config.serialized_init_kwargs
-                else cloudpickle.dumps({}),
+                (
+                    deployment_info.replica_config.serialized_init_kwargs
+                    if deployment_info.replica_config.serialized_init_kwargs
+                    else cloudpickle.dumps({})
+                ),
                 deployment_info.deployment_config.to_proto_bytes(),
                 self._version,
                 deployment_info.ingress,
                 deployment_info.route_prefix,
+                self._tracing_config,
             )
         # TODO(simon): unify the constructor arguments across language
         elif (
@@ -927,13 +934,15 @@ class ActorReplicaWrapper:
                 # String deploymentDef
                 deployment_info.replica_config.deployment_def_name,
                 # byte[] initArgsbytes
-                msgpack_serialize(
-                    cloudpickle.loads(
-                        deployment_info.replica_config.serialized_init_args
+                (
+                    msgpack_serialize(
+                        cloudpickle.loads(
+                            deployment_info.replica_config.serialized_init_args
+                        )
                     )
-                )
-                if self._deployment_is_cross_language
-                else deployment_info.replica_config.serialized_init_args,
+                    if self._deployment_is_cross_language
+                    else deployment_info.replica_config.serialized_init_args
+                ),
                 # byte[] deploymentConfigBytes,
                 deployment_info.deployment_config.to_proto_bytes(),
                 # byte[] deploymentVersionBytes,
@@ -1521,9 +1530,12 @@ class DeploymentReplica:
         self,
         replica_id: ReplicaID,
         version: DeploymentVersion,
+        tracing_config=None,
     ):
         self._replica_id = replica_id
-        self._actor = ActorReplicaWrapper(replica_id, version)
+        self._actor = ActorReplicaWrapper(
+            replica_id, version, tracing_config=tracing_config
+        )
         self._start_time = None
         self._shutdown_start_time: Optional[float] = None
         self._actor_details = ReplicaDetails(
@@ -2544,12 +2556,14 @@ class DeploymentState:
         deployment_scheduler: DeploymentScheduler,
         cluster_node_info_cache: ClusterNodeInfoCache,
         autoscaling_state_manager: AutoscalingStateManager,
+        tracing_config=None,
     ):
         self._id = id
         self._long_poll_host: LongPollHost = long_poll_host
         self._deployment_scheduler = deployment_scheduler
         self._cluster_node_info_cache = cluster_node_info_cache
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._tracing_config = tracing_config
 
         # Each time we set a new deployment goal, we're trying to save new
         # DeploymentInfo and bring current deployment to meet new status.
@@ -2784,6 +2798,7 @@ class DeploymentState:
             new_deployment_replica = DeploymentReplica(
                 replica_id,
                 self._target_state.version,
+                tracing_config=self._tracing_config,
             )
             # If replica is no longer alive, simply don't add it to the
             # deployment state manager to track.
@@ -3603,6 +3618,7 @@ class DeploymentState:
             new_deployment_replica = DeploymentReplica(
                 replica_id,
                 self._target_state.version,
+                tracing_config=self._tracing_config,
             )
             scheduling_request = new_deployment_replica.start(
                 self._target_state.info,
@@ -4902,6 +4918,7 @@ class DeploymentStateManager:
         autoscaling_state_manager: AutoscalingStateManager,
         head_node_id_override: Optional[str] = None,
         create_placement_group_fn_override: Optional[Callable] = None,
+        tracing_config=None,
     ):
         self._kv_store = kv_store
         self._long_poll_host = long_poll_host
@@ -4912,6 +4929,7 @@ class DeploymentStateManager:
             create_placement_group_fn_override,
         )
         self._autoscaling_state_manager = autoscaling_state_manager
+        self._tracing_config = tracing_config
 
         self._shutting_down = False
 
@@ -4944,6 +4962,7 @@ class DeploymentStateManager:
             self._deployment_scheduler,
             self._cluster_node_info_cache,
             self._autoscaling_state_manager,
+            tracing_config=self._tracing_config,
         )
 
     def _map_actor_names_to_deployment(

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -935,6 +935,7 @@ class HAProxyManager(ProxyActorInterface):
         node_ip_address: str,
         logging_config: LoggingConfig,
         long_poll_client: Optional[LongPollClient] = None,
+        tracing_config=None,
     ):  # noqa: F821
         super().__init__(
             node_id=node_id,

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -80,6 +80,7 @@ from ray.serve._private.proxy_request_response import (
 from ray.serve._private.proxy_response_generator import ProxyResponseGenerator
 from ray.serve._private.proxy_router import ProxyRouter
 from ray.serve._private.tracing_utils import (
+    get_tracing_kwargs,
     is_span_recording,
     set_http_span_attributes,
     set_rpc_span_attributes,
@@ -741,6 +742,7 @@ class gRPCProxy(GenericProxy):
             is received. It wraps the request iterator and calls proxy_request.
             The return value is serialized user defined protobuf bytes.
             """
+
             # Create async iterator wrapper for the request stream
             async def async_request_iterator():
                 async for request in request_iterator:
@@ -779,6 +781,7 @@ class gRPCProxy(GenericProxy):
             request is received. It wraps the request iterator and calls proxy_request.
             The return value is a generator of serialized user defined protobuf bytes.
             """
+
             # Create async iterator wrapper for the request stream
             async def async_request_iterator():
                 async for request in request_iterator:
@@ -937,9 +940,11 @@ class gRPCProxy(GenericProxy):
             set_rpc_span_attributes(
                 system=proxy_request.request_type,
                 method=proxy_request.method,
-                status_code=status.code.name
-                if isinstance(status.code, grpc.StatusCode)
-                else grpc.StatusCode.UNKNOWN.name,
+                status_code=(
+                    status.code.name
+                    if isinstance(status.code, grpc.StatusCode)
+                    else grpc.StatusCode.UNKNOWN.name
+                ),
             )
         self._finalize_proxy_tracing(status=status, exc=exc)
 
@@ -1466,6 +1471,7 @@ class ProxyActorInterface(ABC):
         node_ip_address: str,
         logging_config: LoggingConfig,
         log_buffer_size: int = RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
+        tracing_config: Optional["TracingConfig"] = None,  # noqa: F821
     ):
         """Initialize the proxy actor.
 
@@ -1474,11 +1480,13 @@ class ProxyActorInterface(ABC):
             node_ip_address: IP address of the node
             logging_config: Logging configuration
             log_buffer_size: Size of the log buffer
+            tracing_config: Tracing configuration
         """
         self._node_id = node_id
         self._node_ip_address = node_ip_address
         self._logging_config = logging_config
         self._log_buffer_size = log_buffer_size
+        self._tracing_config = tracing_config
 
         self._update_logging_config(logging_config)
 
@@ -1612,11 +1620,13 @@ class ProxyActor(ProxyActorInterface):
         node_ip_address: str,
         logging_config: LoggingConfig,
         long_poll_client: Optional[LongPollClient] = None,
-    ):  # noqa: F821
+        tracing_config: Optional["TracingConfig"] = None,  # noqa: F821
+    ):
         super().__init__(
             node_id=node_id,
             node_ip_address=node_ip_address,
             logging_config=logging_config,
+            tracing_config=tracing_config,
         )
 
         self._grpc_options = grpc_options
@@ -1633,8 +1643,11 @@ class ProxyActor(ProxyActorInterface):
         )
 
         try:
+            tracing_kwargs = get_tracing_kwargs(self._tracing_config)
             is_tracing_setup_successful = setup_tracing(
-                component_name="proxy", component_id=node_ip_address
+                component_name="proxy",
+                component_id=node_ip_address,
+                **tracing_kwargs,
             )
             if is_tracing_setup_successful:
                 logger.info("Successfully set up tracing for proxy")

--- a/python/ray/serve/_private/proxy_state.py
+++ b/python/ray/serve/_private/proxy_state.py
@@ -119,6 +119,7 @@ class ActorProxyWrapper(ProxyWrapper):
         node_ip_address: Optional[str] = None,
         port: Optional[int] = None,
         proxy_actor_class: Type[ProxyActor] = ProxyActor,
+        tracing_config=None,
     ):
         # initialize with provided proxy actor handle or get or create a new one.
         self._actor_handle = actor_handle or self._get_or_create_proxy_actor(
@@ -130,6 +131,7 @@ class ActorProxyWrapper(ProxyWrapper):
             port=port,
             proxy_actor_class=proxy_actor_class,
             logging_config=logging_config,
+            tracing_config=tracing_config,
         )
         self._ready_check_future = None
         self._health_check_future = None
@@ -152,6 +154,7 @@ class ActorProxyWrapper(ProxyWrapper):
         port: int,
         logging_config: LoggingConfig,
         proxy_actor_class: Type[ProxyActor] = ProxyActor,
+        tracing_config=None,
     ) -> ProxyWrapper:
         """Helper to start or reuse existing proxy.
 
@@ -183,6 +186,7 @@ class ActorProxyWrapper(ProxyWrapper):
             node_id=node_id,
             node_ip_address=node_ip_address,
             logging_config=logging_config,
+            tracing_config=tracing_config,
         )
 
     @property
@@ -603,8 +607,10 @@ class ProxyStateManager:
         actor_proxy_wrapper_class: Type[ProxyWrapper] = ActorProxyWrapper,
         timer: TimerBase = Timer(),
         running_native_proxies: bool = False,
+        tracing_config=None,
     ):
         self.logging_config = logging_config
+        self._tracing_config = tracing_config
         self._http_options = http_options or HTTPOptions()
         self._grpc_options = grpc_options or gRPCOptions()
         self._proxy_states: Dict[NodeId, ProxyState] = dict()
@@ -861,6 +867,7 @@ class ProxyStateManager:
             node_id=node_id,
             node_ip_address=node_ip_address,
             proxy_actor_class=proxy_actor_class or self._proxy_actor_class,
+            tracing_config=self._tracing_config,
         )
 
     def _start_fallback_proxy_if_needed(

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -136,6 +136,7 @@ from ray.serve._private.thirdparty.get_asgi_route_name import (
 from ray.serve._private.tracing_utils import (
     TraceContextManager,
     extract_propagated_context,
+    get_tracing_kwargs,
     is_span_recording,
     is_tracing_enabled,
     set_http_span_attributes,
@@ -1005,6 +1006,7 @@ class Replica:
         version: DeploymentVersion,
         ingress: bool,
         route_prefix: str,
+        tracing_config=None,
     ):
         self._version = version
         self._replica_id = replica_id
@@ -1012,6 +1014,7 @@ class Replica:
         self._deployment_config = deployment_config
         self._ingress = ingress
         self._route_prefix = route_prefix
+        self._tracing_config = tracing_config
         self._component_name = f"{self._deployment_id.name}"
         if self._deployment_id.app_name:
             self._component_name = (
@@ -1102,10 +1105,12 @@ class Replica:
         self._event_loop.set_exception_handler(asyncio_grpc_exception_handler)
 
         try:
+            tracing_kwargs = get_tracing_kwargs(self._tracing_config)
             is_tracing_setup_successful = setup_tracing(
                 component_type=ServeComponentType.REPLICA,
                 component_name=self._component_name,
                 component_id=self._component_id,
+                **tracing_kwargs,
             )
             if is_tracing_setup_successful:
                 logger.info("Successfully set up tracing for replica")
@@ -2664,6 +2669,7 @@ class ReplicaActor:
         version: DeploymentVersion,
         ingress: bool,
         route_prefix: str,
+        tracing_config=None,
     ):
         deployment_config = DeploymentConfig.from_proto_bytes(
             deployment_config_proto_bytes
@@ -2680,6 +2686,7 @@ class ReplicaActor:
             version=version,
             ingress=ingress,
             route_prefix=route_prefix,
+            tracing_config=tracing_config,
         )
 
     def push_proxy_handle(self, handle: ActorHandle):

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -339,6 +339,7 @@ class MockReplicaActorWrapper:
         self,
         replica_id: ReplicaID,
         version: DeploymentVersion,
+        tracing_config=None,
     ):
         self._replica_id = replica_id
         self._actor_name = replica_id.to_full_id_str()

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -294,7 +294,7 @@ def create_propagated_context() -> Dict[str, str]:
 
 
 def extract_propagated_context(
-    propagated_context: Optional[Dict[str, str]] = None
+    propagated_context: Optional[Dict[str, str]] = None,
 ) -> Optional[Dict[str, str]]:
     """Extract the trace context from a Trace Context Propagator."""
     if is_tracing_enabled() and propagated_context and TraceContextTextMapPropagator:
@@ -499,3 +499,28 @@ def _is_generator_function(func):
 
 def _is_async_function(func):
     return inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
+
+
+def get_tracing_kwargs(tracing_config: Optional[Any] = None) -> Dict[str, Any]:
+    """Extract tracing kwargs from a TracingConfig for passing to setup_tracing.
+
+    If tracing_config is None or tracing is not enabled, returns kwargs that
+    will cause setup_tracing to use its default behavior (env var based).
+
+    Args:
+        tracing_config: Optional TracingConfig instance.
+
+    Returns:
+        Dict with tracing_exporter_import_path and tracing_sampling_ratio keys.
+    """
+    if tracing_config is None:
+        return {}
+
+    kwargs = {}
+    if tracing_config.enabled:
+        kwargs["tracing_exporter_import_path"] = tracing_config.exporter_import_path
+        kwargs["tracing_sampling_ratio"] = tracing_config.sampling_ratio
+    else:
+        # Explicitly disable tracing by passing empty exporter path
+        kwargs["tracing_exporter_import_path"] = ""
+    return kwargs

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -74,6 +74,7 @@ def start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     logging_config: Union[None, dict, LoggingConfig] = None,
+    tracing_config: Union[None, dict, "TracingConfig"] = None,  # noqa: F821
     **kwargs,
 ):
     """Start Serve on the cluster.
@@ -99,12 +100,15 @@ def start(
           class See `gRPCOptions` for supported options.
         logging_config: logging config options for the serve component (
             controller & proxy).
+        tracing_config: tracing config options for the serve component (
+            controller, proxy & replica).
     """
     http_options = prepare_imperative_http_options(proxy_location, http_options)
     _private_api.serve_start(
         http_options=http_options,
         grpc_options=grpc_options,
         global_logging_config=logging_config,
+        global_tracing_config=tracing_config,
         **kwargs,
     )
 
@@ -672,12 +676,14 @@ def _run_many(
                 name=t.name,
                 route_prefix=t.route_prefix,
                 logging_config=t.logging_config,
-                make_deployment_handle=make_local_deployment_handle
-                if _local_testing_mode
-                else None,
-                default_runtime_env=ray.get_runtime_context().runtime_env
-                if not _local_testing_mode
-                else None,
+                make_deployment_handle=(
+                    make_local_deployment_handle if _local_testing_mode else None
+                ),
+                default_runtime_env=(
+                    ray.get_runtime_context().runtime_env
+                    if not _local_testing_mode
+                    else None
+                ),
                 external_scaler_enabled=t.external_scaler_enabled,
             )
         )

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -30,8 +30,11 @@ from ray.serve._private.constants import (
     DEFAULT_CONSUMER_CONCURRENCY,
     DEFAULT_GRPC_PORT,
     DEFAULT_MAX_ONGOING_REQUESTS,
+    DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
     DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S,
     RAY_SERVE_LOG_ENCODING,
+    RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+    RAY_SERVE_TRACING_SAMPLING_RATIO,
     SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
@@ -215,6 +218,74 @@ class LoggingConfig(BaseModel):
         if not isinstance(other, LoggingConfig):
             return False
         return self._compute_hash() == other._compute_hash()
+
+
+@PublicAPI(stability="alpha")
+class TracingConfig(BaseModel):
+    """Tracing config for configuring OpenTelemetry tracing in Serve.
+
+    This config allows users to enable/disable tracing, configure the
+    tracing exporter, and set the sampling ratio for traces.
+
+    Example:
+
+        .. code-block:: python
+
+            from ray import serve
+            from ray.serve.schema import TracingConfig
+
+            # Enable tracing with default settings.
+            serve.start(tracing_config=TracingConfig(enabled=True))
+
+            # Enable tracing with a custom exporter.
+            serve.start(
+                tracing_config=TracingConfig(
+                    enabled=True,
+                    exporter_import_path="my_module:my_exporter",
+                    sampling_ratio=0.1,
+                )
+            )
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default_factory=lambda: bool(RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH),
+        description=(
+            "Whether tracing is enabled. Defaults to True if the "
+            "RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH environment variable is set, "
+            "otherwise False."
+        ),
+    )
+    exporter_import_path: str = Field(
+        default_factory=lambda: RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+        description=(
+            "Import path for the tracing exporter function. Defaults to the value "
+            "of the RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH environment variable. "
+            "When enabled is True and this is empty, defaults to the built-in "
+            "console span exporter."
+        ),
+    )
+    sampling_ratio: float = Field(
+        default_factory=lambda: RAY_SERVE_TRACING_SAMPLING_RATIO,
+        description=(
+            "Sampling ratio for traces, between 0.0 and 1.0. Defaults to the value "
+            "of the RAY_SERVE_TRACING_SAMPLING_RATIO environment variable (0.01)."
+        ),
+    )
+
+    @field_validator("sampling_ratio")
+    @classmethod
+    def validate_sampling_ratio(cls, v):
+        if v < 0.0 or v > 1.0:
+            raise ValueError(f"sampling_ratio must be between 0.0 and 1.0, got {v}.")
+        return v
+
+    @model_validator(mode="after")
+    def fill_default_exporter_when_enabled(self):
+        if self.enabled and not self.exporter_import_path:
+            self.exporter_import_path = DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+        return self
 
 
 @PublicAPI(stability="stable")
@@ -999,6 +1070,10 @@ class ServeDeploySchema(BaseModel):
     logging_config: Optional[LoggingConfig] = Field(
         default=None,
         description="Logging config for configuring serve components logs.",
+    )
+    tracing_config: Optional[TracingConfig] = Field(
+        default=None,
+        description="Tracing config for configuring OpenTelemetry tracing in Serve.",
     )
     applications: List[ServeApplicationSchema] = Field(
         ..., description="The set of applications to run on the Ray cluster."

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -27,6 +27,7 @@ from ray.serve.schema import (
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
+    TracingConfig,
 )
 from ray.serve.tests.common.remote_uris import (
     TEST_DEPLOY_GROUP_PINNED_URI,
@@ -1402,6 +1403,95 @@ def test_serve_instance_details_is_json_serializable():
     deployment = application["deployments"]["deployment1"]
     autoscaling_config = deployment["deployment_config"]["autoscaling_config"]
     assert "_serialized_policy_def" not in autoscaling_config
+
+
+class TestTracingConfig:
+    """Tests for the TracingConfig schema."""
+
+    def test_default_config(self):
+        """Test default TracingConfig values."""
+        config = TracingConfig()
+        # By default (no env var set), enabled should be False and
+        # exporter_import_path should be empty string.
+        assert isinstance(config.enabled, bool)
+        assert isinstance(config.exporter_import_path, str)
+        assert isinstance(config.sampling_ratio, float)
+
+    def test_enabled_true(self):
+        """Test enabling tracing explicitly."""
+        config = TracingConfig(enabled=True)
+        assert config.enabled is True
+
+    def test_enabled_false(self):
+        """Test disabling tracing explicitly."""
+        config = TracingConfig(enabled=False)
+        assert config.enabled is False
+
+    def test_custom_exporter_import_path(self):
+        """Test setting a custom exporter import path."""
+        config = TracingConfig(
+            enabled=True,
+            exporter_import_path="my_module:my_exporter",
+        )
+        assert config.exporter_import_path == "my_module:my_exporter"
+
+    def test_custom_sampling_ratio(self):
+        """Test setting a custom sampling ratio."""
+        config = TracingConfig(sampling_ratio=0.5)
+        assert config.sampling_ratio == 0.5
+
+    def test_sampling_ratio_zero(self):
+        """Test sampling ratio at lower bound."""
+        config = TracingConfig(sampling_ratio=0.0)
+        assert config.sampling_ratio == 0.0
+
+    def test_sampling_ratio_one(self):
+        """Test sampling ratio at upper bound."""
+        config = TracingConfig(sampling_ratio=1.0)
+        assert config.sampling_ratio == 1.0
+
+    def test_sampling_ratio_too_low(self):
+        """Test that sampling ratio below 0.0 raises ValueError."""
+        with pytest.raises(ValidationError, match="sampling_ratio"):
+            TracingConfig(sampling_ratio=-0.1)
+
+    def test_sampling_ratio_too_high(self):
+        """Test that sampling ratio above 1.0 raises ValueError."""
+        with pytest.raises(ValidationError, match="sampling_ratio"):
+            TracingConfig(sampling_ratio=1.1)
+
+    def test_extra_fields_forbidden(self):
+        """Test that extra fields are not allowed."""
+        with pytest.raises(ValidationError):
+            TracingConfig(unknown_field="value")
+
+    def test_enabled_true_empty_exporter_fills_default(self):
+        """Test that when enabled=True and exporter_import_path is empty,
+        the default exporter path is filled in."""
+        config = TracingConfig(enabled=True, exporter_import_path="")
+        assert config.exporter_import_path != ""
+        assert "default_tracing_exporter" in config.exporter_import_path
+
+    def test_enabled_false_empty_exporter_stays_empty(self):
+        """Test that when enabled=False and exporter_import_path is empty,
+        it stays empty."""
+        config = TracingConfig(enabled=False, exporter_import_path="")
+        assert config.exporter_import_path == ""
+
+    def test_serve_deploy_schema_with_tracing_config(self):
+        """Test that ServeDeploySchema accepts tracing_config field."""
+        schema = ServeDeploySchema(
+            applications=[
+                ServeApplicationSchema(
+                    name="test_app",
+                    import_path="test_module:app",
+                )
+            ],
+            tracing_config=TracingConfig(enabled=True, sampling_ratio=0.5),
+        )
+        assert schema.tracing_config is not None
+        assert schema.tracing_config.enabled is True
+        assert schema.tracing_config.sampling_ratio == 0.5
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Summary

  Adds a `TracingConfig` class for configuring OpenTelemetry tracing in Ray Serve and wires it through the
  entire actor hierarchy. Replaces env-var-only tracing setup with a proper configuration object,
  consistent with HTTPOptions/gRPCOptions.


  Part 1 of 2 for issue #61788.

  ### Changes

  **Schema:**
  - New `TracingConfig` pydantic model (`schema.py`) with `enabled`, `exporter_import_path`,
  `sampling_ratio`
  - Added to `ServeDeploySchema` for YAML/REST API support
  - Exported in `ray.serve` public API + API doc entry

  **Proxy path:**
  - `serve.start(tracing_config=...)` parameter
  - Normalization in `_start_controller()` (None/dict → TracingConfig)
  - Controller → ProxyStateManager → ProxyActor/HAProxyManager → `setup_tracing()`

  **Replica path:**
  - Controller → ApplicationStateManager → ApplicationState → DeploymentStateManager → DeploymentState →
  DeploymentReplica → init_args → ReplicaActor → setup_tracing()

  ### Design
  - **Global only** — cluster-level, not per-app or per-deployment
  - **Static** — set once at startup, no hot-reload of existing actors
  - **No proto changes** — constructor arg through actor hierarchy
  - **Backward compatible** — env vars still work as defaults when tracing_config is None

  ## Test plan
  - [x] 13 unit tests for TracingConfig validation
  - [x] Existing proxy/replica/deployment state tests pass
