### PR TITLE
[core] Disable PythonGCThread for workers to eliminate GIL contention

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2850,7 +2850,7 @@ cdef class CoreWorker:
         self.event_loop_executor = None
 
         self._gc_thread = None
-        if RayConfig.instance().start_python_gc_manager_thread():
+        if RayConfig.instance().start_python_gc_manager_thread() and self.is_driver:
             self._gc_thread = PythonGCThread()
             self._gc_thread.start()
 
@@ -4596,7 +4596,10 @@ cdef class CoreWorker:
         return self.current_runtime_env
 
     def trigger_gc(self):
-        self._gc_thread.trigger_gc()
+        if self._gc_thread is not None:
+            self._gc_thread.trigger_gc()
+        else:
+            gc.collect()
 
     def get_pending_children_task_ids(self, parent_task_id: TaskID):
         cdef:


### PR DESCRIPTION
## Why

`PythonGCThread` (`python/ray/_private/gc_collect_manager.py`) is a Python daemon thread that blocks on `threading.Event.wait()` and calls `gc.collect()` whenever the raylet signals a GC event (~every 100 ms via `raylet_check_gc_period_milliseconds`). Because `gc.collect()` holds the GIL for milliseconds, this thread can preempt latency-sensitive actor workloads — in particular sync actors running an infinite event loop (e.g. SGLang's `SchedulerActor`) — at a 100 ms cadence, causing measurable P99 ITL and E2E latency regressions.

Drivers (interactive sessions) benefit from responsive GC, so the thread is kept there. Workers don't need a dedicated GC thread: the `gc_collect` C callback's existing inline-`gc.collect()` fallback path handles raylet-triggered GC safely on the calling thread.

## Changes

**`python/ray/_raylet.pyx` — thread creation (`CoreWorker.__cinit__`)**

```python
# before
if RayConfig.instance().start_python_gc_manager_thread():

# after
if RayConfig.instance().start_python_gc_manager_thread() and self.is_driver:
```

`self.is_driver` is already set from `worker_type` at line 2790. Workers (`WORKER_MODE`, `SPILL_WORKER_MODE`, `RESTORE_WORKER_MODE`) skip the thread; drivers (`SCRIPT_MODE`) keep it.

**`python/ray/_raylet.pyx` — `CoreWorker.trigger_gc()`**

```python
# before
def trigger_gc(self):
    self._gc_thread.trigger_gc()

# after
def trigger_gc(self):
    if self._gc_thread is not None:
        self._gc_thread.trigger_gc()
    else:
        gc.collect()
```

The `gc_collect` C callback dispatches to `trigger_gc()` when `start_python_gc_manager_thread` is `True`. After this change a worker with that config flag set would have `_gc_thread = None` and would previously `AttributeError`-crash on raylet GC signals. The fallback to inline `gc.collect()` preserves correct behavior.

## Testing
<img width="395" height="387" alt="image" src="https://github.com/user-attachments/assets/bc2e927a-4867-48ed-9e88-acdd7b19fecb" />


Existing unit tests for `PythonGCThread` / `gc_collect_manager` cover the thread path. The `trigger_gc` fallback is exercised by any test that triggers GC with a worker-mode `CoreWorker`.

For the latency regression: A/B benchmark SGLang `SchedulerActor` with `--use-ray` at high request rates before and after; acceptance criteria are mean E2E within 5% of the non-Ray backend and P99 ITL within 5% across rates.