### PR TITLE
[Data] Remove comment in `DefaultClusterAutoscalerV2`

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -111,10 +111,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         to directly scale up nodes.
       * Cluster scaling down isn't handled here. It depends on the idle node
         termination.
-
-    Notes:
-      * It doesn't consider multiple concurrent Datasets for now, as the cluster
-        utilization is calculated by "dataset_usage / global_resources".
     """
 
     # Default cluster utilization threshold to trigger scaling up.


### PR DESCRIPTION
The `DefaultClusterAutoscalerV2`  contains a comment stating that the autoscaler calculates utilization against global resources.
```python
    Notes:
      * It doesn't consider multiple concurrent Datasets for now, as the cluster
        utilization is calculated by "dataset_usage / global_resources".
```

This isn't true anymore. It calculates the utilization against the dataset's allocation rather than global resources.

In this PR, I've removed the outdated comment.