### PR TITLE
[core] Disable test_torch_tensor_dag_gpu cgraph test

### DIFF
--- a/python/ray/dag/BUILD.bazel
+++ b/python/ray/dag/BUILD.bazel
@@ -145,6 +145,8 @@ py_test(
         "compiled_graphs",
         "custom_setup",
         "exclusive",
+        #Disabled as this is consistently failing in CI and cgraphs will be deprecated/removed soon
+        "manual",
         "multi_gpu",
         "no_windows",
         "team:core",

--- a/python/ray/dag/BUILD.bazel
+++ b/python/ray/dag/BUILD.bazel
@@ -145,7 +145,7 @@ py_test(
         "compiled_graphs",
         "custom_setup",
         "exclusive",
-        #Disabled as this is consistently failing in CI and cgraphs will be deprecated/removed soon
+        # Disabled as this test is consistently failing in CI and cgraphs will be deprecated/removed soon.
         "manual",
         "multi_gpu",
         "no_windows",


### PR DESCRIPTION
This test is consistently failing in CI but it's a cgraph test hence it will be deprecated/removed soon. Hence just disabling from CI for now. 
