### PR TITLE
[Core] Fix get_last_job() not actually sorting in test_task_events_2

### DIFF
--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -1020,8 +1020,7 @@ ray.get([f.options(name="f.{task_name}").remote() for _ in range(10)])
 
     def get_last_job() -> str:
         jobs = list_jobs()
-        sorted(jobs, key=lambda x: x["job_id"])
-        return jobs[-1].job_id
+        return max(jobs, key=lambda x: x["job_id"]).job_id
 
     async def verify_tasks(task_name: str):
         # Query with job directly.

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -1020,7 +1020,7 @@ ray.get([f.options(name="f.{task_name}").remote() for _ in range(10)])
 
     def get_last_job() -> str:
         jobs = list_jobs()
-        return max(jobs, key=lambda x: x["job_id"]).job_id
+        return return max(jobs, key=lambda x: x.job_id).job_id
 
     async def verify_tasks(task_name: str):
         # Query with job directly.

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -1020,7 +1020,7 @@ ray.get([f.options(name="f.{task_name}").remote() for _ in range(10)])
 
     def get_last_job() -> str:
         jobs = list_jobs()
-        return return max(jobs, key=lambda x: x.job_id).job_id
+        return max(jobs, key=lambda x: x.job_id).job_id
 
     async def verify_tasks(task_name: str):
         # Query with job directly.


### PR DESCRIPTION

## Description
sorted() returns a new sorted list instead of sorting in place. As a result, get_last_job() was returning an arbitrary job instead of the latest one.