### PR TITLE
[Data] Add debug logging to SplitCoordinator and OutputSplitter

### DIFF
--- a/python/ray/data/_internal/execution/operators/output_splitter.py
+++ b/python/ray/data/_internal/execution/operators/output_splitter.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import time
 from dataclasses import replace
@@ -23,6 +24,8 @@ from ray.data._internal.stats import StatsDict
 from ray.data.block import Block, BlockAccessor, BlockMetadata
 from ray.data.context import DataContext
 from ray.types import ObjectRef
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_OUTPUT_SPLITTER_MAX_BUFFERING_FACTOR = env_float(
     "RAY_DATA_DEFAULT_OUTPUT_SPLITTER_MAX_BUFFERING_FACTOR", 2
@@ -92,6 +95,11 @@ class OutputSplitter(InternalQueueOperatorMixin, PhysicalOperator):
 
         self._locality_hits = 0
         self._locality_misses = 0
+
+        logger.debug(
+            f"OutputSplitter created: {n=}, {equal=}, {locality_hints=}, "
+            f"{self._max_buffer_size=}"
+        )
 
     def num_outputs_total(self) -> Optional[int]:
         # OutputSplitter does not change the number of blocks,

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -198,7 +198,7 @@ class SplitCoordinator:
         # Store the error raised from the `gen_epoch` call.
         self._gen_epoch_error: Optional[Exception] = None
 
-        logger.info(f"SplitCoordinator created: {n=}, {locality_hints=}")
+        logger.debug(f"SplitCoordinator created: {n=}, {locality_hints=}")
 
     def get_dataset_context(self) -> DataContext:
         return self._data_context

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -346,7 +346,6 @@ class SplitCoordinator:
                 self._report_prefetched_bytes_to_executor()
 
                 # Track per-split row dispatch count.
-                metadata = block[1]
                 self._num_rows_dispatched[output_split_idx] += (
                     metadata.num_rows if metadata.num_rows else 0
                 )

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -29,6 +29,8 @@ BLOCKED_CLIENT_WARN_TIMEOUT = 30
 class StreamSplitDataIterator(DataIterator):
     """Implements a collection of iterators over a shared data stream."""
 
+    YIELD_LOG_INTERVAL_S = 10
+
     @staticmethod
     def create(
         base_dataset: "Dataset",
@@ -60,18 +62,25 @@ class StreamSplitDataIterator(DataIterator):
         self._output_split_idx = output_split_idx
         self._world_size = world_size
         self._iter_stats = DatasetStats(metadata={}, parent=None)
+        logger.debug(
+            f"StreamSplitDataIterator created: split={output_split_idx}, {world_size=}"
+        )
 
     def _to_ref_bundle_iterator(
         self,
     ) -> Tuple[Iterator[RefBundle], Optional[DatasetStats], bool, None]:
         def gen_blocks() -> Iterator[RefBundle]:
+            logger.debug(f"Split {self._output_split_idx}: requesting new epoch.")
             cur_epoch = ray.get(
                 self._coord_actor.start_epoch.remote(self._output_split_idx)
             )
+            logger.debug(f"Split {self._output_split_idx}: epoch {cur_epoch} started")
+
             # Initial get with 0 prefetched bytes.
             future: ObjectRef[Optional[RefBundle]] = self._coord_actor.get.remote(
                 cur_epoch, self._output_split_idx, 0
             )
+            last_log_time = 0.0
             while True:
                 block_ref_and_md: Optional[RefBundle] = ray.get(future)
                 if not block_ref_and_md:
@@ -95,6 +104,17 @@ class StreamSplitDataIterator(DataIterator):
                         schema=block_ref_and_md.schema,
                     )
 
+                    # Log dispatch progress.
+                    now = time.time()
+                    if now - last_log_time >= self.YIELD_LOG_INTERVAL_S:
+                        last_log_time = now
+                        logger.debug(
+                            f"Split {self._output_split_idx} epoch {cur_epoch}: "
+                            f"consumer resumed after yield"
+                        )
+
+            logger.debug(f"Split {self._output_split_idx}: epoch {cur_epoch} exhausted")
+
         # Return None for executor since StreamSplitDataIterator has its own
         # mechanism for reporting prefetched bytes via SplitCoordinator.
         return gen_blocks(), self._iter_stats, False, None
@@ -103,6 +123,7 @@ class StreamSplitDataIterator(DataIterator):
         """Implements DataIterator."""
         # Merge the locally recorded iter stats and the remotely recorded
         # stream execution stats.
+        logger.debug(f"Split {self._output_split_idx}: fetching stats remote")
         stats = ray.get(self._coord_actor.stats.remote())
         summary = stats.to_summary()
         summary.iter_stats = self._iter_stats.to_summary().iter_stats
@@ -133,6 +154,8 @@ class SplitCoordinator:
     This actor runs a streaming executor locally on its main thread. Clients can
     retrieve results via actor calls running on other threads.
     """
+
+    DISPATCH_LOG_INTERVAL_S = 10
 
     def __init__(
         self,
@@ -167,9 +190,15 @@ class SplitCoordinator:
         # Add a new stats field to track coordinator overhead
         self._coordinator_overhead_s = 0.0
 
+        # Per-split row dispatch counters (reset each epoch in _barrier).
+        self._num_rows_dispatched: Dict[int, int] = dict.fromkeys(range(n), 0)
+        self._last_dispatch_log_time: float = 0.0
+
         self._output_iterator = None
         # Store the error raised from the `gen_epoch` call.
         self._gen_epoch_error: Optional[Exception] = None
+
+        logger.info(f"SplitCoordinator created: {n=}, {locality_hints=}")
 
     def get_dataset_context(self) -> DataContext:
         return self._data_context
@@ -233,8 +262,15 @@ class SplitCoordinator:
                     self._output_iterator = execute_to_legacy_bundle_iterator(
                         self._current_executor, plan
                     )
+                    logger.debug(
+                        f"Starting epoch {self._cur_epoch} (all {self._n} clients "
+                        "synced)."
+                    )
 
                 except Exception as e:
+                    logger.warning(
+                        f"Error creating executor for epoch {self._cur_epoch}: {e}"
+                    )
                     self._gen_epoch_error = e
 
         if self._gen_epoch_error is not None:
@@ -246,6 +282,8 @@ class SplitCoordinator:
         self._unfinished_clients_in_epoch = self._n
         self._next_bundle.clear()
         self._gen_epoch_error = None
+        # Reset per-split dispatch counters for the new epoch.
+        self._num_rows_dispatched = dict.fromkeys(range(self._n), 0)
 
     def get(
         self,
@@ -300,18 +338,43 @@ class SplitCoordinator:
                 self._next_bundle[output_split_idx] = next_bundle
                 if not next_bundle.blocks:
                     del self._next_bundle[output_split_idx]
+
                 # Update client prefetched bytes and report to resource manager.
                 self._client_prefetched_bytes[
                     output_split_idx
                 ] = client_prefetched_bytes
                 self._report_prefetched_bytes_to_executor()
 
+                # Track per-split row dispatch count.
+                metadata = block[1]
+                num_rows = metadata.num_rows if metadata.num_rows else 0
+                self._num_rows_dispatched[output_split_idx] += num_rows
+
+            self._maybe_log_dispatch(
+                split_idx=output_split_idx,
+                epoch_id=epoch_id,
+                num_rows_dispatched=self._num_rows_dispatched[output_split_idx],
+                client_prefetched_bytes=client_prefetched_bytes,
+            )
+
             returned_normally = True
             return RefBundle(
                 [block], schema=schema, owns_blocks=next_bundle.owns_blocks
             )
         except StopIteration:
+            num_rows = self._num_rows_dispatched[output_split_idx]
+            logger.debug(
+                f"Split {output_split_idx} epoch {epoch_id} finished, dispatched "
+                f"{num_rows} rows."
+            )
             return None
+        except Exception as e:
+            num_rows = self._num_rows_dispatched[output_split_idx]
+            logger.warning(
+                f"Split {output_split_idx} epoch {epoch_id} get() failed after "
+                f"{num_rows} rows: {e}"
+            )
+            raise
         finally:
             # Clear prefetched bytes on any exit (StopIteration or other
             # exceptions) to avoid stale backpressure data.
@@ -347,8 +410,33 @@ class SplitCoordinator:
         with self._lock:
             return dict(self._client_prefetched_bytes)
 
+    def _maybe_log_dispatch(
+        self,
+        *,
+        split_idx: int,
+        epoch_id: int,
+        num_rows_dispatched: int,
+        client_prefetched_bytes: int,
+    ) -> None:
+        """Log dispatch progress, throttled to once per interval.
+
+        The intention for throttling is to avoid overwhelming the logs with too many
+        messages.
+        """
+        now = time.time()
+        if now - self._last_dispatch_log_time < self.DISPATCH_LOG_INTERVAL_S:
+            return
+
+        logger.debug(
+            f"Split {split_idx} epoch {epoch_id} returned block: "
+            f"{num_rows_dispatched=}, {client_prefetched_bytes=}"
+        )
+
+        self._last_dispatch_log_time = now
+
     def shutdown_executor(self):
         """Shuts down the internal data executor."""
+        logger.debug(f"Shutting down executor (epoch={self._cur_epoch}).")
         with self._lock:
             # Call shutdown on the executor
             if self._current_executor is not None:
@@ -356,6 +444,9 @@ class SplitCoordinator:
 
     def _barrier(self, split_idx: int) -> int:
         """Arrive and block until the start of the given epoch."""
+        logger.debug(
+            f"Split {split_idx} arriving at barrier for epoch {self._cur_epoch + 1}."
+        )
 
         # Decrement and await all clients to arrive here.
         with self._lock:

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -325,7 +325,7 @@ class SplitCoordinator:
                 next_bundle = self._output_iterator.get_next(output_split_idx)
 
             schema = next_bundle.schema
-            block = next_bundle.blocks[-1]
+            block, metadata = next_bundle.blocks[-1]
             next_bundle = RefBundle(
                 blocks=next_bundle.blocks[:-1],
                 schema=next_bundle.schema,
@@ -347,20 +347,21 @@ class SplitCoordinator:
 
                 # Track per-split row dispatch count.
                 metadata = block[1]
-                num_rows = metadata.num_rows if metadata.num_rows else 0
-                self._num_rows_dispatched[output_split_idx] += num_rows
-                num_rows_total = self._num_rows_dispatched[output_split_idx]
+                self._num_rows_dispatched[output_split_idx] += (
+                    metadata.num_rows if metadata.num_rows else 0
+                )
+                num_rows_dispatched = self._num_rows_dispatched[output_split_idx]
 
             self._maybe_log_dispatch(
                 split_idx=output_split_idx,
                 epoch_id=epoch_id,
-                num_rows_dispatched=num_rows_total,
+                num_rows_dispatched=num_rows_dispatched,
                 client_prefetched_bytes=client_prefetched_bytes,
             )
 
             returned_normally = True
             return RefBundle(
-                [block], schema=schema, owns_blocks=next_bundle.owns_blocks
+                [(block, metadata)], schema=schema, owns_blocks=next_bundle.owns_blocks
             )
         except StopIteration:
             with self._lock:

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -349,11 +349,12 @@ class SplitCoordinator:
                 metadata = block[1]
                 num_rows = metadata.num_rows if metadata.num_rows else 0
                 self._num_rows_dispatched[output_split_idx] += num_rows
+                num_rows_total = self._num_rows_dispatched[output_split_idx]
 
             self._maybe_log_dispatch(
                 split_idx=output_split_idx,
                 epoch_id=epoch_id,
-                num_rows_dispatched=self._num_rows_dispatched[output_split_idx],
+                num_rows_dispatched=num_rows_total,
                 client_prefetched_bytes=client_prefetched_bytes,
             )
 
@@ -362,14 +363,16 @@ class SplitCoordinator:
                 [block], schema=schema, owns_blocks=next_bundle.owns_blocks
             )
         except StopIteration:
-            num_rows = self._num_rows_dispatched[output_split_idx]
+            with self._lock:
+                num_rows = self._num_rows_dispatched[output_split_idx]
             logger.debug(
                 f"Split {output_split_idx} epoch {epoch_id} finished, dispatched "
                 f"{num_rows} rows."
             )
             return None
         except Exception as e:
-            num_rows = self._num_rows_dispatched[output_split_idx]
+            with self._lock:
+                num_rows = self._num_rows_dispatched[output_split_idx]
             logger.warning(
                 f"Split {output_split_idx} epoch {epoch_id} get() failed after "
                 f"{num_rows} rows: {e}"
@@ -424,15 +427,15 @@ class SplitCoordinator:
         messages.
         """
         now = time.time()
-        if now - self._last_dispatch_log_time < self.DISPATCH_LOG_INTERVAL_S:
-            return
+        with self._lock:
+            if now - self._last_dispatch_log_time < self.DISPATCH_LOG_INTERVAL_S:
+                return
+            self._last_dispatch_log_time = now
 
         logger.debug(
             f"Split {split_idx} epoch {epoch_id} returned block: "
             f"{num_rows_dispatched=}, {client_prefetched_bytes=}"
         )
-
-        self._last_dispatch_log_time = now
 
     def shutdown_executor(self):
         """Shuts down the internal data executor."""
@@ -444,12 +447,12 @@ class SplitCoordinator:
 
     def _barrier(self, split_idx: int) -> int:
         """Arrive and block until the start of the given epoch."""
-        logger.debug(
-            f"Split {split_idx} arriving at barrier for epoch {self._cur_epoch + 1}."
-        )
-
         # Decrement and await all clients to arrive here.
         with self._lock:
+            logger.debug(
+                f"Split {split_idx} arriving at barrier for epoch "
+                f"{self._cur_epoch + 1}."
+            )
             starting_epoch = self._cur_epoch
             self._unfinished_clients_in_epoch -= 1
 


### PR DESCRIPTION
## Description

The streaming split pipeline (SplitCoordinator, OutputSplitter, StreamSplitDataIterator) has almost no observability, making it difficult to debug issues in production. This adds debug logging at key lifecycle points and a throttled dispatch log in the hot path.

**SplitCoordinator:**
- `__init__`: DEBUG log with `n` and `locality_hints`
- `get()`: throttled DEBUG log with rows dispatched and prefetch bytes; DEBUG on epoch finish; WARNING on unexpected errors
- `_barrier`: DEBUG on client arrival and epoch start; WARNING on executor creation failure
- `shutdown_executor`: DEBUG log

**StreamSplitDataIterator:**
- `__init__`: DEBUG log with split index and world size
- `gen_blocks`: DEBUG on epoch request/start/exhaustion; throttled DEBUG after yield (consumer resume)
- `stats()`: DEBUG before remote call

**OutputSplitter:**
- `__init__`: DEBUG log with `n`, `equal`, `locality_hints`, `max_buffer_size`

## Related issues

None.

## Additional information

All hot-path logs (SplitCoordinator dispatch, consumer yield) are time-throttled to avoid log spam. Lifecycle logs (init, epoch transitions, shutdown) are not throttled since they are infrequent.