### PR TITLE
[WIP][Core][GPU fraction] Change StrictPack to check availability per-bundle instead of aggregated bundle to prevent false positive

### DIFF
--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -341,8 +341,12 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
     std::vector<const ResourceRequest *> allocated_requests;
     allocated_requests.reserve(resource_request_list.size());
 
+    const auto &node_resources = cluster_resource_manager_.GetNodeResources(node_id);
+
     for (const auto *request : resource_request_list) {
-      if (cluster_resource_manager_.SubtractNodeAvailableResources(node_id, *request)) {
+      if (node_resources.IsAvailable(*request)) {
+        RAY_CHECK(
+            cluster_resource_manager_.SubtractNodeAvailableResources(node_id, *request));
         allocated_requests.push_back(request);
       } else {
         for (const auto *prev_request : allocated_requests) {

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -339,21 +339,23 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
   // would be falsely rejected by strict per-instance capacity checks.
   auto try_allocate_all_bundles = [&](scheduling::NodeID node_id) -> bool {
     std::vector<const ResourceRequest *> allocated_requests;
+    allocated_requests.reserve(resource_request_list.size());
+
     for (const auto *request : resource_request_list) {
       if (cluster_resource_manager_.SubtractNodeAvailableResources(node_id, *request)) {
         allocated_requests.push_back(request);
       } else {
         for (const auto *prev_request : allocated_requests) {
-          cluster_resource_manager_.AddNodeAvailableResources(
-              node_id, prev_request->GetResourceSet());
+          RAY_CHECK(cluster_resource_manager_.AddNodeAvailableResources(
+              node_id, prev_request->GetResourceSet()));
         }
         return false;
       }
     }
 
     for (const auto *request : allocated_requests) {
-      cluster_resource_manager_.AddNodeAvailableResources(node_id,
-                                                          request->GetResourceSet());
+      RAY_CHECK(cluster_resource_manager_.AddNodeAvailableResources(
+          node_id, request->GetResourceSet()));
     }
 
     return true;

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -333,9 +333,9 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
   }
 
   // Try each candidate node by allocating bundles one by one (per-bundle
-  // SubtractNodeAvailableResources). 
+  // SubtractNodeAvailableResources).
   // TODO: This avoids the aggregated-request problem and prepares for
-  // upcoming per-instance availability tracking, where a summed demand 
+  // upcoming per-instance availability tracking, where a summed demand
   // would be falsely rejected by strict per-instance capacity checks.
   auto try_allocate_all_bundles = [&](scheduling::NodeID node_id) -> bool {
     std::vector<const ResourceRequest *> allocated_requests;
@@ -352,10 +352,10 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
     }
 
     for (const auto *request : allocated_requests) {
-      cluster_resource_manager_.AddNodeAvailableResources(
-          node_id, request->GetResourceSet());
+      cluster_resource_manager_.AddNodeAvailableResources(node_id,
+                                                          request->GetResourceSet());
     }
-    
+
     return true;
   };
 

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -332,29 +332,64 @@ SchedulingResult BundleStrictPackSchedulingPolicy::Schedule(
     return SchedulingResult::Infeasible();
   }
 
-  std::pair<scheduling::NodeID, const Node *> best_node(scheduling::NodeID::Nil(),
-                                                        nullptr);
+  // Try each candidate node by allocating bundles one by one (per-bundle
+  // SubtractNodeAvailableResources). 
+  // TODO: This avoids the aggregated-request problem and prepares for
+  // upcoming per-instance availability tracking, where a summed demand 
+  // would be falsely rejected by strict per-instance capacity checks.
+  auto try_allocate_all_bundles = [&](scheduling::NodeID node_id) -> bool {
+    std::vector<const ResourceRequest *> allocated_requests;
+    for (const auto *request : resource_request_list) {
+      if (cluster_resource_manager_.SubtractNodeAvailableResources(node_id, *request)) {
+        allocated_requests.push_back(request);
+      } else {
+        for (const auto *prev_request : allocated_requests) {
+          cluster_resource_manager_.AddNodeAvailableResources(
+              node_id, prev_request->GetResourceSet());
+        }
+        return false;
+      }
+    }
+
+    for (const auto *request : allocated_requests) {
+      cluster_resource_manager_.AddNodeAvailableResources(
+          node_id, request->GetResourceSet());
+    }
+    
+    return true;
+  };
+
+  scheduling::NodeID best_node_id = scheduling::NodeID::Nil();
   if (!options.bundle_strict_pack_soft_target_node_id_.IsNil()) {
-    if (candidate_nodes.contains(options.bundle_strict_pack_soft_target_node_id_)) {
-      best_node = GetBestNode(
-          aggregated_resource_request,
-          absl::flat_hash_map<scheduling::NodeID, const ray::Node *>{
-              {options.bundle_strict_pack_soft_target_node_id_,
-               candidate_nodes[options.bundle_strict_pack_soft_target_node_id_]}},
-          options);
+    if (candidate_nodes.contains(options.bundle_strict_pack_soft_target_node_id_) &&
+        try_allocate_all_bundles(options.bundle_strict_pack_soft_target_node_id_)) {
+      best_node_id = options.bundle_strict_pack_soft_target_node_id_;
     }
   }
 
-  if (best_node.first.IsNil()) {
-    best_node = GetBestNode(aggregated_resource_request, candidate_nodes, options);
+  if (best_node_id.IsNil()) {
+    // Score viable candidates per-bundle using the existing scorer.
+    // try_allocate_all_bundles already verified all bundles fit, so each
+    // individual Score(bundle) will pass IsAvailable.
+    double best_score = -1;
+    for (const auto &[node_id, node] : candidate_nodes) {
+      if (!try_allocate_all_bundles(node_id)) {
+        continue;
+      }
+      double score = 0;
+      for (const auto *request : resource_request_list) {
+        score += node_scorer_->Score(*request, node->GetLocalView());
+      }
+      if (best_node_id.IsNil() || score > best_score) {
+        best_score = score;
+        best_node_id = node_id;
+      }
+    }
   }
 
-  // Select the node with the highest score.
-  // `StrictPackSchedule` does not need to consider the scheduling context, because it
-  // only schedules to a node and triggers rescheduling when node dead.
   std::vector<scheduling::NodeID> result_nodes;
-  if (!best_node.first.IsNil()) {
-    result_nodes.resize(resource_request_list.size(), best_node.first);
+  if (!best_node_id.IsNil()) {
+    result_nodes.resize(resource_request_list.size(), best_node_id);
   }
   if (result_nodes.empty()) {
     // Can't meet the scheduling requirements temporarily.


### PR DESCRIPTION
## PR Description
This PR is the first step in fixing the `STRICT_PACK` false positive issue during node availability checks.




To completely resolve this issue, we are taking a two-step approach:
1. **This PR** make `StrictPack` check availability per-bundle instead of the aggregated bundle
2. After **[Upcoming PR](https://github.com/ray-project/ray/pull/62005)** updates `NodeResources` to track per-instance availability, `SubtractNodeAvailableResources` and `AddNodeAvailableResources` will be updated to perform per-instance manipulation instead of scalar math


### `STRICT_PACK` False Positive Problem
Currently, scheduling relies on aggregated scalar values. For example, consider a node with two GPUs, each with `0.5` availability (an aggregated capacity of `1.0`). If `STRICT_PACK` needs to schedule two bundles requiring `0.1` and `0.7` GPUs, the aggregated request is `0.8`. 

The scheduler sees `0.8 <= 1.0` and incorrectly assumes the node is a valid fit. However, during local allocation, the node actually can't fit the `0.7` bundle, resulting in a false positive and unnecessary spillbacks.


### Solution
Instead of checking the availability of an aggregated bundle, we evaluate each bundle individually using the following way:
* We loop through each bundle and check its individual availability.
* If it fits, we temporarily deduct its usage via `SubtractNodeAvailableResources`. 
* If *any* bundle in the group fails to fit, we immediately roll back the successful allocations using `AddNodeAvailableResources` and reject the node.

**Note:** Once `SubtractNodeAvailableResources` is updated in [the upcoming PR](https://github.com/ray-project/ray/pull/62005), we will be able to use it directly to determine whether a node can fit a specific bundle, bypassing the need for a separate `NodeResources::IsAvailable` check.

## Testing
This logic successfully passes [StrictPackFractionalUnitResourceTest](https://github.com/ray-project/ray/pull/62005/changes#diff-6f16a3ab77ff42aa4a2e33b6a00f6cbfa78cefe71aac8b08a7b91ea62fb5281fR580-R599), which is not included in this PR since it relies on the `NodeResources::available` data structure changes introduced in [the upcoming PR](https://github.com/ray-project/ray/pull/62005)

## Related PR
Related to https://github.com/ray-project/ray/pull/62005

