### PR TITLE
[train] Deflake validation resumption again

### DIFF
--- a/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
+++ b/python/ray/train/v2/_internal/execution/checkpoint/validation_manager.py
@@ -168,7 +168,12 @@ class ValidationManager(ControllerCallback, ReportCallback, WorkerGroupCallback)
         checkpoint_to_metrics = {}
         try:
             checkpoint_to_metrics[checkpoint] = ray.get(task)
-        except (ray.exceptions.RayTaskError, ray.exceptions.TaskCancelledError):
+        except ray.exceptions.TaskCancelledError:
+            logger.info(
+                f"Validation was cancelled for checkpoint {checkpoint}, likely because the train run was aborted. "
+                "It will be retried in the next train run with the same storage path if there is one."
+            )
+        except ray.exceptions.RayTaskError:
             checkpoint_to_metrics[checkpoint] = {}
             logger.exception(f"Validation failed for checkpoint {checkpoint}")
             # TODO: track failed validations - see ed45912bb6ed435de06ac1cd58e9918e6825b4fe

--- a/python/ray/train/v2/tests/test_validation_manager.py
+++ b/python/ray/train/v2/tests/test_validation_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 import unittest.mock
 from unittest.mock import create_autospec
 
@@ -230,52 +229,6 @@ def test_checkpoint_validation_management_success_after_retry(tmp_path):
     assert vm._kick_off_validations() == 0
     checkpoint_manager.update_checkpoints_with_metrics.assert_called_once_with(
         {training_result.checkpoint: {"score": 100}}
-    )
-
-
-def test_checkpoint_validation_management_slow_validation_fn(tmp_path):
-    checkpoint_manager = create_autospec(CheckpointManager, instance=True)
-
-    def infinite_waiting_validation_fn(checkpoint):
-        while True:
-            time.sleep(1)
-
-    vm = validation_manager.ValidationManager(
-        checkpoint_manager=checkpoint_manager,
-        validation_config=ValidationConfig(fn=infinite_waiting_validation_fn),
-    )
-    timing_out_training_result = create_dummy_training_reports(
-        num_results=1,
-        storage_context=StorageContext(
-            storage_path=tmp_path,
-            experiment_dir_name="checkpoint_validation_management_slow_validation_fn_experiment",
-        ),
-    )[0]
-
-    vm.after_report(
-        training_report=_TrainingReport(
-            metrics=timing_out_training_result.metrics,
-            checkpoint=timing_out_training_result.checkpoint,
-            validation=True,
-        ),
-        metrics={},
-    )
-    assert vm._poll_validations() == 0
-    assert vm._kick_off_validations() == 1
-
-    # Finish the task by cancelling it
-    timing_out_task = next(iter(vm._pending_validations))
-    ray.cancel(timing_out_task)
-    with pytest.raises(ray.exceptions.TaskCancelledError):
-        ray.get(timing_out_task)
-
-    # Verify that poll processes finished task
-    assert vm._poll_validations() == 0
-    assert vm._kick_off_validations() == 0
-    checkpoint_manager.update_checkpoints_with_metrics.assert_called_once_with(
-        {
-            timing_out_training_result.checkpoint: {},
-        }
     )
 
 


### PR DESCRIPTION
# Summary

We were seeing this error in release tests:

```
[2026-04-07T23:36:05Z] E               ray.train.WorkerGroupError: Training failed due to worker errors:
--
[2026-04-07T23:36:05Z] E               [Rank 0 Error Snippet]:
[2026-04-07T23:36:05Z] E               Traceback (most recent call last):
[2026-04-07T23:36:05Z] E                 File "/root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/bin/python/ray/train/v2/test_async_checkpointing_validation.runfiles/io_ray/python/ray/train/v2/tests/test_async_checkpointing_validation.py", line 511, in train_fn_second
[2026-04-07T23:36:05Z] E                   assert rc[0].metrics == {"score": expected_score}
[2026-04-07T23:36:05Z] E               AssertionError: assert {} == {'score': 1}
[2026-04-07T23:36:05Z] E                +  where {} = ReportedCheckpoint(checkpoint=Checkpoint(filesystem=local, path=/tmp/pytest-of-root/pytest-
```

There's a race condition between abort() and before_controller_shutdown():
  1. First trainer's before_controller_shutdown() polls the stalling validation in a loop with await asyncio.sleep(1)           
  2. SIGINT triggers abort() which calls before_controller_abort() → ray.cancel(task), then ray.actor.exit_actor()
  3. exit_actor() raises AsyncioActorExit which becomes SystemExit — but this doesn't immediately cancel other running          
  coroutines                                                                                                                    
  4. Before the actor fully dies, before_controller_shutdown can resume from sleep, poll the now-cancelled task, and process it 
  5. In _process_finished_validation, TaskCancelledError is caught and treated the same as RayTaskError — returning {checkpoint: {}} (empty metrics)                                                                                                          
  6. update_checkpoints_with_metrics({checkpoint: {}}) marks the checkpoint as VALIDATED with metrics={} and saves state        
  7. The second trainer loads this state and sees status=VALIDATED, metrics={} instead of retrying the validation

Also removed unhelpful test - we only `ray.cancel` on abort, which should not mark the validation as completed.

# Testing

Unit tests, though note that the error that this PR fixes is inherently flaky.