### PR TITLE
[Serve] Restore safe max_concurrency default for deployment actors

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -244,6 +244,15 @@ CONTROLLER_MAX_CONCURRENCY = get_env_int_positive(
     "RAY_SERVE_CONTROLLER_MAX_CONCURRENCY", 15_000
 )
 
+#: Default max_concurrency for sync deployment actors. Each unit of
+#: max_concurrency on a sync actor materializes as one OS thread via the
+#: C++ BoundedExecutor (#62661), so this caps the thread count at a safe
+#: ceiling while still allowing enough concurrent calls to avoid the
+#: default-of-1 serialization regression from #62708.
+DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY = get_env_int_positive(
+    "RAY_SERVE_DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY", 100
+)
+
 DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S = 20
 DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S = 2
 DEFAULT_HEALTH_CHECK_PERIOD_S = 10

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -253,6 +253,16 @@ DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY = get_env_int_positive(
     "RAY_SERVE_DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY", 100
 )
 
+#: Default max_concurrency for async deployment actors. Async actors use
+#: lightweight asyncio fibers (no per-unit OS thread cost) so this can
+#: stay large enough to absorb deployment-actor fan-in. Kept as a
+#: dedicated knob — separate from CONTROLLER_MAX_CONCURRENCY — so tuning
+#: the controller's concurrency does not silently change deployment-actor
+#: behaviour and vice versa.
+DEFAULT_ASYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY = get_env_int_positive(
+    "RAY_SERVE_DEFAULT_ASYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY", 15_000
+)
+
 DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S = 20
 DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S = 2
 DEFAULT_HEALTH_CHECK_PERIOD_S = 10

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 import ray
 from ray import ObjectRef, cloudpickle
 from ray._common import ray_constants
+from ray._private.async_compat import has_async_methods
 from ray.actor import ActorHandle
 from ray.exceptions import (
     RayActorError,
@@ -44,6 +45,7 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.config import DeploymentConfig, GangSchedulingConfig
 from ray.serve._private.constants import (
+    CONTROLLER_MAX_CONCURRENCY,
     DEFAULT_LATENCY_BUCKET_MS,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_PERIOD_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_TIMEOUT_S,
@@ -233,6 +235,23 @@ class DeploymentActorWrapper:
             # Serve recreates deployment actors after failed health checks instead
             # of relying on Ray actor restarts.
             actor_options["max_restarts"] = 0
+            # Choose a safe default for max_concurrency when the user hasn't
+            # specified one. Sync deployment actors materialize max_concurrency
+            # as OS threads via the C++ BoundedExecutor, so unbounded values
+            # (e.g. CONTROLLER_MAX_CONCURRENCY=15000) crash workers (#62661).
+            # Without any default, sync actors fall back to Ray Core's default
+            # of 1, which silently serializes deployment-actor calls (#62708).
+            # Async actors use lightweight fibers and can keep the larger cap.
+            if "max_concurrency" not in actor_options:
+                try:
+                    user_cls = actor_cls.__ray_metadata__.modified_class
+                except AttributeError:
+                    user_cls = actor_cls
+                actor_options["max_concurrency"] = (
+                    CONTROLLER_MAX_CONCURRENCY
+                    if has_async_methods(user_cls)
+                    else 100
+                )
             self._handle = actor_cls.options(
                 name=self._actor_name,
                 namespace=SERVE_NAMESPACE,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -47,6 +47,7 @@ from ray.serve._private.config import DeploymentConfig, GangSchedulingConfig
 from ray.serve._private.constants import (
     CONTROLLER_MAX_CONCURRENCY,
     DEFAULT_LATENCY_BUCKET_MS,
+    DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_PERIOD_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_TIMEOUT_S,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
@@ -250,7 +251,7 @@ class DeploymentActorWrapper:
                 actor_options["max_concurrency"] = (
                     CONTROLLER_MAX_CONCURRENCY
                     if has_async_methods(user_cls)
-                    else 100
+                    else DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY
                 )
             self._handle = actor_cls.options(
                 name=self._actor_name,

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -45,7 +45,7 @@ from ray.serve._private.common import (
 )
 from ray.serve._private.config import DeploymentConfig, GangSchedulingConfig
 from ray.serve._private.constants import (
-    CONTROLLER_MAX_CONCURRENCY,
+    DEFAULT_ASYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY,
     DEFAULT_LATENCY_BUCKET_MS,
     DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY,
     DEPLOYMENT_ACTOR_HEALTH_CHECK_PERIOD_S,
@@ -239,17 +239,19 @@ class DeploymentActorWrapper:
             # Choose a safe default for max_concurrency when the user hasn't
             # specified one. Sync deployment actors materialize max_concurrency
             # as OS threads via the C++ BoundedExecutor, so unbounded values
-            # (e.g. CONTROLLER_MAX_CONCURRENCY=15000) crash workers (#62661).
+            # crash workers (#62661); use a safe sync-actor-specific default.
             # Without any default, sync actors fall back to Ray Core's default
             # of 1, which silently serializes deployment-actor calls (#62708).
-            # Async actors use lightweight fibers and can keep the larger cap.
+            # Async actors use lightweight fibers and get their own constant
+            # so deployment-actor concurrency is not coupled to the
+            # controller-specific CONTROLLER_MAX_CONCURRENCY env var.
             if "max_concurrency" not in actor_options:
                 try:
                     user_cls = actor_cls.__ray_metadata__.modified_class
                 except AttributeError:
                     user_cls = actor_cls
                 actor_options["max_concurrency"] = (
-                    CONTROLLER_MAX_CONCURRENCY
+                    DEFAULT_ASYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY
                     if has_async_methods(user_cls)
                     else DEFAULT_SYNC_DEPLOYMENT_ACTOR_MAX_CONCURRENCY
                 )


### PR DESCRIPTION
## Description

Fixes #62708.

#62661 fixed the 15K-thread crash in deployment actor creation by removing `actor_options.setdefault("max_concurrency", CONTROLLER_MAX_CONCURRENCY)`. With no replacement default, sync deployment actors fall through to Ray Core's `max_concurrency=1`, silently serializing deployment-actor calls — the regression described in #62708 and acknowledged as "Sync classes: cap at max_concurrency=100" in #62661's commit message.

This restores a safe default for both actor shapes:

- Async deployment actor classes (lightweight fibers, no OS-thread cost) keep `CONTROLLER_MAX_CONCURRENCY=15000`, matching the pre-#62661 behaviour.
- Sync deployment actor classes (each `max_concurrency` unit materializes as an OS thread via `BoundedExecutor`) get `100`, small enough to avoid the thread-explosion crash and large enough to handle typical deployment-actor fan-in.

User-supplied `max_concurrency` in `actor_options` continues to take precedence via the `if "max_concurrency" not in actor_options` guard, so any caller that has already configured a value is unaffected.

## Related issues
Fixes #62708. Follow-up to #62661.

## Additional information

Async detection uses the existing `ray._private.async_compat.has_async_methods()` helper. `actor_cls` is a `ray.remote`-wrapped `ActorClass`; the user class is reached via the standard `__ray_metadata__.modified_class` attribute (with a graceful fallback to `actor_cls` itself if the attribute is not present, e.g. for future test shims).
