### PR TITLE
[data] Disable hanging issue detection by default

### DIFF
--- a/python/ray/data/_internal/issue_detection/issue_detector_configuration.py
+++ b/python/ray/data/_internal/issue_detection/issue_detector_configuration.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass, field
 from typing import List, Type
 
 from ray.data._internal.issue_detection.detectors import (
-    HangingExecutionIssueDetector,
     HangingExecutionIssueDetectorConfig,
     HashShuffleAggregatorIssueDetector,
     HashShuffleAggregatorIssueDetectorConfig,

--- a/python/ray/data/_internal/issue_detection/issue_detector_configuration.py
+++ b/python/ray/data/_internal/issue_detection/issue_detector_configuration.py
@@ -25,7 +25,8 @@ class IssueDetectorsConfiguration:
     )
     detectors: List[Type[IssueDetector]] = field(
         default_factory=lambda: [
-            HangingExecutionIssueDetector,
+            # TODO(Justin): Enable once it's non-blocking
+            # HangingExecutionIssueDetector,
             HashShuffleAggregatorIssueDetector,
             HighMemoryIssueDetector,
         ]

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -114,8 +114,7 @@ class TestHangingExecutionIssueDetector:
 
         # Explicitly enable hanging detection for this test
         ctx = DataContext.get_current()
-        if HangingExecutionIssueDetector not in ctx.issue_detectors_config.detectors:
-            ctx.issue_detectors_config.detectors.append(HangingExecutionIssueDetector)
+        ctx.issue_detectors_config.detectors [HangingExecutionIssueDetector]
         detector_cfg = ctx.issue_detectors_config.hanging_detector_config
         detector_cfg.detection_time_interval_s = 0.00
 

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -92,7 +92,6 @@ class TestHangingExecutionIssueDetector:
         assert detector._op_task_stats_min_count == min_count
         assert detector._op_task_stats_std_factor_threshold == std_factor
 
-    @pytest.mark.skip(reason="Skipping until hanging issue detection is non-blocking")
     @patch(
         "ray.data._internal.execution.interfaces.op_runtime_metrics.TaskDurationStats"
     )
@@ -113,8 +112,10 @@ class TestHangingExecutionIssueDetector:
         mock_stats.mean.return_value = mocked_mean
         mock_stats.stddev.return_value = mocked_stddev
 
-        # Set a short issue detection interval for testing
+        # Explicitly enable hanging detection for this test
         ctx = DataContext.get_current()
+        if HangingExecutionIssueDetector not in ctx.issue_detectors_config.detectors:
+            ctx.issue_detectors_config.detectors.append(HangingExecutionIssueDetector)
         detector_cfg = ctx.issue_detectors_config.hanging_detector_config
         detector_cfg.detection_time_interval_s = 0.00
 

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -92,6 +92,7 @@ class TestHangingExecutionIssueDetector:
         assert detector._op_task_stats_min_count == min_count
         assert detector._op_task_stats_std_factor_threshold == std_factor
 
+    @pytest.mark.skip(reason="Skipping until hanging issue detection is non-blocking")
     @patch(
         "ray.data._internal.execution.interfaces.op_runtime_metrics.TaskDurationStats"
     )

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -114,7 +114,7 @@ class TestHangingExecutionIssueDetector:
 
         # Explicitly enable hanging detection for this test
         ctx = DataContext.get_current()
-        ctx.issue_detectors_config.detectors [HangingExecutionIssueDetector]
+        ctx.issue_detectors_config.detectors = [HangingExecutionIssueDetector]
         detector_cfg = ctx.issue_detectors_config.hanging_detector_config
         detector_cfg.detection_time_interval_s = 0.00
 


### PR DESCRIPTION
## Description
Currently the hanging issue detection makes state API calls in the streaming executor loop, which can be expensive. This PR disables it until we find the right solution (ie, make it non-blocking)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
