### PR TITLE
[Docs] Deflake working-with-images doctest caused by PyTorch model download message

### DIFF
--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -257,6 +257,7 @@ Finally, call :meth:`Dataset.map_batches() <ray.data.Dataset.map_batches>`.
     predictions.show(3)
 
 .. testoutput::
+    :options: +SKIP
 
     {'class': 118}
     {'class': 153}


### PR DESCRIPTION
## Why are these changes needed?

The doctest in `doc/source/data/working-with-images.rst` is flaky in CI. When running the image inference example, PyTorch sometimes prints a model download message to stdout:

```
(MapWorker(...) pid=7278) Downloading: "https://download.pytorch.org/models/resnet18-f37072fd.pth" to /root/.cache/torch/hub/checkpoints/resnet18-f37072fd.pth
```

This happens because CI containers start fresh with no cache, so the model weights get downloaded on every cold run. The extra line causes the doctest to fail since it doesn't match the expected output.

## What's the fix?

Add `:options: +SKIP` to the `.. testoutput::` block after `predictions.show(3)`. This tells the test runner to skip checking the output, while keeping the expected output visible in the rendered docs for readers.

---
Closes https://github.com/ray-project/ray/issues/62283