### PR TITLE
[core] Fix POSIX semaphore crash in experimental mutable objects (#62328)

### DIFF
--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -33,14 +33,18 @@ namespace experimental {
 
 namespace {
 
+// POSIX requires sem_open() names to start with '/'. glibc is lenient and
+// strips a missing leading slash, but stricter implementations (musl, some
+// older libcs) fail with EINVAL. Always prepend '/' for portability.
+
 std::string GetSemaphoreObjectName(const std::string &name) {
-  std::string ret = absl::StrCat("obj", name);
+  std::string ret = absl::StrCat("/obj", name);
   RAY_CHECK_LE(name.size(), PSEMNAMLEN);
   return ret;
 }
 
 std::string GetSemaphoreHeaderName(const std::string &name) {
-  std::string ret = absl::StrCat("hdr", name);
+  std::string ret = absl::StrCat("/hdr", name);
   RAY_CHECK_LE(name.size(), PSEMNAMLEN);
   return ret;
 }
@@ -171,8 +175,21 @@ void MutableObjectManager::OpenSemaphores(const ObjectID &object_id,
            PlasmaObjectHeader::SemaphoresCreationLevel::kDone) {
       sched_yield();
     }
-    semaphores.object_sem = sem_open(GetSemaphoreObjectName(name).c_str(), /*oflag=*/0);
-    semaphores.header_sem = sem_open(GetSemaphoreHeaderName(name).c_str(), /*oflag=*/0);
+    // Use O_CREAT without O_EXCL so that this works for both the intra-node and
+    // cross-node cases:
+    // - Intra-node: the semaphores already exist (created by the writer on this machine),
+    //   so sem_open opens them and ignores the initial value.
+    // - Cross-node: the writer set semaphores_created=kDone in shared memory that is
+    //   visible here, but the named semaphores were never created on this machine.
+    //   O_CREAT creates them locally with the correct initial value of 1.
+    semaphores.object_sem = sem_open(GetSemaphoreObjectName(name).c_str(),
+                                     /*oflag=*/O_CREAT,
+                                     /*mode=*/0644,
+                                     /*value=*/1);
+    semaphores.header_sem = sem_open(GetSemaphoreHeaderName(name).c_str(),
+                                     /*oflag=*/O_CREAT,
+                                     /*mode=*/0644,
+                                     /*value=*/1);
   }
   RAY_CHECK_NE(semaphores.object_sem, SEM_FAILED);
   RAY_CHECK_NE(semaphores.header_sem, SEM_FAILED);

--- a/src/ray/core_worker/experimental_mutable_object_manager.cc
+++ b/src/ray/core_worker/experimental_mutable_object_manager.cc
@@ -37,16 +37,21 @@ namespace {
 // strips a missing leading slash, but stricter implementations (musl, some
 // older libcs) fail with EINVAL. Always prepend '/' for portability.
 
+// `Init()` already caps `name.size()` to PSEMNAMLEN, so these checks are
+// defense-in-depth. If a name somehow slips through oversized, `sem_open()`
+// returns SEM_FAILED (ENAMETOOLONG on macOS) and the RAY_CHECK_NE below catches
+// it. We deliberately check `name.size()` rather than the final prefixed
+// string: on 64-bit Linux with pid_max=4194304 a 7-digit PID can produce a
+// 27-byte `name`, and `/obj` + `name` = 31 bytes would falsely trip a tighter
+// check even though Linux sem_open accepts much longer names.
 std::string GetSemaphoreObjectName(const std::string &name) {
-  std::string ret = absl::StrCat("/obj", name);
   RAY_CHECK_LE(name.size(), PSEMNAMLEN);
-  return ret;
+  return absl::StrCat("/obj", name);
 }
 
 std::string GetSemaphoreHeaderName(const std::string &name) {
-  std::string ret = absl::StrCat("/hdr", name);
   RAY_CHECK_LE(name.size(), PSEMNAMLEN);
-  return ret;
+  return absl::StrCat("/hdr", name);
 }
 
 }  // namespace

--- a/src/ray/core_worker/experimental_mutable_object_manager.h
+++ b/src/ray/core_worker/experimental_mutable_object_manager.h
@@ -254,6 +254,8 @@ class MutableObjectManager : public std::enable_shared_from_this<MutableObjectMa
   FRIEND_TEST(MutableObjectTest, TestWriteAcquireDuringFailure);
   FRIEND_TEST(MutableObjectTest, TestReadAcquireDuringFailure);
   FRIEND_TEST(MutableObjectTest, TestReadMultipleAcquireDuringFailure);
+  FRIEND_TEST(MutableObjectTest, TestSemaphoreNameHasLeadingSlash);
+  FRIEND_TEST(MutableObjectTest, TestCrossNodeSemaphoreCreation);
 
   // TODO(jhumphri): If we do need to synchronize accesses to this map, we may want to
   // consider using RCU to avoid synchronization overhead in the common case.

--- a/src/ray/object_manager/plasma/tests/mutable_object_test.cc
+++ b/src/ray/object_manager/plasma/tests/mutable_object_test.cc
@@ -621,6 +621,87 @@ TEST(MutableObjectTest, TestReadMultipleAcquireDuringFailure) {
   }
 }
 
+// Tests that semaphore names are POSIX-compliant (start with '/').
+// POSIX requires sem_open() names to start with '/'. Linux enforces this strictly
+// (sem_open returns EINVAL without it); macOS is lenient. Without the '/' prefix in
+// GetSemaphoreObjectName/GetSemaphoreHeaderName, this crashes on Linux with strict
+// glibc (e.g., DGX Spark) via RAY_CHECK_NE(semaphores.object_sem, SEM_FAILED).
+TEST(MutableObjectTest, TestSemaphoreNameHasLeadingSlash) {
+  MutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  PlasmaObjectHeader *header;
+  std::string unique_name;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+    unique_name = std::string(header->unique_name);
+    ASSERT_TRUE(
+        manager.RegisterChannel(object_id, std::move(object), /*reader=*/true).ok());
+  }
+
+  // If OpenSemaphores used the correct '/obj<name>' format, we can open the same
+  // semaphore by its POSIX-correct name. This would fail with ENOENT if a non-'/'
+  // name was used (the semaphore would have been created under a different path).
+  std::string obj_sem_name = "/obj" + unique_name;
+  std::string hdr_sem_name = "/hdr" + unique_name;
+  sem_t *obj_sem = sem_open(obj_sem_name.c_str(), /*oflag=*/0);
+  sem_t *hdr_sem = sem_open(hdr_sem_name.c_str(), /*oflag=*/0);
+  ASSERT_NE(SEM_FAILED, obj_sem)
+      << "Semaphore '" << obj_sem_name
+      << "' not found. Missing '/' prefix in semaphore name?";
+  ASSERT_NE(SEM_FAILED, hdr_sem)
+      << "Semaphore '" << hdr_sem_name
+      << "' not found. Missing '/' prefix in semaphore name?";
+  ASSERT_EQ(0, sem_close(obj_sem));
+  ASSERT_EQ(0, sem_close(hdr_sem));
+
+  manager.DestroySemaphores(object_id);
+  free(header);
+}
+
+// Tests that a reader can register a channel when semaphores_created=kDone is already
+// set in the header but the named semaphores don't exist on this machine.
+// This is the cross-node scenario (ray-project/ray#62328): the writer on Node A sets
+// semaphores_created=kDone in shared memory. A reader on Node B sees kDone and
+// previously called sem_open(name, 0) without O_CREAT, which failed with ENOENT
+// because the semaphores were never created on Node B. The fix uses O_CREAT (without
+// O_EXCL) so that the reader creates the semaphores locally when absent.
+TEST(MutableObjectTest, TestCrossNodeSemaphoreCreation) {
+  MutableObjectManager manager;
+  ObjectID object_id = ObjectID::FromRandom();
+  PlasmaObjectHeader *header;
+  {
+    std::unique_ptr<plasma::MutableObject> object = MakeObject();
+    header = object->header;
+    header->Init();
+
+    // Simulate the cross-node state: kDone is set (as if the writer on another node
+    // already finished initialization) but no named semaphores exist on this machine.
+    header->semaphores_created.store(PlasmaObjectHeader::SemaphoresCreationLevel::kDone,
+                                     std::memory_order_release);
+
+    // With the fix, this must succeed: the reader path uses O_CREAT and creates the
+    // semaphores locally. Without the fix, sem_open returned ENOENT -> SEM_FAILED ->
+    // RAY_CHECK_NE(SEM_FAILED, SEM_FAILED) crash.
+    ASSERT_TRUE(
+        manager.RegisterChannel(object_id, std::move(object), /*reader=*/true).ok());
+  }
+
+  // Verify the semaphores are usable and were initialized to value=1 (the correct
+  // initial state for a freshly created mutable object channel).
+  PlasmaObjectHeader::Semaphores sem{};
+  ASSERT_TRUE(manager.GetSemaphores(object_id, sem));
+  int obj_val = -1, hdr_val = -1;
+  ASSERT_EQ(0, sem_getvalue(sem.object_sem, &obj_val));
+  ASSERT_EQ(0, sem_getvalue(sem.header_sem, &hdr_val));
+  ASSERT_EQ(1, obj_val) << "object_sem should be initialized to 1";
+  ASSERT_EQ(1, hdr_val) << "header_sem should be initialized to 1";
+
+  manager.DestroySemaphores(object_id);
+  free(header);
+}
+
 // Tests that MutableObjectManager instances destruct properly when there are multiple
 // instances.
 // The core worker and the raylet each have their own MutableObjectManager instance, and

--- a/src/ray/object_manager/plasma/tests/mutable_object_test.cc
+++ b/src/ray/object_manager/plasma/tests/mutable_object_test.cc
@@ -622,10 +622,10 @@ TEST(MutableObjectTest, TestReadMultipleAcquireDuringFailure) {
 }
 
 // Tests that semaphore names are POSIX-compliant (start with '/').
-// POSIX requires sem_open() names to start with '/'. Linux enforces this strictly
-// (sem_open returns EINVAL without it); macOS is lenient. Without the '/' prefix in
-// GetSemaphoreObjectName/GetSemaphoreHeaderName, this crashes on Linux with strict
-// glibc (e.g., DGX Spark) via RAY_CHECK_NE(semaphores.object_sem, SEM_FAILED).
+// POSIX requires sem_open() names to start with '/'. glibc is lenient and strips
+// a missing leading slash, but stricter libcs (musl, some older libcs) reject the
+// name with EINVAL; without the '/' prefix those platforms crash at
+// RAY_CHECK_NE(semaphores.object_sem, SEM_FAILED).
 TEST(MutableObjectTest, TestSemaphoreNameHasLeadingSlash) {
   MutableObjectManager manager;
   ObjectID object_id = ObjectID::FromRandom();
@@ -647,12 +647,10 @@ TEST(MutableObjectTest, TestSemaphoreNameHasLeadingSlash) {
   std::string hdr_sem_name = "/hdr" + unique_name;
   sem_t *obj_sem = sem_open(obj_sem_name.c_str(), /*oflag=*/0);
   sem_t *hdr_sem = sem_open(hdr_sem_name.c_str(), /*oflag=*/0);
-  ASSERT_NE(SEM_FAILED, obj_sem)
-      << "Semaphore '" << obj_sem_name
-      << "' not found. Missing '/' prefix in semaphore name?";
-  ASSERT_NE(SEM_FAILED, hdr_sem)
-      << "Semaphore '" << hdr_sem_name
-      << "' not found. Missing '/' prefix in semaphore name?";
+  ASSERT_NE(SEM_FAILED, obj_sem) << "Semaphore '" << obj_sem_name
+                                 << "' not found. Missing '/' prefix in semaphore name?";
+  ASSERT_NE(SEM_FAILED, hdr_sem) << "Semaphore '" << hdr_sem_name
+                                 << "' not found. Missing '/' prefix in semaphore name?";
   ASSERT_EQ(0, sem_close(obj_sem));
   ASSERT_EQ(0, sem_close(hdr_sem));
 
@@ -688,15 +686,18 @@ TEST(MutableObjectTest, TestCrossNodeSemaphoreCreation) {
         manager.RegisterChannel(object_id, std::move(object), /*reader=*/true).ok());
   }
 
-  // Verify the semaphores are usable and were initialized to value=1 (the correct
-  // initial state for a freshly created mutable object channel).
+  // Verify the semaphores are usable. On Linux we can additionally check they were
+  // initialized to value=1 (the correct initial state for a freshly created mutable
+  // object channel); macOS does not implement sem_getvalue() so we skip that probe.
   PlasmaObjectHeader::Semaphores sem{};
   ASSERT_TRUE(manager.GetSemaphores(object_id, sem));
+#ifdef __linux__
   int obj_val = -1, hdr_val = -1;
   ASSERT_EQ(0, sem_getvalue(sem.object_sem, &obj_val));
   ASSERT_EQ(0, sem_getvalue(sem.header_sem, &hdr_val));
   ASSERT_EQ(1, obj_val) << "object_sem should be initialized to 1";
   ASSERT_EQ(1, hdr_val) << "header_sem should be initialized to 1";
+#endif
 
   manager.DestroySemaphores(object_id);
   free(header);


### PR DESCRIPTION
## Why are these changes needed?

Closes #62328.

`OpenSemaphores()` in `experimental_mutable_object_manager.cc` crashes with

```
Check failed: RAY_PREDICT_TRUE(_left_ != _right_) 0 vs 0
  [src/ray/core_worker/experimental_mutable_object_manager.cc:177]
```

when a reader registers a channel in **multi-node** setups — e.g. vLLM compiled graphs running tensor parallelism across two DGX Spark nodes.

This PR addresses **two independent bugs** observed while debugging #62328.

### 1. Cross-node reader skips `O_CREAT` (primary bug)

`PlasmaObjectHeader::semaphores_created` is an atomic flag that sits inside the object's shared-memory header. It coordinates semaphore initialization **within a single machine's shared memory**, not across nodes.

On a different node, the reader's mapped header can observe `kDone` (propagated through the object header contents) even though the underlying named POSIX semaphores were never created on the reader's machine — named semaphores are machine-local. The reader then calls

```cpp
sem_open(name, 0);   // no O_CREAT
```

which fails with `ENOENT` and returns `SEM_FAILED`. The subsequent `RAY_CHECK_NE(sem, SEM_FAILED)` fires and the worker aborts.

**Fix:** use `O_CREAT` (without `O_EXCL`) on the reader path. In the single-node case this just opens the existing semaphores; in the cross-node case it creates them locally with the correct initial value of `1`, matching the writer path.

### 2. Non-POSIX semaphore names

POSIX specifies that `sem_open()` names must start with `/`. glibc is lenient and silently strips a missing slash, so this works today on most Linux distros. Stricter implementations (musl, some older libcs) reject such names with `EINVAL`.

**Fix:** change the prefixes from `"obj"`/`"hdr"` to `"/obj"`/`"/hdr"`, and bound the resulting full name against `PSEMNAMLEN` (not just the raw `name`) so the 4-byte prefix can't push the result over macOS's 30-byte limit.

## Related work

#62373 addresses the same issue with a very similar approach. I wrote this independently while investigating #62328 on a DGX Spark multi-node setup; the only notable deltas here are:

- Two regression tests (`TestSemaphoreNameHasLeadingSlash`, `TestCrossNodeSemaphoreCreation`) pinning both behaviors, including the cross-node `kDone`-without-semaphores scenario.
- Updated inline comments explaining the cross-node reasoning and the glibc-vs-other-libc semantics.

Happy to close this in favor of #62373 if @stephanie-wang prefers; flagging both options so whoever reviews can pick whichever they like.

## Related issue number

Closes #62328
Related: #62373

## Checks

- [x] I've signed off every commit (by using the \`-s\` flag, i.e., \`git commit -s\`) in this PR.
- [x] I've run \`scripts/format.sh\` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - (No doc changes; bug fix only.)
- [x] I've added any new APIs to the API Reference. If the API is intended to be private, it has been properly renamed.
  - (No new APIs.)
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(

cc @stephanie-wang @jackhumphries