### PR TITLE
[core] pin cupy-cuda12x in LLM BYOD for RDT A100 benchmark

### DIFF
--- a/release/ray_release/byod/byod_llm_pin_cupy_cuda12x.sh
+++ b/release/ray_release/byod/byod_llm_pin_cupy_cuda12x.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# The LLM BYOD extra-testdeps lock can resolve a newer cupy-cuda12x than the
+# ray-llm base image (see python/deplocks/llm/rayllm_py311_cu128.lock /
+# rayllm_py312_cu130.lock). That breaks Ray's NCCL collectives, which import
+# CuPy. Re-pin to the same version as the LLM base after BYOD pip install.
+pip3 install --no-cache-dir "cupy-cuda12x==13.6.0"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2323,6 +2323,7 @@
   cluster:
     byod:
       type: llm-cu128 # llm image already has nixl
+      post_build_script: byod_llm_pin_cupy_cuda12x.sh # match cupy-cuda12x to ray-llm base lock (BYOD testdeps can float major)
       runtime_env: # env vars for nixl
         - UCX_TLS=all
         - UCX_NET_DEVICES=all


### PR DESCRIPTION


## Description
Add byod_llm_pin_cupy_cuda12x.sh so custom BYOD images reinstall cupy-cuda12x==13.6.0 after extra-testdeps, matching the ray-llm base lock and avoiding NCCL collective import failures from a newer CuPy.


## Related issues
https://github.com/anyscale/ray/issues/1177

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
