### PR TITLE
[Core][GPU fraction][2/n] Remove unrealistic GPU resource counts in test_placement_group_mini_integration and some clean up

### DIFF
--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -39,6 +39,7 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
 
     @ray.remote(num_cpus=0)
     def pg_launcher(num_pgs_to_create):
+        print("Creating pgs")
         pgs = []
         for _ in range(num_pgs_to_create):
             pgs.append(placement_group(bundles, strategy="STRICT_SPREAD"))
@@ -53,6 +54,7 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
                 pgs_removed.append(pg)
             else:
                 pgs_unremoved.append(pg)
+        print(len(pgs_unremoved))
 
         tasks = []
         # Randomly schedule tasks or actors on placement groups that

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -28,69 +28,65 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
         nodes.append(cluster.add_node(num_cpus=3, resources=custom_resources))
     cluster.wait_for_nodes()
     num_nodes = len(nodes)
-
-    ray.init(address=cluster.address)
-    bundles = [{"pg_custom": 1}] * num_nodes
-
-    @ray.remote(num_cpus=0, resources={"pg_custom": 1}, max_calls=0)
-    def mock_task():
-        time.sleep(0.1)
-        return True
-
-    @ray.remote(num_cpus=0)
-    def pg_launcher(num_pgs_to_create):
-        pgs = []
-        for _ in range(num_pgs_to_create):
-            pgs.append(placement_group(bundles, strategy="STRICT_SPREAD"))
-
-        pgs_removed = []
-        pgs_unremoved = []
-        # Randomly choose placement groups to remove.
-        if pg_removal:
-            print("removing pgs")
-        for pg in pgs:
-            if random() < 0.5 and pg_removal:
-                pgs_removed.append(pg)
-            else:
-                pgs_unremoved.append(pg)
-
-        tasks = []
-        # Randomly schedule tasks or actors on placement groups that
-        # are not removed.
-        for pg in pgs_unremoved:
-            for i in range(num_nodes):
-                tasks.append(
-                    mock_task.options(
-                        scheduling_strategy=PlacementGroupSchedulingStrategy(
-                            placement_group=pg, placement_group_bundle_index=i
-                        )
-                    ).remote()
-                )
-        # Remove the rest of placement groups.
-        if pg_removal:
-            for pg in pgs_removed:
-                remove_placement_group(pg)
-        ray.get(tasks)
-        # Since placement groups are scheduled, remove them.
-        for pg in pgs_unremoved:
-            remove_placement_group(pg)
-
     try:
+        ray.init(address=cluster.address)
+        bundles = [{"pg_custom": 1}] * num_nodes
+
+        @ray.remote(num_cpus=0, resources={"pg_custom": 1}, max_calls=0)
+        def mock_task():
+            time.sleep(0.1)
+            return True
+
+        @ray.remote(num_cpus=0)
+        def pg_launcher(num_pgs_to_create):
+            pgs = []
+            for _ in range(num_pgs_to_create):
+                pgs.append(placement_group(bundles, strategy="STRICT_SPREAD"))
+
+            pgs_removed = []
+            pgs_unremoved = []
+            # Randomly choose placement groups to remove.
+            if pg_removal:
+                print("removing pgs")
+            for pg in pgs:
+                if random() < 0.5 and pg_removal:
+                    pgs_removed.append(pg)
+                else:
+                    pgs_unremoved.append(pg)
+
+            tasks = []
+            # Randomly schedule tasks or actors on placement groups that
+            # are not removed.
+            for pg in pgs_unremoved:
+                for i in range(num_nodes):
+                    tasks.append(
+                        mock_task.options(
+                            scheduling_strategy=PlacementGroupSchedulingStrategy(
+                                placement_group=pg, placement_group_bundle_index=i
+                            )
+                        ).remote()
+                    )
+            # Remove the rest of placement groups.
+            if pg_removal:
+                for pg in pgs_removed:
+                    remove_placement_group(pg)
+            ray.get(tasks)
+            # Since placement groups are scheduled, remove them.
+            for pg in pgs_unremoved:
+                remove_placement_group(pg)
+
         pg_launchers = []
         for _ in range(3):
             pg_launchers.append(pg_launcher.remote(num_pgs // 3))
 
         ray.get(pg_launchers, timeout=240)
-    finally:
         ray.shutdown()
 
-    ray.init(address=cluster.address)
+        ray.init(address=cluster.address)
 
-    cluster_resources = ray.cluster_resources()
-    cluster_resources.pop("memory")
-    cluster_resources.pop("object_store_memory")
-
-    try:
+        cluster_resources = ray.cluster_resources()
+        cluster_resources.pop("memory")
+        cluster_resources.pop("object_store_memory")
 
         def wait_for_resource_recovered():
             for resource, val in ray.available_resources().items():

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -21,7 +21,6 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
     resource_quantity = num_pgs
     num_nodes = 5
     custom_resources = {"pg_custom": resource_quantity}
-    num_pg = resource_quantity
 
     # TODO(sang): Cluster setup. Remove when running in real clusters.
     nodes = []
@@ -40,9 +39,8 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
 
     @ray.remote(num_cpus=0)
     def pg_launcher(num_pgs_to_create):
-        print("Creating pgs")
         pgs = []
-        for i in range(num_pgs_to_create):
+        for _ in range(num_pgs_to_create):
             pgs.append(placement_group(bundles, strategy="STRICT_SPREAD"))
 
         pgs_removed = []
@@ -55,7 +53,6 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
                 pgs_removed.append(pg)
             else:
                 pgs_unremoved.append(pg)
-        print(len(pgs_unremoved))
 
         tasks = []
         # Randomly schedule tasks or actors on placement groups that
@@ -78,27 +75,34 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
         for pg in pgs_unremoved:
             remove_placement_group(pg)
 
-    pg_launchers = []
-    for _ in range(3):
-        pg_launchers.append(pg_launcher.remote(num_pg // 3))
+    try:
+        pg_launchers = []
+        for _ in range(3):
+            pg_launchers.append(pg_launcher.remote(num_pgs // 3))
 
-    ray.get(pg_launchers, timeout=240)
-    ray.shutdown()
+        ray.get(pg_launchers, timeout=240)
+    finally:
+        ray.shutdown()
+
     ray.init(address=cluster.address)
 
     cluster_resources = ray.cluster_resources()
     cluster_resources.pop("memory")
     cluster_resources.pop("object_store_memory")
 
-    def wait_for_resource_recovered():
-        for resource, val in ray.available_resources().items():
-            if resource in cluster_resources and cluster_resources[resource] != val:
-                return False
-            if "_group_" in resource:
-                return False
-        return True
+    try:
 
-    wait_for_condition(wait_for_resource_recovered)
+        def wait_for_resource_recovered():
+            for resource, val in ray.available_resources().items():
+                if resource in cluster_resources and cluster_resources[resource] != val:
+                    return False
+                if "_group_" in resource:
+                    return False
+            return True
+
+        wait_for_condition(wait_for_resource_recovered)
+    finally:
+        ray.shutdown()
 
 
 @pytest.mark.parametrize("execution_number", range(1))

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -28,77 +28,75 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
         nodes.append(cluster.add_node(num_cpus=3, resources=custom_resources))
     cluster.wait_for_nodes()
     num_nodes = len(nodes)
-    try:
-        ray.init(address=cluster.address)
-        bundles = [{"pg_custom": 1}] * num_nodes
 
-        @ray.remote(num_cpus=0, resources={"pg_custom": 1}, max_calls=0)
-        def mock_task():
-            time.sleep(0.1)
-            return True
+    ray.init(address=cluster.address)
+    bundles = [{"pg_custom": 1}] * num_nodes
 
-        @ray.remote(num_cpus=0)
-        def pg_launcher(num_pgs_to_create):
-            pgs = []
-            for _ in range(num_pgs_to_create):
-                pgs.append(placement_group(bundles, strategy="STRICT_SPREAD"))
+    @ray.remote(num_cpus=0, resources={"pg_custom": 1}, max_calls=0)
+    def mock_task():
+        time.sleep(0.1)
+        return True
 
-            pgs_removed = []
-            pgs_unremoved = []
-            # Randomly choose placement groups to remove.
-            if pg_removal:
-                print("removing pgs")
-            for pg in pgs:
-                if random() < 0.5 and pg_removal:
-                    pgs_removed.append(pg)
-                else:
-                    pgs_unremoved.append(pg)
+    @ray.remote(num_cpus=0)
+    def pg_launcher(num_pgs_to_create):
+        pgs = []
+        for _ in range(num_pgs_to_create):
+            pgs.append(placement_group(bundles, strategy="STRICT_SPREAD"))
 
-            tasks = []
-            # Randomly schedule tasks or actors on placement groups that
-            # are not removed.
-            for pg in pgs_unremoved:
-                for i in range(num_nodes):
-                    tasks.append(
-                        mock_task.options(
-                            scheduling_strategy=PlacementGroupSchedulingStrategy(
-                                placement_group=pg, placement_group_bundle_index=i
-                            )
-                        ).remote()
-                    )
-            # Remove the rest of placement groups.
-            if pg_removal:
-                for pg in pgs_removed:
-                    remove_placement_group(pg)
-            ray.get(tasks)
-            # Since placement groups are scheduled, remove them.
-            for pg in pgs_unremoved:
+        pgs_removed = []
+        pgs_unremoved = []
+        # Randomly choose placement groups to remove.
+        if pg_removal:
+            print("removing pgs")
+        for pg in pgs:
+            if random() < 0.5 and pg_removal:
+                pgs_removed.append(pg)
+            else:
+                pgs_unremoved.append(pg)
+
+        tasks = []
+        # Randomly schedule tasks or actors on placement groups that
+        # are not removed.
+        for pg in pgs_unremoved:
+            for i in range(num_nodes):
+                tasks.append(
+                    mock_task.options(
+                        scheduling_strategy=PlacementGroupSchedulingStrategy(
+                            placement_group=pg, placement_group_bundle_index=i
+                        )
+                    ).remote()
+                )
+        # Remove the rest of placement groups.
+        if pg_removal:
+            for pg in pgs_removed:
                 remove_placement_group(pg)
+        ray.get(tasks)
+        # Since placement groups are scheduled, remove them.
+        for pg in pgs_unremoved:
+            remove_placement_group(pg)
 
-        pg_launchers = []
-        for _ in range(3):
-            pg_launchers.append(pg_launcher.remote(num_pgs // 3))
+    pg_launchers = []
+    for _ in range(3):
+        pg_launchers.append(pg_launcher.remote(num_pgs // 3))
 
-        ray.get(pg_launchers, timeout=240)
-        ray.shutdown()
+    ray.get(pg_launchers, timeout=240)
+    ray.shutdown()
 
-        ray.init(address=cluster.address)
+    ray.init(address=cluster.address)
 
-        cluster_resources = ray.cluster_resources()
-        cluster_resources.pop("memory")
-        cluster_resources.pop("object_store_memory")
+    cluster_resources = ray.cluster_resources()
+    cluster_resources.pop("memory")
+    cluster_resources.pop("object_store_memory")
 
-        def wait_for_resource_recovered():
-            for resource, val in ray.available_resources().items():
-                if resource in cluster_resources and cluster_resources[resource] != val:
-                    return False
-                if "_group_" in resource:
-                    return False
-            return True
+    def wait_for_resource_recovered():
+        for resource, val in ray.available_resources().items():
+            if resource in cluster_resources and cluster_resources[resource] != val:
+                return False
+            if "_group_" in resource:
+                return False
+        return True
 
-        wait_for_condition(wait_for_resource_recovered)
-    finally:
-        ray.shutdown()
+    wait_for_condition(wait_for_resource_recovered)
 
 
 @pytest.mark.parametrize("execution_number", range(1))

--- a/python/ray/tests/test_placement_group_mini_integration.py
+++ b/python/ray/tests/test_placement_group_mini_integration.py
@@ -21,26 +21,19 @@ def run_mini_integration_test(cluster, pg_removal=True, num_pgs=999):
     resource_quantity = num_pgs
     num_nodes = 5
     custom_resources = {"pg_custom": resource_quantity}
-    # Create pg that uses 1 resource of cpu & custom resource.
     num_pg = resource_quantity
 
     # TODO(sang): Cluster setup. Remove when running in real clusters.
     nodes = []
     for _ in range(num_nodes):
-        nodes.append(
-            cluster.add_node(
-                num_cpus=3, num_gpus=resource_quantity, resources=custom_resources
-            )
-        )
+        nodes.append(cluster.add_node(num_cpus=3, resources=custom_resources))
     cluster.wait_for_nodes()
     num_nodes = len(nodes)
 
     ray.init(address=cluster.address)
-    while not ray.is_initialized():
-        time.sleep(0.1)
-    bundles = [{"GPU": 1, "pg_custom": 1}] * num_nodes
+    bundles = [{"pg_custom": 1}] * num_nodes
 
-    @ray.remote(num_cpus=0, num_gpus=1, max_calls=0)
+    @ray.remote(num_cpus=0, resources={"pg_custom": 1}, max_calls=0)
     def mock_task():
         time.sleep(0.1)
         return True


### PR DESCRIPTION
## Description

This PR removes the 999 GPU resources per node in `test_placement_group_mini_integration`, as nodes typically have only 8 or 16 GPUs at max in practice. Additionally, an upcoming [per-instance resources tracking](https://github.com/ray-project/ray/pull/62005) causes the Ray syncer to broadcast the resource vector of length 999 every 100ms, which causes scheduling to stop working and results in performance regressions in this test

## Related PR
Related to https://github.com/ray-project/ray/pull/62005

## Additional information
After patching https://github.com/ray-project/ray/pull/62005, the test pass successfully
```
 python/ray/tests/test_placement_group_mini_integration.py ✓✓✓✓                                                                                     100% ██████████

Results (231.74s):
       4 passed
```