### PR TITLE
[serve] Add 3072 and 4096 replicas cases to serve_controller_benchmark_haproxy

### DIFF
--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -323,7 +323,7 @@ class Benchmarker:
 # See https://github.com/ray-project/ray/issues/60680 for more details.
 
 CONTROLLER_BENCH_CONFIG = {
-    "checkpoints": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048],
+    "checkpoints": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 3072, 4096],
     "marination_period_s": 180,
     "sample_interval_s": 5,
 }
@@ -338,7 +338,7 @@ _CONTROLLER_AUTOSCALING_CONFIG = {
 _CONTROLLER_WAITER_TIMEOUT_S = 1200
 
 # SignalActor from ray._common.test_utils; use high max_concurrency for many
-# concurrent waiters (up to 2048+ in controller benchmark).
+# concurrent waiters (up to 4096 in controller benchmark).
 _SignalActorForController = _SignalActor.options(max_concurrency=100000)
 
 

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -1,8 +1,10 @@
 cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
 region: us-west-2
 
-# 1k max replicas (1000 / 8 = 125 containers needed)
-max_workers: 130
+# 4096 max replicas; ceil(4096 * 0.4 / 8) = 205 nodes needed; +15 buffer
+# 0.4 cpu per replica
+# 8 cpu per node
+max_workers: 220
 
 head_node_type:
     name: head_node
@@ -20,8 +22,8 @@ worker_node_types:
       # smaller min workers will make the head node cpu usage very high, and crash the head node.
       # issue: https://github.com/ray-project/ray/issues/18908
       min_workers: 5
-      # 1k max replicas
-      max_workers: 130
+      # 4096 max replicas
+      max_workers: 220
       use_spot: false
       resources:
         custom_resources:


### PR DESCRIPTION
Increase the scale of the `serve_controller_benchmark_haproxy`

**Details:**
* Increased the maximum number of checkpoints in the `CONTROLLER_BENCH_CONFIG` from 2048 to 4096 in `common.py`, allowing the benchmark to test higher replica counts.
* Increased `max_workers` from 130 to 220 in `compute_tpl_8_cpu_autoscaling.yaml` to support up to 4096 replicas.
