### PR TITLE
[LLM] Fix vllm.inputs.data compatibility break in vllm_engine_stage

### DIFF
--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -535,7 +535,7 @@ class vLLMEngineWrapper:
             multi_modal_data = request.multimodal_data
 
         if request.prompt_token_ids is not None:
-            llm_prompt = vllm.inputs.data.TokensPrompt(
+            llm_prompt = vllm.inputs.TokensPrompt(
                 prompt_token_ids=request.prompt_token_ids,
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=request.mm_processor_kwargs,
@@ -543,7 +543,7 @@ class vLLMEngineWrapper:
             )
         else:
             assert request.prompt
-            llm_prompt = vllm.inputs.data.TextPrompt(
+            llm_prompt = vllm.inputs.TextPrompt(
                 prompt=request.prompt,
                 multi_modal_data=multi_modal_data,
                 mm_processor_kwargs=request.mm_processor_kwargs,


### PR DESCRIPTION
## Description

`vllm.inputs.data` was removed in vLLM PR [#35182](https://github.com/vllm-project/vllm/pull/35182) (`[Misc] Reorganize inputs`, merged 2026-03-26), which deleted `vllm/inputs/data.py` and moved `TokensPrompt` and `TextPrompt` into `vllm/inputs/llm.py`, re-exporting them from `vllm.inputs`.

This breaks `vllm_engine_stage.py` for any vLLM ≥ 0.19.0:

```
AttributeError: module 'vllm.inputs' has no attribute 'data'
```

At least the following Ray releases are affected: 2.52.0, 2.53.0, 2.54.0, 2.54.1, and nightly — all current stable releases and the nightly build are broken.

Fix: replace the two `vllm.inputs.data.*` references with `vllm.inputs.*`. No argument changes — `prompt_token_ids`, `multi_modal_data`, `mm_processor_kwargs`, and `multi_modal_uuids` are all still valid fields in the new location.

## Related issues

N/A

## Additional information

Before (broken with vLLM ≥ 0.19.0):
```python
llm_prompt = vllm.inputs.data.TokensPrompt(...)
llm_prompt = vllm.inputs.data.TextPrompt(...)
```

After:
```python
llm_prompt = vllm.inputs.TokensPrompt(...)
llm_prompt = vllm.inputs.TextPrompt(...)
```
