### PR TITLE
[RLlib] Fix ValueError in synchronous_parallel_sample for NaN agent steps

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -2885,6 +2885,18 @@ py_test(
 # Tag: utils
 # --------------------------------------------------------------------
 
+# Execution / rollout ops
+py_test(
+    name = "execution/tests/test_rollout_ops_nan",
+    size = "small",
+    srcs = ["execution/tests/test_rollout_ops_nan.py"],
+    tags = [
+        "team:rllib",
+        "utils",
+    ],
+    deps = [":conftest"],
+)
+
 # Checkpointables
 py_test(
     name = "utils/tests/test_checkpointable",

--- a/rllib/execution/rollout_ops.py
+++ b/rllib/execution/rollout_ops.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import List, Optional, Union
 
 import tree
@@ -142,6 +143,7 @@ def synchronous_parallel_sample(
                     int(agent_stat)
                     for stat_dict in stats_dicts
                     for agent_stat in stat_dict[NUM_AGENT_STEPS_SAMPLED].values()
+                    if not math.isnan(float(agent_stat))
                 )
             else:
                 agent_or_env_steps += sum(

--- a/rllib/execution/tests/test_rollout_ops_nan.py
+++ b/rllib/execution/tests/test_rollout_ops_nan.py
@@ -1,60 +1,31 @@
-"""Unit test for NaN-resilience in synchronous_parallel_sample's agent-step counter."""
+"""Regression test for NaN agent-step entries in synchronous_parallel_sample."""
 import math
 import unittest
 
 
-class TestNanAgentStepFiltering(unittest.TestCase):
-    """Verify the NaN guard added to synchronous_parallel_sample.
+_NUM_AGENT_STEPS_SAMPLED = "num_agent_steps_sampled"
 
-    The original list-comp called int(agent_stat) unconditionally, which raises
-    ValueError when the stat is float('nan').  The fix wraps the comprehension
-    with `if not math.isnan(float(agent_stat))` so NaN entries are skipped.
-    """
 
-    _NUM_AGENT_STEPS_SAMPLED = "num_agent_steps_sampled"
+def _count_agent_steps(stats_dicts):
+    # Mirrors the patched generator in rllib/execution/rollout_ops.py.
+    return sum(
+        int(agent_stat)
+        for stat_dict in stats_dicts
+        for agent_stat in stat_dict[_NUM_AGENT_STEPS_SAMPLED].values()
+        if not math.isnan(float(agent_stat))
+    )
 
-    def _sum_agent_steps(self, stats_dicts):
-        """Mirror of the patched generator expression in rollout_ops.py."""
-        return sum(
-            int(agent_stat)
-            for stat_dict in stats_dicts
-            for agent_stat in stat_dict[self._NUM_AGENT_STEPS_SAMPLED].values()
-            if not math.isnan(float(agent_stat))
-        )
 
-    def test_clean_stats(self):
-        stats = [{self._NUM_AGENT_STEPS_SAMPLED: {"agent0": 10, "agent1": 20}}]
-        self.assertEqual(self._sum_agent_steps(stats), 30)
-
-    def test_nan_stat_skipped(self):
+class TestNanAgentSteps(unittest.TestCase):
+    def test_skips_nan_entries(self):
         stats = [
-            {self._NUM_AGENT_STEPS_SAMPLED: {"agent0": float("nan"), "agent1": 5}}
+            {_NUM_AGENT_STEPS_SAMPLED: {"a": 3, "b": float("nan"), "c": 7}}
         ]
-        self.assertEqual(self._sum_agent_steps(stats), 5)
+        self.assertEqual(_count_agent_steps(stats), 10)
 
-    def test_all_nan_returns_zero(self):
-        stats = [
-            {self._NUM_AGENT_STEPS_SAMPLED: {"agent0": float("nan")}}
-        ]
-        self.assertEqual(self._sum_agent_steps(stats), 0)
-
-    def test_nan_without_guard_raises(self):
-        """Without the guard, int(float('nan')) raises ValueError."""
-        stats = [
-            {self._NUM_AGENT_STEPS_SAMPLED: {"agent0": float("nan")}}
-        ]
-        with self.assertRaises((ValueError, OverflowError)):
-            sum(
-                int(agent_stat)
-                for stat_dict in stats
-                for agent_stat in stat_dict[self._NUM_AGENT_STEPS_SAMPLED].values()
-            )
-
-    def test_mixed_nan_and_valid(self):
-        stats = [
-            {self._NUM_AGENT_STEPS_SAMPLED: {"a": 3, "b": float("nan"), "c": 7}}
-        ]
-        self.assertEqual(self._sum_agent_steps(stats), 10)
+    def test_clean_stats_unchanged(self):
+        stats = [{_NUM_AGENT_STEPS_SAMPLED: {"a": 10, "b": 20}}]
+        self.assertEqual(_count_agent_steps(stats), 30)
 
 
 if __name__ == "__main__":

--- a/rllib/execution/tests/test_rollout_ops_nan.py
+++ b/rllib/execution/tests/test_rollout_ops_nan.py
@@ -1,0 +1,61 @@
+"""Unit test for NaN-resilience in synchronous_parallel_sample's agent-step counter."""
+import math
+import unittest
+
+
+class TestNanAgentStepFiltering(unittest.TestCase):
+    """Verify the NaN guard added to synchronous_parallel_sample.
+
+    The original list-comp called int(agent_stat) unconditionally, which raises
+    ValueError when the stat is float('nan').  The fix wraps the comprehension
+    with `if not math.isnan(float(agent_stat))` so NaN entries are skipped.
+    """
+
+    _NUM_AGENT_STEPS_SAMPLED = "num_agent_steps_sampled"
+
+    def _sum_agent_steps(self, stats_dicts):
+        """Mirror of the patched generator expression in rollout_ops.py."""
+        return sum(
+            int(agent_stat)
+            for stat_dict in stats_dicts
+            for agent_stat in stat_dict[self._NUM_AGENT_STEPS_SAMPLED].values()
+            if not math.isnan(float(agent_stat))
+        )
+
+    def test_clean_stats(self):
+        stats = [{self._NUM_AGENT_STEPS_SAMPLED: {"agent0": 10, "agent1": 20}}]
+        self.assertEqual(self._sum_agent_steps(stats), 30)
+
+    def test_nan_stat_skipped(self):
+        stats = [
+            {self._NUM_AGENT_STEPS_SAMPLED: {"agent0": float("nan"), "agent1": 5}}
+        ]
+        self.assertEqual(self._sum_agent_steps(stats), 5)
+
+    def test_all_nan_returns_zero(self):
+        stats = [
+            {self._NUM_AGENT_STEPS_SAMPLED: {"agent0": float("nan")}}
+        ]
+        self.assertEqual(self._sum_agent_steps(stats), 0)
+
+    def test_nan_without_guard_raises(self):
+        """Without the guard, int(float('nan')) raises ValueError."""
+        stats = [
+            {self._NUM_AGENT_STEPS_SAMPLED: {"agent0": float("nan")}}
+        ]
+        with self.assertRaises((ValueError, OverflowError)):
+            sum(
+                int(agent_stat)
+                for stat_dict in stats
+                for agent_stat in stat_dict[self._NUM_AGENT_STEPS_SAMPLED].values()
+            )
+
+    def test_mixed_nan_and_valid(self):
+        stats = [
+            {self._NUM_AGENT_STEPS_SAMPLED: {"a": 3, "b": float("nan"), "c": 7}}
+        ]
+        self.assertEqual(self._sum_agent_steps(stats), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rllib/execution/tests/test_rollout_ops_nan.py
+++ b/rllib/execution/tests/test_rollout_ops_nan.py
@@ -1,29 +1,76 @@
-"""Regression test for NaN agent-step entries in synchronous_parallel_sample."""
+"""Regression test for NaN agent-step entries in synchronous_parallel_sample.
+
+A MultiAgentEnv with ``count_steps_by="agent_steps"`` leaves NaN entries in the
+per-agent ``NUM_AGENT_STEPS_SAMPLED`` metric for agents that previously stepped
+but are absent from the current batch. ``synchronous_parallel_sample`` calls
+``int()`` on every per-agent value to advance its stopping criterion, which used
+to raise ``ValueError: cannot convert float NaN to integer``. See #62635.
+"""
+
 import math
 import unittest
 
-_NUM_AGENT_STEPS_SAMPLED = "num_agent_steps_sampled"
+from ray.rllib.execution.rollout_ops import synchronous_parallel_sample
+from ray.rllib.policy.sample_batch import SampleBatch
+from ray.rllib.utils.metrics import NUM_AGENT_STEPS_SAMPLED
 
 
-def _count_agent_steps(stats_dicts):
-    # Mirrors the patched generator in rllib/execution/rollout_ops.py.
-    return sum(
-        int(agent_stat)
-        for stat_dict in stats_dicts
-        for agent_stat in stat_dict[_NUM_AGENT_STEPS_SAMPLED].values()
-        if not math.isnan(float(agent_stat))
+class _FakeEnvRunner:
+    """Local EnvRunner stub returning a fixed sample batch and metrics dict."""
+
+    def __init__(self, agent_steps):
+        self._agent_steps = agent_steps
+
+    def sample(self, **kwargs):
+        return SampleBatch()
+
+    def get_metrics(self):
+        return {NUM_AGENT_STEPS_SAMPLED: dict(self._agent_steps)}
+
+
+class _FakeEnvRunnerGroup:
+    """Local-only EnvRunnerGroup stub (no remote workers)."""
+
+    def __init__(self, agent_steps):
+        self.local_env_runner = _FakeEnvRunner(agent_steps)
+
+    def num_remote_workers(self):
+        return 0
+
+
+def _collect(agent_steps):
+    _, stats_dicts = synchronous_parallel_sample(
+        worker_set=_FakeEnvRunnerGroup(agent_steps),
+        max_agent_steps=1,
+        concat=False,
+        _return_metrics=True,
     )
+    return stats_dicts
 
 
 class TestNanAgentSteps(unittest.TestCase):
-    def test_skips_nan_entries(self):
-        stats = [{_NUM_AGENT_STEPS_SAMPLED: {"a": 3, "b": float("nan"), "c": 7}}]
-        self.assertEqual(_count_agent_steps(stats), 10)
+    def test_all_agents_active(self):
+        # No agent is absent, so no NaN entries: every step is counted.
+        stats = _collect({"agent_0": 3, "agent_1": 7})
+        self.assertEqual(len(stats), 1)
+        self.assertEqual(
+            stats[0][NUM_AGENT_STEPS_SAMPLED], {"agent_0": 3, "agent_1": 7}
+        )
 
-    def test_clean_stats_unchanged(self):
-        stats = [{_NUM_AGENT_STEPS_SAMPLED: {"a": 10, "b": 20}}]
-        self.assertEqual(_count_agent_steps(stats), 30)
+    def test_some_agents_inactive(self):
+        # agent_1 was active before but is absent now, leaving a NaN entry.
+        # This used to raise ValueError; it must now complete and skip the NaN.
+        agent_steps = {"agent_0": 4, "agent_1": float("nan"), "agent_2": 6}
+        stats = _collect(agent_steps)
+        self.assertEqual(len(stats), 1)
+        returned = stats[0][NUM_AGENT_STEPS_SAMPLED]
+        active = sum(int(v) for v in returned.values() if not math.isnan(float(v)))
+        self.assertEqual(active, 10)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/execution/tests/test_rollout_ops_nan.py
+++ b/rllib/execution/tests/test_rollout_ops_nan.py
@@ -2,7 +2,6 @@
 import math
 import unittest
 
-
 _NUM_AGENT_STEPS_SAMPLED = "num_agent_steps_sampled"
 
 
@@ -18,9 +17,7 @@ def _count_agent_steps(stats_dicts):
 
 class TestNanAgentSteps(unittest.TestCase):
     def test_skips_nan_entries(self):
-        stats = [
-            {_NUM_AGENT_STEPS_SAMPLED: {"a": 3, "b": float("nan"), "c": 7}}
-        ]
+        stats = [{_NUM_AGENT_STEPS_SAMPLED: {"a": 3, "b": float("nan"), "c": 7}}]
         self.assertEqual(_count_agent_steps(stats), 10)
 
     def test_clean_stats_unchanged(self):


### PR DESCRIPTION
Fixes #62635.

## Why

In a `MultiAgentEnv` with `count_steps_by="agent_steps"`, agents that were previously active but are absent from the current episode batch leave `NaN` entries in the `NUM_AGENT_STEPS_SAMPLED` per-agent metrics (`SumStats(nan; window=None; len=1)`). The generator expression in `synchronous_parallel_sample` that sums these stats calls `int()` on every value, which crashes:

```
ValueError: cannot convert float NaN to integer
```

## Fix

Add a `math.isnan` guard to skip `NaN` entries, so only agents that actually stepped in the current batch contribute to the step count. This matches the reporter's suggested fix in the issue.

```python
agent_or_env_steps += sum(
    int(agent_stat)
    for stat_dict in stats_dicts
    for agent_stat in stat_dict[NUM_AGENT_STEPS_SAMPLED].values()
    if not math.isnan(float(agent_stat))  # skip absent agents
)
```

## Testing

The fix is a one-line filter addition. The reporter confirmed this exact pattern resolves the crash in their MultiAgentEnv setup with PPO and `count_steps_by="agent_steps"`. The NaN values are a natural consequence of agents that previously created their AgentID key in the MetricsLogger but are absent from the current batch, skipping them is correct because they contributed zero steps.