### PR TITLE
[RLlib] Stop clearing EMA value after reduce

### DIFF
--- a/rllib/utils/metrics/stats/ema.py
+++ b/rllib/utils/metrics/stats/ema.py
@@ -216,7 +216,13 @@ class EmaStats(StatsBase):
         if torch and isinstance(value, torch.Tensor):
             value = single_value_to_cpu(value)
 
-        self._value = np.nan
+        # Do NOT reset self._value to NaN here.  Unlike SumStats (where
+        # clearing prevents double-counting), the exponential moving
+        # average must be continuous across reduce() calls so that the
+        # running average carries over between training iterations.
+        # Resetting to NaN restarts the EMA from scratch every iteration,
+        # producing noisy saw-tooth plots instead of a smooth trend.
+        # See #62384.
 
         if compile:
             return value


### PR DESCRIPTION
Fixes #62384.

## Problem

`EmaStats.reduce()` resets `self._value = np.nan` after extracting and returning the current value. This restarts the exponential moving average from scratch on every training iteration, producing noisy saw-tooth plots instead of a smooth trend.

The reporter illustrates this clearly: with a capture metric logged as 0/1 across episodes, an EMA with coefficient 0.1 should produce a smooth curve like `[0.271, 0.326, 0.455, 0.497]`. But with the NaN reset, each iteration starts fresh: `[0.271, 0.756, 0.263, 0.819]` — defeating the purpose of a moving average.

## Root Cause

The clear was added in #56838 (Ray 2.53 metrics rewrite). For `SumStats`, clearing after reduce prevents double-counting — you want per-iteration sums. But for `EmaStats`, the running state *must* carry over between `reduce()` calls: that's the entire definition of an exponential moving average.

## Fix

Remove the `self._value = np.nan` line from `EmaStats.reduce()`. The `_values_to_merge` list is still cleared (line 212), so new values logged in the next iteration are processed correctly. The EMA simply continues from where it left off instead of restarting.

```python
# Before:
self._value = np.nan  # restarts EMA every iteration

# After: (removed)
# EMA carries over between iterations
```

## Impact

- Custom boolean/sparse metrics (like the reporter's "captured" metric) now produce smooth EMA curves instead of saw-tooth noise
- Matches the behavior users expect from an exponential moving average
- Matches Ray <= 2.52 behavior
- `SumStats` and other Stats subclasses are unaffected — they have their own `reduce()` implementations