### PR TITLE
[Data][Docs] Add collate_fn documentation and examples

### DIFF
--- a/doc/source/data/working-with-pytorch.rst
+++ b/doc/source/data/working-with-pytorch.rst
@@ -8,6 +8,7 @@ Ray Data integrates with the PyTorch ecosystem.
 This guide describes how to:
 
 * :ref:`Iterate over your dataset as Torch tensors for model training <iterating_pytorch>`
+* :ref:`Customize tensor conversion with collate functions <collate_fn_pytorch>`
 * :ref:`Write transformations that deal with Torch tensors <transform_pytorch>`
 * :ref:`Perform batch inference with Torch models <batch_inference_pytorch>`
 * :ref:`Save Datasets containing Torch tensors <saving_pytorch>`
@@ -79,6 +80,60 @@ Ray Data integrates with :ref:`Ray Train <train-docs>` for easy data ingest for 
 
 
 For more details, see the :ref:`Ray Train user guide <data-ingest-torch>`.
+
+.. _collate_fn_pytorch:
+
+Custom collate functions
+~~~~~~~~~~~~~~~~~~~~~~~~
+Use a custom ``collate_fn`` to control how data batches are converted to tensors
+before being passed to your model. This is useful for last-mile formatting such
+as padding, masking, or packaging tensors into custom data structures.
+
+To define a custom collate function, subclass one of the following base classes
+depending on the input format you want:
+
+* :class:`~ray.data.collate_fn.ArrowBatchCollateFn` -- receives a ``pyarrow.Table`` (recommended for best performance).
+* :class:`~ray.data.collate_fn.NumpyBatchCollateFn` -- receives a ``Dict[str, np.ndarray]``.
+* :class:`~ray.data.collate_fn.PandasBatchCollateFn` -- receives a ``pd.DataFrame``.
+
+.. testcode::
+
+    import pyarrow as pa
+    import torch
+    import ray
+    from ray.data.collate_fn import ArrowBatchCollateFn
+
+    class MyCollateFn(ArrowBatchCollateFn):
+        def __call__(self, batch: pa.Table) -> dict:
+            return {
+                "features": torch.as_tensor(batch["col_1"].to_numpy(), dtype=torch.float32),
+                "labels": torch.as_tensor(batch["col_2"].to_numpy(), dtype=torch.long),
+            }
+
+    ds = ray.data.from_items([
+        {"col_1": 1.0, "col_2": 0},
+        {"col_1": 2.0, "col_2": 1},
+        {"col_1": 3.0, "col_2": 0},
+        {"col_1": 4.0, "col_2": 1},
+    ])
+
+    for batch in ds.iterator().iter_torch_batches(
+        batch_size=2, collate_fn=MyCollateFn()
+    ):
+        print(batch)
+
+.. testoutput::
+
+    {'features': tensor([1., 2.]), 'labels': tensor([0, 1])}
+    {'features': tensor([3., 4.]), 'labels': tensor([0, 1])}
+
+.. note::
+
+    Passing a plain function to ``collate_fn`` is deprecated. Use a callable
+    class that inherits from one of the base classes above.
+
+For scaling expensive collate functions across multiple nodes, see
+:ref:`train-scaling-collation-functions`.
 
 .. _transform_pytorch:
 

--- a/python/ray/data/collate_fn.py
+++ b/python/ray/data/collate_fn.py
@@ -172,9 +172,27 @@ class CollateFn(Generic[DataBatchType]):
 @DeveloperAPI
 class ArrowBatchCollateFn(CollateFn["pyarrow.Table"]):
     """Collate function that takes pyarrow.Table as the input batch type.
-    Arrow tables with chunked arrays can be efficiently transferred to GPUs without
-    combining the chunks with the `arrow_batch_to_tensors` utility function.
-    See `DefaultCollateFn` for example.
+
+    Arrow tables with chunked arrays can be efficiently transferred to GPUs
+    without combining the chunks with the ``arrow_batch_to_tensors`` utility
+    function. See ``DefaultCollateFn`` for a reference implementation.
+
+    This is the recommended collate function type for best performance.
+
+    Examples:
+        >>> import pyarrow as pa
+        >>> import torch
+        >>> import ray
+        >>> from ray.data.collate_fn import ArrowBatchCollateFn
+        >>> class MyCollateFn(ArrowBatchCollateFn):
+        ...     def __call__(self, batch: pa.Table) -> torch.Tensor:
+        ...         return torch.as_tensor(batch["id"].to_numpy() + 5)
+        >>> ds = ray.data.range(4)
+        >>> for batch in ds.iterator().iter_torch_batches(
+        ...     batch_size=4, collate_fn=MyCollateFn()
+        ... ):
+        ...     print(batch)
+        tensor([5, 6, 7, 8])
     """
 
     def __call__(self, batch: "pyarrow.Table") -> "CollatedData":
@@ -191,7 +209,24 @@ class ArrowBatchCollateFn(CollateFn["pyarrow.Table"]):
 
 @DeveloperAPI
 class NumpyBatchCollateFn(CollateFn[Dict[str, np.ndarray]]):
-    """Collate function that takes a dictionary of numpy arrays as the input batch type."""
+    """Collate function that takes a dictionary of numpy arrays as the input batch type.
+
+    Examples:
+        >>> from typing import Dict
+        >>> import numpy as np
+        >>> import torch
+        >>> import ray
+        >>> from ray.data.collate_fn import NumpyBatchCollateFn
+        >>> class MyCollateFn(NumpyBatchCollateFn):
+        ...     def __call__(self, batch: Dict[str, np.ndarray]) -> torch.Tensor:
+        ...         return torch.as_tensor(batch["id"] + 5)
+        >>> ds = ray.data.range(4)
+        >>> for batch in ds.iterator().iter_torch_batches(
+        ...     batch_size=4, collate_fn=MyCollateFn()
+        ... ):
+        ...     print(batch)
+        tensor([5, 6, 7, 8])
+    """
 
     def __call__(self, batch: Dict[str, np.ndarray]) -> "CollatedData":
         """Convert a batch of numpy arrays to collated format.
@@ -207,7 +242,23 @@ class NumpyBatchCollateFn(CollateFn[Dict[str, np.ndarray]]):
 
 @DeveloperAPI
 class PandasBatchCollateFn(CollateFn["pandas.DataFrame"]):
-    """Collate function that takes a pandas.DataFrame as the input batch type."""
+    """Collate function that takes a pandas.DataFrame as the input batch type.
+
+    Examples:
+        >>> import pandas as pd
+        >>> import torch
+        >>> import ray
+        >>> from ray.data.collate_fn import PandasBatchCollateFn
+        >>> class MyCollateFn(PandasBatchCollateFn):
+        ...     def __call__(self, batch: pd.DataFrame) -> torch.Tensor:
+        ...         return torch.as_tensor(batch["id"].to_numpy() + 5)
+        >>> ds = ray.data.range(4)
+        >>> for batch in ds.iterator().iter_torch_batches(
+        ...     batch_size=4, collate_fn=MyCollateFn()
+        ... ):
+        ...     print(batch)
+        tensor([5, 6, 7, 8])
+    """
 
     def __call__(self, batch: "pandas.DataFrame") -> "CollatedData":
         """Convert a batch of pandas.DataFrame to collated format.


### PR DESCRIPTION
## Description

The deprecation warning for `iter_torch_batches(collate_fn=...)` tells users to switch from plain functions to callable classes (`ArrowBatchCollateFn`, `NumpyBatchCollateFn`, `PandasBatchCollateFn`), but no user-facing documentation showed how to use them.

This PR adds:

1. **A "Custom collate functions" section** to `doc/source/data/working-with-pytorch.rst` with:
   - Explanation of the three collate fn base classes
   - A working testcode example using `ArrowBatchCollateFn`
   - A deprecation note about plain functions
   - A link to the existing scaling collation guide

2. **`Examples:` sections** in each base class docstring in `collate_fn.py` (`ArrowBatchCollateFn`, `NumpyBatchCollateFn`, `PandasBatchCollateFn`)

## Related issues

Fixes #55767

## Additional information

- The `iter_torch_batches` docstring already has examples (added after the issue was filed), but the main user-facing doc page (`working-with-pytorch.rst`) only had a one-sentence mention with no code
- The collate fn classes in `collate_fn.py` had no `Examples:` in their docstrings
- All pre-commit hooks pass