### PR TITLE
[Serve] Deflake replica_healthy gauge check in test_metrics

### DIFF
--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -904,23 +904,27 @@ def test_replica_metrics_fields(metrics_start_shutdown):
     ) == expected_output
     assert err_requests[0]["exception_type"] == "ZeroDivisionError"
 
-    wait_for_condition(
-        lambda: len(
-            get_metric_dictionaries("ray_serve_deployment_replica_healthy", wait=False)
+    expected_deployments = {("f", "app1"), ("g", "app2"), ("h", "app3")}
+    health_timeseries = PrometheusTimeseries()
+
+    def _check_replica_healthy():
+        metrics = get_metric_dictionaries(
+            "ray_serve_deployment_replica_healthy",
+            wait=False,
+            timeseries=health_timeseries,
         )
-        == 3,
-        timeout=40,
+        return {
+            (m["deployment"], m["application"]) for m in metrics
+        } >= expected_deployments
+
+    wait_for_condition(_check_replica_healthy, timeout=40)
+    health_metrics = get_metric_dictionaries(
+        "ray_serve_deployment_replica_healthy", timeseries=health_timeseries
     )
-    health_metrics = get_metric_dictionaries("ray_serve_deployment_replica_healthy")
-    expected_output = {
-        ("f", "app1"),
-        ("g", "app2"),
-        ("h", "app3"),
-    }
     assert {
         (health_metric["deployment"], health_metric["application"])
         for health_metric in health_metrics
-    } == expected_output
+    } >= expected_deployments
 
 
 def test_deployment_error_counter_exception_type(metrics_start_shutdown):

--- a/python/ray/serve/tests/test_metrics_haproxy.py
+++ b/python/ray/serve/tests/test_metrics_haproxy.py
@@ -30,6 +30,7 @@ import ray
 from ray import serve
 from ray._common.network_utils import parse_address
 from ray._common.test_utils import (
+    PrometheusTimeseries,
     SignalActor,
     fetch_prometheus_metrics,
     wait_for_condition,
@@ -908,23 +909,27 @@ def test_replica_metrics_fields(metrics_start_shutdown):
         err_requests[0]["application"],
     ) == expected_output
 
-    wait_for_condition(
-        lambda: len(
-            get_metric_dictionaries("ray_serve_deployment_replica_healthy", wait=False)
+    expected_deployments = {("f", "app1"), ("g", "app2"), ("h", "app3")}
+    health_timeseries = PrometheusTimeseries()
+
+    def _check_replica_healthy():
+        metrics = get_metric_dictionaries(
+            "ray_serve_deployment_replica_healthy",
+            wait=False,
+            timeseries=health_timeseries,
         )
-        == 3,
-        timeout=40,
+        return {
+            (m["deployment"], m["application"]) for m in metrics
+        } >= expected_deployments
+
+    wait_for_condition(_check_replica_healthy, timeout=40)
+    health_metrics = get_metric_dictionaries(
+        "ray_serve_deployment_replica_healthy", timeseries=health_timeseries
     )
-    health_metrics = get_metric_dictionaries("ray_serve_deployment_replica_healthy")
-    expected_output = {
-        ("f", "app1"),
-        ("g", "app2"),
-        ("h", "app3"),
-    }
     assert {
         (health_metric["deployment"], health_metric["application"])
         for health_metric in health_metrics
-    } == expected_output
+    } >= expected_deployments
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows")


### PR DESCRIPTION
## Summary

- Fix flaky `test_replica_metrics_fields` in `test_metrics.py` and `test_metrics_haproxy.py`
- Root cause: `ray_serve_deployment_replica_healthy` gauge values are **ephemeral** in Ray's OpenTelemetry pipeline — `CollectGaugeMetricValues` in `open_telemetry_metric_recorder.cc:222` calls `clear()` on the observations map after each export cycle
- Combined with the `_set_health_gauge` throttle cache (default 10s TTL), each deployment's gauge is only visible for ~1s out of every ~10s. Different deployments' caches expire at different offsets, so **all 3 gauges never appear in the same Prometheus scrape**
- Fix: use a shared `PrometheusTimeseries` across retries to accumulate samples, and wait for the expected set of `(deployment, application)` pairs rather than an exact count

## Changes

1. **Shared `PrometheusTimeseries`**: Instead of creating a fresh timeseries per retry (which only captures a single-instant snapshot), reuse one across retries so gauge samples accumulate even if they appear at different times.

2. **Wait on deployment set, not count**: The wait condition now checks that the expected `{("f","app1"), ("g","app2"), ("h","app3")}` deployment pairs are all present, rather than checking `len == 3`. This is both more precise (won't pass if one replica reports 3 times) and more robust (tolerates stale entries from restarted replicas).

## Root Cause Details

Ray gauge metrics use OpenTelemetry **observable instruments** with a callback pattern. When the OTel SDK collects metrics, it calls `CollectGaugeMetricValues` which:
1. Iterates stored observations and exports them
2. **Clears the map** (`it->second.clear()`)

After clearing, the gauge disappears from the `/metrics` endpoint until `Gauge.set()` is called again. Counters and histograms use **synchronous instruments** and are not affected.

The `_set_health_gauge` throttle cache (`RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S`, default 10s, 0.1s in BUILD.bazel) skips redundant `Gauge.set()` calls. This means the gauge is only re-set every ~10s, and only visible for ~1s after each set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)