### PR TITLE
[Data] Add state-change debug logging to DownstreamCapacityBackpressurePolicy

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
@@ -191,6 +191,7 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
         utilized_budget_fraction = get_utilized_object_store_budget_fraction(
             self._resource_manager, op, consider_downstream_ineligible_ops=True
         )
+        queue_ratio = self._get_queue_ratio(op)
         if (
             utilized_budget_fraction is not None
             and utilized_budget_fraction <= self.OBJECT_STORE_BUDGET_UTIL_THRESHOLD
@@ -198,7 +199,6 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
             # Utilized budget fraction is below threshold, so should skip backpressure.
             result = False
         else:
-            queue_ratio = self._get_queue_ratio(op)
             # Apply backpressure if queue ratio exceeds the threshold.
             result = queue_ratio > self._backpressure_capacity_ratio
 
@@ -208,7 +208,7 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
             downstream_capacity_bytes = self._get_downstream_capacity_size_bytes(op)
             logger.debug(
                 f"Backpressure change {op.name}: {prev} -> {result} "
-                f"(queue_ratio={self._get_queue_ratio(op):.2f}, {queue_size_bytes=}, "
+                f"(queue_ratio={queue_ratio:.2f}, {queue_size_bytes=}, "
                 f"{downstream_capacity_bytes=}, {utilized_budget_fraction=})"
             )
             self._prev_should_backpressure[op] = result

--- a/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
@@ -101,12 +101,16 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
         resource_manager: "ResourceManager",
     ):
         super().__init__(data_context, topology, resource_manager)
+
         self._backpressure_capacity_ratio = (
             self._data_context.downstream_capacity_backpressure_ratio
         )
+        self._prev_should_backpressure: dict["PhysicalOperator", bool] = {}
+
         if self._backpressure_capacity_ratio is not None:
             logger.debug(
-                f"DownstreamCapacityBackpressurePolicy enabled with backpressure capacity ratio: {self._backpressure_capacity_ratio}"
+                "DownstreamCapacityBackpressurePolicy enabled with backpressure "
+                f"capacity ratio: {self._backpressure_capacity_ratio}"
             )
 
     def _get_queue_size_bytes(self, op: "PhysicalOperator") -> int:
@@ -192,11 +196,24 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
             and utilized_budget_fraction <= self.OBJECT_STORE_BUDGET_UTIL_THRESHOLD
         ):
             # Utilized budget fraction is below threshold, so should skip backpressure.
-            return False
+            result = False
+        else:
+            queue_ratio = self._get_queue_ratio(op)
+            # Apply backpressure if queue ratio exceeds the threshold.
+            result = queue_ratio > self._backpressure_capacity_ratio
 
-        queue_ratio = self._get_queue_ratio(op)
-        # Apply backpressure if queue ratio exceeds the threshold.
-        return queue_ratio > self._backpressure_capacity_ratio
+        prev = self._prev_should_backpressure.get(op)
+        if prev != result:
+            queue_size_bytes = self._get_queue_size_bytes(op)
+            downstream_capacity_bytes = self._get_downstream_capacity_size_bytes(op)
+            logger.debug(
+                f"Backpressure change {op.name}: {prev} -> {result} "
+                f"(queue_ratio={self._get_queue_ratio(op):.2f}, {queue_size_bytes=}, "
+                f"{downstream_capacity_bytes=}, {utilized_budget_fraction=})"
+            )
+            self._prev_should_backpressure[op] = result
+
+        return result
 
     def can_add_input(self, op: "PhysicalOperator") -> bool:
         """Determine if we can add input to the operator based on


### PR DESCRIPTION
## Description

`can_add_input` and `max_task_output_bytes_to_read` in `DownstreamCapacityBackpressurePolicy` provide no visibility into when backpressure decisions change. This adds debug logging on state transitions in `_should_apply_backpressure` to help with debugging without spamming logs.

Logs are only emitted when the backpressure state changes for an operator (not every call), following the existing pattern from `ConcurrencyCapBackpressurePolicy`. Each log includes: op name, old/new state, queue ratio, queue size bytes, downstream capacity bytes, and utilized budget fraction.

## Related issues

N/A

## Additional information

N/A