### PR TITLE
[RLlib] Stop impala/APPO learner thread gracefully to combat misleading error messages

### DIFF
--- a/rllib/algorithms/impala/impala_learner.py
+++ b/rllib/algorithms/impala/impala_learner.py
@@ -1,6 +1,8 @@
+import atexit
 import logging
 import queue
 import threading
+import weakref
 from queue import Queue
 from typing import Any, Dict, List
 
@@ -303,6 +305,18 @@ class IMPALALearner(Learner):
         super().remove_module(module_id)
         self.entropy_coeff_schedulers_per_module.pop(module_id)
 
+    @override(Learner)
+    def shutdown(self) -> None:
+        # Stop the learner thread deterministically: setting the stop event
+        # and enqueuing a sentinel wakes the consumer if it's blocked on
+        # `_in_queue.get()`. Then `join` ensures it has fully exited before
+        # we return, so any subsequent `ray.shutdown()`/interpreter teardown
+        # can't race with the daemon thread.
+        thread = getattr(self, "_learner_thread", None)
+        if thread is not None and thread.is_alive():
+            thread.request_stop()
+            thread.join(timeout=5.0)
+
     @classmethod
     @override(Learner)
     def rl_module_required_apis(cls) -> list[type]:
@@ -466,6 +480,20 @@ class _LearnerThread(threading.Thread):
         self._metrics_learner_impala_thread_step_update.set_default_tags(
             {"rllib": "IMPALA/LearnerThread"}
         )
+
+        # Stop cleanly at interpreter shutdown so the daemon thread doesn't
+        # get killed mid-call inside an auto_init-wrapped Ray API (which
+        # would otherwise trigger e.g. `start_reaper` -> `preexec_fn not
+        # supported at interpreter shutdown`). Use a weakref so this hook
+        # doesn't pin the thread (and therefore the Learner) alive.
+        weak_self = weakref.ref(self)
+
+        def _request_stop_at_exit():
+            t = weak_self()
+            if t is not None:
+                t.request_stop()
+
+        atexit.register(_request_stop_at_exit)
 
     # Keeps compatibility, but thread-safe.
     @property

--- a/rllib/algorithms/impala/tests/test_impala.py
+++ b/rllib/algorithms/impala/tests/test_impala.py
@@ -78,6 +78,28 @@ class TestIMPALA(unittest.TestCase):
         finally:
             algo.stop()
 
+    def test_local_learner_thread_stops_on_algo_stop(self):
+        # Regression test: `algo.stop()` -> `LearnerGroup.shutdown()` ->
+        # `IMPALALearner.shutdown()` must stop and join the local IMPALA
+        # `_LearnerThread`. Otherwise the daemon thread keeps spinning and
+        # can race against interpreter shutdown inside an auto_init-wrapped
+        # Ray API.
+        config = (
+            impala.IMPALAConfig()
+            .environment("CartPole-v1")
+            .learners(num_learners=0)
+            .env_runners(num_env_runners=0)
+        )
+        algo = config.build()
+        learner_thread = algo.learner_group._learner._learner_thread
+        self.assertTrue(learner_thread.is_alive())
+
+        algo.stop()
+
+        # `Learner.shutdown()` joins the thread, so it must be dead by the
+        # time `algo.stop()` returns — no extra `join()` needed here.
+        self.assertFalse(learner_thread.is_alive())
+
 
 if __name__ == "__main__":
     import sys

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -355,6 +355,17 @@ class Learner(Checkpointable):
         self._log_trainable_parameters()
         self._is_built = True
 
+    @OverrideToImplementCustomLogic
+    def shutdown(self) -> None:
+        """Releases resources held by this Learner.
+
+        Subclasses that own background threads (e.g. IMPALA's `_LearnerThread`)
+        should override this to stop and join those threads, so that
+        `LearnerGroup.shutdown()` can tear them down deterministically.
+
+        The default implementation is a no-op.
+        """
+
     @property
     def distributed(self) -> bool:
         """Whether the learner is running in distributed mode."""

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -701,6 +701,8 @@ class LearnerGroup(Checkpointable):
 
     def shutdown(self):
         """Shuts down the LearnerGroup."""
+        if self.is_local and self._learner is not None:
+            self._learner.shutdown()
         if self.is_remote and hasattr(self, "_backend_executor"):
             self._backend_executor.shutdown(graceful_termination=True)
         self._is_shut_down = True


### PR DESCRIPTION
Impala/APPO have a learner thread.
We never tell that to stop when we delete Algorithm so meaningless errors occur:

Like this one:

```
    process_info = ray._private.services.start_reaper(fate_share=False)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/artur/miniforge3/envs/raydev/lib/python3.12/site-packages/ray/_private/services.py", line 1114, in start_reaper
    process_info = start_ray_process(
                   ^^^^^^^^^^^^^^^^^^
  File "/Users/artur/miniforge3/envs/raydev/lib/python3.12/site-packages/ray/_private/services.py", line 1043, in start_ray_process
    process = ConsolePopen(
              ^^^^^^^^^^^^^
  File "/Users/artur/miniforge3/envs/raydev/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/Users/artur/miniforge3/envs/raydev/lib/python3.12/subprocess.py", line 1883, in _execute_child
    self.pid = _fork_exec(
               ^^^^^^^^^^^
RuntimeError: preexec_fn not supported at interpreter shutdown
```
