### PR TITLE
[CI] Add hermetic wanda binary to Bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -136,6 +136,10 @@ filegroup(
     urls = ["https://github.com/astral-sh/uv/releases/download/0.9.26/uv-aarch64-apple-darwin.tar.gz"],
 )
 
+load("//bazel:wanda.bzl", "wanda_setup")
+
+wanda_setup()
+
 http_archive(
     name = "com_github_storypku_bazel_iwyu",
     sha256 = "aa78c331a2cb139f73f7d74eeb4d5ab29794af82023ef5d6d5194f76b7d37449",

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_runtime", 
 exports_files([
     "pytest_wrapper.py",
     "default_doctest_pytest_plugin.py",
+    "wanda.bzl",
 ])
 
 py_binary(

--- a/bazel/wanda.bzl
+++ b/bazel/wanda.bzl
@@ -1,0 +1,28 @@
+"""Wanda binary dependency for RayCI build cache digest computation."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+# Keep in sync with .rayciversion.
+WANDA_VERSION = "0.36.0"
+
+def wanda_setup():
+    """Download platform-specific wanda binaries."""
+    http_file(
+        name = "wanda_linux_x86_64",
+        downloaded_file_path = "wanda",
+        executable = True,
+        sha256 = "1614738a4a0721c75c1e950dc42165699a0eeb29acc867d0d66250f8b06b1de7",
+        urls = [
+            "https://github.com/ray-project/rayci/releases/download/v{}/wanda-linux-amd64".format(WANDA_VERSION),
+        ],
+    )
+
+    http_file(
+        name = "wanda_darwin_arm64",
+        downloaded_file_path = "wanda",
+        executable = True,
+        sha256 = "ac28e9dcd0979d333eb7852cd21e48fbf5f2bf4eeaff649748b2f9b68cfc8e28",
+        urls = [
+            "https://github.com/ray-project/rayci/releases/download/v{}/wanda-darwin-arm64".format(WANDA_VERSION),
+        ],
+    )

--- a/ci/build/BUILD.bazel
+++ b/ci/build/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
+load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 
 py_library(
     name = "container_resource_utils",
@@ -50,6 +51,41 @@ py_test(
         "team:ci",
     ],
     deps = [":build_wheel"],
+)
+
+_WANDA_DATA = select({
+    "//bazel:linux_x86_64_config": ["@wanda_linux_x86_64//file"],
+    "//bazel:osx_arm64_config": ["@wanda_darwin_arm64//file"],
+    "//conditions:default": [],
+})
+
+py_binary(
+    name = "wanda",
+    srcs = ["wanda.py"],
+    data = _WANDA_DATA,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":build_common",
+        ci_require("bazel-runfiles"),
+    ],
+)
+
+py_test(
+    name = "wanda_version_test",
+    size = "small",
+    srcs = ["wanda_version_test.py"],
+    data = [
+        "//:.rayciversion",
+        "//bazel:wanda.bzl",
+    ],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ci_require("pytest"),
+        ci_require("bazel-runfiles"),
+    ],
 )
 
 py_library(

--- a/ci/build/wanda.py
+++ b/ci/build/wanda.py
@@ -1,0 +1,64 @@
+"""
+Thin wrapper around the wanda binary that resolves it from Bazel runfiles.
+All arguments are passed through verbatim.
+
+Usage:
+    bazel run //ci/build:wanda -- [wanda args...]
+
+Examples:
+    # Epoch-0 digest for stable cache lookups (local):
+    bazel run //ci/build:wanda -- digest -epoch 0 -env_file rayci.env ci/docker/ray-core.wanda.yaml
+
+    # Match CI build digest (in CI runner with RAYCI_* env vars):
+    bazel run //ci/build:wanda -- digest -rayci
+"""
+from __future__ import annotations
+
+import platform
+import shlex
+import subprocess
+import sys
+
+import runfiles
+
+from ci.build.build_common import BuildError, find_ray_root, log
+
+
+def _wanda_binary() -> str:
+    """Get the path to the wanda binary from bazel runfiles."""
+    r = runfiles.Create()
+    if not r:
+        raise BuildError("Failed to create runfiles resolver")
+
+    system = platform.system()
+    machine = platform.machine().lower()
+
+    if system == "Linux" and machine in ("x86_64", "amd64"):
+        path = r.Rlocation("wanda_linux_x86_64/file/wanda")
+    elif system == "Darwin" and machine in ("arm64", "aarch64"):
+        path = r.Rlocation("wanda_darwin_arm64/file/wanda")
+    else:
+        raise BuildError(f"Unsupported platform: {system}-{machine}")
+
+    if not path:
+        raise BuildError(f"Wanda binary not found in runfiles for {system}-{machine}")
+    return path
+
+
+def main():
+    try:
+        root = find_ray_root()
+        wanda = _wanda_binary()
+    except BuildError as e:
+        log.error(e)
+        sys.exit(1)
+
+    cmd = [wanda] + sys.argv[1:]
+
+    log.info(f"Running: {shlex.join(cmd)}")
+    result = subprocess.run(cmd, cwd=root)
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build/wanda_version_test.py
+++ b/ci/build/wanda_version_test.py
@@ -1,0 +1,28 @@
+"""Verify the wanda binary version in bazel/wanda.bzl matches .rayciversion."""
+
+import re
+import sys
+from pathlib import Path
+
+import runfiles
+
+
+def test_wanda_bzl_version_matches_rayciversion():
+    """Ensure bazel/wanda.bzl downloads wanda at the version pinned in .rayciversion."""
+    r = runfiles.Create()
+    expected = Path(r.Rlocation("io_ray/.rayciversion")).read_text().strip()
+    wanda_bzl = Path(r.Rlocation("io_ray/bazel/wanda.bzl")).read_text()
+
+    match = re.search(r'WANDA_VERSION\s*=\s*"([^"]+)"', wanda_bzl)
+    assert match, "WANDA_VERSION not found in bazel/wanda.bzl"
+    actual = match.group(1)
+    assert actual == expected, (
+        f"bazel/wanda.bzl has WANDA_VERSION = {actual!r} but "
+        f".rayciversion specifies {expected!r}"
+    )
+
+
+if __name__ == "__main__":
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Download platform-specific wanda binaries (v0.36.0) via Bazel http_file
and expose them as a py_binary wrapper at //ci/build:wanda. This provides
a hermetic way to run wanda commands (digest, build) from Bazel without
requiring raymake on PATH.

Includes a version test that ensures bazel/wanda.bzl stays in sync with
.rayciversion.

Topic: wanda-binary
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>