### PR TITLE
[Data] Fix autoscaler bug that blocks timely release of leased resources

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import ray
-from .base_autoscaling_coordinator import AutoscalingCoordinator
+from .base_autoscaling_coordinator import AutoscalingCoordinator, ResourceDict
 from .default_autoscaling_coordinator import (
     DefaultAutoscalingCoordinator,
 )
@@ -139,6 +139,12 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         "RAY_DATA_AUTOSCALING_REQUEST_EXPIRE_TIME_S",
         180,
     )
+    # When utilization drops below the scale-up threshold, keep renewing the last
+    # explicit request for a short time before releasing it.
+    DEFAULT_LOW_UTIL_REQUEST_RELEASE_DELAY_S: float = env_float(
+        "RAY_DATA_LOW_UTIL_REQUEST_RELEASE_DELAY_S",
+        180,
+    )
     # Whether to disable INFO-level logs.
     RAY_DATA_DISABLE_AUTOSCALER_LOGGING = env_bool(
         "RAY_DATA_DISABLE_AUTOSCALER_LOGGING", False
@@ -154,6 +160,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         cluster_scaling_up_delta: float = DEFAULT_CLUSTER_SCALING_UP_DELTA,
         cluster_util_avg_window_s: float = DEFAULT_CLUSTER_UTIL_AVG_WINDOW_S,
         min_gap_between_autoscaling_requests_s: float = MIN_GAP_BETWEEN_AUTOSCALING_REQUESTS,  # noqa: E501
+        low_util_request_release_delay_s: float = DEFAULT_LOW_UTIL_REQUEST_RELEASE_DELAY_S,  # noqa: E501
         autoscaling_coordinator: Optional[AutoscalingCoordinator] = None,
         get_node_counts: Callable[[], Dict[_NodeResourceSpec, int]] = (
             _get_node_resource_spec_and_count
@@ -162,6 +169,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         assert cluster_scaling_up_delta > 0
         assert cluster_util_avg_window_s > 0
         assert min_gap_between_autoscaling_requests_s >= 0
+        assert low_util_request_release_delay_s >= 0
 
         if resource_utilization_calculator is None:
             resource_utilization_calculator = RollingLogicalUtilizationGauge(
@@ -181,8 +189,14 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._min_gap_between_autoscaling_requests_s = (
             min_gap_between_autoscaling_requests_s
         )
+        self._low_util_request_release_delay_s = low_util_request_release_delay_s
         # Last time when a request was sent to Ray's autoscaler.
         self._last_request_time = 0
+        # Track the last non-empty explicit request so low-utilization heartbeats
+        # can keep it alive briefly without turning allocated remaining-share
+        # resources into explicit autoscaler demand.
+        self._last_non_empty_resource_request: List[ResourceDict] = []
+        self._last_non_empty_request_time: Optional[float] = None
         self._requester_id = f"data-{execution_id}"
         self._autoscaling_coordinator = autoscaling_coordinator
         self._get_node_counts = get_node_counts
@@ -214,12 +228,15 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
                 f"CPU={util.cpu:.2f}, GPU={util.gpu:.2f}, memory={util.memory:.2f}, "
                 f"object_store_memory={util.object_store_memory:.2f}."
             )
-            # Send current resources allocation when upscaling is not needed,
-            # to renew our registration on AutoscalingCoordinator.
-            curr_resources = self._autoscaling_coordinator.get_allocated_resources(
-                requester_id=self._requester_id
-            )
-            self._send_resource_request(curr_resources)
+            if self._should_keep_non_empty_request(now):
+                self._send_resource_request(
+                    self._last_non_empty_resource_request,
+                    update_non_empty_request_state=False,
+                )
+            else:
+                # Renew our registration on AutoscalingCoordinator without
+                # keeping explicit autoscaler demand alive.
+                self._send_resource_request([])
             return
 
         # We separate active bundles (existing nodes) from pending bundles (scale-up delta)
@@ -281,7 +298,18 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
 
         logger.log(level, message)
 
-    def _send_resource_request(self, resource_request):
+    def _should_keep_non_empty_request(self, now: float) -> bool:
+        return (
+            self._last_non_empty_request_time is not None
+            and now - self._last_non_empty_request_time
+            < self._low_util_request_release_delay_s
+        )
+
+    def _send_resource_request(
+        self,
+        resource_request: List[ResourceDict],
+        update_non_empty_request_state: bool = True,
+    ):
         # Make autoscaler resource request.
         self._autoscaling_coordinator.request_resources(
             requester_id=self._requester_id,
@@ -289,7 +317,16 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             expire_after_s=self.AUTOSCALING_REQUEST_EXPIRE_TIME_S,
             request_remaining=True,
         )
-        self._last_request_time = time.time()
+        now = time.time()
+        if resource_request and update_non_empty_request_state:
+            self._last_non_empty_resource_request = [
+                bundle.copy() for bundle in resource_request
+            ]
+            self._last_non_empty_request_time = now
+        elif not resource_request:
+            self._last_non_empty_resource_request = []
+            self._last_non_empty_request_time = None
+        self._last_request_time = now
 
     def on_executor_shutdown(self):
         # Cancel the resource request when the executor is shutting down.

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -165,6 +165,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         get_node_counts: Callable[[], Dict[_NodeResourceSpec, int]] = (
             _get_node_resource_spec_and_count
         ),
+        get_time: Callable[[], float] = time.time,
     ):
         assert cluster_scaling_up_delta > 0
         assert cluster_util_avg_window_s > 0
@@ -200,6 +201,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._requester_id = f"data-{execution_id}"
         self._autoscaling_coordinator = autoscaling_coordinator
         self._get_node_counts = get_node_counts
+        self._get_time = get_time
         self._autoscaling_enabled = is_autoscaling_enabled()
 
         # Send an empty request to register ourselves as soon as possible,
@@ -212,7 +214,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._resource_utilization_calculator.observe()
 
         # Limit the frequency of autoscaling requests.
-        now = time.time()
+        now = self._get_time()
         if now - self._last_request_time < self._min_gap_between_autoscaling_requests_s:
             return
 
@@ -228,15 +230,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
                 f"CPU={util.cpu:.2f}, GPU={util.gpu:.2f}, memory={util.memory:.2f}, "
                 f"object_store_memory={util.object_store_memory:.2f}."
             )
-            if self._should_keep_non_empty_request(now):
-                self._send_resource_request(
-                    self._last_non_empty_resource_request,
-                    update_non_empty_request_state=False,
-                )
-            else:
-                # Renew our registration on AutoscalingCoordinator without
-                # keeping explicit autoscaler demand alive.
-                self._send_resource_request([])
+            self._send_resource_request(None)
             return
 
         # We separate active bundles (existing nodes) from pending bundles (scale-up delta)
@@ -307,9 +301,19 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
 
     def _send_resource_request(
         self,
-        resource_request: List[ResourceDict],
-        update_non_empty_request_state: bool = True,
+        resource_request: Optional[List[ResourceDict]],
     ):
+        now = self._get_time()
+        update_non_empty_request_state = True
+        if resource_request is None:
+            if self._should_keep_non_empty_request(now):
+                resource_request = self._last_non_empty_resource_request
+                update_non_empty_request_state = False
+            else:
+                # Renew our registration on AutoscalingCoordinator without
+                # keeping explicit autoscaler demand alive.
+                resource_request = []
+
         # Make autoscaler resource request.
         self._autoscaling_coordinator.request_resources(
             requester_id=self._requester_id,
@@ -317,7 +321,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             expire_after_s=self.AUTOSCALING_REQUEST_EXPIRE_TIME_S,
             request_remaining=True,
         )
-        now = time.time()
         if resource_request and update_non_empty_request_state:
             self._last_non_empty_resource_request = [
                 bundle.copy() for bundle in resource_request

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -36,6 +36,10 @@ _IS_AUTOSCALING_ENABLED_PATH = (
     "default_cluster_autoscaler_v2.is_autoscaling_enabled"
 )
 
+_AUTOSCALER_TIME_PATH = (
+    "ray.data._internal.cluster_autoscaler.default_cluster_autoscaler_v2.time.time"
+)
+
 
 class TestClusterAutoscaling:
     """Tests for cluster autoscaling functions in DefaultClusterAutoscalerV2."""
@@ -306,6 +310,99 @@ class TestClusterAutoscaling:
         utilization = ExecutionResources(cpu=0)
         autoscaler.try_trigger_scaling()
         assert autoscaler.get_total_resources() == ExecutionResources(cpu=1)
+
+    def test_low_utilization_grace_period_keeps_explicit_request(self):
+        """Below the scale-up threshold, the last explicit request is resent briefly.
+
+        This avoids immediately dropping explicit autoscaler demand (and avoids
+        re-submitting ``get_allocated_resources()`` shapes as explicit demand).
+        """
+        current_time = {"t": 0.0}
+
+        def get_time() -> float:
+            return current_time["t"]
+
+        node_resource_spec = _NodeResourceSpec.of(cpu=1, gpu=0, mem=0)
+        fake_coordinator = FakeAutoscalingCoordinator(get_time=get_time)
+        utilization_holder = {
+            "u": ExecutionResources(
+                cpu=0.9, gpu=0.9, object_store_memory=0.9, memory=0.9
+            )
+        }
+
+        class MutableUtilGauge(ResourceUtilizationGauge):
+            def observe(self):
+                pass
+
+            def get(self):
+                return utilization_holder["u"]
+
+        with patch(_AUTOSCALER_TIME_PATH, get_time):
+            autoscaler = DefaultClusterAutoscalerV2(
+                resource_manager=MagicMock(),
+                resource_limits=ExecutionResources.inf(),
+                execution_id="test_low_util_grace",
+                resource_utilization_calculator=MutableUtilGauge(),
+                min_gap_between_autoscaling_requests_s=0,
+                low_util_request_release_delay_s=100,
+                autoscaling_coordinator=fake_coordinator,
+                get_node_counts=lambda: {node_resource_spec: 0},
+            )
+            autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
+
+            current_time["t"] = 10.0
+            autoscaler.try_trigger_scaling()
+            expected = ExecutionResources(cpu=1.0)
+            assert autoscaler.get_total_resources() == expected
+
+            utilization_holder["u"] = ExecutionResources.zero()
+            current_time["t"] = 20.0
+            autoscaler.try_trigger_scaling()
+            assert autoscaler.get_total_resources() == expected
+
+    def test_low_utilization_after_grace_sends_empty_request(self):
+        """After the grace window, low utilization renews with an empty request."""
+        current_time = {"t": 0.0}
+
+        def get_time() -> float:
+            return current_time["t"]
+
+        node_resource_spec = _NodeResourceSpec.of(cpu=1, gpu=0, mem=0)
+        fake_coordinator = FakeAutoscalingCoordinator(get_time=get_time)
+        utilization_holder = {
+            "u": ExecutionResources(
+                cpu=0.9, gpu=0.9, object_store_memory=0.9, memory=0.9
+            )
+        }
+
+        class MutableUtilGauge(ResourceUtilizationGauge):
+            def observe(self):
+                pass
+
+            def get(self):
+                return utilization_holder["u"]
+
+        with patch(_AUTOSCALER_TIME_PATH, get_time):
+            autoscaler = DefaultClusterAutoscalerV2(
+                resource_manager=MagicMock(),
+                resource_limits=ExecutionResources.inf(),
+                execution_id="test_low_util_release",
+                resource_utilization_calculator=MutableUtilGauge(),
+                min_gap_between_autoscaling_requests_s=0,
+                low_util_request_release_delay_s=100,
+                autoscaling_coordinator=fake_coordinator,
+                get_node_counts=lambda: {node_resource_spec: 0},
+            )
+            autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
+
+            current_time["t"] = 10.0
+            autoscaler.try_trigger_scaling()
+            assert autoscaler.get_total_resources() == ExecutionResources(cpu=1.0)
+
+            utilization_holder["u"] = ExecutionResources.zero()
+            current_time["t"] = 200.0
+            autoscaler.try_trigger_scaling()
+            assert autoscaler.get_total_resources() == ExecutionResources.zero()
 
     def test_get_node_resource_spec_and_count_skips_max_count_zero(self):
         """Test that node types with max_count=0 are skipped."""

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -36,10 +36,6 @@ _IS_AUTOSCALING_ENABLED_PATH = (
     "default_cluster_autoscaler_v2.is_autoscaling_enabled"
 )
 
-_AUTOSCALER_TIME_PATH = (
-    "ray.data._internal.cluster_autoscaler.default_cluster_autoscaler_v2.time.time"
-)
-
 
 class TestClusterAutoscaling:
     """Tests for cluster autoscaling functions in DefaultClusterAutoscalerV2."""
@@ -337,28 +333,28 @@ class TestClusterAutoscaling:
             def get(self):
                 return utilization_holder["u"]
 
-        with patch(_AUTOSCALER_TIME_PATH, get_time):
-            autoscaler = DefaultClusterAutoscalerV2(
-                resource_manager=MagicMock(),
-                resource_limits=ExecutionResources.inf(),
-                execution_id="test_low_util_grace",
-                resource_utilization_calculator=MutableUtilGauge(),
-                min_gap_between_autoscaling_requests_s=0,
-                low_util_request_release_delay_s=100,
-                autoscaling_coordinator=fake_coordinator,
-                get_node_counts=lambda: {node_resource_spec: 0},
-            )
-            autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
+        autoscaler = DefaultClusterAutoscalerV2(
+            resource_manager=MagicMock(),
+            resource_limits=ExecutionResources.inf(),
+            execution_id="test_low_util_grace",
+            resource_utilization_calculator=MutableUtilGauge(),
+            min_gap_between_autoscaling_requests_s=0,
+            low_util_request_release_delay_s=100,
+            autoscaling_coordinator=fake_coordinator,
+            get_node_counts=lambda: {node_resource_spec: 0},
+            get_time=get_time,
+        )
+        autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
 
-            current_time["t"] = 10.0
-            autoscaler.try_trigger_scaling()
-            expected = ExecutionResources(cpu=1.0)
-            assert autoscaler.get_total_resources() == expected
+        current_time["t"] = 10.0
+        autoscaler.try_trigger_scaling()
+        expected = ExecutionResources(cpu=1.0)
+        assert autoscaler.get_total_resources() == expected
 
-            utilization_holder["u"] = ExecutionResources.zero()
-            current_time["t"] = 20.0
-            autoscaler.try_trigger_scaling()
-            assert autoscaler.get_total_resources() == expected
+        utilization_holder["u"] = ExecutionResources.zero()
+        current_time["t"] = 20.0
+        autoscaler.try_trigger_scaling()
+        assert autoscaler.get_total_resources() == expected
 
     def test_low_utilization_after_grace_sends_empty_request(self):
         """After the grace window, low utilization renews with an empty request."""
@@ -382,27 +378,27 @@ class TestClusterAutoscaling:
             def get(self):
                 return utilization_holder["u"]
 
-        with patch(_AUTOSCALER_TIME_PATH, get_time):
-            autoscaler = DefaultClusterAutoscalerV2(
-                resource_manager=MagicMock(),
-                resource_limits=ExecutionResources.inf(),
-                execution_id="test_low_util_release",
-                resource_utilization_calculator=MutableUtilGauge(),
-                min_gap_between_autoscaling_requests_s=0,
-                low_util_request_release_delay_s=100,
-                autoscaling_coordinator=fake_coordinator,
-                get_node_counts=lambda: {node_resource_spec: 0},
-            )
-            autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
+        autoscaler = DefaultClusterAutoscalerV2(
+            resource_manager=MagicMock(),
+            resource_limits=ExecutionResources.inf(),
+            execution_id="test_low_util_release",
+            resource_utilization_calculator=MutableUtilGauge(),
+            min_gap_between_autoscaling_requests_s=0,
+            low_util_request_release_delay_s=100,
+            autoscaling_coordinator=fake_coordinator,
+            get_node_counts=lambda: {node_resource_spec: 0},
+            get_time=get_time,
+        )
+        autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
 
-            current_time["t"] = 10.0
-            autoscaler.try_trigger_scaling()
-            assert autoscaler.get_total_resources() == ExecutionResources(cpu=1.0)
+        current_time["t"] = 10.0
+        autoscaler.try_trigger_scaling()
+        assert autoscaler.get_total_resources() == ExecutionResources(cpu=1.0)
 
-            utilization_holder["u"] = ExecutionResources.zero()
-            current_time["t"] = 200.0
-            autoscaler.try_trigger_scaling()
-            assert autoscaler.get_total_resources() == ExecutionResources.zero()
+        utilization_holder["u"] = ExecutionResources.zero()
+        current_time["t"] = 200.0
+        autoscaler.try_trigger_scaling()
+        assert autoscaler.get_total_resources() == ExecutionResources.zero()
 
     def test_get_node_resource_spec_and_count_skips_max_count_zero(self):
         """Test that node types with max_count=0 are skipped."""


### PR DESCRIPTION
## Description

This PR fixes a Ray Data bug that **blocked timely release of leased resources**
by the cluster autoscaler.

Previously, when utilization dropped below the scale-up threshold,
`DefaultClusterAutoscalerV2` **sent** `get_allocated_resources()` as **explicit
resource requests**. That kept explicit demand pinned and prevented the
cluster autoscaler from releasing leased resources in a timely manner until
dataset completion, causing avoidable over-allocation and waste.

The new behavior is:

- Keep the last non-empty explicit resource request only for a bounded grace
  window.
- After the grace window, send an empty explicit resource request (`[]`)
  while keeping requester registration alive, so the cluster autoscaler can
  release leased resources earlier.

This is implemented by tracking the last non-empty explicit resource request and
timestamp, and by introducing `RAY_DATA_LOW_UTIL_REQUEST_RELEASE_DELAY_S`
(default `180s`).

## Related issues

N/A (no public issue linked)

## Additional information

### Files changed

- `python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py`
- `python/ray/data/tests/test_default_cluster_autoscaler_v2.py`

### Validation

- Added regression tests for:
  - in-grace retention of the last explicit resource request
  - post-grace sending of an empty explicit resource request
