### PR TITLE
[CI] Add format_platform_tag and build_platform_reverse_map to supported_images

### DIFF
--- a/ci/ray_ci/BUILD.bazel
+++ b/ci/ray_ci/BUILD.bazel
@@ -2,6 +2,21 @@ load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 py_library(
+    name = "supported_images",
+    srcs = ["supported_images.py"],
+    data = [
+        "//:.rayciversion",
+        "//:ray-images.json",
+    ],
+    visibility = [
+        "//ci/build:__pkg__",
+        "//ci/ray_ci:__subpackages__",
+        "//release:__subpackages__",
+    ],
+    deps = [],
+)
+
+py_library(
     name = "ray_image_lib",
     srcs = [
         "configs.py",

--- a/ci/ray_ci/automation/image_tags_lib.py
+++ b/ci/ray_ci/automation/image_tags_lib.py
@@ -12,34 +12,13 @@ from ci.ray_ci.automation.crane_lib import (
 )
 from ci.ray_ci.configs import DEFAULT_PYTHON_TAG_VERSION
 from ci.ray_ci.docker_container import GPU_PLATFORM
+from ci.ray_ci.supported_images import format_platform_tag  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
 
 class ImageTagsError(Exception):
     """Error raised when image tag operations fail."""
-
-
-def format_platform_tag(platform: str) -> str:
-    """
-    Format platform as -cpu, -tpu, or shortened CUDA version.
-
-    Examples:
-        cpu -> -cpu
-        tpu -> -tpu
-        cu12.1.1-cudnn8 -> -cu121
-        cu12.3.2-cudnn9 -> -cu123
-    """
-    if platform == "cpu":
-        return "-cpu"
-    if platform == "tpu":
-        return "-tpu"
-    # cu12.3.2-cudnn9 -> -cu123
-    platform_base = platform.split("-", 1)[0]
-    parts = platform_base.split(".")
-    if len(parts) < 2:
-        raise ImageTagsError(f"Unrecognized GPU platform format: {platform}")
-    return f"-{parts[0]}{parts[1]}"
 
 
 def format_python_tag(python_version: str) -> str:

--- a/ci/ray_ci/automation/test_image_tags_lib.py
+++ b/ci/ray_ci/automation/test_image_tags_lib.py
@@ -3,7 +3,6 @@ import sys
 import pytest
 
 from ci.ray_ci.automation.image_tags_lib import (
-    ImageTagsError,
     format_platform_tag,
     format_python_tag,
     get_platform_suffixes,
@@ -31,7 +30,7 @@ class TestFormatPlatformTag:
         assert format_platform_tag(platform) == expected
 
     def test_invalid_platform_raises_error(self):
-        with pytest.raises(ImageTagsError):
+        with pytest.raises(ValueError):
             format_platform_tag("invalid")
 
 

--- a/ci/ray_ci/automation/test_push_release_test_image.py
+++ b/ci/ray_ci/automation/test_push_release_test_image.py
@@ -2,10 +2,6 @@ import sys
 
 import pytest
 
-from ci.ray_ci.automation.image_tags_lib import (
-    format_platform_tag,
-    format_python_tag,
-)
 from ci.ray_ci.automation.push_release_test_image import ReleaseTestImagePushContext
 from ci.ray_ci.configs import DEFAULT_PYTHON_TAG_VERSION
 from ci.ray_ci.docker_container import GPU_PLATFORM
@@ -30,36 +26,6 @@ def make_ctx(
         rayci_build_id=rayci_build_id,
         pull_request=pull_request,
     )
-
-
-class TestFormatPythonTag:
-    @pytest.mark.parametrize(
-        ("python_version", "expected"),
-        [
-            ("3.10", "-py310"),
-            ("3.11", "-py311"),
-            ("3.12", "-py312"),
-            ("3.9", "-py39"),
-        ],
-    )
-    def test_format_python_tag(self, python_version, expected):
-        assert format_python_tag(python_version) == expected
-
-
-class TestFormatPlatformTag:
-    @pytest.mark.parametrize(
-        ("platform", "expected"),
-        [
-            ("cpu", "-cpu"),
-            ("cu11.7.1-cudnn8", "-cu117"),
-            ("cu11.8.0-cudnn8", "-cu118"),
-            ("cu12.1.1-cudnn8", "-cu121"),
-            ("cu12.3.2-cudnn9", "-cu123"),
-            ("cu12.8.1-cudnn", "-cu128"),
-        ],
-    )
-    def test_format_platform_tag(self, platform, expected):
-        assert format_platform_tag(platform) == expected
 
 
 class TestWandaImageName:

--- a/ci/ray_ci/supported_images.py
+++ b/ci/ray_ci/supported_images.py
@@ -1,7 +1,7 @@
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 _RAYCI_VERSION_FILE = ".rayciversion"
 
@@ -45,3 +45,44 @@ def get_exceptions(image_type: str) -> List[dict]:
 
 def get_default(image_type: str, key: str) -> str:
     return get_image_config(image_type)["defaults"][key]
+
+
+def format_platform_tag(platform: str) -> str:
+    """
+    Format platform as -cpu, -tpu, or shortened CUDA version.
+
+    Examples:
+        cpu -> -cpu
+        tpu -> -tpu
+        cu12.1.1-cudnn8 -> -cu121
+        cu12.3.2-cudnn9 -> -cu123
+    """
+    if platform == "cpu":
+        return "-cpu"
+    if platform == "tpu":
+        return "-tpu"
+    # cu12.3.2-cudnn9 -> -cu123
+    platform_base = platform.split("-", 1)[0]
+    parts = platform_base.split(".")
+    if len(parts) < 2:
+        raise ValueError(f"Unrecognized GPU platform format: {platform}")
+    return f"-{parts[0]}{parts[1]}"
+
+
+def build_platform_reverse_map() -> Dict[str, str]:
+    """
+    Build a reverse map from short platform tag to full platform string.
+
+    Uses format_platform_tag on every platform across all image types in
+    ray-images.json.  The returned dict maps the short form (without leading
+    hyphen, e.g. "cu123") to the full platform string (e.g.
+    "cu12.3.2-cudnn9").
+    """
+    reverse_map: Dict[str, str] = {}
+    images = load_supported_images()
+    for image_type_config in images.values():
+        for platform in image_type_config.get("platforms", []):
+            short = format_platform_tag(platform).lstrip("-")
+            if short not in reverse_map:
+                reverse_map[short] = platform
+    return reverse_map

--- a/ci/ray_ci/supported_images.py
+++ b/ci/ray_ci/supported_images.py
@@ -83,6 +83,12 @@ def build_platform_reverse_map() -> Dict[str, str]:
     for image_type_config in images.values():
         for platform in image_type_config.get("platforms", []):
             short = format_platform_tag(platform).lstrip("-")
-            if short not in reverse_map:
+            if short in reverse_map:
+                if reverse_map[short] != platform:
+                    raise ValueError(
+                        f"Ambiguous short platform tag '{short}': "
+                        f"could be '{platform}' or '{reverse_map[short]}'"
+                    )
+            else:
                 reverse_map[short] = platform
     return reverse_map

--- a/ci/ray_ci/test_supported_images.py
+++ b/ci/ray_ci/test_supported_images.py
@@ -4,7 +4,12 @@ Validates ray-images.json is well-formed and internally consistent.
 
 import pytest
 
-from ci.ray_ci.supported_images import get_image_config, load_supported_images
+from ci.ray_ci.supported_images import (
+    build_platform_reverse_map,
+    format_platform_tag,
+    get_image_config,
+    load_supported_images,
+)
 
 IMAGE_TYPES = list(load_supported_images().keys())
 REQUIRED_KEYS = ["defaults", "python", "platforms", "architectures"]
@@ -72,3 +77,53 @@ class TestRayImagesSchema:
             assert isinstance(
                 v, str
             ), f"{image_type}: architecture {v!r} is {type(v).__name__}, not str"
+
+
+class TestFormatPlatformTag:
+    @pytest.mark.parametrize(
+        ("platform", "expected"),
+        [
+            ("cpu", "-cpu"),
+            ("tpu", "-tpu"),
+            ("cu11.7.1-cudnn8", "-cu117"),
+            ("cu11.8.0-cudnn8", "-cu118"),
+            ("cu12.1.1-cudnn8", "-cu121"),
+            ("cu12.3.2-cudnn9", "-cu123"),
+            ("cu12.8.1-cudnn", "-cu128"),
+            ("cu13.0.0-cudnn", "-cu130"),
+        ],
+    )
+    def test_format_platform_tag(self, platform, expected):
+        assert format_platform_tag(platform) == expected
+
+    def test_invalid_platform_raises_error(self):
+        with pytest.raises(ValueError):
+            format_platform_tag("invalid")
+
+
+class TestBuildPlatformReverseMap:
+    def test_returns_dict(self):
+        reverse_map = build_platform_reverse_map()
+        assert isinstance(reverse_map, dict)
+        assert len(reverse_map) > 0
+
+    def test_cpu_maps_to_cpu(self):
+        reverse_map = build_platform_reverse_map()
+        assert reverse_map["cpu"] == "cpu"
+
+    def test_short_tags_map_to_full_platforms(self):
+        reverse_map = build_platform_reverse_map()
+        # Every value should be a full platform string
+        for short, full in reverse_map.items():
+            assert format_platform_tag(full).lstrip("-") == short, (
+                f"Reverse map inconsistency: {short!r} -> {full!r} "
+                f"but format_platform_tag({full!r}) = {format_platform_tag(full)!r}"
+            )
+
+    def test_known_mappings(self):
+        reverse_map = build_platform_reverse_map()
+        # These platforms should exist in ray-images.json
+        if "cu123" in reverse_map:
+            assert reverse_map["cu123"] == "cu12.3.2-cudnn9"
+        if "cu121" in reverse_map:
+            assert reverse_map["cu121"] == "cu12.1.1-cudnn8"

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -502,6 +502,7 @@ py_library(
         ":test_automation",
         ":util",
         ":wheels",
+        "//ci/ray_ci:supported_images",
         bk_require("anyscale"),
         bk_require("aws-requests-auth"),
         bk_require("azure-storage-blob"),


### PR DESCRIPTION
Move format_platform_tag() from image_tags_lib.py to supported_images.py (zero external deps) and add build_platform_reverse_map() for mapping short platform tags back to full platform strings.

Create narrow //ci/ray_ci:supported_images Bazel target visible to //release:__subpackages__. Re-import format_platform_tag in image_tags_lib.py. Update tests for ValueError (was ImageTagsError). Remove duplicate test classes from test_push_release_test_image.py.

Topic: shared-lib
Relative: rayci-39
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>