### PR TITLE
[ci] Add generic extract_wanda_artifact tool

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -361,6 +361,34 @@ py_binary(
 )
 
 py_binary(
+    name = "extract_wanda_artifact",
+    srcs = ["extract_wanda_artifact.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    deps = [
+        ":crane_lib",
+        "//ci/ray_ci:ray_ci_lib",
+        ci_require("click"),
+    ],
+)
+
+py_test(
+    name = "test_extract_wanda_artifact",
+    size = "small",
+    srcs = ["test_extract_wanda_artifact.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":crane_lib",
+        ":extract_wanda_artifact",
+        ci_require("click"),
+        ci_require("pytest"),
+    ],
+)
+
+py_binary(
     name = "push_ray_image",
     srcs = ["push_ray_image.py"],
     exec_compatible_with = ["//bazel:py3"],

--- a/ci/ray_ci/automation/extract_wanda_artifact.py
+++ b/ci/ray_ci/automation/extract_wanda_artifact.py
@@ -1,0 +1,99 @@
+"""
+Extract globs from a Wanda-cached image to a local directory.
+"""
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import click
+
+from ci.ray_ci.automation.crane_lib import CraneError, call_crane_export
+from ci.ray_ci.utils import ecr_docker_login, logger
+
+
+@click.command()
+@click.option(
+    "--wanda-image-name",
+    type=str,
+    required=True,
+    help="Wanda image name (without repo/build-id prefix).",
+)
+@click.option(
+    "--file-glob",
+    type=str,
+    required=True,
+    help="Glob pattern for files to extract (e.g. '*.whl', '*.tgz').",
+)
+@click.option(
+    "--output-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=".",
+    help="Directory to place extracted files (default: current directory).",
+)
+@click.option(
+    "--rayci-work-repo",
+    type=str,
+    envvar="RAYCI_WORK_REPO",
+    required=True,
+    help="RAYCI work repository URL.",
+)
+@click.option(
+    "--rayci-build-id",
+    type=str,
+    envvar="RAYCI_BUILD_ID",
+    required=True,
+    help="RAYCI build ID.",
+)
+def main(
+    wanda_image_name: str,
+    file_glob: str,
+    output_dir: Path,
+    rayci_work_repo: str,
+    rayci_build_id: str,
+) -> None:
+    """Extract artifacts matching a glob pattern from a Wanda-cached image."""
+    wanda_image = f"{rayci_work_repo}:{rayci_build_id}-{wanda_image_name}"
+    logger.info(f"Extracting '{file_glob}' from: {wanda_image}")
+
+    ecr_registry = rayci_work_repo.split("/")[0]
+    ecr_docker_login(ecr_registry)
+
+    if not output_dir.is_absolute():
+        workspace = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+        if workspace:
+            output_dir = Path(workspace) / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        try:
+            call_crane_export(wanda_image, tmpdir)
+        except CraneError as e:
+            raise click.ClickException(str(e))
+
+        matches = [f for f in Path(tmpdir).rglob(file_glob) if f.is_file()]
+        if not matches:
+            raise click.ClickException(
+                f"No files matching '{file_glob}' in image {wanda_image}"
+            )
+
+        seen = set()
+        for f in matches:
+            if f.name in seen:
+                raise click.ClickException(
+                    f"Duplicate basename '{f.name}' in image {wanda_image}: "
+                    f"found at multiple paths"
+                )
+            seen.add(f.name)
+
+        for f in matches:
+            dest = output_dir / f.name
+            shutil.copy2(f, dest)
+            logger.info(f"  {f.name} ({f.stat().st_size} bytes)")
+
+    logger.info(f"Extracted {len(matches)} file(s) to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/test_extract_wanda_artifact.py
+++ b/ci/ray_ci/automation/test_extract_wanda_artifact.py
@@ -1,0 +1,249 @@
+"""Tests for extract_wanda_artifact."""
+
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from click.testing import CliRunner
+
+from ci.ray_ci.automation.crane_lib import CraneError
+from ci.ray_ci.automation.extract_wanda_artifact import main
+
+# crane requires a real container registry, so we mock it and ecr_docker_login.
+# The mock simulates crane export by writing files to the output directory.
+_MODULE = "ci.ray_ci.automation.extract_wanda_artifact"
+
+
+def _invoke(args, crane_side_effect):
+    with mock.patch(
+        f"{_MODULE}.call_crane_export", side_effect=crane_side_effect
+    ), mock.patch(f"{_MODULE}.ecr_docker_login"):
+        return CliRunner().invoke(main, args)
+
+
+def _base_args(**overrides):
+    defaults = {
+        "--wanda-image-name": "test-image",
+        "--file-glob": "*.tgz",
+        "--rayci-work-repo": "ecr.example.com/repo",
+        "--rayci-build-id": "build-123",
+    }
+    defaults.update(overrides)
+    args = []
+    for k, v in defaults.items():
+        args.extend([k, v])
+    return args
+
+
+class TestExtraction:
+    def test_single_tgz(self):
+        def export(tag, d):
+            (Path(d) / "ray.tgz").write_bytes(b"content")
+            (Path(d) / "other.txt").write_bytes(b"noise")
+
+        with tempfile.TemporaryDirectory() as outdir:
+            result = _invoke(_base_args(**{"--output-dir": outdir}), export)
+            assert result.exit_code == 0, result.output
+            assert (Path(outdir) / "ray.tgz").read_bytes() == b"content"
+            assert not (Path(outdir) / "other.txt").exists()
+
+    def test_multiple_matches(self):
+        def export(tag, d):
+            (Path(d) / "a.tgz").write_bytes(b"aaa")
+            (Path(d) / "b.tgz").write_bytes(b"bbb")
+
+        with tempfile.TemporaryDirectory() as outdir:
+            result = _invoke(
+                _base_args(**{"--output-dir": outdir}),
+                export,
+            )
+            assert result.exit_code == 0, result.output
+            assert (Path(outdir) / "a.tgz").exists()
+            assert (Path(outdir) / "b.tgz").exists()
+
+    def test_nested_files_found_via_rglob(self):
+        def export(tag, d):
+            nested = Path(d) / "opt" / "artifacts"
+            nested.mkdir(parents=True)
+            (nested / "ray.tgz").write_bytes(b"nested")
+
+        with tempfile.TemporaryDirectory() as outdir:
+            result = _invoke(
+                _base_args(**{"--output-dir": outdir}),
+                export,
+            )
+            assert result.exit_code == 0, result.output
+            assert (Path(outdir) / "ray.tgz").read_bytes() == b"nested"
+
+    def test_custom_glob_whl(self):
+        def export(tag, d):
+            (Path(d) / "ray.whl").write_bytes(b"wheel")
+            (Path(d) / "ray.tgz").write_bytes(b"tarball")
+
+        with tempfile.TemporaryDirectory() as outdir:
+            result = _invoke(
+                _base_args(**{"--file-glob": "*.whl", "--output-dir": outdir}),
+                export,
+            )
+            assert result.exit_code == 0, result.output
+            assert (Path(outdir) / "ray.whl").exists()
+            assert not (Path(outdir) / "ray.tgz").exists()
+
+    def test_missing_file_glob_errors(self):
+        args = [
+            "--wanda-image-name",
+            "test-image",
+            "--rayci-work-repo",
+            "ecr.example.com/repo",
+            "--rayci-build-id",
+            "build-123",
+        ]
+        result = _invoke(args, lambda tag, d: None)
+        assert result.exit_code != 0
+        assert "--file-glob" in result.output
+
+    def test_creates_output_dir(self):
+        def export(tag, d):
+            (Path(d) / "ray.tgz").write_bytes(b"content")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outdir = Path(tmpdir) / "new" / "nested"
+            result = _invoke(
+                _base_args(**{"--output-dir": str(outdir)}),
+                export,
+            )
+            assert result.exit_code == 0, result.output
+            assert (outdir / "ray.tgz").exists()
+
+
+class TestErrorHandling:
+    def test_no_matching_files(self):
+        def export(tag, d):
+            (Path(d) / "something.txt").write_bytes(b"")
+
+        result = _invoke(_base_args(), export)
+        assert result.exit_code != 0
+        assert "No files matching" in result.output
+
+    def test_empty_image(self):
+        result = _invoke(_base_args(), lambda tag, d: None)
+        assert result.exit_code != 0
+
+    def test_duplicate_basenames_raises(self):
+        def export(tag, d):
+            (Path(d) / "ray.tgz").write_bytes(b"top")
+            nested = Path(d) / "sub"
+            nested.mkdir()
+            (nested / "ray.tgz").write_bytes(b"nested")
+
+        result = _invoke(_base_args(), export)
+        assert result.exit_code != 0
+        assert "Duplicate basename" in result.output
+
+    def test_crane_error_becomes_click_exception(self):
+        def export(tag, d):
+            raise CraneError("crane export failed (rc=1)")
+
+        result = _invoke(_base_args(), export)
+        assert result.exit_code != 0
+        assert "crane export failed" in result.output
+        # ClickException prints "Error: <message>" without a traceback.
+        assert "Traceback" not in result.output
+
+    def test_directories_matching_glob_are_skipped(self):
+        def export(tag, d):
+            # A directory whose name matches the glob should not be copied;
+            # only the regular file inside it should be extracted.
+            (Path(d) / "weirdly-named.tgz").mkdir()
+            (Path(d) / "real.tgz").write_bytes(b"content")
+
+        with tempfile.TemporaryDirectory() as outdir:
+            result = _invoke(_base_args(**{"--output-dir": outdir}), export)
+            assert result.exit_code == 0, result.output
+            assert (Path(outdir) / "real.tgz").is_file()
+            assert not (Path(outdir) / "weirdly-named.tgz").exists()
+
+    def test_duplicate_detected_before_any_copy(self):
+        # Interleaving validation with copying would leave the first file
+        # behind on disk before the duplicate is reported. Verify nothing
+        # is copied when a duplicate exists anywhere in the match set.
+        def export(tag, d):
+            (Path(d) / "a.tgz").write_bytes(b"first")
+            nested = Path(d) / "sub"
+            nested.mkdir()
+            (nested / "a.tgz").write_bytes(b"second")
+
+        with tempfile.TemporaryDirectory() as outdir:
+            result = _invoke(_base_args(**{"--output-dir": outdir}), export)
+            assert result.exit_code != 0
+            assert "Duplicate basename" in result.output
+            assert list(Path(outdir).iterdir()) == []
+
+
+class TestWorkspaceResolution:
+    def test_relative_output_resolved_against_workspace(self):
+        # Under `bazel run`, cwd is the runfiles tree and BUILD_WORKSPACE_DIRECTORY
+        # points at the workspace root. Relative --output-dir must resolve there.
+        def export(tag, d):
+            (Path(d) / "ray.tgz").write_bytes(b"content")
+
+        with tempfile.TemporaryDirectory() as workspace, mock.patch.dict(
+            "os.environ", {"BUILD_WORKSPACE_DIRECTORY": workspace}
+        ):
+            result = _invoke(_base_args(**{"--output-dir": ".whl"}), export)
+            assert result.exit_code == 0, result.output
+            assert (Path(workspace) / ".whl" / "ray.tgz").read_bytes() == b"content"
+
+    def test_absolute_output_not_rewritten(self):
+        def export(tag, d):
+            (Path(d) / "ray.tgz").write_bytes(b"content")
+
+        with tempfile.TemporaryDirectory() as workspace, tempfile.TemporaryDirectory() as outdir, mock.patch.dict(
+            "os.environ", {"BUILD_WORKSPACE_DIRECTORY": workspace}
+        ):
+            result = _invoke(_base_args(**{"--output-dir": outdir}), export)
+            assert result.exit_code == 0, result.output
+            assert (Path(outdir) / "ray.tgz").exists()
+            assert not (Path(workspace) / outdir.lstrip("/")).exists()
+
+
+class TestImageTag:
+    def test_constructs_repo_buildid_name(self):
+        captured = []
+
+        def export(tag, d):
+            captured.append(tag)
+            (Path(d) / "f.tgz").write_bytes(b"")
+
+        _invoke(
+            _base_args(
+                **{
+                    "--wanda-image-name": "my-image",
+                    "--rayci-work-repo": "ecr.aws.com/rayci",
+                    "--rayci-build-id": "abc-123",
+                }
+            ),
+            export,
+        )
+        assert captured == ["ecr.aws.com/rayci:abc-123-my-image"]
+
+
+class TestECRLogin:
+    def test_extracts_registry_host(self):
+        registries = []
+
+        def export(tag, d):
+            (Path(d) / "f.tgz").write_bytes(b"")
+
+        with mock.patch(f"{_MODULE}.call_crane_export", side_effect=export), mock.patch(
+            f"{_MODULE}.ecr_docker_login", side_effect=lambda r: registries.append(r)
+        ):
+            CliRunner().invoke(
+                main,
+                _base_args(
+                    **{
+                        "--rayci-work-repo": "830883877497.dkr.ecr.us-west-2.amazonaws.com/rayci"
+                    }
+                ),
+            )
+        assert registries == ["830883877497.dkr.ecr.us-west-2.amazonaws.com"]


### PR DESCRIPTION
Click CLI that extracts files matching a glob from a Wanda-cached image via crane export. Requires --wanda-image-name and --file-glob (e.g. '*.whl', '*.tgz'); takes --output-dir (default '.'). Errors on zero matches and on duplicate basenames across nested paths.

Topic: generic-extract
Signed-off-by: andrew <andrew@anyscale.com>