### PR TITLE
[Data] Convert abstract logical operator classes to frozen dataclasses

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -23,10 +23,6 @@ class LogicalOperator(Operator, ABC):
     _input_dependencies: List["LogicalOperator"] = field(repr=False)
     _num_outputs: Optional[int] = field(default=None, repr=False)
 
-    def __post_init__(self):
-        for x in self._input_dependencies:
-            assert isinstance(x, LogicalOperator), x
-
     @property
     @abstractmethod
     def num_outputs(self) -> Optional[int]:
@@ -52,10 +48,15 @@ class LogicalOperator(Operator, ABC):
 
     @property
     def input_dependencies(self) -> List["LogicalOperator"]:
-        return super().input_dependencies  # type: ignore
+        value = super().input_dependencies  # type: ignore
+        for x in value:
+            assert isinstance(x, LogicalOperator), x
+        return value
 
     @input_dependencies.setter
     def input_dependencies(self, value: List["LogicalOperator"]) -> None:
+        for x in value:
+            assert isinstance(x, LogicalOperator), x
         object.__setattr__(self, "_input_dependencies", value)
 
     def post_order_iter(self) -> Iterator["LogicalOperator"]:

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
     from ray.data.block import Schema
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class LogicalOperator(Operator, ABC):
     """Abstract class for logical operators.
 
@@ -17,23 +19,13 @@ class LogicalOperator(Operator, ABC):
     physical operator.
     """
 
-    def __init__(
-        self,
-        input_dependencies: List["LogicalOperator"],
-        num_outputs: Optional[int] = None,
-        *,
-        name: Optional[str] = None,
-    ):
-        if name is None:
-            name = self.__class__.__name__
-        super().__init__(
-            name,
-            input_dependencies,
-        )
-        for x in input_dependencies:
-            assert isinstance(x, LogicalOperator), x
+    _name: str = field(repr=False)
+    _input_dependencies: List["LogicalOperator"] = field(repr=False)
+    _num_outputs: Optional[int] = field(default=None, repr=False)
 
-        self._num_outputs: Optional[int] = num_outputs
+    def __post_init__(self):
+        for x in self._input_dependencies:
+            assert isinstance(x, LogicalOperator), x
 
     @property
     @abstractmethod
@@ -64,7 +56,7 @@ class LogicalOperator(Operator, ABC):
 
     @input_dependencies.setter
     def input_dependencies(self, value: List["LogicalOperator"]) -> None:
-        self._input_dependencies = value
+        object.__setattr__(self, "_input_dependencies", value)
 
     def post_order_iter(self) -> Iterator["LogicalOperator"]:
         return super().post_order_iter()  # type: ignore

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -27,6 +27,7 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class AbstractAllToAll(LogicalOperator):
     """Abstract class for logical operators should be converted to physical
     AllToAllOperator.
@@ -55,12 +56,12 @@ class AbstractAllToAll(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            input_dependencies=[input_op],
-            num_outputs=num_outputs,
-            name=name,
+            _name=name or self.__class__.__name__,
+            _input_dependencies=[input_op],
+            _num_outputs=num_outputs,
         )
-        self.ray_remote_args = ray_remote_args or {}
-        self.sub_progress_bar_names = sub_progress_bar_names
+        object.__setattr__(self, "ray_remote_args", ray_remote_args or {})
+        object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
 
     @property
     def num_outputs(self) -> Optional[int]:

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -30,6 +30,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class AbstractMap(AbstractOneToOne):
     """Abstract class for logical operators that should be converted to physical
     MapOperator.
@@ -78,16 +79,19 @@ class AbstractMap(AbstractOneToOne):
             num_outputs=num_outputs,
             name=name,
         )
-        self.min_rows_per_bundled_input = min_rows_per_bundled_input
-        self.ray_remote_args = ray_remote_args or {}
-        self.ray_remote_args_fn = ray_remote_args_fn
-        self.compute = compute or TaskPoolStrategy()
-        self.per_block_limit = None
+        object.__setattr__(
+            self, "min_rows_per_bundled_input", min_rows_per_bundled_input
+        )
+        object.__setattr__(self, "ray_remote_args", ray_remote_args or {})
+        object.__setattr__(self, "ray_remote_args_fn", ray_remote_args_fn)
+        object.__setattr__(self, "compute", compute or TaskPoolStrategy())
+        object.__setattr__(self, "per_block_limit", None)
 
     def set_per_block_limit(self, per_block_limit: int):
-        self.per_block_limit = per_block_limit
+        object.__setattr__(self, "per_block_limit", per_block_limit)
 
 
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class AbstractUDFMap(AbstractMap):
     """Abstract class for logical operators performing a UDF that should be converted
     to physical MapOperator.
@@ -146,12 +150,12 @@ class AbstractUDFMap(AbstractMap):
             ray_remote_args=ray_remote_args,
             compute=compute,
         )
-        self.fn = fn
-        self.fn_args = fn_args
-        self.fn_kwargs = fn_kwargs
-        self.fn_constructor_args = fn_constructor_args
-        self.fn_constructor_kwargs = fn_constructor_kwargs
-        self.ray_remote_args_fn = ray_remote_args_fn
+        object.__setattr__(self, "fn", fn)
+        object.__setattr__(self, "fn_args", fn_args)
+        object.__setattr__(self, "fn_kwargs", fn_kwargs)
+        object.__setattr__(self, "fn_constructor_args", fn_constructor_args)
+        object.__setattr__(self, "fn_constructor_kwargs", fn_constructor_kwargs)
+        object.__setattr__(self, "ray_remote_args_fn", ray_remote_args_fn)
 
     def _get_operator_name(self, op_name: str, fn: UserDefinedFunction):
         """Gets the Operator name including the map `fn` UDF name."""

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -14,6 +14,7 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class NAry(LogicalOperator):
     """Base class for n-ary operators, which take multiple input operators."""
 
@@ -27,8 +28,9 @@ class NAry(LogicalOperator):
             input_ops: The input operators.
         """
         super().__init__(
-            input_dependencies=list(input_ops),
-            num_outputs=num_outputs,
+            _name=self.__class__.__name__,
+            _input_dependencies=list(input_ops),
+            _num_outputs=num_outputs,
         )
 
     @property

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -20,6 +20,7 @@ __all__ = [
 ]
 
 
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class AbstractOneToOne(LogicalOperator):
     """Abstract class for one-to-one logical operators, which
     have one input and one output dependency.
@@ -45,11 +46,11 @@ class AbstractOneToOne(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            input_dependencies=[input_op] if input_op else [],
-            num_outputs=num_outputs,
-            name=name,
+            _name=name or self.__class__.__name__,
+            _input_dependencies=[input_op] if input_op else [],
+            _num_outputs=num_outputs,
         )
-        self.can_modify_num_rows = can_modify_num_rows
+        object.__setattr__(self, "can_modify_num_rows", can_modify_num_rows)
 
     @property
     def num_outputs(self) -> Optional[int]:

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -37,6 +37,13 @@ def _check_valid_plan_and_result(
 
 
 class _DummyLogicalOperator(LogicalOperator):
+    def __init__(self, input_dependencies, name=None, num_outputs=None):
+        super().__init__(
+            _name=name or self.__class__.__name__,
+            _input_dependencies=input_dependencies,
+            _num_outputs=num_outputs,
+        )
+
     @property
     def num_outputs(self):
         return self._num_outputs

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -91,50 +91,75 @@ class DummyLogicalOperator(LogicalOperator):
     """A dummy logical operator for testing _get_logical_args with various data types."""
 
     def __init__(self, input_op=None):
-        super().__init__(input_dependencies=[], name="DummyOperator")
+        super().__init__(
+            _name="DummyOperator",
+            _input_dependencies=[],
+            _num_outputs=None,
+        )
 
         # Test various data types that might be returned by _get_logical_args
-        self._string_value = "test_string"
-        self._int_value = 42
-        self._float_value = 3.14
-        self._bool_value = True
-        self._none_value = None
-        self._list_value = [1, 2, 3, "string", None]
-        self._dict_value = {"key1": "value1", "key2": 123, "key3": None}
-        self._nested_dict = {
-            "level1": {
-                "level2": {
-                    "level3": "deep_value",
-                    "numbers": [1, 2, 3],
-                    "mixed": {"a": 1, "b": "string", "c": None},
+        object.__setattr__(self, "_string_value", "test_string")
+        object.__setattr__(self, "_int_value", 42)
+        object.__setattr__(self, "_float_value", 3.14)
+        object.__setattr__(self, "_bool_value", True)
+        object.__setattr__(self, "_none_value", None)
+        object.__setattr__(self, "_list_value", [1, 2, 3, "string", None])
+        object.__setattr__(
+            self, "_dict_value", {"key1": "value1", "key2": 123, "key3": None}
+        )
+        object.__setattr__(
+            self,
+            "_nested_dict",
+            {
+                "level1": {
+                    "level2": {
+                        "level3": "deep_value",
+                        "numbers": [1, 2, 3],
+                        "mixed": {"a": 1, "b": "string", "c": None},
+                    }
                 }
-            }
-        }
-        self._tuple_value = (1, "string", None, 3.14)
-        self._set_value = {1}
-        self._bytes_value = b"binary_data"
-        self._complex_dict = {
-            "string_keys": {"a": 1, "b": 2},
-            "int_keys": {1: "one", 2: "two"},  # This should cause issues if not handled
-            "mixed_keys": {"str": "value", 1: "int_key", None: "none_key"},
-        }
-        self._empty_containers = {
-            "empty_list": [],
-            "empty_dict": {},
-            "empty_tuple": (),
-            "empty_set": set(),
-        }
-        self._special_values = {
-            "zero": 0,
-            "negative": -1,
-            "large_int": 999999999999999999,
-            "small_float": 0.0000001,
-            "inf": float("inf"),
-            "neg_inf": float("-inf"),
-            "nan": float("nan"),
-        }
+            },
+        )
+        object.__setattr__(self, "_tuple_value", (1, "string", None, 3.14))
+        object.__setattr__(self, "_set_value", {1})
+        object.__setattr__(self, "_bytes_value", b"binary_data")
+        object.__setattr__(
+            self,
+            "_complex_dict",
+            {
+                "string_keys": {"a": 1, "b": 2},
+                "int_keys": {
+                    1: "one",
+                    2: "two",
+                },  # This should cause issues if not handled
+                "mixed_keys": {"str": "value", 1: "int_key", None: "none_key"},
+            },
+        )
+        object.__setattr__(
+            self,
+            "_empty_containers",
+            {
+                "empty_list": [],
+                "empty_dict": {},
+                "empty_tuple": (),
+                "empty_set": set(),
+            },
+        )
+        object.__setattr__(
+            self,
+            "_special_values",
+            {
+                "zero": 0,
+                "negative": -1,
+                "large_int": 999999999999999999,
+                "small_float": 0.0000001,
+                "inf": float("inf"),
+                "neg_inf": float("-inf"),
+                "nan": float("nan"),
+            },
+        )
 
-        self._data_class = TestDataclass()
+        object.__setattr__(self, "_data_class", TestDataclass())
 
     @property
     def num_outputs(self):

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -3,6 +3,13 @@ from ray.data.context import DataContext
 
 
 class DummyLogicalOperator(LogicalOperator):
+    def __init__(self, input_dependencies, name=None, num_outputs=None):
+        super().__init__(
+            _name=name or self.__class__.__name__,
+            _input_dependencies=input_dependencies,
+            _num_outputs=num_outputs,
+        )
+
     @property
     def num_outputs(self):
         return self._num_outputs


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

After finishing the remaining concrete operator coverage, the next step in the split plan is to convert `LogicalOperator` and the abstract logical operator base classes into frozen dataclasses.

#### What this PR changes:

Makes the following abstract logical operator classes frozen dataclasses:
- `LogicalOperator`
- `NAry`
- `AbstractOneToOne`
- `AbstractMap`
- `AbstractUDFMap`
- `AbstractAllToAll`

This PR also makes `_name`, `_input_dependencies`, and `_num_outputs` proper dataclass fields on `LogicalOperator`, removing the manual `LogicalOperator.__init__`.

Extending the same step to additional abstract-base state runs into concrete dataclass constructor-generation errors (for example, `TypeError: non-default argument 'input_op' follows default argument`), so the broader field-model cleanup remains in the later follow-up PRs.

This PR does not include the later `_name` derived-field work, `_apply_transform` deduplication, `input_op: InitVar` replacement, or broader logical-rule cleanup follow-ups.

## Related issues

Closes #60312

## Additional information

This PR corresponds to the current split-plan step for making `LogicalOperator` and the abstract logical operator base classes frozen dataclasses.

### Tests

- `python -m pre_commit run --files python/ray/data/_internal/logical/interfaces/logical_operator.py python/ray/data/_internal/logical/operators/n_ary_operator.py python/ray/data/_internal/logical/operators/one_to_one_operator.py python/ray/data/_internal/logical/operators/map_operator.py python/ray/data/_internal/logical/operators/all_to_all_operator.py`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_execution_optimizer_basic.py -k 'map or repartition or sort or union or zip'`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_union.py python/ray/data/tests/test_split.py -k 'union or split'`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_join.py -k 'inner or outer or semi or anti'`

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- PR-Next-0: Convert remaining concrete logical operators to frozen dataclasses
- This PR: make `LogicalOperator` and the abstract logical operator base classes frozen dataclasses

Next:
- make `_name` a derived field
- deduplicate `_apply_transform`
- replace `input_op: InitVar` with a real `input_dependencies` field
- remove `input_dependency` on `AbstractOneToOne`
- clean up `_get_args`
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`
