### PR TITLE
[core] Rename MarkPreparePhaseStarted to MarkPrepareRequestPending

### DIFF
--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -147,7 +147,7 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
     const auto &node_id = entry.first;
     const auto &bundles_per_node = entry.second;
     for (const auto &bundle : bundles_per_node) {
-      lease_status_tracker->MarkPreparePhaseStarted(node_id, bundle);
+      lease_status_tracker->MarkPrepareRequestPending(node_id, bundle);
     }
 
     // TODO(sang): The callback might not be called at all if nodes are dead. We should
@@ -864,7 +864,7 @@ std::shared_ptr<LeaseStatusTracker> LeaseStatusTracker::CreatePrepared(
   for (const auto &bundle : prepared_bundles) {
     const BundleID bundle_id = bundle->BundleId();
     const NodeID node_id = schedule_map[bundle_id];
-    tracker->MarkPreparePhaseStarted(node_id, bundle);
+    tracker->MarkPrepareRequestPending(node_id, bundle);
     tracker->MarkPrepareRequestReturned(node_id, bundle, Status::OK());
   }
 
@@ -873,7 +873,7 @@ std::shared_ptr<LeaseStatusTracker> LeaseStatusTracker::CreatePrepared(
   return tracker;
 }
 
-bool LeaseStatusTracker::MarkPreparePhaseStarted(
+bool LeaseStatusTracker::MarkPrepareRequestPending(
     const NodeID &node_id, const std::shared_ptr<const BundleSpecification> &bundle) {
   const auto &bundle_id = bundle->BundleId();
   return node_to_bundles_when_preparing_[node_id].emplace(bundle_id).second;

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -141,8 +141,8 @@ class LeaseStatusTracker {
   /// \param node_id Id of a node where prepare request is sent.
   /// \param bundle Bundle specification the node is supposed to prepare.
   /// \return False if the prepare phase was already started. True otherwise.
-  bool MarkPreparePhaseStarted(const NodeID &node_id,
-                               const std::shared_ptr<const BundleSpecification> &bundle);
+  bool MarkPrepareRequestPending(
+      const NodeID &node_id, const std::shared_ptr<const BundleSpecification> &bundle);
 
   /// Indicate the tracker that all prepare requests are returned.
   ///


### PR DESCRIPTION
## Description
This PR renames `MarkPreparePhaseStarted` to `MarkPrepareRequestPending`. 

While the original name `MarkPreparePhaseStarted` sounds like a one-time state transition, the function actually registers a specific bundle to a node in the `node_to_bundles_when_preparing_` ledger. The new name `MarkPrepareRequestPending` accurately describes its behavior

```c++
bool LeaseStatusTracker::MarkPrepareRequestPending(
    const NodeID &node_id, const std::shared_ptr<const BundleSpecification> &bundle) {
  const auto &bundle_id = bundle->BundleId();
  return node_to_bundles_when_preparing_[node_id].emplace(bundle_id).second;
}
```

The new name also align to the API naming convention
* **Prepare Phase:**
    * `MarkPrepareRequestPending`
    * `MarkPrepareRequestReturned`
* **Commit Phase:**
    * `MarkCommitPhaseStarted`
    * `MarkCommitRequestReturned`

*Note: `MarkCommitPhaseStarted` is intentionally left unchanged because its name accurately describes its behavior (performing a one-time transition of the leasing state to `COMMITTING`).*