### PR TITLE
[Data] Fix thread leak in _run_transforming_worker causing iter_tf_batches deadlock

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1191,7 +1191,8 @@ def make_async_gen(
             output_queue.put(e)
 
         finally:
-            fn_gen.close()
+            if hasattr(fn_gen, "close"):
+                fn_gen.close()
 
     # Start workers threads
     filling_worker_thread = threading.Thread(

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1172,8 +1172,9 @@ def make_async_gen(
         #
         # NOTE: `queue.get` is blocking!
         input_queue_iter = iter(input_queue.get, SENTINEL)
-        fn_gen = fn(input_queue_iter)
+        fn_gen = None
         try:
+            fn_gen = fn(input_queue_iter)
             for result in fn_gen:
                 # Enqueue result of the transformation
                 output_queue.put(result)
@@ -1191,7 +1192,7 @@ def make_async_gen(
             output_queue.put(e)
 
         finally:
-            if hasattr(fn_gen, "close"):
+            if fn_gen is not None and hasattr(fn_gen, "close"):
                 fn_gen.close()
 
     # Start workers threads

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1168,13 +1168,13 @@ def make_async_gen(
 
     # Transforming worker
     def _run_transforming_worker(input_queue, output_queue):
+        # Create iterator draining the queue, until it receives sentinel
+        #
+        # NOTE: `queue.get` is blocking!
+        input_queue_iter = iter(input_queue.get, SENTINEL)
+        fn_gen = fn(input_queue_iter)
         try:
-            # Create iterator draining the queue, until it receives sentinel
-            #
-            # NOTE: `queue.get` is blocking!
-            input_queue_iter = iter(input_queue.get, SENTINEL)
-
-            for result in fn(input_queue_iter):
+            for result in fn_gen:
                 # Enqueue result of the transformation
                 output_queue.put(result)
 
@@ -1189,6 +1189,9 @@ def make_async_gen(
             # NOTE: In this case we simply enqueue the exception rather than
             #       interrupting
             output_queue.put(e)
+
+        finally:
+            fn_gen.close()
 
     # Start workers threads
     filling_worker_thread = threading.Thread(


### PR DESCRIPTION
### What this PR does

Fixes a deadlock in `iter_tf_batches()` that happens after multiple epochs.

### Root cause

Ray Data uses nested background threads to stream and format batches. When an epoch ends, the outer threads get interrupted and exit but they never closed the inner TF formatting threads. Those inner threads stay alive, stuck waiting on queues. After enough epochs they pile up and eventually block resources that new epochs need, causing a deadlock.

### Fix

In `_run_transforming_worker`, add `finally: fn_gen.close()` so the inner pipeline is always closed when the outer thread exits, no matter the reason.

```python
except InterruptedError:
    pass
except Exception as e:
    logger.warning("Caught exception in transforming worker!", exc_info=e)
    output_queue.put(e)
finally:
    fn_gen.close()  # always clean up inner threads
```
---
Closes #62352