### PR TITLE
[Data] Remove `op_resource_reservation_enabled` kill-switch

### DIFF
--- a/python/ray/data/_internal/execution/__init__.py
+++ b/python/ray/data/_internal/execution/__init__.py
@@ -27,11 +27,6 @@ def create_resource_allocator(
 ) -> Optional["OpResourceAllocator"]:
     """Creates ``OpResourceAllocator`` instances.``"""
 
-    if not data_context.op_resource_reservation_enabled:
-        # This is a historical kill-switch to disable resource allocator, that
-        # will be soon deprecated and removed.
-        return None
-
     logger.debug(
         f"Using op resource allocator version: "
         f"{DEFAULT_USE_OP_RESOURCE_ALLOCATOR_VERSION!r}"

--- a/python/ray/data/_internal/execution/callbacks/resource_allocator_prometheus_callback.py
+++ b/python/ray/data/_internal/execution/callbacks/resource_allocator_prometheus_callback.py
@@ -105,11 +105,10 @@ class ResourceAllocatorPrometheusCallback(ExecutionCallback):
         tags: Dict[str, str],
         resource_manager: ResourceManager,
     ):
-        if resource_manager.op_resource_allocator_enabled():
-            resource_allocator = resource_manager.op_resource_allocator
-            output_budget_bytes = resource_allocator.get_output_budget(op)
-            if output_budget_bytes is not None:
-                if math.isinf(output_budget_bytes):
-                    # Convert inf to -1 to represent unlimited bytes to read
-                    output_budget_bytes = -1
-                self._max_bytes_to_read_gauge.set(output_budget_bytes, tags=tags)
+        resource_allocator = resource_manager.op_resource_allocator
+        output_budget_bytes = resource_allocator.get_output_budget(op)
+        if output_budget_bytes is not None:
+            if math.isinf(output_budget_bytes):
+                # Convert inf to -1 to represent unlimited bytes to read
+                output_budget_bytes = -1
+            self._max_bytes_to_read_gauge.set(output_budget_bytes, tags=tags)

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -57,17 +57,9 @@ class ResourceManager:
     # The interval in seconds at which the global resource limits are refreshed.
     GLOBAL_LIMITS_UPDATE_INTERVAL_S = 1
 
-    # The fraction of the object store capacity that will be used as the default object
-    # store memory limit for the streaming executor,
-    # when `OpResourceAllocator` is enabled.
     DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION = env_float(
         "RAY_DATA_OBJECT_STORE_MEMORY_LIMIT_FRACTION", 0.5
     )
-
-    # The fraction of the object store capacity that will be used as the default object
-    # store memory limit for the streaming executor,
-    # when `OpResourceAllocator` is not enabled.
-    DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION_NO_RESERVATION = 0.25
 
     def __init__(
         self,
@@ -105,18 +97,14 @@ class ResourceManager:
         # operator's output usage.
         self._output_operator = self._terminal_operator_from_topology(topology)
 
-        self._op_resource_allocator: Optional[
-            "OpResourceAllocator"
-        ] = create_resource_allocator(self, data_context)
+        self._op_resource_allocator: "OpResourceAllocator" = create_resource_allocator(
+            self, data_context
+        )
 
         self._object_store_memory_limit_fraction = (
             data_context.override_object_store_memory_limit_fraction
             if data_context.override_object_store_memory_limit_fraction is not None
-            else (
-                self.DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION
-                if self.op_resource_allocator_enabled()
-                else self.DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION_NO_RESERVATION
-            )
+            else self.DEFAULT_OBJECT_STORE_MEMORY_LIMIT_FRACTION
         )
 
     def _terminal_operator_from_topology(
@@ -253,8 +241,7 @@ class ResourceManager:
             # DatasetStats and updated on the Ray Data dashboard.
             op._metrics.obj_store_mem_used = op_usage.object_store_memory
 
-        if self._op_resource_allocator is not None:
-            self._update_allocated_budgets()
+        self._update_allocated_budgets()
 
     def _update_allocated_budgets(self):
         completed_ops_usage = self._get_completed_ops_usage()
@@ -377,52 +364,42 @@ class ResourceManager:
                 f" (in={memory_string(self.get_mem_op_internal(op))},"
                 f"out={memory_string(self.get_mem_op_outputs(op))})"
             )
-            if self._op_resource_allocator is not None:
-                allocation = self._op_resource_allocator.get_allocation(op)
-                if allocation:
-                    usage_str += f", alloc=(cpu={allocation.cpu:.1f}"
-                    usage_str += f",gpu={allocation.gpu:.1f}"
-                    usage_str += f",obj_store={allocation.object_store_memory_str()})"
+            allocation = self._op_resource_allocator.get_allocation(op)
+            if allocation:
+                usage_str += f", alloc=(cpu={allocation.cpu:.1f}"
+                usage_str += f",gpu={allocation.gpu:.1f}"
+                usage_str += f",obj_store={allocation.object_store_memory_str()})"
 
-                budget = self._op_resource_allocator.get_budget(op)
-                if budget:
-                    usage_str += f", budget=(cpu={budget.cpu:.1f}"
-                    usage_str += f",gpu={budget.gpu:.1f}"
-                    usage_str += f",obj_store={budget.object_store_memory_str()}"
+            budget = self._op_resource_allocator.get_budget(op)
+            if budget:
+                usage_str += f", budget=(cpu={budget.cpu:.1f}"
+                usage_str += f",gpu={budget.gpu:.1f}"
+                usage_str += f",obj_store={budget.object_store_memory_str()}"
 
-                    # Remaining memory budget for producing new task outputs.
-                    if isinstance(
-                        self._op_resource_allocator, ReservationOpResourceAllocator
-                    ):
-                        reserved_for_output = memory_string(
-                            self._op_resource_allocator._output_budgets.get(op, 0)
-                        )
-                        usage_str += f",out={reserved_for_output})"
+                # Remaining memory budget for producing new task outputs.
+                if isinstance(
+                    self._op_resource_allocator, ReservationOpResourceAllocator
+                ):
+                    reserved_for_output = memory_string(
+                        self._op_resource_allocator._output_budgets.get(op, 0)
+                    )
+                    usage_str += f",out={reserved_for_output})"
 
         return usage_str
-
-    def op_resource_allocator_enabled(self) -> bool:
-        """Return whether OpResourceAllocator is enabled."""
-        return self._op_resource_allocator is not None
 
     @property
     def op_resource_allocator(self) -> "OpResourceAllocator":
         """Return the OpResourceAllocator."""
-        assert self._op_resource_allocator is not None
         return self._op_resource_allocator
 
     def get_budget(self, op: PhysicalOperator) -> Optional[ExecutionResources]:
         """Return the budget for the given operator, or None if the operator
         has unlimited budget."""
-        if self._op_resource_allocator is None:
-            return None
         return self._op_resource_allocator.get_budget(op)
 
     def get_allocation(self, op: PhysicalOperator) -> Optional[ExecutionResources]:
         """Return the allocation of the given operator, or None if the operator
         doesn't have a designated allocation."""
-        if self._op_resource_allocator is None:
-            return None
         return self._op_resource_allocator.get_allocation(op)
 
     def is_op_eligible(self, op: PhysicalOperator) -> bool:
@@ -468,9 +445,7 @@ class ResourceManager:
                 yield from self.get_downstream_eligible_ops(next_op)
 
     def max_task_output_bytes_to_read(self, op: PhysicalOperator) -> Optional[int]:
-        if self._op_resource_allocator is not None:
-            return self._op_resource_allocator.max_task_output_bytes_to_read(op)
-        return None
+        return self._op_resource_allocator.max_task_output_bytes_to_read(op)
 
     def _get_completed_ops_usage(self) -> ExecutionResources:
         """

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -227,10 +227,6 @@ DEFAULT_ACTOR_INIT_RETRY_ON_ERRORS = False
 
 DEFAULT_ACTOR_INIT_MAX_RETRIES = 3
 
-DEFAULT_ENABLE_OP_RESOURCE_RESERVATION = env_bool(
-    "RAY_DATA_ENABLE_OP_RESOURCE_RESERVATION", True
-)
-
 DEFAULT_OP_RESOURCE_RESERVATION_RATIO = float(
     os.environ.get("RAY_DATA_OP_RESERVATION_RATIO", "0.5")
 )
@@ -553,8 +549,6 @@ class DataContext:
         actor_init_max_retries: Maximum number of consecutive retries for actor
             initialization failures. The counter resets when an actor successfully
             initializes. Default is 3. Set to -1 for infinite retries.
-        op_resource_reservation_enabled: Whether to enable resource reservation for
-            operators to prevent resource contention.
         op_resource_reservation_ratio: The ratio of the total resources to reserve for
             each operator.
         max_errored_blocks: Max number of blocks that are allowed to have errors,
@@ -756,7 +750,6 @@ class DataContext:
     ] = DEFAULT_ACTOR_TASK_RETRY_ON_ERRORS
     actor_init_retry_on_errors: bool = DEFAULT_ACTOR_INIT_RETRY_ON_ERRORS
     actor_init_max_retries: int = DEFAULT_ACTOR_INIT_MAX_RETRIES
-    op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
     op_resource_reservation_ratio: float = DEFAULT_OP_RESOURCE_RESERVATION_RATIO
     max_errored_blocks: int = DEFAULT_MAX_ERRORED_BLOCKS
     log_internal_stack_trace_to_stdout: bool = (

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -40,7 +40,6 @@ class TestReservationOpResourceAllocator:
             yield
 
     def test_basic(self, restore_data_context):
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -81,7 +80,6 @@ class TestReservationOpResourceAllocator:
             side_effect=mock_get_global_limits
         )
 
-        assert resource_manager.op_resource_allocator_enabled()
         allocator = resource_manager._op_resource_allocator
         assert isinstance(allocator, ReservationOpResourceAllocator)
 
@@ -208,7 +206,6 @@ class TestReservationOpResourceAllocator:
     def test_reserve_min_resource_requirements(self, restore_data_context):
         """Test that we'll reserve at least min_resource_requirements
         for each operator."""
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         global_limits = ExecutionResources(cpu=7, gpu=0, object_store_memory=800)
@@ -361,7 +358,6 @@ class TestReservationOpResourceAllocator:
         We cap op_shared so that total allocation <= max_resource_usage.
         Excess shared resources should remain available for other operators.
         """
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -439,7 +435,6 @@ class TestReservationOpResourceAllocator:
 
     def test_budget_capped_by_max_resource_usage_all_capped(self, restore_data_context):
         """Test when all operators are capped, remaining shared resources are not given."""
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -496,7 +491,6 @@ class TestReservationOpResourceAllocator:
 
     def test_only_handle_eligible_ops(self, restore_data_context):
         """Test that we only handle non-completed map ops."""
-        DataContext.get_current().op_resource_reservation_enabled = True
 
         input = make_ref_bundles([[x] for x in range(1)])
         o1 = InputDataBuffer(DataContext.get_current(), input)
@@ -517,7 +511,6 @@ class TestReservationOpResourceAllocator:
             return_value=ExecutionResources.zero()
         )
 
-        assert resource_manager.op_resource_allocator_enabled()
         allocator = resource_manager._op_resource_allocator
         assert isinstance(allocator, ReservationOpResourceAllocator)
 
@@ -541,7 +534,6 @@ class TestReservationOpResourceAllocator:
         With unified allocation (no GPU special-casing), GPU flows through
         the normal shared allocation path just like CPU and memory.
         """
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -590,7 +582,6 @@ class TestReservationOpResourceAllocator:
 
     def test_multiple_gpu_operators(self, restore_data_context):
         """Test GPU allocation for multiple GPU operators."""
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -684,7 +675,6 @@ class TestReservationOpResourceAllocator:
         This is a regression test for the bug where ActorPoolStrategy(min_size=1, max_size=None)
         with GPU actors would not get any GPU budget, preventing autoscaling.
         """
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -743,7 +733,6 @@ class TestReservationOpResourceAllocator:
         actors doesn't need new GPUs). The fix uses min_scheduling_resources()
         which returns the per-actor GPU requirement.
         """
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         # Build pipeline: Input -> Read -> Preprocess -> Infer(GPU) -> Write
@@ -805,7 +794,6 @@ class TestReservationOpResourceAllocator:
 
         With unified allocation, bounded operator is capped, unbounded gets remaining.
         """
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -866,7 +854,6 @@ class TestReservationOpResourceAllocator:
         Non-GPU operators (Read, Write) should have 0 GPUs reserved, ensuring
         all GPUs are available for GPU operators (Infer1, Infer2).
         """
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -950,7 +937,6 @@ class TestReservationOpResourceAllocator:
 
     def test_reservation_accounts_for_completed_ops(self, restore_data_context):
         """Test that resource reservation properly accounts for completed ops."""
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])
@@ -1038,7 +1024,6 @@ class TestReservationOpResourceAllocator:
                 v
                 o8 (ZipOperator) <-- o7 (InputDataBuffer, completed)
         """
-        DataContext.get_current().op_resource_reservation_enabled = True
         DataContext.get_current().op_resource_reservation_ratio = 0.5
 
         o1 = InputDataBuffer(DataContext.get_current(), [])

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -70,7 +70,6 @@ def mock_resource_manager(
     return MagicMock(
         get_global_limits=MagicMock(return_value=global_limits),
         get_global_usage=MagicMock(return_value=global_usage),
-        op_resource_allocator_enabled=MagicMock(return_value=True),
     )
 
 


### PR DESCRIPTION
This PR remove the `op_resource_reservation_enabled` flag, which was a historical kill-switch for the resource allocator that defaulted to `True`. Since it's always on, the flag and its associated env var (`RAY_DATA_ENABLE_OP_RESOURCE_RESERVATION`) are dead code.