### PR TITLE
[Data] Enable filter pushdown through Download operator

### DIFF
--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -124,7 +124,7 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Download(AbstractOneToOne):
+class Download(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for download operation.
 
     Supports downloading from multiple URI columns in a single operation.
@@ -167,3 +167,9 @@ class Download(AbstractOneToOne):
                 filesystem=self.filesystem,
             )
         return transform(target)
+
+    def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
+        # Download only adds new columns (output_bytes_column_names) from URI columns.
+        # It doesn't modify or remove existing columns, so filters on existing
+        # columns can safely pass through.
+        return PredicatePassThroughBehavior.PASSTHROUGH

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -7,6 +7,7 @@ from ray.data._internal.logical.interfaces import (
     PredicatePassThroughBehavior,
 )
 from ray.data.block import BlockMetadata
+from ray.data.expressions import Expr
 
 if TYPE_CHECKING:
     import pyarrow
@@ -169,7 +170,21 @@ class Download(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
         return transform(target)
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
-        # Download only adds new columns (output_bytes_column_names) from URI columns.
-        # It doesn't modify or remove existing columns, so filters on existing
-        # columns can safely pass through.
-        return PredicatePassThroughBehavior.PASSTHROUGH
+        # Download adds new columns, so pushdown depends on whether the
+        # predicate references those new columns or only pre-existing ones.
+        return PredicatePassThroughBehavior.CONDITIONAL
+
+    def can_push_predicate_through(self, predicate_expr: "Expr") -> bool:
+        """Return True if the predicate can safely pass through Download.
+
+        Filters on pre-existing columns can be pushed before Download.
+        Filters referencing columns produced by Download must stay after it.
+        """
+        from ray.data._internal.planner.plan_expression.expression_visitors import (
+            _ColumnReferenceCollector,
+        )
+
+        collector = _ColumnReferenceCollector()
+        collector.visit(predicate_expr)
+        pred_cols = set(collector.get_column_refs() or [])
+        return not (pred_cols & set(self.output_bytes_column_names))

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -229,19 +229,6 @@ class PredicatePushdown(Rule):
                     f"got {len(input_op.input_dependencies)}"
                 )
 
-                # Block pushdown if the predicate references columns produced
-                # by this operator (e.g., Download's output_bytes_column_names).
-                if isinstance(input_op, Download):
-                    from ray.data._internal.planner.plan_expression.expression_visitors import (
-                        _ColumnReferenceCollector,
-                    )
-
-                    collector = _ColumnReferenceCollector()
-                    collector.visit(predicate_expr)
-                    pred_cols = set(collector.get_column_refs() or [])
-                    if pred_cols & set(input_op.output_bytes_column_names):
-                        return filter_op
-
                 # Apply column substitution if needed
                 if (
                     behavior
@@ -298,13 +285,25 @@ class PredicatePushdown(Rule):
         For operators with multiple inputs, we can push predicates that reference
         only one side down to that side, when semantically safe.
         """
+        predicate_expr = filter_op.predicate_expr
+
+        # Single-input conditional operators (e.g. Download)
+        if hasattr(conditional_op, "can_push_predicate_through"):
+            if not conditional_op.can_push_predicate_through(predicate_expr):
+                return filter_op
+            new_filter = Filter(
+                conditional_op.input_dependencies[0],
+                predicate_expr=predicate_expr,
+            )
+            pushed_filter = cls._try_push_down_predicate(new_filter)
+            return cls._clone_op_with_new_inputs(conditional_op, [pushed_filter])
+
+        # Multi-input conditional operators (e.g. Join)
         # Check if operator supports conditional pushdown by having the required method
         if not hasattr(conditional_op, "which_side_to_push_predicate"):
             return filter_op
 
-        push_side = conditional_op.which_side_to_push_predicate(
-            filter_op.predicate_expr
-        )
+        push_side = conditional_op.which_side_to_push_predicate(predicate_expr)
 
         if push_side is None:
             # Cannot push through
@@ -317,7 +316,7 @@ class PredicatePushdown(Rule):
         new_inputs = list(conditional_op.input_dependencies)
         branch_filter = Filter(
             new_inputs[branch_idx],
-            predicate_expr=filter_op.predicate_expr,
+            predicate_expr=predicate_expr,
         )
         new_inputs[branch_idx] = cls._try_push_down_predicate(branch_filter)
 

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -10,7 +10,13 @@ from ray.data._internal.logical.interfaces import (
     PredicatePassThroughBehavior,
     Rule,
 )
-from ray.data._internal.logical.operators import AbstractMap, Filter, Limit, Project
+from ray.data._internal.logical.operators import (
+    AbstractMap,
+    Download,
+    Filter,
+    Limit,
+    Project,
+)
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     _ColumnSubstitutionVisitor,
 )
@@ -321,6 +327,15 @@ class PredicatePushdown(Rule):
         if isinstance(op, Limit):
             assert len(new_inputs) == 1, len(new_inputs)
             return Limit(new_inputs[0], op.limit)
+        if isinstance(op, Download):
+            assert len(new_inputs) == 1, len(new_inputs)
+            return Download(
+                new_inputs[0],
+                uri_column_names=op.uri_column_names,
+                output_bytes_column_names=op.output_bytes_column_names,
+                ray_remote_args=op.ray_remote_args,
+                filesystem=op.filesystem,
+            )
         if isinstance(op, AbstractMap) and is_dataclass(op):
             assert len(new_inputs) == 1, len(new_inputs)
             return replace(op, input_op=new_inputs[0])

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -229,6 +229,19 @@ class PredicatePushdown(Rule):
                     f"got {len(input_op.input_dependencies)}"
                 )
 
+                # Block pushdown if the predicate references columns produced
+                # by this operator (e.g., Download's output_bytes_column_names).
+                if isinstance(input_op, Download):
+                    from ray.data._internal.planner.plan_expression.expression_visitors import (
+                        _ColumnReferenceCollector,
+                    )
+
+                    collector = _ColumnReferenceCollector()
+                    collector.visit(predicate_expr)
+                    pred_cols = set(collector.get_column_refs() or [])
+                    if pred_cols & set(input_op.output_bytes_column_names):
+                        return filter_op
+
                 # Apply column substitution if needed
                 if (
                     behavior

--- a/python/ray/data/tests/test_predicate_pushdown.py
+++ b/python/ray/data/tests/test_predicate_pushdown.py
@@ -493,6 +493,24 @@ class TestPassthroughBehavior:
             optimized_plan, Filter, Download
         ), "Filter should be pushed before Download"
 
+    def test_filter_on_download_output_column_not_pushed(
+        self, ray_start_regular_shared
+    ):
+        """Filter on columns produced by Download should not push through."""
+        table = pa.Table.from_arrays(
+            [pa.array(["uri_0"]), pa.array([0])],
+            names=["uri", "id"],
+        )
+        base_ds = ray.data.from_arrow(table)
+        ds = base_ds.with_column("bytes", download("uri")).filter(
+            expr=col("bytes").is_not_null()
+        )
+
+        optimized_plan = LogicalOptimizer().optimize(ds._plan._logical_plan)
+        assert plan_operator_comes_before(
+            optimized_plan, Download, Filter
+        ), "Filter on Download output columns must stay after Download"
+
 
 class TestPassthroughWithSubstitutionBehavior:
     """Tests for PASSTHROUGH_WITH_SUBSTITUTION behavior operators.

--- a/python/ray/data/tests/test_predicate_pushdown.py
+++ b/python/ray/data/tests/test_predicate_pushdown.py
@@ -11,6 +11,7 @@ from packaging.version import parse as version_parse
 import ray
 from ray.data import Dataset
 from ray.data._internal.logical.operators import (
+    Download,
     Filter,
     Limit,
     Project,
@@ -19,7 +20,7 @@ from ray.data._internal.logical.operators import (
 )
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.util import rows_same
-from ray.data.expressions import col
+from ray.data.expressions import col, download
 from ray.data.tests.conftest import *  # noqa
 from ray.data.tests.test_execution_optimizer_limit_pushdown import (
     _check_valid_plan_and_result,
@@ -468,6 +469,29 @@ class TestPassthroughBehavior:
         assert plan_operator_comes_before(
             optimized_plan, Filter, Sort
         ), "Fused filter should come before Sort"
+
+    def test_filter_pushes_through_download(self, ray_start_regular_shared):
+        """Filter should push through Download operator."""
+        table = pa.Table.from_arrays(
+            [
+                pa.array(["uri_0", "uri_1", "uri_2"]),
+                pa.array(range(3)),
+            ],
+            names=["uri", "id"],
+        )
+        base_ds = ray.data.from_arrow(table)
+        ds = base_ds.with_column("bytes", download("uri")).filter(expr=col("id") < 2)
+
+        # Verify plan optimization only (skip execution — Download creates an
+        # actor pool pipeline that deadlocks with limited test resources).
+        optimized_plan = LogicalOptimizer().optimize(ds._plan._logical_plan)
+        assert plan_has_operator(optimized_plan, Filter), "Filter should exist"
+        assert plan_has_operator(
+            optimized_plan, Download
+        ), "Download should remain in plan"
+        assert plan_operator_comes_before(
+            optimized_plan, Filter, Download
+        ), "Filter should be pushed before Download"
 
 
 class TestPassthroughWithSubstitutionBehavior:


### PR DESCRIPTION
## Description

Filter predicates placed after a Download operation are now pushed through it during logical plan optimization. Since Download only adds new columns (downloaded bytes) without modifying or removing existing ones, filters on pre-existing columns can safely evaluate before downloading. This avoids fetching bytes from URIs for rows that would be filtered out, reducing unnecessary network I/O.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
