### PR TITLE
[Data] Remove thin delegations in ExecutionPlan

### DIFF
--- a/python/ray/data/_internal/execution/legacy_compat.py
+++ b/python/ray/data/_internal/execution/legacy_compat.py
@@ -135,7 +135,7 @@ def _execute_dag(
 
     # Enforce to preserve ordering if the plan has operators
     # required to do so, such as Zip and Sort.
-    if preserve_order or plan.require_preserve_order():
+    if preserve_order or plan._logical_plan.require_preserve_order():
         executor._options.preserve_order = True
 
     return executor.execute(dag, initial_stats=stats, callbacks=callbacks)

--- a/python/ray/data/_internal/plan.py
+++ b/python/ray/data/_internal/plan.py
@@ -145,12 +145,6 @@ class ExecutionPlan:
         plan_copy._dataset_name = self._dataset_name
         return plan_copy
 
-    def initial_num_blocks(self) -> Optional[int]:
-        """Get the estimated number of blocks from the logical plan
-        after applying execution plan optimizations, but prior to
-        fully executing the dataset."""
-        return self._logical_plan.initial_num_blocks()
-
     @omit_traceback_stdout
     def execute_to_iterator(
         self,
@@ -330,21 +324,13 @@ class ExecutionPlan:
         # "InputDataBuffer" physical operators, which will be ignored when generating
         # stats, see `StreamingExecutor._generate_stats`.
         # TODO(hchen): Unify the logic by saving the initial stats in `InputDataBuffer
-        if self.has_lazy_input():
+        if self._logical_plan.has_lazy_input():
             return DatasetStats(metadata={}, parent=None)
         else:
             return self._in_stats
-
-    def has_lazy_input(self) -> bool:
-        """Return whether this plan has lazy input blocks."""
-        return self._logical_plan.has_lazy_input()
 
     def has_computed_output(self) -> bool:
         """Whether this plan has a computed snapshot for the final operator, i.e. for
         the output of this plan.
         """
         return self._cache.get_bundle(self._logical_plan.dag) is not None
-
-    def require_preserve_order(self) -> bool:
-        """Whether this plan requires to preserve order."""
-        return self._logical_plan.require_preserve_order()

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -1997,7 +1997,7 @@ class Dataset:
         import pandas as pd
         import pyarrow as pa
 
-        if self._plan.initial_num_blocks() == 0:
+        if self._logical_plan.initial_num_blocks() == 0:
             raise ValueError("Cannot sample from an empty Dataset.")
 
         if fraction < 0 or fraction > 1:
@@ -3932,7 +3932,7 @@ class Dataset:
             The number of records in the dataset.
         """
         # Handle empty dataset.
-        if self._plan.initial_num_blocks() == 0:
+        if self._logical_plan.initial_num_blocks() == 0:
             return 0
 
         # For parquet, we can return the count directly from metadata.
@@ -7236,7 +7236,7 @@ class Dataset:
         from ipywidgets import HTML, Tab
 
         metadata = {
-            "num_blocks": self._plan.initial_num_blocks(),
+            "num_blocks": self._logical_plan.initial_num_blocks(),
             "num_rows": self._meta_count(),
         }
         # Show metadata if available, but don't trigger execution.
@@ -7424,7 +7424,7 @@ class MaterializedDataset(Dataset, Generic[T]):
         Returns:
             The number of blocks of this :class:`Dataset`.
         """
-        return self._plan.initial_num_blocks()
+        return self._logical_plan.initial_num_blocks()
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/tests/datasource/test_image.py
+++ b/python/ray/data/tests/datasource/test_image.py
@@ -158,14 +158,14 @@ class TestReadImages:
         try:
             root = "example://image-datasets/simple"
             ds = ray.data.read_images(root, override_num_blocks=1)
-            assert ds._plan.initial_num_blocks() == 1
+            assert ds._logical_plan.initial_num_blocks() == 1
             ds = ds.materialize()
             # Verify dynamic block splitting taking effect to generate more blocks.
-            assert ds._plan.initial_num_blocks() == 3
+            assert ds._logical_plan.initial_num_blocks() == 3
 
             # Test union of same datasets
             union_ds = ds.union(ds, ds, ds).materialize()
-            assert union_ds._plan.initial_num_blocks() == 12
+            assert union_ds._logical_plan.initial_num_blocks() == 12
         finally:
             ctx.target_max_block_size = target_max_block_size
 

--- a/python/ray/data/tests/test_auto_parallelism.py
+++ b/python/ray/data/tests/test_auto_parallelism.py
@@ -129,15 +129,15 @@ def test_auto_parallelism_basic(shutdown_only):
     context.read_op_min_num_blocks = 1
     # Datasource bound.
     ds = ray.data.range_tensor(5, shape=(100,), override_num_blocks=-1)
-    assert ds._plan.initial_num_blocks() == 5, ds
+    assert ds._logical_plan.initial_num_blocks() == 5, ds
     # CPU bound. TODO(ekl) we should fix range datasource to respect parallelism more
     # properly, currently it can go a little over.
     ds = ray.data.range_tensor(10000, shape=(100,), override_num_blocks=-1)
-    assert ds._plan.initial_num_blocks() == 16, ds
+    assert ds._logical_plan.initial_num_blocks() == 16, ds
     # Block size bound.
     ds = ray.data.range_tensor(100000000, shape=(100,), override_num_blocks=-1)
-    assert ds._plan.initial_num_blocks() >= 590, ds
-    assert ds._plan.initial_num_blocks() <= 600, ds
+    assert ds._logical_plan.initial_num_blocks() >= 590, ds
+    assert ds._logical_plan.initial_num_blocks() <= 600, ds
 
 
 def test_auto_parallelism_placement_group(shutdown_only):
@@ -148,7 +148,7 @@ def test_auto_parallelism_placement_group(shutdown_only):
         context = DataContext.get_current()
         context.min_parallelism = 1
         ds = ray.data.range_tensor(2000, shape=(100,), override_num_blocks=-1)
-        return ds._plan.initial_num_blocks()
+        return ds._logical_plan.initial_num_blocks()
 
     # 1/16 * 4 * 16 = 4
     pg = ray.util.placement_group([{"CPU": 1}])

--- a/python/ray/data/tests/test_block_sizing.py
+++ b/python/ray/data/tests/test_block_sizing.py
@@ -120,7 +120,7 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
     ds = shuffle_fn(ray.data.range(N), **kwargs).materialize()
     assert (
         num_blocks_expected
-        <= ds._plan.initial_num_blocks()
+        <= ds._logical_plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
 
@@ -153,7 +153,7 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         num_blocks_expected = int(num_blocks_expected * 2.2)
     assert (
         num_blocks_expected
-        <= ds._plan.initial_num_blocks()
+        <= ds._logical_plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
     num_intermediate_blocks = _estimate_intermediate_blocks(
@@ -173,7 +173,7 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
     ds = shuffle_fn(ray.data.range(N), **kwargs).materialize()
     assert (
         num_blocks_expected
-        <= ds._plan.initial_num_blocks()
+        <= ds._logical_plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
     num_intermediate_blocks = _estimate_intermediate_blocks(
@@ -190,7 +190,7 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
         block_size_expected //= 2.2
     assert (
         num_blocks_expected
-        <= ds._plan.initial_num_blocks()
+        <= ds._logical_plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
     num_intermediate_blocks = _estimate_intermediate_blocks(
@@ -209,7 +209,7 @@ def test_shuffle(shutdown_only, restore_data_context, shuffle_op):
     ds = shuffle_fn(ray.data.range(N).map(lambda x: x), **kwargs).materialize()
     assert (
         num_blocks_expected
-        <= ds._plan.initial_num_blocks()
+        <= ds._logical_plan.initial_num_blocks()
         <= num_blocks_expected * 1.5
     )
 
@@ -237,7 +237,7 @@ def test_target_max_block_size_infinite_or_default_disables_splitting_globally(
     ctx.target_max_block_size = 1_000_000  # ~1MB
 
     ds_with_limit = ray.data.range(N, override_num_blocks=1).materialize()
-    blocks_with_limit = ds_with_limit._plan.initial_num_blocks()
+    blocks_with_limit = ds_with_limit._logical_plan.initial_num_blocks()
 
     # Now test with target_max_block_size = None (should not split)
     ctx.target_max_block_size = None  # Disable block size limit
@@ -245,7 +245,7 @@ def test_target_max_block_size_infinite_or_default_disables_splitting_globally(
     ds_unlimited = (
         ray.data.range(N, override_num_blocks=1).map(lambda x: x).materialize()
     )
-    blocks_unlimited = ds_unlimited._plan.initial_num_blocks()
+    blocks_unlimited = ds_unlimited._logical_plan.initial_num_blocks()
 
     # Verify that unlimited creates fewer blocks (no splitting)
     assert blocks_unlimited <= blocks_with_limit

--- a/python/ray/data/tests/test_consumption.py
+++ b/python/ray/data/tests/test_consumption.py
@@ -259,12 +259,12 @@ def test_basic(ray_start_regular_shared):
 
 def test_range(ray_start_regular_shared):
     ds = ray.data.range(10, override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 10
+    assert ds._logical_plan.initial_num_blocks() == 10
     assert ds.count() == 10
     assert ds.take() == [{"id": i} for i in range(10)]
 
     ds = ray.data.range(10, override_num_blocks=2)
-    assert ds._plan.initial_num_blocks() == 2
+    assert ds._logical_plan.initial_num_blocks() == 2
     assert ds.count() == 10
     assert ds.take() == [{"id": i} for i in range(10)]
 
@@ -564,7 +564,7 @@ def test_union(ray_start_regular_shared, restore_data_context):
 
     # Test lazy union.
     ds = ds.union(ds, ds, ds, ds)
-    assert ds._plan.initial_num_blocks() == 50
+    assert ds._logical_plan.initial_num_blocks() == 50
     assert ds.count() == 100
     assert ds.sum() == 950
 

--- a/python/ray/data/tests/test_dataset_creation.py
+++ b/python/ray/data/tests/test_dataset_creation.py
@@ -49,7 +49,7 @@ def test_from_items_parallelism(ray_start_regular_shared, parallelism):
     ds = ray.data.from_items(records, override_num_blocks=parallelism)
     out = ds.take_all()
     assert out == records
-    assert ds._plan.initial_num_blocks() == parallelism
+    assert ds._logical_plan.initial_num_blocks() == parallelism
 
 
 def test_from_items_parallelism_truncated(ray_start_regular_shared):
@@ -61,7 +61,7 @@ def test_from_items_parallelism_truncated(ray_start_regular_shared):
     ds = ray.data.from_items(records, override_num_blocks=parallelism)
     out = ds.take_all()
     assert out == records
-    assert ds._plan.initial_num_blocks() == n
+    assert ds._logical_plan.initial_num_blocks() == n
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_dynamic_block_split.py
+++ b/python/ray/data/tests/test_dynamic_block_split.py
@@ -210,7 +210,7 @@ def test_dataset(
     # Note the following calls to ds will not fully execute it.
     assert ds.schema() is not None
     assert ds.count() == num_blocks_per_task * num_tasks
-    assert ds._plan.initial_num_blocks() == num_tasks
+    assert ds._logical_plan.initial_num_blocks() == num_tasks
     last_snapshot = assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
             task_count={
@@ -228,7 +228,7 @@ def test_dataset(
     map_ds = ds.map_batches(identity_func, compute=compute)
     map_ds = map_ds.materialize()
     num_blocks_expected = num_tasks * num_blocks_per_task
-    assert map_ds._plan.initial_num_blocks() == num_blocks_expected
+    assert map_ds._logical_plan.initial_num_blocks() == num_blocks_expected
     expected_actor_name = f"MapWorker(ReadRandomBytes->MapBatches({func_name}))"
     assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
@@ -253,34 +253,45 @@ def test_dataset(
         compute=compute,
     )
     map_ds = map_ds.materialize()
-    assert map_ds._plan.initial_num_blocks() == 1
+    assert map_ds._logical_plan.initial_num_blocks() == 1
     map_ds = ds.map(identity_func, compute=compute)
     map_ds = map_ds.materialize()
-    assert map_ds._plan.initial_num_blocks() == num_blocks_per_task * num_tasks
+    assert map_ds._logical_plan.initial_num_blocks() == num_blocks_per_task * num_tasks
 
     ds_list = ds.split(5)
     assert len(ds_list) == 5
     for new_ds in ds_list:
-        assert new_ds._plan.initial_num_blocks() == num_blocks_per_task * num_tasks / 5
+        assert (
+            new_ds._logical_plan.initial_num_blocks()
+            == num_blocks_per_task * num_tasks / 5
+        )
 
     train, test = ds.train_test_split(test_size=0.25)
-    assert train._plan.initial_num_blocks() == num_blocks_per_task * num_tasks * 0.75
-    assert test._plan.initial_num_blocks() == num_blocks_per_task * num_tasks * 0.25
+    assert (
+        train._logical_plan.initial_num_blocks()
+        == num_blocks_per_task * num_tasks * 0.75
+    )
+    assert (
+        test._logical_plan.initial_num_blocks()
+        == num_blocks_per_task * num_tasks * 0.25
+    )
 
     new_ds = ds.union(ds, ds)
-    assert new_ds._plan.initial_num_blocks() == num_tasks * 3
+    assert new_ds._logical_plan.initial_num_blocks() == num_tasks * 3
     new_ds = new_ds.materialize()
-    assert new_ds._plan.initial_num_blocks() == num_blocks_per_task * num_tasks * 3
+    assert (
+        new_ds._logical_plan.initial_num_blocks() == num_blocks_per_task * num_tasks * 3
+    )
 
     new_ds = ds.random_shuffle()
-    assert new_ds._plan.initial_num_blocks() == num_tasks
+    assert new_ds._logical_plan.initial_num_blocks() == num_tasks
     new_ds = ds.randomize_block_order()
-    assert new_ds._plan.initial_num_blocks() == num_tasks
+    assert new_ds._logical_plan.initial_num_blocks() == num_tasks
     assert ds.groupby("one").count().count() == num_blocks_per_task * num_tasks
 
     new_ds = ds.zip(ds)
     new_ds = new_ds.materialize()
-    assert new_ds._plan.initial_num_blocks() == num_blocks_per_task * num_tasks
+    assert new_ds._logical_plan.initial_num_blocks() == num_blocks_per_task * num_tasks
 
     assert len(ds.take(5)) == 5
     assert len(ds.take_all()) == num_blocks_per_task * num_tasks
@@ -306,12 +317,12 @@ def test_filter(ray_start_regular_shared, target_max_block_size):
     ds = ds.filter(lambda _: True)
     ds = ds.materialize()
     assert ds.count() == num_blocks_per_task
-    assert ds._plan.initial_num_blocks() == num_blocks_per_task
+    assert ds._logical_plan.initial_num_blocks() == num_blocks_per_task
 
     ds = ds.filter(lambda _: False)
     ds = ds.materialize()
     assert ds.count() == 0
-    assert ds._plan.initial_num_blocks() == num_blocks_per_task
+    assert ds._logical_plan.initial_num_blocks() == num_blocks_per_task
 
 
 @pytest.mark.skip("Needs zero-copy optimization for read->map_batches.")
@@ -511,7 +522,7 @@ def test_block_slicing(
         ),
         override_num_blocks=num_tasks,
     ).materialize()
-    assert ds._plan.initial_num_blocks() == expected_num_blocks
+    assert ds._logical_plan.initial_num_blocks() == expected_num_blocks
 
     block_sizes = []
     num_rows = 0

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -117,14 +117,18 @@ def test_repartition_e2e(
         assert "RepartitionReduce" in ds_stats.metadata
 
     ds = ray.data.range(10000, override_num_blocks=10).repartition(20, shuffle=shuffle)
-    assert ds._plan.initial_num_blocks() == 20, ds._plan.initial_num_blocks()
+    assert (
+        ds._logical_plan.initial_num_blocks() == 20
+    ), ds._logical_plan.initial_num_blocks()
     assert ds.sum() == sum(range(10000))
     assert ds._block_num_rows() == [500] * 20, ds._block_num_rows()
     _check_repartition_usage_and_stats(ds)
 
     # Test num_output_blocks > num_rows to trigger empty block handling.
     ds = ray.data.range(20, override_num_blocks=10).repartition(40, shuffle=shuffle)
-    assert ds._plan.initial_num_blocks() == 40, ds._plan.initial_num_blocks()
+    assert (
+        ds._logical_plan.initial_num_blocks() == 40
+    ), ds._logical_plan.initial_num_blocks()
     assert ds.sum() == sum(range(20))
     if shuffle:
         assert ds._block_num_rows() == [10] * 2 + [0] * (40 - 2), ds._block_num_rows()
@@ -134,7 +138,9 @@ def test_repartition_e2e(
 
     # Test case where number of rows does not divide equally into num_output_blocks.
     ds = ray.data.range(22).repartition(4, shuffle=shuffle)
-    assert ds._plan.initial_num_blocks() == 4, ds._plan.initial_num_blocks()
+    assert (
+        ds._logical_plan.initial_num_blocks() == 4
+    ), ds._logical_plan.initial_num_blocks()
     assert ds.sum() == sum(range(22))
     if shuffle:
         assert ds._block_num_rows() == [9, 9, 4, 0], ds._block_num_rows()
@@ -144,7 +150,9 @@ def test_repartition_e2e(
 
     # Test case where we do not split on repartitioning.
     ds = ray.data.range(10, override_num_blocks=1).repartition(1, shuffle=shuffle)
-    assert ds._plan.initial_num_blocks() == 1, ds._plan.initial_num_blocks()
+    assert (
+        ds._logical_plan.initial_num_blocks() == 1
+    ), ds._logical_plan.initial_num_blocks()
     assert ds.sum() == sum(range(10))
     assert ds._block_num_rows() == [10], ds._block_num_rows()
     _check_repartition_usage_and_stats(ds)

--- a/python/ray/data/tests/test_map_batches.py
+++ b/python/ray/data/tests/test_map_batches.py
@@ -550,7 +550,7 @@ def test_map_batches_block_bundling_auto(
     num_blocks = max(10, 2 * batch_size // block_size)
     ds = ray.data.range(num_blocks * block_size, override_num_blocks=num_blocks)
     # Confirm that we have the expected number of initial blocks.
-    assert ds._plan.initial_num_blocks() == num_blocks
+    assert ds._logical_plan.initial_num_blocks() == num_blocks
 
     # Blocks should be bundled up to the batch size.
     ds1 = ds.map_batches(lambda x: x, batch_size=batch_size).materialize()
@@ -562,11 +562,11 @@ def test_map_batches_block_bundling_auto(
         / max(math.ceil(batch_size / block_size), 1)
     )
 
-    assert ds1._plan.initial_num_blocks() == num_expected_blocks
+    assert ds1._logical_plan.initial_num_blocks() == num_expected_blocks
 
     # Blocks should not be bundled up when batch_size is not specified.
     ds2 = ds.map_batches(lambda x: x).materialize()
-    assert ds2._plan.initial_num_blocks() == num_blocks
+    assert ds2._logical_plan.initial_num_blocks() == num_blocks
 
 
 @pytest.mark.parametrize(
@@ -594,11 +594,11 @@ def test_map_batches_block_bundling_skewed_manual(
         [pd.DataFrame({"a": [1] * block_size}) for block_size in block_sizes]
     )
     # Confirm that we have the expected number of initial blocks.
-    assert ds._plan.initial_num_blocks() == num_blocks
+    assert ds._logical_plan.initial_num_blocks() == num_blocks
     ds = ds.map_batches(lambda x: x, batch_size=batch_size).materialize()
 
     # Blocks should be bundled up to the batch size.
-    assert ds._plan.initial_num_blocks() == expected_num_blocks
+    assert ds._logical_plan.initial_num_blocks() == expected_num_blocks
 
 
 BLOCK_BUNDLING_SKEWED_TEST_CASES = [
@@ -623,7 +623,7 @@ def test_map_batches_block_bundling_skewed_auto(
         [pd.DataFrame({"a": [1] * block_size}) for block_size in block_sizes]
     )
     # Confirm that we have the expected number of initial blocks.
-    assert ds._plan.initial_num_blocks() == num_blocks
+    assert ds._logical_plan.initial_num_blocks() == num_blocks
     ds = ds.map_batches(lambda x: x, batch_size=batch_size).materialize()
 
     curr = 0
@@ -637,7 +637,7 @@ def test_map_batches_block_bundling_skewed_auto(
         num_out_blocks += 1
 
     # Blocks should be bundled up to the batch size.
-    assert ds._plan.initial_num_blocks() == num_out_blocks
+    assert ds._logical_plan.initial_num_blocks() == num_out_blocks
 
 
 def test_map_batches_preserve_empty_blocks(
@@ -646,7 +646,7 @@ def test_map_batches_preserve_empty_blocks(
     ds = ray.data.range(10, override_num_blocks=10)
     ds = ds.map_batches(lambda x: [])
     ds = ds.map_batches(lambda x: x)
-    assert ds._plan.initial_num_blocks() == 10, ds
+    assert ds._logical_plan.initial_num_blocks() == 10, ds
 
 
 def test_map_batches_combine_empty_blocks(

--- a/python/ray/data/tests/test_optimize.py
+++ b/python/ray/data/tests/test_optimize.py
@@ -291,9 +291,9 @@ def test_optimize_lazy_reuse_base_data(
 
 def test_require_preserve_order(ray_start_regular_shared):
     ds1 = ray.data.range(100).map_batches(lambda x: x).zip(ray.data.range(100))
-    assert ds1._plan.require_preserve_order()
+    assert ds1._logical_plan.require_preserve_order()
     ds2 = ray.data.range(100).map_batches(lambda x: x).repartition(10)
-    assert not ds2._plan.require_preserve_order()
+    assert not ds2._logical_plan.require_preserve_order()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_random_access.py
+++ b/python/ray/data/tests/test_random_access.py
@@ -34,7 +34,7 @@ def test_basic(ray_start_regular_shared, pandas):
 
 def test_empty_blocks(ray_start_regular_shared):
     ds = ray.data.range(10).repartition(20)
-    assert ds._plan.initial_num_blocks() == 20
+    assert ds._logical_plan.initial_num_blocks() == 20
     rad = ds.to_random_access_dataset("id")
     for i in range(10):
         assert ray.get(rad.get_async(i)) == {"id": i}

--- a/python/ray/data/tests/test_random_e2e.py
+++ b/python/ray/data/tests/test_random_e2e.py
@@ -130,7 +130,10 @@ def test_random_shuffle(
     assert r1 != r2, (r1, r2)
 
     assert (
-        ray.data.range(100).random_shuffle().repartition(1)._plan.initial_num_blocks()
+        ray.data.range(100)
+        .random_shuffle()
+        .repartition(1)
+        ._logical_plan.initial_num_blocks()
         == 1
     )
     r1 = ray.data.range(100).random_shuffle().repartition(1).take(999)

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -16,20 +16,20 @@ def test_repartition_shuffle(
     ray_start_regular_shared_2_cpus, disable_fallback_to_object_extension
 ):
     ds = ray.data.range(20, override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 10
+    assert ds._logical_plan.initial_num_blocks() == 10
     assert ds.sum() == 190
 
     ds2 = ds.repartition(5, shuffle=True)
-    assert ds2._plan.initial_num_blocks() == 5
+    assert ds2._logical_plan.initial_num_blocks() == 5
     assert ds2.sum() == 190
 
     ds3 = ds2.repartition(20, shuffle=True)
-    assert ds3._plan.initial_num_blocks() == 20
+    assert ds3._logical_plan.initial_num_blocks() == 20
     assert ds3.sum() == 190
 
     large = ray.data.range(10000, override_num_blocks=10)
     large = large.repartition(20, shuffle=True)
-    assert large._plan.initial_num_blocks() == 20
+    assert large._logical_plan.initial_num_blocks() == 20
     assert large.sum() == 49995000
 
 
@@ -44,21 +44,21 @@ def test_key_based_repartition_shuffle(
     context.hash_shuffle_operator_actor_num_cpus_override = 0.001
 
     ds = ray.data.range(20, override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 10
+    assert ds._logical_plan.initial_num_blocks() == 10
     assert ds.sum() == 190
     assert ds._block_num_rows() == [2] * 10
 
     ds2 = ds.repartition(3, keys=["id"])
-    assert ds2._plan.initial_num_blocks() == 3
+    assert ds2._logical_plan.initial_num_blocks() == 3
     assert ds2.sum() == 190
 
     ds3 = ds.repartition(5, keys=["id"])
-    assert ds3._plan.initial_num_blocks() == 5
+    assert ds3._logical_plan.initial_num_blocks() == 5
     assert ds3.sum() == 190
 
     large = ray.data.range(10000, override_num_blocks=100)
     large = large.repartition(20, keys=["id"])
-    assert large._plan.initial_num_blocks() == 20
+    assert large._logical_plan.initial_num_blocks() == 20
 
     # Assert block sizes distribution
     assert sum(large._block_num_rows()) == 10000
@@ -71,29 +71,29 @@ def test_repartition_noshuffle(
     ray_start_regular_shared_2_cpus, disable_fallback_to_object_extension
 ):
     ds = ray.data.range(20, override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 10
+    assert ds._logical_plan.initial_num_blocks() == 10
     assert ds.sum() == 190
     assert ds._block_num_rows() == [2] * 10
 
     ds2 = ds.repartition(5, shuffle=False)
-    assert ds2._plan.initial_num_blocks() == 5
+    assert ds2._logical_plan.initial_num_blocks() == 5
     assert ds2.sum() == 190
     assert ds2._block_num_rows() == [4, 4, 4, 4, 4]
 
     ds3 = ds2.repartition(20, shuffle=False)
-    assert ds3._plan.initial_num_blocks() == 20
+    assert ds3._logical_plan.initial_num_blocks() == 20
     assert ds3.sum() == 190
     assert ds3._block_num_rows() == [1] * 20
 
     # Test num_partitions > num_rows
     ds4 = ds.repartition(40, shuffle=False)
-    assert ds4._plan.initial_num_blocks() == 40
+    assert ds4._logical_plan.initial_num_blocks() == 40
 
     assert ds4.sum() == 190
     assert ds4._block_num_rows() == [1] * 20 + [0] * 20
 
     ds5 = ray.data.range(22).repartition(4)
-    assert ds5._plan.initial_num_blocks() == 4
+    assert ds5._logical_plan.initial_num_blocks() == 4
     assert ds5._block_num_rows() == [5, 6, 5, 6]
 
     large = ray.data.range(10000, override_num_blocks=10)
@@ -105,20 +105,20 @@ def test_repartition_shuffle_arrow(
     ray_start_regular_shared_2_cpus, disable_fallback_to_object_extension
 ):
     ds = ray.data.range(20, override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 10
+    assert ds._logical_plan.initial_num_blocks() == 10
     assert ds.count() == 20
 
     ds2 = ds.repartition(5, shuffle=True)
-    assert ds2._plan.initial_num_blocks() == 5
+    assert ds2._logical_plan.initial_num_blocks() == 5
     assert ds2.count() == 20
 
     ds3 = ds2.repartition(20, shuffle=True)
-    assert ds3._plan.initial_num_blocks() == 20
+    assert ds3._logical_plan.initial_num_blocks() == 20
     assert ds3.count() == 20
 
     large = ray.data.range(10000, override_num_blocks=10)
     large = large.repartition(20, shuffle=True)
-    assert large._plan.initial_num_blocks() == 20
+    assert large._logical_plan.initial_num_blocks() == 20
     assert large.count() == 10000
 
 

--- a/python/ray/data/tests/test_shuffle_diagnostics.py
+++ b/python/ray/data/tests/test_shuffle_diagnostics.py
@@ -29,12 +29,12 @@ def test_debug_limit_shuffle_execution_to_num_blocks(
     ds = ray.data.range(1000, override_num_blocks=parallelism)
     shuffled_ds = shuffle_fn(ds).materialize()
     shuffled_ds = shuffled_ds.materialize()
-    assert shuffled_ds._plan.initial_num_blocks() == parallelism
+    assert shuffled_ds._logical_plan.initial_num_blocks() == parallelism
 
     ds.context.set_config("debug_limit_shuffle_execution_to_num_blocks", 1)
     shuffled_ds = shuffle_fn(ds).materialize()
     shuffled_ds = shuffled_ds.materialize()
-    assert shuffled_ds._plan.initial_num_blocks() == 1
+    assert shuffled_ds._logical_plan.initial_num_blocks() == 1
 
 
 def test_memory_usage(

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -350,7 +350,7 @@ def test_split_proportionately(ray_start_regular_shared_2_cpus):
 
 def test_split(ray_start_regular_shared_2_cpus):
     ds = ray.data.range(20, override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 10
+    assert ds._logical_plan.initial_num_blocks() == 10
     assert ds.sum() == 190
     assert ds._block_num_rows() == [2] * 10
 

--- a/python/ray/data/tests/test_splitblocks.py
+++ b/python/ray/data/tests/test_splitblocks.py
@@ -58,7 +58,7 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
 
     ds = ray.data.read_csv("example://iris.csv", override_num_blocks=1)
     materialized_ds = ds.materialize()
-    assert materialized_ds._plan.initial_num_blocks() == 1
+    assert materialized_ds._logical_plan.initial_num_blocks() == 1
     last_snapshot = assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
             task_count={
@@ -69,7 +69,7 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
     )
 
     materialized_ds = ds.map_batches(lambda x: x).materialize()
-    assert materialized_ds._plan.initial_num_blocks() == 1
+    assert materialized_ds._logical_plan.initial_num_blocks() == 1
     last_snapshot = assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
             task_count={
@@ -83,8 +83,11 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
     assert "Operator 1 ReadCSV->MapBatches" in stats, stats
 
     ds = ray.data.read_csv("example://iris.csv", override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 1
-    assert ds.map_batches(lambda x: x).materialize()._plan.initial_num_blocks() == 10
+    assert ds._logical_plan.initial_num_blocks() == 1
+    assert (
+        ds.map_batches(lambda x: x).materialize()._logical_plan.initial_num_blocks()
+        == 10
+    )
     last_snapshot = assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
             task_count={
@@ -95,7 +98,7 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
         last_snapshot,
     )
 
-    assert ds.materialize()._plan.initial_num_blocks() == 10
+    assert ds.materialize()._logical_plan.initial_num_blocks() == 10
     last_snapshot = assert_core_execution_metrics_equals(
         CoreExecutionMetrics(
             task_count={
@@ -106,9 +109,12 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
     )
 
     ds = ray.data.read_csv("example://iris.csv", override_num_blocks=100)
-    assert ds._plan.initial_num_blocks() == 1
-    assert ds.map_batches(lambda x: x).materialize()._plan.initial_num_blocks() == 100
-    assert ds.materialize()._plan.initial_num_blocks() == 100
+    assert ds._logical_plan.initial_num_blocks() == 1
+    assert (
+        ds.map_batches(lambda x: x).materialize()._logical_plan.initial_num_blocks()
+        == 100
+    )
+    assert ds.materialize()._logical_plan.initial_num_blocks() == 100
 
     ds = ds.map_batches(lambda x: x).materialize()
     stats = ds.stats()
@@ -119,7 +125,7 @@ def test_small_file_split(ray_start_10_cpus_shared, restore_data_context):
     ds.context.target_max_block_size = 1
     ds = ds.map_batches(lambda x: x).materialize()
     # 150 rows.
-    assert ds._plan.initial_num_blocks() == 150
+    assert ds._logical_plan.initial_num_blocks() == 150
     print(ds.stats())
 
 
@@ -132,30 +138,30 @@ def test_large_file_additional_split(ray_start_10_cpus_shared, tmp_path):
     ds.repartition(1).write_parquet(tmp_path)
 
     ds = ray.data.read_parquet(tmp_path, override_num_blocks=1)
-    assert ds._plan.initial_num_blocks() == 1
+    assert ds._logical_plan.initial_num_blocks() == 1
     print(ds.materialize().stats())
     assert (
-        5 < ds.materialize()._plan.initial_num_blocks() < 20
+        5 < ds.materialize()._logical_plan.initial_num_blocks() < 20
     )  # Size-based block split
 
     ds = ray.data.read_parquet(tmp_path, override_num_blocks=10)
-    assert ds._plan.initial_num_blocks() == 1
-    assert 5 < ds.materialize()._plan.initial_num_blocks() < 20
+    assert ds._logical_plan.initial_num_blocks() == 1
+    assert 5 < ds.materialize()._logical_plan.initial_num_blocks() < 20
 
     ds = ray.data.read_parquet(tmp_path, override_num_blocks=100)
-    assert ds._plan.initial_num_blocks() == 1
-    assert 50 < ds.materialize()._plan.initial_num_blocks() < 200
+    assert ds._logical_plan.initial_num_blocks() == 1
+    assert 50 < ds.materialize()._logical_plan.initial_num_blocks() < 200
 
     ds = ray.data.read_parquet(tmp_path, override_num_blocks=1000)
-    assert ds._plan.initial_num_blocks() == 1
-    assert 500 < ds.materialize()._plan.initial_num_blocks() < 2000
+    assert ds._logical_plan.initial_num_blocks() == 1
+    assert 500 < ds.materialize()._logical_plan.initial_num_blocks() < 2000
 
 
 def test_map_batches_split(ray_start_10_cpus_shared, restore_data_context):
     ds = ray.data.range(1000, override_num_blocks=1).map_batches(
         lambda x: x, batch_size=1000
     )
-    assert ds.materialize()._plan.initial_num_blocks() == 1
+    assert ds.materialize()._logical_plan.initial_num_blocks() == 1
 
     ctx = ray.data.context.DataContext.get_current()
     # 100 integer rows per block.
@@ -164,12 +170,12 @@ def test_map_batches_split(ray_start_10_cpus_shared, restore_data_context):
     ds = ray.data.range(1000, override_num_blocks=1).map_batches(
         lambda x: x, batch_size=1000
     )
-    assert ds.materialize()._plan.initial_num_blocks() == 10
+    assert ds.materialize()._logical_plan.initial_num_blocks() == 10
 
     # A single row is already larger than the target block
     # size.
     ds.context.target_max_block_size = 4
-    assert ds.materialize()._plan.initial_num_blocks() == 1000
+    assert ds.materialize()._logical_plan.initial_num_blocks() == 1000
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
`ExecutionPlan` inline-wraps a lot of functionality of `LogicalPlan`. Since `ExecutionPlan` has to be removed, we should remove these inlines.

## Related issues
#60358

## Additional information
N/A