### PR TITLE
[Build] Fix out-of-order gRPC response causing stale actor task cancellation

### DIFF
--- a/src/ray/core_worker_rpc_client/core_worker_client.cc
+++ b/src/ray/core_worker_rpc_client/core_worker_client.cc
@@ -66,13 +66,13 @@ void CoreWorkerClient::PushActorTask(std::unique_ptr<PushTaskRequest> request,
     absl::MutexLock lock(&mutex_);
     const std::string &group = request->task_spec().concurrency_group_name();
     int64_t group_seq = request->sequence_number();
-    auto it = max_finished_group_seq_no_.find(group);
-    if (it == max_finished_group_seq_no_.end()) {
-      max_finished_group_seq_no_[group] = group_seq - 1;
+    auto it = group_seq_state_.find(group);
+    if (it == group_seq_state_.end()) {
+      group_seq_state_.emplace(group, GroupSeqState(group_seq - 1));
     }
     // The RPC client assumes that the first request put into the send queue will be
     // the first task handled by the server.
-    RAY_CHECK_LE(max_finished_group_seq_no_[group], group_seq);
+    RAY_CHECK_LE(group_seq_state_.at(group).contiguous_watermark, group_seq);
     send_queue_.emplace_back(std::move(request), std::move(callback));
   }
   SendRequests();
@@ -111,7 +111,7 @@ void CoreWorkerClient::SendRequests() {
     int64_t task_size = RequestSizeInBytes(*request);
     int64_t seq_no = request->sequence_number();
     std::string group = request->task_spec().concurrency_group_name();
-    request->set_client_processed_up_to(max_finished_group_seq_no_[group]);
+    request->set_client_processed_up_to(group_seq_state_.at(group).contiguous_watermark);
     rpc_bytes_in_flight_ += task_size;
 
     auto rpc_callback =
@@ -119,9 +119,9 @@ void CoreWorkerClient::SendRequests() {
             Status status, rpc::PushTaskReply &&reply) {
           {
             absl::MutexLock lk(&mutex_);
-            auto it = max_finished_group_seq_no_.find(group);
-            if (it != max_finished_group_seq_no_.end() && seq_no > it->second) {
-              it->second = seq_no;
+            auto it = group_seq_state_.find(group);
+            if (it != group_seq_state_.end()) {
+              it->second.MarkCompleted(seq_no);
             }
             rpc_bytes_in_flight_ -= task_size;
             RAY_CHECK(rpc_bytes_in_flight_ >= 0);

--- a/src/ray/core_worker_rpc_client/core_worker_client.h
+++ b/src/ray/core_worker_rpc_client/core_worker_client.h
@@ -16,6 +16,7 @@
 
 #include <deque>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
 
@@ -237,8 +238,39 @@ class CoreWorkerClient : public std::enable_shared_from_this<CoreWorkerClient>,
   /// The number of bytes currently in flight.
   int64_t rpc_bytes_in_flight_ ABSL_GUARDED_BY(mutex_) = 0;
 
-  /// Per-concurrency-group max sequence number we have processed responses for.
-  absl::flat_hash_map<std::string, int64_t> max_finished_group_seq_no_
+  /// Tracks the highest contiguous sequence number completed per concurrency group.
+  /// When responses arrive out of order, we buffer the non-contiguous completions
+  /// and only advance the watermark when contiguity is restored. This ensures
+  /// client_processed_up_to accurately reflects what the server can safely skip.
+  struct GroupSeqState {
+    /// The highest contiguous seq_no for which we have received a response.
+    /// All seq_nos <= this value have completed.
+    int64_t contiguous_watermark;
+    /// Seq_nos that completed out of order (above the watermark).
+    std::set<int64_t> pending_completions;
+
+    explicit GroupSeqState(int64_t initial) : contiguous_watermark(initial) {}
+
+    /// Record a completed seq_no. Advances the watermark if possible.
+    void MarkCompleted(int64_t seq_no) {
+      if (seq_no <= contiguous_watermark) {
+        return;  // Already accounted for.
+      }
+      if (seq_no == contiguous_watermark + 1) {
+        contiguous_watermark = seq_no;
+        // Drain any buffered completions that are now contiguous.
+        while (!pending_completions.empty() &&
+               *pending_completions.begin() == contiguous_watermark + 1) {
+          contiguous_watermark = *pending_completions.begin();
+          pending_completions.erase(pending_completions.begin());
+        }
+      } else {
+        pending_completions.insert(seq_no);
+      }
+    }
+  };
+
+  absl::flat_hash_map<std::string, GroupSeqState> group_seq_state_
       ABSL_GUARDED_BY(mutex_);
 };
 


### PR DESCRIPTION
With gRPC 1.68.2, RPC responses can arrive out of order. The client previously tracked the max completed sequence number per concurrency group and sent it as client_processed_up_to. When a high-numbered response arrived before lower-numbered ones, client_processed_up_to jumped ahead, causing the server to advance next_seq_no and cancel all in-flight RPCs with lower sequence numbers as "stale".

Fix by tracking the highest *contiguous* completed sequence number instead of the absolute max. Out-of-order completions are buffered until contiguity is restored, ensuring client_processed_up_to only advances when all prior sequences have truly completed.

Failing tests: test_actor_advanced (fork_consistency, pickled_handle_consistency, nested_fork), test_basic_5 (test_preload_workers timeout), test_actor (define_actor_within_remote_function), test_class_dag, test_actor_pool, Java actor tests (testConcurrentCall, testSubmittingManyTasksToOneActor)

Topic: fix-grpc-stale-rpc
Relative: bazel-7-5-upgrade
Signed-off-by: andrew <andrew@anyscale.com>