### PR TITLE
[Data] Compute Expressions-struct field_by_index

### DIFF
--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -756,7 +756,9 @@ class Expr(ABC):
             ...         pa.field("age", pa.int32())
             ...     ]))
             ... }))
-            >>> ds = ds.with_column("age", col("user").struct["age"])  # doctest: +SKIP
+            >>> ds = ds.with_column("age", col("user").struct["age"])  # by name  # doctest: +SKIP
+            >>> ds = ds.with_column("name", col("user").struct.field_by_index(0))  # by index  # doctest: +SKIP
+            >>> ds = ds.with_column("name2", col("user").struct[0])  # bracket by index  # doctest: +SKIP
         """
         from ray.data.namespace_expressions.struct_namespace import _StructNamespace
 

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -756,9 +756,9 @@ class Expr(ABC):
             ...         pa.field("age", pa.int32())
             ...     ]))
             ... }))
-            >>> ds = ds.with_column("age", col("user").struct["age"])  # by name  # doctest: +SKIP
-            >>> ds = ds.with_column("name", col("user").struct.field_by_index(0))  # by index  # doctest: +SKIP
-            >>> ds = ds.with_column("name2", col("user").struct[0])  # bracket by index  # doctest: +SKIP
+            >>> ds = ds.with_column("age", col("user").struct["age"])  # by name
+            >>> ds = ds.with_column("name", col("user").struct.field_by_index(0))  # by index
+            >>> ds = ds.with_column("name2", col("user").struct[0])  # bracket by index
         """
         from ray.data.namespace_expressions.struct_namespace import _StructNamespace
 

--- a/python/ray/data/namespace_expressions/struct_namespace.py
+++ b/python/ray/data/namespace_expressions/struct_namespace.py
@@ -50,7 +50,7 @@ class _StructNamespace:
         """
         if isinstance(key, str):
             return self.field(key)
-        if isinstance(key, int):
+        if isinstance(key, int) and not isinstance(key, bool):
             return self.field_by_index(key)
         raise TypeError(
             f"Struct indices must be strings or integers, not {type(key).__name__}"
@@ -88,6 +88,12 @@ class _StructNamespace:
         Returns:
             UDFExpr that extracts the specified field from each struct.
         """
+        if not isinstance(index, int) or isinstance(index, bool):
+            raise TypeError(
+                f"Struct field index must be an integer, not {type(index).__name__}"
+            )
+        if index < 0:
+            raise ValueError(f"Struct field index must be non-negative, got {index}")
         return_dtype = DataType(object)
         if self._expr.data_type.is_arrow_type():
             arrow_type = self._expr.data_type.to_arrow_dtype()

--- a/python/ray/data/namespace_expressions/struct_namespace.py
+++ b/python/ray/data/namespace_expressions/struct_namespace.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import pyarrow
 import pyarrow.compute as pc
@@ -34,20 +34,27 @@ class _StructNamespace:
 
     _expr: Expr
 
-    def __getitem__(self, field_name: str) -> "PyArrowComputeUDFExpr":
+    def __getitem__(self, key: Union[str, int]) -> "PyArrowComputeUDFExpr":
         """Extract a field using bracket notation.
 
         Args:
-            field_name: The name of the field to extract.
+            key: The field name or index to extract.
 
         Returns:
             PyArrowComputeUDFExpr that extracts the specified field from each struct.
 
         Example:
-            >>> col("user").struct["age"]  # Get age field  # doctest: +SKIP
+            >>> col("user").struct["age"]  # Get age field by name  # doctest: +SKIP
+            >>> col("user").struct[1]  # Get second field by index  # doctest: +SKIP
             >>> col("user").struct["address"].struct["city"]  # Get nested city field  # doctest: +SKIP
         """
-        return self.field(field_name)
+        if isinstance(key, str):
+            return self.field(key)
+        if isinstance(key, int):
+            return self.field_by_index(key)
+        raise TypeError(
+            f"Struct indices must be strings or integers, not {type(key).__name__}"
+        )
 
     def field(self, field_name: str) -> "PyArrowComputeUDFExpr":
         """Extract a field from a struct.
@@ -70,4 +77,27 @@ class _StructNamespace:
 
         return _create_pyarrow_compute_udf(pc.struct_field, return_dtype)(
             self._expr, field_name
+        )
+
+    def field_by_index(self, index: int) -> "PyArrowComputeUDFExpr":
+        """Extract a field from a struct by index.
+
+        Args:
+            index: The index of the field to extract.
+
+        Returns:
+            UDFExpr that extracts the specified field from each struct.
+        """
+        return_dtype = DataType(object)
+        if self._expr.data_type.is_arrow_type():
+            arrow_type = self._expr.data_type.to_arrow_dtype()
+            if pyarrow.types.is_struct(arrow_type):
+                try:
+                    field_type = arrow_type[index].type
+                    return_dtype = DataType.from_arrow(field_type)
+                except IndexError:
+                    pass
+
+        return _create_pyarrow_compute_udf(pc.struct_field, return_dtype)(
+            self._expr, index
         )

--- a/python/ray/data/namespace_expressions/struct_namespace.py
+++ b/python/ray/data/namespace_expressions/struct_namespace.py
@@ -44,9 +44,10 @@ class _StructNamespace:
             PyArrowComputeUDFExpr that extracts the specified field from each struct.
 
         Example:
-            >>> col("user").struct["age"]  # Get age field by name  # doctest: +SKIP
-            >>> col("user").struct[1]  # Get second field by index  # doctest: +SKIP
-            >>> col("user").struct["address"].struct["city"]  # Get nested city field  # doctest: +SKIP
+            >>> from ray.data.expressions import col
+            >>> expr = col("user").struct["age"]  # Get age field by name
+            >>> expr = col("user").struct[1]  # Get second field by index
+            >>> expr = col("user").struct["address"].struct["city"]  # Get nested city field
         """
         if isinstance(key, str):
             return self.field(key)

--- a/python/ray/data/tests/expressions/test_namespace_struct.py
+++ b/python/ray/data/tests/expressions/test_namespace_struct.py
@@ -43,6 +43,39 @@ DATASET_FORMATS = ["pandas", "arrow"]
 class TestStructNamespace:
     """Tests for struct namespace operations."""
 
+    def test_struct_bracket_bool_index_raises(self, dataset_format):
+        """Test struct[bool] raises TypeError instead of being treated as int."""
+        del dataset_format  # Unused, required by class-level parametrization.
+
+        with pytest.raises(
+            TypeError, match="Struct indices must be strings or integers"
+        ):
+            col("user").struct[True]
+
+    def test_struct_field_by_index_non_integer_raises(self, dataset_format):
+        """Test struct.field_by_index() rejects non-integer indices."""
+        del dataset_format  # Unused, required by class-level parametrization.
+
+        with pytest.raises(TypeError, match="Struct field index must be an integer"):
+            col("user").struct.field_by_index("1")
+
+        with pytest.raises(TypeError, match="Struct field index must be an integer"):
+            col("user").struct.field_by_index(True)
+
+    def test_struct_field_by_index_negative_raises(self, dataset_format):
+        """Test struct.field_by_index() rejects negative indices."""
+        del dataset_format  # Unused, required by class-level parametrization.
+
+        with pytest.raises(
+            ValueError, match="Struct field index must be non-negative, got -1"
+        ):
+            col("user").struct.field_by_index(-1)
+
+        with pytest.raises(
+            ValueError, match="Struct field index must be non-negative, got -1"
+        ):
+            col("user").struct[-1]
+
     def test_struct_field(self, ray_start_regular_shared, dataset_format):
         """Test struct.field() extracts field."""
         arrow_table = pa.table(

--- a/python/ray/data/tests/expressions/test_namespace_struct.py
+++ b/python/ray/data/tests/expressions/test_namespace_struct.py
@@ -109,6 +109,80 @@ class TestStructNamespace:
         )
         assert rows_same(result, expected)
 
+    def test_struct_field_by_index(self, ray_start_regular_shared, dataset_format):
+        """Test struct.field_by_index() extracts field by position."""
+        if dataset_format == "pandas":
+            pytest.skip(
+                "Index-based struct access requires stable Arrow struct field ordering."
+            )
+        arrow_table = pa.table(
+            {
+                "user": pa.array(
+                    [
+                        {"name": "Alice", "age": 30},
+                        {"name": "Bob", "age": 25},
+                    ],
+                    type=pa.struct(
+                        [
+                            pa.field("name", pa.string()),
+                            pa.field("age", pa.int32()),
+                        ]
+                    ),
+                )
+            }
+        )
+        items_data = [
+            {"user": {"name": "Alice", "age": 30}},
+            {"user": {"name": "Bob", "age": 25}},
+        ]
+        ds = _create_dataset(items_data, dataset_format, arrow_table)
+
+        result = ds.with_column("age", col("user").struct.field_by_index(1)).to_pandas()
+        expected = pd.DataFrame(
+            {
+                "user": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}],
+                "age": [30, 25],
+            }
+        )
+        assert rows_same(result, expected)
+
+    def test_struct_bracket_with_index(self, ray_start_regular_shared, dataset_format):
+        """Test struct[index] bracket notation."""
+        if dataset_format == "pandas":
+            pytest.skip(
+                "Index-based struct access requires stable Arrow struct field ordering."
+            )
+        arrow_table = pa.table(
+            {
+                "user": pa.array(
+                    [
+                        {"name": "Alice", "age": 30},
+                        {"name": "Bob", "age": 25},
+                    ],
+                    type=pa.struct(
+                        [
+                            pa.field("name", pa.string()),
+                            pa.field("age", pa.int32()),
+                        ]
+                    ),
+                )
+            }
+        )
+        items_data = [
+            {"user": {"name": "Alice", "age": 30}},
+            {"user": {"name": "Bob", "age": 25}},
+        ]
+        ds = _create_dataset(items_data, dataset_format, arrow_table)
+
+        result = ds.with_column("name", col("user").struct[0]).to_pandas()
+        expected = pd.DataFrame(
+            {
+                "user": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}],
+                "name": ["Alice", "Bob"],
+            }
+        )
+        assert rows_same(result, expected)
+
     def test_struct_nested_field(self, ray_start_regular_shared, dataset_format):
         """Test nested struct field access with .field()."""
         arrow_table = pa.table(

--- a/python/ray/data/tests/expressions/test_namespace_struct.py
+++ b/python/ray/data/tests/expressions/test_namespace_struct.py
@@ -52,15 +52,13 @@ class TestStructNamespace:
         ):
             col("user").struct[True]
 
-    def test_struct_field_by_index_non_integer_raises(self, dataset_format):
+    @pytest.mark.parametrize("bad_index", ["1", True])
+    def test_struct_field_by_index_non_integer_raises(self, dataset_format, bad_index):
         """Test struct.field_by_index() rejects non-integer indices."""
         del dataset_format  # Unused, required by class-level parametrization.
 
         with pytest.raises(TypeError, match="Struct field index must be an integer"):
-            col("user").struct.field_by_index("1")
-
-        with pytest.raises(TypeError, match="Struct field index must be an integer"):
-            col("user").struct.field_by_index(True)
+            col("user").struct.field_by_index(bad_index)
 
     def test_struct_field_by_index_negative_raises(self, dataset_format):
         """Test struct.field_by_index() rejects negative indices."""


### PR DESCRIPTION
## Description
Add index-based field access for struct namespace operations in Ray Data.

### Changes
- Add `struct.field_by_index(field_index: int)` in `python/ray/data/namespace_expressions/struct_namespace.py`
- Extend `struct.__getitem__` to accept both:
  - `str` (existing behavior): `col("s").struct["field"]`
  - `int` (new): `col("s").struct[0]`
- Keep type inference for Arrow-backed struct dtypes
- Add key-type validation for `.struct[...]`
- Update `Expr.struct` examples in `python/ray/data/expressions.py` to show index-based usage

## Related issues
Related to #58674

## Additional information
- `python -m pytest -v --doctest-modules python/ray/data/namespace_expressions/struct_namespace.py`
- `python -m pytest -v python/ray/data/tests/expressions/test_namespace_struct.py`
- `python -m pytest -v --doctest-modules python/ray/data/expressions.py -k 'struct and Expr'`