### PR TITLE
[ci] preventing conda auto update temporarily 

### DIFF
--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -12,6 +12,10 @@ powershell ci/ray_ci/windows/install_bazelisk.ps1
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.9.22/install.ps1 | iex"
 
 conda init
+# TODO(ci): Remove once conda fixes the splitext bug in delete.py (conda/conda#14612).
+# Conda 26.3.1 crashes on Windows when it tries to clean up a locked exe during
+# a build-variant swap. Preventing self-update avoids that code path.
+conda config --set auto_update_conda false
 conda install -q -y python="${PYTHON_FULL_VERSION}" requests=2.32.3
 # Force CA trust stack to the newest versions available at build time.
 conda update -c conda-forge -q -y ca-certificates certifi

--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -12,7 +12,7 @@ powershell ci/ray_ci/windows/install_bazelisk.ps1
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.9.22/install.ps1 | iex"
 
 conda init
-# TODO(ci): Remove once conda fixes the splitext bug in delete.py (conda/conda#14612).
+# TODO(ci): Remove once conda fixes the splitext bug in delete.py (conda/conda#15760).
 # Conda 26.3.1 crashes on Windows when it tries to clean up a locked exe during
 # a build-variant swap. Preventing self-update avoids that code path.
 conda config --set auto_update_conda false


### PR DESCRIPTION
Due to conda windows bug https://github.com/conda/conda/issues/15760
auto updates fail on windows due to Permission issue when cleaning up old conda files

Temporarily preventing auto updates until bug is fixed

Failing build https://buildkite.com/ray-project/premerge/builds/63893#019d6e4c-d676-4048-8603-b1171a243f69