### PR TITLE
[Data] Convert all-to-all, join, read, and write logical operators to frozen dataclasses

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1087,12 +1087,6 @@ python/ray/data/_internal/logging.py
     DOC201: Function `register_dataset_logger` does not have a return section in docstring
     DOC201: Function `unregister_dataset_logger` does not have a return section in docstring
 --------------------
-python/ray/data/_internal/logical/operators/join_operator.py
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `Join.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `Join.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [aggregator_ray_remote_args: Optional[Dict[str, Any]], join_type: str, left_columns_suffix: Optional[str], left_input_op: LogicalOperator, left_key_columns: Tuple[str], num_partitions: int, partition_size_hint: Optional[int], right_columns_suffix: Optional[str], right_input_op: LogicalOperator, right_key_columns: Tuple[str]].
---------------------
 python/ray/data/_internal/logical/operators/n_ary_operator.py
     DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
     DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from dataclasses import InitVar, dataclass, field, replace
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -66,19 +67,37 @@ class AbstractAllToAll(LogicalOperator):
         return self._num_outputs
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for randomize_block_order."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        seed_config: Optional[RandomSeedConfig] = None,
-    ):
-        super().__init__(
-            input_op,
-            name="RandomizeBlockOrder",
-        )
-        self.seed_config = seed_config or RandomSeedConfig()
+    input_op: InitVar[LogicalOperator]
+    seed_config: Optional[RandomSeedConfig] = None
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    sub_progress_bar_names: Optional[List[str]] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.seed_config is None:
+            object.__setattr__(self, "seed_config", RandomSeedConfig())
+        object.__setattr__(self, "_name", "RandomizeBlockOrder")
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        input_op = self.input_dependencies[0]
+        transformed_input = input_op._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is input_op:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -97,26 +116,49 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for random_shuffle."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        name: str = "RandomShuffle",
-        seed_config: Optional[RandomSeedConfig] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-    ):
-        super().__init__(
-            input_op,
-            sub_progress_bar_names=[
-                ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
-                ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
-            ],
-            ray_remote_args=ray_remote_args,
-            name=name,
-        )
-        self.seed_config = seed_config or RandomSeedConfig()
+    input_op: InitVar[LogicalOperator]
+    name: InitVar[str] = "RandomShuffle"
+    seed_config: Optional[RandomSeedConfig] = None
+    ray_remote_args: Optional[Dict[str, Any]] = None
+    sub_progress_bar_names: Optional[List[str]] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator, name: str):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.seed_config is None:
+            object.__setattr__(self, "seed_config", RandomSeedConfig())
+        if self.ray_remote_args is None:
+            object.__setattr__(self, "ray_remote_args", {})
+        if self.sub_progress_bar_names is None:
+            object.__setattr__(
+                self,
+                "sub_progress_bar_names",
+                [
+                    ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
+                    ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
+                ],
+            )
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        input_op = self.input_dependencies[0]
+        transformed_input = input_op._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is input_op:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -135,18 +177,24 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for repartition."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        num_outputs: int,
-        shuffle: bool,
-        keys: Optional[List[str]] = None,
-        sort: bool = False,
-    ):
-        if shuffle:
+    input_op: InitVar[LogicalOperator]
+    num_outputs: InitVar[int]
+    shuffle: bool = False
+    keys: Optional[List[str]] = None
+    sort: bool = False
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    sub_progress_bar_names: Optional[List[str]] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator, num_outputs: int):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.shuffle:
             sub_progress_bar_names = [
                 ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
@@ -155,14 +203,26 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
             sub_progress_bar_names = [
                 ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
             ]
-        super().__init__(
-            input_op,
-            num_outputs=num_outputs,
-            sub_progress_bar_names=sub_progress_bar_names,
-        )
-        self.shuffle = shuffle
-        self.keys = keys
-        self.sort = sort
+        object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", num_outputs)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        input_op = self.input_dependencies[0]
+        transformed_input = input_op._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is input_op:
+            target = self
+        else:
+            target = replace(
+                self,
+                input_op=transformed_input,
+                num_outputs=self.num_outputs,
+            )
+        return transform(target)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -181,25 +241,45 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for sort."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        sort_key: SortKey,
-        batch_format: Optional[str] = "default",
-    ):
-        super().__init__(
-            input_op,
-            sub_progress_bar_names=[
+    input_op: InitVar[LogicalOperator]
+    sort_key: SortKey
+    batch_format: Optional[str] = "default"
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    sub_progress_bar_names: Optional[List[str]] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        object.__setattr__(
+            self,
+            "sub_progress_bar_names",
+            [
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
                 ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        self.sort_key = sort_key
-        self.batch_format = batch_format
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        input_op = self.input_dependencies[0]
+        transformed_input = input_op._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is input_op:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -218,26 +298,44 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Aggregate(AbstractAllToAll):
     """Logical operator for aggregate."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        key: Optional[str],
-        aggs: List[AggregateFn],
-        num_partitions: Optional[int] = None,
-        batch_format: Optional[str] = "default",
-    ):
-        super().__init__(
-            input_op,
-            sub_progress_bar_names=[
+    input_op: InitVar[LogicalOperator]
+    key: Optional[str]
+    aggs: List[AggregateFn]
+    num_partitions: Optional[int] = None
+    batch_format: Optional[str] = "default"
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    sub_progress_bar_names: Optional[List[str]] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        object.__setattr__(
+            self,
+            "sub_progress_bar_names",
+            [
                 SortTaskSpec.SORT_SAMPLE_SUB_PROGRESS_BAR_NAME,
                 ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        self.key = key
-        self.aggs = aggs
-        self.num_partitions = num_partitions
-        self.batch_format = batch_format
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        input_op = self.input_dependencies[0]
+        transformed_input = input_op._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is input_op:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -1,5 +1,6 @@
+from dataclasses import InitVar, dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Tuple
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -40,59 +41,71 @@ class JoinSide(Enum):
     RIGHT = 1
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for join."""
 
-    def __init__(
+    left_input_op: InitVar[LogicalOperator]
+    right_input_op: InitVar[LogicalOperator]
+    join_type: JoinType | str
+    left_key_columns: Tuple[str]
+    right_key_columns: Tuple[str]
+    num_partitions: InitVar[int]
+    left_columns_suffix: Optional[str] = None
+    right_columns_suffix: Optional[str] = None
+    partition_size_hint: Optional[int] = None
+    aggregator_ray_remote_args: Optional[Dict[str, Any]] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, repr=False)
+
+    def __post_init__(
         self,
         left_input_op: LogicalOperator,
         right_input_op: LogicalOperator,
-        join_type: str,
-        left_key_columns: Tuple[str],
-        right_key_columns: Tuple[str],
-        *,
         num_partitions: int,
-        left_columns_suffix: Optional[str] = None,
-        right_columns_suffix: Optional[str] = None,
-        partition_size_hint: Optional[int] = None,
-        aggregator_ray_remote_args: Optional[Dict[str, Any]] = None,
     ):
-        """
-        Args:
-            left_input_op: The input operator at left hand side.
-            right_input_op: The input operator at right hand side.
-            join_type: The kind of join that should be performed, one of ("inner",
-               "left_outer", "right_outer", "full_outer", "left_semi", "right_semi",
-               "left_anti", "right_anti").
-            left_key_columns: The columns from the left Dataset that should be used as
-              keys of the join operation.
-            right_key_columns: The columns from the right Dataset that should be used as
-              keys of the join operation.
-            partition_size_hint: Hint to joining operator about the estimated
-              avg expected size of the resulting partition (in bytes)
-            num_partitions: Total number of expected blocks outputted by this
-                operator.
-        """
-
         try:
-            join_type_enum = JoinType(join_type)
+            join_type_enum = JoinType(self.join_type)
         except ValueError:
             raise ValueError(
-                f"Invalid join type: '{join_type}'. "
+                f"Invalid join type: '{self.join_type}'. "
                 f"Supported join types are: {', '.join(jt.value for jt in JoinType)}."
             )
 
-        super().__init__(left_input_op, right_input_op, num_outputs=num_partitions)
+        object.__setattr__(self, "join_type", join_type_enum)
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(
+            self,
+            "_input_dependencies",
+            [left_input_op, right_input_op],
+        )
+        object.__setattr__(self, "_num_outputs", num_partitions)
 
-        self.left_key_columns = left_key_columns
-        self.right_key_columns = right_key_columns
-        self.join_type = join_type_enum
-
-        self.left_columns_suffix = left_columns_suffix
-        self.right_columns_suffix = right_columns_suffix
-
-        self.partition_size_hint = partition_size_hint
-        self.aggregator_ray_remote_args = aggregator_ray_remote_args
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        left_input = self.input_dependencies[0]
+        right_input = self.input_dependencies[1]
+        transformed_left = left_input._apply_transform(transform)
+        transformed_right = right_input._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_left is left_input and transformed_right is right_input:
+            target = self
+        else:
+            target = Join(
+                transformed_left,
+                transformed_right,
+                self.join_type,
+                self.left_key_columns,
+                self.right_key_columns,
+                num_partitions=self.num_outputs,
+                left_columns_suffix=self.left_columns_suffix,
+                right_columns_suffix=self.right_columns_suffix,
+                partition_size_hint=self.partition_size_hint,
+                aggregator_ray_remote_args=self.aggregator_ray_remote_args,
+            )
+        return transform(target)
 
     @staticmethod
     def _validate_schemas(

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,6 +1,6 @@
-import copy
 import functools
 import math
+from dataclasses import InitVar, dataclass, field, replace
 from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
@@ -23,6 +23,7 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Read(
     AbstractMap,
     SourceOperator,
@@ -31,38 +32,42 @@ class Read(
 ):
     """Logical operator for read."""
 
-    # TODO: make this a frozen dataclass. https://github.com/ray-project/ray/issues/55747
-    def __init__(
-        self,
-        datasource: Datasource,
-        datasource_or_legacy_reader: Union[Datasource, Reader],
-        parallelism: int,
-        num_outputs: Optional[int] = None,
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-    ):
-        super().__init__(
-            name=f"Read{datasource.get_name()}",
-            input_op=None,
-            can_modify_num_rows=True,
-            num_outputs=num_outputs,
-            ray_remote_args=ray_remote_args,
-            compute=compute,
-        )
-        self.datasource = datasource
-        self.datasource_or_legacy_reader = datasource_or_legacy_reader
-        self.parallelism = parallelism
-        self.detected_parallelism = None
+    datasource: Datasource
+    datasource_or_legacy_reader: Union[Datasource, Reader]
+    parallelism: int
+    num_outputs: InitVar[Optional[int]] = None
+    ray_remote_args: Optional[Dict[str, Any]] = None
+    compute: Optional[ComputeStrategy] = None
+    detected_parallelism: Optional[int] = None
+    can_modify_num_rows: bool = field(init=False, default=True)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    ray_remote_args_fn: None = field(init=False, default=None)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list = field(init=False, repr=False, default_factory=list)
+    _num_outputs: Optional[int] = field(init=False, repr=False)
+
+    def __post_init__(self, num_outputs: Optional[int]):
+        if self.ray_remote_args is None:
+            object.__setattr__(self, "ray_remote_args", {})
+        if self.compute is None:
+            from ray.data._internal.compute import TaskPoolStrategy
+
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(self, "_name", f"Read{self.datasource.get_name()}")
+        object.__setattr__(self, "_input_dependencies", [])
+        object.__setattr__(self, "_num_outputs", num_outputs)
 
     def output_data(self):
         return None
 
-    def set_detected_parallelism(self, parallelism: int):
+    def set_detected_parallelism(self, parallelism: int) -> "Read":
         """
         Set the true parallelism that should be used during execution. This
         should be specified by the user or detected by the optimizer.
         """
-        self.detected_parallelism = parallelism
+        object.__setattr__(self, "detected_parallelism", parallelism)
+        return self
 
     def get_detected_parallelism(self) -> int:
         """
@@ -184,13 +189,13 @@ class Read(
         self,
         projection_map: Optional[Dict[str, str]],
     ) -> "Read":
-        clone = copy.copy(self)
-
         projected_datasource = self.datasource.apply_projection(projection_map)
-        clone.datasource = projected_datasource
-        clone.datasource_or_legacy_reader = projected_datasource
-
-        return clone
+        return replace(
+            self,
+            datasource=projected_datasource,
+            datasource_or_legacy_reader=projected_datasource,
+            num_outputs=self.num_outputs,
+        )
 
     def get_column_renames(self) -> Optional[Dict[str, str]]:
         return self.datasource.get_column_renames()
@@ -204,8 +209,9 @@ class Read(
     def apply_predicate(self, predicate_expr: Expr) -> "Read":
         predicated_datasource = self.datasource.apply_predicate(predicate_expr)
 
-        clone = copy.copy(self)
-        clone.datasource = predicated_datasource
-        clone.datasource_or_legacy_reader = predicated_datasource
-
-        return clone
+        return replace(
+            self,
+            datasource=predicated_datasource,
+            datasource_or_legacy_reader=predicated_datasource,
+            num_outputs=self.num_outputs,
+        )

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -1,4 +1,5 @@
-from typing import Any, Dict, Optional, Union
+from dataclasses import InitVar, dataclass, field, replace
+from typing import Any, Callable, Dict, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -11,30 +12,51 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Write(AbstractMap):
     """Logical operator for write."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        datasink_or_legacy_datasource: Union[Datasink, Datasource],
-        ray_remote_args: Optional[Dict[str, Any]] = None,
-        compute: Optional[ComputeStrategy] = None,
-        **write_args,
-    ):
-        if isinstance(datasink_or_legacy_datasource, Datasink):
+    input_op: InitVar[LogicalOperator]
+    datasink_or_legacy_datasource: Union[Datasink, Datasource]
+    ray_remote_args: Optional[Dict[str, Any]] = None
+    compute: Optional[ComputeStrategy] = None
+    write_args: Dict[str, Any] = field(default_factory=dict)
+    can_modify_num_rows: bool = field(init=False, default=True)
+    min_rows_per_bundled_input: Optional[int] = field(init=False)
+    ray_remote_args_fn: None = field(init=False, default=None)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        if isinstance(self.datasink_or_legacy_datasource, Datasink):
             min_rows_per_bundled_input = (
-                datasink_or_legacy_datasource.min_rows_per_write
+                self.datasink_or_legacy_datasource.min_rows_per_write
             )
         else:
             min_rows_per_bundled_input = None
+        if self.ray_remote_args is None:
+            object.__setattr__(self, "ray_remote_args", {})
+        if self.compute is None:
+            from ray.data._internal.compute import TaskPoolStrategy
 
-        super().__init__(
-            input_op=input_op,
-            can_modify_num_rows=True,
-            min_rows_per_bundled_input=min_rows_per_bundled_input,
-            ray_remote_args=ray_remote_args,
-            compute=compute,
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(
+            self, "min_rows_per_bundled_input", min_rows_per_bundled_input
         )
-        self.datasink_or_legacy_datasource = datasink_or_legacy_datasource
-        self.write_args = write_args
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        input_op = self.input_dependencies[0]
+        transformed_input = input_op._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is input_op:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)

--- a/python/ray/data/_internal/logical/rules/inherit_batch_format.py
+++ b/python/ray/data/_internal/logical/rules/inherit_batch_format.py
@@ -1,4 +1,5 @@
 import copy
+from dataclasses import replace
 
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
 from ray.data._internal.logical.operators import AbstractAllToAll, MapBatches
@@ -28,6 +29,16 @@ class InheritBatchFormatRule(Rule):
             upstream_op = node.input_dependencies[0]
             while upstream_op.input_dependencies:
                 if isinstance(upstream_op, MapBatches) and upstream_op.batch_format:
+                    if not hasattr(node, "batch_format"):
+                        return node
+                    if isinstance(node, AbstractAllToAll) and hasattr(
+                        node, "__dataclass_fields__"
+                    ):
+                        return replace(
+                            node,
+                            input_op=node.input_dependencies[0],
+                            batch_format=upstream_op.batch_format,
+                        )
                     new_op = copy.copy(node)
                     new_op.batch_format = upstream_op.batch_format
                     return new_op

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -9,6 +9,7 @@ from ray.data._internal.logical.operators import (
     AbstractOneToOne,
     Download,
     Limit,
+    Read,
     Union,
 )
 
@@ -190,6 +191,12 @@ class LimitPushdownRule(Rule):
         """Apply per-block limit to operators that support it."""
         if isinstance(op, AbstractMap):
             if is_dataclass(op):
+                if isinstance(op, Read):
+                    return replace(
+                        op,
+                        per_block_limit=limit,
+                        num_outputs=op.num_outputs,
+                    )
                 assert len(op.input_dependencies) == 1, len(op.input_dependencies)
                 return replace(
                     op,

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -10,7 +10,15 @@ from ray.data._internal.logical.interfaces import (
     PredicatePassThroughBehavior,
     Rule,
 )
-from ray.data._internal.logical.operators import AbstractMap, Filter, Limit, Project
+from ray.data._internal.logical.operators import (
+    AbstractAllToAll,
+    AbstractMap,
+    Filter,
+    Join,
+    Limit,
+    Project,
+    Repartition,
+)
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     _ColumnSubstitutionVisitor,
 )
@@ -324,6 +332,26 @@ class PredicatePushdown(Rule):
         if isinstance(op, AbstractMap) and is_dataclass(op):
             assert len(new_inputs) == 1, len(new_inputs)
             return replace(op, input_op=new_inputs[0])
+        if isinstance(op, AbstractAllToAll) and is_dataclass(op):
+            assert len(new_inputs) == 1, len(new_inputs)
+            kwargs = {"input_op": new_inputs[0]}
+            if isinstance(op, Repartition):
+                kwargs["num_outputs"] = op.num_outputs
+            return replace(op, **kwargs)
+        if isinstance(op, Join) and is_dataclass(op):
+            assert len(new_inputs) == 2, len(new_inputs)
+            return Join(
+                new_inputs[0],
+                new_inputs[1],
+                op.join_type,
+                op.left_key_columns,
+                op.right_key_columns,
+                num_partitions=op.num_outputs,
+                left_columns_suffix=op.left_columns_suffix,
+                right_columns_suffix=op.right_columns_suffix,
+                partition_size_hint=op.partition_size_hint,
+                aggregator_ray_remote_args=op.aggregator_ray_remote_args,
+            )
         new_op = copy.copy(op)
         new_op.input_dependencies = new_inputs
         return new_op

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -107,12 +107,12 @@ class SetReadParallelismRule(Rule):
                 continue
             logical_op = plan.op_map[op]
             if isinstance(logical_op, Read):
-                self._apply(op, logical_op)
+                self._apply(plan, op, logical_op)
             ops += op.input_dependencies
 
         return plan
 
-    def _apply(self, op: PhysicalOperator, logical_op: Read):
+    def _apply(self, plan: PhysicalPlan, op: PhysicalOperator, logical_op: Read):
         estimated_in_mem_bytes = logical_op.infer_metadata().size_bytes
 
         (
@@ -134,7 +134,7 @@ class SetReadParallelismRule(Rule):
                 f"Using autodetected parallelism={detected_parallelism} "
                 f"for operator {logical_op.name} to satisfy {reason}."
             )
-        logical_op.set_detected_parallelism(detected_parallelism)
+        plan.op_map[op] = logical_op.set_detected_parallelism(detected_parallelism)
 
         if k is not None:
             logger.debug(


### PR DESCRIPTION
## Description

This PR implements converting all-to-all, join, read, and write logical operators to frozen dataclasses.

#### Why this is needed:

- This is the D3 operator-group step under #60312.
- It removes in-place mutation paths for these logical operators.
- It keeps the scope limited to logical all-to-all/join/read/write operators and the minimum rule updates needed for frozen compatibility.

#### What this PR changes:

- Converts logical operators to frozen dataclasses:
  - all-to-all logical operators:
    - `RandomizeBlocks`
    - `RandomShuffle`
    - `Repartition`
    - `Sort`
    - `Aggregate`
  - `Join`
  - `Read`
  - `Write`
- Applies construction cleanup for frozen compatibility:
  - uses `InitVar[LogicalOperator]` + `__post_init__` where needed to initialize `_name`, `_input_dependencies`, and `_num_outputs`
  - keeps `eq=False` intentionally to avoid introducing field-based equality/hash semantics as part of this PR
- Adds frozen-safe transform behavior for these operators:
  - operators recreate nodes on input change instead of mutating inputs in place
- Updates optimizer rules to avoid mutating frozen instances:
  - `inherit_batch_format.py`: rebuilds frozen all-to-all operators when inheriting batch format
  - `limit_pushdown.py`: uses frozen-safe recreation/replace logic for `Read` per-block-limit handling
  - `predicate_pushdown.py`: uses frozen-safe recreation/replace logic for frozen all-to-all operators and `Join`
  - `set_read_parallelism.py`: adapts `Read` parallelism setting for the frozen `Read` operator shape
- Scope is intentionally D3-only:
  - no `input_op` -> `input_dependencies` cleanup in this PR
  - no `AbstractFrom` restructuring in this PR
  - no equality/comparability semantics changes in this PR

## Related issues

Related to #60312.

## Additional information

### Tests

Validated with targeted existing tests:
- `python/ray/data/tests/test_execution_optimizer_advanced.py`
- `python/ray/data/tests/test_join.py`

### Stack Plan

To complete [#60312](https://github.com/ray-project/ray/issues/60312), the original stack was:

1. https://github.com/ray-project/ray/pull/60529
2. https://github.com/ray-project/ray/pull/60528
3. https://github.com/ray-project/ray/pull/60530
4. https://github.com/ray-project/ray/pull/60531

Since PR4 was still too large, it is being further split:

1. PR-A: default `LogicalOperator` naming behavior https://github.com/ray-project/ray/pull/61020
2. PR-B: move `output_dependencies` responsibility to physical side https://github.com/ray-project/ray/pull/61107
3. PR-C: make `LogicalOperator` an ABC with abstract `num_outputs` https://github.com/ray-project/ray/pull/61308
4. PR-D: convert logical operators to frozen dataclasses in small groups (D1/D2/D3)
    - D1: one-to-one operators https://github.com/ray-project/ray/pull/61364
    - D2: map operators https://github.com/ray-project/ray/pull/61481
    - D3: all-to-all + join/read/write operators (this PR)

Planned follow-ups (not blocking this stack):
- Converting all `input_op` usage to `input_dependencies`
- Potential `AbstractFrom` restructuring
