### PR TITLE
[Core] Add `chips_per_vm` arg to TPU utils to handle edge case topologies

### DIFF
--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -55,15 +55,11 @@ TPU_SINGLE_HOST_BOUNDS = "1,1,1"
 DEFAULT_TPU_NUM_CHIPS_PER_HOST = 4
 DEFAULT_TPU_NUM_CORES_PER_CHIP = 2
 
-# Accelerators that are 4 chips per host: v2, v3, v4, v5p, v6e, v7x
-# Accelerators that are 8 chips per host: v5e
-SINGLE_HOST_8_CHIPS_TPU_TYPE = "v5litepod"
+# Accelerators that support up to 8 chips per host for single-host topologies: v5e, v6e
+TPU_8_CHIPS_PER_HOST_TYPES = ("v5litepod", "v6e")
 
-# TPU v6e single host topologies
-TPU_V6E_SINGLE_HOST_TOPOLOGIES = ("1x1", "2x2", "2x4")
-
-# TPU v6e single host types
-TPU_V6E_SINGLE_HOST_TYPES = ("v6e-1", "v6e-4", "v6e-8")
+# Topologies that are always sub-host or single-host
+TPU_SINGLE_HOST_TOPOLOGIES = ("1x1", "2x2", "2x4")
 
 # Accelerators that are 2 cores per chip: v2, v3, v4, v5p, v7x
 # Accelerators that are 1 core per chip: v5e, v6e
@@ -152,14 +148,33 @@ def _accelerator_type_check(accelerator_type: str):
         )
 
 
+def get_total_chips_from_accelerator_type(accelerator_type: str) -> int:
+    """Calculates total chips from a GCP accelerator ("pod") type string (e.g. "v6e-16")."""
+    _accelerator_type_check(accelerator_type)
+
+    parts = accelerator_type.split("-")
+    if len(parts) < 2:
+        raise ValueError(
+            f"Accelerator type must include size (e.g. 'v6e-8'), got: {accelerator_type}"
+        )
+
+    num_cores = int(parts[1])
+    cores_per_chip = get_tpu_cores_per_chip(accelerator_type)
+
+    return num_cores // cores_per_chip
+
+
 def get_num_tpu_visible_chips_per_host(accelerator_type: str) -> int:
     _accelerator_type_check(accelerator_type)
-    if (
-        accelerator_type.startswith(SINGLE_HOST_8_CHIPS_TPU_TYPE)
-        or accelerator_type in TPU_V6E_SINGLE_HOST_TYPES
-    ):
-        return 8
 
+    if accelerator_type.startswith(TPU_8_CHIPS_PER_HOST_TYPES):
+        total_chips = get_total_chips_from_accelerator_type(accelerator_type)
+
+        # Sub/single-host topologies return their exact chip count
+        if total_chips <= 8:
+            return total_chips
+
+    # Multi-host topologies default to 4 visible chips per host
     return DEFAULT_TPU_NUM_CHIPS_PER_HOST
 
 
@@ -218,30 +233,28 @@ def fetch_tpu_slice_name_from_pg(pg):
 def get_chips_per_host(topology: str, accelerator_version: str) -> int:
     """Get the number of chips per host based on topology and accelerator version.
 
-    The current rule is as follows:
-        Default chips per host is 4.
-        If accelerator_version is v5e or v6e:
-            If topology total chips < 8, return total chips (partial host).
-            Otherwise return 8.
-        If accelerator_version is v5p or other versions, the chips per host will be 4
+    Rules for determining the default number of chips per host:
+        - Default for most TPU generations (v4, v5p, v7x, etc.) is 4 chips per host.
+        - For v5e and v6e:
+            - Topologies with <= 8 chips use the exact chip count (e.g. 1x1 -> 1).
+              These topologies are always sub or single-host.
+            - Multi-host topologies (> 8 chips) default to 4-chip hosts.
 
     Args:
-        topology: The TPU topology string (e.g. "2x2x2").
-        accelerator_version: The accelerator version of the node (e.g. "V4", "v4").
+        topology: The TPU topology string (e.g. "2x2x2", "2x4").
+        accelerator_version: The accelerator version string (e.g. "v4", "v6e").
 
     Returns:
-        A int representing the number of chips per host
+        The default number of chips per host for the given configuration.
     """
     total_chips = get_num_chips_from_topology(topology)
 
-    # Check for 8-chip host types, v5litepod or v6e (1x1, 2x2, 2x4 only)
-    if accelerator_version.strip().lower() == SINGLE_HOST_8_CHIPS_TPU_TYPE or (
-        accelerator_version.strip().lower() == "v6e"
-        and topology.strip().lower() in TPU_V6E_SINGLE_HOST_TOPOLOGIES
+    # Check for 8-chip host types (v5litepod, v6e) for single host setups
+    if (
+        accelerator_version.strip().lower() in TPU_8_CHIPS_PER_HOST_TYPES
+        and topology.strip().lower() in TPU_SINGLE_HOST_TOPOLOGIES
     ):
-        if total_chips < 8:
-            return total_chips
-        return 8
+        return total_chips
 
     return DEFAULT_TPU_NUM_CHIPS_PER_HOST
 

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -283,5 +283,46 @@ def test_is_valid_tpu_accelerator_type(accelerator_type, expected):
     )
 
 
+def test_get_total_chips_from_accelerator_type():
+    assert tpu.get_total_chips_from_accelerator_type("v6e-16") == 16
+    assert tpu.get_total_chips_from_accelerator_type("v6e-8") == 8
+    assert (
+        tpu.get_total_chips_from_accelerator_type("v7x-16") == 8
+    )  # v7x has 2 cores per chip
+    assert (
+        tpu.get_total_chips_from_accelerator_type("v4-8") == 4
+    )  # v4 has 2 cores per chip
+
+    # Test invalid cases
+    with pytest.raises(ValueError, match="Accelerator type must include size"):
+        tpu.get_total_chips_from_accelerator_type("v6e")
+
+    with pytest.raises(ValueError, match="Invalid accelerator type"):
+        tpu.get_total_chips_from_accelerator_type("invalid-8")
+
+
+def test_get_num_tpu_visible_chips_per_host():
+    # v6e multi-host (4 chips per VM)
+    assert tpu.get_num_tpu_visible_chips_per_host("v6e-16") == 4
+    assert tpu.get_num_tpu_visible_chips_per_host("v6e-32") == 4
+
+    # v6e single-host/sub-host (exact chip count)
+    assert tpu.get_num_tpu_visible_chips_per_host("v6e-8") == 8
+    assert tpu.get_num_tpu_visible_chips_per_host("v6e-4") == 4
+    assert tpu.get_num_tpu_visible_chips_per_host("v6e-1") == 1
+
+    # v5litepod multi-host defaults to 4, single-host is 8 chips
+    assert tpu.get_num_tpu_visible_chips_per_host("v5litepod-16") == 4
+    assert tpu.get_num_tpu_visible_chips_per_host("v5litepod-8") == 8
+
+    # v5litepod sub-host
+    assert tpu.get_num_tpu_visible_chips_per_host("v5litepod-4") == 4
+    assert tpu.get_num_tpu_visible_chips_per_host("v5litepod-1") == 1
+
+    # Other TPU generations default to 4
+    assert tpu.get_num_tpu_visible_chips_per_host("v4-8") == 4
+    assert tpu.get_num_tpu_visible_chips_per_host("v5p-8") == 4
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_tpu.py
+++ b/python/ray/tests/test_tpu.py
@@ -250,6 +250,41 @@ def ray_tpu_cluster(ray_start_cluster):
     ray.shutdown()
 
 
+@pytest.fixture
+def ray_v6e_tpu_cluster(ray_start_cluster):
+    """
+    Simulates a Ray cluster with two v6e-8 slices (2x4 topology).
+
+    """
+    pod_type = "v6e-8"
+    topology = "2x4"
+    cluster = ray_start_cluster
+
+    for i in range(2):
+        env_common = {
+            "TPU_NAME": f"test-v6e-slice-{i}",
+            "TPU_ACCELERATOR_TYPE": pod_type,
+            "TPU_TOPOLOGY": topology,
+        }
+        head_labels = {
+            "ray.io/tpu-slice-name": f"test-v6e-slice-{i}",
+            "ray.io/tpu-worker-id": "0",
+            "ray.io/tpu-pod-type": pod_type,
+            "ray.io/tpu-topology": topology,
+        }
+        # A single-host v6e-8 has 8 chips on one node
+        cluster.add_node(
+            num_cpus=4,
+            resources={"TPU": 8, f"TPU-{pod_type}-head": 1},
+            env_vars={**env_common, "TPU_WORKER_ID": "0"},
+            labels=head_labels,
+        )
+
+    ray.init(address=cluster.address)
+    yield cluster
+    ray.shutdown()
+
+
 def test_fetch_tpu_slice_name_from_pg(ray_tpu_cluster):
     """Tests that the slice name can be fetched from a PG."""
     tpu_head_pg = ray.util.placement_group(bundles=[{"TPU-v4-16-head": 1}])
@@ -764,6 +799,44 @@ def test_get_tpu_nodes_for_slice(mock_nodes_call, mock_is_initialized):
 def test_get_tpu_nodes_for_slice_uninitialized(mock_is_initialized):
     """Test that the utility gracefully handles an uninitialized Ray context."""
     assert ray.util.tpu.get_tpu_nodes_for_slice("slice-A") == []
+
+
+def test_get_tpu_worker_resources_chips_per_vm_override():
+    """Test that chips_per_vm correctly overrides the default resource calculations."""
+
+    # Default behavior: v6e 2x4 defaults to a single 8-chip host
+    num_workers, resources = ray.util.tpu.get_tpu_worker_resources(
+        topology="2x4", accelerator_type="v6e"
+    )
+    assert num_workers == 1
+    assert resources["TPU"] == 8
+
+    # Override behavior: v6e 2x4 forced to 4 chips per VM (2 hosts)
+    num_workers_override, resources_override = ray.util.tpu.get_tpu_worker_resources(
+        topology="2x4", accelerator_type="v6e", chips_per_vm=4
+    )
+    assert num_workers_override == 2
+    assert resources_override["TPU"] == 4
+
+
+def test_slice_placement_group_chips_per_vm_override(ray_v6e_tpu_cluster):
+    """Test that SlicePlacementGroup respects chips_per_vm for host calculation."""
+
+    # Default behavior (1 VM with 8 chips)
+    default_pg = SlicePlacementGroup(topology="2x4", accelerator_version="v6e")
+    assert default_pg.chips_per_host == 8
+    assert default_pg.num_hosts == 1
+    assert default_pg.num_bundles == 1
+    assert default_pg.bundle_resources["TPU"] == 8
+
+    # User-specified override behavior (2 VMs with 4 chips each)
+    override_pg = SlicePlacementGroup(
+        topology="2x4", accelerator_version="v6e", chips_per_vm=4
+    )
+    assert override_pg.chips_per_host == 4
+    assert override_pg.num_hosts == 2
+    assert override_pg.num_bundles == 2
+    assert override_pg.bundle_resources["TPU"] == 4
 
 
 if __name__ == "__main__":

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -668,7 +668,7 @@ def slice_placement_group(
             a topology, with the bundle resources set to the number of TPU in a host.
             Ex: Specifying {"TPU": 1} for a 4x4 topology would result in 16 bundles, each with 1 TPU.
             If resources_per_bundle=None for the same topology, there would be 4 bundles with 4 TPU each.
-        num_slices: The number of tpu slices within the placement group
+        num_slices: The number of tpu slices within the placement group.
         chips_per_vm: An optional override for the number of chips per TPU VM.
             Useful for ambiguous topologies like v6e 2x4 which have 1 host, but can be provisioned
             as either 1 VM (8 chips) or 2 VMs (4 chips each).

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -136,6 +136,7 @@ def get_tpu_worker_resources(
     accelerator_type: str,
     resources_per_unit: Optional[Dict[str, float]] = None,
     num_slices: int = 1,
+    chips_per_vm: Optional[int] = None,
 ) -> Tuple[int, Dict[str, float]]:
     """
     Calculates the number of workers and the resources required for each worker
@@ -147,6 +148,9 @@ def get_tpu_worker_resources(
         resources_per_unit: Optional manual override for resources per unit. If
             unspecified, the number of TPU chips in a host is assumed.
         num_slices: The number of TPU slices.
+        chips_per_vm: An optional override for the number of chips per VM.
+            If unspecified, this is inferred automatically from the topology
+            and accelerator type.
 
     Returns:
         A tuple containing:
@@ -155,7 +159,9 @@ def get_tpu_worker_resources(
     """
     accelerator_version = get_tpu_version_from_type(accelerator_type)
 
-    chips_per_host = get_chips_per_host(topology, accelerator_version)
+    resolved_chips_per_vm = chips_per_vm or get_chips_per_host(
+        topology, accelerator_version
+    )
     total_chips_per_slice = get_num_chips_from_topology(topology)
 
     total_chips_available = total_chips_per_slice * num_slices
@@ -168,7 +174,7 @@ def get_tpu_worker_resources(
 
     # If user didn't specify TPU, default to # of chips on 1 host.
     if "TPU" not in final_resources:
-        final_resources["TPU"] = chips_per_host
+        final_resources["TPU"] = resolved_chips_per_vm
 
     tpus_per_unit = final_resources["TPU"]
 
@@ -433,6 +439,9 @@ class SlicePlacementGroup:
                 will live as a global object independent of the creator.
 
             num_slices: Number of TPU slices in the SlicePlacementGroup. Defaults to 1 when unspecified.
+            chips_per_vm: An optional override for the number of chips per VM. Useful for resolving
+                ambiguous topologies (e.g. v6e 2x4) where the slice could physically consist of
+                a single 8-chip VM or two 4-chip VMs.
 
         Examples:
 
@@ -473,6 +482,7 @@ class SlicePlacementGroup:
         lifetime: Optional[str] = None,
         # default
         num_slices: int = 1,
+        chips_per_vm: Optional[int] = None,
     ):
         self._topology = topology.strip().lower()
         self._accelerator_version = get_tpu_version_from_type(
@@ -487,12 +497,15 @@ class SlicePlacementGroup:
             accelerator_type=self._accelerator_version,
             resources_per_unit=resources_per_bundle,
             num_slices=self._num_slices,
+            chips_per_vm=chips_per_vm,
         )
 
-        self._chips_per_host = get_chips_per_host(
+        self._chips_per_host = chips_per_vm or get_chips_per_host(
             self._topology, self._accelerator_version
         )
 
+        # Within Ray, a "host" corresponds to a user-visible compute VM.
+        # This may differ from the physical hardware host definitions in GCP/GKE docs.
         total_chips = get_num_chips_from_topology(self._topology)
         hosts_per_slice = max(1, total_chips // self._chips_per_host)
         self._num_hosts = hosts_per_slice * self._num_slices
@@ -639,6 +652,7 @@ def slice_placement_group(
     accelerator_version: str,
     resources_per_bundle: Optional[Dict[str, float]] = None,
     num_slices: int = 1,
+    chips_per_vm: Optional[int] = None,
     **kwargs,
 ) -> SlicePlacementGroup:
     """Asynchronously creates a PlacementGroup for a TPU slice.
@@ -655,6 +669,9 @@ def slice_placement_group(
             Ex: Specifying {"TPU": 1} for a 4x4 topology would result in 16 bundles, each with 1 TPU.
             If resources_per_bundle=None for the same topology, there would be 4 bundles with 4 TPU each.
         num_slices: The number of tpu slices within the placement group
+        chips_per_vm: An optional override for the number of chips per TPU VM.
+            Useful for ambiguous topologies like v6e 2x4 which have 1 host, but can be provisioned
+            as either 1 VM (8 chips) or 2 VMs (4 chips each).
         **kwargs: Additional arguments for the placement group, such as 'name', 'lifetime', or 'strategy'.
 
     Returns:
@@ -666,5 +683,6 @@ def slice_placement_group(
         accelerator_version=accelerator_version,
         resources_per_bundle=resources_per_bundle,
         num_slices=num_slices,
+        chips_per_vm=chips_per_vm,
         **kwargs,
     )

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -421,54 +421,53 @@ class SlicePlacementGroup:
     - Pod type: The TPU accelerator version and the number of chips in a topology. (e.g. v6e-128, v5p-8).
     - Accelerator topology: The physical topology representing the structure (e.g. 2x2x2, 16x16).
 
-        Args:
-            topology: The TPU topology string (e.g. "2x2x2").
-            accelerator_version: The TPU accelerator generation (e.g. "v6e", "v5p", "v4").
-            resources_per_bundle: Optionally specify the resources to include in every worker bundle.
-            strategy: PlacementGroup parameter. The strategy to create the placement group. Currently default to "SPREAD"
+    Args:
+        topology: The TPU topology string (e.g. "2x2x2").
+        accelerator_version: The TPU accelerator generation (e.g. "v6e", "v5p", "v4").
+        resources_per_bundle: Optionally specify the resources to include in every worker bundle.
+        strategy: PlacementGroup parameter. The strategy to create the placement group. Currently default to "SPREAD"
 
-             - "PACK": Packs Bundles into as few nodes as possible.
-             - "SPREAD": Places Bundles across distinct nodes as even as possible.
-             - "STRICT_PACK": Packs Bundles into one node. The group is
-               not allowed to span multiple nodes.
-             - "STRICT_SPREAD": Packs Bundles across distinct nodes.
+            - "PACK": Packs Bundles into as few nodes as possible.
+            - "SPREAD": Places Bundles across distinct nodes as even as possible.
+            - "STRICT_PACK": Packs Bundles into one node. The group is
+              not allowed to span multiple nodes.
+            - "STRICT_SPREAD": Packs Bundles across distinct nodes.
 
-            lifetime: PlacementGroup parameter. Either `None`, which defaults to the placement group
-                will fate share with its creator and will be deleted once its
-                creator is dead, or "detached", which means the placement group
-                will live as a global object independent of the creator.
+        name: PlacementGroup parameter. The name of the placement group.
+        lifetime: PlacementGroup parameter. Either `None`, which defaults to the placement group
+            will fate share with its creator and will be deleted once its
+            creator is dead, or "detached", which means the placement group
+            will live as a global object independent of the creator.
+        num_slices: Number of TPU slices in the SlicePlacementGroup. Defaults to 1 when unspecified.
+        chips_per_vm: An optional override for the number of chips per VM. Useful for resolving
+            ambiguous topologies (e.g. v6e 2x4) where the slice could physically consist of
+            a single 8-chip VM or two 4-chip VMs.
 
-            num_slices: Number of TPU slices in the SlicePlacementGroup. Defaults to 1 when unspecified.
-            chips_per_vm: An optional override for the number of chips per VM. Useful for resolving
-                ambiguous topologies (e.g. v6e 2x4) where the slice could physically consist of
-                a single 8-chip VM or two 4-chip VMs.
+    Examples:
 
-        Examples:
+    .. testcode:: python
+        :skipif: True
 
-        .. testcode:: python
-            :skipif: True
+        import ray
+        from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+        from ray.util.tpu import SlicePlacementGroup
 
-            import ray
-            from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-            from ray.util.tpu import SlicePlacementGroup
+        slice_handle = SlicePlacementGroup(topology="4x4", accelerator_version="v6e")
+        slice_pg = slice_handle.placement_group
+        ray.get(slice_pg.ready(), timeout=10)
 
-            slice_handle = SlicePlacementGroup(topology="4x4", accelerator_version="v6e")
-            slice_pg = slice_handle.placement_group
-            ray.get(slice_pg.ready(), timeout=10)
+        @ray.remote(num_cpus=0, resources={'TPU': 4})
+        def spmd_task(world, rank):
+            print(f"Current TPU is rank {rank} of {world}")
 
-            @ray.remote(num_cpus=0, resources={'TPU': 4})
-            def spmd_task(world, rank):
-                print(f"Current TPU is rank {rank} of {world}")
-
-            tasks = [
-                spmd_task.options(
-                    scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=slice_pg,
-                    )
-                ).remote(world=4, rank=i)
-                for i in range(slice_handle.num_hosts)
-            ]
-
+        tasks = [
+            spmd_task.options(
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=slice_pg,
+                )
+            ).remote(world=4, rank=i)
+            for i in range(slice_handle.num_hosts)
+        ]
     """
 
     def __init__(


### PR DESCRIPTION
## Description
Follow up to https://github.com/ray-project/ray/pull/62306 per the discussion [here](https://github.com/ray-project/ray/pull/62306#discussion_r3030550978).

This change introduces a `chips_per_vm` override parameter to resolve ambiguity in  TPU slice shapes (like v6e 2x4) where a topology can be provisioned as either a single 8-chip VM or multiple 4-chip VMs. This is an edge case for [v6e TPU topologies](https://docs.cloud.google.com/tpu/docs/v6e#configurations), but it would be useful to add an optional parameter to support it so that users can request their desired topology without mismatches in the number of bundles created by the `SlicePlacementGroup`.

What we changed
- Adjusted `get_chips_per_host` defaults to align with both v6e and v5e machine types. If # of chips is <= 8 with a sub or single-host topology, we should always just return the chip count. For chips > 8, these are multi-host configurations which are always 4 chips per host/VM.
- Added a `chips_per_vm` parameter to `SlicePlacementGroup`.  If provided, `chips_per_vm` is used to calculate the number of bundles to provision for the PG. Otherwise, we default to the expected number of hosts based on the topology.

## Related issues


## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
