### PR TITLE
fix(llm): accelerator_type silently ignored with CPU-only configs

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -468,6 +468,64 @@ class LLMConfig(BaseModelExtended):
 
         return self
 
+    @model_validator(mode="after")
+    def _validate_accelerator_type_with_gpu_config(self):
+        """Validate that accelerator_type is not set when use_gpu would be False.
+        
+        When accelerator_type is specified but use_gpu would resolve to False
+        (e.g., use_cpu=True or CPU-only placement_group_config), this is a
+        contradictory configuration that should raise an error rather than
+        silently ignoring the accelerator_type.
+        """
+        if self.accelerator_type is None:
+            return self
+        
+        # Compute use_gpu similar to VLLMEngineConfig.use_gpu
+        use_gpu = self._compute_use_gpu()
+        
+        if not use_gpu:
+            # Determine the reason for use_gpu being False
+            reason = []
+            if self.use_cpu is True:
+                reason.append("use_cpu=True")
+            if self.placement_group_config:
+                bundles = self.placement_group_config.get("bundles", [])
+                bundle_per_worker = self.placement_group_config.get("bundle_per_worker")
+                if bundle_per_worker and bundle_per_worker.get("GPU", 0) == 0:
+                    reason.append("bundle_per_worker has no GPU resources")
+                elif bundles and not any(b.get("GPU", 0) > 0 for b in bundles):
+                    reason.append("bundles have no GPU resources")
+            
+            reason_str = f" ({', '.join(reason)})" if reason else ""
+            raise ValueError(
+                f"accelerator_type '{self.accelerator_type}' is set but GPU is not being used{reason_str}. "
+                "accelerator_type specifies GPU hardware requirements and cannot be used with CPU-only "
+                "configurations. Either remove accelerator_type or use a GPU-enabled configuration."
+            )
+        return self
+
+    def _compute_use_gpu(self) -> bool:
+        """Compute whether GPU would be used, similar to VLLMEngineConfig.use_gpu."""
+        # Explicit use_cpu setting takes precedence over all other configurations
+        if isinstance(self.use_cpu, bool):
+            return not self.use_cpu
+
+        # Check placement_group_config for explicit GPU specification
+        if self.placement_group_config:
+            # Check bundle_per_worker inside placement_group_config
+            bundle_per_worker = self.placement_group_config.get("bundle_per_worker")
+            if bundle_per_worker:
+                return bundle_per_worker.get("GPU", 0) > 0
+
+            # Check bundles list
+            bundles = self.placement_group_config.get("bundles", [])
+            if bundles:
+                # If any bundle has GPU > 0, we use GPU
+                return any(bundle.get("GPU", 0) > 0 for bundle in bundles)
+
+        # Default to GPU when no accelerator_type is specified or when accelerator_type is a known GPU
+        return True
+
     def multiplex_config(self) -> ServeMultiplexConfig:
         multiplex_config = None
         if self.lora_config:

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -301,6 +301,36 @@ class VLLMEngineConfig(BaseModelExtended):
 
         return bundles
 
+    @model_validator(mode="after")
+    def validate_accelerator_type_with_gpu_config(self):
+        """Validate that accelerator_type is not set when use_gpu is False.
+        
+        When accelerator_type is specified but use_gpu resolves to False
+        (e.g., use_cpu=True or CPU-only placement_group_config), this is a
+        contradictory configuration that should raise an error rather than
+        silently ignoring the accelerator_type.
+        """
+        if self.accelerator_type and not self.use_gpu:
+            # Determine the reason for use_gpu being False
+            reason = []
+            if self.use_cpu is True:
+                reason.append("use_cpu=True")
+            if self.placement_group_config:
+                bundles = self.placement_group_config.get("bundles", [])
+                bundle_per_worker = self.placement_group_config.get("bundle_per_worker")
+                if bundle_per_worker and bundle_per_worker.get("GPU", 0) == 0:
+                    reason.append("bundle_per_worker has no GPU resources")
+                elif bundles and not any(b.get("GPU", 0) > 0 for b in bundles):
+                    reason.append("bundles have no GPU resources")
+            
+            reason_str = f" ({', '.join(reason)})" if reason else ""
+            raise ValueError(
+                f"accelerator_type '{self.accelerator_type}' is set but GPU is not being used{reason_str}. "
+                "accelerator_type specifies GPU hardware requirements and cannot be used with CPU-only "
+                "configurations. Either remove accelerator_type or use a GPU-enabled configuration."
+            )
+        return self
+
     @property
     def use_gpu(self) -> bool:
         """Returns True if vLLM is configured to use GPU resources."""

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -316,16 +316,74 @@ class TestUseCpuLogic:
         engine_config_gpu = llm_config_gpu.get_engine_config()
         assert engine_config_gpu.use_gpu is True
 
-    def test_use_cpu_precedence_over_accelerator_type(self):
-        """Test that explicit use_cpu setting takes precedence over accelerator_type."""
-        # use_cpu=True should override GPU accelerator_type
-        llm_config_cpu_override = LLMConfig(
+    def test_accelerator_type_with_use_cpu_raises_error(self):
+        """Test that accelerator_type with use_cpu=True raises a validation error."""
+        # use_cpu=True with accelerator_type should raise an error
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="accelerator_type.*is set but GPU is not being used",
+        ):
+            LLMConfig(
+                model_loading_config=ModelLoadingConfig(model_id="test_model"),
+                use_cpu=True,
+                accelerator_type="L4",
+            )
+
+    def test_accelerator_type_with_cpu_only_placement_group_raises_error(self):
+        """Test that accelerator_type with CPU-only placement_group_config raises an error."""
+        # accelerator_type with CPU-only bundles should raise an error
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="accelerator_type.*is set but GPU is not being used",
+        ):
+            LLMConfig(
+                model_loading_config=ModelLoadingConfig(model_id="test_model"),
+                accelerator_type="L4",
+                placement_group_config={
+                    "bundles": [{"CPU": 4}],
+                    "strategy": "PACK",
+                },
+            )
+
+        # accelerator_type with CPU-only bundle_per_worker should raise an error
+        with pytest.raises(
+            pydantic.ValidationError,
+            match="accelerator_type.*is set but GPU is not being used",
+        ):
+            LLMConfig(
+                model_loading_config=ModelLoadingConfig(model_id="test_model"),
+                accelerator_type="L4",
+                placement_group_config={
+                    "bundle_per_worker": {"CPU": 4},
+                    "strategy": "PACK",
+                },
+            )
+
+    def test_accelerator_type_with_gpu_placement_group_works(self):
+        """Test that accelerator_type with GPU placement_group_config is valid."""
+        # accelerator_type with GPU bundles should work
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test_model"),
+            accelerator_type="L4",
+            placement_group_config={
+                "bundles": [{"CPU": 4, "GPU": 1}],
+                "strategy": "PACK",
+            },
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.use_gpu is True
+        assert engine_config.accelerator_type == "L4"
+
+    def test_use_cpu_without_accelerator_type_works(self):
+        """Test that use_cpu=True without accelerator_type is valid."""
+        llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test_model"),
             use_cpu=True,
-            accelerator_type="L4",  # GPU type but use_cpu=True should take precedence
         )
-        engine_config = llm_config_cpu_override.get_engine_config()
-        assert engine_config.use_gpu is False  # use_cpu=True takes precedence
+        assert llm_config.use_cpu is True
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.use_gpu is False
+        assert engine_config.accelerator_type is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #62138

## Summary
This PR fixes an issue where the `accelerator_type` parameter was silently ignored when using CPU-only configurations.

## Changes
- Fixed the handling of `accelerator_type` for CPU-only configs in LLM serving
- Ensures proper validation and error messages when accelerator type is specified

## Testing
- Tested with CPU-only configurations
- Verified that accelerator_type is properly handled

## Related Issue
Closes #62138