### PR TITLE
[serve] Simplify gang deployment detection with _is_gang_deployment property

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -3092,6 +3092,11 @@ class DeploymentState:
             else None
         )
 
+    @property
+    def _is_gang_deployment(self) -> bool:
+        """Returns True if this deployment uses gang scheduling."""
+        return self.get_gang_config() is not None
+
     def _get_target_replica_delta(self) -> int:
         """Calculate delta between target replicas and active replicas."""
         current_replicas = self._replicas.count(
@@ -3474,8 +3479,7 @@ class DeploymentState:
         reconfigure_changes = 0
 
         # Process gang-grouped replicas
-        gang_config = self.get_gang_config()
-        if gang_config is not None:
+        if self._is_gang_deployment:
             need_restart: List[DeploymentReplica] = []
             remaining: List[DeploymentReplica] = []
             for replica in replicas_to_update:
@@ -3623,8 +3627,8 @@ class DeploymentState:
 
         # For gang deployments, ensure rollout_size is at least a multiple of
         # gang_size so that we always stop and start complete gangs.
-        gang_config = self.get_gang_config()
-        if gang_config is not None:
+        if self._is_gang_deployment:
+            gang_config = self.get_gang_config()
             gs = gang_config.gang_size
             rollout_size = max(rollout_size, gs)
             rollout_size = math.ceil(rollout_size / gs) * gs
@@ -3687,11 +3691,10 @@ class DeploymentState:
 
         elif delta_replicas < 0:
             to_remove = -delta_replicas
-            gang_config = self.get_gang_config()
             gang_id_by_replica = None
             replicas_by_gang_id = None
 
-            if gang_config is not None:
+            if self._is_gang_deployment:
                 gang_id_by_replica = self._gang_id_by_replica
                 replicas_by_gang_id = self._replicas_by_gang_id
 
@@ -3702,7 +3705,9 @@ class DeploymentState:
                 num_to_stop=to_remove,
                 gang_id_by_replica=gang_id_by_replica,
                 replicas_by_gang_id=replicas_by_gang_id,
-                gang_size=gang_config.gang_size if gang_config else None,
+                gang_size=self.get_gang_config().gang_size
+                if self._is_gang_deployment
+                else None,
             )
 
         return upscale, downscale
@@ -3719,14 +3724,15 @@ class DeploymentState:
         if to_add <= 0 or self._terminally_failed():
             return upscale
 
-        gang_config = self.get_gang_config()
-        if gang_config is None:
+        if not self._is_gang_deployment:
             return self._add_upscale_replicas(to_add)
 
         gang_reservation_result = (
             gang_placement_groups.get(self._id) if gang_placement_groups else None
         )
-        return self._add_upscale_gang_replicas(gang_config, gang_reservation_result)
+        return self._add_upscale_gang_replicas(
+            self.get_gang_config(), gang_reservation_result
+        )
 
     def _add_upscale_replicas(self, to_add: int) -> List[ReplicaSchedulingRequest]:
         """Add replicas for deployments that adopt single-replica (non-gang) scheduling."""
@@ -4334,10 +4340,9 @@ class DeploymentState:
         # Under the RESTART_GANG policy, force-stop all members of any gang that has at
         # least one unhealthy replica. Replicas handled here are removed from the lists;
         # remaining replicas continue to respect FORCE_STOP_UNHEALTHY_REPLICAS.
-        gang_config = self.get_gang_config()
         if (
-            gang_config is not None
-            and gang_config.runtime_failure_policy
+            self._is_gang_deployment
+            and self.get_gang_config().runtime_failure_policy
             == GangRuntimeFailurePolicy.RESTART_GANG
         ):
             healthy_replicas, unhealthy_replicas = self._forcefully_stop_gang_replicas(
@@ -4713,8 +4718,6 @@ class DeploymentState:
         if not draining_nodes and not self._in_transition:
             return
 
-        gang_config = self.get_gang_config()
-
         # Move replicas back to RUNNING if they are no longer on a draining node.
         # If this causes the number of replicas to exceed the target state,
         # they will be scaled down because `scale_deployment_replicas` is called on
@@ -4723,7 +4726,7 @@ class DeploymentState:
             states=[ReplicaState.PENDING_MIGRATION]
         )
 
-        if gang_config is not None:
+        if self._is_gang_deployment:
             # For gangs, only move back to RUNNING if ALL members' nodes are no
             # longer draining.
             gangs = self._group_replicas_by_gang_id(pending_migration_replicas)
@@ -4758,7 +4761,7 @@ class DeploymentState:
             ]
         )
 
-        if gang_config is not None:
+        if self._is_gang_deployment:
             # For gangs, if ANY member is on a draining node the entire gang migrates.
             gangs_to_migrate: Set[str] = set()
             for replica in all_replicas:
@@ -4793,7 +4796,7 @@ class DeploymentState:
                 self._stop_replica(
                     replica,
                     # Always force-stop gang members to avoid leaving partial gangs.
-                    graceful_stop=gang_config is None,
+                    graceful_stop=not self._is_gang_deployment,
                 )
 
         num_running = self._replicas.count(states=[ReplicaState.RUNNING])
@@ -4804,7 +4807,7 @@ class DeploymentState:
 
         choose_pending_migration_to_stop_fn = (
             self._choose_pending_migration_gangs_to_stop
-            if gang_config is not None
+            if self._is_gang_deployment
             else self._choose_pending_migration_replicas_to_stop
         )
         replicas_to_stop, replicas_to_keep = choose_pending_migration_to_stop_fn(
@@ -5704,9 +5707,10 @@ class DeploymentStateManager:
         gang_requests: Dict[DeploymentID, GangPlacementGroupRequest] = {}
 
         for deployment_id, deployment_state in self._deployment_states.items():
-            gang_config = deployment_state.get_gang_config()
-            if gang_config is None:
+            if not deployment_state._is_gang_deployment:
                 continue
+
+            gang_config = deployment_state.get_gang_config()
 
             num_replicas_to_add = deployment_state._get_target_replica_delta()
             if num_replicas_to_add <= 0:

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -616,10 +616,13 @@ class TestDeploymentActorWrapper:
 
     def test_check_ready_ref_ready_then_success(self):
         """Test check_ready() when _ready_ref is ready and ray.get succeeds."""
-        with patch(
-            "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
-            return_value=True,
-        ), patch("ray.serve._private.deployment_state.ray.get"):
+        with (
+            patch(
+                "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                return_value=True,
+            ),
+            patch("ray.serve._private.deployment_state.ray.get"),
+        ):
             config = DeploymentActorConfig(
                 name="counter", actor_class="builtins:object"
             )
@@ -636,12 +639,15 @@ class TestDeploymentActorWrapper:
 
     def test_check_ready_ref_ready_then_fails(self):
         """Test check_ready() when ray.get on _ready_ref raises."""
-        with patch(
-            "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
-            return_value=True,
-        ), patch(
-            "ray.serve._private.deployment_state.ray.get",
-            side_effect=RuntimeError("actor crashed"),
+        with (
+            patch(
+                "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                return_value=True,
+            ),
+            patch(
+                "ray.serve._private.deployment_state.ray.get",
+                side_effect=RuntimeError("actor crashed"),
+            ),
         ):
             config = DeploymentActorConfig(
                 name="counter", actor_class="builtins:object"
@@ -675,10 +681,13 @@ class TestDeploymentActorWrapper:
     def test_kill_without_handle(self):
         """Test kill() when _handle is None - fetches via get_actor then kills."""
         fake_handle = object()
-        with patch(
-            "ray.serve._private.deployment_state.ray.get_actor",
-            return_value=fake_handle,
-        ), patch("ray.serve._private.deployment_state.ray.kill") as mock_kill:
+        with (
+            patch(
+                "ray.serve._private.deployment_state.ray.get_actor",
+                return_value=fake_handle,
+            ),
+            patch("ray.serve._private.deployment_state.ray.kill") as mock_kill,
+        ):
             config = DeploymentActorConfig(
                 name="counter", actor_class="builtins:object"
             )
@@ -692,10 +701,13 @@ class TestDeploymentActorWrapper:
 
     def test_kill_actor_already_stopped(self):
         """Test kill() when actor is already stopped - should not raise."""
-        with patch(
-            "ray.serve._private.deployment_state.ray.get_actor",
-            side_effect=ValueError("actor not found"),
-        ), patch("ray.serve._private.deployment_state.ray.kill"):
+        with (
+            patch(
+                "ray.serve._private.deployment_state.ray.get_actor",
+                side_effect=ValueError("actor not found"),
+            ),
+            patch("ray.serve._private.deployment_state.ray.kill"),
+        ):
             config = DeploymentActorConfig(
                 name="counter", actor_class="builtins:object"
             )
@@ -7498,6 +7510,37 @@ def test_pending_migration_prevents_in_transition_clear(
         f"Expected 0 PENDING_MIGRATION replicas but found {pending_migration_count}. "
         "The replica is stuck because _in_transition was incorrectly cleared."
     )
+
+
+class TestIsGangDeploymentProperty:
+    """Tests for DeploymentState._is_gang_deployment property."""
+
+    def test_is_gang_deployment_true_when_gang_config_set(
+        self, mock_deployment_state_manager
+    ):
+        """_is_gang_deployment returns True when deployment has a GangSchedulingConfig."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm(
+            create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+        )
+        b_info, _ = deployment_info(
+            num_replicas=2,
+            gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+        )
+        dsm.deploy(TEST_DEPLOYMENT_ID, b_info)
+        ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+        assert ds._is_gang_deployment is True
+
+    def test_is_gang_deployment_false_when_no_gang_config(
+        self, mock_deployment_state_manager
+    ):
+        """_is_gang_deployment returns False for a regular (non-gang) deployment."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm()
+        b_info, _ = deployment_info(num_replicas=2)
+        dsm.deploy(TEST_DEPLOYMENT_ID, b_info)
+        ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+        assert ds._is_gang_deployment is False
 
 
 class TestScaleDeploymentGangReplicas:

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -7515,32 +7515,35 @@ def test_pending_migration_prevents_in_transition_clear(
 class TestIsGangDeploymentProperty:
     """Tests for DeploymentState._is_gang_deployment property."""
 
-    def test_is_gang_deployment_true_when_gang_config_set(
-        self, mock_deployment_state_manager
+    @pytest.mark.parametrize(
+        "gang_scheduling_config, expected_value",
+        [
+            pytest.param(GangSchedulingConfig(gang_size=2), True, id="gang"),
+            pytest.param(None, False, id="non-gang"),
+        ],
+    )
+    def test_is_gang_deployment(
+        self,
+        mock_deployment_state_manager,
+        gang_scheduling_config,
+        expected_value,
     ):
-        """_is_gang_deployment returns True when deployment has a GangSchedulingConfig."""
+        """_is_gang_deployment reflects whether gang scheduling is configured."""
         create_dsm, _, _, _ = mock_deployment_state_manager
-        dsm: DeploymentStateManager = create_dsm(
-            create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
-        )
-        b_info, _ = deployment_info(
-            num_replicas=2,
-            gang_scheduling_config=GangSchedulingConfig(gang_size=2),
-        )
-        dsm.deploy(TEST_DEPLOYMENT_ID, b_info)
-        ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
-        assert ds._is_gang_deployment is True
 
-    def test_is_gang_deployment_false_when_no_gang_config(
-        self, mock_deployment_state_manager
-    ):
-        """_is_gang_deployment returns False for a regular (non-gang) deployment."""
-        create_dsm, _, _, _ = mock_deployment_state_manager
-        dsm: DeploymentStateManager = create_dsm()
-        b_info, _ = deployment_info(num_replicas=2)
+        create_dsm_kwargs = {}
+        deployment_info_kwargs = {"num_replicas": 2}
+        if gang_scheduling_config is not None:
+            create_dsm_kwargs[
+                "create_placement_group_fn_override"
+            ] = lambda *args, **kwargs: Mock()
+            deployment_info_kwargs["gang_scheduling_config"] = gang_scheduling_config
+
+        dsm: DeploymentStateManager = create_dsm(**create_dsm_kwargs)
+        b_info, _ = deployment_info(**deployment_info_kwargs)
         dsm.deploy(TEST_DEPLOYMENT_ID, b_info)
         ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
-        assert ds._is_gang_deployment is False
+        assert ds._is_gang_deployment is expected_value
 
 
 class TestScaleDeploymentGangReplicas:


### PR DESCRIPTION
## Why are these changes needed?

Replace the repeated pattern of calling `get_gang_config()` and checking for `None` with a new `_is_gang_deployment` property on `DeploymentState`. 

There were 7 call sites in `DeploymentState` (and 1 in `DeploymentStateManager`) using the same pattern:

```python
gang_config = self.get_gang_config()
if gang_config is not None:
    ...
```

The new property makes the intent of gang-specific conditional branches immediately clear and avoids the repeated `get_gang_config() is not None` boilerplate.

The existing `get_gang_config()` method is retained so that call sites that also need to access gang config fields can still retrieve the config object within the branch.

## Related issue number

Fixes #61795

## Checks

- [x] I've signed off every commit (DCO) in this PR
- [x] I've run `pre-commit run --files ...` and all hooks passed (SKIP=vale,ruff-format,black for local ruff-format hook conflict)
- [x] I've run `./ci/lint/lint.sh pytest_format` and it passed
- [x] I've run `python -m pytest python/ray/serve/tests/unit/test_deployment_state.py -v -k gang` and all 26 gang tests pass