### PR TITLE
[Serve] Fix throughput regression from call_soon_threadsafe in router callbacks

### DIFF
--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -1,9 +1,9 @@
 import asyncio
-import collections
 import enum
 import logging
 import math
 import random
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
@@ -502,10 +502,10 @@ class RequestRouter(ABC):
         self._replica_queue_len_cache = ReplicaQueueLengthCache(
             get_curr_time_s=get_curr_time_s,
         )
-        # Completed replica IDs pending cache decrement. Appended from
-        # worker threads via add_done_callback (deque.append is GIL-atomic),
-        # drained on the event loop thread before each routing decision.
-        self._pending_cache_decrements: collections.deque = collections.deque()
+        # Lock to protect _replica_queue_len_cache from concurrent access
+        # in decrement_queue_len_cache, which may be called from worker
+        # threads via add_done_callback.
+        self._queue_len_cache_lock = threading.Lock()
 
         # Throttle state for router queue length gauge updates.
         # Maps replica_id -> last update timestamp to avoid excessive metric updates.
@@ -850,35 +850,27 @@ class RequestRouter(ABC):
     def on_send_request(self, replica_id: ReplicaID):
         """Increment queue length cache when a request is sent to a replica."""
         if self._use_replica_queue_len_cache:
-            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
-            new_queue_len = num_ongoing_requests + 1
-            self._replica_queue_len_cache.update(replica_id, new_queue_len)
+            with self._queue_len_cache_lock:
+                num_ongoing_requests = (
+                    self._replica_queue_len_cache.get(replica_id) or 0
+                )
+                new_queue_len = num_ongoing_requests + 1
+                self._replica_queue_len_cache.update(replica_id, new_queue_len)
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
-    def enqueue_cache_decrement(self, replica_id: ReplicaID):
-        """Enqueue a cache decrement for a replica.
+    def decrement_queue_len_cache(self, replica_id: ReplicaID):
+        """Decrement the queue length cache for a replica.
 
-        Called from worker threads via add_done_callback when a request
-        finishes. deque.append is GIL-atomic so no lock is needed.
-
-        The actual cache update happens on the event loop thread when
-        drain_pending_cache_decrements() is called before each routing
-        decision.
+        Called when a request finishes on a replica, regardless of outcome.
+        Thread-safe: may be called from worker threads via add_done_callback.
         """
-        self._pending_cache_decrements.append(replica_id)
-
-    def drain_pending_cache_decrements(self):
-        """Apply all pending cache decrements. Must be called from the
-        event loop thread (e.g., at the start of each routing decision)."""
-        while self._pending_cache_decrements:
-            try:
-                replica_id = self._pending_cache_decrements.popleft()
-            except IndexError:
-                break
-            current = self._replica_queue_len_cache.get(replica_id)
+        if self._use_replica_queue_len_cache:
+            with self._queue_len_cache_lock:
+                current = self._replica_queue_len_cache.get(replica_id)
+                if current is not None:
+                    new_queue_len = max(0, current - 1)
+                    self._replica_queue_len_cache.update(replica_id, new_queue_len)
             if current is not None:
-                new_queue_len = max(0, current - 1)
-                self._replica_queue_len_cache.update(replica_id, new_queue_len)
                 self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
     def update_replicas(self, replicas: List[RunningReplica]):
@@ -1055,9 +1047,6 @@ class RequestRouter(ABC):
         Among replicas that respond within the deadline and don't have full queues, the
         one with the lowest queue length is chosen.
         """
-        # Apply any pending cache decrements from completed requests.
-        self.drain_pending_cache_decrements()
-
         lowest_queue_len = math.inf
         chosen_replica_id: Optional[str] = None
         not_in_cache: List[RunningReplica] = []

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -1,9 +1,9 @@
 import asyncio
+import collections
 import enum
 import logging
 import math
 import random
-import threading
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
@@ -502,10 +502,9 @@ class RequestRouter(ABC):
         self._replica_queue_len_cache = ReplicaQueueLengthCache(
             get_curr_time_s=get_curr_time_s,
         )
-        # Lock to protect _replica_queue_len_cache from concurrent access
-        # in decrement_queue_len_cache, which may be called from worker
-        # threads via add_done_callback.
-        self._queue_len_cache_lock = threading.Lock()
+        # Pending cache decrements from worker threads. deque.append is
+        # GIL-atomic; drained on the event loop before routing decisions.
+        self._pending_cache_decrements: collections.deque = collections.deque()
 
         # Throttle state for router queue length gauge updates.
         # Maps replica_id -> last update timestamp to avoid excessive metric updates.
@@ -850,27 +849,31 @@ class RequestRouter(ABC):
     def on_send_request(self, replica_id: ReplicaID):
         """Increment queue length cache when a request is sent to a replica."""
         if self._use_replica_queue_len_cache:
-            with self._queue_len_cache_lock:
-                num_ongoing_requests = (
-                    self._replica_queue_len_cache.get(replica_id) or 0
-                )
-                new_queue_len = num_ongoing_requests + 1
-                self._replica_queue_len_cache.update(replica_id, new_queue_len)
+            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
+            new_queue_len = num_ongoing_requests + 1
+            self._replica_queue_len_cache.update(replica_id, new_queue_len)
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
-    def decrement_queue_len_cache(self, replica_id: ReplicaID):
-        """Decrement the queue length cache for a replica.
+    def enqueue_cache_decrement(self, replica_id: ReplicaID):
+        """Enqueue a cache decrement for a replica.
 
-        Called when a request finishes on a replica, regardless of outcome.
-        Thread-safe: may be called from worker threads via add_done_callback.
+        Called from worker threads via add_done_callback when a request
+        finishes. deque.append is GIL-atomic, no lock needed. The actual
+        update happens on the event loop via drain_pending_cache_decrements.
         """
-        if self._use_replica_queue_len_cache:
-            with self._queue_len_cache_lock:
-                current = self._replica_queue_len_cache.get(replica_id)
-                if current is not None:
-                    new_queue_len = max(0, current - 1)
-                    self._replica_queue_len_cache.update(replica_id, new_queue_len)
+        self._pending_cache_decrements.append(replica_id)
+
+    def drain_pending_cache_decrements(self):
+        """Apply pending cache decrements. Called on the event loop thread."""
+        while self._pending_cache_decrements:
+            try:
+                replica_id = self._pending_cache_decrements.popleft()
+            except IndexError:
+                break
+            current = self._replica_queue_len_cache.get(replica_id)
             if current is not None:
+                new_queue_len = max(0, current - 1)
+                self._replica_queue_len_cache.update(replica_id, new_queue_len)
                 self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
     def update_replicas(self, replicas: List[RunningReplica]):
@@ -1047,6 +1050,8 @@ class RequestRouter(ABC):
         Among replicas that respond within the deadline and don't have full queues, the
         one with the lowest queue length is chosen.
         """
+        self.drain_pending_cache_decrements()
+
         lowest_queue_len = math.inf
         chosen_replica_id: Optional[str] = None
         not_in_cache: List[RunningReplica] = []

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -3,6 +3,7 @@ import enum
 import logging
 import math
 import random
+import threading
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
@@ -501,6 +502,10 @@ class RequestRouter(ABC):
         self._replica_queue_len_cache = ReplicaQueueLengthCache(
             get_curr_time_s=get_curr_time_s,
         )
+        # Lock to protect _replica_queue_len_cache from concurrent access
+        # in decrement_queue_len_cache, which may be called from worker
+        # threads via add_done_callback.
+        self._queue_len_cache_lock = threading.Lock()
 
         # Throttle state for router queue length gauge updates.
         # Maps replica_id -> last update timestamp to avoid excessive metric updates.
@@ -845,9 +850,12 @@ class RequestRouter(ABC):
     def on_send_request(self, replica_id: ReplicaID):
         """Increment queue length cache when a request is sent to a replica."""
         if self._use_replica_queue_len_cache:
-            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
-            new_queue_len = num_ongoing_requests + 1
-            self._replica_queue_len_cache.update(replica_id, new_queue_len)
+            with self._queue_len_cache_lock:
+                num_ongoing_requests = (
+                    self._replica_queue_len_cache.get(replica_id) or 0
+                )
+                new_queue_len = num_ongoing_requests + 1
+                self._replica_queue_len_cache.update(replica_id, new_queue_len)
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
     def decrement_queue_len_cache(self, replica_id: ReplicaID):
@@ -860,12 +868,17 @@ class RequestRouter(ABC):
 
         Should NOT be called for rejected requests — on_new_queue_len_info
         already corrects the cache with the replica's actual queue length.
+
+        Thread-safe: this may be called from C++ worker threads or gRPC
+        callback threads via add_done_callback.
         """
         if self._use_replica_queue_len_cache:
-            current = self._replica_queue_len_cache.get(replica_id)
+            with self._queue_len_cache_lock:
+                current = self._replica_queue_len_cache.get(replica_id)
+                if current is not None:
+                    new_queue_len = max(0, current - 1)
+                    self._replica_queue_len_cache.update(replica_id, new_queue_len)
             if current is not None:
-                new_queue_len = max(0, current - 1)
-                self._replica_queue_len_cache.update(replica_id, new_queue_len)
                 self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
     def update_replicas(self, replicas: List[RunningReplica]):

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -502,8 +502,8 @@ class RequestRouter(ABC):
         self._replica_queue_len_cache = ReplicaQueueLengthCache(
             get_curr_time_s=get_curr_time_s,
         )
-        # Pending cache decrements from worker threads. deque.append is
-        # GIL-atomic; drained on the event loop before routing decisions.
+        # Pending cache decrements, appended from worker threads and
+        # drained on the event loop before routing decisions.
         self._pending_cache_decrements: collections.deque = collections.deque()
 
         # Throttle state for router queue length gauge updates.
@@ -855,16 +855,12 @@ class RequestRouter(ABC):
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
     def enqueue_cache_decrement(self, replica_id: ReplicaID):
-        """Enqueue a cache decrement for a replica.
-
-        Called from worker threads via add_done_callback when a request
-        finishes. deque.append is GIL-atomic, no lock needed. The actual
-        update happens on the event loop via drain_pending_cache_decrements.
-        """
+        """Thread-safe: enqueue a cache decrement to be applied before the
+        next routing decision."""
         self._pending_cache_decrements.append(replica_id)
 
     def drain_pending_cache_decrements(self):
-        """Apply pending cache decrements. Called on the event loop thread."""
+        """Apply pending cache decrements. Must run on the event loop."""
         while self._pending_cache_decrements:
             try:
                 replica_id = self._pending_cache_decrements.popleft()

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -1,9 +1,9 @@
 import asyncio
+import collections
 import enum
 import logging
 import math
 import random
-import threading
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict, deque
@@ -502,10 +502,10 @@ class RequestRouter(ABC):
         self._replica_queue_len_cache = ReplicaQueueLengthCache(
             get_curr_time_s=get_curr_time_s,
         )
-        # Lock to protect _replica_queue_len_cache from concurrent access
-        # in decrement_queue_len_cache, which may be called from worker
-        # threads via add_done_callback.
-        self._queue_len_cache_lock = threading.Lock()
+        # Completed replica IDs pending cache decrement. Appended from
+        # worker threads via add_done_callback (deque.append is GIL-atomic),
+        # drained on the event loop thread before each routing decision.
+        self._pending_cache_decrements: collections.deque = collections.deque()
 
         # Throttle state for router queue length gauge updates.
         # Maps replica_id -> last update timestamp to avoid excessive metric updates.
@@ -850,35 +850,35 @@ class RequestRouter(ABC):
     def on_send_request(self, replica_id: ReplicaID):
         """Increment queue length cache when a request is sent to a replica."""
         if self._use_replica_queue_len_cache:
-            with self._queue_len_cache_lock:
-                num_ongoing_requests = (
-                    self._replica_queue_len_cache.get(replica_id) or 0
-                )
-                new_queue_len = num_ongoing_requests + 1
-                self._replica_queue_len_cache.update(replica_id, new_queue_len)
+            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
+            new_queue_len = num_ongoing_requests + 1
+            self._replica_queue_len_cache.update(replica_id, new_queue_len)
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
-    def decrement_queue_len_cache(self, replica_id: ReplicaID):
-        """Decrement the queue length cache for a replica.
+    def enqueue_cache_decrement(self, replica_id: ReplicaID):
+        """Enqueue a cache decrement for a replica.
 
-        Called via add_done_callback when a request finishes on a replica,
-        regardless of outcome (success, failure, or cancellation). This is
-        correct: any request that was actually sent occupies a queue slot,
-        and the slot is freed when the request completes for any reason.
+        Called from worker threads via add_done_callback when a request
+        finishes. deque.append is GIL-atomic so no lock is needed.
 
-        Should NOT be called for rejected requests — on_new_queue_len_info
-        already corrects the cache with the replica's actual queue length.
-
-        Thread-safe: this may be called from C++ worker threads or gRPC
-        callback threads via add_done_callback.
+        The actual cache update happens on the event loop thread when
+        drain_pending_cache_decrements() is called before each routing
+        decision.
         """
-        if self._use_replica_queue_len_cache:
-            with self._queue_len_cache_lock:
-                current = self._replica_queue_len_cache.get(replica_id)
-                if current is not None:
-                    new_queue_len = max(0, current - 1)
-                    self._replica_queue_len_cache.update(replica_id, new_queue_len)
+        self._pending_cache_decrements.append(replica_id)
+
+    def drain_pending_cache_decrements(self):
+        """Apply all pending cache decrements. Must be called from the
+        event loop thread (e.g., at the start of each routing decision)."""
+        while self._pending_cache_decrements:
+            try:
+                replica_id = self._pending_cache_decrements.popleft()
+            except IndexError:
+                break
+            current = self._replica_queue_len_cache.get(replica_id)
             if current is not None:
+                new_queue_len = max(0, current - 1)
+                self._replica_queue_len_cache.update(replica_id, new_queue_len)
                 self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
     def update_replicas(self, replicas: List[RunningReplica]):
@@ -1055,6 +1055,9 @@ class RequestRouter(ABC):
         Among replicas that respond within the deadline and don't have full queues, the
         one with the lowest queue length is chosen.
         """
+        # Apply any pending cache decrements from completed requests.
+        self.drain_pending_cache_decrements()
+
         lowest_queue_len = math.inf
         chosen_replica_id: Optional[str] = None
         not_in_cache: List[RunningReplica] = []

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -862,10 +862,7 @@ class RequestRouter(ABC):
     def drain_pending_cache_decrements(self):
         """Apply pending cache decrements. Must run on the event loop."""
         while self._pending_cache_decrements:
-            try:
-                replica_id = self._pending_cache_decrements.popleft()
-            except IndexError:
-                break
+            replica_id = self._pending_cache_decrements.popleft()
             current = self._replica_queue_len_cache.get(replica_id)
             if current is not None:
                 new_queue_len = max(0, current - 1)

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -807,31 +807,48 @@ class AsyncioRouter:
         replica_id: ReplicaID,
         internal_request_id: str,
         replica_actor_id: Optional[ray.ActorID],
+        should_decrement_cache: list,
         result: Union[Any, RayError],
     ) -> None:
+        """Called from worker threads via add_done_callback.
+
+        The happy path (metrics + on_request_completed + cache decrement) is
+        thread-safe and runs directly. Error handling (actor died/unavailable)
+        mutates shared router state and is deferred to the event loop.
+
+        should_decrement_cache is a mutable single-element list used as a
+        flag. For the with-rejection path, it is set to True after acceptance
+        on the event loop thread before this callback fires.
+        """
+        # Thread-safe: dec uses self._queries_lock internally.
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
             self._metrics_manager.dec_num_running_requests_for_replica(replica_id)
 
-        # Notify request router that request completed (for cleanup, e.g., token release)
+        # Thread-safe: on_request_completed is a no-op in the base class.
         if self.request_router:
             self.request_router.on_request_completed(replica_id, internal_request_id)
+            # GIL-atomic deque append, drained on event loop before routing.
+            if should_decrement_cache[0]:
+                self.request_router.enqueue_cache_decrement(replica_id)
 
+        # Error handling: mutates shared state, must run on event loop.
         actor_died_error = self._get_actor_died_error(result)
         if actor_died_error is not None:
-            self._handle_actor_died_error(
-                replica_id, replica_actor_id, actor_died_error
+            self._event_loop.call_soon_threadsafe(
+                self._handle_actor_died_error,
+                replica_id,
+                replica_actor_id,
+                actor_died_error,
             )
         elif isinstance(result, ActorUnavailableError):
-            # There are network issues, or replica has died but GCS is down so
-            # ActorUnavailableError will be raised until GCS recovers. For the
-            # time being, invalidate the cache entry so that we don't try to
-            # send requests to this replica without actively probing, and retry
-            # routing request.
-            if self.request_router:
-                self.request_router.on_replica_actor_unavailable(replica_id)
-            logger.warning(
-                f"Request failed because {replica_id} is temporarily unavailable."
-            )
+            def _handle_unavailable():
+                if self.request_router:
+                    self.request_router.on_replica_actor_unavailable(replica_id)
+                logger.warning(
+                    f"Request failed because {replica_id} is temporarily unavailable."
+                )
+
+            self._event_loop.call_soon_threadsafe(_handle_unavailable)
 
     def _get_actor_died_error(
         self, result: Union[Any, RayError]
@@ -925,34 +942,29 @@ class AsyncioRouter:
                 self._metrics_manager.inc_num_running_requests_for_replica(
                     replica.replica_id
                 )
-            # Always register callback to notify router when request completes
-            # (needed for token release in queue-based routing, metrics tracking, etc.)
+            # Single callback per request. For the with-rejection path, a
+            # mutable list acts as a flag that is set to True after acceptance,
+            # checked by the callback at execution time. This avoids a second
+            # add_done_callback registration.
+            should_decrement = [not with_rejection]
             callback = partial(
                 self._process_finished_request,
                 replica.replica_id,
                 pr.metadata.internal_request_id,
                 replica.actor_id,
+                should_decrement,
             )
             result.add_done_callback(callback)
             callback_registered = True
 
             if not with_rejection:
-                result.add_done_callback(
-                    lambda _: self.request_router.decrement_queue_len_cache(
-                        replica.replica_id,
-                    )
-                )
                 return result
 
             queue_info = await result.get_rejection_response()
             self.request_router.on_new_queue_len_info(replica.replica_id, queue_info)
             if queue_info.accepted:
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
-                result.add_done_callback(
-                    lambda _: self.request_router.decrement_queue_len_cache(
-                        replica.replica_id,
-                    )
-                )
+                should_decrement[0] = True
                 return result
 
             # Request was rejected: cancel so done callbacks fire.

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -807,7 +807,7 @@ class AsyncioRouter:
         replica_id: ReplicaID,
         internal_request_id: str,
         replica_actor_id: Optional[ray.ActorID],
-        should_decrement_cache: list,
+        decrement_cache: list,
         result: Union[Any, RayError],
     ) -> None:
         """Called from worker threads via add_done_callback.
@@ -820,7 +820,7 @@ class AsyncioRouter:
 
         if self.request_router:
             self.request_router.on_request_completed(replica_id, internal_request_id)
-            if should_decrement_cache[0]:
+            if decrement_cache[0]:
                 self.request_router.enqueue_cache_decrement(replica_id)
 
         actor_died_error = self._get_actor_died_error(result)
@@ -933,17 +933,15 @@ class AsyncioRouter:
                 self._metrics_manager.inc_num_running_requests_for_replica(
                     replica.replica_id
                 )
-            # Single callback per request. For the with-rejection path, a
-            # mutable list acts as a flag that is set to True after acceptance,
-            # checked by the callback at execution time. This avoids a second
-            # add_done_callback registration.
-            should_decrement = [not with_rejection]
+            # Use a mutable flag so the with-rejection path can enable
+            # cache decrement after acceptance without a second callback.
+            decrement_cache = [not with_rejection]
             callback = partial(
                 self._process_finished_request,
                 replica.replica_id,
                 pr.metadata.internal_request_id,
                 replica.actor_id,
-                should_decrement,
+                decrement_cache,
             )
             result.add_done_callback(callback)
             callback_registered = True
@@ -955,7 +953,7 @@ class AsyncioRouter:
             self.request_router.on_new_queue_len_info(replica.replica_id, queue_info)
             if queue_info.accepted:
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
-                should_decrement[0] = True
+                decrement_cache[0] = True
                 return result
 
             # Request was rejected: cancel so done callbacks fire.

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -807,7 +807,6 @@ class AsyncioRouter:
         replica_id: ReplicaID,
         internal_request_id: str,
         replica_actor_id: Optional[ray.ActorID],
-        decrement_queue_len_cache: bool,
         result: Union[Any, RayError],
     ) -> None:
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
@@ -816,8 +815,6 @@ class AsyncioRouter:
         # Notify request router that request completed (for cleanup, e.g., token release)
         if self.request_router:
             self.request_router.on_request_completed(replica_id, internal_request_id)
-            if decrement_queue_len_cache:
-                self.request_router.decrement_queue_len_cache(replica_id)
 
         actor_died_error = self._get_actor_died_error(result)
         if actor_died_error is not None:
@@ -930,31 +927,22 @@ class AsyncioRouter:
                 )
             # Always register callback to notify router when request completes
             # (needed for token release in queue-based routing, metrics tracking, etc.)
-            # A single callback handles both request cleanup and cache
-            # decrement to avoid the overhead of multiple add_done_callback
-            # registrations per request.
-
-            if not with_rejection:
-                callback = partial(
-                    self._process_finished_request,
-                    replica.replica_id,
-                    pr.metadata.internal_request_id,
-                    replica.actor_id,
-                    True,  # decrement_queue_len_cache
-                )
-                result.add_done_callback(callback)
-                callback_registered = True
-                return result
-
             callback = partial(
                 self._process_finished_request,
                 replica.replica_id,
                 pr.metadata.internal_request_id,
                 replica.actor_id,
-                False,  # decrement_queue_len_cache — not yet known if accepted
             )
             result.add_done_callback(callback)
             callback_registered = True
+
+            if not with_rejection:
+                result.add_done_callback(
+                    lambda _: self.request_router.decrement_queue_len_cache(
+                        replica.replica_id,
+                    )
+                )
+                return result
 
             queue_info = await result.get_rejection_response()
             self.request_router.on_new_queue_len_info(replica.replica_id, queue_info)

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -938,7 +938,7 @@ class AsyncioRouter:
 
             if not with_rejection:
                 result.add_done_callback(
-                    lambda _: self.request_router.decrement_queue_len_cache(
+                    lambda _: self.request_router.enqueue_cache_decrement(
                         replica.replica_id,
                     )
                 )
@@ -949,7 +949,7 @@ class AsyncioRouter:
             if queue_info.accepted:
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
                 result.add_done_callback(
-                    lambda _: self.request_router.decrement_queue_len_cache(
+                    lambda _: self.request_router.enqueue_cache_decrement(
                         replica.replica_id,
                     )
                 )

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -812,26 +812,17 @@ class AsyncioRouter:
     ) -> None:
         """Called from worker threads via add_done_callback.
 
-        The happy path (metrics + on_request_completed + cache decrement) is
-        thread-safe and runs directly. Error handling (actor died/unavailable)
-        mutates shared router state and is deferred to the event loop.
-
-        should_decrement_cache is a mutable single-element list used as a
-        flag. For the with-rejection path, it is set to True after acceptance
-        on the event loop thread before this callback fires.
+        Metrics and request completion run directly (thread-safe).
+        Error handling is deferred to the event loop.
         """
-        # Thread-safe: dec uses self._queries_lock internally.
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
             self._metrics_manager.dec_num_running_requests_for_replica(replica_id)
 
-        # Thread-safe: on_request_completed is a no-op in the base class.
         if self.request_router:
             self.request_router.on_request_completed(replica_id, internal_request_id)
-            # GIL-atomic deque append, drained on event loop before routing.
             if should_decrement_cache[0]:
                 self.request_router.enqueue_cache_decrement(replica_id)
 
-        # Error handling: mutates shared state, must run on event loop.
         actor_died_error = self._get_actor_died_error(result)
         if actor_died_error is not None:
             self._event_loop.call_soon_threadsafe(

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -807,6 +807,7 @@ class AsyncioRouter:
         replica_id: ReplicaID,
         internal_request_id: str,
         replica_actor_id: Optional[ray.ActorID],
+        decrement_queue_len_cache: bool,
         result: Union[Any, RayError],
     ) -> None:
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
@@ -815,6 +816,8 @@ class AsyncioRouter:
         # Notify request router that request completed (for cleanup, e.g., token release)
         if self.request_router:
             self.request_router.on_request_completed(replica_id, internal_request_id)
+            if decrement_queue_len_cache:
+                self.request_router.decrement_queue_len_cache(replica_id)
 
         actor_died_error = self._get_actor_died_error(result)
         if actor_died_error is not None:
@@ -927,29 +930,38 @@ class AsyncioRouter:
                 )
             # Always register callback to notify router when request completes
             # (needed for token release in queue-based routing, metrics tracking, etc.)
+            # A single callback handles both request cleanup and cache
+            # decrement to avoid the overhead of multiple add_done_callback
+            # registrations per request.
+
+            if not with_rejection:
+                callback = partial(
+                    self._process_finished_request,
+                    replica.replica_id,
+                    pr.metadata.internal_request_id,
+                    replica.actor_id,
+                    True,  # decrement_queue_len_cache
+                )
+                result.add_done_callback(callback)
+                callback_registered = True
+                return result
+
             callback = partial(
                 self._process_finished_request,
                 replica.replica_id,
                 pr.metadata.internal_request_id,
                 replica.actor_id,
+                False,  # decrement_queue_len_cache — not yet known if accepted
             )
             result.add_done_callback(callback)
             callback_registered = True
-
-            if not with_rejection:
-                result.add_done_callback(
-                    lambda _: self.request_router.enqueue_cache_decrement(
-                        replica.replica_id,
-                    )
-                )
-                return result
 
             queue_info = await result.get_rejection_response()
             self.request_router.on_new_queue_len_info(replica.replica_id, queue_info)
             if queue_info.accepted:
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
                 result.add_done_callback(
-                    lambda _: self.request_router.enqueue_cache_decrement(
+                    lambda _: self.request_router.decrement_queue_len_cache(
                         replica.replica_id,
                     )
                 )

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -927,26 +927,18 @@ class AsyncioRouter:
                 )
             # Always register callback to notify router when request completes
             # (needed for token release in queue-based routing, metrics tracking, etc.)
-            # NOTE: add_done_callback fires from a C++ worker thread (for actor
-            # ObjectRefs) or a gRPC callback thread. _process_finished_request
-            # and decrement_queue_len_cache both access shared router state
-            # (e.g., _replica_queue_len_cache) that is not thread-safe, so we
-            # schedule them on the router's event loop.
             callback = partial(
                 self._process_finished_request,
                 replica.replica_id,
                 pr.metadata.internal_request_id,
                 replica.actor_id,
             )
-            result.add_done_callback(
-                lambda _, cb=callback: self._event_loop.call_soon_threadsafe(cb, _)
-            )
+            result.add_done_callback(callback)
             callback_registered = True
 
             if not with_rejection:
                 result.add_done_callback(
-                    lambda _: self._event_loop.call_soon_threadsafe(
-                        self.request_router.decrement_queue_len_cache,
+                    lambda _: self.request_router.decrement_queue_len_cache(
                         replica.replica_id,
                     )
                 )
@@ -957,8 +949,7 @@ class AsyncioRouter:
             if queue_info.accepted:
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
                 result.add_done_callback(
-                    lambda _: self._event_loop.call_soon_threadsafe(
-                        self.request_router.decrement_queue_len_cache,
+                    lambda _: self.request_router.decrement_queue_len_cache(
                         replica.replica_id,
                     )
                 )

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -1759,7 +1759,7 @@ async def test_queue_len_cache_entries_added_correctly(pow_2_router):
 )
 async def test_queue_len_cache_decremented_on_request_completion(pow_2_router):
     """
-    Verify that enqueue_cache_decrement + drain decrements the queue length cache.
+    Verify that decrement_queue_len_cache decrements the queue length cache.
     Without this, with max_ongoing_requests=1 the cache gets stuck at 1
     after routing, causing every subsequent pick to require blocking probe RPCs.
     """
@@ -1773,8 +1773,7 @@ async def test_queue_len_cache_decremented_on_request_completion(pow_2_router):
     assert s._replica_queue_len_cache.get(r1.replica_id) == 1
 
     # Request completes - cache should decrement to 0
-    s.enqueue_cache_decrement(r1.replica_id)
-    s.drain_pending_cache_decrements()
+    s.decrement_queue_len_cache(r1.replica_id)
     assert s._replica_queue_len_cache.get(r1.replica_id) == 0
 
 
@@ -1798,16 +1797,13 @@ async def test_queue_len_cache_decremented_multiple_requests(pow_2_router):
     assert s._replica_queue_len_cache.get(r1.replica_id) == 3
 
     # Each completion decrements
-    s.enqueue_cache_decrement(r1.replica_id)
-    s.drain_pending_cache_decrements()
+    s.decrement_queue_len_cache(r1.replica_id)
     assert s._replica_queue_len_cache.get(r1.replica_id) == 2
 
-    s.enqueue_cache_decrement(r1.replica_id)
-    s.drain_pending_cache_decrements()
+    s.decrement_queue_len_cache(r1.replica_id)
     assert s._replica_queue_len_cache.get(r1.replica_id) == 1
 
-    s.enqueue_cache_decrement(r1.replica_id)
-    s.drain_pending_cache_decrements()
+    s.decrement_queue_len_cache(r1.replica_id)
     assert s._replica_queue_len_cache.get(r1.replica_id) == 0
 
 
@@ -1829,8 +1825,7 @@ async def test_queue_len_cache_decrement_does_not_go_negative(pow_2_router):
     s._replica_queue_len_cache.update(r1.replica_id, 0)
 
     # Duplicate or spurious completion - should stay at 0
-    s.enqueue_cache_decrement(r1.replica_id)
-    s.drain_pending_cache_decrements()
+    s.decrement_queue_len_cache(r1.replica_id)
     assert s._replica_queue_len_cache.get(r1.replica_id) == 0
 
 
@@ -1844,7 +1839,7 @@ async def test_queue_len_cache_decrement_does_not_go_negative(pow_2_router):
 )
 async def test_queue_len_cache_decrement_skipped_when_expired(pow_2_router):
     """
-    Verify that enqueue_cache_decrement does not add a cache entry when the
+    Verify that decrement_queue_len_cache does not add a cache entry when the
     replica's cache entry has expired (get returns None).
     """
     s = pow_2_router
@@ -1857,8 +1852,7 @@ async def test_queue_len_cache_decrement_skipped_when_expired(pow_2_router):
     assert s._replica_queue_len_cache.get(r1.replica_id) is None
 
     # Completion should not add an entry (we only update when current is not None)
-    s.enqueue_cache_decrement(r1.replica_id)
-    s.drain_pending_cache_decrements()
+    s.decrement_queue_len_cache(r1.replica_id)
 
     # Cache should still be empty - we don't incorrectly create an entry
     assert s._replica_queue_len_cache.get(r1.replica_id) is None

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -1759,7 +1759,7 @@ async def test_queue_len_cache_entries_added_correctly(pow_2_router):
 )
 async def test_queue_len_cache_decremented_on_request_completion(pow_2_router):
     """
-    Verify that decrement_queue_len_cache decrements the queue length cache.
+    Verify that enqueue_cache_decrement + drain decrements the queue length cache.
     Without this, with max_ongoing_requests=1 the cache gets stuck at 1
     after routing, causing every subsequent pick to require blocking probe RPCs.
     """
@@ -1773,7 +1773,8 @@ async def test_queue_len_cache_decremented_on_request_completion(pow_2_router):
     assert s._replica_queue_len_cache.get(r1.replica_id) == 1
 
     # Request completes - cache should decrement to 0
-    s.decrement_queue_len_cache(r1.replica_id)
+    s.enqueue_cache_decrement(r1.replica_id)
+    s.drain_pending_cache_decrements()
     assert s._replica_queue_len_cache.get(r1.replica_id) == 0
 
 
@@ -1797,13 +1798,16 @@ async def test_queue_len_cache_decremented_multiple_requests(pow_2_router):
     assert s._replica_queue_len_cache.get(r1.replica_id) == 3
 
     # Each completion decrements
-    s.decrement_queue_len_cache(r1.replica_id)
+    s.enqueue_cache_decrement(r1.replica_id)
+    s.drain_pending_cache_decrements()
     assert s._replica_queue_len_cache.get(r1.replica_id) == 2
 
-    s.decrement_queue_len_cache(r1.replica_id)
+    s.enqueue_cache_decrement(r1.replica_id)
+    s.drain_pending_cache_decrements()
     assert s._replica_queue_len_cache.get(r1.replica_id) == 1
 
-    s.decrement_queue_len_cache(r1.replica_id)
+    s.enqueue_cache_decrement(r1.replica_id)
+    s.drain_pending_cache_decrements()
     assert s._replica_queue_len_cache.get(r1.replica_id) == 0
 
 
@@ -1825,7 +1829,8 @@ async def test_queue_len_cache_decrement_does_not_go_negative(pow_2_router):
     s._replica_queue_len_cache.update(r1.replica_id, 0)
 
     # Duplicate or spurious completion - should stay at 0
-    s.decrement_queue_len_cache(r1.replica_id)
+    s.enqueue_cache_decrement(r1.replica_id)
+    s.drain_pending_cache_decrements()
     assert s._replica_queue_len_cache.get(r1.replica_id) == 0
 
 
@@ -1839,7 +1844,7 @@ async def test_queue_len_cache_decrement_does_not_go_negative(pow_2_router):
 )
 async def test_queue_len_cache_decrement_skipped_when_expired(pow_2_router):
     """
-    Verify that decrement_queue_len_cache does not add a cache entry when the
+    Verify that enqueue_cache_decrement does not add a cache entry when the
     replica's cache entry has expired (get returns None).
     """
     s = pow_2_router
@@ -1852,7 +1857,8 @@ async def test_queue_len_cache_decrement_skipped_when_expired(pow_2_router):
     assert s._replica_queue_len_cache.get(r1.replica_id) is None
 
     # Completion should not add an entry (we only update when current is not None)
-    s.decrement_queue_len_cache(r1.replica_id)
+    s.enqueue_cache_decrement(r1.replica_id)
+    s.drain_pending_cache_decrements()
 
     # Cache should still be empty - we don't incorrectly create an entry
     assert s._replica_queue_len_cache.get(r1.replica_id) is None

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1,4 +1,5 @@
 import asyncio
+import collections
 import concurrent.futures
 import random
 import sys
@@ -159,6 +160,7 @@ class FakeRequestRouter(RequestRouter):
         self._replica_to_return: Optional[FakeReplica] = None
         self._replica_to_return_on_retry: Optional[FakeReplica] = None
         self._replica_queue_len_cache = ReplicaQueueLengthCache()
+        self._pending_cache_decrements = collections.deque()
         self._dropped_replicas: Set[ReplicaID] = set()
         self._use_queue_len_cache = use_queue_len_cache
         self._use_replica_queue_len_cache = use_queue_len_cache


### PR DESCRIPTION
## Summary

#61755 wrapped all of `_process_finished_request` in `call_soon_threadsafe` to schedule it on the event loop, making it thread-safe. This added per-request cross-thread wakeups that regressed throughput by 5-9%.

Reverting `call_soon_threadsafe` consistently recovers throughput (~+7% relative to HEAD across multiple sessions). However, we were unable to find a thread-safe alternative that recovers performance — every approach we tried (locks, deques, merged callbacks, mutable flags) adds overhead that offsets the savings from removing `call_soon_threadsafe`.

This PR currently contains the best thread-safe approach (single callback + mutable flag + deque for cache decrements), but it does **not** meaningfully improve throughput over HEAD. See iteration log below.

The commit history includes intermediate approaches — review the final file state.

## Benchmark (m7a.4xlarge, 16 vCPU, same-session A/B)

| Metric       | HEAD  | Full revert (unsafe) | Baseline (Feb 23) |
|------------- |-------|----------------------|-------------------|
| handle_100   | 1523  | 1601 (+5.1%)         | 1724              |
| handle_800   | 1300  | 1407 (+8.2%)         | 1535              |
| http         | 464   | 483 (+4.1%)          | 528               |

No thread-safe variant we tested improved over HEAD. See [iteration logs](https://github.com/eicherseiji/ray/tree/fix/serve-throughput-regression-call-soon-threadsafe) for details.

## What we tried

| # | Approach | Result |
|---|----------|--------|
| 1 | Direct happy path, `call_soon_threadsafe` error paths, deque cache | ~0% vs HEAD |
| 2 | Fold cache into single callback (no-rejection only) | ~0% (benchmark uses with-rejection) |
| 3 | Single callback + mutable flag for all paths | ~0% (extra partial arg offsets savings) |
| 4 | Plain bool, two callbacks | -8% (worse than HEAD) |
| 5 | Merged `call_soon_threadsafe` (1 per request) | 0% |
| 6 | Two direct callbacks, no deque | ~0% |
| 7 | `threading.Lock` on cache | ~0% |
| 8 | Deque for cache, `call_soon_threadsafe` for `_process_finished_request` | 0% |

**Key finding:** At ~1700 RPS, the cost of `call_soon_threadsafe` (~500ns) ≈ cost of any thread-safety machinery we add. The only way to recover throughput is to remove `call_soon_threadsafe` entirely, which restores the pre-#61755 threading model with races on error paths (actor died/unavailable).

## Test plan

- [x] `pytest python/ray/serve/tests/unit/test_pow_2_request_router.py` — 128 passed
- [x] `pytest python/ray/serve/tests/unit/test_router.py` — 47 passed
- [ ] `python release/serve_tests/workloads/microbenchmarks.py --run-throughput`