### PR TITLE
[core][ippr][5/N] add standalone KubeRay IPPR provider

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/ippr_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/ippr_provider.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any, Dict, Optional, Union
 
 import jsonschema
@@ -12,6 +13,8 @@ from ray.autoscaler.v2.schema import (
     IPPRSpecsSchema,
     IPPRStatus,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class KubeRayIPPRProvider:
@@ -183,9 +186,79 @@ class KubeRayIPPRProvider:
 
         self._ippr_specs = IPPRSpecs(groups=groups)
 
+    def sync_with_raylets(self) -> None:
+        """Propagate completed K8s resizes to Raylets via GCS.
+
+        For any pod whose K8s resize has completed, update the corresponding Raylet's local resource
+        instances via GCS gRPC and clear the pending timestamp on the pod's
+        ``ray.io/ippr-status`` annotation.
+
+
+        Three situations we can have exceptions are:
+        1. K8s API is not available.
+        2. GCS is not available.
+        3. Raylet is not available.
+        If a raylet is truly dead, its pod will also be deleted eventually.
+        All of the above exceptions can only be resolved in the future reconcile loops.
+        """
+        for ippr_status in self._ippr_statuses.values():
+            if not ippr_status.need_sync_with_raylet():
+                continue
+            try:
+                self._gcs_client.resize_raylet_resource_instances(
+                    ippr_status.raylet_id,
+                    {
+                        "CPU": ippr_status.current_cpu,
+                        "memory": ippr_status.current_memory,
+                    },
+                )
+                self._patch_ippr_status(ippr_status, resizing_at=None)
+                ippr_status.resizing_at = None
+                logger.info(f"Pod {ippr_status.cloud_instance_id} resized successfully")
+            except Exception as e:
+                logger.error(
+                    f"Failed to resize pod {ippr_status.cloud_instance_id}: {e}"
+                )
+
     def get_ippr_specs(self) -> IPPRSpecs:
         """Return the current validated IPPR specs."""
         return self._ippr_specs
+
+    def get_ippr_statuses(self) -> Dict[str, IPPRStatus]:
+        """Return the latest per-pod IPPR statuses keyed by pod name."""
+        return self._ippr_statuses
+
+    def _patch_ippr_status(
+        self, resize: IPPRStatus, resizing_at: Optional[int]
+    ) -> None:
+        """Save the IPPR status to the pod annotation ``ray.io/ippr-status``.
+        The annotation is used to track the IPPR status of the pod across reconcile loops.
+
+        Args:
+            resize: The IPPR status to save.
+            resizing_at: Timestamp while a resize is in progress; pass ``None``
+                to clear after the resize completes (e.g. from ``sync_with_raylets``).
+        """
+        self._k8s_api_client.patch(
+            "pods/{}".format(resize.cloud_instance_id),
+            {
+                "metadata": {
+                    "annotations": {
+                        "ray.io/ippr-status": json.dumps(
+                            {
+                                "raylet-id": resize.raylet_id,
+                                "resizing-at": resizing_at,
+                                "suggested-max-cpu": resize.suggested_max_cpu,
+                                "suggested-max-memory": resize.suggested_max_memory,
+                                "last-failed-at": resize.last_failed_at,
+                                "last-failed-reason": resize.last_failed_reason,
+                            }
+                        )
+                    }
+                }
+            },
+            content_type="application/strategic-merge-patch+json",
+        )
 
 
 def _build_ippr_group_spec(

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/ippr_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/ippr_provider.py
@@ -217,7 +217,10 @@ class KubeRayIPPRProvider:
                 logger.info(f"Pod {ippr_status.cloud_instance_id} resized successfully")
             except Exception as e:
                 logger.error(
-                    f"Failed to resize pod {ippr_status.cloud_instance_id}: {e}"
+                    f"Failed to resize pod {ippr_status.cloud_instance_id}: {e}. "
+                    "If this persists, check GCS (e.g. Head/GCS logs and Raylet reachability) "
+                    "and Kubernetes (e.g. API errors, pod events, ray.io/ippr-status) for "
+                    "related request failures."
                 )
 
     def get_ippr_specs(self) -> IPPRSpecs:

--- a/python/ray/autoscaler/v2/tests/test_ippr_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_ippr_provider.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+import time
 import unittest
 from typing import Any, Dict
 from unittest.mock import MagicMock
@@ -11,6 +12,7 @@ import pytest
 from ray.autoscaler.v2.instance_manager.cloud_providers.kuberay.ippr_provider import (
     KubeRayIPPRProvider,
 )
+from ray.autoscaler.v2.schema import IPPRStatus
 from ray.autoscaler.v2.tests.test_node_provider import (
     MockKubernetesHttpApiClient,
 )
@@ -256,6 +258,74 @@ class TestKubeRayIPPRProvider(unittest.TestCase):
 
         with pytest.raises(ValueError):
             self.provider.validate_and_set_ippr_specs(rc)
+
+    def test_sync_with_raylets_calls_gcs_and_clears_resizing_at_on_pod(self):
+        Gi = 1024 * 1024 * 1024
+        rc = _make_ray_cluster_with_ippr(
+            {"small-group": {"max-cpu": 8, "max-memory": "32Gi", "resize-timeout": 60}}
+        )
+        self.provider.validate_and_set_ippr_specs(rc)
+        spec = self.provider.get_ippr_specs().groups["small-group"]
+        raylet_hex = "0" * 56
+        st = IPPRStatus(
+            cloud_instance_id="ray-worker-1",
+            spec=spec,
+            current_cpu=2.0,
+            current_memory=4 * Gi,
+            desired_cpu=2.0,
+            desired_memory=4 * Gi,
+            resizing_at=123,
+            raylet_id=raylet_hex,
+        )
+        self.provider._ippr_statuses["ray-worker-1"] = st
+        assert st.need_sync_with_raylet()
+
+        self.gcs.resize_raylet_resource_instances.return_value = {
+            "CPU": 2.0,
+            "memory": 4 * Gi,
+        }
+
+        self.provider.sync_with_raylets()
+
+        self.gcs.resize_raylet_resource_instances.assert_called_once_with(
+            raylet_hex,
+            {"CPU": 2.0, "memory": 4 * Gi},
+        )
+
+        ann_payload = self.k8s.get_patches("pods/ray-worker-1")
+        assert ann_payload is not None
+        parsed = json.loads(
+            ann_payload["metadata"]["annotations"]["ray.io/ippr-status"]
+        )
+        assert parsed["raylet-id"] == raylet_hex
+        assert parsed["resizing-at"] is None
+
+    def test_sync_with_raylets_missing_raylet_address_noop(self):
+        Gi = 1024 * 1024 * 1024
+        rc = _make_ray_cluster_with_ippr(
+            {"small-group": {"max-cpu": 8, "max-memory": "32Gi", "resize-timeout": 60}}
+        )
+        self.provider.validate_and_set_ippr_specs(rc)
+        spec = self.provider.get_ippr_specs().groups["small-group"]
+        raylet_hex = "0" * 56
+        st = IPPRStatus(
+            cloud_instance_id="ray-worker-1",
+            spec=spec,
+            current_cpu=2.0,
+            current_memory=4 * Gi,
+            desired_cpu=2.0,
+            desired_memory=4 * Gi,
+            resizing_at=int(time.time()),
+            raylet_id=raylet_hex,
+        )
+        self.provider._ippr_statuses["ray-worker-1"] = st
+        self.gcs.resize_raylet_resource_instances.side_effect = ValueError(
+            f"Raylet {raylet_hex} is not alive."
+        )
+        self.provider.sync_with_raylets()
+
+        with pytest.raises(KeyError):
+            _ = self.k8s.get_patches("pods/ray-worker-1")
 
 
 if __name__ == "__main__":

--- a/python/ray/autoscaler/v2/tests/test_node_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_node_provider.py
@@ -7,7 +7,7 @@ import unittest
 # coding: utf-8
 # coding: utf-8
 from collections import defaultdict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 from unittest.mock import MagicMock
 
 import pytest  # noqa
@@ -354,11 +354,16 @@ class MockKubernetesHttpApiClient(IKubernetesHttpApiClient):
 
         raise NotImplementedError(f"get {path}")
 
-    def patch(self, path: str, patches: List[Dict[str, Any]]):
+    def patch(
+        self,
+        path: str,
+        patches: Union[List[Dict[str, Any]], Dict[str, Any]],
+        content_type: str = "application/json-patch+json",
+    ):
         self._patches[path] = patches
         return {path: patches}
 
-    def get_patches(self, path: str) -> List[Dict[str, Any]]:
+    def get_patches(self, path: str) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         return self._patches[path]
 
 


### PR DESCRIPTION
## Description

This PR introduces the new `KubeRayIPPRProvider`, which is the utility that provides IPPR helpers and will be wired up with `KubeRayNodeProvider` and the autoscaler in the upcoming final IPPR PR.

The following are the helpers it provides:

1. `validate_and_set_ippr_specs` (in the previous PR)
2. `sync_with_raylets` (in this PR)
3. `sync_ippr_status_from_pods` (in the next PR)
4. `do_ippr_requests` (in the next PR)
5. `get_ippr_statuses` (in this PR)

The first 3 helpers will be invoked during the sync phase of each autoscaler reconciliation for reconciling both sides of Ray and Kubernetes.

The last 2 helpers will be invoked after the sync phase for the autoscaler to decide whether to do IPPR or not during the bin packing simulation.

But this PR only introduces the `KubeRayIPPRProvider`. There are no actual behavior changes in the autoscaler yet. The actual behavior changes will come in the next PR.
