### PR TITLE
[Data] - Clean up `test_parquet.py`

### DIFF
--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -557,7 +557,7 @@ def test_projection_pushdown_non_partitioned(ray_start_regular_shared, temp_dir)
     assert ds.count() == 150
 
     # Test projection pushed down into read op
-    ds = ray.data.read_parquet(path).select_columns("variety")
+    ds = ray.data.read_parquet(path, override_num_blocks=1).select_columns("variety")
 
     assert explain_plan(ds._logical_plan).strip() == (
         "-------- Logical Plan --------\n"
@@ -580,7 +580,7 @@ def test_projection_pushdown_non_partitioned(ray_start_regular_shared, temp_dir)
     assert ds.count() == 150
 
     # Assert empty projection is reading no data
-    ds = ray.data.read_parquet(path).select_columns([])
+    ds = ray.data.read_parquet(path, override_num_blocks=1).select_columns([])
 
     summary = ds.materialize()._plan.stats().to_summary()
 
@@ -688,7 +688,6 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
             1000, shape=(1000,), override_num_blocks=10
         ).write_parquet(tensor_output_path)
         ds = ray.data.read_parquet(tensor_output_path)
-        assert ds._plan.initial_num_blocks() > 1
         data_size = ds.size_bytes()
         assert (
             data_size >= 6_000_000 and data_size <= 10_000_000
@@ -716,7 +715,6 @@ def test_parquet_reader_estimate_data_size(shutdown_only, tmp_path):
             text_output_path
         )
         ds = ray.data.read_parquet(text_output_path)
-        assert ds._plan.initial_num_blocks() > 1
         data_size = ds.size_bytes()
         assert (
             data_size >= 700_000 and data_size <= 2_200_000


### PR DESCRIPTION
## Description
- Explicitly setting `override_num_blocks=1` for the requisite tests
- Removing assertion for `initial_num_blocks() > 1` since we're moving away from eagerly reading all file metadata up front in DsV2

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
