### PR TITLE
[tune] fix dark mode readability for status/progress tables

### DIFF
--- a/python/ray/widgets/templates/trial_progress.html.j2
+++ b/python/ray/widgets/templates/trial_progress.html.j2
@@ -14,4 +14,18 @@
 .trialProgress td {
   white-space: nowrap;
 }
+
+:root[data-jp-theme-light="false"] .trialProgress,
+body.vscode-dark .trialProgress {
+  --tp-bg: var(--jp-layout-color1, #1e1e1e);
+  --tp-fg: var(--jp-content-font-color1, #e0e0e0);
+}
+
+.trialProgress table,
+.trialProgress th,
+.trialProgress td {
+  background-color: var(--tp-bg, #fff);
+  color: var(--tp-fg, #000);
+  border: 1px solid var(--jp-border-color0, #444);
+}
 </style>

--- a/python/ray/widgets/templates/trial_progress.html.j2
+++ b/python/ray/widgets/templates/trial_progress.html.j2
@@ -6,7 +6,9 @@
 .trialProgress {
   display: flex;
   flex-direction: column;
-  color: var(--jp-ui-font-color1);
+  --tp-bg: var(--jp-layout-color1, #fff);
+  --tp-fg: var(--jp-content-font-color1, #000);
+  color: var(--tp-fg);
 }
 .trialProgress h3 {
   font-weight: bold;
@@ -21,11 +23,15 @@ body.vscode-dark .trialProgress {
   --tp-fg: var(--jp-content-font-color1, #e0e0e0);
 }
 
+.trialProgress table {
+  border-collapse: collapse;
+}
+
 .trialProgress table,
 .trialProgress th,
 .trialProgress td {
-  background-color: var(--tp-bg, #fff);
-  color: var(--tp-fg, #000);
-  border: 1px solid var(--jp-border-color0, #444);
+  background-color: var(--tp-bg);
+  color: var(--tp-fg);
+  border: var(--jp-border-width, 1px) solid var(--jp-border-color0, #444);
 }
 </style>

--- a/python/ray/widgets/templates/tune_status.html.j2
+++ b/python/ray/widgets/templates/tune_status.html.j2
@@ -46,4 +46,18 @@
   border-left-style: solid;
   margin: 0.5em 1em 0.5em 1em;
 }
+
+:root[data-jp-theme-light="false"] .tuneStatus,
+body.vscode-dark .tuneStatus {
+  --ts-bg: var(--jp-layout-color1, #1e1e1e);
+  --ts-fg: var(--jp-content-font-color1, #e0e0e0);
+}
+
+.tuneStatus table,
+.tuneStatus th,
+.tuneStatus td {
+  background-color: var(--ts-bg, #fff);
+  color: var(--ts-fg, #000);
+  border: 1px solid var(--jp-border-color0, #444);
+}
 </style>

--- a/python/ray/widgets/templates/tune_status.html.j2
+++ b/python/ray/widgets/templates/tune_status.html.j2
@@ -19,7 +19,9 @@
 </div>
 <style>
 .tuneStatus {
-  color: var(--jp-ui-font-color1);
+  --ts-bg: var(--jp-layout-color1, #fff);
+  --ts-fg: var(--jp-content-font-color1, #000);
+  color: var(--ts-fg);
 }
 .tuneStatus .systemInfo {
   display: flex;
@@ -53,11 +55,15 @@ body.vscode-dark .tuneStatus {
   --ts-fg: var(--jp-content-font-color1, #e0e0e0);
 }
 
+.tuneStatus table {
+  border-collapse: collapse;
+}
+
 .tuneStatus table,
 .tuneStatus th,
 .tuneStatus td {
-  background-color: var(--ts-bg, #fff);
-  color: var(--ts-fg, #000);
-  border: 1px solid var(--jp-border-color0, #444);
+  background-color: var(--ts-bg);
+  color: var(--ts-fg);
+  border: var(--jp-border-width, 1px) solid var(--jp-border-color0, #444);
 }
 </style>


### PR DESCRIPTION
## Why are these changes needed?

`JupyterNotebookReporter` renders two HTML templates (`tune_status.html.j2` and `trial_progress.html.j2`) to display live status and trial-progress tables. 
These templates originally styled only the container divs, so table cells inherited a dark background and a dark font colour in notebook dark themes.
As a result, users saw an "empty" table when running `tuner.fit()` in dark mode (see #52656).

This PR appends a small, theme-aware CSS block to both templates that:
* Uses JupyterLab's public CSS variables (`--jp-layout-color1`, `--jp-content-font-color1`, `--jp-border-color0`) for automatic theme switching;
* Falls back to `#fff/#000` in plain HTML viewers;
* Leaves light-theme appearance unchanged.

*(Note: This is a continuation of the abandoned PR #53969 which was closed due to inactivity. I am recreating this PR from #62363 to satisfy the DCO compliance check with the exact requested `noreply` email).*

## Related issue number
Closes #52656

## Checks
- [x] I've signed off every commit (using `git commit -s`).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] No doc/API changes required (HTML templates only).
- [x] Manual test: verified visibility in JupyterLab Dark, VS Code Dark+, and a light theme.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested (template-only change; manually validated)