### PR TITLE
[core] print out the grpc peer address on GCS's HandleUnregisterNode

### DIFF
--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -168,10 +168,12 @@ void GcsNodeManager::HandleCheckAlive(rpc::CheckAliveRequest request,
 
 void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
                                           rpc::UnregisterNodeReply *reply,
-                                          rpc::SendReplyCallback send_reply_callback) {
+                                          rpc::SendReplyCallback send_reply_callback,
+                                          const std::string &grpc_peer) {
   absl::MutexLock lock(&mutex_);
   NodeID node_id = NodeID::FromBinary(request.node_id());
-  RAY_LOG(DEBUG).WithField(node_id) << "HandleUnregisterNode() for node";
+  RAY_LOG(INFO).WithField(node_id).WithField("grpc_peer", grpc_peer)
+      << "HandleUnregisterNode() for node";
   auto node = RemoveNodeFromCache(
       node_id, request.node_death_info(), rpc::GcsNodeInfo::DEAD, current_sys_time_ms());
   if (!node) {

--- a/src/ray/gcs/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_node_manager.h
@@ -70,7 +70,8 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   /// Handle unregister rpc request come from raylet.
   void HandleUnregisterNode(rpc::UnregisterNodeRequest request,
                             rpc::UnregisterNodeReply *reply,
-                            rpc::SendReplyCallback send_reply_callback) override;
+                            rpc::SendReplyCallback send_reply_callback,
+                            const std::string &grpc_peer) override;
 
   /// TODO(#56627): This method is only called by autoscaler v1. It will be deleted
   /// once autoscaler v1 is fully deprecated. Autoscaler v2 calls

--- a/src/ray/gcs/grpc_service_interfaces.h
+++ b/src/ray/gcs/grpc_service_interfaces.h
@@ -90,7 +90,8 @@ class NodeInfoGcsServiceHandler {
 
   virtual void HandleUnregisterNode(UnregisterNodeRequest request,
                                     UnregisterNodeReply *reply,
-                                    SendReplyCallback send_reply_callback) = 0;
+                                    SendReplyCallback send_reply_callback,
+                                    const std::string &grpc_peer) = 0;
 
   virtual void HandleCheckAlive(CheckAliveRequest request,
                                 CheckAliveReply *reply,

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -52,7 +52,8 @@ void NodeInfoGrpcService::InitServerCallFactories(
                                   max_active_rpcs_per_handler_,
                                   ClusterIdAuthType::EMPTY_AUTH);
   RPC_SERVICE_HANDLER(NodeInfoGcsService, RegisterNode, max_active_rpcs_per_handler_)
-  RPC_SERVICE_HANDLER(NodeInfoGcsService, UnregisterNode, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER_WITH_GRPC_PEER(
+      NodeInfoGcsService, UnregisterNode, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(NodeInfoGcsService, DrainNode, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(NodeInfoGcsService, GetAllNodeInfo, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(

--- a/src/ray/gcs/tests/export_api/gcs_node_manager_export_event_test.cc
+++ b/src/ray/gcs/tests/export_api/gcs_node_manager_export_event_test.cc
@@ -136,7 +136,7 @@ TEST_F(GcsNodeManagerExportAPITest, TestExportEventUnregisterNode) {
       [](ray::Status status, std::function<void()> f1, std::function<void()> f2) {};
 
   node_manager.HandleUnregisterNode(
-      unregister_request, &unregister_reply, send_reply_callback);
+      unregister_request, &unregister_reply, send_reply_callback, "");
   io_service_.poll();
 
   std::vector<std::string> vc;

--- a/src/ray/gcs/tests/gcs_node_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_node_manager_test.cc
@@ -137,7 +137,7 @@ TEST_F(GcsNodeManagerTest, TestRayEventNodeEvents) {
   auto send_unregister_reply_callback =
       [](ray::Status status, std::function<void()> f1, std::function<void()> f2) {};
   node_manager.HandleUnregisterNode(
-      unregister_request, &unregister_reply, send_unregister_reply_callback);
+      unregister_request, &unregister_reply, send_unregister_reply_callback, "");
   // Exhaust the event loop
   while (io_context_->poll() > 0) {
   }
@@ -446,7 +446,7 @@ TEST_F(GcsNodeManagerTest, TestHandleGetAllNodeInfo) {
     auto send_unregister_reply_callback =
         [](ray::Status status, std::function<void()> f1, std::function<void()> f2) {};
     node_manager.HandleUnregisterNode(
-        unregister_request, &unregister_reply, send_unregister_reply_callback);
+        unregister_request, &unregister_reply, send_unregister_reply_callback, "");
     // Ensure the unregister request is processed
     while (io_context_->poll() > 0)
       ;
@@ -641,7 +641,7 @@ TEST_F(GcsNodeManagerTest, TestHandleGetAllNodeAddressAndLiveness) {
           // NoOp
         };
     node_manager.HandleUnregisterNode(
-        unregister_request, &unregister_reply, send_unregister_reply_callback);
+        unregister_request, &unregister_reply, send_unregister_reply_callback, "");
     while (io_context_->poll() > 0)
       ;
   }


### PR DESCRIPTION
## Description
This will allow us to trace where the HandleUnregisterNode request is coming from.

We also make the log an INFO log so that we can have a better understanding of the lifecycle of a node by default from the GCS perspective.
