### PR TITLE
[dashboard] Reduce CI log spam from failing to parse UTC offsets

### DIFF
--- a/python/ray/dashboard/client/src/common/timezone.ts
+++ b/python/ray/dashboard/client/src/common/timezone.ts
@@ -9,8 +9,7 @@ const getCurrentUTCOffset = (timeZone: string) => {
     const formatted = formatter.format(date);
     const match = formatted.match(/GMT([+-]\d{1,2}(?::\d{2})?)?/);
     return match ? match[0] : "";
-  } catch (e) {
-    console.warn(`Error getting UTC offset for ${timeZone}:`, e);
+  } catch {
     return "";
   }
 };

--- a/python/ray/dashboard/client/src/common/timezone.ts
+++ b/python/ray/dashboard/client/src/common/timezone.ts
@@ -1,3 +1,5 @@
+let warnedUTCOffsetError = false;
+
 const getCurrentUTCOffset = (timeZone: string) => {
   try {
     const date = new Date();
@@ -9,7 +11,11 @@ const getCurrentUTCOffset = (timeZone: string) => {
     const formatted = formatter.format(date);
     const match = formatted.match(/GMT([+-]\d{1,2}(?::\d{2})?)?/);
     return match ? match[0] : "";
-  } catch {
+  } catch (e) {
+    if (!warnedUTCOffsetError) {
+      warnedUTCOffsetError = true;
+      console.warn(`Error getting UTC offset for ${timeZone}:`, e);
+    }
     return "";
   }
 };


### PR DESCRIPTION
The dashboard logs have a huge amount of warning spam which makes them slow to load: https://buildkite.com/ray-project/premerge/builds/63869#019d6d6d-b1a5-4abe-a93b-a88c9b9c81e2/L2377

I am only logging the warning at most once now. No behavior change.