### PR TITLE
[Data] Fix OOM in map_batches by slicing before de-fragmenting Arrow blocks

### DIFF
--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -1,3 +1,4 @@
+import logging
 import warnings
 from typing import Optional
 
@@ -9,6 +10,8 @@ from ray.data._internal.execution.util import memory_string
 from ray.data._internal.util import get_total_obj_store_mem_on_node
 from ray.data.block import Block, BlockAccessor
 from ray.util import log_once
+
+logger = logging.getLogger(__name__)
 
 # Delay compaction until the shuffle buffer has reached this ratio over the min
 # shuffle buffer size. Setting this to 1 minimizes memory usage, at the cost of
@@ -130,17 +133,37 @@ class Batcher(BatcherInterface):
                 output.add_block(accessor.to_block())
                 needed -= accessor.num_rows()
             else:
-                # Try de-fragmenting table in case its columns
-                # have too many chunks (potentially hindering performance of
-                # subsequent slicing operation)
+                # We only need part of this block. Slice first, then de-fragment only
+                # the small batch slice — not the full block. Previously the full block
+                # was de-fragmented first, creating an untracked heap copy (100+ MiB).
+                batch_slice = accessor.slice(0, needed, copy=False)
                 if isinstance(accessor, ArrowBlockAccessor):
-                    accessor = BlockAccessor.for_block(
-                        transform_pyarrow.try_combine_chunked_columns(block)
+                    # De-fragment the batch slice so downstream Arrow→numpy conversion
+                    # gets a contiguous array. Log when the source block is fragmented
+                    # (many parquet row groups merged) to aid memory diagnostics.
+                    block_max_chunks = max(
+                        (col.num_chunks for col in accessor._table.columns),
+                        default=0,
                     )
-
-                # We only need part of the block to fill out a batch.
-                output.add_block(accessor.slice(0, needed, copy=False))
-                # Add the rest of the block to the leftovers.
+                    if (
+                        block_max_chunks
+                        >= transform_pyarrow.MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS
+                    ):
+                        logger.debug(
+                            "Batcher: source block has up to %d chunks per column "
+                            "(>= threshold %d). Previously this would have triggered "
+                            "a full-block heap copy (~%d MiB); now only de-fragmenting "
+                            "the %d-row batch slice.",
+                            block_max_chunks,
+                            transform_pyarrow.MIN_NUM_CHUNKS_TO_TRIGGER_COMBINE_CHUNKS,
+                            accessor.size_bytes() // (1024 * 1024),
+                            needed,
+                        )
+                    batch_slice = transform_pyarrow.try_combine_chunked_columns(
+                        batch_slice
+                    )
+                output.add_block(batch_slice)
+                # Leftover is a zero-copy view of the original plasma-backed block.
                 leftover.append(accessor.slice(needed, accessor.num_rows(), copy=False))
                 needed = 0
 

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -333,6 +333,11 @@ class BatchMapTransformFn(MapTransformFn):
 
         self._batch_fn = batch_fn
 
+    @property
+    def batch_format(self) -> Optional[BatchFormat]:
+        """The batch format this transform expects its input in."""
+        return self._batch_format
+
     def _pre_process(self, blocks: Iterable[Block]) -> Iterable[MapTransformFnData]:
         # TODO make batch-udf zero-copy by default
         ensure_copy = not self._zero_copy_batch and self._batch_size is not None

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
 
@@ -15,9 +16,20 @@ from ray.data._internal.execution.operators.map_operator import (
     MapOperator,
     _map_task,
 )
-from ray.data._internal.execution.operators.map_transformer import MapTransformer
+from ray.data._internal.execution.operators.map_transformer import (
+    BatchMapTransformFn,
+    MapTransformer,
+)
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data.context import DataContext
+
+# Per-task heap overhead multiplier for numpy batch format tasks.
+# Arrow → numpy conversion (strings, decimals, dates) allocates worker heap that
+# Ray Core's object-store accounting cannot see; a `memory` request makes it visible.
+# Tunable via RAY_DATA_NUMPY_TASK_MEMORY_FACTOR (default: 0.5 × target_max_block_size).
+_NUMPY_TASK_MEMORY_FACTOR: float = float(
+    os.environ.get("RAY_DATA_NUMPY_TASK_MEMORY_FACTOR", "0.5")
+)
 
 
 class TaskPoolMapOperator(MapOperator):
@@ -86,6 +98,28 @@ class TaskPoolMapOperator(MapOperator):
 
         self._max_concurrency = max_concurrency
         self._current_logical_usage = ExecutionResources.zero()
+
+        # For numpy tasks, inject a `memory` request so Ray Core's node-level
+        # scheduler accounts for untracked worker heap (Arrow→numpy conversion).
+        # _ray_remote_args is always a dict here (set by parent via _canonicalize_ray_remote_args).
+        if "memory" not in self._ray_remote_args:
+            uses_numpy = any(
+                isinstance(fn, BatchMapTransformFn) and fn.batch_format == "numpy"
+                for fn in map_transformer.get_transform_fns()
+            )
+            if uses_numpy:
+                block_size = data_context.target_max_block_size or 0
+                estimated_heap = int(block_size * _NUMPY_TASK_MEMORY_FACTOR)
+                if estimated_heap > 0:
+                    self._ray_remote_args = {
+                        **self._ray_remote_args,
+                        "memory": estimated_heap,
+                    }
+                    # Mirror into metrics so the dashboard shows the injected budget.
+                    self._remote_args_for_metrics = {
+                        **self._remote_args_for_metrics,
+                        "memory": estimated_heap,
+                    }
 
         # NOTE: Unlike static Ray remote args, dynamic arguments extracted from the
         #       blocks themselves are going to be passed inside `fn.options(...)`


### PR DESCRIPTION
## Description

`map_batches` with `batch_format="numpy"` causes worker OOM kills on large TPCH datasets. The root cause is in `Batcher.next_batch()`: when a block is larger than `batch_size`, it called `try_combine_chunked_columns` on the **entire block** before slicing. TPCH lineitem blocks merged from many parquet row groups have ~23 chunks per column, triggering a full 128 MiB heap copy per task — invisible to the resource manager, which only tracks object-store (plasma) bytes. With 60 concurrent tasks this adds ~7.6 GiB of untracked heap on top of the ~33 GiB plasma load, pushing nodes past the physical RAM limit.

**Fix 1 (primary):** Slice the batch first, then de-fragment only the small batch slice. The leftover stays as a zero-copy view of the original plasma-backed block, eliminating the per-task heap copy entirely.

**Fix 2 (secondary):** For `batch_format="numpy"` tasks, automatically inject a `memory` request into `ray_remote_args` (`target_max_block_size × 0.5` by default, tunable via `RAY_DATA_NUMPY_TASK_MEMORY_FACTOR`). This lets Ray Core's node-level scheduler account for Arrow→numpy conversion overhead (strings, decimals, dates expand into Python object arrays) when placing tasks, preventing over-scheduling before the OS kill threshold is reached.

## Additional information

The OOM is confirmed by the `map_batches_fixed_size_tasks_numpy_once` nightly benchmark logs:

```
(raylet) Workers killed due to memory pressure (OOM) ... [repeated 2x across cluster] MapBatches: Tasks: 60; object store: 907B ← nearly zero plasma, but workers OOM
```

The 907 bytes of object store in the MapBatches row shows the OOM is from worker heap, not plasma. The ReadParquet operator holds ~33 GiB in plasma (queued input blocks); the batcher's untracked heap copy was the tipping factor.

The `memory` injection is skipped if the user has already specified `memory` in their own `ray_remote_args`, preserving backward compatibility.