### PR TITLE
[Data] Tighten worker node death check

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -284,10 +284,12 @@ def run_dead_node_check():
         unexpected_termination = common_pb2.NodeDeathInfo.Reason.Value(
             "UNEXPECTED_TERMINATION"
         )
+        unspecified = common_pb2.NodeDeathInfo.Reason.Value("UNSPECIFIED")
         dead_nodes = [
             node["NodeID"]
             for node in ray.nodes()
-            if not node["Alive"] and node.get("DeathReason") == unexpected_termination
+            if not node["Alive"]
+            and node.get("DeathReason") in [unexpected_termination, unspecified]
         ]
         if dead_nodes:
             logger.error(f"Dead nodes found, node IDs: {dead_nodes}")

--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -276,11 +276,19 @@ def run_oom_check():
 def run_dead_node_check():
     # Connect to the cluster and check for dead nodes
     import ray
+    from ray.core.generated import common_pb2
 
     return_code = 0
     try:
         ray.init(address="auto")  # Connect to the local cluster
-        dead_nodes = [node["NodeID"] for node in ray.nodes() if not node["Alive"]]
+        unexpected_termination = common_pb2.NodeDeathInfo.Reason.Value(
+            "UNEXPECTED_TERMINATION"
+        )
+        dead_nodes = [
+            node["NodeID"]
+            for node in ray.nodes()
+            if not node["Alive"] and node.get("DeathReason") == unexpected_termination
+        ]
         if dead_nodes:
             logger.error(f"Dead nodes found, node IDs: {dead_nodes}")
             return_code = 1

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -181,7 +181,7 @@
       columns:
         - "column08 column13 column14"   # 84 groups
         - "column02 column14"  # 7M groups
-
+  cluster:
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -10,6 +10,7 @@
       runtime_env:
         # Enable verbose stats for resource manager (to troubleshoot autoscaling)
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        # Fail the test if a worker OOMs
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         # Fail the test if a node dies
         - RAYTEST_FAIL_ON_DEAD_NODES=1
@@ -45,7 +46,7 @@
       runtime_env:
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=0  # Allow worker OOM during test
-        - RAYTEST_FAIL_ON_DEAD_NODES=0  # Allow node death during test
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 
   matrix:
@@ -181,12 +182,6 @@
         - "column08 column13 column14"   # 84 groups
         - "column02 column14"  # 7M groups
 
-  cluster:
-    byod:
-      runtime_env:
-        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
-        - RAYTEST_FAIL_ON_WORKER_OOM=1
-        - RAYTEST_FAIL_ON_DEAD_NODES=0  # Allow node death during test
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -496,7 +491,9 @@
   cluster:
     byod:
       runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=0
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 
   run:
@@ -617,11 +614,6 @@
   group: data-batch-inference
 
   cluster:
-    byod:
-      runtime_env:
-        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
-        - RAYTEST_FAIL_ON_WORKER_OOM=1
-        - RAYTEST_FAIL_ON_DEAD_NODES=0  # Allow node death during test
     cluster_compute: heterogeneous_memory_compute.yaml
 
   run:
@@ -808,7 +800,7 @@
           case: fixed_size
           cluster_type: fixed_size
           args: --inference-concurrency 100 100
-          fail_on_dead_nodes: 0 # Allow node death during test
+          fail_on_dead_nodes: 1
       - with:
           case: autoscaling
           cluster_type: autoscaling


### PR DESCRIPTION
1. Tighten the worker node death check so that we do not count idle terminated nodes, and only count nodes that were terminated due to an unexpected reason
2. Set RAYTEST_FAIL_ON_DEAD_NODE to 1 for all, to catch expected failures with tightened check
3. Also check that RAYTEST_FAIL_ON_WORKER_OOM is set everywhere default is overridden