### PR TITLE
[Serve] Fix flaky test_util by bumping Bazel size and adding wait_for_condition

### DIFF
--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -84,7 +84,6 @@ py_test_module_list(
         "test_proxy_actor_wrapper.py",
         "test_replica_request_context.py",
         "test_serve_with_tracing.py",
-        "test_util.py",
         "test_websockets.py",
     ],
     tags = [
@@ -141,6 +140,7 @@ py_test_module_list(
         "test_streaming_response.py",
         "test_task_consumer_autoscaling.py",
         "test_task_processor.py",
+        "test_util.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/serve/tests/test_util.py
+++ b/python/ray/serve/tests/test_util.py
@@ -10,6 +10,7 @@ from fastapi.encoders import jsonable_encoder
 import ray
 from ray import serve
 from ray._common.constants import HEAD_NODE_RESOURCE_NAME
+from ray._common.test_utils import wait_for_condition
 from ray.serve._private.constants import SERVE_NAMESPACE
 from ray.serve._private.utils import (
     Semaphore,
@@ -450,7 +451,19 @@ def test_get_all_live_placement_group_names(ray_instance):
     pg8 = ray.util.placement_group([{"CPU": 0.1}], lifetime="detached")
     assert pg8.wait()
 
-    assert set(get_all_live_placement_group_names()) == {"pg3", "pg4", "pg5", "pg6"}
+    # Use wait_for_condition to allow GCS state to propagate after
+    # remove_placement_group(). Removal is async — the scheduling state may not
+    # have flipped to REMOVED by the time we query.
+    def check_live_placement_group_names():
+        assert set(get_all_live_placement_group_names()) == {
+            "pg3",
+            "pg4",
+            "pg5",
+            "pg6",
+        }
+        return True
+
+    wait_for_condition(check_live_placement_group_names, timeout=10)
 
 
 def test_get_active_placement_group_ids(ray_instance):
@@ -506,21 +519,22 @@ def test_get_active_placement_group_ids(ray_instance):
     ).remote()
     ray.get(actor_non_serve.ready.remote())
 
-    active_ids = get_active_placement_group_ids()
-
-    # Should contain the PG ID for the live Serve actor's PG
     pg_with_actor_id = pg_with_actor.id.hex()
-    assert pg_with_actor_id in active_ids
-
-    # Should NOT contain the PG with no actor or the PG whose actor was killed
     pg_no_actor_id = pg_no_actor.id.hex()
     pg_killed_id = pg_killed.id.hex()
-    assert pg_no_actor_id not in active_ids
-    assert pg_killed_id not in active_ids
-
-    # Should NOT contain the PG for the non-Serve actor
     pg_non_serve_id = pg_non_serve.id.hex()
-    assert pg_non_serve_id not in active_ids
+
+    # Use wait_for_condition to allow GCS state to propagate after ray.kill().
+    # ray.kill() is async — the actor's ALIVE -> DEAD transition in GCS may lag.
+    def check_active_placement_group_ids():
+        active_ids = get_active_placement_group_ids()
+        assert pg_with_actor_id in active_ids
+        assert pg_no_actor_id not in active_ids
+        assert pg_killed_id not in active_ids
+        assert pg_non_serve_id not in active_ids
+        return True
+
+    wait_for_condition(check_active_placement_group_ids, timeout=10)
 
 
 def test_is_running_in_asyncio_loop_false():


### PR DESCRIPTION
## Summary
- **Move `test_util.py` from Bazel `small` (60s timeout) to `medium` (300s)** — the test runs 4 Ray cluster lifecycles + GitHub archive download, regularly exceeding 60s under CI load
- **Add `wait_for_condition` in `test_get_active_placement_group_ids`** — `ray.kill()` is async; the test was immediately querying `list_actors(state="ALIVE")` without waiting for GCS state propagation
- **Add `wait_for_condition` in `test_get_all_live_placement_group_names`** — `remove_placement_group()` is async; the test was immediately asserting PG table state

🤖 Generated with [Claude Code](https://claude.com/claude-code)