### PR TITLE
[core] Loosen restriction on worker thread count

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -268,7 +268,7 @@ def test_worker_thread_count(monkeypatch, shutdown_only):
         ray.get(actor.get_thread_count.remote())
     # Lowering these numbers in this assert should be celebrated,
     # increasing these numbers should be scrutinized
-    assert ray.get(actor.get_thread_count.remote()) in {21, 22, 23}
+    assert ray.get(actor.get_thread_count.remote()) in {20, 21, 22, 23}
 
 
 # https://github.com/ray-project/ray/issues/7287


### PR DESCRIPTION
Saw an instance where this was 20: https://buildkite.com/ray-project/premerge/builds/63482#019d4a7d-27aa-4534-847c-779514bd915b/L1902

Given it's _lower_ than the existing limits, I don't think it's worth scrutinizing too much and instead am opting to widen the accepted range in the test.