### PR TITLE
[Serve] Deflake test_autoscaling_target_capacity_update: reduce replica counts

### DIFF
--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -669,9 +669,16 @@ class TestTargetCapacityUpdateAndServeStatus:
         # buildkite, but need to investigate why it fails locally.
         app_name = "controlled_app"
         deployment_name = "controlled"
+        # Keep min_replicas=10 so integer rounding aligns with
+        # get_capacity_adjusted_num_replicas (which applies max(1, ...));
+        # int(0.1 * min_replicas) = 1 matches the autoscaler floor at
+        # target_capacity=10. initial must be > min so the cap=None step
+        # triggers DOWNSCALING (from initial to min). Reduce initial/max from
+        # 30/70 to 12/20 so the cap=100 upscale only creates ~11 new replicas
+        # (was 29), avoiding Ray scheduling timeouts in CI.
         min_replicas = 10
-        initial_replicas = 30
-        max_replicas = 70
+        initial_replicas = 12
+        max_replicas = 20
 
         lifecycle_signal = SignalActor.options(
             name="lifecycle_signal", namespace=SERVE_NAMESPACE

--- a/python/ray/serve/tests/test_target_capacity.py
+++ b/python/ray/serve/tests/test_target_capacity.py
@@ -669,13 +669,6 @@ class TestTargetCapacityUpdateAndServeStatus:
         # buildkite, but need to investigate why it fails locally.
         app_name = "controlled_app"
         deployment_name = "controlled"
-        # Keep min_replicas=10 so integer rounding aligns with
-        # get_capacity_adjusted_num_replicas (which applies max(1, ...));
-        # int(0.1 * min_replicas) = 1 matches the autoscaler floor at
-        # target_capacity=10. initial must be > min so the cap=None step
-        # triggers DOWNSCALING (from initial to min). Reduce initial/max from
-        # 30/70 to 12/20 so the cap=100 upscale only creates ~11 new replicas
-        # (was 29), avoiding Ray scheduling timeouts in CI.
         min_replicas = 10
         initial_replicas = 12
         max_replicas = 20


### PR DESCRIPTION
### Why this is needed

`test_target_capacity.py` is still flaky after #62422. The remaining hotspot is `test_autoscaling_target_capacity_update` in the `metr_agg_at_controller_and_replicas` env variant (**5% non-pass rate**, 4 flaky in 80 runs on Linux).

### Buildkite evidence (Linux env variant failures)

- https://buildkite.com/ray-project/postmerge/builds/17033#019d8e75-0612-49fd-86fb-b6777ca561ac (`metr_agg_at_controller` on gRPC tests)
- https://buildkite.com/ray-project/postmerge/builds/17009#019d8a61-f45b-40dd-9779-6b6c17b8f1c1 (`metr_agg_at_controller_and_replicas` on tests)

Failure pattern from CI:
```
replica_states={'RUNNING': 15, 'STARTING': 20},
message='Upscaling from 15 to 35 replicas.'
...
"6 replicas that have taken more than 30s to be scheduled.
This may be due to waiting for the cluster to auto-scale..."
```

Note: Windows `metr_disab` failures (e.g. build 16996) are a separate issue — Ray node startup timeouts during fixture setup, unrelated to autoscaling logic.

### Root cause

The test uses `initial_replicas=30` and `max_replicas=70`. At the `target_capacity=100` step, it scales from 1 replica to `initial_replicas=30` — **29 new Ray actors must be scheduled and initialized** in a single step. The `unblock_replica_creation_and_deletion` helper waits for `ApplicationStatus.RUNNING` with a 30s timeout, but Ray actor scheduling alone for 29 actors exceeds 30s under CI load.

This is amplified in the `metr_agg_at_controller_and_replicas` env variant because `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER=1` + `RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE=0` causes the autoscaler to use time-weighted averaging over a 200ms window, producing noisy metrics that lead to multi-step upscaling (e.g., 15→25→35 instead of one jump to 35).

### Fix

Reduce `initial_replicas` 30→12 and `max_replicas` 70→20. Keep `min_replicas=10`. 

The test verifies autoscaling math (`target_capacity` correctly bounds the autoscaler via `get_capacity_adjusted_num_replicas`). This math is identical with smaller numbers.

## Test plan
- [x] 3/3 passes with `metr_agg_at_controller_and_replicas` env vars (the flakiest Linux variant)
- [x] 10/10 full file pass with env variant
- [x] 10/10 full file pass without env variant (base config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)