### PR TITLE
[Release / Python 3.13] Update core release tests to use Python 3.13

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2413,7 +2413,7 @@
     script: python experimental/rdt_single_node_microbenchmark.py
 
 - name: rdt_single_node_A100_microbenchmark
-  python: "3.10"
+  python: "3.11"
   group: core-daily-test
   team: core
   frequency: weekly

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -845,7 +845,7 @@
 #######################
 
 - name: long_running_actor_deaths
-  python: "3.10"
+  python: "3.13"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -883,7 +883,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_actor_tasks
-  python: "3.10"
+  python: "3.13"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -923,7 +923,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_drivers
-  python: "3.10"
+  python: "3.13"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -965,7 +965,7 @@
         cluster_compute: tpl_cpu_4_gce.yaml
 
 - name: long_running_many_tasks
-  python: "3.10"
+  python: "3.13"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1005,7 +1005,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_many_tasks_serialized_ids
-  python: "3.10"
+  python: "3.13"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1045,7 +1045,7 @@
         cluster_compute: tpl_cpu_1_gce.yaml
 
 - name: long_running_node_failures
-  python: "3.10"
+  python: "3.13"
   group: Long running tests
   working_dir: long_running_tests
 
@@ -1352,7 +1352,7 @@
 # Runtime env tests
 ########################
 - name: runtime_env_rte_many_tasks_actors
-  python: "3.10"
+  python: "3.13"
   group: Runtime env tests
   working_dir: runtime_env_tests
 
@@ -1381,7 +1381,7 @@
 
 
 - name: runtime_env_wheel_urls
-  python: "3.10"
+  python: "3.13"
   group: Runtime env tests
   working_dir: runtime_env_tests
 
@@ -2213,7 +2213,7 @@
 ########################
 
 - name: shuffle_100gb
-  python: "3.10"
+  python: "3.13"
   group: core-multi-test
   working_dir: nightly_tests
 
@@ -2239,7 +2239,7 @@
 
 
 - name: stress_test_placement_group
-  python: "3.10"
+  python: "3.13"
   group: core-multi-test
   working_dir: nightly_tests
   env: aws_perf
@@ -2263,7 +2263,7 @@
         cluster_compute: stress_tests/placement_group_tests_compute_gce.yaml
 
 - name: autoscaling_shuffle_1tb_1000_partitions
-  python: "3.10"
+  python: "3.13"
   group: core-multi-test
   working_dir: nightly_tests
 
@@ -2287,7 +2287,7 @@
         cluster_compute: shuffle/shuffle_compute_autoscaling_gce.yaml
 
 - name: microbenchmark
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2314,7 +2314,7 @@
       python: "3.12"
 
 - name: compiled_graphs
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2328,7 +2328,7 @@
     script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py --experimental
 
 - name: compiled_graphs_GPU
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2344,7 +2344,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py
 
 - name: compiled_graphs_GPU_multinode
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2360,7 +2360,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py --distributed
 
 - name: compiled_graphs_GPU_cu130
-  python: "3.12"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2378,7 +2378,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py
 
 - name: compiled_graphs_GPU_multinode_cu130
-  python: "3.12"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2396,7 +2396,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py --distributed
 
 - name: rdt_single_node_T4_microbenchmark
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2413,7 +2413,7 @@
     script: python experimental/rdt_single_node_microbenchmark.py
 
 - name: rdt_single_node_A100_microbenchmark
-  python: "3.11"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: weekly
@@ -2450,7 +2450,7 @@
 #     script: python experimental/rdt_microbenchmark.py --distributed
 
 - name: benchmark_worker_startup
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2478,6 +2478,7 @@
         cluster_compute: only_head_node_1gpu_64cpu_gce.yaml
 
 - name: dask_on_ray_100gb_sort
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2502,7 +2503,7 @@
 
 
 - name: stress_test_state_api_scale
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2550,7 +2551,7 @@
 
 
 - name: shuffle_20gb_with_state_api
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2577,7 +2578,7 @@
         cluster_compute: shuffle/shuffle_compute_single_gce.yaml
 
 - name: stress_test_many_tasks
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
   env: aws_perf
@@ -2617,7 +2618,7 @@
         frequency: manual
 
 - name: stress_test_dead_actors
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
   env: aws_perf
@@ -2660,7 +2661,7 @@
 # The full test is not stable, so run the smoke test only.
 # See https://github.com/ray-project/ray/issues/23244.
 - name: threaded_actors_stress_test
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2719,7 +2720,7 @@
 #         timeout: 600
 
 - name: stress_test_many_runtime_envs
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2746,7 +2747,7 @@
         frequency: manual
 
 - name: single_node_oom
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2778,6 +2779,7 @@
 
 
 - name: dask_on_ray_1tb_sort
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2797,11 +2799,11 @@
 
 
 - name: many_nodes_actor_test_on_v2
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: benchmarks
 
-  frequency: nightly-3x
+  frequency: nightly
   team: core
   cluster:
     anyscale_sdk_2026: true
@@ -2841,7 +2843,7 @@
 #
 
 - name: pg_autoscaling_regression_test
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2863,7 +2865,7 @@
         cluster_compute: placement_group_tests/compute_gce.yaml
 
 - name: placement_group_performance_test
-  python: "3.10"
+  python: "3.13"
   group: core-daily-test
   working_dir: nightly_tests
 
@@ -2892,7 +2894,7 @@
 #########################
 
 - name: single_node
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -2919,7 +2921,7 @@
         cluster_compute: single_node_gce.yaml
 
 - name: object_store
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -2948,7 +2950,7 @@
         cluster_compute: object_store_gce.yaml
 
 - name: small_objects
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -2972,7 +2974,7 @@
     - __suffix__: aws
 
 - name: large_objects
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -2996,11 +2998,11 @@
     - __suffix__: aws
 
 - name: many_actors
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
-  frequency: nightly-3x
+  frequency: nightly
   team: core
   env: aws_perf
   cluster:
@@ -3026,7 +3028,7 @@
         cluster_compute: distributed_gce.yaml
 
 - name: many_actors_smoke_test
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -3047,7 +3049,7 @@
 
 
 - name: many_tasks
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -3077,7 +3079,7 @@
         cluster_compute: distributed_gce.yaml
 
 - name: many_pgs
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -3108,7 +3110,7 @@
 
 
 - name: many_pgs_smoke_test
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -3129,7 +3131,7 @@
 
 
 - name: many_nodes
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -3158,7 +3160,7 @@
         cluster_compute: many_nodes_gce.yaml
 
 - name: scheduling_test_many_0s_tasks_many_nodes
-  python: "3.10"
+  python: "3.13"
   group: core-scalability-test
   working_dir: benchmarks
 
@@ -3229,7 +3231,7 @@
 ##################
 
 - name: chaos_many_tasks_baseline
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3253,7 +3255,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_many_tasks_kill_raylet
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3278,7 +3280,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_many_tasks_terminate_instance
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3298,7 +3300,7 @@
     - __suffix__: aws
 
 - name: chaos_many_tasks_iptable_failure_injection
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3329,7 +3331,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_many_actors_baseline
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3353,7 +3355,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_many_actors_kill_raylet
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3378,7 +3380,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_many_actors_terminate_instance
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3398,7 +3400,7 @@
     - __suffix__: aws
 
 - name: chaos_many_actors_iptable_failure_injection
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3429,7 +3431,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_streaming_generator_baseline
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3453,7 +3455,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_streaming_generator_kill_raylet
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3478,7 +3480,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_streaming_generator_terminate_instance
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3498,7 +3500,7 @@
     - __suffix__: aws
 
 - name: chaos_streaming_generator_iptable_failure_injection
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3529,7 +3531,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_object_ref_borrowing_baseline
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3553,7 +3555,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_object_ref_borrowing_kill_raylet
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3578,7 +3580,7 @@
         cluster_compute: chaos_test/compute_template_gce.yaml
 
 - name: chaos_object_ref_borrowing_terminate_instance
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3598,7 +3600,7 @@
     - __suffix__: aws
 
 - name: chaos_object_ref_borrowing_iptable_failure_injection
-  python: "3.10"
+  python: "3.13"
   group: core-nightly-test
   working_dir: nightly_tests
 
@@ -3632,7 +3634,7 @@
 # Observability tests
 #####################
 - name: agent_stress_test
-  python: "3.10"
+  python: "3.13"
   group: core-observability-test
   working_dir: dashboard
 
@@ -3972,7 +3974,7 @@
         script: RAY_UP_enable_autoscaler_v2=1 RAY_TRIM_AUTOSCALER_SSH_KEYS=1 python launch_and_verify_cluster.py gcp/example-gpu-docker.yaml
 
 - name: autoscaler_aws
-  python: "3.10"
+  python: "3.13"
   group: autoscaler-test
   working_dir: autoscaling_tests
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2360,7 +2360,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py --distributed
 
 - name: compiled_graphs_GPU_cu130
-  python: "3.10"
+  python: "3.12"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2378,7 +2378,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py
 
 - name: compiled_graphs_GPU_multinode_cu130
-  python: "3.10"
+  python: "3.12"
   group: core-daily-test
   team: core
   frequency: nightly

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -2328,7 +2328,7 @@
     script: OMP_NUM_THREADS=64 RAY_ADDRESS=local python run_microbenchmark.py --experimental
 
 - name: compiled_graphs_GPU
-  python: "3.13"
+  python: "3.10"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2344,7 +2344,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py
 
 - name: compiled_graphs_GPU_multinode
-  python: "3.13"
+  python: "3.10"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2360,7 +2360,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py --distributed
 
 - name: compiled_graphs_GPU_cu130
-  python: "3.13"
+  python: "3.10"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2378,7 +2378,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py
 
 - name: compiled_graphs_GPU_multinode_cu130
-  python: "3.13"
+  python: "3.10"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2396,7 +2396,7 @@
     script: python experimental/compiled_graph_gpu_microbenchmark.py --distributed
 
 - name: rdt_single_node_T4_microbenchmark
-  python: "3.13"
+  python: "3.10"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -2413,7 +2413,7 @@
     script: python experimental/rdt_single_node_microbenchmark.py
 
 - name: rdt_single_node_A100_microbenchmark
-  python: "3.13"
+  python: "3.10"
   group: core-daily-test
   team: core
   frequency: weekly
@@ -2450,7 +2450,7 @@
 #     script: python experimental/rdt_microbenchmark.py --distributed
 
 - name: benchmark_worker_startup
-  python: "3.13"
+  python: "3.10"
   group: core-daily-test
   team: core
   frequency: nightly
@@ -3634,7 +3634,7 @@
 # Observability tests
 #####################
 - name: agent_stress_test
-  python: "3.13"
+  python: "3.10"
   group: core-observability-test
   working_dir: dashboard
 


### PR DESCRIPTION
[DO NOT MERGE] experimental PR only

## Description
This PR adds Python 3.13 to all release tests that are `team: core` to test that these tests are compatible with python 3.13

For tests that are nightly-3x, I've changed to nightly to help test them with a single release run
