### PR TITLE
[Data] Always align to 64 bytes when serialize buffer to ensuring downstream consumers get properly aligned memory pointers (#62237)

### DIFF
--- a/python/ray/includes/serialization.pxi
+++ b/python/ray/includes/serialization.pxi
@@ -5,12 +5,9 @@ import cython
 
 DEF MEMCOPY_THREADS = 6
 
-# This is the default alignment value for len(buffer) < 2048.
-DEF kMinorBufferAlign = 8
-# This is the default alignment value for len(buffer) >= 2048.
+# This is the default alignment value for any buffer.
 # Some projects like Arrow use it for possible SIMD acceleration.
 DEF kMajorBufferAlign = 64
-DEF kMajorBufferSize = 2048
 DEF kMemcopyDefaultBlocksize = 64
 DEF kMemcopyDefaultThreshold = 1024 * 1024
 DEF kLanguageSpecificTypeExtensionId = 101
@@ -311,12 +308,8 @@ cdef class Pickle5Writer:
                 buffer.add_strides(view.strides[i])
 
         # Increase buffer address.
-        if view.len < kMajorBufferSize:
-            self._curr_buffer_addr = padded_length(
-                self._curr_buffer_addr, kMinorBufferAlign)
-        else:
-            self._curr_buffer_addr = padded_length(
-                self._curr_buffer_addr, kMajorBufferAlign)
+        self._curr_buffer_addr = padded_length(
+            self._curr_buffer_addr, kMajorBufferAlign)
         buffer.set_address(self._curr_buffer_addr)
         self._curr_buffer_addr += view.len
         self.buffers.push_back(view)

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -769,7 +769,8 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
     # It should pass.
     ray.get(test.remote())
 
-@pytest.mark.parametrize("row_nums", [3,  100, 1000, 3000])
+
+@pytest.mark.parametrize("row_nums", [3, 100, 1000, 3000])
 def test_serialization_arrow_table(ray_start_regular, row_nums):
     pytest.importorskip("pyarrow")
     import decimal

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -769,6 +769,31 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
     # It should pass.
     ray.get(test.remote())
 
+@pytest.mark.parametrize("row_nums", [3,  100, 1000, 3000])
+def test_serialization_arrow_table(ray_start_regular, row_nums):
+    pytest.importorskip("pyarrow")
+    import decimal
+    import pyarrow as pa
+
+    @ray.remote
+    def func():
+        return pa.table({
+            "a": pa.array([1] * row_nums),
+            "b": pa.array(["hello"] * row_nums),
+            "dec": pa.array(
+                [decimal.Decimal("1.23")] * row_nums,
+                type=pa.decimal128(38, 10)
+            )
+        })
+
+    tbl = ray.get(func.remote())
+    for col in tbl.columns:
+        for chk in col.chunks:
+            for buf in chk.buffers():
+                if buf is not None:
+                    assert buf.address % 64 == 0, (
+                        f"Buffer not 64-byte aligned: address=0x{buf.address:x}"
+                    )
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -796,5 +796,6 @@ def test_serialization_arrow_table(ray_start_regular, row_nums):
                         f"Buffer not 64-byte aligned: address=0x{buf.address:x}"
                     )
 
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
Ray currently aligns buffer to 8 bytes if they are less than 2048 bytes, and 64 bytes if larger. When using Ray with small Lance tables, an error occurs because the underlying Lance logic expects Decimal128 to be 16-byte aligned. Since Ray uses 8-byte alignment for small data, it fails Lance's alignment check. 

see issue : (#62237)

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
>

## Related issues
> #62237

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
