### PR TITLE
[autoscaler][v2] Fix ReadOnlyProvider.terminate() signature mismatch with ICloudInstanceProvider"

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/read_only/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/read_only/cloud_provider.py
@@ -61,7 +61,7 @@ class ReadOnlyProvider(ICloudInstanceProvider):
 
         return cloud_instances
 
-    def terminate(self, instance_id: CloudInstanceId) -> None:
+    def terminate(self, ids: List[CloudInstanceId], request_id: str) -> None:
         raise NotImplementedError("Cannot terminate instances in read-only mode.")
 
     def launch(

--- a/python/ray/autoscaler/v2/tests/test_subscribers.py
+++ b/python/ray/autoscaler/v2/tests/test_subscribers.py
@@ -8,6 +8,9 @@ import pytest
 
 from ray._common.test_utils import wait_for_condition
 from ray._common.utils import binary_to_hex, hex_to_binary
+from ray.autoscaler.v2.instance_manager.cloud_providers.read_only.cloud_provider import (
+    ReadOnlyProvider,
+)
 from ray.autoscaler.v2.instance_manager.subscribers.cloud_instance_updater import (
     CloudInstanceUpdater,
 )
@@ -292,6 +295,45 @@ class TestCloudInstanceUpdater:
             return True
 
         wait_for_condition(verify)
+
+
+class TestReadOnlyProvider:
+    def test_terminate_raises_not_implemented_with_correct_interface(self):
+        """ReadOnlyProvider.terminate() must accept ids and request_id kwargs.
+
+        Regression test for:
+          TypeError: ReadOnlyProvider.terminate() got an unexpected keyword
+          argument 'ids'
+
+        CloudInstanceUpdater calls provider.terminate(ids=..., request_id=...)
+        which matches the ICloudInstanceProvider interface. ReadOnlyProvider
+        must accept the same signature even though it raises NotImplementedError.
+        """
+        provider = object.__new__(ReadOnlyProvider)  # skip __init__ (needs GCS)
+
+        with pytest.raises(NotImplementedError):
+            provider.terminate(ids=["node-1", "node-2"], request_id="req-1")
+
+    def test_terminate_via_cloud_instance_updater_raises_not_implemented(self):
+        """Verify the full call path: CloudInstanceUpdater -> ReadOnlyProvider.
+
+        When a TERMINATING event arrives, CloudInstanceUpdater calls
+        provider.terminate(ids=..., request_id=...). With ReadOnlyProvider this
+        should surface as NotImplementedError, not TypeError.
+        """
+        provider = object.__new__(ReadOnlyProvider)
+        updater = CloudInstanceUpdater(cloud_provider=provider)
+
+        with pytest.raises(NotImplementedError):
+            updater.notify(
+                [
+                    InstanceUpdateEvent(
+                        new_instance_status=Instance.TERMINATING,
+                        instance_id="i-1",
+                        cloud_instance_id="cloud-node-1",
+                    ),
+                ]
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?
`ReadOnlyProvider.terminate()` had an incorrect method signature that did not match the `ICloudInstanceProvider` abstract interface, causing a `TypeError` in laptop mode / manual cluster setups when the autoscaler v2 attempts to terminate instances.
**Before (broken):**
```python
def terminate(self, instance_id: CloudInstanceId) -> None:
    raise NotImplementedError("Cannot terminate instances in read-only mode.")
```
**After (fixed):**
```python
def terminate(self, ids: List[CloudInstanceId], request_id: str) -> None:
    raise NotImplementedError("Cannot terminate instances in read-only mode.")
```
`CloudInstanceUpdater._terminate_instances()` calls `provider.terminate(ids=..., request_id=...)` per the `ICloudInstanceProvider` interface contract. With `ReadOnlyProvider`, this triggered:
```
TypeError: ReadOnlyProvider.terminate() got an unexpected keyword argument 'ids'
```
instead of the expected `NotImplementedError`.

The fix aligns the signature with the interface. The `NotImplementedError` semantics are preserved — `ReadOnlyProvider` is intentionally read-only and should never actually terminate instances.
Other implementations (`NodeProviderAdapter`, `KubeRayProvider`) already had the correct signature.

## Related issue number
Closes #62250 

## Checks
- [x] I've signed off every commit (see [Contribution guide](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html))
- [x] I've run `scripts/format.sh` to lint the changes in this PR
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/
- [x] I've made sure the tests are passing. Unit tests are run automatically.
- [x] Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(