### PR TITLE
[ci] Migrate scheduling and single node benchmark compute configs to new schema

### DIFF
--- a/release/benchmarks/scheduling.yaml
+++ b/release/benchmarks/scheduling.yaml
@@ -1,26 +1,19 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 999
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: m5.4xlarge
     resources:
       # Assume the node has 64 CPU instead of 16.
       # This should be fine since each task has little
       # computation in scheduling tests.
-      cpu: 64
-      custom_resources:
-        node: 1
+      CPU: 64
+      node: 1
 
-worker_node_types:
-    - name: worker_node
-      instance_type: m5.4xlarge
-      min_workers: 31
-      max_workers: 31
-      use_spot: false
+worker_nodes:
+    - instance_type: m5.4xlarge
+      min_nodes: 31
+      max_nodes: 31
+      market_type: ON_DEMAND
       resources:
-        cpu: 64
-        custom_resources:
-          node: 1
+        CPU: 64
+        node: 1

--- a/release/benchmarks/scheduling_gce.yaml
+++ b/release/benchmarks/scheduling_gce.yaml
@@ -1,28 +1,21 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west1
-allowed_azs:
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+zones:
     - us-west1-c
 
-max_workers: 999
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: n2-standard-16
     resources:
       # Assume the node has 64 CPU instead of 16.
       # This should be fine since each task has little
       # computation in scheduling tests.
-      cpu: 64
-      custom_resources:
-        node: 1
+      CPU: 64
+      node: 1
 
-worker_node_types:
-    - name: worker_node
-      instance_type: n2-standard-16
-      min_workers: 31
-      max_workers: 31
-      use_spot: false
+worker_nodes:
+    - instance_type: n2-standard-16
+      min_nodes: 31
+      max_nodes: 31
+      market_type: ON_DEMAND
       resources:
-        cpu: 64
-        custom_resources:
-          node: 1
+        CPU: 64
+        node: 1

--- a/release/benchmarks/single_node.yaml
+++ b/release/benchmarks/single_node.yaml
@@ -1,20 +1,16 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 0
-
-advanced_configurations_json:
+advanced_instance_config:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
             DeleteOnTermination: true
             VolumeSize: 500
 
-head_node_type:
-    name: head_node
+head_node:
     instance_type: m4.16xlarge
     resources:
       # 128 GB
       object_store_memory: 128000000000
 
-worker_node_types: []
+worker_nodes: []

--- a/release/benchmarks/single_node_gce.yaml
+++ b/release/benchmarks/single_node_gce.yaml
@@ -1,11 +1,8 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west1
-allowed_azs:
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+zones:
     - us-west1-c
 
-max_workers: 0
-
-gcp_advanced_configurations_json:
+advanced_instance_config:
   instance_properties:
     disks:
       - boot: true
@@ -13,11 +10,10 @@ gcp_advanced_configurations_json:
         initialize_params:
           disk_size_gb: 500
 
-head_node_type:
-    name: head_node
+head_node:
     instance_type: n2-standard-64
     resources:
       # 128 GB
       object_store_memory: 128000000000
 
-worker_node_types: []
+worker_nodes: []

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2826,7 +2826,6 @@
       frequency: manual
       cluster:
         cluster_compute: single_node_gce.yaml
-        anyscale_sdk_2026: true
 
 - name: object_store
   python: "3.10"
@@ -3084,7 +3083,6 @@
       frequency: manual
       cluster:
         cluster_compute: scheduling_gce.yaml
-        anyscale_sdk_2026: true
 
 
 # - name: scheduling_test_many_5s_tasks_single_node

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2826,6 +2826,7 @@
       frequency: manual
       cluster:
         cluster_compute: single_node_gce.yaml
+        anyscale_sdk_2026: true
 
 - name: object_store
   python: "3.10"
@@ -3083,6 +3084,7 @@
       frequency: manual
       cluster:
         cluster_compute: scheduling_gce.yaml
+        anyscale_sdk_2026: true
 
 
 # - name: scheduling_test_many_5s_tasks_single_node

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2812,6 +2812,7 @@
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
     cluster_compute: single_node.yaml
+    anyscale_sdk_2026: true
 
   run:
     timeout: 12000
@@ -3065,6 +3066,7 @@
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
     cluster_compute: scheduling.yaml
+    anyscale_sdk_2026: true
 
   run:
     timeout: 3600


### PR DESCRIPTION
## Summary
- Migrated 4 compute config files to the new Anyscale SDK schema: `scheduling.yaml`, `scheduling_gce.yaml`, `single_node.yaml`, `single_node_gce.yaml`
- Updated 2 test entries (`single_node`, `scheduling_test_many_0s_tasks_many_nodes`) in `release_tests.yaml` with `anyscale_sdk_2026: true` flag
- Key transformations: `cloud_id` -> `cloud`, `head_node_type` -> `head_node`, `worker_node_types` -> `worker_nodes`, flattened `custom_resources`, renamed `advanced_configurations_json`/`gcp_advanced_configurations_json` -> `advanced_instance_config`, `use_spot: false` -> `market_type: ON_DEMAND`, `min/max_workers` -> `min/max_nodes`

## Test plan
- [x] All 4 configs validated against `ComputeConfig.from_yaml()`
- [x] Verify `single_node` nightly tests pass on Buildkite
- [x] Verify `scheduling_test_many_0s_tasks_many_nodes` nightly tests pass on Buildkite

🤖 Generated with [Claude Code](https://claude.com/claude-code)