### PR TITLE
[core][Let the driver I/O context breathe] Resolve task dependencies synchronously when objects already exist

### DIFF
--- a/src/ray/core_worker/task_submission/dependency_resolver.cc
+++ b/src/ray/core_worker/task_submission/dependency_resolver.cc
@@ -131,8 +131,8 @@ void LocalDependencyResolver::ResolveDependencies(
   }
 
   for (const auto &obj_id : local_dependency_ids) {
-    in_memory_store_.GetAsync(
-        obj_id, [this, task_id, obj_id](std::shared_ptr<RayObject> obj) {
+    auto resolve_object_dependency =
+        [this, task_id, obj_id](std::shared_ptr<RayObject> obj) {
           RAY_CHECK(obj != nullptr);
 
           std::unique_ptr<TaskState> resolved_task_state = nullptr;
@@ -168,7 +168,18 @@ void LocalDependencyResolver::ResolveDependencies(
           if (resolved_task_state) {
             resolved_task_state->on_dependencies_resolved_(resolved_task_state->status);
           }
-        });
+        };
+
+    // GetAsync always posts a callback to the I/O event queue even when the
+    // object already exists (see #47833 for why). In workloads like Data shuffle, all map outputs
+    // are ready before reduce tasks are submitted, so checking synchronously
+    // first avoids flooding the I/O context with callbacks.
+    auto existing = in_memory_store_.GetIfExists(obj_id);
+    if (existing != nullptr) {
+      resolve_object_dependency(std::move(existing));
+    } else {
+      in_memory_store_.GetAsync(obj_id, std::move(resolve_object_dependency));
+    }
   }
 
   for (const auto &actor_id : actor_dependency_ids) {

--- a/src/ray/core_worker/task_submission/dependency_resolver.cc
+++ b/src/ray/core_worker/task_submission/dependency_resolver.cc
@@ -171,7 +171,8 @@ void LocalDependencyResolver::ResolveDependencies(
         };
 
     // GetAsync always posts a callback to the I/O event queue even when the
-    // object already exists (see #47833 for why). In workloads like Data shuffle, all map outputs
+    // object already exists (see https://github.com/ray-project/ray/pull/47833
+    // for why). In workloads like Data shuffle, all map outputs
     // are ready before reduce tasks are submitted, so checking synchronously
     // first avoids flooding the I/O context with callbacks.
     auto existing = in_memory_store_.GetIfExists(obj_id);

--- a/src/ray/core_worker/task_submission/dependency_resolver.cc
+++ b/src/ray/core_worker/task_submission/dependency_resolver.cc
@@ -133,42 +133,41 @@ void LocalDependencyResolver::ResolveDependencies(
   for (const auto &obj_id : local_dependency_ids) {
     auto resolve_object_dependency =
         [this, task_id, obj_id](std::shared_ptr<RayObject> obj) {
-          RAY_CHECK(obj != nullptr);
+      RAY_CHECK(obj != nullptr);
 
-          std::unique_ptr<TaskState> resolved_task_state = nullptr;
-          std::vector<ObjectID> inlined_dependency_ids;
-          std::vector<ObjectID> contained_ids;
-          {
-            absl::MutexLock lock(&mu_);
+      std::unique_ptr<TaskState> resolved_task_state = nullptr;
+      std::vector<ObjectID> inlined_dependency_ids;
+      std::vector<ObjectID> contained_ids;
+      {
+        absl::MutexLock lock(&mu_);
 
-            auto it = pending_tasks_.find(task_id);
-            // The dependency resolution for the task has been cancelled.
-            if (it == pending_tasks_.end()) {
-              return;
-            }
-            auto &state = it->second;
-            state->local_dependencies[obj_id] = std::move(obj);
-            if (--state->obj_dependencies_remaining == 0) {
-              InlineDependencies(state->local_dependencies,
-                                 state->task,
-                                 &inlined_dependency_ids,
-                                 &contained_ids,
-                                 tensor_transport_getter_);
-              if (state->actor_dependencies_remaining == 0) {
-                resolved_task_state = std::move(state);
-                pending_tasks_.erase(it);
-              }
-            }
+        auto it = pending_tasks_.find(task_id);
+        // The dependency resolution for the task has been cancelled.
+        if (it == pending_tasks_.end()) {
+          return;
+        }
+        auto &state = it->second;
+        state->local_dependencies[obj_id] = std::move(obj);
+        if (--state->obj_dependencies_remaining == 0) {
+          InlineDependencies(state->local_dependencies,
+                             state->task,
+                             &inlined_dependency_ids,
+                             &contained_ids,
+                             tensor_transport_getter_);
+          if (state->actor_dependencies_remaining == 0) {
+            resolved_task_state = std::move(state);
+            pending_tasks_.erase(it);
           }
+        }
+      }
 
-          if (!inlined_dependency_ids.empty()) {
-            task_manager_.OnTaskDependenciesInlined(inlined_dependency_ids,
-                                                    contained_ids);
-          }
-          if (resolved_task_state) {
-            resolved_task_state->on_dependencies_resolved_(resolved_task_state->status);
-          }
-        };
+      if (!inlined_dependency_ids.empty()) {
+        task_manager_.OnTaskDependenciesInlined(inlined_dependency_ids, contained_ids);
+      }
+      if (resolved_task_state) {
+        resolved_task_state->on_dependencies_resolved_(resolved_task_state->status);
+      }
+    };
 
     // GetAsync always posts a callback to the I/O event queue even when the
     // object already exists (see https://github.com/ray-project/ray/pull/47833

--- a/src/ray/core_worker/task_submission/dependency_resolver.cc
+++ b/src/ray/core_worker/task_submission/dependency_resolver.cc
@@ -131,8 +131,8 @@ void LocalDependencyResolver::ResolveDependencies(
   }
 
   for (const auto &obj_id : local_dependency_ids) {
-    auto resolve_object_dependency =
-        [this, task_id, obj_id](std::shared_ptr<RayObject> obj) {
+    auto resolve_object_dependency = [this, task_id, obj_id](
+                                         std::shared_ptr<RayObject> obj) {
       RAY_CHECK(obj != nullptr);
 
       std::unique_ptr<TaskState> resolved_task_state = nullptr;

--- a/src/ray/core_worker/task_submission/tests/dependency_resolver_test.cc
+++ b/src/ray/core_worker/task_submission/tests/dependency_resolver_test.cc
@@ -415,8 +415,8 @@ TEST(LocalDependencyResolverTest, TestCancelDependencyResolution) {
   io_context.Stop();
 }
 
-// Even if dependencies are already local, the ResolveDependencies callbacks are still
-// called asynchronously in the event loop as a different task.
+// Test that dependencies already in the store are resolved synchronously
+// via GetIfExists, without posting to the I/O event queue.
 TEST(LocalDependencyResolverTest, TestDependenciesAlreadyLocal) {
   auto store = DefaultCoreWorkerMemoryStoreWithThread::Create();
   auto task_manager = std::make_shared<MockTaskManager>();
@@ -433,12 +433,8 @@ TEST(LocalDependencyResolverTest, TestDependenciesAlreadyLocal) {
   TaskSpecification task;
   task.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(obj.Binary());
   bool ok = false;
-  std::promise<bool> dependencies_resolved;
-  resolver.ResolveDependencies(task, [&](Status) {
-    ok = true;
-    dependencies_resolved.set_value(true);
-  });
-  ASSERT_TRUE(dependencies_resolved.get_future().get());
+  resolver.ResolveDependencies(task, [&](Status) { ok = true; });
+  // Callback must have fired synchronously, before ResolveDependencies returned.
   ASSERT_TRUE(ok);
   // Check for leaks.
   ASSERT_EQ(resolver.NumPendingTasks(), 0);


### PR DESCRIPTION

## Description
The driver's single threaded I/O context is the bottleneck for many workloads. When it's overwhelmed, everything slows down.

Workloads like Ray Data shuffle have two phases: map and reduce. You can't start reduce until all map tasks are done, which means all map objects are already in the memory store.

Normally for large shuffles, the reduce tasks have very long object args. In core, what we do is the driver, as the reduce task submitter, needs to check task dependencies before submitting. In our case, track if each object is ready or not.

We did this by calling GetAsync, which always puts a checking callback into the driver I/O context. This can create up to 1,028,921 GetAsync.Callback events, taking 17% of I/O thread time in the worst case during my experiments. Each callback takes 0.04ms to execute but waits 5,719ms on average in the queue. The reason GetAsync must be async is to avoid deadlock, you can read more on this: #47833

So we can't modify GetAsync. What we do instead is when resolving task dependencies, we first check if the object is ready. If it is, mark it resolved immediately. Checking object readiness and marking it resolved don't have any lock issues, so we are safe here.

The improvement is great: we almost eliminate all those GetAsync.Callback events, and achieve ~9.2% end-to-end speedup in shuffle.