### PR TITLE
[Core][Let the driver I/O context breathe]: remove per lease request backlog reporting

### DIFF
--- a/src/ray/core_worker/task_submission/normal_task_submitter.cc
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.cc
@@ -248,8 +248,6 @@ void NormalTaskSubmitter::ReportWorkerBacklogInternal() {
     // so we need to aggregate backlog sizes of different scheduling keys
     // with the same scheduling class
     backlogs[scheduling_class].second += scheduling_key_and_entry.second.BacklogSize();
-    scheduling_key_and_entry.second.last_reported_backlog_size =
-        scheduling_key_and_entry.second.BacklogSize();
   }
 
   std::vector<rpc::WorkerBacklogReport> backlog_reports;
@@ -260,16 +258,6 @@ void NormalTaskSubmitter::ReportWorkerBacklogInternal() {
     backlog_reports.emplace_back(backlog_report);
   }
   local_raylet_client_->ReportWorkerBacklog(worker_id_, backlog_reports);
-}
-
-void NormalTaskSubmitter::ReportWorkerBacklogIfNeeded(
-    const SchedulingKey &scheduling_key) {
-  const auto &scheduling_key_entry = scheduling_key_entries_[scheduling_key];
-
-  if (scheduling_key_entry.last_reported_backlog_size !=
-      scheduling_key_entry.BacklogSize()) {
-    ReportWorkerBacklogInternal();
-  }
 }
 
 void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduling_key,
@@ -503,7 +491,6 @@ void NormalTaskSubmitter::RequestNewWorkerIfNeeded(const SchedulingKey &scheduli
       task_queue.size(),
       is_selected_based_on_locality);
   scheduling_key_entry.pending_lease_requests.emplace(lease_id, *raylet_address);
-  ReportWorkerBacklogIfNeeded(scheduling_key);
 
   // Lease more workers if there are still pending tasks and
   // and we haven't hit the max_pending_lease_requests yet.

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -181,11 +181,6 @@ class NormalTaskSubmitter {
   /// Report worker backlog information to the local raylet
   void ReportWorkerBacklogInternal() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
-  /// Report backlog if the backlog size is changed for this scheduling key
-  /// since last report
-  void ReportWorkerBacklogIfNeeded(const SchedulingKey &scheduling_key)
-      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
-
   /// Request a new worker from the raylet if no such requests are currently in
   /// flight and there are tasks queued. If a raylet address is provided, then
   /// the worker should be requested from the raylet at that address. Else, the
@@ -321,7 +316,6 @@ class NormalTaskSubmitter {
     absl::flat_hash_set<rpc::Address> active_workers;
     // Keep track of how many workers have tasks to do.
     uint32_t num_busy_workers = 0;
-    int64_t last_reported_backlog_size = 0;
 
     // Check whether it's safe to delete this SchedulingKeyEntry from the
     // scheduling_key_entries_ hashmap.

--- a/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
+++ b/src/ray/core_worker/task_submission/tests/normal_task_submitter_test.cc
@@ -873,7 +873,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeases) {
     ASSERT_EQ(worker_client->callbacks.size(), i + 1);
     ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, concurrency + i + 1);
     ASSERT_EQ(raylet_client->num_workers_requested, concurrency + i + 1);
-    ASSERT_EQ(raylet_client->reported_backlog_size, concurrency - i - 1);
   }
   for (int i = 0; i < concurrency; i++) {
     ASSERT_TRUE(
@@ -881,7 +880,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeases) {
     ASSERT_EQ(worker_client->callbacks.size(), concurrency + i + 1);
     ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, tasks.size());
     ASSERT_EQ(raylet_client->num_workers_requested, tasks.size());
-    ASSERT_EQ(raylet_client->reported_backlog_size, 0);
   }
 
   // All workers returned.
@@ -893,7 +891,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeases) {
   ASSERT_EQ(task_manager->num_tasks_complete, tasks.size());
   ASSERT_EQ(task_manager->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
-  ASSERT_EQ(raylet_client->reported_backlog_size, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
@@ -927,15 +924,12 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamic) {
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, local_node_id));
   ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, 2);
   ASSERT_EQ(raylet_client->num_workers_requested, 2);
-  ASSERT_EQ(raylet_client->reported_backlog_size, tasks.size() - 2);
 
   // Increase max concurrency. Should request leases up to the max concurrency.
   rateLimiter->limit_ = concurrency;
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, local_node_id));
   ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, 2 + concurrency);
   ASSERT_EQ(raylet_client->num_workers_requested, 2 + concurrency);
-  ASSERT_EQ(raylet_client->reported_backlog_size,
-            tasks.size() - raylet_client->num_workers_requested);
 
   // Decrease max concurrency again. Should not request any more leases even as
   // previous requests are granted, since we are still over the current
@@ -945,8 +939,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamic) {
     ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", i, local_node_id));
     ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, 2 + concurrency);
     ASSERT_EQ(raylet_client->num_workers_requested, 2 + concurrency);
-    ASSERT_EQ(raylet_client->reported_backlog_size,
-              tasks.size() - raylet_client->num_workers_requested);
   }
 
   // Grant remaining leases with max lease concurrency of 1.
@@ -975,7 +967,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamic) {
   ASSERT_EQ(task_manager->num_tasks_complete, tasks.size());
   ASSERT_EQ(task_manager->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
-  ASSERT_EQ(raylet_client->reported_backlog_size, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
@@ -1012,7 +1003,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamicWithSpillback) 
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, local_node_id));
   ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, 2);
   ASSERT_EQ(raylet_client->num_workers_requested, 2);
-  ASSERT_EQ(raylet_client->reported_backlog_size, tasks.size() - 2);
 
   // Increase max concurrency.
   rateLimiter->limit_ = concurrency;
@@ -1024,8 +1014,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamicWithSpillback) 
   // rest from the raylet returned by the lease policy.
   ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, concurrency + 1);
   ASSERT_EQ(raylet_client->num_workers_requested, 2 + concurrency);
-  ASSERT_EQ(raylet_client->reported_backlog_size,
-            tasks.size() - raylet_client->num_workers_requested + 1);
 
   // Decrease max concurrency again. Should not request any more leases even as
   // previous requests are granted, since we are still over the current
@@ -1035,8 +1023,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamicWithSpillback) 
     ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", i, local_node_id));
     ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, concurrency + 1);
     ASSERT_EQ(raylet_client->num_workers_requested, 2 + concurrency);
-    ASSERT_EQ(raylet_client->reported_backlog_size,
-              tasks.size() - raylet_client->num_workers_requested + 1);
   }
 
   // Grant remaining leases with max lease concurrency of 1.
@@ -1065,7 +1051,6 @@ TEST_F(NormalTaskSubmitterTest, TestConcurrentWorkerLeasesDynamicWithSpillback) 
   ASSERT_EQ(task_manager->num_tasks_complete, tasks.size());
   ASSERT_EQ(task_manager->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
-  ASSERT_EQ(raylet_client->reported_backlog_size, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These
@@ -1085,21 +1070,18 @@ TEST_F(NormalTaskSubmitterTest, TestSubmitMultipleTasks) {
   submitter.SubmitTask(task3);
   ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, 1);
   ASSERT_EQ(raylet_client->num_workers_requested, 1);
-  ASSERT_EQ(raylet_client->reported_backlog_size, 0);
 
   // Task 1 is pushed; worker 2 is requested.
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1000, local_node_id));
   ASSERT_EQ(worker_client->callbacks.size(), 1);
   ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, 2);
   ASSERT_EQ(raylet_client->num_workers_requested, 2);
-  ASSERT_EQ(raylet_client->reported_backlog_size, 1);
 
   // Task 2 is pushed; worker 3 is requested.
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1001, local_node_id));
   ASSERT_EQ(worker_client->callbacks.size(), 2);
   ASSERT_EQ(lease_policy_ptr->num_lease_policy_consults, 3);
   ASSERT_EQ(raylet_client->num_workers_requested, 3);
-  ASSERT_EQ(raylet_client->reported_backlog_size, 0);
 
   // Task 3 is pushed; no more workers requested.
   ASSERT_TRUE(raylet_client->GrantWorkerLease("localhost", 1002, local_node_id));
@@ -1116,7 +1098,6 @@ TEST_F(NormalTaskSubmitterTest, TestSubmitMultipleTasks) {
   ASSERT_EQ(task_manager->num_tasks_complete, 3);
   ASSERT_EQ(task_manager->num_tasks_failed, 0);
   ASSERT_EQ(raylet_client->num_leases_canceled, 0);
-  ASSERT_EQ(raylet_client->reported_backlog_size, 0);
   ASSERT_FALSE(raylet_client->ReplyCancelWorkerLease());
 
   // Check that there are no entries left in the scheduling_key_entries_ hashmap. These


### PR DESCRIPTION
## Description

The driver's single threaded I/O context is the bottleneck for many cases. When it's overwhelmed, everything slows down.

Workloads like Ray Data shuffle submit extremely large batches of remote tasks running at once. These patterns generate bursts of lease requests, each might triggering a backlog report RPC that competes for I/O thread time.

An external user reported the same issue: 11.69M backlog RPCs from 120 workers over 3 hours, causing `ProcessMessageHeader` to queue for 55s on average ([link](https://github.com/ray-project/ray/pull/60800#issuecomment-3876009281)). 

So our goal is to reduce the backlog in reporting and let the driver I/O context breathe. **This PR focuses on saving the driver in scenarios when you need burst submitted tasks/actors(ray data shuffle pattern)** and of course also for high frequency short task where needs rapid lease grants.


Workers limit the number of outstanding lease requests per scheduling class(to control max ongoing lease requests and avoid deadlock for nested tasks). The raylet only sees these pending requests, not the full queue behind them. So workers periodically report "how many tasks are still waiting" (the backlog) to the raylet, which passes it to gcs and eventually to the autoscaler for scaling decisions.

There are two reporting paths:
1. Periodic heartbeat: every 1s, unconditionally reports the full backlog
2. Per lease request: ReportWorkerBacklogIfNeeded fires after every lease request is sent, triggering a full report if the backlog changed. **Under sustained backlog, this produces one report per lease request instead of one per second.**

And worker backlog is only consumed by the autoscaler. The data flows through: Worker -> Raylet → GCS -> Autoscaler. In this flow:
- GCS pulls resource loads from each raylet **every 1s** 
- autoscaler pulls from GCS **every 5s**.
- **The rest of this chain already operates at 1s and 5s intervals. The Worker -> Raylet leg reporting once per second via heartbeat is more than sufficient. There is no need for high-frequency per lease request reporting.**

## Performance Gain

- Single node, 128 CPUs(we only cares about impact to burst submitting o driver io context here). 
- Burst-submit N scheduling classes × M fast tasks (just return 1)(num_cpus=1 and memory=(i+1)*1MB)
- Different memory values per class to create distinct scheduling classes. 3 runs averaged per data point.
- Wall time = submit + ray.get. 

<img width="2400" height="900" alt="image" src="https://github.com/user-attachments/assets/ca92b069-9d05-4319-92ee-171539f523e1" />


## Things I think you might ask
Q: It seems the problem path needs to be triggered only if you have a sustained backlog in each scheduling class, but I heard the data is actually per scheduling class per task?
A: Originally, the data basically will have different memory requests per task, and thus each task has its own scheduling class. that's worse! They will have thousands of scheduling classes and completely overwhelm driver IO in another way. They will reduce the scheduling classes by bucketing memory; this way, they will have pending tasks in the queue for each scheduling class.