### PR TITLE
[Data] Fix concurrent writes race condition in write_parquet

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -16,17 +16,6 @@ if TYPE_CHECKING:
 
 WRITE_FILE_MAX_ATTEMPTS = 10
 WRITE_FILE_RETRY_MAX_BACKOFF_SECONDS = 32
-
-# Map Ray Data's SaveMode to pyarrow's existing_data_behavior property which is exposed via the
-# `pyarrow.dataset.write_dataset` function.
-# Docs: https://arrow.apache.org/docs/python/generated/pyarrow.dataset.write_dataset.html
-EXISTING_DATA_BEHAVIOR_MAP = {
-    SaveMode.APPEND: "overwrite_or_ignore",
-    SaveMode.OVERWRITE: "overwrite_or_ignore",  # delete_matching is not a suitable choice for parallel writes.
-    SaveMode.IGNORE: "overwrite_or_ignore",
-    SaveMode.ERROR: "overwrite_or_ignore",
-}
-
 FILE_FORMAT = "parquet"
 
 # These args are part of https://arrow.apache.org/docs/python/generated/pyarrow.fs.FileSystem.html#pyarrow.fs.FileSystem.open_output_stream
@@ -278,9 +267,8 @@ class ParquetDatasink(_FileDatasink):
 
         row_group_size = write_kwargs.pop("row_group_size", None)
 
-        existing_data_behavior = EXISTING_DATA_BEHAVIOR_MAP.get(
-            self.mode, "overwrite_or_ignore"
-        )
+        # We set this to "overwrite_or_ignore", to avoid the race condition seen in parallel writes when this is set to "error". The driver already handles the save mode check in on_write_start.
+        existing_data_behavior = "overwrite_or_ignore"
 
         (
             min_rows_per_group,
@@ -294,6 +282,7 @@ class ParquetDatasink(_FileDatasink):
 
         basename_template = self._get_basename_template(filename, write_uuid)
 
+        # Note that the driver already handles the save mode logic, checking if the directory exists and raising an error if it does on SaveMode.ERROR
         ds.write_dataset(
             data=tables,
             base_dir=self.path,

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -24,7 +24,7 @@ EXISTING_DATA_BEHAVIOR_MAP = {
     SaveMode.APPEND: "overwrite_or_ignore",
     SaveMode.OVERWRITE: "overwrite_or_ignore",  # delete_matching is not a suitable choice for parallel writes.
     SaveMode.IGNORE: "overwrite_or_ignore",
-    SaveMode.ERROR: "error",
+    SaveMode.ERROR: "overwrite_or_ignore",
 }
 
 FILE_FORMAT = "parquet"

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -814,7 +814,7 @@ def test_parquet_write_error_save_mode_concurrent_write(
 
     with pytest.raises(ValueError, match="already exists"):
         ds.write_parquet(path, mode="error")
-    shutil.rmtree(local_path)
+    shutil.rmtree(path)
 
 
 def test_parquet_write_append_save_mode(ray_start_regular_shared, local_path):

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -780,7 +780,9 @@ def test_parquet_write_ignore_save_mode(ray_start_regular_shared, local_path):
     assert in_memory_table.equals(on_disk_table)
 
 
-def test_parquet_write_error_save_mode(ray_start_regular_shared, local_path):
+def test_parquet_write_error_save_mode_simple_write(
+    ray_start_regular_shared, local_path
+):
     data_path = local_path
     path = os.path.join(data_path, "test_parquet_dir")
     os.mkdir(path)
@@ -798,6 +800,21 @@ def test_parquet_write_error_save_mode(ray_start_regular_shared, local_path):
     on_disk_table = pq.read_table(path)
 
     assert in_memory_table.equals(on_disk_table)
+
+
+def test_parquet_write_error_save_mode_concurrent_write(
+    ray_start_regular_shared, local_path
+):
+    path = os.path.join(local_path, "test_parquet_dir")
+    ds = ray.data.range(1000, override_num_blocks=4)
+    # Should succeed, data should not exist before write
+    ds.write_parquet(path, mode="error")
+    # Verify that data was written correctly
+    assert ray.data.read_parquet(path).count() == 1000
+
+    with pytest.raises(ValueError, match="already exists"):
+        ds.write_parquet(path, mode="error")
+    shutil.rmtree(local_path)
 
 
 def test_parquet_write_append_save_mode(ray_start_regular_shared, local_path):


### PR DESCRIPTION
## Description
This PR fixes the race condition causing an incorrect "file already found" error on concurrent writes in `write_parquet` with `SaveMode.ERROR`.
Small change to `EXISTING_DATA_BEHAVIOR_MAP` in `parquet_datasink.py`, setting the key for `SaveMode.Error` to `"overwrite_or_ignore"` instead of `"error"`. The reason for this is because we already check for the existence of the file once on the driver before triggering the writes. Previous behaviour caused a race condition when launching parallel writes, because the first worker might write the directory, which later workers would see, and raise an error.

## Related issues
Fixes #62019 
## Additional information
Added a new test `test_parquet_write_error_save_mode_concurrent_write` to force parallel writes by setting `override_num_blocks > 0` and modified existing write parquet test name to `test_parquet_write_error_save_mode_simple_write`