### PR TITLE
[Serve] Reject unknown fields in AutoscalingConfig

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -551,6 +551,8 @@ class AutoscalingPolicy(BaseModel):
 class AutoscalingConfig(BaseModel):
     """Config for the Serve Autoscaler."""
 
+    model_config = ConfigDict(extra="forbid")
+
     # Please keep these options in sync with those in
     # `src/ray/protobuf/serve.proto`.
 

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -385,6 +385,19 @@ class TestDeploymentSchema:
         }
         DeploymentSchema.model_validate(deployment_options)
 
+    def test_autoscaling_config_rejects_extra_fields(self):
+        """Misplaced deployment-level options inside autoscaling_config should
+        raise a validation error instead of being silently ignored."""
+        deployment_schema = self.get_minimal_deployment_schema()
+        deployment_schema["num_replicas"] = None
+        deployment_schema["autoscaling_config"] = {
+            "min_replicas": 1,
+            "max_replicas": 5,
+            "max_ongoing_requests": 10,  # Wrong: belongs at deployment level
+        }
+        with pytest.raises(ValidationError, match="max_ongoing_requests"):
+            DeploymentSchema.model_validate(deployment_schema)
+
     def test_route_prefix_nullable(self):
         deployment_options = {"name": "test", "route_prefix": None}
         DeploymentSchema.model_validate(deployment_options)


### PR DESCRIPTION
## Why are these changes needed?

`AutoscalingConfig` silently accepts and ignores unknown fields. This causes confusing behavior when users accidentally place deployment-level options (e.g. `max_ongoing_requests`) inside `autoscaling_config` in their YAML configs — the option is silently dropped and the default value is used instead, with no indication anything is wrong.

For example, this config silently ignores `max_ongoing_requests` and uses the default (5):

```yaml
deployments:
  - name: MyDeployment
    autoscaling_config:
      max_ongoing_requests: 10   # silently ignored
      target_ongoing_requests: 5
      min_replicas: 10
      max_replicas: 100
```

The correct config should have `max_ongoing_requests` at the deployment level:

```yaml
deployments:
  - name: MyDeployment
    max_ongoing_requests: 10     # correct
    autoscaling_config:
      target_ongoing_requests: 5
      min_replicas: 10
      max_replicas: 100
```

## Changes

- Add `model_config = ConfigDict(extra="forbid")` to `AutoscalingConfig`, consistent with `LoggingConfig` and `DeploymentDetails` which already use this pattern.
- Add a unit test verifying that misplaced fields raise a `ValidationError`.

Note: In `DeploymentSchema`, `autoscaling_config` is typed as `Union[Dict, AutoscalingConfig]`, so the dict form still passes through the schema layer. However, the validation fires when `DeploymentConfig` is constructed (which types `autoscaling_config` as `Optional[AutoscalingConfig]`), and also when `AutoscalingConfig(...)` is called directly in `_apply_deployment_overrides`.

## Related issue

Closes #61439

## Checks

- [x] Lint and type checks pass locally
- [x] Unit test added
- [x] Existing tests unaffected — `test_serve_instance_details_is_json_serializable` passes `_serialized_policy_def` via `DeploymentSchema`'s `Union[Dict, ...]` path, which matches `Dict` first and bypasses `AutoscalingConfig` validation