### PR TITLE
[core] Include `ray_gtest_main` in `ray_cc_test` targets by default

### DIFF
--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -145,8 +145,8 @@ def ray_cc_library(name, strip_include_prefix = "/src", copts = [], visibility =
     )
 
 def ray_cc_test(name, deps = [], linkopts = [], copts = [], use_ray_gtest_main = True, **kwargs):
-    # Allow skipping the default `ray_gtest_main` function for tests that need bespoke
-    # setup logic.
+    # By default, all `ray_cc_test` targets use `ray_gtest_main`.
+    # Some tests might need bespoke setup logic, so let them skip this dependency.
     if use_ray_gtest_main:
       deps = deps + ["//src/ray/common:ray_gtest_main"]
 

--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -148,7 +148,7 @@ def ray_cc_test(name, deps = [], linkopts = [], copts = [], use_ray_gtest_main =
     # Allow skipping the default `ray_gtest_main` function for tests that need bespoke
     # setup logic.
     if use_ray_gtest_main:
-      deps.append("//src/ray/common:ray_gtest_main")
+      deps = deps + ["//src/ray/common:ray_gtest_main"]
 
     cc_test(
         name = name,

--- a/bazel/ray.bzl
+++ b/bazel/ray.bzl
@@ -144,9 +144,15 @@ def ray_cc_library(name, strip_include_prefix = "/src", copts = [], visibility =
         **kwargs
     )
 
-def ray_cc_test(name, linkopts = [], copts = [], **kwargs):
+def ray_cc_test(name, deps = [], linkopts = [], copts = [], use_ray_gtest_main = True, **kwargs):
+    # Allow skipping the default `ray_gtest_main` function for tests that need bespoke
+    # setup logic.
+    if use_ray_gtest_main:
+      deps.append("//src/ray/common:ray_gtest_main")
+
     cc_test(
         name = name,
+        deps = deps,
         copts = COPTS_TESTS + copts,
         linkopts = linkopts + ["-pie"],
         **kwargs

--- a/src/ray/.cursor/BUGBOT.md
+++ b/src/ray/.cursor/BUGBOT.md
@@ -34,3 +34,11 @@
 > - https://github.com/ray-project/ray/pull/56474
 > - https://github.com/ray-project/ray/pull/59610
 > - https://github.com/ray-project/ray/pull/52622
+
+## Rule: Use ray_gtest_main for ray_cc_test targets
+- Look at any changes in ray_cc_test targets in BUILD.bazel files.
+- If the ray_cc_test target contains gtest or gtest_main as dependencies, post the following message:
+
+> ⚠️ `gtest` and `gtest_main` are included by default as part of `ray_gtest_main` in `ray_cc_test` targets.
+>
+> Only include these targets if you need to override the default logic in `ray_gtest_main`. To do so, set `use_ray_gtest_main = False` in the `ray_cc_test` target.

--- a/src/ray/.cursor/BUGBOT.md
+++ b/src/ray/.cursor/BUGBOT.md
@@ -36,9 +36,9 @@
 > - https://github.com/ray-project/ray/pull/52622
 
 ## Rule: Use ray_gtest_main for ray_cc_test targets
-- Look at any changes in ray_cc_test targets in BUILD.bazel files.
+- Look at changes to ray_cc_test targets in BUILD.bazel files.
 - If the ray_cc_test target contains gtest or gtest_main as dependencies, post the following message:
 
 > ⚠️ `gtest` and `gtest_main` are included by default as part of `ray_gtest_main` in `ray_cc_test` targets.
 >
-> Only include these targets if you need to override the default logic in `ray_gtest_main`. To do so, set `use_ray_gtest_main = False` in the `ray_cc_test` target.
+> Only include these targets if you need to override the default logic in `ray_gtest_main`. To do so, set `use_ray_gtest_main = False` in the `ray_cc_test` target. You probably don't need to do this.

--- a/src/ray/common/BUILD.bazel
+++ b/src/ray/common/BUILD.bazel
@@ -1,5 +1,11 @@
 load("//bazel:ray.bzl", "ray_cc_library")
 
+# Default main function that configures the Ray logger and sets up failure signal
+# handling to aid with debugging.
+#
+# Included by default in ray_cc_test (see bazel/ray.bzl for ray_cc_test definition).
+# To use a custom main function instead (like `gtest_main`), set
+# `use_ray_gtest_main = False` in the `ray_cc_test` target.
 ray_cc_library(
     name = "ray_gtest_main",
     testonly = True,

--- a/src/ray/common/cgroup2/integration_tests/BUILD.bazel
+++ b/src/ray/common/cgroup2/integration_tests/BUILD.bazel
@@ -14,7 +14,6 @@ ray_cc_test(
         "@platforms//os:linux",
     ],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status",
         "//src/ray/common:status_or",
         "//src/ray/common/cgroup2:cgroup_test_utils",

--- a/src/ray/common/cgroup2/tests/BUILD.bazel
+++ b/src/ray/common/cgroup2/tests/BUILD.bazel
@@ -11,7 +11,6 @@ ray_cc_test(
         "@platforms//os:linux",
     ],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status",
         "//src/ray/common:status_or",
         "//src/ray/common/cgroup2:cgroup_test_utils",
@@ -30,7 +29,6 @@ ray_cc_test(
         "team:core",
     ],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status",
         "//src/ray/common:status_or",
         "//src/ray/common/cgroup2:cgroup_driver_interface",

--- a/src/ray/common/scheduling/tests/BUILD.bazel
+++ b/src/ray/common/scheduling/tests/BUILD.bazel
@@ -8,7 +8,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/scheduling:cluster_resource_data",
     ],
 )
@@ -21,7 +20,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/scheduling:resource_set",
     ],
 )
@@ -34,7 +32,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/scheduling:resource_instance_set",
     ],
 )
@@ -48,7 +45,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:ray_config",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/scheduling:scheduling_ids",
     ],
 )
@@ -61,7 +57,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/scheduling:label_selector",
     ],
 )
@@ -74,7 +69,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/scheduling:fallback_strategy",
     ],
 )

--- a/src/ray/common/tests/BUILD.bazel
+++ b/src/ray/common/tests/BUILD.bazel
@@ -7,7 +7,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
     ],
 )
 
@@ -18,7 +17,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:event_stats",
-        "//src/ray/common:ray_gtest_main",
     ],
 )
 
@@ -30,7 +28,6 @@ ray_cc_test(
     deps = [
         "//src/ray/common:grpc_util",
         "//src/ray/common:ray_config",
-        "//src/ray/common:ray_gtest_main",
     ],
 )
 
@@ -41,7 +38,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:common_cc_proto",
     ],
 )
@@ -51,7 +47,6 @@ ray_cc_test(
     srcs = ["task_spec_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common/scheduling:scheduling_class_util",
     ],
@@ -65,7 +60,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:bundle_location_index",
-        "//src/ray/common:ray_gtest_main",
     ],
 )
 
@@ -85,7 +79,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:grpc_util",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status",
         "@com_github_grpc_grpc//:grpc++",
     ],
@@ -98,7 +91,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         ":testing",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status_or",
     ],
 )
@@ -120,7 +112,6 @@ ray_cc_test(
         "//src/ray/common:id",
         "//src/ray/common:memory_monitor_test_fixture",
         "//src/ray/common:memory_monitor_utils",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/cgroup2:cgroup_test_utils",
         "//src/ray/util:process",
         "@boost//:filesystem",
@@ -144,7 +135,6 @@ ray_cc_test(
     deps = [
         "//src/ray/common:memory_monitor_interface",
         "//src/ray/common:memory_monitor_test_fixture",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:threshold_memory_monitor",
         "@boost//:thread",
     ],
@@ -165,7 +155,6 @@ ray_cc_test(
     ],
     deps = [
         "//src/ray/common:event_memory_monitor",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/cgroup2:cgroup_test_utils",
         "//src/ray/util:logging",
         "@boost//:thread",
@@ -187,7 +176,6 @@ ray_cc_test(
     ],
     deps = [
         "//src/ray/common:pressure_memory_monitor",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/cgroup2:cgroup_test_utils",
         "//src/ray/util:logging",
         "@boost//:thread",
@@ -203,7 +191,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:grpc_util",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:common_cc_proto",
     ],
 )
@@ -214,7 +201,6 @@ ray_cc_test(
     srcs = ["source_location_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:source_location",
     ],
 )

--- a/src/ray/core_worker/actor_management/tests/BUILD.bazel
+++ b/src/ray/core_worker/actor_management/tests/BUILD.bazel
@@ -7,7 +7,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker/actor_management:actor_creator",
         "//src/ray/gcs_rpc_client:gcs_client",
@@ -23,7 +22,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:reference_counter",
         "//src/ray/core_worker/actor_management:actor_manager",

--- a/src/ray/core_worker/task_execution/tests/BUILD.bazel
+++ b/src/ray/core_worker/task_execution/tests/BUILD.bazel
@@ -5,7 +5,6 @@ ray_cc_test(
     srcs = ["thread_pool_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker/task_execution:thread_pool",
     ],
 )
@@ -15,7 +14,6 @@ ray_cc_test(
     srcs = ["fiber_state_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker/task_execution:fiber",
         "//src/ray/util:logging",
     ],
@@ -27,7 +25,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker/task_execution:concurrency_group_manager",
     ],
@@ -38,7 +35,6 @@ ray_cc_test(
     srcs = ["normal_task_execution_queue_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker/task_execution:common",
         "//src/ray/core_worker/task_execution:normal_task_execution_queue",
     ],
@@ -50,7 +46,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker/task_execution:common",
         "//src/ray/core_worker/task_execution:ordered_actor_task_execution_queue",
@@ -65,7 +60,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker/task_execution:common",
         "//src/ray/core_worker/task_execution:task_receiver",

--- a/src/ray/core_worker/task_submission/tests/BUILD.bazel
+++ b/src/ray/core_worker/task_submission/tests/BUILD.bazel
@@ -7,7 +7,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker/actor_management:fake_actor_creator",
@@ -22,7 +21,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker/task_submission:out_of_order_actor_submit_queue",
     ],
 )
@@ -33,7 +31,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker:reference_counter",
         "//src/ray/core_worker/task_submission:actor_task_submitter",
         "//src/ray/pubsub:fake_publisher",
@@ -49,7 +46,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:reference_counter",
@@ -70,7 +66,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:memory_store",

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -7,7 +7,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/core_worker:core_worker_lib",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -6,7 +6,6 @@ ray_cc_test(
     srcs = ["core_worker_resubmit_queue_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker:core_worker_lib",
     ],
 )
@@ -17,7 +16,6 @@ ray_cc_test(
     srcs = ["shutdown_coordinator_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker:shutdown_coordinator",
         "@com_google_absl//absl/synchronization",
     ],
@@ -30,7 +28,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status",
         "//src/ray/common:status_or",
         "//src/ray/common:test_utils",
@@ -47,7 +44,6 @@ ray_cc_test(
     deps = [
         "//src/mock/ray/pubsub:mock_publisher",
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:ray_object",
         "//src/ray/core_worker:memory_store",
         "//src/ray/core_worker:reference_counter",
@@ -69,7 +65,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:memory_store",
         "//src/ray/core_worker:object_recovery_manager",
@@ -89,7 +84,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:memory_store",
@@ -109,7 +103,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:task_event_buffer",
@@ -131,7 +124,6 @@ ray_cc_test(
     ],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:task_event_buffer",
         "//src/ray/gcs_rpc_client:gcs_client",
@@ -148,7 +140,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:common",
         "//src/ray/core_worker:generator_waiter",
@@ -162,7 +153,6 @@ ray_cc_test(
     srcs = ["lease_policy_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker:lease_policy",
     ],
 )
@@ -184,7 +174,6 @@ ray_cc_test(
     }),
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker:experimental_mutable_object_provider",
         "//src/ray/object_manager:object_manager_common",
         "//src/ray/object_manager/plasma:plasma_client",
@@ -204,7 +193,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:fake_periodical_runner",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker:core_worker_lib",
         "//src/ray/core_worker:grpc_service",

--- a/src/ray/core_worker/tests/BUILD.bazel
+++ b/src/ray/core_worker/tests/BUILD.bazel
@@ -7,6 +7,7 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/core_worker:core_worker_lib",
+        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/ray/core_worker_rpc_client/tests/BUILD.bazel
+++ b/src/ray/core_worker_rpc_client/tests/BUILD.bazel
@@ -9,7 +9,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
     ],

--- a/src/ray/gcs/actor/tests/BUILD.bazel
+++ b/src/ray/gcs/actor/tests/BUILD.bazel
@@ -12,7 +12,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:runtime_env",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
@@ -36,7 +35,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
@@ -64,7 +62,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/gcs/actor:gcs_actor",

--- a/src/ray/gcs/postable/tests/BUILD.bazel
+++ b/src/ray/gcs/postable/tests/BUILD.bazel
@@ -6,7 +6,6 @@ ray_cc_test(
     srcs = ["postable_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs/postable",
     ],
 )
@@ -16,7 +15,6 @@ ray_cc_test(
     srcs = ["function_traits_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs/postable:function_traits",
     ],
 )

--- a/src/ray/gcs/store_client/tests/BUILD.bazel
+++ b/src/ray/gcs/store_client/tests/BUILD.bazel
@@ -25,7 +25,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         ":store_client_test_lib",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs/store_client:redis_store_client",
         "//src/ray/util:network_util",
         "//src/ray/util:path_utils",
@@ -56,7 +55,6 @@ ray_cc_test(
     ],
     deps = [
         ":store_client_test_lib",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs/store_client:redis_store_client",
         "//src/ray/util:network_util",
         "//src/ray/util:path_utils",
@@ -72,7 +70,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         ":store_client_test_lib",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs/store_client:in_memory_store_client",
     ],
 )
@@ -84,7 +81,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         ":store_client_test_lib",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs/store_client:in_memory_store_client",
         "//src/ray/gcs/store_client:observable_store_client",
         "//src/ray/observability:fake_metric",
@@ -97,7 +93,6 @@ ray_cc_test(
     srcs = ["redis_callback_reply_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs/store_client:redis_store_client",
     ],
 )
@@ -116,7 +111,6 @@ ray_cc_test(
     },
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs/store_client:redis_store_client",
         "//src/ray/util:raii",

--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -7,7 +7,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs:gcs_function_manager",
     ],
 )
@@ -20,7 +19,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//src/ray/common:fake_periodical_runner",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs:gcs_pubsub_handler",
         "//src/ray/pubsub:gcs_publisher",
         "//src/ray/pubsub:publisher",
@@ -37,7 +35,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_placement_group_manager",
         "//src/ray/observability:fake_metric",
@@ -66,7 +63,6 @@ ray_cc_test(
     ],
     visibility = ["//visibility:private"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_server_lib",
         "//src/ray/observability:fake_metric",
@@ -91,7 +87,6 @@ ray_cc_test(
     tags = ["team:core"],
     visibility = ["//visibility:private"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_kv_manager",
         "//src/ray/gcs:gcs_store_client_kv",
@@ -112,7 +107,6 @@ ray_cc_test(
     ],
     visibility = ["//visibility:private"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs:gcs_health_check_manager",
         "//src/ray/observability:fake_metric",
         "//src/ray/rpc:grpc_server",
@@ -131,7 +125,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_node_manager",
         "//src/ray/gcs/store_client:in_memory_store_client",
@@ -151,7 +144,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/gcs:gcs_job_manager",
@@ -173,7 +165,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:protobuf_utils",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_task_manager",
     ],
@@ -192,7 +183,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_placement_group_manager",
         "//src/ray/gcs/store_client:in_memory_store_client",
@@ -214,7 +204,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
         "//src/ray/gcs:gcs_node_manager",
@@ -241,7 +230,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_store_client_kv",
         "//src/ray/gcs:gcs_worker_manager",
@@ -278,7 +266,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":gcs_table_storage_test_lib",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_table_storage",
         "//src/ray/gcs/store_client/tests:store_client_test_lib",
@@ -293,7 +280,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         ":gcs_table_storage_test_lib",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_table_storage",
         "//src/ray/gcs/store_client:in_memory_store_client",
@@ -313,7 +299,6 @@ ray_cc_test(
         "//:ray_mock",
         "//src/ray/common:asio",
         "//src/ray/common:protobuf_utils",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_autoscaler_state_manager",
         "//src/ray/gcs:gcs_init_data",
@@ -334,7 +319,6 @@ ray_cc_test(
     visibility = ["//visibility:private"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_node_manager",
         "//src/ray/gcs:gcs_resource_manager",
@@ -353,7 +337,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_usage_stats_client",
     ],
@@ -371,7 +354,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_job_manager",
         "//src/ray/gcs:gcs_kv_manager",
@@ -392,7 +374,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:asio",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:runtime_env",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
@@ -419,7 +400,6 @@ ray_cc_test(
     ],
     deps = [
         "//src/mock/ray/pubsub:mock_publisher",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_node_manager",
         "//src/ray/gcs/store_client:in_memory_store_client",
@@ -436,7 +416,6 @@ ray_cc_test(
     tags = ["team:core"],
     visibility = ["//visibility:private"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs:gcs_ray_event_converter",
     ],
 )

--- a/src/ray/gcs_rpc_client/tests/BUILD.bazel
+++ b/src/ray/gcs_rpc_client/tests/BUILD.bazel
@@ -8,7 +8,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs_rpc_client:gcs_client",
     ],
@@ -34,7 +33,6 @@ ray_cc_test(
     }),
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_server_lib",
         "//src/ray/gcs_rpc_client:gcs_client",
@@ -69,7 +67,6 @@ ray_cc_test(
         "team:core",
     ],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_server_lib",
         "//src/ray/gcs_rpc_client:gcs_client",
@@ -98,7 +95,6 @@ ray_cc_test(
         "team:core",
     ],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/gcs:gcs_server_lib",
         "//src/ray/gcs_rpc_client:gcs_client",
@@ -117,7 +113,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs_rpc_client:gcs_client",
     ],
 )

--- a/src/ray/object_manager/plasma/tests/BUILD.bazel
+++ b/src/ray/object_manager/plasma/tests/BUILD.bazel
@@ -6,7 +6,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager/plasma:plasma_allocator",
         "@com_google_absl//absl/strings:str_format",
     ],
@@ -17,7 +16,6 @@ ray_cc_test(
     srcs = ["object_store_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager/plasma:plasma_object_store",
         "@com_google_absl//absl/random",
         "@com_google_absl//absl/strings:str_format",
@@ -33,7 +31,6 @@ ray_cc_test(
     ],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker:experimental_mutable_object_manager",
         "//src/ray/object_manager:object_manager_common",
     ],
@@ -47,7 +44,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager/plasma:obj_lifecycle_mgr",
         "@com_google_absl//absl/random",
     ],
@@ -58,7 +54,6 @@ ray_cc_test(
     srcs = ["eviction_policy_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager/plasma:plasma_eviction_policy",
         "//src/ray/object_manager/plasma:plasma_object_store",
     ],

--- a/src/ray/object_manager/tests/BUILD.bazel
+++ b/src/ray/object_manager/tests/BUILD.bazel
@@ -9,7 +9,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager:pull_manager",
     ],
 )
@@ -23,7 +22,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager:object_buffer_pool",
     ],
 )
@@ -36,7 +34,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
         "//src/ray/object_manager:ownership_object_directory",
         "//src/ray/pubsub:fake_subscriber",
@@ -51,7 +48,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager:push_manager",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -66,7 +62,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager:chunk_object_reader",
         "//src/ray/object_manager:memory_object_reader",
         "//src/ray/object_manager:spilled_object_reader",
@@ -85,7 +80,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager/plasma:plasma_store_server_lib",
     ],
 )
@@ -98,7 +92,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager/plasma:plasma_store_server_lib",
     ],
 )
@@ -112,7 +105,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/object_manager",
         "//src/ray/object_manager/plasma:fake_plasma_client",
         "//src/ray/object_manager_rpc_client:fake_object_manager_client",

--- a/src/ray/observability/tests/BUILD.bazel
+++ b/src/ray/observability/tests/BUILD.bazel
@@ -6,7 +6,6 @@ ray_cc_test(
     srcs = ["open_telemetry_metric_recorder_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:open_telemetry_metric_recorder",
     ],
 )
@@ -17,7 +16,6 @@ ray_cc_test(
     srcs = ["ray_event_recorder_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:fake_metric",
         "//src/ray/observability:ray_actor_definition_event",
         "//src/ray/observability:ray_actor_lifecycle_event",
@@ -33,7 +31,6 @@ ray_cc_test(
     srcs = ["ray_driver_job_lifecycle_event_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:ray_driver_job_lifecycle_event",
     ],
 )
@@ -44,7 +41,6 @@ ray_cc_test(
     srcs = ["ray_actor_definition_event_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:ray_actor_definition_event",
     ],
 )
@@ -55,7 +51,6 @@ ray_cc_test(
     srcs = ["ray_actor_lifecycle_event_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:ray_actor_lifecycle_event",
     ],
 )
@@ -66,7 +61,6 @@ ray_cc_test(
     srcs = ["ray_node_definition_event_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:ray_node_definition_event",
     ],
 )

--- a/src/ray/pubsub/tests/BUILD.bazel
+++ b/src/ray/pubsub/tests/BUILD.bazel
@@ -6,7 +6,6 @@ ray_cc_test(
     srcs = ["publisher_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/pubsub:publisher",
     ],
 )
@@ -19,7 +18,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/pubsub:subscriber",
     ],
 )
@@ -31,7 +29,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:grpc_util",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:pubsub_cc_grpc",
         "//src/ray/pubsub:publisher",
         "//src/ray/pubsub:subscriber",
@@ -48,7 +45,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:ray_config",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status",
         "//src/ray/protobuf:gcs_service_cc_grpc",
         "//src/ray/pubsub:python_gcs_subscriber",

--- a/src/ray/ray_syncer/tests/BUILD.bazel
+++ b/src/ray/ray_syncer/tests/BUILD.bazel
@@ -11,7 +11,6 @@ ray_cc_test(
     ],
     deps = [
         "//src/mock/ray/ray_syncer:mock_ray_syncer",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/ray_syncer",
         "//src/ray/rpc:grpc_server",

--- a/src/ray/raylet/scheduling/policy/tests/BUILD.bazel
+++ b/src/ray/raylet/scheduling/policy/tests/BUILD.bazel
@@ -8,7 +8,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet/scheduling:composite_scheduling_policy",
     ],
 )
@@ -21,7 +20,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet/scheduling:composite_scheduling_policy",
         "//src/ray/raylet/scheduling:hybrid_scheduling_policy",
         "@com_google_absl//absl/random:mock_distributions",

--- a/src/ray/raylet/scheduling/tests/BUILD.bazel
+++ b/src/ray/raylet/scheduling/tests/BUILD.bazel
@@ -11,7 +11,6 @@ ray_cc_test(
         "//:ray_mock",
         "//src/ray/common:lease",
         "//src/ray/common:ray_config",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/gcs_rpc_client:gcs_client",
@@ -28,7 +27,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:fake_metric",
         "//src/ray/raylet/scheduling:cluster_resource_scheduler",
         "//src/ray/raylet/scheduling:scheduling_context",
@@ -45,7 +43,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/observability:fake_metric",
         "//src/ray/raylet/scheduling:local_resource_manager",
         "//src/ray/util:clock",
@@ -61,7 +58,6 @@ ray_cc_test(
         "//:ray_mock",
         "//src/ray/common:id",
         "//src/ray/common:lease",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/observability:fake_metric",
@@ -83,7 +79,6 @@ ray_cc_test(
         "//:ray_mock",
         "//src/ray/common:id",
         "//src/ray/common:lease",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/raylet/scheduling:cluster_lease_manager",
@@ -102,7 +97,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet/scheduling:cluster_resource_manager",
     ],
 )

--- a/src/ray/raylet/tests/BUILD.bazel
+++ b/src/ray/raylet/tests/BUILD.bazel
@@ -22,7 +22,6 @@ ray_cc_test(
     srcs = ["wait_manager_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet:wait_manager",
     ],
 )
@@ -37,7 +36,6 @@ ray_cc_test(
     ],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
         "//src/ray/raylet:worker",
         "//src/ray/raylet:worker_pool",
@@ -61,7 +59,6 @@ ray_cc_test(
         "//:ray_mock",
         "//src/ray/common:asio",
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
         "//src/ray/gcs_rpc_client:gcs_client",
@@ -82,7 +79,6 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/scheduling:placement_group_util",
         "//src/ray/observability:fake_metric",
         "//src/ray/raylet:placement_group_resource_manager",
@@ -99,7 +95,6 @@ ray_cc_test(
         "//:ray_mock",
         "//src/ray/common:asio",
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:runtime_env_agent_cc_proto",
         "//src/ray/raylet:runtime_env_agent_client",
         "//src/ray/util:env",
@@ -116,7 +111,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//:ray_mock",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:test_utils",
         "//src/ray/observability:fake_metric",
         "//src/ray/raylet:lease_dependency_manager",
@@ -135,7 +129,6 @@ ray_cc_test(
         ":util",
         "//src/ray/common:asio",
         "//src/ray/common:lease",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet:worker_killing_policy_group_by_owner",
         "//src/ray/util:fake_process",
     ],
@@ -153,7 +146,6 @@ ray_cc_test(
         ":util",
         "//src/ray/common:lease",
         "//src/ray/common:memory_monitor_interface",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet:worker_killing_policy_by_time",
     ],
 )
@@ -171,7 +163,6 @@ ray_cc_test(
         ":util",
         "//:ray_mock",
         "//src/ray/common:lease",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:ray_object",
         "//src/ray/common:task_common",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
@@ -197,7 +188,6 @@ ray_cc_test(
     srcs = ["throttler_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet:throttler",
         "@com_google_absl//absl/time",
     ],

--- a/src/ray/raylet_ipc_client/tests/BUILD.bazel
+++ b/src/ray/raylet_ipc_client/tests/BUILD.bazel
@@ -8,7 +8,6 @@ ray_cc_test(
     deps = [
         "//src/ray/common:asio",
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/raylet_ipc_client:client_connection",
         "//src/ray/util:network_util",
         "@boost//:asio",

--- a/src/ray/raylet_rpc_client/tests/BUILD.bazel
+++ b/src/ray/raylet_rpc_client/tests/BUILD.bazel
@@ -6,7 +6,6 @@ ray_cc_test(
     srcs = ["raylet_client_pool_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/gcs_rpc_client:gcs_client",
         "//src/ray/raylet_rpc_client:fake_raylet_client",
         "//src/ray/raylet_rpc_client:raylet_client_pool",

--- a/src/ray/rpc/authentication/tests/BUILD.bazel
+++ b/src/ray/rpc/authentication/tests/BUILD.bazel
@@ -8,7 +8,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/rpc/authentication:authentication_token",
     ],
 )
@@ -22,7 +21,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:ray_config",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/rpc/authentication:authentication_token_loader",
         "//src/ray/util:env",
     ],
@@ -36,7 +34,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:test_service_cc_grpc",
         "//src/ray/rpc:grpc_client",
         "//src/ray/rpc:grpc_server",

--- a/src/ray/rpc/tests/BUILD.bazel
+++ b/src/ray/rpc/tests/BUILD.bazel
@@ -8,7 +8,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/rpc:rpc_chaos",
     ],
 )
@@ -32,7 +31,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         ":grpc_test_common",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:test_service_cc_grpc",
         "//src/ray/rpc:grpc_client",
         "//src/ray/rpc:grpc_server",
@@ -47,7 +45,6 @@ ray_cc_test(
     ],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/rpc:metrics_agent_client",
     ],
 )

--- a/src/ray/stats/tests/BUILD.bazel
+++ b/src/ray/stats/tests/BUILD.bazel
@@ -6,7 +6,6 @@ ray_cc_test(
     srcs = ["metric_with_open_telemetry_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/stats:stats_metric",
     ],
 )
@@ -22,7 +21,6 @@ ray_cc_test(
         "team:core",
     ],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/stats:stats_lib",
     ],
 )
@@ -33,7 +31,6 @@ ray_cc_test(
     srcs = ["percentile_tracker_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/stats:percentile_tracker",
     ],
 )

--- a/src/ray/util/internal/tests/BUILD.bazel
+++ b/src/ray/util/internal/tests/BUILD.bazel
@@ -13,7 +13,6 @@ ray_cc_test(
     ],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/tests:testing",
         "//src/ray/util:filesystem",
         "//src/ray/util/internal:stream_redirection_handle",

--- a/src/ray/util/tests/BUILD.bazel
+++ b/src/ray/util/tests/BUILD.bazel
@@ -18,7 +18,6 @@ ray_cc_test(
     tags = ["team:core"],
     visibility = ["//visibility:private"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:file_persistence",
     ],
 )
@@ -28,7 +27,6 @@ ray_cc_test(
     srcs = ["array_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:array",
     ],
 )
@@ -39,7 +37,6 @@ ray_cc_test(
     srcs = ["thread_checker_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:thread_checker",
     ],
 )
@@ -51,7 +48,6 @@ ray_cc_test(
     linkstatic = True,
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:container_util",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
@@ -64,7 +60,6 @@ ray_cc_test(
     srcs = ["counter_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:counter_map",
     ],
 )
@@ -80,7 +75,6 @@ ray_cc_test(
     ],
     deps = [
         "//src/ray/common:ray_config",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:gcs_cc_proto",
         "//src/ray/util:event",
         "//src/ray/util:path_utils",
@@ -94,7 +88,6 @@ ray_cc_test(
     srcs = ["exponential_backoff_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:exponential_backoff",
     ],
 )
@@ -105,7 +98,6 @@ ray_cc_test(
     srcs = ["filesystem_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:filesystem",
         "//src/ray/util:path_utils",
         "//src/ray/util:string_utils",
@@ -125,9 +117,10 @@ ray_cc_test(
         "no_ubsan",
         "team:core",
     ],
+    # Uses gtest_main (not ray_gtest_main) because this test manages its
+    # own logging setup and checks stderr output directly.
+    use_ray_gtest_main = False,
     deps = [
-        # Uses gtest_main (not ray_gtest_main) because this test manages its
-        # own logging setup and checks stderr output directly.
         "@com_google_googletest//:gtest_main",
         "//src/ray/common:status",
         "//src/ray/util:env",
@@ -146,7 +139,6 @@ ray_cc_test(
     srcs = ["sequencer_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:logging",
         "//src/ray/util:sequencer",
     ],
@@ -158,7 +150,6 @@ ray_cc_test(
     srcs = ["signal_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:logging",
         "//src/ray/util:path_utils",
         "//src/ray/util:raii",
@@ -171,7 +162,6 @@ ray_cc_test(
     srcs = ["process_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:process",
         "//src/ray/util:process_utils",
         "@boost//:process",
@@ -184,7 +174,6 @@ ray_cc_test(
     srcs = ["network_util_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:network_util",
     ],
 )
@@ -195,7 +184,6 @@ ray_cc_test(
     srcs = ["proto_schema_backward_compatibility_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/protobuf:gcs_cc_proto",
         "@boost//:range",
     ],
@@ -207,7 +195,6 @@ ray_cc_test(
     srcs = ["size_literals_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:size_literals",
     ],
 )
@@ -218,7 +205,6 @@ ray_cc_test(
     srcs = ["shared_lru_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:shared_lru",
     ],
 )
@@ -229,7 +215,6 @@ ray_cc_test(
     srcs = ["scoped_env_setter_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:scoped_env_setter",
     ],
 )
@@ -241,7 +226,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/tests:testing",
         "//src/ray/util:filesystem",
         "//src/ray/util:pipe_logger",
@@ -265,7 +249,6 @@ ray_cc_test(
     ],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/tests:testing",
         "//src/ray/util:filesystem",
         "//src/ray/util:stream_redirection",
@@ -290,7 +273,6 @@ ray_cc_test(
     srcs = ["spdlog_fd_sink_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:compat",
         "//src/ray/util:spdlog_fd_sink",
     ],
@@ -303,7 +285,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:id",
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/tests:testing",
         "//src/ray/util:filesystem",
         "//src/ray/util:spdlog_fd_sink",
@@ -319,7 +300,6 @@ ray_cc_test(
     srcs = ["temporary_directory_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:temporary_directory",
     ],
 )
@@ -330,7 +310,6 @@ ray_cc_test(
     srcs = ["compat_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:compat",
         "//src/ray/util:filesystem",
     ],
@@ -344,7 +323,6 @@ ray_cc_test(
         "team:core",
     ],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:process",
     ],
 )
@@ -355,7 +333,6 @@ ray_cc_test(
     srcs = ["scoped_dup2_wrapper_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common/tests:testing",
         "//src/ray/util:compat",
         "//src/ray/util:filesystem",
@@ -371,7 +348,6 @@ ray_cc_test(
     srcs = ["concurrent_flat_map_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/util:concurrent_flat_map",
     ],
 )
@@ -383,7 +359,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/common:file_system_monitor",
-        "//src/ray/common:ray_gtest_main",
     ],
 )
 
@@ -393,7 +368,6 @@ ray_cc_test(
     srcs = ["string_utils_test.cc"],
     tags = ["team:core"],
     deps = [
-        "//src/ray/common:ray_gtest_main",
         "//src/ray/common:status_or",
         "//src/ray/util:string_utils",
     ],

--- a/src/ray/util/tests/BUILD.bazel
+++ b/src/ray/util/tests/BUILD.bazel
@@ -7,7 +7,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/util:clock",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 
@@ -263,7 +262,6 @@ ray_cc_test(
     tags = ["team:core"],
     deps = [
         "//src/ray/util:cmd_line_utils",
-        "@com_google_googletest//:gtest_main",
     ],
 )
 

--- a/src/ray/util/tests/BUILD.bazel
+++ b/src/ray/util/tests/BUILD.bazel
@@ -121,7 +121,6 @@ ray_cc_test(
     # own logging setup and checks stderr output directly.
     use_ray_gtest_main = False,
     deps = [
-        "@com_google_googletest//:gtest_main",
         "//src/ray/common:status",
         "//src/ray/util:env",
         "//src/ray/util:filesystem",
@@ -129,6 +128,7 @@ ray_cc_test(
         "//src/ray/util:time",
         "@boost//:asio",
         "@com_google_absl//absl/strings:str_format",
+        "@com_google_googletest//:gtest_main",
         "@nlohmann_json",
     ],
 )


### PR DESCRIPTION
Follow up to: https://github.com/ray-project/ray/pull/62444

Instead of including the target manually in every test, I am now injecting it in the `ray_cc_test` target. This can be disabled with the `use_ray_gtest_main` flag.

Also added a bugbot rule to avoid people adding the dependencies unnecessarily.