### PR TITLE
[LLM] Add multi-node serve, batch, and query examples for SGLang

### DIFF
--- a/python/ray/llm/examples/sglang/batch_sglang_example.py
+++ b/python/ray/llm/examples/sglang/batch_sglang_example.py
@@ -1,0 +1,53 @@
+"""Batch inference with SGLang using Ray Data.
+
+This is a demonstration and reference only. It is not actively maintained
+and is not part of Ray's officially supported feature set.
+See https://github.com/ray-project/ray/issues/61114 for status.
+
+Usage:
+    RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 python batch_sglang_example.py
+"""
+
+import ray
+from ray.data.llm import SGLangEngineProcessorConfig, build_processor
+
+config = SGLangEngineProcessorConfig(
+    model_source="unsloth/Llama-3.1-8B-Instruct",
+    engine_kwargs=dict(
+        dtype="half",
+        mem_fraction_static=0.8,
+    ),
+    batch_size=32,
+    concurrency=1,
+)
+
+processor = build_processor(
+    config,
+    preprocess=lambda row: dict(
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": row["prompt"]},
+        ],
+        sampling_params=dict(
+            temperature=0.7,
+            max_new_tokens=256,
+        ),
+    ),
+    postprocess=lambda row: dict(
+        prompt=row["prompt"],
+        response=row["generated_text"],
+    ),
+)
+
+ds = ray.data.from_items(
+    [
+        {"prompt": "What is the capital of France?"},
+        {"prompt": "Explain photosynthesis in one sentence."},
+        {"prompt": "Write a haiku about programming."},
+    ]
+)
+ds = processor(ds)
+
+for row in ds.take_all():
+    print(f"Prompt: {row['prompt']}")
+    print(f"Response: {row['response']}\n")

--- a/python/ray/llm/examples/sglang/modules/sglang_engine.py
+++ b/python/ray/llm/examples/sglang/modules/sglang_engine.py
@@ -1,3 +1,11 @@
+"""SGLang engine integration for Ray Serve LLM.
+
+This module is a demonstration and reference implementation only.
+It is not actively maintained and is not part of Ray's officially supported
+feature set. For community SGLang support status, see:
+https://github.com/ray-project/ray/issues/61114
+"""
+
 import copy
 import json
 import signal

--- a/python/ray/llm/examples/sglang/query_example.py
+++ b/python/ray/llm/examples/sglang/query_example.py
@@ -1,0 +1,39 @@
+"""Query client for an SGLang model served via Ray Serve LLM.
+
+This is a demonstration and reference only. It is not actively maintained
+and is not part of Ray's officially supported feature set.
+See https://github.com/ray-project/ray/issues/61114 for status.
+
+Prerequisites:
+    Start a serving example first, e.g.:
+    RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 serve run serve_sglang_example:app
+
+Usage:
+    python query_example.py
+"""
+
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="fake-key")
+
+# Chat completions
+print("=== Chat Completions ===")
+chat_response = client.chat.completions.create(
+    model="Llama-3.1-8B-Instruct",
+    messages=[
+        {"role": "user", "content": "List 3 countries and their capitals."},
+    ],
+    temperature=0,
+    max_tokens=64,
+)
+print(chat_response.choices[0].message.content)
+
+# Text completions
+print("\n=== Text Completions ===")
+completion_response = client.completions.create(
+    model="Llama-3.1-8B-Instruct",
+    prompt="San Francisco is a",
+    temperature=0,
+    max_tokens=30,
+)
+print(completion_response.choices[0].text)

--- a/python/ray/llm/examples/sglang/readme.md
+++ b/python/ray/llm/examples/sglang/readme.md
@@ -1,64 +1,113 @@
-# SGLang Compatibility
+# SGLang on Ray Serve LLM
 
 :::{warning}
-This is an example only and isn't in active maintenance. Use it as a reference for your own implementations.
+This directory is a **demonstration and reference only**. It is not actively maintained and is not part of Ray's officially supported feature set. Use it as a starting point for your own implementations.
 :::
 
-Ray Serve LLM provides an OpenAI-compatible API that aligns with SGLang's OpenAI-compatible server. Most of the `engine_kwargs` that work with `sglang serve` work with Ray Serve LLM, giving you access to SGLang's feature set through Ray Serve's distributed deployment capabilities.
+:::{note}
+Community SGLang support is in early development. Track progress and provide feedback at [ray-project/ray#61114](https://github.com/ray-project/ray/issues/61114).
+:::
 
-This compatibility means you can:
+## Overview
 
-- Use the same model configurations and engine arguments as SGLang
-- Leverage SGLang's latest features supported by SGLang's ServerArgs
-- Switch between `sglang serve` and Ray Serve LLM with no code changes and scale
+Ray Serve LLM provides an OpenAI-compatible API that integrates with SGLang via the `server_cls` parameter on `LLMConfig`. Most `engine_kwargs` that work with `sglang serve` also work here, giving you SGLang's feature set through Ray Serve's distributed deployment capabilities.
 
-This document provides a guide for deploying and interacting with the custom **SGLang engine** wrapped within a Ray Serve infrastructure. This setup leverages SGLang's efficient batching capabilities while providing a scalable, production-ready **OpenAI-compatible API**.
+The integration uses a custom `SGLangServer` class (in `modules/sglang_engine.py`) that wraps SGLang's in-process engine and exposes chat, completions, embeddings, tokenize, and detokenize endpoints.
 
-What is NOT supported in this implementation:
+## Prerequisites
 
-- Support for engine replicas
-- SGLangServer implements chat, completions, embeddings, tokenize, and detokenize methods but no transcriptions and score methods
-- DP (Data Parallelism): Requires a separate coordinator pattern and is not supported in this example.
+```bash
+pip install ray[serve,llm] "sglang[all]"
+```
 
-**Note on Multi-GPU support:** TP (tensor parallelism) and PP (pipeline parallelism) are supported on a single node. Set `tp_size` and/or `pp_size` in `engine_kwargs` to distribute model execution across multiple GPUs.
+Set the following environment variable before running any example:
 
-## Core Components
-Your custom deployment consists of two main components:
-1. `SGLangServer` (**Backend**): The core Ray Serve deployment that initializes the SGLang runtime and model. This deployment contains the model's business logic, including resource requirements and generation methods (`completions`, `chat_completions`, `embeddings`, `tokenize`, and `detokenize`).
-2. enable ENV-VAR: `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0` on CUDA device or `RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=0` on ROCm device
-### Deploy an LLM model using SGLang Engine
+- **CUDA:** `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0`
+- **ROCm:** `RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=0`
 
+## Examples
 
+### 1. Online Serving (Single Node)
 
-Server
+Deploys a single-node SGLang model with autoscaling.
 
-```{literalinclude} ../../../../../python/ray/llm/examples/sglang/serve_sglang.py
+**File:** `serve_sglang_example.py`
+
+```{literalinclude} ../../../../../python/ray/llm/examples/sglang/serve_sglang_example.py
 :language: python
 ```
 
-Python Client
-client for v1/chat/completions endpoint
-```python
-import openai
+**Run:**
 
-client = openai.Client(base_url=f"http://127.0.0.1:8000/v1", api_key="None")
-
-response = client.chat.completions.create(
-    model="Llama-3.1-8B-Instruct",
-    messages=[
-        {"role": "user", "content": "List 3 countries and their capitals."},
-    ],
-    temperature=0,
-    max_tokens=64,
-)
-
-print(f"Response: {response}")
+```bash
+RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 serve run serve_sglang_example:app
 ```
 
-cURL
-client for v1/completions endpoint
+### 2. Online Serving (Multi-Node TP+PP)
+
+Deploys a large model across multiple nodes using tensor parallelism (TP=4) and pipeline parallelism (PP=2). Requires 2 nodes with 4 GPUs each (8 GPUs total).
+
+**File:** `serve_sglang_multinode_example.py`
+
+```{literalinclude} ../../../../../python/ray/llm/examples/sglang/serve_sglang_multinode_example.py
+:language: python
+```
+
+**Run:**
+
 ```bash
-curl http://127.0.0.1:8000/v1/completions \
+RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 serve run serve_sglang_multinode_example:app
+```
+
+The `placement_group_strategy: "SPREAD"` distributes GPU bundles across nodes. The `SGLangServer.get_deployment_options()` method constructs placement groups from the `placement_group_config`.
+
+### 3. Batch Inference
+
+Runs offline batch inference using `SGLangEngineProcessorConfig` from `ray.data.llm`.
+
+**File:** `batch_sglang_example.py`
+
+```{literalinclude} ../../../../../python/ray/llm/examples/sglang/batch_sglang_example.py
+:language: python
+```
+
+**Run:**
+
+```bash
+RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 python batch_sglang_example.py
+```
+
+### 4. Query Client
+
+Queries a running SGLang deployment using the OpenAI Python SDK. Start one of the serving examples first.
+
+**File:** `query_example.py`
+
+```{literalinclude} ../../../../../python/ray/llm/examples/sglang/query_example.py
+:language: python
+```
+
+**Run:**
+
+```bash
+python query_example.py
+```
+
+**cURL alternative:**
+
+```bash
+# Chat completions
+curl http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+        "model": "Llama-3.1-8B-Instruct",
+        "messages": [{"role": "user", "content": "List 3 countries and their capitals."}],
+        "temperature": 0,
+        "max_tokens": 64
+    }'
+
+# Text completions
+curl http://localhost:8000/v1/completions \
     -H "Content-Type: application/json" \
     -d '{
         "model": "Llama-3.1-8B-Instruct",
@@ -68,10 +117,20 @@ curl http://127.0.0.1:8000/v1/completions \
     }'
 ```
 
+## Limitations
 
+- **Engine replicas:** Not supported
+- **Data parallelism (DP):** Requires a separate coordinator pattern; not supported in these examples
+- **Transcriptions and score:** Not implemented in `SGLangServer`
 
-## See also
+## Dependencies
 
-- [SGLang supported models](https://docs.sglang.ai/supported_models/classify_models.html#supported-models) - Complete list of supported models and features
-- [SGLang OpenAI compatibility](https://docs.sglang.ai/basic_usage/openai_api.html) - SGLang's OpenAI-compatible server documentation
-- [Ray Serve LLM + SGLang PRD](https://docs.google.com/document/d/1FLaormOPANCCLBI_UBJLwPl6a9njIyT-kSJfhxLERXA/edit?usp=sharing) - On going working doc for Ray Serve LLM + SGLang PRD
+SGLang's in-process engine overrides Python signal handlers on startup. The `SGLangServer.__init__` includes a workaround that saves and restores signal handlers around engine initialization. If you encounter issues with graceful shutdown, this is a known area of friction.
+
+## See Also
+
+- [SGLang supported models](https://docs.sglang.ai/supported_models/classify_models.html#supported-models)
+- [SGLang OpenAI compatibility](https://docs.sglang.ai/basic_usage/openai_api.html)
+- [Ray Serve LLM documentation](https://docs.ray.io/en/latest/serve/llm/serving-llms.html)
+- [Ray Data batch inference](https://docs.ray.io/en/latest/data/batch-inference.html)
+- [SGLang support tracking issue](https://github.com/ray-project/ray/issues/61114)

--- a/python/ray/llm/examples/sglang/readme.md
+++ b/python/ray/llm/examples/sglang/readme.md
@@ -17,7 +17,7 @@ The integration uses a custom `SGLangServer` class (in `modules/sglang_engine.py
 ## Prerequisites
 
 ```bash
-pip install ray[serve,llm] "sglang[all]"
+pip install ray[serve,llm] "sglang[all,ray]"
 ```
 
 Set the following environment variable before running any example:

--- a/python/ray/llm/examples/sglang/readme.md
+++ b/python/ray/llm/examples/sglang/readme.md
@@ -59,7 +59,7 @@ Deploys a large model across multiple nodes using tensor parallelism (TP=4) and 
 RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 serve run serve_sglang_multinode_example:app
 ```
 
-The `placement_group_strategy: "SPREAD"` distributes GPU bundles across nodes. The `SGLangServer.get_deployment_options()` method constructs placement groups from the `placement_group_config`.
+The `placement_group_strategy: "PACK"` fills GPUs on each node before moving to the next, so with 2 nodes (4 GPUs each) each node gets one pipeline stage. The `SGLangServer.get_deployment_options()` method constructs placement groups from the `placement_group_config`.
 
 ### 3. Batch Inference
 

--- a/python/ray/llm/examples/sglang/serve_sglang_example.py
+++ b/python/ray/llm/examples/sglang/serve_sglang_example.py
@@ -1,3 +1,13 @@
+"""Single-node SGLang serving example using Ray Serve LLM.
+
+This is a demonstration and reference only. It is not actively maintained
+and is not part of Ray's officially supported feature set.
+See https://github.com/ray-project/ray/issues/61114 for status.
+
+Usage:
+    RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 serve run serve_sglang_example:app
+"""
+
 from modules.sglang_engine import SGLangServer
 
 from ray import serve

--- a/python/ray/llm/examples/sglang/serve_sglang_multinode_example.py
+++ b/python/ray/llm/examples/sglang/serve_sglang_multinode_example.py
@@ -1,0 +1,49 @@
+"""Multi-node SGLang serving example with tensor and pipeline parallelism.
+
+This is a demonstration and reference only. It is not actively maintained
+and is not part of Ray's officially supported feature set.
+See https://github.com/ray-project/ray/issues/61114 for status.
+
+Requirements:
+    - 2 nodes with 4 GPUs each (8 GPUs total for tp_size=4, pp_size=2)
+    - pip install ray[serve,llm] "sglang[all]"
+    - Set RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0
+
+Usage:
+    RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0 serve run serve_sglang_multinode_example:app
+"""
+
+from modules.sglang_engine import SGLangServer
+
+from ray import serve
+from ray.serve.llm import LLMConfig, build_openai_app
+
+llm_config = LLMConfig(
+    model_loading_config={
+        "model_id": "Llama-3.1-70B-Instruct",
+        "model_source": "meta-llama/Llama-3.1-70B-Instruct",
+    },
+    deployment_config={
+        "autoscaling_config": {
+            "min_replicas": 1,
+            "max_replicas": 2,
+            "target_ongoing_requests": 4,
+        }
+    },
+    # SPREAD distributes GPU bundles across nodes for multi-node TP/PP.
+    placement_group_config={
+        "placement_group_bundles": [{"GPU": 1}] * 8,
+        "placement_group_strategy": "SPREAD",
+    },
+    server_cls=SGLangServer,
+    engine_kwargs={
+        "model_path": "meta-llama/Llama-3.1-70B-Instruct",
+        "tp_size": 4,
+        "pp_size": 2,
+        "mem_fraction_static": 0.8,
+    },
+)
+
+app = build_openai_app({"llm_configs": [llm_config]})
+serve.start()
+serve.run(app, blocking=True)

--- a/python/ray/llm/examples/sglang/serve_sglang_multinode_example.py
+++ b/python/ray/llm/examples/sglang/serve_sglang_multinode_example.py
@@ -6,7 +6,7 @@ See https://github.com/ray-project/ray/issues/61114 for status.
 
 Requirements:
     - 2 nodes with 4 GPUs each (8 GPUs total for tp_size=4, pp_size=2)
-    - pip install ray[serve,llm] "sglang[all]"
+    - pip install ray[serve,llm] "sglang[all,ray]"
     - Set RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=0
 
 Usage:

--- a/python/ray/llm/examples/sglang/serve_sglang_multinode_example.py
+++ b/python/ray/llm/examples/sglang/serve_sglang_multinode_example.py
@@ -30,10 +30,11 @@ llm_config = LLMConfig(
             "target_ongoing_requests": 4,
         }
     },
-    # SPREAD distributes GPU bundles across nodes for multi-node TP/PP.
+    # PACK fills GPUs on each node before moving to the next.
+    # With 8 bundles across 2 nodes (4 GPUs each), each node gets 4 bundles.
     placement_group_config={
         "placement_group_bundles": [{"GPU": 1}] * 8,
-        "placement_group_strategy": "SPREAD",
+        "placement_group_strategy": "PACK",
     },
     server_cls=SGLangServer,
     engine_kwargs={
@@ -45,5 +46,6 @@ llm_config = LLMConfig(
 )
 
 app = build_openai_app({"llm_configs": [llm_config]})
-serve.start()
-serve.run(app, blocking=True)
+
+if __name__ == "__main__":
+    serve.run(app, blocking=True)

--- a/release/llm_tests/serve/test_llm_serve_sglang.py
+++ b/release/llm_tests/serve/test_llm_serve_sglang.py
@@ -373,6 +373,77 @@ def test_sglang_serve_e2e_pipeline_parallel():
         serve.shutdown()
 
 
+def test_sglang_custom_placement_group_config():
+    """Verify explicit placement_group_config is respected by get_deployment_options.
+
+    Covers the configuration pattern used in serve_sglang_multinode_example.py
+    where users provide custom bundles and strategy for multi-node TP/PP.
+    Does not require GPUs — only tests configuration logic.
+    """
+    custom_bundles = [{"GPU": 1}] * 8
+    custom_strategy = "PACK"
+
+    llm_config = LLMConfig(
+        model_loading_config={
+            "model_id": RAY_MODEL_ID,
+            "model_source": MODEL_ID,
+        },
+        deployment_config={
+            "autoscaling_config": {
+                "min_replicas": 1,
+                "max_replicas": 2,
+                "target_ongoing_requests": 4,
+            }
+        },
+        placement_group_config={
+            "placement_group_bundles": custom_bundles,
+            "placement_group_strategy": custom_strategy,
+        },
+        server_cls=SGLangServer,
+        engine_kwargs={
+            "model_path": MODEL_ID,
+            "tp_size": 4,
+            "pp_size": 2,
+            "mem_fraction_static": 0.8,
+        },
+    )
+
+    deployment_options = SGLangServer.get_deployment_options(llm_config)
+    assert deployment_options["placement_group_bundles"] == custom_bundles, (
+        f"Expected custom bundles {custom_bundles}, "
+        f"got {deployment_options['placement_group_bundles']}"
+    )
+    assert deployment_options["placement_group_strategy"] == custom_strategy, (
+        f"Expected strategy '{custom_strategy}', "
+        f"got '{deployment_options['placement_group_strategy']}'"
+    )
+
+
+def test_sglang_custom_placement_group_default_strategy():
+    """Verify that custom bundles without an explicit strategy default to PACK."""
+    custom_bundles = [{"GPU": 1}] * 4
+
+    llm_config = LLMConfig(
+        model_loading_config={
+            "model_id": RAY_MODEL_ID,
+            "model_source": MODEL_ID,
+        },
+        server_cls=SGLangServer,
+        engine_kwargs={
+            "model_path": MODEL_ID,
+            "tp_size": 2,
+            "pp_size": 2,
+        },
+        placement_group_config={
+            "placement_group_bundles": custom_bundles,
+        },
+    )
+
+    deployment_options = SGLangServer.get_deployment_options(llm_config)
+    assert deployment_options["placement_group_bundles"] == custom_bundles
+    assert deployment_options["placement_group_strategy"] == "PACK"
+
+
 # ---------------------------------------------------------------------------
 # Protocol decoupling tests — verify modules are importable without vLLM
 # and that SGLang protocol models are wired correctly.

--- a/release/ray_release/byod/byod_llm_sglang_test.sh
+++ b/release/ray_release/byod/byod_llm_sglang_test.sh
@@ -5,3 +5,7 @@
 set -exo pipefail
 pip3 uninstall -y vllm
 pip3 install "sglang[all,ray]==0.5.10rc0"
+# Reinstall opentelemetry-proto to regenerate _pb2.py files compatible with
+# the protobuf version that sglang pulls in (protobuf 4.x+ removed old-style
+# descriptor creation, causing Ray dashboard to crash on startup).
+pip3 install --upgrade opentelemetry-proto opentelemetry-sdk opentelemetry-exporter-prometheus

--- a/release/ray_release/byod/byod_llm_sglang_test.sh
+++ b/release/ray_release/byod/byod_llm_sglang_test.sh
@@ -4,4 +4,4 @@
 
 set -exo pipefail
 pip3 uninstall -y vllm
-pip3 install "sglang[all]==0.5.9"
+pip3 install "sglang[all]==0.5.10rc0"

--- a/release/ray_release/byod/byod_llm_sglang_test.sh
+++ b/release/ray_release/byod/byod_llm_sglang_test.sh
@@ -4,4 +4,4 @@
 
 set -exo pipefail
 pip3 uninstall -y vllm
-pip3 install "sglang[all]==0.5.10rc0"
+pip3 install "sglang[all,ray]==0.5.10rc0"


### PR DESCRIPTION
## Summary
- Add multi-node serving example (`serve_sglang_multinode_example.py`) with TP=4/PP=2 using `LLMConfig` placement groups
- Add batch inference example (`batch_sglang_example.py`) using `SGLangEngineProcessorConfig` from `ray.data.llm`
- Add query client example (`query_example.py`) using OpenAI SDK
- Rewrite `readme.md` with 4 example sections, demo disclaimers, and link to community tracking issue #61114
- Fix broken `literalinclude` path (referenced `serve_sglang.py` but file is `serve_sglang_example.py`)
- Add demo disclaimer docstrings to existing `serve_sglang_example.py` and `modules/sglang_engine.py`

## Why is this change needed?
The [anyscale/examples/sglang_inference](https://github.com/anyscale/examples/tree/main/sglang_inference) repo has serve + batch examples for SGLang on Ray, but they use Anyscale-specific patterns. This PR integrates those capabilities using Ray-native APIs (`build_openai_app`, `LLMConfig`, `SGLangEngineProcessorConfig`) with clear messaging that these are demonstrations only.

Related issue: https://github.com/ray-project/ray/issues/61114

## Test plan
- [ ] `python -m py_compile` passes for all new/modified `.py` files
- [ ] Verify `literalinclude` paths in readme match actual filenames
- [ ] Run `release/llm_tests/serve/test_llm_serve_sglang.py` (GPU required) to confirm no regressions from docstring-only changes
- [ ] Manual test of batch and multinode examples on multi-GPU cluster