### PR TITLE
[Core] Adopt absl::InlinedVector for small, frequently-allocated collections

### DIFF
--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -249,9 +249,9 @@ int64_t TaskSpecification::GeneratorBackpressureNumObjects() const {
   return result;
 }
 
-std::vector<ObjectID> TaskSpecification::DynamicReturnIds() const {
+absl::InlinedVector<ObjectID, 8> TaskSpecification::DynamicReturnIds() const {
   RAY_CHECK(message_->returns_dynamic());
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
   for (const auto &dynamic_return_id : message_->dynamic_return_ids()) {
     dynamic_return_ids.push_back(ObjectID::FromBinary(dynamic_return_id));
   }
@@ -350,8 +350,8 @@ bool TaskSpecification::GetNodeAffinitySchedulingStrategySoft() const {
   return GetSchedulingStrategy().node_affinity_scheduling_strategy().soft();
 }
 
-std::vector<ObjectID> TaskSpecification::GetDependencyIds() const {
-  std::vector<ObjectID> dependencies;
+absl::InlinedVector<ObjectID, 8> TaskSpecification::GetDependencyIds() const {
+  absl::InlinedVector<ObjectID, 8> dependencies;
   for (size_t i = 0; i < NumArgs(); ++i) {
     if (ArgByRef(i)) {
       dependencies.push_back(ArgObjectId(i));

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "ray/common/function_descriptor.h"
 #include "ray/common/grpc_util.h"
 #include "ray/common/id.h"
@@ -193,7 +194,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
 
   int64_t GeneratorBackpressureNumObjects() const;
 
-  std::vector<ObjectID> DynamicReturnIds() const;
+  absl::InlinedVector<ObjectID, 8> DynamicReturnIds() const;
 
   void AddDynamicReturnId(const ObjectID &dynamic_return_id);
 
@@ -260,7 +261,7 @@ class TaskSpecification : public MessageWrapper<rpc::TaskSpec> {
   /// mutated.
   ///
   /// \return The recomputed IDs of the dependencies for the task.
-  std::vector<ObjectID> GetDependencyIds() const;
+  absl::InlinedVector<ObjectID, 8> GetDependencyIds() const;
 
   /// Return the dependencies of this task. This is recomputed each time, so it can
   /// be used if the task spec is mutated.

--- a/src/ray/core_worker/actor_management/actor_manager.cc
+++ b/src/ray/core_worker/actor_management/actor_manager.cc
@@ -267,9 +267,9 @@ void ActorManager::HandleActorStateNotification(const ActorID &actor_id,
   }
 }
 
-std::vector<ObjectID> ActorManager::GetActorHandleIDsFromHandles() {
+absl::InlinedVector<ObjectID, 8> ActorManager::GetActorHandleIDsFromHandles() {
   absl::MutexLock lock(&mutex_);
-  std::vector<ObjectID> actor_handle_ids;
+  absl::InlinedVector<ObjectID, 8> actor_handle_ids;
   for (const auto &handle : actor_handles_) {
     auto actor_id = handle.first;
     auto actor_handle_id = ObjectID::ForActorHandle(actor_id);

--- a/src/ray/core_worker/actor_management/actor_manager.h
+++ b/src/ray/core_worker/actor_management/actor_manager.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/inlined_vector.h"
 #include "ray/core_worker/actor_management/actor_creator.h"
 #include "ray/core_worker/actor_management/actor_handle.h"
 #include "ray/core_worker/reference_counter_interface.h"
@@ -132,7 +133,7 @@ class ActorManager {
 
   /// Get a list of actor_ids from existing actor handles.
   /// This is used for debugging purpose.
-  std::vector<ObjectID> GetActorHandleIDsFromHandles();
+  absl::InlinedVector<ObjectID, 8> GetActorHandleIDsFromHandles();
 
   /// Function that's invoked when the actor is permanatly dead.
   ///

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -852,7 +852,8 @@ void CoreWorker::RecordMetrics() {
 std::unordered_map<ObjectID, std::pair<size_t, size_t>>
 CoreWorker::GetAllReferenceCounts() const {
   auto counts = reference_counter_->GetAllReferenceCounts();
-  std::vector<ObjectID> actor_handle_ids = actor_manager_->GetActorHandleIDsFromHandles();
+  absl::InlinedVector<ObjectID, 8> actor_handle_ids =
+      actor_manager_->GetActorHandleIDsFromHandles();
   // Strip actor IDs from the ref counts since there is no associated ObjectID
   // in the language frontend.
   for (const auto &actor_handle_id : actor_handle_ids) {
@@ -861,7 +862,8 @@ CoreWorker::GetAllReferenceCounts() const {
   return counts;
 }
 
-std::vector<TaskID> CoreWorker::GetPendingChildrenTasks(const TaskID &task_id) const {
+absl::InlinedVector<TaskID, 8> CoreWorker::GetPendingChildrenTasks(
+    const TaskID &task_id) const {
   return task_manager_->GetPendingChildrenTasks(task_id);
 }
 
@@ -4480,7 +4482,7 @@ bool CoreWorker::IsIdle() const {
 }
 
 Status CoreWorker::WaitForActorRegistered(const std::vector<ObjectID> &ids) {
-  std::vector<ActorID> actor_ids;
+  absl::InlinedVector<ActorID, 8> actor_ids;
   for (const auto &id : ids) {
     if (ObjectID::IsActorID(id)) {
       actor_ids.emplace_back(ObjectID::ToActorID(id));

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/inlined_vector.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/common/asio/periodical_runner.h"
 #include "ray/common/buffer.h"
@@ -401,7 +402,7 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// Return all pending children task ids for a given parent task id.
   /// The parent task id should exist in the current worker.
   /// For debugging and testing only.
-  std::vector<TaskID> GetPendingChildrenTasks(const TaskID &task_id) const;
+  absl::InlinedVector<TaskID, 8> GetPendingChildrenTasks(const TaskID &task_id) const;
 
   /// Get the RPC address of this worker.
   ///

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -219,7 +219,7 @@ void ReferenceCounter::AddObjectRefStats(
 
 void ReferenceCounter::AddOwnedObject(
     const ObjectID &object_id,
-    const std::vector<ObjectID> &inner_ids,
+    const absl::InlinedVector<ObjectID, 8> &contained_ids,
     const rpc::Address &owner_address,
     const std::string &call_site,
     const int64_t object_size,
@@ -305,8 +305,9 @@ void ReferenceCounter::OwnDynamicStreamingTaskReturnRef(const ObjectID &object_i
                                     /*tensor_transport=*/std::nullopt));
 }
 
-void ReferenceCounter::TryReleaseLocalRefs(const std::vector<ObjectID> &object_ids,
-                                           std::vector<ObjectID> *deleted) {
+void ReferenceCounter::TryReleaseLocalRefs(
+    const absl::InlinedVector<ObjectID, 8> &object_ids,
+    absl::InlinedVector<ObjectID, 8> *deleted) {
   absl::MutexLock lock(&mutex_);
   for (const auto &object_id : object_ids) {
     auto it = object_id_refs_.find(object_id);
@@ -461,7 +462,7 @@ void ReferenceCounter::ReleaseAllLocalReferences() {
 }
 
 void ReferenceCounter::RemoveLocalReference(const ObjectID &object_id,
-                                            std::vector<ObjectID> *deleted) {
+                                            absl::InlinedVector<ObjectID, 8> *deleted) {
   if (object_id.IsNil()) {
     return;
   }
@@ -495,10 +496,10 @@ void ReferenceCounter::RemoveLocalReferenceInternal(const ObjectID &object_id,
 }
 
 void ReferenceCounter::UpdateSubmittedTaskReferences(
-    const std::vector<ObjectID> &return_ids,
-    const std::vector<ObjectID> &argument_ids_to_add,
-    const std::vector<ObjectID> &argument_ids_to_remove,
-    std::vector<ObjectID> *deleted) {
+    const absl::InlinedVector<ObjectID, 8> &return_ids,
+    const absl::InlinedVector<ObjectID, 8> &argument_ids_to_add,
+    const absl::InlinedVector<ObjectID, 8> &argument_ids_to_remove,
+    absl::InlinedVector<ObjectID, 8> *deleted) {
   absl::MutexLock lock(&mutex_);
   for (const auto &return_id : return_ids) {
     UpdateObjectPendingCreationInternal(return_id, true);
@@ -527,7 +528,7 @@ void ReferenceCounter::UpdateSubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateResubmittedTaskReferences(
-    const std::vector<ObjectID> &argument_ids) {
+    const absl::InlinedVector<ObjectID, 8> &argument_ids) {
   absl::MutexLock lock(&mutex_);
   for (const ObjectID &argument_id : argument_ids) {
     auto it = object_id_refs_.find(argument_id);
@@ -541,12 +542,12 @@ void ReferenceCounter::UpdateResubmittedTaskReferences(
 }
 
 void ReferenceCounter::UpdateFinishedTaskReferences(
-    const std::vector<ObjectID> &return_ids,
+    const absl::InlinedVector<ObjectID, 8> &return_ids,
     const std::vector<ObjectID> &argument_ids,
     bool release_lineage,
     const rpc::Address &worker_addr,
     const ReferenceTableProto &borrowed_refs,
-    std::vector<ObjectID> *deleted) {
+    absl::InlinedVector<ObjectID, 8> *deleted) {
   absl::MutexLock lock(&mutex_);
   for (const auto &return_id : return_ids) {
     UpdateObjectPendingCreationInternal(return_id, false);
@@ -609,7 +610,7 @@ int64_t ReferenceCounter::ReleaseLineageReferences(ReferenceTable::iterator ref)
 void ReferenceCounter::RemoveSubmittedTaskReferences(
     const std::vector<ObjectID> &argument_ids,
     bool release_lineage,
-    std::vector<ObjectID> *deleted) {
+    absl::InlinedVector<ObjectID, 8> *deleted) {
   for (const ObjectID &argument_id : argument_ids) {
     RAY_LOG(DEBUG) << "Releasing ref for submitted task argument " << argument_id;
     auto it = object_id_refs_.find(argument_id);
@@ -1028,7 +1029,7 @@ ReferenceCounter::GetAllReferenceCounts() const {
 void ReferenceCounter::PopAndClearLocalBorrowers(
     const std::vector<ObjectID> &borrowed_ids,
     ReferenceTableProto *proto,
-    std::vector<ObjectID> *deleted) {
+    absl::InlinedVector<ObjectID, 8> *deleted) {
   absl::MutexLock lock(&mutex_);
   // Reuse the `encountered_ids` set to deduplicate object IDs across loop iterations.
   absl::flat_hash_set<ObjectID> encountered_ids;

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -25,6 +25,7 @@
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/inlined_vector.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/common/id.h"
 #include "ray/common/status.h"
@@ -73,19 +74,22 @@ class ReferenceCounter : public ReferenceCounterInterface,
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   void RemoveLocalReference(const ObjectID &object_id,
-                            std::vector<ObjectID> *deleted) override
+                            absl::InlinedVector<ObjectID, 8> *deleted) override
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   void UpdateSubmittedTaskReferences(
-      const std::vector<ObjectID> &return_ids,
-      const std::vector<ObjectID> &argument_ids_to_add,
-      const std::vector<ObjectID> &argument_ids_to_remove = std::vector<ObjectID>(),
-      std::vector<ObjectID> *deleted = nullptr) override ABSL_LOCKS_EXCLUDED(mutex_);
-
-  void UpdateResubmittedTaskReferences(const std::vector<ObjectID> &argument_ids) override
+      const absl::InlinedVector<ObjectID, 8> &return_ids,
+      const absl::InlinedVector<ObjectID, 8> &argument_ids_to_add,
+      const absl::InlinedVector<ObjectID, 8> &argument_ids_to_remove =
+          absl::InlinedVector<ObjectID, 8>(),
+      absl::InlinedVector<ObjectID, 8> *deleted = nullptr) override
       ABSL_LOCKS_EXCLUDED(mutex_);
 
-  void UpdateFinishedTaskReferences(const std::vector<ObjectID> &return_ids,
+  void UpdateResubmittedTaskReferences(
+      const absl::InlinedVector<ObjectID, 8> &argument_ids) override
+      ABSL_LOCKS_EXCLUDED(mutex_);
+
+  void UpdateFinishedTaskReferences(const absl::InlinedVector<ObjectID, 8> &return_ids,
                                     const std::vector<ObjectID> &argument_ids,
                                     bool release_lineage,
                                     const rpc::Address &worker_addr,
@@ -95,7 +99,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   void AddOwnedObject(
       const ObjectID &object_id,
-      const std::vector<ObjectID> &contained_ids,
+      const absl::InlinedVector<ObjectID, 8> &contained_ids,
       const rpc::Address &owner_address,
       const std::string &call_site,
       const int64_t object_size,
@@ -112,8 +116,8 @@ class ReferenceCounter : public ReferenceCounterInterface,
                                         const ObjectID &generator_id) override
       ABSL_LOCKS_EXCLUDED(mutex_);
 
-  void TryReleaseLocalRefs(const std::vector<ObjectID> &object_ids,
-                           std::vector<ObjectID> *deleted) override
+  void TryReleaseLocalRefs(const absl::InlinedVector<ObjectID, 8> &object_ids,
+                           absl::InlinedVector<ObjectID, 8> *deleted) override
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   bool CheckGeneratorRefsLineageOutOfScope(const ObjectID &generator_id,
@@ -184,7 +188,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   void PopAndClearLocalBorrowers(const std::vector<ObjectID> &borrowed_ids,
                                  ReferenceTableProto *proto,
-                                 std::vector<ObjectID> *deleted) override
+                                 absl::InlinedVector<ObjectID, 8> *deleted) override
       ABSL_LOCKS_EXCLUDED(mutex_);
 
   void AddNestedObjectIds(const ObjectID &object_id,
@@ -557,7 +561,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// dependencies.
   void RemoveSubmittedTaskReferences(const std::vector<ObjectID> &argument_ids,
                                      bool release_lineage,
-                                     std::vector<ObjectID> *deleted)
+                                     absl::InlinedVector<ObjectID, 8> *deleted)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Helper method to mark that this ObjectID contains another ObjectID(s).
@@ -660,7 +664,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// callbacks. Assumes that the entry is in object_id_refs_ and invalidates the
   /// iterator.
   void DeleteReferenceInternal(ReferenceTable::iterator entry,
-                               std::vector<ObjectID> *deleted)
+                               absl::InlinedVector<ObjectID, 8> *deleted)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// To respond to the object's owner once we are no longer borrowing it.  The
@@ -729,7 +733,7 @@ class ReferenceCounter : public ReferenceCounterInterface,
   /// This method is internal and not thread-safe. mutex_ lock must be held before
   /// calling this method.
   void RemoveLocalReferenceInternal(const ObjectID &object_id,
-                                    std::vector<ObjectID> *deleted)
+                                    absl::InlinedVector<ObjectID, 8> *deleted)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Address of our RPC server. This is used to determine whether we own a

--- a/src/ray/core_worker/reference_counter_interface.h
+++ b/src/ray/core_worker/reference_counter_interface.h
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "ray/common/id.h"
 #include "ray/core_worker/lease_policy.h"
 #include "ray/pubsub/publisher_interface.h"
@@ -75,7 +76,7 @@ class ReferenceCounterInterface {
  protected:
   // Returns the amount of lineage in bytes released.
   using LineageReleasedCallback =
-      std::function<int64_t(const ObjectID &, std::vector<ObjectID> *)>;
+      std::function<int64_t(const ObjectID &, absl::InlinedVector<ObjectID, 8> *)>;
 
  public:
   using ReferenceTableProto =
@@ -106,7 +107,7 @@ class ReferenceCounterInterface {
   /// \param[in] object_id The object to decrement the count for.
   /// \param[out] deleted List to store objects that hit zero ref count.
   virtual void RemoveLocalReference(const ObjectID &object_id,
-                                    std::vector<ObjectID> *deleted) = 0;
+                                    absl::InlinedVector<ObjectID, 8> *deleted) = 0;
 
   /// Add references for the provided object IDs that correspond to them being
   /// dependencies to a submitted task. If lineage pinning is enabled, then
@@ -120,10 +121,11 @@ class ReferenceCounterInterface {
   /// \param[out] deleted Any objects that are newly out of scope after this
   /// function call.
   virtual void UpdateSubmittedTaskReferences(
-      const std::vector<ObjectID> &return_ids,
-      const std::vector<ObjectID> &argument_ids_to_add,
-      const std::vector<ObjectID> &argument_ids_to_remove = std::vector<ObjectID>(),
-      std::vector<ObjectID> *deleted = nullptr) = 0;
+      const absl::InlinedVector<ObjectID, 8> &return_ids,
+      const absl::InlinedVector<ObjectID, 8> &argument_ids_to_add,
+      const absl::InlinedVector<ObjectID, 8> &argument_ids_to_remove =
+          absl::InlinedVector<ObjectID, 8>(),
+      absl::InlinedVector<ObjectID, 8> *deleted = nullptr) = 0;
 
   /// Add references for the object dependencies of a resubmitted task. This
   /// does not increment the arguments' lineage ref counts because we should
@@ -131,7 +133,7 @@ class ReferenceCounterInterface {
   ///
   /// \param[in] argument_ids The arguments of the task to add references for.
   virtual void UpdateResubmittedTaskReferences(
-      const std::vector<ObjectID> &argument_ids) = 0;
+      const absl::InlinedVector<ObjectID, 8> &argument_ids) = 0;
 
   /// Update object references that were given to a submitted task. The task
   /// may still be borrowing any object IDs that were contained in its
@@ -148,13 +150,13 @@ class ReferenceCounterInterface {
   /// worker and/or a task that the worker submitted.
   /// \param[out] deleted The object IDs whos reference counts reached zero.
   virtual void UpdateFinishedTaskReferences(
-      const std::vector<ObjectID> &return_ids,
+      const absl::InlinedVector<ObjectID, 8> &return_ids,
       const std::vector<ObjectID> &argument_ids,
       bool release_lineage,
       const rpc::Address &worker_addr,
       const ::google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount>
           &borrowed_refs,
-      std::vector<ObjectID> *deleted) = 0;
+      absl::InlinedVector<ObjectID, 8> *deleted) = 0;
 
   /// Add an object that we own. The object may depend on other objects.
   /// Dependencies for each ObjectID must be set at most once. The local
@@ -185,7 +187,7 @@ class ReferenceCounterInterface {
   /// \param[in] tensor_transport The transport used for the object.
   virtual void AddOwnedObject(
       const ObjectID &object_id,
-      const std::vector<ObjectID> &contained_ids,
+      const absl::InlinedVector<ObjectID, 8> &contained_ids,
       const rpc::Address &owner_address,
       const std::string &call_site,
       const int64_t object_size,
@@ -233,8 +235,8 @@ class ReferenceCounterInterface {
   /// are in scope.
   /// \param[out] deleted Any released object refs that went out of scope. The
   /// object values should be deleted.
-  virtual void TryReleaseLocalRefs(const std::vector<ObjectID> &object_ids,
-                                   std::vector<ObjectID> *deleted) = 0;
+  virtual void TryReleaseLocalRefs(const absl::InlinedVector<ObjectID, 8> &object_ids,
+                                   absl::InlinedVector<ObjectID, 8> *deleted) = 0;
 
   /// Check if a generator's lineage has gone out of scope. This checks if we
   /// still have entries for the generator ref and all refs returned by the
@@ -409,7 +411,7 @@ class ReferenceCounterInterface {
   virtual void PopAndClearLocalBorrowers(
       const std::vector<ObjectID> &borrowed_ids,
       ::google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount> *proto,
-      std::vector<ObjectID> *deleted) = 0;
+      absl::InlinedVector<ObjectID, 8> *deleted) = 0;
 
   /// Mark that this ObjectID contains another ObjectID(s). This should be
   /// called in two cases:

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "absl/strings/match.h"
 #include "ray/common/buffer.h"
 #include "ray/common/protobuf_utils.h"
@@ -89,9 +90,9 @@ absl::flat_hash_set<ObjectID> ObjectRefStream::GetItemsUnconsumed() const {
   return result;
 }
 
-std::vector<ObjectID> ObjectRefStream::PopUnconsumedItems() {
+absl::InlinedVector<ObjectID, 8> ObjectRefStream::PopUnconsumedItems() {
   // Get all unconsumed refs.
-  std::vector<ObjectID> unconsumed_ids;
+  absl::InlinedVector<ObjectID, 8> unconsumed_ids;
   for (int64_t index = 0; index <= max_index_seen_; index++) {
     const auto &object_id = GetObjectRefAtIndex(index);
     auto it = refs_written_to_stream_.find(object_id);
@@ -245,7 +246,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
                  << " retries, " << max_oom_retries << " oom retries";
 
   // Add references for the dependencies to the task.
-  std::vector<ObjectID> task_deps;
+  absl::InlinedVector<ObjectID, 8> task_deps;
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
       task_deps.push_back(spec.ArgObjectId(i));
@@ -268,7 +269,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
   size_t num_returns = spec.NumReturns();
   std::vector<rpc::ObjectReference> returned_refs;
   returned_refs.reserve(num_returns);
-  std::vector<ObjectID> return_ids;
+  absl::InlinedVector<ObjectID, 8> return_ids;
   return_ids.reserve(num_returns);
   auto tensor_transport = spec.TensorTransport();
   for (size_t i = 0; i < num_returns; i++) {
@@ -351,7 +352,7 @@ std::vector<rpc::ObjectReference> TaskManager::AddPendingTask(
 }
 
 std::optional<rpc::ErrorType> TaskManager::ResubmitTask(
-    const TaskID &task_id, std::vector<ObjectID> *task_deps) {
+    const TaskID &task_id, absl::InlinedVector<ObjectID, 8> *task_deps) {
   RAY_CHECK(task_deps->empty());
   TaskSpecification spec;
   bool should_queue_generator_resubmit = false;
@@ -435,8 +436,8 @@ void TaskManager::SetupTaskEntryForResubmit(TaskEntry &task_entry) {
   }
 }
 
-void TaskManager::UpdateReferencesForResubmit(const TaskSpecification &spec,
-                                              std::vector<ObjectID> *task_deps) {
+void TaskManager::UpdateReferencesForResubmit(
+    const TaskSpecification &spec, absl::InlinedVector<ObjectID, 8> *task_deps) {
   task_deps->reserve(spec.NumArgs());
   for (size_t i = 0; i < spec.NumArgs(); i++) {
     if (spec.ArgByRef(i)) {
@@ -710,7 +711,7 @@ bool TaskManager::TryDelObjectRefStreamInternal(const ObjectID &generator_id) {
 
   // Remove any unconsumed refs from the stream metadata in-memory store.
   auto unconsumed_ids = stream_it->second.PopUnconsumedItems();
-  std::vector<ObjectID> deleted;
+  absl::InlinedVector<ObjectID, 8> deleted;
   reference_counter_.TryReleaseLocalRefs(unconsumed_ids, &deleted);
   in_memory_store_.Delete(deleted);
 
@@ -914,9 +915,9 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
   bool first_execution = false;
   const auto store_in_plasma_ids =
       GetTaskReturnObjectsToStoreInPlasma(task_id, &first_execution);
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
   std::vector<ObjectID> dynamic_returns_in_plasma;
-  std::vector<ObjectID> direct_return_ids;
+  absl::InlinedVector<ObjectID, 8> direct_return_ids;
   if (reply.dynamic_return_objects_size() > 0) {
     RAY_CHECK(reply.return_objects_size() == 1)
         << "Dynamic generators only supported for num_returns=1";
@@ -1393,9 +1394,9 @@ void TaskManager::ShutdownIfNeeded() {
 }
 
 void TaskManager::OnTaskDependenciesInlined(
-    const std::vector<ObjectID> &inlined_dependency_ids,
-    const std::vector<ObjectID> &contained_ids) {
-  std::vector<ObjectID> deleted;
+    const absl::InlinedVector<ObjectID, 8> &inlined_dependency_ids,
+    const absl::InlinedVector<ObjectID, 8> &contained_ids) {
+  absl::InlinedVector<ObjectID, 8> deleted;
   reference_counter_.UpdateSubmittedTaskReferences(
       /*return_ids=*/{},
       /*argument_ids_to_add=*/contained_ids,
@@ -1411,7 +1412,7 @@ void TaskManager::RemoveFinishedTaskReferences(
     const ReferenceCounterInterface::ReferenceTableProto &borrowed_refs) {
   std::vector<ObjectID> plasma_dependencies = ExtractPlasmaDependencies(spec);
 
-  std::vector<ObjectID> return_ids;
+  absl::InlinedVector<ObjectID, 8> return_ids;
   size_t num_returns = spec.NumReturns();
   return_ids.reserve(num_returns);
   for (size_t i = 0; i < num_returns; i++) {
@@ -1430,7 +1431,7 @@ void TaskManager::RemoveFinishedTaskReferences(
     }
   }
 
-  std::vector<ObjectID> deleted;
+  absl::InlinedVector<ObjectID, 8> deleted;
   reference_counter_.UpdateFinishedTaskReferences(return_ids,
                                                   plasma_dependencies,
                                                   release_lineage,
@@ -1440,8 +1441,8 @@ void TaskManager::RemoveFinishedTaskReferences(
   in_memory_store_.Delete(deleted);
 }
 
-int64_t TaskManager::RemoveLineageReference(const ObjectID &object_id,
-                                            std::vector<ObjectID> *released_objects) {
+int64_t TaskManager::RemoveLineageReference(
+    const ObjectID &object_id, absl::InlinedVector<ObjectID, 8> *released_objects) {
   absl::MutexLock lock(&mu_);
   const int64_t total_lineage_footprint_bytes_prev(total_lineage_footprint_bytes_);
 
@@ -1638,9 +1639,9 @@ std::optional<TaskSpecification> TaskManager::GetTaskSpec(const TaskID &task_id)
   return it->second.spec_;
 }
 
-std::vector<TaskID> TaskManager::GetPendingChildrenTasks(
+absl::InlinedVector<TaskID, 8> TaskManager::GetPendingChildrenTasks(
     const TaskID &parent_task_id) const {
-  std::vector<TaskID> ret_vec;
+  absl::InlinedVector<TaskID, 8> ret_vec;
   absl::MutexLock lock(&mu_);
   for (const auto &it : submissible_tasks_) {
     if (it.second.IsPending() && (it.second.spec_.ParentTaskId() == parent_task_id)) {

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -24,6 +24,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/inlined_vector.h"
 #include "absl/synchronization/mutex.h"
 #include "ray/common/id.h"
 #include "ray/common/status.h"
@@ -151,7 +152,7 @@ class ObjectRefStream {
   /// TryReadNextItem.
   ///
   /// \return A list of object IDs that are not read yet.
-  std::vector<ObjectID> PopUnconsumedItems();
+  absl::InlinedVector<ObjectID, 8> PopUnconsumedItems();
 
   /// \return Index of the last consumed item, -1 if nothing is consumed yet.
   int64_t LastConsumedIndex() const { return next_index_ - 1; }
@@ -234,7 +235,8 @@ class TaskManager : public TaskManagerInterface {
                    {"Source", "owner"}});
             });
     reference_counter_.SetReleaseLineageCallback(
-        [this](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
+        [this](const ObjectID &object_id,
+               absl::InlinedVector<ObjectID, 8> *ids_to_release) {
           return RemoveLineageReference(object_id, ids_to_release);
           ShutdownIfNeeded();
         });
@@ -245,8 +247,8 @@ class TaskManager : public TaskManagerInterface {
                                                    const std::string &call_site,
                                                    int max_retries = 0) override;
 
-  std::optional<rpc::ErrorType> ResubmitTask(const TaskID &task_id,
-                                             std::vector<ObjectID> *task_deps) override;
+  std::optional<rpc::ErrorType> ResubmitTask(
+      const TaskID &task_id, absl::InlinedVector<ObjectID, 8> *task_deps) override;
 
   /// Wait for all pending tasks to finish, and then shutdown.
   ///
@@ -463,8 +465,9 @@ class TaskManager : public TaskManagerInterface {
       const rpc::RayErrorInfo *ray_error_info,
       const absl::flat_hash_set<ObjectID> &store_in_plasma_ids) ABSL_LOCKS_EXCLUDED(mu_);
 
-  void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
-                                 const std::vector<ObjectID> &contained_ids) override;
+  void OnTaskDependenciesInlined(
+      const absl::InlinedVector<ObjectID, 8> &inlined_dependency_ids,
+      const absl::InlinedVector<ObjectID, 8> &contained_ids) override;
 
   void MarkTaskNoRetry(const TaskID &task_id) override;
 
@@ -475,7 +478,8 @@ class TaskManager : public TaskManagerInterface {
   std::optional<TaskSpecification> GetTaskSpec(const TaskID &task_id) const override;
 
   /// Return specs for pending children tasks of the given parent task.
-  std::vector<TaskID> GetPendingChildrenTasks(const TaskID &parent_task_id) const;
+  absl::InlinedVector<TaskID, 8> GetPendingChildrenTasks(
+      const TaskID &parent_task_id) const;
 
   /// Return whether this task can be submitted for execution.
   ///
@@ -657,7 +661,7 @@ class TaskManager : public TaskManagerInterface {
   /// task's arguments whose lineage should also be released.
   /// \param[out] The amount of lineage in bytes that was removed.
   int64_t RemoveLineageReference(const ObjectID &object_id,
-                                 std::vector<ObjectID> *ids_to_release)
+                                 absl::InlinedVector<ObjectID, 8> *ids_to_release)
       ABSL_LOCKS_EXCLUDED(mu_);
 
   /// Helper function to call RemoveSubmittedTaskReferences on the remaining
@@ -747,7 +751,7 @@ class TaskManager : public TaskManagerInterface {
 
   /// Update the references for a task that is being resubmitted.
   void UpdateReferencesForResubmit(const TaskSpecification &spec,
-                                   std::vector<ObjectID> *task_deps)
+                                   absl::InlinedVector<ObjectID, 8> *task_deps)
       ABSL_LOCKS_EXCLUDED(mu_);
 
   /// Used to store task results.

--- a/src/ray/core_worker/task_manager_interface.h
+++ b/src/ray/core_worker/task_manager_interface.h
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "ray/common/id.h"
 #include "ray/common/lease/lease.h"
 #include "ray/common/scheduling/scheduling_ids.h"
@@ -119,7 +120,7 @@ class TaskManagerInterface {
   /// appopriate error type to propagate for the object if the task was not successfully
   /// resubmitted.
   virtual std::optional<rpc::ErrorType> ResubmitTask(
-      const TaskID &task_id, std::vector<ObjectID> *task_deps) = 0;
+      const TaskID &task_id, absl::InlinedVector<ObjectID, 8> *task_deps) = 0;
 
   /// Record that the given task is scheduled and wait for execution.
   ///
@@ -140,8 +141,8 @@ class TaskManagerInterface {
   /// task spec, because a serialized copy of the ID was contained in one of
   /// the inlined dependencies.
   virtual void OnTaskDependenciesInlined(
-      const std::vector<ObjectID> &inlined_dependency_ids,
-      const std::vector<ObjectID> &contained_ids) = 0;
+      const absl::InlinedVector<ObjectID, 8> &inlined_dependency_ids,
+      const absl::InlinedVector<ObjectID, 8> &contained_ids) = 0;
 
   /// Record that the given task's dependencies have been created and the task
   /// can now be scheduled for execution.

--- a/src/ray/core_worker/task_submission/actor_submit_queue.h
+++ b/src/ray/core_worker/task_submission/actor_submit_queue.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
 #include "absl/types/optional.h"
 #include "ray/common/id.h"
 #include "ray/common/task/task_spec.h"
@@ -64,7 +65,7 @@ class IActorSubmitQueue {
   virtual void MarkTaskCanceled(const std::string &concurrency_group,
                                 uint64_t sequence_no) = 0;
   /// Clear the queue and returns all tasks ids that haven't been sent yet.
-  virtual std::vector<TaskID> ClearAllTasks() = 0;
+  virtual absl::InlinedVector<TaskID, 8> ClearAllTasks() = 0;
   /// Find next task to send.
   /// \return
   ///   - nullopt if no task ready to send

--- a/src/ray/core_worker/task_submission/actor_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/actor_task_submitter.cc
@@ -387,7 +387,7 @@ void ActorTaskSubmitter::DisconnectActor(const ActorID &actor_id,
   absl::flat_hash_map<TaskAttempt, rpc::ClientCallback<rpc::PushTaskReply>>
       inflight_task_callbacks;
   std::deque<std::shared_ptr<PendingTaskWaitingForDeathInfo>> wait_for_death_info_tasks;
-  std::vector<TaskID> task_ids_to_fail;
+  absl::InlinedVector<TaskID, 8> task_ids_to_fail;
   {
     absl::MutexLock lock(&mu_);
     auto queue = client_queues_.find(actor_id);

--- a/src/ray/core_worker/task_submission/dependency_resolver.cc
+++ b/src/ray/core_worker/task_submission/dependency_resolver.cc
@@ -26,8 +26,8 @@ namespace {
 void InlineDependencies(
     const absl::flat_hash_map<ObjectID, std::shared_ptr<RayObject>> &dependencies,
     TaskSpecification &task,
-    std::vector<ObjectID> *inlined_dependency_ids,
-    std::vector<ObjectID> *contained_ids,
+    absl::InlinedVector<ObjectID, 8> *inlined_dependency_ids,
+    absl::InlinedVector<ObjectID, 8> *contained_ids,
     const TensorTransportGetter &tensor_transport_getter) {
   auto &msg = task.GetMutableMessage();
   size_t found = 0;
@@ -136,8 +136,8 @@ void LocalDependencyResolver::ResolveDependencies(
           RAY_CHECK(obj != nullptr);
 
           std::unique_ptr<TaskState> resolved_task_state = nullptr;
-          std::vector<ObjectID> inlined_dependency_ids;
-          std::vector<ObjectID> contained_ids;
+          absl::InlinedVector<ObjectID, 8> inlined_dependency_ids;
+          absl::InlinedVector<ObjectID, 8> contained_ids;
           {
             absl::MutexLock lock(&mu_);
 

--- a/src/ray/core_worker/task_submission/out_of_order_actor_submit_queue.cc
+++ b/src/ray/core_worker/task_submission/out_of_order_actor_submit_queue.cc
@@ -123,8 +123,8 @@ void OutofOrderActorSubmitQueue::MarkDependencyResolved(
       position, std::make_pair(std::move(spec), /*dependency_resolved*/ true));
 }
 
-std::vector<TaskID> OutofOrderActorSubmitQueue::ClearAllTasks() {
-  std::vector<TaskID> task_ids;
+absl::InlinedVector<TaskID, 8> OutofOrderActorSubmitQueue::ClearAllTasks() {
+  absl::InlinedVector<TaskID, 8> task_ids;
   for (const auto &[_, queue] : pending_queue_per_group_) {
     for (const auto &[__, spec] : queue) {
       task_ids.push_back(spec.first.TaskId());

--- a/src/ray/core_worker/task_submission/out_of_order_actor_submit_queue.h
+++ b/src/ray/core_worker/task_submission/out_of_order_actor_submit_queue.h
@@ -56,7 +56,7 @@ class OutofOrderActorSubmitQueue : public IActorSubmitQueue {
   // popped via PopNextTaskToSend.
   void MarkTaskCanceled(const std::string &concurrency_group, uint64_t position) override;
   /// Clear the queue and returns all tasks ids that haven't been sent yet.
-  std::vector<TaskID> ClearAllTasks() override;
+  absl::InlinedVector<TaskID, 8> ClearAllTasks() override;
   /// Find next task to send.
   /// \return
   ///   - nullopt if no task ready to send

--- a/src/ray/core_worker/task_submission/sequential_actor_submit_queue.cc
+++ b/src/ray/core_worker/task_submission/sequential_actor_submit_queue.cc
@@ -133,8 +133,8 @@ void SequentialActorSubmitQueue::MarkDependencyResolved(
   }
 }
 
-std::vector<TaskID> SequentialActorSubmitQueue::ClearAllTasks() {
-  std::vector<TaskID> task_ids;
+absl::InlinedVector<TaskID, 8> SequentialActorSubmitQueue::ClearAllTasks() {
+  absl::InlinedVector<TaskID, 8> task_ids;
   for (const auto &[_, requests] : requests_per_group_) {
     for (const auto &[seq_no, spec] : requests) {
       task_ids.push_back(spec.first.TaskId());

--- a/src/ray/core_worker/task_submission/sequential_actor_submit_queue.h
+++ b/src/ray/core_worker/task_submission/sequential_actor_submit_queue.h
@@ -55,7 +55,7 @@ class SequentialActorSubmitQueue : public IActorSubmitQueue {
   void MarkTaskCanceled(const std::string &concurrency_group,
                         uint64_t sequence_no) override;
   /// Clear the queue and returns all tasks ids that haven't been sent yet.
-  std::vector<TaskID> ClearAllTasks() override;
+  absl::InlinedVector<TaskID, 8> ClearAllTasks() override;
   /// Find next task to send.
   /// \return
   ///   - nullopt if no task ready to send

--- a/src/ray/core_worker/task_submission/tests/dependency_resolver_test.cc
+++ b/src/ray/core_worker/task_submission/tests/dependency_resolver_test.cc
@@ -102,8 +102,9 @@ class MockTaskManager : public MockTaskManagerInterface {
     return true;
   }
 
-  void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
-                                 const std::vector<ObjectID> &contained_ids) override {
+  void OnTaskDependenciesInlined(
+      const absl::InlinedVector<ObjectID, 8> &inlined_dependency_ids,
+      const absl::InlinedVector<ObjectID, 8> &contained_ids) override {
     num_inlined_dependencies += inlined_dependency_ids.size();
     num_contained_ids += contained_ids.size();
   }

--- a/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
@@ -183,8 +183,9 @@ class MockTaskManager : public MockTaskManagerInterface {
     return true;
   }
 
-  void OnTaskDependenciesInlined(const std::vector<ObjectID> &inlined_dependency_ids,
-                                 const std::vector<ObjectID> &contained_ids) override {
+  void OnTaskDependenciesInlined(
+      const absl::InlinedVector<ObjectID, 8> &inlined_dependency_ids,
+      const absl::InlinedVector<ObjectID, 8> &contained_ids) override {
     num_inlined_dependencies += inlined_dependency_ids.size();
     num_contained_ids += contained_ids.size();
   }

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -503,7 +503,7 @@ TEST_F(CoreWorkerTest, HandleGetObjectStatusObjectFreedBetweenRequests) {
   EXPECT_EQ("test_data", reply1.object().data());
   EXPECT_EQ("meta", reply1.object().metadata());
 
-  std::vector<ObjectID> objects_to_free = {object_id};
+  absl::InlinedVector<ObjectID, 8> objects_to_free = {object_id};
   memory_store_->Delete(objects_to_free);
 
   std::promise<Status> promise2;
@@ -658,12 +658,13 @@ TEST(BatchingPassesTwoTwoOneIntoPlasmaGet, CallsPlasmaGetInCorrectBatches) {
                                *std::make_shared<ray::observability::FakeGauge>());
 
   // Fake plasma client that records Get calls.
-  std::vector<std::vector<ObjectID>> observed_batches;
+  std::vector<absl::InlinedVector<ObjectID, 8>> observed_batches;
   class RecordingPlasmaGetClient : public plasma::FakePlasmaClient {
    public:
-    explicit RecordingPlasmaGetClient(std::vector<std::vector<ObjectID>> *observed)
+    explicit RecordingPlasmaGetClient(
+        std::vector<absl::InlinedVector<ObjectID, 8>> *observed)
         : observed_(observed) {}
-    Status Get(const std::vector<ObjectID> &object_ids,
+    Status Get(const absl::InlinedVector<ObjectID, 8> &object_ids,
                int64_t timeout_ms,
                std::vector<plasma::ObjectBuffer> *object_buffers) override {
       if (observed_ != nullptr) {
@@ -680,7 +681,7 @@ TEST(BatchingPassesTwoTwoOneIntoPlasmaGet, CallsPlasmaGetInCorrectBatches) {
     }
 
    private:
-    std::vector<std::vector<ObjectID>> *observed_;
+    std::vector<absl::InlinedVector<ObjectID, 8>> *observed_;
   };
 
   auto fake_plasma = std::make_shared<RecordingPlasmaGetClient>(&observed_batches);
@@ -695,7 +696,7 @@ TEST(BatchingPassesTwoTwoOneIntoPlasmaGet, CallsPlasmaGetInCorrectBatches) {
       /*get_current_call_site=*/nullptr);
 
   // Build a set of 5 object ids.
-  std::vector<ObjectID> ids;
+  absl::InlinedVector<ObjectID, 8> ids;
   for (int i = 0; i < 5; i++) ids.push_back(ObjectID::FromRandom());
   const auto owner_addresses = ref_counter.GetOwnerAddresses(ids);
 
@@ -1153,7 +1154,7 @@ TEST_P(HandleWaitForActorRefDeletedRetriesTest, ActorRefDeletedForRegisteredActo
       });
 
   if (delete_actor_handle) {
-    std::vector<ObjectID> deleted;
+    absl::InlinedVector<ObjectID, 8> deleted;
     // Triggers the send_reply_callback which is stored in the reference counter
     reference_counter_->RemoveLocalReference(actor_creation_return_id, &deleted);
     ASSERT_EQ(deleted.size(), 1u);
@@ -1258,7 +1259,7 @@ TEST_P(HandleWaitForActorRefDeletedWhileRegisteringRetriesTest,
   ASSERT_FALSE(actor_creator_->IsActorInRegistering(actor_id));
 
   if (delete_actor_handle) {
-    std::vector<ObjectID> deleted;
+    absl::InlinedVector<ObjectID, 8> deleted;
     // Triggers the send_reply_callback which is stored in the reference counter
     reference_counter_->RemoveLocalReference(actor_creation_return_id, &deleted);
     ASSERT_EQ(deleted.size(), 1u);

--- a/src/ray/core_worker/tests/lease_policy_test.cc
+++ b/src/ray/core_worker/tests/lease_policy_test.cc
@@ -23,7 +23,7 @@
 namespace ray {
 namespace core {
 
-LeaseSpecification CreateFakeLease(std::vector<ObjectID> deps) {
+LeaseSpecification CreateFakeLease(absl::InlinedVector<ObjectID, 8> deps) {
   rpc::LeaseSpec spec;
   for (auto &dep : deps) {
     spec.add_dependencies()->set_object_id(dep.Binary());
@@ -69,7 +69,7 @@ TEST(LocalLeasePolicyTest, TestReturnFallback) {
   LocalLeasePolicy local_lease_policy(fallback_rpc_address);
   ObjectID obj1 = ObjectID::FromRandom();
   ObjectID obj2 = ObjectID::FromRandom();
-  std::vector<ObjectID> deps{obj1, obj2};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2};
   auto lease_spec = CreateFakeLease(deps);
   auto [best_node_address, is_selected_based_on_locality] =
       local_lease_policy.GetBestNodeForLease(lease_spec);
@@ -92,7 +92,7 @@ TEST(LocalityAwareLeasePolicyTest, TestBestLocalityFallbackSpreadSchedulingStrat
       std::make_shared<MockLocalityDataProvider>(locality_data);
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactory, fallback_rpc_address);
-  std::vector<ObjectID> deps{obj1, obj2};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2};
   auto lease_spec = CreateFakeLease(deps);
   lease_spec.GetMutableMessage()
       .mutable_scheduling_strategy()
@@ -121,7 +121,7 @@ TEST(LocalityAwareLeasePolicyTest,
       std::make_shared<MockLocalityDataProvider>(locality_data);
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactory, fallback_rpc_address);
-  std::vector<ObjectID> deps{obj1, obj2};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2};
   auto lease_spec = CreateFakeLease(deps);
   NodeID node_affinity_node = NodeID::FromRandom();
   lease_spec.GetMutableMessage()
@@ -151,7 +151,7 @@ TEST(LocalityAwareLeasePolicyTest, TestBestLocalityDominatingNode) {
       std::make_shared<MockLocalityDataProvider>(locality_data);
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactory, fallback_rpc_address);
-  std::vector<ObjectID> deps{obj1, obj2};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2};
   auto lease_spec = CreateFakeLease(deps);
   auto [best_node_address, is_selected_based_on_locality] =
       locality_lease_policy.GetBestNodeForLease(lease_spec);
@@ -177,7 +177,7 @@ TEST(LocalityAwareLeasePolicyTest, TestBestLocalityBiggerObject) {
       std::make_shared<MockLocalityDataProvider>(locality_data);
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactory, fallback_rpc_address);
-  std::vector<ObjectID> deps{obj1, obj2};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2};
   auto lease_spec = CreateFakeLease(deps);
   auto [best_node_address, is_selected_based_on_locality] =
       locality_lease_policy.GetBestNodeForLease(lease_spec);
@@ -207,7 +207,7 @@ TEST(LocalityAwareLeasePolicyTest, TestBestLocalityBetterNode) {
       std::make_shared<MockLocalityDataProvider>(locality_data);
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactory, fallback_rpc_address);
-  std::vector<ObjectID> deps{obj1, obj2, obj3};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2, obj3};
   auto lease_spec = CreateFakeLease(deps);
   auto [best_node_address, is_selected_based_on_locality] =
       locality_lease_policy.GetBestNodeForLease(lease_spec);
@@ -231,7 +231,7 @@ TEST(LocalityAwareLeasePolicyTest, TestBestLocalityFallbackNoLocations) {
       std::make_shared<MockLocalityDataProvider>(locality_data);
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactory, fallback_rpc_address);
-  std::vector<ObjectID> deps{obj1, obj2};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2};
   auto lease_spec = CreateFakeLease(deps);
   auto [best_node_address, is_selected_based_on_locality] =
       locality_lease_policy.GetBestNodeForLease(lease_spec);
@@ -250,7 +250,7 @@ TEST(LocalityAwareLeasePolicyTest, TestBestLocalityFallbackNoDeps) {
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactory, fallback_rpc_address);
   // No lease dependencies.
-  std::vector<ObjectID> deps;
+  absl::InlinedVector<ObjectID, 8> deps;
   auto lease_spec = CreateFakeLease(deps);
   auto [best_node_address, is_selected_based_on_locality] =
       locality_lease_policy.GetBestNodeForLease(lease_spec);
@@ -275,7 +275,7 @@ TEST(LocalityAwareLeasePolicyTest, TestBestLocalityFallbackAddrFetchFail) {
   // Provided node address factory always returns absl::nullopt.
   LocalityAwareLeasePolicy locality_lease_policy(
       *mock_locality_data_provider, MockNodeAddrFactoryAlwaysNull, fallback_rpc_address);
-  std::vector<ObjectID> deps{obj1, obj2};
+  absl::InlinedVector<ObjectID, 8> deps{obj1, obj2};
   auto lease_spec = CreateFakeLease(deps);
   auto [best_node_address, is_selected_based_on_locality] =
       locality_lease_policy.GetBestNodeForLease(lease_spec);

--- a/src/ray/core_worker/tests/memory_store_test.cc
+++ b/src/ray/core_worker/tests/memory_store_test.cc
@@ -253,10 +253,10 @@ TEST_F(TestMemoryStoreWait, TestWaitNoWaiting) {
   // Object 2 is in plasma
   // Object 3 is ready in memory store
   // num_objects is 2 (expect 0 and 4 in ready, 1 and 2 in plasma_object_ids)
-  std::vector<ObjectID> object_ids = {ObjectID::FromRandom(),
-                                      ObjectID::FromRandom(),
-                                      ObjectID::FromRandom(),
-                                      ObjectID::FromRandom()};
+  absl::InlinedVector<ObjectID, 8> object_ids = {ObjectID::FromRandom(),
+                                                 ObjectID::FromRandom(),
+                                                 ObjectID::FromRandom(),
+                                                 ObjectID::FromRandom()};
   absl::flat_hash_set<ObjectID> object_ids_set = {object_ids.begin(), object_ids.end()};
   int num_objects = 2;
 
@@ -283,10 +283,10 @@ TEST_F(TestMemoryStoreWait, TestWaitWithWaiting) {
   // Object 2 will be in plasma after wait is called
   // Object 3 will be in ready in memory store after wait is called
   // num_objects is 4 (expect 0 and 3 in ready, 1 and 2 in plasma_object_ids)
-  std::vector<ObjectID> object_ids = {ObjectID::FromRandom(),
-                                      ObjectID::FromRandom(),
-                                      ObjectID::FromRandom(),
-                                      ObjectID::FromRandom()};
+  absl::InlinedVector<ObjectID, 8> object_ids = {ObjectID::FromRandom(),
+                                                 ObjectID::FromRandom(),
+                                                 ObjectID::FromRandom(),
+                                                 ObjectID::FromRandom()};
   absl::flat_hash_set<ObjectID> object_ids_set = {object_ids.begin(), object_ids.end()};
   int num_objects = 4;
 

--- a/src/ray/core_worker/tests/mutable_object_provider_test.cc
+++ b/src/ray/core_worker/tests/mutable_object_provider_test.cc
@@ -89,14 +89,14 @@ class MockRayletClient : public rpc::FakeRayletClient {
     pushed_objects_.push_back(object_id);
   }
 
-  std::vector<ObjectID> pushed_objects() {
+  absl::InlinedVector<ObjectID, 8> pushed_objects() {
     absl::MutexLock guard(&lock_);
     return pushed_objects_;
   }
 
  private:
   absl::Mutex lock_;
-  std::vector<ObjectID> pushed_objects_;
+  absl::InlinedVector<ObjectID, 8> pushed_objects_;
 };
 
 std::shared_ptr<RayletClientInterface> GetMockRayletClient(

--- a/src/ray/core_worker/tests/object_recovery_manager_test.cc
+++ b/src/ray/core_worker/tests/object_recovery_manager_test.cc
@@ -45,14 +45,14 @@ class MockTaskManager : public MockTaskManagerInterface {
  public:
   MockTaskManager() {}
 
-  void AddTask(const TaskID &task_id, std::vector<ObjectID> task_deps) {
+  void AddTask(const TaskID &task_id, absl::InlinedVector<ObjectID, 8> task_deps) {
     task_specs[task_id] = task_deps;
   }
 
   void CancelTask(const TaskID &task_id) { cancelled_tasks.insert(task_id); }
 
-  std::optional<rpc::ErrorType> ResubmitTask(const TaskID &task_id,
-                                             std::vector<ObjectID> *task_deps) override {
+  std::optional<rpc::ErrorType> ResubmitTask(
+      const TaskID &task_id, absl::InlinedVector<ObjectID, 8> *task_deps) override {
     if (task_specs.find(task_id) == task_specs.end()) {
       return rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE_MAX_ATTEMPTS_EXCEEDED;
     }
@@ -67,7 +67,7 @@ class MockTaskManager : public MockTaskManagerInterface {
     return std::nullopt;
   }
 
-  absl::flat_hash_map<TaskID, std::vector<ObjectID>> task_specs;
+  absl::flat_hash_map<TaskID, absl::InlinedVector<ObjectID, 8>> task_specs;
   absl::flat_hash_set<TaskID> cancelled_tasks;
   int num_tasks_resubmitted = 0;
 };
@@ -76,7 +76,7 @@ class MockRayletClient : public rpc::FakeRayletClient {
  public:
   void PinObjectIDs(
       const rpc::Address &caller_address,
-      const std::vector<ObjectID> &object_ids,
+      const absl::InlinedVector<ObjectID, 8> &object_ids,
       const ObjectID &generator_id,
       const rpc::ClientCallback<rpc::PinObjectIDsReply> &callback) override {
     RAY_LOG(INFO) << "PinObjectIDs " << object_ids.size();
@@ -171,7 +171,7 @@ class ObjectRecoveryManagerTestBase : public ::testing::Test {
               memory_store_->Put(data, object_id, ref_counter_->HasReference(object_id));
             }) {
     ref_counter_->SetReleaseLineageCallback(
-        [](const ObjectID &, std::vector<ObjectID> *args) { return 0; });
+        [](const ObjectID &, absl::InlinedVector<ObjectID, 8> *args) { return 0; });
   }
 
   void TearDown() override {
@@ -343,8 +343,8 @@ TEST_F(ObjectRecoveryManagerTest, TestReconstructionSuppression) {
 }
 
 TEST_F(ObjectRecoveryManagerTest, TestReconstructionChain) {
-  std::vector<ObjectID> object_ids;
-  std::vector<ObjectID> dependencies;
+  absl::InlinedVector<ObjectID, 8> object_ids;
+  absl::InlinedVector<ObjectID, 8> dependencies;
   for (int i = 0; i < 3; i++) {
     ObjectID object_id = ObjectID::FromRandom();
     ref_counter_->AddOwnedObject(object_id,

--- a/src/ray/core_worker/tests/reference_counter_test.cc
+++ b/src/ray/core_worker/tests/reference_counter_test.cc
@@ -458,10 +458,11 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
   void HandleSubmittedTaskFinished(
       const ObjectID &return_id,
       const ObjectID &arg_id,
-      const absl::flat_hash_map<ObjectID, std::vector<ObjectID>> &nested_return_ids = {},
+      const absl::flat_hash_map<ObjectID, absl::InlinedVector<ObjectID, 8>>
+          &nested_return_ids = {},
       const rpc::Address &borrower_address = empty_borrower,
       const ReferenceCounterInterface::ReferenceTableProto &borrower_refs = empty_refs) {
-    std::vector<ObjectID> arguments;
+    absl::InlinedVector<ObjectID, 8> arguments;
     for (const auto &pair : nested_return_ids) {
       // NOTE(swang): https://github.com/ray-project/ray/issues/17553.
       rc_.AddNestedObjectIds(pair.first, pair.second, address_);
@@ -500,14 +501,14 @@ class MockWorkerClient : public MockCoreWorkerClientInterface {
   ReferenceCounter rc_;
   absl::flat_hash_map<int, std::function<void()>> borrower_callbacks_;
   int num_requests_ = 0;
-  std::vector<ObjectID> return_ids_;
+  absl::InlinedVector<ObjectID, 8> return_ids_;
   bool failed_ = false;
 };
 
 // Tests basic incrementing/decrementing of direct/submitted task reference counts. An
 // entry should only be removed once both of its reference counts reach zero.
 TEST_F(ReferenceCountTest, TestBasic) {
-  std::vector<ObjectID> out;
+  absl::InlinedVector<ObjectID, 8> out;
 
   ObjectID id1 = ObjectID::FromRandom();
   ObjectID id2 = ObjectID::FromRandom();
@@ -600,7 +601,7 @@ TEST_F(ReferenceCountTest, TestUnreconstructableObjectOutOfScope) {
   auto callback = [&](const ObjectID &object_id) { *out_of_scope = true; };
 
   // The object goes out of scope once it has no more refs.
-  std::vector<ObjectID> out;
+  absl::InlinedVector<ObjectID, 8> out;
   ASSERT_FALSE(rc->AddObjectOutOfScopeOrFreedCallback(id, callback));
   rc->AddOwnedObject(id,
                      {},
@@ -2578,7 +2579,7 @@ TEST_F(ReferenceCountLineageEnabledTest, TestUnreconstructableObjectOutOfScope) 
   auto callback = [&](const ObjectID &object_id) { *out_of_scope = true; };
 
   // The object goes out of scope once it has no more refs.
-  std::vector<ObjectID> out;
+  absl::InlinedVector<ObjectID, 8> out;
   ASSERT_FALSE(rc->AddObjectOutOfScopeOrFreedCallback(id, callback));
   rc->AddOwnedObject(id,
                      {},
@@ -2628,13 +2629,13 @@ TEST_F(ReferenceCountLineageEnabledTest, TestUnreconstructableObjectOutOfScope) 
 
 // Test to make sure that we call the lineage released callback correctly.
 TEST_F(ReferenceCountLineageEnabledTest, TestBasicLineage) {
-  std::vector<ObjectID> out;
-  std::vector<ObjectID> lineage_deleted;
+  absl::InlinedVector<ObjectID, 8> out;
+  absl::InlinedVector<ObjectID, 8> lineage_deleted;
 
   ObjectID id = ObjectID::FromRandom();
 
   rc->SetReleaseLineageCallback(
-      [&](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
+      [&](const ObjectID &object_id, absl::InlinedVector<ObjectID, 8> *ids_to_release) {
         lineage_deleted.push_back(object_id);
         return 0;
       });
@@ -2663,10 +2664,10 @@ TEST_F(ReferenceCountLineageEnabledTest, TestBasicLineage) {
 // have gone out of scope, but their Reference entry is pinned until the final
 // object goes out of scope.
 TEST_F(ReferenceCountLineageEnabledTest, TestPinLineageRecursive) {
-  std::vector<ObjectID> out;
-  std::vector<ObjectID> lineage_deleted;
+  absl::InlinedVector<ObjectID, 8> out;
+  absl::InlinedVector<ObjectID, 8> lineage_deleted;
 
-  std::vector<ObjectID> ids;
+  absl::InlinedVector<ObjectID, 8> ids;
   for (int i = 0; i < 3; i++) {
     ObjectID id = ObjectID::FromRandom();
     ids.push_back(id);
@@ -2680,7 +2681,7 @@ TEST_F(ReferenceCountLineageEnabledTest, TestPinLineageRecursive) {
   }
 
   rc->SetReleaseLineageCallback(
-      [&](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
+      [&](const ObjectID &object_id, absl::InlinedVector<ObjectID, 8> *ids_to_release) {
         lineage_deleted.push_back(object_id);
         // Simulate releasing objects in downstream_id's lineage.
         size_t i = 0;
@@ -2726,7 +2727,7 @@ TEST_F(ReferenceCountLineageEnabledTest, TestPinLineageRecursive) {
 }
 
 TEST_F(ReferenceCountLineageEnabledTest, TestEvictLineage) {
-  std::vector<ObjectID> ids;
+  absl::InlinedVector<ObjectID, 8> ids;
   for (int i = 0; i < 3; i++) {
     ObjectID id = ObjectID::FromRandom();
     ids.push_back(id);
@@ -2738,9 +2739,9 @@ TEST_F(ReferenceCountLineageEnabledTest, TestEvictLineage) {
                        LineageReconstructionEligibility::ELIGIBLE,
                        /*add_local_ref=*/true);
   }
-  std::vector<ObjectID> lineage_deleted;
+  absl::InlinedVector<ObjectID, 8> lineage_deleted;
   rc->SetReleaseLineageCallback(
-      [&](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
+      [&](const ObjectID &object_id, absl::InlinedVector<ObjectID, 8> *ids_to_release) {
         lineage_deleted.push_back(object_id);
         if (object_id == ids[1]) {
           // ID1 depends on ID0.
@@ -2778,8 +2779,8 @@ TEST_F(ReferenceCountLineageEnabledTest, TestEvictLineage) {
 }
 
 TEST_F(ReferenceCountLineageEnabledTest, TestResubmittedTask) {
-  std::vector<ObjectID> out;
-  std::vector<ObjectID> lineage_deleted;
+  absl::InlinedVector<ObjectID, 8> out;
+  absl::InlinedVector<ObjectID, 8> lineage_deleted;
 
   ObjectID id = ObjectID::FromRandom();
   rc->AddOwnedObject(id,
@@ -2791,7 +2792,7 @@ TEST_F(ReferenceCountLineageEnabledTest, TestResubmittedTask) {
                      /*add_local_ref=*/true);
 
   rc->SetReleaseLineageCallback(
-      [&](const ObjectID &object_id, std::vector<ObjectID> *ids_to_release) {
+      [&](const ObjectID &object_id, absl::InlinedVector<ObjectID, 8> *ids_to_release) {
         lineage_deleted.push_back(object_id);
         return 0;
       });
@@ -3184,7 +3185,7 @@ TEST_F(ReferenceCountTest, TestOwnDynamicStreamingTaskReturnRef) {
   ASSERT_TRUE(rc->GetOwner(object_id, &added_address));
   ASSERT_EQ(address.ip_address(), added_address.ip_address());
   // Verify it had 1 local reference.
-  std::vector<ObjectID> deleted;
+  absl::InlinedVector<ObjectID, 8> deleted;
   rc->RemoveLocalReference(object_id, &deleted);
   ASSERT_EQ(rc->NumObjectIDsInScope(), 1);
   ASSERT_EQ(deleted.size(), 1);
@@ -3272,7 +3273,7 @@ TEST_F(ReferenceCountTest, TestOwnedObjectCounters) {
   ASSERT_EQ((size_metrics[{{"State", "InMemory"}}]), 150);
 
   // Test 6: Delete objects
-  std::vector<ObjectID> deleted;
+  absl::InlinedVector<ObjectID, 8> deleted;
   rc->RemoveLocalReference(pending_id1, &deleted);
   rc->RecordMetrics();
   count_metrics = owned_object_count_metric_->GetTagToValue();

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -38,7 +38,7 @@ namespace ray {
 namespace core {
 
 TaskSpecification CreateTaskHelper(uint64_t num_returns,
-                                   std::vector<ObjectID> dependencies,
+                                   absl::InlinedVector<ObjectID, 8> dependencies,
                                    bool dynamic_returns = false,
                                    bool streaming_generator = false,
                                    int64_t generator_backpressure_num_objects = -1,
@@ -295,7 +295,7 @@ TEST_F(TaskManagerTest, TestTaskSuccess) {
             0);
   ASSERT_EQ(num_retries_, 0);
 
-  std::vector<ObjectID> removed;
+  absl::InlinedVector<ObjectID, 8> removed;
   reference_counter_->RemoveLocalReference(return_id, &removed);
   ASSERT_EQ(removed[0], return_id);
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
@@ -330,7 +330,7 @@ TEST_F(TaskManagerTest, TestTaskFailure) {
   ASSERT_EQ(stored_error, error);
   ASSERT_EQ(num_retries_, 0);
 
-  std::vector<ObjectID> removed;
+  absl::InlinedVector<ObjectID, 8> removed;
   reference_counter_->RemoveLocalReference(return_id, &removed);
   ASSERT_EQ(removed[0], return_id);
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
@@ -399,7 +399,7 @@ TEST_F(TaskManagerTest, TestFailPendingTask) {
   ASSERT_TRUE(results[0]->IsException(&stored_error));
   ASSERT_EQ(stored_error, rpc::ErrorType::LOCAL_RAYLET_DIED);
 
-  std::vector<ObjectID> removed;
+  absl::InlinedVector<ObjectID, 8> removed;
   reference_counter_->RemoveLocalReference(return_id, &removed);
   ASSERT_EQ(removed[0], return_id);
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
@@ -465,7 +465,7 @@ TEST_F(TaskManagerTest, TestTaskReconstruction) {
   ASSERT_TRUE(results[0]->IsException(&stored_error));
   ASSERT_EQ(stored_error, error);
 
-  std::vector<ObjectID> removed;
+  absl::InlinedVector<ObjectID, 8> removed;
   reference_counter_->RemoveLocalReference(return_id, &removed);
   ASSERT_EQ(removed[0], return_id);
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);
@@ -516,7 +516,7 @@ TEST_F(TaskManagerTest, TestResubmitCanceledTask) {
   // Check that resubmitting a canceled task does not crash and returns
   // OBJECT_UNRECONSTRUCTABLE_TASK_CANCELLED.
   manager_.MarkTaskCanceled(spec.TaskId());
-  std::vector<ObjectID> task_deps;
+  absl::InlinedVector<ObjectID, 8> task_deps;
   ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &task_deps),
             rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE_TASK_CANCELLED);
 
@@ -1127,7 +1127,7 @@ TEST_F(TaskManagerLineageTest, TestResubmitTask) {
   int num_retries = 3;
 
   // Cannot resubmit a task whose spec we do not have.
-  std::vector<ObjectID> resubmitted_task_deps;
+  absl::InlinedVector<ObjectID, 8> resubmitted_task_deps;
   ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps),
             rpc::ErrorType::OBJECT_UNRECONSTRUCTABLE_MAX_ATTEMPTS_EXCEEDED);
   ASSERT_TRUE(resubmitted_task_deps.empty());
@@ -1222,7 +1222,7 @@ TEST_F(TaskManagerLineageTest, TestResubmittedTaskNondeterministicReturns) {
   // The task finished, its return ID is still in scope, and the return object
   // was stored in plasma. It is okay to resubmit it now.
   ASSERT_TRUE(stored_in_plasma.empty());
-  std::vector<ObjectID> resubmitted_task_deps;
+  absl::InlinedVector<ObjectID, 8> resubmitted_task_deps;
   ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps), std::nullopt);
   ASSERT_EQ(num_retries_, 1);
   ASSERT_EQ(last_delay_ms_, 0);
@@ -1286,7 +1286,7 @@ TEST_F(TaskManagerLineageTest, TestResubmittedTaskFails) {
   // The task finished, its return ID is still in scope, and the return object
   // was stored in plasma. It is okay to resubmit it now.
   ASSERT_TRUE(stored_in_plasma.empty());
-  std::vector<ObjectID> resubmitted_task_deps;
+  absl::InlinedVector<ObjectID, 8> resubmitted_task_deps;
   ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps), std::nullopt);
   ASSERT_EQ(num_retries_, 1);
   ASSERT_EQ(last_delay_ms_, 0);
@@ -1317,7 +1317,7 @@ TEST_F(TaskManagerLineageTest, TestDynamicReturnsTask) {
   ASSERT_TRUE(manager_.IsTaskPending(spec.TaskId()));
   ASSERT_FALSE(manager_.IsTaskWaitingForExecution(spec.TaskId()));
 
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
 
   // The task completes and returns dynamic returns.
   {
@@ -1379,7 +1379,7 @@ TEST_F(TaskManagerLineageTest, TestResubmittedDynamicReturnsTaskFails) {
   ASSERT_TRUE(manager_.IsTaskPending(spec.TaskId()));
   ASSERT_FALSE(manager_.IsTaskWaitingForExecution(spec.TaskId()));
 
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
 
   // The task completes and returns dynamic returns.
   {
@@ -1406,7 +1406,7 @@ TEST_F(TaskManagerLineageTest, TestResubmittedDynamicReturnsTaskFails) {
 
   // Resubmit the task.
   ASSERT_TRUE(stored_in_plasma.empty());
-  std::vector<ObjectID> resubmitted_task_deps;
+  absl::InlinedVector<ObjectID, 8> resubmitted_task_deps;
   ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &resubmitted_task_deps), std::nullopt);
   ASSERT_EQ(num_retries_, 1);
   ASSERT_EQ(last_delay_ms_, 0);
@@ -1708,7 +1708,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamBasic) {
   manager_.AddPendingTask(caller_address, spec, "", 0);
 
   auto last_idx = 2;
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
   std::vector<std::shared_ptr<Buffer>> datas;
   for (auto i = 0; i < last_idx; i++) {
     auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), i + 2);
@@ -1764,7 +1764,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamCancellation) {
   manager_.AddPendingTask(caller_address, spec, "", 0);
 
   auto last_idx = 2;
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
   std::vector<std::shared_ptr<Buffer>> datas;
   for (auto i = 0; i < last_idx; i++) {
     auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), i + 2);
@@ -1823,7 +1823,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamCancellationOutOfOrderReports) {
   manager_.AddPendingTask(caller_address, spec, "", 0);
 
   std::vector<int64_t> idx_to_report = {0, 3};
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
   std::vector<std::shared_ptr<Buffer>> datas;
   for (auto idx : idx_to_report) {
     auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), idx + 2);
@@ -1913,7 +1913,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamMixture) {
   manager_.AddPendingTask(caller_address, spec, "", 0);
 
   auto last_idx = 2;
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
   std::vector<std::shared_ptr<Buffer>> datas;
   for (auto i = 0; i < last_idx; i++) {
     auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), i + 2);
@@ -2438,7 +2438,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamOutofOrder) {
   manager_.AddPendingTask(caller_address, spec, "", /*num_retries=*/0);
 
   auto last_idx = 2;
-  std::vector<ObjectID> dynamic_return_ids;
+  absl::InlinedVector<ObjectID, 8> dynamic_return_ids;
   // EoF reported first.
   CompletePendingStreamingTask(spec, caller_address, 2);
 
@@ -2603,7 +2603,7 @@ TEST_F(TaskManagerTest, TestObjectRefStreamTemporarilyOwnGeneratorReturnRefIfNee
     ASSERT_TRUE(status.ok());
   }
 
-  std::vector<ObjectID> removed;
+  absl::InlinedVector<ObjectID, 8> removed;
   reference_counter_->RemoveLocalReference(dynamic_return_id_index_1, &removed);
   ASSERT_EQ(removed.size(), 1UL);
   ASSERT_FALSE(reference_counter_->HasReference(dynamic_return_id_index_1));
@@ -2845,7 +2845,7 @@ TEST_F(TaskManagerLineageTest, RecoverIntermediateObjectInStreamingGenerator) {
   manager_.MarkTaskWaitingForExecution(
       spec.TaskId(), NodeID::FromRandom(), WorkerID::FromRandom());
   ASSERT_TRUE(manager_.IsTaskWaitingForExecution(spec.TaskId()));
-  std::vector<ObjectID> task_deps;
+  absl::InlinedVector<ObjectID, 8> task_deps;
   ASSERT_EQ(manager_.ResubmitTask(spec.TaskId(), &task_deps), std::nullopt);
   ASSERT_TRUE(task_deps.empty());
   ASSERT_TRUE(manager_.IsTaskWaitingForExecution(spec.TaskId()));
@@ -2927,7 +2927,7 @@ TEST_F(TaskManagerTest, TestGPUObjectTaskSuccess) {
 
   // Call `RemoveLocalReference` to simulate that the GPU object ref is out of scope.
   // Then, the GPU object should be removed.
-  std::vector<ObjectID> removed;
+  absl::InlinedVector<ObjectID, 8> removed;
   reference_counter_->RemoveLocalReference(gpu_obj_ref, &removed);
   ASSERT_EQ(removed[0], gpu_obj_ref);
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 1);


### PR DESCRIPTION
## Summary

This PR addresses replacing small, frequently allocated `std::vector<ObjectID>`, `std::vector<TaskID>`, and `std::vector<ActorID>` usages in Ray Core hot paths with `absl::InlinedVector<..., 8>`.

The goal is to reduce heap allocations in code paths where these ID collections are usually very small, but created very frequently.

## What This PR Changes

### Core hot paths

Replaces small ID vectors with `absl::InlinedVector<..., 8>` in the following areas:

- `src/ray/common/task/task_spec.{h,cc}`
  - `DynamicReturnIds()`
  - `GetDependencyIds()`

- `src/ray/core_worker/task_manager.{h,cc}`
  - task dependency and return ID handling
  - inlined dependency handling
  - unconsumed object ref stream handling
  - pending child task collection

- `src/ray/core_worker/reference_counter.{h,cc}`
- `src/ray/core_worker/reference_counter_interface.h`
  - submitted / finished task reference updates
  - local ref release paths
  - owned object / contained ID handling

- `src/ray/core_worker/task_submission/dependency_resolver.cc`
  - inlined dependency ID and contained ID accumulation

### Additional small-ID collection cleanup

Also updates a few small `TaskID` / `ActorID` collections that are expected to stay small in practice:

- `src/ray/core_worker/actor_management/actor_manager.{h,cc}`
  - actor handle ID collection

- `src/ray/core_worker/core_worker.{h,cc}`
  - pending child task retrieval
  - actor registration wait path temporary actor ID collection

- `src/ray/core_worker/task_submission/actor_submit_queue.h`
- `src/ray/core_worker/task_submission/out_of_order_actor_submit_queue.{h,cc}`
- `src/ray/core_worker/task_submission/sequential_actor_submit_queue.{h,cc}`
- `src/ray/core_worker/task_submission/actor_task_submitter.cc`
  - queue cleanup / pending task ID collection

## Tests

Updates affected mocks and tests to match the new interface/container types, including:

- `src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc`
- `src/ray/core_worker/task_submission/tests/dependency_resolver_test.cc`

### Related Issue
Closes #59884 