### PR TITLE
[Data] Clamping Batch Size to Fall Within C++ 32-bit Int Range

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -89,6 +89,12 @@ NUM_CPUS_FOR_META_FETCH_TASK = 0.5
 DEFAULT_PARQUET_READER_ROW_BATCH_SIZE = 10_000
 FILE_READING_RETRY = 8
 
+# `ParquetFileFragment.to_batches` passes `batch_size` through PyArrow's Cython
+# layer as a C ``int`` (32-bit). Larger values raise
+# `OverflowError: value too large to convert to int` (e.g. when estimated batch
+# size from bytes-per-row blows up for sparse or highly compressed batches).
+_MAX_PYARROW_TO_BATCHES_BATCH_SIZE = 2**31 - 1
+
 # The default size multiplier for reading Parquet data source in Arrow.
 # Parquet data format is encoded with various encoding techniques (such as
 # dictionary, RLE, delta), so Arrow in-memory representation uses much more memory
@@ -873,6 +879,21 @@ def read_fragments(
                     yield table
 
 
+def _coerce_pyarrow_fragment_batch_size(batch_size: Any) -> int:
+    """Coerce and clamp batch size for `ParquetFileFragment.to_batches` (C int range)."""
+    bs = int(batch_size)
+    coerced = min(max(bs, 1), _MAX_PYARROW_TO_BATCHES_BATCH_SIZE)
+    if coerced != bs:
+        logger.debug(
+            "Clamping Parquet fragment read batch_size from %s to %s "
+            "(PyArrow ``to_batches`` requires batch_size in [1, %s]).",
+            bs,
+            coerced,
+            _MAX_PYARROW_TO_BATCHES_BATCH_SIZE,
+        )
+    return coerced
+
+
 def _read_batches_from(
     fragment: "ParquetFileFragment",
     *,
@@ -910,6 +931,11 @@ def _read_batches_from(
     # NOTE: Arrow's ``to_batches`` expects ``batch_size`` as an int
     if batch_size is not None:
         to_batches_kwargs.setdefault("batch_size", batch_size)
+
+    if to_batches_kwargs.get("batch_size") is not None:
+        to_batches_kwargs["batch_size"] = _coerce_pyarrow_fragment_batch_size(
+            to_batches_kwargs["batch_size"]
+        )
 
     partition_col_values = _parse_partition_column_values(
         fragment, partition_columns, partitioning

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -879,8 +879,15 @@ def read_fragments(
                     yield table
 
 
-def _coerce_pyarrow_fragment_batch_size(batch_size: Any) -> int:
-    """Coerce and clamp batch size for `ParquetFileFragment.to_batches` (C int range)."""
+def _coerce_pyarrow_fragment_batch_size(batch_size: object) -> int:
+    """Coerce and clamp batch size for `ParquetFileFragment.to_batches` (C int range).
+
+    The parameter is typed as :class:`object` because values often come from untyped
+    containers (e.g. `to_batches_kwargs`).
+
+    Values are converted with :func:`int` (Python's usual rules: `bool` becomes 0/1,
+    `float` truncates toward zero) then clamped to `[1, MAX]`.
+    """
     bs = int(batch_size)
     coerced = min(max(bs, 1), _MAX_PYARROW_TO_BATCHES_BATCH_SIZE)
     if coerced != bs:

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -879,22 +879,19 @@ def read_fragments(
                     yield table
 
 
-def _coerce_pyarrow_fragment_batch_size(batch_size: object) -> int:
-    """Coerce and clamp batch size for `ParquetFileFragment.to_batches` (C int range).
+def _coerce_pyarrow_fragment_batch_size(batch_size: int) -> int:
+    """Clamp batch size for ``ParquetFileFragment.to_batches`` to PyArrow's C int range.
 
-    The parameter is typed as :class:`object` because values often come from untyped
-    containers (e.g. `to_batches_kwargs`).
-
-    Values are converted with :func:`int` (Python's usual rules: `bool` becomes 0/1,
-    `float` truncates toward zero) then clamped to `[1, MAX]`.
+    Expects a value already converted with :func:`int` (callers reading from untyped
+    kwargs should do ``int(...)`` before calling). Values outside
+    ``[1, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE]`` are clamped.
     """
-    bs = int(batch_size)
-    coerced = min(max(bs, 1), _MAX_PYARROW_TO_BATCHES_BATCH_SIZE)
-    if coerced != bs:
+    coerced = min(max(batch_size, 1), _MAX_PYARROW_TO_BATCHES_BATCH_SIZE)
+    if coerced != batch_size:
         logger.debug(
             "Clamping Parquet fragment read batch_size from %s to %s "
             "(PyArrow ``to_batches`` requires batch_size in [1, %s]).",
-            bs,
+            batch_size,
             coerced,
             _MAX_PYARROW_TO_BATCHES_BATCH_SIZE,
         )
@@ -941,7 +938,7 @@ def _read_batches_from(
 
     if to_batches_kwargs.get("batch_size") is not None:
         to_batches_kwargs["batch_size"] = _coerce_pyarrow_fragment_batch_size(
-            to_batches_kwargs["batch_size"]
+            int(to_batches_kwargs["batch_size"])
         )
 
     partition_col_values = _parse_partition_column_values(

--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -886,7 +886,9 @@ def _coerce_pyarrow_fragment_batch_size(batch_size: int) -> int:
     kwargs should do ``int(...)`` before calling). Values outside
     ``[1, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE]`` are clamped.
     """
-    coerced = min(max(batch_size, 1), _MAX_PYARROW_TO_BATCHES_BATCH_SIZE)
+    if batch_size <= 0:
+        raise ValueError(f"Batch size must be > 0, got {batch_size}")
+    coerced = min(batch_size, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE)
     if coerced != batch_size:
         logger.debug(
             "Clamping Parquet fragment read batch_size from %s to %s "

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -2677,7 +2677,8 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
 class TestParquetFragmentBatchSizeCoercion:
     """Regression: PyArrow ``Fragment.to_batches`` uses a C int for ``batch_size``.
 
-    ``_coerce_pyarrow_fragment_batch_size`` clamps to ``[1, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE]``.
+    ``_coerce_pyarrow_fragment_batch_size`` raises for non-positive values and clamps
+    values above ``_MAX_PYARROW_TO_BATCHES_BATCH_SIZE`` to that maximum.
     """
 
     @pytest.mark.parametrize(
@@ -2686,13 +2687,17 @@ class TestParquetFragmentBatchSizeCoercion:
             (2**31, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
             (10**12, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
             (_MAX_PYARROW_TO_BATCHES_BATCH_SIZE, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
-            (0, 1),
-            (-5, 1),
+            (0, ValueError),
+            (-3, ValueError),
             (10_000, 10_000),
         ],
     )
     def test_coerce_pyarrow_fragment_batch_size(self, raw, expected):
-        assert _coerce_pyarrow_fragment_batch_size(raw) == expected
+        if expected is ValueError:
+            with pytest.raises(ValueError, match="Batch size must be > 0"):
+                _coerce_pyarrow_fragment_batch_size(raw)
+        else:
+            assert _coerce_pyarrow_fragment_batch_size(raw) == expected
 
     @pytest.mark.parametrize(
         "batch_size,to_batches_kwargs,expected_batch_size_passed_to_to_batches",
@@ -2701,16 +2706,16 @@ class TestParquetFragmentBatchSizeCoercion:
             (None, {"batch_size": 2**31}, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
             (10_000, None, 10_000),
             (None, {"batch_size": np.int64(10_000)}, 10_000),
-            (0, None, 1),
-            (-3, None, 1),
-            (None, {"batch_size": 0}, 1),
-            (None, {"batch_size": -1}, 1),
+            (0, None, ValueError),
+            (-3, None, ValueError),
+            (None, {"batch_size": 0}, ValueError),
+            (None, {"batch_size": -1}, ValueError),
         ],
     )
     def test_read_batches_from_coerces_fragment_batch_size_to_c_int_range(
         self, batch_size, to_batches_kwargs, expected_batch_size_passed_to_to_batches
     ):
-        """``batch_size`` passed to ``fragment.to_batches`` is clamped to C int range."""
+        """``batch_size`` passed to ``fragment.to_batches`` is coerced for PyArrow's C int."""
 
         captured: dict = {}
 
@@ -2725,20 +2730,27 @@ class TestParquetFragmentBatchSizeCoercion:
         fragment.to_batches = fake_to_batches
 
         schema = pa.schema([("x", pa.int64())])
-        out = list(
-            _read_batches_from(
-                fragment,
-                schema=schema,
-                data_columns=["x"],
-                data_columns_rename_map=None,
-                partition_columns=None,
-                partitioning=Partitioning("hive"),
-                batch_size=batch_size,
-                to_batches_kwargs=to_batches_kwargs,
+
+        def run_read():
+            return list(
+                _read_batches_from(
+                    fragment,
+                    schema=schema,
+                    data_columns=["x"],
+                    data_columns_rename_map=None,
+                    partition_columns=None,
+                    partitioning=Partitioning("hive"),
+                    batch_size=batch_size,
+                    to_batches_kwargs=to_batches_kwargs,
+                )
             )
-        )
-        assert out == []
-        assert captured["batch_size"] == expected_batch_size_passed_to_to_batches
+
+        if expected_batch_size_passed_to_to_batches is ValueError:
+            with pytest.raises(ValueError, match="Batch size must be > 0"):
+                run_read()
+        else:
+            assert run_read() == []
+            assert captured["batch_size"] == expected_batch_size_passed_to_to_batches
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -4,6 +4,7 @@ import shutil
 import time
 from dataclasses import dataclass
 from typing import Optional, Union
+from unittest.mock import MagicMock
 
 import fsspec
 import numpy as np
@@ -19,7 +20,10 @@ from pytest_lazy_fixtures import lf as lazy_fixture
 import ray
 from ray.data import FileShuffleConfig, Schema
 from ray.data._internal.datasource.parquet_datasource import (
+    _MAX_PYARROW_TO_BATCHES_BATCH_SIZE,
     ParquetDatasource,
+    _coerce_pyarrow_fragment_batch_size,
+    _read_batches_from,
 )
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
@@ -2668,6 +2672,75 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
     actual_data = set(pd.read_parquet(out_path).itertuples(index=False))
     expected_data = set(pd.concat([df1, df2]).itertuples(index=False))
     assert actual_data == expected_data, (actual_data, expected_data)
+
+
+class TestParquetFragmentBatchSizeCoercion:
+    """Regression: PyArrow ``Fragment.to_batches`` uses a C int for ``batch_size``."""
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (2**31, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
+            (10**12, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
+            (_MAX_PYARROW_TO_BATCHES_BATCH_SIZE, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
+            (0, 1),
+            (-5, 1),
+            (10_000, 10_000),
+            (np.int64(10_000), 10_000),
+        ],
+    )
+    def test_coerce_pyarrow_fragment_batch_size(self, raw, expected):
+        assert _coerce_pyarrow_fragment_batch_size(raw) == expected
+
+    @pytest.mark.parametrize(
+        "batch_size,to_batches_kwargs",
+        [
+            (10**12, None),
+            (None, {"batch_size": 2**31}),
+            (10_000, None),
+            (None, {"batch_size": np.int64(10_000)}),
+        ],
+    )
+    def test_read_batches_from_clamps_batch_size_kwarg(
+        self, batch_size, to_batches_kwargs
+    ):
+        captured: dict = {}
+
+        def fake_to_batches(
+            *, columns=None, filter=None, schema=None, use_threads=False, **kwargs
+        ):
+            captured["batch_size"] = kwargs.get("batch_size")
+            return iter([])
+
+        fragment = MagicMock()
+        fragment.path = "/tmp/test.parquet"
+        fragment.to_batches = fake_to_batches
+
+        schema = pa.schema([("x", pa.int64())])
+        out = list(
+            _read_batches_from(
+                fragment,
+                schema=schema,
+                data_columns=["x"],
+                data_columns_rename_map=None,
+                partition_columns=None,
+                partitioning=Partitioning("hive"),
+                batch_size=batch_size,
+                to_batches_kwargs=to_batches_kwargs,
+            )
+        )
+        assert out == []
+        if batch_size is not None:
+            if batch_size < _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
+                assert captured["batch_size"] == int(batch_size)
+            else:
+                assert captured["batch_size"] == _MAX_PYARROW_TO_BATCHES_BATCH_SIZE
+        else:
+            tb_bs = to_batches_kwargs["batch_size"]
+            if int(tb_bs) < _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
+                assert captured["batch_size"] == int(tb_bs)
+            else:
+                assert captured["batch_size"] == _MAX_PYARROW_TO_BATCHES_BATCH_SIZE
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -2675,7 +2675,11 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
 
 
 class TestParquetFragmentBatchSizeCoercion:
-    """Regression: PyArrow ``Fragment.to_batches`` uses a C int for ``batch_size``."""
+    """Regression: PyArrow `Fragment.to_batches` uses a C int for `batch_size`.
+
+    Exercises `_coerce_pyarrow_fragment_batch_size`: `int()` coercion and clamping
+    to PyArrow's valid range (mirrors values from kwargs).
+    """
 
     @pytest.mark.parametrize(
         "raw,expected",
@@ -2687,10 +2691,24 @@ class TestParquetFragmentBatchSizeCoercion:
             (-5, 1),
             (10_000, 10_000),
             (np.int64(10_000), 10_000),
+            (True, 1),
+            (False, 1),
+            (3.7, 3),
+            (10.0, 10),
+            ("100", 100),
         ],
     )
     def test_coerce_pyarrow_fragment_batch_size(self, raw, expected):
         assert _coerce_pyarrow_fragment_batch_size(raw) == expected
+
+    @pytest.mark.parametrize("bad", [None, object()])
+    def test_coerce_pyarrow_fragment_batch_size_int_raises_type_error(self, bad):
+        with pytest.raises(TypeError):
+            _coerce_pyarrow_fragment_batch_size(bad)
+
+    def test_coerce_pyarrow_fragment_batch_size_invalid_string(self):
+        with pytest.raises(ValueError):
+            _coerce_pyarrow_fragment_batch_size("not_an_int")
 
     @pytest.mark.parametrize(
         "batch_size,to_batches_kwargs",
@@ -2699,6 +2717,10 @@ class TestParquetFragmentBatchSizeCoercion:
             (None, {"batch_size": 2**31}),
             (10_000, None),
             (None, {"batch_size": np.int64(10_000)}),
+            (0, None),
+            (-3, None),
+            (None, {"batch_size": 0}),
+            (None, {"batch_size": -1}),
         ],
     )
     def test_read_batches_from_clamps_batch_size_kwarg(
@@ -2731,16 +2753,21 @@ class TestParquetFragmentBatchSizeCoercion:
         )
         assert out == []
         if batch_size is not None:
-            if batch_size < _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
-                assert captured["batch_size"] == int(batch_size)
-            else:
+            ib = int(batch_size)
+            if ib < 1:
+                assert captured["batch_size"] == 1
+            elif ib > _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
                 assert captured["batch_size"] == _MAX_PYARROW_TO_BATCHES_BATCH_SIZE
+            else:
+                assert captured["batch_size"] == ib
         else:
-            tb_bs = to_batches_kwargs["batch_size"]
-            if int(tb_bs) < _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
-                assert captured["batch_size"] == int(tb_bs)
-            else:
+            tb_bs = int(to_batches_kwargs["batch_size"])
+            if tb_bs < 1:
+                assert captured["batch_size"] == 1
+            elif tb_bs > _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
                 assert captured["batch_size"] == _MAX_PYARROW_TO_BATCHES_BATCH_SIZE
+            else:
+                assert captured["batch_size"] == tb_bs
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -2675,10 +2675,9 @@ def test_fsspec_filesystem(ray_start_regular_shared, tmp_path):
 
 
 class TestParquetFragmentBatchSizeCoercion:
-    """Regression: PyArrow `Fragment.to_batches` uses a C int for `batch_size`.
+    """Regression: PyArrow ``Fragment.to_batches`` uses a C int for ``batch_size``.
 
-    Exercises `_coerce_pyarrow_fragment_batch_size`: `int()` coercion and clamping
-    to PyArrow's valid range (mirrors values from kwargs).
+    ``_coerce_pyarrow_fragment_batch_size`` clamps to ``[1, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE]``.
     """
 
     @pytest.mark.parametrize(
@@ -2690,42 +2689,29 @@ class TestParquetFragmentBatchSizeCoercion:
             (0, 1),
             (-5, 1),
             (10_000, 10_000),
-            (np.int64(10_000), 10_000),
-            (True, 1),
-            (False, 1),
-            (3.7, 3),
-            (10.0, 10),
-            ("100", 100),
         ],
     )
     def test_coerce_pyarrow_fragment_batch_size(self, raw, expected):
         assert _coerce_pyarrow_fragment_batch_size(raw) == expected
 
-    @pytest.mark.parametrize("bad", [None, object()])
-    def test_coerce_pyarrow_fragment_batch_size_int_raises_type_error(self, bad):
-        with pytest.raises(TypeError):
-            _coerce_pyarrow_fragment_batch_size(bad)
-
-    def test_coerce_pyarrow_fragment_batch_size_invalid_string(self):
-        with pytest.raises(ValueError):
-            _coerce_pyarrow_fragment_batch_size("not_an_int")
-
     @pytest.mark.parametrize(
-        "batch_size,to_batches_kwargs",
+        "batch_size,to_batches_kwargs,expected_batch_size_passed_to_to_batches",
         [
-            (10**12, None),
-            (None, {"batch_size": 2**31}),
-            (10_000, None),
-            (None, {"batch_size": np.int64(10_000)}),
-            (0, None),
-            (-3, None),
-            (None, {"batch_size": 0}),
-            (None, {"batch_size": -1}),
+            (10**12, None, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
+            (None, {"batch_size": 2**31}, _MAX_PYARROW_TO_BATCHES_BATCH_SIZE),
+            (10_000, None, 10_000),
+            (None, {"batch_size": np.int64(10_000)}, 10_000),
+            (0, None, 1),
+            (-3, None, 1),
+            (None, {"batch_size": 0}, 1),
+            (None, {"batch_size": -1}, 1),
         ],
     )
-    def test_read_batches_from_clamps_batch_size_kwarg(
-        self, batch_size, to_batches_kwargs
+    def test_read_batches_from_coerces_fragment_batch_size_to_c_int_range(
+        self, batch_size, to_batches_kwargs, expected_batch_size_passed_to_to_batches
     ):
+        """``batch_size`` passed to ``fragment.to_batches`` is clamped to C int range."""
+
         captured: dict = {}
 
         def fake_to_batches(
@@ -2752,22 +2738,7 @@ class TestParquetFragmentBatchSizeCoercion:
             )
         )
         assert out == []
-        if batch_size is not None:
-            ib = int(batch_size)
-            if ib < 1:
-                assert captured["batch_size"] == 1
-            elif ib > _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
-                assert captured["batch_size"] == _MAX_PYARROW_TO_BATCHES_BATCH_SIZE
-            else:
-                assert captured["batch_size"] == ib
-        else:
-            tb_bs = int(to_batches_kwargs["batch_size"])
-            if tb_bs < 1:
-                assert captured["batch_size"] == 1
-            elif tb_bs > _MAX_PYARROW_TO_BATCHES_BATCH_SIZE:
-                assert captured["batch_size"] == _MAX_PYARROW_TO_BATCHES_BATCH_SIZE
-            else:
-                assert captured["batch_size"] == tb_bs
+        assert captured["batch_size"] == expected_batch_size_passed_to_to_batches
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
PyArrow’s `ParquetFileFragment.to_batches` passes `batch_size` through the Cython layer as a 32-bit C int. When Ray inferred enormous batch sizes from tiny effective bytes-per-row, calls into PyArrow raised `OverflowError: value too large to convert to int`. This change normalizes every `batch_size` in `_read_batches_from` to `[1, 2**31 − 1]` before `to_batches`, emits a debug log only when a value is actually clamped.

## Additional information
Added tests for the clamp function and for `_read_batches_from` via a mocked fragment.
