### PR TITLE
[Data] Remove warning instructing users to increase `RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION`

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -25,7 +25,6 @@ from ray.data._internal.execution.operators.hash_shuffle import (
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.execution.util import memory_string
-from ray.data._internal.util import GiB
 from ray.data.context import DataContext
 from ray.util.debug import log_once
 
@@ -120,8 +119,6 @@ class ResourceManager:
             )
         )
 
-        self._warn_about_object_store_memory_if_needed()
-
     def _terminal_operator_from_topology(
         self, topology: "Topology"
     ) -> PhysicalOperator:
@@ -145,35 +142,6 @@ class ResourceManager:
             "Expected exactly one terminal operator in topology, found "
             f"{len(sinks)}: {sinks!r}"
         )
-
-    def _warn_about_object_store_memory_if_needed(self):
-        """Warn if object store memory is configured below 50% of total memory."""
-        import ray
-        from ray.data.context import WARN_PREFIX
-        from ray.util.debug import log_once
-
-        if not ray.is_initialized():
-            return
-
-        cluster_resources = ray.cluster_resources()
-        total_memory = cluster_resources.get("memory", 0)
-        object_store_memory = cluster_resources.get("object_store_memory", 0)
-
-        # Check if we have actual numeric values (not mocks or None)
-        if total_memory > 0:
-            object_store_fraction = object_store_memory / total_memory
-
-            if object_store_fraction < 0.5 and log_once(
-                "ray_data_object_store_memory_warning"
-            ):
-                logger.warning(
-                    f"{WARN_PREFIX} Ray's object store is configured to use only "
-                    f"{object_store_fraction:.1%} of available memory ({object_store_memory / GiB:.1f}GiB "
-                    f"out of {total_memory / GiB:.1f}GiB total). For optimal Ray Data performance, "
-                    f"we recommend setting the object store to at least 50% of available memory. "
-                    f"You can do this by setting the 'object_store_memory' parameter when calling "
-                    f"ray.init() or by setting the RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION environment variable."
-                )
 
     def set_external_consumer_bytes(self, num_bytes: int) -> None:
         """Set the bytes buffered by external consumers."""


### PR DESCRIPTION
https://github.com/ray-project/ray/pull/53857 introduced an unconditional warning instructing Ray Data users to increase `RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION` from 0.3 to 0.5. This is reasonable advice for pipelines bottlenecked on object store memory, where more buffer space genuinely helps throughput.                                                                                                     

However, for well-balanced streaming pipelines (e.g., offline inference), good performance doesn't require buffering large amounts of data. Over-allocating object store memory in these cases is counterproductive:                                                                                                                                                                  
              
  - Reduced concurrency: More object store memory means less logical memory available for scheduling, which means fewer concurrent tasks.                                                                                            
  - OOM risk: If the system aggressively buffers data up to the object store limit, it eats into physical memory headroom.                                                                     
   
  This PR removes the unconditional warning so it doesn't mislead users running common streaming workloads. 