### PR TITLE
[serve] Return healthy on head node even when zero ingress replicas exist

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -986,7 +986,9 @@ class HAProxyManager(ProxyActorInterface):
             f"logger with logging config: {logging_config}"
         )
 
-        self._haproxy = HAProxyApi(cfg=HAProxyConfig(http_options=http_options, is_head=is_head))
+        self._haproxy = HAProxyApi(
+            cfg=HAProxyConfig(http_options=http_options, is_head=is_head)
+        )
         self._haproxy_start_task = self.event_loop.create_task(self._haproxy.start())
 
     async def shutdown(self) -> None:

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -57,6 +57,7 @@ from ray.serve._private.haproxy_templates import (
 from ray.serve._private.logging_utils import get_component_logger_file_path
 from ray.serve._private.long_poll import LongPollClient, LongPollNamespace
 from ray.serve._private.proxy import ProxyActorInterface
+from ray.serve._private.utils import get_head_node_id
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.schema import (
     LoggingConfig,
@@ -388,6 +389,8 @@ class HAProxyConfig:
 
     balance_algorithm: str = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM
 
+    is_head: bool = False
+
     @property
     def frontend_host(self) -> str:
         if self.http_options.host is None or self.http_options.host == "0.0.0.0":
@@ -407,12 +410,12 @@ class HAProxyConfig:
         if not self.has_received_routes:
             router_ready_for_traffic = False
             router_message = NO_ROUTES_MESSAGE
-        elif not self.has_received_servers:
-            router_ready_for_traffic = False
-            router_message = NO_REPLICAS_MESSAGE
-        else:
+        elif self.is_head or self.has_received_servers:
             router_ready_for_traffic = True
             router_message = ""
+        else:
+            router_ready_for_traffic = False
+            router_message = NO_REPLICAS_MESSAGE
 
         if not self.pass_health_checks:
             healthy = False
@@ -974,6 +977,8 @@ class HAProxyManager(ProxyActorInterface):
             call_in_event_loop=self.event_loop,
         )
 
+        is_head = self._node_id == get_head_node_id()
+
         startup_msg = f"HAProxy starting on node {self._node_id} (HTTP port: {self._http_options.port})."
         logger.info(startup_msg)
         logger.debug(
@@ -981,7 +986,7 @@ class HAProxyManager(ProxyActorInterface):
             f"logger with logging config: {logging_config}"
         )
 
-        self._haproxy = HAProxyApi(cfg=HAProxyConfig(http_options=http_options))
+        self._haproxy = HAProxyApi(cfg=HAProxyConfig(http_options=http_options, is_head=is_head))
         self._haproxy_start_task = self.event_loop.create_task(self._haproxy.start())
 
     async def shutdown(self) -> None:

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -997,6 +997,13 @@ def test_scale_from_zero_via_fallback_proxy(ray_shutdown):
 
     serve.run(ScaleToZeroApp.bind(), name="s2z_app", route_prefix="/s2z")
 
+    wait_for_condition(
+        lambda: httpx.get("http://localhost:8000/-/routes").status_code == 200,
+    )
+    wait_for_condition(
+        lambda: httpx.get("http://localhost:8000/-/healthz").status_code == 200,
+    )
+
     # Wait for the app to be running and initially serve a request
     wait_for_condition(
         lambda: httpx.get("http://localhost:8000/s2z").status_code == 200,


### PR DESCRIPTION
Haproxy currently fails health checks if it has never received any ingress replicas via long poll. This promotes requests to be sent to nodes with an haproxy that's ready to serve traffic as nodes are scaling up, as opposed to a node who's haproxy is still waiting for targets via long poll.

However, when the serve application starts with 0 ingress replicas, this could mean that all haproxy return unhealthy. this PR changes that so that the head node haproxy always returns healthy as long as the routes table has been sent to it. This mimics the existing serve proxy's behavior: https://github.com/ray-project/ray/blob/ef6ba17a36a978a935d074578d1562d2d285e221/python/ray/serve/_private/proxy_router.py#L58-L85