### PR TITLE
[Data] Release pinned blocks after dataset execution (executor shutdown, terminal ops, OutputSplitter)

### DIFF
--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -184,7 +184,11 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
                 b = replace(b, output_split_idx=i)
                 self._output_queue.add(b)
                 self._metrics.on_output_queued(b)
-        self._buffer.clear()
+        # Drain truncated remainder through the metrics layer.
+        # A bare self._buffer.clear() would bypass on_input_dequeued,
+        # orphaning RefBundle references in _metrics._internal_inqueues
+        # that pin ObjectRefs in the object store.
+        self.clear_internal_input_queue()
 
     def internal_input_queue_num_blocks(self) -> int:
         return self._buffer.num_blocks()

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -334,27 +334,21 @@ class StreamingExecutor(Executor, threading.Thread):
         self, force: bool, exception: Optional[Exception] = None
     ) -> None:
         """Drain topology queues after operator shutdown (releases block refs)."""
-        output_op, _ = self._output_node
         for op, state in self._topology.items():
             if isinstance(op, InternalQueueOperatorMixin):
                 op.clear_internal_input_queue()
                 op.clear_internal_output_queue()
-
-            # Multi-split sink: only skip clearing the output queue on cooperative
-            # *success* shutdown (siblings may still be draining). Failure paths set
-            # OpState._exception; consumers will not drain leftover bundles, so clear
-            # to release pins.
-            is_live_multi_split_sink = (
-                op is output_op
-                and op.num_output_splits() > 1
-                and not force
-                and exception is None
-            )
-            clear_output = not is_live_multi_split_sink
-            if clear_output:
-                state.output_queue.clear()
+            # Input queues alias upstream output queues; clears the DAG except the sink.
             for inqueue in state.input_queues:
                 inqueue.clear()
+
+        output_op, _ = self._output_node
+        # Clear sink output unless cooperative multi-split success (splits may still read).
+        is_live_multi_split_sink = (
+            output_op.num_output_splits() > 1 and not force and exception is None
+        )
+        if not is_live_multi_split_sink:
+            self._topology[output_op].output_queue.clear()
 
     def run(self):
         """Run the control loop in a helper thread.

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -339,15 +339,18 @@ class StreamingExecutor(Executor, threading.Thread):
             if isinstance(op, InternalQueueOperatorMixin):
                 op.clear_internal_input_queue()
                 op.clear_internal_output_queue()
-            # Multi-split sink: only skip clearing on cooperative *success* shutdown
-            # (siblings may still be draining). Failure paths set OpState._exception;
-            # consumers will not drain leftover bundles, so clear to release pins.
-            clear_output = (
-                force
-                or exception is not None
-                or op is not output_op
-                or op.num_output_splits() <= 1
+
+            # Multi-split sink: only skip clearing the output queue on cooperative
+            # *success* shutdown (siblings may still be draining). Failure paths set
+            # OpState._exception; consumers will not drain leftover bundles, so clear
+            # to release pins.
+            is_live_multi_split_sink = (
+                op is output_op
+                and op.num_output_splits() > 1
+                and not force
+                and exception is None
             )
+            clear_output = not is_live_multi_split_sink
             if clear_output:
                 state.output_queue.clear()
             for inqueue in state.input_queues:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -298,6 +298,8 @@ class StreamingExecutor(Executor, threading.Thread):
             for op in self._topology.keys():
                 op.shutdown(timer, force=force)
 
+            self._clear_topology_queues_post_shutdown(force, exception)
+
             min_ = round(timer.min(), 3)
             max_ = round(timer.max(), 3)
             total = round(timer.get(), 3)
@@ -327,6 +329,29 @@ class StreamingExecutor(Executor, threading.Thread):
             self._data_context.set_dataset_logger_id(
                 unregister_dataset_logger(self._dataset_id)
             )
+
+    def _clear_topology_queues_post_shutdown(
+        self, force: bool, exception: Optional[Exception] = None
+    ) -> None:
+        """Drain topology queues after operator shutdown (releases block refs)."""
+        output_op, _ = self._output_node
+        for op, state in self._topology.items():
+            if isinstance(op, InternalQueueOperatorMixin):
+                op.clear_internal_input_queue()
+                op.clear_internal_output_queue()
+            # Multi-split sink: only skip clearing on cooperative *success* shutdown
+            # (siblings may still be draining). Failure paths set OpState._exception;
+            # consumers will not drain leftover bundles, so clear to release pins.
+            clear_output = (
+                force
+                or exception is not None
+                or op is not output_op
+                or op.num_output_splits() <= 1
+            )
+            if clear_output:
+                state.output_queue.clear()
+            for inqueue in state.input_queues:
+                inqueue.clear()
 
     def run(self):
         """Run the control loop in a helper thread.

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -537,14 +537,19 @@ def update_operator_states(topology: Topology) -> None:
             op_state.inputs_done_called = True
 
     # Traverse the topology in reverse topological order.
-    # For each op, if all of its downstream operators have completed.
+    # For each op, if all of its downstream operators have completed,
     # call mark_execution_finished() to also complete this op.
     for op, op_state in reversed(list(topology.items())):
 
         dependents_completed = len(op.output_dependencies) > 0 and all(
             dep.has_completed() for dep in op.output_dependencies
         )
-        if dependents_completed:
+        # For terminal operators (no output dependencies, e.g. OutputSplitter),
+        # mark execution finished once the operator has fully completed so that
+        # internal queues are properly cleared via clear_internal_input_queue()
+        # and clear_internal_output_queue().
+        terminal_completed = len(op.output_dependencies) == 0 and op.has_completed()
+        if dependents_completed or terminal_completed:
             op.mark_execution_finished()
 
         # Drain external input queue if current operator is execution finished.

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -158,6 +158,59 @@ def test_output_split_e2e(ray_start_10_cpus_shared):
     assert len(c1.out) == 10, c0.out
 
 
+def test_output_split_shutdown_preserves_sibling_split_queues(ray_start_10_cpus_shared):
+    """If one split consumer finishes first, executor shutdown must not clear the
+    other split's output queue; slower consumers still need those RefBundles.
+    """
+    executor = StreamingExecutor(DataContext.get_current())
+    inputs = make_ref_bundles([[x] for x in range(20)])
+    o1 = InputDataBuffer(DataContext.get_current(), inputs)
+    o2 = OutputSplitter(o1, 2, equal=True, data_context=DataContext.get_current())
+    it = executor.execute(o2)
+
+    slow_ready = threading.Event()
+    slow_go = threading.Event()
+    c0_out: List[RefBundle] = []
+    c1_out: List[RefBundle] = []
+    thread_errors: List[BaseException] = []
+
+    def consume_split(idx: int, out: List[RefBundle], hold_before_reads: bool):
+        try:
+            if hold_before_reads:
+                slow_ready.set()
+                slow_go.wait()
+            while True:
+                try:
+                    out.append(it.get_next(output_split_idx=idx))
+                except StopIteration:
+                    break
+        except BaseException as e:
+            thread_errors.append(e)
+
+    t_slow = threading.Thread(target=consume_split, args=(1, c1_out, True))
+    t_fast = threading.Thread(target=consume_split, args=(0, c0_out, False))
+    t_slow.start()
+    assert slow_ready.wait(timeout=30)
+    t_fast.start()
+    t_fast.join(timeout=60)
+    assert not t_fast.is_alive()
+    slow_go.set()
+    t_slow.join(timeout=60)
+    assert not t_slow.is_alive()
+    assert not thread_errors, thread_errors
+
+    def get_outputs(out: List[RefBundle]):
+        outputs = []
+        for bundle in out:
+            for block_ref in bundle.block_refs:
+                ids: pd.Series = ray.get(block_ref)["id"]
+                outputs.extend(ids.values)
+        return outputs
+
+    assert get_outputs(c0_out) == list(range(0, 20, 2))
+    assert get_outputs(c1_out) == list(range(1, 20, 2))
+
+
 def test_streaming_split_e2e(ray_start_10_cpus_shared):
     def get_lengths(*iterators, use_iter_batches=True):
         lengths = []


### PR DESCRIPTION
### Summary

`Dataset.streaming_split()` can keep `ObjectRef`s alive across epochs because the split coordinator holds an iterator that closes over the executor topology, and because `OutputSplitter` can leave the metrics “shadow” input queue out of sync with the real buffer after `equal=True` truncation. This PR fixes both issues.

### What was going wrong

1. **Topology + queues across epochs**  
   The coordinator keeps `_output_iterator` until the next epoch replaces it. Anything reachable from the old executor’s topology (including `OpState` queues) can pin the object store until that chain is dropped and queues are drained.

2. **Truncated remainder + metrics**  
   After equalizing splits, a bare `_buffer.clear()` emptied the real buffer without `on_input_dequeued`, so `OpRuntimeMetrics` could still hold `RefBundle`s for the truncated remainder.

3. **Terminal `OutputSplitter` and `mark_execution_finished`**  
   `mark_execution_finished()` (which clears internal queues via the mixin) was not run for operators with no downstream deps, so terminal splitters did not follow the same lifecycle path as other ops.

### What we changed

- **`OutputSplitter.all_inputs_done`**: replace `_buffer.clear()` with `clear_internal_input_queue()` so truncation drains through metrics and releases refs consistently.  
- **`update_operator_states`**: treat fully completed terminal ops like split sinks as finished for execution and run `mark_execution_finished()` when `output_dependencies` is empty.  
- **`StreamingExecutor.shutdown`**: after `op.shutdown()`, call `_clear_topology_queues_post_shutdown(force)` to clear internal queues and topology `OpState` queues; **for the DAG sink with `num_output_splits > 1`, skip clearing the external output queues on cooperative (`force=False`) shutdown** so other splits keep their bundles; **`force=True` still clears everything** (e.g. epoch rollover in `SplitCoordinator._try_start_new_epoch`).  
- **Tests**: `test_output_split_shutdown_preserves_sibling_split_queues` covers fast vs slow split consumers.

### Links (for reviewers)

- Cooperative shutdown from first exhausted split: [`streaming_executor.py` (`_ClosingIterator.get_next`)](https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/execution/streaming_executor.py#L688-L710)  
- Forced teardown on epoch advance: [`stream_split_iterator.py` (`_try_start_new_epoch`)](https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/iterator/stream_split_iterator.py#L216-L228)  
- Barrier / when the next epoch starts (not tied to first consumer finishing): [`start_epoch` / `_barrier`](https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/iterator/stream_split_iterator.py#L205-L214), [`_barrier` → `_try_start_new_epoch`](https://github.com/ray-project/ray/blob/master/python/ray/data/_internal/iterator/stream_split_iterator.py#L357-L382)