### PR TITLE
[Data] Disable dead node check for 3 release tests

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -46,7 +46,7 @@
       runtime_env:
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=0  # Allow worker OOM during test
-        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=0
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 
   matrix:
@@ -618,7 +618,7 @@
       runtime_env:
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=0
-        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=0
     cluster_compute: heterogeneous_memory_compute.yaml
 
   run:


### PR DESCRIPTION
## Description
Disable the dead node post-test check for the following release tests, because of OOM terminated nodes
```
heteregenous_memory_batch_inference
read_large_parquet_fixed_size
read_large_parquet_autoscaling
```
