### PR TITLE
[release] Declare forge as an explicit depends_on for publish steps

### DIFF
--- a/.buildkite/release/build.rayci.yml
+++ b/.buildkite/release/build.rayci.yml
@@ -133,6 +133,7 @@ steps:
         --image-type ray
         --upload
     depends_on:
+      - forge
       - ray-anyscale-cpu-build($)
     array:
       python:
@@ -154,6 +155,7 @@ steps:
         --image-type ray
         --upload
     depends_on:
+      - forge
       - ray-anyscale-cuda-build($)
     array:
       gpu:
@@ -204,6 +206,7 @@ steps:
         --image-type ray-llm
         --upload
     depends_on:
+      - forge
       - ray-llm-anyscale-cuda-build($)
     array:
       gpu:
@@ -249,6 +252,7 @@ steps:
         --image-type ray-ml
         --upload
     depends_on:
+      - forge
       - ray-ml-anyscale-cuda-build($)
     array:
       python:


### PR DESCRIPTION
The four :crane: publish: steps in build.rayci.yml run inside the forge docker image (via the default docker plugin), but the dependency on the forge wanda step was implicit — not declared via depends_on. In the default unpruned pipeline this works because rayci includes every step regardless, but under RAYCI_SELECT pruning (where only the selected step and its transitive upstream deps are emitted), the forge step gets filtered out and the publish step crashes with "manifest for citemp:{build_id}-forge not found".

Making the dep explicit lets rayci's upstream dep walker include forge in the pruned pipeline whenever any publish step is selected.

Topic: release-publish-forge-deps
Signed-off-by: andrew <andrew@anyscale.com>