### PR TITLE
[serve][3/N] Adapt request routing to account for session stickiness

### DIFF
--- a/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
+++ b/python/ray/llm/_internal/serve/routing_policies/prefix_aware/prefix_aware_router.py
@@ -16,15 +16,14 @@ from ray.serve._private.common import ReplicaID
 from ray.serve._private.constants import (
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
+    SERVE_MULTIPLEX_DIMENSION_NAME,
     SERVE_NAMESPACE,
 )
 from ray.serve._private.replica_result import ReplicaResult
-from ray.serve._private.request_router import (
-    PowerOfTwoChoicesRequestRouter,
-)
 from ray.serve._private.request_router.common import (
     PendingRequest,
 )
+from ray.serve._private.request_router.pow_2_router import select_pow2_pair
 from ray.serve._private.request_router.replica_wrapper import (
     RunningReplica,
 )
@@ -32,25 +31,25 @@ from ray.serve._private.request_router.request_router import (
     LocalityMixin,
     MultiplexMixin,
     RequestRouter,
+    rank_replicas_by_session_and_locality,
 )
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
-    """Extends the PowerOfTwoChoicesRequestRouter with prefix-matching capabilities.
+    """Routes LLM requests by layering prefix-cache affinity on top of the
+    standard model / session / locality priority.
 
-    This request router optimizes replica selection by considering input text prefixes:
-
-    1. Mixes between three strategies to balance prefix cache hit rate and load balancing:
-       - When load is balanced (queue length difference < threshold), it selects replicas
-         with the highest prefix match rate for the input text
-       - When load is balanced but match rate is below 10%, it falls back to the smallest tenants
-       - When load is imbalanced, it uses the default Power of Two selection
-
-    2. Maintains a prefix tree to track which replicas have processed similar inputs:
-       - Inserts prompt text into the prefix tree after routing
-       - Uses this history to inform future routing decisions
+    Priority (highest to lowest):
+      1. Model multiplex ID — hard filter to replicas that have the model cached.
+      2. Session affinity and locality — equal-weight tiebreakers; a session-
+         warm remote replica ties with a session-cold node-local one.
+      3. Prefix cache affinity — within a session+locality tier, prefer
+         replicas whose prefix tree already contains the input text. If the
+         match rate is below ``match_rate_threshold`` or the load is
+         imbalanced, fall back to power-of-two queue length within that tier.
+      4. Power-of-two queue length — final tiebreaker inside a tier.
 
     This approach improves performance by routing related requests to the same replicas,
     increasing cache locality and reducing overhead for language model inference.
@@ -212,9 +211,9 @@ class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
     ) -> List[RunningReplica]:
         """
         Returns a set of candidate replicas, of which the one with the smallest replica queue will be chosen.
-        0. Default: same as pow 2 request router, return 2 replicas at random.
+        0. Default: return [] so the caller falls back to pow2 selection.
         1. If load is balanced, choose replica(s) with highest prefix match rate. If highest hit rate is below 10% or no match found, use replicas with smallest KV cache usage.
-        2. If load is imbalanced, use default.
+        2. If load is imbalanced, return [].
         """
         chosen_replica_id_strings = []
         if (
@@ -274,7 +273,12 @@ class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
                             smallest_tenants_id_strings is not None
                             and len(smallest_tenants_id_strings) > 0
                         ):
-                            chosen_replica_id_strings = smallest_tenants_id_strings
+                            candidate_ids = set(candidate_replica_ids_strings)
+                            chosen_replica_id_strings = [
+                                s
+                                for s in smallest_tenants_id_strings
+                                if s in candidate_ids
+                            ]
                     else:
                         if (
                             matched_tenant_id_strings is not None
@@ -283,10 +287,8 @@ class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
                             chosen_replica_id_strings = matched_tenant_id_strings
                 # End Sphinx tag: __end_prefix_match_component__
         return [
-            [
-                self._replicas[ReplicaID.from_full_id_str(chosen_id_string)]
-                for chosen_id_string in chosen_replica_id_strings
-            ]
+            self._replicas[ReplicaID.from_full_id_str(chosen_id_string)]
+            for chosen_id_string in chosen_replica_id_strings
         ]
 
     # Start Sphinx tag: __begin_on_replica_actor_died__
@@ -338,57 +340,52 @@ class PrefixCacheAffinityRouter(LocalityMixin, MultiplexMixin, RequestRouter):
         self,
         candidate_replicas: List[RunningReplica],
         pending_request: Optional[PendingRequest] = None,
-    ) -> List[RunningReplica]:
-        """One iteration of the power of two choices procedure that chooses
-         (at most) two random available replicas.
+    ) -> List[List[RunningReplica]]:
+        """Return candidate replica pools ordered from best tier to worst.
 
-        For multiplexing, this will first attempt to choose replicas that have the
-        requested model ID for a configured timeout. If no replicas with the matching
-        model ID are available after that timeout, it will fall back to the regular
-        procedure.
+        Each pool contains the prefix-matched replicas of one
+        session+locality tier (over model-filtered survivors), or a
+        power-of-two pair drawn at random when prefix can't decide (no
+        prompt, imbalanced queues, or match rate below threshold). The
+        outer routing loop probes pools top-down and only falls through
+        to the next one when every replica in the current pool rejects
+        the request.
         """
-        # Start Sphinx tag: __begin_pow2_router_base__
-        # Get fallback replicas from PowerOfTwoChoicesRequestRouter
-        fallback_replicas = await PowerOfTwoChoicesRequestRouter.choose_replicas(
-            self,
-            candidate_replicas=candidate_replicas,
-            pending_request=pending_request,
+        # Step 1: model hard filter.
+        multiplex_ids = (
+            pending_request.metadata.multiplex_ids
+            if pending_request is not None
+            else {}
         )
-        if pending_request is None or not fallback_replicas:
-            return fallback_replicas
-        # End Sphinx tag: __end_pow2_router_base__
-
-        if (
-            pending_request is not None
-            and pending_request.metadata.multiplexed_model_id
-        ):
-            # Get candidates for multiplexed model ID.
+        if multiplex_ids.get(SERVE_MULTIPLEX_DIMENSION_NAME.MODEL):
             candidate_replica_ids = self.apply_multiplex_routing(
                 pending_request=pending_request,
             )
         else:
-            # Get candidates for locality preference.
-            candidate_replica_ids = self.apply_locality_routing(
-                pending_request=pending_request,
-            )
+            candidate_replica_ids = self._replica_id_set
+
         if not candidate_replica_ids:
-            return fallback_replicas
+            return []
 
-        # Convert candidate replica IDs to RunningReplica objects.
-        replica_id_to_replica_map = {
-            replica.replica_id: replica for replica in candidate_replicas
-        }
-        candidate_replicas = [
-            replica_id_to_replica_map[candidate_replica_id]
-            for candidate_replica_id in candidate_replica_ids
-        ]
-        chosen_replicas = await self._prefix_match_best_replicas(
-            pending_request, candidate_replicas
+        # Step 2: rank survivors by session + locality (equal-weight).
+        session_id = multiplex_ids.get(SERVE_MULTIPLEX_DIMENSION_NAME.SESSION)
+        session_warm_replica_ids = self._multiplex_dim_id_to_replica_ids.get(
+            SERVE_MULTIPLEX_DIMENSION_NAME.SESSION, {}
+        ).get(session_id, set())
+        filtered_replicas = [self._replicas[rid] for rid in candidate_replica_ids]
+        ranked_tiers = rank_replicas_by_session_and_locality(
+            filtered_replicas,
+            session_warm_replica_ids,
+            self._colocated_replica_ids,
         )
-        if chosen_replicas[0]:
-            return chosen_replicas
 
-        return fallback_replicas
+        # Step 3: within each tier, prefer prefix-matched replicas; fall back
+        # to pow2 queue length when prefix produces nothing for that tier.
+        result: List[List[RunningReplica]] = []
+        for tier in ranked_tiers:
+            matched = await self._prefix_match_best_replicas(pending_request, tier)
+            result.append(matched if matched else select_pow2_pair(tier))
+        return result
 
     # Start Sphinx tag: __begin_on_request_routed__
     def on_request_routed(

--- a/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/test_prefix_aware_request_router.py
@@ -49,6 +49,10 @@ def prefix_request_router(tree_actor, request):
             handle_source=DeploymentHandleSource.REPLICA,
             use_replica_queue_len_cache=False,
             get_curr_time_s=TIMER.time,
+            self_node_id=params.get("self_node_id"),
+            self_availability_zone=params.get("self_availability_zone"),
+            prefer_local_node_routing=params.get("prefer_local_node_routing", False),
+            prefer_local_az_routing=params.get("prefer_local_az_routing", False),
         )
         return request_router
 
@@ -83,7 +87,9 @@ class ChatRequest:
         self.messages = messages
 
 
-def fake_pending_request(prompt=None, messages=None) -> PendingRequest:
+def fake_pending_request(
+    prompt=None, messages=None, multiplex_ids=None
+) -> PendingRequest:
     if prompt is not None:
         args = [PromptRequest(prompt)]
     elif messages is not None:
@@ -97,6 +103,7 @@ def fake_pending_request(prompt=None, messages=None) -> PendingRequest:
         metadata=RequestMetadata(
             request_id=generate_request_id(),
             internal_request_id=generate_request_id(),
+            multiplex_ids=multiplex_ids or {},
         ),
         created_at=time.time(),
     )
@@ -251,6 +258,253 @@ class TestPrefixAwareLogic:
             assert (
                 await prefix_request_router._choose_replica_for_request(chat_req) == r1
             )
+
+
+TEST_ROUTER_NODE_ID = "router-node"
+TEST_ROUTER_AZ = "router-az"
+
+
+@pytest.mark.parametrize(
+    "prefix_request_router",
+    [
+        {
+            "self_node_id": TEST_ROUTER_NODE_ID,
+            "self_availability_zone": TEST_ROUTER_AZ,
+            "prefer_local_node_routing": True,
+            "prefer_local_az_routing": True,
+        }
+    ],
+    indirect=True,
+)
+class TestSessionLocalityTiebreaker:
+    """Priority: model (hard filter) > session == locality > prefix > pow2.
+
+    These mirror the pow2 router's equivalent cases. Replicas have equal
+    queue length and no prefix-tree entries so the decision must come
+    strictly from the session+locality tiering.
+    """
+
+    @pytest.mark.asyncio
+    async def test_model_plus_session_prefers_warm_session(self, prefix_request_router):
+        r_warm = FakeRunningReplica(
+            "r_warm",
+            multiplex_dim_to_ids={"model": {"m1"}, "session": {"s1"}},
+        )
+        r_cold = FakeRunningReplica(
+            "r_cold",
+            multiplex_dim_to_ids={"model": {"m1"}, "session": set()},
+        )
+        r_warm.set_queue_len_response(0)
+        r_cold.set_queue_len_response(0)
+        prefix_request_router.update_replicas([r_warm, r_cold])
+
+        req = fake_pending_request(
+            prompt="hi", multiplex_ids={"model": "m1", "session": "s1"}
+        )
+        for _ in range(10):
+            chosen = await prefix_request_router._choose_replica_for_request(req)
+            assert chosen == r_warm
+
+    @pytest.mark.asyncio
+    async def test_model_plus_locality_prefers_local(self, prefix_request_router):
+        r_local = FakeRunningReplica(
+            "r_local",
+            node_id=TEST_ROUTER_NODE_ID,
+            availability_zone=TEST_ROUTER_AZ,
+            multiplex_dim_to_ids={"model": {"m1"}},
+        )
+        r_remote = FakeRunningReplica(
+            "r_remote",
+            node_id="other-node",
+            availability_zone="other-az",
+            multiplex_dim_to_ids={"model": {"m1"}},
+        )
+        r_local.set_queue_len_response(0)
+        r_remote.set_queue_len_response(0)
+        prefix_request_router.update_replicas([r_local, r_remote])
+
+        req = fake_pending_request(prompt="hi", multiplex_ids={"model": "m1"})
+        for _ in range(10):
+            chosen = await prefix_request_router._choose_replica_for_request(req)
+            assert chosen == r_local
+
+    @pytest.mark.asyncio
+    async def test_session_plus_locality_prefers_local(self, prefix_request_router):
+        r_local = FakeRunningReplica(
+            "r_local",
+            node_id=TEST_ROUTER_NODE_ID,
+            availability_zone=TEST_ROUTER_AZ,
+            multiplex_dim_to_ids={"session": {"s1"}},
+        )
+        r_remote = FakeRunningReplica(
+            "r_remote",
+            node_id="other-node",
+            availability_zone="other-az",
+            multiplex_dim_to_ids={"session": {"s1"}},
+        )
+        r_local.set_queue_len_response(0)
+        r_remote.set_queue_len_response(0)
+        prefix_request_router.update_replicas([r_local, r_remote])
+
+        req = fake_pending_request(prompt="hi", multiplex_ids={"session": "s1"})
+        for _ in range(10):
+            chosen = await prefix_request_router._choose_replica_for_request(req)
+            assert chosen == r_local
+
+    @pytest.mark.asyncio
+    async def test_session_plus_model_prefers_model_loaded(self, prefix_request_router):
+        r_with_model = FakeRunningReplica(
+            "r_with_model",
+            multiplex_dim_to_ids={"model": {"m1"}, "session": {"s1"}},
+        )
+        r_without_model = FakeRunningReplica(
+            "r_without_model",
+            multiplex_dim_to_ids={"model": set(), "session": {"s1"}},
+        )
+        r_with_model.set_queue_len_response(0)
+        r_without_model.set_queue_len_response(0)
+        prefix_request_router.update_replicas([r_with_model, r_without_model])
+
+        req = fake_pending_request(
+            prompt="hi", multiplex_ids={"model": "m1", "session": "s1"}
+        )
+        for _ in range(10):
+            chosen = await prefix_request_router._choose_replica_for_request(req)
+            assert chosen == r_with_model
+
+    @pytest.mark.asyncio
+    async def test_prefix_match_only_within_best_tier(self, prefix_request_router):
+        """Locality dominates prefix: a prefix hit on a remote replica does
+        not override a session-cold but node-local replica in the top tier.
+        """
+        r_local = FakeRunningReplica(
+            "r_local",
+            node_id=TEST_ROUTER_NODE_ID,
+            availability_zone=TEST_ROUTER_AZ,
+        )
+        r_remote = FakeRunningReplica(
+            "r_remote",
+            node_id="other-node",
+            availability_zone="other-az",
+        )
+        r_local.set_queue_len_response(0)
+        r_remote.set_queue_len_response(0)
+        prefix_request_router.update_replicas([r_local, r_remote])
+
+        # Seed the remote replica with a hot prefix.
+        ray.get(
+            prefix_request_router._tree_actor.insert.remote(
+                "Hello world",
+                r_remote.replica_id.to_full_id_str(),
+                time.time(),
+            )
+        )
+
+        req = fake_pending_request(prompt="Hello world")
+        for _ in range(10):
+            chosen = await prefix_request_router._choose_replica_for_request(req)
+            # Locality puts r_local in tier 0; prefix match in tier 2 never wins.
+            assert chosen == r_local
+
+    @pytest.mark.asyncio
+    async def test_low_match_rate_smallest_tenant_restricted_to_tier(
+        self, prefix_request_router
+    ):
+        """Low-match-rate fallback to the smallest-tenant is confined to the
+        current tier — a globally-smaller tenant in a lower tier must not be
+        chosen for the top tier's pool.
+        """
+        r_local = FakeRunningReplica(
+            "r_local",
+            node_id=TEST_ROUTER_NODE_ID,
+            availability_zone=TEST_ROUTER_AZ,
+            multiplex_dim_to_ids={"session": {"s1"}},
+        )
+        r_remote = FakeRunningReplica(
+            "r_remote",
+            node_id="other-node",
+            availability_zone="other-az",
+        )
+        r_local.set_queue_len_response(0)
+        r_remote.set_queue_len_response(0)
+        prefix_request_router.update_replicas([r_local, r_remote])
+
+        # Give r_local prior history; r_remote stays at 0 chars so it is the
+        # globally-smallest tenant. Without the tier intersection, the top
+        # tier's low-match-rate fallback would wrongly pick r_remote.
+        ray.get(
+            prefix_request_router._tree_actor.insert.remote(
+                "earlier prompt here",
+                r_local.replica_id.to_full_id_str(),
+                time.time(),
+            )
+        )
+
+        req = fake_pending_request(prompt="xyz", multiplex_ids={"session": "s1"})
+        for _ in range(10):
+            chosen = await prefix_request_router._choose_replica_for_request(req)
+            assert chosen == r_local
+
+
+@pytest.mark.parametrize(
+    "prefix_request_router",
+    [
+        {
+            "self_node_id": TEST_ROUTER_NODE_ID,
+            "self_availability_zone": TEST_ROUTER_AZ,
+            "prefer_local_node_routing": True,
+            "prefer_local_az_routing": True,
+            "imbalanced_threshold": 2,
+        }
+    ],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_imbalance_within_top_tier_stays_in_tier(prefix_request_router):
+    """When the top tier is internally imbalanced, prefix match is skipped
+    for that tier and pow2 queue length picks within it — a prefix hit in a
+    lower tier must not cause a cross-tier hop.
+    """
+    r_warm_low = FakeRunningReplica(
+        "r_warm_low",
+        node_id=TEST_ROUTER_NODE_ID,
+        availability_zone=TEST_ROUTER_AZ,
+        multiplex_dim_to_ids={"session": {"s1"}},
+    )
+    r_warm_high = FakeRunningReplica(
+        "r_warm_high",
+        node_id=TEST_ROUTER_NODE_ID,
+        availability_zone=TEST_ROUTER_AZ,
+        multiplex_dim_to_ids={"session": {"s1"}},
+    )
+    r_cold = FakeRunningReplica(
+        "r_cold",
+        node_id="other-node",
+        availability_zone="other-az",
+    )
+    r_warm_low.set_queue_len_response(0)
+    # Imbalanced against r_warm_low (diff=5 > threshold=2), but both still
+    # under max_ongoing_requests so the probe accepts them.
+    r_warm_high.set_queue_len_response(5)
+    r_cold.set_queue_len_response(0)
+    prefix_request_router.update_replicas([r_warm_low, r_warm_high, r_cold])
+
+    # Seed the lower tier with a perfect prefix match to tempt a cross-tier
+    # hop; the test asserts we resist it.
+    ray.get(
+        prefix_request_router._tree_actor.insert.remote(
+            "Hello world",
+            r_cold.replica_id.to_full_id_str(),
+            time.time(),
+        )
+    )
+
+    req = fake_pending_request(prompt="Hello world", multiplex_ids={"session": "s1"})
+    for _ in range(10):
+        chosen = await prefix_request_router._choose_replica_for_request(req)
+        # Top tier imbalanced → pow2 within tier → r_warm_low wins on shorter
+        # queue. r_cold's prefix hit in the lower tier is ignored.
+        assert chosen == r_warm_low
 
 
 class TestEvictionBehavior:

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1,3 +1,4 @@
+import enum
 import os
 import warnings
 from typing import List
@@ -401,9 +402,17 @@ SERVE_LOG_EXTRA_FIELDS = "ray_serve_extra_fields"
 SERVE_MULTIPLEX_HEADER_PREFIX = "serve_multiplexed_"
 SERVE_MULTIPLEX_HEADER_SUFFIX = "_id"
 
+# Canonical multiplex dimension names
+class SERVE_MULTIPLEX_DIMENSION_NAME(str, enum.Enum):
+    MODEL = "model"
+    SESSION = "session"
+
+
 # Expose multiplexed model ID so telemetry can reference it without re-deriving the string.
 SERVE_MULTIPLEXED_MODEL_ID = (
-    f"{SERVE_MULTIPLEX_HEADER_PREFIX}model{SERVE_MULTIPLEX_HEADER_SUFFIX}"
+    f"{SERVE_MULTIPLEX_HEADER_PREFIX}"
+    f"{SERVE_MULTIPLEX_DIMENSION_NAME.MODEL.value}"
+    f"{SERVE_MULTIPLEX_HEADER_SUFFIX}"
 )
 
 # Conventional session header name.

--- a/python/ray/serve/_private/request_router/pow_2_router.py
+++ b/python/ray/serve/_private/request_router/pow_2_router.py
@@ -7,6 +7,7 @@ from typing import (
 
 from ray.serve._private.constants import (
     SERVE_LOGGER_NAME,
+    SERVE_MULTIPLEX_DIMENSION_NAME,
 )
 from ray.serve._private.request_router.common import (
     PendingRequest,
@@ -19,9 +20,39 @@ from ray.serve._private.request_router.request_router import (
     LocalityMixin,
     MultiplexMixin,
     RequestRouter,
+    rank_replicas_by_session_and_locality,
 )
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+def select_pow2_pair(candidates: List[RunningReplica]) -> List[RunningReplica]:
+    """
+    Pick at most two distinct replicas uniformly at random from ``candidates``.
+
+    Optimized selection: use direct randrange for k=2 instead of random.sample.
+    This is ~1.9x faster for the common case of selecting 2 replicas.
+
+    Correctness proof: We pick i uniformly from [0, n), then j uniformly from
+    [0, n-1) and shift j up if j >= i. Every ordered pair (i, j) with i != j
+    has probability: Pr(i,j) = 1/n * 1/(n-1) = 1/(n(n-1))
+    This matches random.sample(k=2): uniform among all 2-permutations.
+    """
+    n = len(candidates)
+    if n <= 1:
+        return list(candidates)
+    if n == 2:
+        # Randomize order to ensure fair selection when queue lengths are equal.
+        return (
+            [candidates[0], candidates[1]]
+            if random.getrandbits(1)
+            else [candidates[1], candidates[0]]
+        )
+    i = random.randrange(n)
+    j = random.randrange(n - 1)
+    if j >= i:
+        j += 1
+    return [candidates[i], candidates[j]]
 
 
 class PowerOfTwoChoicesRequestRouter(
@@ -47,6 +78,16 @@ class PowerOfTwoChoicesRequestRouter(
     procedure concurrently. This task will not necessarily satisfy the request that
     started it (in order to maintain the FIFO order). The total number of tasks is
     capped at (2 * num_replicas).
+
+    Priority order:
+      1. Model multiplex ID — hard filter. Requests for a specific model are
+         confined to replicas that have it cached (falling back to replicas
+         with the fewest models loaded if none match within the match timeout).
+      2. Session affinity and locality — equal-weight tiebreakers. A replica
+         with a warm session and a replica on the same node share the top
+         tier; a session-warm remote replica ties with a session-cold
+         node-local one.
+      3. Power-of-two queue length — final tiebreaker within a tier.
     """
 
     async def choose_replicas(
@@ -54,53 +95,41 @@ class PowerOfTwoChoicesRequestRouter(
         candidate_replicas: List[RunningReplica],
         pending_request: Optional[PendingRequest] = None,
     ) -> List[List[RunningReplica]]:
-        """One iteration of the power of two choices procedure that chooses
-         (at most) two random available replicas.
+        """Return candidate replica pools ordered from best tier to worst.
 
-        For multiplexing, this will first attempt to choose replicas that have the
-        requested model ID for a configured timeout. If no replicas with the matching
-        model ID are available after that timeout, it will fall back to the regular
-        procedure.
+        Each pool holds up to two replicas drawn at random for the power-
+        of-two choice. The outer routing loop probes pools top-down and
+        only falls through to the next one when every replica in the
+        current pool rejects the request.
         """
-        if (
-            pending_request is not None
-            and pending_request.metadata.multiplexed_model_id
-        ):
-            # Get candidates for multiplexed model ID.
+        # Step 1: Model hard filter -- `apply_multiplex_routing` handles the
+        # match-timeout / fewest-models fallback internally.
+        multiplex_ids = (
+            pending_request.metadata.multiplex_ids
+            if pending_request is not None
+            else {}
+        )
+        if multiplex_ids.get(SERVE_MULTIPLEX_DIMENSION_NAME.MODEL):
             candidate_replica_ids = self.apply_multiplex_routing(
                 pending_request=pending_request,
             )
         else:
-            # Get candidates for locality preference.
-            candidate_replica_ids = self.apply_locality_routing(
-                pending_request=pending_request,
-            )
+            candidate_replica_ids = self._replica_id_set
 
         if not candidate_replica_ids:
             return []
 
-        # Optimized selection: use direct randrange for k=2 instead of random.sample.
-        # This is ~1.9x faster for the common case of selecting 2 replicas.
-        #
-        # Correctness proof: We pick i uniformly from [0, n), then j uniformly from
-        # [0, n-1) and shift j up if j >= i. Every ordered pair (i, j) with i != j
-        # has probability: Pr(i,j) = 1/n * 1/(n-1) = 1/(n(n-1))
-        # This matches random.sample(k=2): uniform among all 2-permutations.
-        candidates = tuple(candidate_replica_ids)
-        n = len(candidates)
-        if n == 1:
-            chosen_ids = [candidates[0]]
-        elif n == 2:
-            # Randomize order to ensure fair selection when queue lengths are equal
-            if random.getrandbits(1):
-                chosen_ids = [candidates[0], candidates[1]]
-            else:
-                chosen_ids = [candidates[1], candidates[0]]
-        else:
-            i = random.randrange(n)
-            j = random.randrange(n - 1)
-            if j >= i:
-                j += 1
-            chosen_ids = [candidates[i], candidates[j]]
+        # Step 2: Rank survivors by session + locality.
+        session_id = multiplex_ids.get(SERVE_MULTIPLEX_DIMENSION_NAME.SESSION)
+        session_warm_replica_ids = self._multiplex_dim_id_to_replica_ids.get(
+            SERVE_MULTIPLEX_DIMENSION_NAME.SESSION, {}
+        ).get(session_id, set())
+        filtered_replicas = [self._replicas[rid] for rid in candidate_replica_ids]
+        ranked_tiers = rank_replicas_by_session_and_locality(
+            filtered_replicas,
+            session_warm_replica_ids,
+            self._colocated_replica_ids,
+        )
 
-        return [[self._replicas[chosen_id] for chosen_id in chosen_ids]]
+        # Step 3: Power-of-two pairs per tier — caller walks tiers in order.
+        return [select_pow2_pair(tier) for tier in ranked_tiers]

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -13,6 +13,7 @@ from typing import (
     Deque,
     Dict,
     List,
+    Mapping,
     Optional,
     Set,
     Tuple,
@@ -54,6 +55,46 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 class LocalityScope(str, enum.Enum):
     NODE = "NODE"
     AVAILABILITY_ZONE = "AVAILABILITY_ZONE"
+
+
+def rank_replicas_by_session_and_locality(
+    replicas: List[RunningReplica],
+    session_warm_replica_ids: Set[ReplicaID],
+    colocated_replica_ids: Mapping[LocalityScope, Set[ReplicaID]],
+) -> List[List[RunningReplica]]:
+    """Group replicas into priority tiers by combined session + locality score.
+
+    Each replica receives:
+      session_rank  = 0 if replica_id is in session_warm_replica_ids else 1
+      locality_rank = 0 (same node) / 1 (same AZ) / 2 (remote)
+
+    Replicas are bucketed by session_rank + locality_rank; lower totals are
+    preferred. Session and locality contribute equal weight, and the caller uses
+    pow2 queue-length picking to break the tie within each tier.
+
+    Args:
+        replicas: The replicas to rank.
+        session_warm_replica_ids: IDs of replicas that already have the
+            request's session cached.
+        colocated_replica_ids: Per-locality-scope (NODE / AZ) sets of replica
+            IDs that count as colocated with the router.
+
+    Returns:
+        A list of non-empty tiers in priority order (best first).
+    """
+    tiers: Dict[int, List[RunningReplica]] = {}
+    same_node = colocated_replica_ids.get(LocalityScope.NODE, set())
+    same_az = colocated_replica_ids.get(LocalityScope.AVAILABILITY_ZONE, set())
+    for replica in replicas:
+        session_rank = 0 if replica.replica_id in session_warm_replica_ids else 1
+        if replica.replica_id in same_node:
+            locality_rank = 0
+        elif replica.replica_id in same_az:
+            locality_rank = 1
+        else:
+            locality_rank = 2
+        tiers.setdefault(session_rank + locality_rank, []).append(replica)
+    return [tiers[score] for score in sorted(tiers)]
 
 
 @PublicAPI(stability="alpha")
@@ -105,10 +146,15 @@ class LocalityMixin:
         new_colocated_replica_ids = defaultdict(set)
 
         for r in replicas:
-            if self._self_node_id is not None and r.node_id == self._self_node_id:
+            if (
+                self._prefer_local_node_routing
+                and self._self_node_id is not None
+                and r.node_id == self._self_node_id
+            ):
                 new_colocated_replica_ids[LocalityScope.NODE].add(r.replica_id)
             if (
-                self._self_availability_zone is not None
+                self._prefer_local_az_routing
+                and self._self_availability_zone is not None
                 and r.availability_zone == self._self_availability_zone
             ):
                 new_colocated_replica_ids[LocalityScope.AVAILABILITY_ZONE].add(

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -4,7 +4,7 @@ import os
 import random
 import sys
 import time
-from typing import Dict, Optional, Set
+from typing import Dict, List, Optional, Set
 
 import pytest
 
@@ -33,6 +33,10 @@ from ray.serve._private.request_router import (
     RunningReplica,
 )
 from ray.serve._private.request_router.common import ReplicaQueueLengthCache
+from ray.serve._private.request_router.request_router import (
+    LocalityScope,
+    rank_replicas_by_session_and_locality,
+)
 from ray.serve._private.test_utils import MockTimer
 from ray.serve._private.utils import generate_request_id
 
@@ -1428,6 +1432,143 @@ class TestModelMultiplexing:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "pow_2_router",
+    [{"prefer_local_node": True, "prefer_local_az": True, "az": ROUTER_AZ}],
+    indirect=True,
+)
+class TestSessionLocalityTiebreaker:
+    """Priority: model (hard filter) > session == locality > pow2 queue.
+
+    Each case pins down one arm of the tiebreaker matrix. All replicas have
+    equal queue length so pow2 alone cannot disambiguate — the right answer
+    comes strictly from the session+locality tiering.
+    """
+
+    async def test_model_plus_session_prefers_warm_session(self, pow_2_router):
+        # Two replicas host the model; prefer the one with the warm session.
+        s = pow_2_router
+        r_warm = FakeRunningReplica(
+            "r_warm",
+            multiplex_dim_to_ids={"model": {"m1"}, "session": {"s1"}},
+        )
+        r_cold = FakeRunningReplica(
+            "r_cold",
+            multiplex_dim_to_ids={"model": {"m1"}, "session": set()},
+        )
+        r_warm.set_queue_len_response(0)
+        r_cold.set_queue_len_response(0)
+        s.update_replicas([r_warm, r_cold])
+
+        request = fake_pending_request(multiplex_ids={"model": "m1", "session": "s1"})
+        chosen = await s._choose_replica_for_request(request)
+        assert chosen == r_warm
+
+    async def test_model_plus_locality_prefers_local(self, pow_2_router):
+        # Two replicas host the model; prefer the local (same-node) one.
+        s = pow_2_router
+        r_local = FakeRunningReplica(
+            "r_local",
+            node_id=ROUTER_NODE_ID,
+            availability_zone=ROUTER_AZ,
+            multiplex_dim_to_ids={"model": {"m1"}},
+        )
+        r_remote = FakeRunningReplica(
+            "r_remote",
+            node_id="other-node",
+            availability_zone="other-az",
+            multiplex_dim_to_ids={"model": {"m1"}},
+        )
+        r_local.set_queue_len_response(0)
+        r_remote.set_queue_len_response(0)
+        s.update_replicas([r_local, r_remote])
+
+        request = fake_pending_request(multiplex_ids={"model": "m1"})
+        chosen = await s._choose_replica_for_request(request)
+        assert chosen == r_local
+
+    async def test_session_plus_locality_prefers_local(self, pow_2_router):
+        # Session has spilled to two replicas; prefer the local one (no
+        # model dimension involved, so model filter is a no-op).
+        s = pow_2_router
+        r_local = FakeRunningReplica(
+            "r_local",
+            node_id=ROUTER_NODE_ID,
+            availability_zone=ROUTER_AZ,
+            multiplex_dim_to_ids={"session": {"s1"}},
+        )
+        r_remote = FakeRunningReplica(
+            "r_remote",
+            node_id="other-node",
+            availability_zone="other-az",
+            multiplex_dim_to_ids={"session": {"s1"}},
+        )
+        r_local.set_queue_len_response(0)
+        r_remote.set_queue_len_response(0)
+        s.update_replicas([r_local, r_remote])
+
+        request = fake_pending_request(multiplex_ids={"session": "s1"})
+        chosen = await s._choose_replica_for_request(request)
+        assert chosen == r_local
+
+    async def test_session_plus_model_prefers_model_loaded(self, pow_2_router):
+        # Session maps to two replicas; only one has the model loaded. The
+        # model hard filter narrows to that replica before session/locality
+        # ranking even runs.
+        s = pow_2_router
+        r_with_model = FakeRunningReplica(
+            "r_with_model",
+            multiplex_dim_to_ids={"model": {"m1"}, "session": {"s1"}},
+        )
+        r_without_model = FakeRunningReplica(
+            "r_without_model",
+            multiplex_dim_to_ids={"model": set(), "session": {"s1"}},
+        )
+        r_with_model.set_queue_len_response(0)
+        r_without_model.set_queue_len_response(0)
+        s.update_replicas([r_with_model, r_without_model])
+
+        request = fake_pending_request(multiplex_ids={"model": "m1", "session": "s1"})
+        chosen = await s._choose_replica_for_request(request)
+        assert chosen == r_with_model
+
+    async def test_session_warm_remote_ties_with_session_cold_local(self, pow_2_router):
+        # Equal-weight tiebreaker: a session-warm remote replica and a
+        # session-cold node-local replica share a tier, so pow2 queue
+        # length (here: the replica with the shorter queue) decides.
+        s = pow_2_router
+        loop = get_or_create_event_loop()
+        r_warm_remote = FakeRunningReplica(
+            "r_warm_remote",
+            node_id="other-node",
+            availability_zone="other-az",
+            multiplex_dim_to_ids={"session": {"s1"}},
+        )
+        r_cold_local = FakeRunningReplica(
+            "r_cold_local",
+            node_id=ROUTER_NODE_ID,
+            availability_zone=ROUTER_AZ,
+            multiplex_dim_to_ids={"session": set()},
+        )
+        # Same tier — pow2 queue length breaks the tie; give r_cold_local
+        # the shorter queue so the test is deterministic.
+        r_warm_remote.set_queue_len_response(5)
+        r_cold_local.set_queue_len_response(0)
+        s.update_replicas([r_warm_remote, r_cold_local])
+
+        tasks = [
+            loop.create_task(
+                s._choose_replica_for_request(
+                    fake_pending_request(multiplex_ids={"session": "s1"})
+                )
+            )
+            for _ in range(10)
+        ]
+        chosen = await asyncio.gather(*tasks)
+        assert all(replica == r_cold_local for replica in chosen)
+
+
+@pytest.mark.asyncio
 async def test_get_queue_len_cancelled_on_timeout(pow_2_router):
     """
     Verify that `get_queue_len` is cancelled if the `queue_len_response_deadline_s`
@@ -1994,21 +2135,28 @@ async def test_replicas_actor_unavailable_error(
     indirect=True,
 )
 async def test_locality_aware_backoff_skips_sleeps(pow_2_router):
-    """
-    When the request router fails to route a request to a replica on the same node, and
-    the same zone, it should not sleep before retrying and add additional latency.
+    """When the top locality tier rejects, broadening to same-AZ and then to
+    remote replicas must not insert a backoff sleep.
+
+    A single ``choose_replicas`` call returns all locality tiers (same-node →
+    same-AZ → remote) in priority order, so the outer retry loop walks them
+    without re-entering ``choose_replicas`` and without hitting the backoff
+    sleep (configured to 999s by the fixture). The sleep only fires when
+    every tier is exhausted.
     """
     s = pow_2_router
-    original_apply_locality_routing = s.apply_locality_routing
-    chosen_replicas = []
+    original_choose_replicas = s.choose_replicas
+    tier_history: List[List[List[RunningReplica]]] = []
 
-    def tracking_apply_locality_routing(pending_request=None):
-        result = original_apply_locality_routing(pending_request)
-        # Track the replica IDs that were candidates at this locality scope
-        chosen_replicas.append(list(result))
-        return result
+    async def tracking_choose_replicas(candidate_replicas, pending_request=None):
+        tiers = await original_choose_replicas(
+            candidate_replicas=candidate_replicas,
+            pending_request=pending_request,
+        )
+        tier_history.append([list(tier) for tier in tiers])
+        return tiers
 
-    s.apply_locality_routing = tracking_apply_locality_routing
+    s.choose_replicas = tracking_choose_replicas
 
     loop = get_or_create_event_loop()
     task = loop.create_task(s._choose_replica_for_request(fake_pending_request()))
@@ -2036,27 +2184,20 @@ async def test_locality_aware_backoff_skips_sleeps(pow_2_router):
     s.update_replicas([r1, r2, r3])
 
     done, pending = await asyncio.wait([task], timeout=10)
-    if len(pending) == 1:
-        # r3 was not chosen after trying local node and local AZ. Which is fine.
-        # clear all pending tasks
-        task.cancel()
-        s._routing_tasks.clear()
-        s._pending_requests_to_fulfill.clear()
-        s._pending_requests_to_route.clear()
-    else:
+    # A 999s backoff sleep would overshoot this 10s deadline, so completing
+    # within the window is itself the "no added latency" assertion.
+    assert len(done) == 1
+    assert done.pop().result() == r3
 
-        # The request will be served by r3 without added latency.
-        # Since we set up the `backoff_s` to be 999s on every attempt, this 10s timeout will still
-        # capture the extra delay if it was added between routing loop.
-        assert len(done) == 1
-        assert done.pop().result() == r3
-
-    # assert that we tried local node, followed by local AZ, followed by all replicas
-    assert len(chosen_replicas) in (3, 4)
-    assert set(chosen_replicas[0]) == {r1.replica_id}
-    assert set(chosen_replicas[1]) == {r1.replica_id, r2.replica_id}
-    # assert intersection of chosen_replicas[2] and {r1.replica_id, r2.replica_id, r3.replica_id} is not empty
-    assert set(chosen_replicas[2]) & {r1.replica_id, r2.replica_id, r3.replica_id}
+    # The first choose_replicas call must have surfaced all three locality
+    # tiers in priority order (same-node, same-AZ, remote) — that's how the
+    # outer loop walks to r3 without re-entering choose_replicas.
+    assert len(tier_history) >= 1
+    first_tiers = tier_history[0]
+    assert len(first_tiers) == 3
+    assert {r.replica_id for r in first_tiers[0]} == {r1.replica_id}
+    assert {r.replica_id for r in first_tiers[1]} == {r2.replica_id}
+    assert {r.replica_id for r in first_tiers[2]} == {r3.replica_id}
 
 
 @pytest.mark.parametrize(
@@ -2105,6 +2246,8 @@ async def test_select_available_replicas(pow_2_router: PowerOfTwoChoicesRequestR
     [
         {
             "az": ROUTER_AZ,
+            "prefer_local_node": True,
+            "prefer_local_az": True,
         },
     ],
     indirect=True,
@@ -2239,6 +2382,56 @@ async def test_rank_replicas_via_multiplex(
         [replica_with_no_model],  # replica with fewer cached models ranked 1
         [replica_with_other_models],  # replica with more cached models ranked 2
     ]
+
+
+def test_rank_replicas_by_session_and_locality():
+    """Tiers are bucketed by (session_rank + locality_rank), lower is better.
+
+    Session and locality contribute equal weight, so a session-warm remote
+    replica (1 + 2 = 3) does NOT share a tier with a session-cold same-AZ
+    replica (1 + 1 = 2); however a session-warm same-AZ replica (0 + 1 = 1)
+    does share a tier with a session-cold same-node replica (1 + 0 = 1).
+    """
+    r_warm_node = FakeRunningReplica("r_warm_node")
+    r_warm_az = FakeRunningReplica("r_warm_az")
+    r_cold_node = FakeRunningReplica("r_cold_node")
+    r_cold_az = FakeRunningReplica("r_cold_az")
+    r_cold_remote = FakeRunningReplica("r_cold_remote")
+    all_replicas = [r_warm_node, r_warm_az, r_cold_node, r_cold_az, r_cold_remote]
+
+    session_warm_ids = {r_warm_node.replica_id, r_warm_az.replica_id}
+    colocated = {
+        LocalityScope.NODE: {r_warm_node.replica_id, r_cold_node.replica_id},
+        LocalityScope.AVAILABILITY_ZONE: {
+            r_warm_node.replica_id,
+            r_cold_node.replica_id,
+            r_warm_az.replica_id,
+            r_cold_az.replica_id,
+        },
+    }
+    tiers = rank_replicas_by_session_and_locality(
+        all_replicas, session_warm_ids, colocated
+    )
+    # Convert inner lists to sets so order within a tier is irrelevant.
+    assert [set(tier) for tier in tiers] == [
+        {r_warm_node},  # score 0: session warm + same node
+        {r_warm_az, r_cold_node},  # score 1: warm+AZ or cold+node (equal-weight tie)
+        {r_cold_az},  # score 2: cold + same AZ
+        {r_cold_remote},  # score 3: cold + remote
+    ]
+
+
+def test_rank_replicas_by_session_and_locality_empty_signals():
+    """Without session id or locality preference, all replicas land in a single
+    tier — the caller (pow2) then decides purely by queue length.
+    """
+    r1 = FakeRunningReplica("r1")
+    r2 = FakeRunningReplica("r2")
+    tiers = rank_replicas_by_session_and_locality(
+        [r1, r2], session_warm_replica_ids=set(), colocated_replica_ids={}
+    )
+    assert len(tiers) == 1
+    assert set(tiers[0]) == {r1, r2}
 
 
 def test_request_router_backoff_params_default():


### PR DESCRIPTION
## Summary
Adapts `PowerOfTwoChoicesRequestRouter` and `PrefixCacheAffinityRouter` to the session multiplex dimension added in the parent branch. Establishes a consistent priority across both routers: **model (hard filter) > session == locality (equal-weight tiebreakers) > [prefix within tier] > pow2 queue length**.

## Priority pipeline

1. **Model**: hard filter via `apply_multiplex_routing("model")`. Existing match-timeout / fewest-models fallback preserved.
2. **Session + locality**: equal-weight tiebreaker. Each replica gets `session_rank + locality_rank`: `session_rank ∈ {0 warm, 1 cold}`, `locality_rank ∈ {0 node, 1 AZ, 2 remote}`. A session-warm remote replica and a session-cold node-local replica share a tier.
3. **Prefix match** (prefix-aware only: within each tier; falls back to pow2 within the tier when prefix can't decide.
4. **Pow2 queue length**: within a tier.

## Behavior vs master
- **Matched-model replicas all tied on session/locality** → pow2 pair within the set. *Equivalent to master.*
- **Matched-model replicas where some are session-warm or node-local** → warm/local tier probed first. *New capability; master randomized across the full match set.*
- **No model, same-node replicas (locality-only)** → all locality tiers returned in one `choose_replicas` call; outer loop walks node → AZ → remote without re-entering. *Equivalent top-tier behavior, fewer re-entries on fallback.*

## Collateral fixes
- `LocalityMixin`: `_update_colocated_replica_ids_with_replicas` now gates population on `prefer_local_*` flags. This aligns `rank_replicas_via_locality` with `apply_locality_routing` (it previously tiered by node/AZ even when the deployment had opted out — latent inconsistency between the two mixin helpers).
- `select_pow2_pair` extracted from `pow_2_router.py`; both routers reuse it.
- `_prefix_match_best_replicas` returns a flat `List[RunningReplica]`; its smallest-tenant fallback intersects with the current tier so global queries can't leak across tiers.

## [WIP] Benchmark
- [ ] Prefix-sharing dataset
- [ ] Session stickiness

## Related issues
https://github.com/ray-project/ray/issues/62645

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
