### PR TITLE
[Data] Add jq() function to Expressions string namespace

### DIFF
--- a/python/ray/data/namespace_expressions/string_namespace.py
+++ b/python/ray/data/namespace_expressions/string_namespace.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
+import json
+import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Callable, List, Literal, Tuple, Union
 
 import pyarrow
 import pyarrow.compute as pc
 
 from ray.data.datatype import DataType
-from ray.data.expressions import _create_pyarrow_compute_udf
+from ray.data.expressions import _create_pyarrow_compute_udf, pyarrow_udf
 
 if TYPE_CHECKING:
-    from ray.data.expressions import Expr, PyArrowComputeUDFExpr
+    from ray.data.expressions import Expr, PyArrowComputeUDFExpr, UDFExpr
 
 
 def _create_str_udf(
@@ -374,3 +376,125 @@ class _StringNamespace:
         return _create_str_udf(pc_func, DataType.string())(
             self._expr, width=width, padding=fillchar
         )
+
+    def jq(self, filter_expr: str) -> "UDFExpr":
+        """Apply a jq-style filter expression to JSON strings.
+
+        Parses each string as JSON and extracts values using a jq-like path
+        expression. The result is returned as a JSON-encoded string (scalars
+        like strings and numbers are returned as their JSON representation).
+
+        Supported syntax:
+            - Field access: ``.name``, ``.user.email``
+            - Array indexing: ``.[0]``, ``.items[1]``
+            - Chained paths: ``.items[0].name``
+
+        Args:
+            filter_expr: A jq-style filter expression starting with ``.``.
+
+        Returns:
+            Expression that extracts the value from each JSON string.
+
+        Example:
+            >>> from ray.data.expressions import col  # doctest: +SKIP
+            >>> col("data").str.jq(".name")  # doctest: +SKIP
+            >>> col("data").str.jq(".items[0].name")  # doctest: +SKIP
+        """
+        steps = _parse_jq_filter(filter_expr)
+
+        @pyarrow_udf(return_dtype=DataType.string())
+        def _jq_filter(arr: pyarrow.Array) -> pyarrow.Array:
+            results: List[Union[str, None]] = []
+            for val in arr.to_pylist():
+                if val is None:
+                    results.append(None)
+                    continue
+                try:
+                    obj = json.loads(val)
+                    obj = _apply_jq_steps(obj, steps)
+                    if obj is None:
+                        results.append(None)
+                    elif isinstance(obj, str):
+                        results.append(obj)
+                    else:
+                        results.append(json.dumps(obj, ensure_ascii=False))
+                except (json.JSONDecodeError, TypeError):
+                    results.append(None)
+            return pyarrow.array(results, type=pyarrow.string())
+
+        return _jq_filter(self._expr)
+
+
+_JQ_TOKEN_RE = re.compile(
+    r"""
+    \.(\w+)       # .fieldName
+    | \[(\d+)\]   # [index]
+    """,
+    re.VERBOSE,
+)
+
+
+def _parse_jq_filter(
+    expr: str,
+) -> List[Tuple[str, Union[str, int]]]:
+    """Parse a jq filter like ``.foo.bar[0].baz`` into a list of steps.
+
+    Returns a list of ``("field", name)`` or ``("index", int)`` tuples.
+
+    Raises:
+        ValueError: If the expression is empty or cannot be fully parsed.
+    """
+    expr = expr.strip()
+    if not expr.startswith("."):
+        raise ValueError(f"jq filter must start with '.', got: {expr!r}")
+
+    steps: List[Tuple[str, Union[str, int]]] = []
+    pos = 0
+    # Skip the leading dot if it's just the identity '.'
+    if expr == ".":
+        return steps
+
+    for m in _JQ_TOKEN_RE.finditer(expr):
+        if m.start() < pos:
+            continue
+        # Ensure there are no gaps (unparsed characters)
+        if m.start() != pos and not (pos == 0 and m.start() == 0):
+            gap = expr[pos : m.start()]
+            if gap not in ("", "."):
+                raise ValueError(f"Unsupported jq syntax at position {pos}: {expr!r}")
+        pos = m.end()
+        field, index = m.group(1), m.group(2)
+        if field is not None:
+            steps.append(("field", field))
+        else:
+            steps.append(("index", int(index)))
+
+    if pos < len(expr):
+        raise ValueError(f"Unsupported jq syntax at position {pos}: {expr!r}")
+
+    if not steps:
+        raise ValueError(f"Empty jq filter: {expr!r}")
+
+    return steps
+
+
+def _apply_jq_steps(obj: Any, steps: List[Tuple[str, Union[str, int]]]) -> Any:
+    """Traverse *obj* according to the parsed jq steps.
+
+    Returns ``None`` if any step fails (missing key, out-of-bounds index, or
+    type mismatch).
+    """
+    for kind, key in steps:
+        if obj is None:
+            return None
+        if kind == "field":
+            if isinstance(obj, dict):
+                obj = obj.get(key)
+            else:
+                return None
+        elif kind == "index":
+            if isinstance(obj, list) and -len(obj) <= key < len(obj):
+                obj = obj[key]
+            else:
+                return None
+    return obj

--- a/python/ray/data/namespace_expressions/string_namespace.py
+++ b/python/ray/data/namespace_expressions/string_namespace.py
@@ -404,30 +404,32 @@ class _StringNamespace:
 
         @pyarrow_udf(return_dtype=DataType.string())
         def _jq_filter(arr: pyarrow.Array) -> pyarrow.Array:
-            results: List[Union[str, None]] = []
-            for val in arr.to_pylist():
+            def _process(val):
                 if val is None:
-                    results.append(None)
-                    continue
+                    return None
                 try:
                     obj = json.loads(val)
                     obj = _apply_jq_steps(obj, steps)
                     if obj is None:
-                        results.append(None)
-                    elif isinstance(obj, str):
-                        results.append(obj)
-                    else:
-                        results.append(json.dumps(obj, ensure_ascii=False))
+                        return None
+                    return (
+                        obj
+                        if isinstance(obj, str)
+                        else json.dumps(obj, ensure_ascii=False)
+                    )
                 except (json.JSONDecodeError, TypeError):
-                    results.append(None)
-            return pyarrow.array(results, type=pyarrow.string())
+                    return None
+
+            return pyarrow.array(
+                [_process(v.as_py()) for v in arr], type=pyarrow.string()
+            )
 
         return _jq_filter(self._expr)
 
 
 _JQ_TOKEN_RE = re.compile(
     r"""
-    \.(\w+)       # .fieldName
+    (\w+)         # fieldName (after a dot)
     | \[(\d+)\]   # [index]
     """,
     re.VERBOSE,
@@ -439,7 +441,11 @@ def _parse_jq_filter(
 ) -> List[Tuple[str, Union[str, int]]]:
     """Parse a jq filter like ``.foo.bar[0].baz`` into a list of steps.
 
-    Returns a list of ``("field", name)`` or ``("index", int)`` tuples.
+    Args:
+        expr: A jq-style filter expression starting with ``"."``.
+
+    Returns:
+        A list of ``("field", name)`` or ``("index", int)`` tuples.
 
     Raises:
         ValueError: If the expression is empty or cannot be fully parsed.
@@ -449,20 +455,26 @@ def _parse_jq_filter(
         raise ValueError(f"jq filter must start with '.', got: {expr!r}")
 
     steps: List[Tuple[str, Union[str, int]]] = []
-    pos = 0
     # Skip the leading dot if it's just the identity '.'
     if expr == ".":
         return steps
 
-    for m in _JQ_TOKEN_RE.finditer(expr):
+    # Start after the mandatory leading dot.
+    pos = 1
+    for m in _JQ_TOKEN_RE.finditer(expr, pos=1):
         if m.start() < pos:
             continue
         # Ensure there are no gaps (unparsed characters)
-        if m.start() != pos and not (pos == 0 and m.start() == 0):
-            gap = expr[pos : m.start()]
-            if gap not in ("", "."):
-                raise ValueError(f"Unsupported jq syntax at position {pos}: {expr!r}")
+        if m.start() > pos:
+            raise ValueError(f"Unsupported jq syntax at position {pos}: {expr!r}")
         pos = m.end()
+        # Consume a dot separator before the next field name.
+        # A dot is only valid when followed by a word character (field name).
+        if pos < len(expr) and expr[pos] == ".":
+            if pos + 1 < len(expr) and re.match(r"\w", expr[pos + 1]):
+                pos += 1  # consume the dot separator
+            else:
+                raise ValueError(f"Unsupported jq syntax at position {pos}: {expr!r}")
         field, index = m.group(1), m.group(2)
         if field is not None:
             steps.append(("field", field))

--- a/python/ray/data/tests/expressions/test_namespace_string.py
+++ b/python/ray/data/tests/expressions/test_namespace_string.py
@@ -322,6 +322,61 @@ class TestStringTransform:
         assert rows_same(result, expected)
 
 
+@pytest.mark.parametrize("dataset_format", DATASET_FORMATS)
+@pytest.mark.parametrize(
+    "filter_expr,input_values,expected_values",
+    [
+        # Simple field access
+        (".name", ['{"name": "alice"}', '{"name": "bob"}'], ["alice", "bob"]),
+        # Nested field access
+        (
+            ".user.email",
+            ['{"user": {"email": "a@b.com"}}'],
+            ["a@b.com"],
+        ),
+        # Array indexing
+        (".[0]", ['["x", "y", "z"]'], ["x"]),
+        (".items[1]", ['{"items": [10, 20, 30]}'], ["20"]),
+        # Chained path with array index
+        (
+            ".items[0].name",
+            ['{"items": [{"name": "first"}, {"name": "second"}]}'],
+            ["first"],
+        ),
+        # Non-existent key returns None
+        (".missing", ['{"name": "alice"}'], [None]),
+        # Invalid JSON returns None
+        (".name", ["not-json"], [None]),
+        # Null input returns None
+        (".name", [None], [None]),
+        # Numeric value returned as JSON string
+        (".age", ['{"age": 30}'], ["30"]),
+        # Boolean value returned as JSON string
+        (".active", ['{"active": true}'], ["true"]),
+        # Identity filter
+        (".", ['{"a": 1}'], ['{"a": 1}']),
+    ],
+)
+class TestStringJq:
+    """Tests for jq-style JSON extraction on string columns."""
+
+    def test_string_jq(
+        self,
+        ray_start_regular_shared,
+        dataset_format,
+        filter_expr,
+        input_values,
+        expected_values,
+    ):
+        data = [{"data": v} for v in input_values]
+        ds = _create_dataset(data, dataset_format)
+
+        result = ds.with_column("result", col("data").str.jq(filter_expr)).to_pandas()
+
+        expected = pd.DataFrame({"data": input_values, "result": expected_values})
+        assert rows_same(result, expected)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

Add a `jq()` method to the `_StringNamespace` in Ray Data Expressions, enabling users to apply jq-style filter expressions on JSON string columns.

When working with datasets that contain JSON-encoded string columns, users frequently need to extract specific fields or nested values. Currently this requires writing custom UDFs with json.loads() + manual path traversal. A built-in `jq()`
  expression would make this much more ergonomic.

  Support basic jq filter syntax:
  - Field access: .name, .user.email
  - Array indexing: .[0], .items[1]
  - Nested paths: .a.b.c, .items[0].name

```
  import ray
  from ray.data.expressions import col

  ds = ray.data.from_items([
      {"data": '{"name": "alice", "age": 30}'},
      {"data": '{"name": "bob", "age": 25}'},
  ])

  # Extract the "name" field from JSON strings
  ds = ds.with_column("name", col("data").str.jq(".name"))

  # Nested access
  ds2 = ray.data.from_items([
      {"data": '{"user": {"email": "a@b.com"}}'},
  ])
  ds2 = ds2.with_column("email", col("data").str.jq(".user.email"))
```

## Related issues
Related to #58674 

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
