### PR TITLE
[serve][LLM] Fix HF config loading for models with custom rope_scaling

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -256,9 +256,7 @@ class LLMConfig(BaseModelExtended):
     _engine_config: EngineConfigType = PrivateAttr(None)
     _callback_instance: Optional[CallbackBase] = PrivateAttr(None)
 
-    def _load_hf_config(
-        self, model_id_or_path: str, trust_remote_code: bool = False
-    ):
+    def _load_hf_config(self, model_id_or_path: str, trust_remote_code: bool = False):
         """Load the HuggingFace config for a model.
 
         Uses AutoConfig which loads the model-specific config class (e.g.
@@ -286,7 +284,9 @@ class LLMConfig(BaseModelExtended):
         attribute based on whether the config has `vision_config`. All LVM models has
         `vision_config` setup.
         """
-        hf_config = self._load_hf_config(model_id_or_path, trust_remote_code=trust_remote_code)
+        hf_config = self._load_hf_config(
+            model_id_or_path, trust_remote_code=trust_remote_code
+        )
         self._supports_vision = hasattr(hf_config, "vision_config")
 
     def _set_model_architecture(
@@ -317,8 +317,12 @@ class LLMConfig(BaseModelExtended):
         self, model_id_or_path: str, trust_remote_code: bool = False
     ) -> None:
         """Apply the checkpoint info to the model config."""
-        self._infer_supports_vision(model_id_or_path, trust_remote_code=trust_remote_code)
-        self._set_model_architecture(model_id_or_path, trust_remote_code=trust_remote_code)
+        self._infer_supports_vision(
+            model_id_or_path, trust_remote_code=trust_remote_code
+        )
+        self._set_model_architecture(
+            model_id_or_path, trust_remote_code=trust_remote_code
+        )
 
     def get_or_create_callback(self) -> Optional[CallbackBase]:
         """Get or create the callback instance for this process.

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -286,7 +286,7 @@ class LLMConfig(BaseModelExtended):
         attribute based on whether the config has `vision_config`. All LVM models has
         `vision_config` setup.
         """
-        hf_config = self._load_hf_config(model_id_or_path, trust_remote_code)
+        hf_config = self._load_hf_config(model_id_or_path, trust_remote_code=trust_remote_code)
         self._supports_vision = hasattr(hf_config, "vision_config")
 
     def _set_model_architecture(
@@ -301,7 +301,7 @@ class LLMConfig(BaseModelExtended):
         """
         if model_id_or_path:
             hf_config = self._load_hf_config(
-                model_id_or_path, trust_remote_code
+                model_id_or_path, trust_remote_code=trust_remote_code
             )
             if (
                 hf_config
@@ -317,7 +317,7 @@ class LLMConfig(BaseModelExtended):
         self, model_id_or_path: str, trust_remote_code: bool = False
     ) -> None:
         """Apply the checkpoint info to the model config."""
-        self._infer_supports_vision(model_id_or_path, trust_remote_code)
+        self._infer_supports_vision(model_id_or_path, trust_remote_code=trust_remote_code)
         self._set_model_architecture(model_id_or_path, trust_remote_code=trust_remote_code)
 
     def get_or_create_callback(self) -> Optional[CallbackBase]:

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -256,50 +256,59 @@ class LLMConfig(BaseModelExtended):
     _engine_config: EngineConfigType = PrivateAttr(None)
     _callback_instance: Optional[CallbackBase] = PrivateAttr(None)
 
-    def _infer_supports_vision(self, model_id_or_path: str) -> None:
+    def _load_hf_config(
+        self, model_id_or_path: str, trust_remote_code: bool = False
+    ):
+        """Load the HuggingFace config for a model.
+
+        Uses AutoConfig which loads the model-specific config class (e.g.
+        DeepseekV3Config) instead of the generic PretrainedConfig.  The generic
+        base class can fail for models whose config.json contains fields (like
+        ``rope_scaling``) that require model-specific post-init logic.
+        """
+        try:
+            return transformers.AutoConfig.from_pretrained(
+                model_id_or_path, trust_remote_code=trust_remote_code
+            )
+        except Exception as e:
+            raise ValueError(
+                f"Failed to load Hugging Face config for "
+                f"model_id='{model_id_or_path}'. Ensure `model_id` is a valid "
+                f"Hugging Face repo or a local path that contains a valid "
+                f"`config.json` file. Original error: {repr(e)}"
+            ) from e
+
+    def _infer_supports_vision(
+        self, model_id_or_path: str, trust_remote_code: bool = False
+    ) -> None:
         """Called in llm node initializer together with other transformers calls. It
         loads the model config from huggingface and sets the supports_vision
         attribute based on whether the config has `vision_config`. All LVM models has
         `vision_config` setup.
         """
-        try:
-            hf_config = transformers.PretrainedConfig.from_pretrained(model_id_or_path)
-            self._supports_vision = hasattr(hf_config, "vision_config")
-        except Exception as e:
-            raise ValueError(
-                f"Failed to load Hugging Face config for model_id='{model_id_or_path}'.\
-                        Ensure `model_id` is a valid Hugging Face repo or a local path that \
-                        contains a valid `config.json` file. "
-                f"Original error: {repr(e)}"
-            ) from e
+        hf_config = self._load_hf_config(model_id_or_path, trust_remote_code)
+        self._supports_vision = hasattr(hf_config, "vision_config")
 
     def _set_model_architecture(
         self,
         model_id_or_path: Optional[str] = None,
         model_architecture: Optional[str] = None,
+        trust_remote_code: bool = False,
     ) -> None:
         """Called in llm node initializer together with other transformers calls. It
         loads the model config from huggingface and sets the model_architecture
         attribute based on whether the config has `architectures`.
         """
         if model_id_or_path:
-            try:
-                hf_config = transformers.PretrainedConfig.from_pretrained(
-                    model_id_or_path
-                )
-                if (
-                    hf_config
-                    and hasattr(hf_config, "architectures")
-                    and hf_config.architectures
-                ):
-                    self._model_architecture = hf_config.architectures[0]
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to load Hugging Face config for model_id='{model_id_or_path}'.\
-                        Ensure `model_id` is a valid Hugging Face repo or a local path that \
-                        contains a valid `config.json` file. "
-                    f"Original error: {repr(e)}"
-                ) from e
+            hf_config = self._load_hf_config(
+                model_id_or_path, trust_remote_code
+            )
+            if (
+                hf_config
+                and hasattr(hf_config, "architectures")
+                and hf_config.architectures
+            ):
+                self._model_architecture = hf_config.architectures[0]
 
         if model_architecture:
             self._model_architecture = model_architecture
@@ -308,8 +317,8 @@ class LLMConfig(BaseModelExtended):
         self, model_id_or_path: str, trust_remote_code: bool = False
     ) -> None:
         """Apply the checkpoint info to the model config."""
-        self._infer_supports_vision(model_id_or_path)
-        self._set_model_architecture(model_id_or_path)
+        self._infer_supports_vision(model_id_or_path, trust_remote_code)
+        self._set_model_architecture(model_id_or_path, trust_remote_code=trust_remote_code)
 
     def get_or_create_callback(self) -> Optional[CallbackBase]:
         """Get or create the callback instance for this process.

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pydantic
 import pytest
@@ -416,6 +417,201 @@ class TestAcceleratorConfigLogic:
 
         tpu_accel_with_topo = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
         assert tpu_accel_with_topo.requires_deferred_placement_group is True
+
+
+class TestCheckpointInfo:
+    """Tests for _load_hf_config, _infer_supports_vision, _set_model_architecture,
+    and apply_checkpoint_info."""
+
+    def _make_llm_config(self) -> LLMConfig:
+        return LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test_model")
+        )
+
+    # ------------------------------------------------------------------
+    # _load_hf_config
+    # ------------------------------------------------------------------
+
+    def test_load_hf_config_uses_autoconfig(self):
+        """_load_hf_config must call AutoConfig.from_pretrained, not PretrainedConfig."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock()
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ) as mock_auto:
+            result = llm_config._load_hf_config("some/model")
+
+        mock_auto.assert_called_once_with("some/model", trust_remote_code=False)
+        assert result is mock_hf_config
+
+    def test_load_hf_config_passes_trust_remote_code(self):
+        """trust_remote_code is forwarded to AutoConfig.from_pretrained."""
+        llm_config = self._make_llm_config()
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=MagicMock()
+        ) as mock_auto:
+            llm_config._load_hf_config("some/model", trust_remote_code=True)
+
+        mock_auto.assert_called_once_with("some/model", trust_remote_code=True)
+
+    def test_load_hf_config_wraps_exception(self):
+        """Failures in AutoConfig.from_pretrained become a ValueError with a clear message."""
+        llm_config = self._make_llm_config()
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained",
+            side_effect=RuntimeError("network error"),
+        ):
+            with pytest.raises(ValueError, match="Failed to load Hugging Face config"):
+                llm_config._load_hf_config("bad/model")
+
+    # ------------------------------------------------------------------
+    # _infer_supports_vision
+    # ------------------------------------------------------------------
+
+    def test_infer_supports_vision_with_vision_config(self):
+        """_infer_supports_vision sets _supports_vision=True when config has vision_config."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock(spec=["vision_config"])
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ):
+            llm_config._infer_supports_vision("vision/model")
+
+        assert llm_config._supports_vision is True
+
+    def test_infer_supports_vision_without_vision_config(self):
+        """_infer_supports_vision sets _supports_vision=False when config lacks vision_config."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock(spec=[])  # no vision_config attribute
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ):
+            llm_config._infer_supports_vision("text-only/model")
+
+        assert llm_config._supports_vision is False
+
+    def test_infer_supports_vision_forwards_trust_remote_code(self):
+        """_infer_supports_vision passes trust_remote_code to _load_hf_config."""
+        llm_config = self._make_llm_config()
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=MagicMock(spec=[])
+        ) as mock_auto:
+            llm_config._infer_supports_vision("some/model", trust_remote_code=True)
+
+        mock_auto.assert_called_once_with("some/model", trust_remote_code=True)
+
+    # ------------------------------------------------------------------
+    # _set_model_architecture
+    # ------------------------------------------------------------------
+
+    def test_set_model_architecture_from_hf_config(self):
+        """Architecture is read from hf_config.architectures[0] when model_id is given."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock()
+        mock_hf_config.architectures = ["DeepseekV3ForCausalLM"]
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ):
+            llm_config._set_model_architecture(model_id_or_path="some/model")
+
+        assert llm_config._model_architecture == "DeepseekV3ForCausalLM"
+
+    def test_set_model_architecture_explicit_kwarg_overrides_hf(self):
+        """An explicit model_architecture kwarg always wins over the HF config value."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock()
+        mock_hf_config.architectures = ["FromHF"]
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ):
+            llm_config._set_model_architecture(
+                model_id_or_path="some/model",
+                model_architecture="ExplicitArch",
+            )
+
+        assert llm_config._model_architecture == "ExplicitArch"
+
+    def test_set_model_architecture_explicit_kwarg_without_model_id(self):
+        """model_architecture kwarg is applied even when no model_id_or_path is given."""
+        llm_config = self._make_llm_config()
+
+        llm_config._set_model_architecture(model_architecture="StandaloneArch")
+
+        assert llm_config._model_architecture == "StandaloneArch"
+
+    def test_set_model_architecture_no_architectures_attribute(self):
+        """When the hf_config has no architectures, _model_architecture stays at its default."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock(spec=[])  # no architectures attribute
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ):
+            llm_config._set_model_architecture(model_id_or_path="some/model")
+
+        assert llm_config._model_architecture == "UNSPECIFIED"
+
+    def test_set_model_architecture_forwards_trust_remote_code(self):
+        """trust_remote_code is forwarded through _set_model_architecture."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock()
+        mock_hf_config.architectures = ["SomeArch"]
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ) as mock_auto:
+            llm_config._set_model_architecture(
+                model_id_or_path="some/model", trust_remote_code=True
+            )
+
+        mock_auto.assert_called_once_with("some/model", trust_remote_code=True)
+
+    # ------------------------------------------------------------------
+    # apply_checkpoint_info
+    # ------------------------------------------------------------------
+
+    @pytest.mark.parametrize("trust_remote_code", [False, True])
+    def test_apply_checkpoint_info_threads_trust_remote_code(
+        self, trust_remote_code: bool
+    ):
+        """apply_checkpoint_info passes trust_remote_code to both sub-methods."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock()
+        mock_hf_config.architectures = ["SomeArch"]
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ) as mock_auto:
+            llm_config.apply_checkpoint_info(
+                "some/model", trust_remote_code=trust_remote_code
+            )
+
+        # AutoConfig should be called twice (once per sub-method), each with the flag.
+        assert mock_auto.call_count == 2
+        for call in mock_auto.call_args_list:
+            assert call.kwargs["trust_remote_code"] == trust_remote_code
+
+    def test_apply_checkpoint_info_sets_both_attributes(self):
+        """apply_checkpoint_info correctly sets _supports_vision and _model_architecture."""
+        llm_config = self._make_llm_config()
+        mock_hf_config = MagicMock(spec=["architectures", "vision_config"])
+        mock_hf_config.architectures = ["LlavaForCausalLM"]
+
+        with patch(
+            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
+        ):
+            llm_config.apply_checkpoint_info("vision/model")
+
+        assert llm_config._supports_vision is True
+        assert llm_config._model_architecture == "LlavaForCausalLM"
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -424,9 +424,7 @@ class TestCheckpointInfo:
     and apply_checkpoint_info."""
 
     def _make_llm_config(self) -> LLMConfig:
-        return LLMConfig(
-            model_loading_config=ModelLoadingConfig(model_id="test_model")
-        )
+        return LLMConfig(model_loading_config=ModelLoadingConfig(model_id="test_model"))
 
     # ------------------------------------------------------------------
     # _load_hf_config

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -420,194 +420,24 @@ class TestAcceleratorConfigLogic:
 
 
 class TestCheckpointInfo:
-    """Tests for _load_hf_config, _infer_supports_vision, _set_model_architecture,
-    and apply_checkpoint_info."""
-
-    def _make_llm_config(self) -> LLMConfig:
-        return LLMConfig(model_loading_config=ModelLoadingConfig(model_id="test_model"))
-
-    # ------------------------------------------------------------------
-    # _load_hf_config
-    # ------------------------------------------------------------------
-
-    def test_load_hf_config_uses_autoconfig(self):
-        """_load_hf_config must call AutoConfig.from_pretrained, not PretrainedConfig."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock()
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ) as mock_auto:
-            result = llm_config._load_hf_config("some/model")
-
-        mock_auto.assert_called_once_with("some/model", trust_remote_code=False)
-        assert result is mock_hf_config
-
-    def test_load_hf_config_passes_trust_remote_code(self):
-        """trust_remote_code is forwarded to AutoConfig.from_pretrained."""
-        llm_config = self._make_llm_config()
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=MagicMock()
-        ) as mock_auto:
-            llm_config._load_hf_config("some/model", trust_remote_code=True)
-
-        mock_auto.assert_called_once_with("some/model", trust_remote_code=True)
-
-    def test_load_hf_config_wraps_exception(self):
-        """Failures in AutoConfig.from_pretrained become a ValueError with a clear message."""
-        llm_config = self._make_llm_config()
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained",
-            side_effect=RuntimeError("network error"),
-        ):
-            with pytest.raises(ValueError, match="Failed to load Hugging Face config"):
-                llm_config._load_hf_config("bad/model")
-
-    # ------------------------------------------------------------------
-    # _infer_supports_vision
-    # ------------------------------------------------------------------
-
-    def test_infer_supports_vision_with_vision_config(self):
-        """_infer_supports_vision sets _supports_vision=True when config has vision_config."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock(spec=["vision_config"])
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ):
-            llm_config._infer_supports_vision("vision/model")
-
-        assert llm_config._supports_vision is True
-
-    def test_infer_supports_vision_without_vision_config(self):
-        """_infer_supports_vision sets _supports_vision=False when config lacks vision_config."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock(spec=[])  # no vision_config attribute
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ):
-            llm_config._infer_supports_vision("text-only/model")
-
-        assert llm_config._supports_vision is False
-
-    def test_infer_supports_vision_forwards_trust_remote_code(self):
-        """_infer_supports_vision passes trust_remote_code to _load_hf_config."""
-        llm_config = self._make_llm_config()
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=MagicMock(spec=[])
-        ) as mock_auto:
-            llm_config._infer_supports_vision("some/model", trust_remote_code=True)
-
-        mock_auto.assert_called_once_with("some/model", trust_remote_code=True)
-
-    # ------------------------------------------------------------------
-    # _set_model_architecture
-    # ------------------------------------------------------------------
-
-    def test_set_model_architecture_from_hf_config(self):
-        """Architecture is read from hf_config.architectures[0] when model_id is given."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock()
-        mock_hf_config.architectures = ["DeepseekV3ForCausalLM"]
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ):
-            llm_config._set_model_architecture(model_id_or_path="some/model")
-
-        assert llm_config._model_architecture == "DeepseekV3ForCausalLM"
-
-    def test_set_model_architecture_explicit_kwarg_overrides_hf(self):
-        """An explicit model_architecture kwarg always wins over the HF config value."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock()
-        mock_hf_config.architectures = ["FromHF"]
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ):
-            llm_config._set_model_architecture(
-                model_id_or_path="some/model",
-                model_architecture="ExplicitArch",
-            )
-
-        assert llm_config._model_architecture == "ExplicitArch"
-
-    def test_set_model_architecture_explicit_kwarg_without_model_id(self):
-        """model_architecture kwarg is applied even when no model_id_or_path is given."""
-        llm_config = self._make_llm_config()
-
-        llm_config._set_model_architecture(model_architecture="StandaloneArch")
-
-        assert llm_config._model_architecture == "StandaloneArch"
-
-    def test_set_model_architecture_no_architectures_attribute(self):
-        """When the hf_config has no architectures, _model_architecture stays at its default."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock(spec=[])  # no architectures attribute
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ):
-            llm_config._set_model_architecture(model_id_or_path="some/model")
-
-        assert llm_config._model_architecture == "UNSPECIFIED"
-
-    def test_set_model_architecture_forwards_trust_remote_code(self):
-        """trust_remote_code is forwarded through _set_model_architecture."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock()
-        mock_hf_config.architectures = ["SomeArch"]
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ) as mock_auto:
-            llm_config._set_model_architecture(
-                model_id_or_path="some/model", trust_remote_code=True
-            )
-
-        mock_auto.assert_called_once_with("some/model", trust_remote_code=True)
-
-    # ------------------------------------------------------------------
-    # apply_checkpoint_info
-    # ------------------------------------------------------------------
-
-    @pytest.mark.parametrize("trust_remote_code", [False, True])
-    def test_apply_checkpoint_info_threads_trust_remote_code(
-        self, trust_remote_code: bool
-    ):
-        """apply_checkpoint_info passes trust_remote_code to both sub-methods."""
-        llm_config = self._make_llm_config()
-        mock_hf_config = MagicMock()
-        mock_hf_config.architectures = ["SomeArch"]
-
-        with patch(
-            "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ) as mock_auto:
-            llm_config.apply_checkpoint_info(
-                "some/model", trust_remote_code=trust_remote_code
-            )
-
-        # AutoConfig should be called twice (once per sub-method), each with the flag.
-        assert mock_auto.call_count == 2
-        for call in mock_auto.call_args_list:
-            assert call.kwargs["trust_remote_code"] == trust_remote_code
-
-    def test_apply_checkpoint_info_sets_both_attributes(self):
-        """apply_checkpoint_info correctly sets _supports_vision and _model_architecture."""
-        llm_config = self._make_llm_config()
+    def test_apply_checkpoint_info_uses_autoconfig_and_threads_trust_remote_code(self):
+        """apply_checkpoint_info uses AutoConfig (not PretrainedConfig) and forwards
+        trust_remote_code to every HF config load call."""
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test_model")
+        )
         mock_hf_config = MagicMock(spec=["architectures", "vision_config"])
         mock_hf_config.architectures = ["LlavaForCausalLM"]
 
         with patch(
             "transformers.AutoConfig.from_pretrained", return_value=mock_hf_config
-        ):
-            llm_config.apply_checkpoint_info("vision/model")
+        ) as mock_auto:
+            llm_config.apply_checkpoint_info("vision/model", trust_remote_code=True)
 
+        assert all(
+            call.kwargs["trust_remote_code"] is True
+            for call in mock_auto.call_args_list
+        )
         assert llm_config._supports_vision is True
         assert llm_config._model_architecture == "LlavaForCausalLM"
 


### PR DESCRIPTION
## Summary

- Use `AutoConfig.from_pretrained()` instead of `PretrainedConfig.from_pretrained()` in `LLMConfig._infer_supports_vision` and `LLMConfig._set_model_architecture`
- Thread `trust_remote_code` from `apply_checkpoint_info` through to the config loading calls (it was previously accepted but silently ignored)

## Why

`PretrainedConfig.from_pretrained()` loads a generic base config class that lacks model-specific `__post_init__` logic. For models like **DeepSeek-V3-0324** whose `config.json` contains `rope_scaling`, the generic class fails during `transformers>=5.x` rope parameter standardization:

```
AttributeError: 'PreTrainedConfig' object has no attribute 'max_position_embeddings'
```

This is because the base `PretrainedConfig` doesn't define `max_position_embeddings`, but the rope standardization code (`transformers/modeling_rope_utils.py:standardize_rope_params`) unconditionally accesses it.

`AutoConfig.from_pretrained()` loads the correct model-specific config class (e.g. `DeepseekV3Config`) which properly defines all required attributes.

## Test plan

- [x] Verified `AutoConfig.from_pretrained("deepseek-ai/DeepSeek-V3-0324", trust_remote_code=True)` succeeds where `PretrainedConfig.from_pretrained()` crashes
- [x] Existing tests pass (`_set_model_architecture` call sites in tests use the `model_architecture=` kwarg path which doesn't load HF config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)