### PR TITLE
[ci] Skip mac smoke test on raydepsets lock updates except macos_depset

### DIFF
--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -39,8 +39,8 @@ python/_raylet.pyx: ml tune train data python dashboard linux_wheels macos_wheel
 # macos_depset lock is consumed by the mac smoke test, so it must emit macos_wheels.
 python/deplocks/ci/macos_depset_py3.10.lock: macos_wheels
 # Other deplock updates should NOT trigger the mac smoke test (no macos_wheels).
-python/deplocks/base_deps/ray_base_deps_py3.10.lock: ml tune train data python dashboard linux_wheels java
-python/deplocks/ci/data-base-ci_depset_py3.10.lock: ml tune train data python dashboard linux_wheels java
+python/deplocks/base_deps/ray_base_deps_py3.10.lock: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
+python/deplocks/ci/data-base-ci_depset_py3.10.lock: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
 # LLM deplocks still hit the earlier llm rule block.
 python/deplocks/llm/ray_py311_cpu.lock: llm
 

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -35,6 +35,15 @@ python/setup.py: ml tune train serve workflow data python dashboard linux_wheels
 python/requirements/test-requirements.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/_raylet.pyx: ml tune train data python dashboard linux_wheels macos_wheels java
 
+# === Raydepsets lock files ===
+# macos_depset lock is consumed by the mac smoke test, so it must emit macos_wheels.
+python/deplocks/ci/macos_depset_py3.10.lock: macos_wheels
+# Other deplock updates should NOT trigger the mac smoke test (no macos_wheels).
+python/deplocks/base_deps/ray_base_deps_py3.10.lock: ml tune train data python dashboard linux_wheels java
+python/deplocks/ci/data-base-ci_depset_py3.10.lock: ml tune train data python dashboard linux_wheels java
+# LLM deplocks still hit the earlier llm rule block.
+python/deplocks/llm/ray_py311_cpu.lock: llm
+
 # === Buildkite Configs ===
 
 .buildkite/ml.rayci.yml: ml train train_gpu tune

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -95,10 +95,12 @@ python/deplocks/ci/macos_depset_py*
 # Raydepsets-generated lock files. These do NOT affect the macOS smoke
 # test (which only consumes macos_depset_py*, handled above), so we
 # deliberately omit macos_wheels here to avoid running mac tests on
-# unrelated lock updates.
+# unrelated lock updates. Otherwise mirrors the python/setup.py rule's
+# tag set so general dependency changes still fan out across CI.
 python/deplocks/
-@ ml tune train data
+@ ml tune train serve workflow data min_build
 @ python dashboard linux_wheels java
+@ python_dependencies
 ;
 
 python/setup.py

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -85,6 +85,22 @@ python/ray/dashboard/
 @ dashboard linux_wheels python
 ;
 
+# The macOS smoke test installs this specific lock file
+# (ci/ray_ci/macos/macos_ci.sh), so changes here must still trigger
+# macos_wheels. Must precede the general python/deplocks/ rule below.
+python/deplocks/ci/macos_depset_py*
+@ macos_wheels
+;
+
+# Raydepsets-generated lock files. These do NOT affect the macOS smoke
+# test (which only consumes macos_depset_py*, handled above), so we
+# deliberately omit macos_wheels here to avoid running mac tests on
+# unrelated lock updates.
+python/deplocks/
+@ ml tune train data
+@ python dashboard linux_wheels java
+;
+
 python/setup.py
 python/requirements.txt
 python/requirements_compiled.txt


### PR DESCRIPTION
  **Summary**

  - Stop running the mac: smoke test job (and other macos_wheels-tagged jobs) on raydepsets lock-file updates under python/deplocks/, since those locks don't affect the macOS build path.
  - Keep the mac smoke test running when python/deplocks/ci/macos_depset_py*.lock changes -- ci/ray_ci/macos/macos_ci.sh:136 installs that exact lock, so it's the one raydepsets output that actually matters for mac CI.

  **Changes**
  - .buildkite/test.rules.txt: two new rules before the python/setup.py block.
    - Specific: python/deplocks/ci/macos_depset_py* → macos_wheels
    - General: python/deplocks/ → ml tune train data python dashboard linux_wheels java (mirrors the python/ catchall minus macos_wheels)
  - .buildkite/test.rules.test.txt: new assertions covering macos_depset, two generic deplocks (base_deps + data-base-ci), and an LLM deplock (to confirm the earlier llm rule still wins first-match).