### PR TITLE
[core] Deflake node manager test

### DIFF
--- a/src/ray/common/cgroup2/BUILD.bazel
+++ b/src/ray/common/cgroup2/BUILD.bazel
@@ -74,7 +74,7 @@ ray_cc_library(
     hdrs = [
         "noop_cgroup_manager.h",
     ],
-    visibility = [":__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         ":cgroup_driver_interface",
         ":cgroup_manager_interface",

--- a/src/ray/raylet/tests/BUILD.bazel
+++ b/src/ray/raylet/tests/BUILD.bazel
@@ -165,6 +165,7 @@ ray_cc_test(
         "//src/ray/common:lease",
         "//src/ray/common:ray_object",
         "//src/ray/common:task_common",
+        "//src/ray/common/cgroup2:noop_cgroup_manager",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/core_worker_rpc_client:fake_core_worker_client",
         "//src/ray/object_manager/plasma:fake_plasma_client",

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -34,6 +34,7 @@
 #include "mock/ray/rpc/worker/core_worker_client.h"
 #include "ray/common/buffer.h"
 #include "ray/common/bundle_spec.h"
+#include "ray/common/cgroup2/noop_cgroup_manager.h"
 #include "ray/common/flatbuf_utils.h"
 #include "ray/common/scheduling/cluster_resource_data.h"
 #include "ray/common/scheduling/resource_set.h"
@@ -437,7 +438,7 @@ class NodeManagerTest : public ::testing::Test {
         /*shutdown_raylet_gracefully=*/
         [](const auto &) {},
         [](const std::string &) {},
-        nullptr,
+        std::make_unique<NoopCgroupManager>(),
         shutting_down_,
         *placement_group_resource_manager_,
         boost::asio::basic_socket_acceptor<local_stream_protocol>(io_service_),


### PR DESCRIPTION
In #62168 we modified the memory monitor constructor to take in a cgroup_manager which for tests is effectively passing a nullptr where we're expecting a const ref: https://github.com/ray-project/ray/pull/62168/changes#diff-d2f22b8f1bf5f9be47dacae8b467a72ee94629df12ffcc18b13447192ff3dbcfL246

Since it's not actually used in the node_manager_test I'm assuming that's how it passed CI, but it's getting flagged (rightfully) by the UBSAN test. Passing a noop cgroup manager instead. 
