### PR TITLE
[Core][2/n] Implement GCS Placement Group Fallback Scheduler

### DIFF
--- a/src/ray/common/placement_group.h
+++ b/src/ray/common/placement_group.h
@@ -69,6 +69,11 @@ class PlacementGroupSpecification : public MessageWrapper<rpc::PlacementGroupSpe
   std::vector<BundleSpecification> bundles_;
 };
 
+struct PlacementGroupSchedulingOption {
+  std::vector<std::unordered_map<std::string, double>> bundles;
+  std::vector<std::unordered_map<std::string, std::string>> bundle_label_selector;
+};
+
 class PlacementGroupSpecBuilder {
  public:
   PlacementGroupSpecBuilder() : message_(std::make_shared<rpc::PlacementGroupSpec>()) {}
@@ -88,7 +93,8 @@ class PlacementGroupSpecBuilder {
       const ActorID &creator_actor_id,
       bool is_creator_detached_actor,
       const std::vector<std::unordered_map<std::string, std::string>>
-          &bundle_label_selector = {}) {
+          &bundle_label_selector = {},
+      const std::vector<PlacementGroupSchedulingOption> &fallback_strategy = {}) {
     message_->set_placement_group_id(placement_group_id.Binary());
     message_->set_name(name);
     message_->set_strategy(strategy);
@@ -129,6 +135,35 @@ class PlacementGroupSpecBuilder {
         }
       }
     }
+
+    if (!fallback_strategy.empty()) {
+      for (const auto &option : fallback_strategy) {
+        auto *message_option = message_->add_fallback_strategy();
+
+        // Set bundles for scheduling option (primary and fallbacks).
+        for (size_t i = 0; i < option.bundles.size(); i++) {
+          const auto &resources = option.bundles[i];
+          auto *message_bundle = message_option->add_bundles();
+          auto *mutable_bundle_id = message_bundle->mutable_bundle_id();
+          mutable_bundle_id->set_bundle_index(i);
+          mutable_bundle_id->set_placement_group_id(placement_group_id.Binary());
+          auto *mutable_unit_resources = message_bundle->mutable_unit_resources();
+          for (const auto &pair : resources) {
+            if (pair.second > 0) {
+              mutable_unit_resources->insert({pair.first, pair.second});
+            }
+          }
+
+          if (option.bundle_label_selector.size() > i) {
+            auto *mutable_label_selector = message_bundle->mutable_label_selector();
+            for (const auto &pair : option.bundle_label_selector[i]) {
+              (*mutable_label_selector)[pair.first] = pair.second;
+            }
+          }
+        }
+      }
+    }
+
     return *this;
   }
 

--- a/src/ray/common/scheduling/label_selector.h
+++ b/src/ray/common/scheduling/label_selector.h
@@ -154,4 +154,11 @@ inline std::optional<absl::flat_hash_set<std::string>> GetHardNodeAffinityValues
   return std::nullopt;
 }
 
+inline bool IsGpuAcceleratorConstraint(const LabelConstraint &constraint) {
+  return constraint.GetLabelKey() == kLabelKeyNodeAcceleratorType &&
+         constraint.GetOperator() == LabelSelectorOperator::LABEL_IN &&
+         (constraint.GetLabelValues().contains(kGB300) ||
+          constraint.GetLabelValues().contains(kGB200));
+}
+
 }  // namespace ray

--- a/src/ray/common/scheduling/tests/label_selector_test.cc
+++ b/src/ray/common/scheduling/tests/label_selector_test.cc
@@ -208,4 +208,30 @@ TEST(LabelSelectorTest, Deduplication) {
   ASSERT_EQ(selector.GetConstraints().size(), 4);
 }
 
+TEST(LabelSelectorTest, TestIsGpuAcceleratorConstraint) {
+  // GB300
+  LabelConstraint c1(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_IN, {kGB300});
+  ASSERT_TRUE(IsGpuAcceleratorConstraint(c1));
+
+  // GB200
+  LabelConstraint c2(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_IN, {kGB200});
+  ASSERT_TRUE(IsGpuAcceleratorConstraint(c2));
+
+  // Wrong Key
+  LabelConstraint c3("wrong-key", LabelSelectorOperator::LABEL_IN, {kGB300});
+  ASSERT_FALSE(IsGpuAcceleratorConstraint(c3));
+
+  // Wrong Operator
+  LabelConstraint c4(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_NOT_IN, {kGB300});
+  ASSERT_FALSE(IsGpuAcceleratorConstraint(c4));
+
+  // Non-GPU value
+  LabelConstraint c5(
+      kLabelKeyNodeAcceleratorType, LabelSelectorOperator::LABEL_IN, {"N2D"});
+  ASSERT_FALSE(IsGpuAcceleratorConstraint(c5));
+}
+
 }  // namespace ray

--- a/src/ray/common/tests/BUILD.bazel
+++ b/src/ray/common/tests/BUILD.bazel
@@ -53,6 +53,16 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "placement_group_spec_test",
+    srcs = ["placement_group_spec_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:placement_group",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+ray_cc_test(
     name = "bundle_location_index_test",
     srcs = [
         "bundle_location_index_test.cc",

--- a/src/ray/common/tests/BUILD.bazel
+++ b/src/ray/common/tests/BUILD.bazel
@@ -58,7 +58,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:placement_group",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/ray/common/tests/placement_group_spec_test.cc
+++ b/src/ray/common/tests/placement_group_spec_test.cc
@@ -1,0 +1,70 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "ray/common/placement_group.h"
+
+namespace ray {
+
+TEST(PlacementGroupSpecTest, TestPlacementGroupSpecBuilderSchedulingOptions) {
+  PlacementGroupSpecBuilder builder;
+
+  std::vector<PlacementGroupSchedulingOption> scheduling_options;
+
+  // Option 1
+  PlacementGroupSchedulingOption option1;
+  option1.bundles = {{{"CPU", 1.0}}};
+  scheduling_options.push_back(option1);
+
+  // Option 2
+  PlacementGroupSchedulingOption option2;
+  option2.bundles = {{{"CPU", 2.0}}};
+  scheduling_options.push_back(option2);
+
+  PlacementGroupID pg_id = PlacementGroupID::Of(JobID::FromInt(1));
+  std::vector<std::unordered_map<std::string, double>> bundles = {{{"CPU", 1.0}}};
+
+  builder.SetPlacementGroupSpec(pg_id,
+                                "test_pg",
+                                bundles,
+                                rpc::PlacementStrategy::PACK,
+                                /*is_detached=*/false,
+                                /*soft_target_node_id=*/NodeID::Nil(),
+                                /*job_id=*/JobID::FromInt(1),
+                                /*creator_actor_id=*/ActorID::Nil(),
+                                /*is_creator_detached_actor=*/false,
+                                /*bundle_label_selector=*/{},
+                                scheduling_options);
+
+  PlacementGroupSpecification spec = builder.Build();
+
+  // Verify that the proto message has the expected fields.
+  const auto &proto = spec.GetMessage();
+
+  ASSERT_EQ(proto.fallback_strategy_size(), 2);
+
+  const auto &p_option1 = proto.fallback_strategy(0);
+  ASSERT_EQ(p_option1.bundles_size(), 1);
+  ASSERT_EQ(p_option1.bundles(0).unit_resources().at("CPU"), 1.0);
+
+  const auto &p_option2 = proto.fallback_strategy(1);
+  ASSERT_EQ(p_option2.bundles_size(), 1);
+  ASSERT_EQ(p_option2.bundles(0).unit_resources().at("CPU"), 2.0);
+}
+
+}  // namespace ray

--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -119,6 +119,7 @@ ray_cc_library(
     visibility = [":__subpackages__"],
     deps = [
         "//src/ray/common:id",
+        "//src/ray/common:placement_group",
         "//src/ray/common:ray_object",
         "//src/ray/common:task_common",
         "//src/ray/util:process",
@@ -320,6 +321,7 @@ ray_cc_library(
     hdrs = ["generator_waiter.h"],
     deps = [
         ":common",
+        "//src/ray/common:placement_group",
         "@com_google_absl//absl/synchronization",
     ],
 )

--- a/src/ray/core_worker/common.h
+++ b/src/ray/core_worker/common.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "ray/common/id.h"
+#include "ray/common/placement_group.h"
 #include "ray/common/ray_object.h"
 #include "ray/common/scheduling/fallback_strategy.h"
 #include "ray/common/scheduling/label_selector.h"
@@ -232,13 +233,15 @@ struct PlacementGroupCreationOptions {
       bool is_detached_p,
       NodeID soft_target_node_id = NodeID::Nil(),
       std::vector<std::unordered_map<std::string, std::string>> bundle_label_selector =
-          {})
+          {},
+      std::vector<PlacementGroupSchedulingOption> fallback_strategy = {})
       : name_(std::move(name)),
         strategy_(strategy),
         bundles_(std::move(bundles)),
         is_detached_(is_detached_p),
         soft_target_node_id_(soft_target_node_id),
-        bundle_label_selector_(std::move(bundle_label_selector)) {
+        bundle_label_selector_(std::move(bundle_label_selector)),
+        fallback_strategy_(std::move(fallback_strategy)) {
     RAY_CHECK(soft_target_node_id_.IsNil() || strategy_ == PlacementStrategy::STRICT_PACK)
         << "soft_target_node_id only works with STRICT_PACK now";
   }
@@ -259,6 +262,8 @@ struct PlacementGroupCreationOptions {
   const NodeID soft_target_node_id_;
   /// The label selectors to apply per-bundle in this placement group.
   const std::vector<std::unordered_map<std::string, std::string>> bundle_label_selector_;
+  /// A list of scheduling options defining fallback strategies for scheduling.
+  const std::vector<PlacementGroupSchedulingOption> fallback_strategy_;
 };
 
 class ObjectLocation {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -2257,6 +2257,20 @@ Status CoreWorker::CreatePlacementGroup(
       }
     }
   }
+
+  for (const auto &option : placement_group_creation_options.fallback_strategy_) {
+    for (const auto &bundle : option.bundles) {
+      for (const auto &resource : bundle) {
+        if (resource.first == kBundle_ResourceLabel) {
+          std::ostringstream stream;
+          stream << kBundle_ResourceLabel
+                 << " is a system reserved resource, which is not "
+                 << "allowed to be used in placement group fallback options. ";
+          return Status::Invalid(stream.str());
+        }
+      }
+    }
+  }
   const PlacementGroupID placement_group_id = PlacementGroupID::Of(GetCurrentJobId());
   PlacementGroupSpecBuilder builder;
   builder.SetPlacementGroupSpec(placement_group_id,
@@ -2268,7 +2282,8 @@ Status CoreWorker::CreatePlacementGroup(
                                 worker_context_->GetCurrentJobID(),
                                 worker_context_->GetCurrentActorID(),
                                 worker_context_->CurrentActorDetached(),
-                                placement_group_creation_options.bundle_label_selector_);
+                                placement_group_creation_options.bundle_label_selector_,
+                                placement_group_creation_options.fallback_strategy_);
   PlacementGroupSpecification placement_group_spec = builder.Build();
   *return_placement_group_id = placement_group_id;
   RAY_LOG(INFO).WithField(placement_group_id)

--- a/src/ray/gcs/gcs_placement_group.cc
+++ b/src/ray/gcs/gcs_placement_group.cc
@@ -182,9 +182,17 @@ std::optional<std::string> GcsPlacementGroup::GetLabelDomainAssignment(
 
 void GcsPlacementGroup::SetLabelDomainAssignment(const std::string &label_key,
                                                  const std::string &label_value) {
+  if (placement_group_table_data_.label_domain_key().empty()) {
+    placement_group_table_data_.set_label_domain_key(label_key);
+  } else {
+    // Prevent silently overwriting the label domain key during assignment.
+    RAY_CHECK(placement_group_table_data_.label_domain_key() == label_key)
+        << "Attempted to silently overwrite PG label_domain_key '"
+        << placement_group_table_data_.label_domain_key()
+        << "' with a conflicting assignment key '" << label_key << "'";
+  }
   (*placement_group_table_data_.mutable_label_domain_assignments())[label_key] =
       label_value;
-  placement_group_table_data_.set_label_domain_key(label_key);
 }
 
 void GcsPlacementGroup::ClearLabelDomainAssignments() {

--- a/src/ray/gcs/gcs_placement_group.cc
+++ b/src/ray/gcs/gcs_placement_group.cc
@@ -61,7 +61,6 @@ std::string GcsPlacementGroup::GetRayNamespace() const {
 
 std::vector<std::shared_ptr<const BundleSpecification>> &GcsPlacementGroup::GetBundles()
     const {
-  // Fill the cache if it wasn't.
   if (cached_bundle_specs_.empty()) {
     const auto &bundles = placement_group_table_data_.bundles();
     for (const auto &bundle : bundles) {
@@ -164,10 +163,7 @@ void GcsPlacementGroup::ComputeLabelDomainKey() {
   const LabelSelector &label_selector =
       first_bundle.GetRequiredResources().GetLabelSelector();
   for (const LabelConstraint &constraint : label_selector.GetConstraints()) {
-    if (constraint.GetLabelKey() == kLabelKeyNodeAcceleratorType &&
-        constraint.GetOperator() == LabelSelectorOperator::LABEL_IN &&
-        (constraint.GetLabelValues().contains(kGB300) ||
-         constraint.GetLabelValues().contains(kGB200))) {
+    if (IsGpuAcceleratorConstraint(constraint)) {
       placement_group_table_data_.set_label_domain_key(kGpuDomainLabelKey);
       return;
     }
@@ -188,11 +184,47 @@ void GcsPlacementGroup::SetLabelDomainAssignment(const std::string &label_key,
                                                  const std::string &label_value) {
   (*placement_group_table_data_.mutable_label_domain_assignments())[label_key] =
       label_value;
+  placement_group_table_data_.set_label_domain_key(label_key);
 }
 
 void GcsPlacementGroup::ClearLabelDomainAssignments() {
   placement_group_table_data_.mutable_label_domain_assignments()->clear();
 }
 
+const google::protobuf::RepeatedPtrField<rpc::PlacementGroupSchedulingOption>
+    &GcsPlacementGroup::GetPlacementGroupSchedulingOptions() const {
+  return placement_group_table_data_.scheduling_options();
+}
+
+int32_t GcsPlacementGroup::GetActiveSchedulingOptionIndex() const {
+  if (placement_group_table_data_.has_active_scheduling_option_index()) {
+    return placement_group_table_data_.active_scheduling_option_index();
+  }
+  return -1;  // pending PG
+}
+
+void GcsPlacementGroup::UpdateActiveSchedulingOptionIndex(int32_t index) {
+  if (!placement_group_table_data_.has_active_scheduling_option_index() ||
+      index != placement_group_table_data_.active_scheduling_option_index()) {
+    placement_group_table_data_.set_active_scheduling_option_index(index);
+    cached_bundle_specs_.clear();
+
+    const auto &options = GetPlacementGroupSchedulingOptions();
+    if (index >= 0 && index < options.size()) {
+      const auto &active_option = options.Get(index);
+      if (active_option.bundles_size() > 0) {
+        placement_group_table_data_.mutable_bundles()->CopyFrom(active_option.bundles());
+
+        // Ensure all bundle IDs are properly populated with the PG ID and index
+        for (int i = 0; i < placement_group_table_data_.bundles_size(); i++) {
+          auto *bundle = placement_group_table_data_.mutable_bundles(i);
+          bundle->mutable_bundle_id()->set_placement_group_id(
+              placement_group_table_data_.placement_group_id());
+          bundle->mutable_bundle_id()->set_bundle_index(i);
+        }
+      }
+    }
+  }
+}
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/gcs_placement_group.h
+++ b/src/ray/gcs/gcs_placement_group.h
@@ -76,6 +76,14 @@ class GcsPlacementGroup {
     placement_group_table_data_.set_soft_target_node_id(
         placement_group_spec.soft_target_node_id());
     placement_group_table_data_.set_ray_namespace(ray_namespace);
+    // Index 0: primary strategy.
+    auto *primary_option = placement_group_table_data_.add_scheduling_options();
+    *primary_option->mutable_bundles() = placement_group_spec.bundles();
+
+    // Index 1..N: fallback strategies.
+    for (const auto &fb : placement_group_spec.fallback_strategy()) {
+      *placement_group_table_data_.add_scheduling_options() = fb;
+    }
     placement_group_table_data_.set_placement_group_creation_timestamp_ms(
         current_sys_time_ms());
     ComputeLabelDomainKey();
@@ -155,6 +163,9 @@ class GcsPlacementGroup {
 
   const rpc::PlacementGroupStats &GetStats() const;
 
+  const google::protobuf::RepeatedPtrField<rpc::PlacementGroupSchedulingOption>
+      &GetPlacementGroupSchedulingOptions() const;
+
   rpc::PlacementGroupStats *GetMutableStats();
 
   /// Get the node label key used for label-domain-aware scheduling (e.g.
@@ -171,6 +182,10 @@ class GcsPlacementGroup {
   /// Clear all label domain assignments (used when all bundles for label-domain PGs are
   /// unplaced).
   void ClearLabelDomainAssignments();
+
+  int32_t GetActiveSchedulingOptionIndex() const;
+
+  void UpdateActiveSchedulingOptionIndex(int32_t index);
 
  private:
   // XXX.

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -686,15 +686,33 @@ std::optional<std::string> ExtractLabelDomain(
   // Check if a domain was set for the PG, if so return it
   std::optional<std::string> label_domain = placement_group.GetLabelDomainKey();
   if (label_domain.has_value()) {
-    // During a partial reschedule preserve the domain to maintain affinity
-    // for the currently placed bundles.
-    if (!is_scheduling_all_bundles) {
+    const std::string &key = label_domain.value();
+
+    // If the label domain is not GPU-related, return it. Only GPU Accelerator
+    // label domains are dynamically injected, so if a non-GPU label domain is
+    // set it's explicitly required by the PG.
+    if (key != kGpuDomainLabelKey) {
       return label_domain;
     }
 
-    // Explicitly set domains are PG-level and immutable
-    if (label_domain.value() != kGpuDomainLabelKey) {
+    // During a partial reschedule preserve the domain to maintain affinity
+    // for the currently placed bundles.
+    if (placement_group.GetLabelDomainAssignment(key).has_value()) {
       return label_domain;
+    }
+
+    // If a label domain is set with no assignment, verify that the current active
+    // requests require a labl domain.
+    for (const auto *request : active_requests) {
+      for (const auto &constraint : request->GetLabelSelector().GetConstraints()) {
+        if (key == kGpuDomainLabelKey) {
+          if (IsGpuAcceleratorConstraint(constraint)) {
+            return label_domain;
+          }
+        } else if (constraint.key == key) {
+          return label_domain;
+        }
+      }
     }
   }
 

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -39,6 +39,70 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
       cluster_resource_scheduler_(cluster_resource_scheduler),
       raylet_client_pool_(raylet_client_pool) {}
 
+class ScopedResourceMasker {
+ public:
+  ScopedResourceMasker(
+      ClusterResourceScheduler &scheduler,
+      const std::vector<
+          std::pair<ray::NodeID, std::shared_ptr<const BundleSpecification>>>
+          &committed_bundle_pairs)
+      : scheduler_(scheduler) {
+    auto &manager = scheduler_.GetClusterResourceManager();
+    for (const auto &pair : committed_bundle_pairs) {
+      auto node_id = scheduling::NodeID(pair.first.Binary());
+
+      if (!manager.HasNode(node_id)) {
+        // Check if node still exists
+        continue;
+      }
+
+      auto bundle = pair.second;
+      absl::flat_hash_map<std::string, double> effective_resources;
+      const auto &node_resources = manager.GetNodeResources(node_id);
+      auto required_resource_map =
+          bundle->GetRequiredResources().GetResourceSet().GetResourceMap();
+
+      for (const auto &entry : required_resource_map) {
+        auto resource_id = scheduling::ResourceID(entry.first);
+        double total = node_resources.total.Get(resource_id).Double();
+        double available = node_resources.available.Get(resource_id).Double();
+        double requested = entry.second;
+
+        // The amount of resources we can effectively add without
+        // exceeding the node's total capacity.
+        double room = std::max(0.0, total - available);
+        double effective_add = std::min(requested, room);
+
+        if (effective_add > 0.0) {
+          effective_resources[entry.first] = effective_add;
+        }
+      }
+
+      auto effective_request = ResourceMapToResourceRequest(
+          effective_resources, /*requires_object_store_memory=*/false);
+
+      manager.AddNodeAvailableResources(node_id, effective_request.GetResourceSet());
+      masked_nodes_.push_back(node_id);
+      masked_resources_.push_back(effective_request);
+    }
+  }
+
+  ~ScopedResourceMasker() {
+    for (size_t i = 0; i < masked_nodes_.size(); ++i) {
+      scheduler_.GetClusterResourceManager().SubtractNodeAvailableResources(
+          masked_nodes_[i], masked_resources_[i]);
+    }
+  }
+
+  ScopedResourceMasker(const ScopedResourceMasker &) = delete;
+  ScopedResourceMasker &operator=(const ScopedResourceMasker &) = delete;
+
+ private:
+  ClusterResourceScheduler &scheduler_;
+  std::vector<scheduling::NodeID> masked_nodes_;
+  std::vector<ResourceRequest> masked_resources_;
+};
+
 void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     const SchedulePgRequest &request) {
   const auto &placement_group = request.placement_group;
@@ -55,36 +119,141 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     return;
   }
 
-  const auto &bundles = placement_group->GetUnplacedBundles();
   const auto &strategy = placement_group->GetStrategy();
+  const auto &all_bundles = placement_group->GetBundles();
+  bool is_scheduling_all_bundles =
+      (placement_group->GetUnplacedBundles().size() == all_bundles.size());
 
   // For label-domain PGs: if ALL bundles are unplaced (total failure), clear the
   // domain assignment so a new domain can be selected. If only some bundles are
   // unplaced (partial failure), we attempt to reschedule the bundles on the same domain.
-  if (placement_group->GetLabelDomainKey().has_value()) {
-    const std::vector<std::shared_ptr<const BundleSpecification>> &all_bundles =
-        placement_group->GetBundles();
-    bool is_total_failure = (bundles.size() == all_bundles.size());
-    if (is_total_failure) {
-      placement_group->ClearLabelDomainAssignments();
-      RAY_LOG(INFO) << "All bundles for pg " << placement_group->GetPlacementGroupID()
-                    << " are unplaced, rescheduling on a new label domain";
-    }
+  if (is_scheduling_all_bundles && placement_group->GetLabelDomainKey().has_value()) {
+    placement_group->ClearLabelDomainAssignments();
+    RAY_LOG(INFO) << "All bundles for pg " << placement_group->GetPlacementGroupID()
+                  << " are unplaced, rescheduling on a new label domain";
   }
 
-  RAY_LOG(DEBUG) << "Scheduling placement group " << placement_group->GetName()
-                 << ", id: " << placement_group->GetPlacementGroupID()
-                 << ", bundles size = " << bundles.size();
+  RAY_LOG(INFO) << "Scheduling placement group " << placement_group->GetName()
+                << ", id: " << placement_group->GetPlacementGroupID()
+                << ", bundles size = " << placement_group->GetUnplacedBundles().size();
 
   std::vector<const ResourceRequest *> resource_request_list;
-  resource_request_list.reserve(bundles.size());
-  for (const auto &bundle : bundles) {
+  resource_request_list.reserve(placement_group->GetUnplacedBundles().size());
+  for (const auto &bundle : placement_group->GetUnplacedBundles()) {
     resource_request_list.emplace_back(&bundle->GetRequiredResources());
   }
 
-  auto scheduling_options = CreateSchedulingOptions(*placement_group, strategy);
-  auto scheduling_result = cluster_resource_scheduler_.SchedulePlacementGroup(
-      resource_request_list, scheduling_options);
+  const auto &placement_group_scheduling_options =
+      placement_group->GetPlacementGroupSchedulingOptions();
+
+  int used_index = placement_group->GetActiveSchedulingOptionIndex();
+  if (used_index < 0 || is_scheduling_all_bundles) {
+    used_index = 0;  // Reset to primary strategy
+  }
+
+  SchedulingResult scheduling_result;
+  bool is_feasible = false;
+
+  // If we reset to the primary strategy during a full reschedule, reconstruct the primary
+  // resource requests to avoid scheduling with stale shapes.
+  std::vector<ResourceRequest> primary_requests;
+  std::vector<const ResourceRequest *> primary_request_ptrs;
+
+  if (is_scheduling_all_bundles &&
+      placement_group->GetActiveSchedulingOptionIndex() > 0 &&
+      placement_group_scheduling_options.size() > 0) {
+    for (const auto &b : placement_group_scheduling_options.Get(0).bundles()) {
+      BundleSpecification bundle_spec(b);
+      primary_requests.push_back(bundle_spec.GetRequiredResources());
+    }
+    for (size_t j = 0; j < primary_requests.size(); ++j) {
+      primary_request_ptrs.push_back(&primary_requests[j]);
+    }
+  } else {
+    // Otherwise, use the in-memory bundles.
+    primary_request_ptrs = resource_request_list;
+  }
+
+  // Track currently committed bundles so that we can accurately evaluate freed
+  // resources during a reschedule.
+  std::vector<std::pair<ray::NodeID, std::shared_ptr<const BundleSpecification>>>
+      committed_bundle_pairs;
+  auto maybe_committed = committed_bundle_location_index_.GetBundleLocations(
+      placement_group->GetPlacementGroupID());
+  if (maybe_committed.has_value()) {
+    for (const auto &entry : *maybe_committed.value()) {
+      committed_bundle_pairs.emplace_back(entry.second.first, entry.second.second);
+    }
+  }
+
+  // Mask for the primary attempt only if it is a full reschedule.
+  // This prevents resource state corruption during partial reschedules.
+  std::optional<ScopedResourceMasker> resource_masker;
+  if (is_scheduling_all_bundles && !committed_bundle_pairs.empty()) {
+    resource_masker.emplace(cluster_resource_scheduler_, committed_bundle_pairs);
+  }
+
+  scheduling_result = cluster_resource_scheduler_.SchedulePlacementGroup(
+      primary_request_ptrs,
+      CreateSchedulingOptions(*placement_group, strategy, primary_request_ptrs));
+
+  is_feasible = is_feasible || !scheduling_result.status.IsInfeasible();
+
+  bool needs_full_reschedule = false;
+
+  if (is_scheduling_all_bundles && !scheduling_result.status.IsSuccess() &&
+      placement_group_scheduling_options.size() > 1) {
+    // When falling back to more scheduling options, utilize the resource masker
+    // to evaluate accurate resource usage for the current scheduling attempt.
+    if (!resource_masker.has_value() && !committed_bundle_pairs.empty()) {
+      resource_masker.emplace(cluster_resource_scheduler_, committed_bundle_pairs);
+    }
+
+    for (int i = 1; i < placement_group_scheduling_options.size(); ++i) {
+      const auto &option = placement_group_scheduling_options.Get(i);
+      std::vector<ResourceRequest> fallback_requests;
+      std::vector<const ResourceRequest *> fallback_request_ptrs;
+
+      if (option.bundles_size() > 0) {
+        for (const auto &b : option.bundles()) {
+          BundleSpecification bundle_spec(b);
+          fallback_requests.push_back(bundle_spec.GetRequiredResources());
+        }
+      } else {
+        continue;
+      }
+
+      for (size_t j = 0; j < fallback_requests.size(); ++j) {
+        fallback_request_ptrs.push_back(&fallback_requests[j]);
+      }
+
+      auto fallback_result = cluster_resource_scheduler_.SchedulePlacementGroup(
+          fallback_request_ptrs,
+          CreateSchedulingOptions(*placement_group, strategy, fallback_request_ptrs));
+
+      is_feasible = is_feasible || !fallback_result.status.IsInfeasible();
+
+      if (fallback_result.status.IsSuccess()) {
+        scheduling_result = fallback_result;
+        used_index = i;
+        needs_full_reschedule = true;
+        break;
+      }
+    }
+  }
+
+  // If the primary or fallback strategy succeeds during a full reschedule,
+  // clean up any lingering stale resources from the old shape.
+  if (needs_full_reschedule ||
+      (is_scheduling_all_bundles && scheduling_result.status.IsSuccess())) {
+    resource_masker.reset();
+    DestroyPlacementGroupBundleResourcesIfExists(placement_group->GetPlacementGroupID());
+    is_scheduling_all_bundles = true;
+  }
+
+  if (scheduling_result.status.IsSuccess()) {
+    placement_group->UpdateActiveSchedulingOptionIndex(used_index);
+  }
 
   auto result_status = scheduling_result.status;
   const auto &selected_nodes = scheduling_result.selected_nodes;
@@ -94,12 +263,11 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
         << "Failed to schedule placement group " << placement_group->GetName()
         << ", id: " << placement_group->GetPlacementGroupID()
         << ", because current resources can't satisfy the required resource. IsFailed: "
-        << result_status.IsFailed() << " IsInfeasible: " << result_status.IsInfeasible()
+        << result_status.IsFailed() << " IsInfeasible: " << !is_feasible
         << " IsPartialSuccess: " << result_status.IsPartialSuccess();
-    bool infeasible = result_status.IsInfeasible();
     // If the placement group creation has failed,
     // but if it is not infeasible, it is retryable to create.
-    failure_callback(placement_group, /*is_feasible*/ !infeasible);
+    failure_callback(placement_group, is_feasible);
     return;
   }
 
@@ -107,7 +275,13 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
                  << placement_group->GetPlacementGroupID()
                  << ". Selected node size: " << selected_nodes.size();
 
-  RAY_CHECK(bundles.size() == selected_nodes.size());
+  std::vector<std::shared_ptr<const BundleSpecification>> current_bundles;
+  if (is_scheduling_all_bundles) {
+    current_bundles = placement_group->GetBundles();
+  } else {
+    current_bundles = placement_group->GetUnplacedBundles();
+  }
+  RAY_CHECK(current_bundles.size() == selected_nodes.size());
 
   if (scheduling_result.selected_label_domain.has_value()) {
     const auto &[label_domain_key, label_domain_value] =
@@ -121,12 +295,12 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
   // Covert to a map of bundle to node.
   ScheduleMap bundle_to_node;
   for (size_t i = 0; i < selected_nodes.size(); ++i) {
-    bundle_to_node[bundles[i]->BundleId()] =
+    bundle_to_node[current_bundles[i]->BundleId()] =
         NodeID::FromBinary(selected_nodes[i].Binary());
   }
 
-  auto lease_status_tracker =
-      std::make_shared<LeaseStatusTracker>(placement_group, bundles, bundle_to_node);
+  auto lease_status_tracker = std::make_shared<LeaseStatusTracker>(
+      placement_group, current_bundles, bundle_to_node);
   RAY_CHECK(placement_group_leasing_in_progress_
                 .emplace(placement_group->GetPlacementGroupID(), lease_status_tracker)
                 .second);
@@ -140,7 +314,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
       node_to_bundles;
   for (size_t i = 0; i < selected_nodes.size(); ++i) {
     node_to_bundles[NodeID::FromBinary(selected_nodes[i].Binary())].emplace_back(
-        bundles[i]);
+        current_bundles[i]);
   }
 
   for (const auto &entry : node_to_bundles) {
@@ -175,7 +349,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
 void GcsPlacementGroupScheduler::DestroyPlacementGroupBundleResourcesIfExists(
     const PlacementGroupID &placement_group_id) {
-  auto &bundle_locations =
+  auto bundle_locations =
       committed_bundle_location_index_.GetBundleLocations(placement_group_id);
   if (bundle_locations.has_value()) {
     // There could be leasing bundles and committed bundles at the same time if placement
@@ -490,10 +664,40 @@ GcsPlacementGroupScheduler::CreateSchedulingContext(
   return std::make_unique<BundleSchedulingContext>(std::move(bundle_locations));
 }
 
-SchedulingOptions GcsPlacementGroupScheduler::CreateSchedulingOptions(
-    const GcsPlacementGroup &placement_group, rpc::PlacementStrategy strategy) {
-  std::optional<std::pair<std::string, std::optional<std::string>>> target_label_domain;
+namespace {
+// Retrieves the label domain for the placement group.
+// If already set, it returns the existing label domain for the PG.
+// Otherwise it scans all active requests (primary or fallbacks) for a domain trigger.
+std::optional<std::string> ExtractLabelDomain(
+    const GcsPlacementGroup &placement_group,
+    const std::vector<const ResourceRequest *> &active_requests) {
+  // Check if a domain was requested for the PG.
   std::optional<std::string> label_domain = placement_group.GetLabelDomainKey();
+  if (label_domain.has_value()) {
+    return label_domain;
+  }
+
+  // If no domain is set, check the active bundles for a domain trigger.
+  for (const auto *request : active_requests) {
+    for (const auto &constraint : request->GetLabelSelector().GetConstraints()) {
+      if (IsGpuAcceleratorConstraint(constraint)) {
+        return kGpuDomainLabelKey;
+      }
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace
+
+SchedulingOptions GcsPlacementGroupScheduler::CreateSchedulingOptions(
+    const GcsPlacementGroup &placement_group,
+    rpc::PlacementStrategy strategy,
+    const std::vector<const ResourceRequest *> &active_requests) {
+  std::optional<std::pair<std::string, std::optional<std::string>>> target_label_domain;
+
+  std::optional<std::string> label_domain =
+      ExtractLabelDomain(placement_group, active_requests);
+
   if (label_domain.has_value()) {
     const std::string &label_domain_key = label_domain.value();
     std::optional<std::string> label_value =
@@ -648,7 +852,7 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupPreparedBundleResources(
 void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
     const PlacementGroupID &placement_group_id) {
   // Get the locations of committed bundles.
-  const auto &maybe_bundle_locations =
+  auto maybe_bundle_locations =
       committed_bundle_location_index_.GetBundleLocations(placement_group_id);
   if (maybe_bundle_locations.has_value()) {
     const auto &committed_bundle_locations = maybe_bundle_locations.value();

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -265,6 +265,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
         << ", because current resources can't satisfy the required resource. IsFailed: "
         << result_status.IsFailed() << " IsInfeasible: " << !is_feasible
         << " IsPartialSuccess: " << result_status.IsPartialSuccess();
+    resource_masker.reset();
     // If the placement group creation has failed,
     // but if it is not infeasible, it is retryable to create.
     failure_callback(placement_group, is_feasible);

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -667,13 +667,14 @@ GcsPlacementGroupScheduler::CreateSchedulingContext(
 namespace {
 // Retrieves the label domain for the placement group.
 // If already set, it returns the existing label domain for the PG.
-// Otherwise it scans all active requests (primary or fallbacks) for a domain trigger.
+// Otherwise it scans the active requests (primary or fallbacks) for a domain trigger.
 std::optional<std::string> ExtractLabelDomain(
     const GcsPlacementGroup &placement_group,
     const std::vector<const ResourceRequest *> &active_requests) {
-  // Check if a domain was requested for the PG.
+  // Check if a domain was set for the PG, if so return it
   std::optional<std::string> label_domain = placement_group.GetLabelDomainKey();
-  if (label_domain.has_value()) {
+  if (label_domain.has_value() &&
+      placement_group.GetLabelDomainAssignment(label_domain.value()).has_value()) {
     return label_domain;
   }
 

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -48,28 +48,34 @@ class ScopedResourceMasker {
           &committed_bundle_pairs)
       : scheduler_(scheduler) {
     auto &manager = scheduler_.GetClusterResourceManager();
+
+    // Aggregate requested resources by node.
+    absl::flat_hash_map<scheduling::NodeID, absl::flat_hash_map<std::string, double>>
+        aggregated_resources;
+
     for (const auto &pair : committed_bundle_pairs) {
       auto node_id = scheduling::NodeID(pair.first.Binary());
-
       if (!manager.HasNode(node_id)) {
-        // Check if node still exists
         continue;
       }
+      auto required_resource_map =
+          pair.second->GetRequiredResources().GetResourceSet().GetResourceMap();
+      for (const auto &entry : required_resource_map) {
+        aggregated_resources[node_id][entry.first] += entry.second;
+      }
+    }
 
-      auto bundle = pair.second;
+    for (const auto &[node_id, total_requested] : aggregated_resources) {
       absl::flat_hash_map<std::string, double> effective_resources;
       const auto &node_resources = manager.GetNodeResources(node_id);
-      auto required_resource_map =
-          bundle->GetRequiredResources().GetResourceSet().GetResourceMap();
 
-      for (const auto &entry : required_resource_map) {
+      for (const auto &entry : total_requested) {
         auto resource_id = scheduling::ResourceID(entry.first);
         double total = node_resources.total.Get(resource_id).Double();
         double available = node_resources.available.Get(resource_id).Double();
         double requested = entry.second;
 
-        // The amount of resources we can effectively add without
-        // exceeding the node's total capacity.
+        // Cap the addition so available never exceeds total capacity
         double room = std::max(0.0, total - available);
         double effective_add = std::min(requested, room);
 
@@ -195,7 +201,8 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
   scheduling_result = cluster_resource_scheduler_.SchedulePlacementGroup(
       primary_request_ptrs,
-      CreateSchedulingOptions(*placement_group, strategy, primary_request_ptrs));
+      CreateSchedulingOptions(
+          *placement_group, strategy, primary_request_ptrs, is_scheduling_all_bundles));
 
   is_feasible = is_feasible || !scheduling_result.status.IsInfeasible();
 
@@ -229,7 +236,10 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
 
       auto fallback_result = cluster_resource_scheduler_.SchedulePlacementGroup(
           fallback_request_ptrs,
-          CreateSchedulingOptions(*placement_group, strategy, fallback_request_ptrs));
+          CreateSchedulingOptions(*placement_group,
+                                  strategy,
+                                  fallback_request_ptrs,
+                                  is_scheduling_all_bundles));
 
       is_feasible = is_feasible || !fallback_result.status.IsInfeasible();
 
@@ -671,15 +681,24 @@ namespace {
 // Otherwise it scans the active requests (primary or fallbacks) for a domain trigger.
 std::optional<std::string> ExtractLabelDomain(
     const GcsPlacementGroup &placement_group,
-    const std::vector<const ResourceRequest *> &active_requests) {
+    const std::vector<const ResourceRequest *> &active_requests,
+    bool is_scheduling_all_bundles) {
   // Check if a domain was set for the PG, if so return it
   std::optional<std::string> label_domain = placement_group.GetLabelDomainKey();
-  if (label_domain.has_value() &&
-      placement_group.GetLabelDomainAssignment(label_domain.value()).has_value()) {
-    return label_domain;
+  if (label_domain.has_value()) {
+    // During a partial reschedule preserve the domain to maintain affinity
+    // for the currently placed bundles.
+    if (!is_scheduling_all_bundles) {
+      return label_domain;
+    }
+
+    // Explicitly set domains are PG-level and immutable
+    if (label_domain.value() != kGpuDomainLabelKey) {
+      return label_domain;
+    }
   }
 
-  // If no domain is set, check the active bundles for a domain trigger.
+  // If no explicit domain is set, check the active bundles for a domain trigger.
   for (const auto *request : active_requests) {
     for (const auto &constraint : request->GetLabelSelector().GetConstraints()) {
       if (IsGpuAcceleratorConstraint(constraint)) {
@@ -694,11 +713,12 @@ std::optional<std::string> ExtractLabelDomain(
 SchedulingOptions GcsPlacementGroupScheduler::CreateSchedulingOptions(
     const GcsPlacementGroup &placement_group,
     rpc::PlacementStrategy strategy,
-    const std::vector<const ResourceRequest *> &active_requests) {
+    const std::vector<const ResourceRequest *> &active_requests,
+    bool is_scheduling_all_bundles) {
   std::optional<std::pair<std::string, std::optional<std::string>>> target_label_domain;
 
   std::optional<std::string> label_domain =
-      ExtractLabelDomain(placement_group, active_requests);
+      ExtractLabelDomain(placement_group, active_requests, is_scheduling_all_bundles);
 
   if (label_domain.has_value()) {
     const std::string &label_domain_key = label_domain.value();

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -463,7 +463,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   SchedulingOptions CreateSchedulingOptions(
       const GcsPlacementGroup &placement_group,
       rpc::PlacementStrategy strategy,
-      const std::vector<const ResourceRequest *> &active_requests);
+      const std::vector<const ResourceRequest *> &active_requests,
+      bool is_scheduling_all_bundles);
 
   /// Try to release bundle resource to cluster resource manager.
   ///

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -15,6 +15,7 @@
 
 #include <list>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -459,8 +460,10 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
       const PlacementGroupID &placement_group_id);
 
   /// Create scheduling options.
-  SchedulingOptions CreateSchedulingOptions(const GcsPlacementGroup &placement_group,
-                                            rpc::PlacementStrategy strategy);
+  SchedulingOptions CreateSchedulingOptions(
+      const GcsPlacementGroup &placement_group,
+      rpc::PlacementStrategy strategy,
+      const std::vector<const ResourceRequest *> &active_requests);
 
   /// Try to release bundle resource to cluster resource manager.
   ///

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -1429,5 +1429,470 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestBundlesRemovedWhenNodeDead) {
   ASSERT_EQ(scheduler_->waiting_removed_bundles_.size(), 0);
 }
 
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategySuccess) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  // Set an unsatisfiable primary label selector for the first bundle
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Option 0: Primary
+  spec->add_fallback_strategy();
+
+  // Option 1: Satisfiable fallback strategy
+  auto *option = spec->add_fallback_strategy();
+  auto *fallback_bundle1 = option->add_bundles();
+  (*fallback_bundle1->mutable_unit_resources())["CPU"] = 1.0;
+  auto *fallback_bundle2 = option->add_bundles();
+  (*fallback_bundle2->mutable_unit_resources())["CPU"] = 1.0;
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(1, raylet_clients_[0]->num_lease_requested);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategyFailure) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  // Set an unsatisfiable primary label selector for the first bundle
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Option 0: Primary
+  spec->add_fallback_strategy();
+
+  // Option 1: Unsatisfiable fallback strategy
+  auto *option = spec->add_fallback_strategy();
+  auto *fallback_bundle1 = option->add_bundles();
+  (*fallback_bundle1->mutable_unit_resources())["CPU"] = 1.0;
+  auto *selector = fallback_bundle1->mutable_label_selector();
+  (*selector)["type"] = "B200";
+  auto *fallback_bundle2 = option->add_bundles();
+  (*fallback_bundle2->mutable_unit_resources())["CPU"] = 1.0;
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(0, raylet_clients_[0]->num_lease_requested);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestPlacementGroupFallbackStrategyMultipleOptionsSuccess) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  // Set an unsatisfiable primary label selector for the first bundle
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Option 1: Unsatisfiable (B200)
+  {
+    auto *option = spec->add_fallback_strategy();
+    auto *fallback_bundle = option->add_bundles();
+    (*fallback_bundle->mutable_unit_resources())["CPU"] = 1.0;
+
+    auto *selector = fallback_bundle->mutable_label_selector();
+    (*selector)["type"] = "B200";
+  }
+
+  // Option 2: Satisfiable (A100)
+  {
+    auto *option = spec->add_fallback_strategy();
+    auto *fallback_bundle = option->add_bundles();
+    (*fallback_bundle->mutable_unit_resources())["CPU"] = 1.0;
+
+    auto *selector = fallback_bundle->mutable_label_selector();
+    (*selector)["type"] = "A100";
+  }
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(1, raylet_clients_[0]->num_lease_requested);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategyEmptyOptions) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())["type"] = "A100";
+  AddNode(node);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest();
+  auto *spec = request.mutable_placement_group_spec();
+
+  auto *bundle_spec = spec->mutable_bundles(0);
+  (*bundle_spec->mutable_label_selector())["type"] = "V100";
+
+  // Create an empty option. It will fall back to the primary bundles (which fail).
+  spec->add_fallback_strategy();
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_EQ(0, raylet_clients_[0]->num_lease_requested);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::FAILURE);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestPlacementGroupSchedulingOptionsBundleOverrideSuccess) {
+  // Add a node with 2 CPUs
+  auto node = GenNodeInfo();
+  AddNode(node, 2);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  // Request a PG with 3 bundles of 1 CPU each (requires 3 CPUs total)
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 3);
+  auto *spec = request.mutable_placement_group_spec();
+
+  for (int i = 0; i < 3; ++i) {
+    auto *bundle = spec->mutable_bundles(i);
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  // Set a fallback strategy that overrides bundles to 2 bundles of 1 CPU each.
+  // Option 0: Primary attempt
+  spec->add_fallback_strategy();
+
+  // Option 1: Fallback attempt (2 bundles override)
+  auto *option1 = spec->add_fallback_strategy();
+
+  // Create 2 override bundles
+  for (int i = 0; i < 2; ++i) {
+    auto *bundle = option1->add_bundles();
+    auto *bundle_id = bundle->mutable_bundle_id();
+    bundle_id->set_bundle_index(i);
+    bundle_id->set_placement_group_id(spec->placement_group_id());
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool is_infeasible) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  // The first attempt (3 bundles) fails because node only has 2 CPUs.
+  // The second attempt (2 bundles) succeeds.
+  ASSERT_EQ(1, raylet_clients_[0]->num_lease_requested);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(0, GcsPlacementGroupStatus::FAILURE);
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  // Verify that the active index is 1 (the fallback option)
+  ASSERT_EQ(2, placement_group->GetActiveSchedulingOptionIndex());
+
+  // Verify that the bundles list in PG is updated to the override bundles (size 2)
+  ASSERT_EQ(2, placement_group->GetBundles().size());
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupRescheduleResetsToPrimary) {
+  auto node1 = GenNodeInfo(0);
+  AddNode(node1, 2);
+  auto failure_handler = [this](std::shared_ptr<GcsPlacementGroup> placement_group,
+                                bool is_infeasible) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    failure_placement_groups_.emplace_back(std::move(placement_group));
+  };
+  auto success_handler = [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.emplace_back(std::move(placement_group));
+  };
+
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 3);
+  auto *spec = request.mutable_placement_group_spec();
+  spec->add_fallback_strategy();                  // Option 0 (Primary)
+  auto *option1 = spec->add_fallback_strategy();  // Option 1
+  for (int i = 0; i < 2; ++i) {
+    auto *bundle = option1->add_bundles();
+    auto *bundle_id = bundle->mutable_bundle_id();
+    bundle_id->set_bundle_index(i);
+    bundle_id->set_placement_group_id(spec->placement_group_id());
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  ASSERT_EQ(2, placement_group->GetActiveSchedulingOptionIndex());
+  ASSERT_EQ(2, placement_group->GetBundles().size());
+
+  // Add a second node with 3 CPUs (so primary now fits)
+  auto node2 = GenNodeInfo(1);
+  AddNode(node2, 3);
+  ASSERT_EQ(2, gcs_node_manager_->GetAllAliveNodes().size());
+
+  // Simulate node death rescheduling by resetting index to 0 manually
+  placement_group->UpdateActiveSchedulingOptionIndex(0);
+
+  // Clear node id of first bundle to trigger rescheduling of it
+  placement_group->GetMutableBundle(0)->clear_node_id();
+
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  // Scheduler should try and succeed with primary option.
+  ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(2, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestScopedResourceMaskerUsesBaseResourcesDuringReschedule) {
+  // Add a single node with 2 CPUs.
+  auto node = GenNodeInfo();
+  AddNode(node, 2);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  // Create a PG requiring 2 CPUs total
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 2);
+  auto *spec = request.mutable_placement_group_spec();
+  for (int i = 0; i < 2; ++i) {
+    (*spec->mutable_bundles(i)->mutable_unit_resources())["CPU"] = 1.0;
+  }
+  spec->add_fallback_strategy();  // Option 0 (Primary)
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  auto failure_handler = [this](std::shared_ptr<GcsPlacementGroup> pg, bool) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    failure_placement_groups_.emplace_back(std::move(pg));
+  };
+  auto success_handler = [this](std::shared_ptr<GcsPlacementGroup> pg) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.emplace_back(std::move(pg));
+  };
+
+  // Initial schedule succeeds and uses both CPUs on the node
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  success_placement_groups_.clear();
+  raylet_clients_[0]->commit_callbacks.clear();
+
+  // Simulate a reschedule scenario where the bundles are unplaced
+  placement_group->GetMutableBundle(0)->clear_node_id();
+  placement_group->GetMutableBundle(1)->clear_node_id();
+
+  // Try to schedule again, resource masker should successfully simulate freeing
+  // the resources from the previous run and schedule on the same node.
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  // Verify it successfully schedules instead of immediately failing
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, TestFallbackImplicitLabelDomainAssigned) {
+  auto node = GenNodeInfo();
+  (*node->mutable_labels())[kLabelKeyNodeAcceleratorType] = kGB300;
+  (*node->mutable_labels())[kGpuDomainLabelKey] = "domain-1";
+  AddNode(node, 2);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 1);
+  auto *spec = request.mutable_placement_group_spec();
+  (*spec->mutable_bundles(0)->mutable_unit_resources())["CPU"] = 1.0;
+  (*spec->mutable_bundles(0)->mutable_unit_resources())["TPU"] = 1.0;
+
+  auto *fallback = spec->add_fallback_strategy();
+  auto *fallback_bundle = fallback->add_bundles();
+  (*fallback_bundle->mutable_unit_resources())["CPU"] = 1.0;
+  (*fallback_bundle->mutable_label_selector())[kLabelKeyNodeAcceleratorType] = kGB300;
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  auto failure_handler = [this](std::shared_ptr<GcsPlacementGroup> pg, bool) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    failure_placement_groups_.emplace_back(std::move(pg));
+  };
+  auto success_handler = [this](std::shared_ptr<GcsPlacementGroup> pg) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.emplace_back(std::move(pg));
+  };
+
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest,
+       TestPlacementGroupPartialRescheduleOnFallbackStrategy) {
+  // Add a node with 2 CPUs
+  auto node1 = GenNodeInfo(0);
+  AddNode(node1, 2);
+  ASSERT_EQ(1, gcs_node_manager_->GetAllAliveNodes().size());
+
+  // Request an infeasible PG requiring 3 CPUs
+  auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 3);
+  auto *spec = request.mutable_placement_group_spec();
+
+  for (int i = 0; i < 3; ++i) {
+    auto *bundle = spec->mutable_bundles(i);
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  // Option 1: Fallback attempt (2 bundles of 1 CPU - Feasible)
+  auto *option1 = spec->add_fallback_strategy();
+  for (int i = 0; i < 2; ++i) {
+    auto *bundle = option1->add_bundles();
+    auto *bundle_id = bundle->mutable_bundle_id();
+    bundle_id->set_bundle_index(i);
+    bundle_id->set_placement_group_id(spec->placement_group_id());
+    (*bundle->mutable_unit_resources())["CPU"] = 1.0;
+  }
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
+
+  auto failure_handler = [this](std::shared_ptr<GcsPlacementGroup> pg, bool) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    failure_placement_groups_.emplace_back(std::move(pg));
+  };
+  auto success_handler = [this](std::shared_ptr<GcsPlacementGroup> pg) {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.emplace_back(std::move(pg));
+  };
+
+  // Should successfully fallback to and schedule on option 1
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  ASSERT_EQ(1, placement_group->GetActiveSchedulingOptionIndex());
+  ASSERT_EQ(2, placement_group->GetBundles().size());
+
+  {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.clear();
+  }
+  raylet_clients_[0]->commit_callbacks.clear();
+  raylet_clients_[0]->num_lease_requested = 0;
+
+  // Add a second node for the partial reschedule
+  auto node2 = GenNodeInfo(1);
+  AddNode(node2, 2);
+
+  // Simulate a node dying, clear only one bundle's node_id.
+  placement_group->GetMutableBundle(0)->clear_node_id();
+
+  // Reschedule the single unplaced bundle
+  scheduler_->ScheduleUnplacedBundles(
+      SchedulePgRequest{placement_group, failure_handler, success_handler});
+
+  // We expect the scheduler to successfully place the 1 missing fallback bundle
+  if (raylet_clients_[0]->num_lease_requested > 0) {
+    ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+    WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+    ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  } else {
+    ASSERT_TRUE(raylet_clients_[1]->GrantPrepareBundleResources());
+    WaitPendingDone(raylet_clients_[1]->commit_callbacks, 1);
+    ASSERT_TRUE(raylet_clients_[1]->GrantCommitBundleResources());
+  }
+
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  // The active index should safely remain 1.
+  ASSERT_EQ(1, placement_group->GetActiveSchedulingOptionIndex());
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -1742,7 +1742,10 @@ TEST_F(GcsPlacementGroupSchedulerTest,
   ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
   WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
 
-  success_placement_groups_.clear();
+  {
+    absl::MutexLock lock(&placement_group_requests_mutex_);
+    success_placement_groups_.clear();
+  }
   raylet_clients_[0]->commit_callbacks.clear();
 
   // Simulate a reschedule scenario where the bundles are unplaced

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -1442,9 +1442,6 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategySuccess
   auto *bundle_spec = spec->mutable_bundles(0);
   (*bundle_spec->mutable_label_selector())["type"] = "V100";
 
-  // Option 0: Primary
-  spec->add_fallback_strategy();
-
   // Option 1: Satisfiable fallback strategy
   auto *option = spec->add_fallback_strategy();
   auto *fallback_bundle1 = option->add_bundles();
@@ -1484,9 +1481,6 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupFallbackStrategyFailure
   // Set an unsatisfiable primary label selector for the first bundle
   auto *bundle_spec = spec->mutable_bundles(0);
   (*bundle_spec->mutable_label_selector())["type"] = "V100";
-
-  // Option 0: Primary
-  spec->add_fallback_strategy();
 
   // Option 1: Unsatisfiable fallback strategy
   auto *option = spec->add_fallback_strategy();
@@ -1616,10 +1610,6 @@ TEST_F(GcsPlacementGroupSchedulerTest,
     (*bundle->mutable_unit_resources())["CPU"] = 1.0;
   }
 
-  // Set a fallback strategy that overrides bundles to 2 bundles of 1 CPU each.
-  // Option 0: Primary attempt
-  spec->add_fallback_strategy();
-
   // Option 1: Fallback attempt (2 bundles override)
   auto *option1 = spec->add_fallback_strategy();
 
@@ -1655,7 +1645,7 @@ TEST_F(GcsPlacementGroupSchedulerTest,
   WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
 
   // Verify that the active index is 1 (the fallback option)
-  ASSERT_EQ(2, placement_group->GetActiveSchedulingOptionIndex());
+  ASSERT_EQ(1, placement_group->GetActiveSchedulingOptionIndex());
 
   // Verify that the bundles list in PG is updated to the override bundles (size 2)
   ASSERT_EQ(2, placement_group->GetBundles().size());
@@ -1676,7 +1666,6 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupRescheduleResetsToPrima
 
   auto request = GenCreatePlacementGroupRequest("", rpc::PlacementStrategy::PACK, 3);
   auto *spec = request.mutable_placement_group_spec();
-  spec->add_fallback_strategy();                  // Option 0 (Primary)
   auto *option1 = spec->add_fallback_strategy();  // Option 1
   for (int i = 0; i < 2; ++i) {
     auto *bundle = option1->add_bundles();
@@ -1696,7 +1685,7 @@ TEST_F(GcsPlacementGroupSchedulerTest, TestPlacementGroupRescheduleResetsToPrima
   ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
   WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
 
-  ASSERT_EQ(2, placement_group->GetActiveSchedulingOptionIndex());
+  ASSERT_EQ(1, placement_group->GetActiveSchedulingOptionIndex());
   ASSERT_EQ(2, placement_group->GetBundles().size());
 
   // Add a second node with 3 CPUs (so primary now fits)
@@ -1733,7 +1722,6 @@ TEST_F(GcsPlacementGroupSchedulerTest,
   for (int i = 0; i < 2; ++i) {
     (*spec->mutable_bundles(i)->mutable_unit_resources())["CPU"] = 1.0;
   }
-  spec->add_fallback_strategy();  // Option 0 (Primary)
 
   auto placement_group = std::make_shared<GcsPlacementGroup>(request, "", counter_);
 

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -709,6 +709,9 @@ message PlacementGroupSpec {
   // Otherwise, the bundles can be placed elsewhere.
   // This only applies to STRICT_PACK pg.
   bytes soft_target_node_id = 11;
+  // The list of fallback options to try if the primary resource request cannot be
+  // scheduled.
+  repeated PlacementGroupSchedulingOption fallback_strategy = 12;
 }
 
 message ObjectReference {
@@ -1110,6 +1113,14 @@ message FallbackOption {
 // node.
 message FallbackStrategy {
   repeated FallbackOption options = 1;
+}
+
+// A single fallback option for a Placement Group. Defines requirements for a Placement
+// Group to use for scheduling, including bundle overrides.
+message PlacementGroupSchedulingOption {
+  // Overrides the entire bundles list for this attempt.
+  // Bundles includes the per-bundle label selectors if specified.
+  repeated Bundle bundles = 1;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/ray/protobuf/gcs.proto
+++ b/src/ray/protobuf/gcs.proto
@@ -648,7 +648,9 @@ message PlacementGroupTableData {
   bytes placement_group_id = 1;
   // The name of the placement group.
   string name = 2;
-  // The array of the bundle in Placement Group.
+  // The currently active bundles for this placement group.
+  // If scheduled via a fallback strategy, this contains the fallback's bundles.
+  // This is empty for pending placement groups.
   repeated Bundle bundles = 3;
   // The schedule strategy of this Placement Group.
   PlacementStrategy strategy = 4;
@@ -688,6 +690,10 @@ message PlacementGroupTableData {
   // The node label key that identifies the label domain for this placement group
   // (e.g. "ray.io/gpu-domain"). Empty if the PG does not use label-domain scheduling.
   string label_domain_key = 18;
+  // The primary and fallback scheduling options for this placement group.
+  repeated PlacementGroupSchedulingOption scheduling_options = 19;
+  // The index in placement_group_scheduling_options that is currently being used.
+  optional int32 active_scheduling_option_index = 20;
 }
 
 message JobTableData {


### PR DESCRIPTION
## Description
This PR implements the core scheduling and state management logic in the Ray GCS server and CoreWorker to dynamically attempt and iterate through fallback placement group strategies when scheduling fails.

Specifically, this PR:
- 

This PR includes the proto changes from https://github.com/ray-project/ray/pull/62041.
- Updated `GcsPlacementGroupScheduler` to catch infeasibility errors and  iterate through fallback options until one succeeds or all are exhausted.
- Implemented resource masking (`ScopedResourceMasker`) to safely reserve temporary bundle slots during fallback attempts without erroneously changing the global cluster resource views before a new scheduling option has been chosen
- We retry all possible scheduling options when a previously scheduled node fails or triggers a full placement group reschedule
- Updated core worker and cython bindings to properly propagate and validate fallback strategy creation

RPC fault-tolerance & idempotency standards guide here:
https://github.com/ray-project/ray/tree/master/doc/source/ray-core/internals/rpc-fault-tolerance.rst has been reviewed and followed for the proto change.

## Related issues
https://github.com/ray-project/ray/issues/51564

## Additional information
Implements logic from this PR: https://github.com/ray-project/ray/pull/59024 which grew too large
