### PR TITLE
[core] fix HandleIsLocalWorkerDead for drivers

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2138,8 +2138,10 @@ void NodeManager::HandleReturnWorkerLease(rpc::ReturnWorkerLeaseRequest request,
 void NodeManager::HandleIsLocalWorkerDead(rpc::IsLocalWorkerDeadRequest request,
                                           rpc::IsLocalWorkerDeadReply *reply,
                                           rpc::SendReplyCallback send_reply_callback) {
-  reply->set_is_dead(worker_pool_.GetRegisteredWorker(
-                         WorkerID::FromBinary(request.worker_id())) == nullptr);
+  const auto worker_id = WorkerID::FromBinary(request.worker_id());
+  const bool registered = worker_pool_.GetRegisteredWorker(worker_id) != nullptr ||
+                          worker_pool_.GetRegisteredDriver(worker_id) != nullptr;
+  reply->set_is_dead(!registered);
   send_reply_callback(Status::OK(), /*success=*/nullptr, /*failure=*/nullptr);
 }
 

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -346,6 +346,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
                              rpc::CancelLocalTaskReply *reply,
                              rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleIsLocalWorkerDead(rpc::IsLocalWorkerDeadRequest request,
+                               rpc::IsLocalWorkerDeadReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override;
+
  private:
   FRIEND_TEST(NodeManagerStaticTest, TestHandleReportWorkerBacklog);
 
@@ -652,10 +656,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   void HandleShutdownRaylet(rpc::ShutdownRayletRequest request,
                             rpc::ShutdownRayletReply *reply,
                             rpc::SendReplyCallback send_reply_callback) override;
-
-  void HandleIsLocalWorkerDead(rpc::IsLocalWorkerDeadRequest request,
-                               rpc::IsLocalWorkerDeadReply *reply,
-                               rpc::SendReplyCallback send_reply_callback) override;
 
   /// Handle a `NodeStats` request.
   void HandleGetNodeStats(rpc::GetNodeStatsRequest request,

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -486,6 +486,65 @@ class NodeManagerTest : public ::testing::Test {
       fake_node_manager_unexpected_worker_failure_total_count_;
 };
 
+TEST_F(NodeManagerTest, HandleIsLocalWorkerDeadUnknownWorker) {
+  WorkerID worker_id = WorkerID::FromRandom();
+  EXPECT_CALL(mock_worker_pool_, GetRegisteredWorker(worker_id))
+      .WillOnce(Return(nullptr));
+  EXPECT_CALL(mock_worker_pool_, GetRegisteredDriver(worker_id))
+      .WillOnce(Return(nullptr));
+  rpc::IsLocalWorkerDeadRequest request;
+  request.set_worker_id(worker_id.Binary());
+  rpc::IsLocalWorkerDeadReply reply;
+  bool replied = false;
+  node_manager_->HandleIsLocalWorkerDead(
+      request,
+      &reply,
+      [&](Status, std::function<void()> success, std::function<void()> failure) {
+        replied = true;
+      });
+  EXPECT_TRUE(replied);
+  EXPECT_TRUE(reply.is_dead());
+}
+
+TEST_F(NodeManagerTest, HandleIsLocalWorkerDeadRegisteredDriver) {
+  WorkerID worker_id = WorkerID::FromRandom();
+  auto driver = std::make_shared<MockWorker>(worker_id, 10);
+  EXPECT_CALL(mock_worker_pool_, GetRegisteredWorker(worker_id))
+      .WillOnce(Return(nullptr));
+  EXPECT_CALL(mock_worker_pool_, GetRegisteredDriver(worker_id)).WillOnce(Return(driver));
+  rpc::IsLocalWorkerDeadRequest request;
+  request.set_worker_id(worker_id.Binary());
+  rpc::IsLocalWorkerDeadReply reply;
+  bool replied = false;
+  node_manager_->HandleIsLocalWorkerDead(
+      request,
+      &reply,
+      [&](Status, std::function<void()> success, std::function<void()> failure) {
+        replied = true;
+      });
+  EXPECT_TRUE(replied);
+  EXPECT_FALSE(reply.is_dead());
+}
+
+TEST_F(NodeManagerTest, HandleIsLocalWorkerDeadRegisteredWorker) {
+  WorkerID worker_id = WorkerID::FromRandom();
+  auto worker = std::make_shared<MockWorker>(worker_id, 10);
+  // || short-circuits: GetRegisteredDriver is never called when worker is found.
+  EXPECT_CALL(mock_worker_pool_, GetRegisteredWorker(worker_id)).WillOnce(Return(worker));
+  rpc::IsLocalWorkerDeadRequest request;
+  request.set_worker_id(worker_id.Binary());
+  rpc::IsLocalWorkerDeadReply reply;
+  bool replied = false;
+  node_manager_->HandleIsLocalWorkerDead(
+      request,
+      &reply,
+      [&](Status, std::function<void()> success, std::function<void()> failure) {
+        replied = true;
+      });
+  EXPECT_TRUE(replied);
+  EXPECT_FALSE(reply.is_dead());
+}
+
 TEST_F(NodeManagerTest, TestRegisterGcsAndCheckSelfAlive) {
   EXPECT_CALL(*mock_gcs_client_->mock_node_accessor,
               AsyncSubscribeToNodeAddressAndLivenessChange(_, _))


### PR DESCRIPTION
This is found during debugging a hanging streaming generator. We have these logs:

```
{"asctime":"2026-04-09 00:33:06,719","levelname":"W","message":"Core worker 10.0.191.167 has been unavailable for more than 1 seconds","filename":"retryable_grpc_client.cc","lineno":85}
{"asctime":"2026-04-09 00:33:06,724","levelname":"I","message":"Disconnecting core worker client because the worker is dead","filename":"core_worker_client_pool.cc","lineno":55,"worker_id":"02000000ffffffffffffffffffffffffffffffffffffffffffffffff","node_id":"576a2709c6d48e4fdfabe9d993b315652ee8e53d0096bd93bc368379"}
{"asctime":"2026-04-09 00:33:06,724","levelname":"W","message":"Failed to report streaming generator return to the caller. The yield'ed ObjectRef may not be usable. Disconnected: GRPC client is shut down.","filename":"core_worker.cc","lineno":3206,"object_id":"d337091b4a9d35daffffffffffffffffffffffff0200000003000000"}
```

The streaming generator above was not able to send the yield back to the owner (the driver) because the `RetryableGrpcClient` had been shut down after the owner was unavailable for more than 1 second, probably due to being overloaded.

However, the `RetryableGrpcClient` was shut down because it got `the worker is dead` message from the raylet on the head node via the `raylet_client->IsLocalWorkerDead()`, and that message was wrong.

The problem is that the `HandleIsLocalWorkerDead` on the raylet didn't check if the worker was one of the drivers it had, so it said the worker was dead wrongly.

So the fix is simply to let it check the drivers as well, so that `RetryableGrpcClient` won't be shut down incorrectly.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
