### PR TITLE
[CI] Convert release/build.rayci.yml from matrix to array syntax

### DIFF
--- a/.buildkite/_images.rayci.yml
+++ b/.buildkite/_images.rayci.yml
@@ -2,248 +2,247 @@ group: images
 sort_key: "_images"
 steps:
   - name: raycpubase
-    label: "wanda: ray-py{{matrix}}-cpu-base"
+    label: "wanda: ray-py{{array.python}}-cpu-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
 
   - name: raycpubaseextra
-    label: "wanda: ray-py{{matrix}}-cpu-base-extra"
+    label: "wanda: ray-py{{array.python}}-cpu-base-extra"
     wanda: docker/base-extra/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: ""
-    depends_on: raycpubase
+    depends_on: raycpubase($)
 
   - name: raytpubase
-    label: "wanda: ray-py{{matrix}}-tpu-base"
+    label: "wanda: ray-py{{array.python}}-tpu-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/tpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
 
   - name: raycudabase
-    label: "wanda: ray-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""
 
   - name: raycudabaseextra
-    label: "wanda: ray-py{{matrix.python}}-cu{{matrix.cuda}}-base-extra"
+    label: "wanda: ray-py{{array.python}}-cu{{array.cuda}}-base-extra"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
+        - "13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: ""
-    depends_on: raycudabase
+    depends_on: raycudabase($)
 
   - name: ray-llmbase
-    label: "wanda: ray-llm-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-llm-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/ray-llm/cuda.wanda.yaml
-    depends_on: raycudabase
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    depends_on: raycudabase($)
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
 
   - name: ray-llmbaseextra
-    label: "wanda: ray-llm-py{{matrix.python}}-cu{{matrix.cuda}}-base-extra"
+    label: "wanda: ray-llm-py{{array.python}}-cu{{array.cuda}}-base-extra"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-llm"
       ARCH_SUFFIX: ""
-    depends_on: ray-llmbase
+    depends_on: ray-llmbase($)
 
   - name: ray-mlcpubase
-    label: "wanda: ray-ml-py{{matrix}}-cpu-base"
+    label: "wanda: ray-ml-py{{array.python}}-cpu-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/ray-ml/cpu.wanda.yaml
-    depends_on: raycpubase
-    matrix:
-      - "3.10"
-      - "3.11"
+    depends_on: raycpubase($)
+    array:
+      python:
+        - "3.10"
+        - "3.11"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
 
   - name: ray-mlcpubaseextra
-    label: "wanda: ray-ml-py{{matrix}}-cpu-base-extra"
+    label: "wanda: ray-ml-py{{array.python}}-cpu-base-extra"
     wanda: docker/base-extra/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray-ml"
       ARCH_SUFFIX: ""
-    depends_on: ray-mlcpubase
+    depends_on: ray-mlcpubase($)
 
   - name: ray-mlcudabase
-    label: "wanda: ray-ml-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-ml-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
     wanda: docker/ray-ml/cuda.wanda.yaml
-    depends_on: raycudabase
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-        cuda:
-          - "12.1.1-cudnn8"
+    depends_on: raycudabase($)
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+      cuda:
+        - "12.1.1-cudnn8"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
 
   - name: ray-mlcudabaseextra
-    label: "wanda: ray-ml-py{{matrix.python}}-cu{{matrix.cuda}}-base-extra"
+    label: "wanda: ray-ml-py{{array.python}}-cu{{array.cuda}}-base-extra"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-        cuda:
-          - "12.1.1-cudnn8"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+      cuda:
+        - "12.1.1-cudnn8"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-ml"
       ARCH_SUFFIX: ""
-    depends_on: ray-mlcudabase
+    depends_on: ray-mlcudabase($)
 
   - name: ray-slimcpubase
-    label: "wanda: ray-slim-py{{matrix}}-cpu-base"
+    label: "wanda: ray-slim-py{{array.python}}-cpu-base"
     tags:
       - python_dependencies
       - docker
       - skip-on-release-tests
     wanda: docker/base-slim/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
 
   - name: ray-slimcudabase
-    label: "wanda: ray-slim-py{{matrix.python}}-cu{{matrix.cuda}}-base"
+    label: "wanda: ray-slim-py{{array.python}}-cu{{array.cuda}}-base"
     tags:
       - python_dependencies
       - docker
       - skip-on-release-tests
     wanda: docker/base-slim/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1"
-          - "11.8.0"
-          - "12.1.1"
-          - "12.3.2"
-          - "12.4.1"
-          - "12.5.1"
-          - "12.6.3"
-          - "12.8.1"
-          - "12.9.1"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1"
+        - "11.8.0"
+        - "12.1.1"
+        - "12.3.2"
+        - "12.4.1"
+        - "12.5.1"
+        - "12.6.3"
+        - "12.8.1"
+        - "12.9.1"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: ""

--- a/.buildkite/_wheel-build.rayci.yml
+++ b/.buildkite/_wheel-build.rayci.yml
@@ -2,17 +2,18 @@ group: wheel build
 sort_key: "_wheel-build"
 steps:
   - name: ray-core-build
-    label: "wanda: core binary parts py{{matrix}} (x86_64)"
+    label: "wanda: core binary parts py{{array.python}} (x86_64)"
     wanda: ci/docker/ray-core.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
       HOSTTYPE: "x86_64"
     tags:
@@ -40,23 +41,24 @@ steps:
       - java
 
   - name: ray-wheel-build
-    label: "wanda: wheel py{{matrix}} (x86_64)"
+    label: "wanda: wheel py{{array.python}} (x86_64)"
     wanda: ci/docker/ray-wheel.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
       HOSTTYPE: "x86_64"
     tags:
       - release_wheels
       - linux_wheels
     depends_on:
-      - ray-core-build
+      - ray-core-build($)
       - ray-java-build
       - ray-dashboard-build

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -98,7 +98,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycpubase
+      - raycpubase(*)
 
   - name: ray-image-tpu-build
     label: "wanda: ray py{{matrix}} tpu (x86_64)"
@@ -118,7 +118,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raytpubase
+      - raytpubase(*)
 
   - label: ":tapioca: smoke test: ray tpu image"
     instance_type: small
@@ -166,7 +166,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycudabase
+      - raycudabase(*)
 
   - label: ":crane: publish: ray py{{matrix}} (x86_64)"
     key: ray_images_push
@@ -221,7 +221,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycpubaseextra
+      - raycpubaseextra(*)
 
   - name: ray-extra-image-cuda-build
     label: "wanda: ray-extra py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
@@ -254,7 +254,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - raycudabaseextra
+      - raycudabaseextra(*)
 
   - name: ray-llm-image-cuda-build
     label: "wanda: ray-llm py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
@@ -280,7 +280,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - ray-llmbase
+      - ray-llmbase(*)
 
   - name: ray-llm-extra-image-cuda-build
     label: "wanda: ray-llm-extra py{{matrix.python}} cu{{matrix.cuda}} (x86_64)"
@@ -306,7 +306,7 @@ steps:
       - oss
     depends_on:
       - ray-wheel-build
-      - ray-llmbaseextra
+      - ray-llmbaseextra(*)
 
   - label: ":crane: publish: ray-extra py{{matrix}} (x86_64)"
     key: ray_extra_images_push

--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -14,7 +14,7 @@ steps:
       - "3.13"
       - "3.14"
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - forge
     tags:
       - release_wheels
@@ -46,7 +46,7 @@ steps:
       - linux_wheels
       - oss
     depends_on:
-      - ray-core-build
+      - ray-core-build(*)
       - ray-cpp-core-build
       - ray-java-build
       - ray-dashboard-build
@@ -97,7 +97,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycpubase(*)
 
   - name: ray-image-tpu-build
@@ -117,7 +117,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raytpubase(*)
 
   - label: ":tapioca: smoke test: ray tpu image"
@@ -165,7 +165,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycudabase(*)
 
   - label: ":crane: publish: ray py{{matrix}} (x86_64)"
@@ -220,7 +220,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycpubaseextra(*)
 
   - name: ray-extra-image-cuda-build
@@ -253,7 +253,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycudabaseextra(*)
 
   - name: ray-llm-image-cuda-build
@@ -279,7 +279,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - ray-llmbase(*)
 
   - name: ray-llm-extra-image-cuda-build
@@ -305,7 +305,7 @@ steps:
       - docker
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - ray-llmbaseextra(*)
 
   - label: ":crane: publish: ray-extra py{{matrix}} (x86_64)"

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -1,7 +1,7 @@
 group: core tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds
@@ -269,7 +269,7 @@ steps:
       - manylinux-x86_64
       - corebuild-multipy
       - forge
-      - ray-wheel-build
+      - ray-wheel-build(*)
 
   - label: ":ray: core: minimal tests {{matrix}}"
     tags:

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -473,7 +473,7 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - corebuild-multipy
 
   - label: ":ray: core: runtime env container tests"
@@ -495,7 +495,7 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - corebuild-multipy
 
   - label: ":core: core: spark-on-ray tests"

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -2,7 +2,7 @@ group: data tests
 depends_on:
   - forge
   - oss-ci-base_ml-multipy
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -5,7 +5,7 @@ steps:
     wanda: ci/docker/doc.build.wanda.yaml
     depends_on:
       - oss-ci-base_build-multipy
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build
     matrix:
       - "3.10"

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -18,7 +18,7 @@ steps:
       - k8sbuild
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - ray-core-build
       - ray-dashboard-build
 
@@ -46,6 +46,6 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - ray-core-build
       - ray-dashboard-build

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -19,7 +19,7 @@ steps:
       - manylinux-x86_64
       - forge
       - raycpubase(*)
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build
 
   - label: ":kubernetes: chaos {{matrix.workload}} under {{matrix.fault}}"
@@ -47,5 +47,5 @@ steps:
       - manylinux-x86_64
       - forge
       - raycpubase(*)
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build

--- a/.buildkite/llm.rayci.yml
+++ b/.buildkite/llm.rayci.yml
@@ -1,7 +1,7 @@
 group: llm tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   - name: llmbuild

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -1,7 +1,7 @@
 group: ml tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -23,7 +23,7 @@ steps:
         --python-version 3.10
     depends_on:
       - doctestbuild
-      - ray-core-build
+      - ray-core-build(*)
       - ray-dashboard-build
 
   # java

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -90,7 +90,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycpubaseextra-testdeps
 
   - name: ray-anyscale-cuda-build
@@ -119,7 +119,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - raycudabaseextra-testdeps
 
   - label: ":crane: publish: ray-anyscale py{{matrix.python}} {{matrix.platform}}"
@@ -173,7 +173,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - ray-llmbaseextra-testdeps
 
   - label: ":crane: publish: ray-llm-anyscale py{{matrix.python}} {{matrix.platform}}"
@@ -220,7 +220,7 @@ steps:
     tags:
       - oss
     depends_on:
-      - ray-wheel-build
+      - ray-wheel-build(*)
       - ray-mlcudabaseextra-testdeps
 
   - label: ":crane: publish: ray-ml-anyscale py{{matrix}} cu12.1.1-cudnn8"

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -1,128 +1,126 @@
 group: release build
 steps:
   - name: raycpubaseextra-testdeps
-    label: "wanda: ray.py{{matrix}}.cpu.base-extra-testdeps"
+    label: "wanda: ray.py{{array.python}}.cpu.base-extra-testdeps"
     wanda: docker/base-extra-testdeps/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray"
     depends_on:
       - raycpubaseextra(*)
 
   - name: raycudabaseextra-testdeps
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base-extra-testdeps"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.base-extra-testdeps"
     wanda: docker/base-extra-testdeps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "12.3.2-cudnn9"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "12.3.2-cudnn9"
       adjustments:
         - with:
             python: "3.12"
             cuda: "13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray"
     depends_on:
       - raycudabaseextra(*)
 
   - name: ray-llmbaseextra-testdeps
-    label: "wanda: ray.py{{matrix.python}}.llm.base-extra-testdeps (cuda {{matrix.cuda}})"
+    label: "wanda: ray.py{{array.python}}.llm.base-extra-testdeps (cuda {{array.cuda}})"
     wanda: docker/base-extra-testdeps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-llm"
     depends_on:
       - ray-llmbaseextra(*)
 
   - name: ray-mlcudabaseextra-testdeps
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.ml.base-extra-testdeps"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.ml.base-extra-testdeps"
     wanda: docker/base-extra-testdeps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-        cuda:
-          - "12.1.1-cudnn8"
+    array:
+      python:
+        - "3.10"
+      cuda:
+        - "12.1.1-cudnn8"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-ml"
     depends_on:
       - ray-mlcudabaseextra(*)
 
   - name: ray-anyscale-cpu-build
-    label: "wanda: ray-anyscale py{{matrix}} cpu"
+    label: "wanda: ray-anyscale py{{array.python}} cpu"
     wanda: ci/docker/ray-anyscale-cpu.wanda.yaml
     env_file: rayci.env
-    matrix:
-      # This list should be kept in sync with the list of supported Python in
-      # release test suite
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        # This list should be kept in sync with the list of supported Python in
+        # release test suite
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - raycpubaseextra-testdeps
+      - ray-wheel-build($)
+      - raycpubaseextra-testdeps($)
 
   - name: ray-anyscale-cuda-build
-    label: "wanda: ray-anyscale py{{matrix.python}} cu{{matrix.cuda}}"
+    label: "wanda: ray-anyscale py{{array.python}} {{array.platform}}"
     wanda: ci/docker/ray-anyscale-cuda.wanda.yaml
     env_file: rayci.env
-    matrix:
-      setup:
-        python:
-          # This list should be kept in sync with the list of supported Python in
-          # release test suite
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "12.3.2-cudnn9"
+    array:
+      platform:
+        - "cu12.3.2-cudnn9"
+      python:
+        # This list should be kept in sync with the list of supported Python in
+        # release test suite
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
       adjustments:
         - with:
             python: "3.12"
-            cuda: "13.0.0-cudnn"
+            platform: "cu13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      PLATFORM: "{{array.platform}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - raycudabaseextra-testdeps
+      - ray-wheel-build($)
+      - raycudabaseextra-testdeps($)
 
-  - label: ":crane: publish: ray-anyscale py{{matrix.python}} {{matrix.platform}}"
+  - label: ":crane: publish: ray-anyscale py{{array.python}} {{array.platform}}"
     key: anyscalebuild
     instance_type: release-medium
     mount_buildkite_agent: true
@@ -130,53 +128,51 @@ steps:
       - oss
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
-        --python-version {{matrix.python}}
-        --platform {{matrix.platform}}
+        --python-version {{array.python}}
+        --platform {{array.platform}}
         --image-type ray
         --upload
     depends_on:
-      - ray-anyscale-cpu-build
-      - ray-anyscale-cuda-build
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        platform:
-          - cu12.3.2-cudnn9
-          - cpu
+      - ray-anyscale-cpu-build(*)
+      - ray-anyscale-cuda-build(*)
+    array:
+      platform:
+        - cu12.3.2-cudnn9
+        - cpu
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
       adjustments:
         - with:
             python: "3.12"
             platform: cu13.0.0-cudnn
 
   - name: ray-llm-anyscale-cuda-build
-    label: "wanda: ray-llm-anyscale py{{matrix.python}} cu{{matrix.cuda}}"
+    label: "wanda: ray-llm-anyscale py{{array.python}} {{array.platform}}"
     wanda: ci/docker/ray-llm-anyscale-cuda.wanda.yaml
     env_file: rayci.env
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    array:
+      platform:
+        - "cu13.0.0-cudnn"
+      python:
+        - "3.12"
       adjustments:
         - with:
             python: "3.11"
-            cuda: "12.8.1-cudnn"
+            platform: "cu12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      PLATFORM: "{{array.platform}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - ray-llmbaseextra-testdeps
+      - ray-wheel-build($)
+      - ray-llmbaseextra-testdeps($)
 
-  - label: ":crane: publish: ray-llm-anyscale py{{matrix.python}} {{matrix.platform}}"
+  - label: ":crane: publish: ray-llm-anyscale py{{array.python}} {{array.platform}}"
     key: anyscalellmbuild
     instance_type: release-medium
     mount_buildkite_agent: true
@@ -184,46 +180,44 @@ steps:
       - oss
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
-        --python-version {{matrix.python}}
-        --platform {{matrix.platform}}
+        --python-version {{array.python}}
+        --platform {{array.platform}}
         --image-type ray-llm
         --upload
     depends_on:
-      - ray-llm-anyscale-cuda-build
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        platform:
-          - cu13.0.0-cudnn
+      - ray-llm-anyscale-cuda-build($)
+    array:
+      platform:
+        - cu13.0.0-cudnn
+      python:
+        - "3.12"
       adjustments:
         - with:
             python: "3.11"
             platform: "cu12.8.1-cudnn"
 
   - name: ray-ml-anyscale-cuda-build
-    label: "wanda: ray-ml-anyscale py{{matrix.python}} cu{{matrix.cuda}}"
+    label: "wanda: ray-ml-anyscale py{{array.python}} {{array.platform}}"
     wanda: ci/docker/ray-ml-anyscale-cuda.wanda.yaml
     env_file: rayci.env
-    matrix:
-      setup:
-        python:
-          # This list should be kept in sync with the list of supported Python in
-          # release test suite
-          - "3.10"
-        cuda:
-          - "12.1.1-cudnn8"
+    array:
+      platform:
+        - "cu12.1.1-cudnn8"
+      python:
+        # This list should be kept in sync with the list of supported Python in
+        # release test suite
+        - "3.10"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      PLATFORM: "{{array.platform}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - ray-mlcudabaseextra-testdeps
+      - ray-wheel-build($)
+      - ray-mlcudabaseextra-testdeps($)
 
-  - label: ":crane: publish: ray-ml-anyscale py{{matrix}} cu12.1.1-cudnn8"
+  - label: ":crane: publish: ray-ml-anyscale py{{array.python}} cu12.1.1-cudnn8"
     key: anyscalemlbuild
     instance_type: release-medium
     mount_buildkite_agent: true
@@ -231,11 +225,12 @@ steps:
       - oss
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cu12.1.1-cudnn8
         --image-type ray-ml
         --upload
     depends_on:
-      - ray-ml-anyscale-cuda-build
-    matrix:
-      - "3.10"
+      - ray-ml-anyscale-cuda-build($)
+    array:
+      python:
+        - "3.10"

--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -12,7 +12,7 @@ steps:
       PYTHON_VERSION: "{{matrix}}"
       IMAGE_TYPE: "ray"
     depends_on:
-      - raycpubaseextra
+      - raycpubaseextra(*)
 
   - name: raycudabaseextra-testdeps
     label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base-extra-testdeps"
@@ -35,7 +35,7 @@ steps:
       CUDA_VERSION: "{{matrix.cuda}}"
       IMAGE_TYPE: "ray"
     depends_on:
-      - raycudabaseextra
+      - raycudabaseextra(*)
 
   - name: ray-llmbaseextra-testdeps
     label: "wanda: ray.py{{matrix.python}}.llm.base-extra-testdeps (cuda {{matrix.cuda}})"
@@ -55,7 +55,7 @@ steps:
       CUDA_VERSION: "{{matrix.cuda}}"
       IMAGE_TYPE: "ray-llm"
     depends_on:
-      - ray-llmbaseextra
+      - ray-llmbaseextra(*)
 
   - name: ray-mlcudabaseextra-testdeps
     label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.ml.base-extra-testdeps"
@@ -71,7 +71,7 @@ steps:
       CUDA_VERSION: "{{matrix.cuda}}"
       IMAGE_TYPE: "ray-ml"
     depends_on:
-      - ray-mlcudabaseextra
+      - ray-mlcudabaseextra(*)
 
   - name: ray-anyscale-cpu-build
     label: "wanda: ray-anyscale py{{matrix}} cpu"

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,7 +1,7 @@
 group: rllib tests
 depends_on:
   - forge
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -203,7 +203,7 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase
+      - raycpubase(*)
       - servebuild-multipy
 
   - label: ":ray-serve: serve: tracing tests"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -2,7 +2,7 @@ group: serve tests
 depends_on:
   - forge
   - oss-ci-base_build-multipy
-  - ray-core-build
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds
@@ -124,7 +124,7 @@ steps:
       - manylinux-x86_64
       - servebuild-multipy
       - forge
-      - ray-wheel-build
+      - ray-wheel-build(*)
 
   - label: ":ray-serve: serve: doc tests"
     tags:

--- a/ci/docker/ray-anyscale-cuda.wanda.yaml
+++ b/ci/docker/ray-anyscale-cuda.wanda.yaml
@@ -4,10 +4,10 @@
 #
 # This produces the anyscale test image for GPU release tests.
 #
-name: "ray-anyscale-py$PYTHON_VERSION-cu$CUDA_VERSION$ARCH_SUFFIX"
+name: "ray-anyscale-py$PYTHON_VERSION-$PLATFORM$ARCH_SUFFIX"
 disable_caching: true
 froms:
-  - "cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra-testdeps"  # CUDA base with test deps
+  - "cr.ray.io/rayproject/ray-py$PYTHON_VERSION-$PLATFORM-base-extra-testdeps"  # CUDA base with test deps
   - "cr.ray.io/rayproject/ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"                    # Ray wheel
 dockerfile: ci/docker/ray-image.Dockerfile
 build_args:
@@ -15,6 +15,6 @@ build_args:
   - ARCH_SUFFIX
   - IMAGE_TYPE=ray
   - BASE_VARIANT=base-extra-testdeps
-  - PLATFORM=cu$CUDA_VERSION
+  - PLATFORM
   - RAY_COMMIT=$BUILDKITE_COMMIT
   - RAY_VERSION

--- a/ci/docker/ray-llm-anyscale-cuda.wanda.yaml
+++ b/ci/docker/ray-llm-anyscale-cuda.wanda.yaml
@@ -4,10 +4,10 @@
 #
 # This produces the anyscale test image for ray-llm GPU release tests.
 #
-name: "ray-llm-anyscale-py$PYTHON_VERSION-cu$CUDA_VERSION$ARCH_SUFFIX"
+name: "ray-llm-anyscale-py$PYTHON_VERSION-$PLATFORM$ARCH_SUFFIX"
 disable_caching: true
 froms:
-  - "cr.ray.io/rayproject/ray-llm-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra-testdeps"  # ray-llm base with test deps
+  - "cr.ray.io/rayproject/ray-llm-py$PYTHON_VERSION-$PLATFORM-base-extra-testdeps"  # ray-llm base with test deps
   - "cr.ray.io/rayproject/ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"                        # Ray wheel
 dockerfile: ci/docker/ray-image.Dockerfile
 build_args:
@@ -15,6 +15,6 @@ build_args:
   - ARCH_SUFFIX
   - BASE_VARIANT=base-extra-testdeps
   - IMAGE_TYPE=ray-llm
-  - PLATFORM=cu$CUDA_VERSION
+  - PLATFORM
   - RAY_COMMIT=$BUILDKITE_COMMIT
   - RAY_VERSION

--- a/ci/docker/ray-ml-anyscale-cuda.wanda.yaml
+++ b/ci/docker/ray-ml-anyscale-cuda.wanda.yaml
@@ -4,10 +4,10 @@
 #
 # This produces the anyscale test image for ray-ml GPU release tests.
 #
-name: "ray-ml-anyscale-py$PYTHON_VERSION-cu$CUDA_VERSION$ARCH_SUFFIX"
+name: "ray-ml-anyscale-py$PYTHON_VERSION-$PLATFORM$ARCH_SUFFIX"
 disable_caching: true
 froms:
-  - "cr.ray.io/rayproject/ray-ml-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra-testdeps"  # ray-ml base with test deps
+  - "cr.ray.io/rayproject/ray-ml-py$PYTHON_VERSION-$PLATFORM-base-extra-testdeps"  # ray-ml base with test deps
   - "cr.ray.io/rayproject/ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"                       # Ray wheel
 dockerfile: ci/docker/ray-image.Dockerfile
 build_args:
@@ -15,6 +15,6 @@ build_args:
   - ARCH_SUFFIX
   - BASE_VARIANT=base-extra-testdeps
   - IMAGE_TYPE=ray-ml
-  - PLATFORM=cu$CUDA_VERSION
+  - PLATFORM
   - RAY_COMMIT=$BUILDKITE_COMMIT
   - RAY_VERSION


### PR DESCRIPTION
Convert all release build steps from Buildkite matrix to rayci array syntax. CUDA build steps use the platform dimension (aligned with publish steps and wandas) instead of cuda.

Dependency selectors:
- testdeps → image steps: (*) (different pipeline group)
- build → wheel-build: ($) (shared python dimension)
- build → testdeps: ($) (shared dimensions)
- publish → build: (*) (will be refined in a follow-up)
- anyscalellmbuild/anyscalemlbuild → build: ($) (dimensions aligned)

Topic: array-release-yaml
Relative: wanda-platform-env
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>