### PR TITLE
[core] validate JobConfig code_search_path type

### DIFF
--- a/python/ray/job_config.py
+++ b/python/ray/job_config.py
@@ -57,12 +57,14 @@ class JobConfig:
         self.jvm_options = jvm_options or []
         #: A list of directories or jar files that
         #: specify the search path for user code.
-        self.code_search_path = code_search_path or []
-        # It's difficult to find the error that caused by the
-        # code_search_path is a string. So we assert here.
-        assert isinstance(self.code_search_path, (list, tuple)), (
-            f"The type of code search path is incorrect: " f"{type(code_search_path)}"
-        )
+        validated_code_search_path = code_search_path or []
+        # Validate eagerly so optimized Python runs do not skip this check.
+        if not isinstance(validated_code_search_path, (list, tuple)):
+            raise TypeError(
+                "The type of code search path is incorrect: "
+                f"{type(code_search_path)}"
+            )
+        self.code_search_path = validated_code_search_path
         self._client_job = _client_job
         #: An opaque metadata dictionary.
         self.metadata = metadata or {}

--- a/python/ray/tests/unit/test_job_config_client_validation.py
+++ b/python/ray/tests/unit/test_job_config_client_validation.py
@@ -92,6 +92,18 @@ def test_client_job_flag_initialization(method, value, expected):
     assert config._client_job is expected
 
 
+@pytest.mark.parametrize("method", ["constructor", "from_json"])
+def test_code_search_path_must_be_list_or_tuple(method):
+    """JobConfig should reject invalid code_search_path types consistently."""
+    expected_message = "The type of code search path is incorrect"
+
+    with pytest.raises(TypeError, match=expected_message):
+        if method == "constructor":
+            JobConfig(code_search_path="/tmp/code")
+        else:
+            JobConfig.from_json({"code_search_path": "/tmp/code"})
+
+
 def test_validate_no_local_paths_not_called_for_client_job():
     """Verify _validate_no_local_paths is not called when _client_job=True."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## What this PR does
Replaces the `JobConfig.code_search_path` type check from an `assert` to a stable `TypeError`, so invalid user input is still rejected under optimized Python runs.

## Tests
- Added unit coverage for invalid `code_search_path` in constructor
- Added unit coverage for invalid `code_search_path` in `JobConfig.from_json`
