### PR TITLE
[Core][UV] Fix uv argument parsing with equal-style args

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -320,6 +320,10 @@ def _extract_uv_prefix_args(
         # Keep unknown options as part of uv prefix as long as they appear
         # before the command boundary.
         if option_name not in known_options:
+            if i + 1 < len(raw_args) and not raw_args[i + 1].startswith("-"):
+                uv_args.append(raw_args[i + 1])
+                i += 2
+                continue
             i += 1
             continue
 

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -271,12 +271,15 @@ def _extract_uv_prefix_args(
 
     known_options = set()
     options_requiring_value = set()
+    boolean_options = set()
 
     for option in parser.option_list:
         flags = option._short_opts + option._long_opts
         known_options.update(flags)
         if option.takes_value():
             options_requiring_value.update(flags)
+        else:
+            boolean_options.update(flags)
 
     for group in parser.option_groups:
         for option in group.option_list:
@@ -284,6 +287,8 @@ def _extract_uv_prefix_args(
             known_options.update(flags)
             if option.takes_value():
                 options_requiring_value.update(flags)
+            else:
+                boolean_options.update(flags)
 
     uv_args: List[str] = []
     i = 0
@@ -324,6 +329,10 @@ def _extract_uv_prefix_args(
                 uv_args.append(raw_args[i + 1])
                 i += 2
                 continue
+            i += 1
+            continue
+
+        if option_name in boolean_options:
             i += 1
             continue
 

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -302,6 +302,9 @@ def _extract_uv_prefix_args(
 
         option_name = token.split("=", 1)[0]
         if "=" in token:
+            # In module mode, command begins immediately after the module value.
+            if option_name in {"-m", "--module"}:
+                break
             i += 1
             continue
 
@@ -323,6 +326,16 @@ def _extract_uv_prefix_args(
         i += 1
 
     return uv_args
+
+
+def _has_explicit_python_option(args: List[str]) -> bool:
+    """Return whether uv prefix args already include an explicit Python pin."""
+    for token in args:
+        if token in {"-p", "--python"}:
+            return True
+        if token.startswith("--python="):
+            return True
+    return False
 
 
 def _check_working_dir_files(
@@ -433,6 +446,7 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     # values (e.g. --python, --directory, --module).
     uv_run_args = [cmdline[0], cmdline[1]]
     uv_run_args.extend(_extract_uv_prefix_args(raw_args, parser))
+    has_explicit_python = _has_explicit_python_option(uv_run_args)
 
     # Remove the "--directory" argument since it has already been taken into
     # account when setting the current working directory of the current process.
@@ -452,7 +466,7 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     # 2. env_vars["UV_PYTHON"]
     # 3. current os.environ["UV_PYTHON"]
     # 4. platform.python_version() (since uv run uses the same Python as the driver)
-    if not options.python:
+    if not options.python and not has_explicit_python:
         env_vars = runtime_env.get("env_vars") or {}
         uv_python = (
             env_vars.get("UV_PYTHON")

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -253,92 +253,74 @@ def _parse_args(
     return options, parser.rargs
 
 
-def _extract_uv_prefix_args(raw_args: List[str], command: List[str]) -> List[str]:
-    """Return uv arguments before command starts, preserving unknown uv flags.
+def _extract_uv_prefix_args(
+    raw_args: List[str], parser: optparse.OptionParser
+) -> List[str]:
+    """Return the uv run prefix arguments from raw argv.
 
-    We prefer using parser-provided command boundary when reliable, but fall back to
-    a positional scan for cases where unknown option handling can make `command`
-    effectively equal to the original args.
+    This scanner operates on the original unmodified argv to avoid edge cases where
+    optparse can rewrite unconsumed args (e.g. unknown ``--flag=value`` becoming
+    ``["--flag", "value"]``). We include uv options up to the command boundary:
+
+    - First positional token for script-style runs
+    - End of options marker ``--``
+    - Immediately after ``-m/--module`` value for module-style runs
     """
     if not raw_args:
         return []
 
-    # Usual case: command is a strict suffix of raw args.
-    if command and len(command) < len(raw_args):
-        return raw_args[: len(raw_args) - len(command)]
+    known_options = set()
+    options_requiring_value = set()
 
-    # Fallback: scan left-to-right, treating leading option-like tokens as uv args.
-    # Preserve unknown uv options (`--new-flag`, `--new-flag=value`) and values for
-    # known value-taking options (best-effort) until the command token boundary.
+    for option in parser.option_list:
+        flags = option._short_opts + option._long_opts
+        known_options.update(flags)
+        if option.takes_value():
+            options_requiring_value.update(flags)
+
+    for group in parser.option_groups:
+        for option in group.option_list:
+            flags = option._short_opts + option._long_opts
+            known_options.update(flags)
+            if option.takes_value():
+                options_requiring_value.update(flags)
+
     uv_args: List[str] = []
-    options_requiring_value = {
-        "--extra",
-        "--no-extra",
-        "--group",
-        "--no-group",
-        "--only-group",
-        "--env-file",
-        "--with",
-        "--with-editable",
-        "--with-requirements",
-        "--package",
-        "--index",
-        "--default-index",
-        "-i",
-        "--index-url",
-        "--extra-index-url",
-        "-f",
-        "--find-links",
-        "--keyring-provider",
-        "-P",
-        "--upgrade-package",
-        "--resolution",
-        "--prerelease",
-        "--fork-strategy",
-        "--exclude-newer",
-        "--reinstall-package",
-        "--link-mode",
-        "-C",
-        "--config-setting",
-        "--no-build-isolation-package",
-        "--no-build-package",
-        "--no-binary-package",
-        "--cache-dir",
-        "--refresh-package",
-        "-p",
-        "--python",
-        "--python-preference",
-        "--color",
-        "--allow-insecure-host",
-        "--directory",
-        "--project",
-        "--config-file",
-        "-m",
-        "--module",
-    }
-
     i = 0
+
     while i < len(raw_args):
         token = raw_args[i]
+
         if token == "--":
             break
 
-        if token.startswith("-"):
-            uv_args.append(token)
-            # --flag=value style already carries value in same token.
-            if (
-                "=" not in token
-                and token in options_requiring_value
-                and i + 1 < len(raw_args)
-            ):
-                uv_args.append(raw_args[i + 1])
-                i += 2
-                continue
+        if not token.startswith("-"):
+            # First positional token is command boundary.
+            break
+
+        uv_args.append(token)
+
+        option_name = token.split("=", 1)[0]
+        if "=" in token:
             i += 1
             continue
 
-        # First positional token is command boundary.
-        break
+        if option_name in options_requiring_value and i + 1 < len(raw_args):
+            uv_args.append(raw_args[i + 1])
+            i += 2
+
+            # In module mode, command begins immediately after the module value.
+            if option_name in {"-m", "--module"}:
+                break
+            continue
+
+        # Keep unknown options as part of uv prefix as long as they appear
+        # before the command boundary.
+        if option_name not in known_options:
+            i += 1
+            continue
+
+        i += 1
 
     return uv_args
 
@@ -445,12 +427,12 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     raw_args = cmdline[2:]  # Immutable snapshot for prefix reconstruction.
     args_to_parse = raw_args.copy()  # Mutable copy for parser internals.
     parser = _create_uv_run_parser()
-    (options, command) = _parse_args(parser, args_to_parse)
+    (options, _) = _parse_args(parser, args_to_parse)
 
     # Preserve uv prefix from original argv. Parsing is used only for semantic
     # values (e.g. --python, --directory, --module).
     uv_run_args = [cmdline[0], cmdline[1]]
-    uv_run_args.extend(_extract_uv_prefix_args(raw_args, command))
+    uv_run_args.extend(_extract_uv_prefix_args(raw_args, parser))
 
     # Remove the "--directory" argument since it has already been taken into
     # account when setting the current working directory of the current process.

--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -253,6 +253,96 @@ def _parse_args(
     return options, parser.rargs
 
 
+def _extract_uv_prefix_args(raw_args: List[str], command: List[str]) -> List[str]:
+    """Return uv arguments before command starts, preserving unknown uv flags.
+
+    We prefer using parser-provided command boundary when reliable, but fall back to
+    a positional scan for cases where unknown option handling can make `command`
+    effectively equal to the original args.
+    """
+    if not raw_args:
+        return []
+
+    # Usual case: command is a strict suffix of raw args.
+    if command and len(command) < len(raw_args):
+        return raw_args[: len(raw_args) - len(command)]
+
+    # Fallback: scan left-to-right, treating leading option-like tokens as uv args.
+    # Preserve unknown uv options (`--new-flag`, `--new-flag=value`) and values for
+    # known value-taking options (best-effort) until the command token boundary.
+    uv_args: List[str] = []
+    options_requiring_value = {
+        "--extra",
+        "--no-extra",
+        "--group",
+        "--no-group",
+        "--only-group",
+        "--env-file",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+        "--package",
+        "--index",
+        "--default-index",
+        "-i",
+        "--index-url",
+        "--extra-index-url",
+        "-f",
+        "--find-links",
+        "--keyring-provider",
+        "-P",
+        "--upgrade-package",
+        "--resolution",
+        "--prerelease",
+        "--fork-strategy",
+        "--exclude-newer",
+        "--reinstall-package",
+        "--link-mode",
+        "-C",
+        "--config-setting",
+        "--no-build-isolation-package",
+        "--no-build-package",
+        "--no-binary-package",
+        "--cache-dir",
+        "--refresh-package",
+        "-p",
+        "--python",
+        "--python-preference",
+        "--color",
+        "--allow-insecure-host",
+        "--directory",
+        "--project",
+        "--config-file",
+        "-m",
+        "--module",
+    }
+
+    i = 0
+    while i < len(raw_args):
+        token = raw_args[i]
+        if token == "--":
+            break
+
+        if token.startswith("-"):
+            uv_args.append(token)
+            # --flag=value style already carries value in same token.
+            if (
+                "=" not in token
+                and token in options_requiring_value
+                and i + 1 < len(raw_args)
+            ):
+                uv_args.append(raw_args[i + 1])
+                i += 2
+                continue
+            i += 1
+            continue
+
+        # First positional token is command boundary.
+        break
+
+    return uv_args
+
+
 def _check_working_dir_files(
     uv_run_args: optparse.Values, runtime_env: Dict[str, Any]
 ) -> None:
@@ -351,20 +441,16 @@ def hook(runtime_env: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             "'uv run' environment e.g. by including them in your pyproject.toml."
         )
 
-    # Extract the arguments uv_run_args of 'uv run' that are not part of the command.
-    args_to_parse = cmdline[2:]  # Remove 'uv run' prefix
-    original_length = len(
-        args_to_parse
-    )  # Save before parsing (parser modifies in-place)
-
+    # Extract arguments after `uv run`.
+    raw_args = cmdline[2:]  # Immutable snapshot for prefix reconstruction.
+    args_to_parse = raw_args.copy()  # Mutable copy for parser internals.
     parser = _create_uv_run_parser()
     (options, command) = _parse_args(parser, args_to_parse)
 
-    # Calculate how many arguments were consumed by the parser.
-    # Since disable_interspersed_args() is set, parsing stops at the first
-    # unrecognized argument (the command), so all consumed args are uv options.
-    args_consumed = original_length - len(command)
-    uv_run_args = cmdline[: 2 + args_consumed]
+    # Preserve uv prefix from original argv. Parsing is used only for semantic
+    # values (e.g. --python, --directory, --module).
+    uv_run_args = [cmdline[0], cmdline[1]]
+    uv_run_args.extend(_extract_uv_prefix_args(raw_args, command))
 
     # Remove the "--directory" argument since it has already been taken into
     # account when setting the current working directory of the current process.

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -619,7 +619,13 @@ def test_uv_run_hook_does_not_absorb_command_flags_after_script():
 
     py_executable = runtime_env["py_executable"]
     # --python after script is command-specific and must not be treated as uv arg.
-    assert "--python 3.10" not in py_executable
+    # Compare token pairs instead of raw substring to avoid matching fallback
+    # values like "3.10.22".
+    tokens = py_executable.split()
+    assert not any(
+        tokens[i] == "--python" and tokens[i + 1] == "3.10"
+        for i in range(len(tokens) - 1)
+    )
     assert "--no-project" in py_executable
 
 

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import unittest
 from pathlib import Path
 
 import pytest
@@ -368,6 +369,161 @@ def test_uv_run_parser():
     assert command == ["--model", "Qwen/Qwen3-32B"]
 
 
+def test_uv_run_hook_keeps_equal_style_option_values():
+    """Regression: equal-style command args must not break uv prefix parsing."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "-m",
+        "ray.util.client.server",
+        "--address=172.18.0.2:6379",
+        "--host=127.0.0.1",
+        "--port=23007",
+        "--mode=specific-server",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    # Hook always strips "-m/--module" from uv prefix before producing py_executable.
+    assert " -m " not in py_executable
+    assert "python" in py_executable.split()
+    # Command-specific args should not be injected into the uv prefix.
+    assert "--address=172.18.0.2:6379" not in py_executable
+    assert "--host=127.0.0.1" not in py_executable
+    assert "--port=23007" not in py_executable
+    assert "--mode=specific-server" not in py_executable
+
+
+def test_uv_run_hook_preserves_count_flags():
+    """Regression: count flags should not serialize as '--verbose 2'."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "-vv",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+        "--extra-args",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    assert "--verbose 2" not in py_executable
+    assert "-vv" in py_executable
+
+
+def test_uv_run_hook_preserves_unknown_uv_options():
+    """Unknown uv options should not be dropped when deriving uv prefix."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "--new-uv-flag=example",
+        "--no-project",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+        "--extra-args",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    assert "--new-uv-flag=example" in py_executable
+    assert "--no-project" in py_executable
+
+
+def test_uv_run_hook_preserves_unknown_option_before_known_option():
+    """Unknown uv option before known options should not zero out prefix extraction."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "--new-uv-flag=example",
+        "--project",
+        ".",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+        "--extra-args",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    assert "--new-uv-flag=example" in py_executable
+    assert "--project ." in py_executable
+
+
+def test_uv_run_hook_does_not_absorb_command_flags_after_script():
+    """Flags after script name belong to command, not uv prefix."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "--no-project",
+        "my_script.py",
+        "--python",
+        "3.10",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    # --python after script is command-specific and must not be treated as uv arg.
+    assert "--python 3.10" not in py_executable
+    assert "--no-project" in py_executable
+
+
+def test_uv_run_hook_boundary_not_confused_by_repeated_command_token():
+    """Boundary detection should not truncate uv args on token collisions."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "--project",
+        "my_script.py",
+        "my_script.py",
+        "--flag",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    assert "--project my_script.py" in py_executable
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Not ported to Windows yet.")
 def test_uv_run_runtime_env_hook_e2e(shutdown_only, temp_dir):
     tmp_dir = Path(temp_dir)
@@ -550,9 +706,9 @@ def test_uv_run_ray_client_mode(call_ray_start, tmp_working_dir):
         conn_info = context.client_worker.connection_info()
         runtime_env = conn_info.get("job_config", {}).get("runtime_env", {})
         assert "py_executable" in runtime_env, "UV hook should set py_executable"
-        assert (
-            "uv run" in runtime_env["py_executable"]
-        ), "py_executable should contain 'uv run'"
+        assert "uv run" in runtime_env["py_executable"], (
+            "py_executable should contain 'uv run'"
+        )
 
         @ray.remote
         def emojize():
@@ -562,9 +718,9 @@ def test_uv_run_ray_client_mode(call_ray_start, tmp_working_dir):
 
         # This should work because UV hook detected and propagated UV config
         result = ray.get(emojize.remote())
-        assert (
-            result == "Ray rocks 👍"
-        ), "UV should have installed emoji package on workers"
+        assert result == "Ray rocks 👍", (
+            "UV should have installed emoji package on workers"
+        )
 
     finally:
         ray.shutdown()

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -399,6 +399,25 @@ def test_uv_run_parser():
     ]
 
     parser = _create_uv_run_parser()
+    raw_args = [
+        "--new-uv-flag",
+        "example",
+        "--python",
+        "3.10",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+        "--extra-args",
+    ]
+    assert _extract_uv_prefix_args(raw_args, parser) == [
+        "--new-uv-flag",
+        "example",
+        "--python",
+        "3.10",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+    ]
+
+    parser = _create_uv_run_parser()
     raw_args = ["--no-project", "my_script.py", "--python", "3.10"]
     assert _extract_uv_prefix_args(raw_args, parser) == ["--no-project"]
 
@@ -547,6 +566,34 @@ def test_uv_run_hook_does_not_add_duplicate_python_after_unknown_option():
         runtime_env = hook({})
 
     py_executable = runtime_env["py_executable"]
+    assert "--python 3.10" in py_executable
+    assert py_executable.count("--python") == 1
+
+
+def test_uv_run_hook_does_not_add_duplicate_python_after_unknown_option_with_value():
+    """Unknown option with separate value before --python should preserve python pinning."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "--new-uv-flag",
+        "example",
+        "--python",
+        "3.10",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+        "--extra-args",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    assert "--new-uv-flag example" in py_executable
     assert "--python 3.10" in py_executable
     assert py_executable.count("--python") == 1
 

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -322,6 +322,7 @@ def test_uv_run_runtime_env_hook():
 def test_uv_run_parser():
     from ray._private.runtime_env.uv_runtime_env_hook import (
         _create_uv_run_parser,
+        _extract_uv_prefix_args,
         _parse_args,
     )
 
@@ -367,6 +368,48 @@ def test_uv_run_parser():
     assert options.extras == ["vllm"]
     assert options.module == "my_module.submodule"
     assert command == ["--model", "Qwen/Qwen3-32B"]
+
+    parser = _create_uv_run_parser()
+    raw_args = [
+        "-m",
+        "ray.util.client.server",
+        "--address=172.18.0.2:6379",
+        "--host=127.0.0.1",
+    ]
+    assert _extract_uv_prefix_args(raw_args, parser) == [
+        "-m",
+        "ray.util.client.server",
+    ]
+
+    parser = _create_uv_run_parser()
+    raw_args = [
+        "--new-uv-flag=example",
+        "--project",
+        ".",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+        "--extra-args",
+    ]
+    assert _extract_uv_prefix_args(raw_args, parser) == [
+        "--new-uv-flag=example",
+        "--project",
+        ".",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+    ]
+
+    parser = _create_uv_run_parser()
+    raw_args = ["--no-project", "my_script.py", "--python", "3.10"]
+    assert _extract_uv_prefix_args(raw_args, parser) == ["--no-project"]
+
+    parser = _create_uv_run_parser()
+    raw_args = [
+        "--project",
+        "my_script.py",
+        "my_script.py",
+        "--flag",
+    ]
+    assert _extract_uv_prefix_args(raw_args, parser) == ["--project", "my_script.py"]
 
 
 def test_uv_run_hook_keeps_equal_style_option_values():

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -403,6 +403,12 @@ def test_uv_run_parser():
     assert _extract_uv_prefix_args(raw_args, parser) == ["--no-project"]
 
     parser = _create_uv_run_parser()
+    raw_args = ["--module=ray.util.client.server", "--address=127.0.0.1:10001"]
+    assert _extract_uv_prefix_args(raw_args, parser) == [
+        "--module=ray.util.client.server",
+    ]
+
+    parser = _create_uv_run_parser()
     raw_args = [
         "--project",
         "my_script.py",
@@ -517,6 +523,32 @@ def test_uv_run_hook_preserves_unknown_option_before_known_option():
     py_executable = runtime_env["py_executable"]
     assert "--new-uv-flag=example" in py_executable
     assert "--project ." in py_executable
+
+
+def test_uv_run_hook_does_not_add_duplicate_python_after_unknown_option():
+    """Unknown options before --python should not cause duplicate python pinning."""
+    from ray._private.runtime_env.uv_runtime_env_hook import hook
+
+    cmdline = [
+        find_uv_bin(),
+        "run",
+        "--new-uv-flag=example",
+        "--python",
+        "3.10",
+        "-m",
+        "ray._private.runtime_env.uv_runtime_env_hook",
+        "--extra-args",
+    ]
+
+    with unittest.mock.patch(
+        "ray._private.runtime_env.uv_runtime_env_hook._get_uv_run_cmdline",
+        return_value=cmdline,
+    ):
+        runtime_env = hook({})
+
+    py_executable = runtime_env["py_executable"]
+    assert "--python 3.10" in py_executable
+    assert py_executable.count("--python") == 1
 
 
 def test_uv_run_hook_does_not_absorb_command_flags_after_script():


### PR DESCRIPTION
## What this PR does
- Fixes uv runtime-env hook argument handling to avoid truncating uv args when command args use equal-style flags (for example --address=host:port).
- Replaces fragile consumed-token slicing with reconstruction from parsed uv options.
- Includes option-group options and properly handles count flags (e.g. -vv).
- Adds regression tests covering equal-style args and count-flag preservation.

## Why
Issue #62650 reports failures like "option -m: expected one argument" when launching with uv run and equal-style command args.

## Validation
- Added regression tests in python/ray/tests/test_runtime_env_uv_run.py.
- Local syntax checks pass for modified files (py_compile).

Closes #62650