### PR TITLE
[Data] Enable filter pushdown through StreamingRepartition OP

### DIFF
--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -486,7 +486,7 @@ class FlatMap(AbstractUDFMap):
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class StreamingRepartition(AbstractMap):
+class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for streaming repartition operation.
 
     Args:
@@ -540,3 +540,8 @@ class StreamingRepartition(AbstractMap):
         else:
             target = replace(self, input_op=transformed_input)
         return transform(target)
+
+    def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
+        # StreamingRepartition only re-bundles rows into different block sizes.
+        # It doesn't modify schema or filter rows, so filters can safely pass through.
+        return PredicatePassThroughBehavior.PASSTHROUGH

--- a/python/ray/data/tests/test_predicate_pushdown.py
+++ b/python/ray/data/tests/test_predicate_pushdown.py
@@ -412,10 +412,14 @@ class TestPassthroughBehavior:
         [
             (lambda ds: ds.sort("id"), "Sort"),
             (lambda ds: ds.repartition(10), "Repartition"),
+            (
+                lambda ds: ds.repartition(target_num_rows_per_block=10),
+                "StreamingRepartition",
+            ),
             (lambda ds: ds.random_shuffle(), "RandomShuffle"),
             (lambda ds: ds.limit(50), "Limit"),
         ],
-        ids=["sort", "repartition", "random_shuffle", "limit"],
+        ids=["sort", "repartition", "streaming_repartition", "random_shuffle", "limit"],
     )
     def test_filter_pushes_through_operator(self, base_ds, transform, expected_op_type):
         """Filter should push through passthrough operators."""


### PR DESCRIPTION
## Description
StreamingRepartition only re-bundles rows into fixed-size blocks without modifying schema or row content. Filters can safely pass through it, same as the existing Repartition operator. This allows predicates to be evaluated earlier in the pipeline, reducing the volume of data that gets re-partitioned.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
