### PR TITLE
[core] feature --no-raylet on head node

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -404,27 +404,28 @@ class Node:
             # Wait for the node info to be available in the GCS so that
             # we know it's started up.
 
-            # Grace period to let the Raylet register with the GCS.
-            # We retry in a loop in case it takes longer than expected.
-            time.sleep(0.1)
-            start_time = time.monotonic()
-            raylet_start_wait_time_s = 30
-            while True:
-                try:
-                    # Will raise a RuntimeError if the node info is not available.
-                    node_info = ray._private.services.get_node(
-                        self.gcs_address,
-                        self._node_id,
-                    )
-                    break
-                except RuntimeError as e:
-                    logger.info(f"Failed to get node info {e}")
-                if time.monotonic() - start_time > raylet_start_wait_time_s:
-                    raise Exception(
-                        "The current node timed out during startup. This "
-                        "could happen because some of the raylet failed to "
-                        "startup or the GCS has become overloaded."
-                    )
+            if not (self._ray_params.no_raylet and self.head):
+                # Grace period to let the Raylet register with the GCS.
+                # We retry in a loop in case it takes longer than expected.
+                time.sleep(0.1)
+                start_time = time.monotonic()
+                raylet_start_wait_time_s = 30
+                while True:
+                    try:
+                        # Will raise a RuntimeError if the node info is not available.
+                        node_info = ray._private.services.get_node(
+                            self.gcs_address,
+                            self._node_id,
+                        )
+                        break
+                    except RuntimeError as e:
+                        logger.info(f"Failed to get node info {e}")
+                    if time.monotonic() - start_time > raylet_start_wait_time_s:
+                        raise Exception(
+                            "The current node timed out during startup. This "
+                            "could happen because some of the raylet failed to "
+                            "startup or the GCS has become overloaded."
+                        )
 
         if connect_only:
             # Fetch node info to get labels.
@@ -439,13 +440,16 @@ class Node:
         # 1. user is starting a new ray cluster and does not specify the port, components self-bind.
         # 2. user is connecting to an existing ray cluster, no port info is provided.
         # We always update port info from GCS to ensure consistency.
-        self._ray_params.node_manager_port = node_info["node_manager_port"]
-        self._ray_params.runtime_env_agent_port = node_info["runtime_env_agent_port"]
-        self._ray_params.metrics_agent_port = node_info["metrics_agent_port"]
-        self._ray_params.metrics_export_port = node_info["metrics_export_port"]
-        self._ray_params.dashboard_agent_listen_port = node_info[
-            "dashboard_agent_listen_port"
-        ]
+        if node_info is not None:
+            self._ray_params.node_manager_port = node_info["node_manager_port"]
+            self._ray_params.runtime_env_agent_port = node_info[
+                "runtime_env_agent_port"
+            ]
+            self._ray_params.metrics_agent_port = node_info["metrics_agent_port"]
+            self._ray_params.metrics_export_port = node_info["metrics_export_port"]
+            self._ray_params.dashboard_agent_listen_port = node_info[
+                "dashboard_agent_listen_port"
+            ]
 
         # Makes sure the Node object has valid addresses after setup.
         self.validate_ip_port(self.address)
@@ -1453,7 +1457,16 @@ class Node:
         if self._ray_params.include_log_monitor:
             self.start_log_monitor()
 
-        self.start_raylet(plasma_directory, fallback_directory, object_store_memory)
+        if self._ray_params.no_raylet and self.head:
+            # Persist the temp_dir to GCS so KubeRay autoscaler can discover it without raylet.
+            self.get_gcs_client().internal_kv_put(
+                b"head_node_temp_dir",
+                self.temp_dir.encode(),
+                True,
+                ray_constants.KV_NAMESPACE_SESSION,
+            )
+        else:
+            self.start_raylet(plasma_directory, fallback_directory, object_store_memory)
 
     def _get_system_processes_for_resource_isolation(self) -> str:
         """Returns a list of system processes that will be isolated by raylet.

--- a/python/ray/_private/parameter.py
+++ b/python/ray/_private/parameter.py
@@ -188,6 +188,7 @@ class RayParams:
         node_id: Optional[str] = None,
         resource_isolation_config: Optional[ResourceIsolationConfig] = None,
         proxy_server_url: Optional[str] = None,
+        no_raylet: bool = False,
     ):
         self.redis_address = redis_address
         self.gcs_address = gcs_address
@@ -248,6 +249,7 @@ class RayParams:
         self.cluster_id = cluster_id
         self.node_id = node_id
         self.proxy_server_url = proxy_server_url
+        self.no_raylet = no_raylet
 
         self.resource_isolation_config = resource_isolation_config
         if not self.resource_isolation_config:

--- a/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
+++ b/python/ray/autoscaler/_private/kuberay/run_autoscaler.py
@@ -31,17 +31,36 @@ def _get_log_dir(gcs_client: GcsClient) -> str:
     head_node_selector.is_head_node = True
 
     # We need to wait until head node's raylet is registered in GCS.
-    node_infos = get_all_node_info_until_retrieved(
-        gcs_client,
-        node_selectors=[head_node_selector],
-    )
-
-    node_info = next(iter(node_infos))
-    temp_dir = getattr(node_info, "temp_dir", None)
-    if temp_dir is None:
-        raise Exception(
-            "Node temp_dir was not found in NodeInfo. did the head node's raylet start successfully?"
+    # In --no-raylet mode the head node never registers, so fall back
+    # to the temp_dir persisted in GCS KV store
+    try:
+        node_infos = get_all_node_info_until_retrieved(
+            gcs_client,
+            node_selectors=[head_node_selector],
         )
+
+        node_info = next(iter(node_infos))
+        temp_dir = getattr(node_info, "temp_dir", None)
+    except Exception:
+        temp_dir = None
+
+    if temp_dir is None:
+        raw = gcs_client.internal_kv_get(
+            b"head_node_temp_dir",
+            ray._private.ray_constants.KV_NAMESPACE_SESSION,
+        )
+        if raw is not None:
+            temp_dir = raw.decode()
+            logger.info(
+                "Head node raylet not found; retrieved temp_dir from GCS KV: %s",
+                temp_dir,
+            )
+        else:
+            raise Exception(
+                "Could not determine head node temp_dir. Neither the head node's raylet registered in GCS nor was temp_dir found in the GCS KV store. "
+                "Did the head node start successfully?"
+            )
+
     return os.path.join(temp_dir, ray._private.ray_constants.SESSION_LATEST, "logs")
 
 

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -686,6 +686,14 @@ Windows powershell users need additional escaping:
     "you can set this option to override the server url. "
     "Ex: --proxy-server-url=http://historyserver:8080 ",
 )
+@click.option(
+    "--no-raylet",
+    is_flag=True,
+    default=False,
+    help="If set, the head node will not start a raylet process, running only "
+    "management components (GCS, Dashboard, Monitor). Drivers are scheduled "
+    "on worker nodes instead. Only valid with --head.",
+)
 @add_click_logging_options
 @PublicAPI
 def start(
@@ -735,8 +743,18 @@ def start(
     system_reserved_memory,
     cgroup_path,
     proxy_server_url,
+    no_raylet,
 ):
     """Start Ray processes manually on the local machine."""
+
+    if no_raylet and not head:
+        cli_logger.abort(
+            "The `{}` flag can only be used when starting a head node with `{}`.",
+            cf.bold("--no-raylet"),
+            cf.bold("--head"),
+        )
+    if no_raylet:
+        os.environ["RAY_JOB_ALLOW_DRIVER_ON_WORKER_NODES"] = "1"
 
     # Whether the original arguments include node_ip_address.
     include_node_ip_address = False
@@ -856,6 +874,7 @@ def start(
         resource_isolation_config=resource_isolation_config,
         proxy_server_url=proxy_server_url,
         env_vars=env_vars,
+        no_raylet=no_raylet,
     )
 
     if ray_constants.RAY_START_HOOK in os.environ:

--- a/python/ray/tests/test_ray_init.py
+++ b/python/ray/tests/test_ray_init.py
@@ -358,5 +358,73 @@ def test_ray_init_with_runtime_env_as_object(
     assert "gcs://" in parsed_runtime_env["py_modules"][0]
 
 
+def test_no_raylet_head_node():
+    """Integration test: ray start --head --no-raylet starts GCS without raylet
+    and persists the temp_dir in the GCS KV store so that components like the
+    KubeRay autoscaler can discover the log directory."""
+    from ray._private.utils import read_ray_address
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "ray.scripts.scripts",
+        "start",
+        "--head",
+        "--no-raylet",
+        "--port",
+        "0",
+        "--min-worker-port=0",
+        "--max-worker-port=0",
+    ]
+    stop_cmd = [sys.executable, "-m", "ray.scripts.scripts", "stop", "--force"]
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode()
+    except subprocess.CalledProcessError as e:
+        print(f"ray start failed:\n{e.output.decode()}")
+        raise
+    assert "Ray runtime started." in out
+
+    try:
+        from ray._raylet import GcsClient
+        from ray.core.generated.gcs_service_pb2 import GetAllNodeInfoRequest
+
+        address = read_ray_address()
+        gcs_client = GcsClient(address=address)
+
+        # 1. The GCS KV store must contain the head node's temp_dir.
+        raw_temp_dir = gcs_client.internal_kv_get(
+            b"head_node_temp_dir",
+            ray_constants.KV_NAMESPACE_SESSION,
+        )
+        assert raw_temp_dir is not None, "head_node_temp_dir not found in GCS KV store"
+        temp_dir = raw_temp_dir.decode()
+        assert os.path.isabs(temp_dir), f"Expected absolute path, got: {temp_dir}"
+        assert os.path.isdir(temp_dir), f"temp_dir does not exist: {temp_dir}"
+
+        # 2. No raylet should have registered as the head node.
+        head_selector = GetAllNodeInfoRequest.NodeSelector()
+        head_selector.is_head_node = True
+        head_node_infos = gcs_client.get_all_node_info(
+            node_selectors=[head_selector],
+        )
+        assert (
+            len(head_node_infos) == 0
+        ), f"Expected no head raylet registration, but found {len(head_node_infos)}"
+
+        # 3. _get_log_dir should succeed via the GCS KV fallback path.
+        from ray.autoscaler._private.kuberay.run_autoscaler import _get_log_dir
+
+        log_dir = _get_log_dir(gcs_client)
+        assert log_dir.endswith(
+            "logs"
+        ), f"Expected log_dir ending in 'logs', got: {log_dir}"
+        assert (
+            temp_dir in log_dir
+        ), f"log_dir should be under temp_dir. log_dir={log_dir}, temp_dir={temp_dir}"
+    finally:
+        ray.shutdown()
+        subprocess.check_call(stop_cmd)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
## Description

Added `--no-raylet flag` to `ray start --head`, skipping raylet startup entirely, making the head node purely a management node.

## Related issues
Resolves #62090

## Changes

Since the KubeRay autoscaler's `_get_log_dir()` relied on the head raylet being registered in GCS to discover the log directory, also added a fallback that reads the head node's `temp_dir` from the GCS KV store.

Also added an integration test in `test_ray_init.py`

