### PR TITLE
[serve] Bump HAProxy to avoid CVE-2025-11230

### DIFF
--- a/ci/docker/serve.build.Dockerfile
+++ b/ci/docker/serve.build.Dockerfile
@@ -19,7 +19,7 @@ apt-get install -y --no-install-recommends \
     wget \
     zlib1g-dev
 
-HAPROXY_VERSION="2.8.12"
+HAPROXY_VERSION="2.8.20"
 HAPROXY_BUILD_DIR=$(mktemp -d)
 wget -O "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" "https://www.haproxy.org/download/2.8/src/haproxy-${HAPROXY_VERSION}.tar.gz"
 tar -xzf "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" -C "${HAPROXY_BUILD_DIR}" --strip-components=1

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -263,7 +263,7 @@ apt-get update -y && apt-get install -y --no-install-recommends \
     liblua5.3-dev libpcre3-dev libssl-dev zlib1g-dev
 
 # Build HAProxy from source
-export HAPROXY_VERSION="2.8.12"
+export HAPROXY_VERSION="2.8.20"
 curl -sSfL -o /tmp/haproxy.tar.gz \
   "https://www.haproxy.org/download/2.8/src/haproxy-${HAPROXY_VERSION}.tar.gz"
 mkdir -p /tmp/haproxy-build && tar -xzf /tmp/haproxy.tar.gz -C /tmp/haproxy-build --strip-components=1

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -24,7 +24,7 @@ apt-get install -y --no-install-recommends \
     zlib1g-dev
 
 # Install HAProxy from source
-HAPROXY_VERSION="2.8.12"
+HAPROXY_VERSION="2.8.20"
 HAPROXY_BUILD_DIR=$(mktemp -d)
 curl -sSfL -o "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" "https://www.haproxy.org/download/2.8/src/haproxy-${HAPROXY_VERSION}.tar.gz"
 tar -xzf "${HAPROXY_BUILD_DIR}/haproxy.tar.gz" -C "${HAPROXY_BUILD_DIR}" --strip-components=1

--- a/docker/base-slim/Dockerfile
+++ b/docker/base-slim/Dockerfile
@@ -157,7 +157,7 @@ apt-get install -y --no-install-recommends \
 rm -rf /var/lib/apt/lists/*
 
 # Install HAProxy from source
-HAPROXY_VERSION="2.8.12"
+HAPROXY_VERSION="2.8.20"
 BUILD_DIR=$(mktemp -d)
 curl -sSfL -o "${BUILD_DIR}/haproxy.tar.gz" "https://www.haproxy.org/download/2.8/src/haproxy-${HAPROXY_VERSION}.tar.gz"
 tar -xzf "${BUILD_DIR}/haproxy.tar.gz" -C "${BUILD_DIR}" --strip-components=1


### PR DESCRIPTION
## Summary

Bump HAProxy from 2.8.12 to 2.8.20 in `ci/docker/serve.build.Dockerfile`.

While building the `ray-haproxy` PyPI package (ray-project/ray-haproxy), a Grype CVE scan of the compiled HAProxy 2.8.12 binary flagged two known vulnerabilities:

- **CVE-2025-11230** (High): DoS via the bundled mjson JSON parser. Crafted JSON triggers quadratic parsing complexity, consuming all CPU. Network-based, no auth required. Fixed in 2.8.16.
- **CVE-2025-32464** (Medium): Fixed in 2.8.15.

2.8.20 is the latest patch in the 2.8.x LTS branch.

## Test plan

- [x] Existing HAProxy Serve CI tests pass (`test_haproxy`, `test_haproxy_api`, `test_metrics_haproxy`)
- [x] `serve.build.Dockerfile` builds successfully