### PR TITLE
[release test] chunk release_tests.json uploads under Buildkite 500-job limit

### DIFF
--- a/.buildkite/release/custom-image-build-and-test-init.sh
+++ b/.buildkite/release/custom-image-build-and-test-init.sh
@@ -66,4 +66,15 @@ BUILD_WORKSPACE_DIRECTORY="${PWD}" bazel-bin/release/custom_image_build_and_test
   --test-jobs-output-file .buildkite/release/release_tests.json \
   --rayci-select-output-file /tmp/rayci_select.txt
 
-buildkite-agent pipeline upload .buildkite/release/release_tests.json
+# release_tests_*.json are chunked to stay under Buildkite's per-upload job
+# limit; upload each chunk in order so inter-step dependencies resolve.
+i=0
+while [[ -f ".buildkite/release/release_tests_${i}.json" ]]; do
+    echo "Uploading .buildkite/release/release_tests_${i}.json"
+    buildkite-agent pipeline upload ".buildkite/release/release_tests_${i}.json"
+    i=$((i + 1))
+done
+if [[ $i -eq 0 ]]; then
+    echo "No release test chunks found at .buildkite/release/release_tests_*.json" >&2
+    exit 1
+fi

--- a/release/ray_release/scripts/custom_image_build_and_test_init.py
+++ b/release/ray_release/scripts/custom_image_build_and_test_init.py
@@ -1,9 +1,10 @@
+import glob
 import json
 import os
 import shutil
 import sys
 from pathlib import Path
-from typing import Tuple
+from typing import Any, Dict, List, Tuple
 
 import click
 
@@ -29,6 +30,50 @@ from ray_release.logger import logger
 
 _bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
+
+# Buildkite rejects single pipeline uploads above an organization limit (500
+# at time of writing). We split below that with headroom so future growth
+# or step multipliers we don't account for don't trip the limit again.
+DEFAULT_MAX_JOBS_PER_UPLOAD = 450
+
+
+def _group_job_count(group: Dict[str, Any]) -> int:
+    """Count Buildkite jobs for a group step, including the group itself."""
+    total = 1
+    for step in group.get("steps", []):
+        if isinstance(step, dict):
+            parallelism = step.get("parallelism")
+            if isinstance(parallelism, int) and parallelism > 1:
+                total += parallelism
+                continue
+        total += 1
+    return total
+
+
+def _split_into_batches(
+    steps: List[Dict[str, Any]], max_jobs: int
+) -> List[List[Dict[str, Any]]]:
+    """Greedy-pack top-level group steps into batches of <= max_jobs.
+
+    Groups are atomic: we never split a single group across batches, so if
+    any group alone exceeds max_jobs the caller must split that group.
+    """
+    batches: List[List[Dict[str, Any]]] = [[]]
+    current_count = 0
+    for group in steps:
+        n = _group_job_count(group)
+        if n > max_jobs:
+            raise ValueError(
+                f"group {group.get('group', '<unnamed>')!r} has {n} jobs, "
+                f"exceeds the limit of {max_jobs}; split this group into "
+                f"smaller groups"
+            )
+        if current_count + n > max_jobs and batches[-1]:
+            batches.append([])
+            current_count = 0
+        batches[-1].append(group)
+        current_count += n
+    return batches
 
 
 @click.command(
@@ -88,7 +133,21 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
 @click.option(
     "--test-jobs-output-file",
     type=str,
-    help="The output file for the test jobs json file",
+    help=(
+        "Base path for the test jobs JSON output. The actual output files are "
+        "chunked as <stem>_0.json, <stem>_1.json, ... to stay under the "
+        "Buildkite per-upload job limit; callers should upload each chunk in "
+        "order."
+    ),
+)
+@click.option(
+    "--max-jobs-per-upload",
+    default=DEFAULT_MAX_JOBS_PER_UPLOAD,
+    type=int,
+    help=(
+        "Maximum Buildkite jobs per output chunk file. Counts each group as 1 "
+        "job plus its steps, with `parallelism: N` steps expanding to N jobs."
+    ),
 )
 @click.option(
     "--rayci-select-output-file",
@@ -105,6 +164,7 @@ def main(
     run_per_test: int = 1,
     custom_build_jobs_output_file: str = None,
     test_jobs_output_file: str = None,
+    max_jobs_per_upload: int = DEFAULT_MAX_JOBS_PER_UPLOAD,
     rayci_select_output_file: str = None,
 ):
     global_config_file = os.path.join(
@@ -212,11 +272,23 @@ def main(
 
         with open(os.path.join(PIPELINE_ARTIFACT_PATH, "pipeline.json"), "wt") as fp:
             json.dump(steps, fp)
-        with open(
-            os.path.join(_bazel_workspace_dir, test_jobs_output_file),
-            "wt",
-        ) as fp:
-            json.dump(steps, fp)
+
+        batches = _split_into_batches(steps, max_jobs_per_upload)
+        output_stem, output_ext = os.path.splitext(test_jobs_output_file)
+        for stale in glob.glob(
+            os.path.join(_bazel_workspace_dir, f"{output_stem}_*{output_ext}")
+        ):
+            os.remove(stale)
+        for i, batch in enumerate(batches):
+            chunk_path = os.path.join(
+                _bazel_workspace_dir, f"{output_stem}_{i}{output_ext}"
+            )
+            with open(chunk_path, "wt") as fp:
+                json.dump(batch, fp)
+        logger.info(
+            f"Wrote {len(batches)} chunk file(s) for "
+            f"{sum(_group_job_count(g) for g in steps)} total jobs."
+        )
 
         # Only emit RAYCI_SELECT when a filter narrows the test set; an unfiltered
         # run (e.g. full nightly) wants the complete image pipeline.

--- a/release/ray_release/tests/test_custom_image_build_and_test_init.py
+++ b/release/ray_release/tests/test_custom_image_build_and_test_init.py
@@ -15,7 +15,10 @@ from ray_release.custom_byod_build_init_helper import (
     build_short_gpu_map,
     collect_rayci_select_keys,
 )
-from ray_release.scripts.custom_image_build_and_test_init import main
+from ray_release.scripts.custom_image_build_and_test_init import (
+    _split_into_batches,
+    main,
+)
 
 _bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
@@ -81,7 +84,12 @@ def test_custom_image_build_and_test_init(
     ) as f:
         custom_build_jobs = yaml.safe_load(f)
         assert len(custom_build_jobs["steps"]) == 1  # 1 custom build job
-    with open(os.path.join(_bazel_workspace_dir, test_jobs_output_file), "r") as f:
+    with open(
+        os.path.join(
+            _bazel_workspace_dir, f"{os.path.splitext(test_jobs_output_file)[0]}_0.json"
+        ),
+        "r",
+    ) as f:
         test_jobs = json.load(f)
         assert len(test_jobs) == 1  # 1 group
         assert len(test_jobs[0]["steps"]) == 2  # 2 tests
@@ -141,7 +149,12 @@ def test_custom_image_build_and_test_init_with_block_step(
     ) as f:
         custom_build_jobs = yaml.safe_load(f)
         assert len(custom_build_jobs["steps"]) == 1  # 1 custom build job
-    with open(os.path.join(_bazel_workspace_dir, test_jobs_output_file), "r") as f:
+    with open(
+        os.path.join(
+            _bazel_workspace_dir, f"{os.path.splitext(test_jobs_output_file)[0]}_0.json"
+        ),
+        "r",
+    ) as f:
         test_jobs = json.load(f)
         print(test_jobs)
         assert len(test_jobs) == 2  # 2 groups: block and hello_world
@@ -207,7 +220,12 @@ def test_custom_image_build_and_test_init_without_block_step_automatic(
     ) as f:
         custom_build_jobs = yaml.safe_load(f)
         assert len(custom_build_jobs["steps"]) == 1  # 1 custom build job
-    with open(os.path.join(_bazel_workspace_dir, test_jobs_output_file), "r") as f:
+    with open(
+        os.path.join(
+            _bazel_workspace_dir, f"{os.path.splitext(test_jobs_output_file)[0]}_0.json"
+        ),
+        "r",
+    ) as f:
         test_jobs = json.load(f)
         print(test_jobs)
         assert len(test_jobs) == 1  # 1 group: hello_world
@@ -255,6 +273,163 @@ def test_rayci_select_skipped_when_no_filter(
     )
     assert result.exit_code == 0
     assert not os.path.exists(abs_path)
+
+
+def test_split_into_batches_single_batch():
+    """All groups fit under the limit → 1 batch."""
+    steps = [
+        {"group": "a", "steps": [{"label": "1"}, {"label": "2"}]},
+        {"group": "b", "steps": [{"label": "3"}]},
+    ]
+    batches = _split_into_batches(steps, max_jobs=500)
+    assert len(batches) == 1
+    assert batches[0] == steps
+
+
+def test_split_into_batches_multi_batch():
+    """Groups that don't fit together are split across batches."""
+    # Each group counts as 1 + len(steps) jobs (Buildkite counts the group
+    # itself). group a = 1+3 = 4, group b = 1+3 = 4, group c = 1+2 = 3.
+    steps = [
+        {"group": "a", "steps": [{"x": 1}, {"x": 2}, {"x": 3}]},
+        {"group": "b", "steps": [{"x": 4}, {"x": 5}, {"x": 6}]},
+        {"group": "c", "steps": [{"x": 7}, {"x": 8}]},
+    ]
+    batches = _split_into_batches(steps, max_jobs=5)
+    # a alone = 4 jobs, + b (4) would be 8 > 5, so split
+    # batch 0: [a] (4 jobs)
+    # batch 1: [b] (4 jobs)
+    # batch 2: [c] (3 jobs)
+    assert [[g["group"] for g in batch] for batch in batches] == [
+        ["a"],
+        ["b"],
+        ["c"],
+    ]
+
+
+def test_split_into_batches_packs_small_groups():
+    """Small groups are packed into the same batch when they fit."""
+    steps = [
+        {"group": "a", "steps": [{"x": 1}]},  # 2 jobs
+        {"group": "b", "steps": [{"x": 2}]},  # 2 jobs
+        {"group": "c", "steps": [{"x": 3}]},  # 2 jobs
+    ]
+    batches = _split_into_batches(steps, max_jobs=5)
+    # a+b=4 jobs fits; +c=6 > 5, so c goes to batch 1
+    assert [[g["group"] for g in batch] for batch in batches] == [
+        ["a", "b"],
+        ["c"],
+    ]
+
+
+def test_split_into_batches_oversized_group_raises():
+    """A single group exceeding the limit is a user error; raise."""
+    steps = [
+        {"group": "huge", "steps": [{"x": i} for i in range(10)]},  # 11 jobs
+    ]
+    with pytest.raises(ValueError, match="exceeds the limit"):
+        _split_into_batches(steps, max_jobs=5)
+
+
+def test_split_into_batches_counts_parallelism():
+    """A step with parallelism=N counts as N jobs."""
+    steps = [
+        {
+            "group": "a",
+            "steps": [{"parallelism": 4}, {"label": "x"}],
+        },  # 1 + 4 + 1 = 6 jobs
+    ]
+    batches = _split_into_batches(steps, max_jobs=6)
+    assert len(batches) == 1
+    with pytest.raises(ValueError, match="exceeds the limit"):
+        _split_into_batches(steps, max_jobs=5)
+
+
+@patch.dict("os.environ", {"AUTOMATIC": "1"})
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_custom_image_build_and_test_init_writes_indexed_chunk_file(
+    mock_update_from_s3, mock_is_jailed_with_open_issue
+):
+    """Single-batch runs should still write an indexed chunk file (no un-suffixed path)."""
+    runner = CliRunner()
+    custom_build_jobs_output_file = "custom_build_jobs.yaml"
+    test_jobs_output_file = "test_jobs_indexed.json"
+    result = runner.invoke(
+        main,
+        [
+            "--test-collection-file",
+            "release/ray_release/tests/sample_5_tests.yaml",
+            "--global-config",
+            "oss_config.yaml",
+            "--frequency",
+            "nightly",
+            "--run-jailed-tests",
+            "--run-unstable-tests",
+            "--test-filters",
+            "prefix:hello_world",
+            "--custom-build-jobs-output-file",
+            custom_build_jobs_output_file,
+            "--test-jobs-output-file",
+            test_jobs_output_file,
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    # Default max (450) is well above 5 tests, so expect exactly one chunk.
+    assert os.path.exists(
+        os.path.join(_bazel_workspace_dir, "test_jobs_indexed_0.json")
+    )
+    # The un-suffixed path must not exist — callers should glob *_N.json.
+    assert not os.path.exists(os.path.join(_bazel_workspace_dir, test_jobs_output_file))
+
+
+@patch.dict("os.environ", {"AUTOMATIC": "1"})
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_custom_image_build_and_test_init_cleans_stale_chunks(
+    mock_update_from_s3, mock_is_jailed_with_open_issue
+):
+    """Chunks from a previous run must be removed before writing new ones.
+
+    Persistent Buildkite checkouts keep the workspace between runs; a stale
+    release_tests_2.json from a prior invocation would otherwise get picked
+    up by the upload-loop and inject outdated steps into the pipeline.
+    """
+    stale_path = os.path.join(_bazel_workspace_dir, "test_jobs_stale_9.json")
+    with open(stale_path, "wt") as fp:
+        json.dump([{"group": "leftover", "steps": [{"command": "echo stale"}]}], fp)
+    assert os.path.exists(stale_path)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "--test-collection-file",
+            "release/ray_release/tests/sample_5_tests.yaml",
+            "--global-config",
+            "oss_config.yaml",
+            "--frequency",
+            "nightly",
+            "--run-jailed-tests",
+            "--run-unstable-tests",
+            "--test-filters",
+            "prefix:hello_world",
+            "--custom-build-jobs-output-file",
+            "custom_build_jobs.yaml",
+            "--test-jobs-output-file",
+            "test_jobs_stale.json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert not os.path.exists(
+        stale_path
+    ), f"Stale chunk file {stale_path} was not cleaned up"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Buildkite rejects pipeline uploads above an organization-level job limit (500 at time of writing) with "Pipeline upload rejected: The number of jobs in this upload exceeds your organization limit of 500." The release pipeline's release_tests.json has grown past that; the previous "step dependencies not found" failure had been masking it.

custom_image_build_and_test_init now splits the computed steps into batches of at most --max-jobs-per-upload jobs (default 450 for headroom) and writes each batch to .buildkite/release/release_tests_<i>.json. Groups are atomic — a single group that exceeds the limit raises, matching the approach taken in rayci (ray-project/rayci#483, #484). custom-image-build-and-test-init.sh iterates the chunks and uploads each in order so dependencies between steps in different chunks still resolve.

Topic: chunk-release-test-uploads
Signed-off-by: andrew <andrew@anyscale.com>