### PR TITLE
[Data] Fix ZipOperator freeing shared blocks via _split_at_indices

### DIFF
--- a/python/ray/data/_internal/execution/operators/zip_operator.py
+++ b/python/ray/data/_internal/execution/operators/zip_operator.py
@@ -222,9 +222,18 @@ class ZipOperator(InternalQueueOperatorMixin, NAryOperator):
         # cumulative number of rows as that left block.
         # NOTE: _split_at_indices has a no-op fastpath if the blocks are already
         # aligned.
+        # Determine the ownership of the blocks being split, accounting for the
+        # potential swap above. We must not free blocks that are shared with
+        # other operators (e.g., when the input RefBundle has owns_blocks=False
+        # because it comes from a materialized dataset).
+        if input_side_inverted:
+            split_side_owned = all(b.owns_blocks for b in left_input)
+        else:
+            split_side_owned = all(b.owns_blocks for b in right_input)
         aligned_right_blocks_with_metadata = _split_at_indices(
             right_blocks_with_metadata,
             indices,
+            owned_by_consumer=split_side_owned,
             block_rows=right_block_rows,
         )
         del right_blocks_with_metadata

--- a/python/ray/data/tests/test_zip.py
+++ b/python/ray/data/tests/test_zip.py
@@ -153,6 +153,40 @@ def test_zip_preserve_order(ray_start_regular_shared):
     ), result
 
 
+def test_zip_does_not_free_shared_materialized_blocks(ray_start_regular_shared):
+    """Regression test: ZipOperator should not free blocks from a materialized
+    dataset that is shared with another consumer.
+
+    Previously, ZipOperator._zip() called _split_at_indices() without specifying
+    owned_by_consumer, which defaulted to True. This caused ray.internal.free()
+    to be called on blocks that were shared with other operators in the DAG,
+    leading to ObjectFreedError.
+    """
+    # Create a dataset with 3 blocks (rows [7, 7, 6]) and materialize it.
+    # The materialized blocks have owns_blocks=False.
+    ds = ray.data.range(20, override_num_blocks=3).materialize()
+
+    # Consumer 1: a map_batches that uses the same materialized dataset.
+    mapped_ds = ds.map_batches(lambda batch: batch, batch_format="pandas")
+
+    # Consumer 2: zip the same materialized dataset with another dataset.
+    # This triggers _split_at_indices inside ZipOperator._zip().
+    # Use 2 blocks (rows [10, 10]) so that block boundaries are NOT aligned
+    # with ds's blocks (rows [7, 7, 6]). This forces actual block splitting
+    # (e.g., the first 10-row block gets split at row 7), which exercises
+    # the owned_by_consumer code path in _split_all_blocks.
+    other_ds = ray.data.range(20, override_num_blocks=2)
+    zipped = other_ds.zip(ds)
+
+    # Consuming the zipped result should not raise ObjectFreedError.
+    result = zipped.take_all()
+    assert len(result) == 20
+
+    # The mapped_ds should also work fine (blocks not freed by the zip).
+    result2 = mapped_ds.take_all()
+    assert len(result2) == 20
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
  - ZipOperator._zip() called `_split_at_indices()` without specifying `owned_by_consumer`, which defaults to `True`                                                                                             
  - This caused `ray.internal.free()` to be called on blocks that may be shared with other operators in the DAG                                                                                                  
  - Fixes `ObjectFreedError` in complex DAGs where a materialized dataset is consumed by both `map_batches` and `zip`                                                                                            
                                                                                                                                                                                                                 
  ## Root Cause                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  `_split_at_indices` (`split.py:250`) has `owned_by_consumer: bool = True` as default. When `True`, `_split_all_blocks` calls `trace_deallocation(b, ..., free=True)` which invokes                             
  `ray._private.internal_api.free(ref, local_only=False)` — a global free that bypasses reference counting.                                                                                                      
                                                                                                                          
  In complex DAGs where the same materialized blocks are shared with other operators, this causes `ObjectFreedError`.                                                                                            
                                                                                                                                                                                                                 
  ## Fix                                 
                                                                                                                                                                                                                 
  Pass the correct `owned_by_consumer` flag based on the `RefBundle.owns_blocks` attribute of the input being split, accounting for the potential left/right swap in `_zip()`.
                                                                                                                                                                                                                 
  ## Test plan
  - [x] Added regression test: `test_zip_does_not_free_shared_materialized_blocks`                                                                                                                               
  - [ ] Existing zip tests pass 