### PR TITLE
Add JAX profiler for TPU

### DIFF
--- a/doc/source/ray-core/api/utility.rst
+++ b/doc/source/ray-core/api/utility.rst
@@ -22,6 +22,7 @@ Utility
    ray.util.tpu.get_tpu_num_slices_for_workers
    ray.util.tpu.get_tpu_version_from_type
    ray.util.tpu.get_tpu_worker_resources
+   ray.util.tpu.init_jax_profiler
 
    ray.util.tpu.SlicePlacementGroup
    ray.util.tpu.slice_placement_group

--- a/python/ray/dashboard/modules/reporter/jax_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/jax_profile_manager.py
@@ -1,0 +1,101 @@
+import asyncio
+import logging
+from concurrent.futures import Future, ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class JaxProfilingManager:
+    """JAX profiling manager for Ray Dashboard.
+
+    It connects to the JAX profiler server running on the worker
+    and captures a trace using TensorFlow's profiler client.
+    """
+
+    def __init__(self, profile_dir_path: str):
+        self._root_log_dir = Path(profile_dir_path)
+        self._profile_dir_path = self._root_log_dir / "profiles"
+        self._profile_dir_path.mkdir(parents=True, exist_ok=True)
+        self._executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="jax_profiling_executor"
+        )
+        self._inflight: Optional[Future] = None
+
+    async def jax_profile(
+        self, pid: int, port: int, duration_s: int = 5
+    ) -> Tuple[bool, str]:
+        """Perform JAX profiling by connecting to the JAX server.
+
+        Args:
+            pid: The process ID of the target process (for logging/tracking).
+            port: The port where JAX profiler server is listening.
+            duration_s: Duration of the profiling in seconds.
+
+        Returns:
+            Tuple[bool, str]: (success, trace file path relative to root log dir)
+        """
+        if self._inflight is not None and not self._inflight.done():
+            return (
+                False,
+                "Another JAX profiling session is already in progress on this node.",
+            )
+
+        try:
+            from tensorflow.python.profiler import profiler_client
+        except ImportError as e:
+            return (
+                False,
+                "TensorFlow is required to capture JAX profiles from the Dashboard. "
+                f"Please install `tensorflow` on the node. Error: {e}",
+            )
+
+        address = f"grpc://localhost:{port}"
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        capture_dir = self._profile_dir_path / f"{pid}_{timestamp}"
+        logger.info(
+            f"Capturing JAX profile from {address} for pid {pid} "
+            f"for {duration_s} seconds..."
+        )
+
+        def _capture():
+            try:
+                # profiler_client.trace captures the trace and saves it to logdir
+                profiler_client.trace(
+                    address,
+                    logdir=str(capture_dir),
+                    duration_ms=duration_s * 1000,
+                )
+                return True, ""
+            except Exception as e:
+                return False, f"Failed to capture trace: {e}"
+
+        # Run in executor because trace is blocking
+        future = self._executor.submit(_capture)
+        self._inflight = future
+        try:
+            success, error_msg = await asyncio.wait_for(
+                asyncio.wrap_future(future),
+                timeout=duration_s + 20,
+            )
+        except asyncio.TimeoutError:
+            logger.error(
+                f"JAX profiling timed out after {duration_s + 20} seconds. "
+                "The capture may still be finishing in the background."
+            )
+            return (
+                False,
+                f"JAX profiling timed out after {duration_s + 20} seconds. "
+                "The capture may still be finishing, retry shortly.",
+            )
+
+        if not success:
+            logger.error(f"JAX profiling failed: {error_msg}")
+            return False, error_msg
+
+        logger.info(f"JAX profiling finished. Files saved in {capture_dir}")
+
+        # Return the directory path relative to the root log directory
+        return True, str(capture_dir.relative_to(self._root_log_dir))

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -66,6 +66,7 @@ from ray.dashboard.modules.reporter.gpu_providers import (
     GpuUtilizationInfo,
     TpuUtilizationInfo,
 )
+from ray.dashboard.modules.reporter.jax_profile_manager import JaxProfilingManager
 from ray.dashboard.modules.reporter.profile_manager import (
     CpuProfilingManager,
     MemoryProfilingManager,
@@ -552,6 +553,10 @@ class ReporterAgent(
         )
         self._gpu_profiling_manager.start_monitoring_daemon()
 
+        self._jax_profiling_manager = JaxProfilingManager(
+            profile_dir_path=self._log_dir
+        )
+
         # Create GPU metric provider instance
         self._gpu_metric_provider = GpuMetricProvider()
 
@@ -597,6 +602,15 @@ class ReporterAgent(
             pid=pid, num_iterations=num_iterations
         )
         return reporter_pb2.GpuProfilingReply(success=success, output=output)
+
+    async def JaxProfiling(self, request, context):
+        pid = request.pid
+        port = request.port
+        duration = request.duration if request.HasField("duration") else 5
+        success, output = await self._jax_profiling_manager.jax_profile(
+            pid=pid, port=port, duration_s=duration
+        )
+        return reporter_pb2.JaxProfilingReply(success=success, output=output)
 
     async def MemoryProfiling(self, request, context):
         pid = request.pid

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -380,7 +380,12 @@ class ReportHead(SubprocessModule):
         attempt_number = req.query.get("attempt_number")
         node_id_hex = req.query.get("node_id")
 
-        duration_s = int(req.query.get("duration", 5))
+        try:
+            duration_s = int(req.query.get("duration", 5))
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(
+                text="duration query parameter must be an integer"
+            )
         if duration_s > 60:
             raise ValueError(f"The max duration allowed is 60 seconds: {duration_s}.")
         format = req.query.get("format", "flamegraph")
@@ -504,7 +509,10 @@ class ReportHead(SubprocessModule):
         logger.info(
             f"Sending stack trace request to {build_address(ip, grpc_port)}, pid {pid}, with native={native}, subprocesses={subprocesses}"
         )
-        pid = int(pid)
+        try:
+            pid = int(pid)
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(text="pid must be an integer")
         reply = await reporter_stub.GetTraceback(
             reporter_pb2.GetTracebackRequest(
                 pid=pid, native=native, subprocesses=subprocesses
@@ -572,8 +580,16 @@ class ReportHead(SubprocessModule):
         node_id, ip, http_port, grpc_port = addrs
         reporter_stub = self._make_stub(build_address(ip, grpc_port))
 
-        pid = int(pid)
-        duration_s = int(req.query.get("duration", 5))
+        try:
+            pid = int(pid)
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(text="pid must be an integer")
+        try:
+            duration_s = int(req.query.get("duration", 5))
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(
+                text="duration query parameter must be an integer"
+            )
         if duration_s > 60:
             raise ValueError(f"The max duration allowed is 60 seconds: {duration_s}.")
         format = req.query.get("format", "flamegraph")
@@ -667,17 +683,23 @@ class ReportHead(SubprocessModule):
         reporter_stub = self._make_stub(build_address(ip, grpc_port))
 
         # Profile for num_iterations training steps (calls to optimizer.step())
-        num_iterations = int(req.query.get("num_iterations", 4))
+        try:
+            num_iterations = int(req.query.get("num_iterations", 4))
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(text="num_iterations must be an integer")
 
         logger.info(
             f"Sending GPU profiling request to {build_address(ip, grpc_port)}, pid {pid}. "
             f"Profiling for {num_iterations} training steps."
         )
 
+        try:
+            pid = int(pid)
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(text="pid must be an integer")
+
         reply = await reporter_stub.GpuProfiling(
-            reporter_pb2.GpuProfilingRequest(
-                pid=int(pid), num_iterations=num_iterations
-            )
+            reporter_pb2.GpuProfilingRequest(pid=pid, num_iterations=num_iterations)
         )
 
         if not reply.success:
@@ -697,6 +719,111 @@ class ReportHead(SubprocessModule):
         )
         redirect_url = f"/api/v0/logs/file?{query}"
         raise aiohttp.web.HTTPFound(redirect_url)
+
+    @routes.get("/worker/jax_profile")
+    async def jax_profile(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
+        """Retrieves the JAX profile trace for a specific worker.
+
+        Params:
+            req: A request with the following query parameters:
+                pid: Required. The PID of the worker.
+                port: Optional. The port where JAX profiler server is listening.
+                      If not provided, it will be automatically discovered from GCS.
+                ip or node_id: Required. The IP address or hex ID of the node.
+                duration: Optional. Duration in seconds for profiling (default: 5).
+
+        Returns:
+            JSON response with the path where trace files are saved.
+        """
+        if not RAY_DASHBOARD_ENABLE_PROFILING:
+            return self._profiling_disabled_response()
+
+        pid = req.query.get("pid")
+        port = req.query.get("port")
+        ip = req.query.get("ip")
+        node_id_hex = req.query.get("node_id")
+
+        if not pid:
+            raise ValueError("pid is required")
+        if not node_id_hex and not ip:
+            raise ValueError("ip or node_id is required")
+
+        if node_id_hex:
+            addrs = await self._get_stub_address_by_node_id(
+                NodeID.from_hex(node_id_hex)
+            )
+            if not addrs:
+                raise aiohttp.web.HTTPInternalServerError(
+                    text=f"Failed to get agent address for node at node_id {node_id_hex}"
+                )
+        else:
+            addrs = await self._get_stub_address_by_ip(ip)
+            if not addrs:
+                raise aiohttp.web.HTTPInternalServerError(
+                    text=f"Failed to get agent address for node at IP {ip}"
+                )
+
+        node_id, ip, http_port, grpc_port = addrs
+        reporter_stub = self._make_stub(build_address(ip, grpc_port))
+
+        try:
+            duration_s = int(req.query.get("duration", 5))
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(
+                text="duration query parameter must be an integer"
+            )
+        try:
+            pid = int(pid)
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(text="pid must be an integer")
+
+        if not port:
+            port_bytes = await self.gcs_client.async_internal_kv_get(
+                f"jax_profiler_port:{node_id.hex()}:{pid}".encode(),
+                namespace=KV_NAMESPACE_DASHBOARD,
+                timeout=GCS_RPC_TIMEOUT_SECONDS,
+            )
+            if port_bytes:
+                try:
+                    port = int(port_bytes.decode())
+                except (UnicodeDecodeError, ValueError):
+                    raise aiohttp.web.HTTPInternalServerError(
+                        text=(
+                            f"Discovered JAX profiler port for worker {pid} on node"
+                            f"{node_id.hex()} is corrupt: {port_bytes!r}"
+                        )
+                    )
+            else:
+                raise aiohttp.web.HTTPBadRequest(
+                    text=(
+                        f"port is required because JAX profiler port could not be "
+                        f"automatically discovered for worker {pid} on node {node_id.hex()}"
+                    )
+                )
+        else:
+            try:
+                port = int(port)
+            except ValueError:
+                raise aiohttp.web.HTTPBadRequest(text="port must be an integer")
+
+        logger.info(
+            f"Sending JAX profiling request to {build_address(ip, grpc_port)}, pid {pid}, port {port}"
+        )
+
+        reply = await reporter_stub.JaxProfiling(
+            reporter_pb2.JaxProfilingRequest(pid=pid, port=port, duration=duration_s)
+        )
+
+        if not reply.success:
+            return aiohttp.web.HTTPInternalServerError(text=reply.output)
+
+        logger.info("Returning profiling response, location {}".format(reply.output))
+
+        return dashboard_optional_utils.rest_response(
+            status_code=dashboard_utils.HTTPStatusCode.OK,
+            message="JAX profiling finished.",
+            trace_directory=reply.output,
+        )
 
     @routes.get("/memory_profile")
     async def memory_profile(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
@@ -740,14 +867,14 @@ class ReportHead(SubprocessModule):
         # Either is_task or not, we need to get ip and grpc_port.
         if is_task:
             if "attempt_number" not in req.query:
-                return aiohttp.web.HTTPInternalServerError(
+                raise aiohttp.web.HTTPBadRequest(
                     text=(
                         "Failed to execute task profiling: "
                         "task's attempt number is required"
                     )
                 )
             if "node_id" not in req.query:
-                return aiohttp.web.HTTPInternalServerError(
+                raise aiohttp.web.HTTPBadRequest(
                     text=(
                         "Failed to execute task profiling: "
                         "task's node id is required"
@@ -772,7 +899,12 @@ class ReportHead(SubprocessModule):
                 )
             _, ip, _, grpc_port = addrs
         else:
-            pid = int(req.query["pid"])
+            if "pid" not in req.query:
+                raise aiohttp.web.HTTPBadRequest(text="pid is required")
+            try:
+                pid = int(req.query["pid"])
+            except ValueError:
+                raise aiohttp.web.HTTPBadRequest(text="pid must be an integer")
             ip = req.query.get("ip")
             node_id_hex = req.query.get("node_id")
 
@@ -799,7 +931,12 @@ class ReportHead(SubprocessModule):
         assert pid is not None
         ip_port = build_address(ip, grpc_port)
 
-        duration_s = int(req.query.get("duration", 10))
+        try:
+            duration_s = int(req.query.get("duration", 10))
+        except ValueError:
+            raise aiohttp.web.HTTPBadRequest(
+                text="duration query parameter must be an integer"
+            )
 
         # Default not using `--native`, `--leaks` and `--format` for profiling
         format = req.query.get("format", "flamegraph")

--- a/python/ray/dashboard/modules/reporter/tests/test_jax_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_jax_profiler_manager.py
@@ -1,0 +1,106 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ray.dashboard.modules.reporter.jax_profile_manager import JaxProfilingManager
+from ray.util.tpu import init_jax_profiler
+
+
+@pytest.fixture
+def mock_profiler_client():
+    mock_client = MagicMock()
+    mock_profiler_module = MagicMock()
+    mock_profiler_module.profiler_client = mock_client
+
+    modules_to_patch = {
+        "tensorflow": MagicMock(),
+        "tensorflow.python": MagicMock(),
+        "tensorflow.python.profiler": mock_profiler_module,
+    }
+
+    with patch.dict("sys.modules", modules_to_patch):
+        yield mock_client
+
+
+@pytest.mark.asyncio
+async def test_jax_profile_success(tmp_path, mock_profiler_client):
+    manager = JaxProfilingManager(tmp_path)
+
+    # Mock success
+    mock_profiler_client.trace.return_value = None
+
+    success, output = await manager.jax_profile(pid=123, port=6000, duration_s=2)
+
+    assert success
+    assert output.startswith("profiles")
+    assert "123_" in output
+
+    mock_profiler_client.trace.assert_called_once()
+    call = mock_profiler_client.trace.call_args
+    assert call.args[0] == "grpc://localhost:6000"
+    assert call.kwargs["logdir"].startswith(str(tmp_path / "profiles"))
+    assert call.kwargs["duration_ms"] == 2000
+
+
+@pytest.mark.asyncio
+async def test_jax_profile_failure(tmp_path, mock_profiler_client):
+    manager = JaxProfilingManager(tmp_path)
+
+    # Mock failure
+    mock_profiler_client.trace.side_effect = Exception("Connection failed")
+
+    success, output = await manager.jax_profile(pid=123, port=6000, duration_s=2)
+
+    assert not success
+    assert "Failed to capture trace: Connection failed" in output
+
+
+@pytest.mark.asyncio
+async def test_jax_profile_no_tensorflow(tmp_path):
+    manager = JaxProfilingManager(tmp_path)
+
+    # Force ImportError on tensorflow
+    with patch.dict("sys.modules", {"tensorflow": None}):
+        success, output = await manager.jax_profile(pid=123, port=6000, duration_s=2)
+
+        assert not success
+        assert "TensorFlow is required" in output
+
+
+@patch("ray.util.tpu.os.getpid")
+@patch("ray.util.tpu.os.getenv")
+def test_setup_jax_profiler_success(mock_getenv, mock_getpid):
+    mock_getenv.return_value = "9999"
+    mock_getpid.return_value = 12345
+
+    mock_jax = MagicMock()
+    mock_worker = MagicMock()
+    mock_worker.node.node_id = "mock_node_id_hex"
+
+    with (
+        patch.dict("sys.modules", {"jax": mock_jax}),
+        patch("ray._private.worker.global_worker", mock_worker),
+        patch("ray.experimental.internal_kv._internal_kv_put") as mock_kv_put,
+    ):
+
+        init_jax_profiler()
+
+        mock_jax.profiler.start_server.assert_called_once_with(9999)
+        import ray
+
+        mock_kv_put.assert_called_once_with(
+            "jax_profiler_port:mock_node_id_hex:12345",
+            b"9999",
+            namespace=ray._private.ray_constants.KV_NAMESPACE_DASHBOARD,
+        )
+
+
+def test_setup_jax_profiler_no_jax():
+    with patch.dict("sys.modules", {"jax": None}):
+        # Should skip starting profiler and not raise error
+        init_jax_profiler()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -1,5 +1,7 @@
+import atexit
 import logging
 import math
+import os
 from typing import Any, Dict, List, Optional, Tuple
 
 import ray
@@ -765,3 +767,77 @@ def slice_placement_group(
         chips_per_vm=chips_per_vm,
         **kwargs,
     )
+
+
+@PublicAPI(stability="alpha")
+def init_jax_profiler(port: Optional[int] = None) -> None:
+    """Setup JAX Profiler server for in-process JAX profiling.
+
+    This opens a background gRPC profiling port inside the current worker process
+    and automatically registers the port to GCS internal_kv so that the Ray Dashboard
+    can discover the profiling endpoint.
+
+    Args:
+        port: The port where JAX profiler server should listen. If None, it reads the
+              port from JAX_PROFILER_PORT environment variable (default: 9999).
+
+    Note:
+        JAX profiling is inherently an in-process operation. The JAX profiler server
+        must run inside the memory space of the target worker process executing the
+        JAX/XLA code in order to capture trace events, Python thread stacks, and XLA
+        execution times.
+    """
+    logger = logging.getLogger(__name__)
+
+    try:
+        import jax
+
+        if port is None:
+            port = int(os.getenv("JAX_PROFILER_PORT", "9999"))
+        try:
+            # NOTE: We assume there is at most one JAX worker process per host/node
+            # (which is typical for multi-host JAX/TPU VM training). Therefore, we attempt
+            # to bind directly to a single port without dynamically scanning a range.
+            # If this assumption is relaxed in the future (e.g. multiple JAX workers per node),
+            # we should consider switching to dynamic port scanning/allocation.
+            jax.profiler.start_server(port)
+            logger.info(f"Started JAX profiler server on port {port}")
+
+            # Register the JAX profiler port in GCS internal_kv so dashboard head can auto-discover it.
+            try:
+                worker = ray._private.worker.global_worker
+                if worker and hasattr(worker, "node") and worker.node:
+                    node_id_hex = worker.node.node_id
+                    pid = os.getpid()
+                    key = f"jax_profiler_port:{node_id_hex}:{pid}"
+                    ray.experimental.internal_kv._internal_kv_put(
+                        key,
+                        str(port).encode(),
+                        namespace=ray._private.ray_constants.KV_NAMESPACE_DASHBOARD,
+                    )
+                    logger.info(
+                        f"Registered JAX profiler port {port} in GCS internal_kv"
+                    )
+
+                    atexit.register(_cleanup_jax_profiler_kv, key)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to register JAX profiler port in internal_kv: {e}"
+                )
+
+        except Exception as e:
+            logger.error(f"Failed to start JAX profiler server on port {port}: {e}")
+    except ImportError:
+        logger.warning("JAX is not installed, skipping JAX profiler setup")
+    except Exception as e:
+        logger.error(f"Failed to start JAX profiler server: {e}")
+
+
+def _cleanup_jax_profiler_kv(key: str) -> None:
+    try:
+        ray.experimental.internal_kv._internal_kv_del(
+            key,
+            namespace=ray._private.ray_constants.KV_NAMESPACE_DASHBOARD,
+        )
+    except Exception:
+        pass

--- a/src/ray/protobuf/reporter.proto
+++ b/src/ray/protobuf/reporter.proto
@@ -82,6 +82,19 @@ message MemoryProfilingReply {
   optional string warning = 3;
 }
 
+// JAX profiler request
+message JaxProfilingRequest {
+  uint32 pid = 1;
+  uint32 port = 2;
+  optional uint32 duration = 3;
+}
+
+// JAX profiler result
+message JaxProfilingReply {
+  bool success = 1;
+  string output = 2;
+}
+
 message ReportOCMetricsRequest {
   repeated opencensus.proto.metrics.v1.Metric metrics = 1;
   bytes worker_id = 2;
@@ -101,6 +114,7 @@ service ReporterService {
   rpc CpuProfiling(CpuProfilingRequest) returns (CpuProfilingReply);
   rpc GpuProfiling(GpuProfilingRequest) returns (GpuProfilingReply);
   rpc MemoryProfiling(MemoryProfilingRequest) returns (MemoryProfilingReply);
+  rpc JaxProfiling(JaxProfilingRequest) returns (JaxProfilingReply);
   // Health check to validate whether the service is running
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckReply);
 }


### PR DESCRIPTION
## Description
> Briefly describe what this PR accomplishes and why it's needed.

This PR adds support for capturing JAX execution profiles directly from the Ray Dashboard. This is particularly useful for debugging performance issues in JAX-based workloads running on TPU clusters.
To maintain consistency, this implementation follows the existing pattern established by the GPU profiler ([GpuProfilingManager](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/modules/reporter/gpu_profile_manager.py#L20)) in the Ray dashboard.

Changes:
1. reporter_head.py: Added a new HTTP endpoint /worker/jax_profile to the dashboard head. This endpoint receives profiling requests and routes them via gRPC to the appropriate ReporterAgent on the target node.
2. reporter_agent.py: Added handling for the JaxProfiling gRPC request and instantiated the JaxProfilingManager
3. reporter.proto: Defined JaxProfilingRequest and JaxProfilingReply messages and added the JaxProfiling RPC method to the ReporterService
4. jax_profile_manager.py: Created this new manager to handle the actual profiling interaction. It uses tensorflow.python.profiler.profiler_client to connect to the JAX profiler server running on the worker process.
5. Unit tests to verify success and failure paths of the profiling manager, including mocking the TensorFlow profiler client.

How to verify:
1. Trigger profiling via curl or browser:
```
curl "http://<dashboard-ip>:<port>/worker/jax_profile?pid=<worker_pid>&port=<jax_port>&ip=<worker_ip>&duration=5"
```
2. expected response
```
{"result": true, "msg": "JAX profiling finished.", "data": {"traceDirectory": "profiles"}}
```
3. View in Tensorboard: Copy the generated `.xplane.pb` file from the worker pod's log directory and view it using the TensorBoard profile plugin.

## Related issues

## Additional information

Captured JAX profile, rendered via TensorBoard:

Overview: 
<img width="3456" height="2160" alt="image" src="https://github.com/user-attachments/assets/869df329-7f1d-4649-bfe0-dc1b2eb22d1f" />

Trace view:
<img width="3428" height="1852" alt="image" src="https://github.com/user-attachments/assets/df7a40c1-1f23-47e1-9fa4-df41cebd7e3d" />

