### PR TITLE
[ci] Fix mismatch between bisect instance-type and runner-queue name

### DIFF
--- a/.buildkite/bisect/config.yml
+++ b/.buildkite/bisect/config.yml
@@ -7,7 +7,7 @@ builder_queues:
   builder: builder_queue_branch
 runner_queues:
   default: runner_queue_small_branch
-  macos: macos-branch
+  macos-arm64: macos-branch-arm64
 buildkite_dirs:
   - .buildkite/bisect
 build_env_keys:


### PR DESCRIPTION
## Description
A mismatch in the `instance_type` and `runner_queues` fields of bisect pipeline rayci configs causes all `bisect` pipeline builds to fail.

## Related issues
None

## Additional information
https://buildkite.com/ray-project/bisect/builds/3673/steps/canvas?sid=019d9d9d-05de-4326-b5dc-d818fbcdc71f&tab=output
