### PR TITLE
[Data] - override `_sample_sizes` obstore

### DIFF
--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -302,8 +302,11 @@ class StoreRegistry:
                 # obstore's reqwest client rejects http:// by default. Auto-enable it
                 # to maintain parity with PyArrow (which accepts http:// via fsspec),
                 # but warn about unencrypted traffic.
-                co = {**kwargs.get("client_options", {}), "allow_http": True}
-                kwargs["client_options"] = co
+                client_options = {
+                    **kwargs.get("client_options", {}),
+                    "allow_http": True,
+                }
+                kwargs["client_options"] = client_options
                 if not getattr(self, "_warned_http", False):
                     self._warned_http = True
                     logger.warning(

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -297,10 +297,23 @@ class StoreRegistry:
 
     def get(self, store_url: str) -> Any:
         if store_url not in self._cache:
+            kwargs = dict(self._filesystem_kwargs)
+            if store_url.startswith("http://"):
+                # obstore's reqwest client rejects http:// by default. Auto-enable it
+                # to maintain parity with PyArrow (which accepts http:// via fsspec),
+                # but warn about unencrypted traffic.
+                co = {**kwargs.get("client_options", {}), "allow_http": True}
+                kwargs["client_options"] = co
+                if not getattr(self, "_warned_http", False):
+                    self._warned_http = True
+                    logger.warning(
+                        "Downloading over unencrypted HTTP. "
+                        "Consider using https:// instead."
+                    )
             self._cache[store_url] = self._from_url(
                 store_url,
                 retry_config=self._retry_config,
-                **self._filesystem_kwargs,
+                **kwargs,
             )
         return self._cache[store_url]
 
@@ -496,15 +509,6 @@ async def _download_uris_with_obstore(
             )
             range_threshold = 0
     sem = asyncio.Semaphore(max_conc) if max_conc > 0 else None
-
-    # obstore's reqwest client rejects http:// by default. Auto-enable it
-    # to maintain parity with PyArrow (which accepts http:// via fsspec),
-    # but warn about unencrypted traffic.
-    if any(uri is not None and uri.startswith("http://") for uri in uris):
-        fs_kwargs["client_options"] = {"allow_http": True}
-        logger.warning(
-            "Downloading over unencrypted HTTP. Consider using https:// instead."
-        )
 
     registry = StoreRegistry(retry_config={"max_retries": 10}, **fs_kwargs)
 

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -261,7 +261,16 @@ class AsyncPartitionActor(PartitionActor):
         return asyncio.run(_head_all())
 
     def _attach_file_sizes(self, block: pa.Table) -> pa.Table:
-        """Fetch file sizes for all URIs and attach as hidden columns."""
+        """Fetch file sizes for all URIs and attach as hidden columns.
+        Only called when obstore is available, range splitting is enabled
+        (RAY_DATA_OBSTORE_RANGE_THRESHOLD > 0), and the URI scheme is
+        supported by obstore.  The hidden columns are consumed by
+        ``_download_uris_with_obstore`` and dropped before output.
+        The hidden columns are consumed by ``_download_uris_with_obstore`` and
+        dropped before output. For cloud URIs this uses cheap metadata lookups.
+        For HTTP URIs where sizes are unavailable, stores 0 so the downstream
+        download path falls back to HEAD via obstore.
+        """
         for uri_column_name in self._uri_column_names:
             size_col = f"{_FILE_SIZE_COLUMN_PREFIX}{uri_column_name}"
             uris = block.column(uri_column_name).to_pylist()

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import math
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -9,16 +10,19 @@ import pyarrow.fs as pafs
 from ray.data._internal.planner._obstore_download import (
     _FILE_SIZE_COLUMN_PREFIX,
     RAY_DATA_OBSTORE_RANGE_THRESHOLD,
+    StoreRegistry,
+    _extract_credentials_from_filesystem,
     _is_obstore_supported_url,
 )
 from ray.data._internal.util import RetryingPyFileSystem, _arrow_batcher
 from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
-from ray.data.datasource.path_util import _resolve_paths_and_filesystem
+from ray.data.datasource.path_util import _resolve_paths_and_filesystem, _split_uri
 
 logger = logging.getLogger(__name__)
 
 URI_DOWNLOAD_MAX_WORKERS = 16
+URI_HEAD_MAX_CONCURRENCY = 128
 
 
 class PartitionActor:
@@ -186,9 +190,23 @@ class PartitionActor:
 class AsyncPartitionActor(PartitionActor):
     """Partition actor for the obstore download path.
 
-    When range splitting is enabled, attaches per-URI size columns (from metadata
-    HEADs) so downstream obstore downloads can skip redundant HEAD requests.
+    Uses obstore's async HEAD API for all size-fetching operations, replacing
+    the base class's 16-thread PyArrow ThreadPoolExecutor with fully async
+    requests at up to URI_HEAD_MAX_CONCURRENCY (128) concurrency.
+
+    When range splitting is enabled, attaches per-URI size columns so
+    downstream obstore downloads can skip redundant HEAD requests.
     """
+
+    def __init__(
+        self,
+        uri_column_names: List[str],
+        data_context: DataContext,
+        filesystem: Optional[pafs.FileSystem] = None,
+    ):
+        super().__init__(uri_column_names, data_context, filesystem)
+        fs_kwargs = _extract_credentials_from_filesystem(filesystem)
+        self._registry = StoreRegistry(retry_config={"max_retries": 10}, **fs_kwargs)
 
     def __call__(self, block: pa.Table) -> Iterator[pa.Table]:
         block = self._ensure_arrow_table(block)
@@ -212,19 +230,38 @@ class AsyncPartitionActor(PartitionActor):
             block, uri_column_name
         )
 
-    def _attach_file_sizes(self, block: pa.Table) -> pa.Table:
-        """Fetch file sizes for all URIs and attach as hidden columns.
+    def _sample_sizes(self, uris: List[str]) -> List[int]:
+        """Fetch file sizes concurrently using obstore's async HEAD API.
 
-        Only called when obstore is available, range splitting is enabled
-        (RAY_DATA_OBSTORE_RANGE_THRESHOLD > 0), and the URI scheme is
-        supported by obstore.  The hidden columns are consumed by
-        ``_download_uris_with_obstore`` and dropped before output.
-
-        The hidden columns are consumed by ``_download_uris_with_obstore`` and
-        dropped before output. For cloud URIs this uses cheap metadata lookups.
-        For HTTP URIs where sizes are unavailable, stores 0 so the downstream
-        download path falls back to HEAD via obstore.
+        Overrides the base class to use obstore instead of PyArrow's threaded
+        get_file_info.  This affects all callers: both the initial partition-
+        size estimation (25-file sample) and _attach_file_sizes (all files).
         """
+        import obstore as obs
+
+        if not uris:
+            return []
+
+        sem = asyncio.Semaphore(URI_HEAD_MAX_CONCURRENCY)
+
+        async def _head_one(uri: str) -> int:
+            try:
+                store_url, path = _split_uri(uri)
+                store = self._registry.get(store_url)
+                async with sem:
+                    meta = await obs.head_async(store, path)
+                return meta["size"] if isinstance(meta, dict) else meta.size
+            except Exception as e:
+                logger.debug("obstore HEAD failed for %r: %s", uri, e)
+                return 0
+
+        async def _head_all() -> List[int]:
+            return list(await asyncio.gather(*[_head_one(u) for u in uris]))
+
+        return asyncio.run(_head_all())
+
+    def _attach_file_sizes(self, block: pa.Table) -> pa.Table:
+        """Fetch file sizes for all URIs and attach as hidden columns."""
         for uri_column_name in self._uri_column_names:
             size_col = f"{_FILE_SIZE_COLUMN_PREFIX}{uri_column_name}"
             uris = block.column(uri_column_name).to_pylist()

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -238,11 +238,17 @@ class AsyncPartitionActor(PartitionActor):
         Overrides the base class to use obstore instead of PyArrow's threaded
         get_file_info.  This affects all callers: both the initial partition-
         size estimation (25-file sample) and _attach_file_sizes (all files).
+
+        For URI schemes not supported by obstore (e.g. hdfs://), falls back
+        to the base class's PyArrow-threaded implementation.
         """
         import obstore as obs
 
         if not uris:
             return []
+
+        if not _is_obstore_supported_url(uris[0]):
+            return super()._sample_sizes(uris)
 
         sem = asyncio.Semaphore(URI_HEAD_MAX_CONCURRENCY)
 

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -262,10 +262,12 @@ class AsyncPartitionActor(PartitionActor):
 
     def _attach_file_sizes(self, block: pa.Table) -> pa.Table:
         """Fetch file sizes for all URIs and attach as hidden columns.
+
         Only called when obstore is available, range splitting is enabled
         (RAY_DATA_OBSTORE_RANGE_THRESHOLD > 0), and the URI scheme is
         supported by obstore.  The hidden columns are consumed by
         ``_download_uris_with_obstore`` and dropped before output.
+
         The hidden columns are consumed by ``_download_uris_with_obstore`` and
         dropped before output. For cloud URIs this uses cheap metadata lookups.
         For HTTP URIs where sizes are unavailable, stores 0 so the downstream

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import math
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Iterator, List, Optional, cast
+from typing import Iterator, List, Optional, cast, override
 
 import pyarrow as pa
 import pyarrow.fs as pafs
@@ -230,6 +230,7 @@ class AsyncPartitionActor(PartitionActor):
             block, uri_column_name
         )
 
+    @override
     def _sample_sizes(self, uris: List[str]) -> List[int]:
         """Fetch file sizes concurrently using obstore's async HEAD API.
 

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -257,7 +257,7 @@ class AsyncPartitionActor(PartitionActor):
                 return 0
 
         async def _head_all() -> List[int]:
-            return list(await asyncio.gather(*[_head_one(u) for u in uris]))
+            return await asyncio.gather(*[_head_one(u) for u in uris])
 
         return asyncio.run(_head_all())
 

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -2,10 +2,11 @@ import asyncio
 import logging
 import math
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Iterator, List, Optional, cast, override
+from typing import Iterator, List, Optional, cast
 
 import pyarrow as pa
 import pyarrow.fs as pafs
+from typing_extensions import override
 
 from ray.data._internal.planner._obstore_download import (
     _FILE_SIZE_COLUMN_PREFIX,
@@ -252,12 +253,19 @@ class AsyncPartitionActor(PartitionActor):
                 async with sem:
                     meta = await obs.head_async(store, path)
                 return meta["size"] if isinstance(meta, dict) else meta.size
-            except Exception as e:
-                logger.debug("obstore HEAD failed for %r: %s", uri, e)
-                return 0
+            except Exception:
+                return -1
 
         async def _head_all() -> List[int]:
-            return await asyncio.gather(*[_head_one(u) for u in uris])
+            sizes = await asyncio.gather(*[_head_one(u) for u in uris])
+            failed = [uri for uri, size in zip(uris, sizes) if size == -1]
+            if failed:
+                logger.debug(
+                    "obstore HEAD failed for %d URIs: %s",
+                    len(failed),
+                    failed,
+                )
+            return sizes
 
         return asyncio.run(_head_all())
 

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -254,11 +254,11 @@ class AsyncPartitionActor(PartitionActor):
                     meta = await obs.head_async(store, path)
                 return meta["size"] if isinstance(meta, dict) else meta.size
             except Exception:
-                return -1
+                return 0
 
         async def _head_all() -> List[int]:
             sizes = await asyncio.gather(*[_head_one(u) for u in uris])
-            failed = [uri for uri, size in zip(uris, sizes) if size == -1]
+            failed = [uri for uri, size in zip(uris, sizes) if size == 0]
             if failed:
                 logger.debug(
                     "obstore HEAD failed for %d URIs: %s",


### PR DESCRIPTION
## Description
The AsyncPartitionActor that uses obstore to fetch metadata didn't use the library, therefore throughput was lower than expected on a realistic workload.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
