### PR TITLE
[Data] Fix flaky streaming repartition test: remainder block position is not guaranteed

### DIFF
--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -422,7 +422,8 @@ def test_streaming_repartition_with_partial_last_block(
     """Test repartition with target_num_rows_per_block where last block has fewer rows.
     This test verifies:
     1. N-1 blocks have exactly target_num_rows_per_block rows
-    2. Only the last block can have fewer rows (remainder)
+    2. Exactly one block has fewer rows, and it can appear anywhere
+       in the output, StreamingRepartition does not guarantee ordering.
     """
     # Configure shuffle strategy
     ctx = DataContext.get_current()

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -444,14 +444,16 @@ def test_streaming_repartition_with_partial_last_block(
 
     assert sum(block_row_counts) == num_rows, f"Expected {num_rows} total rows"
 
-    # Verify that all blocks have 20 rows except one block with 10 rows
-    # The block with 10 rows should be the last one
+    # Verify that all blocks have 20 rows except one block with 1 row
+    # The smaller block may appear anywhere in the output order
+    remainder_blocks = [c for c in block_row_counts if c != 20]
     assert (
-        block_row_counts[-1] == 1
-    ), f"Expected last block to have 1 row, got {block_row_counts[-1]}"
-    assert all(
-        count == 20 for count in block_row_counts[:-1]
-    ), f"Expected all blocks except last to have 20 rows, got {block_row_counts}"
+        len(remainder_blocks) == 1
+    ), f"Expected exactly one remainder block, got {block_row_counts}"
+    assert remainder_blocks[0] == num_rows % 20, (
+        f"Expected remainder block to have {num_rows % 20} rows, "
+        f"got {remainder_blocks[0]}. Block counts: {block_row_counts}"
+    )
 
 
 def test_streaming_repartition_non_strict_mode(

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -446,12 +446,13 @@ def test_streaming_repartition_with_partial_last_block(
 
     # Verify that all blocks have 20 rows except one block with 1 row
     # The smaller block may appear anywhere in the output order
-    remainder_blocks = [c for c in block_row_counts if c != 20]
+    target_num_rows_per_block = 20
+    remainder_blocks = [c for c in block_row_counts if c != target_num_rows_per_block]
     assert (
         len(remainder_blocks) == 1
     ), f"Expected exactly one remainder block, got {block_row_counts}"
-    assert remainder_blocks[0] == num_rows % 20, (
-        f"Expected remainder block to have {num_rows % 20} rows, "
+    assert remainder_blocks[0] == num_rows % target_num_rows_per_block, (
+        f"Expected remainder block to have {num_rows % target_num_rows_per_block} rows, "
         f"got {remainder_blocks[0]}. Block counts: {block_row_counts}"
     )
 

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -430,11 +430,14 @@ def test_streaming_repartition_with_partial_last_block(
     ctx._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
 
     num_rows = 101
+    target_num_rows_per_block = 20
 
     table = [{"id": n} for n in range(num_rows)]
     ds = ray.data.from_items(table)
 
-    ds = ds.repartition(target_num_rows_per_block=20, strict=True)
+    ds = ds.repartition(
+        target_num_rows_per_block=target_num_rows_per_block, strict=True
+    )
 
     ds = ds.materialize()
 
@@ -447,7 +450,6 @@ def test_streaming_repartition_with_partial_last_block(
 
     # Verify that all blocks have 20 rows except one block with 1 row
     # The smaller block may appear anywhere in the output order
-    target_num_rows_per_block = 20
     remainder_blocks = [c for c in block_row_counts if c != target_num_rows_per_block]
     assert (
         len(remainder_blocks) == 1


### PR DESCRIPTION
### What

Fixed a flaky test that was failing in CI with:

```
AssertionError: Expected last block to have 1 row, got 20
```

### Why

The test was checking that the remainder block is always the **last** block in the output but `StreamingRepartition` doesn't guarantee that. The remainder block can land anywhere depending on task scheduling, which is non-deterministic.

> *"ordering isn't guaranteed, but the remainder block should appear near the end"*
> — `python/ray/data/_internal/streaming_repartition.py`

### Fix

Instead of checking position, check that exactly one block has the remainder rows, wherever it is — consistent with how the sibling test `test_repartition_guarantee_row_num_to_be_exact` already does it.

---
Closes https://github.com/ray-project/ray/issues/62325