### PR TITLE
[data] Add a concurrency cap to streaming repartition to bound in-fli…

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -451,11 +451,14 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
             bundling and may produce at most one block smaller than target_num_rows_per_block
             per input block without forcing exact sizes through block splitting.
             Defaults to False.
+        concurrency: Optional cap on the number of concurrent streaming repartition
+            tasks.
     """
 
     target_num_rows_per_block: int
     input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     strict: bool = False
+    concurrency: Optional[int] = None
     can_modify_num_rows: bool = field(init=False, default=False)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
@@ -471,8 +474,12 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
                 "target_num_rows_per_block must be positive for streaming repartition, "
                 f"got {self.target_num_rows_per_block}"
             )
+        if self.concurrency is not None and self.concurrency <= 0:
+            raise ValueError(
+                f"concurrency must be positive for streaming repartition, got {self.concurrency}"
+            )
         if self.compute is None:
-            object.__setattr__(self, "compute", TaskPoolStrategy())
+            object.__setattr__(self, "compute", TaskPoolStrategy(size=self.concurrency))
         object.__setattr__(
             self,
             "_name",

--- a/python/ray/data/_internal/logical/rules/combine_shuffles.py
+++ b/python/ray/data/_internal/logical/rules/combine_shuffles.py
@@ -57,10 +57,18 @@ class CombineShuffles(Rule):
             op, StreamingRepartition
         ):
             strict = input_op.strict or op.strict
+            combined_concurrency = input_op.concurrency
+            if combined_concurrency is None:
+                combined_concurrency = op.concurrency
+            elif op.concurrency is not None:
+                # Preserve the tighter upper bound when combining chained
+                # streaming repartition operators.
+                combined_concurrency = min(combined_concurrency, op.concurrency)
             return StreamingRepartition(
                 target_num_rows_per_block=op.target_num_rows_per_block,
                 input_dependencies=[input_op.input_dependencies[0]],
                 strict=strict,
+                concurrency=combined_concurrency,
             )
         elif isinstance(input_op, Repartition) and isinstance(op, Aggregate):
             return Aggregate(

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -240,7 +240,13 @@ class FuseOperators(Rule):
             (
                 isinstance(up_logical_op, AbstractMap)
                 and isinstance(down_logical_op, AbstractMap)
-                and self._can_fuse_map_ops(up_logical_op, down_logical_op)
+                and (
+                    # StreamingRepartition has a dedicated compatibility check
+                    # below that allows inheriting downstream task concurrency.
+                    # Avoid short-circuiting on generic map-op strategy fusion.
+                    isinstance(down_logical_op, StreamingRepartition)
+                    or self._can_fuse_map_ops(up_logical_op, down_logical_op)
+                )
             )
             or (
                 isinstance(up_logical_op, AbstractMap)
@@ -280,6 +286,11 @@ class FuseOperators(Rule):
         if isinstance(down_logical_op, StreamingRepartition):
             if not (
                 isinstance(up_logical_op, MapBatches)
+                and self._fuse_streaming_repartition_compute_strategy(
+                    up_logical_op.compute,
+                    down_logical_op.compute,
+                )
+                is not None
                 and down_logical_op.target_num_rows_per_block is not None
                 and down_logical_op.target_num_rows_per_block > 0
             ):
@@ -340,7 +351,7 @@ class FuseOperators(Rule):
             # Works with any batch_size without cross-task buffering.
             ref_bundler = None
 
-        compute = self._fuse_compute_strategy(
+        compute = self._fuse_streaming_repartition_compute_strategy(
             up_logical_op.compute, down_logical_op.compute
         )
         assert compute is not None
@@ -426,6 +437,30 @@ class FuseOperators(Rule):
             if up_compute.size is not None and up_compute.size != down_compute.max_size:
                 return None
             return down_compute
+
+    @classmethod
+    def _fuse_streaming_repartition_compute_strategy(
+        cls, up_compute: ComputeStrategy, down_compute: ComputeStrategy
+    ) -> Optional[ComputeStrategy]:
+        """Fuse compute strategies for MapBatches -> StreamingRepartition.
+
+        This path allows a default upstream task pool (size=None) to inherit an
+        explicit downstream task cap. That preserves existing fusion behavior
+        while allowing StreamingRepartition to specify its own concurrency limit.
+        """
+        compute = cls._fuse_compute_strategy(up_compute, down_compute)
+        if compute is not None:
+            return compute
+
+        if (
+            isinstance(up_compute, TaskPoolStrategy)
+            and up_compute.size is None
+            and isinstance(down_compute, TaskPoolStrategy)
+            and down_compute.size is not None
+        ):
+            return down_compute
+
+        return None
 
     def _can_merge_target_max_block_size(
         self,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1686,6 +1686,7 @@ class Dataset:
         shuffle: bool = False,
         keys: Optional[List[str]] = None,
         sort: bool = False,
+        concurrency: Optional[int] = None,
     ) -> "Dataset":
         """Repartition the :class:`Dataset` into exactly this number of
         :ref:`blocks <dataset_concept>`.
@@ -1752,6 +1753,9 @@ class Dataset:
                 is set to True.
             sort: Whether the blocks should be sorted after repartitioning. Note,
                 that by default blocks will be sorted in the ascending order.
+            concurrency: Maximum number of concurrent tasks for streaming
+                repartition. This argument is only supported when
+                `target_num_rows_per_block` is set.
 
         Note that you must set either `num_blocks` or `target_num_rows_per_block`
         but not both.
@@ -1794,6 +1798,12 @@ class Dataset:
                 "but not both."
             )
 
+        if target_num_rows_per_block is None and concurrency is not None:
+            raise ValueError(
+                "`concurrency` is only supported when `target_num_rows_per_block` "
+                "is set."
+            )
+
         if target_num_rows_per_block is not None and shuffle:
             raise ValueError(
                 "`shuffle` must be False when `target_num_rows_per_block` is set."
@@ -1804,6 +1814,7 @@ class Dataset:
                 target_num_rows_per_block=target_num_rows_per_block,
                 input_dependencies=[self._logical_plan.dag],
                 strict=strict,
+                concurrency=concurrency,
             )
         else:
             op = Repartition(

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -26,9 +26,13 @@ from ray.data._internal.logical.operators import (
     Repartition,
     Sort,
 )
-from ray.data._internal.logical.operators.map_operator import MapBatches
+from ray.data._internal.logical.operators.map_operator import (
+    MapBatches,
+    StreamingRepartition,
+)
 from ray.data._internal.logical.operators.n_ary_operator import Zip
 from ray.data._internal.logical.operators.write_operator import Write
+from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.logical.rules import (
     ConfigureMapTaskMemoryUsingOutputSize,
 )
@@ -182,6 +186,124 @@ def test_write_operator(ray_start_regular_shared_2_cpus, tmp_path):
 
     # Check that the linked logical operator is the same the input op.
     assert physical_op._logical_operators == [op]
+
+
+def test_streaming_repartition_operator_concurrency(ray_start_regular_shared_2_cpus):
+    ctx = DataContext.get_current()
+    concurrency = 7
+    planner = create_planner()
+    read_op = get_parquet_read_logical_op()
+    op = StreamingRepartition(
+        target_num_rows_per_block=10,
+        input_dependencies=[read_op],
+        concurrency=concurrency,
+    )
+    plan = LogicalPlan(op, ctx)
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
+
+    assert isinstance(physical_op, TaskPoolMapOperator)
+    assert physical_op._max_concurrency == concurrency
+    assert physical_op._logical_operators == [op]
+
+
+def test_dataset_streaming_repartition_concurrency(ray_start_regular_shared_2_cpus):
+    planner = create_planner()
+    ds = ray.data.range(100, override_num_blocks=10).repartition(
+        target_num_rows_per_block=10,
+        concurrency=7,
+    )
+
+    logical_op = ds._logical_plan.dag
+    assert isinstance(logical_op, StreamingRepartition)
+    assert logical_op.concurrency == 7
+    assert logical_op.compute == TaskPoolStrategy(7)
+
+    physical_plan, _ = planner.plan(ds._logical_plan)
+    physical_op = physical_plan.dag
+    assert isinstance(physical_op, TaskPoolMapOperator)
+    assert physical_op._max_concurrency == 7
+    assert physical_op._logical_operators == [logical_op]
+
+
+def test_streaming_repartition_operator_respects_explicit_compute(
+    ray_start_regular_shared_2_cpus,
+):
+    planner = create_planner()
+    read_op = get_parquet_read_logical_op()
+    ctx = DataContext.get_current()
+    op = StreamingRepartition(
+        target_num_rows_per_block=10,
+        input_dependencies=[read_op],
+        concurrency=7,
+        compute=TaskPoolStrategy(3),
+    )
+    plan = LogicalPlan(op, ctx)
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
+
+    assert isinstance(physical_op, TaskPoolMapOperator)
+    assert physical_op._max_concurrency == 3
+    assert physical_op._logical_operators == [op]
+
+
+def test_fused_streaming_repartition_operator_concurrency(
+    ray_start_regular_shared_2_cpus,
+):
+    planner = create_planner()
+    read_op = get_parquet_read_logical_op()
+    ctx = DataContext.get_current()
+    map_batches = MapBatches(
+        fn=lambda batch: batch,
+        input_dependencies=[read_op],
+        batch_size=20,
+    )
+    op = StreamingRepartition(
+        target_num_rows_per_block=10,
+        input_dependencies=[map_batches],
+        concurrency=7,
+    )
+    plan = LogicalPlan(op, ctx)
+    physical_plan, _ = planner.plan(plan)
+    physical_op = physical_plan.dag
+
+    assert isinstance(physical_op, TaskPoolMapOperator)
+    assert physical_op._max_concurrency == 7
+    assert (
+        physical_op.name
+        == "MapBatches(<lambda>)->StreamingRepartition[num_rows_per_block=10,strict=False]"
+    )
+    assert physical_op._logical_operators == [map_batches, op]
+
+
+def test_combined_streaming_repartition_operator_preserves_tighter_concurrency(
+    ray_start_regular_shared_2_cpus,
+):
+    ctx = DataContext.get_current()
+    planner = create_planner()
+    read_op = get_parquet_read_logical_op()
+    op = StreamingRepartition(
+        target_num_rows_per_block=10,
+        input_dependencies=[
+            StreamingRepartition(
+                target_num_rows_per_block=20,
+                input_dependencies=[read_op],
+                concurrency=3,
+            )
+        ],
+        concurrency=7,
+    )
+    optimized_plan = LogicalOptimizer().optimize(LogicalPlan(op, ctx))
+    optimized_op = optimized_plan.dag
+    physical_plan, _ = planner.plan(optimized_plan)
+    physical_op = physical_plan.dag
+
+    assert isinstance(optimized_op, StreamingRepartition)
+    assert optimized_op.target_num_rows_per_block == 10
+    assert optimized_op.concurrency == 3
+    assert isinstance(physical_op, TaskPoolMapOperator)
+    assert physical_op._max_concurrency == 3
+    assert physical_op._logical_operators == [optimized_op]
 
 
 def test_sort_operator(

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -179,25 +179,35 @@ def test_repartition_target_num_rows_per_block(
 
 
 @pytest.mark.parametrize(
-    "num_blocks, target_num_rows_per_block, shuffle, expected_exception_msg",
+    "num_blocks, target_num_rows_per_block, shuffle, concurrency, expected_exception_msg",
     [
         (
             4,
             10,
             False,
+            None,
             "Only one of `num_blocks` or `target_num_rows_per_block` must be set, but not both.",
         ),
         (
             None,
             None,
             False,
+            None,
             "Either `num_blocks` or `target_num_rows_per_block` must be set",
         ),
         (
             None,
             10,
             True,
+            None,
             "`shuffle` must be False when `target_num_rows_per_block` is set.",
+        ),
+        (
+            4,
+            None,
+            False,
+            2,
+            "`concurrency` is only supported when `target_num_rows_per_block` is set.",
         ),
     ],
 )
@@ -206,6 +216,7 @@ def test_repartition_invalid_inputs(
     num_blocks,
     target_num_rows_per_block,
     shuffle,
+    concurrency,
     expected_exception_msg,
     disable_fallback_to_object_extension,
 ):
@@ -214,6 +225,7 @@ def test_repartition_invalid_inputs(
             num_blocks=num_blocks,
             target_num_rows_per_block=target_num_rows_per_block,
             shuffle=shuffle,
+            concurrency=concurrency,
         )
 
 


### PR DESCRIPTION
## Summary

This PR adds an optional concurrency cap for streaming repartition to bound in-flight tasks and make backpressure more predictable.

## Current Problem

In a production pipeline (`ReadParquet -> MapBatches(SegmenterActor) -> StreamingRepartition -> MapBatches(ScoringActor) -> Write`), `StreamingRepartition` can submit too many concurrent tasks when no explicit upper bound is set.

### Evidence from current job logs

```text
2026-03-30 14:33:18,775 INFO logging_progress.py:231 -- ReadParquet: 54015381/54015381
2026-03-30 14:33:18,775 INFO logging_progress.py:233 -- Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 0.0B object store
2026-03-30 14:33:18,775 INFO logging_progress.py:231 -- MapBatches(SegmenterActor): 152366328/152366328
2026-03-30 14:33:18,775 INFO logging_progress.py:233 -- Tasks: 0; Actors: 0; Queued blocks: 0 (0.0B); Resources: 0.0 CPU, 3.2TiB object store; [24/10329 objects local]
2026-03-30 14:33:18,775 INFO logging_progress.py:231 -- StreamingRepartition[num_rows_per_block=1024]: 24556544/23997760
2026-03-30 14:33:18,775 INFO logging_progress.py:233 -- Tasks: 5421 [backpressured:tasks(DownstreamCapacity),outputs(DownstreamCapacity)]; Actors: 0; Queued blocks: 4345 (1.4TiB); Resources: 5421.0 CPU, 428.0GiB object store
2026-03-30 14:33:18,775 INFO logging_progress.py:231 -- MapBatches(ScoringActor): 16264192/23997440
2026-03-30 14:33:18,775 INFO logging_progress.py:233 -- Tasks: 260; Actors: 130 (running=122, restarting=8, pending=0); Queued blocks: 7838 (177.1GiB); Resources: 0.0 CPU, 122.0 GPU, 5.3GiB object store; [94/16143 objects local]
2026-03-30 14:33:18,776 INFO logging_progress.py:231 -- Write: 15778/23435
2026-03-30 14:33:18,776 INFO logging_progress.py:233 -- Tasks: 105; Actors: 0; Queued blocks: 0 (0.0B); Resources: 105.0 CPU, 17.2KiB object store
```

What this snapshot shows:

- `StreamingRepartition` is already backpressured by `DownstreamCapacity`, but still has very high in-flight concurrency (`Tasks: 5421`), large queue buildup (`4345` blocks / `1.4TiB`), and high resource footprint (`5421 CPU`, `428.0GiB` object store).
- Downstream `MapBatches(ScoringActor)` runs at much lower concurrency (`Tasks: 260`, `Actors: 130`), creating a large producer/consumer gap.

Backpressure policies are active, but each one is effectively a soft guardrail here:

- **ConcurrencyCapBackpressurePolicy**: active, but without an explicit configured cap for `StreamingRepartition`, it reacts dynamically to queue changes instead of enforcing a deterministic hard limit.
- **ResourceBudgetBackpressurePolicy**: can throttle based on resource budgets, but depends on allocator state and global pressure, so it does not provide a strict per-operator task bound.
- **DownstreamCapacityBackpressurePolicy**: active and visible in logs, but can engage after substantial in-flight buildup, allowing large transient queue/object-store spikes before rebalancing.

Overall, the existing system can throttle, but it cannot guarantee a stable per-operator concurrency ceiling for `StreamingRepartition`.

## What This PR Changes

- Adds `concurrency: Optional[int]` to `Dataset.repartition(...)` for streaming repartition mode (`target_num_rows_per_block` path).
- Threads concurrency into logical `StreamingRepartition` and maps it to `TaskPoolStrategy(size=concurrency)`.
- Validates `concurrency` usage:
  - must be positive when provided;
  - only allowed with `target_num_rows_per_block`.
- Preserves tighter limits when combining chained `StreamingRepartition` operators.
- Preserves the cap through `MapBatches -> StreamingRepartition` fusion via streaming-specific compute fusion logic.


