### PR TITLE
[CI] Convert _wheel-build.rayci.yml from matrix to array syntax

### DIFF
--- a/.buildkite/_wheel-build.rayci.yml
+++ b/.buildkite/_wheel-build.rayci.yml
@@ -2,17 +2,18 @@ group: wheel build
 sort_key: "_wheel-build"
 steps:
   - name: ray-core-build
-    label: "wanda: core binary parts py{{matrix}} (x86_64)"
+    label: "wanda: core binary parts py{{array.python}} (x86_64)"
     wanda: ci/docker/ray-core.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
       HOSTTYPE: "x86_64"
     tags:
@@ -40,23 +41,24 @@ steps:
       - java
 
   - name: ray-wheel-build
-    label: "wanda: wheel py{{matrix}} (x86_64)"
+    label: "wanda: wheel py{{array.python}} (x86_64)"
     wanda: ci/docker/ray-wheel.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
       HOSTTYPE: "x86_64"
     tags:
       - release_wheels
       - linux_wheels
     depends_on:
-      - ray-core-build
+      - ray-core-build($)
       - ray-java-build
       - ray-dashboard-build

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -15,7 +15,7 @@ steps:
         - "3.13"
         - "3.14"
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - forge
     tags:
       - release_wheels
@@ -47,7 +47,7 @@ steps:
       - linux_wheels
       - oss
     depends_on:
-      - ray-core-build
+      - ray-core-build(*)
       - ray-cpp-core-build
       - ray-java-build
       - ray-dashboard-build
@@ -99,7 +99,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - raycpubase($)
 
   - name: ray-image-tpu-build
@@ -120,7 +120,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - raytpubase($)
 
   - label: ":tapioca: smoke test: ray tpu image"
@@ -167,7 +167,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - raycudabase($)
 
   - label: ":crane: publish: ray py{{array.python}} (x86_64)"
@@ -224,7 +224,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - raycpubaseextra($)
 
   - name: ray-extra-image-cuda-build
@@ -256,7 +256,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - raycudabaseextra($)
 
   - name: ray-llm-image-cuda-build
@@ -281,7 +281,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - ray-llmbase($)
 
   - name: ray-llm-extra-image-cuda-build
@@ -306,7 +306,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build($)
       - ray-llmbaseextra($)
 
   - label: ":crane: publish: ray-extra py{{array.python}} (x86_64)"

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -1,7 +1,7 @@
 group: core tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds
@@ -268,7 +268,7 @@ steps:
       - manylinux-x86_64
       - corebuild-multipy
       - forge
-      - ray-wheel-build
+      - ray-wheel-build(*)
 
   - label: ":ray: core: minimal tests {{matrix}}"
     tags:

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -2,7 +2,7 @@ group: data tests
 depends_on:
   - forge
   - oss-ci-base_ml-multipy
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -5,7 +5,7 @@ steps:
     wanda: ci/docker/doc.build.wanda.yaml
     depends_on:
       - oss-ci-base_build-multipy
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build
     matrix:
       - "3.10"

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -19,7 +19,7 @@ steps:
       - manylinux-x86_64
       - forge
       - raycpubase(*)
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build
 
   - label: ":kubernetes: chaos {{matrix.workload}} under {{matrix.fault}}"
@@ -47,5 +47,5 @@ steps:
       - manylinux-x86_64
       - forge
       - raycpubase(*)
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build

--- a/.buildkite/llm.rayci.yml
+++ b/.buildkite/llm.rayci.yml
@@ -1,7 +1,7 @@
 group: llm tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   - name: llmbuild

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -1,7 +1,7 @@
 group: ml tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -23,7 +23,7 @@ steps:
         --python-version 3.10
     depends_on:
       - doctestbuild
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build
 
   # java

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -90,7 +90,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycpubaseextra-testdeps
 
   - name: ray-anyscale-cuda-build
@@ -119,7 +119,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycudabaseextra-testdeps
 
   - label: ":crane: publish: ray-anyscale py{{matrix.python}} {{matrix.platform}}"
@@ -173,7 +173,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - ray-llmbaseextra-testdeps
 
   - label: ":crane: publish: ray-llm-anyscale py{{matrix.python}} {{matrix.platform}}"
@@ -220,7 +220,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - ray-mlcudabaseextra-testdeps
 
   - label: ":crane: publish: ray-ml-anyscale py{{matrix}} cu12.1.1-cudnn8"

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,7 +1,7 @@
 group: rllib tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -2,7 +2,7 @@ group: serve tests
 depends_on:
   - forge
   - oss-ci-base_build-multipy
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds
@@ -124,7 +124,7 @@ steps:
       - manylinux-x86_64
       - servebuild-multipy
       - forge
-      - ray-wheel-build
+      - ray-wheel-build(*)
 
   - label: ":ray-serve: serve: doc tests"
     tags:


### PR DESCRIPTION
Convert ray-core-build and ray-wheel-build from Buildkite matrix to rayci array syntax. Internal dependency (ray-wheel-build → ray-core-build) uses ($) for shared python dimension matching. All external consumers updated to (*).

Consumer files updated: build.rayci.yml, serve.rayci.yml, core.rayci.yml, doc.rayci.yml, rllib.rayci.yml, ml.rayci.yml, data.rayci.yml, llm.rayci.yml, others.rayci.yml, kuberay.rayci.yml, release/build.rayci.yml

Topic: array-wheel-build
Relative: array-images
Signed-off-by: andrew <andrew@anyscale.com>