### PR TITLE
[data] guard against `None` resource_limit in `_max_throughput_from_resources`

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/throughput_solver.py
+++ b/python/ray/data/_internal/cluster_autoscaler/throughput_solver.py
@@ -100,7 +100,7 @@ def _max_throughput_from_resources(
             getattr(resource_requirements[op], resource_name) / rates[op]
             for op in rates
         )
-        if resource_cost_per_unit_throughput > 0:
+        if resource_cost_per_unit_throughput > 0 and resource_limit is not None:
             max_throughput = min(
                 max_throughput, resource_limit / resource_cost_per_unit_throughput
             )


### PR DESCRIPTION
Closes #62601

## Problem

`_max_throughput_from_resources()` calls `getattr(resource_limits, resource_name)` to get CPU/GPU/memory limits. When a resource is unconstrained, `ExecutionResources` stores `None` for that field. The division `resource_limit / resource_cost_per_unit_throughput` then raises:

```
TypeError: unsupported operand type(s) for /: 'NoneType' and 'float'
```

## Fix

Add a `resource_limit is not None` guard — a `None` limit means the resource is unconstrained and should not bound `max_throughput`:

```python
# Before
if resource_cost_per_unit_throughput > 0:
    max_throughput = min(max_throughput, resource_limit / resource_cost_per_unit_throughput)

# After
if resource_cost_per_unit_throughput > 0 and resource_limit is not None:
    max_throughput = min(max_throughput, resource_limit / resource_cost_per_unit_throughput)
```
