### PR TITLE
[CI] Make Java and dashboard optional in wheel builds

### DIFF
--- a/.buildkite/_wheel-build.rayci.yml
+++ b/.buildkite/_wheel-build.rayci.yml
@@ -55,6 +55,9 @@ steps:
       PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: ""
       HOSTTYPE: "x86_64"
+      JDK_SUFFIX: "-jdk"
+      RAY_JAVA_IMAGE: "cr.ray.io/rayproject/ray-java-build"
+      RAY_DASHBOARD_IMAGE: "cr.ray.io/rayproject/ray-dashboard"
     tags:
       - release_wheels
       - linux_wheels
@@ -62,3 +65,20 @@ steps:
       - ray-core-build($)
       - ray-java-build
       - ray-dashboard-build
+
+  - name: ray-wheel-minimal-build
+    label: "wanda: wheel-minimal py3.13 (x86_64)"
+    wanda: ci/docker/ray-wheel.wanda.yaml
+    env_file: rayci.env
+    env:
+      PYTHON_VERSION: "3.13"
+      ARCH_SUFFIX: ""
+      HOSTTYPE: "x86_64"
+      JDK_SUFFIX: ""
+      RAY_JAVA_IMAGE: "scratch"
+      RAY_DASHBOARD_IMAGE: "scratch"
+    tags:
+      - release_wheels
+      - linux_wheels
+    depends_on:
+      - ray-core-build(python=3.13)

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -161,6 +161,9 @@ steps:
       PYTHON_VERSION: "{{matrix}}"
       ARCH_SUFFIX: "-aarch64"
       HOSTTYPE: "aarch64"
+      JDK_SUFFIX: "-jdk"
+      RAY_JAVA_IMAGE: "cr.ray.io/rayproject/ray-java-build-aarch64"
+      RAY_DASHBOARD_IMAGE: "cr.ray.io/rayproject/ray-dashboard-aarch64"
     tags:
       - release_wheels
       - linux_wheels

--- a/ci/build/build_image.py
+++ b/ci/build/build_image.py
@@ -27,6 +27,7 @@ from ci.build.build_common import (
 )
 
 DEFAULT_ARCHITECTURE = "x86_64"
+RAYCI_REGISTRY = "cr.ray.io/rayproject"
 
 # Maps image type to its base name (YAML config key and Docker Hub repo).
 _BASE_TYPE_MAP: dict[str, str] = {
@@ -188,6 +189,9 @@ class ImageBuildConfig:
         image_type: str,
         python_version: str,
         image_platform: str,
+        *,
+        no_java: bool = False,
+        no_dashboard: bool = False,
     ) -> ImageBuildConfig:
         ray_image = RayImage(
             image_type=image_type,
@@ -219,15 +223,29 @@ class ImageBuildConfig:
             else None
         )
 
+        java_image = (
+            "scratch"
+            if no_java
+            else f"{RAYCI_REGISTRY}/ray-java-build{ray_image.arch_suffix}"
+        )
+        dashboard_image = (
+            "scratch"
+            if no_dashboard
+            else f"{RAYCI_REGISTRY}/ray-dashboard{ray_image.arch_suffix}"
+        )
+
         build_env: dict[str, str] = {
             "PYTHON_VERSION": ray_image.python_version,
             "MANYLINUX_VERSION": manylinux_version,
             "HOSTTYPE": ray_image.architecture,
             "ARCH_SUFFIX": ray_image.arch_suffix,
+            "JDK_SUFFIX": "" if no_java else "-jdk",
             "BUILDKITE_COMMIT": commit,
             "RAY_VERSION": ray_version,
             "IS_LOCAL_BUILD": "true",
             "IMAGE_TYPE": ray_image.repo,
+            "RAY_JAVA_IMAGE": java_image,
+            "RAY_DASHBOARD_IMAGE": dashboard_image,
         }
         if ray_image.platform.startswith("cu"):
             build_env["CUDA_VERSION"] = ray_image.platform.removeprefix("cu")
@@ -481,6 +499,18 @@ def main():
         action="store_true",
         help="List valid platforms for the given image type and exit",
     )
+    parser.add_argument(
+        "--no-java",
+        action="store_true",
+        default=False,
+        help="Build wheel without Java JARs",
+    )
+    parser.add_argument(
+        "--no-dashboard",
+        action="store_true",
+        default=False,
+        help="Build wheel without the dashboard",
+    )
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -502,7 +532,11 @@ def main():
 
     try:
         config = ImageBuildConfig.from_args(
-            args.image_type, python_version, platform_choice
+            args.image_type,
+            python_version,
+            platform_choice,
+            no_java=args.no_java,
+            no_dashboard=args.no_dashboard,
         )
         builder = ImageBuilder(config)
         image_tag = builder.build()

--- a/ci/build/build_wheel.py
+++ b/ci/build/build_wheel.py
@@ -29,6 +29,7 @@ from ci.build.build_common import (
 # Configuration Constants
 SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11", "3.12", "3.13")
 RAYMAKE_SPEC = "ci/docker/ray-wheel.wanda.yaml"
+RAYCI_REGISTRY = "cr.ray.io/rayproject"
 
 
 @dataclass(frozen=True)
@@ -41,20 +42,43 @@ class BuildConfig:
     raymake_version: str
     manylinux_version: str
     commit: str
+    no_java: bool = False
+    no_dashboard: bool = False
 
     @property
     def build_env(self) -> dict[str, str]:
+        java_image = (
+            "scratch"
+            if self.no_java
+            else f"{RAYCI_REGISTRY}/ray-java-build{self.arch_suffix}"
+        )
+        dashboard_image = (
+            "scratch"
+            if self.no_dashboard
+            else f"{RAYCI_REGISTRY}/ray-dashboard{self.arch_suffix}"
+        )
+
         return {
             "PYTHON_VERSION": self.python_version,
             "MANYLINUX_VERSION": self.manylinux_version,
             "HOSTTYPE": self.hosttype,
             "ARCH_SUFFIX": self.arch_suffix,
+            "JDK_SUFFIX": "" if self.no_java else "-jdk",
             "BUILDKITE_COMMIT": self.commit,
             "IS_LOCAL_BUILD": "true",
+            "RAY_JAVA_IMAGE": java_image,
+            "RAY_DASHBOARD_IMAGE": dashboard_image,
         }
 
     @classmethod
-    def from_env(cls, python_version: str, output_dir: str) -> BuildConfig:
+    def from_env(
+        cls,
+        python_version: str,
+        output_dir: str,
+        *,
+        no_java: bool = False,
+        no_dashboard: bool = False,
+    ) -> BuildConfig:
         root = find_ray_root()
         host, suffix = cls._detect_platform()
 
@@ -76,6 +100,8 @@ class BuildConfig:
             raymake_version=raymake_version,
             manylinux_version=manylinux_version,
             commit=commit,
+            no_java=no_java,
+            no_dashboard=no_dashboard,
         )
 
     @staticmethod
@@ -94,6 +120,12 @@ class WheelBuilder:
         if not shutil.which("raymake"):
             raise BuildError("raymake not found. Run via ./build-wheel.sh")
 
+        excluded = []
+        if self.config.no_java:
+            excluded.append("java")
+        if self.config.no_dashboard:
+            excluded.append("dashboard")
+
         log.info("Build configuration:")
         summary = {
             "Python": self.config.python_version,
@@ -101,6 +133,7 @@ class WheelBuilder:
             "Commit": self.config.commit,
             "Raymake": self.config.raymake_version,
             "Manylinux": self.config.manylinux_version,
+            "Excluded": ", ".join(excluded) if excluded else "none",
             "Ray Root": self.config.ray_root,
             "Output Dir": self.config.output_dir,
         }
@@ -156,6 +189,19 @@ def main():
         help="Directory to store wheels (default: .whl)",
     )
 
+    parser.add_argument(
+        "--no-java",
+        action="store_true",
+        default=False,
+        help="Build wheel without Java JARs",
+    )
+    parser.add_argument(
+        "--no-dashboard",
+        action="store_true",
+        default=False,
+        help="Build wheel without the dashboard",
+    )
+
     if len(sys.argv) == 1:
         parser.print_help()
         sys.exit(0)
@@ -164,7 +210,12 @@ def main():
 
     try:
         builder = WheelBuilder(
-            BuildConfig.from_env(args.python_version, args.output_dir)
+            BuildConfig.from_env(
+                args.python_version,
+                args.output_dir,
+                no_java=args.no_java,
+                no_dashboard=args.no_dashboard,
+            )
         )
         output_dir = builder.config.output_dir
         if output_dir.exists():

--- a/ci/docker/ray-wheel.Dockerfile
+++ b/ci/docker/ray-wheel.Dockerfile
@@ -11,17 +11,16 @@
 #
 
 ARG RAY_CORE_IMAGE
-ARG RAY_JAVA_IMAGE
-ARG RAY_DASHBOARD_IMAGE
-ARG MANYLINUX_VERSION
-ARG HOSTTYPE
+ARG RAY_JAVA_IMAGE=scratch
+ARG RAY_DASHBOARD_IMAGE=scratch
+ARG MANYLINUX_IMAGE
 
 FROM ${RAY_CORE_IMAGE} AS ray-core
 FROM ${RAY_JAVA_IMAGE} AS ray-java
 FROM ${RAY_DASHBOARD_IMAGE} AS ray-dashboard
 
 # Main build stage - manylinux2014 provides GLIBC 2.17
-FROM rayproject/manylinux2014:${MANYLINUX_VERSION}-jdk-${HOSTTYPE} AS builder
+FROM ${MANYLINUX_IMAGE} AS builder
 
 ARG PYTHON_VERSION=3.10
 ARG BUILDKITE_COMMIT
@@ -31,8 +30,6 @@ WORKDIR /home/forge/ray
 # Copy artifacts from all stages
 COPY --from=ray-core /ray_pkg.zip /tmp/
 COPY --from=ray-core /ray_py_proto.zip /tmp/
-COPY --from=ray-java /ray_java_pkg.zip /tmp/
-COPY --from=ray-dashboard /dashboard.tar.gz /tmp/
 
 # Source files needed for wheel build
 COPY --chown=forge ci/build/build-manylinux-wheel.sh ci/build/
@@ -44,26 +41,35 @@ USER forge
 # - BUILDKITE_COMMIT: Used for ray.__commit__. Defaults to "unknown" for local builds.
 ENV PYTHON_VERSION=${PYTHON_VERSION} \
     BUILDKITE_COMMIT=${BUILDKITE_COMMIT:-unknown}
-RUN <<'EOF'
+RUN --mount=from=ray-java,target=/mnt/java \
+    --mount=from=ray-dashboard,target=/mnt/dashboard \
+    <<'EOF'
 #!/bin/bash
 set -euo pipefail
 
 # Clean extraction dirs to avoid stale leftovers
-rm -rf /tmp/ray_pkg /tmp/ray_java_pkg
-mkdir -p /tmp/ray_pkg /tmp/ray_java_pkg
+rm -rf /tmp/ray_pkg
+mkdir -p /tmp/ray_pkg
 
 # Unpack pre-built artifacts
 unzip -o /tmp/ray_pkg.zip -d /tmp/ray_pkg
 unzip -o /tmp/ray_py_proto.zip -d python/
-unzip -o /tmp/ray_java_pkg.zip -d /tmp/ray_java_pkg
-mkdir -p python/ray/dashboard/client/build
-tar -xzf /tmp/dashboard.tar.gz -C python/ray/dashboard/client/build/
+
+# Dashboard (optional)
+if [[ -f /mnt/dashboard/dashboard.tar.gz ]]; then
+    mkdir -p python/ray/dashboard/client/build
+    tar -xzf /mnt/dashboard/dashboard.tar.gz -C python/ray/dashboard/client/build/
+fi
 
 # C++ core artifacts
 cp -r /tmp/ray_pkg/ray/* python/ray/
 
-# Java JARs
-cp -r /tmp/ray_java_pkg/ray/* python/ray/
+# Java JARs (optional)
+if [[ -f /mnt/java/ray_java_pkg.zip ]]; then
+    mkdir -p /tmp/ray_java_pkg
+    unzip -o /mnt/java/ray_java_pkg.zip -d /tmp/ray_java_pkg
+    cp -r /tmp/ray_java_pkg/ray/* python/ray/
+fi
 
 # Build ray wheel
 PY_VERSION="${PYTHON_VERSION//./}"

--- a/ci/docker/ray-wheel.wanda.yaml
+++ b/ci/docker/ray-wheel.wanda.yaml
@@ -1,10 +1,10 @@
 name: "ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"
 disable_caching: true
 froms:
-  - "rayproject/manylinux2014:$MANYLINUX_VERSION-jdk-$HOSTTYPE"
+  - "rayproject/manylinux2014:$MANYLINUX_VERSION$JDK_SUFFIX-$HOSTTYPE"
   - "cr.ray.io/rayproject/ray-core-py$PYTHON_VERSION$ARCH_SUFFIX"     # C++ binaries (ray_pkg.zip)
-  - "cr.ray.io/rayproject/ray-java-build$ARCH_SUFFIX"                 # Java JARs
-  - "cr.ray.io/rayproject/ray-dashboard$ARCH_SUFFIX"                  # Dashboard
+  - "$RAY_JAVA_IMAGE"                                                 # Java JARs (scratch to skip)
+  - "$RAY_DASHBOARD_IMAGE"                                            # Dashboard (scratch to skip)
 dockerfile: ci/docker/ray-wheel.Dockerfile
 srcs:
   - pyproject.toml
@@ -14,14 +14,13 @@ srcs:
   - rllib/
 build_args:
   - PYTHON_VERSION
-  - MANYLINUX_VERSION
-  - HOSTTYPE
   - BUILDKITE_COMMIT
   - ARCH_SUFFIX
   - WHEEL_TYPE=ray
+  - MANYLINUX_IMAGE=rayproject/manylinux2014:$MANYLINUX_VERSION$JDK_SUFFIX-$HOSTTYPE
   - RAY_CORE_IMAGE=cr.ray.io/rayproject/ray-core-py$PYTHON_VERSION$ARCH_SUFFIX
-  - RAY_JAVA_IMAGE=cr.ray.io/rayproject/ray-java-build$ARCH_SUFFIX
-  - RAY_DASHBOARD_IMAGE=cr.ray.io/rayproject/ray-dashboard$ARCH_SUFFIX
+  - RAY_JAVA_IMAGE
+  - RAY_DASHBOARD_IMAGE
 artifacts:
   - src: "/opt/artifacts/"
     dst: "./"


### PR DESCRIPTION
Make the ray wheel build configurable so Java JARs and the dashboard can be excluded.

- Dockerfile: use RUN --mount for optional Java/dashboard stages, defaulting to scratch when excluded
- Wanda: use $RAY_JAVA_IMAGE, $RAY_DASHBOARD_IMAGE, and $JDK_SUFFIX env vars to control inclusion
- build_wheel.py: add --no-java and --no-dashboard flags
- Buildkite: add ray-wheel-minimal-build CI step to test the no-java/no-dashboard build path

Topic: optional-java-wheel
Signed-off-by: andrew <andrew@anyscale.com>