### PR TITLE
[build] Replace deprecated Bazel --local_cpu_resources/--local_ram_resources flags

### DIFF
--- a/ci/build/container_resource_utils.py
+++ b/ci/build/container_resource_utils.py
@@ -91,7 +91,7 @@ def main():
     bazel_jobs = max(1, min(cpu_limit, jobs_by_ram))
 
     print(
-        f"--jobs={bazel_jobs} --local_cpu_resources={cpu_limit} --local_ram_resources={mem_limit}"
+        f"--jobs={bazel_jobs} --local_resources=cpu={cpu_limit} --local_resources=memory={mem_limit}"
     )
 
 

--- a/doc/source/ray-contribute/development.rst
+++ b/doc/source/ray-contribute/development.rst
@@ -299,7 +299,7 @@ If your machine runs out of memory during the build, add the following to ``~/.b
 
   .. code-block:: shell
 
-    build --local_ram_resources=HOST_RAM*.5 --local_cpu_resources=4
+    build --local_resources=memory=HOST_RAM*.5 --local_resources=cpu=4
 
   The ``build --disk_cache=~/bazel-cache`` option can also speed up repeated builds.
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -619,7 +619,7 @@ def build(build_python, build_java, build_cpp, build_redis):
 
     if BAZEL_LIMIT_CPUS:
         n = int(BAZEL_LIMIT_CPUS)  # the value must be an int
-        bazel_flags.append(f"--local_cpu_resources={n}")
+        bazel_flags.append(f"--local_resources=cpu={n}")
         warnings.warn(
             "Setting BAZEL_LIMIT_CPUS is deprecated and will be removed in a future"
             " version. Please use BAZEL_ARGS instead.",


### PR DESCRIPTION
Bazel has deprecated --local_cpu_resources and --local_ram_resources in favor of the unified --local_resources=cpu=/--local_resources=memory= syntax. Update the three call sites in the repo so builds stop emitting deprecation warnings.

Topic: fix-bazel-local-resources-args
Signed-off-by: andrew <andrew@anyscale.com>