### PR TITLE
[CI] Read ECR from config instead of hardcoding in test

### DIFF
--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -193,7 +193,7 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
             assert "--python-depset" not in env_only_cmd
 
 
-_ECR = "029272617770.dkr.ecr.us-west-2.amazonaws.com"
+_ECR = get_global_config()["byod_ecr"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Replace the hardcoded ECR registry string in test_custom_byod_build_init_helper with get_global_config()["byod_ecr"], which reads from oss_config.yaml.

Topic: test-ecr-from-config
Signed-off-by: andrew <andrew@anyscale.com>