### PR TITLE
[Serve][Docs] Adding Ray Serve office hours invite into documentation

### DIFF
--- a/doc/source/serve/index.md
+++ b/doc/source/serve/index.md
@@ -306,6 +306,22 @@ or head over to the {doc}`examples` to get started building your Ray Serve appli
 
             Read the API Reference
 
+    .. grid-item-card::
+        :class-img-top: pt-2 w-75 d-block mx-auto fixed-height-img
+
+        **Ray Serve Office Hours**
+        ^^^
+
+        Join our bi-weekly community office hours for anyone working with Ray Serve. Bring questions, issues you're experiencing, or ideas you want to sanity check with the Ray Serve team.
+
+        +++
+        .. button-link:: https://docs.google.com/forms/d/e/1FAIpQLSfyeVy7wYqvjpEz8wjPQg--0fmQc5WvuNoVkW6vPaAJG0Cizw/viewform
+            :color: primary
+            :outline:
+            :expand:
+
+            Sign Up Here
+
 ```
 
 For more, see the following blog posts about Ray Serve:


### PR DESCRIPTION
## Description
The office hours have been ongoing but from my experience attending, it hasn't been getting as much traction as it should. It is difficult to find the invite link; AFAIK, it's only available via the Ray Slack in the announcements chat, if you scroll up far enough...

The description and google form link are directly from the announcement on slack. 

## Related issues
N/A

## Additional information
Are any other components having community meetings/ office hours?
