### PR TITLE
[serve] Fix race condition in multiplex LRU cache update using move_to_end()

### DIFF
--- a/python/ray/serve/multiplex.py
+++ b/python/ray/serve/multiplex.py
@@ -184,9 +184,11 @@ class _ModelMultiplexWrapper:
         self.get_model_requests_counter.inc()
 
         if model_id in self.models:
-            # Move the model to the end of the OrderedDict to ensure LRU caching.
-            model = self.models.pop(model_id)
-            self.models[model_id] = model
+            # Move the model to the end of the OrderedDict to mark it as
+            # most-recently-used. Using move_to_end() instead of pop()+reinsert
+            # avoids a race condition where concurrent coroutines could see the
+            # key as missing during the brief window between pop and reinsert.
+            self.models.move_to_end(model_id)
             return self.models[model_id]
         else:
             # Set the flag to push the multiplexed replica info to the controller


### PR DESCRIPTION
## Why are these changes needed?

Fixes a race condition in the multiplexed model LRU cache update logic.

Fixes #59837

## Problem

In `_ModelMultiplexWrapper.load_model()`, the LRU update for cached models used `pop()` followed by reinsert:

```python
model = self.models.pop(model_id)    # key temporarily removed
self.models[model_id] = model        # key reinserted
```

Under concurrent async execution (multiple coroutines handling requests simultaneously), another coroutine could check `model_id in self.models` during the brief window between `pop()` and reinsert, find the key missing, and proceed to the model loading path — triggering an unnecessary duplicate model load.

## Fix

Replace `pop()` + reinsert with `OrderedDict.move_to_end()`:

```python
self.models.move_to_end(model_id)
```

`move_to_end()` is atomic — it moves the key to the end of the OrderedDict without ever removing it from the dict, eliminating the race window entirely.

This is also simpler (1 line vs 3) and more idiomatic.

## Checks

- [x] One-line change, no behavioral difference in the non-concurrent case
- [x] `move_to_end()` is a built-in `OrderedDict` method available in all supported Python versions
- [x] No new dependencies