### PR TITLE
[CI] Add publish_core_image script for S3 uploads

### DIFF
--- a/.buildkite/copy_files.py
+++ b/.buildkite/copy_files.py
@@ -66,10 +66,11 @@ dest_resp_mapping = {
     "jars": "presigned_resp_prod_wheels",
     "branch_jars": "presigned_resp_prod_wheels",
     "logs": "presigned_logs",
+    "ray-core": "presigned_resp_ray_builds",
 }
 
 
-def upload_paths(paths, resp, destination):
+def upload_paths(paths, resp, destination, key=None):
     dest_key = dest_resp_mapping[destination]
     c = resp.json()[dest_key]
     of = OrderedDict(c["fields"])
@@ -82,13 +83,21 @@ def upload_paths(paths, resp, destination):
 
     for path in paths:
         fn = os.path.split(path)[-1]
-        of["key"] = {
-            "wheels": f"latest/{fn}",
-            "branch_wheels": f"{branch}/{sha}/{fn}",
-            "jars": f"jars/latest/{current_os}/{fn}",
-            "branch_jars": f"jars/{branch}/{sha}/{current_os}/{fn}",
-            "logs": f"bazel_events/{branch}/{sha}/{bk_job_id}/{fn}",
-        }[destination]
+        if key is not None:
+            of["key"] = key
+        else:
+            key_map = {
+                "wheels": f"latest/{fn}",
+                "branch_wheels": f"{branch}/{sha}/{fn}",
+                "jars": f"jars/latest/{current_os}/{fn}",
+                "branch_jars": f"jars/{branch}/{sha}/{current_os}/{fn}",
+                "logs": f"bazel_events/{branch}/{sha}/{bk_job_id}/{fn}",
+            }
+            if destination not in key_map:
+                raise ValueError(
+                    f"Destination {destination!r} requires --key to be specified"
+                )
+            of["key"] = key_map[destination]
         of["file"] = open(path, "rb")
         r = requests.post(c["url"], files=of)
         print(f"Uploaded {path} to {of['key']}", r.status_code)
@@ -100,6 +109,12 @@ if __name__ == "__main__":
     )
     parser.add_argument("--path", type=str, required=False)
     parser.add_argument("--destination", type=str)
+    parser.add_argument(
+        "--key",
+        type=str,
+        required=False,
+        help="Exact S3 key to upload to (overrides default key logic)",
+    )
     args = parser.parse_args()
 
     if os.environ.get("RAYCI_SKIP_UPLOAD", "false") == "true":
@@ -111,6 +126,7 @@ if __name__ == "__main__":
         "branch_wheels",
         "jars",
         "logs",
+        "ray-core",
         "wheels",
         "docker_login",
     }
@@ -124,4 +140,4 @@ if __name__ == "__main__":
     else:
         paths = gather_paths(args.path)
         print("Planning to upload", paths)
-        upload_paths(paths, resp, args.destination)
+        upload_paths(paths, resp, args.destination, key=args.key)

--- a/ci/build/BUILD.bazel
+++ b/ci/build/BUILD.bazel
@@ -89,6 +89,31 @@ py_test(
 )
 
 py_library(
+    name = "publish_core_image_lib",
+    srcs = ["publish_core_image.py"],
+    visibility = ["//visibility:public"],
+    deps = [":build_common"],
+)
+
+py_binary(
+    name = "publish_core_image",
+    srcs = ["publish_core_image.py"],
+    visibility = ["//visibility:public"],
+    deps = [":build_common"],
+)
+
+py_test(
+    name = "publish_core_image_test",
+    size = "small",
+    srcs = ["publish_core_image_test.py"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [":publish_core_image_lib"],
+)
+
+py_library(
     name = "build_image",
     srcs = ["build_image.py"],
     data = ["//:ray-images.json"],

--- a/ci/build/publish_core_image.py
+++ b/ci/build/publish_core_image.py
@@ -1,0 +1,154 @@
+"""
+Publish a ray-core build image to S3 keyed by its wanda digest.
+
+Exports the Docker image from the wanda cache registry and uploads it
+to S3 so local developers can download it by computing the same digest.
+
+Required env vars:
+    PYTHON_VERSION, ARCH_SUFFIX, HOSTTYPE  — wanda build args
+    RAYCI_WORK_REPO, RAYCI_BUILD_ID        — wanda cache coordinates
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+
+from ci.build.build_common import BuildError, find_ray_root, log
+
+WANDA_SPEC = "ci/docker/ray-core.wanda.yaml"
+ENV_FILE = "rayci.env"
+
+
+def s3_key(platform: str, arch: str, python_version: str, digest: str) -> str:
+    """Construct the S3 key for a core digest image."""
+    return f"core-digest/{platform}/{arch}/{python_version}/{digest}"
+
+
+def image_tag(
+    work_repo: str, build_id: str, python_version: str, arch_suffix: str = ""
+) -> str:
+    """Construct the wanda work tag for the ray-core image."""
+    return f"{work_repo}:{build_id}-ray-core-py{python_version}{arch_suffix}"
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise BuildError(f"Required environment variable {name} is not set")
+    return value
+
+
+def compute_digest(ray_root: str) -> str:
+    """Compute the epoch-0 wanda digest for the ray-core spec."""
+    cmd = [
+        "bazel",
+        "run",
+        "//ci/build:wanda",
+        "--",
+        "digest",
+        "-epoch",
+        "0",
+        "-env_file",
+        ENV_FILE,
+        WANDA_SPEC,
+    ]
+    log.info(f"Computing digest: {shlex.join(cmd)}")
+    result = subprocess.run(
+        cmd,
+        cwd=ray_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise BuildError(
+            f"wanda digest failed (rc={result.returncode}): {result.stderr.strip()}"
+        )
+    digest = result.stdout.strip()
+    if not digest:
+        raise BuildError("wanda digest produced empty output")
+    return digest
+
+
+def export_image(tag: str, output_path: str) -> None:
+    """Export a Docker image to a tar file using crane."""
+    cmd = ["crane", "export", tag, output_path]
+    log.info(f"Exporting image: {shlex.join(cmd)}")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        raise BuildError(f"crane export failed (rc={result.returncode})")
+
+
+def upload_to_s3(ray_root: str, key: str, path: str) -> None:
+    """Upload a file to S3 via copy_files.py."""
+    cmd = [
+        "bazel",
+        "run",
+        ".buildkite:copy_files",
+        "--",
+        "--destination",
+        "ray-core",
+        "--key",
+        key,
+        "--path",
+        path,
+    ]
+    log.info(f"Uploading: {shlex.join(cmd)}")
+    result = subprocess.run(cmd, cwd=ray_root)
+    if result.returncode != 0:
+        raise BuildError(f"upload failed (rc={result.returncode})")
+
+
+def publish(dry_run: bool = False) -> None:
+    """Compute digest, export image, and upload to S3."""
+    root = str(find_ray_root())
+
+    python_version = _require_env("PYTHON_VERSION")
+    arch_suffix = os.environ.get("ARCH_SUFFIX", "")
+    hosttype = _require_env("HOSTTYPE")
+    work_repo = _require_env("RAYCI_WORK_REPO")
+    build_id = _require_env("RAYCI_BUILD_ID")
+
+    digest = compute_digest(root)
+    tag = image_tag(work_repo, build_id, python_version, arch_suffix)
+    key = s3_key("linux", hosttype, python_version, digest)
+
+    log.info(f"Digest: {digest}")
+    log.info(f"Image tag: {tag}")
+    log.info(f"S3 key: {key}")
+
+    if dry_run:
+        log.info("Dry run — skipping export and upload")
+        return
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tar_path = os.path.join(tmpdir, f"ray-core-py{python_version}.tar")
+        export_image(tag, tar_path)
+        upload_to_s3(root, key, tar_path)
+
+    log.info("Published successfully")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Publish ray-core image to S3 keyed by wanda digest.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be done without exporting or uploading.",
+    )
+    args = parser.parse_args()
+
+    try:
+        publish(dry_run=args.dry_run)
+    except BuildError as e:
+        log.error(e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/build/publish_core_image_test.py
+++ b/ci/build/publish_core_image_test.py
@@ -1,0 +1,79 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from ci.build.publish_core_image import (
+    image_tag,
+    publish,
+    s3_key,
+)
+
+
+class TestS3Key(unittest.TestCase):
+    def test_basic(self):
+        got = s3_key("linux", "x86_64", "3.12", "sha256:abc123")
+        self.assertEqual(got, "core-digest/linux/x86_64/3.12/sha256:abc123")
+
+    def test_different_python(self):
+        got = s3_key("linux", "x86_64", "3.10", "sha256:def456")
+        self.assertEqual(got, "core-digest/linux/x86_64/3.10/sha256:def456")
+
+
+class TestImageTag(unittest.TestCase):
+    def test_basic(self):
+        got = image_tag("ecr.example.com/repo", "abc123", "3.12")
+        self.assertEqual(got, "ecr.example.com/repo:abc123-ray-core-py3.12")
+
+    def test_with_arch_suffix(self):
+        got = image_tag("ecr.example.com/repo", "abc123", "3.12", "-aarch64")
+        self.assertEqual(got, "ecr.example.com/repo:abc123-ray-core-py3.12-aarch64")
+
+    def test_different_version(self):
+        got = image_tag("registry/citemp", "build42", "3.14")
+        self.assertEqual(got, "registry/citemp:build42-ray-core-py3.14")
+
+
+class TestPublish(unittest.TestCase):
+    _ENV = {
+        "PYTHON_VERSION": "3.12",
+        "ARCH_SUFFIX": "",
+        "HOSTTYPE": "x86_64",
+        "RAYCI_WORK_REPO": "ecr.example.com/citemp",
+        "RAYCI_BUILD_ID": "abc123",
+    }
+
+    @patch("ci.build.publish_core_image.compute_digest")
+    @patch.dict(os.environ, _ENV, clear=False)
+    def test_dry_run(self, mock_digest):
+        mock_digest.return_value = "sha256:deadbeef"
+        # Should not raise, and should not call export or upload
+        publish(dry_run=True)
+        mock_digest.assert_called_once()
+
+    @patch("ci.build.publish_core_image.upload_to_s3")
+    @patch("ci.build.publish_core_image.export_image")
+    @patch("ci.build.publish_core_image.compute_digest")
+    @patch.dict(os.environ, _ENV, clear=False)
+    def test_publish_calls(self, mock_digest, mock_export, mock_upload):
+        mock_digest.return_value = "sha256:deadbeef"
+        publish(dry_run=False)
+
+        mock_export.assert_called_once()
+        tag_arg = mock_export.call_args[0][0]
+        self.assertEqual(tag_arg, "ecr.example.com/citemp:abc123-ray-core-py3.12")
+
+        mock_upload.assert_called_once()
+        key_arg = mock_upload.call_args[0][1]
+        self.assertEqual(key_arg, "core-digest/linux/x86_64/3.12/sha256:deadbeef")
+
+    @patch("ci.build.publish_core_image.compute_digest")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_env_var(self, mock_digest):
+        mock_digest.return_value = "sha256:deadbeef"
+        with self.assertRaises(Exception) as ctx:
+            publish(dry_run=True)
+        self.assertIn("PYTHON_VERSION", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add a tested Python script that exports a ray-core Docker image and
uploads it to S3 keyed by the epoch-0 wanda digest. This enables local
developers to compute the same digest and download the prebuilt image,
skipping the ~30min core build.

Also adds the ray-core destination and --key flag to copy_files.py for
uploading to the ray-builds S3 bucket.

Topic: publish-core-image
Relative: wanda-binary
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>