### PR TITLE
[ci] Migrate object store and many nodes benchmark compute configs to new schema

### DIFF
--- a/release/benchmarks/many_nodes.yaml
+++ b/release/benchmarks/many_nodes.yaml
@@ -1,23 +1,15 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 999
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: r6idn.16xlarge # Network optimized.
     resources:
-      cpu: 0
-      custom_resources:
-        node: 1
-        small: 1
+      node: 1
+      small: 1
 
-worker_node_types:
-    - name: small_worker
-      instance_type: m6i.2xlarge
-      min_workers: 249
-      max_workers: 249
-      use_spot: false
+worker_nodes:
+    - instance_type: m6i.2xlarge
+      min_nodes: 249
+      max_nodes: 249
+      market_type: ON_DEMAND
       resources:
-        custom_resources:
-          node: 1
+        node: 1

--- a/release/benchmarks/many_nodes_gce.yaml
+++ b/release/benchmarks/many_nodes_gce.yaml
@@ -1,25 +1,17 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west1
-allowed_azs:
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+zones:
     - us-west1-c
 
-max_workers: 999
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: n2-standard-64 # Network optimized.
     resources:
-      cpu: 0
-      custom_resources:
-        node: 1
-        small: 1
+      node: 1
+      small: 1
 
-worker_node_types:
-    - name: small_worker
-      instance_type: n2-standard-8
-      min_workers: 249
-      max_workers: 249
-      use_spot: false
+worker_nodes:
+    - instance_type: n2-standard-8
+      min_nodes: 249
+      max_nodes: 249
+      market_type: ON_DEMAND
       resources:
-        custom_resources:
-          node: 1
+        node: 1

--- a/release/benchmarks/object_store.yaml
+++ b/release/benchmarks/object_store.yaml
@@ -1,21 +1,14 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 49
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: m6i.16xlarge
     resources:
-      custom_resources:
-        node: 1
+      node: 1
 
-worker_node_types:
-    - name: worker_node
-      instance_type: m6i.2xlarge
-      min_workers: 49
-      max_workers: 49
-      use_spot: false
+worker_nodes:
+    - instance_type: m6i.2xlarge
+      min_nodes: 49
+      max_nodes: 49
+      market_type: ON_DEMAND
       resources:
-        custom_resources:
-          node: 1
+        node: 1

--- a/release/benchmarks/object_store/large_objects.yaml
+++ b/release/benchmarks/object_store/large_objects.yaml
@@ -1,21 +1,14 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-head_node_type:
-    name: head_node
+head_node:
     instance_type: m6i.16xlarge
     resources:
-      CPU: 0
-      GPU: 0
-      custom_resources:
-        node: 1
+      node: 1
 
-worker_node_types:
-    - name: worker_node
-      instance_type: m6i.4xlarge
-      min_workers: 9
-      max_workers: 9
-      use_spot: false
+worker_nodes:
+    - instance_type: m6i.4xlarge
+      min_nodes: 9
+      max_nodes: 9
+      market_type: ON_DEMAND
       resources:
-        custom_resources:
-          node: 1
+        node: 1

--- a/release/benchmarks/object_store/small_objects.yaml
+++ b/release/benchmarks/object_store/small_objects.yaml
@@ -1,16 +1,10 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-head_node_type:
-    name: head_node
+head_node:
     instance_type: m6i.16xlarge
-    resources:
-      CPU: 0
-      GPU: 0
 
-worker_node_types:
-    - name: worker_node
-      instance_type: m6i.4xlarge
-      min_workers: 4
-      max_workers: 4
-      use_spot: false
+worker_nodes:
+    - instance_type: m6i.4xlarge
+      min_nodes: 4
+      max_nodes: 4
+      market_type: ON_DEMAND

--- a/release/benchmarks/object_store_gce.yaml
+++ b/release/benchmarks/object_store_gce.yaml
@@ -1,23 +1,16 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west1
-allowed_azs:
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+zones:
     - us-west1-c
 
-max_workers: 49
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: n2-standard-64
     resources:
-      custom_resources:
-        node: 1
+      node: 1
 
-worker_node_types:
-    - name: worker_node
-      instance_type: n2-standard-8
-      min_workers: 49
-      max_workers: 49
-      use_spot: false
+worker_nodes:
+    - instance_type: n2-standard-8
+      min_nodes: 49
+      max_nodes: 49
+      market_type: ON_DEMAND
       resources:
-        custom_resources:
-          node: 1
+        node: 1

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2854,7 +2854,6 @@
       frequency: manual
       cluster:
         cluster_compute: object_store_gce.yaml
-        anyscale_sdk_2026: true
 
 - name: small_objects
   python: "3.10"
@@ -3057,7 +3056,6 @@
       frequency: manual
       cluster:
         cluster_compute: many_nodes_gce.yaml
-        anyscale_sdk_2026: true
 
 - name: scheduling_test_many_0s_tasks_many_nodes
   python: "3.10"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2835,6 +2835,7 @@
   team: core
   env: aws_perf
   cluster:
+    anyscale_sdk_2026: true
     byod:
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
@@ -2863,6 +2864,7 @@
   team: core
   env: aws_perf
   cluster:
+    anyscale_sdk_2026: true
     byod:
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
@@ -2886,6 +2888,7 @@
   team: core
   env: aws_perf
   cluster:
+    anyscale_sdk_2026: true
     byod:
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
@@ -3034,6 +3037,7 @@
   team: core
   env: aws_perf
   cluster:
+    anyscale_sdk_2026: true
     byod:
       runtime_env:
         - LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2854,6 +2854,7 @@
       frequency: manual
       cluster:
         cluster_compute: object_store_gce.yaml
+        anyscale_sdk_2026: true
 
 - name: small_objects
   python: "3.10"
@@ -3056,6 +3057,7 @@
       frequency: manual
       cluster:
         cluster_compute: many_nodes_gce.yaml
+        anyscale_sdk_2026: true
 
 - name: scheduling_test_many_0s_tasks_many_nodes
   python: "3.10"


### PR DESCRIPTION
## Summary
- Migrated 6 Anyscale compute config files from legacy schema to new SDK format:
  - `release/benchmarks/many_nodes.yaml`
  - `release/benchmarks/many_nodes_gce.yaml`
  - `release/benchmarks/object_store.yaml`
  - `release/benchmarks/object_store/large_objects.yaml`
  - `release/benchmarks/object_store/small_objects.yaml`
  - `release/benchmarks/object_store_gce.yaml`
- Updated 4 test definitions in `release/release_tests.yaml` (`object_store`, `small_objects`, `large_objects`, `many_nodes`) to add `anyscale_sdk_2026: true` flag to their `cluster:` blocks

Schema changes applied:
- `cloud_id` with `ANYSCALE_CLOUD_ID` -> `cloud` with `ANYSCALE_CLOUD_NAME`
- Removed `region`, `max_workers`, node type `name` fields
- GCE configs: replaced `region` + `allowed_azs` with `zones`
- `head_node_type` -> `head_node`, `worker_node_types` -> `worker_nodes`
- `min_workers`/`max_workers` -> `min_nodes`/`max_nodes`
- `use_spot: false` -> `market_type: ON_DEMAND`
- Flattened `custom_resources` into top-level `resources` dict
- Removed redundant `CPU: 0`/`GPU: 0` from head nodes (new SDK auto-zeros when `worker_nodes` present)

## Test plan
- [x] All 6 configs validated against `ComputeConfig.from_yaml()`
- [x] Verify nightly tests pass with new configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)