### PR TITLE
[Core] deflake test_task_events_2 by asserting explicit task states

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -220,9 +220,6 @@ python/ray/_private/state_api_test_utils.py
     DOC103: Function `invoke_state_api`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , err_msg: Optional[str], key_suffix: Optional[str], print_result: Optional[bool], state_api_fn: Callable, state_stats: StateAPIStats, verify_cb: Callable]. Arguments in the docstring but not in the function signature: [- kwargs: , - state_api_fn: , - state_stats: , - verify_cb: ].
     DOC201: Function `invoke_state_api` does not have a return section in docstring
     DOC103: Method `StateAPIGeneratorActor.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [apis: List[StateAPICallSpec], call_interval_s: float, print_interval_s: float, print_result: bool, wait_after_stop: bool]. Arguments in the docstring but not in the function signature: [- apis: , - call_interval_s: , - print_interval_s: , - print_result: , - wait_after_stop: ].
-    DOC101: Function `verify_tasks_running_or_terminated`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `verify_tasks_running_or_terminated`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [expect_num_tasks: int].
-    DOC201: Function `verify_tasks_running_or_terminated` does not have a return section in docstring
 --------------------
 python/ray/_private/test_utils.py
     DOC101: Function `start_redis_instance`: Docstring contains fewer arguments than in function signature.

--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -409,7 +409,7 @@ def verify_failed_task(
 
 
 @ray.remote
-class PidActor:
+class ExpectedStateActor:
     def __init__(self):
         self.name_to_expected_state = {}
 

--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -408,16 +408,19 @@ def verify_failed_task(
     return True
 
 
-@ray.remote
-class ExpectedStateActor:
-    def __init__(self):
-        self.name_to_expected_state = {}
+def wait_for_task_states(name_to_state: Dict[str, str], timeout: float = 10) -> None:
+    """
+    Block until every task in ``name_to_state`` is observed in its expected
+    state via the State API, or raise if the timeout expires.
+    """
 
-    def get_expected_states(self):
-        return self.name_to_expected_state
+    def _check():
+        for name, state in name_to_state.items():
+            tasks = list_tasks(filters=[("name", "=", name), ("state", "=", state)])
+            assert len(tasks) == 1, f"{name} not in {state}"
+        return True
 
-    def report_expected_state(self, name, expected_state):
-        self.name_to_expected_state[name] = expected_state
+    test_utils.wait_for_condition(_check, timeout=timeout)
 
 
 def _is_actor_task_running(actor_pid: int, task_name: str):

--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -493,31 +493,6 @@ def _is_actor_task_running(actor_pid: int, task_name: str):
     return False
 
 
-def verify_task_states(expected_states: Dict[str, str], expect_num_tasks: int) -> bool:
-    """
-    Verify that each task's state in the State API matches the expected state.
-
-    Args:
-        expected_states: Dict of task name to expected state.
-        expect_num_tasks: Expected number of entries in ``expected_states``.
-
-    Returns:
-        True when every task's state matches. Raises AssertionError otherwise.
-    """
-    assert len(expected_states) == expect_num_tasks, expected_states
-    for task_name, expected_state in expected_states.items():
-        tasks = list_tasks(detail=True, filters=[("name", "=", task_name)])
-        assert len(tasks) == 1, (
-            f"One unique task with {task_name} should be found. "
-            "Use `options(name=<task_name>)` when creating the task."
-        )
-        task = tasks[0]
-        assert (
-            task["state"] == expected_state
-        ), f"{task_name}: expected {expected_state} but got {task['state']}"
-    return True
-
-
 def verify_schema(state, result_dict: dict, detail: bool = False):
     """
     Verify the schema of the result_dict is the same as the state.

--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -2,7 +2,6 @@ import asyncio
 import concurrent.futures
 import logging
 import pprint
-import sys
 import time
 import traceback
 from collections import defaultdict
@@ -412,13 +411,13 @@ def verify_failed_task(
 @ray.remote
 class PidActor:
     def __init__(self):
-        self.name_to_pid = {}
+        self.name_to_expected_state = {}
 
-    def get_pids(self):
-        return self.name_to_pid
+    def get_expected_states(self):
+        return self.name_to_expected_state
 
-    def report_pid(self, name, pid, state=None):
-        self.name_to_pid[name] = (pid, state)
+    def report_expected_state(self, name, expected_state):
+        self.name_to_expected_state[name] = expected_state
 
 
 def _is_actor_task_running(actor_pid: int, task_name: str):
@@ -491,55 +490,28 @@ def _is_actor_task_running(actor_pid: int, task_name: str):
     return False
 
 
-def verify_tasks_running_or_terminated(
-    task_pids: Dict[str, Tuple[int, Optional[str]]], expect_num_tasks: int
-):
+def verify_task_states(expected_states: Dict[str, str], expect_num_tasks: int) -> bool:
     """
-    Check if the tasks in task_pids are in RUNNING state if pid exists
-    and running the task.
-    If the pid is missing or the task is not running the task, check if the task
-    is marked FAILED or FINISHED.
+    Verify that each task's state in the State API matches the expected state.
 
     Args:
-        task_pids: A dict of task name to (pid, expected terminal state).
+        expected_states: Dict of task name to expected state.
+        expect_num_tasks: Expected number of entries in ``expected_states``.
 
+    Returns:
+        True when every task's state matches. Raises AssertionError otherwise.
     """
-    assert len(task_pids) == expect_num_tasks, task_pids
-    for task_name, pid_and_state in task_pids.items():
+    assert len(expected_states) == expect_num_tasks, expected_states
+    for task_name, expected_state in expected_states.items():
         tasks = list_tasks(detail=True, filters=[("name", "=", task_name)])
         assert len(tasks) == 1, (
             f"One unique task with {task_name} should be found. "
             "Use `options(name=<task_name>)` when creating the task."
         )
         task = tasks[0]
-        pid, expected_state = pid_and_state
-
-        # If it's windows/macos, we don't have a way to check if the process
-        # is actually running the task since the process name is just python,
-        # rather than the actual task name.
-        if sys.platform in ["win32", "darwin"]:
-            if expected_state is not None:
-                assert task["state"] == expected_state, task
-            continue
-        if _is_actor_task_running(pid, task_name):
-            assert (
-                "ray::IDLE" not in task["name"]
-            ), "One should not name it 'IDLE' since it's reserved in Ray"
-            assert task["state"] == "RUNNING", task
-            if expected_state is not None:
-                assert task["state"] == expected_state, task
-        else:
-            # Tasks no longer running.
-            if expected_state is None:
-                assert task["state"] in [
-                    "FAILED",
-                    "FINISHED",
-                ], f"{task_name}: {task['task_id']} = {task['state']}"
-            else:
-                assert (
-                    task["state"] == expected_state
-                ), f"expect {expected_state} but {task['state']} for {task}"
-
+        assert (
+            task["state"] == expected_state
+        ), f"{task_name}: expected {expected_state} but got {task['state']}"
     return True
 
 

--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -408,7 +408,7 @@ def verify_failed_task(
     return True
 
 
-def wait_for_task_states(name_to_state: Dict[str, str], timeout: float = 10) -> None:
+def wait_for_task_states(name_to_state: Dict[str, str], timeout: float = 30) -> None:
     """
     Block until every task in ``name_to_state`` is observed in its expected
     state via the State API, or raise if the timeout expires.

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -16,11 +16,11 @@ from ray._common.test_utils import (
 )
 from ray._private import ray_constants
 from ray._private.state_api_test_utils import (
-    ExpectedStateActor,
     _is_actor_task_running,
     get_state_api_manager,
     verify_failed_task,
     verify_task_states,
+    wait_for_task_states,
 )
 from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
@@ -240,12 +240,10 @@ def test_fault_tolerance_detached_actor(shutdown_only):
     """
     ray.init(_system_config=_SYSTEM_CONFIG)
 
-    state_actor = ExpectedStateActor.remote()
-
     # Check a detached actor's parent task's failure do not
     # affect the actor's task subtree.
     @ray.remote(max_retries=0)
-    def parent_starts_detached_actor(state_actor):
+    def parent_starts_detached_actor():
         @ray.remote
         class DetachedActor:
             def __init__(self):
@@ -256,12 +254,7 @@ def test_fault_tolerance_detached_actor(shutdown_only):
                     await asyncio.sleep(0.1)
                 pass
 
-            async def run(self, state_actor):
-                ray.get(
-                    state_actor.report_expected_state.remote(
-                        "detached-actor-run", "RUNNING"
-                    )
-                )
+            async def run(self):
                 self.running = True
                 await asyncio.sleep(999)
 
@@ -269,7 +262,7 @@ def test_fault_tolerance_detached_actor(shutdown_only):
         a = DetachedActor.options(
             name="detached-actor", lifetime="detached", namespace="test"
         ).remote()
-        a.run.options(name="detached-actor-run").remote(state_actor)
+        a.run.options(name="detached-actor-run").remote()
         ray.get(a.running.remote())
 
         # Enough time for events to be reported to GCS.
@@ -278,23 +271,21 @@ def test_fault_tolerance_detached_actor(shutdown_only):
         os._exit(1)
 
     with pytest.raises(ray.exceptions.WorkerCrashedError):
-        ray.get(parent_starts_detached_actor.remote(state_actor))
+        ray.get(parent_starts_detached_actor.remote())
 
     a = ray.get_actor("detached-actor", namespace="test")
-    expected_states = ray.get(state_actor.get_expected_states.remote())
     wait_for_condition(
         verify_task_states,
-        expected_states=expected_states,
+        expected_states={"detached-actor-run": "RUNNING"},
         expect_num_tasks=1,
     )
 
     a = ray.get_actor("detached-actor", namespace="test")
     ray.kill(a)
 
-    expected_states["detached-actor-run"] = "FAILED"
     wait_for_condition(
         verify_task_states,
-        expected_states=expected_states,
+        expected_states={"detached-actor-run": "FAILED"},
         expect_num_tasks=1,
     )
 
@@ -404,60 +395,36 @@ ray.get(parent.remote())
 
 
 @ray.remote
-def task_finish_child(state_actor):
-    ray.get(state_actor.report_expected_state.remote("task_finish_child", "FINISHED"))
+def task_finish_child():
     pass
 
 
 @ray.remote
-def task_sleep_child(state_actor):
-    ray.get(state_actor.report_expected_state.remote("task_sleep_child", "RUNNING"))
+def task_sleep_child():
     time.sleep(999)
 
 
 @ray.remote
 class ChildActor:
-    def children(self, state_actor):
-        ray.get(state_actor.report_expected_state.remote("children", "RUNNING"))
-        ray.get(task_finish_child.options(name="task_finish_child").remote(state_actor))
-        ray.get(task_sleep_child.options(name="task_sleep_child").remote(state_actor))
+    def children(self):
+        ray.get(task_finish_child.options(name="task_finish_child").remote())
+        ray.get(task_sleep_child.options(name="task_sleep_child").remote())
 
 
 @ray.remote
 class Actor:
-    def fail_parent(self, state_actor):
-        ray.get(state_actor.report_expected_state.remote("fail_parent", "FAILED"))
-        ray.get(task_finish_child.options(name="task_finish_child").remote(state_actor))
-        task_sleep_child.options(name="task_sleep_child").remote(state_actor)
-
-        # Wait til child tasks run.
-        def wait_fn():
-            assert (
-                ray.get(state_actor.get_expected_states.remote()).get(
-                    "task_sleep_child"
-                )
-                is not None
-            )
-            assert (
-                list_tasks(filters=[("name", "=", "task_finish_child")])[0]["state"]
-                == "FINISHED"
-            )
-            return True
-
-        wait_for_condition(wait_fn)
+    def fail_parent(self):
+        ray.get(task_finish_child.options(name="task_finish_child").remote())
+        task_sleep_child.options(name="task_sleep_child").remote()
+        wait_for_task_states(
+            {"task_sleep_child": "RUNNING", "task_finish_child": "FINISHED"}
+        )
         raise ValueError("expected to fail.")
 
-    def child_actor(self, state_actor):
-        ray.get(state_actor.report_expected_state.remote("child_actor", "FAILED"))
+    def child_actor(self):
         a = ChildActor.remote()
-        a.children.options(name="children").remote(state_actor)
-        # Wait til child tasks run.
-        wait_for_condition(
-            lambda: ray.get(state_actor.get_expected_states.remote()).get(
-                "task_sleep_child"
-            )
-            is not None
-        )
+        a.children.options(name="children").remote()
+        wait_for_task_states({"task_sleep_child": "RUNNING"})
         raise ValueError("expected to fail.")
 
     def ready(self):
@@ -467,35 +434,40 @@ class Actor:
 def test_fault_tolerance_actor_tasks_failed(shutdown_only):
     ray.init(_system_config=_SYSTEM_CONFIG)
     # Test actor tasks
-    state_actor = ExpectedStateActor.remote()
     with pytest.raises(ray.exceptions.RayTaskError):
         a = Actor.remote()
         ray.get(a.ready.remote())
-        ray.get(a.fail_parent.options(name="fail_parent").remote(state_actor))
+        ray.get(a.fail_parent.options(name="fail_parent").remote())
 
-    # Wait for all tasks to finish:
-    # 3 = fail_parent + task_finish_child + task_sleep_child
+    expected_states = {
+        "fail_parent": "FAILED",
+        "task_finish_child": "FINISHED",
+        "task_sleep_child": "RUNNING",
+    }
     wait_for_condition(
         verify_task_states,
-        expected_states=ray.get(state_actor.get_expected_states.remote()),
+        expected_states=expected_states,
         expect_num_tasks=3,
     )
 
 
 def test_fault_tolerance_nested_actors_failed(shutdown_only):
     ray.init(_system_config=_SYSTEM_CONFIG)
-    state_actor = ExpectedStateActor.remote()
     # Test nested actor tasks
     with pytest.raises(ray.exceptions.RayTaskError):
         a = Actor.remote()
         ray.get(a.ready.remote())
-        ray.get(a.child_actor.options(name="child_actor").remote(state_actor))
+        ray.get(a.child_actor.options(name="child_actor").remote())
 
-    # Wait for all tasks to finish:
-    # 4 = child_actor + children + task_finish_child + task_sleep_child
+    expected_states = {
+        "child_actor": "FAILED",
+        "children": "RUNNING",
+        "task_finish_child": "FINISHED",
+        "task_sleep_child": "RUNNING",
+    }
     wait_for_condition(
         verify_task_states,
-        expected_states=ray.get(state_actor.get_expected_states.remote()),
+        expected_states=expected_states,
         expect_num_tasks=4,
         timeout=30,
     )
@@ -626,14 +598,11 @@ def test_fault_tolerance_chained_task_fail(
     # TODO(#57203): remove this once task event buffer handles this internally.
     wait_for_aggregator_agent_if_enabled(address, node_id)
 
-    def sleep_or_fail(state_actor=None, exit_type=None):
+    def sleep_or_fail(exit_type=None, wait_for_chain=False):
         if exit_type is None:
             time.sleep(999)
-        # Wait until the children run
-        if state_actor:
-            wait_for_condition(
-                lambda: len(ray.get(state_actor.get_expected_states.remote())) == 3,
-            )
+        if wait_for_chain:
+            wait_for_task_states({"A": "RUNNING", "B": "RUNNING", "C": "RUNNING"})
 
         if exit_type == "exit_kill":
             os._exit(1)
@@ -641,47 +610,42 @@ def test_fault_tolerance_chained_task_fail(
             raise ValueError("Expected to fail")
 
     @ray.remote(max_retries=0)
-    def A(exit_type, state_actor):
-        x = B.remote(state_actor)
-        ray.get(state_actor.report_expected_state.remote("A", "FAILED"))
-        sleep_or_fail(state_actor, exit_type)
+    def A(exit_type):
+        x = B.remote()
+        sleep_or_fail(exit_type, wait_for_chain=True)
         ray.get(x)
 
     @ray.remote(max_retries=0)
-    def B(state_actor):
-        x = C.remote(state_actor)
-        ray.get(state_actor.report_expected_state.remote("B", "RUNNING"))
+    def B():
+        x = C.remote()
         sleep_or_fail()
         ray.get(x)
 
     @ray.remote(max_retries=0)
-    def C(state_actor):
-        ray.get(state_actor.report_expected_state.remote("C", "RUNNING"))
+    def C():
         sleep_or_fail()
 
     @ray.remote(max_restarts=0, max_task_retries=0)
     class Actor:
-        def run(self, state_actor):
+        def run(self):
             with pytest.raises(
                 (ray.exceptions.RayTaskError, ray.exceptions.WorkerCrashedError)
             ):
-                ray.get(A.remote(exit_type=exit_type, state_actor=state_actor))
-
-    state_actor = ExpectedStateActor.remote()
+                ray.get(A.remote(exit_type=exit_type))
 
     if actor_or_normal_tasks == "normal_task":
         with pytest.raises(
             (ray.exceptions.RayTaskError, ray.exceptions.WorkerCrashedError)
         ):
-            ray.get(A.remote(exit_type=exit_type, state_actor=state_actor))
+            ray.get(A.remote(exit_type=exit_type))
     else:
         a = Actor.remote()
-        ray.get(a.run.remote(state_actor=state_actor))
+        ray.get(a.run.remote())
 
-    expected_states = ray.get(state_actor.get_expected_states.remote())
     if exit_type == "exit_kill":
-        expected_states["B"] = "FAILED"
-        expected_states["C"] = "FAILED"
+        expected_states = {"A": "FAILED", "B": "FAILED", "C": "FAILED"}
+    else:
+        expected_states = {"A": "FAILED", "B": "RUNNING", "C": "RUNNING"}
     wait_for_condition(
         verify_task_states,
         expected_states=expected_states,
@@ -755,7 +719,6 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
             self.idx_ = 0
             self.death_list_ = death_list
             self.kill_started = False
-            self.name_to_expected_state = {}
 
         async def start_killing(self):
             self.kill_started = True
@@ -770,12 +733,6 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
 
             to_kill = self.death_list_[self.idx_]
             return to_kill
-
-        async def report_expected_state(self, name, expected_state):
-            self.name_to_expected_state[name] = expected_state
-
-        async def get_expected_states(self):
-            return self.name_to_expected_state
 
         async def all_killed(self):
             while self.idx_ < len(self.death_list_):
@@ -820,18 +777,10 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
     @ray.remote(max_task_retries=0, max_restarts=0)
     class Actor:
         def actor_task(self, my_name, killer, execution_graph):
-            ray.get(
-                killer.report_expected_state.remote(
-                    my_name, expected_state_for(my_name)
-                )
-            )
             run_children(my_name, killer, execution_graph)
 
     @ray.remote(max_retries=0)
     def task(my_name, killer, execution_graph):
-        ray.get(
-            killer.report_expected_state.remote(my_name, expected_state_for(my_name))
-        )
         run_children(my_name, killer, execution_graph)
 
     killer = Killer.remote(death_list)
@@ -871,9 +820,10 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
     ray.get(killer.all_killed.remote())
     print("all killed")
 
+    expected_states = {name: expected_state_for(name) for name in tasks}
     wait_for_condition(
         verify_task_states,
-        expected_states=ray.get(killer.get_expected_states.remote()),
+        expected_states=expected_states,
         expect_num_tasks=len(tasks),
         timeout=30,
         retry_interval_ms=500,

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -16,7 +16,7 @@ from ray._common.test_utils import (
 )
 from ray._private import ray_constants
 from ray._private.state_api_test_utils import (
-    PidActor,
+    ExpectedStateActor,
     _is_actor_task_running,
     get_state_api_manager,
     verify_failed_task,
@@ -240,12 +240,12 @@ def test_fault_tolerance_detached_actor(shutdown_only):
     """
     ray.init(_system_config=_SYSTEM_CONFIG)
 
-    pid_actor = PidActor.remote()
+    state_actor = ExpectedStateActor.remote()
 
     # Check a detached actor's parent task's failure do not
     # affect the actor's task subtree.
     @ray.remote(max_retries=0)
-    def parent_starts_detached_actor(pid_actor):
+    def parent_starts_detached_actor(state_actor):
         @ray.remote
         class DetachedActor:
             def __init__(self):
@@ -256,9 +256,9 @@ def test_fault_tolerance_detached_actor(shutdown_only):
                     await asyncio.sleep(0.1)
                 pass
 
-            async def run(self, pid_actor):
+            async def run(self, state_actor):
                 ray.get(
-                    pid_actor.report_expected_state.remote(
+                    state_actor.report_expected_state.remote(
                         "detached-actor-run", "RUNNING"
                     )
                 )
@@ -269,7 +269,7 @@ def test_fault_tolerance_detached_actor(shutdown_only):
         a = DetachedActor.options(
             name="detached-actor", lifetime="detached", namespace="test"
         ).remote()
-        a.run.options(name="detached-actor-run").remote(pid_actor)
+        a.run.options(name="detached-actor-run").remote(state_actor)
         ray.get(a.running.remote())
 
         # Enough time for events to be reported to GCS.
@@ -278,10 +278,10 @@ def test_fault_tolerance_detached_actor(shutdown_only):
         os._exit(1)
 
     with pytest.raises(ray.exceptions.WorkerCrashedError):
-        ray.get(parent_starts_detached_actor.remote(pid_actor))
+        ray.get(parent_starts_detached_actor.remote(state_actor))
 
     a = ray.get_actor("detached-actor", namespace="test")
-    expected_states = ray.get(pid_actor.get_expected_states.remote())
+    expected_states = ray.get(state_actor.get_expected_states.remote())
     wait_for_condition(
         verify_task_states,
         expected_states=expected_states,
@@ -291,7 +291,6 @@ def test_fault_tolerance_detached_actor(shutdown_only):
     a = ray.get_actor("detached-actor", namespace="test")
     ray.kill(a)
 
-    # Verify the actual process no longer running.
     expected_states["detached-actor-run"] = "FAILED"
     wait_for_condition(
         verify_task_states,
@@ -405,36 +404,38 @@ ray.get(parent.remote())
 
 
 @ray.remote
-def task_finish_child(pid_actor):
-    ray.get(pid_actor.report_expected_state.remote("task_finish_child", "FINISHED"))
+def task_finish_child(state_actor):
+    ray.get(state_actor.report_expected_state.remote("task_finish_child", "FINISHED"))
     pass
 
 
 @ray.remote
-def task_sleep_child(pid_actor):
-    ray.get(pid_actor.report_expected_state.remote("task_sleep_child", "RUNNING"))
+def task_sleep_child(state_actor):
+    ray.get(state_actor.report_expected_state.remote("task_sleep_child", "RUNNING"))
     time.sleep(999)
 
 
 @ray.remote
 class ChildActor:
-    def children(self, pid_actor):
-        ray.get(pid_actor.report_expected_state.remote("children", "RUNNING"))
-        ray.get(task_finish_child.options(name="task_finish_child").remote(pid_actor))
-        ray.get(task_sleep_child.options(name="task_sleep_child").remote(pid_actor))
+    def children(self, state_actor):
+        ray.get(state_actor.report_expected_state.remote("children", "RUNNING"))
+        ray.get(task_finish_child.options(name="task_finish_child").remote(state_actor))
+        ray.get(task_sleep_child.options(name="task_sleep_child").remote(state_actor))
 
 
 @ray.remote
 class Actor:
-    def fail_parent(self, pid_actor):
-        ray.get(pid_actor.report_expected_state.remote("fail_parent", "FAILED"))
-        ray.get(task_finish_child.options(name="task_finish_child").remote(pid_actor))
-        task_sleep_child.options(name="task_sleep_child").remote(pid_actor)
+    def fail_parent(self, state_actor):
+        ray.get(state_actor.report_expected_state.remote("fail_parent", "FAILED"))
+        ray.get(task_finish_child.options(name="task_finish_child").remote(state_actor))
+        task_sleep_child.options(name="task_sleep_child").remote(state_actor)
 
         # Wait til child tasks run.
         def wait_fn():
             assert (
-                ray.get(pid_actor.get_expected_states.remote()).get("task_sleep_child")
+                ray.get(state_actor.get_expected_states.remote()).get(
+                    "task_sleep_child"
+                )
                 is not None
             )
             assert (
@@ -446,13 +447,13 @@ class Actor:
         wait_for_condition(wait_fn)
         raise ValueError("expected to fail.")
 
-    def child_actor(self, pid_actor):
-        ray.get(pid_actor.report_expected_state.remote("child_actor", "FAILED"))
+    def child_actor(self, state_actor):
+        ray.get(state_actor.report_expected_state.remote("child_actor", "FAILED"))
         a = ChildActor.remote()
-        a.children.options(name="children").remote(pid_actor)
+        a.children.options(name="children").remote(state_actor)
         # Wait til child tasks run.
         wait_for_condition(
-            lambda: ray.get(pid_actor.get_expected_states.remote()).get(
+            lambda: ray.get(state_actor.get_expected_states.remote()).get(
                 "task_sleep_child"
             )
             is not None
@@ -466,35 +467,35 @@ class Actor:
 def test_fault_tolerance_actor_tasks_failed(shutdown_only):
     ray.init(_system_config=_SYSTEM_CONFIG)
     # Test actor tasks
-    pid_actor = PidActor.remote()
+    state_actor = ExpectedStateActor.remote()
     with pytest.raises(ray.exceptions.RayTaskError):
         a = Actor.remote()
         ray.get(a.ready.remote())
-        ray.get(a.fail_parent.options(name="fail_parent").remote(pid_actor))
+        ray.get(a.fail_parent.options(name="fail_parent").remote(state_actor))
 
     # Wait for all tasks to finish:
     # 3 = fail_parent + task_finish_child + task_sleep_child
     wait_for_condition(
         verify_task_states,
-        expected_states=ray.get(pid_actor.get_expected_states.remote()),
+        expected_states=ray.get(state_actor.get_expected_states.remote()),
         expect_num_tasks=3,
     )
 
 
 def test_fault_tolerance_nested_actors_failed(shutdown_only):
     ray.init(_system_config=_SYSTEM_CONFIG)
-    pid_actor = PidActor.remote()
+    state_actor = ExpectedStateActor.remote()
     # Test nested actor tasks
     with pytest.raises(ray.exceptions.RayTaskError):
         a = Actor.remote()
         ray.get(a.ready.remote())
-        ray.get(a.child_actor.options(name="child_actor").remote(pid_actor))
+        ray.get(a.child_actor.options(name="child_actor").remote(state_actor))
 
     # Wait for all tasks to finish:
     # 4 = child_actor + children + task_finish_child + task_sleep_child
     wait_for_condition(
         verify_task_states,
-        expected_states=ray.get(pid_actor.get_expected_states.remote()),
+        expected_states=ray.get(state_actor.get_expected_states.remote()),
         expect_num_tasks=4,
         timeout=30,
     )
@@ -625,13 +626,13 @@ def test_fault_tolerance_chained_task_fail(
     # TODO(#57203): remove this once task event buffer handles this internally.
     wait_for_aggregator_agent_if_enabled(address, node_id)
 
-    def sleep_or_fail(pid_actor=None, exit_type=None):
+    def sleep_or_fail(state_actor=None, exit_type=None):
         if exit_type is None:
             time.sleep(999)
         # Wait until the children run
-        if pid_actor:
+        if state_actor:
             wait_for_condition(
-                lambda: len(ray.get(pid_actor.get_expected_states.remote())) == 3,
+                lambda: len(ray.get(state_actor.get_expected_states.remote())) == 3,
             )
 
         if exit_type == "exit_kill":
@@ -640,44 +641,44 @@ def test_fault_tolerance_chained_task_fail(
             raise ValueError("Expected to fail")
 
     @ray.remote(max_retries=0)
-    def A(exit_type, pid_actor):
-        x = B.remote(pid_actor)
-        ray.get(pid_actor.report_expected_state.remote("A", "FAILED"))
-        sleep_or_fail(pid_actor, exit_type)
+    def A(exit_type, state_actor):
+        x = B.remote(state_actor)
+        ray.get(state_actor.report_expected_state.remote("A", "FAILED"))
+        sleep_or_fail(state_actor, exit_type)
         ray.get(x)
 
     @ray.remote(max_retries=0)
-    def B(pid_actor):
-        x = C.remote(pid_actor)
-        ray.get(pid_actor.report_expected_state.remote("B", "RUNNING"))
+    def B(state_actor):
+        x = C.remote(state_actor)
+        ray.get(state_actor.report_expected_state.remote("B", "RUNNING"))
         sleep_or_fail()
         ray.get(x)
 
     @ray.remote(max_retries=0)
-    def C(pid_actor):
-        ray.get(pid_actor.report_expected_state.remote("C", "RUNNING"))
+    def C(state_actor):
+        ray.get(state_actor.report_expected_state.remote("C", "RUNNING"))
         sleep_or_fail()
 
     @ray.remote(max_restarts=0, max_task_retries=0)
     class Actor:
-        def run(self, pid_actor):
+        def run(self, state_actor):
             with pytest.raises(
                 (ray.exceptions.RayTaskError, ray.exceptions.WorkerCrashedError)
             ):
-                ray.get(A.remote(exit_type=exit_type, pid_actor=pid_actor))
+                ray.get(A.remote(exit_type=exit_type, state_actor=state_actor))
 
-    pid_actor = PidActor.remote()
+    state_actor = ExpectedStateActor.remote()
 
     if actor_or_normal_tasks == "normal_task":
         with pytest.raises(
             (ray.exceptions.RayTaskError, ray.exceptions.WorkerCrashedError)
         ):
-            ray.get(A.remote(exit_type=exit_type, pid_actor=pid_actor))
+            ray.get(A.remote(exit_type=exit_type, state_actor=state_actor))
     else:
         a = Actor.remote()
-        ray.get(a.run.remote(pid_actor=pid_actor))
+        ray.get(a.run.remote(state_actor=state_actor))
 
-    expected_states = ray.get(pid_actor.get_expected_states.remote())
+    expected_states = ray.get(state_actor.get_expected_states.remote())
     if exit_type == "exit_kill":
         expected_states["B"] = "FAILED"
         expected_states["C"] = "FAILED"

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -385,11 +385,6 @@ ray.get(parent.remote())
 
 
 @ray.remote
-def task_finish_child():
-    pass
-
-
-@ray.remote
 def task_sleep_child():
     time.sleep(999)
 
@@ -397,18 +392,14 @@ def task_sleep_child():
 @ray.remote
 class ChildActor:
     def children(self):
-        ray.get(task_finish_child.options(name="task_finish_child").remote())
         ray.get(task_sleep_child.options(name="task_sleep_child").remote())
 
 
 @ray.remote
 class Actor:
     def fail_parent(self):
-        ray.get(task_finish_child.options(name="task_finish_child").remote())
         task_sleep_child.options(name="task_sleep_child").remote()
-        wait_for_task_states(
-            {"task_sleep_child": "RUNNING", "task_finish_child": "FINISHED"}
-        )
+        wait_for_task_states({"task_sleep_child": "RUNNING"})
         raise ValueError("expected to fail.")
 
     def child_actor(self):
@@ -428,7 +419,6 @@ def test_fault_tolerance_actor_tasks_failed(shutdown_only):
     wait_for_task_states(
         {
             "fail_parent": "FAILED",
-            "task_finish_child": "FINISHED",
             "task_sleep_child": "RUNNING",
         }
     )
@@ -445,7 +435,6 @@ def test_fault_tolerance_nested_actors_failed(shutdown_only):
         {
             "child_actor": "FAILED",
             "children": "RUNNING",
-            "task_finish_child": "FINISHED",
             "task_sleep_child": "RUNNING",
         },
         timeout=30,

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -19,7 +19,6 @@ from ray._private.state_api_test_utils import (
     _is_actor_task_running,
     get_state_api_manager,
     verify_failed_task,
-    verify_task_states,
     wait_for_task_states,
 )
 from ray._private.test_utils import (
@@ -273,21 +272,12 @@ def test_fault_tolerance_detached_actor(shutdown_only):
     with pytest.raises(ray.exceptions.WorkerCrashedError):
         ray.get(parent_starts_detached_actor.remote())
 
-    a = ray.get_actor("detached-actor", namespace="test")
-    wait_for_condition(
-        verify_task_states,
-        expected_states={"detached-actor-run": "RUNNING"},
-        expect_num_tasks=1,
-    )
+    wait_for_task_states({"detached-actor-run": "RUNNING"})
 
     a = ray.get_actor("detached-actor", namespace="test")
     ray.kill(a)
 
-    wait_for_condition(
-        verify_task_states,
-        expected_states={"detached-actor-run": "FAILED"},
-        expect_num_tasks=1,
-    )
+    wait_for_task_states({"detached-actor-run": "FAILED"})
 
     # Verify failed task marked with expected info.
     wait_for_condition(
@@ -427,27 +417,20 @@ class Actor:
         wait_for_task_states({"task_sleep_child": "RUNNING"})
         raise ValueError("expected to fail.")
 
-    def ready(self):
-        pass
-
 
 def test_fault_tolerance_actor_tasks_failed(shutdown_only):
     ray.init(_system_config=_SYSTEM_CONFIG)
     # Test actor tasks
     with pytest.raises(ray.exceptions.RayTaskError):
         a = Actor.remote()
-        ray.get(a.ready.remote())
         ray.get(a.fail_parent.options(name="fail_parent").remote())
 
-    expected_states = {
-        "fail_parent": "FAILED",
-        "task_finish_child": "FINISHED",
-        "task_sleep_child": "RUNNING",
-    }
-    wait_for_condition(
-        verify_task_states,
-        expected_states=expected_states,
-        expect_num_tasks=3,
+    wait_for_task_states(
+        {
+            "fail_parent": "FAILED",
+            "task_finish_child": "FINISHED",
+            "task_sleep_child": "RUNNING",
+        }
     )
 
 
@@ -456,19 +439,15 @@ def test_fault_tolerance_nested_actors_failed(shutdown_only):
     # Test nested actor tasks
     with pytest.raises(ray.exceptions.RayTaskError):
         a = Actor.remote()
-        ray.get(a.ready.remote())
         ray.get(a.child_actor.options(name="child_actor").remote())
 
-    expected_states = {
-        "child_actor": "FAILED",
-        "children": "RUNNING",
-        "task_finish_child": "FINISHED",
-        "task_sleep_child": "RUNNING",
-    }
-    wait_for_condition(
-        verify_task_states,
-        expected_states=expected_states,
-        expect_num_tasks=4,
+    wait_for_task_states(
+        {
+            "child_actor": "FAILED",
+            "children": "RUNNING",
+            "task_finish_child": "FINISHED",
+            "task_sleep_child": "RUNNING",
+        },
         timeout=30,
     )
 
@@ -646,12 +625,7 @@ def test_fault_tolerance_chained_task_fail(
         expected_states = {"A": "FAILED", "B": "FAILED", "C": "FAILED"}
     else:
         expected_states = {"A": "FAILED", "B": "RUNNING", "C": "RUNNING"}
-    wait_for_condition(
-        verify_task_states,
-        expected_states=expected_states,
-        expect_num_tasks=3,
-        timeout=30,
-    )
+    wait_for_task_states(expected_states, timeout=30)
 
 
 NORMAL_TASK = "normal_task"
@@ -821,13 +795,7 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
     print("all killed")
 
     expected_states = {name: expected_state_for(name) for name in tasks}
-    wait_for_condition(
-        verify_task_states,
-        expected_states=expected_states,
-        expect_num_tasks=len(tasks),
-        timeout=30,
-        retry_interval_ms=500,
-    )
+    wait_for_task_states(expected_states, timeout=30)
 
 
 def check_file(type, task_name, expected_log, expect_no_end=False):

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -385,6 +385,11 @@ ray.get(parent.remote())
 
 
 @ray.remote
+def task_finish_child():
+    pass
+
+
+@ray.remote
 def task_sleep_child():
     time.sleep(999)
 
@@ -392,14 +397,18 @@ def task_sleep_child():
 @ray.remote
 class ChildActor:
     def children(self):
+        ray.get(task_finish_child.options(name="task_finish_child").remote())
         ray.get(task_sleep_child.options(name="task_sleep_child").remote())
 
 
 @ray.remote
 class Actor:
     def fail_parent(self):
+        ray.get(task_finish_child.options(name="task_finish_child").remote())
         task_sleep_child.options(name="task_sleep_child").remote()
-        wait_for_task_states({"task_sleep_child": "RUNNING"})
+        wait_for_task_states(
+            {"task_sleep_child": "RUNNING", "task_finish_child": "FINISHED"}
+        )
         raise ValueError("expected to fail.")
 
     def child_actor(self):
@@ -419,6 +428,7 @@ def test_fault_tolerance_actor_tasks_failed(shutdown_only):
     wait_for_task_states(
         {
             "fail_parent": "FAILED",
+            "task_finish_child": "FINISHED",
             "task_sleep_child": "RUNNING",
         }
     )
@@ -435,9 +445,9 @@ def test_fault_tolerance_nested_actors_failed(shutdown_only):
         {
             "child_actor": "FAILED",
             "children": "RUNNING",
+            "task_finish_child": "FINISHED",
             "task_sleep_child": "RUNNING",
-        },
-        timeout=30,
+        }
     )
 
 
@@ -614,7 +624,7 @@ def test_fault_tolerance_chained_task_fail(
         expected_states = {"A": "FAILED", "B": "FAILED", "C": "FAILED"}
     else:
         expected_states = {"A": "FAILED", "B": "RUNNING", "C": "RUNNING"}
-    wait_for_task_states(expected_states, timeout=30)
+    wait_for_task_states(expected_states)
 
 
 NORMAL_TASK = "normal_task"
@@ -784,7 +794,7 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
     print("all killed")
 
     expected_states = {name: expected_state_for(name) for name in tasks}
-    wait_for_task_states(expected_states, timeout=30)
+    wait_for_task_states(expected_states)
 
 
 def check_file(type, task_name, expected_log, expect_no_end=False):

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -733,6 +733,20 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
     ray.init(_system_config=_SYSTEM_CONFIG)
 
     killed_names = {name for name, _ in death_list}
+    exit_killed_names = {name for name, kind in death_list if kind == "exit_kill"}
+
+    parent_of = {"root": None}
+    for p, cs in execution_graph.items():
+        for _, c in cs:
+            parent_of[c] = p
+
+    def has_exit_killed_ancestor(name):
+        cur = parent_of.get(name)
+        while cur is not None:
+            if cur in exit_killed_names:
+                return True
+            cur = parent_of.get(cur)
+        return False
 
     @ray.remote
     class Killer:
@@ -770,7 +784,9 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
             self.idx_ += 1
 
     def expected_state_for(name):
-        return "FAILED" if name in killed_names else "RUNNING"
+        if name in killed_names or has_exit_killed_ancestor(name):
+            return "FAILED"
+        return "RUNNING"
 
     def run_children(my_name, killer, execution_graph):
         children = execution_graph.get(my_name, [])

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -20,7 +20,7 @@ from ray._private.state_api_test_utils import (
     _is_actor_task_running,
     get_state_api_manager,
     verify_failed_task,
-    verify_tasks_running_or_terminated,
+    verify_task_states,
 )
 from ray._private.test_utils import (
     run_string_as_driver_nonblocking,
@@ -258,8 +258,8 @@ def test_fault_tolerance_detached_actor(shutdown_only):
 
             async def run(self, pid_actor):
                 ray.get(
-                    pid_actor.report_pid.remote(
-                        "detached-actor-run", os.getpid(), "RUNNING"
+                    pid_actor.report_expected_state.remote(
+                        "detached-actor-run", "RUNNING"
                     )
                 )
                 self.running = True
@@ -281,10 +281,10 @@ def test_fault_tolerance_detached_actor(shutdown_only):
         ray.get(parent_starts_detached_actor.remote(pid_actor))
 
     a = ray.get_actor("detached-actor", namespace="test")
-    task_pids = ray.get(pid_actor.get_pids.remote())
+    expected_states = ray.get(pid_actor.get_expected_states.remote())
     wait_for_condition(
-        verify_tasks_running_or_terminated,
-        task_pids=task_pids,
+        verify_task_states,
+        expected_states=expected_states,
         expect_num_tasks=1,
     )
 
@@ -292,10 +292,10 @@ def test_fault_tolerance_detached_actor(shutdown_only):
     ray.kill(a)
 
     # Verify the actual process no longer running.
-    task_pids["detached-actor-run"] = (task_pids["detached-actor-run"][0], "FAILED")
+    expected_states["detached-actor-run"] = "FAILED"
     wait_for_condition(
-        verify_tasks_running_or_terminated,
-        task_pids=task_pids,
+        verify_task_states,
+        expected_states=expected_states,
         expect_num_tasks=1,
     )
 
@@ -406,20 +406,20 @@ ray.get(parent.remote())
 
 @ray.remote
 def task_finish_child(pid_actor):
-    ray.get(pid_actor.report_pid.remote("task_finish_child", os.getpid(), "FINISHED"))
+    ray.get(pid_actor.report_expected_state.remote("task_finish_child", "FINISHED"))
     pass
 
 
 @ray.remote
 def task_sleep_child(pid_actor):
-    ray.get(pid_actor.report_pid.remote("task_sleep_child", os.getpid()))
+    ray.get(pid_actor.report_expected_state.remote("task_sleep_child", "RUNNING"))
     time.sleep(999)
 
 
 @ray.remote
 class ChildActor:
     def children(self, pid_actor):
-        ray.get(pid_actor.report_pid.remote("children", os.getpid()))
+        ray.get(pid_actor.report_expected_state.remote("children", "RUNNING"))
         ray.get(task_finish_child.options(name="task_finish_child").remote(pid_actor))
         ray.get(task_sleep_child.options(name="task_sleep_child").remote(pid_actor))
 
@@ -427,14 +427,15 @@ class ChildActor:
 @ray.remote
 class Actor:
     def fail_parent(self, pid_actor):
-        ray.get(pid_actor.report_pid.remote("fail_parent", os.getpid(), "FAILED"))
+        ray.get(pid_actor.report_expected_state.remote("fail_parent", "FAILED"))
         ray.get(task_finish_child.options(name="task_finish_child").remote(pid_actor))
         task_sleep_child.options(name="task_sleep_child").remote(pid_actor)
 
         # Wait til child tasks run.
         def wait_fn():
             assert (
-                ray.get(pid_actor.get_pids.remote()).get("task_sleep_child") is not None
+                ray.get(pid_actor.get_expected_states.remote()).get("task_sleep_child")
+                is not None
             )
             assert (
                 list_tasks(filters=[("name", "=", "task_finish_child")])[0]["state"]
@@ -446,12 +447,14 @@ class Actor:
         raise ValueError("expected to fail.")
 
     def child_actor(self, pid_actor):
-        ray.get(pid_actor.report_pid.remote("child_actor", os.getpid(), "FAILED"))
+        ray.get(pid_actor.report_expected_state.remote("child_actor", "FAILED"))
         a = ChildActor.remote()
         a.children.options(name="children").remote(pid_actor)
         # Wait til child tasks run.
         wait_for_condition(
-            lambda: ray.get(pid_actor.get_pids.remote()).get("task_sleep_child")
+            lambda: ray.get(pid_actor.get_expected_states.remote()).get(
+                "task_sleep_child"
+            )
             is not None
         )
         raise ValueError("expected to fail.")
@@ -472,8 +475,8 @@ def test_fault_tolerance_actor_tasks_failed(shutdown_only):
     # Wait for all tasks to finish:
     # 3 = fail_parent + task_finish_child + task_sleep_child
     wait_for_condition(
-        verify_tasks_running_or_terminated,
-        task_pids=ray.get(pid_actor.get_pids.remote()),
+        verify_task_states,
+        expected_states=ray.get(pid_actor.get_expected_states.remote()),
         expect_num_tasks=3,
     )
 
@@ -490,8 +493,8 @@ def test_fault_tolerance_nested_actors_failed(shutdown_only):
     # Wait for all tasks to finish:
     # 4 = child_actor + children + task_finish_child + task_sleep_child
     wait_for_condition(
-        verify_tasks_running_or_terminated,
-        task_pids=ray.get(pid_actor.get_pids.remote()),
+        verify_task_states,
+        expected_states=ray.get(pid_actor.get_expected_states.remote()),
         expect_num_tasks=4,
         timeout=30,
     )
@@ -628,7 +631,7 @@ def test_fault_tolerance_chained_task_fail(
         # Wait until the children run
         if pid_actor:
             wait_for_condition(
-                lambda: len(ray.get(pid_actor.get_pids.remote())) == 3,
+                lambda: len(ray.get(pid_actor.get_expected_states.remote())) == 3,
             )
 
         if exit_type == "exit_kill":
@@ -636,24 +639,23 @@ def test_fault_tolerance_chained_task_fail(
         else:
             raise ValueError("Expected to fail")
 
-    # Test a chain of tasks
     @ray.remote(max_retries=0)
     def A(exit_type, pid_actor):
         x = B.remote(pid_actor)
-        ray.get(pid_actor.report_pid.remote("A", os.getpid()))
+        ray.get(pid_actor.report_expected_state.remote("A", "FAILED"))
         sleep_or_fail(pid_actor, exit_type)
         ray.get(x)
 
     @ray.remote(max_retries=0)
     def B(pid_actor):
         x = C.remote(pid_actor)
-        ray.get(pid_actor.report_pid.remote("B", os.getpid()))
+        ray.get(pid_actor.report_expected_state.remote("B", "RUNNING"))
         sleep_or_fail()
         ray.get(x)
 
     @ray.remote(max_retries=0)
     def C(pid_actor):
-        ray.get(pid_actor.report_pid.remote("C", os.getpid()))
+        ray.get(pid_actor.report_expected_state.remote("C", "RUNNING"))
         sleep_or_fail()
 
     @ray.remote(max_restarts=0, max_task_retries=0)
@@ -675,10 +677,15 @@ def test_fault_tolerance_chained_task_fail(
         a = Actor.remote()
         ray.get(a.run.remote(pid_actor=pid_actor))
 
+    expected_states = ray.get(pid_actor.get_expected_states.remote())
+    if exit_type == "exit_kill":
+        expected_states["B"] = "FAILED"
+        expected_states["C"] = "FAILED"
     wait_for_condition(
-        verify_tasks_running_or_terminated,
-        task_pids=ray.get(pid_actor.get_pids.remote()),
+        verify_task_states,
+        expected_states=expected_states,
         expect_num_tasks=3,
+        timeout=30,
     )
 
 
@@ -725,13 +732,15 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
 
     ray.init(_system_config=_SYSTEM_CONFIG)
 
+    killed_names = {name for name, _ in death_list}
+
     @ray.remote
     class Killer:
         def __init__(self, death_list):
             self.idx_ = 0
             self.death_list_ = death_list
             self.kill_started = False
-            self.name_to_pids = {}
+            self.name_to_expected_state = {}
 
         async def start_killing(self):
             self.kill_started = True
@@ -747,11 +756,11 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
             to_kill = self.death_list_[self.idx_]
             return to_kill
 
-        async def report_pid(self, name, pid):
-            self.name_to_pids[name] = (pid, None)
+        async def report_expected_state(self, name, expected_state):
+            self.name_to_expected_state[name] = expected_state
 
-        async def get_pids(self):
-            return self.name_to_pids
+        async def get_expected_states(self):
+            return self.name_to_expected_state
 
         async def all_killed(self):
             while self.idx_ < len(self.death_list_):
@@ -759,6 +768,9 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
 
         async def advance_next(self):
             self.idx_ += 1
+
+    def expected_state_for(name):
+        return "FAILED" if name in killed_names else "RUNNING"
 
     def run_children(my_name, killer, execution_graph):
         children = execution_graph.get(my_name, [])
@@ -791,12 +803,18 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
     @ray.remote(max_task_retries=0, max_restarts=0)
     class Actor:
         def actor_task(self, my_name, killer, execution_graph):
-            ray.get(killer.report_pid.remote(my_name, os.getpid()))
+            ray.get(
+                killer.report_expected_state.remote(
+                    my_name, expected_state_for(my_name)
+                )
+            )
             run_children(my_name, killer, execution_graph)
 
     @ray.remote(max_retries=0)
     def task(my_name, killer, execution_graph):
-        ray.get(killer.report_pid.remote(my_name, os.getpid()))
+        ray.get(
+            killer.report_expected_state.remote(my_name, expected_state_for(my_name))
+        )
         run_children(my_name, killer, execution_graph)
 
     killer = Killer.remote(death_list)
@@ -837,8 +855,8 @@ def test_fault_tolerance_advanced_tree(shutdown_only, death_list):
     print("all killed")
 
     wait_for_condition(
-        verify_tasks_running_or_terminated,
-        task_pids=ray.get(killer.get_pids.remote()),
+        verify_task_states,
+        expected_states=ray.get(killer.get_expected_states.remote()),
         expect_num_tasks=len(tasks),
         timeout=30,
         retry_interval_ms=500,


### PR DESCRIPTION

## Description
test_task_events_2 is basically testing the state API, and the original test greps the real running process and uses it as the source of truth to compare with the state API result, like running or not.

These tests are testing the state API, and we have full knowledge to know exactly whether the task/actor will be running or failed. We should just pass the expected state and compare against the state API result.

Grepping the real running process causes a lot of problems. Our `proctitle` is very unreliable, and I have seen the test fail multiple times because `proctitle` fails and the process name has not changed, so the test cannot grep the process, thinks there is no such process, and fails.

Changing to expected state solves this. Most importantly, it makes the test more focused on testing a single thing: the state API. We are not and should not testing anything else or we should add a seperate one.
