### PR TITLE
[core] Deflake `test_job_manager`

### DIFF
--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -1328,7 +1328,7 @@ while True:
             check_job_stopped,
             job_manager=job_manager,
             job_id=job_id,
-            timeout=stop_timeout - 1,
+            timeout=stop_timeout / 2,
         )
 
     await async_wait_for_condition(


### PR DESCRIPTION
Saw timeouts in postmerge: https://buildkite.com/ray-project/postmerge/builds/16842#019d54f5-30b1-4874-a87f-827185f3bb75

This test is inherently flaky and relying on timing conditions. For now, I'm loosening the `stop_timeout - 1` window.