### PR TITLE
[tpu] fix v6e single-host corner cases in get_chips_per_host 

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/tpu.md
+++ b/doc/source/cluster/kubernetes/user-guides/tpu.md
@@ -133,8 +133,8 @@ tasks = [
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=slice_pg,
         )
-    ).remote(world_size=slice_handle.num_workers, rank=i)
-    for i in range(slice_handle.num_workers)
+    ).remote(world_size=slice_handle.num_hosts, rank=i)
+    for i in range(slice_handle.num_hosts)
 ]
 
 results = ray.get(tasks)

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -55,9 +55,9 @@ TPU_SINGLE_HOST_BOUNDS = "1,1,1"
 DEFAULT_TPU_NUM_CHIPS_PER_HOST = 4
 DEFAULT_TPU_NUM_CORES_PER_CHIP = 2
 
-# Accelerators that are 4 chips per host: v2, v3, v4, v5p, v7x
+# Accelerators that are 4 chips per host: v2, v3, v4, v5p, v6e, v7x
 # Accelerators that are 8 chips per host: v5e
-SINGLE_HOST_8_CHIPS_TPU_TYPES = "v5litepod"
+SINGLE_HOST_8_CHIPS_TPU_TYPE = "v5litepod"
 
 # TPU v6e single host topologies
 TPU_V6E_SINGLE_HOST_TOPOLOGIES = ("1x1", "2x2", "2x4")
@@ -155,7 +155,7 @@ def _accelerator_type_check(accelerator_type: str):
 def get_num_tpu_visible_chips_per_host(accelerator_type: str) -> int:
     _accelerator_type_check(accelerator_type)
     if (
-        accelerator_type.startswith(SINGLE_HOST_8_CHIPS_TPU_TYPES)
+        accelerator_type.startswith(SINGLE_HOST_8_CHIPS_TPU_TYPE)
         or accelerator_type in TPU_V6E_SINGLE_HOST_TYPES
     ):
         return 8
@@ -235,7 +235,7 @@ def get_chips_per_host(topology: str, accelerator_version: str) -> int:
     total_chips = get_num_chips_from_topology(topology)
 
     # Check for 8-chip host types, v5litepod or v6e (1x1, 2x2, 2x4 only)
-    if accelerator_version.strip().lower() in SINGLE_HOST_8_CHIPS_TPU_TYPES or (
+    if accelerator_version.strip().lower() == SINGLE_HOST_8_CHIPS_TPU_TYPE or (
         accelerator_version.strip().lower() == "v6e"
         and topology in TPU_V6E_SINGLE_HOST_TOPOLOGIES
     ):

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -59,6 +59,12 @@ DEFAULT_TPU_NUM_CORES_PER_CHIP = 2
 # Accelerators that are 8 chips per host: v5e
 SINGLE_HOST_8_CHIPS_TPU_TYPES = "v5litepod"
 
+# TPU v6e single host topologies
+TPU_V6E_SINGLE_HOST_TOPOLOGIES = ("1x1", "2x2", "2x4")
+
+# TPU v6e single host types
+TPU_V6E_SINGLE_HOST_TYPES = ("v6e-1", "v6e-4", "v6e-8")
+
 # Accelerators that are 2 cores per chip: v2, v3, v4, v5p, v7x
 # Accelerators that are 1 core per chip: v5e, v6e
 SINGLE_CORE_TPU_TYPES = ("v5litepod", "v6e")
@@ -148,10 +154,9 @@ def _accelerator_type_check(accelerator_type: str):
 
 def get_num_tpu_visible_chips_per_host(accelerator_type: str) -> int:
     _accelerator_type_check(accelerator_type)
-    # v6e-8 is a corner case with v6 TPUs that have 8 chips per host
     if (
         accelerator_type.startswith(SINGLE_HOST_8_CHIPS_TPU_TYPES)
-        or accelerator_type == "v6e-8"
+        or accelerator_type in TPU_V6E_SINGLE_HOST_TYPES
     ):
         return 8
 
@@ -229,9 +234,10 @@ def get_chips_per_host(topology: str, accelerator_version: str) -> int:
     """
     total_chips = get_num_chips_from_topology(topology)
 
-    # Check for 8-chip host types, v5litepod or v6e (2x4 only)
+    # Check for 8-chip host types, v5litepod or v6e (1x1, 2x2, 2x4 only)
     if accelerator_version.strip().lower() in SINGLE_HOST_8_CHIPS_TPU_TYPES or (
-        accelerator_version.strip().lower() == "v6e" and topology == "2x4"
+        accelerator_version.strip().lower() == "v6e"
+        and topology in TPU_V6E_SINGLE_HOST_TOPOLOGIES
     ):
         if total_chips < 8:
             return total_chips

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -237,7 +237,7 @@ def get_chips_per_host(topology: str, accelerator_version: str) -> int:
     # Check for 8-chip host types, v5litepod or v6e (1x1, 2x2, 2x4 only)
     if accelerator_version.strip().lower() == SINGLE_HOST_8_CHIPS_TPU_TYPE or (
         accelerator_version.strip().lower() == "v6e"
-        and topology in TPU_V6E_SINGLE_HOST_TOPOLOGIES
+        and topology.strip().lower() in TPU_V6E_SINGLE_HOST_TOPOLOGIES
     ):
         if total_chips < 8:
             return total_chips

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -148,7 +148,11 @@ def _accelerator_type_check(accelerator_type: str):
 
 def get_num_tpu_visible_chips_per_host(accelerator_type: str) -> int:
     _accelerator_type_check(accelerator_type)
-    if accelerator_type.startswith(SINGLE_HOST_8_CHIPS_TPU_TYPES):
+    # v6e-8 is a corner case with v6 TPUs that have 8 chips per host
+    if (
+        accelerator_type.startswith(SINGLE_HOST_8_CHIPS_TPU_TYPES)
+        or accelerator_type == "v6e-8"
+    ):
         return 8
 
     return DEFAULT_TPU_NUM_CHIPS_PER_HOST

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -56,8 +56,8 @@ DEFAULT_TPU_NUM_CHIPS_PER_HOST = 4
 DEFAULT_TPU_NUM_CORES_PER_CHIP = 2
 
 # Accelerators that are 4 chips per host: v2, v3, v4, v5p, v7x
-# Accelerators that are 8 chips per host: v5e, v6e
-SINGLE_HOST_8_CHIPS_TPU_TYPES = ("v5litepod", "v6e")
+# Accelerators that are 8 chips per host: v5e
+SINGLE_HOST_8_CHIPS_TPU_TYPES = "v5litepod"
 
 # Accelerators that are 2 cores per chip: v2, v3, v4, v5p, v7x
 # Accelerators that are 1 core per chip: v5e, v6e
@@ -225,8 +225,10 @@ def get_chips_per_host(topology: str, accelerator_version: str) -> int:
     """
     total_chips = get_num_chips_from_topology(topology)
 
-    # Check for 8-chip host types (v5litepod, v6e)
-    if accelerator_version.strip().lower() in SINGLE_HOST_8_CHIPS_TPU_TYPES:
+    # Check for 8-chip host types, v5litepod or v6e (2x4 only)
+    if accelerator_version.strip().lower() in SINGLE_HOST_8_CHIPS_TPU_TYPES or (
+        accelerator_version.strip().lower() == "v6e" and topology == "2x4"
+    ):
         if total_chips < 8:
             return total_chips
         return 8


### PR DESCRIPTION
## Description

For TPU v6e, only 2x4 topology can be single-host. We want only 2x4 topologies to be considered 8 chips per host and all other v6e topologies to be 4 chips per host. 

Also added a small fix in TPU docs

## Related issues


## Additional information

