### PR TITLE
[ci] Migrate microbenchmark, benchmark-worker-startup, and rllib compute configs to new schema

### DIFF
--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -1,9 +1,6 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 0
-
-advanced_configurations_json:
+advanced_instance_config:
     # Fix the volume size so that IOPS is constant even if the default changes.
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
@@ -12,11 +9,8 @@ advanced_configurations_json:
             # 150GB is the default in Anyscale.
             VolumeSize: 150
 
-head_node_type:
-    name: head_node
+head_node:
     instance_type: g5.16xlarge
     resources:
-        cpu: 64
-        gpu: 64
-
-worker_node_types: []
+        CPU: 64
+        GPU: 64

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -11,6 +11,9 @@ advanced_instance_config:
 
 head_node:
     instance_type: g5.16xlarge
+    # GPU: 64 is an intentional override (instance has 1 physical GPU);
+    # the benchmark script uses --num_gpus_in_cluster 64 to test
+    # resource scheduling with 64 logical GPU slots.
     resources:
         CPU: 64
         GPU: 64

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml
@@ -14,3 +14,5 @@ head_node:
     resources:
         CPU: 64
         GPU: 64
+
+worker_nodes: []

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu_gce.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu_gce.yaml
@@ -11,6 +11,9 @@ advanced_instance_config:
 
 head_node:
     instance_type: n2-standard-64
+    # GPU: 64 is an intentional override (instance has no physical GPU);
+    # the benchmark script uses --num_gpus_in_cluster 64 to test
+    # resource scheduling with 64 logical GPU slots.
     resources:
         CPU: 64
         GPU: 64

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu_gce.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu_gce.yaml
@@ -1,23 +1,16 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west1
-allowed_azs:
-    - us-west1-b
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+zones: [us-west1-b]
 
-gcp_advanced_configurations_json:
-  instance_properties:
-    disks:
-      - boot: true
-        auto_delete: true
-        initialize_params:
-          disk_size_gb: 150
+advanced_instance_config:
+    instance_properties:
+        disks:
+            - boot: true
+              auto_delete: true
+              initialize_params:
+                  disk_size_gb: 150
 
-max_workers: 0
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: n2-standard-64
     resources:
-        cpu: 64
-        gpu: 64
-
-worker_node_types: []
+        CPU: 64
+        GPU: 64

--- a/release/benchmark-worker-startup/only_head_node_1gpu_64cpu_gce.yaml
+++ b/release/benchmark-worker-startup/only_head_node_1gpu_64cpu_gce.yaml
@@ -14,3 +14,5 @@ head_node:
     resources:
         CPU: 64
         GPU: 64
+
+worker_nodes: []

--- a/release/microbenchmark/experimental/compute_a100_gpu.yaml
+++ b/release/microbenchmark/experimental/compute_a100_gpu.yaml
@@ -1,10 +1,4 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 0
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: p4d.24xlarge
-
-worker_node_types: []

--- a/release/microbenchmark/experimental/compute_a100_gpu.yaml
+++ b/release/microbenchmark/experimental/compute_a100_gpu.yaml
@@ -2,3 +2,5 @@ cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
     instance_type: p4d.24xlarge
+
+worker_nodes: []

--- a/release/microbenchmark/experimental/compute_gpu_2x1_aws.yaml
+++ b/release/microbenchmark/experimental/compute_gpu_2x1_aws.yaml
@@ -1,15 +1,13 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 1
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: g4dn.4xlarge
+    resources:
+        CPU: 16
+        GPU: 1
 
-worker_node_types:
-    - name: worker_node
-      instance_type: g4dn.4xlarge
-      max_workers: 1
-      min_workers: 1
-      use_spot: false
+worker_nodes:
+    - instance_type: g4dn.4xlarge
+      min_nodes: 1
+      max_nodes: 1
+      market_type: ON_DEMAND

--- a/release/microbenchmark/experimental/compute_l4_gpu.yaml
+++ b/release/microbenchmark/experimental/compute_l4_gpu.yaml
@@ -1,10 +1,4 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 0
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: g6.12xlarge
-
-worker_node_types: []

--- a/release/microbenchmark/experimental/compute_l4_gpu.yaml
+++ b/release/microbenchmark/experimental/compute_l4_gpu.yaml
@@ -2,3 +2,5 @@ cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
     instance_type: g6.12xlarge
+
+worker_nodes: []

--- a/release/microbenchmark/experimental/compute_l4_gpu_2x1_aws.yaml
+++ b/release/microbenchmark/experimental/compute_l4_gpu_2x1_aws.yaml
@@ -1,15 +1,13 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 1
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: g6.4xlarge
+    resources:
+        CPU: 16
+        GPU: 1
 
-worker_node_types:
-    - name: worker_node
-      instance_type: g6.4xlarge
-      max_workers: 1
-      min_workers: 1
-      use_spot: false
+worker_nodes:
+    - instance_type: g6.4xlarge
+      min_nodes: 1
+      max_nodes: 1
+      market_type: ON_DEMAND

--- a/release/microbenchmark/experimental/compute_t4_gpu.yaml
+++ b/release/microbenchmark/experimental/compute_t4_gpu.yaml
@@ -2,3 +2,5 @@ cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
     instance_type: g4dn.12xlarge
+
+worker_nodes: []

--- a/release/microbenchmark/experimental/compute_t4_gpu.yaml
+++ b/release/microbenchmark/experimental/compute_t4_gpu.yaml
@@ -1,10 +1,4 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 0
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: g4dn.12xlarge
-
-worker_node_types: []

--- a/release/microbenchmark/tpl_64.yaml
+++ b/release/microbenchmark/tpl_64.yaml
@@ -1,10 +1,4 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 0
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: m5.16xlarge
-
-worker_node_types: []

--- a/release/microbenchmark/tpl_64.yaml
+++ b/release/microbenchmark/tpl_64.yaml
@@ -2,3 +2,5 @@ cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
     instance_type: m5.16xlarge
+
+worker_nodes: []

--- a/release/microbenchmark/tpl_64_gce.yaml
+++ b/release/microbenchmark/tpl_64_gce.yaml
@@ -1,12 +1,5 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west1
-allowed_azs:
-    - us-west1-c
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+zones: [us-west1-c]
 
-max_workers: 0
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: n2-standard-64 # aws m5.16xlarge
-
-worker_node_types: []

--- a/release/microbenchmark/tpl_64_gce.yaml
+++ b/release/microbenchmark/tpl_64_gce.yaml
@@ -3,3 +3,5 @@ zones: [us-west1-c]
 
 head_node:
     instance_type: n2-standard-64 # aws m5.16xlarge
+
+worker_nodes: []

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2140,6 +2140,7 @@
   team: rllib
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: gpu
       post_build_script: byod_rllib.sh
@@ -2238,6 +2239,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     cluster_compute: tpl_64.yaml
 
   run:
@@ -2251,6 +2253,7 @@
       env: gce
       frequency: manual
       cluster:
+        anyscale_sdk_2026: true
         cluster_compute: tpl_64_gce.yaml
     - __suffix__: aws.py312
       frequency: weekly
@@ -2264,6 +2267,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     cluster_compute: tpl_64.yaml
 
   run:
@@ -2278,6 +2282,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: gpu
     cluster_compute: experimental/compute_t4_gpu.yaml
@@ -2294,6 +2299,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: gpu
     cluster_compute: experimental/compute_gpu_2x1_aws.yaml
@@ -2310,6 +2316,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: gpu-cu130
       post_build_script: byod_compiled_graph_gpu_cu130.sh
@@ -2328,6 +2335,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: gpu-cu130
       post_build_script: byod_compiled_graph_gpu_cu130.sh
@@ -2346,6 +2354,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: gpu
     cluster_compute: experimental/compute_t4_gpu.yaml
@@ -2363,6 +2372,7 @@
   working_dir: microbenchmark
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: llm-cu128 # llm image already has nixl
       post_build_script: byod_llm_pin_cupy_cuda12x.sh # match cupy-cuda12x to ray-llm base lock (BYOD testdeps can float major)
@@ -2400,6 +2410,7 @@
   working_dir: benchmark-worker-startup
 
   cluster:
+    anyscale_sdk_2026: true
     byod:
       type: gpu
     cluster_compute: only_head_node_1gpu_64cpu.yaml
@@ -2418,6 +2429,7 @@
       env: gce
       frequency: manual
       cluster:
+        anyscale_sdk_2026: true
         cluster_compute: only_head_node_1gpu_64cpu_gce.yaml
 
 - name: dask_on_ray_100gb_sort

--- a/release/rllib_tests/1gpu_16cpus.yaml
+++ b/release/rllib_tests/1gpu_16cpus.yaml
@@ -3,6 +3,8 @@ cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 head_node:
     instance_type: g5.4xlarge
 
+worker_nodes: []
+
 advanced_instance_config:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1

--- a/release/rllib_tests/1gpu_16cpus.yaml
+++ b/release/rllib_tests/1gpu_16cpus.yaml
@@ -1,15 +1,9 @@
-cloud_id: {{env["ANYSCALE_CLOUD_ID"]}}
-region: us-west-2
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
-max_workers: 0
-
-head_node_type:
-    name: head_node
+head_node:
     instance_type: g5.4xlarge
 
-worker_node_types: []
-
-advanced_configurations_json:
+advanced_instance_config:
     BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:


### PR DESCRIPTION
## Summary
- Migrate 10 compute config files to the new Anyscale SDK schema (`cloud_id` -> `cloud`, `head_node_type` -> `head_node`, `worker_node_types` -> `worker_nodes`, etc.)
- Add `anyscale_sdk_2026: true` flag to 12 test cluster blocks in `release_tests.yaml`

## Config files migrated
- `release/microbenchmark/tpl_64.yaml` (AWS, head-only)
- `release/microbenchmark/tpl_64_gce.yaml` (GCE, head-only)
- `release/microbenchmark/experimental/compute_t4_gpu.yaml` (AWS, head-only GPU)
- `release/microbenchmark/experimental/compute_gpu_2x1_aws.yaml` (AWS, head+worker GPU)
- `release/microbenchmark/experimental/compute_a100_gpu.yaml` (AWS, head-only GPU)
- `release/microbenchmark/experimental/compute_l4_gpu.yaml` (AWS, head-only GPU)
- `release/microbenchmark/experimental/compute_l4_gpu_2x1_aws.yaml` (AWS, head+worker GPU)
- `release/benchmark-worker-startup/only_head_node_1gpu_64cpu.yaml` (AWS, head-only GPU)
- `release/benchmark-worker-startup/only_head_node_1gpu_64cpu_gce.yaml` (GCE, head-only)
- `release/rllib_tests/1gpu_16cpus.yaml` (AWS, head-only GPU)

## Tests updated with `anyscale_sdk_2026: true`
- `microbenchmark` (base + GCE variation)
- `compiled_graphs`
- `compiled_graphs_GPU`
- `compiled_graphs_GPU_multinode`
- `compiled_graphs_GPU_cu130`
- `compiled_graphs_GPU_multinode_cu130`
- `rdt_single_node_T4_microbenchmark`
- `rdt_single_node_A100_microbenchmark`
- `benchmark_worker_startup` (base + GCE variation)
- `rllib_learning_tests_pong_appo_torch`

## Test plan
- [x] All 10 config files validated against `ComputeConfig.from_yaml()`
- [x] CI passes with the new configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)