### PR TITLE
[core] Fix overflow on exponential backoff multiplication

### DIFF
--- a/src/ray/util/exponential_backoff.cc
+++ b/src/ray/util/exponential_backoff.cc
@@ -22,12 +22,16 @@ namespace ray {
 uint64_t ExponentialBackoff::GetBackoffMs(uint64_t attempt,
                                           uint64_t base_ms,
                                           uint64_t max_backoff_ms) {
-  auto delay = static_cast<uint64_t>(pow(2, attempt));
-  // Use max_backoff_ms if there is an overflow.
-  if (delay == 0) {
-    return max_backoff_ms;
-  }
-  return std::min(base_ms * delay, max_backoff_ms);
+// Avoid overflowing (2 ^ attempt).
+if (attempt >= 63) {
+  return max_backoff_ms;
+}
+uint64_t multiple = static_cast<uint64_t>(pow(2, attempt));
+// Avoid overflowing the multiplication.
+if (multiple > 0 && base_ms > max_backoff_ms / multiple) {
+  return max_backoff_ms;
+}
+return std::min(base_ms * multiple, max_backoff_ms);
 };
 
 }  // namespace ray

--- a/src/ray/util/exponential_backoff.cc
+++ b/src/ray/util/exponential_backoff.cc
@@ -23,10 +23,13 @@ uint64_t ExponentialBackoff::GetBackoffMs(uint64_t attempt,
                                           uint64_t base_ms,
                                           uint64_t max_backoff_ms) {
   // Avoid overflowing (2 ^ attempt).
-  if (attempt >= 63) {
+  if (attempt > 63) {
     return max_backoff_ms;
   }
-  uint64_t multiple = static_cast<uint64_t>(pow(2, attempt));
+
+  // Equivalent to (2 ^ attempt).
+  uint64_t multiple = 1ULL << attempt;
+
   // Avoid overflowing the multiplication.
   if (multiple > 0 && base_ms > max_backoff_ms / multiple) {
     return max_backoff_ms;

--- a/src/ray/util/exponential_backoff.cc
+++ b/src/ray/util/exponential_backoff.cc
@@ -22,16 +22,16 @@ namespace ray {
 uint64_t ExponentialBackoff::GetBackoffMs(uint64_t attempt,
                                           uint64_t base_ms,
                                           uint64_t max_backoff_ms) {
-// Avoid overflowing (2 ^ attempt).
-if (attempt >= 63) {
-  return max_backoff_ms;
-}
-uint64_t multiple = static_cast<uint64_t>(pow(2, attempt));
-// Avoid overflowing the multiplication.
-if (multiple > 0 && base_ms > max_backoff_ms / multiple) {
-  return max_backoff_ms;
-}
-return std::min(base_ms * multiple, max_backoff_ms);
+  // Avoid overflowing (2 ^ attempt).
+  if (attempt >= 63) {
+    return max_backoff_ms;
+  }
+  uint64_t multiple = static_cast<uint64_t>(pow(2, attempt));
+  // Avoid overflowing the multiplication.
+  if (multiple > 0 && base_ms > max_backoff_ms / multiple) {
+    return max_backoff_ms;
+  }
+  return std::min(base_ms * multiple, max_backoff_ms);
 };
 
 }  // namespace ray

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -37,13 +37,25 @@ TEST(ExponentialBackoffTest, TestExceedMaxBackoffReturnsMaxBackoff) {
 }
 
 TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
-  // 2 ^ 64+ will overflow.
+  // Test against a large attempt number causing overflow.
   for (int i = 64; i < 10000; i++) {
     auto backoff = ExponentialBackoff::GetBackoffMs(
         /*attempt*/ i,
         /*base_ms*/ 1,
         /*max_backoff_ms*/ 1234);
     ASSERT_EQ(backoff, 1234);
+
+  // Test against an attempt number that doesn't cause overflow but
+  // the base multiple does.
+  uint64_t large_base = std::numeric_limits<uint64_t>::max() / 2;
+  uint64_t max_allowed = std::numeric_limits<uint64_t>::max();
+  
+  auto multiplication_overflow = ExponentialBackoff::GetBackoffMs(
+      /*attempt*/ 2, 
+      /*base_ms*/ large_base, 
+      /*max_backoff_ms*/ max_allowed);
+  
+  ASSERT_EQ(multiplication_overflow, max_allowed);
   }
 }
 

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -48,7 +48,7 @@ TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
     ASSERT_EQ(backoff, 1234);
 
     // Test against an attempt number that doesn't cause overflow but
-    // the base multiple does.
+    // multiplying it against the base backoff does.
     uint64_t large_base = std::numeric_limits<uint64_t>::max() / 2;
     uint64_t max_allowed = std::numeric_limits<uint64_t>::max();
 

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -38,7 +38,7 @@ TEST(ExponentialBackoffTest, TestExceedMaxBackoffReturnsMaxBackoff) {
   ASSERT_EQ(backoff, 5);
 }
 
-TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
+TEST(ExponentialBackoffTest, TestOverflowAttemptNumberExponential) {
   // Test against a large attempt number causing overflow.
   for (int i = 64; i < 10000; i++) {
     auto backoff = ExponentialBackoff::GetBackoffMs(
@@ -46,13 +46,14 @@ TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
         /*base_ms*/ 1,
         /*max_backoff_ms*/ 1234);
     ASSERT_EQ(backoff, 1234);
-
-    // Test against an attempt number that doesn't cause overflow but
-    // multiplying it against the base backoff does.
-    uint64_t large_base = std::numeric_limits<uint64_t>::max() / 2;
-    uint64_t max_allowed = std::numeric_limits<uint64_t>::max();
   }
+}
 
+TEST(ExponentialBackoffTest, TestOverflowBaseMultiplication) {
+  // Test against an attempt number that doesn't cause overflow but
+  // multiplying it against the base backoff does.
+  uint64_t large_base = std::numeric_limits<uint64_t>::max() / 2;
+  uint64_t max_allowed = std::numeric_limits<uint64_t>::max();
   auto multiplication_overflow = ExponentialBackoff::GetBackoffMs(
       /*attempt*/ 2,
       /*base_ms*/ large_base,

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -14,6 +14,7 @@
 
 #include "ray/util/exponential_backoff.h"
 
+#include <limits>
 #include <math.h>
 
 #include "gtest/gtest.h"
@@ -45,17 +46,17 @@ TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
         /*max_backoff_ms*/ 1234);
     ASSERT_EQ(backoff, 1234);
 
-  // Test against an attempt number that doesn't cause overflow but
-  // the base multiple does.
-  uint64_t large_base = std::numeric_limits<uint64_t>::max() / 2;
-  uint64_t max_allowed = std::numeric_limits<uint64_t>::max();
-  
-  auto multiplication_overflow = ExponentialBackoff::GetBackoffMs(
-      /*attempt*/ 2, 
-      /*base_ms*/ large_base, 
-      /*max_backoff_ms*/ max_allowed);
-  
-  ASSERT_EQ(multiplication_overflow, max_allowed);
+    // Test against an attempt number that doesn't cause overflow but
+    // the base multiple does.
+    uint64_t large_base = std::numeric_limits<uint64_t>::max() / 2;
+    uint64_t max_allowed = std::numeric_limits<uint64_t>::max();
+
+    auto multiplication_overflow = ExponentialBackoff::GetBackoffMs(
+        /*attempt*/ 2,
+        /*base_ms*/ large_base,
+        /*max_backoff_ms*/ max_allowed);
+
+    ASSERT_EQ(multiplication_overflow, max_allowed);
   }
 }
 

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -51,14 +51,14 @@ TEST(ExponentialBackoffTest, TestOverflowReturnsMaxBackoff) {
     // multiplying it against the base backoff does.
     uint64_t large_base = std::numeric_limits<uint64_t>::max() / 2;
     uint64_t max_allowed = std::numeric_limits<uint64_t>::max();
-
-    auto multiplication_overflow = ExponentialBackoff::GetBackoffMs(
-        /*attempt*/ 2,
-        /*base_ms*/ large_base,
-        /*max_backoff_ms*/ max_allowed);
-
-    ASSERT_EQ(multiplication_overflow, max_allowed);
   }
+
+  auto multiplication_overflow = ExponentialBackoff::GetBackoffMs(
+      /*attempt*/ 2,
+      /*base_ms*/ large_base,
+      /*max_backoff_ms*/ max_allowed);
+
+  ASSERT_EQ(multiplication_overflow, max_allowed);
 }
 
 TEST(ExponentialBackoffTest, GetNext) {

--- a/src/ray/util/tests/exponential_backoff_test.cc
+++ b/src/ray/util/tests/exponential_backoff_test.cc
@@ -14,8 +14,9 @@
 
 #include "ray/util/exponential_backoff.h"
 
-#include <limits>
 #include <math.h>
+
+#include <limits>
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
We guarded against overflow by checking the result of the exponential, but there could still be an overflow when multiplying against `base_ms`.