### PR TITLE
[Data] Convert remaining source logical operators to frozen dataclasses

### DIFF
--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from dataclasses import InitVar, dataclass, field
+from typing import Callable, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
 
@@ -7,6 +8,7 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class Count(LogicalOperator):
     """Logical operator that represents counting the number of rows in inputs.
 
@@ -17,12 +19,28 @@ class Count(LogicalOperator):
 
     COLUMN_NAME = "__num_rows"
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-    ):
-        super().__init__(input_dependencies=[input_op])
+    input_op: InitVar[LogicalOperator]
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
 
     @property
     def num_outputs(self) -> Optional[int]:
         return self._num_outputs
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependencies[0]._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependencies[0]:
+            target = self
+        else:
+            target = Count(transformed_input)
+        return transform(target)

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -1,5 +1,6 @@
 import abc
 import functools
+from dataclasses import InitVar, dataclass, field
 from typing import TYPE_CHECKING, List, Optional, Union
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -27,33 +28,45 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
     """Abstract logical operator for `from_*`."""
 
-    def __init__(
+    input_blocks: InitVar[List[ObjectRef[Block]]]
+    input_metadata: InitVar[List[BlockMetadataWithSchema]]
+    input_data: List[RefBundle] = field(init=False)
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(
+        init=False, repr=False, default_factory=list
+    )
+    _num_outputs: Optional[int] = field(init=False, repr=False)
+
+    def __post_init__(
         self,
         input_blocks: List[ObjectRef[Block]],
         input_metadata: List[BlockMetadataWithSchema],
     ):
-        super().__init__(
-            input_dependencies=[],
-            num_outputs=len(input_blocks),
-        )
-
         assert len(input_blocks) == len(input_metadata), (
             len(input_blocks),
             len(input_metadata),
         )
 
         # `owns_blocks` is False because this op may be shared by multiple Datasets.
-        self.input_data = [
-            RefBundle(
-                [(input_blocks[i], input_metadata[i])],
-                owns_blocks=False,
-                schema=input_metadata[i].schema,
-            )
-            for i in range(len(input_blocks))
-        ]
+        object.__setattr__(
+            self,
+            "input_data",
+            [
+                RefBundle(
+                    [(input_blocks[i], input_metadata[i])],
+                    owns_blocks=False,
+                    schema=input_metadata[i].schema,
+                )
+                for i in range(len(input_blocks))
+            ],
+        )
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [])
+        object.__setattr__(self, "_num_outputs", len(input_blocks))
 
     def output_data(self) -> Optional[List[RefBundle]]:
         return self.input_data

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -1,4 +1,5 @@
 import functools
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -11,18 +12,24 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class InputData(LogicalOperator, SourceOperator):
     """Logical operator for input data.
 
     This may hold cached blocks from a previous Dataset execution.
     """
 
-    def __init__(
-        self,
-        input_data: List[RefBundle],
-    ):
-        super().__init__(input_dependencies=[], num_outputs=len(input_data))
-        self.input_data = input_data
+    input_data: List[RefBundle]
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: list[LogicalOperator] = field(
+        init=False, repr=False, default_factory=list
+    )
+    _num_outputs: Optional[int] = field(init=False, repr=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [])
+        object.__setattr__(self, "_num_outputs", len(self.input_data))
 
     def output_data(self) -> Optional[List[RefBundle]]:
         return self.input_data


### PR DESCRIPTION
## Why

This is the next PR in the logical plan migration stack for #60312.

PR-A / PR-B / PR-C / D1 / D2 handled the default logical operator name, logical-side output dependency cleanup, `LogicalOperator` ABC + `num_outputs`, and frozen dataclass conversion for one-to-one / map operators.

D3 covers all-to-all / join / read / write operators.

This PR covers the remaining source/simple logical operators that were not included there:
- `InputData`
- `Count`
- `AbstractFrom` and its subclasses (`FromItems`, `FromBlocks`, `FromNumpy`, `FromArrow`, `FromPandas`)

## What changed

- Converted `InputData` to a frozen dataclass.
- Converted `Count` to a frozen dataclass.
- Converted `AbstractFrom` to a frozen dataclass, which also covers its subclasses.
- Added a frozen-safe `_apply_transform()` implementation for `Count`.

## Scope

This PR is intentionally limited to frozen dataclass conversion for the remaining source/simple logical operators.

It does **not** include follow-up work such as:
- replacing `input_op` with `input_dependencies`
- `AbstractFrom` restructuring / removing subclasses
- equality / comparability semantics
- broader abstract-base cleanup

## Tests

- `pre-commit run --files python/ray/data/_internal/logical/operators/input_data_operator.py python/ray/data/_internal/logical/operators/count_operator.py python/ray/data/_internal/logical/operators/from_operators.py`
- `PYTHONPATH=python pytest -q python/ray/data/tests/test_split.py python/ray/data/tests/test_operator_fusion.py python/ray/data/tests/test_execution_optimizer_basic.py`

## Stack

This is part of the #60312 logical plan migration stack.
