### PR TITLE
[Data] - Replace read_images test with testing invalid bytes instead testing with empty file

### DIFF
--- a/python/ray/data/tests/datasource/test_image.py
+++ b/python/ray/data/tests/datasource/test_image.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 from typing import Dict
 
 import numpy as np
@@ -169,10 +168,13 @@ class TestReadImages:
         finally:
             ctx.target_max_block_size = target_max_block_size
 
-    def test_unidentified_image_error(ray_start_regular_shared):
-        with tempfile.NamedTemporaryFile(suffix=".png") as file:
-            with pytest.raises(ValueError):
-                ray.data.read_images(paths=file.name).materialize()
+    def test_unidentified_image_error(ray_start_regular_shared, tmp_path):
+        path = str(tmp_path / "invalid.png")
+        with open(path, "wb") as file:
+            file.write(b"spam")  # Invalid bytes for a PNG file
+
+        with pytest.raises(ValueError):
+            ray.data.read_images(paths=file.name).materialize()
 
 
 class TestWriteImages:


### PR DESCRIPTION
## Description
The valueerror should be raised only in the event that the contents of the file are invalid not if the file is empty

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
