### PR TITLE
[core] move the GCS's ReportJobError to a dedicated thread

### DIFF
--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -468,8 +468,11 @@ void GcsServer::InitGcsJobManager(
                                       job_duration_in_seconds_gauge);
   gcs_job_manager_->Initialize(gcs_init_data);
 
+  // ReportJobError is dispatched on pubsub_io_context (same as InternalPubSubGcsService)
+  // so error publish + subscriber long-poll share one event loop.
   rpc_server_.RegisterService(std::make_unique<rpc::JobInfoGrpcService>(
       io_context_provider_.GetDefaultIOContext(),
+      io_context_provider_.GetIOContext<pubsub::GcsPublisher>(),
       *gcs_job_manager_,
       RayConfig::instance().gcs_max_active_rpcs_per_handler()));
 }

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -96,7 +96,12 @@ void JobInfoGrpcService::InitServerCallFactories(
   RPC_SERVICE_HANDLER(JobInfoGcsService, AddJob, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(JobInfoGcsService, MarkJobFinished, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(JobInfoGcsService, GetAllJobInfo, max_active_rpcs_per_handler_)
-  RPC_SERVICE_HANDLER(JobInfoGcsService, ReportJobError, max_active_rpcs_per_handler_)
+  RPC_SERVICE_HANDLER_IO(JobInfoGcsService,
+                         ReportJobError,
+                         JobInfoGcsServiceHandler,
+                         max_active_rpcs_per_handler_,
+                         service_handler_,
+                         pubsub_io_service_)
   RPC_SERVICE_HANDLER(JobInfoGcsService, GetNextJobID, max_active_rpcs_per_handler_)
 }
 

--- a/src/ray/gcs/grpc_services.h
+++ b/src/ray/gcs/grpc_services.h
@@ -137,11 +137,13 @@ class InternalPubSubGrpcService : public GrpcService {
 class JobInfoGrpcService : public GrpcService {
  public:
   explicit JobInfoGrpcService(instrumented_io_context &io_service,
+                              instrumented_io_context &pubsub_io_service,
                               JobInfoGcsServiceHandler &handler,
                               int64_t max_active_rpcs_per_handler)
       : GrpcService(io_service),
         service_handler_(handler),
-        max_active_rpcs_per_handler_(max_active_rpcs_per_handler){};
+        pubsub_io_service_(pubsub_io_service),
+        max_active_rpcs_per_handler_(max_active_rpcs_per_handler) {}
 
  protected:
   grpc::Service &GetGrpcService() override { return service_; }
@@ -155,6 +157,7 @@ class JobInfoGrpcService : public GrpcService {
  private:
   JobInfoGcsService::AsyncService service_;
   JobInfoGcsServiceHandler &service_handler_;
+  instrumented_io_context &pubsub_io_service_;
   int64_t max_active_rpcs_per_handler_;
 };
 

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -59,6 +59,31 @@ namespace rpc {
   _RPC_SERVICE_HANDLER(                                        \
       SERVICE, HANDLER, MAX_ACTIVE_RPCS, ClusterIdAuthType::LAZY_AUTH, true, false)
 
+/// Like RPC_SERVICE_HANDLER, but uses HANDLER_TYPE (instead of SERVICE##Handler),
+/// HANDLER_MEMBER (instead of service_handler_), and IO_SERVICE_MEMBER (instead of
+/// main_service_). Lazy cluster auth, metrics on, no grpc peer. For when one
+/// grpc::Service splits RPCs across handler types or io_contexts.
+#define RPC_SERVICE_HANDLER_IO(                                                         \
+    SERVICE, HANDLER, HANDLER_TYPE, MAX_ACTIVE_RPCS, HANDLER_MEMBER, IO_SERVICE_MEMBER) \
+  std::unique_ptr<ServerCallFactory> HANDLER##_call_factory_at(                         \
+      new ServerCallFactoryImpl<SERVICE,                                                \
+                                HANDLER_TYPE,                                           \
+                                HANDLER##Request,                                       \
+                                HANDLER##Reply,                                         \
+                                ClusterIdAuthType::LAZY_AUTH,                           \
+                                false>(service_,                                        \
+                                       &SERVICE::AsyncService::Request##HANDLER,        \
+                                       HANDLER_MEMBER,                                  \
+                                       &HANDLER_TYPE::Handle##HANDLER,                  \
+                                       cq,                                              \
+                                       IO_SERVICE_MEMBER,                               \
+                                       #SERVICE ".grpc_server." #HANDLER,               \
+                                       cluster_id,                                      \
+                                       auth_token,                                      \
+                                       MAX_ACTIVE_RPCS,                                 \
+                                       true));                                          \
+  server_call_factories->emplace_back(std::move(HANDLER##_call_factory_at));
+
 /// Define a RPC service handler with gRPC server metrics disabled.
 #define RPC_SERVICE_HANDLER_SERVER_METRICS_DISABLED(SERVICE, HANDLER, MAX_ACTIVE_RPCS) \
   _RPC_SERVICE_HANDLER(                                                                \


### PR DESCRIPTION
## Description

Isolate the ReportJobError handler in a dedicated thread to avoid it overloading the default io_context thread and delaying other critical operations, such as actor restarts.


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
