### PR TITLE
[serve][llm] Add timeout to initialize_node() to prevent indefinite hang on model download

### DIFF
--- a/python/ray/llm/_internal/serve/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/utils/node_initialization_utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import Optional
 
 import ray
@@ -17,7 +18,10 @@ logger = get_logger(__name__)
 # Timeout for model file downloads on worker nodes. If downloads hang
 # (e.g., due to resource contention or scheduling issues), initialization
 # will fail with a clear error instead of hanging indefinitely.
-NODE_INITIALIZATION_TIMEOUT_S = 1800  # 30 minutes
+# Configurable via the RAY_LLM_NODE_INITIALIZATION_TIMEOUT_S environment variable.
+NODE_INITIALIZATION_TIMEOUT_S = int(
+    os.getenv("RAY_LLM_NODE_INITIALIZATION_TIMEOUT_S", "1800")
+)
 
 
 def initialize_remote_node(llm_config: LLMConfig) -> Optional[str]:
@@ -82,8 +86,8 @@ async def initialize_node(llm_config: LLMConfig):
             f"cannot schedule the download task due to resource contention "
             f"(e.g., insufficient CPU resources on the node after placement group "
             f"allocation). Check `ray status` to verify available resources on each "
-            f"node. You can also increase the timeout by setting "
-            f"NODE_INITIALIZATION_TIMEOUT_S in node_initialization_utils.py."
+            f"node. You can also increase the timeout by setting the "
+            f"RAY_LLM_NODE_INITIALIZATION_TIMEOUT_S environment variable."
         )
 
     # assume that all paths are the same

--- a/python/ray/llm/_internal/serve/utils/node_initialization_utils.py
+++ b/python/ray/llm/_internal/serve/utils/node_initialization_utils.py
@@ -14,6 +14,11 @@ transformers = try_import("transformers")
 
 logger = get_logger(__name__)
 
+# Timeout for model file downloads on worker nodes. If downloads hang
+# (e.g., due to resource contention or scheduling issues), initialization
+# will fail with a clear error instead of hanging indefinitely.
+NODE_INITIALIZATION_TIMEOUT_S = 1800  # 30 minutes
+
 
 def initialize_remote_node(llm_config: LLMConfig) -> Optional[str]:
 
@@ -63,9 +68,23 @@ async def initialize_node(llm_config: LLMConfig):
         )
 
     logger.info("Running tasks to download model files on worker nodes")
-    paths = await asyncio.gather(
-        *[download_task.remote(llm_config) for download_task in download_tasks]
-    )
+    try:
+        paths = await asyncio.wait_for(
+            asyncio.gather(
+                *[download_task.remote(llm_config) for download_task in download_tasks]
+            ),
+            timeout=NODE_INITIALIZATION_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        raise RuntimeError(
+            f"Model file download on worker nodes timed out after "
+            f"{NODE_INITIALIZATION_TIMEOUT_S}s. This can happen when worker nodes "
+            f"cannot schedule the download task due to resource contention "
+            f"(e.g., insufficient CPU resources on the node after placement group "
+            f"allocation). Check `ray status` to verify available resources on each "
+            f"node. You can also increase the timeout by setting "
+            f"NODE_INITIALIZATION_TIMEOUT_S in node_initialization_utils.py."
+        )
 
     # assume that all paths are the same
     assert paths, "No paths returned from download_model_files"


### PR DESCRIPTION
## Why are these changes needed?

`initialize_node()` can hang indefinitely when model download tasks cannot be scheduled on worker nodes. This happens when there aren't enough CPU resources available after placement group allocation — the download task waits forever for a `RequestWorkerLease` that never completes.

Fixes #59764

## Root Cause (from issue analysis)

The issue had three problems:
1. ~~`num_cpus=1` competing with placement group for CPU~~ → **Already fixed on master** (`num_cpus=0`)
2. ~~`soft=False` waiting indefinitely~~ → Less critical now that `num_cpus=0`
3. **No timeout on `asyncio.gather()`** → **This PR fixes this**

## What changed

Added `asyncio.wait_for()` with a 30-minute timeout around the `asyncio.gather()` call in `initialize_node()`. If the download tasks hang for any reason (resource contention, scheduling issues, network problems), initialization now fails with a clear `RuntimeError` instead of hanging forever.

**Before:**
```
08:01:45,883 INFO Running tasks to download model files on worker nodes
← Hangs here forever, no further logs
```

**After:**
```
08:01:45,883 INFO Running tasks to download model files on worker nodes
RuntimeError: Model file download on worker nodes timed out after 1800s.
This can happen when worker nodes cannot schedule the download task due to
resource contention (e.g., insufficient CPU resources on the node after
placement group allocation). Check `ray status` to verify available
resources on each node.
```

## Design decisions

- **30-minute timeout**: Model downloads for large LLMs (70B+) can legitimately take 20+ minutes on slow networks. 30 minutes is generous enough for real downloads while still catching hangs.
- **Clear error message**: Includes diagnostic guidance (check `ray status`) so users can self-diagnose.
- **Safety net, not primary fix**: The `num_cpus=0` fix (already on master) addresses the root cause. This timeout catches any remaining edge cases.

## Checks
- [x] Minimal change — only adds timeout wrapper around existing `asyncio.gather()`
- [x] No behavioral change for successful downloads
- [x] Error message includes actionable diagnostic steps