### PR TITLE
[Data] Add Dataset.explode() for expanding list columns into rows

### DIFF
--- a/doc/source/data/api/from_other_data_libs.rst
+++ b/doc/source/data/api/from_other_data_libs.rst
@@ -60,6 +60,8 @@ For Pandas Users
      - :meth:`ds.mean() <ray.data.Dataset.mean>`
    * - df.std()
      - :meth:`ds.std() <ray.data.Dataset.std>`
+   * - df.explode()
+     - :meth:`ds.explode() <ray.data.Dataset.explode>`
 
 .. _api-guide-for-pyarrow-users:
 

--- a/doc/source/data/transforming-data.rst
+++ b/doc/source/data/transforming-data.rst
@@ -107,6 +107,34 @@ dictionaries that have the same type as the input, for example:
         # return list of output rows
         return output
 
+Exploding list columns
+~~~~~~~~~~~~~~~~~~~~~~
+
+If your dataset has a column containing lists and you want to expand each list element
+into its own row, call :meth:`~ray.data.Dataset.explode`. All other columns are
+duplicated for each element. Rows with empty or null lists produce zero output rows.
+
+.. testcode::
+
+    import pyarrow as pa
+    import ray
+
+    ds = ray.data.from_arrow(pa.table({
+        "id": [1, 2, 3],
+        "items": [[10, 20], [30], []],
+    }))
+    print(ds.explode("items").take_all())
+
+.. testoutput::
+
+    [{'id': 1, 'items': 10}, {'id': 1, 'items': 20}, {'id': 2, 'items': 30}]
+
+.. tip::
+
+    Use :meth:`~ray.data.Dataset.explode` instead of :meth:`~ray.data.Dataset.flat_map`
+    when you just need to expand a list column — it's more concise and uses optimized
+    columnar operations instead of row-by-row Python iteration.
+
 .. _transforming_batches:
 
 Transforming batches

--- a/python/ray/data/_internal/logical/operators/__init__.py
+++ b/python/ray/data/_internal/logical/operators/__init__.py
@@ -22,6 +22,7 @@ from ray.data._internal.logical.operators.join_operator import Join, JoinSide, J
 from ray.data._internal.logical.operators.map_operator import (
     AbstractMap,
     AbstractUDFMap,
+    Explode,
     Filter,
     FlatMap,
     MapBatches,
@@ -48,6 +49,7 @@ __all__ = [
     "Aggregate",
     "Count",
     "Download",
+    "Explode",
     "Filter",
     "FlatMap",
     "FromArrow",

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -18,6 +18,7 @@ from ray.data.preprocessor import Preprocessor
 __all__ = [
     "AbstractMap",
     "AbstractUDFMap",
+    "Explode",
     "Filter",
     "FlatMap",
     "MapBatches",
@@ -470,6 +471,46 @@ class FlatMap(AbstractUDFMap):
             "_name",
             self._get_operator_name(self.__class__.__name__, self.fn),
         )
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
+
+
+@dataclass(frozen=True, repr=False, eq=False)
+class Explode(AbstractMap):
+    """Logical operator for exploding a list-typed column into multiple rows.
+
+    Each element in the list column becomes its own row, with all other columns
+    duplicated. Empty and null lists produce zero output rows.
+    """
+
+    input_op: InitVar[LogicalOperator]
+    column: str
+    compute: Optional[ComputeStrategy] = None
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
+    can_modify_num_rows: bool = field(init=False, default=True)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    per_block_limit: Optional[int] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.compute is None:
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        object.__setattr__(self, "_name", f"Explode({self.column})")
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -43,6 +43,7 @@ from ray.data._internal.execution.operators.map_transformer import (
 from ray.data._internal.execution.util import make_callable_class_single_threaded
 from ray.data._internal.logical.operators import (
     AbstractUDFMap,
+    Explode,
     Filter,
     FlatMap,
     MapBatches,
@@ -125,6 +126,74 @@ class _MapActorContext:
         thread.start()
         self.udf_map_asyncio_loop = loop
         self.udf_map_asyncio_thread = thread
+
+
+def plan_explode_op(
+    op: Explode,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
+) -> MapOperator:
+    assert len(physical_children) == 1
+    input_physical_dag = physical_children[0]
+
+    # Extract column name before defining closure to avoid serializing the whole op.
+    column = op.column
+    compute = get_compute(op.compute)
+
+    def _explode_block(block: Block) -> Block:
+        import pyarrow.compute as pc
+
+        table = BlockAccessor.for_block(block).to_arrow()
+
+        col_idx = table.schema.get_field_index(column)
+        if col_idx == -1:
+            raise ValueError(
+                f"Column '{column}' not found in schema: {table.schema}"
+            )
+
+        col_arr = table.column(col_idx)
+        col_type = col_arr.type
+        if not (
+            pa.types.is_list(col_type)
+            or pa.types.is_large_list(col_type)
+            or pa.types.is_fixed_size_list(col_type)
+        ):
+            raise ValueError(
+                f"Column '{column}' is not a list type (got {col_type}). "
+                "explode() requires a list-typed column."
+            )
+
+        parent_indices = pc.list_parent_indices(col_arr)
+        flattened = pc.list_flatten(col_arr)
+
+        # Single gather for all columns at once.
+        new_table = table.take(parent_indices)
+
+        # Replace the list column with flattened values.
+        # Use value_field to preserve element nullability and metadata.
+        new_field = col_type.value_field.with_name(
+            table.schema.field(col_idx).name
+        )
+        new_table = new_table.set_column(col_idx, new_field, flattened)
+        return new_table
+
+    output_block_size_option = OutputBlockSizeOption.of(
+        target_max_block_size=data_context.target_max_block_size,
+    )
+    transform_fn = BlockMapTransformFn(
+        _generate_transform_fn_for_map_block(_explode_block),
+        output_block_size_option=output_block_size_option,
+    )
+    map_transformer = MapTransformer([transform_fn], init_fn=None)
+    return MapOperator.create(
+        map_transformer,
+        input_physical_dag,
+        data_context,
+        name=op.name,
+        compute_strategy=compute,
+        ray_remote_args=op.ray_remote_args,
+        ray_remote_args_fn=op.ray_remote_args_fn,
+    )
 
 
 def plan_project_op(

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -147,9 +147,7 @@ def plan_explode_op(
 
         col_idx = table.schema.get_field_index(column)
         if col_idx == -1:
-            raise ValueError(
-                f"Column '{column}' not found in schema: {table.schema}"
-            )
+            raise ValueError(f"Column '{column}' not found in schema: {table.schema}")
 
         col_arr = table.column(col_idx)
         col_type = col_arr.type
@@ -171,9 +169,7 @@ def plan_explode_op(
 
         # Replace the list column with flattened values.
         # Use value_field to preserve element nullability and metadata.
-        new_field = col_type.value_field.with_name(
-            table.schema.field(col_idx).name
-        )
+        new_field = col_type.value_field.with_name(table.schema.field(col_idx).name)
         new_table = new_table.set_column(col_idx, new_field, flattened)
         return new_table
 
@@ -906,6 +902,7 @@ def _generate_transform_fn_for_async_map(
         #       to keep the output ordering the same as that one of the input
         #       iterator.
         completed_tasks_queue = asyncio.Queue(maxsize=max_concurrency)
+
         # NOTE: This method is nested to support Python 3.9 where we only can
         #       init `asyncio.Queue` inside the async function
         async def _reorder() -> None:

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -30,6 +30,7 @@ from ray.data._internal.logical.operators import (
     AbstractUDFMap,
     Count,
     Download,
+    Explode,
     Filter,
     InputData,
     Join,
@@ -50,6 +51,7 @@ from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
 from ray.data._internal.planner.plan_download_op import plan_download_op
 from ray.data._internal.planner.plan_read_op import plan_read_op
 from ray.data._internal.planner.plan_udf_map_op import (
+    plan_explode_op,
     plan_filter_op,
     plan_project_op,
     plan_streaming_repartition_op,
@@ -159,6 +161,7 @@ class Planner:
         InputData: plan_input_data_op,
         Write: plan_write_op,
         AbstractFrom: plan_from_op,
+        Explode: plan_explode_op,
         Filter: plan_filter_op,
         AbstractUDFMap: plan_udf_map_op,
         AbstractAllToAll: plan_all_to_all_op,

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -60,6 +60,7 @@ from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIte
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators import (
     Count,
+    Explode,
     Filter,
     FlatMap,
     InputData,
@@ -1464,6 +1465,51 @@ class Dataset:
             compute=compute,
             ray_remote_args_fn=ray_remote_args_fn,
             ray_remote_args=ray_remote_args,
+        )
+        logical_plan = LogicalPlan(op, self.context)
+        return Dataset(plan, logical_plan)
+
+    @PublicAPI(api_group=BT_API_GROUP)
+    def explode(self, column: str) -> "Dataset":
+        """Expand a list-typed column into multiple rows.
+
+        Each element in the list becomes its own row, with all other columns
+        duplicated. Rows with empty or null lists produce zero output rows.
+
+        Examples:
+
+            .. testcode::
+
+                import ray
+
+                ds = ray.data.from_items([
+                    {"id": 1, "items": [10, 20]},
+                    {"id": 2, "items": [30]},
+                    {"id": 3, "items": []},
+                ])
+                print(ds.explode("items").take_all())
+
+            .. testoutput::
+
+                [{'id': 1, 'items': 10}, {'id': 1, 'items': 20}, {'id': 2, 'items': 30}]
+
+        Args:
+            column: The name of the list-typed column to explode.
+
+        Returns:
+            A new :class:`Dataset` with the list column expanded into rows.
+
+        Raises:
+            ValueError: If the column doesn't exist or is not a list type.
+
+        See Also:
+            :meth:`Dataset.flat_map`: Apply a function that returns multiple
+                rows per input row.
+        """
+        plan = self._plan.copy()
+        op = Explode(
+            input_op=self._logical_plan.dag,
+            column=column,
         )
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6650,9 +6650,9 @@ class Dataset:
         import pyarrow as pa
 
         ref_bundle: RefBundle = self._plan.execute()
-        block_refs: List[ObjectRef["pyarrow.Table"]] = (
-            _ref_bundles_iterator_to_block_refs_list([ref_bundle])
-        )
+        block_refs: List[
+            ObjectRef["pyarrow.Table"]
+        ] = _ref_bundles_iterator_to_block_refs_list([ref_bundle])
         # Schema is safe to call since we have already triggered execution with
         # self._plan.execute(), which will cache the schema
         schema = self.schema(fetch_if_missing=True)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6650,9 +6650,9 @@ class Dataset:
         import pyarrow as pa
 
         ref_bundle: RefBundle = self._plan.execute()
-        block_refs: List[
-            ObjectRef["pyarrow.Table"]
-        ] = _ref_bundles_iterator_to_block_refs_list([ref_bundle])
+        block_refs: List[ObjectRef["pyarrow.Table"]] = (
+            _ref_bundles_iterator_to_block_refs_list([ref_bundle])
+        )
         # Schema is safe to call since we have already triggered execution with
         # self._plan.execute(), which will cache the schema
         schema = self.schema(fetch_if_missing=True)

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -378,9 +378,7 @@ def test_explode_mixed_empty_null_populated(ray_start_regular_shared):
     table = pa.table(
         {
             "id": [1, 2, 3, 4],
-            "items": pa.array(
-                [[10, 20], [], None, [30]], type=pa.list_(pa.int64())
-            ),
+            "items": pa.array([[10, 20], [], None, [30]], type=pa.list_(pa.int64())),
         }
     )
     ds = ray.data.from_arrow(table)

--- a/python/ray/data/tests/test_map.py
+++ b/python/ray/data/tests/test_map.py
@@ -308,6 +308,172 @@ def test_flat_map(
     ]
 
 
+def test_explode_basic(ray_start_regular_shared):
+    """Test basic explode functionality with list column."""
+    ds = ray.data.from_items(
+        [
+            {"id": 1, "items": [10, 20]},
+            {"id": 2, "items": [30]},
+        ]
+    )
+    result = ds.explode("items").take_all()
+    assert result == [
+        {"id": 1, "items": 10},
+        {"id": 1, "items": 20},
+        {"id": 2, "items": 30},
+    ]
+
+
+def test_explode_empty_list(ray_start_regular_shared):
+    """Test that empty lists produce zero output rows."""
+    ds = ray.data.from_items(
+        [
+            {"id": 1, "items": [10]},
+            {"id": 2, "items": []},
+            {"id": 3, "items": [20]},
+        ]
+    )
+    result = ds.explode("items").take_all()
+    assert result == [
+        {"id": 1, "items": 10},
+        {"id": 3, "items": 20},
+    ]
+
+
+def test_explode_null_list(ray_start_regular_shared):
+    """Test that null list values produce zero output rows."""
+    table = pa.table(
+        {
+            "id": [1, 2, 3],
+            "items": pa.array([[10], None, [20]], type=pa.list_(pa.int64())),
+        }
+    )
+    ds = ray.data.from_arrow(table)
+    result = ds.explode("items").take_all()
+    assert result == [
+        {"id": 1, "items": 10},
+        {"id": 3, "items": 20},
+    ]
+
+
+def test_explode_null_elements_in_list(ray_start_regular_shared):
+    """Test that null elements within lists are preserved."""
+    table = pa.table(
+        {
+            "id": [1],
+            "items": pa.array([[10, None, 30]], type=pa.list_(pa.int64())),
+        }
+    )
+    ds = ray.data.from_arrow(table)
+    result = ds.explode("items").take_all()
+    assert len(result) == 3
+    assert result[0] == {"id": 1, "items": 10}
+    assert result[1]["id"] == 1
+    assert result[1]["items"] is None
+    assert result[2] == {"id": 1, "items": 30}
+
+
+def test_explode_mixed_empty_null_populated(ray_start_regular_shared):
+    """Test a mix of empty, null, and populated lists."""
+    table = pa.table(
+        {
+            "id": [1, 2, 3, 4],
+            "items": pa.array(
+                [[10, 20], [], None, [30]], type=pa.list_(pa.int64())
+            ),
+        }
+    )
+    ds = ray.data.from_arrow(table)
+    result = ds.explode("items").take_all()
+    assert result == [
+        {"id": 1, "items": 10},
+        {"id": 1, "items": 20},
+        {"id": 4, "items": 30},
+    ]
+
+
+def test_explode_nonexistent_column(ray_start_regular_shared):
+    """Test that exploding a non-existent column raises ValueError."""
+    ds = ray.data.from_items([{"id": 1, "items": [10]}])
+    with pytest.raises(ValueError, match="not found"):
+        ds.explode("nonexistent").take_all()
+
+
+def test_explode_non_list_column(ray_start_regular_shared):
+    """Test that exploding a non-list column raises ValueError."""
+    ds = ray.data.from_items([{"id": 1, "value": 42}])
+    with pytest.raises(ValueError, match="not a list type"):
+        ds.explode("value").take_all()
+
+
+def test_explode_nested_list(ray_start_regular_shared):
+    """Test exploding nested lists removes one level of nesting."""
+    table = pa.table(
+        {
+            "id": [1],
+            "nested": pa.array(
+                [[[1, 2], [3]]],
+                type=pa.list_(pa.list_(pa.int64())),
+            ),
+        }
+    )
+    ds = ray.data.from_arrow(table)
+    result = ds.explode("nested").take_all()
+    assert result == [
+        {"id": 1, "nested": [1, 2]},
+        {"id": 1, "nested": [3]},
+    ]
+
+
+def test_explode_string_list(ray_start_regular_shared):
+    """Test exploding a list of strings."""
+    table = pa.table(
+        {
+            "id": [1, 2],
+            "words": pa.array(
+                [["hello", "world"], ["foo"]],
+                type=pa.list_(pa.string()),
+            ),
+        }
+    )
+    ds = ray.data.from_arrow(table)
+    result = ds.explode("words").take_all()
+    assert result == [
+        {"id": 1, "words": "hello"},
+        {"id": 1, "words": "world"},
+        {"id": 2, "words": "foo"},
+    ]
+
+
+def test_explode_chaining(ray_start_regular_shared):
+    """Test that explode chains with other operations."""
+    ds = ray.data.from_items(
+        [
+            {"id": 1, "items": [10, 20, 30]},
+            {"id": 2, "items": [40, 50]},
+        ]
+    )
+    result = (
+        ds.explode("items")
+        .filter(lambda row: row["items"] > 20)
+        .select_columns(["items"])
+        .take_all()
+    )
+    assert result == [{"items": 30}, {"items": 40}, {"items": 50}]
+
+
+def test_explode_all_empty(ray_start_regular_shared):
+    """Test that exploding when all lists are empty returns empty dataset."""
+    ds = ray.data.from_items(
+        [
+            {"id": 1, "items": []},
+            {"id": 2, "items": []},
+        ]
+    )
+    result = ds.explode("items").take_all()
+    assert result == []
+
+
 # Helper function to process timestamp data in nanoseconds
 def process_timestamp_data(row):
     # Convert numpy.datetime64 to pd.Timestamp if needed


### PR DESCRIPTION
## Summary
- Add `Dataset.explode(column)` method that expands list-typed columns into multiple rows, with all other columns duplicated
- New `Explode` logical operator (inherits from `AbstractMap`, `can_modify_num_rows=True`) with dedicated `plan_explode_op` physical planner
- Optimized implementation using `table.take(parent_indices)` for single-gather across all columns

## Details
- Supports `list`, `large_list`, and `fixed_size_list` PyArrow types
- Empty/null lists produce zero output rows; null elements within lists are preserved
- Nested lists (`list<list<T>>`) remove one level of nesting (result is `list<T>`)
- Output blocks auto-split via `OutputBlockSizeOption` to handle data expansion
- Non-list or non-existent columns raise `ValueError`

## Example
```python
ds = ray.data.from_items([
    {"id": 1, "items": [10, 20]},
    {"id": 2, "items": [30]},
    {"id": 3, "items": []},
])
ds.explode("items").take_all()
# [{'id': 1, 'items': 10}, {'id': 1, 'items': 20}, {'id': 2, 'items': 30}]
```

## Test plan
- [x] Basic explode functionality
- [x] Empty list → row dropped
- [x] Null list → row dropped  
- [x] Null elements within lists preserved
- [x] Mixed empty/null/populated lists
- [x] Non-existent column → ValueError
- [x] Non-list column → ValueError
- [x] Nested list removes one level
- [x] String list type
- [x] Chaining with filter/select
- [x] All-empty dataset → empty result
- [x] Verified core algorithm against all edge cases with PyArrow
- [x] Verified end-to-end via `ray job submit` on local cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)