### PR TITLE
[CI] Convert _images.rayci.yml from matrix to array syntax

### DIFF
--- a/.buildkite/_images.rayci.yml
+++ b/.buildkite/_images.rayci.yml
@@ -2,248 +2,247 @@ group: images
 sort_key: "_images"
 steps:
   - name: raycpubase
-    label: "wanda: ray-py{{matrix}}-cpu-base"
+    label: "wanda: ray-py{{array.python}}-cpu-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
 
   - name: raycpubaseextra
-    label: "wanda: ray-py{{matrix}}-cpu-base-extra"
+    label: "wanda: ray-py{{array.python}}-cpu-base-extra"
     wanda: docker/base-extra/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: ""
-    depends_on: raycpubase
+    depends_on: raycpubase($)
 
   - name: raytpubase
-    label: "wanda: ray-py{{matrix}}-tpu-base"
+    label: "wanda: ray-py{{array.python}}-tpu-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/tpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
 
   - name: raycudabase
-    label: "wanda: ray-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""
 
   - name: raycudabaseextra
-    label: "wanda: ray-py{{matrix.python}}-cu{{matrix.cuda}}-base-extra"
+    label: "wanda: ray-py{{array.python}}-cu{{array.cuda}}-base-extra"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: ""
-    depends_on: raycudabase
+    depends_on: raycudabase($)
 
   - name: ray-llmbase
-    label: "wanda: ray-llm-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-llm-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/ray-llm/cuda.wanda.yaml
-    depends_on: raycudabase
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    depends_on: raycudabase($)
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
 
   - name: ray-llmbaseextra
-    label: "wanda: ray-llm-py{{matrix.python}}-cu{{matrix.cuda}}-base-extra"
+    label: "wanda: ray-llm-py{{array.python}}-cu{{array.cuda}}-base-extra"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-llm"
       ARCH_SUFFIX: ""
-    depends_on: ray-llmbase
+    depends_on: ray-llmbase($)
 
   - name: ray-mlcpubase
-    label: "wanda: ray-ml-py{{matrix}}-cpu-base"
+    label: "wanda: ray-ml-py{{array.python}}-cpu-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/ray-ml/cpu.wanda.yaml
-    depends_on: raycpubase
-    matrix:
-      - "3.10"
-      - "3.11"
+    depends_on: raycpubase($)
+    array:
+      python:
+        - "3.10"
+        - "3.11"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
 
   - name: ray-mlcpubaseextra
-    label: "wanda: ray-ml-py{{matrix}}-cpu-base-extra"
+    label: "wanda: ray-ml-py{{array.python}}-cpu-base-extra"
     wanda: docker/base-extra/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray-ml"
       ARCH_SUFFIX: ""
-    depends_on: ray-mlcpubase
+    depends_on: ray-mlcpubase($)
 
   - name: ray-mlcudabase
-    label: "wanda: ray-ml-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-ml-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/ray-ml/cuda.wanda.yaml
-    depends_on: raycudabase
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-        cuda:
-          - "12.1.1-cudnn8"
+    depends_on: raycudabase($)
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+      cuda:
+        - "12.1.1-cudnn8"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
 
   - name: ray-mlcudabaseextra
-    label: "wanda: ray-ml-py{{matrix.python}}-cu{{matrix.cuda}}-base-extra"
+    label: "wanda: ray-ml-py{{array.python}}-cu{{array.cuda}}-base-extra"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-        cuda:
-          - "12.1.1-cudnn8"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+      cuda:
+        - "12.1.1-cudnn8"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-ml"
       ARCH_SUFFIX: ""
-    depends_on: ray-mlcudabase
+    depends_on: ray-mlcudabase($)
 
   - name: ray-slimcpubase
-    label: "wanda: ray-slim-py{{matrix}}-cpu-base"
+    label: "wanda: ray-slim-py{{array.python}}-cpu-base"
     tags:
       - python_dependencies
       - docker
       - skip-on-release-tests
     wanda: docker/base-slim/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
 
   - name: ray-slimcudabase
-    label: "wanda: ray-slim-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-slim-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
       - skip-on-release-tests
     wanda: docker/base-slim/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1"
-          - "11.8.0"
-          - "12.1.1"
-          - "12.3.2"
-          - "12.4.1"
-          - "12.5.1"
-          - "12.6.3"
-          - "12.8.1"
-          - "12.9.1"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1"
+        - "11.8.0"
+        - "12.1.1"
+        - "12.3.2"
+        - "12.4.1"
+        - "12.5.1"
+        - "12.6.3"
+        - "12.8.1"
+        - "12.9.1"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -1,18 +1,19 @@
 group: build
 steps:
-  - label: ":arrow_up: upload: wheel py{{matrix}} (x86_64)"
+  - label: ":arrow_up: upload: wheel py{{array.python}} (x86_64)"
     key: linux_wheels_upload
     instance_type: small
     commands:
       - bazel run //ci/ray_ci/automation:extract_wanda_wheels --
-        --wanda-image-name=ray-wheel-py{{matrix}}
+        --wanda-image-name=ray-wheel-py{{array.python}}
       - ./ci/build/copy_build_artifacts.sh wheel
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     depends_on:
       - ray-wheel-build
       - forge
@@ -81,16 +82,17 @@ steps:
     job_env: manylinux-x86_64
 
   - name: ray-image-cpu-build
-    label: "wanda: ray py{{matrix}} cpu (x86_64)"
+    label: "wanda: ray py{{array.python}} cpu (x86_64)"
     wanda: ci/docker/ray-image-cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
     tags:
       - python_dependencies
@@ -98,19 +100,20 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycpubase
+      - raycpubase($)
 
   - name: ray-image-tpu-build
-    label: "wanda: ray py{{matrix}} tpu (x86_64)"
+    label: "wanda: ray py{{array.python}} tpu (x86_64)"
     wanda: ci/docker/ray-image-tpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
     tags:
       - python_dependencies
@@ -118,7 +121,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raytpubase
+      - raytpubase($)
 
   - label: ":tapioca: smoke test: ray tpu image"
     instance_type: small
@@ -132,33 +135,32 @@ steps:
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-ray-py3.10-tpu
         /bin/bash -c "python -c \"import ray; print('ray', ray.__version__); import jax; print('jax', jax.__version__)\""
     depends_on:
-      - ray-image-tpu-build
+      - ray-image-tpu-build(*)
       - forge
 
   - name: ray-image-cuda-build
-    label: "wanda: ray py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    label: "wanda: ray py{{array.python}} cu{{array.cuda}} (x86_64)"
     wanda: ci/docker/ray-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""
     tags:
       - python_dependencies
@@ -166,15 +168,15 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycudabase
+      - raycudabase($)
 
-  - label: ":crane: publish: ray py{{matrix}} (x86_64)"
+  - label: ":crane: publish: ray py{{array.python}} (x86_64)"
     key: ray_images_push
     instance_type: small
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cpu
         --platform tpu
         --platform cu11.7.1-cudnn8
@@ -188,15 +190,16 @@ steps:
         --platform cu12.9.1-cudnn
         --image-type ray
         --architecture x86_64
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     depends_on:
-      - ray-image-cpu-build
-      - ray-image-tpu-build
-      - ray-image-cuda-build
+      - ray-image-cpu-build($)
+      - ray-image-tpu-build($)
+      - ray-image-cuda-build($)
     tags:
       - python_dependencies
       - docker
@@ -204,16 +207,17 @@ steps:
       - skip-on-premerge
 
   - name: ray-extra-image-cpu-build
-    label: "wanda: ray-extra py{{matrix}} cpu (x86_64)"
+    label: "wanda: ray-extra py{{array.python}} cpu (x86_64)"
     wanda: ci/docker/ray-extra-image-cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
     tags:
       - python_dependencies
@@ -221,32 +225,31 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycpubaseextra
+      - raycpubaseextra($)
 
   - name: ray-extra-image-cuda-build
-    label: "wanda: ray-extra py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    label: "wanda: ray-extra py{{array.python}} cu{{array.cuda}} (x86_64)"
     wanda: ci/docker/ray-extra-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""
     tags:
       - python_dependencies
@@ -254,25 +257,24 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycudabaseextra
+      - raycudabaseextra($)
 
   - name: ray-llm-image-cuda-build
-    label: "wanda: ray-llm py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    label: "wanda: ray-llm py{{array.python}} cu{{array.cuda}} (x86_64)"
     wanda: ci/docker/ray-llm-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""
     tags:
       - python_dependencies
@@ -280,25 +282,24 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - ray-llmbase
+      - ray-llmbase($)
 
   - name: ray-llm-extra-image-cuda-build
-    label: "wanda: ray-llm-extra py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
+    label: "wanda: ray-llm-extra py{{array.python}} cu{{array.cuda}} (x86_64)"
     wanda: ci/docker/ray-llm-extra-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""
     tags:
       - python_dependencies
@@ -306,15 +307,15 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - ray-llmbaseextra
+      - ray-llmbaseextra($)
 
-  - label: ":crane: publish: ray-extra py{{matrix}} (x86_64)"
+  - label: ":crane: publish: ray-extra py{{array.python}} (x86_64)"
     key: ray_extra_images_push
     instance_type: small
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cpu
         --platform cu11.7.1-cudnn8
         --platform cu11.8.0-cudnn8
@@ -327,70 +328,69 @@ steps:
         --platform cu12.9.1-cudnn
         --image-type ray-extra
         --architecture x86_64
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     depends_on:
-      - ray-extra-image-cpu-build
-      - ray-extra-image-cuda-build
+      - ray-extra-image-cpu-build($)
+      - ray-extra-image-cuda-build($)
     tags:
       - python_dependencies
       - docker
       - oss
       - skip-on-premerge
 
-  - label: ":crane: publish: ray-llm py{{matrix.python}} {{matrix.platform}} (x86_64)"
+  - label: ":crane: publish: ray-llm py{{array.python}} {{array.platform}} (x86_64)"
     key: ray_llm_images_cuda_push
     instance_type: small
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix.python}}
-        --platform {{matrix.platform}}
+        --python-version {{array.python}}
+        --platform {{array.platform}}
         --image-type ray-llm
         --architecture x86_64
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        platform:
-          - cu13.0.0-cudnn
+    array:
+      python:
+        - "3.12"
+      platform:
+        - cu13.0.0-cudnn
       adjustments:
         - with:
             python: "3.11"
             platform: "cu12.8.1-cudnn"
     depends_on:
-      - ray-llm-image-cuda-build
+      - ray-llm-image-cuda-build($)
     tags:
       - python_dependencies
       - docker
       - oss
       - skip-on-premerge
 
-  - label: ":crane: publish: ray-llm-extra py{{matrix.python}} {{matrix.platform}} (x86_64)"
+  - label: ":crane: publish: ray-llm-extra py{{array.python}} {{array.platform}} (x86_64)"
     key: ray_llm_extra_images_cuda_push
     instance_type: small
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix.python}}
-        --platform {{matrix.platform}}
+        --python-version {{array.python}}
+        --platform {{array.platform}}
         --image-type ray-llm-extra
         --architecture x86_64
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        platform:
-          - cu13.0.0-cudnn
+    array:
+      python:
+        - "3.12"
+      platform:
+        - cu13.0.0-cudnn
       adjustments:
         - with:
             python: "3.11"
             platform: "cu12.8.1-cudnn"
     depends_on:
-      - ray-llm-extra-image-cuda-build
+      - ray-llm-extra-image-cuda-build($)
     tags:
       - python_dependencies
       - docker
@@ -440,6 +440,6 @@ steps:
       - bazel run .buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:generate_index -- --prefix nightly
     depends_on:
-      - ray_images_push
+      - ray_images_push(*)
       - ray_images_push_aarch64
       - forge

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -473,7 +473,7 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - corebuild-multipy
 
   - label: ":ray: core: runtime env container tests"
@@ -495,7 +495,7 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - corebuild-multipy
 
   - label: ":core: core: spark-on-ray tests"

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -18,7 +18,7 @@ steps:
       - k8sbuild
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - ray-core-build
       - ray-dashboard-build
 
@@ -46,6 +46,6 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - ray-core-build
       - ray-dashboard-build

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -12,7 +12,7 @@ steps:
       PYTHON_VERSION: "{{matrix}}"
       IMAGE_TYPE: "ray"
     depends_on:
-      - raycpubaseextra
+      - raycpubaseextra(*)
 
   - name: raycudabaseextra-testdeps
     label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base-extra-testdeps"
@@ -35,7 +35,7 @@ steps:
       CUDA_VERSION: "{{matrix.cuda}}"
       IMAGE_TYPE: "ray"
     depends_on:
-      - raycudabaseextra
+      - raycudabaseextra(*)
 
   - name: ray-llmbaseextra-testdeps
     label: "wanda: ray.py{{matrix.python}}.llm.base-extra-testdeps (cuda {{matrix.cuda}})"
@@ -55,7 +55,7 @@ steps:
       CUDA_VERSION: "{{matrix.cuda}}"
       IMAGE_TYPE: "ray-llm"
     depends_on:
-      - ray-llmbaseextra
+      - ray-llmbaseextra(*)
 
   - name: ray-mlcudabaseextra-testdeps
     label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.ml.base-extra-testdeps"
@@ -71,7 +71,7 @@ steps:
       CUDA_VERSION: "{{matrix.cuda}}"
       IMAGE_TYPE: "ray-ml"
     depends_on:
-      - ray-mlcudabaseextra
+      - ray-mlcudabaseextra(*)
 
   - name: ray-anyscale-cpu-build
     label: "wanda: ray-anyscale py{{matrix}} cpu"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -203,7 +203,7 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - servebuild-multipy
 
   - label: ":ray-serve: serve: tracing tests"


### PR DESCRIPTION
Convert all 13 image build steps from Buildkite matrix to rayci array syntax. Internal dependencies use ($) for shared-dimension matching. External consumers updated to (*) to wait for all image variants.

Files updated:
- _images.rayci.yml: matrix → array conversion
- build.rayci.yml: raycpubase, raytpubase, raycudabase, raycpubaseextra, raycudabaseextra, ray-llmbase, ray-llmbaseextra → (*)
- kuberay.rayci.yml: raycpubase → (*)
- serve.rayci.yml: raycpubase → (*)
- core.rayci.yml: raycpubase → (*)
- release/build.rayci.yml: raycpubaseextra, raycudabaseextra, ray-llmbaseextra, ray-mlcudabaseextra → (*)

Topic: array-images
Relative: rayci-39
Signed-off-by: andrew <andrew@anyscale.com>