### PR TITLE
[ci] Migrate cluster_tests compute configs to new schema

### DIFF
--- a/release/cluster_tests/cpt_autoscaling_1-3_aws.yaml
+++ b/release/cluster_tests/cpt_autoscaling_1-3_aws.yaml
@@ -2,6 +2,8 @@ cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
     instance_type: m5.xlarge  # 4 CPUs
+    resources:
+      CPU: 4
 
 worker_nodes:
     - instance_type: m5.xlarge

--- a/release/cluster_tests/cpt_autoscaling_1-3_aws.yaml
+++ b/release/cluster_tests/cpt_autoscaling_1-3_aws.yaml
@@ -1,13 +1,10 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-head_node_type:
-    name: head_node
+head_node:
     instance_type: m5.xlarge  # 4 CPUs
 
-worker_node_types:
-    - name: worker_node
-      instance_type: m5.xlarge
-      min_workers: 0
-      max_workers: 2
-      use_spot: false
+worker_nodes:
+    - instance_type: m5.xlarge
+      min_nodes: 0
+      max_nodes: 2
+      market_type: ON_DEMAND

--- a/release/cluster_tests/cpt_autoscaling_1-3_gce.yaml
+++ b/release/cluster_tests/cpt_autoscaling_1-3_gce.yaml
@@ -4,6 +4,8 @@ zones:
 
 head_node:
     instance_type: n2-standard-4  # 4 CPUs
+    resources:
+      CPU: 4
 
 worker_nodes:
     - instance_type: n2-standard-4

--- a/release/cluster_tests/cpt_autoscaling_1-3_gce.yaml
+++ b/release/cluster_tests/cpt_autoscaling_1-3_gce.yaml
@@ -1,15 +1,12 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west1
-allowed_azs:
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+zones:
     - us-west1-b
 
-head_node_type:
-    name: head_node
+head_node:
     instance_type: n2-standard-4  # 4 CPUs
 
-worker_node_types:
-    - name: worker_node
-      instance_type: n2-standard-4
-      min_workers: 0
-      max_workers: 2
-      use_spot: false
+worker_nodes:
+    - instance_type: n2-standard-4
+      min_nodes: 0
+      max_nodes: 2
+      market_type: ON_DEMAND

--- a/release/ray_release/tests/test_collection_data.yaml
+++ b/release/ray_release/tests/test_collection_data.yaml
@@ -6,6 +6,7 @@
   cluster:
     byod: {}
     cluster_compute: cpt_autoscaling_1-3_aws.yaml
+    anyscale_sdk_2026: true
   run:
     timeout: 3600
     script: test_script.py

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -214,6 +214,7 @@
   team: ml
 
   cluster:
+    anyscale_sdk_2026: true
     cluster_compute: cpt_autoscaling_1-3_aws.yaml
 
   run:
@@ -228,6 +229,7 @@
       env: gce
       frequency: manual
       cluster:
+        anyscale_sdk_2026: true
         cluster_compute: cpt_autoscaling_1-3_gce.yaml
     - __suffix__: kuberay
       env: kuberay

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -214,7 +214,6 @@
   team: ml
 
   cluster:
-    anyscale_sdk_2026: true
     cluster_compute: cpt_autoscaling_1-3_aws.yaml
 
   run:
@@ -225,6 +224,8 @@
 
   variations:
     - __suffix__: aws
+      cluster:
+        anyscale_sdk_2026: true
     - __suffix__: gce
       env: gce
       frequency: manual


### PR DESCRIPTION
## Summary
- Upgrade 2 legacy compute config files (`cpt_autoscaling_1-3_aws.yaml`, `cpt_autoscaling_1-3_gce.yaml`) to the new Anyscale SDK schema
- Add `anyscale_sdk_2026: true` flag to the `cluster_tune_scale_up_down` test entry (AWS + GCE variants)

## Test plan
- [x] Verify `cluster_tune_scale_up_down` test passes with upgraded configs on AWS
- [x] Verify `cluster_tune_scale_up_down` test passes with upgraded configs on GCE

🤖 Generated with [Claude Code](https://claude.com/claude-code)