### PR TITLE
[ci] Retry bazel builds on remote cache eviction and transient download failures

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -183,6 +183,11 @@ build:ci --progress_report_interval=100
 build:ci --show_progress_rate_limit=15
 build:ci --ui_actions_shown=1024
 build:ci --show_timestamps
+# Retry on CacheNotFoundException from raw-S3 remote cache (AC/CAS eviction mismatch).
+# Remove once the cache is fronted by a server that coordinates AC/CAS eviction (bazel-remote, Buildbarn, etc.).
+build:ci --experimental_remote_cache_eviction_retries=3
+# Retry repository rule HTTP downloads (e.g. http_archive) on transient failures (502/504).
+build:ci --experimental_repository_downloader_retries=3
 # Disable test result caching because py_test under Bazel can import from outside of sandbox, but Bazel only looks at
 # declared dependencies to determine if a result should be cached. More details at:
 # https://github.com/bazelbuild/bazel/issues/7091, https://github.com/bazelbuild/rules_python/issues/382


### PR DESCRIPTION
Adds two retry flags to the ci bazel config:

1. --experimental_remote_cache_eviction_retries=3: when the raw-S3 remote cache serves a stale Action Cache entry whose CAS blob has been evicted (CacheNotFoundException), bazel re-runs the affected actions locally and re-uploads instead of aborting. Observed when a protoc output blob went missing mid-build and failed the ray-core-ha-integration-tests job.

2. --experimental_repository_downloader_retries=3: retries repository rule HTTP downloads (http_archive, etc.) on transient failures like 502/504. Observed when GitHub returned 504 Gateway Timeout for rules_java, rules_proto_grpc, grpc, and other archives, failing both ray-core-cpp-tests and train-ml-tune-tests jobs.

Topic: ci-bazel-cache-eviction-retries
Signed-off-by: andrew <andrew@anyscale.com>