### PR TITLE
[release] Emit RAYCI_SELECT of base-image publish keys from release-test init

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -133,6 +133,7 @@ steps:
         --image-type ray
         --upload
     depends_on:
+      - forge
       - ray-anyscale-cpu-build($)
     array:
       python:
@@ -154,6 +155,7 @@ steps:
         --image-type ray
         --upload
     depends_on:
+      - forge
       - ray-anyscale-cuda-build($)
     array:
       gpu:
@@ -204,6 +206,7 @@ steps:
         --image-type ray-llm
         --upload
     depends_on:
+      - forge
       - ray-llm-anyscale-cuda-build($)
     array:
       gpu:
@@ -249,6 +252,7 @@ steps:
         --image-type ray-ml
         --upload
     depends_on:
+      - forge
       - ray-ml-anyscale-cuda-build($)
     array:
       python:

--- a/.buildkite/release/custom-image-build-and-test-init.sh
+++ b/.buildkite/release/custom-image-build-and-test-init.sh
@@ -63,6 +63,7 @@ fi
 BUILD_WORKSPACE_DIRECTORY="${PWD}" bazel-bin/release/custom_image_build_and_test_init \
   "${RUN_FLAGS[@]}" \
   --custom-build-jobs-output-file .buildkite/release/custom_build_jobs.rayci.yaml \
-  --test-jobs-output-file .buildkite/release/release_tests.json
+  --test-jobs-output-file .buildkite/release/release_tests.json \
+  --rayci-select-output-file /tmp/rayci_select.txt
 
 buildkite-agent pipeline upload .buildkite/release/release_tests.json

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -232,6 +232,20 @@ def get_prerequisite_step(
     return f"{bare_key}--gpu{sanitized}-python{python_raw}"
 
 
+def collect_rayci_select_keys(tests: List[Test], gpu_map: Dict[str, str]) -> Set[str]:
+    """Return the RAYCI_SELECT key set (base-image + custom-BYOD) for the given tests."""
+    keys: Set[str] = set()
+    for test in tests:
+        image = test.get_anyscale_byod_image()
+        base_image = test.get_anyscale_base_byod_image()
+        prereq = get_prerequisite_step(image, base_image, gpu_map)
+        if prereq:
+            keys.add(prereq)
+        if test.require_custom_byod_image():
+            keys.add(generate_custom_build_step_key(image))
+    return keys
+
+
 def _get_step_name(image: str, step_key: str, test_names: List[str]) -> str:
     ecr, tag = image.split(":")
     ecr_repo = ecr.split("/")[-1]

--- a/release/ray_release/scripts/custom_image_build_and_test_init.py
+++ b/release/ray_release/scripts/custom_image_build_and_test_init.py
@@ -21,6 +21,7 @@ from ray_release.config import (
 from ray_release.configs.global_config import init_global_config
 from ray_release.custom_byod_build_init_helper import (
     build_short_gpu_map,
+    collect_rayci_select_keys,
     create_custom_build_yaml,
 )
 from ray_release.exception import ReleaseTestCLIError, ReleaseTestConfigError
@@ -89,6 +90,11 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
     type=str,
     help="The output file for the test jobs json file",
 )
+@click.option(
+    "--rayci-select-output-file",
+    type=str,
+    help="Output file for RAYCI_SELECT (comma-separated base-image publish step keys).",
+)
 def main(
     test_collection_file: Tuple[str],
     run_jailed_tests: bool = False,
@@ -99,6 +105,7 @@ def main(
     run_per_test: int = 1,
     custom_build_jobs_output_file: str = None,
     test_jobs_output_file: str = None,
+    rayci_select_output_file: str = None,
 ):
     global_config_file = os.path.join(
         os.path.dirname(__file__), "..", "configs", global_config
@@ -149,6 +156,8 @@ def main(
         tests,
         gpu_map,
     )
+
+    rayci_select_keys = collect_rayci_select_keys(tests, gpu_map)
 
     # Generate test job steps
     grouped_tests = group_tests(filtered_tests)
@@ -208,6 +217,15 @@ def main(
             "wt",
         ) as fp:
             json.dump(steps, fp)
+
+        # Only emit RAYCI_SELECT when a filter narrows the test set; an unfiltered
+        # run (e.g. full nightly) wants the complete image pipeline.
+        if rayci_select_output_file and test_filters:
+            with open(
+                os.path.join(_bazel_workspace_dir, rayci_select_output_file),
+                "wt",
+            ) as fp:
+                fp.write(",".join(sorted(rayci_select_keys)))
 
         settings["frequency"] = settings["frequency"].value
         settings["priority"] = settings["priority"].value

--- a/release/ray_release/tests/test_custom_image_build_and_test_init.py
+++ b/release/ray_release/tests/test_custom_image_build_and_test_init.py
@@ -7,9 +7,40 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
+from ray_release.buildkite.filter import filter_tests
+from ray_release.buildkite.settings import get_frequency, get_test_filters
+from ray_release.config import read_and_validate_release_test_collection
+from ray_release.configs.global_config import init_global_config
+from ray_release.custom_byod_build_init_helper import (
+    build_short_gpu_map,
+    collect_rayci_select_keys,
+)
 from ray_release.scripts.custom_image_build_and_test_init import main
 
 _bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
+
+
+def _expected_rayci_select_keys(sample_yaml: str) -> set:
+    """Mirror the script's filter + key computation so expectations can't drift."""
+    init_global_config(
+        os.path.join(
+            _bazel_workspace_dir,
+            "release/ray_release/configs/oss_config.yaml",
+        )
+    )
+    gpu_map = build_short_gpu_map(os.path.join(_bazel_workspace_dir, "ray-images.json"))
+    test_collection = read_and_validate_release_test_collection(
+        [os.path.join(_bazel_workspace_dir, sample_yaml)]
+    )
+    filtered = filter_tests(
+        test_collection,
+        frequency=get_frequency("nightly"),
+        test_filters=get_test_filters("prefix:hello_world"),
+        run_jailed_tests=True,
+        run_unstable_tests=True,
+    )
+    tests = [test for test, _ in filtered]
+    return collect_rayci_select_keys(tests, gpu_map)
 
 
 @patch.dict("os.environ", {"BUILDKITE": "1"})
@@ -22,6 +53,7 @@ def test_custom_image_build_and_test_init(
     runner = CliRunner()
     custom_build_jobs_output_file = "custom_build_jobs.yaml"
     test_jobs_output_file = "test_jobs.json"
+    rayci_select_output_file = "rayci_select.txt"
     result = runner.invoke(
         main,
         [
@@ -39,6 +71,8 @@ def test_custom_image_build_and_test_init(
             custom_build_jobs_output_file,
             "--test-jobs-output-file",
             test_jobs_output_file,
+            "--rayci-select-output-file",
+            rayci_select_output_file,
         ],
         catch_exceptions=False,
     )
@@ -54,6 +88,17 @@ def test_custom_image_build_and_test_init(
         assert test_jobs[0]["steps"][0]["label"].startswith("hello_world.aws")
         assert test_jobs[0]["steps"][1]["label"].startswith("hello_world_custom.aws")
 
+    with open(os.path.join(_bazel_workspace_dir, rayci_select_output_file), "r") as f:
+        raw = f.read()
+        keys = [k for k in raw.split(",") if k]
+        expected = _expected_rayci_select_keys(
+            "release/ray_release/tests/sample_tests.yaml"
+        )
+        assert set(keys) == expected
+        assert len(keys) == len(set(keys))  # no duplicates
+        assert keys == sorted(keys)  # stable ordering
+        assert len(expected) == 3  # cpu base + gpu base + custom-BYOD
+
     assert result.exit_code == 0
 
 
@@ -68,6 +113,7 @@ def test_custom_image_build_and_test_init_with_block_step(
     runner = CliRunner()
     custom_build_jobs_output_file = "custom_build_jobs.yaml"
     test_jobs_output_file = "test_jobs.json"
+    rayci_select_output_file = "rayci_select.txt"
     result = runner.invoke(
         main,
         [
@@ -85,6 +131,8 @@ def test_custom_image_build_and_test_init_with_block_step(
             custom_build_jobs_output_file,
             "--test-jobs-output-file",
             test_jobs_output_file,
+            "--rayci-select-output-file",
+            rayci_select_output_file,
         ],
         catch_exceptions=False,
     )
@@ -107,6 +155,17 @@ def test_custom_image_build_and_test_init_with_block_step(
         assert len(test_jobs[1]["steps"]) == num_tests_expected  # 5 tests
         assert test_jobs[1]["steps"][0]["label"].startswith("hello_world.aws")
         assert test_jobs[1]["steps"][1]["label"].startswith("hello_world_custom.aws")
+
+    with open(os.path.join(_bazel_workspace_dir, rayci_select_output_file), "r") as f:
+        raw = f.read()
+        keys = [k for k in raw.split(",") if k]
+        expected = _expected_rayci_select_keys(
+            "release/ray_release/tests/sample_5_tests.yaml"
+        )
+        assert set(keys) == expected
+        assert len(keys) == len(set(keys))  # no duplicates
+        assert keys == sorted(keys)  # stable ordering
+        assert len(expected) == 3  # cpu base + gpu base + custom-BYOD (collapsed)
 
     assert result.exit_code == 0
 
@@ -157,6 +216,45 @@ def test_custom_image_build_and_test_init_without_block_step_automatic(
         assert test_jobs[0]["steps"][1]["label"].startswith("hello_world_custom.aws")
 
     assert result.exit_code == 0
+
+
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_rayci_select_skipped_when_no_filter(
+    mock_update_from_s3, mock_is_jailed_with_open_issue
+):
+    """Unfiltered runs (e.g. full nightly) skip RAYCI_SELECT so rayci runs everything."""
+    runner = CliRunner()
+    custom_build_jobs_output_file = "custom_build_jobs.yaml"
+    test_jobs_output_file = "test_jobs.json"
+    rayci_select_output_file = "rayci_select_no_filter.txt"
+    abs_path = os.path.join(_bazel_workspace_dir, rayci_select_output_file)
+    if os.path.exists(abs_path):
+        os.remove(abs_path)
+    result = runner.invoke(
+        main,
+        [
+            "--test-collection-file",
+            "release/ray_release/tests/sample_tests.yaml",
+            "--global-config",
+            "oss_config.yaml",
+            "--frequency",
+            "nightly",
+            "--run-jailed-tests",
+            "--run-unstable-tests",
+            "--custom-build-jobs-output-file",
+            custom_build_jobs_output_file,
+            "--test-jobs-output-file",
+            test_jobs_output_file,
+            "--rayci-select-output-file",
+            rayci_select_output_file,
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert not os.path.exists(abs_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Before:
https://buildkite.com/ray-project/release/builds/88826/steps/canvas?sid=019d8d53-3ceb-418d-9b71-571a4dbf6699&open=false

After:
https://buildkite.com/ray-project/release/builds/89238/steps/canvas?sid=019d9883-9898-4dcc-80eb-824e79de7829&open=false

The release-test kickoff today runs rayci against every .rayci.yml under .buildkite/release/, so even a nightly scheduling a single test fans out to ~15 wanda image-build steps including CUDA/TPU/ML base images the scheduled test doesn't need.

Rayci accepts RAYCI_SELECT=<comma-separated-keys> as a whitelist and walks its transitive upstream deps. This change has the release-test init script compute that value from the scheduled-test set and write it to /tmp/rayci_select.txt; the outer Buildkite step that invokes this script reads the file and exports RAYCI_SELECT before calling run_rayci.sh.

The key set contains:
  - the base-image publish step key for every scheduled test (e.g. anyscalecpubuild--python310, anyscalecudabuild--gpu<short>-python310, or forge for Anyscale pre-published bases), and
  - the custom-BYOD build step key for every test that requires one (rayci's upstream dep walker pulls in the base-image key automatically via depends_on).

The write is gated on a test filter being applied. Unfiltered runs (full nightly / weekly) skip the write so the outer pipeline's `[[ -f /tmp/rayci_select.txt ]]` guard falls through and rayci runs the complete image pipeline. Filtered runs get the pruned subset.

Both the script and the test helper share collect_rayci_select_keys() in custom_byod_build_init_helper.py so the key-computing logic can't drift, and the test helper applies the same filter_tests() chain as the CLI invocation so the expected set matches the production set.

Topic: rayci-select-release-init
Relative: release-publish-forge-deps
Signed-off-by: andrew <andrew@anyscale.com>