### PR TITLE
[CI] Rename cuda dimension to gpu in anyscale CUDA build steps

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -94,7 +94,7 @@ steps:
       - raycpubaseextra-testdeps
 
   - name: ray-anyscale-cuda-build
-    label: "wanda: ray-anyscale py{{matrix.python}} cu{{matrix.cuda}}"
+    label: "wanda: ray-anyscale py{{matrix.python}} {{matrix.gpu}}"
     wanda: ci/docker/ray-anyscale-cuda.wanda.yaml
     env_file: rayci.env
     matrix:
@@ -106,15 +106,15 @@ steps:
           - "3.11"
           - "3.12"
           - "3.13"
-        cuda:
-          - "12.3.2-cudnn9"
+        gpu:
+          - "cu12.3.2-cudnn9"
       adjustments:
         - with:
             python: "3.12"
-            cuda: "13.0.0-cudnn"
+            gpu: "cu13.0.0-cudnn"
     env:
       PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      GPU: "{{matrix.gpu}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
@@ -122,7 +122,7 @@ steps:
       - ray-wheel-build(*)
       - raycudabaseextra-testdeps
 
-  - label: ":crane: publish: ray-anyscale py{{matrix.python}} {{matrix.platform}}"
+  - label: ":crane: publish: ray-anyscale py{{matrix.python}} {{matrix.gpu}}"
     key: anyscalebuild
     instance_type: release-medium
     mount_buildkite_agent: true
@@ -131,7 +131,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
         --python-version {{matrix.python}}
-        --platform {{matrix.platform}}
+        --platform {{matrix.gpu}}
         --image-type ray
         --upload
     depends_on:
@@ -144,31 +144,31 @@ steps:
           - "3.11"
           - "3.12"
           - "3.13"
-        platform:
+        gpu:
           - cu12.3.2-cudnn9
           - cpu
       adjustments:
         - with:
             python: "3.12"
-            platform: cu13.0.0-cudnn
+            gpu: cu13.0.0-cudnn
 
   - name: ray-llm-anyscale-cuda-build
-    label: "wanda: ray-llm-anyscale py{{matrix.python}} cu{{matrix.cuda}}"
+    label: "wanda: ray-llm-anyscale py{{matrix.python}} {{matrix.gpu}}"
     wanda: ci/docker/ray-llm-anyscale-cuda.wanda.yaml
     env_file: rayci.env
     matrix:
       setup:
         python:
           - "3.12"
-        cuda:
-          - "13.0.0-cudnn"
+        gpu:
+          - "cu13.0.0-cudnn"
       adjustments:
         - with:
             python: "3.11"
-            cuda: "12.8.1-cudnn"
+            gpu: "cu12.8.1-cudnn"
     env:
       PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      GPU: "{{matrix.gpu}}"
       ARCH_SUFFIX: ""
     tags:
       - oss
@@ -176,7 +176,7 @@ steps:
       - ray-wheel-build(*)
       - ray-llmbaseextra-testdeps
 
-  - label: ":crane: publish: ray-llm-anyscale py{{matrix.python}} {{matrix.platform}}"
+  - label: ":crane: publish: ray-llm-anyscale py{{matrix.python}} {{matrix.gpu}}"
     key: anyscalellmbuild
     instance_type: release-medium
     mount_buildkite_agent: true
@@ -185,7 +185,7 @@ steps:
     commands:
       - bazel run //ci/ray_ci/automation:push_release_test_image --
         --python-version {{matrix.python}}
-        --platform {{matrix.platform}}
+        --platform {{matrix.gpu}}
         --image-type ray-llm
         --upload
     depends_on:
@@ -194,15 +194,15 @@ steps:
       setup:
         python:
           - "3.12"
-        platform:
+        gpu:
           - cu13.0.0-cudnn
       adjustments:
         - with:
             python: "3.11"
-            platform: "cu12.8.1-cudnn"
+            gpu: "cu12.8.1-cudnn"
 
   - name: ray-ml-anyscale-cuda-build
-    label: "wanda: ray-ml-anyscale py{{matrix.python}} cu{{matrix.cuda}}"
+    label: "wanda: ray-ml-anyscale py{{matrix.python}} {{matrix.gpu}}"
     wanda: ci/docker/ray-ml-anyscale-cuda.wanda.yaml
     env_file: rayci.env
     matrix:
@@ -211,11 +211,11 @@ steps:
           # This list should be kept in sync with the list of supported Python in
           # release test suite
           - "3.10"
-        cuda:
-          - "12.1.1-cudnn8"
+        gpu:
+          - "cu12.1.1-cudnn8"
     env:
       PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      GPU: "{{matrix.gpu}}"
       ARCH_SUFFIX: ""
     tags:
       - oss

--- a/ci/docker/ray-anyscale-cuda.wanda.yaml
+++ b/ci/docker/ray-anyscale-cuda.wanda.yaml
@@ -4,10 +4,10 @@
 #
 # This produces the anyscale test image for GPU release tests.
 #
-name: "ray-anyscale-py$PYTHON_VERSION-cu$CUDA_VERSION$ARCH_SUFFIX"
+name: "ray-anyscale-py$PYTHON_VERSION-$GPU$ARCH_SUFFIX"
 disable_caching: true
 froms:
-  - "cr.ray.io/rayproject/ray-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra-testdeps"  # CUDA base with test deps
+  - "cr.ray.io/rayproject/ray-py$PYTHON_VERSION-$GPU-base-extra-testdeps"  # CUDA base with test deps
   - "cr.ray.io/rayproject/ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"                    # Ray wheel
 dockerfile: ci/docker/ray-image.Dockerfile
 build_args:
@@ -15,6 +15,6 @@ build_args:
   - ARCH_SUFFIX
   - IMAGE_TYPE=ray
   - BASE_VARIANT=base-extra-testdeps
-  - PLATFORM=cu$CUDA_VERSION
+  - PLATFORM=$GPU
   - RAY_COMMIT=$BUILDKITE_COMMIT
   - RAY_VERSION

--- a/ci/docker/ray-llm-anyscale-cuda.wanda.yaml
+++ b/ci/docker/ray-llm-anyscale-cuda.wanda.yaml
@@ -4,10 +4,10 @@
 #
 # This produces the anyscale test image for ray-llm GPU release tests.
 #
-name: "ray-llm-anyscale-py$PYTHON_VERSION-cu$CUDA_VERSION$ARCH_SUFFIX"
+name: "ray-llm-anyscale-py$PYTHON_VERSION-$GPU$ARCH_SUFFIX"
 disable_caching: true
 froms:
-  - "cr.ray.io/rayproject/ray-llm-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra-testdeps"  # ray-llm base with test deps
+  - "cr.ray.io/rayproject/ray-llm-py$PYTHON_VERSION-$GPU-base-extra-testdeps"  # ray-llm base with test deps
   - "cr.ray.io/rayproject/ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"                        # Ray wheel
 dockerfile: ci/docker/ray-image.Dockerfile
 build_args:
@@ -15,6 +15,6 @@ build_args:
   - ARCH_SUFFIX
   - BASE_VARIANT=base-extra-testdeps
   - IMAGE_TYPE=ray-llm
-  - PLATFORM=cu$CUDA_VERSION
+  - PLATFORM=$GPU
   - RAY_COMMIT=$BUILDKITE_COMMIT
   - RAY_VERSION

--- a/ci/docker/ray-ml-anyscale-cuda.wanda.yaml
+++ b/ci/docker/ray-ml-anyscale-cuda.wanda.yaml
@@ -4,10 +4,10 @@
 #
 # This produces the anyscale test image for ray-ml GPU release tests.
 #
-name: "ray-ml-anyscale-py$PYTHON_VERSION-cu$CUDA_VERSION$ARCH_SUFFIX"
+name: "ray-ml-anyscale-py$PYTHON_VERSION-$GPU$ARCH_SUFFIX"
 disable_caching: true
 froms:
-  - "cr.ray.io/rayproject/ray-ml-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra-testdeps"  # ray-ml base with test deps
+  - "cr.ray.io/rayproject/ray-ml-py$PYTHON_VERSION-$GPU-base-extra-testdeps"  # ray-ml base with test deps
   - "cr.ray.io/rayproject/ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"                       # Ray wheel
 dockerfile: ci/docker/ray-image.Dockerfile
 build_args:
@@ -15,6 +15,6 @@ build_args:
   - ARCH_SUFFIX
   - BASE_VARIANT=base-extra-testdeps
   - IMAGE_TYPE=ray-ml
-  - PLATFORM=cu$CUDA_VERSION
+  - PLATFORM=$GPU
   - RAY_COMMIT=$BUILDKITE_COMMIT
   - RAY_VERSION


### PR DESCRIPTION
Rename the cuda matrix dimension to gpu (with cu-prefixed values)
in the three anyscale CUDA build steps and their wandas.  The wandas
now accept $GPU directly instead of constructing it from
cu$CUDA_VERSION; output is identical since callers pass cu-prefixed
values.

This aligns the dimension name with the publish steps (anyscalebuild, anyscalellmbuild, anyscalemlbuild) which already use a gpu
dimension, enabling precise ($) dependency matching on both gpu
and python when these steps are later converted to array syntax.

Topic: wanda-platform-env
Relative: revert-wheel-conv
Signed-off-by: andrew <andrew@anyscale.com>