### PR TITLE
[serve] Refactor MockTaskProcessorAdapter to use instance attributes instead of class attributes

### DIFF
--- a/python/ray/serve/tests/unit/test_task_consumer.py
+++ b/python/ray/serve/tests/unit/test_task_consumer.py
@@ -18,11 +18,10 @@ from ray.serve.task_consumer import task_consumer, task_handler
 class MockTaskProcessorAdapter(TaskProcessorAdapter):
     """Mock adapter for testing task processor functionality."""
 
-    _start_consumer_received: bool = False
-    _stop_consumer_received: bool = False
-
     def __init__(self, config: TaskProcessorConfig):
         self._config = config
+        self._start_consumer_received: bool = False
+        self._stop_consumer_received: bool = False
         self.register_task_handle_mock = MagicMock()
 
     def initialize(self, consumer_concurrency: int = 3):


### PR DESCRIPTION
## Why are these changes needed?

`MockTaskProcessorAdapter` uses class attributes for `_start_consumer_received` and `_stop_consumer_received`. Since class attributes are shared across all instances, state from one test can leak into another, causing flaky or order-dependent test failures.

Fixes #59714

## What changed

Moved `_start_consumer_received` and `_stop_consumer_received` from class-level attributes to instance attributes initialized in `__init__`:

```python
# Before (class attributes — shared across instances):
class MockTaskProcessorAdapter(TaskProcessorAdapter):
    _start_consumer_received: bool = False
    _stop_consumer_received: bool = False

    def __init__(self, config):
        self._config = config
        self.register_task_handle_mock = MagicMock()

# After (instance attributes — isolated per instance):
class MockTaskProcessorAdapter(TaskProcessorAdapter):
    def __init__(self, config):
        self._config = config
        self._start_consumer_received: bool = False
        self._stop_consumer_received: bool = False
        self.register_task_handle_mock = MagicMock()
```

## Checks
- [x] No functional change — only moves attribute initialization
- [x] All existing tests continue to work (same assertions, same behavior)
- [x] Prevents state leakage between test instances