### PR TITLE
[LLM] Switch SGLang batch engine to sglang RayEngine

### DIFF
--- a/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/sglang_engine_stage.py
@@ -9,6 +9,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional, Tuple, Type
 
 from pydantic import BaseModel, root_validator
 
+import ray
 from ray.llm._internal.batch.constants import SGLangTaskType, TypeSGLangTaskType
 from ray.llm._internal.batch.stages.base import (
     StatefulStage,
@@ -112,15 +113,32 @@ class SGLangEngineWrapper:
         kwargs["skip_tokenizer_init"] = self.skip_tokenizer_init
 
         try:
-            import sglang
+            from sglang.srt.ray.engine import RayEngine as Engine
         except ImportError as e:
             raise ImportError(
-                "SGLang is not installed or failed to import. Please run "
-                "`pip install sglang[all]` to install required dependencies."
+                "SGLang with Ray backend is not installed or failed to import. "
+                "Please run `pip install sglang[all,ray]` to install required "
+                "dependencies."
             ) from e
 
+        # Create the placement group here rather than letting RayEngine
+        # auto-create one. RayEngine's auto-created PG is owned by the job, so
+        # it keeps its GPU bundles reserved for the lifetime of the session even
+        # after Engine.shutdown() kills the SchedulerActors — subsequent engines
+        # then block forever waiting on GPUs. Owning the PG here means shutdown()
+        # can remove exactly the PG this wrapper created, which is also the only
+        # way to get it right when several wrappers run concurrently
+        # (`concurrency > 1`).
+        self._placement_group = self._create_placement_group(kwargs)
+
         # Initialize the SGLang engine
-        self.engine = sglang.Engine(**kwargs)
+        try:
+            self.engine = Engine(placement_group=self._placement_group, **kwargs)
+        except Exception:
+            # shutdown() is never called if __init__ raises, so release the
+            # bundles here instead of leaking them for the rest of the job.
+            self._remove_placement_group()
+            raise
 
         # The performance gets really bad if there are too many requests in the pending queue.
         # We work around it with semaphore to limit the number of concurrent requests in the engine.
@@ -219,11 +237,53 @@ class SGLangEngineWrapper:
             "[SGLang] The request is not finished. This should not happen. Please report this issue to the Ray team."
         )
 
+    @staticmethod
+    def _create_placement_group(engine_kwargs: Dict[str, Any]):
+        """Reserve the GPUs the SGLang SchedulerActors will run on.
+
+        RayEngine treats a caller-supplied placement group as a "custom" PG and
+        requires exactly one GPU per bundle, one bundle per rank. STRICT_PACK
+        keeps all ranks on a single node, which is what the single-node batch
+        stage needs for NCCL.
+        """
+        from ray.util.placement_group import placement_group
+
+        tp_size = engine_kwargs.get("tp_size", 1)
+        pp_size = engine_kwargs.get("pp_size", 1)
+        dp_size = engine_kwargs.get("dp_size", 1)
+        # DP attention folds DP into TP, so the GPU count excludes dp_size.
+        if engine_kwargs.get("enable_dp_attention"):
+            world_size = tp_size * pp_size
+        else:
+            world_size = tp_size * pp_size * dp_size
+
+        pg = placement_group([{"GPU": 1}] * world_size, strategy="STRICT_PACK")
+        ray.get(pg.ready())
+        return pg
+
+    def _remove_placement_group(self):
+        """Release the bundles reserved by ``_create_placement_group``."""
+        pg = getattr(self, "_placement_group", None)
+        if pg is None:
+            return
+        self._placement_group = None
+        try:
+            from ray.util.placement_group import remove_placement_group
+
+            remove_placement_group(pg)
+        except Exception:
+            logger.exception("Failed to remove the SGLang placement group")
+
     def shutdown(self):
-        """Shutdown the SGLang engine."""
+        """Shutdown the SGLang engine and release the PG it created."""
         if hasattr(self.engine, "shutdown"):
             logger.info("Shutting down SGLang engine")
+            # RayEngine.shutdown() kills its own SchedulerActors.
             self.engine.shutdown()
+
+        # The actors are gone but the bundles they occupied stay reserved until
+        # the PG is removed, so the next engine could not schedule without this.
+        self._remove_placement_group()
 
 
 class SGLangEngineStageUDF(StatefulStageUDF):
@@ -356,19 +416,16 @@ class SGLangEngineStage(StatefulStage):
         """
         map_batches_kwargs = values["map_batches_kwargs"]
         accelerator_type = map_batches_kwargs.get("accelerator_type", "")
-        fn_constructor_kwargs = values["fn_constructor_kwargs"]
-        engine_kwargs = fn_constructor_kwargs.get("engine_kwargs", {})
 
         ray_remote_args = {}
         if accelerator_type:
             ray_remote_args["accelerator_type"] = accelerator_type
 
-        # Set up num_gpus required
-        tp_size = engine_kwargs.get("tp_size", 1)
-        dp_size = engine_kwargs.get("dp_size", 1)
-        num_gpus = tp_size * dp_size
-
-        ray_remote_args["num_gpus"] = num_gpus
+        # RayEngine spawns its own SchedulerActors that claim the GPUs via a
+        # placement group, so the outer Ray Data actor must request zero GPUs —
+        # otherwise the outer actor's reservation and the inner SchedulerActors'
+        # reservations double-count and deadlock on GPU-tight clusters.
+        ray_remote_args["num_gpus"] = 0
         map_batches_kwargs.update(ray_remote_args)
         return values
 

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -70,7 +70,9 @@ def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):
         "zero_copy_batch": True,
         "max_concurrency": 4,
         "accelerator_type": gpu_type,
-        "num_gpus": 4,  # Based on tp_size=2, dp_size=2 in engine_kwargs
+        # RayEngine claims GPUs via its own placement group, so the outer
+        # Ray Data actor must request zero GPUs to avoid double-counting.
+        "num_gpus": 0,
     }
 
 

--- a/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_sglang_engine_stage.py
@@ -56,52 +56,67 @@ def mock_sglang_wrapper():
 @pytest.fixture
 def mock_sgl_engine():
     """Mock the SGLang engine and its _generate_async method."""
-    with (
-        patch(
-            "ray.llm._internal.batch.stages.sglang_engine_stage.SGLangEngineWrapper._generate_async"
-        ) as mock_generate_async,
-    ):
-        try:
-            import sglang  # noqa: F401
-        except ImportError:
-            # Mock sglang module if it's not installed in test env.
-            mock_sgl = MagicMock()
-            mock_sgl.Engine = AsyncMock()
-            sys.modules["sglang"] = mock_sgl
-        num_running_requests = 0
-        request_lock = asyncio.Lock()
+    mock_engine_module = MagicMock()
+    mock_engine_module.RayEngine = MagicMock()
 
-        # Configure mock engine's generate behavior to simulate delay
-        async def mock_generate(request):
-            nonlocal num_running_requests
-            async with request_lock:
-                num_running_requests += 1
+    sglang_modules = {
+        "sglang": MagicMock(),
+        "sglang.srt": MagicMock(),
+        "sglang.srt.ray": MagicMock(),
+        "sglang.srt.ray.engine": mock_engine_module,
+    }
 
-            # This will be checked in tests that use max_pending_requests
-            max_pending_requests = getattr(mock_generate, "max_pending_requests", -1)
-            if max_pending_requests > 0:
-                assert num_running_requests <= max_pending_requests
+    with patch.dict(sys.modules, sglang_modules):
+        with (
+            patch(
+                "ray.llm._internal.batch.stages.sglang_engine_stage.SGLangEngineWrapper._generate_async"
+            ) as mock_generate_async,
+            # The wrapper reserves the SchedulerActor GPUs itself; don't let the
+            # unit tests actually claim bundles from the cluster.
+            patch(
+                "ray.llm._internal.batch.stages.sglang_engine_stage.SGLangEngineWrapper._create_placement_group",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "ray.llm._internal.batch.stages.sglang_engine_stage.SGLangEngineWrapper._remove_placement_group"
+            ),
+        ):
+            num_running_requests = 0
+            request_lock = asyncio.Lock()
 
-            await asyncio.sleep(0.1)  # Reduced sleep time for faster tests
+            # Configure mock engine's generate behavior to simulate delay
+            async def mock_generate(request):
+                nonlocal num_running_requests
+                async with request_lock:
+                    num_running_requests += 1
 
-            async with request_lock:
-                num_running_requests -= 1
+                # This will be checked in tests that use max_pending_requests
+                max_pending_requests = getattr(
+                    mock_generate, "max_pending_requests", -1
+                )
+                if max_pending_requests > 0:
+                    assert num_running_requests <= max_pending_requests
 
-            # Create a mock SGLang output
-            return {
-                "prompt": request.prompt,
-                "prompt_token_ids": None,
-                "text": f"Response to: {request.prompt}",
-                "meta_info": {
-                    "prompt_tokens": 3,
-                    "completion_tokens": request.params.get("max_new_tokens", 3),
-                    "finish_reason": "stop",
-                },
-                "output_ids": [4, 5, 6],
-            }
+                await asyncio.sleep(0.1)  # Reduced sleep time for faster tests
 
-        mock_generate_async.side_effect = mock_generate
-        yield mock_generate_async
+                async with request_lock:
+                    num_running_requests -= 1
+
+                # Create a mock SGLang output
+                return {
+                    "prompt": request.prompt,
+                    "prompt_token_ids": None,
+                    "text": f"Response to: {request.prompt}",
+                    "meta_info": {
+                        "prompt_tokens": 3,
+                        "completion_tokens": request.params.get("max_new_tokens", 3),
+                        "finish_reason": "stop",
+                    },
+                    "output_ids": [4, 5, 6],
+                }
+
+            mock_generate_async.side_effect = mock_generate
+            yield mock_generate_async
 
 
 def test_sglang_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
@@ -142,7 +157,7 @@ def test_sglang_engine_stage_post_init(gpu_type, model_llama_3_2_216M):
         "zero_copy_batch": True,
         "max_concurrency": 4,
         "accelerator_type": gpu_type,
-        "num_gpus": 4,
+        "num_gpus": 0,
     }
 
 
@@ -245,8 +260,20 @@ async def test_sglang_wrapper(
 @pytest.mark.asyncio
 async def test_sglang_error_handling(model_llama_3_2_216M):
     """Test error handling when SGLang is not available."""
-    with patch.dict(sys.modules, {"sglang": None}):
-        with pytest.raises(ImportError, match="SGLang is not installed"):
+    # The production code imports `sglang.srt.ray.engine`. Patching only
+    # "sglang" is not enough when sglang is installed: the submodule is already
+    # cached in sys.modules and the import resolves without consulting the
+    # None-ed parent. Null out the whole chain.
+    sglang_modules = {
+        "sglang": None,
+        "sglang.srt": None,
+        "sglang.srt.ray": None,
+        "sglang.srt.ray.engine": None,
+    }
+    with patch.dict(sys.modules, sglang_modules):
+        with pytest.raises(
+            ImportError, match="SGLang with Ray backend is not installed"
+        ):
             SGLangEngineWrapper(
                 model=model_llama_3_2_216M,
                 idx_in_batch_column="__idx_in_batch",

--- a/release/llm_tests/batch/test_batch_sglang.py
+++ b/release/llm_tests/batch/test_batch_sglang.py
@@ -1,9 +1,28 @@
+import gc
 import sys
 
 import pytest
 
 import ray
 from ray.data.llm import SGLangEngineProcessorConfig, build_processor
+
+
+@pytest.fixture(autouse=True)
+def _release_engine_gpus():
+    """Force the SGLang engines of a finished test to release their GPUs.
+
+    Ray Data keeps its MapWorker actors warm after a dataset completes, so the
+    SGLangEngineWrapper (and therefore its SchedulerActors and placement group)
+    stays alive until the worker is collected. With the parametrized cases
+    reserving 2 and 4 GPUs on a 4-GPU cluster, the next case would otherwise
+    block forever waiting on bundles the previous one still holds.
+
+    SGLangEngineStageUDF.__del__ runs the real teardown; this just makes sure it
+    happens between tests. The wrapper removes its own placement group, so
+    nothing needs to be reaped by hand here.
+    """
+    yield
+    gc.collect()
 
 
 def test_chat_template():

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4939,6 +4939,8 @@
   cluster:
     byod:
       type: llm-cu130
+      runtime_env:
+        - RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
       post_build_script: byod_llm_sglang_test.sh
     anyscale_sdk_2026: true
     cluster_compute: llm_4xl4.yaml


### PR DESCRIPTION
## Why are these changes needed?

Split out of #62504 — this is the **batch-side only** subset, the counterpart to #62888 (serve). #62888 must merge first, since this PR's release test depends on the sglang pin introduced there.

Switch `SGLangEngineStage` from `sglang.Engine` to `sglang.srt.ray.engine.RayEngine` so the Ray-native sglang backend is used inside Ray Data batch workers. RayEngine claims GPUs via its own placement group, so the outer Ray Data actor is set to `num_gpus=0` to avoid double-counting. Scheduler actors and the RayEngine-owned placement group are torn down on stage shutdown to avoid leaking GPUs between batches.

## Changes

- `_internal/batch/stages/sglang_engine_stage.py`
  - Import `sglang.srt.ray.engine.RayEngine as Engine` and update the install-hint error message to reference `sglang[all,ray]`.
  - Set `num_gpus=0` on the outer Ray Data actor so RayEngine fully owns GPU allocation.
  - On shutdown, reap the sglang scheduler actors and remove the RayEngine-owned placement group.
- `tests/batch/gpu/processor/test_sglang_engine_proc.py`: expect `num_gpus=0` on the actor (RayEngine owns the placement group).
- `tests/batch/gpu/stages/test_sglang_engine_stage.py`: update for the new shutdown path and `num_gpus=0` actor layout.
- `release/llm_tests/batch/test_batch_sglang.py`: new e2e batch release test.
- `release/release_tests.yaml`: register `llm_batch_sglang_llama` and set `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1` so RayEngine controls device visibility.

The sglang pin (`sgl-project/sglang@c0172aef6eabca1eb1a8ac9b359f57cd7a0490e8`) needed by RayEngine lands via #62888, so this PR doesn't re-pin it.

## Related issue number

Part of the work for https://github.com/ray-project/ray/issues/61114. Serve-engine counterpart is #62888.

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- Testing Strategy
  - [x] Unit tests
  - [x] Release tests (`llm_batch_sglang_llama`)
  - [ ] This PR is not tested :(