### PR TITLE
[Data] Ensure consistent nan_is_null semantics in unique_post_fn of encoder

### DIFF
--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -1356,7 +1356,8 @@ def unique_post_fn(
 
         # Drop nulls if requested
         if drop_na_values:
-            values = pc.drop_null(values)
+            mask = pc.is_null(values, nan_is_null=True)
+            values = pc.filter(values, pc.invert(mask))
         else:
             if pc.any(pc.is_null(values, nan_is_null=True)).as_py():
                 raise ValueError(


### PR DESCRIPTION
## Description
This is a follow-up PR to https://github.com/ray-project/ray/pull/62618 to ensure consistent behavior in `gen_value_index_arrow_from_arrow` of `encoder.py`. Previously, if `drop_na_values` was True, we were dropping nulls (and not NaNs). This PR ensures that we drop NaNs as well