### PR TITLE
[CI] Split anyscalebuild into cpu/cuda for precise deps + update Python

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -120,8 +120,29 @@ steps:
       - ray-wheel-build($)
       - raycudabaseextra-testdeps($)
 
+  - label: ":crane: publish: ray-anyscale py{{array.python}} cpu"
+    key: anyscalecpubuild
+    instance_type: release-medium
+    mount_buildkite_agent: true
+    tags:
+      - oss
+    commands:
+      - bazel run //ci/ray_ci/automation:push_release_test_image --
+        --python-version {{array.python}}
+        --platform cpu
+        --image-type ray
+        --upload
+    depends_on:
+      - ray-anyscale-cpu-build($)
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+
   - label: ":crane: publish: ray-anyscale py{{array.python}} {{array.platform}}"
-    key: anyscalebuild
+    key: anyscalecudabuild
     instance_type: release-medium
     mount_buildkite_agent: true
     tags:
@@ -133,12 +154,10 @@ steps:
         --image-type ray
         --upload
     depends_on:
-      - ray-anyscale-cpu-build(*)
-      - ray-anyscale-cuda-build(*)
+      - ray-anyscale-cuda-build($)
     array:
       platform:
         - cu12.3.2-cudnn9
-        - cpu
       python:
         - "3.10"
         - "3.11"

--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -20,6 +20,7 @@ state_machine:
   branch:
     aws_bucket: ray-ci-results
 release_image_step:
-  ray: anyscalebuild
+  ray_cpu: anyscalecpubuild
+  ray_cuda: anyscalecudabuild
   ray_ml: anyscalemlbuild
   ray_llm: anyscalellmbuild

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -16,7 +16,8 @@ class GlobalConfig(TypedDict):
     ci_pipeline_premerge: List[str]
     ci_pipeline_postmerge: List[str]
     ci_pipeline_buildkite_secret: str
-    release_image_step_ray: str
+    release_image_step_ray_cpu: str
+    release_image_step_ray_cuda: str
     release_image_step_ray_ml: str
     release_image_step_ray_llm: str
 
@@ -88,7 +89,12 @@ def _init_global_config(config_file: str):
             "buildkite_secret"
         ),
         kuberay_disabled=config_content.get("kuberay", {}).get("disabled", 0) == 1,
-        release_image_step_ray=config_content.get("release_image_step", {}).get("ray"),
+        release_image_step_ray_cpu=config_content.get("release_image_step", {}).get(
+            "ray_cpu"
+        ),
+        release_image_step_ray_cuda=config_content.get("release_image_step", {}).get(
+            "ray_cuda"
+        ),
         release_image_step_ray_ml=config_content.get("release_image_step", {}).get(
             "ray_ml"
         ),

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -1,11 +1,11 @@
 import hashlib
-import json
 import os
-from functools import lru_cache
-from pathlib import Path
+import re
 from typing import Dict, List, Optional, Tuple
 
 import yaml
+
+from ci.ray_ci.supported_images import build_platform_reverse_map
 
 from ray_release.configs.global_config import get_global_config
 from ray_release.logger import logger
@@ -129,54 +129,66 @@ def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
         yaml.dump(build_config, f, default_flow_style=False, sort_keys=False)
 
 
-@lru_cache(maxsize=1)
-def _platform_reverse_map() -> Dict[str, str]:
-    """Map short platform tags (e.g. 'cu123') to full strings (e.g. 'cu12.3.2-cudnn9')."""
-    path = Path(__file__).resolve().parents[2] / "ray-images.json"
-    if not path.exists():
-        # Bazel runfiles layout
-        for parent in Path(__file__).resolve().parents:
-            candidate = parent / "ray-images.json"
-            if candidate.exists():
-                path = candidate
-                break
-    images = json.loads(path.read_text())
-    reverse: Dict[str, str] = {}
-    for cfg in images.values():
-        for platform in cfg.get("platforms", []):
-            if platform in ("cpu", "tpu"):
-                short = platform
-            else:
-                base = platform.split("-", 1)[0]
-                parts = base.split(".")
-                short = f"{parts[0]}{parts[1]}" if len(parts) >= 2 else platform
-            if short in reverse and reverse[short] != platform:
-                raise ValueError(
-                    f"Ambiguous short platform tag '{short}': "
-                    f"could be '{platform}' or '{reverse[short]}'"
-                )
-            reverse[short] = platform
-    return reverse
-
-
 def _sanitize_array_value(value: str) -> str:
     """Strip dots and dashes from a value for rayci array key construction."""
     return value.replace(".", "").replace("-", "")
 
 
 def get_prerequisite_step(image: str, base_image: str) -> Optional[str]:
-    """Get the base image build step for a job that depends on it."""
+    """Get the base image build step for a job that depends on it.
+
+    Returns the array-suffixed Buildkite step key for the publish step that
+    produces the base image.  For example, for a ray image with python 3.10 and
+    platform cpu the returned key is ``anyscalecpubuild--python310``.
+    """
     config = get_global_config()
     image_repository, _ = image.split(":")
     image_name = image_repository.split("/")[-1]
     if base_image.startswith(ANYSCALE_RAY_IMAGE_PREFIX):
         return "forge"
+
+    # Parse base_image tag: {build_id}-py{ver}-{suffix}
+    _, tag = base_image.rsplit(":", 1)
+    tag_parts = tag.split("-")
+    py_index = None
+    for i, part in enumerate(tag_parts):
+        if re.match(r"^py\d+$", part):
+            py_index = i
+            break
+
     if image_name == "ray-ml":
-        return config["release_image_step_ray_ml"]
-    elif image_name == "ray-llm":
-        return config["release_image_step_ray_llm"]
+        bare_key = config["release_image_step_ray_ml"]
+        if py_index is None:
+            return bare_key
+        python_raw = tag_parts[py_index][2:]
+        return f"{bare_key}--python{python_raw}"
+
+    if image_name == "ray-llm":
+        bare_key = config["release_image_step_ray_llm"]
     else:
-        return config["release_image_step_ray"]
+        # ray image: pick cpu or cuda key based on tag suffix
+        tag_suffix = "-".join(tag_parts[py_index + 1 :]) if py_index is not None else ""
+        if tag_suffix == "cpu":
+            bare_key = config["release_image_step_ray_cpu"]
+        else:
+            bare_key = config["release_image_step_ray_cuda"]
+
+    if py_index is None:
+        return bare_key
+
+    python_raw = tag_parts[py_index][2:]  # e.g., "310"
+    tag_suffix = "-".join(tag_parts[py_index + 1 :])  # e.g., "cu123" or "cpu"
+
+    if tag_suffix == "cpu":
+        # anyscalecpubuild has only a python dimension
+        return f"{bare_key}--python{python_raw}"
+
+    # cuda steps have two dimensions (platform, python) in alphabetical order
+    reverse_map = build_platform_reverse_map()
+    full_platform = reverse_map.get(tag_suffix, tag_suffix)
+    sanitized_platform = _sanitize_array_value(full_platform)
+
+    return f"{bare_key}--platform{sanitized_platform}-python{python_raw}"
 
 
 def _get_step_name(image: str, step_key: str, test_names: List[str]) -> str:

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -188,28 +188,60 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
 
 
 def test_get_prerequisite_step():
-    config = get_global_config()
-    assert (
-        get_prerequisite_step(
-            "ray-project/ray-ml:abc123-custom", "ray-project/ray-ml:abc123-base"
-        )
-        == config["release_image_step_ray_ml"]
-    )
-    assert (
-        get_prerequisite_step(
-            "ray-project/ray-llm:abc123-custom", "ray-project/ray-llm:abc123-base"
-        )
-        == config["release_image_step_ray_llm"]
-    )
-    assert (
-        get_prerequisite_step(
-            "ray-project/ray:abc123-custom", "ray-project/ray:abc123-base"
-        )
-        == config["release_image_step_ray"]
-    )
+    # anyscale base image → always "forge"
     assert (
         get_prerequisite_step("anyscale/ray:abc123-custom", "anyscale/ray:abc123-base")
         == "forge"
+    )
+
+    # ray-ml has only a python dimension → anyscalemlbuild--python{ver}
+    assert (
+        get_prerequisite_step(
+            "ray-project/ray-ml:abc123-custom",
+            "ray-project/ray-ml:abc123-py310-gpu",
+        )
+        == "anyscalemlbuild--python310"
+    )
+    assert (
+        get_prerequisite_step(
+            "ray-project/ray-ml:abc123-custom",
+            "ray-project/ray-ml:abc123-py311-gpu",
+        )
+        == "anyscalemlbuild--python311"
+    )
+
+    # ray cpu → anyscalecpubuild (python dimension only)
+    assert (
+        get_prerequisite_step(
+            "ray-project/ray:abc123-custom",
+            "ray-project/ray:abc123-py310-cpu",
+        )
+        == "anyscalecpubuild--python310"
+    )
+
+    # ray cuda → anyscalecudabuild (platform + python dimensions)
+    assert (
+        get_prerequisite_step(
+            "ray-project/ray:abc123-custom",
+            "ray-project/ray:abc123-py311-cu123",
+        )
+        == "anyscalecudabuild--platformcu1232cudnn9-python311"
+    )
+
+    # ray-llm has platform and python dimensions → anyscalellmbuild--platform{X}-python{Y}
+    assert (
+        get_prerequisite_step(
+            "ray-project/ray-llm:abc123-custom",
+            "ray-project/ray-llm:abc123-py311-cu128",
+        )
+        == "anyscalellmbuild--platformcu1281cudnn-python311"
+    )
+    assert (
+        get_prerequisite_step(
+            "ray-project/ray-llm:abc123-custom",
+            "ray-project/ray-llm:abc123-py312-cu130",
+        )
+        == "anyscalellmbuild--platformcu1300cudnn-python312"
     )
 
 

--- a/release/ray_release/tests/test_global_config.py
+++ b/release/ray_release/tests/test_global_config.py
@@ -34,7 +34,8 @@ ci_pipeline:
     - hi
     - three
 release_image_step:
-  ray: anyscalebuild
+  ray_cpu: anyscalecpubuild
+  ray_cuda: anyscalecudabuild
   ray_ml: anyscalemlbuild
   ray_llm: anyscalellmbuild
 """
@@ -56,7 +57,8 @@ def test_init_global_config() -> None:
         )
         assert config["state_machine_pr_aws_bucket"] == "ray-ci-pr-results"
         assert config["state_machine_disabled"] is True
-        assert config["release_image_step_ray"] == "anyscalebuild"
+        assert config["release_image_step_ray_cpu"] == "anyscalecpubuild"
+        assert config["release_image_step_ray_cuda"] == "anyscalecudabuild"
         assert config["release_image_step_ray_ml"] == "anyscalemlbuild"
         assert config["release_image_step_ray_llm"] == "anyscalellmbuild"
         assert config["byod_ecr"] == "029272617770.dkr.ecr.us-west-2.amazonaws.com"


### PR DESCRIPTION
Split the single anyscalebuild publish step into anyscalecpubuild
(python dim only, depends on ray-anyscale-cpu-build via $) and
anyscalecudabuild (platform+python dims, depends on
ray-anyscale-cuda-build via $).  Each publish variant now waits only
for its matching build instead of all builds.

Update oss_config.yaml with separate ray_cpu/ray_cuda keys.
Rewrite get_prerequisite_step() to parse the base_image tag, select
the right publish step key, and construct array-suffixed keys using
the helpers from the previous commit.

Topic: array-release-python
Relative: array-release-helpers
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>