### PR TITLE
Add ability to specify existing subnet/nsg for Azure clusters

### DIFF
--- a/doc/source/cluster/vms/references/ray-cluster-configuration.rst
+++ b/doc/source/cluster/vms/references/ray-cluster-configuration.rst
@@ -132,6 +132,8 @@ Provider
             :ref:`subscription_id <cluster-configuration-subscription-id>`: str
             :ref:`msi_name <cluster-configuration-msi-name>`: str
             :ref:`msi_resource_group <cluster-configuration-msi-resource-group>`: str
+            :ref:`subnet_id <cluster-configuration-subnet-id>`: str
+            :ref:`nsg_id <cluster-configuration-nsg-id>`: str
             :ref:`cache_stopped_nodes <cluster-configuration-cache-stopped-nodes>`: bool
             :ref:`use_internal_ips <cluster-configuration-use-internal-ips>`: bool
             :ref:`use_external_head_ip <cluster-configuration-use-external-head-ip>`: bool
@@ -1126,6 +1128,76 @@ The user that Ray will authenticate with when launching new nodes.
     .. tab-item:: GCP
 
         Not available.
+
+    .. tab-item:: vSphere
+
+        Not available.
+
+.. _cluster-configuration-subnet-id:
+
+``provider.subnet_id``
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+    .. tab-item:: AWS
+
+        Not available at the provider level. For AWS, use ``SubnetIds`` in the node config
+        to deploy into existing subnets. See the `AWS subnets example <https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-subnets.yaml>`_.
+
+    .. tab-item:: Azure
+
+        The full Azure resource ID of an existing subnet to deploy Ray cluster nodes into,
+        instead of creating a new VNET and subnet. When set, Ray skips VNET and subnet
+        creation entirely. This is useful for data privacy and compliance scenarios where
+        nodes must be deployed into a pre-configured network with existing security controls,
+        private endpoints, and service endpoints.
+
+        Example: ``/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<subnet>``
+
+        * **Required:** No
+        * **Importance:** Medium
+        * **Type:** String
+        * **Default:** ``null`` (Ray creates a new VNET and subnet)
+
+    .. tab-item:: GCP
+
+        Not available at the provider level. For GCP, use ``networkInterfaces`` with a
+        ``subnetwork`` path in the node config. See the `GCP full example <https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/gcp/example-full.yaml>`_.
+
+    .. tab-item:: vSphere
+
+        Not available.
+
+.. _cluster-configuration-nsg-id:
+
+``provider.nsg_id``
+~~~~~~~~~~~~~~~~~~~
+
+.. tab-set::
+
+    .. tab-item:: AWS
+
+        Not available at the provider level. For AWS, use ``SecurityGroupIds`` in the node config
+        to use existing security groups. See the `AWS security group example <https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/example-security-group.yaml>`_.
+
+    .. tab-item:: Azure
+
+        The full Azure resource ID of an existing Network Security Group (NSG) to use for
+        Ray cluster nodes, instead of creating a new one. When set, Ray skips NSG creation.
+        This is typically used together with ``subnet_id`` when deploying into a pre-existing
+        network. If not set, Ray creates a default NSG with an SSH inbound rule.
+
+        Example: ``/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkSecurityGroups/<nsg>``
+
+        * **Required:** No
+        * **Importance:** Medium
+        * **Type:** String
+        * **Default:** ``null`` (Ray creates a new NSG)
+
+    .. tab-item:: GCP
+
+        Not available. GCP firewall rules are managed at the project/network level.
 
     .. tab-item:: vSphere
 

--- a/doc/source/cluster/vms/user-guides/launching-clusters/azure.md
+++ b/doc/source/cluster/vms/user-guides/launching-clusters/azure.md
@@ -113,6 +113,31 @@ ray down example-full.yaml
 
 Congratulations, you have started a Ray cluster on Azure!
 
+### Using an existing VNET (Bring Your Own VNET)
+
+For data privacy, compliance, or enterprise networking scenarios, you can deploy Ray cluster nodes into a pre-existing Azure Virtual Network instead of having Ray create one automatically.
+
+To use an existing VNET and NSG, add `subnet_id` and optionally `nsg_id` to your provider configuration:
+
+```yaml
+provider:
+    type: azure
+    location: westus2
+    resource_group: my-resource-group
+    subscription_id: 00000000-0000-0000-0000-000000000000
+    subnet_id: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<subnet>
+    nsg_id: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkSecurityGroups/<nsg>
+```
+
+When `subnet_id` is set, Ray skips VNET and subnet creation entirely. When `nsg_id` is set, Ray skips NSG creation. If only `subnet_id` is provided without `nsg_id`, Ray creates a default NSG with SSH access.
+
+This allows Ray nodes to:
+- Inherit existing network security controls, route tables, and firewall rules.
+- Access data through private endpoints and service endpoints already configured in your VNET.
+- Operate within enterprise hub-and-spoke network topologies.
+
+When tearing down a cluster with `ray down`, user-provided VNET, subnet, and NSG resources are preserved.
+
 ## Using Azure portal
 
 Alternatively, you can deploy a cluster using Azure portal directly. Please note that autoscaling is done using Azure VM Scale Sets and not through the Ray autoscaler. This will deploy [Azure Data Science VMs (DSVM)](https://azure.microsoft.com/en-us/services/virtual-machines/data-science-virtual-machines/) for both the head node and the auto-scalable cluster managed by [Azure Virtual Machine Scale Sets](https://azure.microsoft.com/en-us/services/virtual-machine-scale-sets/).

--- a/python/ray/autoscaler/_private/_azure/azure-config-template.json
+++ b/python/ray/autoscaler/_private/_azure/azure-config-template.json
@@ -28,7 +28,21 @@
         },
         "createMsi": {
             "type": "bool",
-            "defaultValue": "true"
+            "defaultValue": true
+        },
+        "createVnet": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "If false, skip VNET and subnet creation (use existing subnet_id)."
+            }
+        },
+        "createNsg": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "If false, skip NSG creation (use existing nsg_id)."
+            }
         },
         "roleAssignmentGuid": {
             "type": "string",
@@ -70,6 +84,7 @@
             ]
         },
         {
+            "condition": "[parameters('createNsg')]",
             "type": "Microsoft.Network/networkSecurityGroups",
             "apiVersion": "2024-10-01",
             "name": "[variables('nsgName')]",
@@ -93,6 +108,7 @@
             }
         },
         {
+            "condition": "[parameters('createVnet')]",
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2024-10-01",
             "name": "[variables('vnetName')]",
@@ -122,10 +138,12 @@
     ],
     "outputs": {
         "subnet": {
+            "condition": "[parameters('createVnet')]",
             "type": "string",
             "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('subnetName'))]"
         },
         "nsg": {
+            "condition": "[parameters('createNsg')]",
             "type": "string",
             "value": "[variables('nsg')]"
         },

--- a/python/ray/autoscaler/_private/_azure/config.py
+++ b/python/ray/autoscaler/_private/_azure/config.py
@@ -109,86 +109,100 @@ def _configure_resource_group(config):
         f"/Microsoft.Authorization/roleAssignments/{role_assignment_guid}"
     )
 
+    # Check if user wants to use an existing VNET/subnet instead of creating one.
+    use_existing_subnet = "subnet_id" in config["provider"]
+    use_existing_nsg = "nsg_id" in config["provider"]
+
+    if use_existing_subnet:
+        logger.info(
+            "Using existing subnet: %s", config["provider"]["subnet_id"]
+        )
+    if use_existing_nsg:
+        logger.info(
+            "Using existing NSG: %s", config["provider"]["nsg_id"]
+        )
+
     subnet_mask = config["provider"].get("subnet_mask")
     if subnet_mask is None:
         # choose a random subnet, skipping most common value of 0
         random.seed(unique_id)
         subnet_mask = "10.{}.0.0/16".format(random.randint(1, 254))
-    logger.info("Using subnet mask: %s", subnet_mask)
 
-    # Copy over properties from existing subnet.
-    # Addresses issue (https://github.com/Azure/azure-quickstart-templates/issues/2786)
-    # where existing subnet properties will get overwritten unless explicitly specified
-    # during multiple deployments even if vnet/subnet do not change.
-    # May eventually be fixed by passing empty subnet list if they already exist:
-    # https://techcommunity.microsoft.com/t5/azure-networking-blog/azure-virtual-network-now-supports-updates-without-subnet/ba-p/4067952
-    list_by_rg = get_azure_sdk_function(
-        client=resource_client.resources, function_name="list_by_resource_group"
-    )
-    existing_vnets = list(
-        list_by_rg(
-            resource_group,
-            f"substringof('{unique_id}', name) and "
-            "resourceType eq 'Microsoft.Network/virtualNetworks'",
+    if not use_existing_subnet:
+        logger.info("Using subnet mask: %s", subnet_mask)
+        # Copy over properties from existing subnet.
+        # Addresses issue (https://github.com/Azure/azure-quickstart-templates/issues/2786)
+        # where existing subnet properties will get overwritten unless explicitly specified
+        # during multiple deployments even if vnet/subnet do not change.
+        # May eventually be fixed by passing empty subnet list if they already exist:
+        # https://techcommunity.microsoft.com/t5/azure-networking-blog/azure-virtual-network-now-supports-updates-without-subnet/ba-p/4067952
+        list_by_rg = get_azure_sdk_function(
+            client=resource_client.resources, function_name="list_by_resource_group"
         )
-    )
-    if len(existing_vnets) > 0:
-        vnid = existing_vnets[0].id
-        get_by_id = get_azure_sdk_function(
-            client=resource_client.resources, function_name="get_by_id"
+        existing_vnets = list(
+            list_by_rg(
+                resource_group,
+                f"substringof('{unique_id}', name) and "
+                "resourceType eq 'Microsoft.Network/virtualNetworks'",
+            )
         )
+        if len(existing_vnets) > 0:
+            vnid = existing_vnets[0].id
+            get_by_id = get_azure_sdk_function(
+                client=resource_client.resources, function_name="get_by_id"
+            )
 
-        # Query for supported API versions for Microsoft.Network/virtualNetworks
-        # because resource_client.DEFAULT_API_VERSION is not always supported.
-        # (Example: "2024-11-01" is the default at the time of this writing)
-        # Use "2024-10-01" as a fallback if we can't determine the latest stable version.
-        vnet_api_version = "2024-10-01"
-        try:
-            # Get supported API versions for Microsoft.Network provider
-            providers = resource_client.providers.get("Microsoft.Network")
-            vnet_resource_type = next(
+            # Query for supported API versions for Microsoft.Network/virtualNetworks
+            # because resource_client.DEFAULT_API_VERSION is not always supported.
+            # (Example: "2024-11-01" is the default at the time of this writing)
+            # Use "2024-10-01" as a fallback if we can't determine the latest stable version.
+            vnet_api_version = "2024-10-01"
+            try:
+                # Get supported API versions for Microsoft.Network provider
+                providers = resource_client.providers.get("Microsoft.Network")
+                vnet_resource_type = next(
+                    (
+                        rt
+                        for rt in providers.resource_types
+                        if rt.resource_type == "virtualNetworks"
+                    ),
+                    None,
+                )
+                if vnet_resource_type and vnet_resource_type.api_versions:
+                    stable_versions = [
+                        v for v in vnet_resource_type.api_versions if "preview" not in v
+                    ]
+                    versions_to_consider = (
+                        stable_versions or vnet_resource_type.api_versions
+                    )
+                    vnet_api_version = sorted(versions_to_consider)[-1]
+                    logger.info(
+                        "Using API version: %s for virtualNetworks", vnet_api_version
+                    )
+                else:
+                    logger.warning(
+                        "Could not determine supported API versions for virtualNetworks, using fallback version %s",
+                        vnet_api_version,
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to query Microsoft.Network provider: %s. Using fallback API version 2024-10-01",
+                    str(e),
+                )
+
+            subnet = get_by_id(vnid, vnet_api_version).properties["subnets"][0]
+            template_vnet = next(
                 (
-                    rt
-                    for rt in providers.resource_types
-                    if rt.resource_type == "virtualNetworks"
+                    rs
+                    for rs in template["resources"]
+                    if rs["type"] == "Microsoft.Network/virtualNetworks"
                 ),
                 None,
             )
-            if vnet_resource_type and vnet_resource_type.api_versions:
-                stable_versions = [
-                    v for v in vnet_resource_type.api_versions if "preview" not in v
-                ]
-                versions_to_consider = (
-                    stable_versions or vnet_resource_type.api_versions
-                )
-                vnet_api_version = sorted(versions_to_consider)[-1]
-                logger.info(
-                    "Using API version: %s for virtualNetworks", vnet_api_version
-                )
-            else:
-                logger.warning(
-                    "Could not determine supported API versions for virtualNetworks, using fallback version %s",
-                    vnet_api_version,
-                )
-        except Exception as e:
-            logger.warning(
-                "Failed to query Microsoft.Network provider: %s. Using fallback API version 2024-10-01",
-                str(e),
-            )
-
-        subnet = get_by_id(vnid, vnet_api_version).properties["subnets"][0]
-        template_vnet = next(
-            (
-                rs
-                for rs in template["resources"]
-                if rs["type"] == "Microsoft.Network/virtualNetworks"
-            ),
-            None,
-        )
-        if template_vnet is not None:
-            template_subnets = template_vnet["properties"].get("subnets")
-            if template_subnets is not None:
-                template_subnets[0]["properties"].update(subnet["properties"])
+            if template_vnet is not None:
+                template_subnets = template_vnet["properties"].get("subnets")
+                if template_subnets is not None:
+                    template_subnets[0]["properties"].update(subnet["properties"])
 
     # Get or create an MSI name and resource group.
     # Defaults to current resource group if not provided.
@@ -318,6 +332,8 @@ def _configure_resource_group(config):
                 "msiResourceGroup": {"value": msi_resource_group},
                 "createMsi": {"value": not use_existing_msi},
                 "roleAssignmentGuid": {"value": role_assignment_guid},
+                "createVnet": {"value": not use_existing_subnet},
+                "createNsg": {"value": not use_existing_nsg},
             },
         }
     }
@@ -337,8 +353,17 @@ def _configure_resource_group(config):
 
     # append output resource ids to be used with vm creation
     config["provider"]["msi"] = outputs["msi"]["value"]
-    config["provider"]["nsg"] = outputs["nsg"]["value"]
-    config["provider"]["subnet"] = outputs["subnet"]["value"]
+
+    # Use user-provided subnet/NSG IDs if specified, otherwise use template outputs
+    if use_existing_subnet:
+        config["provider"]["subnet"] = config["provider"]["subnet_id"]
+    else:
+        config["provider"]["subnet"] = outputs["subnet"]["value"]
+
+    if use_existing_nsg:
+        config["provider"]["nsg"] = config["provider"]["nsg_id"]
+    else:
+        config["provider"]["nsg"] = outputs["nsg"]["value"]
 
     return config
 

--- a/python/ray/autoscaler/_private/_azure/node_provider.py
+++ b/python/ray/autoscaler/_private/_azure/node_provider.py
@@ -670,7 +670,10 @@ class AzureNodeProvider(NodeProvider):
             time.sleep(0.1)
 
     def cleanup_cluster_resources(self):
-        """Delete shared cluster infrastructure (MSI, NSG, Subnet, VNet)."""
+        """Delete shared cluster infrastructure (MSI, NSG, Subnet, VNet).
+
+        Resources provided by the user (subnet_id, nsg_id) are not deleted.
+        """
 
         resource_group = self.provider_config["resource_group"]
 
@@ -678,13 +681,25 @@ class AzureNodeProvider(NodeProvider):
             resource_group, self.provider_config.get("msi")
         )
 
+        # Skip subnet/VNET cleanup if user provided their own subnet
+        use_existing_subnet = "subnet_id" in self.provider_config
         subnet_id = self.provider_config.get("subnet")
-        vnet_name = self._cleanup_subnet(resource_group, subnet_id)
+        vnet_name = None
+        if not use_existing_subnet:
+            vnet_name = self._cleanup_subnet(resource_group, subnet_id)
+        else:
+            logger.info("Skipping subnet/VNET cleanup (user-provided subnet_id)")
 
+        # Skip NSG cleanup if user provided their own NSG
+        use_existing_nsg = "nsg_id" in self.provider_config
         nsg_id = self.provider_config.get("nsg")
-        self._cleanup_nsg(resource_group, nsg_id)
+        if not use_existing_nsg:
+            self._cleanup_nsg(resource_group, nsg_id)
+        else:
+            logger.info("Skipping NSG cleanup (user-provided nsg_id)")
 
-        self._cleanup_vnet(resource_group, subnet_id, vnet_name)
+        if not use_existing_subnet:
+            self._cleanup_vnet(resource_group, subnet_id, vnet_name)
 
         self._cleanup_role_assignments(resource_group, msi_principal_id)
 

--- a/python/ray/autoscaler/azure/example-full.yaml
+++ b/python/ray/autoscaler/azure/example-full.yaml
@@ -55,6 +55,14 @@ provider:
     # If both options below are true, only the head node will have a public IP address provisioned.
     # use_internal_ips: True
     # use_external_head_ip: True
+    # Set an existing subnet resource ID to deploy into a pre-existing VNET
+    # instead of creating a new one. This is useful for data privacy/compliance
+    # scenarios where you need VMs in a specific network with existing security controls.
+    # When set, Ray will skip VNET/subnet creation entirely.
+    # subnet_id: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<subnet>
+    # Set an existing NSG resource ID to use instead of creating a new one.
+    # If not set, Ray will create a default NSG with SSH access.
+    # nsg_id: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/networkSecurityGroups/<nsg>
 
 # How Ray will authenticate with newly launched nodes.
 auth:


### PR DESCRIPTION

## Description
Adds the ability to specify an existing VNET and/or NetworkSecurityGroup for Azure VM based clusters.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information

This has been tested manually (both ray cluster bring up and tear down) and everything works as expected.
I have also update the docs and existing azure-full example to show how to use the new fields in the cluster template files.
