### PR TITLE
[CI] Convert release/build.rayci.yml to array + update get_prerequisite_step

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -1,182 +1,197 @@
 group: release build
 steps:
   - name: raycpubaseextra-testdeps
-    label: "wanda: ray.py{{matrix}}.cpu.base-extra-testdeps"
+    label: "wanda: ray.py{{array.python}}.cpu.base-extra-testdeps"
     wanda: docker/base-extra-testdeps/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray"
     depends_on:
       - raycpubaseextra(*)
 
   - name: raycudabaseextra-testdeps
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base-extra-testdeps"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.base-extra-testdeps"
     wanda: docker/base-extra-testdeps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "12.3.2-cudnn9"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "12.3.2-cudnn9"
       adjustments:
         - with:
             python: "3.12"
             cuda: "13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray"
     depends_on:
       - raycudabaseextra(*)
 
   - name: ray-llmbaseextra-testdeps
-    label: "wanda: ray.py{{matrix.python}}.llm.base-extra-testdeps (cuda {{matrix.cuda}})"
+    label: "wanda: ray.py{{array.python}}.llm.base-extra-testdeps (cuda {{array.cuda}})"
     wanda: docker/base-extra-testdeps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+    array:
+      python:
+        - "3.12"
+      cuda:
+        - "13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
             cuda: "12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-llm"
     depends_on:
       - ray-llmbaseextra(*)
 
   - name: ray-mlcudabaseextra-testdeps
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.ml.base-extra-testdeps"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.ml.base-extra-testdeps"
     wanda: docker/base-extra-testdeps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-        cuda:
-          - "12.1.1-cudnn8"
+    array:
+      python:
+        - "3.10"
+      cuda:
+        - "12.1.1-cudnn8"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray-ml"
     depends_on:
       - ray-mlcudabaseextra(*)
 
   - name: ray-anyscale-cpu-build
-    label: "wanda: ray-anyscale py{{matrix}} cpu"
+    label: "wanda: ray-anyscale py{{array.python}} cpu"
     wanda: ci/docker/ray-anyscale-cpu.wanda.yaml
     env_file: rayci.env
-    matrix:
-      # This list should be kept in sync with the list of supported Python in
-      # release test suite
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        # This list should be kept in sync with the list of supported Python in
+        # release test suite
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - raycpubaseextra-testdeps
+      - ray-wheel-build($)
+      - raycpubaseextra-testdeps($)
 
   - name: ray-anyscale-cuda-build
-    label: "wanda: ray-anyscale py{{matrix.python}} {{matrix.gpu}}"
+    label: "wanda: ray-anyscale py{{array.python}} {{array.gpu}}"
     wanda: ci/docker/ray-anyscale-cuda.wanda.yaml
     env_file: rayci.env
-    matrix:
-      setup:
-        python:
-          # This list should be kept in sync with the list of supported Python in
-          # release test suite
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        gpu:
-          - "cu12.3.2-cudnn9"
+    array:
+      gpu:
+        - "cu12.3.2-cudnn9"
+      python:
+        # This list should be kept in sync with the list of supported Python in
+        # release test suite
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
       adjustments:
         - with:
             python: "3.12"
             gpu: "cu13.0.0-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      GPU: "{{matrix.gpu}}"
+      PYTHON_VERSION: "{{array.python}}"
+      GPU: "{{array.gpu}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - raycudabaseextra-testdeps
+      - ray-wheel-build($)
+      - raycudabaseextra-testdeps($)
 
-  - label: ":crane: publish: ray-anyscale py{{matrix.python}} {{matrix.gpu}}"
-    key: anyscalebuild
+  - label: ":crane: publish: ray-anyscale py{{array.python}} cpu"
+    key: anyscalecpubuild
     instance_type: release-medium
     mount_buildkite_agent: true
     tags:
       - oss
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
-        --python-version {{matrix.python}}
-        --platform {{matrix.gpu}}
+        --python-version {{array.python}}
+        --platform cpu
         --image-type ray
         --upload
     depends_on:
-      - ray-anyscale-cpu-build
-      - ray-anyscale-cuda-build
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        gpu:
-          - cu12.3.2-cudnn9
-          - cpu
+      - ray-anyscale-cpu-build($)
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+
+  - label: ":crane: publish: ray-anyscale py{{array.python}} {{array.gpu}}"
+    key: anyscalecudabuild
+    instance_type: release-medium
+    mount_buildkite_agent: true
+    tags:
+      - oss
+    commands:
+      - bazel run //ci/ray_ci/automation:push_release_test_image --
+        --python-version {{array.python}}
+        --platform {{array.gpu}}
+        --image-type ray
+        --upload
+    depends_on:
+      - ray-anyscale-cuda-build($)
+    array:
+      gpu:
+        - cu12.3.2-cudnn9
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
       adjustments:
         - with:
             python: "3.12"
             gpu: cu13.0.0-cudnn
 
   - name: ray-llm-anyscale-cuda-build
-    label: "wanda: ray-llm-anyscale py{{matrix.python}} {{matrix.gpu}}"
+    label: "wanda: ray-llm-anyscale py{{array.python}} {{array.gpu}}"
     wanda: ci/docker/ray-llm-anyscale-cuda.wanda.yaml
     env_file: rayci.env
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        gpu:
-          - "cu13.0.0-cudnn"
+    array:
+      gpu:
+        - "cu13.0.0-cudnn"
+      python:
+        - "3.12"
       adjustments:
         - with:
             python: "3.11"
             gpu: "cu12.8.1-cudnn"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      GPU: "{{matrix.gpu}}"
+      PYTHON_VERSION: "{{array.python}}"
+      GPU: "{{array.gpu}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - ray-llmbaseextra-testdeps
+      - ray-wheel-build($)
+      - ray-llmbaseextra-testdeps($)
 
-  - label: ":crane: publish: ray-llm-anyscale py{{matrix.python}} {{matrix.gpu}}"
+  - label: ":crane: publish: ray-llm-anyscale py{{array.python}} {{array.gpu}}"
     key: anyscalellmbuild
     instance_type: release-medium
     mount_buildkite_agent: true
@@ -184,46 +199,44 @@ steps:
       - oss
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
-        --python-version {{matrix.python}}
-        --platform {{matrix.gpu}}
+        --python-version {{array.python}}
+        --platform {{array.gpu}}
         --image-type ray-llm
         --upload
     depends_on:
-      - ray-llm-anyscale-cuda-build
-    matrix:
-      setup:
-        python:
-          - "3.12"
-        gpu:
-          - cu13.0.0-cudnn
+      - ray-llm-anyscale-cuda-build($)
+    array:
+      gpu:
+        - cu13.0.0-cudnn
+      python:
+        - "3.12"
       adjustments:
         - with:
             python: "3.11"
             gpu: "cu12.8.1-cudnn"
 
   - name: ray-ml-anyscale-cuda-build
-    label: "wanda: ray-ml-anyscale py{{matrix.python}} {{matrix.gpu}}"
+    label: "wanda: ray-ml-anyscale py{{array.python}} {{array.gpu}}"
     wanda: ci/docker/ray-ml-anyscale-cuda.wanda.yaml
     env_file: rayci.env
-    matrix:
-      setup:
-        python:
-          # This list should be kept in sync with the list of supported Python in
-          # release test suite
-          - "3.10"
-        gpu:
-          - "cu12.1.1-cudnn8"
+    array:
+      gpu:
+        - "cu12.1.1-cudnn8"
+      python:
+        # This list should be kept in sync with the list of supported Python in
+        # release test suite
+        - "3.10"
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      GPU: "{{matrix.gpu}}"
+      PYTHON_VERSION: "{{array.python}}"
+      GPU: "{{array.gpu}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
     depends_on:
-      - ray-wheel-build(*)
-      - ray-mlcudabaseextra-testdeps
+      - ray-wheel-build($)
+      - ray-mlcudabaseextra-testdeps($)
 
-  - label: ":crane: publish: ray-ml-anyscale py{{matrix}} cu12.1.1-cudnn8"
+  - label: ":crane: publish: ray-ml-anyscale py{{array.python}} cu12.1.1-cudnn8"
     key: anyscalemlbuild
     instance_type: release-medium
     mount_buildkite_agent: true
@@ -231,11 +244,12 @@ steps:
       - oss
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cu12.1.1-cudnn8
         --image-type ray-ml
         --upload
     depends_on:
-      - ray-ml-anyscale-cuda-build
-    matrix:
-      - "3.10"
+      - ray-ml-anyscale-cuda-build($)
+    array:
+      python:
+        - "3.10"

--- a/ci/ray_ci/oss_config.yaml
+++ b/ci/ray_ci/oss_config.yaml
@@ -20,6 +20,7 @@ state_machine:
   branch:
     aws_bucket: ray-ci-results
 release_image_step:
-  ray: anyscalebuild
+  ray_cpu: anyscalecpubuild
+  ray_cuda: anyscalecudabuild
   ray_ml: anyscalemlbuild
   ray_llm: anyscalellmbuild

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -714,6 +714,7 @@ py_test(
         "ray_release/configs/oss_config.yaml",
         "ray_release/tests/sample_5_tests.yaml",
         "ray_release/tests/sample_tests.yaml",
+        "//:ray-images.json",
     ],
     exec_compatible_with = ["//bazel:py3"],
     tags = [

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -79,6 +79,7 @@ def get_step_for_test_group(
     global_config: Optional[str] = None,
     is_concurrency_limit: bool = True,
     block_step_key: Optional[str] = None,
+    gpu_map: Optional[Dict[str, str]] = None,
 ):
     steps = []
     for group in sorted(grouped_tests):
@@ -98,6 +99,7 @@ def get_step_for_test_group(
                     priority_val=priority,
                     global_config=global_config,
                     block_step_key=block_step_key,
+                    gpu_map=gpu_map,
                 )
 
                 if not is_concurrency_limit:
@@ -122,6 +124,7 @@ def get_step(
     priority_val: int = 0,
     global_config: Optional[str] = None,
     block_step_key: Optional[str] = None,
+    gpu_map: Optional[Dict[str, str]] = None,
 ):
     env = env or {}
     step = copy.deepcopy(_DEFAULT_STEP_TEMPLATE)
@@ -201,7 +204,7 @@ def get_step(
     if test.require_custom_byod_image():
         step["depends_on"] = generate_custom_build_step_key(image)
     else:
-        step["depends_on"] = get_prerequisite_step(image, base_image)
+        step["depends_on"] = get_prerequisite_step(image, base_image, gpu_map)
 
     if block_step_key:
         if not step["depends_on"]:

--- a/release/ray_release/configs/global_config.py
+++ b/release/ray_release/configs/global_config.py
@@ -16,7 +16,8 @@ class GlobalConfig(TypedDict):
     ci_pipeline_premerge: List[str]
     ci_pipeline_postmerge: List[str]
     ci_pipeline_buildkite_secret: str
-    release_image_step_ray: str
+    release_image_step_ray_cpu: str
+    release_image_step_ray_cuda: str
     release_image_step_ray_ml: str
     release_image_step_ray_llm: str
 
@@ -88,7 +89,12 @@ def _init_global_config(config_file: str):
             "buildkite_secret"
         ),
         kuberay_disabled=config_content.get("kuberay", {}).get("disabled", 0) == 1,
-        release_image_step_ray=config_content.get("release_image_step", {}).get("ray"),
+        release_image_step_ray_cpu=config_content.get("release_image_step", {}).get(
+            "ray_cpu"
+        ),
+        release_image_step_ray_cuda=config_content.get("release_image_step", {}).get(
+            "ray_cuda"
+        ),
         release_image_step_ray_ml=config_content.get("release_image_step", {}).get(
             "ray_ml"
         ),

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -52,7 +52,9 @@ def get_images_from_tests(
     return list(custom_byod_images.values()), custom_image_test_names_map
 
 
-def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
+def create_custom_build_yaml(
+    destination_file: str, tests: List[Test], gpu_map: Dict[str, str]
+) -> None:
     """Create a yaml file for building custom BYOD images"""
     config = get_global_config()
     if (
@@ -121,7 +123,7 @@ def create_custom_build_yaml(destination_file: str, tests: List[Test]) -> None:
                 build_cmd,
             ],
         }
-        step["depends_on"] = get_prerequisite_step(image, base_image)
+        step["depends_on"] = get_prerequisite_step(image, base_image, gpu_map)
         build_config["steps"].append(step)
 
     with open(destination_file, "w") as f:
@@ -170,19 +172,64 @@ def _sanitize_array_value(value: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]", "", value)
 
 
-def get_prerequisite_step(image: str, base_image: str) -> Optional[str]:
-    """Get the base image build step for a job that depends on it."""
+def get_prerequisite_step(
+    image: str,
+    base_image: str,
+    gpu_map: Optional[Dict[str, str]] = None,
+) -> Optional[str]:
+    """Get the base image build step for a job that depends on it.
+
+    Returns the array-suffixed Buildkite step key for the publish step
+    that produces the base image.
+    """
+    if gpu_map is None:
+        gpu_map = {}
     config = get_global_config()
     image_repository, _ = image.split(":")
     image_name = image_repository.split("/")[-1]
     if base_image.startswith(ANYSCALE_RAY_IMAGE_PREFIX):
         return "forge"
+
+    # Parse base_image tag: {build_id}-py{ver}-{suffix}
+    _, tag = base_image.rsplit(":", 1)
+    tag_parts = tag.split("-")
+    py_index = None
+    for i, part in enumerate(tag_parts):
+        if re.match(r"^py\d+$", part):
+            py_index = i
+            break
+
     if image_name == "ray-ml":
-        return config["release_image_step_ray_ml"]
-    elif image_name == "ray-llm":
-        return config["release_image_step_ray_llm"]
+        bare_key = config["release_image_step_ray_ml"]
+        if py_index is None:
+            return bare_key
+        return f"{bare_key}--python{tag_parts[py_index][2:]}"
+
+    if image_name == "ray-llm":
+        bare_key = config["release_image_step_ray_llm"]
     else:
-        return config["release_image_step_ray"]
+        # ray: pick cpu or cuda key based on tag suffix
+        tag_suffix = "-".join(tag_parts[py_index + 1 :]) if py_index is not None else ""
+        if tag_suffix == "cpu":
+            bare_key = config["release_image_step_ray_cpu"]
+        else:
+            bare_key = config["release_image_step_ray_cuda"]
+
+    if py_index is None:
+        return bare_key
+
+    python_raw = tag_parts[py_index][2:]  # e.g., "310"
+    tag_suffix = "-".join(tag_parts[py_index + 1 :])  # e.g., "cu123" or "cpu"
+
+    if tag_suffix == "cpu":
+        # anyscalecpubuild has only a python dimension
+        return f"{bare_key}--python{python_raw}"
+
+    # cuda publish steps have gpu + python dimensions (alphabetical order)
+    full_gpu = gpu_map.get(tag_suffix, tag_suffix)
+    sanitized = _sanitize_array_value(full_gpu)
+
+    return f"{bare_key}--gpu{sanitized}-python{python_raw}"
 
 
 def _get_step_name(image: str, step_key: str, test_names: List[str]) -> str:

--- a/release/ray_release/scripts/custom_image_build_and_test_init.py
+++ b/release/ray_release/scripts/custom_image_build_and_test_init.py
@@ -19,7 +19,10 @@ from ray_release.config import (
     read_and_validate_release_test_collection,
 )
 from ray_release.configs.global_config import init_global_config
-from ray_release.custom_byod_build_init_helper import create_custom_build_yaml
+from ray_release.custom_byod_build_init_helper import (
+    build_short_gpu_map,
+    create_custom_build_yaml,
+)
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
 from ray_release.logger import logger
 
@@ -137,10 +140,14 @@ def main(
             "not return any tests to run. Adjust your filters."
         )
     tests = [test for test, _ in filtered_tests]
+
+    gpu_map = build_short_gpu_map(os.path.join(_bazel_workspace_dir, "ray-images.json"))
+
     # Generate custom image build steps
     create_custom_build_yaml(
         os.path.join(_bazel_workspace_dir, custom_build_jobs_output_file),
         tests,
+        gpu_map,
     )
 
     # Generate test job steps
@@ -185,6 +192,7 @@ def main(
         global_config=global_config,
         is_concurrency_limit=not no_concurrency_limit,
         block_step_key=block_step["key"] if block_step else None,
+        gpu_map=gpu_map,
     )
     steps = [{"group": "block", "steps": [block_step]}] + steps if block_step else steps
 

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -21,6 +21,7 @@ from ray_release.test import Test
 from ray_release.util import AZURE_REGISTRY_NAME
 
 init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+_GPU_MAP = build_short_gpu_map(bazel_runfile("ray-images.json"))
 
 
 @mock.patch.dict(os.environ, {"RAY_WANT_COMMIT_IN_IMAGE": "abc123"})
@@ -133,7 +134,9 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
     ]
     with tempfile.TemporaryDirectory() as tmpdir:
         create_custom_build_yaml(
-            os.path.join(tmpdir, "custom_byod_build.rayci.yml"), tests
+            os.path.join(tmpdir, "custom_byod_build.rayci.yml"),
+            tests,
+            _GPU_MAP,
         )
         with open(os.path.join(tmpdir, "custom_byod_build.rayci.yml"), "r") as f:
             content = yaml.safe_load(f)
@@ -190,30 +193,101 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
             assert "--python-depset" not in env_only_cmd
 
 
-def test_get_prerequisite_step():
-    config = get_global_config()
-    assert (
-        get_prerequisite_step(
-            "ray-project/ray-ml:abc123-custom", "ray-project/ray-ml:abc123-base"
-        )
-        == config["release_image_step_ray_ml"]
-    )
-    assert (
-        get_prerequisite_step(
-            "ray-project/ray-llm:abc123-custom", "ray-project/ray-llm:abc123-base"
-        )
-        == config["release_image_step_ray_llm"]
-    )
-    assert (
-        get_prerequisite_step(
-            "ray-project/ray:abc123-custom", "ray-project/ray:abc123-base"
-        )
-        == config["release_image_step_ray"]
-    )
-    assert (
-        get_prerequisite_step("anyscale/ray:abc123-custom", "anyscale/ray:abc123-base")
-        == "forge"
-    )
+_ECR = "029272617770.dkr.ecr.us-west-2.amazonaws.com"
+
+
+@pytest.mark.parametrize(
+    ("image", "base_image", "expected"),
+    [
+        # Anyscale-prefixed base images → "forge"
+        ("anyscale/ray:abc123-custom", "anyscale/ray:abc123-base", "forge"),
+        ("custom_ecr/ray-ml:abc123-custom", "anyscale/ray:2.50.0-py310-cpu", "forge"),
+        # ray-ml: python dimension only
+        (
+            "ray-project/ray-ml:a-c",
+            "ray-project/ray-ml:a-py310-gpu",
+            "anyscalemlbuild--python310",
+        ),
+        (
+            "ray-project/ray-ml:a-c",
+            "ray-project/ray-ml:a-py311-gpu",
+            "anyscalemlbuild--python311",
+        ),
+        # ray cpu → anyscalecpubuild (python only)
+        (
+            "ray-project/ray:a-c",
+            "ray-project/ray:a-py310-cpu",
+            "anyscalecpubuild--python310",
+        ),
+        (
+            "ray-project/ray:a-c",
+            "ray-project/ray:a-py313-cpu",
+            "anyscalecpubuild--python313",
+        ),
+        # ray cuda → anyscalecudabuild (platform + python)
+        (
+            "ray-project/ray:a-c",
+            "ray-project/ray:a-py311-cu123",
+            "anyscalecudabuild--gpucu1232cudnn9-python311",
+        ),
+        (
+            "ray-project/ray:a-c",
+            "ray-project/ray:a-py312-cu130",
+            "anyscalecudabuild--gpucu1300cudnn-python312",
+        ),
+        # ray-llm
+        (
+            "ray-project/ray-llm:a-c",
+            "ray-project/ray-llm:a-py311-cu128",
+            "anyscalellmbuild--gpucu1281cudnn-python311",
+        ),
+        (
+            "ray-project/ray-llm:a-c",
+            "ray-project/ray-llm:a-py312-cu130",
+            "anyscalellmbuild--gpucu1300cudnn-python312",
+        ),
+        # ECR-prefixed base_image (production format)
+        (
+            f"{_ECR}/anyscale/ray:bid-py310-cpu-hash",
+            f"{_ECR}/anyscale/ray:bid-py310-cpu",
+            "anyscalecpubuild--python310",
+        ),
+        # Build ID with dashes
+        (
+            "ray-project/ray:a-b-c-x",
+            "ray-project/ray:a-b-c-py312-cpu",
+            "anyscalecpubuild--python312",
+        ),
+        # Unknown platform falls back to raw value
+        (
+            "ray-project/ray:a-c",
+            "ray-project/ray:a-py310-cu999",
+            "anyscalecudabuild--gpucu999-python310",
+        ),
+        # No python version → bare config key (cuda is default for ray without suffix)
+        ("ray-project/ray:a-c", "ray-project/ray:a-base", "anyscalecudabuild"),
+        ("ray-project/ray-ml:a-c", "ray-project/ray-ml:a-base", "anyscalemlbuild"),
+    ],
+    ids=[
+        "forge-bare",
+        "forge-versioned",
+        "ray-ml-py310",
+        "ray-ml-py311",
+        "ray-cpu-py310",
+        "ray-cpu-py313",
+        "ray-cuda-cu123",
+        "ray-cuda-cu130",
+        "ray-llm-cu128",
+        "ray-llm-cu130",
+        "ecr-prefix",
+        "dashed-build-id",
+        "unknown-platform",
+        "no-python-ray",
+        "no-python-ray-ml",
+    ],
+)
+def test_get_prerequisite_step(image, base_image, expected):
+    assert get_prerequisite_step(image, base_image, _GPU_MAP) == expected
 
 
 @pytest.mark.parametrize(

--- a/release/ray_release/tests/test_global_config.py
+++ b/release/ray_release/tests/test_global_config.py
@@ -34,7 +34,8 @@ ci_pipeline:
     - hi
     - three
 release_image_step:
-  ray: anyscalebuild
+  ray_cpu: anyscalecpubuild
+  ray_cuda: anyscalecudabuild
   ray_ml: anyscalemlbuild
   ray_llm: anyscalellmbuild
 """
@@ -56,7 +57,8 @@ def test_init_global_config() -> None:
         )
         assert config["state_machine_pr_aws_bucket"] == "ray-ci-pr-results"
         assert config["state_machine_disabled"] is True
-        assert config["release_image_step_ray"] == "anyscalebuild"
+        assert config["release_image_step_ray_cpu"] == "anyscalecpubuild"
+        assert config["release_image_step_ray_cuda"] == "anyscalecudabuild"
         assert config["release_image_step_ray_ml"] == "anyscalemlbuild"
         assert config["release_image_step_ray_llm"] == "anyscalellmbuild"
         assert config["byod_ecr"] == "029272617770.dkr.ecr.us-west-2.amazonaws.com"


### PR DESCRIPTION
Convert all release build steps from Buildkite matrix to rayci array
syntax.  Build steps use ($) to depend only on their matching python
wheel and testdeps.  Publish steps use ($) which matches on shared
dimensions (python, and platform where aligned by the wanda-platform-env
pre-req).

Update get_prerequisite_step() to construct array-suffixed Buildkite
step keys (e.g. anyscalebuild--platformcpu-python310) by parsing the
base_image tag and mapping short platform tags to full strings via a
constant lookup table.

Topic: array-release
Relative: platform-map-refactor
Signed-off-by: andrew <andrew@anyscale.com>