### PR TITLE
[ci][llm] Narrow down `LD_LIBRARY_PATH` override to fix ssh connection

### DIFF
--- a/ci/docker/llm.build.Dockerfile
+++ b/ci/docker/llm.build.Dockerfile
@@ -22,7 +22,10 @@ pip install --no-deps -r python/deplocks/llm/rayllm_test_${PYTHON_CODE}_${RAY_CU
 
 EOF
 
-# Conda's libstdc++ provides CXXABI_1.3.15 needed by ICU 78 and other
-# C++ libraries pulled in by vLLM 0.17.0. Place it before the system copy
-# so the dynamic linker finds it first.
-ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+# vLLM 0.17.0 eagerly imports xgrammar -> ICU 78 -> CXXABI_1.3.15.
+# System libstdc++ only has 1.3.13; we need conda's newer copy.
+# Only expose libstdc++ — putting all of anaconda/lib on LD_LIBRARY_PATH
+# overrides system OpenSSL and breaks ssh-keygen (version mismatch).
+RUN mkdir -p /home/ray/lib-overrides && \
+    ln -sf /home/ray/anaconda3/lib/libstdc++.so.6 /home/ray/lib-overrides/libstdc++.so.6
+ENV LD_LIBRARY_PATH=/home/ray/lib-overrides${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -617,11 +617,13 @@ C/C++ runtime dependencies incompatibility
    Ray 2.55 installs vLLM 0.18.0. Depending on the conda environment, you may encounter
    incompatibilities with native runtime libraries (for example, ``libstdc++``, ``CXXABI``, ``ICU``).
 
-   In such cases, configure ``LD_LIBRARY_PATH`` to prefer the conda environment's libraries over system libraries.
+   In such cases, override just the ``libstdc++`` library from your conda environment with ``LD_LIBRARY_PATH``:
 
    .. code-block:: shell
 
-      export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+      mkdir -p "${CONDA_PREFIX}/lib-overrides"
+      ln -sf "${CONDA_PREFIX}/lib/libstdc++.so.6" "${CONDA_PREFIX}/lib-overrides/libstdc++.so.6"
+      export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib-overrides${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 **Usage data collection**: Ray collects anonymous usage data to improve Ray Data LLM. To opt out, see :ref:`Ray usage stats <ref-usage-stats>`.
 

--- a/doc/source/serve/llm/troubleshooting.md
+++ b/doc/source/serve/llm/troubleshooting.md
@@ -82,10 +82,12 @@ serve.run(app, blocking=True)
 :::{admonition} Known issue
 Ray 2.55 installs vLLM 0.18.0. Depending on the conda environment, you may encounter incompatibilities with native runtime libraries (for example, `libstdc++`, `CXXABI`, `ICU`).
 
-In such cases, configure `LD_LIBRARY_PATH` to prefer the conda environment's libraries over system libraries.
+In such cases, override just the ``libstdc++`` library from your conda environment with `LD_LIBRARY_PATH`:
 
 ```shell
-export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+mkdir -p "${CONDA_PREFIX}/lib-overrides"
+ln -sf "${CONDA_PREFIX}/lib/libstdc++.so.6" "${CONDA_PREFIX}/lib-overrides/libstdc++.so.6"
+export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib-overrides${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 ```
 :::
 

--- a/docker/ray-llm/Dockerfile
+++ b/docker/ray-llm/Dockerfile
@@ -67,5 +67,9 @@ sudo apt-get clean
 EOF
 
 # vLLM 0.17.0 eagerly imports xgrammar -> ICU 78 -> CXXABI_1.3.15.
-# System libstdc++ only has 1.3.13; prepend conda's newer copy.
-ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+# System libstdc++ only has 1.3.13; we need conda's newer copy.
+# Only expose libstdc++ — putting all of anaconda/lib on LD_LIBRARY_PATH
+# overrides system OpenSSL and breaks ssh-keygen (version mismatch).
+RUN mkdir -p /home/ray/lib-overrides && \
+    ln -sf /home/ray/anaconda3/lib/libstdc++.so.6 /home/ray/lib-overrides/libstdc++.so.6
+ENV LD_LIBRARY_PATH=/home/ray/lib-overrides${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}

--- a/release/hello_world_tests/sanity_check_ssh.sh
+++ b/release/hello_world_tests/sanity_check_ssh.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Sanity check that ssh tooling works inside the image.
+# A too-broad LD_LIBRARY_PATH (e.g. pointing at anaconda3/lib) can shadow
+# the system OpenSSL and cause ssh-keygen / ssh to segfault or fail with
+# a version-mismatch error.
+
+set -euo pipefail
+
+echo "--- Checking ssh client version"
+ssh -V
+
+echo "--- Checking ssh-keygen (ed25519)"
+ssh-keygen -t ed25519 -f /tmp/sanity_ssh_key -N "" -q
+rm -f /tmp/sanity_ssh_key /tmp/sanity_ssh_key.pub
+
+echo "--- Checking ssh-keygen (rsa)"
+ssh-keygen -t rsa -b 2048 -f /tmp/sanity_ssh_key_rsa -N "" -q
+rm -f /tmp/sanity_ssh_key_rsa /tmp/sanity_ssh_key_rsa.pub
+
+echo "SSH sanity check passed."

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -201,6 +201,48 @@
   variations:
     - __suffix__: aws
 
+#######################
+# SSH sanity checks
+#######################
+
+- name: ssh_sanity_check
+  python: "3.11"
+  team: reef
+  group: hello_world
+  frequency: nightly
+  working_dir: hello_world_tests
+
+  cluster:
+    anyscale_sdk_2026: true
+    cluster_compute: hello_world_compute_config.yaml
+
+  run:
+    timeout: 600
+    script: bash sanity_check_ssh.sh
+
+  variations:
+    - __suffix__: aws
+
+- name: ssh_sanity_check_llm
+  python: "3.11"
+  team: llm
+  group: hello_world
+  frequency: nightly
+  working_dir: hello_world_tests
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      type: llm-cu128
+    # Doesn't need GPUs to run ssh sanity check
+    cluster_compute: hello_world_compute_config.yaml
+
+  run:
+    timeout: 600
+    script: bash sanity_check_ssh.sh
+
+  variations:
+    - __suffix__: aws
 
 #######################
 # Cluster scaling tests


### PR DESCRIPTION
## Description
The previous `ENV LD_LIBRARY_PATH=/home/ray/anaconda3/lib...` was added to provide a newer `libstdc++.so.6` (with `CXXABI_1.3.15`) required by vLLM's `xgrammar -> ICU 78` import chain. However, prepending the entire anaconda lib directory also overrides system OpenSSL. This causes the ssh connection from the head node to worker nodes to fail.

## Changes
Create a `/home/ray/lib-overrides/` directory containing only a symlink to anaconda's `libstdc++.so.6`, and point `LD_LIBRARY_PATH` there instead. This gives vLLM the C++ ABI symbols it needs without polluting the library search path with anaconda's OpenSSL or other system-level libraries.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
