### PR TITLE
[Core] add dependency info to taskspec debugstring

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -569,10 +569,12 @@ std::string TaskSpecification::DebugString() const {
   }
 
   stream << ", dependencies={";
-  for (size_t i = 0; i < NumArgs(); ++i) {
-    if (ArgByRef(i)) {
-      stream << ArgObjectId(i) << ", ";
+  const auto dependencies = GetDependencyIds();
+  for (size_t i = 0; i < dependencies.size(); ++i) {
+    if (i > 0) {
+      stream << ", ";
     }
+    stream << dependencies[i];
   }
   stream << "}";
 

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -568,6 +568,14 @@ std::string TaskSpecification::DebugString() const {
     }
   }
 
+  stream << ", dependencies={";
+  for (size_t i = 0; i < NumArgs(); ++i) {
+    if (ArgByRef(i)) {
+      stream << ArgObjectId(i) << ", ";
+    }
+  }
+  stream << "}";
+
   return stream.str();
 }
 


### PR DESCRIPTION
## Description
> To improve troubleshooting, add dependency information to the debug string in the task specification.
