### PR TITLE
[Core] Use ACTOR_STATUS from custom_types in validate_actor_state_name

### DIFF
--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1660,14 +1660,17 @@ def parse_pg_formatted_resources_to_original(
 
 
 def validate_actor_state_name(actor_state_name):
-    from ray._private.custom_types import ACTOR_STATUS
-
     if actor_state_name is None:
         return
+
+    from ray._private.custom_types import ACTOR_STATUS
+
     if actor_state_name not in ACTOR_STATUS:
+        quoted = [f'"{s}"' for s in ACTOR_STATUS]
+        states_str = ", ".join(quoted[:-1]) + f", or {quoted[-1]}"
         raise ValueError(
             f'"{actor_state_name}" is not a valid actor state name, '
-            f"it must be one of the following: {', '.join(ACTOR_STATUS)}"
+            f"it must be one of the following: {states_str}"
         )
 
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -1660,20 +1660,14 @@ def parse_pg_formatted_resources_to_original(
 
 
 def validate_actor_state_name(actor_state_name):
+    from ray._private.custom_types import ACTOR_STATUS
+
     if actor_state_name is None:
         return
-    actor_state_names = [
-        "DEPENDENCIES_UNREADY",
-        "PENDING_CREATION",
-        "ALIVE",
-        "RESTARTING",
-        "DEAD",
-    ]
-    if actor_state_name not in actor_state_names:
+    if actor_state_name not in ACTOR_STATUS:
         raise ValueError(
             f'"{actor_state_name}" is not a valid actor state name, '
-            'it must be one of the following: "DEPENDENCIES_UNREADY", '
-            '"PENDING_CREATION", "ALIVE", "RESTARTING", or "DEAD"'
+            f"it must be one of the following: {', '.join(ACTOR_STATUS)}"
         )
 
 


### PR DESCRIPTION
## Description

`validate_actor_state_name` in `utils.py` maintained its own hard-coded list of
valid actor states, duplicating `ACTOR_STATUS` from `custom_types.py`. This
replaces it with a direct reference to the shared constant, which is already
validated against the protobuf enum at import time.

Also makes the error message dynamic, so it stays in sync automatically if
states are added or removed in the future.

## Related issues

Closes #50397

## Additional information

- Used a lazy import to avoid circular dependency (`utils.py` is imported early)
- Behavior is identical: same inputs, same outputs, same error messages