### PR TITLE
[Serve] Avoid destructor error when FastAPI ingress init fails

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -602,6 +602,9 @@ class ASGIAppReplicaWrapper:
     # NOTE: __del__ must be async so that we can run ASGI shutdown
     # in the same event loop.
     async def __del__(self):
+        if not hasattr(self, "_serve_asgi_lifespan"):
+            return
+
         # LifespanOn's logger logs in INFO level thus becomes spammy.
         # Within this block we temporarily uplevel for cleaner logging.
         from ray.serve._private.logging_utils import LoggingContext

--- a/python/ray/serve/tests/unit/test_user_callable_wrapper.py
+++ b/python/ray/serve/tests/unit/test_user_callable_wrapper.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
+import ray.serve._private.replica as replica_module
 from ray import serve
 from ray.serve._private.common import (
     DeploymentID,
@@ -623,6 +624,40 @@ async def test_http_handler(
         "type": "http.response.body",
         "body": b"Hello b'\"world\"'!",
     }
+
+
+failing_init_app = FastAPI()
+
+
+@serve.ingress(failing_init_app)
+class FailingFastAPIRequestHandler:
+    def __init__(self):
+        raise RuntimeError("init failed")
+
+
+@pytest.mark.parametrize("run_user_code_in_separate_thread", [False, True])
+@pytest.mark.asyncio
+async def test_fastapi_init_failure_destructor_is_noop(
+    monkeypatch, run_user_code_in_separate_thread: bool
+):
+    logged_messages = []
+
+    def mock_exception(msg, *args, **kwargs):
+        logged_messages.append(msg)
+
+    monkeypatch.setattr(replica_module.logger, "exception", mock_exception)
+
+    user_callable_wrapper = _make_user_callable_wrapper(
+        FailingFastAPIRequestHandler,
+        run_user_code_in_separate_thread=run_user_code_in_separate_thread,
+    )
+
+    with pytest.raises(RuntimeError, match="init failed"):
+        await user_callable_wrapper.initialize_callable()
+
+    await user_callable_wrapper.call_destructor()
+
+    assert logged_messages == []
 
 
 class TestSeparateThread:


### PR DESCRIPTION
## Description

When a `@serve.ingress(FastAPI())` deployment fails during `__init__`, the replica cleanup path can log an extra error:

```text
AttributeError: object has no attribute '_serve_asgi_lifespan'
```

This happens because the object is created via `__new__`, but `ASGIAppReplicaWrapper.__init__` never finishes, so `_serve_asgi_lifespan` is never set. Later, `call_destructor()` still invokes `__del__`, which unconditionally accesses that attribute.

This change makes `ASGIAppReplicaWrapper.__del__` a no-op when `_serve_asgi_lifespan` was never initialized.

## Related issues

Fixes #62078

## Additional information

- Minimal fix: add a guard in `python/ray/serve/_private/http_util.py`
- Added a unit test covering FastAPI ingress init failure followed by destructor cleanup
- Verified existing destructor behavior still works

## Test plan

```bash
pytest -q python/ray/serve/tests/unit/test_user_callable_wrapper.py -k fastapi_init_failure_destructor_is_noop -vv
pytest -q python/ray/serve/tests/unit/test_user_callable_wrapper.py -k 'destructor_only_called_once or fastapi_init_failure_destructor_is_noop' -vv
```