### PR TITLE
[llm] Unify duplicated PlacementGroup config schemes

### DIFF
--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -487,6 +487,9 @@ Ray Data LLM supports cross-node parallelism, including tensor parallelism and p
 
 You can customize the placement group configuration to control how Ray places vLLM engine workers across nodes. Use ``bundle_per_worker`` for basic per-worker resource specification (auto-replicated based on TP*PP), or ``bundles`` for full control over individual bundles. While you can specify the degree of tensor and pipeline parallelism, the specific assignment of model ranks to GPUs is managed by the vLLM engine.
 
+.. note::
+   In each bundle dict, omitted ``CPU`` or ``GPU`` keys are treated as **0**. Specify the resources each worker needs explicitly.
+
 .. literalinclude:: doc_code/working-with-llms/basic_llm_example.py
     :language: python
     :start-after: __custom_placement_group_strategy_config_example_start__

--- a/doc/source/serve/llm/user-guides/cross-node-parallelism.md
+++ b/doc/source/serve/llm/user-guides/cross-node-parallelism.md
@@ -79,6 +79,10 @@ You can customize how Ray places vLLM engine workers across nodes using `placeme
 
 The `bundle_per_worker` option inside `placement_group_config` lets you specify resources for each worker without manually creating the full bundle list. Ray automatically replicates this bundle based on `tensor_parallel_size * pipeline_parallel_size`. This field is mutually exclusive with `bundles`.
 
+:::{note}
+In each bundle dict, `CPU` and `GPU` are numeric amounts. If you omit either key, it is treated as **0** — set both explicitly when your workers need CPUs and GPUs (there is no implicit default GPU when you only specify CPU, or vice versa).
+:::
+
 ::::{tab-set}
 
 :::{tab-item} Python

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -1,10 +1,10 @@
 """The vLLM engine processor."""
 
 import logging
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, Optional
 
 import transformers
-from pydantic import ConfigDict, Field, model_validator, root_validator
+from pydantic import Field, root_validator
 
 import ray
 from ray.data.block import UserDefinedFunction
@@ -40,8 +40,8 @@ from ray.llm._internal.batch.stages.configs import (
     TokenizerStageConfig,
     resolve_stage_config,
 )
-from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.observability.telemetry_utils import DEFAULT_GPU_TYPE
+from ray.llm._internal.common.placement import PlacementGroupConfig
 from ray.llm._internal.common.utils.download_utils import (
     STREAMING_LOAD_FORMATS,
     NodeModelDownloadable,
@@ -52,43 +52,6 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_MODEL_ARCHITECTURE = "UNKNOWN_MODEL_ARCHITECTURE"
-
-
-class BundleSchema(BaseModelExtended):
-    model_config = ConfigDict(extra="allow")
-    CPU: Optional[int] = Field(default=1, description="The number of CPUs per bundle.")
-    GPU: Optional[int] = Field(default=1, description="The number of GPUs per bundle.")
-
-
-class PlacementGroupSchema(BaseModelExtended):
-    bundle_per_worker: Optional[BundleSchema] = Field(
-        default=None,
-        description="Resource bundle specification for each worker. "
-        "Auto-replicated based on tensor_parallel_size * pipeline_parallel_size. "
-        "Cannot be used together with 'bundles'.",
-    )
-    bundles: Optional[List[BundleSchema]] = Field(
-        default=None, description="The bundles for the placement group."
-    )
-    strategy: Literal["PACK", "STRICT_PACK", "SPREAD", "STRICT_SPREAD"] = Field(
-        default="PACK", description="The strategy for the placement group."
-    )
-
-    @model_validator(mode="after")
-    def validate_bundle_options(self):
-        if self.bundle_per_worker is not None and self.bundles is not None:
-            raise ValueError(
-                "Cannot specify both 'bundle_per_worker' and 'bundles' in "
-                "placement_group_config. Use 'bundle_per_worker' for simple "
-                "per-worker resource specification (auto-replicated by tp*pp), "
-                "or 'bundles' for full control."
-            )
-        if self.bundle_per_worker is None and self.bundles is None:
-            raise ValueError(
-                "placement_group_config must specify either 'bundle_per_worker' "
-                "or 'bundles'."
-            )
-        return self
 
 
 class vLLMEngineProcessorConfig(OfflineProcessorConfig):
@@ -158,7 +121,7 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
     def validate_placement_group_config(cls, values):
         placement_group_config = values.get("placement_group_config")
         if placement_group_config is not None:
-            values["placement_group_config"] = PlacementGroupSchema(
+            values["placement_group_config"] = PlacementGroupConfig(
                 **placement_group_config
             ).model_dump()
         return values

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, Optional
 
 import transformers
-from pydantic import Field, root_validator
+from pydantic import Field, model_validator
 
 import ray
 from ray.data.block import UserDefinedFunction
@@ -96,7 +96,8 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
         "Example with bundles: {'bundles': [{'CPU': 1, 'GPU': 1}] * 4, 'strategy': 'SPREAD'}.",
     )
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def validate_task_type(cls, values):
         task_type = values.get("task_type", vLLMTaskType.GENERATE)
         if task_type not in vLLMTaskType.values():
@@ -117,7 +118,8 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
         values["engine_kwargs"] = engine_kwargs
         return values
 
-    @root_validator(pre=True)
+    @model_validator(mode="before")
+    @classmethod
     def validate_placement_group_config(cls, values):
         placement_group_config = values.get("placement_group_config")
         if placement_group_config is not None:

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Dict, Optional
 
 import transformers
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 import ray
 from ray.data.block import UserDefinedFunction
@@ -118,15 +118,14 @@ class vLLMEngineProcessorConfig(OfflineProcessorConfig):
         values["engine_kwargs"] = engine_kwargs
         return values
 
-    @model_validator(mode="before")
+    @field_validator("placement_group_config")
     @classmethod
-    def validate_placement_group_config(cls, values):
-        placement_group_config = values.get("placement_group_config")
-        if placement_group_config is not None:
-            values["placement_group_config"] = PlacementGroupConfig(
-                **placement_group_config
-            ).model_dump()
-        return values
+    def validate_placement_group_config(cls, value):
+        if value is None:
+            return None
+        # Validate through PlacementGroupConfig, then dump back to dict
+        validated = PlacementGroupConfig(**value)
+        return validated.model_dump()
 
 
 def build_vllm_engine_processor(

--- a/python/ray/llm/_internal/common/placement.py
+++ b/python/ray/llm/_internal/common/placement.py
@@ -31,7 +31,7 @@ class BundleConfig(BaseModelExtended):
     @model_validator(mode="after")
     def validate_extra_resources(self):
         """Ensure custom resources (TPU, accelerator_type, etc.) are non-negative."""
-        extra_resources = self.__pydantic_extra__
+        extra_resources = self.model_extra
         if not extra_resources:
             return self
         for key, value in extra_resources.items():

--- a/python/ray/llm/_internal/common/placement.py
+++ b/python/ray/llm/_internal/common/placement.py
@@ -1,0 +1,79 @@
+from typing import List, Literal, Optional
+
+from pydantic import ConfigDict, Field, model_validator
+
+from ray.llm._internal.common.base_pydantic import BaseModelExtended
+
+
+class BundleConfig(BaseModelExtended):
+    """Configuration for a single placement group bundle.
+
+    Resource counts are floats to align with Ray's internal resource
+    representation, which supports fractional values (e.g. GPU=0.5).
+    Both CPU and GPU default to 0.0 — the schema does not inject hidden
+    resource requests. Extra fields are allowed for custom Ray resources (e.g. TPU,
+    accelerator_type:L4).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    CPU: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="The number of CPUs per bundle.",
+    )
+    GPU: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="The number of GPUs per bundle.",
+    )
+
+    @model_validator(mode="after")
+    def validate_extra_resources(self):
+        """Ensure custom resources (TPU, accelerator_type, etc.) are non-negative."""
+        extra_resources = self.__pydantic_extra__
+        if not extra_resources:
+            return self
+        for key, value in extra_resources.items():
+            if not isinstance(value, (int, float)):
+                raise ValueError(
+                    f"Resource '{key}' must be a number, got {type(value).__name__}"
+                )
+            if value < 0:
+                raise ValueError(f"Resource '{key}' must be non-negative, got {value}")
+        return self
+
+
+class PlacementGroupConfig(BaseModelExtended):
+    """Configuration for placement group."""
+
+    bundle_per_worker: Optional[BundleConfig] = Field(
+        default=None,
+        description=(
+            "Resource bundle specification for each worker. "
+            "Auto-replicated based on tensor_parallel_size * pipeline_parallel_size. "
+            "Cannot be used together with 'bundles'."
+        ),
+    )
+    bundles: Optional[List[BundleConfig]] = Field(
+        default=None, description="List of resource bundles"
+    )
+    strategy: Literal["PACK", "SPREAD", "STRICT_PACK", "STRICT_SPREAD"] = Field(
+        default="PACK", description="Placement group strategy"
+    )
+
+    @model_validator(mode="after")
+    def validate_bundle_options(self):
+        if self.bundle_per_worker is not None and self.bundles is not None:
+            raise ValueError(
+                "Cannot specify both 'bundle_per_worker' and 'bundles' in "
+                "placement_group_config. Use 'bundle_per_worker' for simple "
+                "per-worker resource specification (auto-replicated by tp*pp), "
+                "or 'bundles' for full control."
+            )
+        if self.bundle_per_worker is None and self.bundles is None:
+            raise ValueError(
+                "placement_group_config must specify either 'bundle_per_worker' "
+                "or 'bundles'."
+            )
+        return self

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -1,13 +1,14 @@
 import copy
 import dataclasses
 import os
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Optional
 
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.entrypoints.openai.cli_args import FrontendArgs
 
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
+from ray.llm._internal.common.placement import PlacementGroupConfig
 from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig
 from ray.llm._internal.common.utils.import_utils import try_import
 from ray.llm._internal.serve.constants import (
@@ -30,54 +31,6 @@ from ray.util.placement_group import (
 KV_TRANSFER_PARAMS_KEY = "kv_transfer_params"
 vllm = try_import("vllm")
 logger = get_logger(__name__)
-
-
-class BundleConfig(BaseModelExtended):
-    """Configuration for placement group bundle.
-
-    Note: Counts are floats to align with Ray resource typing.
-    """
-
-    CPU: float = Field(default=0.0, ge=0.0, description="Number of CPUs per bundle")
-    GPU: float = Field(default=1.0, ge=0.0, description="Number of GPUs per bundle")
-
-    class Config:
-        extra = "allow"  # Allow arbitrary resource types
-
-
-class PlacementGroupConfig(BaseModelExtended):
-    """Configuration for placement group."""
-
-    bundle_per_worker: Optional[BundleConfig] = Field(
-        default=None,
-        description=(
-            "Resource bundle specification for each worker. "
-            "Auto-replicated based on tensor_parallel_size * pipeline_parallel_size. "
-            "Cannot be used together with 'bundles'."
-        ),
-    )
-    bundles: Optional[List[BundleConfig]] = Field(
-        default=None, description="List of resource bundles"
-    )
-    strategy: Literal["PACK", "SPREAD", "STRICT_PACK", "STRICT_SPREAD"] = Field(
-        default="PACK", description="Placement group strategy"
-    )
-
-    @model_validator(mode="after")
-    def validate_bundle_options(self):
-        if self.bundle_per_worker is not None and self.bundles is not None:
-            raise ValueError(
-                "Cannot specify both 'bundle_per_worker' and 'bundles' in "
-                "placement_group_config. Use 'bundle_per_worker' for simple "
-                "per-worker resource specification (auto-replicated by tp*pp), "
-                "or 'bundles' for full control."
-            )
-        if self.bundle_per_worker is None and self.bundles is None:
-            raise ValueError(
-                "placement_group_config must specify either 'bundle_per_worker' "
-                "or 'bundles'."
-            )
-        return self
 
 
 class VLLMEngineConfig(BaseModelExtended):

--- a/python/ray/llm/tests/common/test_placement.py
+++ b/python/ray/llm/tests/common/test_placement.py
@@ -81,5 +81,12 @@ def test_placement_group_config_invalid_strategy_rejected():
         )
 
 
+def test_placement_group_config_from_raw_dict():
+    pg = PlacementGroupConfig(
+        **{"bundle_per_worker": {"CPU": 2, "GPU": 1}, "strategy": "SPREAD"}
+    )
+    assert pg.bundle_per_worker.CPU == 2
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/common/test_placement.py
+++ b/python/ray/llm/tests/common/test_placement.py
@@ -1,5 +1,7 @@
 """Unit tests for ray.llm._internal.common.placement."""
 
+import sys
+
 import pytest
 from pydantic import ValidationError
 
@@ -77,3 +79,7 @@ def test_placement_group_config_invalid_strategy_rejected():
                 "strategy": "INVALID",
             }
         )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/common/test_placement.py
+++ b/python/ray/llm/tests/common/test_placement.py
@@ -1,0 +1,79 @@
+"""Unit tests for ray.llm._internal.common.placement."""
+
+import pytest
+from pydantic import ValidationError
+
+from ray.llm._internal.common.placement import BundleConfig, PlacementGroupConfig
+
+
+def test_bundle_config_defaults_returns_float():
+    b = BundleConfig()
+    d = b.model_dump()
+    assert d["CPU"] == 0.0 and d["GPU"] == 0.0
+
+    b2 = BundleConfig(CPU=2, GPU=1)
+    assert b2.model_dump() == {"CPU": 2.0, "GPU": 1.0}
+
+
+def test_bundle_config_fractional_gpu():
+    b = BundleConfig(GPU=0.5, CPU=1.0)
+    assert b.model_dump()["GPU"] == 0.5
+
+
+def test_bundle_config_extra_custom_resource():
+    b = BundleConfig(CPU=0.0, GPU=0.0, TPU=4.0)
+    d = b.model_dump()
+    assert d["TPU"] == 4.0
+
+
+def test_bundle_config_extra_resource_negative_rejected():
+    with pytest.raises(ValueError, match="non-negative"):
+        BundleConfig(TPU=-1.0)
+
+
+def test_bundle_config_extra_resource_non_numeric_rejected():
+    with pytest.raises(ValueError, match="must be a number"):
+        BundleConfig(CPU=0.0, GPU=0.0, bad="x")
+
+
+def test_placement_group_config_bundles_only():
+    pg = PlacementGroupConfig(
+        bundles=[BundleConfig(GPU=1.0, CPU=1.0)],
+        strategy="PACK",
+    )
+    out = pg.model_dump()
+    assert out["bundles"][0]["GPU"] == 1.0
+    assert out["strategy"] == "PACK"
+
+
+def test_placement_group_config_bundle_per_worker_only():
+    pg = PlacementGroupConfig(
+        bundle_per_worker=BundleConfig(GPU=1.0, CPU=2.0),
+        strategy="SPREAD",
+    )
+    out = pg.model_dump()
+    assert out["bundle_per_worker"]["GPU"] == 1.0
+    assert out["strategy"] == "SPREAD"
+
+
+def test_placement_group_config_rejects_neither_bundles_nor_per_worker():
+    with pytest.raises(ValueError, match="either 'bundle_per_worker'"):
+        PlacementGroupConfig(strategy="PACK")
+
+
+def test_placement_group_config_rejects_both_bundles_and_per_worker():
+    with pytest.raises(ValueError, match="Cannot specify both"):
+        PlacementGroupConfig(
+            bundles=[BundleConfig(GPU=1.0)],
+            bundle_per_worker=BundleConfig(GPU=1.0),
+        )
+
+
+def test_placement_group_config_invalid_strategy_rejected():
+    with pytest.raises(ValidationError):
+        PlacementGroupConfig.model_validate(
+            {
+                "bundles": [{"GPU": 1.0, "CPU": 0.0}],
+                "strategy": "INVALID",
+            }
+        )

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -598,10 +598,10 @@ class TestGetDeploymentOptions:
         )
         serve_options = LLMServer.get_deployment_options(llm_config)
         # First bundle has replica actor resources merged in (CPU: 1 from config + 1 from replica = 2)
-        # All bundles get GPU: 1.0 added as accelerator hint (and CPU: 0.0 for workers)
+        # Bundles are validated via PlacementGroupConfig: omitted CPU/GPU become 0.0 (no implicit GPU).
         assert serve_options["placement_group_bundles"] == [
-            {"CPU": 2.0, "GPU": 1.0, "XPU": 1}
-        ] + [{"CPU": 0.0, "GPU": 1.0, "XPU": 1} for _ in range(5)]
+            {"CPU": 2.0, "GPU": 0.0, "XPU": 1}
+        ] + [{"CPU": 0.0, "GPU": 0.0, "XPU": 1} for _ in range(5)]
         assert serve_options["placement_group_strategy"] == "PACK"
 
     def test_get_serve_options_with_accelerator_type(self):

--- a/release/llm_tests/batch/test_batch_vllm.py
+++ b/release/llm_tests/batch/test_batch_vllm.py
@@ -498,10 +498,10 @@ def test_async_udf_queue_capped(concurrency):
             "ray",
             dict(bundles=[{"CPU": 1, "GPU": 1}] * 4, strategy="STRICT_PACK"),
         ),
-        # Custom placement group leaving GPU and strategy unspecified
+        # Strategy omitted (PACK default). Omitted GPU now validates as 0.0; explicit GPU: 1 for this GPU job.
         (
             "ray",
-            dict(bundles=[{"CPU": 1}] * 4),
+            dict(bundles=[{"CPU": 1, "GPU": 1}] * 4),
         ),
         # Empty placement group
         (


### PR DESCRIPTION
## Description
- This PR introduces a single shared module,` ray.llm._internal.common.placement`, with BundleConfig and PlacementGroupConfig  for placement_group_config.
- Batch (vllm_engine_proc.py) and Serve (vllm_models.py) both validate placement_group_config through this module and keep storing a plain dict downstream.
- Adds` test_placement.py` for the shared validation rules.
### Why it’s needed
- Removes duplicated placement definitions and drift between Serve and batch, so behavior and validation stay aligned.

## Related issues
Fixes: #61994 

