### PR TITLE
[core] move the GCS's ReportJobError to InternalPubSubGcsService

### DIFF
--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -148,6 +148,7 @@ ray_cc_library(
         "//src/ray/pubsub:gcs_publisher",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 

--- a/src/ray/gcs/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_job_manager.cc
@@ -460,14 +460,6 @@ void GcsJobManager::HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
   gcs_table_storage_.JobTable().GetAll({std::move(on_done), io_context_});
 }
 
-void GcsJobManager::HandleReportJobError(rpc::ReportJobErrorRequest request,
-                                         rpc::ReportJobErrorReply *reply,
-                                         rpc::SendReplyCallback send_reply_callback) {
-  auto job_id = JobID::FromBinary(request.job_error().job_id());
-  gcs_publisher_.PublishError(job_id.Hex(), std::move(*request.mutable_job_error()));
-  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
-}
-
 void GcsJobManager::HandleGetNextJobID(rpc::GetNextJobIDRequest request,
                                        rpc::GetNextJobIDReply *reply,
                                        rpc::SendReplyCallback send_reply_callback) {

--- a/src/ray/gcs/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_job_manager.h
@@ -90,10 +90,6 @@ class GcsJobManager : public rpc::JobInfoGcsServiceHandler {
                            rpc::GetAllJobInfoReply *reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
-  void HandleReportJobError(rpc::ReportJobErrorRequest request,
-                            rpc::ReportJobErrorReply *reply,
-                            rpc::SendReplyCallback send_reply_callback) override;
-
   void HandleGetNextJobID(rpc::GetNextJobIDRequest request,
                           rpc::GetNextJobIDReply *reply,
                           rpc::SendReplyCallback send_reply_callback) override;

--- a/src/ray/gcs/grpc_service_interfaces.h
+++ b/src/ray/gcs/grpc_service_interfaces.h
@@ -140,6 +140,10 @@ class InternalPubSubGcsServiceHandler {
                                 GcsPublishReply *reply,
                                 SendReplyCallback send_reply_callback) = 0;
 
+  virtual void HandleReportJobError(ReportJobErrorRequest request,
+                                    ReportJobErrorReply *reply,
+                                    SendReplyCallback send_reply_callback) = 0;
+
   virtual void HandleGcsSubscriberPoll(GcsSubscriberPollRequest request,
                                        GcsSubscriberPollReply *reply,
                                        SendReplyCallback send_reply_callback) = 0;
@@ -168,10 +172,6 @@ class JobInfoGcsServiceHandler {
                                    SendReplyCallback send_reply_callback) = 0;
 
   virtual void AddJobFinishedListener(JobFinishListenerCallback listener) = 0;
-
-  virtual void HandleReportJobError(ReportJobErrorRequest request,
-                                    ReportJobErrorReply *reply,
-                                    SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleGetNextJobID(GetNextJobIDRequest request,
                                   GetNextJobIDReply *reply,

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -83,6 +83,8 @@ void InternalPubSubGrpcService::InitServerCallFactories(
     std::shared_ptr<const AuthenticationToken> auth_token) {
   RPC_SERVICE_HANDLER(InternalPubSubGcsService, GcsPublish, max_active_rpcs_per_handler_);
   RPC_SERVICE_HANDLER(
+      InternalPubSubGcsService, ReportJobError, max_active_rpcs_per_handler_);
+  RPC_SERVICE_HANDLER(
       InternalPubSubGcsService, GcsSubscriberPoll, max_active_rpcs_per_handler_);
   RPC_SERVICE_HANDLER(
       InternalPubSubGcsService, GcsSubscriberCommandBatch, max_active_rpcs_per_handler_);
@@ -96,7 +98,6 @@ void JobInfoGrpcService::InitServerCallFactories(
   RPC_SERVICE_HANDLER(JobInfoGcsService, AddJob, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(JobInfoGcsService, MarkJobFinished, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(JobInfoGcsService, GetAllJobInfo, max_active_rpcs_per_handler_)
-  RPC_SERVICE_HANDLER(JobInfoGcsService, ReportJobError, max_active_rpcs_per_handler_)
   RPC_SERVICE_HANDLER(JobInfoGcsService, GetNextJobID, max_active_rpcs_per_handler_)
 }
 

--- a/src/ray/gcs/pubsub_handler.cc
+++ b/src/ray/gcs/pubsub_handler.cc
@@ -17,6 +17,8 @@
 #include <string>
 #include <utility>
 
+#include "ray/common/id.h"
+
 namespace ray {
 namespace gcs {
 
@@ -32,6 +34,15 @@ void InternalPubSubHandler::HandleGcsPublish(rpc::GcsPublishRequest request,
     gcs_publisher_.GetPublisher().Publish(std::move(msg));
   }
   send_reply_callback(Status::OK(), nullptr, nullptr);
+}
+
+void InternalPubSubHandler::HandleReportJobError(
+    rpc::ReportJobErrorRequest request,
+    rpc::ReportJobErrorReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
+  auto job_id = JobID::FromBinary(request.job_error().job_id());
+  gcs_publisher_.PublishError(job_id.Hex(), std::move(*request.mutable_job_error()));
+  GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }
 
 // Needs to use rpc::GcsSubscriberPollRequest and rpc::GcsSubscriberPollReply here,

--- a/src/ray/gcs/pubsub_handler.cc
+++ b/src/ray/gcs/pubsub_handler.cc
@@ -17,6 +17,7 @@
 #include <string>
 #include <utility>
 
+#include "absl/strings/str_format.h"
 #include "ray/common/id.h"
 
 namespace ray {
@@ -40,7 +41,17 @@ void InternalPubSubHandler::HandleReportJobError(
     rpc::ReportJobErrorRequest request,
     rpc::ReportJobErrorReply *reply,
     rpc::SendReplyCallback send_reply_callback) {
-  auto job_id = JobID::FromBinary(request.job_error().job_id());
+  const auto &job_id_binary = request.job_error().job_id();
+  if (job_id_binary.size() != JobID::Size()) {
+    send_reply_callback(Status::InvalidArgument(absl::StrFormat(
+                            "Invalid job_id: expected length %zu bytes, got %zu",
+                            JobID::Size(),
+                            job_id_binary.size())),
+                        nullptr,
+                        nullptr);
+    return;
+  }
+  const auto job_id = JobID::FromBinary(job_id_binary);
   gcs_publisher_.PublishError(job_id.Hex(), std::move(*request.mutable_job_error()));
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
 }

--- a/src/ray/gcs/pubsub_handler.h
+++ b/src/ray/gcs/pubsub_handler.h
@@ -37,6 +37,10 @@ class InternalPubSubHandler : public rpc::InternalPubSubGcsServiceHandler {
                         rpc::GcsPublishReply *reply,
                         rpc::SendReplyCallback send_reply_callback) final;
 
+  void HandleReportJobError(rpc::ReportJobErrorRequest request,
+                            rpc::ReportJobErrorReply *reply,
+                            rpc::SendReplyCallback send_reply_callback) final;
+
   void HandleGcsSubscriberPoll(rpc::GcsSubscriberPollRequest request,
                                rpc::GcsSubscriberPollReply *reply,
                                rpc::SendReplyCallback send_reply_callback) final;

--- a/src/ray/gcs/tests/pubsub_handler_test.cc
+++ b/src/ray/gcs/tests/pubsub_handler_test.cc
@@ -202,6 +202,31 @@ TEST_F(PubSubHandlerTest, HandleReportJobErrorPublishesToSubscribedErrorChannel)
   EXPECT_EQ(msg.error_info_message().error_message(), "test job error");
 }
 
+TEST_F(PubSubHandlerTest, HandleReportJobErrorRejectsInvalidJobIdLength) {
+  rpc::ReportJobErrorRequest err_req;
+  err_req.mutable_job_error()->set_job_id("");
+  err_req.mutable_job_error()->set_error_message("x");
+
+  rpc::ReportJobErrorReply err_reply;
+  Status err_status;
+  pubsub_handler_->HandleReportJobError(
+      err_req,
+      &err_reply,
+      [&err_status](const Status &status, std::function<void()>, std::function<void()>) {
+        err_status = status;
+      });
+  ASSERT_TRUE(err_status.IsInvalidArgument()) << err_status;
+
+  err_req.mutable_job_error()->set_job_id("short");
+  pubsub_handler_->HandleReportJobError(
+      err_req,
+      &err_reply,
+      [&err_status](const Status &status, std::function<void()>, std::function<void()>) {
+        err_status = status;
+      });
+  ASSERT_TRUE(err_status.IsInvalidArgument()) << err_status;
+}
+
 }  // namespace gcs
 }  // namespace ray
 

--- a/src/ray/gcs/tests/pubsub_handler_test.cc
+++ b/src/ray/gcs/tests/pubsub_handler_test.cc
@@ -22,8 +22,10 @@
 #include "ray/common/asio/fake_periodical_runner.h"
 #include "ray/common/id.h"
 #include "ray/common/ray_config.h"
+#include "ray/common/status.h"
 #include "ray/pubsub/gcs_publisher.h"
 #include "ray/pubsub/publisher.h"
+#include "src/ray/protobuf/gcs_service.pb.h"
 
 namespace ray {
 namespace gcs {
@@ -144,6 +146,60 @@ TEST_F(
                          std::function<void()>) { received_status = status; });
 
   ASSERT_TRUE(received_status.IsInvalidArgument());
+}
+
+TEST_F(PubSubHandlerTest, HandleReportJobErrorPublishesToSubscribedErrorChannel) {
+  const auto subscriber_id = UniqueID::FromRandom();
+  const JobID job_id = JobID::FromInt(42);
+
+  rpc::GcsSubscriberCommandBatchRequest sub_req;
+  sub_req.set_subscriber_id(subscriber_id.Binary());
+  auto *cmd = sub_req.add_commands();
+  cmd->set_channel_type(rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
+  cmd->mutable_subscribe_message();
+
+  rpc::GcsSubscriberCommandBatchReply sub_reply;
+  Status sub_status;
+  pubsub_handler_->HandleGcsSubscriberCommandBatch(
+      sub_req,
+      &sub_reply,
+      [&sub_status](const Status &status, std::function<void()>, std::function<void()>) {
+        sub_status = status;
+      });
+  ASSERT_TRUE(sub_status.ok()) << sub_status;
+
+  rpc::ReportJobErrorRequest err_req;
+  err_req.mutable_job_error()->set_job_id(job_id.Binary());
+  err_req.mutable_job_error()->set_error_message("test job error");
+
+  rpc::ReportJobErrorReply err_reply;
+  Status err_status;
+  pubsub_handler_->HandleReportJobError(
+      err_req,
+      &err_reply,
+      [&err_status](const Status &status, std::function<void()>, std::function<void()>) {
+        err_status = status;
+      });
+  ASSERT_TRUE(err_status.ok()) << err_status;
+  EXPECT_EQ(StatusCode(err_reply.status().code()), StatusCode::OK);
+
+  rpc::GcsSubscriberPollRequest poll_req;
+  poll_req.set_subscriber_id(subscriber_id.Binary());
+  poll_req.set_max_processed_sequence_id(0);
+  rpc::GcsSubscriberPollReply poll_reply;
+  Status poll_status;
+  pubsub_handler_->HandleGcsSubscriberPoll(
+      poll_req,
+      &poll_reply,
+      [&poll_status](const Status &status, std::function<void()>, std::function<void()>) {
+        poll_status = status;
+      });
+  ASSERT_TRUE(poll_status.ok()) << poll_status;
+  ASSERT_EQ(poll_reply.pub_messages_size(), 1);
+  const auto &msg = poll_reply.pub_messages(0);
+  EXPECT_EQ(msg.channel_type(), rpc::ChannelType::RAY_ERROR_INFO_CHANNEL);
+  EXPECT_EQ(msg.key_id(), job_id.Hex());
+  EXPECT_EQ(msg.error_info_message().error_message(), "test job error");
 }
 
 }  // namespace gcs

--- a/src/ray/gcs_rpc_client/rpc_client.h
+++ b/src/ray/gcs_rpc_client/rpc_client.h
@@ -267,12 +267,6 @@ class GcsRpcClient {
                              job_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
-  /// Report job error to GCS Service.
-  VOID_GCS_RPC_CLIENT_METHOD(JobInfoGcsService,
-                             ReportJobError,
-                             job_info_grpc_client_,
-                             /*method_timeout_ms*/ -1, )
-
   /// Get next job id from GCS Service.
   VOID_GCS_RPC_CLIENT_METHOD(JobInfoGcsService,
                              GetNextJobID,
@@ -521,6 +515,10 @@ class GcsRpcClient {
   /// Operations for pubsub
   VOID_GCS_RPC_CLIENT_METHOD(InternalPubSubGcsService,
                              GcsPublish,
+                             internal_pubsub_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+  VOID_GCS_RPC_CLIENT_METHOD(InternalPubSubGcsService,
+                             ReportJobError,
                              internal_pubsub_grpc_client_,
                              /*method_timeout_ms*/ -1, )
   VOID_GCS_RPC_CLIENT_METHOD(InternalPubSubGcsService,

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -73,8 +73,6 @@ service JobInfoGcsService {
   rpc MarkJobFinished(MarkJobFinishedRequest) returns (MarkJobFinishedReply);
   // Get information of all jobs from GCS Service.
   rpc GetAllJobInfo(GetAllJobInfoRequest) returns (GetAllJobInfoReply);
-  // Report job error.
-  rpc ReportJobError(ReportJobErrorRequest) returns (ReportJobErrorReply);
   // Get next job id.
   rpc GetNextJobID(GetNextJobIDRequest) returns (GetNextJobIDReply);
 }
@@ -710,6 +708,8 @@ service InternalPubSubGcsService {
   /// The request to sent to GCS to publish messages.
   /// Currently only supporting error info, logs and Python function messages.
   rpc GcsPublish(GcsPublishRequest) returns (GcsPublishReply);
+  /// Report job error.
+  rpc ReportJobError(ReportJobErrorRequest) returns (ReportJobErrorReply);
   /// The long polling request sent to GCS for pubsub operations.
   /// The long poll request will be replied once there are a batch of messages that
   /// need to be published to the caller (subscriber).


### PR DESCRIPTION
## Description

Move the ReportJobError handler to InternalPubSubGcsService for using the pubsub_io_context thread so that it won't delay other critical operations, such as actor restarts.

