### PR TITLE
[core] fix ObjectRefStream::PeekNextItem in the case of EOS

### DIFF
--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -160,6 +160,11 @@ bool ObjectRefStream::IsFinished() const {
 
 std::pair<ObjectID, bool> ObjectRefStream::PeekNextItem() {
   const auto &object_id = GetObjectRefAtIndex(next_index_);
+  // EOF is never inserted into refs_written_to_stream_; TryReadNextItem uses
+  // IsFinished() instead. Match that so peek/wait agree at the sentinel index.
+  if (IsFinished()) {
+    return {object_id, true};
+  }
   if (refs_written_to_stream_.find(object_id) == refs_written_to_stream_.end()) {
     return {object_id, false};
   } else {

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -1901,6 +1901,45 @@ TEST_F(TaskManagerTest, TestPeekObjectReady) {
   CompletePendingStreamingTask(spec, caller_address, 1);
 }
 
+// After all streamed chunks are consumed, the next index is the EOF sentinel.
+// It is not recorded in refs_written_to_stream_; Peek must still report ready
+// so callers align with TryReadNextItem (ObjectRefEndOfStream).
+TEST_F(TaskManagerTest, TestPeekObjectReadyAtEof) {
+  auto spec =
+      CreateTaskHelper(1, {}, /*dynamic_returns=*/true, /*is_streaming_generator=*/true);
+  auto generator_id = spec.ReturnId(0);
+  rpc::Address caller_address;
+  manager_.AddPendingTask(caller_address, spec, "", 0);
+
+  auto dynamic_return_id = ObjectID::FromIndex(spec.TaskId(), 2);
+  auto data = GenerateRandomBuffer();
+  auto req = GetIntermediateTaskReturn(
+      /*idx*/ 0,
+      /*finished*/ false,
+      generator_id,
+      /*dynamic_return_id*/ dynamic_return_id,
+      /*data*/ data,
+      /*set_in_plasma*/ false);
+  ASSERT_TRUE(manager_.HandleReportGeneratorItemReturns(
+      req, /*execution_signal_callback*/ [](Status, int64_t) {}));
+  CompletePendingStreamingTask(spec, caller_address, 1);
+
+  ObjectID obj_id;
+  ASSERT_TRUE(manager_.TryReadObjectRefStream(generator_id, &obj_id).ok());
+  ASSERT_EQ(obj_id, dynamic_return_id);
+
+  const auto eof_id = ObjectID::FromIndex(spec.TaskId(), 3);
+  {
+    auto [peek_id, ready] = manager_.PeekObjectRefStream(generator_id);
+    ASSERT_EQ(peek_id, eof_id);
+    ASSERT_TRUE(ready);
+  }
+  auto status = manager_.TryReadObjectRefStream(generator_id, &obj_id);
+  ASSERT_TRUE(status.IsObjectRefEndOfStream());
+
+  manager_.TryDelObjectRefStream(generator_id);
+}
+
 TEST_F(TaskManagerTest, TestObjectRefStreamMixture) {
   /**
    * Test the basic cases, but write and read are mixed up.


### PR DESCRIPTION
> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
