### PR TITLE
[Data] Demote dataset logger registration log to debug

### DIFF
--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -413,7 +413,7 @@ def register_dataset_logger(dataset_id: str) -> Optional[int]:
     # regardless of whether it is active or inactive.
     local_logger = logging.getLogger(__name__)
     local_logger.addHandler(log_handler)
-    local_logger.info("Registered dataset logger for dataset %s", dataset_id)
+    local_logger.debug("Registered dataset logger for dataset %s", dataset_id)
 
     _DATASET_LOGGER_HANDLER[dataset_id] = log_handler
     if not _ACTIVE_DATASET:


### PR DESCRIPTION
## Description
The "Registered dataset logger for dataset ..." message is unconditionally emitted at INFO level on every dataset creation and isn't actionable to users. This demotes it to DEBUG to reduce log noise.

## Related issues
None.

## Additional information
The concurrent-dataset warning (when a new dataset registers while another is already active) is kept at INFO because it's less frequent and more useful for debugging performance issues.