### PR TITLE
[core] stricter feasibility definition for placement groups

### DIFF
--- a/src/ray/gcs/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_placement_group_manager.cc
@@ -228,9 +228,10 @@ void GcsPlacementGroupManager::OnPlacementGroupCreationFailed(
       // group by rescheduling the bundles of the dead node. This should have higher
       // priority than trying to place other placement groups.
 
-      // NOTE: If this placement group does not become readily available in time, there is a chance it may starve future
-      // placement groups, as this will be consistently tried and scheduled. However, this
-      // use case seems to be pretty esoteric and for now will just be documented here.
+      // NOTE: If this placement group does not become readily available in time, there is
+      // a chance it may starve future placement groups, as this will be consistently
+      // tried and scheduled. However, this use case seems to be pretty esoteric and for
+      // now will just be documented here.
       stats->set_scheduling_state(rpc::PlacementGroupStats::FAILED_TO_COMMIT_RESOURCES);
       AddToPendingQueue(std::move(placement_group), /*rank=*/0);
     } else if (state == rpc::PlacementGroupTableData::PENDING) {

--- a/src/ray/gcs/gcs_placement_group_manager.cc
+++ b/src/ray/gcs/gcs_placement_group_manager.cc
@@ -227,6 +227,10 @@ void GcsPlacementGroupManager::OnPlacementGroupCreationFailed(
       // NOTE: If a node is dead, the placement group scheduler should try to recover the
       // group by rescheduling the bundles of the dead node. This should have higher
       // priority than trying to place other placement groups.
+
+      // NOTE: If this placement group does not become readily available in time, there is a chance it may starve future
+      // placement groups, as this will be consistently tried and scheduled. However, this
+      // use case seems to be pretty esoteric and for now will just be documented here.
       stats->set_scheduling_state(rpc::PlacementGroupStats::FAILED_TO_COMMIT_RESOURCES);
       AddToPendingQueue(std::move(placement_group), /*rank=*/0);
     } else if (state == rpc::PlacementGroupTableData::PENDING) {

--- a/src/ray/raylet/scheduling/BUILD.bazel
+++ b/src/ray/raylet/scheduling/BUILD.bazel
@@ -219,6 +219,7 @@ ray_cc_library(
     srcs = ["policy/label_domain_bundle_scheduling_policy.cc"],
     hdrs = ["policy/label_domain_bundle_scheduling_policy.h"],
     deps = [
+        ":cluster_resource_manager",
         ":scheduling_policy",
     ],
 )

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -237,6 +237,41 @@ bool ClusterResourceManager::HasFeasibleResources(
   return it->second.GetLocalView().IsFeasible(resource_request);
 }
 
+bool ClusterResourceManager::IsRequestFeasible(
+    const std::vector<const ResourceRequest *> &resource_request_list,
+    const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes) {
+  // Stage 1: each bundle is individually feasible on at least one node.
+  for (const auto &request : resource_request_list) {
+    bool bundle_feasible = std::any_of(
+        candidate_nodes.begin(), candidate_nodes.end(), [&](const auto &entry) {
+          // Validates both resource and label constraints are feasible.
+          return entry.second->GetLocalView().IsFeasible(*request);
+        });
+    if (!bundle_feasible) {
+      return false;
+    }
+  }
+
+  // Stage 2: aggregate demand across all bundles does not exceed aggregate
+  // total capacity across all candidate nodes, per resource. A pure necessary
+  // condition, so passing does not prove feasibility, but failing proves
+  // infeasibility regardless of placement strategy.
+  ResourceSet aggregate_demand;
+  for (const ResourceRequest *request : resource_request_list) {
+    aggregate_demand += request->GetResourceSet();
+  }
+  for (auto resource_id : aggregate_demand.ResourceIds()) {
+    FixedPoint total_capacity;
+    for (const auto &[node_id, node] : candidate_nodes) {
+      total_capacity += node->GetLocalView().total.Get(resource_id);
+    }
+    if (total_capacity < aggregate_demand.Get(resource_id)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool ClusterResourceManager::HasAvailableResources(
     scheduling::NodeID node_id,
     const ResourceRequest &resource_request,

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -111,6 +111,25 @@ class ClusterResourceManager {
   bool HasFeasibleResources(scheduling::NodeID node_id,
                             const ResourceRequest &resource_request) const;
 
+  /// Checks whether a set of placement group bundles is structurally feasible
+  /// on the given candidate nodes. Applies two necessary conditions:
+  ///  1. Each bundle is individually feasible on at least one candidate node
+  ///     (resource and label constraints).
+  ///  2. Aggregate bundle demand does not exceed aggregate candidate capacity,
+  ///     per resource.
+  ///
+  /// Returning true does not prove a placement exists under any specific
+  /// strategy (distinctness, bin-packing, etc. are not considered here);
+  /// returning false proves no placement can exist on this candidate set.
+  ///
+  /// Static because it only reads the passed-in candidate map — no instance
+  /// state is needed, which lets callers that don't hold a
+  /// ClusterResourceManager reference (e.g. LabelDomainSchedulingPolicyInterface)
+  /// share the same implementation.
+  static bool IsRequestFeasible(
+      const std::vector<const ResourceRequest *> &resource_request_list,
+      const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes);
+
   /// Add available resource to a given node.
   /// Return false if such node doesn't exist.
   bool AddNodeAvailableResources(scheduling::NodeID node_id,

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.cc
@@ -33,17 +33,8 @@ SchedulingResult SortSchedulingResult(const SchedulingResult &result,
 bool BundleSchedulingPolicy::IsRequestFeasible(
     const std::vector<const ResourceRequest *> &resource_request_list,
     const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes) const {
-  for (const auto &request : resource_request_list) {
-    bool bundle_feasible = std::any_of(
-        candidate_nodes.begin(), candidate_nodes.end(), [&](const auto &entry) {
-          // Validates both resource and label constraints are feasible.
-          return entry.second->GetLocalView().IsFeasible(*request);
-        });
-    if (!bundle_feasible) {
-      return false;
-    }
-  }
-  return true;
+  return ClusterResourceManager::IsRequestFeasible(resource_request_list,
+                                                   candidate_nodes);
 }
 
 std::pair<std::vector<int>, std::vector<const ResourceRequest *>>
@@ -157,7 +148,7 @@ SchedulingResult BundlePackSchedulingPolicy::Schedule(
   const auto &sorted_index = sorted_result.first;
   const auto &sorted_resource_request_list = sorted_result.second;
 
-  if (!IsRequestFeasible(sorted_resource_request_list, candidate_nodes)) {
+  if (!IsRequestFeasible(resource_request_list, candidate_nodes)) {
     RAY_LOG(DEBUG) << "Request requires labels or resources not present in the cluster.";
     return SchedulingResult::Infeasible();
   }
@@ -238,7 +229,7 @@ SchedulingResult BundleSpreadSchedulingPolicy::Schedule(
   const auto &sorted_index = sorted_result.first;
   const auto &sorted_resource_request_list = sorted_result.second;
 
-  if (!IsRequestFeasible(sorted_resource_request_list, candidate_nodes)) {
+  if (!IsRequestFeasible(resource_request_list, candidate_nodes)) {
     RAY_LOG(DEBUG) << "Request requires labels or resources not present in the cluster.";
     return SchedulingResult::Infeasible();
   }
@@ -409,7 +400,7 @@ SchedulingResult BundleStrictSpreadSchedulingPolicy::Schedule(
   const auto &sorted_index = sorted_result.first;
   const auto &sorted_resource_request_list = sorted_result.second;
 
-  if (!IsRequestFeasible(sorted_resource_request_list, candidate_nodes)) {
+  if (!IsRequestFeasible(resource_request_list, candidate_nodes)) {
     RAY_LOG(DEBUG) << "Request requires labels or resources not present in the cluster.";
     return SchedulingResult::Infeasible();
   }

--- a/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/bundle_scheduling_policy.h
@@ -42,14 +42,22 @@ class BundleSchedulingPolicy : public IBundleSchedulingPolicy {
   std::pair<std::vector<int>, std::vector<const ResourceRequest *>> SortRequiredResources(
       const std::vector<const ResourceRequest *> &resource_request_list);
 
-  /// Checks if every bundle is individually feasible on at least one node in the cluster.
+  /// Checks whether a set of bundles is structurally feasible on the given
+  /// candidate nodes. Two necessary conditions are tested:
+  ///  1. Each bundle is individually feasible on at least one candidate node
+  ///     (resource and label constraints).
+  ///  2. The aggregate resource demand across all bundles does not exceed the
+  ///     aggregate total resources of the candidate nodes, per resource.
+  ///
+  /// Returning true does not guarantee that a placement exists under any
+  /// specific strategy (e.g. bin-packing or distinctness constraints are not
+  /// checked here); returning false proves no placement can exist.
   ///
   /// \param resource_request_list The list of resource and label constraints for each
   /// bundle.
   /// \param candidate_nodes The candidate nodes in the cluster available for
   /// scheduling.
-  /// \return True if all bundles are feasible on at least one node, false
-  /// otherwise.
+  /// \return True if both feasibility conditions are met, false otherwise.
   bool IsRequestFeasible(
       const std::vector<const ResourceRequest *> &resource_request_list,
       const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes) const;

--- a/src/ray/raylet/scheduling/policy/label_domain_bundle_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/label_domain_bundle_scheduling_policy.cc
@@ -14,42 +14,16 @@
 
 #include "ray/raylet/scheduling/policy/label_domain_bundle_scheduling_policy.h"
 
+#include "ray/raylet/scheduling/cluster_resource_manager.h"
+
 namespace ray {
 namespace raylet_scheduling_policy {
 
-// TODO(#61778): Move this to the cluster resource manager.
 bool LabelDomainSchedulingPolicyInterface::IsRequestFeasible(
     const std::vector<const ResourceRequest *> &resource_request_list,
     const absl::flat_hash_map<scheduling::NodeID, const Node *> &candidate_nodes) const {
-  // Check that each bundle is individually feasible on at least one node.
-  for (const ResourceRequest *const &request : resource_request_list) {
-    bool bundle_feasible =
-        std::any_of(candidate_nodes.begin(),
-                    candidate_nodes.end(),
-                    [&](const std::pair<const scheduling::NodeID, const Node *> &entry) {
-                      return entry.second->GetLocalView().IsFeasible(*request);
-                    });
-    if (!bundle_feasible) {
-      return false;
-    }
-  }
-
-  // Check that aggregate demand does not exceed aggregate capacity.
-  ResourceSet aggregate_demand;
-  for (const ResourceRequest *request : resource_request_list) {
-    aggregate_demand += request->GetResourceSet();
-  }
-  for (auto resource_id : aggregate_demand.ResourceIds()) {
-    FixedPoint total_capacity;
-    for (const auto &[node_id, node] : candidate_nodes) {
-      total_capacity += node->GetLocalView().total.Get(resource_id);
-    }
-    if (total_capacity < aggregate_demand.Get(resource_id)) {
-      return false;
-    }
-  }
-
-  return true;
+  return ClusterResourceManager::IsRequestFeasible(resource_request_list,
+                                                   candidate_nodes);
 }
 
 SchedulingResult LabelDomainStrictPackSchedulingPolicy::Schedule(

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -692,6 +692,107 @@ TEST_F(SchedulingPolicyTest, StrictSpreadBundleLabelSelectorInfeasibleTest) {
   ASSERT_TRUE(result.status.IsInfeasible());
 }
 
+TEST_F(SchedulingPolicyTest, PackBundleAggregateInsufficientInfeasibleTest) {
+  // 4 bundles of {CPU: 4} on a cluster totaling {CPU: 8}: aggregate demand
+  // exceeds aggregate capacity, so PACK must return Infeasible rather than
+  // Failed (which would spin on the pending queue).
+  nodes.emplace(local_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  nodes.emplace(remote_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 4}}, false);
+  std::vector<const ResourceRequest *> req_list = {&req, &req, &req, &req};
+
+  auto pack_op = SchedulingOptions::BundlePack();
+  auto result =
+      raylet_scheduling_policy::BundlePackSchedulingPolicy(*cluster_resource_manager)
+          .Schedule(req_list, pack_op, GetCandidateNodes(*cluster_resource_manager));
+
+  ASSERT_TRUE(result.status.IsInfeasible());
+}
+
+TEST_F(SchedulingPolicyTest, SpreadBundleAggregateInsufficientInfeasibleTest) {
+  // Same scenario as PackBundleAggregateInsufficientInfeasibleTest but for SPREAD.
+  nodes.emplace(local_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  nodes.emplace(remote_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 4}}, false);
+  std::vector<const ResourceRequest *> req_list = {&req, &req, &req, &req};
+
+  auto spread_op = SchedulingOptions::BundleSpread();
+  auto result =
+      raylet_scheduling_policy::BundleSpreadSchedulingPolicy(*cluster_resource_manager)
+          .Schedule(req_list, spread_op, GetCandidateNodes(*cluster_resource_manager));
+
+  ASSERT_TRUE(result.status.IsInfeasible());
+}
+
+TEST_F(SchedulingPolicyTest, StrictSpreadBundleAggregateInsufficientInfeasibleTest) {
+  // Same scenario for STRICT_SPREAD. Four bundles on two nodes also trips the
+  // cardinality check, so use three bundles and three nodes where the
+  // aggregate demand still exceeds the aggregate capacity.
+  nodes.emplace(local_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  nodes.emplace(remote_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  nodes.emplace(remote_node_2, CreateNodeResources(5, 5, 0, 0, 0, 0));
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 5}}, false);
+  std::vector<const ResourceRequest *> req_list = {&req, &req, &req};
+
+  auto strict_spread_op = SchedulingOptions::BundleStrictSpread();
+  auto result =
+      raylet_scheduling_policy::BundleStrictSpreadSchedulingPolicy(
+          *cluster_resource_manager)
+          .Schedule(
+              req_list, strict_spread_op, GetCandidateNodes(*cluster_resource_manager));
+
+  ASSERT_TRUE(result.status.IsInfeasible());
+}
+
+TEST_F(SchedulingPolicyTest, PackBundleAggregateBoundaryFeasibleTest) {
+  // Aggregate demand exactly equals aggregate capacity: still be
+  // treated as feasible. If this test fails, please be wary whether we
+  // want to mark PG as infeasible, where it may be stuck in infeasible
+  // queue.
+  nodes.emplace(local_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  nodes.emplace(remote_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 4}}, false);
+  std::vector<const ResourceRequest *> req_list = {&req, &req};
+
+  auto pack_op = SchedulingOptions::BundlePack();
+  auto result =
+      raylet_scheduling_policy::BundlePackSchedulingPolicy(*cluster_resource_manager)
+          .Schedule(req_list, pack_op, GetCandidateNodes(*cluster_resource_manager));
+
+  ASSERT_TRUE(result.status.IsSuccess());
+}
+
+TEST_F(SchedulingPolicyTest, StrictPackBundleAggregateUnchangedTest) {
+  // 2 bundles of {CPU: 3} across two {CPU: 4} nodes: aggregate demand (6)
+  // fits in aggregate capacity (8), but STRICT_PACK requires all on one node
+  // (max 4), so it remains Infeasible. Confirms STRICT_PACK still uses its
+  // stricter aggregate-fits-on-one-node check rather than the looser
+  // sum-dominance check now in IsRequestFeasible.
+  nodes.emplace(local_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  nodes.emplace(remote_node, CreateNodeResources(4, 4, 0, 0, 0, 0));
+  auto cluster_resource_manager = MockClusterResourceManager(nodes);
+
+  ResourceRequest req = ResourceMapToResourceRequest({{"CPU", 3}}, false);
+  std::vector<const ResourceRequest *> req_list = {&req, &req};
+
+  auto strict_pack_op = SchedulingOptions::BundleStrictPack(scheduling::NodeID::Nil());
+  auto result =
+      raylet_scheduling_policy::BundleStrictPackSchedulingPolicy(
+          *cluster_resource_manager)
+          .Schedule(
+              req_list, strict_pack_op, GetCandidateNodes(*cluster_resource_manager));
+
+  ASSERT_TRUE(result.status.IsInfeasible());
+}
+
 TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
   // We have two racks, rack-1 has 18 nodes, rack-2 has 2 nodes
   // Each node has 4 GPUs and 2 CPUs.

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
@@ -125,7 +125,7 @@ class GcsResourceSchedulerTest : public ::testing::Test {
     }
     const auto &result2 = cluster_resource_scheduler_->SchedulePlacementGroup(
         resource_request_list, scheduling_options);
-    ASSERT_TRUE(result2.status.IsFailed());
+    ASSERT_TRUE(result2.status.IsInfeasible());
     ASSERT_EQ(result2.selected_nodes.size(), 0);
 
     // Check for resource leaks.


### PR DESCRIPTION
## Description
There is known issue for a feasible, rescheduling placement group to starve existing placement groups in the pending queue. Made the feasibility definition for placement groups stricter to have the chances of this happening less. The same pending group now might be marked infeasible in some cases, and will later be woken up when nodes are added to the cluster.

## Testing
new tests added here
bazel test //src/ray/raylet/scheduling/... --test_output=errors

ensures no regression
bazel test //src/ray/raylet/... --test_output=errors
bazel test //src/ray/gcs/... --test_output=errors
pytest python/ray/tests/test_placement_group*.py -xvs