### PR TITLE
[Data] Skip unconditional null strip in `find_partition_index`

### DIFF
--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -899,9 +899,11 @@ def find_partition_index(
         # Stripping them before searching avoids a TypeError from np.searchsorted
         # on None values — and if desired_val is also None, the answer is simply
         # the end of the non-null region.
-        col_vals = col_vals[
-            ~pd.isna(col_vals)
-        ]  # remove nulls from the tail of col_vals
+        # Use the Arrow column's O(1) null_count to skip the
+        # expensive pd.isna + boolean indexing when there are no nulls (the
+        # common case).
+        if table[col_name].null_count > 0:
+            col_vals = col_vals[~pd.isna(col_vals)]
         if desired_val is None:
             return left + len(col_vals)
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -895,21 +895,15 @@ def find_partition_index(
         col_vals = table[col_name].to_numpy()[left:right]
         desired_val = desired[i]
 
-        # Nulls sort last in Arrow, so they accumulate at the tail of col_vals.
-        # Stripping them before searching avoids a TypeError from np.searchsorted
-        # on None values — and if desired_val is also None, the answer is simply
-        # the end of the non-null region.
-        # Use the Arrow column's O(1) null_count to skip the
-        # expensive pd.isna + boolean indexing when there are no nulls (the
-        # common case).
+        # Nulls and NaN sort last in Arrow, so they accumulate at the tail of
+        # col_vals. Strip them before np.searchsorted to avoid incorrect bounds.
+        # Use O(1) null_count as a fast path, and fall back to np.isnan for
+        # float columns that may contain NaN without Arrow nulls.
         column = table[col_name]
-        has_nulls = (
-            column.null_count > 0
-            if hasattr(column, "null_count")
-            else column.isna().any()
-        )
-        if has_nulls:
+        if hasattr(column, "null_count") and column.null_count > 0:
             col_vals = col_vals[~pd.isna(col_vals)]
+        elif col_vals.dtype.kind == "f" and np.isnan(col_vals).any():
+            col_vals = col_vals[~np.isnan(col_vals)]
         if desired_val is None:
             return left + len(col_vals)
 

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -902,7 +902,13 @@ def find_partition_index(
         # Use the Arrow column's O(1) null_count to skip the
         # expensive pd.isna + boolean indexing when there are no nulls (the
         # common case).
-        if table[col_name].null_count > 0:
+        column = table[col_name]
+        has_nulls = (
+            column.null_count > 0
+            if hasattr(column, "null_count")
+            else column.isna().any()
+        )
+        if has_nulls:
             col_vals = col_vals[~pd.isna(col_vals)]
         if desired_val is None:
             return left + len(col_vals)

--- a/python/ray/data/tests/test_util.py
+++ b/python/ray/data/tests/test_util.py
@@ -366,6 +366,23 @@ def test_find_partition_index_with_nulls():
     assert find_partition_index(table, (None,), sort_key) == 3
 
 
+def test_find_partition_index_with_nan():
+    # NaN sorts after regular values in Arrow (before nulls).
+    table = pa.table({"value": [1.0, 2.0, 3.0, float("nan"), float("nan")]})
+    sort_key = SortKey(key=["value"], descending=[False])
+    assert find_partition_index(table, (2.0,), sort_key) == 1
+    assert find_partition_index(table, (4.0,), sort_key) == 3
+
+
+def test_find_partition_index_with_nan_and_nulls():
+    # NaN sorts after regular values, nulls sort after NaN.
+    table = pa.table({"value": [1.0, 2.0, 3.0, float("nan"), None]})
+    sort_key = SortKey(key=["value"], descending=[False])
+    assert find_partition_index(table, (2.0,), sort_key) == 1
+    assert find_partition_index(table, (4.0,), sort_key) == 3
+    assert find_partition_index(table, (None,), sort_key) == 3
+
+
 def test_find_partition_index_duplicates():
     table = pa.table({"value": [2, 2, 2, 2, 2]})
     sort_key = SortKey(key=["value"], descending=[False])


### PR DESCRIPTION
## Description
`find_partition_index` was changed to unconditionally run pd.isna(col_vals) + boolean indexing on every iteration to strip nulls.

This is O(n) with an array allocation on every call, and find_partition_index is called O(blocks × boundaries × columns) times during the sort-shuffle map phase. For SF100 with no nulls (the common case), this added ~10k+ unnecessary allocations per task, causing map tasks to regress from ~3-4 min to ~5-6 min (~50% slower).

Fix: use Arrow's O(1) column.null_count to skip the expensive path when there are no nulls.

### Release test result
Regressed runtime: 600+ seconds
```
Result of case main: {'time': 380.45604542899997, 'object_store_spilled_total_gb': 0.0, 'sf': '100', 'group_by': ['column08', 'column13', 'column14'], 'shuffle_strategy': 'sort_shuffle_pull_based', 'aggregate': True, 'map_groups': False}
--
Finished benchmark, metrics exported to '/tmp/release_test_out.json':
{
"main": {
"time": 424.48728577200006,
"object_store_spilled_total_gb": 0.0,
"sf": "100",
"group_by": [
"column08",
"column13",
"column14"
],
"shuffle_strategy": "sort_shuffle_pull_based",
"aggregate": true,
"map_groups": false
}
}

```
## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
