### PR TITLE
[CI] Add filter_release_build_yaml to trim build steps by test needs

### DIFF
--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -177,11 +177,7 @@ def get_prerequisite_step(
     base_image: str,
     gpu_map: Optional[Dict[str, str]] = None,
 ) -> Optional[str]:
-    """Get the base image build step for a job that depends on it.
-
-    Returns the array-suffixed Buildkite step key for the publish step
-    that produces the base image.
-    """
+    """Return the Buildkite step key for the base image build step."""
     if gpu_map is None:
         gpu_map = {}
     config = get_global_config()
@@ -240,3 +236,180 @@ def _get_step_name(image: str, step_key: str, test_names: List[str]) -> str:
     for test_name in test_names[:2]:
         step_name += f" {test_name}"
     return step_name
+
+
+def collect_needed_variants(
+    tests: List[Test],
+    gpu_map: Dict[str, str],
+) -> Tuple[Set[str], Set[str], Dict[str, Optional[Set[str]]]]:
+    """Collect needed python versions, image types, and CUDA gpus from tests.
+
+    Returns (needed_python, needed_image_types, cuda_needs) where cuda_needs
+    maps image type to a set of full gpu strings, or ``None`` to keep all.
+    """
+    needed_python: Set[str] = set()
+    needed_image_types: Set[str] = set()
+    cuda_needs: Dict[str, Optional[Set[str]]] = {}
+
+    for test in tests:
+        needed_python.add(test.get_python_version())
+        tag_suffix = test.get_tag_suffix()
+
+        if test.use_byod_ml_image():
+            img_type = "ray-ml"
+        elif test.use_byod_llm_image():
+            img_type = "ray-llm"
+        elif tag_suffix == "cpu":
+            needed_image_types.add("ray-cpu")
+            continue
+        else:
+            img_type = "ray-cuda"
+
+        needed_image_types.add(img_type)
+        gpu = gpu_map.get(tag_suffix)
+
+        if gpu:
+            if img_type not in cuda_needs or cuda_needs[img_type] is not None:
+                cuda_needs.setdefault(img_type, set()).add(gpu)
+        else:
+            # Can't determine specific CUDA gpu; keep all variants.
+            cuda_needs[img_type] = None
+
+    return needed_python, needed_image_types, cuda_needs
+
+
+def _get_step_image_type(step: dict) -> Optional[str]:
+    """Return "ray-cpu", "ray-cuda", "ray-ml", "ray-llm", or None."""
+    name = step.get("name", "")
+    key = step.get("key", "")
+    image_type = step.get("env", {}).get("IMAGE_TYPE", "")
+
+    if image_type == "ray-llm" or "llm" in name or "llm" in key:
+        return "ray-llm"
+    if image_type == "ray-ml" or "ray-ml" in name or "ml" in key:
+        return "ray-ml"
+    if "cpu" in name or "cpu" in key:
+        return "ray-cpu"
+    if "cuda" in name or "cuda" in key:
+        return "ray-cuda"
+    return None
+
+
+def _filter_array_dimension(
+    values: List[str],
+    allowed: Set[str],
+    prefix: str = "",
+) -> List[str]:
+    """Keep only values present in *allowed* (prepending *prefix* first)."""
+    return [v for v in values if f"{prefix}{v}" in allowed]
+
+
+def _global_cuda_filter(
+    cuda_needs: Dict[str, Optional[Set[str]]],
+) -> Optional[Set[str]]:
+    """Union all per-image-type CUDA needs; ``None`` means keep all."""
+    result: Set[str] = set()
+    for gpus in cuda_needs.values():
+        if gpus is None:
+            return None
+        result.update(gpus)
+    return result
+
+
+def filter_release_build_yaml(
+    path: str,
+    needed_python: Set[str],
+    needed_image_types: Set[str],
+    cuda_needs: Dict[str, Optional[Set[str]]],
+    *,
+    filter_by_image_type: bool = True,
+) -> None:
+    """Filter a rayci YAML file in-place to only needed variants.
+
+    Trims array dimensions and adjustments; removes steps with no viable
+    combinations.  When *filter_by_image_type* is True, also removes steps
+    whose image type is not in *needed_image_types*.
+    """
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    global_cuda = _global_cuda_filter(cuda_needs) if not filter_by_image_type else None
+
+    filtered_steps = []
+    for step in data.get("steps", []):
+        img_type = _get_step_image_type(step)
+
+        if filter_by_image_type:
+            if img_type is not None and img_type not in needed_image_types:
+                continue
+
+        array = step.get("array")
+        if not array:
+            filtered_steps.append(step)
+            continue
+
+        # Filter python dimension.
+        if "python" in array:
+            array["python"] = _filter_array_dimension(array["python"], needed_python)
+
+        # Determine which CUDA gpus to keep.
+        if filter_by_image_type:
+            cuda_filter = cuda_needs.get(img_type) if img_type else None
+            should_filter_cuda = img_type in cuda_needs and cuda_filter is not None
+        else:
+            cuda_filter = global_cuda
+            should_filter_cuda = global_cuda is not None
+
+        if should_filter_cuda:
+            if "gpu" in array:
+                array["gpu"] = _filter_array_dimension(array["gpu"], cuda_filter)
+            if "cuda" in array:
+                array["cuda"] = _filter_array_dimension(
+                    array["cuda"], cuda_filter, prefix="cu"
+                )
+
+        # Filter adjustments.
+        if "adjustments" in array:
+            filtered_adj = []
+            for adj in array["adjustments"]:
+                w = adj.get("with", {})
+                keep = True
+                if "python" in w and w["python"] not in needed_python:
+                    keep = False
+                if should_filter_cuda:
+                    if "gpu" in w and w["gpu"] not in cuda_filter:
+                        keep = False
+                    if "cuda" in w and f"cu{w['cuda']}" not in cuda_filter:
+                        keep = False
+                if keep:
+                    filtered_adj.append(adj)
+            if filtered_adj:
+                array["adjustments"] = filtered_adj
+            else:
+                del array["adjustments"]
+
+        # If base arrays were emptied but adjustments remain, reconstruct
+        # minimal base arrays from adjustment values so rayci can expand them.
+        remaining_adj = array.get("adjustments", [])
+        for dim in list(array.keys()):
+            if dim == "adjustments" or not isinstance(array[dim], list):
+                continue
+            if len(array[dim]) == 0 and remaining_adj:
+                values = sorted(
+                    {a["with"][dim] for a in remaining_adj if dim in a.get("with", {})}
+                )
+                array[dim] = values
+
+        # Check if any combinations remain.
+        base_dims = [
+            v for k, v in array.items() if k != "adjustments" and isinstance(v, list)
+        ]
+        has_base_combos = all(len(d) > 0 for d in base_dims) if base_dims else False
+        has_adjustments = bool(array.get("adjustments"))
+
+        if has_base_combos or has_adjustments:
+            filtered_steps.append(step)
+
+    data["steps"] = filtered_steps
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -10,10 +10,13 @@ import yaml
 from ray_release.bazel import bazel_runfile
 from ray_release.configs.global_config import get_global_config, init_global_config
 from ray_release.custom_byod_build_init_helper import (
+    _get_step_image_type,
     _get_step_name,
     _short_tag,
     build_short_gpu_map,
+    collect_needed_variants,
     create_custom_build_yaml,
+    filter_release_build_yaml,
     generate_custom_build_step_key,
     get_prerequisite_step,
 )
@@ -224,7 +227,7 @@ _ECR = get_global_config()["byod_ecr"]
             "ray-project/ray:a-py313-cpu",
             "anyscalecpubuild--python313",
         ),
-        # ray cuda → anyscalecudabuild (platform + python)
+        # ray cuda → anyscalecudabuild (gpu + python)
         (
             "ray-project/ray:a-c",
             "ray-project/ray:a-py311-cu123",
@@ -258,7 +261,7 @@ _ECR = get_global_config()["byod_ecr"]
             "ray-project/ray:a-b-c-py312-cpu",
             "anyscalecpubuild--python312",
         ),
-        # Unknown platform falls back to raw value
+        # Unknown gpu falls back to the raw value
         (
             "ray-project/ray:a-c",
             "ray-project/ray:a-py310-cu999",
@@ -281,7 +284,7 @@ _ECR = get_global_config()["byod_ecr"]
         "ray-llm-cu130",
         "ecr-prefix",
         "dashed-build-id",
-        "unknown-platform",
+        "unknown-gpu",
         "no-python-ray",
         "no-python-ray-ml",
     ],
@@ -333,6 +336,470 @@ def test_get_step_name():
         )
         == ":tapioca: build custom: ray-ml:py39-cpu (abc123) test_1 test_2"
     )
+
+
+def _make_test(name="t", python="3.10", byod_type="cpu"):
+    """Helper to create a minimal Test with byod config."""
+    t = Test(
+        name=name,
+        frequency="manual",
+        group="g",
+        team="team",
+        working_dir=".",
+    )
+    if python != "3.10":
+        t["python"] = python
+    if byod_type != "cpu":
+        t["cluster"] = {"byod": {"type": byod_type}}
+    return t
+
+
+class TestCollectNeededVariants:
+    def test_single_cpu_test(self):
+        tests = [_make_test(python="3.10", byod_type="cpu")]
+        py, types, cuda = collect_needed_variants(tests, _GPU_MAP)
+        assert py == {"3.10"}
+        assert types == {"ray-cpu"}
+        assert cuda == {}
+
+    def test_single_cuda_test(self):
+        tests = [_make_test(python="3.11", byod_type="cu123")]
+        py, types, cuda = collect_needed_variants(tests, _GPU_MAP)
+        assert py == {"3.11"}
+        assert types == {"ray-cuda"}
+        assert cuda == {"ray-cuda": {"cu12.3.2-cudnn9"}}
+
+    def test_cuda_cu128(self):
+        tests = [_make_test(python="3.10", byod_type="cu128")]
+        py, types, cuda = collect_needed_variants(tests, _GPU_MAP)
+        assert py == {"3.10"}
+        assert types == {"ray-cuda"}
+        assert cuda == {"ray-cuda": {"cu12.8.1-cudnn"}}
+
+    def test_llm_test(self):
+        tests = [_make_test(python="3.12", byod_type="llm-cu130")]
+        py, types, cuda = collect_needed_variants(tests, _GPU_MAP)
+        assert py == {"3.12"}
+        assert types == {"ray-llm"}
+        assert cuda == {"ray-llm": {"cu13.0.0-cudnn"}}
+
+    def test_llm_cu128(self):
+        tests = [_make_test(python="3.11", byod_type="llm-cu128")]
+        py, types, cuda = collect_needed_variants(tests, _GPU_MAP)
+        assert py == {"3.11"}
+        assert types == {"ray-llm"}
+        assert cuda == {"ray-llm": {"cu12.8.1-cudnn"}}
+
+    def test_ml_gpu_test_keeps_all_cuda(self):
+        tests = [_make_test(python="3.10", byod_type="gpu")]
+        py, types, cuda = collect_needed_variants(tests, _GPU_MAP)
+        assert py == {"3.10"}
+        assert types == {"ray-ml"}
+        assert cuda == {"ray-ml": None}
+
+    def test_mixed_tests(self):
+        tests = [
+            _make_test(name="a", python="3.10", byod_type="cpu"),
+            _make_test(name="b", python="3.12", byod_type="llm-cu130"),
+        ]
+        py, types, cuda = collect_needed_variants(tests, _GPU_MAP)
+        assert py == {"3.10", "3.12"}
+        assert types == {"ray-cpu", "ray-llm"}
+        assert cuda == {"ray-llm": {"cu13.0.0-cudnn"}}
+
+
+class TestGetStepImageType:
+    def test_cpu_by_name(self):
+        assert _get_step_image_type({"name": "raycpubaseextra-testdeps"}) == "ray-cpu"
+
+    def test_cuda_by_name(self):
+        assert _get_step_image_type({"name": "raycudabaseextra-testdeps"}) == "ray-cuda"
+
+    def test_llm_by_name(self):
+        assert _get_step_image_type({"name": "ray-llmbaseextra-testdeps"}) == "ray-llm"
+
+    def test_ml_by_name(self):
+        assert (
+            _get_step_image_type({"name": "ray-mlcudabaseextra-testdeps"}) == "ray-ml"
+        )
+
+    def test_cpu_by_key(self):
+        assert _get_step_image_type({"key": "anyscalecpubuild"}) == "ray-cpu"
+
+    def test_cuda_by_key(self):
+        assert _get_step_image_type({"key": "anyscalecudabuild"}) == "ray-cuda"
+
+    def test_llm_by_key(self):
+        assert _get_step_image_type({"key": "anyscalellmbuild"}) == "ray-llm"
+
+    def test_ml_by_key(self):
+        assert _get_step_image_type({"key": "anyscalemlbuild"}) == "ray-ml"
+
+    def test_image_type_env(self):
+        assert _get_step_image_type({"env": {"IMAGE_TYPE": "ray-llm"}}) == "ray-llm"
+        assert _get_step_image_type({"env": {"IMAGE_TYPE": "ray-ml"}}) == "ray-ml"
+
+    def test_unknown(self):
+        assert _get_step_image_type({"name": "forge"}) is None
+
+
+# A minimal build.rayci.yml for testing filter_release_build_yaml.
+_SAMPLE_BUILD_YAML = {
+    "group": "release build",
+    "steps": [
+        {
+            "name": "raycpubaseextra-testdeps",
+            "env": {"IMAGE_TYPE": "ray"},
+            "array": {
+                "python": ["3.10", "3.11", "3.12", "3.13"],
+            },
+        },
+        {
+            "name": "raycudabaseextra-testdeps",
+            "env": {"IMAGE_TYPE": "ray"},
+            "array": {
+                "python": ["3.10", "3.11", "3.12", "3.13"],
+                "cuda": ["12.3.2-cudnn9"],
+                "adjustments": [
+                    {"with": {"python": "3.12", "cuda": "13.0.0-cudnn"}},
+                ],
+            },
+        },
+        {
+            "name": "ray-llmbaseextra-testdeps",
+            "env": {"IMAGE_TYPE": "ray-llm"},
+            "array": {
+                "python": ["3.12"],
+                "cuda": ["13.0.0-cudnn"],
+                "adjustments": [
+                    {"with": {"python": "3.11", "cuda": "12.8.1-cudnn"}},
+                ],
+            },
+        },
+        {
+            "name": "ray-mlcudabaseextra-testdeps",
+            "env": {"IMAGE_TYPE": "ray-ml"},
+            "array": {
+                "python": ["3.10"],
+                "cuda": ["12.1.1-cudnn8"],
+            },
+        },
+        {
+            "key": "anyscalecpubuild",
+            "array": {
+                "python": ["3.10", "3.11", "3.12", "3.13"],
+            },
+        },
+        {
+            "key": "anyscalecudabuild",
+            "array": {
+                "gpu": ["cu12.3.2-cudnn9"],
+                "python": ["3.10", "3.11", "3.12", "3.13"],
+                "adjustments": [
+                    {"with": {"python": "3.12", "gpu": "cu13.0.0-cudnn"}},
+                ],
+            },
+        },
+        {
+            "key": "anyscalellmbuild",
+            "array": {
+                "gpu": ["cu13.0.0-cudnn"],
+                "python": ["3.12"],
+                "adjustments": [
+                    {"with": {"python": "3.11", "gpu": "cu12.8.1-cudnn"}},
+                ],
+            },
+        },
+        {
+            "key": "anyscalemlbuild",
+            "array": {
+                "python": ["3.10"],
+            },
+        },
+    ],
+}
+
+
+class TestFilterReleaseBuildYaml:
+    def _write_and_filter(self, tmpdir, needed_python, needed_image_types, cuda_needs):
+        path = os.path.join(tmpdir, "build.rayci.yml")
+        with open(path, "w") as f:
+            yaml.dump(_SAMPLE_BUILD_YAML, f, default_flow_style=False, sort_keys=False)
+        filter_release_build_yaml(path, needed_python, needed_image_types, cuda_needs)
+        with open(path) as f:
+            return yaml.safe_load(f)
+
+    def test_cpu_py310_only(self):
+        """Simulates name:many_nodes.aws — only py310 cpu needed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                needed_python={"3.10"},
+                needed_image_types={"ray-cpu"},
+                cuda_needs={},
+            )
+        step_ids = [s.get("name") or s.get("key") for s in result["steps"]]
+        assert "raycpubaseextra-testdeps" in step_ids
+        assert "anyscalecpubuild" in step_ids
+        # CUDA, LLM, ML steps should be removed.
+        assert "raycudabaseextra-testdeps" not in step_ids
+        assert "ray-llmbaseextra-testdeps" not in step_ids
+        assert "ray-mlcudabaseextra-testdeps" not in step_ids
+        assert "anyscalecudabuild" not in step_ids
+        assert "anyscalellmbuild" not in step_ids
+        assert "anyscalemlbuild" not in step_ids
+        # Python should be trimmed to only 3.10.
+        cpu_step = next(
+            s for s in result["steps"] if s.get("name") == "raycpubaseextra-testdeps"
+        )
+        assert cpu_step["array"]["python"] == ["3.10"]
+
+    def test_llm_cu130_py312(self):
+        """Only ray-llm with cu130 and py312."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                needed_python={"3.12"},
+                needed_image_types={"ray-llm"},
+                cuda_needs={"ray-llm": {"cu13.0.0-cudnn"}},
+            )
+        step_ids = [s.get("name") or s.get("key") for s in result["steps"]]
+        assert "ray-llmbaseextra-testdeps" in step_ids
+        assert "anyscalellmbuild" in step_ids
+        # Non-LLM steps removed.
+        assert "raycpubaseextra-testdeps" not in step_ids
+        assert "raycudabaseextra-testdeps" not in step_ids
+        # The LLM step should have only cu13 base, no cu128 adjustment.
+        llm_step = next(
+            s for s in result["steps"] if s.get("name") == "ray-llmbaseextra-testdeps"
+        )
+        assert llm_step["array"]["cuda"] == ["13.0.0-cudnn"]
+        assert "adjustments" not in llm_step["array"]
+
+    def test_llm_adjustment_only(self):
+        """ray-llm with cu128/py311 — only the adjustment matches."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                needed_python={"3.11"},
+                needed_image_types={"ray-llm"},
+                cuda_needs={"ray-llm": {"cu12.8.1-cudnn"}},
+            )
+        step_ids = [s.get("name") or s.get("key") for s in result["steps"]]
+        assert "ray-llmbaseextra-testdeps" in step_ids
+        assert "anyscalellmbuild" in step_ids
+        # The base arrays should be reconstructed from adjustment values.
+        llm_step = next(
+            s for s in result["steps"] if s.get("name") == "ray-llmbaseextra-testdeps"
+        )
+        assert "3.11" in llm_step["array"]["python"]
+        assert "12.8.1-cudnn" in llm_step["array"]["cuda"]
+
+    def test_ml_gpu_keeps_all_cuda(self):
+        """ray-ml with byod_type 'gpu' (no specific CUDA) keeps all variants."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                needed_python={"3.10"},
+                needed_image_types={"ray-ml"},
+                cuda_needs={"ray-ml": None},
+            )
+        step_ids = [s.get("name") or s.get("key") for s in result["steps"]]
+        assert "ray-mlcudabaseextra-testdeps" in step_ids
+        assert "anyscalemlbuild" in step_ids
+        ml_step = next(
+            s
+            for s in result["steps"]
+            if s.get("name") == "ray-mlcudabaseextra-testdeps"
+        )
+        assert ml_step["array"]["cuda"] == ["12.1.1-cudnn8"]
+
+    def test_full_build_keeps_everything(self):
+        """When all image types and python versions are needed."""
+        all_python = {"3.10", "3.11", "3.12", "3.13"}
+        all_types = {"ray-cpu", "ray-cuda", "ray-ml", "ray-llm"}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                needed_python=all_python,
+                needed_image_types=all_types,
+                cuda_needs={
+                    "ray-cuda": None,
+                    "ray-llm": None,
+                    "ray-ml": None,
+                },
+            )
+        assert len(result["steps"]) == len(_SAMPLE_BUILD_YAML["steps"])
+
+    def test_empty_array_removes_step(self):
+        """If no python versions match, step is removed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                needed_python={"3.14"},
+                needed_image_types={"ray-cpu"},
+                cuda_needs={},
+            )
+        step_ids = [s.get("name") or s.get("key") for s in result["steps"]]
+        assert "raycpubaseextra-testdeps" not in step_ids
+        assert "anyscalecpubuild" not in step_ids
+
+
+# A minimal _images.rayci.yml for testing filter_by_image_type=False.
+_SAMPLE_IMAGES_YAML = {
+    "group": "images",
+    "steps": [
+        {
+            "name": "raycpubase",
+            "array": {"python": ["3.10", "3.11", "3.12", "3.13"]},
+        },
+        {
+            "name": "raycpubaseextra",
+            "env": {"IMAGE_TYPE": "ray"},
+            "array": {"python": ["3.10", "3.11", "3.12", "3.13"]},
+        },
+        {
+            "name": "raycudabase",
+            "array": {
+                "python": ["3.10", "3.11", "3.12", "3.13"],
+                "cuda": [
+                    "12.3.2-cudnn9",
+                    "12.8.1-cudnn",
+                    "13.0.0-cudnn",
+                ],
+            },
+        },
+        {
+            "name": "raycudabaseextra",
+            "env": {"IMAGE_TYPE": "ray"},
+            "array": {
+                "python": ["3.10", "3.11", "3.12", "3.13"],
+                "cuda": [
+                    "12.3.2-cudnn9",
+                    "12.8.1-cudnn",
+                    "13.0.0-cudnn",
+                ],
+            },
+        },
+        {
+            "name": "ray-llmbase",
+            "array": {
+                "python": ["3.12"],
+                "cuda": ["13.0.0-cudnn"],
+                "adjustments": [
+                    {"with": {"python": "3.11", "cuda": "12.8.1-cudnn"}},
+                ],
+            },
+        },
+        {
+            "name": "ray-mlcudabase",
+            "array": {"python": ["3.10"], "cuda": ["12.1.1-cudnn8"]},
+        },
+    ],
+}
+
+# A minimal _wheel-build.rayci.yml.
+_SAMPLE_WHEEL_YAML = {
+    "group": "wheel build",
+    "steps": [
+        {
+            "name": "ray-core-build",
+            "array": {"python": ["3.10", "3.11", "3.12", "3.13", "3.14"]},
+        },
+        {"name": "ray-dashboard-build"},
+        {
+            "name": "ray-wheel-build",
+            "array": {"python": ["3.10", "3.11", "3.12", "3.13", "3.14"]},
+        },
+    ],
+}
+
+
+class TestFilterSharedYaml:
+    """Tests for filter_by_image_type=False (shared _images / _wheel-build)."""
+
+    def _write_and_filter(self, tmpdir, sample, needed_python, cuda_needs):
+        path = os.path.join(tmpdir, "test.rayci.yml")
+        with open(path, "w") as f:
+            yaml.dump(sample, f, default_flow_style=False, sort_keys=False)
+        filter_release_build_yaml(
+            path,
+            needed_python,
+            needed_image_types=set(),
+            cuda_needs=cuda_needs,
+            filter_by_image_type=False,
+        )
+        with open(path) as f:
+            return yaml.safe_load(f)
+
+    def test_images_cpu_py310_only(self):
+        """CPU-only test: all CUDA steps removed, python trimmed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir, _SAMPLE_IMAGES_YAML, {"3.10"}, cuda_needs={}
+            )
+        step_names = [s["name"] for s in result["steps"]]
+        # CPU base images kept with python 3.10.
+        assert "raycpubase" in step_names
+        assert "raycpubaseextra" in step_names
+        cpu = next(s for s in result["steps"] if s["name"] == "raycpubase")
+        assert cpu["array"]["python"] == ["3.10"]
+        # All CUDA steps removed (cuda filtered to empty).
+        assert "raycudabase" not in step_names
+        assert "raycudabaseextra" not in step_names
+        assert "ray-llmbase" not in step_names
+        assert "ray-mlcudabase" not in step_names
+
+    def test_images_llm_cu130_py312(self):
+        """LLM test: CUDA filtered to cu130 only."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                _SAMPLE_IMAGES_YAML,
+                {"3.12"},
+                cuda_needs={"ray-llm": {"cu13.0.0-cudnn"}},
+            )
+        step_names = [s["name"] for s in result["steps"]]
+        assert "raycudabase" in step_names
+        cuda_base = next(s for s in result["steps"] if s["name"] == "raycudabase")
+        assert cuda_base["array"]["python"] == ["3.12"]
+        assert cuda_base["array"]["cuda"] == ["13.0.0-cudnn"]
+        # LLM base kept, adjustment (cu128/py311) removed.
+        assert "ray-llmbase" in step_names
+        llm = next(s for s in result["steps"] if s["name"] == "ray-llmbase")
+        assert llm["array"]["cuda"] == ["13.0.0-cudnn"]
+        assert "adjustments" not in llm["array"]
+
+    def test_images_ml_gpu_keeps_all_cuda(self):
+        """ray-ml 'gpu' → cuda_needs has None → all CUDA kept."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir,
+                _SAMPLE_IMAGES_YAML,
+                {"3.10"},
+                cuda_needs={"ray-ml": None},
+            )
+        step_names = [s["name"] for s in result["steps"]]
+        assert "raycudabase" in step_names
+        cuda_base = next(s for s in result["steps"] if s["name"] == "raycudabase")
+        assert cuda_base["array"]["python"] == ["3.10"]
+        # All 3 CUDA variants kept.
+        assert len(cuda_base["array"]["cuda"]) == 3
+
+    def test_wheel_build_py310_only(self):
+        """Wheel builds trimmed to needed python; non-array steps kept."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = self._write_and_filter(
+                tmpdir, _SAMPLE_WHEEL_YAML, {"3.10"}, cuda_needs={}
+            )
+        step_names = [s["name"] for s in result["steps"]]
+        assert "ray-core-build" in step_names
+        assert "ray-dashboard-build" in step_names
+        assert "ray-wheel-build" in step_names
+        core = next(s for s in result["steps"] if s["name"] == "ray-core-build")
+        assert core["array"]["python"] == ["3.10"]
+        wheel = next(s for s in result["steps"] if s["name"] == "ray-wheel-build")
+        assert wheel["array"]["python"] == ["3.10"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add collect_needed_variants() to extract python versions, image types, and CUDA platforms from selected tests. Add filter_release_build_yaml() to rewrite build.rayci.yml in-place, removing steps for unneeded image types and trimming array dimensions (python, platform, cuda) and adjustments to only needed values. Steps left with no viable combinations are removed entirely.

This is the library/logic layer — the init script integration comes in the next commit.

Topic: release-build-filter
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>