### PR TITLE
[data] Include column name and target type in ArrowConversionError

### DIFF
--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -238,10 +238,22 @@ class ArrowConversionError(Exception):
 
     MAX_DATA_STR_LEN = 200
 
-    def __init__(self, data_str: str):
+    def __init__(
+        self,
+        data_str: str,
+        column_name: Optional[str] = None,
+        pa_type: Optional["pa.DataType"] = None,
+    ):
         if len(data_str) > self.MAX_DATA_STR_LEN:
             data_str = data_str[: self.MAX_DATA_STR_LEN] + "..."
-        message = f"Error converting data to Arrow: {data_str}"
+        if column_name is not None:
+            type_info = f" (target type: {pa_type})" if pa_type is not None else ""
+            message = (
+                f"Error converting column '{column_name}'{type_info}"
+                f" to Arrow: {data_str}"
+            )
+        else:
+            message = f"Error converting data to Arrow: {data_str}"
         super().__init__(message)
 
 
@@ -397,7 +409,9 @@ def _convert_to_pyarrow_native_array(
 
         return pa.array(column_values, type=pa_type)
     except Exception as e:
-        raise ArrowConversionError(str(column_values)) from e
+        raise ArrowConversionError(
+            str(column_values), column_name=column_name, pa_type=pa_type
+        ) from e
 
 
 def _coerce_np_datetime_to_pa_timestamp_precision(

--- a/python/ray/data/_internal/tensor_extensions/arrow.py
+++ b/python/ray/data/_internal/tensor_extensions/arrow.py
@@ -363,6 +363,7 @@ def _convert_to_pyarrow_native_array(
     """Converts provided NumPy `ndarray` into PyArrow's `array` while only utilizing
     Arrow's natively supported types (ie no custom extension types)"""
 
+    pa_type = None
     try:
         # NOTE: Python's `datetime` only supports precision up to us and could
         #       inadvertently lose precision when handling Pandas `Timestamp` type.

--- a/python/ray/data/tests/unit/test_arrow_type_conversion.py
+++ b/python/ray/data/tests/unit/test_arrow_type_conversion.py
@@ -190,7 +190,7 @@ def test_convert_to_pyarrow_array_object_ext_type_fallback():
 
     assert (
         str(exc_info.value)
-        == "Error converting data to Arrow: ['hi' 1 None list([[[[]]]]) {'a': [[{'b': 2, 'c': UserObj(i=123)}]]}\n UserObj(i=456)]"  # noqa: E501
+        == "Error converting column 'py_object_column' (target type: string) to Arrow: ['hi' 1 None list([[[[]]]]) {'a': [[{'b': 2, 'c': UserObj(i=123)}]]}\n UserObj(i=456)]"  # noqa: E501
     )
 
     # Subsequently, assert that fallback to `ArrowObjectExtensionType` succeeds


### PR DESCRIPTION
## Why are these changes needed?

`ArrowConversionError` previously only showed the data that failed to convert, making it hard to identify which column caused the issue. For example, the raw Arrow error looks like:

```
File "pyarrow/array.pxi", line 405, in pyarrow.lib.asarray
File "pyarrow/array.pxi", line 375, in pyarrow.lib.array
File "pyarrow/array.pxi", line 46, in pyarrow.lib._sequence_to_array
File "pyarrow/error.pxi", line 155, in pyarrow.lib.pyarrow_internal_check_status
File "pyarrow/error.pxi", line 92, in pyarrow.lib.check_status
pyarrow.lib.ArrowTypeError: Expected bytes, got a 'numpy.float32' object
```

This gives no indication of which column or what type conversion was attempted. With this change, the wrapped error now includes the column name and inferred target type:

Before:
```
Error converting data to Arrow: [b'hello', 2.0]
```

After:
```
Error converting column 'my_column' (target type: binary) to Arrow: [b'hello', 2.0]
```

### Repro script

```python
import ray
import numpy as np

ray.init()

ds = ray.data.range(2)

def mix_types(batch):
    return {"my_column": [b"hello", np.float32(2.0)]}

ds.map_batches(mix_types, batch_size=2).write_parquet("/tmp/out")
```

## Related issue number

N/A

## Checks

- [x] I've signed off every commit.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests