### PR TITLE
[RLlib] Preserve PBT-perturbed hyperparameters across checkpoint restore

### DIFF
--- a/rllib/policy/policy.py
+++ b/rllib/policy/policy.py
@@ -1027,8 +1027,14 @@ class Policy(metaclass=ABCMeta):
                     f"action space ({self.action_space})."
                 )
             # Override config, if part of the spec.
+            # Merge rather than replace: current self.config may contain
+            # hyperparameters perturbed by PBT that should survive a
+            # checkpoint restore (the checkpoint carries the *cloned*
+            # trial's config, not the perturbed one).
             if policy_spec.config:
-                self.config = policy_spec.config
+                restored = policy_spec.config
+                restored.update(self.config)
+                self.config = restored
 
         # Override NN weights.
         self.set_weights(state["weights"])

--- a/rllib/policy/torch_policy_v2.py
+++ b/rllib/policy/torch_policy_v2.py
@@ -949,6 +949,14 @@ class TorchPolicyV2(Policy):
                     s["state"], device=self.device
                 )
                 o.load_state_dict(optim_state_dict)
+            # Re-apply the current learning rate from this policy's config
+            # so that PBT-perturbed lr values are not overwritten by the
+            # cloned checkpoint's optimizer state.
+            current_lr = self.config.get("lr")
+            if current_lr is not None:
+                for o in self._optimizers:
+                    for pg in o.param_groups:
+                        pg["lr"] = current_lr
         # Set exploration's state.
         if hasattr(self, "exploration") and "_exploration_state" in state:
             self.exploration.set_state(state=state["_exploration_state"])


### PR DESCRIPTION
## Why are these changes needed?

PBT correctly perturbs hyperparameters on `algorithm.config` via `trial.set_config()`, but checkpoint restore in `Policy.set_state()` unconditionally replaces `policy.config` with the cloned trial's serialized config, silently discarding `clip_param`, `lambda`, and `lr`. Additionally, `TorchPolicyV2.set_state()` restores optimizer `param_groups` from the checkpoint, overwriting the perturbed learning rate.

This PR merges the checkpoint config under the current policy config (so PBT-perturbed values take precedence) and re-applies the current `lr` to optimizer param groups after state restoration.

Fixes #62173

## Related issue number

#62173