### PR TITLE
[Serve] Fix flaky TestInitialReplicasHandling timeouts

### DIFF
--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -945,6 +945,7 @@ class TestInitialReplicasHandling:
             wait_for_condition(
                 check_expected_num_replicas,
                 deployment_to_num_replicas={deployment_name: num_replicas},
+                timeout=30,
             )
 
     def test_initial_replicas_scales_up_and_down(
@@ -996,6 +997,7 @@ class TestInitialReplicasHandling:
             wait_for_condition(
                 check_expected_num_replicas,
                 deployment_to_num_replicas={deployment_name: num_replicas},
+                timeout=30,
             )
 
     def test_initial_replicas_zero(
@@ -1111,6 +1113,7 @@ class TestInitialReplicasHandling:
                 )
             },
             app_name="app1",
+            timeout=30,
         )
         wait_for_condition(
             check_expected_num_replicas,
@@ -1120,6 +1123,7 @@ class TestInitialReplicasHandling:
                 )
             },
             app_name="app2",
+            timeout=30,
         )
 
 


### PR DESCRIPTION
## Summary
- Increase `wait_for_condition` timeouts from 10s (default) to 30s in `TestInitialReplicasHandling` tests
- The 10s default was insufficient for the full replica lifecycle (actor scheduling + gRPC server init + autoscaler convergence + downscale), which takes 13-15s
- Verified stable with 5 consecutive green runs locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>