### PR TITLE
[Core] Fix lease cleanup on worker failure (#62093)

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -975,12 +975,16 @@ void NodeManager::NodeRemoved(const NodeID &node_id) {
 
   // Clean up workers that were owned by processes that were on the failed
   // node.
+  std::vector<std::shared_ptr<WorkerInterface>> workers_owned_by_failed_node;
   for (const auto &[_, worker] : leased_workers_) {
     const auto owner_node_id = NodeID::FromBinary(worker->GetOwnerAddress().node_id());
     RAY_CHECK(!owner_node_id.IsNil());
-    if (worker->IsDetachedActor() || owner_node_id != node_id) {
-      continue;
+    if (!worker->IsDetachedActor() && owner_node_id == node_id) {
+      workers_owned_by_failed_node.emplace_back(worker);
     }
+  }
+  for (const auto &worker : workers_owned_by_failed_node) {
+    const auto owner_node_id = NodeID::FromBinary(worker->GetOwnerAddress().node_id());
     // If the leased worker's owner was on the failed node, then kill the leased
     // worker.
     RAY_LOG(INFO).WithField(worker->WorkerId()).WithField(owner_node_id)
@@ -1030,13 +1034,18 @@ void NodeManager::HandleUnexpectedWorkerFailure(const WorkerID &worker_id) {
 
   cluster_lease_manager_.CancelAllLeasesOwnedBy(worker_id);
 
+  std::vector<std::shared_ptr<WorkerInterface>> workers_owned_by_failed_worker;
   for (const auto &[_, worker] : leased_workers_) {
     const auto owner_worker_id =
         WorkerID::FromBinary(worker->GetOwnerAddress().worker_id());
     RAY_CHECK(!owner_worker_id.IsNil());
-    if (worker->IsDetachedActor() || owner_worker_id != worker_id) {
-      continue;
+    if (!worker->IsDetachedActor() && owner_worker_id == worker_id) {
+      workers_owned_by_failed_worker.emplace_back(worker);
     }
+  }
+  for (const auto &worker : workers_owned_by_failed_worker) {
+    const auto owner_worker_id =
+        WorkerID::FromBinary(worker->GetOwnerAddress().worker_id());
     // If the failed worker was a leased worker's owner, then kill the leased worker.
     RAY_LOG(INFO)
             .WithField(worker->WorkerId())

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -985,7 +985,9 @@ void NodeManager::NodeRemoved(const NodeID &node_id) {
     // worker.
     RAY_LOG(INFO).WithField(worker->WorkerId()).WithField(owner_node_id)
         << "Killing leased worker because its owner's node died.";
-    worker->KillAsync(io_service_);
+    DestroyWorker(worker,
+                  rpc::WorkerExitType::SYSTEM_ERROR,
+                  "Worker killed because its owner's node died.");
   }
 
   // Below, when we remove node_id from all of these data structures, we could
@@ -1040,7 +1042,9 @@ void NodeManager::HandleUnexpectedWorkerFailure(const WorkerID &worker_id) {
             .WithField(worker->WorkerId())
             .WithField("owner_worker_id", owner_worker_id)
         << "Killing leased worker because its owner died.";
-    worker->KillAsync(io_service_);
+    DestroyWorker(worker,
+                  rpc::WorkerExitType::SYSTEM_ERROR,
+                  "Worker killed because its owner died.");
   }
 
   // LocalObjectManager has spilled + pinned copies; ObjectManager has

--- a/src/ray/raylet/tests/BUILD.bazel
+++ b/src/ray/raylet/tests/BUILD.bazel
@@ -10,6 +10,7 @@ ray_cc_library(
         "//src/ray/common:lease",
         "//src/ray/protobuf:common_cc_proto",
         "//src/ray/raylet:worker_interface",
+        "//src/ray/raylet_ipc_client:client_connection",
         "//src/ray/util:clock",
         "//src/ray/util:compat",
         "//src/ray/util:fake_process",

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -126,9 +126,9 @@ class FakeLocalObjectManager : public LocalObjectManagerInterface {
 };
 
 LeaseSpecification BuildLeaseSpec(
-    const std::unordered_map<std::string, double> &resources) {
+    const std::unordered_map<std::string, double> &resources,
+    const rpc::Address &caller_address = rpc::Address()) {
   TaskSpecBuilder builder;
-  rpc::Address empty_address;
   rpc::JobConfig config;
   FunctionDescriptor function_descriptor =
       FunctionDescriptorBuilder::BuildPython("x", "", "", "");
@@ -141,7 +141,7 @@ LeaseSpecification BuildLeaseSpec(
                             TaskID::Nil(),
                             0,
                             TaskID::Nil(),
-                            empty_address,
+                            caller_address,
                             1,
                             false,
                             false,
@@ -510,6 +510,41 @@ class NodeManagerTest : public ::testing::Test {
   ray::observability::FakeCounter fake_memory_manager_worker_eviction_total_count_;
   ray::observability::FakeCounter
       fake_node_manager_unexpected_worker_failure_total_count_;
+
+  std::shared_ptr<MockWorker> LeaseWorkerWithOwner(const rpc::Address &owner_address) {
+    PopWorkerCallback pop_worker_callback;
+    EXPECT_CALL(mock_worker_pool_, PopWorker(_, _))
+        .WillOnce(
+            [&](const LeaseSpecification &lease_spec, const PopWorkerCallback &callback) {
+              pop_worker_callback = callback;
+            });
+
+    const auto lease_spec = BuildLeaseSpec({{"CPU", 1}}, owner_address);
+    std::promise<Status> promise;
+    rpc::RequestWorkerLeaseReply reply;
+    rpc::RequestWorkerLeaseRequest request;
+    request.mutable_lease_spec()->CopyFrom(lease_spec.GetMessage());
+    node_manager_->HandleRequestWorkerLease(
+        request,
+        &reply,
+        [&](Status status, std::function<void()> success, std::function<void()> failure) {
+          promise.set_value(status);
+        });
+
+    const auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10, clock_);
+    worker->SetConnection(ClientConnection::Create(
+        [](std::shared_ptr<ClientConnection>, int64_t, const std::vector<uint8_t> &) {},
+        [](std::shared_ptr<ClientConnection>, const boost::system::error_code &) {},
+        local_stream_socket(io_service_),
+        "mock_worker_connection",
+        {}));
+    ON_CALL(mock_worker_pool_,
+            GetRegisteredWorker(testing::A<const std::shared_ptr<ClientConnection> &>()))
+        .WillByDefault(Return(worker));
+    pop_worker_callback(worker, PopWorkerStatus::OK, "");
+    RAY_CHECK(promise.get_future().get().ok());
+    return worker;
+  }
 };
 
 TEST_F(NodeManagerTest, HandleIsLocalWorkerDeadUnknownWorker) {
@@ -1648,5 +1683,63 @@ TEST_P(ReleaseUnusedBundlesRetriesTest, TestHandleReleaseUnusedBundlesRetries) {
 INSTANTIATE_TEST_SUITE_P(ReleaseUnusedBundlesRetriesVariations,
                          ReleaseUnusedBundlesRetriesTest,
                          ::testing::Bool());
+
+TEST_F(NodeManagerTest, TestHandleUnexpectedWorkerFailureCleansUpLease) {
+  // Capture the worker-failure subscription callback so we can trigger it later.
+  std::function<void(rpc::WorkerDeltaData)> publish_worker_failure_callback;
+  EXPECT_CALL(*mock_gcs_client_->mock_worker_accessor,
+              AsyncSubscribeToWorkerFailures(_, _))
+      .WillOnce([&](const rpc::ItemCallback<rpc::WorkerDeltaData> &subscribe,
+                    const rpc::StatusCallback &done) {
+        publish_worker_failure_callback = subscribe;
+        return Status::OK();
+      });
+
+  node_manager_->RegisterGcs();
+  while (!publish_worker_failure_callback) {
+    io_service_.run_one();
+  }
+
+  const auto owner_worker_id = WorkerID::FromRandom();
+  rpc::Address owner_address;
+  owner_address.set_worker_id(owner_worker_id.Binary());
+  const auto worker = LeaseWorkerWithOwner(owner_address);
+  ASSERT_EQ(leased_workers_.size(), 1);
+
+  rpc::WorkerDeltaData delta_data;
+  delta_data.set_worker_id(owner_worker_id.Binary());
+  publish_worker_failure_callback(std::move(delta_data));
+
+  ASSERT_TRUE(worker->IsKilled());
+  ASSERT_EQ(leased_workers_.size(), 0);
+}
+
+TEST_F(NodeManagerTest, TestNodeRemovedCleansUpLease) {
+  // Capture the node-change subscription callback so we can trigger it later.
+  std::function<void(const NodeID &id, rpc::GcsNodeAddressAndLiveness &&node_info)>
+      publish_node_change_callback;
+  EXPECT_CALL(*mock_gcs_client_->mock_node_accessor,
+              AsyncSubscribeToNodeAddressAndLivenessChange(_, _))
+      .WillOnce([&](const rpc::SubscribeCallback<NodeID, rpc::GcsNodeAddressAndLiveness>
+                        &subscribe,
+                    const rpc::StatusCallback &done) {
+        publish_node_change_callback = subscribe;
+      });
+
+  node_manager_->RegisterGcs();
+
+  const auto owner_node_id = NodeID::FromRandom();
+  rpc::Address owner_address;
+  owner_address.set_node_id(owner_node_id.Binary());
+  const auto worker = LeaseWorkerWithOwner(owner_address);
+  ASSERT_EQ(leased_workers_.size(), 1);
+
+  rpc::GcsNodeAddressAndLiveness node_info;
+  node_info.set_state(GcsNodeInfo::DEAD);
+  publish_node_change_callback(owner_node_id, std::move(node_info));
+
+  ASSERT_TRUE(worker->IsKilled());
+  ASSERT_EQ(leased_workers_.size(), 0);
+}
 
 }  // namespace ray::raylet

--- a/src/ray/raylet/tests/util.h
+++ b/src/ray/raylet/tests/util.h
@@ -23,6 +23,7 @@
 #include "ray/asio/instrumented_io_context.h"
 #include "ray/common/lease/lease.h"
 #include "ray/raylet/worker_interface.h"
+#include "ray/raylet_ipc_client/client_connection.h"
 #include "ray/util/clock.h"
 #include "ray/util/compat.h"
 #include "ray/util/fake_process.h"
@@ -144,7 +145,12 @@ class MockWorker : public WorkerInterface {
     return lease_->GetLeaseSpecification().IsDetachedActor();
   }
 
-  const std::shared_ptr<ClientConnection> Connection() const override { return nullptr; }
+  const std::shared_ptr<ClientConnection> Connection() const override {
+    return connection_;
+  }
+  void SetConnection(std::shared_ptr<ClientConnection> connection) {
+    connection_ = std::move(connection);
+  }
   const rpc::Address &GetOwnerAddress() const override { return address_; }
   std::optional<pid_t> GetSavedProcessGroupId() const override { return std::nullopt; }
   void SetSavedProcessGroupId(pid_t pgid) override { (void)pgid; }
@@ -202,6 +208,7 @@ class MockWorker : public WorkerInterface {
   std::unique_ptr<ProcessInterface> proc_;
   std::atomic<bool> killing_ = false;
   std::shared_ptr<rpc::CoreWorkerClientInterface> rpc_client_;
+  std::shared_ptr<ClientConnection> connection_;
   ClockInterface &clock_;
 };
 


### PR DESCRIPTION
## Description

This PR fixes issue #62093 where pinned arguments are not properly released when a worker is killed due to:
1. Owner worker failure (`HandleUnexpectedWorkerFailure`)
2. Owner node failure (`NodeRemoved`)

### Root Cause

When a worker's owner dies, the NodeManager kills the leased worker using `KillAsync()`. However, `KillAsync()` sets `IsDead()` flag before any cleanup happens. This prevents `ReleaseWorker()` from properly releasing the lease and unpinning arguments, causing "ghost" leases where pinned arguments remain stuck in object store.

### Solution

Replace `KillAsync()` with `DestroyWorker()` which:
1. First calls `DisconnectClient()` → `CleanupLease()` → `ReleaseWorker()` to properly release the lease and unpin arguments
2. Then calls `KillAsync()` to terminate the worker

This ensures proper cleanup sequence regardless of worker death timing.

### Code Changes

- **`node_manager.cc`**: Use `DestroyWorker` instead of `KillAsync` in `NodeRemoved()` and `HandleUnexpectedWorkerFailure()`
- **Tests**: Add comprehensive tests for lease cleanup scenarios

## Related issues

Fixes https://github.com/ray-project/ray/issues/62093

## Additional information

### Test Coverage

Added two new test cases in `node_manager_test.cc`:
- `TestHandleUnexpectedWorkerFailureCleansUpLease`: Verifies lease cleanup when owner worker dies
- `TestNodeRemovedCleansUpLease`: Verifies lease cleanup when owner node dies

### Verification

```bash
bazel test //src/ray/raylet/tests:node_manager_test
```