### PR TITLE
[Data] Deprecate DataIterator.to_torch

### DIFF
--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -36,7 +36,7 @@ from ray.data.collate_fn import (
     is_tensor_batch_type,
 )
 from ray.data.context import DataContext
-from ray.util.annotations import PublicAPI, RayDeprecationWarning
+from ray.util.annotations import Deprecated, PublicAPI, RayDeprecationWarning
 
 if TYPE_CHECKING:
     import tensorflow as tf
@@ -616,6 +616,7 @@ class DataIterator(abc.ABC):
 
         return mapped_iterable
 
+    @Deprecated
     def to_torch(
         self,
         *,
@@ -724,6 +725,11 @@ class DataIterator(abc.ABC):
         Returns:
             A torch IterableDataset.
         """
+        warnings.warn(
+            "`DataIterator.to_torch` is deprecated and will be removed after "
+            "October 2026. Use `DataIterator.iter_torch_batches` instead.",
+            DeprecationWarning,
+        )
         import torch
 
         from ray.data._internal.torch_iterable_dataset import TorchIterableDataset

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -728,7 +728,8 @@ class DataIterator(abc.ABC):
         warnings.warn(
             "`DataIterator.to_torch` is deprecated and will be removed after "
             "October 2026. Use `DataIterator.iter_torch_batches` instead.",
-            DeprecationWarning,
+            RayDeprecationWarning,
+            stacklevel=2,
         )
         import torch
 

--- a/python/ray/data/tests/test_iterator.py
+++ b/python/ray/data/tests/test_iterator.py
@@ -290,6 +290,11 @@ def test_torch_conversion_default_collate_fn_threading(
                 assert torch.equal(t1, t2)
 
 
+def test_to_torch_emits_deprecation_warning(ray_start_regular_shared):
+    with pytest.warns(DeprecationWarning):
+        ray.data.range(1).iterator().to_torch()
+
+
 @pytest.mark.parametrize("should_equalize", [True, False])
 def test_iterator_to_materialized_dataset(ray_start_regular_shared, should_equalize):
     """Tests that `DataIterator.materialize` fully consumes the


### PR DESCRIPTION
## Description

PR #48692 deprecated `Dataset.to_torch` but missed deprecating `DataIterator.to_torch`. This adds a `@Deprecated` decorator and `DeprecationWarning` to `DataIterator.to_torch`, directing users to use `DataIterator.iter_torch_batches` instead.

## Related issues

Follow-up to #48692.

## Additional information

Changes:
- Added `@Deprecated` decorator and `warnings.warn` to `DataIterator.to_torch` in `iterator.py`
- Added `test_to_torch_emits_deprecation_warning` test in `test_iterator.py`