### PR TITLE
[llm][serve] Fix duplicate 'data: [DONE]' in streaming SSE responses

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -352,7 +352,7 @@ async def _openai_json_wrapper(
     done_sent = False
     async for response in generator:
         packet = _apply_openai_json_format(response)
-        if any(p.strip() == "data: [DONE]" for p in packet.split("\n\n")):
+        if packet.strip().endswith("data: [DONE]"):
             done_sent = True
         yield packet
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -352,7 +352,7 @@ async def _openai_json_wrapper(
     done_sent = False
     async for response in generator:
         packet = _apply_openai_json_format(response)
-        if any(p.strip() == "data: [DONE]" for p in packet.split("\n\n")):
+        if "data: [DONE]" in packet:
             done_sent = True
         yield packet
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -346,13 +346,18 @@ async def _openai_json_wrapper(
 
     Yields:
         String chunks in OpenAI SSE format: "data: {json}\n\n", with a final
-        "data: [DONE]\n\n" to indicate completion.
+        "data: [DONE]\n\n" to indicate completion. If the upstream generator
+        already yields a "data: [DONE]" sentinel, it is not duplicated.
     """
+    done_sent = False
     async for response in generator:
         packet = _apply_openai_json_format(response)
+        if packet.strip() == "data: [DONE]":
+            done_sent = True
         yield packet
 
-    yield "data: [DONE]\n\n"
+    if not done_sent:
+        yield "data: [DONE]\n\n"
 
 
 @asynccontextmanager

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -352,7 +352,7 @@ async def _openai_json_wrapper(
     done_sent = False
     async for response in generator:
         packet = _apply_openai_json_format(response)
-        if "data: [DONE]" in packet:
+        if any(p.strip() == "data: [DONE]" for p in packet.split("\n\n")):
             done_sent = True
         yield packet
 

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -352,7 +352,7 @@ async def _openai_json_wrapper(
     done_sent = False
     async for response in generator:
         packet = _apply_openai_json_format(response)
-        if packet.strip() == "data: [DONE]":
+        if any(p.strip() == "data: [DONE]" for p in packet.split("\n\n")):
             done_sent = True
         yield packet
 

--- a/python/ray/llm/tests/serve/cpu/deployments/test_openai_json_wrapper.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/test_openai_json_wrapper.py
@@ -1,0 +1,31 @@
+import pytest
+
+from ray.llm._internal.serve.core.ingress.ingress import _openai_json_wrapper
+
+
+async def _async_gen_from_list(items):
+    for item in items:
+        yield item
+
+
+@pytest.mark.asyncio
+class TestOpenAIJsonWrapper:
+    async def test_no_duplicate_done_when_upstream_sends_done(self):
+        """When the upstream generator already yields 'data: [DONE]', the
+        wrapper must not append a second one."""
+        upstream = ["data: {\"id\": 1}\n\n", "data: [DONE]\n\n"]
+        chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list(upstream))]
+        assert chunks == upstream
+        assert chunks.count("data: [DONE]\n\n") == 1
+
+    async def test_done_appended_when_upstream_does_not_send_done(self):
+        """When the upstream generator does not yield 'data: [DONE]', the
+        wrapper must append it."""
+        upstream = ["data: {\"id\": 1}\n\n"]
+        chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list(upstream))]
+        assert chunks == ["data: {\"id\": 1}\n\n", "data: [DONE]\n\n"]
+
+    async def test_done_appended_for_empty_stream(self):
+        """An empty upstream stream should still produce a [DONE] sentinel."""
+        chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list([]))]
+        assert chunks == ["data: [DONE]\n\n"]

--- a/python/ray/llm/tests/serve/cpu/deployments/test_openai_json_wrapper.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/test_openai_json_wrapper.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from ray.llm._internal.serve.core.ingress.ingress import _openai_json_wrapper
@@ -13,7 +15,7 @@ class TestOpenAIJsonWrapper:
     async def test_no_duplicate_done_when_upstream_sends_done(self):
         """When the upstream generator already yields 'data: [DONE]', the
         wrapper must not append a second one."""
-        upstream = ["data: {\"id\": 1}\n\n", "data: [DONE]\n\n"]
+        upstream = ['data: {"id": 1}\n\n', "data: [DONE]\n\n"]
         chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list(upstream))]
         assert chunks == upstream
         assert chunks.count("data: [DONE]\n\n") == 1
@@ -21,9 +23,9 @@ class TestOpenAIJsonWrapper:
     async def test_done_appended_when_upstream_does_not_send_done(self):
         """When the upstream generator does not yield 'data: [DONE]', the
         wrapper must append it."""
-        upstream = ["data: {\"id\": 1}\n\n"]
+        upstream = ['data: {"id": 1}\n\n']
         chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list(upstream))]
-        assert chunks == ["data: {\"id\": 1}\n\n", "data: [DONE]\n\n"]
+        assert chunks == ['data: {"id": 1}\n\n', "data: [DONE]\n\n"]
 
     async def test_done_appended_for_empty_stream(self):
         """An empty upstream stream should still produce a [DONE] sentinel."""
@@ -33,6 +35,10 @@ class TestOpenAIJsonWrapper:
     async def test_no_duplicate_done_when_upstream_sends_done_batched(self):
         """When the upstream generator yields a batch containing 'data: [DONE]',
         the wrapper must not append a second one."""
-        upstream = [["data: {\"id\": 1}\n\n", "data: [DONE]\n\n"]]
+        upstream = [['data: {"id": 1}\n\n', "data: [DONE]\n\n"]]
         chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list(upstream))]
-        assert chunks == ["data: {\"id\": 1}\n\ndata: [DONE]\n\n"]
+        assert chunks == ['data: {"id": 1}\n\ndata: [DONE]\n\n']
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/test_openai_json_wrapper.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/test_openai_json_wrapper.py
@@ -29,3 +29,10 @@ class TestOpenAIJsonWrapper:
         """An empty upstream stream should still produce a [DONE] sentinel."""
         chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list([]))]
         assert chunks == ["data: [DONE]\n\n"]
+
+    async def test_no_duplicate_done_when_upstream_sends_done_batched(self):
+        """When the upstream generator yields a batch containing 'data: [DONE]',
+        the wrapper must not append a second one."""
+        upstream = [["data: {\"id\": 1}\n\n", "data: [DONE]\n\n"]]
+        chunks = [c async for c in _openai_json_wrapper(_async_gen_from_list(upstream))]
+        assert chunks == ["data: {\"id\": 1}\n\ndata: [DONE]\n\n"]


### PR DESCRIPTION
Fixes #62228
