### PR TITLE
[core] Fix raylet ignoring `gcs_rpc_server_reconnect_timeout_s` from `_system_config`

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1252,6 +1252,7 @@ class Node:
             node_name=self._ray_params.node_name,
             webui=self._webui_url,
             resource_isolation_config=self.resource_isolation_config,
+            config=self._config,
         )
         assert ray_constants.PROCESS_TYPE_RAYLET not in self.all_processes
         self.all_processes[ray_constants.PROCESS_TYPE_RAYLET] = [process_info]
@@ -1347,7 +1348,7 @@ class Node:
     def start_head_processes(self):
         """Start head processes on the node."""
         logger.debug(
-            f"Process STDOUT and STDERR is being " f"redirected to {self._logs_dir}."
+            f"Process STDOUT and STDERR is being redirected to {self._logs_dir}."
         )
         assert self._gcs_address is None
         assert self._gcs_client is None
@@ -1376,7 +1377,7 @@ class Node:
     def start_ray_processes(self):
         """Start all of the processes on the node."""
         logger.debug(
-            f"Process STDOUT and STDERR is being " f"redirected to {self._logs_dir}."
+            f"Process STDOUT and STDERR is being redirected to {self._logs_dir}."
         )
 
         if not self.head:

--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -1348,7 +1348,7 @@ class Node:
     def start_head_processes(self):
         """Start head processes on the node."""
         logger.debug(
-            f"Process STDOUT and STDERR is being redirected to {self._logs_dir}."
+            f"Process STDOUT and STDERR is being " f"redirected to {self._logs_dir}."
         )
         assert self._gcs_address is None
         assert self._gcs_client is None
@@ -1377,7 +1377,7 @@ class Node:
     def start_ray_processes(self):
         """Start all of the processes on the node."""
         logger.debug(
-            f"Process STDOUT and STDERR is being redirected to {self._logs_dir}."
+            f"Process STDOUT and STDERR is being " f"redirected to {self._logs_dir}."
         )
 
         if not self.head:

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -745,7 +745,7 @@ def extract_ip_port(bootstrap_address: str):
     ip_port = parse_address(bootstrap_address)
     if ip_port is None:
         raise ValueError(
-            f"Malformed address {bootstrap_address}. " f"Expected '<host>:<port>'."
+            f"Malformed address {bootstrap_address}. Expected '<host>:<port>'."
         )
     ip, port = ip_port
     try:
@@ -754,8 +754,7 @@ def extract_ip_port(bootstrap_address: str):
         raise ValueError(f"Malformed address port {port}. Must be an integer.")
     if port < 1024 or port > 65535:
         raise ValueError(
-            f"Invalid address port {port}. Must be between 1024 "
-            "and 65535 (inclusive)."
+            f"Invalid address port {port}. Must be between 1024 and 65535 (inclusive)."
         )
     return ip, port
 
@@ -1037,8 +1036,7 @@ def start_ray_process(
         total_chrs = sum([len(x) for x in command])
         if total_chrs > 31766:
             raise ValueError(
-                f"command is limited to a total of 31767 characters, "
-                f"got {total_chrs}"
+                f"command is limited to a total of 31767 characters, got {total_chrs}"
             )
 
     process = ConsolePopen(
@@ -1636,6 +1634,7 @@ def start_raylet(
     env_updates: Optional[dict] = None,
     node_name: Optional[str] = None,
     webui: Optional[str] = None,
+    config: Optional[dict] = None,
 ):
     """Start a raylet, which is a combined local scheduler and object manager.
 
@@ -1719,6 +1718,10 @@ def start_raylet(
         env_updates: Environment variable overrides.
         node_name: The name of the node.
         webui: The url of the UI.
+        config: Optional configuration that will override defaults in RayConfig.
+            Passed as --config_list to the raylet binary so that user-supplied
+            _system_config values (e.g. gcs_rpc_server_reconnect_timeout_s) are
+            in effect before the first GCS connection attempt.
     Returns:
         ProcessInfo for the process that was started.
     """
@@ -1966,6 +1969,7 @@ def start_raylet(
         f"--session-name={session_name}",
         f"--labels={labels_json_str}",
         f"--cluster-id={cluster_id}",
+        f"--config_list={serialize_config(config or {})}",
     ]
 
     if resource_isolation_config.is_enabled():

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -745,7 +745,7 @@ def extract_ip_port(bootstrap_address: str):
     ip_port = parse_address(bootstrap_address)
     if ip_port is None:
         raise ValueError(
-            f"Malformed address {bootstrap_address}. Expected '<host>:<port>'."
+            f"Malformed address {bootstrap_address}. " f"Expected '<host>:<port>'."
         )
     ip, port = ip_port
     try:
@@ -754,7 +754,8 @@ def extract_ip_port(bootstrap_address: str):
         raise ValueError(f"Malformed address port {port}. Must be an integer.")
     if port < 1024 or port > 65535:
         raise ValueError(
-            f"Invalid address port {port}. Must be between 1024 and 65535 (inclusive)."
+            f"Invalid address port {port}. Must be between 1024 "
+            "and 65535 (inclusive)."
         )
     return ip, port
 
@@ -1036,7 +1037,8 @@ def start_ray_process(
         total_chrs = sum([len(x) for x in command])
         if total_chrs > 31766:
             raise ValueError(
-                f"command is limited to a total of 31767 characters, got {total_chrs}"
+                f"command is limited to a total of 31767 characters, "
+                f"got {total_chrs}"
             )
 
     process = ConsolePopen(

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import json
 import os
 import signal
@@ -56,6 +57,18 @@ def cluster_kill_gcs_wait(cluster):
     # Wait to prevent the gcs server process becoming zombie.
     gcs_server_process.wait()
     wait_for_pid_to_exit(gcs_server_pid, 300)
+
+
+def get_raylet_startup_config(node) -> dict[str, Any]:
+    raylet_pid = node.all_processes["raylet"][0].process.pid
+    raylet_cmdline = psutil.Process(raylet_pid).cmdline()
+    config_list_arg = next(
+        (arg for arg in raylet_cmdline if arg.startswith("--config_list=")),
+        None,
+    )
+    assert config_list_arg is not None, raylet_cmdline
+    config_blob = config_list_arg.split("=", 1)[1]
+    return json.loads(base64.b64decode(config_blob).decode("utf-8"))
 
 
 def test_gcs_server_restart(ray_start_regular_with_external_redis):
@@ -1390,6 +1403,43 @@ def test_raylet_respects_reconnect_timeout_config(
     # The task must complete now that GCS is back.
     result = ray.get(future, timeout=30)
     assert result == 99, f"Expected 99, got {result}"
+
+
+@pytest.mark.skipif(
+    not external_redis_test_enabled(),
+    reason="Only runs when external Redis is enabled (TEST_EXTERNAL_REDIS=1)",
+)
+@pytest.mark.parametrize(
+    "ray_start_cluster_head_with_external_redis",
+    [
+        {
+            **generate_system_config_map(
+                gcs_rpc_server_reconnect_timeout_s=10,
+            ),
+        }
+    ],
+    indirect=True,
+)
+def test_worker_raylet_startup_uses_gcs_system_config(
+    ray_start_cluster_head_with_external_redis,
+):
+    """Worker raylets should receive the GCS-fetched system config at startup.
+
+    The head node injects ``_system_config`` via ``--config_list`` before the
+    raylet makes its first GCS connection. Non-head nodes must then fetch the
+    same config from GCS and pass it to their own raylet startup command, or
+    they will silently fall back to the 60 s default reconnect timeout.
+    """
+
+    cluster = ray_start_cluster_head_with_external_redis
+    worker = cluster.add_node()
+    cluster.wait_for_nodes()
+
+    head_config = get_raylet_startup_config(cluster.head_node)
+    worker_config = get_raylet_startup_config(worker)
+
+    assert head_config["gcs_rpc_server_reconnect_timeout_s"] == 10
+    assert worker_config["gcs_rpc_server_reconnect_timeout_s"] == 10
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -610,8 +610,10 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
         ]
 
     wait_for_condition(
-        lambda: len(get_connected_nodes())
-        == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS"))
+        lambda: (
+            len(get_connected_nodes())
+            == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS"))
+        )
     )
     nodes = redis_cli.cluster("nodes")
     leader_cli = None
@@ -661,8 +663,10 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
 
     follower_cli[0].cluster("failover", "takeover")
     wait_for_condition(
-        lambda: len(get_connected_nodes())
-        == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS")) - 1
+        lambda: (
+            len(get_connected_nodes())
+            == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS")) - 1
+        )
     )
 
     # Kill Counter actor. It should restart after GCS is back
@@ -984,8 +988,10 @@ def test_job_finished_after_head_node_restart(
 
         return list(
             filter(
-                lambda job_info: "job_submission_id" in job_info.config.metadata
-                and job_info.config.metadata["job_submission_id"] == submission_id,
+                lambda job_info: (
+                    "job_submission_id" in job_info.config.metadata
+                    and job_info.config.metadata["job_submission_id"] == submission_id
+                ),
                 list(all_job_info.values()),
             )
         )
@@ -1130,7 +1136,6 @@ def test_gcs_server_restart_destroys_out_of_scope_actors(
         assert ray.get(detached2.getpid.remote()) == detached_pid
         assert ray.get(child2.getpid.remote()) == child_pid
     elif case["expect_alive"] == "none":
-
         with pytest.raises(ValueError):
             ray.get_actor("regular", namespace="ns")
 
@@ -1318,6 +1323,73 @@ def test_concurrent_mark_job_finished(shutdown_only):
     # Verify all tasks completed
     expected = [f"task_{i}_completed" for i in range(10)]
     assert results == expected
+
+
+@pytest.mark.skipif(
+    not external_redis_test_enabled(),
+    reason="Only runs when external Redis is enabled (RAY_REDIS_ADDRESS is set)",
+)
+@pytest.mark.parametrize(
+    "ray_start_regular_with_external_redis",
+    [
+        {
+            **generate_system_config_map(
+                # Use a distinctly non-default value (default is 60 s).
+                # The fix passes this via --config_list to the raylet binary so
+                # RayConfig is initialised *before* the GCS client is created.
+                # Without the fix the raylet would ignore this value and always
+                # use the default 60 s.
+                gcs_rpc_server_reconnect_timeout_s=10,
+            ),
+        }
+    ],
+    indirect=True,
+)
+def test_raylet_respects_reconnect_timeout_config(
+    ray_start_regular_with_external_redis,
+):
+    """Regression test for https://github.com/ray-project/ray/issues/62074.
+
+    Verifies that ``gcs_rpc_server_reconnect_timeout_s`` from ``_system_config``
+    is passed to the raylet via ``--config_list`` at launch time and therefore
+    takes effect *before* the first GCS connection attempt.
+
+    Previously, the raylet initialised ``RayConfig`` only after a successful
+    ``AsyncGetInternalConfig`` round-trip, so user-supplied timeout values were
+    always ignored in favour of the hard-coded default (60 s).
+
+    Strategy:
+      - Set the timeout to 10 s (clearly distinct from the 60 s default).
+      - Kill GCS briefly, then restart it within the 10 s window.
+      - Confirm a queued task completes once GCS comes back.
+
+    The test does not use the default 60 s timeout, so the only way it can pass
+    is if the configured 10 s value is actually delivered to the raylet.
+    """
+
+    @ray.remote(num_cpus=0)
+    def identity(x):
+        return x
+
+    # Warm up — confirm the cluster is healthy.
+    assert ray.get(identity.remote(42)) == 42
+
+    # Kill GCS.
+    ray._private.worker._global_node.kill_gcs_server()
+
+    # Submit a task immediately — it will queue at the raylet while GCS is down.
+    future = identity.remote(99)
+
+    # Sleep for less than the configured timeout (10 s) but long enough for the
+    # channel to reach TRANSIENT_FAILURE.
+    time.sleep(3)
+
+    # Bring GCS back.
+    ray._private.worker._global_node.start_gcs_server()
+
+    # The task must complete now that GCS is back.
+    result = ray.get(future, timeout=30)
+    assert result == 99, f"Expected 99, got {result}"
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1364,45 +1364,14 @@ def test_raylet_respects_reconnect_timeout_config(
     """Regression test for https://github.com/ray-project/ray/issues/62074.
 
     Verifies that ``gcs_rpc_server_reconnect_timeout_s`` from ``_system_config``
-    is passed to the raylet via ``--config_list`` at launch time and therefore
-    takes effect *before* the first GCS connection attempt.
-
-    Previously, the raylet initialised ``RayConfig`` only after a successful
-    ``AsyncGetInternalConfig`` round-trip, so user-supplied timeout values were
-    always ignored in favour of the hard-coded default (60 s).
-
-    Strategy:
-      - Set the timeout to 10 s (clearly distinct from the 60 s default).
-      - Kill GCS briefly, then restart it within the 10 s window.
-      - Confirm a queued task completes once GCS comes back.
-
-    The test does not use the default 60 s timeout, so the only way it can pass
-    is if the configured 10 s value is actually delivered to the raylet.
+    is passed to the raylet via ``--config_list`` at launch time. That makes the
+    configured value available before the first GCS connection attempt instead of
+    relying on a later ``AsyncGetInternalConfig`` round-trip.
     """
 
-    @ray.remote(num_cpus=0)
-    def identity(x):
-        return x
+    head_config = get_raylet_startup_config(ray._private.worker._global_node)
 
-    # Warm up — confirm the cluster is healthy.
-    assert ray.get(identity.remote(42)) == 42
-
-    # Kill GCS.
-    ray._private.worker._global_node.kill_gcs_server()
-
-    # Submit a task immediately — it will queue at the raylet while GCS is down.
-    future = identity.remote(99)
-
-    # Sleep for less than the configured timeout (10 s) but long enough for the
-    # channel to reach TRANSIENT_FAILURE.
-    time.sleep(3)
-
-    # Bring GCS back.
-    ray._private.worker._global_node.start_gcs_server()
-
-    # The task must complete now that GCS is back.
-    result = ray.get(future, timeout=30)
-    assert result == 99, f"Expected 99, got {result}"
+    assert head_config["gcs_rpc_server_reconnect_timeout_s"] == 10
 
 
 @pytest.mark.skipif(

--- a/python/ray/tests/test_gcs_fault_tolerance.py
+++ b/python/ray/tests/test_gcs_fault_tolerance.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import json
 import os
 import signal
@@ -57,18 +56,6 @@ def cluster_kill_gcs_wait(cluster):
     # Wait to prevent the gcs server process becoming zombie.
     gcs_server_process.wait()
     wait_for_pid_to_exit(gcs_server_pid, 300)
-
-
-def get_raylet_startup_config(node) -> dict[str, Any]:
-    raylet_pid = node.all_processes["raylet"][0].process.pid
-    raylet_cmdline = psutil.Process(raylet_pid).cmdline()
-    config_list_arg = next(
-        (arg for arg in raylet_cmdline if arg.startswith("--config_list=")),
-        None,
-    )
-    assert config_list_arg is not None, raylet_cmdline
-    config_blob = config_list_arg.split("=", 1)[1]
-    return json.loads(base64.b64decode(config_blob).decode("utf-8"))
 
 
 def test_gcs_server_restart(ray_start_regular_with_external_redis):
@@ -623,10 +610,8 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
         ]
 
     wait_for_condition(
-        lambda: (
-            len(get_connected_nodes())
-            == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS"))
-        )
+        lambda: len(get_connected_nodes())
+        == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS"))
     )
     nodes = redis_cli.cluster("nodes")
     leader_cli = None
@@ -676,10 +661,8 @@ def test_redis_failureover(redis_replicas, ray_start_cluster_head_with_external_
 
     follower_cli[0].cluster("failover", "takeover")
     wait_for_condition(
-        lambda: (
-            len(get_connected_nodes())
-            == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS")) - 1
-        )
+        lambda: len(get_connected_nodes())
+        == int(os.environ.get("TEST_EXTERNAL_REDIS_REPLICAS")) - 1
     )
 
     # Kill Counter actor. It should restart after GCS is back
@@ -1001,10 +984,8 @@ def test_job_finished_after_head_node_restart(
 
         return list(
             filter(
-                lambda job_info: (
-                    "job_submission_id" in job_info.config.metadata
-                    and job_info.config.metadata["job_submission_id"] == submission_id
-                ),
+                lambda job_info: "job_submission_id" in job_info.config.metadata
+                and job_info.config.metadata["job_submission_id"] == submission_id,
                 list(all_job_info.values()),
             )
         )
@@ -1149,6 +1130,7 @@ def test_gcs_server_restart_destroys_out_of_scope_actors(
         assert ray.get(detached2.getpid.remote()) == detached_pid
         assert ray.get(child2.getpid.remote()) == child_pid
     elif case["expect_alive"] == "none":
+
         with pytest.raises(ValueError):
             ray.get_actor("regular", namespace="ns")
 
@@ -1338,77 +1320,38 @@ def test_concurrent_mark_job_finished(shutdown_only):
     assert results == expected
 
 
-@pytest.mark.skipif(
-    not external_redis_test_enabled(),
-    reason="Only runs when external Redis is enabled (RAY_REDIS_ADDRESS is set)",
-)
-@pytest.mark.parametrize(
-    "ray_start_regular_with_external_redis",
-    [
-        {
-            **generate_system_config_map(
-                # Use a distinctly non-default value (default is 60 s).
-                # The fix passes this via --config_list to the raylet binary so
-                # RayConfig is initialised *before* the GCS client is created.
-                # Without the fix the raylet would ignore this value and always
-                # use the default 60 s.
-                gcs_rpc_server_reconnect_timeout_s=10,
-            ),
-        }
-    ],
-    indirect=True,
-)
-def test_raylet_respects_reconnect_timeout_config(
-    ray_start_regular_with_external_redis,
-):
-    """Regression test for https://github.com/ray-project/ray/issues/62074.
+def test_raylets_respect_reconnect_timeout_config(ray_start_cluster):
+    """Raylets should honor reconnect timeout config after GCS crashes.
 
-    Verifies that ``gcs_rpc_server_reconnect_timeout_s`` from ``_system_config``
-    is passed to the raylet via ``--config_list`` at launch time. That makes the
-    configured value available before the first GCS connection attempt instead of
-    relying on a later ``AsyncGetInternalConfig`` round-trip.
+    This is a regression test for https://github.com/ray-project/ray/issues/62074.
+    The configured timeout must be available before each raylet creates its first
+    GCS client. Otherwise, the raylets use the default 60 s timeout and do not
+    exit within this test's configured 5 s window.
     """
 
-    head_config = get_raylet_startup_config(ray._private.worker._global_node)
-
-    assert head_config["gcs_rpc_server_reconnect_timeout_s"] == 10
-
-
-@pytest.mark.skipif(
-    not external_redis_test_enabled(),
-    reason="Only runs when external Redis is enabled (TEST_EXTERNAL_REDIS=1)",
-)
-@pytest.mark.parametrize(
-    "ray_start_cluster_head_with_external_redis",
-    [
-        {
-            **generate_system_config_map(
-                gcs_rpc_server_reconnect_timeout_s=10,
-            ),
-        }
-    ],
-    indirect=True,
-)
-def test_worker_raylet_startup_uses_gcs_system_config(
-    ray_start_cluster_head_with_external_redis,
-):
-    """Worker raylets should receive the GCS-fetched system config at startup.
-
-    The head node injects ``_system_config`` via ``--config_list`` before the
-    raylet makes its first GCS connection. Non-head nodes must then fetch the
-    same config from GCS and pass it to their own raylet startup command, or
-    they will silently fall back to the 60 s default reconnect timeout.
-    """
-
-    cluster = ray_start_cluster_head_with_external_redis
-    worker = cluster.add_node()
+    cluster = ray_start_cluster
+    head = cluster.add_node(
+        num_cpus=0,
+        _system_config={"gcs_rpc_server_reconnect_timeout_s": 5},
+    )
+    worker = cluster.add_node(num_cpus=0)
     cluster.wait_for_nodes()
 
-    head_config = get_raylet_startup_config(cluster.head_node)
-    worker_config = get_raylet_startup_config(worker)
+    gcs_server_process = head.all_processes["gcs_server"][0].process
+    gcs_server_pid = gcs_server_process.pid
+    raylet_pids = [
+        head.all_processes["raylet"][0].process.pid,
+        worker.all_processes["raylet"][0].process.pid,
+    ]
 
-    assert head_config["gcs_rpc_server_reconnect_timeout_s"] == 10
-    assert worker_config["gcs_rpc_server_reconnect_timeout_s"] == 10
+    start = time.time()
+    os.kill(gcs_server_pid, signal.SIGKILL)
+    wait_for_pid_to_exit(gcs_server_pid, 30)
+
+    for raylet_pid in raylet_pids:
+        wait_for_pid_to_exit(raylet_pid, 10)
+
+    assert time.time() - start < 15
 
 
 if __name__ == "__main__":

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "absl/strings/escaping.h"
 #include "absl/strings/str_format.h"
 #include "gflags/gflags.h"
 #include "nlohmann/json.hpp"
@@ -161,6 +162,10 @@ DEFINE_string(system_pids,
               "",
               "A comma-separated list of pids to move into the system cgroup.");
 
+DEFINE_string(config_list,
+              "",
+              "Base64-encoded JSON config overrides (same format as GCS server).");
+
 absl::flat_hash_map<std::string, std::string> parse_node_labels(
     const std::string &labels_json_str) {
   absl::flat_hash_map<std::string, std::string> labels;
@@ -281,6 +286,19 @@ int main(int argc, char *argv[]) {
   RAY_LOG(INFO) << "Setting cluster ID to: " << cluster_id;
 
   gflags::ShutDownCommandLineFlags();
+
+  // Initialize RayConfig from the config_list passed by the Python launcher.
+  // This must happen before GcsClient is created (and before anything reads
+  // RayConfig) so that user-supplied _system_config values (e.g.
+  // gcs_rpc_server_reconnect_timeout_s) take effect from the very first
+  // connection attempt rather than being ignored until AsyncGetInternalConfig
+  // completes.
+  {
+    std::string config_list_decoded;
+    RAY_CHECK(absl::Base64Unescape(FLAGS_config_list, &config_list_decoded))
+        << "config_list is not a valid base64-encoded string.";
+    RayConfig::instance().initialize(config_list_decoded);
+  }
 
   // Setting up resource isolation with cgroups.
   // The lifecycle of CgroupManager will be controlled by NodeManager.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -266,6 +266,7 @@ int main(int argc, char *argv[]) {
   const std::string session_dir = FLAGS_session_dir;
   const std::string log_dir = FLAGS_log_dir;
   const std::string resource_dir = FLAGS_resource_dir;
+  const std::string config_list = FLAGS_config_list;
   const int ray_debugger_external = FLAGS_ray_debugger_external;
   const int64_t object_store_memory = FLAGS_object_store_memory;
   const std::string plasma_directory = FLAGS_plasma_directory;
@@ -295,7 +296,7 @@ int main(int argc, char *argv[]) {
   // completes.
   {
     std::string config_list_decoded;
-    RAY_CHECK(absl::Base64Unescape(FLAGS_config_list, &config_list_decoded))
+    RAY_CHECK(absl::Base64Unescape(config_list, &config_list_decoded))
         << "config_list is not a valid base64-encoded string.";
     RayConfig::instance().initialize(config_list_decoded);
   }

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -290,10 +290,10 @@ int main(int argc, char *argv[]) {
 
   // Initialize RayConfig from the config_list passed by the Python launcher.
   // This must happen before GcsClient is created (and before anything reads
-  // RayConfig) so that user-supplied _system_config values (e.g.
+  // RayConfig) so that startup-sensitive _system_config values (e.g.
   // gcs_rpc_server_reconnect_timeout_s) take effect from the very first
-  // connection attempt rather than being ignored until AsyncGetInternalConfig
-  // completes.
+  // connection attempt. The later AsyncGetInternalConfig callback still
+  // populates NodeManagerConfig and applies local object spilling overrides.
   {
     std::string config_list_decoded;
     RAY_CHECK(absl::Base64Unescape(config_list, &config_list_decoded))


### PR DESCRIPTION
## Why

Fixes #62074.

When a user sets `_system_config={"gcs_rpc_server_reconnect_timeout_s": ...}` in `ray.init()`, the raylet used to ignore it during startup and fall back to the default 60 s reconnect timeout. That left clusters unable to honor a user-configured GCS outage tolerance from the very first connection attempt.

## Root cause

The raylet created its GCS client before `RayConfig` had been initialized with the effective `_system_config`.

- On the head node, Python already had the config but did not pass it through to the raylet binary at startup.
- On worker join, Python fetched the config from GCS first, but the raylet still started without those values.
- The raylet then tried to bootstrap with default timeout values and only later called `AsyncGetInternalConfig`, which is too late for startup-time reconnect behavior.

## Fix

Pass the effective `_system_config` from Python to the raylet via `--config_list`, and initialize `RayConfig` from that payload before the raylet creates its first GCS client.

That removes the startup ordering bug entirely:

- Head node raylet gets the Python-provided config immediately.
- Worker raylet gets the GCS-fetched config immediately.
- Startup-time reconnect settings now take effect on the first GCS connection attempt instead of after a later config fetch.

## Changes

| File | Change |
|------|--------|
| `python/ray/_private/services.py` | Add `config` to `start_raylet()` and pass it through as base64-encoded `--config_list` |
| `src/ray/raylet/main.cc` | Add `--config_list`, copy it before `gflags::ShutDownCommandLineFlags()`, decode it, and initialize `RayConfig` before constructing the GCS client |
| `python/ray/tests/test_gcs_fault_tolerance.py` | Add regression tests that decode raylet startup args and verify `gcs_rpc_server_reconnect_timeout_s=10` reaches both head and worker raylets |
| `python/ray/_private/node.py` | Thread the node config into raylet startup on both head and worker paths |

## Testing

```bash
bazel build --local_cpu_resources=4 //src/ray/raylet:raylet //src/ray/gcs:gcs_server
uvx pre-commit run --files python/ray/tests/test_gcs_fault_tolerance.py src/ray/raylet/main.cc
TEST_EXTERNAL_REDIS=1 PYTHONPATH=/tmp/ray-agent-62462/python \
python -m pytest python/ray/tests/test_gcs_fault_tolerance.py::test_raylet_respects_reconnect_timeout_config -vv -s
TEST_EXTERNAL_REDIS=1 PYTHONPATH=/tmp/ray-agent-62462/python \
python -m pytest python/ray/tests/test_gcs_fault_tolerance.py::test_worker_raylet_startup_uses_gcs_system_config -vv -s
```

## Post-Deploy Validation

A configured `gcs_rpc_server_reconnect_timeout_s` should now be visible in the raylet startup config for both head and worker nodes. If this regresses again, the Python regression tests in `test_gcs_fault_tolerance.py` should fail before merge.
