### PR TITLE
[core] Remove deprecation warning for runtime_env container

### DIFF
--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -391,12 +391,6 @@ class RuntimeEnv(dict):
                     f"Specified fields: {invalid_keys}"
                 )
 
-            logger.warning(
-                "The `container` runtime environment field is DEPRECATED and will be "
-                "removed after July 31, 2025. Use `image_uri` instead. See "
-                "https://docs.ray.io/en/latest/serve/advanced-guides/multi-app-container.html."  # noqa
-            )
-
         if self.get("image_uri"):
             image_uri_plugin_cls = get_image_uri_plugin_cls()
             invalid_keys = (


### PR DESCRIPTION
We've had a couple users mention the deprecation warning for the runtime_env container option and the fact that not all functionality like providing container run arguments is in place for the new image_uri option. Since we've already passed the deprecation date by a long margin, and it's unlikely we'll provide new options for image_uri in the near term, the deprecation warning should be removed and the container option will remain as a supported option. 