### PR TITLE
[Data] Fix Pandas block size estimation for nested torch tensors

### DIFF
--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -522,10 +522,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         from ray.data.extensions import TensorArrayElement, TensorDtype
 
         pd = lazy_import_pandas()
-        try:
-            import torch
-        except ImportError:
-            torch = None
+        torch_tensor_type = getattr(sys.modules.get("torch"), "Tensor", None)
 
         def get_deep_size(obj):
             """Calculates the memory size of objects,
@@ -558,7 +555,9 @@ class PandasBlockAccessor(TableBlockAccessor):
                 # Handle specific cases
                 if isinstance(current, np.ndarray):
                     total_size += current.nbytes - size  # Avoid double counting
-                elif torch is not None and isinstance(current, torch.Tensor):
+                elif torch_tensor_type is not None and isinstance(
+                    current, torch_tensor_type
+                ):
                     total_size += current.nelement() * current.element_size() - size
                 elif isinstance(current, pd.DataFrame):
                     total_size += (

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -522,6 +522,10 @@ class PandasBlockAccessor(TableBlockAccessor):
         from ray.data.extensions import TensorArrayElement, TensorDtype
 
         pd = lazy_import_pandas()
+        try:
+            import torch
+        except ImportError:
+            torch = None
 
         def get_deep_size(obj):
             """Calculates the memory size of objects,
@@ -554,6 +558,8 @@ class PandasBlockAccessor(TableBlockAccessor):
                 # Handle specific cases
                 if isinstance(current, np.ndarray):
                     total_size += current.nbytes - size  # Avoid double counting
+                elif torch is not None and isinstance(current, torch.Tensor):
+                    total_size += current.nelement() * current.element_size() - size
                 elif isinstance(current, pd.DataFrame):
                     total_size += (
                         current.memory_usage(index=True, deep=True).sum() - size

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -332,6 +332,47 @@ class TestSizeBytes:
             true_value,
         )
 
+    def test_nested_torch_tensors(ray_start_regular_shared):
+        torch = pytest.importorskip("torch")
+
+        n = 2048
+        input_dict = {
+            "features": {
+                "dense": torch.randn(n, 512),
+                "sparse": torch.randn(n, 128),
+                "attention_mask": torch.ones(n, 2048),
+            },
+            "embeddings": {
+                "token_emb": torch.randn(n, 2048),
+                "position_emb": torch.randn(n, 2048),
+            },
+        }
+        target_dict = {
+            "labels": {
+                "class": torch.ones(n, dtype=torch.long),
+                "weights": torch.randn(n),
+            },
+        }
+        df = pd.DataFrame({"input": [input_dict], "target": [target_dict]})
+
+        block_accessor = PandasBlockAccessor.for_block(df)
+        block_size = block_accessor.size_bytes()
+
+        tensors = [
+            input_dict["features"]["dense"],
+            input_dict["features"]["sparse"],
+            input_dict["features"]["attention_mask"],
+            input_dict["embeddings"]["token_emb"],
+            input_dict["embeddings"]["position_emb"],
+            target_dict["labels"]["class"],
+            target_dict["labels"]["weights"],
+        ]
+        true_value = sum(t.nelement() * t.element_size() for t in tensors)
+        assert block_size == pytest.approx(true_value, rel=0.1), (
+            block_size,
+            true_value,
+        )
+
     def test_nested_objects(ray_start_regular_shared):
         size = 10
         rows = 10_000

--- a/python/ray/data/tests/test_pandas_block.py
+++ b/python/ray/data/tests/test_pandas_block.py
@@ -1,6 +1,7 @@
 import pickle
 import random
 import sys
+import types
 
 import numpy as np
 import pandas as pd
@@ -371,6 +372,19 @@ class TestSizeBytes:
         assert block_size == pytest.approx(true_value, rel=0.1), (
             block_size,
             true_value,
+        )
+
+    def test_partially_initialized_torch_module(ray_start_regular_shared, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", types.SimpleNamespace())
+
+        block = pd.DataFrame({"animals": ["Flamingo", "Centipede"]})
+        block_accessor = PandasBlockAccessor.for_block(block)
+        bytes_size = block_accessor.size_bytes()
+
+        memory_usage = block.memory_usage(index=True, deep=True).sum()
+        assert bytes_size == pytest.approx(memory_usage, rel=0.1), (
+            bytes_size,
+            memory_usage,
         )
 
     def test_nested_objects(ray_start_regular_shared):


### PR DESCRIPTION
## Why are these changes needed?

`PandasBlockAccessor.size_bytes()` can massively underestimate the size of pandas blocks when object-dtype columns contain nested `torch.Tensor` values.

Today, `get_deep_size()` handles nested containers such as `dict`, `list`, `tuple`, `set`, `np.ndarray`, `pd.DataFrame`, and `TensorArrayElement`, but it does not special-case `torch.Tensor`. As a result, tensor objects fall back to `sys.getsizeof()`, which only measures the Python object wrapper and not the underlying tensor buffer.

This causes Ray Data to report blocks that are actually tens of MB as only a few KB. In practice, this can affect:

- backpressure and memory accounting
- block splitting decisions
- reported dataset/block stats

While implementing this fix, we also found that importing `torch` directly inside `size_bytes()` is unsafe. `size_bytes()` is called frequently during execution, and in some environments `torch` may be present in `sys.modules` but only partially initialized, which can trigger import-time failures in unrelated Ray Data workflows.

## What changes are included in this PR?

This PR updates `PandasBlockAccessor.size_bytes()` to account for nested `torch.Tensor` payload sizes without importing `torch` during size estimation.

Specifically:
- detect `torch.Tensor` objects only if `torch` is already available in `sys.modules`
- add `tensor.nelement() * tensor.element_size()` to the estimated size, similar to how `np.ndarray.nbytes` is already handled
- avoid importing `torch` from `size_bytes()`, preventing failures when `torch` is only partially initialized

This PR also adds regression tests covering:
- pandas object columns containing nested torch tensors
- the case where `torch` is present in `sys.modules` but not fully initialized

## How was this PR tested?

Added regression tests in:

- `python/ray/data/tests/test_pandas_block.py`

The tests verify that:
- `PandasBlockAccessor.size_bytes()` returns a value close to the summed payload size of nested torch tensors stored inside pandas object columns
- `size_bytes()` does not fail when a partially initialized `torch` module is present

## Related issues
Closes #62254 
