### PR TITLE
[Data] Convert remaining concrete logical operators to frozen dataclasses

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -90,8 +90,10 @@ python/ray/data/_internal/logical/operators/count_operator.py
 python/ray/data/_internal/logical/operators/all_to_all_operator.py
 python/ray/data/_internal/logical/operators/join_operator.py
 python/ray/data/_internal/logical/operators/map_operator.py
+python/ray/data/_internal/logical/operators/n_ary_operator.py
 python/ray/data/_internal/logical/operators/one_to_one_operator.py
 python/ray/data/_internal/logical/operators/read_operator.py
+python/ray/data/_internal/logical/operators/streaming_split_operator.py
 python/ray/data/_internal/logical/operators/write_operator.py
 python/ray/data/_internal/logical/optimizers.py
 python/ray/data/_internal/logical/rules/combine_shuffles.py

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -54,10 +54,6 @@ class Zip(NAry):
         object.__setattr__(self, "_input_dependencies", list(input_ops))
         object.__setattr__(self, "_num_outputs", None)
 
-    @property
-    def num_outputs(self) -> Optional[int]:
-        return self._num_outputs
-
     def _apply_transform(
         self, transform: Callable[[LogicalOperator], LogicalOperator]
     ) -> LogicalOperator:
@@ -103,10 +99,6 @@ class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
         object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", list(input_ops))
         object.__setattr__(self, "_num_outputs", None)
-
-    @property
-    def num_outputs(self) -> Optional[int]:
-        return self._num_outputs
 
     def _apply_transform(
         self, transform: Callable[[LogicalOperator], LogicalOperator]

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -35,14 +36,45 @@ class NAry(LogicalOperator):
         return self._num_outputs
 
 
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class Zip(NAry):
     """Logical operator for zip."""
+
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __init__(
         self,
         *input_ops: LogicalOperator,
     ):
-        super().__init__(*input_ops)
+        for input_op in input_ops:
+            assert isinstance(input_op, LogicalOperator), input_op
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", list(input_ops))
+        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_inputs = [
+            input_op._apply_transform(transform) for input_op in self.input_dependencies
+        ]
+        target: LogicalOperator
+        if all(
+            transformed_input is input_op
+            for transformed_input, input_op in zip(
+                transformed_inputs, self.input_dependencies
+            )
+        ):
+            target = self
+        else:
+            target = Zip(*transformed_inputs)
+        return transform(target)
 
     def estimated_num_outputs(self):
         total_num_outputs = 0
@@ -54,14 +86,45 @@ class Zip(NAry):
         return total_num_outputs
 
 
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for union."""
+
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __init__(
         self,
         *input_ops: LogicalOperator,
     ):
-        super().__init__(*input_ops)
+        for input_op in input_ops:
+            assert isinstance(input_op, LogicalOperator), input_op
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", list(input_ops))
+        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return self._num_outputs
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        transformed_inputs = [
+            input_op._apply_transform(transform) for input_op in self.input_dependencies
+        ]
+        target: LogicalOperator
+        if all(
+            transformed_input is input_op
+            for transformed_input, input_op in zip(
+                transformed_inputs, self.input_dependencies
+            )
+        ):
+            target = self
+        else:
+            target = Union(*transformed_inputs)
+        return transform(target)
 
     def estimated_num_outputs(self):
         total_num_outputs = 0

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -27,6 +27,7 @@ class StreamingSplit(LogicalOperator):
         assert isinstance(input_op, LogicalOperator), input_op
         object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
 
     def _apply_transform(
         self, transform: Callable[[LogicalOperator], LogicalOperator]

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -1,4 +1,5 @@
-from typing import TYPE_CHECKING, List, Optional
+from dataclasses import InitVar, dataclass, field
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
 
@@ -10,20 +11,39 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class StreamingSplit(LogicalOperator):
     """Logical operator that represents splitting the input data to `n` splits."""
 
-    def __init__(
-        self,
-        input_op: LogicalOperator,
-        num_splits: int,
-        equal: bool,
-        locality_hints: Optional[List["NodeIdStr"]] = None,
-    ):
-        super().__init__(input_dependencies=[input_op])
-        self.num_splits = num_splits
-        self.equal = equal
-        self.locality_hints = locality_hints
+    input_op: InitVar[LogicalOperator]
+    num_splits: int
+    equal: bool
+    locality_hints: Optional[List["NodeIdStr"]] = None
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        object.__setattr__(self, "_name", self.__class__.__name__)
+        object.__setattr__(self, "_input_dependencies", [input_op])
+
+    def _apply_transform(
+        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    ) -> LogicalOperator:
+        input_op = self.input_dependencies[0]
+        transformed_input = input_op._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is input_op:
+            target = self
+        else:
+            target = StreamingSplit(
+                transformed_input,
+                num_splits=self.num_splits,
+                equal=self.equal,
+                locality_hints=self.locality_hints,
+            )
+        return transform(target)
 
     @property
     def num_outputs(self) -> Optional[int]:

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -19,6 +19,7 @@ from ray.data._internal.logical.operators import (
     Project,
     RandomShuffle,
     Repartition,
+    Union,
 )
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     _ColumnSubstitutionVisitor,
@@ -355,6 +356,8 @@ class PredicatePushdown(Rule):
                 partition_size_hint=op.partition_size_hint,
                 aggregator_ray_remote_args=op.aggregator_ray_remote_args,
             )
+        if isinstance(op, Union) and is_dataclass(op):
+            return Union(*new_inputs)
         new_op = copy.copy(op)
         new_op.input_dependencies = new_inputs
         return new_op


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

A few concrete logical operators still needed to be converted before moving on to the
abstract-class and field-model cleanup. This PR handles that remaining concrete
operator coverage.

#### What this PR changes:

Converts the remaining concrete logical operators to frozen dataclasses:
- `Zip`
- `Union`
- `StreamingSplit`

This PR also makes the minimum rule update needed for frozen compatibility:
- `PredicatePushdown` now reconstructs frozen `Union` operators instead of falling back
  to `copy.copy()` + input mutation.

This PR is intentionally limited to concrete operator conversion plus the minimal
`Union` predicate-pushdown compatibility update. It does not include the later
abstract-class, derived-field, or broader rule-cleanup follow-ups.

## Related issues

Closes #60312

## Additional information

This PR covers the remaining concrete logical operators called out in the current
split plan: `Zip`, `Union`, and `StreamingSplit`.

### Tests

- `python -m pre_commit run --files python/ray/data/_internal/logical/operators/n_ary_operator.py python/ray/data/_internal/logical/operators/streaming_split_operator.py python/ray/data/_internal/logical/rules/predicate_pushdown.py ci/lint/pyrefly-excluded-files.txt`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_union.py python/ray/data/tests/test_execution_optimizer_limit_pushdown.py -k 'union'`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_execution_optimizer_advanced.py -k 'zip'`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_split.py -k 'split'`

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- This PR: convert the remaining concrete logical operators to frozen dataclasses

Next:
- make `LogicalOperator` and abstract logical classes frozen dataclasses
- make `_name` a derived field
- deduplicate `_apply_transform`
- replace `input_op: InitVar` with a real `input_dependencies` field
- remove `input_dependency` on `AbstractOneToOne`
- clean up `_get_args`
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`
