### PR TITLE
[ci] Windows Wanda image: fix conda PermissionError in microcheck windowsbuild

### DIFF
--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -12,6 +12,10 @@ powershell ci/ray_ci/windows/install_bazelisk.ps1
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.9.22/install.ps1 | iex"
 
 conda init
+# TODO(ci): Remove once conda fixes the splitext bug in delete.py (conda/conda#15760).
+# Conda 26.3.1 crashes on Windows when it tries to clean up a locked exe during
+# a build-variant swap. Preventing self-update avoids that code path.
+conda config --set auto_update_conda false
 # Include ca-certificates + certifi in this solve so the trust store is refreshed with
 # Python/requests (ray-project/ray#61545). Avoid a follow-up `conda update -c conda-forge`:
 # it can replace conda.exe in place on Windows and fail in Docker (PermissionError on
@@ -27,7 +31,9 @@ pip install -U --ignore-installed -c python/requirements_compiled.txt \
   -r python/requirements/test-requirements.txt \
   -r python/requirements/ml/dl-cpu-requirements.txt
 
-# Ensure urllib/requests see an up-to-date certifi bundle after constrained installs.
+# The installs above use `-c python/requirements_compiled.txt`, which pins exact versions. If we
+# passed that file again here, certifi would stay on the pinned (possibly old) version. We run
+# without it so pip can install the latest certifi. Upgrading certifi alone is low risk for this CI image.
 python -m pip install -U certifi
 
 # Clean up caches to minimize image size. These caches are not needed, and

--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -12,13 +12,12 @@ powershell ci/ray_ci/windows/install_bazelisk.ps1
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/0.9.22/install.ps1 | iex"
 
 conda init
-# TODO(ci): Remove once conda fixes the splitext bug in delete.py (conda/conda#15760).
-# Conda 26.3.1 crashes on Windows when it tries to clean up a locked exe during
-# a build-variant swap. Preventing self-update avoids that code path.
-conda config --set auto_update_conda false
-conda install -q -y python="${PYTHON_FULL_VERSION}" requests=2.32.3
-# Force CA trust stack to the newest versions available at build time.
-conda update -c conda-forge -q -y ca-certificates certifi
+# Include ca-certificates + certifi in this solve so the trust store is refreshed with
+# Python/requests (ray-project/ray#61545). Avoid a follow-up `conda update -c conda-forge`:
+# it can replace conda.exe in place on Windows and fail in Docker (PermissionError on
+# conda.exe.c~; see conda/conda#15760).
+# Use `conda install` (explicit specs) rather than `conda update` (broader "newest compatible" refresh/upgrade more of the environment including conda itself which can cause issues with the build).
+conda install -q -y python="${PYTHON_FULL_VERSION}" requests=2.32.3 ca-certificates certifi
 
 # Install torch first, as some dependencies (e.g. torch-spline-conv) need torch to be
 # installed for their own install.
@@ -27,6 +26,9 @@ pip install -U --ignore-installed -c python/requirements_compiled.txt \
   -r python/requirements.txt \
   -r python/requirements/test-requirements.txt \
   -r python/requirements/ml/dl-cpu-requirements.txt
+
+# Ensure urllib/requests see an up-to-date certifi bundle after constrained installs.
+python -m pip install -U certifi
 
 # Clean up caches to minimize image size. These caches are not needed, and
 # removing them help with the build speed.


### PR DESCRIPTION
# PR: Fix `windowsbuild` conda PermissionError on Windows


---

## Description

The **`wanda: windowsbuild`** CI check was intermittently failing during the Windows image build.

### What was going wrong

After installing Python and dependencies via `conda`, a follow-up command:
```bash
conda update -c conda-forge ca-certificates certifi
```

would sometimes cause conda to update *itself* in-place. On Windows, this triggers a
`PermissionError` when conda tries to clean up its own temp files (e.g. `conda.exe.c~`).
The CI job then fails, even though the only goal was to refresh SSL certificates.

A previous fix ([#62441](https://github.com/ray-project/ray/pull/62441)) disabled some
self-update behavior via `conda config --set auto_update_conda false`, but the explicit
`conda update` step was never removed, so the risky path could still run.

### Why this is hard to catch

This failure is **intermittent**. The same script can pass on one run and fail on another
depending on agent load, caching, and timing. When cleanup does fail, conda 26.x can hit a
**secondary bug** in its own error handling ([conda/conda#15760](https://github.com/conda/conda/issues/15760)),
adding noise to the logs. A green `windowsbuild` after #62441 doesn't mean the underlying
issue is gone.

### What this PR does

- Moves `ca-certificates` and `certifi` into the *same* initial `conda install` as Python
  and requests — no separate update step needed
- Adds `python -m pip install -U certifi` after pip installs for a full cert refresh
- **Removes** the `conda update -c conda-forge` line entirely

> ### Why avoid `conda update` on Windows?
> Unlike `conda install` with explicit specs, `conda update` can upgrade conda itself and widen the blast radius to unrelated packages. Replacing a running `conda.exe` inside a Windows Docker container is fragile and the source of this failure.

---

## Related Issues

| PR / Issue | Description |
|---|---|
| [ray-project/ray#61545](https://github.com/ray-project/ray/pull/61545) | Original Windows cert refresh attempt |
| [ray-project/ray#62441](https://github.com/ray-project/ray/pull/62441) | Partial mitigation; this PR removes the explicit conda update that still triggered failures |
| [conda/conda#15760](https://github.com/conda/conda/issues/15760) | Upstream conda bug in cleanup/error path (`splitext`) |

**Observed failure:** intermittent `PermissionError` on `conda.exe.c~` in the BuildKite
microcheck for `wanda: windowsbuild`.