### PR TITLE
[train] Increase get_actor timeout

### DIFF
--- a/python/ray/train/v2/_internal/callbacks/placement_group_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/placement_group_callback.py
@@ -28,7 +28,7 @@ class PlacementGroupCleanerCallback(ControllerCallback, WorkerGroupCallback):
 
     def __init__(
         self,
-        check_interval_s: float = 5.0,
+        check_interval_s: float = 1.0,
         get_actor_timeout_s: float = GET_ACTOR_TIMEOUT_S,
         stop_timeout: Optional[float] = None,
     ):

--- a/python/ray/train/v2/_internal/callbacks/placement_group_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/placement_group_callback.py
@@ -25,7 +25,7 @@ class PlacementGroupCleanerCallback(ControllerCallback, WorkerGroupCallback):
     dies ungracefully.
     """
 
-    def __init__(self, check_interval_s: float = 1.0):
+    def __init__(self, check_interval_s: float = 5.0):
         """Initialize the callback.
 
         Args:

--- a/python/ray/train/v2/_internal/callbacks/placement_group_callback.py
+++ b/python/ray/train/v2/_internal/callbacks/placement_group_callback.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Optional
 
 import ray
 from ray.exceptions import RayActorError
+from ray.train.v2._internal.constants import GET_ACTOR_TIMEOUT_S
 from ray.train.v2._internal.execution.callback import (
     ControllerCallback,
     WorkerGroupCallback,
@@ -25,14 +26,27 @@ class PlacementGroupCleanerCallback(ControllerCallback, WorkerGroupCallback):
     dies ungracefully.
     """
 
-    def __init__(self, check_interval_s: float = 5.0):
+    def __init__(
+        self,
+        check_interval_s: float = 5.0,
+        get_actor_timeout_s: float = GET_ACTOR_TIMEOUT_S,
+        stop_timeout: Optional[float] = None,
+    ):
         """Initialize the callback.
 
         Args:
             check_interval_s: How often (in seconds) the cleaner should check
                 if the controller is still alive.
+            get_actor_timeout_s: How long to wait when calling the get actor state api.
+            stop_timeout: How long to wait for the cleaner to stop.
         """
         self._check_interval_s = check_interval_s
+        self._get_actor_timeout_s = get_actor_timeout_s
+        self._stop_timeout = stop_timeout
+        if self._stop_timeout is None:
+            self._stop_timeout = max(
+                2.0, self._check_interval_s * 2 + self._get_actor_timeout_s
+            )
         self._cleaner: Optional[PlacementGroupCleaner] = None
         self._controller_actor_id: Optional[str] = None
 
@@ -50,6 +64,8 @@ class PlacementGroupCleanerCallback(ControllerCallback, WorkerGroupCallback):
             ).remote(
                 controller_actor_id=self._controller_actor_id,
                 check_interval_s=self._check_interval_s,
+                get_actor_timeout_s=self._get_actor_timeout_s,
+                stop_timeout=self._stop_timeout,
             )
 
             logger.debug(
@@ -104,8 +120,7 @@ class PlacementGroupCleanerCallback(ControllerCallback, WorkerGroupCallback):
 
         try:
             # Stop the cleaner gracefully (it won't clean up the PG)
-            stop_timeout_s = max(2.0, self._check_interval_s * 2)
-            ray.get(self._cleaner.stop.remote(), timeout=stop_timeout_s)
+            ray.get(self._cleaner.stop.remote(), timeout=self._stop_timeout)
         except RayActorError:
             logger.debug(
                 "PlacementGroupCleaner exited before stop completed; ignoring."

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -84,12 +84,12 @@ STATE_ACTOR_RECONCILIATION_INTERVAL_S_ENV_VAR = (
     "RAY_TRAIN_STATE_ACTOR_RECONCILIATION_INTERVAL_S"
 )
 DEFAULT_STATE_ACTOR_RECONCILIATION_INTERVAL_S: float = 30.0
-# TODO: `ray.util.state.api.get_actor` takes 10-50ms but we cannot pick lower than 2s
-# due to https://github.com/ray-project/ray/issues/54153. Lower this after fix.
-GET_ACTOR_TIMEOUT_S: int = 2
+# TODO: `ray.util.state.api.get_actor` typically takes 10-50ms but can take longer
+# when there is high load on the cluster.
+GET_ACTOR_TIMEOUT_S: int = 10
 # GET_ACTOR_TIMEOUT_S_ENV_VAR * CONTROLLERS_TO_POLL_PER_ITERATION_ENV_VAR should be
 # way less than STATE_ACTOR_RECONCILIATION_INTERVAL_S_ENV_VAR.
-CONTROLLERS_TO_POLL_PER_ITERATION: int = 5
+CONTROLLERS_TO_POLL_PER_ITERATION: int = 2
 
 # Environment variable for Train execution callbacks
 RAY_TRAIN_CALLBACKS_ENV_VAR = "RAY_TRAIN_CALLBACKS"

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -88,7 +88,8 @@ DEFAULT_STATE_ACTOR_RECONCILIATION_INTERVAL_S: float = 30.0
 # when there is high load on the cluster.
 GET_ACTOR_TIMEOUT_S: int = 10
 # GET_ACTOR_TIMEOUT_S * CONTROLLERS_TO_POLL_PER_ITERATION should be
-# way less than STATE_ACTOR_RECONCILIATION_INTERVAL_S.
+# way less than STATE_ACTOR_RECONCILIATION_INTERVAL_S to give the state actor
+# time to update live train run state.
 CONTROLLERS_TO_POLL_PER_ITERATION: int = 1
 
 # Environment variable for Train execution callbacks

--- a/python/ray/train/v2/_internal/constants.py
+++ b/python/ray/train/v2/_internal/constants.py
@@ -87,9 +87,9 @@ DEFAULT_STATE_ACTOR_RECONCILIATION_INTERVAL_S: float = 30.0
 # TODO: `ray.util.state.api.get_actor` typically takes 10-50ms but can take longer
 # when there is high load on the cluster.
 GET_ACTOR_TIMEOUT_S: int = 10
-# GET_ACTOR_TIMEOUT_S_ENV_VAR * CONTROLLERS_TO_POLL_PER_ITERATION_ENV_VAR should be
-# way less than STATE_ACTOR_RECONCILIATION_INTERVAL_S_ENV_VAR.
-CONTROLLERS_TO_POLL_PER_ITERATION: int = 2
+# GET_ACTOR_TIMEOUT_S * CONTROLLERS_TO_POLL_PER_ITERATION should be
+# way less than STATE_ACTOR_RECONCILIATION_INTERVAL_S.
+CONTROLLERS_TO_POLL_PER_ITERATION: int = 1
 
 # Environment variable for Train execution callbacks
 RAY_TRAIN_CALLBACKS_ENV_VAR = "RAY_TRAIN_CALLBACKS"

--- a/python/ray/train/v2/_internal/execution/controller/placement_group_cleaner.py
+++ b/python/ray/train/v2/_internal/execution/controller/placement_group_cleaner.py
@@ -21,7 +21,7 @@ class PlacementGroupCleaner:
     def __init__(
         self,
         controller_actor_id: str,
-        check_interval_s: float = 1.0,
+        check_interval_s: float = 5.0,
     ):
         self._controller_actor_id = controller_actor_id
         self._check_interval_s = check_interval_s

--- a/python/ray/train/v2/_internal/execution/controller/placement_group_cleaner.py
+++ b/python/ray/train/v2/_internal/execution/controller/placement_group_cleaner.py
@@ -4,7 +4,6 @@ import threading
 from typing import Optional
 
 import ray
-from ray.train.v2._internal.constants import GET_ACTOR_TIMEOUT_S
 from ray.train.v2._internal.state.util import is_actor_alive
 from ray.util.placement_group import PlacementGroup, remove_placement_group
 
@@ -21,14 +20,17 @@ class PlacementGroupCleaner:
     def __init__(
         self,
         controller_actor_id: str,
-        check_interval_s: float = 5.0,
+        check_interval_s: float,
+        get_actor_timeout_s: float,
+        stop_timeout: Optional[float],
     ):
         self._controller_actor_id = controller_actor_id
         self._check_interval_s = check_interval_s
+        self._get_actor_timeout_s = get_actor_timeout_s
+        self._stop_timeout = stop_timeout
         self._pg_queue: queue.Queue = queue.Queue()
         self._stop_event = threading.Event()
         self._monitor_thread: Optional[threading.Thread] = None
-        self._get_actor_timeout_s = GET_ACTOR_TIMEOUT_S
         self._exiting: bool = False
 
     def register_placement_group(self, placement_group: PlacementGroup):
@@ -133,11 +135,10 @@ class PlacementGroupCleaner:
 
         # Signal stop and wait for thread to exit
         self._stop_event.set()
-        join_timeout = max(2.0, self._check_interval_s * 2)
-        self._monitor_thread.join(timeout=join_timeout)
+        self._monitor_thread.join(timeout=self._stop_timeout)
         if self._monitor_thread.is_alive():
             logger.warning(
-                "Monitor thread did not exit within %.2f seconds", join_timeout
+                "Monitor thread did not exit within %.2f seconds", self._stop_timeout
             )
             return False
 

--- a/python/ray/train/v2/tests/test_placement_group_cleaner.py
+++ b/python/ray/train/v2/tests/test_placement_group_cleaner.py
@@ -80,7 +80,12 @@ def test_placement_group_cleaner_basic_lifecycle(monitoring_started_signal):
             lifetime="detached",
             get_if_exists=False,
         )
-        .remote(controller_actor_id=controller_id, check_interval_s=0.1)
+        .remote(
+            controller_actor_id=controller_id,
+            check_interval_s=0.1,
+            get_actor_timeout_s=2,
+            stop_timeout=5,
+        )
     )
 
     # Create a placement group
@@ -134,7 +139,12 @@ def test_pg_cleaner_cleans_up_on_controller_death(monitoring_started_signal):
             lifetime="detached",
             get_if_exists=False,
         )
-        .remote(controller_actor_id=controller_id, check_interval_s=0.1)
+        .remote(
+            controller_actor_id=controller_id,
+            check_interval_s=0.1,
+            get_actor_timeout_s=2,
+            stop_timeout=5,
+        )
     )
 
     # Create a placement group
@@ -188,6 +198,8 @@ def test_pg_cleaner_exits_on_controller_death_without_pg_registration(
         .remote(
             controller_actor_id=controller_id,
             check_interval_s=0.1,
+            get_actor_timeout_s=2,
+            stop_timeout=5,
         )
     )
 
@@ -217,7 +229,12 @@ def test_pg_cleaner_handles_duplicate_start():
             lifetime="detached",
             get_if_exists=False,
         )
-        .remote(controller_actor_id=controller_id, check_interval_s=0.1)
+        .remote(
+            controller_actor_id=controller_id,
+            check_interval_s=0.1,
+            get_actor_timeout_s=2,
+            stop_timeout=5,
+        )
     )
 
     pg = placement_group([{"CPU": 1}], strategy="SPREAD")

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -300,7 +300,10 @@ def test_train_state_actor_abort_dead_controller_live_runs(monkeypatch):
 
     # Create TrainStateActor with interesting runs and run attempts.
     # NOTE: TrainStateActor will poll for real but its updates are idempotent.
-    actor = TrainStateActor(enable_state_actor_reconciliation=True)
+    actor = TrainStateActor(
+        enable_state_actor_reconciliation=True,
+        controllers_to_poll_per_iteration=5,
+    )
     finished_controller_run = create_mock_train_run(
         status=RunStatus.FINISHED,
         controller_actor_id="finished_controller_id",


### PR DESCRIPTION
# Summary

We are seeing the following spammy timeout logs from the [is_actor_alive api](https://github.com/ray-project/ray/blob/a4048d48cb66e464c60ceee9453bc606cdafff17/python/ray/train/v2/_internal/state/util.py#L51): 

`
2026-03-26 23:26:27,546 WARNING placement_group_cleaner.py:85 -- Failed to query Ray Train Controller actor state. State API may be temporarily unavailable. Continuing to monitor. job_id=02000000 worker_id=a44fd7025264656d230a02306daf485f2a5e930810e148f7739f445f node_id=9f2821292a65838ab5e4be2aacbf073e0467d28094a85d149ec8ea63 actor_id=5a9d38e3895ea36df6bd7f0c02000000 task_id=aeb165f386153bb8b6d526326db3be1f9d5843f302000000 task_name= task_func_name= actor_name= timestamp_ns=1774592787546699009
`

Increasing the timeout from 2-10s to avoid this. 

Old is_actor_alive rate limiting in Ray Train:
* state actor: every 30s, poll 5 times and wait 2s each. Rate limited to 1 every 6s
* placement group cleaner: every 1s, poll once and wait 2s. Rate limited to 1 every second in the fast case and 1 every 3s in the timeout case.

New is_actor_alive rate limiting in Ray Train:
* state actor: every 30s, poll 1 time and wait 10s each. Rate limited to 1 every 30s. Note that for the state actor we intentionally poll less often to give the state actor time to update live train run state.
* placement group cleaner: every 1s, poll once and wait 10s. Rate limited to 1 every 1s in the fast case and 1 every 11s in the timeout case.

We can consider exponential backoff if needed but that may cause more problems e.g. after the state api gets back online, we might wait too long before cleaning the placement group. 

# Testing

Unit tests