### PR TITLE
[Data] Decouple sub-progress metrics from progress bar implementations

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/task_context.py
+++ b/python/ray/data/_internal/execution/interfaces/task_context.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.operators.map_transformer import MapTransformer
-    from ray.data._internal.progress.base_progress import BaseProgressBar
+    from ray.data._internal.progress.base_progress import (
+        ProgressMetrics,
+        SubProgressUpdater,
+    )
 
 
 _thread_local = threading.local()
@@ -22,10 +25,13 @@ class TaskContext:
     # Name of the operator that this task belongs to.
     op_name: str
 
-    # The dictionary of sub progress bar to update. The key is name of sub progress
-    # bar. Note this is only used on driver side.
+    # Immutable sub-progress snapshots keyed by sub-progress name.
+    # Note this is only used on the driver side.
     # TODO(chengsu): clean it up from TaskContext with new optimizer framework.
-    sub_progress_bar_dict: Optional[Dict[str, "BaseProgressBar"]] = None
+    sub_progress_metrics: Optional[Dict[str, "ProgressMetrics"]] = None
+
+    # Driver-side helpers for mutating the immutable sub-progress snapshots.
+    sub_progress_updaters: Optional[Dict[str, "SubProgressUpdater"]] = None
 
     # NOTE(hchen): `upstream_map_transformer` and `upstream_map_ray_remote_args`
     # are only used for `RandomShuffle`. DO NOT use them for other operators.
@@ -86,3 +92,19 @@ class TaskContext:
             yield context
         finally:
             cls.reset_current()
+
+    @property
+    def sub_progress_bar_dict(self):
+        return self.sub_progress_updaters
+
+    @sub_progress_bar_dict.setter
+    def sub_progress_bar_dict(self, value):
+        self.sub_progress_updaters = value
+
+    @property
+    def sub_progress_tracker_dict(self):
+        return self.sub_progress_updaters
+
+    @sub_progress_tracker_dict.setter
+    def sub_progress_tracker_dict(self, value):
+        self.sub_progress_updaters = value

--- a/python/ray/data/_internal/execution/interfaces/task_context.py
+++ b/python/ray/data/_internal/execution/interfaces/task_context.py
@@ -92,19 +92,3 @@ class TaskContext:
             yield context
         finally:
             cls.reset_current()
-
-    @property
-    def sub_progress_bar_dict(self):
-        return self.sub_progress_updaters
-
-    @sub_progress_bar_dict.setter
-    def sub_progress_bar_dict(self, value):
-        self.sub_progress_updaters = value
-
-    @property
-    def sub_progress_tracker_dict(self):
-        return self.sub_progress_updaters
-
-    @sub_progress_tracker_dict.setter
-    def sub_progress_tracker_dict(self, value):
-        self.sub_progress_updaters = value

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -1,4 +1,5 @@
 import abc
+import typing
 from typing import List, Optional
 
 from typing_extensions import override
@@ -11,12 +12,11 @@ from ray.data._internal.execution.interfaces import (
     TaskContext,
 )
 from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
-from ray.data._internal.progress.base_progress import (
-    ProgressMetrics,
-    SubProgressUpdater,
-)
 from ray.data._internal.stats import StatsDict
 from ray.data.context import DataContext
+
+if typing.TYPE_CHECKING:
+    from ray.data._internal.progress.base_progress import ProgressMetrics
 
 
 class InternalQueueOperatorMixin(PhysicalOperator, abc.ABC):
@@ -136,25 +136,13 @@ class AllToAllOperator(InternalQueueOperatorMixin, SubProgressMixin, PhysicalOpe
         # Keep the legacy attribute name during the transition. Some internal
         # call sites still read this field directly instead of using the mixin.
         self._sub_progress_bar_names = sub_progress_bar_names
-        self._sub_progress_metrics = (
-            {
-                name: ProgressMetrics(name=name, total=None, completed=0)
-                for name in sub_progress_bar_names
-            }
+        (
+            self._sub_progress_metrics,
+            self._sub_progress_updaters,
+        ) = (
+            self._create_sub_progress_state(sub_progress_bar_names)
             if sub_progress_bar_names is not None
-            else None
-        )
-        self._sub_progress_updaters = (
-            {
-                name: SubProgressUpdater(
-                    self._sub_progress_metrics,
-                    name=name,
-                    max_name_length=100,
-                )
-                for name in sub_progress_bar_names
-            }
-            if sub_progress_bar_names is not None
-            else None
+            else (None, None)
         )
         self._input_buffer: FIFOBundleQueue = FIFOBundleQueue()
         self._output_buffer: FIFOBundleQueue = FIFOBundleQueue()

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -133,6 +133,9 @@ class AllToAllOperator(InternalQueueOperatorMixin, SubProgressMixin, PhysicalOpe
         self._next_task_index = 0
         self._num_outputs = num_outputs
         self._output_rows = 0
+        # Keep the legacy attribute name during the transition. Some internal
+        # call sites still read this field directly instead of using the mixin.
+        self._sub_progress_bar_names = sub_progress_bar_names
         self._sub_progress_names = sub_progress_bar_names
         self._sub_progress_metrics = (
             {

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -136,7 +136,6 @@ class AllToAllOperator(InternalQueueOperatorMixin, SubProgressMixin, PhysicalOpe
         # Keep the legacy attribute name during the transition. Some internal
         # call sites still read this field directly instead of using the mixin.
         self._sub_progress_bar_names = sub_progress_bar_names
-        self._sub_progress_names = sub_progress_bar_names
         self._sub_progress_metrics = (
             {
                 name: ProgressMetrics(name=name, total=None, completed=0)

--- a/python/ray/data/_internal/execution/operators/base_physical_operator.py
+++ b/python/ray/data/_internal/execution/operators/base_physical_operator.py
@@ -1,5 +1,4 @@
 import abc
-import typing
 from typing import List, Optional
 
 from typing_extensions import override
@@ -11,12 +10,13 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
     TaskContext,
 )
-from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
+from ray.data._internal.progress.base_progress import (
+    ProgressMetrics,
+    SubProgressUpdater,
+)
 from ray.data._internal.stats import StatsDict
 from ray.data.context import DataContext
-
-if typing.TYPE_CHECKING:
-    from ray.data._internal.progress.base_progress import BaseProgressBar
 
 
 class InternalQueueOperatorMixin(PhysicalOperator, abc.ABC):
@@ -100,9 +100,7 @@ class OneToOneOperator(PhysicalOperator):
         return self.input_dependencies[0]
 
 
-class AllToAllOperator(
-    InternalQueueOperatorMixin, SubProgressBarMixin, PhysicalOperator
-):
+class AllToAllOperator(InternalQueueOperatorMixin, SubProgressMixin, PhysicalOperator):
     """A blocking operator that executes once its inputs are complete.
 
     This operator implements distributed sort / shuffle operations, etc.
@@ -135,8 +133,27 @@ class AllToAllOperator(
         self._next_task_index = 0
         self._num_outputs = num_outputs
         self._output_rows = 0
-        self._sub_progress_bar_names = sub_progress_bar_names
-        self._sub_progress_bar_dict = None
+        self._sub_progress_names = sub_progress_bar_names
+        self._sub_progress_metrics = (
+            {
+                name: ProgressMetrics(name=name, total=None, completed=0)
+                for name in sub_progress_bar_names
+            }
+            if sub_progress_bar_names is not None
+            else None
+        )
+        self._sub_progress_updaters = (
+            {
+                name: SubProgressUpdater(
+                    self._sub_progress_metrics,
+                    name=name,
+                    max_name_length=100,
+                )
+                for name in sub_progress_bar_names
+            }
+            if sub_progress_bar_names is not None
+            else None
+        )
         self._input_buffer: FIFOBundleQueue = FIFOBundleQueue()
         self._output_buffer: FIFOBundleQueue = FIFOBundleQueue()
         self._stats: StatsDict = {}
@@ -176,7 +193,8 @@ class AllToAllOperator(
         ctx = TaskContext(
             task_idx=self._next_task_index,
             op_name=self.name,
-            sub_progress_bar_dict=self._sub_progress_bar_dict,
+            sub_progress_metrics=self._sub_progress_metrics,
+            sub_progress_updaters=self._sub_progress_updaters,
             target_max_block_size_override=self.target_max_block_size_override,
         )
         # NOTE: We don't account object store memory use from intermediate `bulk_fn`
@@ -213,13 +231,11 @@ class AllToAllOperator(
     def progress_str(self) -> str:
         return f"{self.num_output_rows_total() or 0} rows output"
 
-    def get_sub_progress_bar_names(self) -> Optional[List[str]]:
-        return self._sub_progress_bar_names
+    def get_sub_progress_metrics(self) -> Optional[dict[str, "ProgressMetrics"]]:
+        return self._sub_progress_metrics
 
-    def set_sub_progress_bar(self, name: str, pg: "BaseProgressBar"):
-        if self._sub_progress_bar_dict is None:
-            self._sub_progress_bar_dict = {}
-        self._sub_progress_bar_dict[name] = pg
+    def get_sub_progress_updaters(self):
+        return self._sub_progress_updaters
 
     def supports_fusion(self):
         return True

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -8,7 +8,6 @@ import queue
 import random
 import threading
 import time
-import typing
 from collections import defaultdict, deque
 from dataclasses import dataclass
 from typing import (
@@ -54,9 +53,13 @@ from ray.data._internal.execution.interfaces.physical_operator import (
     TaskExecDriverStats,
     estimate_total_num_of_blocks,
 )
-from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.output_buffer import BlockOutputBuffer, OutputBlockSizeOption
+from ray.data._internal.progress.base_progress import (
+    ProgressMetrics,
+    SubProgressUpdater,
+)
 from ray.data._internal.stats import OpRuntimeMetrics
 from ray.data._internal.table_block import TableBlockAccessor
 from ray.data._internal.util import GiB, MiB
@@ -76,9 +79,6 @@ from ray.data.context import (
     DEFAULT_TARGET_MAX_BLOCK_SIZE,
     DataContext,
 )
-
-if typing.TYPE_CHECKING:
-    from ray.data._internal.progress.base_progress import BaseProgressBar
 
 logger = logging.getLogger(__name__)
 
@@ -468,7 +468,7 @@ def _derive_max_shuffle_aggregators(
     )
 
 
-class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
+class HashShufflingOperatorBase(PhysicalOperator, SubProgressMixin):
     """Physical operator base-class for any operators requiring hash-based
     shuffling.
 
@@ -647,10 +647,28 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         self._health_monitoring_start_time: float = 0.0
         self._pending_aggregators_refs: Optional[List[ObjectRef[ActorHandle]]] = None
 
-        # sub-progress bar initializations
-        self._shuffle_bar = None
+        # Driver-side sub-progress metrics for manager-owned display state.
+        self._sub_progress_metrics = {
+            self.shuffle_name: ProgressMetrics(
+                name=self.shuffle_name, total=None, completed=0
+            ),
+            self.reduce_name: ProgressMetrics(
+                name=self.reduce_name, total=None, completed=0
+            ),
+        }
+        self._sub_progress_updaters = {
+            self.shuffle_name: SubProgressUpdater(
+                self._sub_progress_metrics,
+                name=self.shuffle_name,
+                max_name_length=100,
+            ),
+            self.reduce_name: SubProgressUpdater(
+                self._sub_progress_metrics,
+                name=self.reduce_name,
+                max_name_length=100,
+            ),
+        }
         self._shuffle_metrics = OpRuntimeMetrics(self)
-        self._reduce_bar = None
         self._reduce_metrics = OpRuntimeMetrics(self)
 
     def start(self, options: ExecutionOptions) -> None:
@@ -771,7 +789,9 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                 )
 
                 # Update Shuffle progress bar
-                self._shuffle_bar.update(increment=input_block_metadata.num_rows or 0)
+                self._sub_progress_updaters[self.shuffle_name].update(
+                    increment=input_block_metadata.num_rows or 0
+                )
 
             # TODO update metrics
             task = self._shuffling_tasks[input_index][
@@ -807,7 +827,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
                 self._shuffle_metrics,
                 total_num_tasks=None,
             )
-            self._shuffle_bar.update(total=num_rows)
+            self._sub_progress_updaters[self.shuffle_name].update(total=num_rows)
 
     def has_next(self) -> bool:
         self._try_finalize()
@@ -881,7 +901,7 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
             self._estimated_output_num_rows = num_rows
 
             # Update Finalize progress bar
-            self._reduce_bar.update(
+            self._sub_progress_updaters[self.reduce_name].update(
                 increment=bundle.num_rows() or 0, total=self.num_output_rows_total()
             )
 
@@ -1280,14 +1300,11 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
     ) -> Optional[Tuple[int, int]]:
         return None
 
-    def get_sub_progress_bar_names(self) -> Optional[List[str]]:
-        return [self.shuffle_name, self.reduce_name]
+    def get_sub_progress_metrics(self) -> Optional[Dict[str, ProgressMetrics]]:
+        return self._sub_progress_metrics
 
-    def set_sub_progress_bar(self, name: str, pg: "BaseProgressBar"):
-        if self.shuffle_name == name:
-            self._shuffle_bar = pg
-        elif self.reduce_name == name:
-            self._reduce_bar = pg
+    def get_sub_progress_updaters(self):
+        return self._sub_progress_updaters
 
 
 class HashShuffleOperator(HashShufflingOperatorBase):

--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -56,10 +56,7 @@ from ray.data._internal.execution.interfaces.physical_operator import (
 from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.output_buffer import BlockOutputBuffer, OutputBlockSizeOption
-from ray.data._internal.progress.base_progress import (
-    ProgressMetrics,
-    SubProgressUpdater,
-)
+from ray.data._internal.progress.base_progress import ProgressMetrics
 from ray.data._internal.stats import OpRuntimeMetrics
 from ray.data._internal.table_block import TableBlockAccessor
 from ray.data._internal.util import GiB, MiB
@@ -647,27 +644,10 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressMixin):
         self._health_monitoring_start_time: float = 0.0
         self._pending_aggregators_refs: Optional[List[ObjectRef[ActorHandle]]] = None
 
-        # Driver-side sub-progress metrics for manager-owned display state.
-        self._sub_progress_metrics = {
-            self.shuffle_name: ProgressMetrics(
-                name=self.shuffle_name, total=None, completed=0
-            ),
-            self.reduce_name: ProgressMetrics(
-                name=self.reduce_name, total=None, completed=0
-            ),
-        }
-        self._sub_progress_updaters = {
-            self.shuffle_name: SubProgressUpdater(
-                self._sub_progress_metrics,
-                name=self.shuffle_name,
-                max_name_length=100,
-            ),
-            self.reduce_name: SubProgressUpdater(
-                self._sub_progress_metrics,
-                name=self.reduce_name,
-                max_name_length=100,
-            ),
-        }
+        (
+            self._sub_progress_metrics,
+            self._sub_progress_updaters,
+        ) = self._create_sub_progress_state([self.shuffle_name, self.reduce_name])
         self._shuffle_metrics = OpRuntimeMetrics(self)
         self._reduce_metrics = OpRuntimeMetrics(self)
 

--- a/python/ray/data/_internal/execution/operators/sub_progress.py
+++ b/python/ray/data/_internal/execution/operators/sub_progress.py
@@ -1,31 +1,35 @@
 import typing
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 if typing.TYPE_CHECKING:
-    from ray.data._internal.progress.base_progress import BaseProgressBar
+    from ray.data._internal.progress.base_progress import (
+        ProgressMetrics,
+        SubProgressUpdater,
+    )
 
 
-class SubProgressBarMixin(ABC):
-    """Abstract class for operators that support sub-progress bars"""
+class SubProgressMixin(ABC):
+    """Abstract class for operators that support driver-side sub-progress tracking."""
 
     @abstractmethod
+    def get_sub_progress_metrics(self) -> Optional[Dict[str, "ProgressMetrics"]]:
+        """
+        Returns sub-progress metrics keyed by sub-progress name.
+        """
+        ...
+
+    def get_sub_progress_updaters(self) -> Optional[Dict[str, "SubProgressUpdater"]]:
+        """Returns driver-side helpers for mutating sub-progress metrics."""
+        return None
+
+    # Backward-compatible wrappers during the transition away from "bar" naming.
     def get_sub_progress_bar_names(self) -> Optional[List[str]]:
-        """
-        Returns list of sub-progress bar names
+        metrics = self.get_sub_progress_metrics()
+        return list(metrics.keys()) if metrics is not None else None
 
-        This is used to create the sub-progress bars in the progress manager.
-        Note that sub-progress bars will be created in the order returned by
-        this method.
-        """
-        ...
+    def get_sub_progress_names(self) -> Optional[List[str]]:
+        return self.get_sub_progress_bar_names()
 
-    @abstractmethod
-    def set_sub_progress_bar(self, name: str, pg: "BaseProgressBar"):
-        """
-        Sets sub-progress bars
 
-        name: name of sub-progress bar
-        pg: a progress bar. Can be sub-progress bars for rich, tqdm, etc.
-        """
-        ...
+SubProgressBarMixin = SubProgressMixin

--- a/python/ray/data/_internal/execution/operators/sub_progress.py
+++ b/python/ray/data/_internal/execution/operators/sub_progress.py
@@ -1,6 +1,6 @@
 import typing
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 if typing.TYPE_CHECKING:
     from ray.data._internal.progress.base_progress import (
@@ -22,14 +22,3 @@ class SubProgressMixin(ABC):
     def get_sub_progress_updaters(self) -> Optional[Dict[str, "SubProgressUpdater"]]:
         """Returns driver-side helpers for mutating sub-progress metrics."""
         return None
-
-    # Backward-compatible wrappers during the transition away from "bar" naming.
-    def get_sub_progress_bar_names(self) -> Optional[List[str]]:
-        metrics = self.get_sub_progress_metrics()
-        return list(metrics.keys()) if metrics is not None else None
-
-    def get_sub_progress_names(self) -> Optional[List[str]]:
-        return self.get_sub_progress_bar_names()
-
-
-SubProgressBarMixin = SubProgressMixin

--- a/python/ray/data/_internal/execution/operators/sub_progress.py
+++ b/python/ray/data/_internal/execution/operators/sub_progress.py
@@ -1,6 +1,6 @@
 import typing
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Tuple
 
 if typing.TYPE_CHECKING:
     from ray.data._internal.progress.base_progress import (
@@ -19,6 +19,30 @@ class SubProgressMixin(ABC):
         """
         ...
 
+    @abstractmethod
     def get_sub_progress_updaters(self) -> Optional[Dict[str, "SubProgressUpdater"]]:
         """Returns driver-side helpers for mutating sub-progress metrics."""
-        return None
+        ...
+
+    @classmethod
+    def _create_sub_progress_state(
+        cls, names: List[str]
+    ) -> Tuple[Dict[str, "ProgressMetrics"], Dict[str, "SubProgressUpdater"]]:
+        from ray.data._internal.progress.base_progress import (
+            BaseExecutionProgressManager,
+            ProgressMetrics,
+            SubProgressUpdater,
+        )
+
+        metrics = {
+            name: ProgressMetrics(name=name, total=None, completed=0) for name in names
+        }
+        updaters = {
+            name: SubProgressUpdater(
+                metrics,
+                name=name,
+                max_name_length=BaseExecutionProgressManager.MAX_NAME_LENGTH,
+            )
+            for name in names
+        }
+        return metrics, updaters

--- a/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
+++ b/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import pickle
 import time
-import typing
 from typing import (
     Dict,
     Iterator,
@@ -31,14 +30,14 @@ from ray.data._internal.execution.interfaces.physical_operator import (
 from ray.data._internal.execution.operators.hash_shuffle import (
     _get_total_cluster_resources,
 )
-from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
+from ray.data._internal.progress.base_progress import (
+    ProgressMetrics,
+    SubProgressUpdater,
+)
 from ray.data._internal.stats import OpRuntimeMetrics
 from ray.data.block import Block, BlockAccessor, BlockStats, to_stats
 from ray.data.context import DataContext
-
-if typing.TYPE_CHECKING:
-
-    from ray.data._internal.progress.base_progress import BaseProgressBar
 
 logger = logging.getLogger(__name__)
 
@@ -398,7 +397,7 @@ def _derive_num_gpu_ranks(data_context: DataContext) -> int:
 # ---------------------------------------------------------------------------
 
 
-class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
+class GPUShuffleOperator(PhysicalOperator, SubProgressMixin):
     """GPU-native shuffle operator using RAPIDS MPF + UCXX.
 
     Unlike the CPU ``HashShuffleOperator``, this operator:
@@ -469,9 +468,22 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
         self._shuffled_blocks_stats: List[BlockStats] = []
         self._output_blocks_stats: List[BlockStats] = []
 
-        # Progress bars (populated by SubProgressBarMixin callbacks)
-        self._shuffle_bar = None
-        self._reduce_bar = None
+        self._sub_progress_metrics = {
+            "GPU Shuffle": ProgressMetrics(name="GPU Shuffle", total=None, completed=0),
+            "GPU Reduce": ProgressMetrics(name="GPU Reduce", total=None, completed=0),
+        }
+        self._sub_progress_updaters = {
+            "GPU Shuffle": SubProgressUpdater(
+                self._sub_progress_metrics,
+                name="GPU Shuffle",
+                max_name_length=100,
+            ),
+            "GPU Reduce": SubProgressUpdater(
+                self._sub_progress_metrics,
+                name="GPU Reduce",
+                max_name_length=100,
+            ),
+        }
 
         # Metrics
         self._shuffle_metrics = OpRuntimeMetrics(self)
@@ -511,8 +523,9 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
                 task_id=task.get_task_id(),
             )
 
-            if self._shuffle_bar is not None:
-                self._shuffle_bar.update(total=self._next_block_idx)
+            self._sub_progress_updaters["GPU Shuffle"].update(
+                total=self._next_block_idx
+            )
 
     def _is_inserting_done(self) -> bool:
         return self._inputs_complete and len(self._insert_tasks) == 0
@@ -589,7 +602,7 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
             self._estimated_output_num_rows = num_rows
 
             # Update Finalize progress bar
-            self._reduce_bar.update(
+            self._sub_progress_updaters["GPU Reduce"].update(
                 increment=bundle.num_rows() or 0, total=self.num_output_rows_total()
             )
 
@@ -693,17 +706,14 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressBarMixin):
         )
 
     # ------------------------------------------------------------------
-    # SubProgressBarMixin
+    # SubProgressMixin
     # ------------------------------------------------------------------
 
-    def get_sub_progress_bar_names(self) -> List[str]:
-        return ["GPU Shuffle", "GPU Reduce"]
+    def get_sub_progress_metrics(self) -> Dict[str, ProgressMetrics]:
+        return self._sub_progress_metrics
 
-    def set_sub_progress_bar(self, name: str, pg: "BaseProgressBar") -> None:
-        if name == "GPU Shuffle":
-            self._shuffle_bar = pg
-        elif name == "GPU Reduce":
-            self._reduce_bar = pg
+    def get_sub_progress_updaters(self):
+        return self._sub_progress_updaters
 
     # ------------------------------------------------------------------
     # Stats

--- a/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
+++ b/python/ray/data/_internal/gpu_shuffle/hash_shuffle.py
@@ -31,10 +31,7 @@ from ray.data._internal.execution.operators.hash_shuffle import (
     _get_total_cluster_resources,
 )
 from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
-from ray.data._internal.progress.base_progress import (
-    ProgressMetrics,
-    SubProgressUpdater,
-)
+from ray.data._internal.progress.base_progress import ProgressMetrics
 from ray.data._internal.stats import OpRuntimeMetrics
 from ray.data.block import Block, BlockAccessor, BlockStats, to_stats
 from ray.data.context import DataContext
@@ -420,6 +417,9 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressMixin):
     single call.
     """
 
+    GPU_SHUFFLE_PROGRESS_NAME = "GPU Shuffle"
+    GPU_REDUCE_PROGRESS_NAME = "GPU Reduce"
+
     def __init__(
         self,
         input_op: PhysicalOperator,
@@ -468,22 +468,12 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressMixin):
         self._shuffled_blocks_stats: List[BlockStats] = []
         self._output_blocks_stats: List[BlockStats] = []
 
-        self._sub_progress_metrics = {
-            "GPU Shuffle": ProgressMetrics(name="GPU Shuffle", total=None, completed=0),
-            "GPU Reduce": ProgressMetrics(name="GPU Reduce", total=None, completed=0),
-        }
-        self._sub_progress_updaters = {
-            "GPU Shuffle": SubProgressUpdater(
-                self._sub_progress_metrics,
-                name="GPU Shuffle",
-                max_name_length=100,
-            ),
-            "GPU Reduce": SubProgressUpdater(
-                self._sub_progress_metrics,
-                name="GPU Reduce",
-                max_name_length=100,
-            ),
-        }
+        (
+            self._sub_progress_metrics,
+            self._sub_progress_updaters,
+        ) = self._create_sub_progress_state(
+            [self.GPU_SHUFFLE_PROGRESS_NAME, self.GPU_REDUCE_PROGRESS_NAME]
+        )
 
         # Metrics
         self._shuffle_metrics = OpRuntimeMetrics(self)
@@ -523,7 +513,7 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressMixin):
                 task_id=task.get_task_id(),
             )
 
-            self._sub_progress_updaters["GPU Shuffle"].update(
+            self._sub_progress_updaters[self.GPU_SHUFFLE_PROGRESS_NAME].update(
                 total=self._next_block_idx
             )
 
@@ -602,7 +592,7 @@ class GPUShuffleOperator(PhysicalOperator, SubProgressMixin):
             self._estimated_output_num_rows = num_rows
 
             # Update Finalize progress bar
-            self._sub_progress_updaters["GPU Reduce"].update(
+            self._sub_progress_updaters[self.GPU_REDUCE_PROGRESS_NAME].update(
                 increment=bundle.num_rows() or 0, total=self.num_output_rows_total()
             )
 

--- a/python/ray/data/_internal/planner/aggregate.py
+++ b/python/ray/data/_internal/planner/aggregate.py
@@ -67,7 +67,7 @@ def generate_aggregate_fn(
         else:
             # Use same number of output partitions.
             num_outputs = num_mappers
-            sample_bar = ctx.sub_progress_bar_dict[
+            sample_bar = ctx.sub_progress_updaters[
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME
             ]
             # Sample boundaries for aggregate key.

--- a/python/ray/data/_internal/planner/exchange/pull_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/pull_based_shuffle_task_scheduler.py
@@ -76,10 +76,10 @@ class PullBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         shuffle_map = cached_remote_fn(self._exchange_spec.map)
         shuffle_reduce = cached_remote_fn(self._exchange_spec.reduce)
 
-        sub_progress_bar_dict = task_ctx.sub_progress_bar_dict
+        sub_progress_updaters = task_ctx.sub_progress_updaters
         bar_name = ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME
-        assert bar_name in sub_progress_bar_dict, sub_progress_bar_dict
-        map_bar = sub_progress_bar_dict[bar_name]
+        assert bar_name in sub_progress_updaters, sub_progress_updaters
+        map_bar = sub_progress_updaters[bar_name]
 
         if _debug_limit_execution_to_num_blocks is not None:
             input_blocks_list = input_blocks_list[:_debug_limit_execution_to_num_blocks]
@@ -111,8 +111,8 @@ class PullBasedShuffleTaskScheduler(ExchangeTaskScheduler):
         self.warn_on_high_local_memory_store_usage()
 
         bar_name = ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME
-        assert bar_name in sub_progress_bar_dict, sub_progress_bar_dict
-        reduce_bar = sub_progress_bar_dict[bar_name]
+        assert bar_name in sub_progress_updaters, sub_progress_updaters
+        reduce_bar = sub_progress_updaters[bar_name]
 
         if _debug_limit_execution_to_num_blocks is not None:
             output_num_blocks = _debug_limit_execution_to_num_blocks

--- a/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/push_based_shuffle_task_scheduler.py
@@ -534,10 +534,10 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
             [output_num_blocks, stage.merge_schedule, *self._exchange_spec._map_args],
         )
 
-        sub_progress_bar_dict = task_ctx.sub_progress_bar_dict
+        sub_progress_updaters = task_ctx.sub_progress_updaters
         bar_name = ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME
-        assert bar_name in sub_progress_bar_dict, sub_progress_bar_dict
-        map_bar = sub_progress_bar_dict[bar_name]
+        assert bar_name in sub_progress_updaters, sub_progress_updaters
+        map_bar = sub_progress_updaters[bar_name]
         map_stage_executor = _PipelinedStageExecutor(
             map_stage_iter, stage.num_map_tasks_per_round, progress_bar=map_bar
         )
@@ -586,8 +586,8 @@ class PushBasedShuffleTaskScheduler(ExchangeTaskScheduler):
 
         # Execute and wait for the reduce stage.
         bar_name = ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME
-        assert bar_name in sub_progress_bar_dict, sub_progress_bar_dict
-        reduce_bar = sub_progress_bar_dict[bar_name]
+        assert bar_name in sub_progress_updaters, sub_progress_updaters
+        reduce_bar = sub_progress_updaters[bar_name]
 
         shuffle_reduce = cached_remote_fn(self._exchange_spec.reduce)
         reduce_stage_iter = _ReduceStageIterator(

--- a/python/ray/data/_internal/planner/exchange/split_repartition_task_scheduler.py
+++ b/python/ray/data/_internal/planner/exchange/split_repartition_task_scheduler.py
@@ -82,10 +82,10 @@ class SplitRepartitionTaskScheduler(ExchangeTaskScheduler):
             split_block_refs.append(b)
             split_metadata.extend(m)
 
-        sub_progress_bar_dict = ctx.sub_progress_bar_dict
+        sub_progress_updaters = ctx.sub_progress_updaters
         bar_name = ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME
-        assert bar_name in sub_progress_bar_dict, sub_progress_bar_dict
-        reduce_bar = sub_progress_bar_dict[bar_name]
+        assert bar_name in sub_progress_updaters, sub_progress_updaters
+        reduce_bar = sub_progress_updaters[bar_name]
 
         reduce_task = cached_remote_fn(self._exchange_spec.reduce)
         reduce_return = [

--- a/python/ray/data/_internal/planner/sort.py
+++ b/python/ray/data/_internal/planner/sort.py
@@ -45,7 +45,7 @@ def generate_sort_fn(
 
         # Sample boundaries for sort key.
         if not sort_key.boundaries:
-            sample_bar = ctx.sub_progress_bar_dict[
+            sample_bar = ctx.sub_progress_updaters[
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME
             ]
             boundaries = SortTaskSpec.sample_boundaries(

--- a/python/ray/data/_internal/progress/base_progress.py
+++ b/python/ray/data/_internal/progress/base_progress.py
@@ -2,10 +2,11 @@ import logging
 import threading
 import typing
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 import ray
-from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.progress.utils import truncate_operator_name
 
 if typing.TYPE_CHECKING:
@@ -127,8 +128,8 @@ class BaseExecutionProgressManager(ABC):
         verbose_progress: bool,
     ):
         """Initialize the progress manager, create all necessary progress bars
-        and sub-progress bars for the given topology. Sub-progress bars are
-        created for operators that implement the SubProgressBarMixin.
+        and sub-progress trackers for the given topology. Concrete progress bars
+        are created only for operators that implement the SubProgressMixin.
 
         Args:
             dataset_id: id of Dataset
@@ -192,27 +193,65 @@ class BaseExecutionProgressManager(ABC):
         ...
 
 
-class NoopSubProgressBar(BaseProgressBar):
-    """Sub-Progress Bar for Noop (Disabled) Progress Manager"""
+@dataclass(frozen=True)
+class ProgressMetrics:
+    name: str
+    total: Optional[int]
+    completed: int
 
-    def __init__(self, name: str, max_name_length: int):
+
+class SubProgressUpdater(BaseProgressBar):
+    """Driver-side helper that updates immutable sub-progress metrics."""
+
+    def __init__(
+        self,
+        metrics_by_name: Dict[str, ProgressMetrics],
+        name: str,
+        max_name_length: int,
+        display_bar: Optional[BaseProgressBar] = None,
+    ):
+        self._metrics_by_name = metrics_by_name
+        self._name = name
         self._max_name_length = max_name_length
+        self._display_bar = display_bar
         self._desc = truncate_operator_name(name, self._max_name_length)
+
+    def set_display_bar(self, display_bar: Optional[BaseProgressBar]) -> None:
+        self._display_bar = display_bar
+        metrics = self._metrics_by_name[self._name]
+        if self._display_bar is not None:
+            self._display_bar.set_description(self._desc)
+            self._display_bar.update(total=metrics.total)
+            if metrics.completed:
+                self._display_bar.update(metrics.completed)
 
     def set_description(self, name: str) -> None:
         self._desc = truncate_operator_name(name, self._max_name_length)
+        if self._display_bar is not None:
+            self._display_bar.set_description(self._desc)
 
     def get_description(self) -> str:
         return self._desc
 
     def update(self, increment: int = 0, total: Optional[int] = None) -> None:
-        pass
+        metrics = self._metrics_by_name[self._name]
+        new_total = total if total is not None else metrics.total
+        new_completed = metrics.completed + increment
+        self._metrics_by_name[self._name] = ProgressMetrics(
+            name=metrics.name,
+            total=new_total,
+            completed=new_completed,
+        )
+        if self._display_bar is not None:
+            self._display_bar.update(increment, total)
 
     def refresh(self):
-        pass
+        if self._display_bar is not None:
+            self._display_bar.refresh()
 
     def close(self):
-        pass
+        if self._display_bar is not None:
+            self._display_bar.close()
 
 
 class NoopExecutionProgressManager(BaseExecutionProgressManager):
@@ -227,15 +266,13 @@ class NoopExecutionProgressManager(BaseExecutionProgressManager):
     ):
         for state in topology.values():
             op = state.op
-            if not isinstance(op, SubProgressBarMixin):
+            if not isinstance(op, SubProgressMixin):
                 continue
-            sub_pg_names = op.get_sub_progress_bar_names()
-            if sub_pg_names is not None:
-                for name in sub_pg_names:
-                    pg = NoopSubProgressBar(
-                        name=name, max_name_length=self.MAX_NAME_LENGTH
-                    )
-                    op.set_sub_progress_bar(name, pg)
+            updaters = op.get_sub_progress_updaters()
+            if updaters is None:
+                continue
+            for updater in updaters.values():
+                updater.set_display_bar(None)
 
     def start(self) -> None:
         pass

--- a/python/ray/data/_internal/progress/base_progress.py
+++ b/python/ray/data/_internal/progress/base_progress.py
@@ -3,10 +3,9 @@ import threading
 import typing
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import ray
-from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.progress.utils import truncate_operator_name
 
 if typing.TYPE_CHECKING:
@@ -195,6 +194,8 @@ class BaseExecutionProgressManager(ABC):
 
 @dataclass(frozen=True)
 class ProgressMetrics:
+    """Immutable snapshot of sub-progress state exposed to progress managers."""
+
     name: str
     total: Optional[int]
     completed: int
@@ -208,50 +209,40 @@ class SubProgressUpdater(BaseProgressBar):
         metrics_by_name: Dict[str, ProgressMetrics],
         name: str,
         max_name_length: int,
-        display_bar: Optional[BaseProgressBar] = None,
     ):
         self._metrics_by_name = metrics_by_name
         self._name = name
         self._max_name_length = max_name_length
-        self._display_bar = display_bar
         self._desc = truncate_operator_name(name, self._max_name_length)
+        self._lock = threading.Lock()
+        self._update_callbacks: List[Callable[[ProgressMetrics], None]] = []
 
-    def set_display_bar(self, display_bar: Optional[BaseProgressBar]) -> None:
-        self._display_bar = display_bar
-        metrics = self._metrics_by_name[self._name]
-        if self._display_bar is not None:
-            self._display_bar.set_description(self._desc)
-            self._display_bar.update(total=metrics.total)
-            if metrics.completed:
-                self._display_bar.update(metrics.completed)
+    def add_update_callback(self, callback: Callable[[ProgressMetrics], None]) -> None:
+        with self._lock:
+            self._update_callbacks.append(callback)
+            metrics = self._metrics_by_name[self._name]
+        callback(metrics)
 
     def set_description(self, name: str) -> None:
         self._desc = truncate_operator_name(name, self._max_name_length)
-        if self._display_bar is not None:
-            self._display_bar.set_description(self._desc)
 
     def get_description(self) -> str:
         return self._desc
 
     def update(self, increment: int = 0, total: Optional[int] = None) -> None:
-        metrics = self._metrics_by_name[self._name]
-        new_total = total if total is not None else metrics.total
-        new_completed = metrics.completed + increment
-        self._metrics_by_name[self._name] = ProgressMetrics(
-            name=metrics.name,
-            total=new_total,
-            completed=new_completed,
-        )
-        if self._display_bar is not None:
-            self._display_bar.update(increment, total)
-
-    def refresh(self):
-        if self._display_bar is not None:
-            self._display_bar.refresh()
-
-    def close(self):
-        if self._display_bar is not None:
-            self._display_bar.close()
+        with self._lock:
+            metrics = self._metrics_by_name[self._name]
+            new_total = total if total is not None else metrics.total
+            new_completed = metrics.completed + increment
+            updated_metrics = ProgressMetrics(
+                name=metrics.name,
+                total=new_total,
+                completed=new_completed,
+            )
+            self._metrics_by_name[self._name] = updated_metrics
+            callbacks = list(self._update_callbacks)
+        for callback in callbacks:
+            callback(updated_metrics)
 
 
 class NoopExecutionProgressManager(BaseExecutionProgressManager):
@@ -264,15 +255,7 @@ class NoopExecutionProgressManager(BaseExecutionProgressManager):
         show_op_progress: bool,
         verbose_progress: bool,
     ):
-        for state in topology.values():
-            op = state.op
-            if not isinstance(op, SubProgressMixin):
-                continue
-            updaters = op.get_sub_progress_updaters()
-            if updaters is None:
-                continue
-            for updater in updaters.values():
-                updater.set_display_bar(None)
+        pass
 
     def start(self) -> None:
         pass

--- a/python/ray/data/_internal/progress/base_progress.py
+++ b/python/ray/data/_internal/progress/base_progress.py
@@ -245,6 +245,15 @@ class SubProgressUpdater(BaseProgressBar):
             callback(updated_metrics)
 
 
+def make_sub_progress_sync_callback(
+    display_bar: Any,
+) -> Callable[[ProgressMetrics], None]:
+    def sync_display(metrics: ProgressMetrics) -> None:
+        display_bar.update_absolute(metrics.completed, metrics.total)
+
+    return sync_display
+
+
 class NoopExecutionProgressManager(BaseExecutionProgressManager):
     """Noop Data Execution Progress Display Manager (Progress Display Disabled)"""
 

--- a/python/ray/data/_internal/progress/logging_progress.py
+++ b/python/ray/data/_internal/progress/logging_progress.py
@@ -145,7 +145,7 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
             sub_progress_updaters = op.get_sub_progress_updaters()
             if sub_progress_metrics is None or sub_progress_updaters is None:
                 continue
-            for name, metrics in sub_progress_metrics.items():
+            for name in sub_progress_metrics:
                 if sub_progress_bar_enabled:
                     display_pg = LoggingSubProgressBar(
                         name=name, total=total, max_name_length=self.MAX_NAME_LENGTH

--- a/python/ray/data/_internal/progress/logging_progress.py
+++ b/python/ray/data/_internal/progress/logging_progress.py
@@ -7,14 +7,13 @@ from typing import Callable, Dict, List, Optional
 
 from ray._common.utils import env_integer
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
-from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.execution.streaming_executor_state import (
     format_op_state_summary,
 )
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
-    NoopSubProgressBar,
 )
 from ray.data._internal.progress.utils import truncate_operator_name
 
@@ -126,7 +125,7 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
                 continue
             total = op.num_output_rows_total() or 1
 
-            contains_sub_progress_bars = isinstance(op, SubProgressBarMixin)
+            contains_sub_progress_bars = isinstance(op, SubProgressMixin)
             sub_progress_bar_enabled = show_op_progress and (
                 contains_sub_progress_bars or verbose_progress
             )
@@ -142,20 +141,20 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
             if not contains_sub_progress_bars:
                 continue
 
-            sub_pg_names = op.get_sub_progress_bar_names()
-            if sub_pg_names is None:
+            sub_progress_metrics = op.get_sub_progress_metrics()
+            sub_progress_updaters = op.get_sub_progress_updaters()
+            if sub_progress_metrics is None or sub_progress_updaters is None:
                 continue
-            for name in sub_pg_names:
+            for name, metrics in sub_progress_metrics.items():
                 if sub_progress_bar_enabled:
-                    pg = LoggingSubProgressBar(
+                    display_pg = LoggingSubProgressBar(
                         name=name, total=total, max_name_length=self.MAX_NAME_LENGTH
                     )
-                    self._sub_progress_metrics[state].append(pg)
                 else:
-                    pg = NoopSubProgressBar(
-                        name=name, max_name_length=self.MAX_NAME_LENGTH
-                    )
-                op.set_sub_progress_bar(name, pg)
+                    display_pg = None
+                if display_pg is not None:
+                    self._sub_progress_metrics[state].append(display_pg)
+                sub_progress_updaters[name].set_display_bar(display_pg)
 
     # Management
     def start(self):

--- a/python/ray/data/_internal/progress/logging_progress.py
+++ b/python/ray/data/_internal/progress/logging_progress.py
@@ -11,10 +11,7 @@ from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.execution.streaming_executor_state import (
     format_op_state_summary,
 )
-from ray.data._internal.progress.base_progress import (
-    BaseExecutionProgressManager,
-    BaseProgressBar,
-)
+from ray.data._internal.progress.base_progress import BaseExecutionProgressManager
 from ray.data._internal.progress.utils import truncate_operator_name
 
 if typing.TYPE_CHECKING:
@@ -31,54 +28,6 @@ class _LoggingMetrics:
     desc: Optional[str]
     completed: int
     total: Optional[int]
-
-
-class LoggingSubProgressBar(BaseProgressBar):
-    """Thin wrapper to provide identical interface to the ProgressBar.
-
-    Internally passes relevant logging metrics to `LoggingExecutionProgressManager`.
-    Sub-progress is actually handled by Ray through operators, while operator-level
-    and total progress is handled by the `StreamingExecutor`. To ensure log-order,
-    this class helps to pass metric data to the progress manager so progress metrics
-    are logged centrally.
-    """
-
-    def __init__(
-        self,
-        name: str,
-        total: Optional[int] = None,
-        max_name_length: int = 100,
-    ):
-        """Initialize sub-progress bar
-
-        Args:
-            name: name of sub-progress bar
-            total: total number of output rows. None for unknown.
-            max_name_length: maximum operator name length (unused).
-        """
-        del max_name_length  # unused
-        self._total = total
-        self._completed = 0
-        self._name = name
-
-    def set_description(self, name: str) -> None:
-        pass  # unused
-
-    def get_description(self) -> str:
-        return ""  # unused
-
-    def update(self, increment: int = 0, total: Optional[int] = None):
-        if total is not None:
-            self._total = total
-        self._completed += increment
-
-    def get_logging_metrics(self) -> _LoggingMetrics:
-        return _LoggingMetrics(
-            name=f"    - {self._name}",
-            desc=None,
-            completed=self._completed,
-            total=self._total,
-        )
 
 
 class LoggingExecutionProgressManager(BaseExecutionProgressManager):
@@ -115,9 +64,7 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
             name="Total Progress", desc=None, completed=0, total=None
         )
         self._op_progress_metrics: Dict["OpState", _LoggingMetrics] = {}
-        self._sub_progress_metrics: Dict[
-            "OpState", List[LoggingSubProgressBar]
-        ] = defaultdict(list)
+        self._sub_progress_names: Dict["OpState", List[str]] = defaultdict(list)
 
         for state in self._topology.values():
             op = state.op
@@ -142,19 +89,11 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
                 continue
 
             sub_progress_metrics = op.get_sub_progress_metrics()
-            sub_progress_updaters = op.get_sub_progress_updaters()
-            if sub_progress_metrics is None or sub_progress_updaters is None:
+            if sub_progress_metrics is None:
                 continue
             for name in sub_progress_metrics:
                 if sub_progress_bar_enabled:
-                    display_pg = LoggingSubProgressBar(
-                        name=name, total=total, max_name_length=self.MAX_NAME_LENGTH
-                    )
-                else:
-                    display_pg = None
-                if display_pg is not None:
-                    self._sub_progress_metrics[state].append(display_pg)
-                sub_progress_updaters[name].set_display_bar(display_pg)
+                    self._sub_progress_names[state].append(name)
 
     # Management
     def start(self):
@@ -184,8 +123,22 @@ class LoggingExecutionProgressManager(BaseExecutionProgressManager):
             if metrics is None:
                 continue
             _log_op_or_sub_progress(metrics)
-            for pg in self._sub_progress_metrics[opstate]:
-                _log_op_or_sub_progress(pg.get_logging_metrics())
+            if isinstance(opstate.op, SubProgressMixin):
+                sub_progress_metrics = opstate.op.get_sub_progress_metrics()
+                if sub_progress_metrics is None:
+                    continue
+                for name in self._sub_progress_names[opstate]:
+                    metrics = sub_progress_metrics.get(name)
+                    if metrics is None:
+                        continue
+                    _log_op_or_sub_progress(
+                        _LoggingMetrics(
+                            name=f"    - {metrics.name}",
+                            desc=None,
+                            completed=metrics.completed,
+                            total=metrics.total,
+                        )
+                    )
 
         # finish logging
         logger.info(lastline)

--- a/python/ray/data/_internal/progress/rich_progress.py
+++ b/python/ray/data/_internal/progress/rich_progress.py
@@ -207,7 +207,7 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
             if sub_progress_metrics is None or sub_progress_updaters is None:
                 continue
 
-            for name, metrics in sub_progress_metrics.items():
+            for name in sub_progress_metrics:
                 if sub_progress_bar_enabled:
                     progress = self._make_progress_bar(
                         _TREE_VERTICAL_SUB_PROGRESS, "", 10

--- a/python/ray/data/_internal/progress/rich_progress.py
+++ b/python/ray/data/_internal/progress/rich_progress.py
@@ -20,14 +20,13 @@ from rich.table import Column, Table
 from rich.text import Text
 
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
-from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.execution.streaming_executor_state import (
     format_op_state_summary,
 )
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
-    NoopSubProgressBar,
 )
 from ray.data._internal.progress.utils import truncate_operator_name
 
@@ -179,7 +178,7 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
             if isinstance(op, InputDataBuffer):
                 continue
 
-            contains_sub_progress_bars = isinstance(op, SubProgressBarMixin)
+            contains_sub_progress_bars = isinstance(op, SubProgressMixin)
             sub_progress_bar_enabled = self._show_op_progress and (
                 contains_sub_progress_bars or self._verbose_progress
             )
@@ -203,11 +202,12 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
             if not contains_sub_progress_bars:
                 continue
 
-            sub_progress_bar_names = op.get_sub_progress_bar_names()
-            if sub_progress_bar_names is None:
+            sub_progress_metrics = op.get_sub_progress_metrics()
+            sub_progress_updaters = op.get_sub_progress_updaters()
+            if sub_progress_metrics is None or sub_progress_updaters is None:
                 continue
 
-            for name in sub_progress_bar_names:
+            for name, metrics in sub_progress_metrics.items():
                 if sub_progress_bar_enabled:
                     progress = self._make_progress_bar(
                         _TREE_VERTICAL_SUB_PROGRESS, "", 10
@@ -221,7 +221,7 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
                         count_str="0/?",
                     )
                     rows.append(progress)
-                    pg = RichSubProgressBar(
+                    display_pg = RichSubProgressBar(
                         name=name,
                         total=total,
                         progress=progress,
@@ -229,11 +229,10 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
                         max_name_length=self.MAX_NAME_LENGTH,
                     )
                 else:
-                    pg = NoopSubProgressBar(
-                        name=name, max_name_length=self.MAX_NAME_LENGTH
-                    )
-                op.set_sub_progress_bar(name, pg)
-                self._sub_progress_bars.append(pg)
+                    display_pg = None
+                sub_progress_updaters[name].set_display_bar(display_pg)
+                if display_pg is not None:
+                    self._sub_progress_bars.append(display_pg)
         if rows:
             self._layout_table.add_row(Text(f"  {_TREE_VERTICAL}", no_wrap=True))
             for row in rows:

--- a/python/ray/data/_internal/progress/rich_progress.py
+++ b/python/ray/data/_internal/progress/rich_progress.py
@@ -27,6 +27,7 @@ from ray.data._internal.execution.streaming_executor_state import (
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
+    make_sub_progress_sync_callback,
 )
 from ray.data._internal.progress.utils import truncate_operator_name
 
@@ -136,7 +137,6 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
     ):
         self._dataset_id = dataset_id
         self._sub_progress_bars: List[BaseProgressBar] = []
-        self._sub_progress_display: List[Tuple["OpState", str, RichSubProgressBar]] = []
         self._show_op_progress = show_op_progress
         self._verbose_progress = verbose_progress
         self._start_time: Optional[float] = None
@@ -238,14 +238,13 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
                     display_pg = None
                 if display_pg is not None:
                     display_pg.update_absolute(metrics.completed, metrics.total)
-                    self._sub_progress_display.append((state, name, display_pg))
                     self._sub_progress_bars.append(display_pg)
                     if (
                         sub_progress_updaters is not None
                         and name in sub_progress_updaters
                     ):
                         sub_progress_updaters[name].add_update_callback(
-                            _make_sub_progress_sync_callback(display_pg)
+                            make_sub_progress_sync_callback(display_pg)
                         )
         if rows:
             self._layout_table.add_row(Text(f"  {_TREE_VERTICAL}", no_wrap=True))
@@ -357,23 +356,6 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
         # stats
         stats_str = format_op_state_summary(op_state, resource_manager)
         stats.plain = f"{_TREE_VERTICAL_INDENT}{stats_str}"
-
-        if isinstance(op_state.op, SubProgressMixin):
-            metrics_by_name = op_state.op.get_sub_progress_metrics()
-            if metrics_by_name is None:
-                return
-            for state, name, display_pg in self._sub_progress_display:
-                if state is not op_state or name not in metrics_by_name:
-                    continue
-                metrics = metrics_by_name[name]
-                display_pg.update_absolute(metrics.completed, metrics.total)
-
-
-def _make_sub_progress_sync_callback(display_pg: RichSubProgressBar):
-    def sync_display(metrics):
-        display_pg.update_absolute(metrics.completed, metrics.total)
-
-    return sync_display
 
 
 # utilities

--- a/python/ray/data/_internal/progress/rich_progress.py
+++ b/python/ray/data/_internal/progress/rich_progress.py
@@ -106,6 +106,12 @@ class RichSubProgressBar(BaseProgressBar):
             self._completed += increment
             self._update(self._completed, self._total)
 
+    def update_absolute(self, completed: int, total: Optional[int] = None) -> None:
+        if self._enabled:
+            self._completed = completed
+            self._total = total
+            self._update(self._completed, self._total)
+
     def complete(self) -> None:
         if self._enabled:
             self._update(self._completed, self._completed)
@@ -130,6 +136,7 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
     ):
         self._dataset_id = dataset_id
         self._sub_progress_bars: List[BaseProgressBar] = []
+        self._sub_progress_display: List[Tuple["OpState", str, RichSubProgressBar]] = []
         self._show_op_progress = show_op_progress
         self._verbose_progress = verbose_progress
         self._start_time: Optional[float] = None
@@ -203,19 +210,18 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
                 continue
 
             sub_progress_metrics = op.get_sub_progress_metrics()
-            sub_progress_updaters = op.get_sub_progress_updaters()
-            if sub_progress_metrics is None or sub_progress_updaters is None:
+            if sub_progress_metrics is None:
                 continue
+            sub_progress_updaters = op.get_sub_progress_updaters()
 
-            for name in sub_progress_metrics:
+            for name, metrics in sub_progress_metrics.items():
                 if sub_progress_bar_enabled:
                     progress = self._make_progress_bar(
                         _TREE_VERTICAL_SUB_PROGRESS, "", 10
                     )
-                    total = state.op.num_output_rows_total()
                     tid = progress.add_task(
                         name,
-                        total=total if total is not None else 1,
+                        total=metrics.total if metrics.total is not None else 1,
                         start=True,
                         rate_str="? rows/s",
                         count_str="0/?",
@@ -223,16 +229,24 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
                     rows.append(progress)
                     display_pg = RichSubProgressBar(
                         name=name,
-                        total=total,
+                        total=metrics.total,
                         progress=progress,
                         tid=tid,
                         max_name_length=self.MAX_NAME_LENGTH,
                     )
                 else:
                     display_pg = None
-                sub_progress_updaters[name].set_display_bar(display_pg)
                 if display_pg is not None:
+                    display_pg.update_absolute(metrics.completed, metrics.total)
+                    self._sub_progress_display.append((state, name, display_pg))
                     self._sub_progress_bars.append(display_pg)
+                    if (
+                        sub_progress_updaters is not None
+                        and name in sub_progress_updaters
+                    ):
+                        sub_progress_updaters[name].add_update_callback(
+                            _make_sub_progress_sync_callback(display_pg)
+                        )
         if rows:
             self._layout_table.add_row(Text(f"  {_TREE_VERTICAL}", no_wrap=True))
             for row in rows:
@@ -343,6 +357,23 @@ class RichExecutionProgressManager(BaseExecutionProgressManager):
         # stats
         stats_str = format_op_state_summary(op_state, resource_manager)
         stats.plain = f"{_TREE_VERTICAL_INDENT}{stats_str}"
+
+        if isinstance(op_state.op, SubProgressMixin):
+            metrics_by_name = op_state.op.get_sub_progress_metrics()
+            if metrics_by_name is None:
+                return
+            for state, name, display_pg in self._sub_progress_display:
+                if state is not op_state or name not in metrics_by_name:
+                    continue
+                metrics = metrics_by_name[name]
+                display_pg.update_absolute(metrics.completed, metrics.total)
+
+
+def _make_sub_progress_sync_callback(display_pg: RichSubProgressBar):
+    def sync_display(metrics):
+        display_pg.update_absolute(metrics.completed, metrics.total)
+
+    return sync_display
 
 
 # utilities

--- a/python/ray/data/_internal/progress/tqdm_progress.py
+++ b/python/ray/data/_internal/progress/tqdm_progress.py
@@ -3,14 +3,13 @@ import typing
 from typing import Dict, List, Optional
 
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
-from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
+from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
 from ray.data._internal.execution.streaming_executor_state import (
     format_op_state_summary,
 )
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
-    NoopSubProgressBar,
 )
 from ray.data._internal.progress.progress_bar import ProgressBar
 
@@ -81,7 +80,7 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
                 continue
             total = op.num_output_rows_total() or 1
 
-            contains_sub_progress_bars = isinstance(op, SubProgressBarMixin)
+            contains_sub_progress_bars = isinstance(op, SubProgressMixin)
             sub_progress_bar_enabled = show_op_progress and (
                 contains_sub_progress_bars or verbose_progress
             )
@@ -102,12 +101,13 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
             if not contains_sub_progress_bars:
                 continue
 
-            sub_pg_names = op.get_sub_progress_bar_names()
-            if sub_pg_names is None:
+            sub_progress_metrics = op.get_sub_progress_metrics()
+            sub_progress_updaters = op.get_sub_progress_updaters()
+            if sub_progress_metrics is None or sub_progress_updaters is None:
                 continue
-            for name in sub_pg_names:
+            for name, metrics in sub_progress_metrics.items():
                 if sub_progress_bar_enabled:
-                    pg = TqdmSubProgressBar(
+                    display_pg = TqdmSubProgressBar(
                         name=f"  *- {name}",
                         total=total,
                         unit="row",
@@ -117,12 +117,10 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
                     )
                     num_progress_bars += 1
                 else:
-                    pg = NoopSubProgressBar(
-                        name=f"  *- {name}",
-                        max_name_length=self.MAX_NAME_LENGTH,
-                    )
-                op.set_sub_progress_bar(name, pg)
-                self._sub_progress_bars.append(pg)
+                    display_pg = None
+                sub_progress_updaters[name].set_display_bar(display_pg)
+                if display_pg is not None:
+                    self._sub_progress_bars.append(display_pg)
 
     # Management
     def start(self):

--- a/python/ray/data/_internal/progress/tqdm_progress.py
+++ b/python/ray/data/_internal/progress/tqdm_progress.py
@@ -105,7 +105,7 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
             sub_progress_updaters = op.get_sub_progress_updaters()
             if sub_progress_metrics is None or sub_progress_updaters is None:
                 continue
-            for name, metrics in sub_progress_metrics.items():
+            for name in sub_progress_metrics:
                 if sub_progress_bar_enabled:
                     display_pg = TqdmSubProgressBar(
                         name=f"  *- {name}",

--- a/python/ray/data/_internal/progress/tqdm_progress.py
+++ b/python/ray/data/_internal/progress/tqdm_progress.py
@@ -1,6 +1,6 @@
 import logging
 import typing
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
@@ -60,6 +60,7 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
         self._dataset_id = dataset_id
 
         self._sub_progress_bars: List[BaseProgressBar] = []
+        self._sub_progress_display: List[Tuple["OpState", str, TqdmSubProgressBar]] = []
         self._op_display: Dict["OpState", TqdmSubProgressBar] = {}
 
         num_progress_bars = 0
@@ -102,14 +103,14 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
                 continue
 
             sub_progress_metrics = op.get_sub_progress_metrics()
-            sub_progress_updaters = op.get_sub_progress_updaters()
-            if sub_progress_metrics is None or sub_progress_updaters is None:
+            if sub_progress_metrics is None:
                 continue
-            for name in sub_progress_metrics:
+            sub_progress_updaters = op.get_sub_progress_updaters()
+            for name, metrics in sub_progress_metrics.items():
                 if sub_progress_bar_enabled:
                     display_pg = TqdmSubProgressBar(
                         name=f"  *- {name}",
-                        total=total,
+                        total=metrics.total,
                         unit="row",
                         position=num_progress_bars,
                         max_name_length=self.MAX_NAME_LENGTH,
@@ -118,9 +119,17 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
                     num_progress_bars += 1
                 else:
                     display_pg = None
-                sub_progress_updaters[name].set_display_bar(display_pg)
                 if display_pg is not None:
+                    display_pg.update_absolute(metrics.completed, metrics.total)
+                    self._sub_progress_display.append((state, name, display_pg))
                     self._sub_progress_bars.append(display_pg)
+                    if (
+                        sub_progress_updaters is not None
+                        and name in sub_progress_updaters
+                    ):
+                        sub_progress_updaters[name].add_update_callback(
+                            _make_sub_progress_sync_callback(display_pg)
+                        )
 
     # Management
     def start(self):
@@ -158,3 +167,20 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
             )
             summary_str = format_op_state_summary(opstate, resource_manager)
             pg.set_description(f"- {opstate.op.name}: {summary_str}")
+
+        if isinstance(opstate.op, SubProgressMixin):
+            metrics_by_name = opstate.op.get_sub_progress_metrics()
+            if metrics_by_name is None:
+                return
+            for state, name, display_pg in self._sub_progress_display:
+                if state is not opstate or name not in metrics_by_name:
+                    continue
+                metrics = metrics_by_name[name]
+                display_pg.update_absolute(metrics.completed, metrics.total)
+
+
+def _make_sub_progress_sync_callback(display_pg: TqdmSubProgressBar):
+    def sync_display(metrics):
+        display_pg.update_absolute(metrics.completed, metrics.total)
+
+    return sync_display

--- a/python/ray/data/_internal/progress/tqdm_progress.py
+++ b/python/ray/data/_internal/progress/tqdm_progress.py
@@ -1,6 +1,6 @@
 import logging
 import typing
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.sub_progress import SubProgressMixin
@@ -10,6 +10,7 @@ from ray.data._internal.execution.streaming_executor_state import (
 from ray.data._internal.progress.base_progress import (
     BaseExecutionProgressManager,
     BaseProgressBar,
+    make_sub_progress_sync_callback,
 )
 from ray.data._internal.progress.progress_bar import ProgressBar
 
@@ -60,7 +61,6 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
         self._dataset_id = dataset_id
 
         self._sub_progress_bars: List[BaseProgressBar] = []
-        self._sub_progress_display: List[Tuple["OpState", str, TqdmSubProgressBar]] = []
         self._op_display: Dict["OpState", TqdmSubProgressBar] = {}
 
         num_progress_bars = 0
@@ -121,14 +121,13 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
                     display_pg = None
                 if display_pg is not None:
                     display_pg.update_absolute(metrics.completed, metrics.total)
-                    self._sub_progress_display.append((state, name, display_pg))
                     self._sub_progress_bars.append(display_pg)
                     if (
                         sub_progress_updaters is not None
                         and name in sub_progress_updaters
                     ):
                         sub_progress_updaters[name].add_update_callback(
-                            _make_sub_progress_sync_callback(display_pg)
+                            make_sub_progress_sync_callback(display_pg)
                         )
 
     # Management
@@ -167,20 +166,3 @@ class TqdmExecutionProgressManager(BaseExecutionProgressManager):
             )
             summary_str = format_op_state_summary(opstate, resource_manager)
             pg.set_description(f"- {opstate.op.name}: {summary_str}")
-
-        if isinstance(opstate.op, SubProgressMixin):
-            metrics_by_name = opstate.op.get_sub_progress_metrics()
-            if metrics_by_name is None:
-                return
-            for state, name, display_pg in self._sub_progress_display:
-                if state is not opstate or name not in metrics_by_name:
-                    continue
-                metrics = metrics_by_name[name]
-                display_pg.update_absolute(metrics.completed, metrics.total)
-
-
-def _make_sub_progress_sync_callback(display_pg: TqdmSubProgressBar):
-    def sync_display(metrics):
-        display_pg.update_absolute(metrics.completed, metrics.total)
-
-    return sync_display

--- a/python/ray/data/tests/test_gpu_shuffle.py
+++ b/python/ray/data/tests/test_gpu_shuffle.py
@@ -319,20 +319,18 @@ class TestGPUShuffleOperatorConstructor:
 
     def test_progress_bar_names(self):
         op = self._make_op()
-        names = op.get_sub_progress_bar_names()
+        names = list(op.get_sub_progress_metrics().keys())
         assert names == ["GPU Shuffle", "GPU Reduce"]
 
-    def test_set_sub_progress_bar_shuffle(self):
+    def test_sub_progress_metric_shuffle(self):
         op = self._make_op()
-        mock_bar = MagicMock()
-        op.set_sub_progress_bar("GPU Shuffle", mock_bar)
-        assert op._shuffle_bar is mock_bar
+        metric = op.get_sub_progress_metrics()["GPU Shuffle"]
+        assert metric is not None
 
-    def test_set_sub_progress_bar_reduce(self):
+    def test_sub_progress_metric_reduce(self):
         op = self._make_op()
-        mock_bar = MagicMock()
-        op.set_sub_progress_bar("GPU Reduce", mock_bar)
-        assert op._reduce_bar is mock_bar
+        metric = op.get_sub_progress_metrics()["GPU Reduce"]
+        assert metric is not None
 
     def test_initial_state(self):
         op = self._make_op()

--- a/python/ray/data/tests/test_operators.py
+++ b/python/ray/data/tests/test_operators.py
@@ -15,7 +15,7 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.util import make_ref_bundles
-from ray.data._internal.progress.base_progress import NoopSubProgressBar
+from ray.data._internal.progress.base_progress import ProgressMetrics
 from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
 from ray.data.tests.util import (
@@ -72,8 +72,8 @@ def test_input_data_buffer(ray_start_regular_shared):
 
 def test_all_to_all_operator():
     def dummy_all_transform(bundles: List[RefBundle], ctx):
-        assert len(ctx.sub_progress_bar_dict) == 2
-        assert list(ctx.sub_progress_bar_dict.keys()) == ["Test1", "Test2"]
+        assert len(ctx.sub_progress_metrics) == 2
+        assert list(ctx.sub_progress_metrics.keys()) == ["Test1", "Test2"]
         return make_ref_bundles([[1, 2], [3, 4]]), {"FooStats": []}
 
     input_op = InputDataBuffer(
@@ -89,13 +89,9 @@ def test_all_to_all_operator():
         name="TestAll",
     )
 
-    # Initialize progress bar.
-    for name in op.get_sub_progress_bar_names():
-        pg = NoopSubProgressBar(
-            name=name,
-            max_name_length=100,
-        )
-        op.set_sub_progress_bar(name, pg)
+    metrics = op.get_sub_progress_metrics()
+    assert list(metrics.keys()) == ["Test1", "Test2"]
+    assert all(isinstance(metric, ProgressMetrics) for metric in metrics.values())
 
     # Feed data.
     op.start(ExecutionOptions())

--- a/python/ray/data/tests/test_progress_bar.py
+++ b/python/ray/data/tests/test_progress_bar.py
@@ -6,6 +6,10 @@ import pytest
 from pytest import fixture
 
 import ray
+from ray.data._internal.progress.base_progress import (
+    ProgressMetrics,
+    SubProgressUpdater,
+)
 from ray.data._internal.progress.progress_bar import ProgressBar
 
 
@@ -81,6 +85,25 @@ def test_progress_bar(enable_tqdm_ray):
     pb.update(total + 1, total)
     assert pb._bar.total == total + 1
     pb.close()
+
+
+def test_sub_progress_updater_updates_metrics_and_notifies_callback():
+    metrics_by_name = {
+        "Shuffle": ProgressMetrics(name="Shuffle", total=None, completed=0)
+    }
+    updater = SubProgressUpdater(metrics_by_name, "Shuffle", max_name_length=100)
+    snapshots = []
+
+    updater.add_update_callback(snapshots.append)
+    updater.update(increment=3, total=10)
+
+    assert metrics_by_name["Shuffle"] == ProgressMetrics(
+        name="Shuffle", total=10, completed=3
+    )
+    assert snapshots == [
+        ProgressMetrics(name="Shuffle", total=None, completed=0),
+        ProgressMetrics(name="Shuffle", total=10, completed=3),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR refactors Ray Data sub-progress reporting so operators expose sub-progress as metrics instead of receiving concrete progress bar objects from progress managers.

Before this change, the flow looked like this:

1. Operator exposed sub-progress bar names.
2. Progress manager created sub-progress bar objects.
3. Progress manager injected those bar objects back into the operator.
4. Operator and scheduler logic updated those objects directly.

After this change, the flow is:

1. Operator exposes `Dict[str, ProgressMetrics]`.
2. Driver-side execution updates sub-progress through internal updater helpers.
3. Progress managers read the metrics and attach display-specific state as needed.
4. Progress managers own rendering, while operators own execution state.

This removes the previous bi-directional coupling between operators and progress bar implementations.

## What Changed

### API changes

- Replace the sub-progress name-only interface with a metrics-based interface:
  - `get_sub_progress_metrics() -> Dict[str, ProgressMetrics]`
- `ProgressMetrics` is now a frozen dataclass snapshot with:
  - `name`
  - `total`
  - `completed`

### Internal execution changes

- Introduce internal `SubProgressUpdater` helpers for driver-side mutation paths that still need:
  - `update(...)`
  - `fetch_until_complete(...)`
  - `block_until_complete(...)`
- `TaskContext` now carries:
  - `sub_progress_metrics`
  - `sub_progress_updaters`

### Progress manager changes

- `tqdm`, `rich`, `logging`, and `noop` progress managers no longer inject sub-progress bar objects back into operators.
- Managers now attach display-specific state to internal updater helpers and render from metrics.
- `NoopSubProgressBar` is no longer needed.

### Operator and scheduler updates

Updated the following sub-progress users to the new model:

- `AllToAllOperator`
- CPU hash shuffle
- GPU shuffle
- sort / aggregate sampling
- pull-based shuffle scheduler
- push-based shuffle scheduler
- split repartition scheduler

## Why This Design

This PR keeps the external sub-progress interface simple and metrics-based, while preserving existing driver-side execution behavior for shuffle/sample paths that still need incremental wait-and-update helpers.

Conceptually:

```text
Before:
Operator <-> ProgressManager <-> ProgressBar object

After:
Operator -> ProgressMetrics
Execution -> SubProgressUpdater -> ProgressMetrics
ProgressManager -> render ProgressMetrics
```

This is a middle ground that removes bar injection and keeps the metrics interface clean, without rewriting all driver-side progress update paths at once.

## Related Issues

- Closes #60082
- Related: #60083
- Related: #42191
- Related: #33517
