### PR TITLE
[train] Add shuffle quality metrics to image classification benchmark

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1616,12 +1616,12 @@
     - __suffix__: full_training.parquet
       run:
         timeout: 2000
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --image_classification_data_format=parquet --track_shuffle_quality=True
 
     - __suffix__: full_training.parquet.preserve_order
       run:
         timeout: 2000
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --image_classification_data_format=parquet --preserve_order=True
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --image_classification_data_format=parquet --preserve_order=True --track_shuffle_quality=True
 
     - __suffix__: full_training.parquet.torch_dataloader
       run:
@@ -1631,12 +1631,12 @@
     - __suffix__: skip_training.parquet
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet --track_shuffle_quality=True
 
     - __suffix__: skip_training.parquet.preserve_order
       run:
         timeout: 1200
-        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet --preserve_order=True
+        script: RAY_TRAIN_V2_ENABLED=1 python train_benchmark.py --task=image_classification --dataloader_type=ray_data --num_workers=16 --skip_train_step=True --skip_validation_at_epoch_end=True --image_classification_data_format=parquet --preserve_order=True --track_shuffle_quality=True
 
     - __suffix__: skip_training.parquet.torch_dataloader
       run:

--- a/release/train_tests/benchmark/config.py
+++ b/release/train_tests/benchmark/config.py
@@ -50,6 +50,7 @@ class RayDataConfig(DataLoaderConfig):
     enable_shard_locality: bool = True
     preserve_order: bool = False
     ray_data_pin_memory: bool = False
+    track_shuffle_quality: bool = False
 
 
 class TorchConfig(DataLoaderConfig):

--- a/release/train_tests/benchmark/image_classification/factory.py
+++ b/release/train_tests/benchmark/image_classification/factory.py
@@ -230,18 +230,6 @@ class ShuffleQualityTracker:
             metrics["shuffle_quality/min_unique_files_per_2k_rows"] = min(window_counts)
             metrics["shuffle_quality/max_unique_files_per_2k_rows"] = max(window_counts)
 
-        # Max run length (consecutive rows from same file)
-        if ids:
-            max_run = 1
-            current_run = 1
-            for i in range(1, len(ids)):
-                if ids[i] == ids[i - 1]:
-                    current_run += 1
-                    max_run = max(max_run, current_run)
-                else:
-                    current_run = 1
-            metrics["shuffle_quality/max_run_length"] = max_run
-
         return metrics
 
 

--- a/release/train_tests/benchmark/image_classification/factory.py
+++ b/release/train_tests/benchmark/image_classification/factory.py
@@ -18,7 +18,11 @@ from benchmark_factory import BenchmarkFactory
 from config import BenchmarkConfig, DataloaderType, ImageClassificationConfig
 from dataloader_factory import BaseDataLoaderFactory
 from torch_dataloader_factory import TorchDataLoaderFactory
-from ray_dataloader_factory import RayDataLoaderFactory
+from ray_dataloader_factory import (
+    RayDataLoaderFactory,
+    get_or_create_spill_metrics_monitor,
+)
+from constants import DatasetKey
 from logger_utils import ContextLoggerAdapter
 
 logger = ContextLoggerAdapter(logging.getLogger(__name__))
@@ -311,18 +315,6 @@ class CustomArrowCollateFn(ArrowBatchCollateFn):
         return tensors["image"], tensors["label"]
 
 
-class TrackingCollateFn(CollateFn):
-    """Wraps a collate function with shuffle quality tracking."""
-
-    def __init__(self, inner: CollateFn, tracker: ShuffleQualityTracker):
-        self._inner = inner
-        self._tracker = tracker
-
-    def __call__(self, batch: "pyarrow.Table") -> Tuple[torch.Tensor, torch.Tensor]:
-        self._tracker.observe(batch)
-        return self._inner(batch)
-
-
 class ImageClassificationRayDataLoaderFactory(RayDataLoaderFactory):
     """Factory for creating Ray DataLoader for image classification tasks."""
 
@@ -331,12 +323,46 @@ class ImageClassificationRayDataLoaderFactory(RayDataLoaderFactory):
         self._shuffle_tracker: Optional[ShuffleQualityTracker] = None
 
     def _get_collate_fn(self) -> Optional[CollateFn]:
-        collate_fn = CustomArrowCollateFn(
+        return CustomArrowCollateFn(
             device=ray.train.torch.get_device(),
             pin_memory=self.get_dataloader_config().ray_data_pin_memory,
         )
+
+    def get_train_dataloader(self):
+        """Get training dataloader with shuffle quality tracking.
+
+        Overrides the base class to iterate raw Arrow batches so we can
+        observe the 'path' column for shuffle quality metrics before
+        passing batches through the collate function.
+        """
+        if self._spill_monitor is None:
+            self._spill_monitor = get_or_create_spill_metrics_monitor()
+
+        ds_iterator = ray.train.get_dataset_shard(DatasetKey.TRAIN)
+        self._ray_ds_iterators[DatasetKey.TRAIN] = ds_iterator
+
+        dataloader_config = self.get_dataloader_config()
+        collate_fn = self._get_collate_fn()
         self._shuffle_tracker = ShuffleQualityTracker()
-        return TrackingCollateFn(collate_fn, self._shuffle_tracker)
+
+        arrow_batches = ds_iterator.iter_batches(
+            batch_size=dataloader_config.train_batch_size,
+            batch_format="pyarrow",
+            local_shuffle_buffer_size=(
+                dataloader_config.local_buffer_shuffle_size
+                if dataloader_config.local_buffer_shuffle_size > 0
+                else None
+            ),
+            prefetch_batches=dataloader_config.ray_data_prefetch_batches,
+            drop_last=True,
+        )
+
+        def _tracking_iter():
+            for batch in arrow_batches:
+                self._shuffle_tracker.observe(batch)
+                yield collate_fn(batch)
+
+        return _tracking_iter()
 
     def get_metrics(self) -> Dict:
         metrics = super().get_metrics()

--- a/release/train_tests/benchmark/image_classification/factory.py
+++ b/release/train_tests/benchmark/image_classification/factory.py
@@ -18,11 +18,7 @@ from benchmark_factory import BenchmarkFactory
 from config import BenchmarkConfig, DataloaderType, ImageClassificationConfig
 from dataloader_factory import BaseDataLoaderFactory
 from torch_dataloader_factory import TorchDataLoaderFactory
-from ray_dataloader_factory import (
-    RayDataLoaderFactory,
-    get_or_create_spill_metrics_monitor,
-)
-from constants import DatasetKey
+from ray_dataloader_factory import RayDataLoaderFactory
 from logger_utils import ContextLoggerAdapter
 
 logger = ContextLoggerAdapter(logging.getLogger(__name__))
@@ -178,61 +174,6 @@ class ImageClassificationTorchDataLoaderFactory(TorchDataLoaderFactory):
             raise
 
 
-class ShuffleQualityTracker:
-    """Tracks shuffle quality metrics by observing file source diversity in batches."""
-
-    def __init__(self):
-        self._unique_files_per_batch: list = []
-        self._all_file_ids: list = []
-        self._file_id_map: Dict[str, int] = {}
-
-    def _path_to_id(self, path: str) -> int:
-        if path not in self._file_id_map:
-            self._file_id_map[path] = len(self._file_id_map)
-        return self._file_id_map[path]
-
-    def observe(self, batch: "pyarrow.Table") -> None:
-        """Record shuffle quality stats from a batch containing a 'path' column."""
-        if "path" not in batch.column_names:
-            return
-        paths = batch.column("path").to_pylist()
-        self._unique_files_per_batch.append(len(set(paths)))
-        self._all_file_ids.extend(self._path_to_id(p) for p in paths)
-
-    def get_metrics(self) -> Dict[str, float]:
-        """Return shuffle quality metrics accumulated across batches."""
-        if not self._unique_files_per_batch:
-            return {}
-        total = sum(self._unique_files_per_batch)
-        count = len(self._unique_files_per_batch)
-        metrics = {
-            "shuffle_quality/mean_unique_files_per_batch": total / count,
-            "shuffle_quality/min_unique_files_per_batch": min(
-                self._unique_files_per_batch
-            ),
-            "shuffle_quality/max_unique_files_per_batch": max(
-                self._unique_files_per_batch
-            ),
-            "shuffle_quality/num_batches_measured": count,
-        }
-
-        # Compute unique files in sliding windows of ~2000 rows
-        window_size = 2000
-        ids = self._all_file_ids
-        if len(ids) >= window_size:
-            window_counts = []
-            for start in range(0, len(ids) - window_size + 1, window_size):
-                window = ids[start : start + window_size]
-                window_counts.append(len(set(window)))
-            metrics["shuffle_quality/mean_unique_files_per_2k_rows"] = sum(
-                window_counts
-            ) / len(window_counts)
-            metrics["shuffle_quality/min_unique_files_per_2k_rows"] = min(window_counts)
-            metrics["shuffle_quality/max_unique_files_per_2k_rows"] = max(window_counts)
-
-        return metrics
-
-
 class CustomArrowCollateFn(ArrowBatchCollateFn):
     """Custom collate function for converting Arrow batches to PyTorch tensors."""
 
@@ -308,55 +249,12 @@ class ImageClassificationRayDataLoaderFactory(RayDataLoaderFactory):
 
     def __init__(self, benchmark_config: BenchmarkConfig):
         super().__init__(benchmark_config)
-        self._shuffle_tracker: Optional[ShuffleQualityTracker] = None
 
     def _get_collate_fn(self) -> Optional[CollateFn]:
         return CustomArrowCollateFn(
             device=ray.train.torch.get_device(),
             pin_memory=self.get_dataloader_config().ray_data_pin_memory,
         )
-
-    def get_train_dataloader(self):
-        """Get training dataloader with shuffle quality tracking.
-
-        Overrides the base class to iterate raw Arrow batches so we can
-        observe the 'path' column for shuffle quality metrics before
-        passing batches through the collate function.
-        """
-        if self._spill_monitor is None:
-            self._spill_monitor = get_or_create_spill_metrics_monitor()
-
-        ds_iterator = ray.train.get_dataset_shard(DatasetKey.TRAIN)
-        self._ray_ds_iterators[DatasetKey.TRAIN] = ds_iterator
-
-        dataloader_config = self.get_dataloader_config()
-        collate_fn = self._get_collate_fn()
-        self._shuffle_tracker = ShuffleQualityTracker()
-
-        arrow_batches = ds_iterator.iter_batches(
-            batch_size=dataloader_config.train_batch_size,
-            batch_format="pyarrow",
-            local_shuffle_buffer_size=(
-                dataloader_config.local_buffer_shuffle_size
-                if dataloader_config.local_buffer_shuffle_size > 0
-                else None
-            ),
-            prefetch_batches=dataloader_config.ray_data_prefetch_batches,
-            drop_last=True,
-        )
-
-        def _tracking_iter():
-            for batch in arrow_batches:
-                self._shuffle_tracker.observe(batch)
-                yield collate_fn(batch)
-
-        return _tracking_iter()
-
-    def get_metrics(self) -> Dict:
-        metrics = super().get_metrics()
-        if self._shuffle_tracker is not None:
-            metrics.update(self._shuffle_tracker.get_metrics())
-        return metrics
 
 
 class ImageClassificationMockDataLoaderFactory(BaseDataLoaderFactory):

--- a/release/train_tests/benchmark/image_classification/factory.py
+++ b/release/train_tests/benchmark/image_classification/factory.py
@@ -206,10 +206,69 @@ class CustomArrowCollateFn(ArrowBatchCollateFn):
         self.num_workers = num_workers
         self._threadpool: Optional[ThreadPoolExecutor] = None
 
+        # Shuffle quality tracking
+        self._unique_files_per_batch: list = []
+        self._all_file_ids: list = []
+        self._file_id_map: Dict[str, int] = {}
+
     def __del__(self):
         """Clean up threadpool on destruction."""
         if getattr(self, "_threadpool", None):
             self._threadpool.shutdown(wait=False)
+
+    def _path_to_id(self, path: str) -> int:
+        if path not in self._file_id_map:
+            self._file_id_map[path] = len(self._file_id_map)
+        return self._file_id_map[path]
+
+    def get_shuffle_quality_metrics(self) -> Dict[str, float]:
+        """Return shuffle quality metrics accumulated across batches."""
+        if not self._unique_files_per_batch:
+            return {}
+        total = sum(self._unique_files_per_batch)
+        count = len(self._unique_files_per_batch)
+        metrics = {
+            "shuffle_quality/mean_unique_files_per_batch": total / count,
+            "shuffle_quality/min_unique_files_per_batch": min(
+                self._unique_files_per_batch
+            ),
+            "shuffle_quality/max_unique_files_per_batch": max(
+                self._unique_files_per_batch
+            ),
+            "shuffle_quality/num_batches_measured": count,
+        }
+
+        # Compute unique files in sliding windows of ~2000 rows
+        window_size = 2000
+        ids = self._all_file_ids
+        if len(ids) >= window_size:
+            window_counts = []
+            for start in range(0, len(ids) - window_size + 1, window_size):
+                window = ids[start : start + window_size]
+                window_counts.append(len(set(window)))
+            metrics["shuffle_quality/mean_unique_files_per_2k_rows"] = sum(
+                window_counts
+            ) / len(window_counts)
+            metrics["shuffle_quality/min_unique_files_per_2k_rows"] = min(
+                window_counts
+            )
+            metrics["shuffle_quality/max_unique_files_per_2k_rows"] = max(
+                window_counts
+            )
+
+        # Max run length (consecutive rows from same file)
+        if ids:
+            max_run = 1
+            current_run = 1
+            for i in range(1, len(ids)):
+                if ids[i] == ids[i - 1]:
+                    current_run += 1
+                    max_run = max(max_run, current_run)
+                else:
+                    current_run = 1
+            metrics["shuffle_quality/max_run_length"] = max_run
+
+        return metrics
 
     def __call__(self, batch: "pyarrow.Table") -> Tuple[torch.Tensor, torch.Tensor]:
         """Convert an Arrow batch to PyTorch tensors.
@@ -227,12 +286,20 @@ class CustomArrowCollateFn(ArrowBatchCollateFn):
         if self.num_workers > 0 and self._threadpool is None:
             self._threadpool = ThreadPoolExecutor(max_workers=self.num_workers)
 
+        # Track shuffle quality: count unique source files in this batch
+        if "path" in batch.column_names:
+            paths = batch.column("path").to_pylist()
+            unique_files = len(set(paths))
+            self._unique_files_per_batch.append(unique_files)
+            self._all_file_ids.extend(self._path_to_id(p) for p in paths)
+
         # For GPU transfer, we can skip the combining chunked arrays. This is because
         # we can convert the chunked arrays to corresponding numpy format and then to
         # Tensors and transfer the corresponding list of Tensors to GPU directly.
         # However, for CPU transfer, we need to combine the chunked arrays first
         # before converting to numpy format and then to Tensors.
         combine_chunks = self.device is not None and self.device.type == "cpu"
+        batch = batch.select(["image", "label"])
         tensors = arrow_batch_to_tensors(
             batch,
             dtypes=self.dtypes,
@@ -248,12 +315,20 @@ class ImageClassificationRayDataLoaderFactory(RayDataLoaderFactory):
 
     def __init__(self, benchmark_config: BenchmarkConfig):
         super().__init__(benchmark_config)
+        self._collate_fn_instance: Optional[CustomArrowCollateFn] = None
 
     def _get_collate_fn(self) -> Optional[CollateFn]:
-        return CustomArrowCollateFn(
+        self._collate_fn_instance = CustomArrowCollateFn(
             device=ray.train.torch.get_device(),
             pin_memory=self.get_dataloader_config().ray_data_pin_memory,
         )
+        return self._collate_fn_instance
+
+    def get_metrics(self) -> Dict:
+        metrics = super().get_metrics()
+        if self._collate_fn_instance is not None:
+            metrics.update(self._collate_fn_instance.get_shuffle_quality_metrics())
+        return metrics
 
 
 class ImageClassificationMockDataLoaderFactory(BaseDataLoaderFactory):

--- a/release/train_tests/benchmark/image_classification/factory.py
+++ b/release/train_tests/benchmark/image_classification/factory.py
@@ -174,6 +174,73 @@ class ImageClassificationTorchDataLoaderFactory(TorchDataLoaderFactory):
             raise
 
 
+class ShuffleQualityTracker:
+    """Tracks shuffle quality metrics by observing file source diversity in batches."""
+
+    def __init__(self):
+        self._unique_files_per_batch: list = []
+        self._all_file_ids: list = []
+        self._file_id_map: Dict[str, int] = {}
+
+    def _path_to_id(self, path: str) -> int:
+        if path not in self._file_id_map:
+            self._file_id_map[path] = len(self._file_id_map)
+        return self._file_id_map[path]
+
+    def observe(self, batch: "pyarrow.Table") -> None:
+        """Record shuffle quality stats from a batch containing a 'path' column."""
+        if "path" not in batch.column_names:
+            return
+        paths = batch.column("path").to_pylist()
+        self._unique_files_per_batch.append(len(set(paths)))
+        self._all_file_ids.extend(self._path_to_id(p) for p in paths)
+
+    def get_metrics(self) -> Dict[str, float]:
+        """Return shuffle quality metrics accumulated across batches."""
+        if not self._unique_files_per_batch:
+            return {}
+        total = sum(self._unique_files_per_batch)
+        count = len(self._unique_files_per_batch)
+        metrics = {
+            "shuffle_quality/mean_unique_files_per_batch": total / count,
+            "shuffle_quality/min_unique_files_per_batch": min(
+                self._unique_files_per_batch
+            ),
+            "shuffle_quality/max_unique_files_per_batch": max(
+                self._unique_files_per_batch
+            ),
+            "shuffle_quality/num_batches_measured": count,
+        }
+
+        # Compute unique files in sliding windows of ~2000 rows
+        window_size = 2000
+        ids = self._all_file_ids
+        if len(ids) >= window_size:
+            window_counts = []
+            for start in range(0, len(ids) - window_size + 1, window_size):
+                window = ids[start : start + window_size]
+                window_counts.append(len(set(window)))
+            metrics["shuffle_quality/mean_unique_files_per_2k_rows"] = sum(
+                window_counts
+            ) / len(window_counts)
+            metrics["shuffle_quality/min_unique_files_per_2k_rows"] = min(window_counts)
+            metrics["shuffle_quality/max_unique_files_per_2k_rows"] = max(window_counts)
+
+        # Max run length (consecutive rows from same file)
+        if ids:
+            max_run = 1
+            current_run = 1
+            for i in range(1, len(ids)):
+                if ids[i] == ids[i - 1]:
+                    current_run += 1
+                    max_run = max(max_run, current_run)
+                else:
+                    current_run = 1
+            metrics["shuffle_quality/max_run_length"] = max_run
+
+        return metrics
+
+
 class CustomArrowCollateFn(ArrowBatchCollateFn):
     """Custom collate function for converting Arrow batches to PyTorch tensors."""
 
@@ -206,69 +273,10 @@ class CustomArrowCollateFn(ArrowBatchCollateFn):
         self.num_workers = num_workers
         self._threadpool: Optional[ThreadPoolExecutor] = None
 
-        # Shuffle quality tracking
-        self._unique_files_per_batch: list = []
-        self._all_file_ids: list = []
-        self._file_id_map: Dict[str, int] = {}
-
     def __del__(self):
         """Clean up threadpool on destruction."""
         if getattr(self, "_threadpool", None):
             self._threadpool.shutdown(wait=False)
-
-    def _path_to_id(self, path: str) -> int:
-        if path not in self._file_id_map:
-            self._file_id_map[path] = len(self._file_id_map)
-        return self._file_id_map[path]
-
-    def get_shuffle_quality_metrics(self) -> Dict[str, float]:
-        """Return shuffle quality metrics accumulated across batches."""
-        if not self._unique_files_per_batch:
-            return {}
-        total = sum(self._unique_files_per_batch)
-        count = len(self._unique_files_per_batch)
-        metrics = {
-            "shuffle_quality/mean_unique_files_per_batch": total / count,
-            "shuffle_quality/min_unique_files_per_batch": min(
-                self._unique_files_per_batch
-            ),
-            "shuffle_quality/max_unique_files_per_batch": max(
-                self._unique_files_per_batch
-            ),
-            "shuffle_quality/num_batches_measured": count,
-        }
-
-        # Compute unique files in sliding windows of ~2000 rows
-        window_size = 2000
-        ids = self._all_file_ids
-        if len(ids) >= window_size:
-            window_counts = []
-            for start in range(0, len(ids) - window_size + 1, window_size):
-                window = ids[start : start + window_size]
-                window_counts.append(len(set(window)))
-            metrics["shuffle_quality/mean_unique_files_per_2k_rows"] = sum(
-                window_counts
-            ) / len(window_counts)
-            metrics["shuffle_quality/min_unique_files_per_2k_rows"] = min(
-                window_counts
-            )
-            metrics["shuffle_quality/max_unique_files_per_2k_rows"] = max(
-                window_counts
-            )
-
-        # Max run length (consecutive rows from same file)
-        if ids:
-            max_run = 1
-            current_run = 1
-            for i in range(1, len(ids)):
-                if ids[i] == ids[i - 1]:
-                    current_run += 1
-                    max_run = max(max_run, current_run)
-                else:
-                    current_run = 1
-            metrics["shuffle_quality/max_run_length"] = max_run
-
-        return metrics
 
     def __call__(self, batch: "pyarrow.Table") -> Tuple[torch.Tensor, torch.Tensor]:
         """Convert an Arrow batch to PyTorch tensors.
@@ -285,13 +293,6 @@ class CustomArrowCollateFn(ArrowBatchCollateFn):
 
         if self.num_workers > 0 and self._threadpool is None:
             self._threadpool = ThreadPoolExecutor(max_workers=self.num_workers)
-
-        # Track shuffle quality: count unique source files in this batch
-        if "path" in batch.column_names:
-            paths = batch.column("path").to_pylist()
-            unique_files = len(set(paths))
-            self._unique_files_per_batch.append(unique_files)
-            self._all_file_ids.extend(self._path_to_id(p) for p in paths)
 
         # For GPU transfer, we can skip the combining chunked arrays. This is because
         # we can convert the chunked arrays to corresponding numpy format and then to
@@ -310,24 +311,37 @@ class CustomArrowCollateFn(ArrowBatchCollateFn):
         return tensors["image"], tensors["label"]
 
 
+class TrackingCollateFn(CollateFn):
+    """Wraps a collate function with shuffle quality tracking."""
+
+    def __init__(self, inner: CollateFn, tracker: ShuffleQualityTracker):
+        self._inner = inner
+        self._tracker = tracker
+
+    def __call__(self, batch: "pyarrow.Table") -> Tuple[torch.Tensor, torch.Tensor]:
+        self._tracker.observe(batch)
+        return self._inner(batch)
+
+
 class ImageClassificationRayDataLoaderFactory(RayDataLoaderFactory):
     """Factory for creating Ray DataLoader for image classification tasks."""
 
     def __init__(self, benchmark_config: BenchmarkConfig):
         super().__init__(benchmark_config)
-        self._collate_fn_instance: Optional[CustomArrowCollateFn] = None
+        self._shuffle_tracker: Optional[ShuffleQualityTracker] = None
 
     def _get_collate_fn(self) -> Optional[CollateFn]:
-        self._collate_fn_instance = CustomArrowCollateFn(
+        collate_fn = CustomArrowCollateFn(
             device=ray.train.torch.get_device(),
             pin_memory=self.get_dataloader_config().ray_data_pin_memory,
         )
-        return self._collate_fn_instance
+        self._shuffle_tracker = ShuffleQualityTracker()
+        return TrackingCollateFn(collate_fn, self._shuffle_tracker)
 
     def get_metrics(self) -> Dict:
         metrics = super().get_metrics()
-        if self._collate_fn_instance is not None:
-            metrics.update(self._collate_fn_instance.get_shuffle_quality_metrics())
+        if self._shuffle_tracker is not None:
+            metrics.update(self._shuffle_tracker.get_metrics())
         return metrics
 
 

--- a/release/train_tests/benchmark/image_classification/parquet/factory.py
+++ b/release/train_tests/benchmark/image_classification/parquet/factory.py
@@ -49,9 +49,11 @@ class ImageClassificationParquetRayDataLoaderFactory(
                 - "val": Validation dataset without transforms
         """
         # Create training dataset with image decoding and transforms
+        # include_paths=True adds a "path" column for shuffle quality tracking
         train_ds = ray.data.read_parquet(
             self._data_dirs[DatasetKey.TRAIN],
             columns=["image", "label"],
+            include_paths=True,
         ).map(get_preprocess_map_fn(decode_image=True, random_transforms=True))
 
         if self.get_dataloader_config().limit_training_rows > 0:

--- a/release/train_tests/benchmark/image_classification/parquet/imagenet.py
+++ b/release/train_tests/benchmark/image_classification/parquet/imagenet.py
@@ -53,6 +53,10 @@ def get_preprocess_map_fn(
         row["image"] = np.array(crop_resize_transform(row["image"]))
         row["label"] = IMAGENET_WNID_TO_ID[row["label"]]
 
-        return {"image": row["image"], "label": row["label"]}
+        result = {"image": row["image"], "label": row["label"]}
+        # Preserve path column for shuffle quality tracking if present
+        if "path" in row:
+            result["path"] = row["path"]
+        return result
 
     return map_fn

--- a/release/train_tests/benchmark/ray_dataloader_factory.py
+++ b/release/train_tests/benchmark/ray_dataloader_factory.py
@@ -264,6 +264,9 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
         def _tracking_iter():
             for batch in arrow_batches:
                 self._shuffle_tracker.observe(batch)
+                # Combine chunked arrays so the collate function receives
+                # single-chunk columns (matching iter_torch_batches behavior).
+                batch = batch.combine_chunks()
                 yield collate_fn(batch)
 
         return _tracking_iter()

--- a/release/train_tests/benchmark/ray_dataloader_factory.py
+++ b/release/train_tests/benchmark/ray_dataloader_factory.py
@@ -102,11 +102,67 @@ def get_or_create_spill_metrics_monitor(
     ).remote(poll_interval_s=poll_interval_s)
 
 
+class ShuffleQualityTracker:
+    """Tracks shuffle quality metrics by observing file source diversity in batches."""
+
+    def __init__(self):
+        self._unique_files_per_batch: list = []
+        self._all_file_ids: list = []
+        self._file_id_map: Dict[str, int] = {}
+
+    def _path_to_id(self, path: str) -> int:
+        if path not in self._file_id_map:
+            self._file_id_map[path] = len(self._file_id_map)
+        return self._file_id_map[path]
+
+    def observe(self, batch) -> None:
+        """Record shuffle quality stats from a batch containing a 'path' column."""
+        if "path" not in batch.column_names:
+            return
+        paths = batch.column("path").to_pylist()
+        self._unique_files_per_batch.append(len(set(paths)))
+        self._all_file_ids.extend(self._path_to_id(p) for p in paths)
+
+    def get_metrics(self) -> Dict[str, float]:
+        """Return shuffle quality metrics accumulated across batches."""
+        if not self._unique_files_per_batch:
+            return {}
+        total = sum(self._unique_files_per_batch)
+        count = len(self._unique_files_per_batch)
+        metrics = {
+            "shuffle_quality/mean_unique_files_per_batch": total / count,
+            "shuffle_quality/min_unique_files_per_batch": min(
+                self._unique_files_per_batch
+            ),
+            "shuffle_quality/max_unique_files_per_batch": max(
+                self._unique_files_per_batch
+            ),
+            "shuffle_quality/num_batches_measured": count,
+        }
+
+        # Compute unique files in sliding windows of ~2000 rows
+        window_size = 2000
+        ids = self._all_file_ids
+        if len(ids) >= window_size:
+            window_counts = []
+            for start in range(0, len(ids) - window_size + 1, window_size):
+                window = ids[start : start + window_size]
+                window_counts.append(len(set(window)))
+            metrics["shuffle_quality/mean_unique_files_per_2k_rows"] = sum(
+                window_counts
+            ) / len(window_counts)
+            metrics["shuffle_quality/min_unique_files_per_2k_rows"] = min(window_counts)
+            metrics["shuffle_quality/max_unique_files_per_2k_rows"] = max(window_counts)
+
+        return metrics
+
+
 class RayDataLoaderFactory(BaseDataLoaderFactory):
     def __init__(self, benchmark_config: BenchmarkConfig) -> None:
         super().__init__(benchmark_config)
         self._ray_ds_iterators = {}
         self._spill_monitor: Optional[ray.actor.ActorHandle] = None
+        self._shuffle_tracker: Optional[ShuffleQualityTracker] = None
 
         dataloader_config = self.get_dataloader_config()
         assert isinstance(dataloader_config, RayDataConfig), type(dataloader_config)
@@ -156,6 +212,10 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
         self._ray_ds_iterators[DatasetKey.TRAIN] = ds_iterator
 
         dataloader_config = self.get_dataloader_config()
+
+        if dataloader_config.track_shuffle_quality:
+            return self._train_dataloader_with_tracking()
+
         return iter(
             ds_iterator.iter_torch_batches(
                 batch_size=dataloader_config.train_batch_size,
@@ -170,6 +230,43 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
                 pin_memory=dataloader_config.ray_data_pin_memory,
             )
         )
+
+    def _train_dataloader_with_tracking(self):
+        """Get training dataloader with shuffle quality tracking.
+
+        Iterates raw Arrow batches to observe the 'path' column for
+        shuffle quality metrics before passing batches through the
+        collate function. Subclasses can call this from
+        get_train_dataloader() to opt in.
+        """
+        if self._spill_monitor is None:
+            self._spill_monitor = get_or_create_spill_metrics_monitor()
+
+        ds_iterator = ray.train.get_dataset_shard(DatasetKey.TRAIN)
+        self._ray_ds_iterators[DatasetKey.TRAIN] = ds_iterator
+
+        dataloader_config = self.get_dataloader_config()
+        collate_fn = self._get_collate_fn()
+        self._shuffle_tracker = ShuffleQualityTracker()
+
+        arrow_batches = ds_iterator.iter_batches(
+            batch_size=dataloader_config.train_batch_size,
+            batch_format="pyarrow",
+            local_shuffle_buffer_size=(
+                dataloader_config.local_buffer_shuffle_size
+                if dataloader_config.local_buffer_shuffle_size > 0
+                else None
+            ),
+            prefetch_batches=dataloader_config.ray_data_prefetch_batches,
+            drop_last=True,
+        )
+
+        def _tracking_iter():
+            for batch in arrow_batches:
+                self._shuffle_tracker.observe(batch)
+                yield collate_fn(batch)
+
+        return _tracking_iter()
 
     def get_val_dataloader(self):
         """Get the validation dataloader.
@@ -276,5 +373,8 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
                 metrics.update(spill_metrics)
             except Exception as e:
                 logger.warning(f"Failed to collect spill rate metrics: {e}")
+
+        if self._shuffle_tracker is not None:
+            metrics.update(self._shuffle_tracker.get_metrics())
 
         return metrics


### PR DESCRIPTION
Add instrumentation to measure data shuffling quality in the parquet image classification benchmark. This enables tracking how well rows from different source files are mixed across training batches, which is useful for evaluating shuffle configurations like RowGroupShuffleConfig.

Metrics added (per-worker, reported alongside existing dataloader metrics):
- shuffle_quality/mean_unique_files_per_batch
- shuffle_quality/mean_unique_files_per_2k_rows (sliding window)

Implementation:
- Pass include_paths=True to read_parquet() for training dataset
- Preserve path column through preprocessing map function
- Add `track_shuffle_quality` flag to RayDataConfig (default: False)
- When enabled, RayDataLoaderFactory.get_train_dataloader() iterates raw
  Arrow batches via iter_batches(batch_format="pyarrow"), observes the
  path column in a ShuffleQualityTracker, then passes batches through
  the collate function
- Shuffle quality tracking lives in RayDataLoaderFactory, fully decoupled
  from any collate function implementation
- Report metrics via RayDataLoaderFactory.get_metrics()
- Enable tracking for parquet benchmarks in release_tests.yaml:
  full_training.parquet, full_training.parquet.preserve_order,
  skip_training.parquet, skip_training.parquet.preserve_order