### PR TITLE
[data][4/n] Port V1 parquet followups into V2: shuffle, stub col, tensor check, local scheduling

### DIFF
--- a/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import pyarrow as pa
@@ -57,6 +57,24 @@ class FileManifest:
         This doesn't make a copy of the underlying data.
         """
         return self._block
+
+    def shuffle(self, seed: Optional[int]) -> "FileManifest":
+        """Return a new `FileManifest` with rows permuted.
+
+        Args:
+            seed: Random seed. ``None`` for non-deterministic shuffling.
+
+        Returns:
+            A new `FileManifest` with the same rows in a shuffled order. The
+            underlying row alignment between `paths` and `file_sizes` is
+            preserved because the permutation is applied to the block as a
+            whole.
+        """
+        n = len(self)
+        if n <= 1:
+            return self
+        permutation = np.random.default_rng(seed).permutation(n)
+        return FileManifest(self._block.take(permutation))
 
     @classmethod
     def construct_manifest(

--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -6,6 +6,7 @@ import pyarrow.dataset as pds
 from pyarrow import compute as pc
 from pyarrow.fs import FileSystem, LocalFileSystem
 
+from ray.data._internal.arrow_block import _BATCH_SIZE_PRESERVING_STUB_COL_NAME
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.readers.base_reader import Reader
 from ray.data._internal.util import iterate_with_retry
@@ -129,6 +130,18 @@ class FileReader(Reader[FileManifest]):
                         pa.array([fragment_path] * table.num_rows, type=pa.string()),
                     )
 
+                if table.num_columns == 0 and table.num_rows > 0:
+                    # Guards against ``pa.concat_tables`` collapsing rows when
+                    # a batch has zero columns (e.g., empty projection for a
+                    # count query). The stub column is dropped by downstream
+                    # projections.
+                    table = table.append_column(
+                        _BATCH_SIZE_PRESERVING_STUB_COL_NAME,
+                        pa.nulls(table.num_rows),
+                    )
+
+                table = self._transform_batch(table)
+
                 self._on_batch_read(table)
                 rows_read += len(table)
                 yield table
@@ -155,12 +168,20 @@ class FileReader(Reader[FileManifest]):
         """
         return {}
 
+    def _transform_batch(self, table: pa.Table) -> pa.Table:
+        """Hook for per-batch transformations applied before yielding.
+
+        Subclasses can override this to apply format-specific transforms
+        (e.g., a user-supplied block UDF).
+        """
+        return table
+
     @staticmethod
     def _read_batches(
         scanner: pds.Scanner,
     ) -> Iterator[tuple[pa.Table, str]]:
         """Yield non-empty (table, fragment_path) pairs from scanner batches."""
         for tagged in scanner.scan_batches():
-            table = pa.Table.from_batches([tagged.record_batch])
+            table = pa.Table.from_batches(batches=[tagged.record_batch])
             if table.num_rows > 0:
                 yield table, tagged.fragment.path

--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -140,8 +140,6 @@ class FileReader(Reader[FileManifest]):
                         pa.nulls(table.num_rows),
                     )
 
-                table = self._transform_batch(table)
-
                 self._on_batch_read(table)
                 rows_read += len(table)
                 yield table
@@ -167,14 +165,6 @@ class FileReader(Reader[FileManifest]):
         Subclasses override this to inject format-specific options.
         """
         return {}
-
-    def _transform_batch(self, table: pa.Table) -> pa.Table:
-        """Hook for per-batch transformations applied before yielding.
-
-        Subclasses can override this to apply format-specific transforms
-        (e.g., a user-supplied block UDF).
-        """
-        return table
 
     @staticmethod
     def _read_batches(

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import pyarrow as pa
 import pyarrow.dataset as pds
@@ -17,6 +17,7 @@ from ray.data._internal.datasource_v2.readers.file_reader import (
 from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
     PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
 )
+from ray.data.block import Block
 from ray.util.annotations import DeveloperAPI
 
 logger = logging.getLogger(__name__)
@@ -139,6 +140,7 @@ class ParquetFileReader(FileReader):
         ignore_prefixes: Optional[List[str]] = None,
         target_block_size: Optional[int] = None,
         include_paths: bool = False,
+        _block_udf: Optional[Callable[[Block], Block]] = None,
     ):
         """Initialize the Parquet reader.
 
@@ -155,6 +157,8 @@ class ParquetFileReader(FileReader):
                 Used for adaptive batch sizing when ``batch_size`` is not set.
             include_paths: If True, include the source file path in a
                 ``'path'`` column for each row.
+            _block_udf: Optional per-batch transform applied to each read
+                block before it is yielded. Internal.
         """
         super().__init__(
             format=FileFormat.PARQUET,
@@ -169,6 +173,7 @@ class ParquetFileReader(FileReader):
         )
         self._explicit_batch_size = batch_size
         self._target_block_size = target_block_size
+        self._block_udf = _block_udf
         self._sampled_batch_size: int | object = (
             _UNSET  # pyrefly: ignore[bad-assignment]
         )
@@ -215,6 +220,12 @@ class ParquetFileReader(FileReader):
             return
         row_size = table.nbytes / table.num_rows
         self._sampled_batch_size = max(math.ceil(self._target_block_size / row_size), 1)
+
+    def _transform_batch(self, table: pa.Table) -> pa.Table:
+        """Apply the user-supplied block UDF, if any."""
+        if self._block_udf is not None and table.num_rows > 0:
+            return self._block_udf(table)
+        return table
 
     @override
     def _arrow_scanner_kwargs(self) -> dict:

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import Callable, List, Optional
+from typing import List, Optional
 
 import pyarrow as pa
 import pyarrow.dataset as pds
@@ -17,7 +17,6 @@ from ray.data._internal.datasource_v2.readers.file_reader import (
 from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
     PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
 )
-from ray.data.block import Block
 from ray.util.annotations import DeveloperAPI
 
 logger = logging.getLogger(__name__)
@@ -140,7 +139,6 @@ class ParquetFileReader(FileReader):
         ignore_prefixes: Optional[List[str]] = None,
         target_block_size: Optional[int] = None,
         include_paths: bool = False,
-        _block_udf: Optional[Callable[[Block], Block]] = None,
     ):
         """Initialize the Parquet reader.
 
@@ -157,8 +155,6 @@ class ParquetFileReader(FileReader):
                 Used for adaptive batch sizing when ``batch_size`` is not set.
             include_paths: If True, include the source file path in a
                 ``'path'`` column for each row.
-            _block_udf: Optional per-batch transform applied to each read
-                block before it is yielded. Internal.
         """
         super().__init__(
             format=FileFormat.PARQUET,
@@ -173,7 +169,6 @@ class ParquetFileReader(FileReader):
         )
         self._explicit_batch_size = batch_size
         self._target_block_size = target_block_size
-        self._block_udf = _block_udf
         self._sampled_batch_size: int | object = (
             _UNSET  # pyrefly: ignore[bad-assignment]
         )
@@ -220,12 +215,6 @@ class ParquetFileReader(FileReader):
             return
         row_size = table.nbytes / table.num_rows
         self._sampled_batch_size = max(math.ceil(self._target_block_size / row_size), 1)
-
-    def _transform_batch(self, table: pa.Table) -> pa.Table:
-        """Apply the user-supplied block UDF, if any."""
-        if self._block_udf is not None and table.num_rows > 0:
-            return self._block_udf(table)
-        return table
 
     @override
     def _arrow_scanner_kwargs(self) -> dict:

--- a/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
@@ -165,7 +165,9 @@ class ArrowFileScanner(
         """Plan parallel work units, pruning files by partition predicate first.
 
         If a partition predicate is set, files whose partition values do not
-        satisfy the predicate are removed from the manifest before splitting.
+        satisfy the predicate are removed from the manifest. The pruned
+        manifest is then handed to ``FileScanner.plan``, which applies the
+        shuffle (if configured) before splitting.
 
         Args:
             manifest: FileManifest to partition.

--- a/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
@@ -1,21 +1,43 @@
-from typing import List, Optional
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, List, Literal, Optional, Union
 
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.scanners.scanner import Scanner
+from ray.data._internal.util import _is_local_scheme
 from ray.data.context import DataContext
+from ray.data.datasource.file_based_datasource import (
+    FileShuffleConfig,
+    _validate_shuffle_arg,
+)
 from ray.util.annotations import DeveloperAPI
+
+if TYPE_CHECKING:
+    from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 
 @DeveloperAPI
+@dataclass(frozen=True)
 class FileScanner(Scanner[FileManifest]):
     """Base scanner for file-based datasources.
 
-    Provides a default plan() implementation that splits FileManifest by files.
-    Subclasses implement format-specific read_schema() and create_reader().
+    Provides a default plan() implementation that shuffles (if configured)
+    and splits a FileManifest by files. Subclasses implement format-specific
+    read_schema() and create_reader().
 
     PyArrow Dataset-based scanners should subclass ``ArrowFileScanner``; use
-    ``FileScanner`` directly for non-Arrow file formats that only share splitting.
+    ``FileScanner`` directly for non-Arrow file formats that only share
+    splitting and shuffling.
     """
+
+    # kw_only so subclass dataclasses can declare their own required fields
+    # (like ``ArrowFileScanner.schema``) without running into the "non-default
+    # argument follows default argument" dataclass inheritance rule.
+    shuffle: Union[Literal["files"], FileShuffleConfig, None] = field(
+        default=None, kw_only=True
+    )
+
+    def __post_init__(self) -> None:
+        _validate_shuffle_arg(self.shuffle)
 
     def plan(
         self,
@@ -23,10 +45,11 @@ class FileScanner(Scanner[FileManifest]):
         parallelism: int,
         data_context: Optional["DataContext"] = None,
     ) -> List[FileManifest]:
-        """Split manifest into parallel work units by files.
+        """Shuffle (if configured) and split a manifest into parallel work units.
 
-        Distributes files as evenly as possible across the target parallelism.
-        If there are fewer files than parallelism, creates one partition per file.
+        When file listing is adaptive (``LazyFileIndex``), only the files
+        known at plan time participate in the shuffle; files streamed in at
+        execution time are not reordered.
 
         Args:
             manifest: FileManifest to partition.
@@ -36,6 +59,17 @@ class FileScanner(Scanner[FileManifest]):
         Returns:
             List of FileManifest objects for parallel execution.
         """
+        if self.shuffle is not None:
+            execution_idx = (
+                data_context._execution_idx if data_context is not None else 0
+            )
+            if self.shuffle == "files":
+                seed = None
+            else:
+                assert isinstance(self.shuffle, FileShuffleConfig)
+                seed = self.shuffle.get_seed(execution_idx)
+            manifest = manifest.shuffle(seed)
+
         num_files = len(manifest)
         if parallelism <= 0 or num_files == 0:
             return [manifest] if num_files > 0 else []
@@ -60,3 +94,33 @@ class FileScanner(Scanner[FileManifest]):
                 start += size
 
         return partitions
+
+    @staticmethod
+    def compute_local_scheduling(
+        paths: Union[str, List[str]],
+    ) -> Optional["NodeAffinitySchedulingStrategy"]:
+        """Return a node-affinity scheduling strategy for local-scheme reads.
+
+        When paths point to a local filesystem, pin read tasks to the driver
+        node with hard affinity so they can access those files. Returns
+        ``None`` for remote paths, which any node can read. Raises under Ray
+        Client because cluster nodes can't see the driver's local files.
+        """
+        import ray
+
+        if not _is_local_scheme(paths):
+            return None
+
+        if ray.util.client.ray.is_connected():
+            raise ValueError(
+                "Because you're using Ray Client, read tasks scheduled on the "
+                "Ray cluster can't access your local files. To fix this issue, "
+                "store files in cloud storage or a distributed filesystem like "
+                "NFS."
+            )
+
+        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+        return NodeAffinitySchedulingStrategy(
+            ray.get_runtime_context().get_node_id(), soft=False
+        )

--- a/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
@@ -107,6 +107,7 @@ class FileScanner(Scanner[FileManifest]):
         Client because cluster nodes can't see the driver's local files.
         """
         import ray
+        import ray.util.client
 
         if not _is_local_scheme(paths):
             return None

--- a/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
@@ -1,6 +1,5 @@
-import logging
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Optional
 
 import pyarrow as pa
 
@@ -13,10 +12,7 @@ from ray.data._internal.datasource_v2.readers.parquet_file_reader import (
 from ray.data._internal.datasource_v2.scanners.arrow_file_scanner import (
     ArrowFileScanner,
 )
-from ray.data.block import Block
 from ray.util.annotations import DeveloperAPI
-
-logger = logging.getLogger(__name__)
 
 
 @DeveloperAPI
@@ -32,28 +28,12 @@ class ParquetScanner(ArrowFileScanner):
 
     target_block_size: Optional[int] = None
     include_paths: bool = False
-    _block_udf: Optional[Callable[[Block], Block]] = None
 
     def read_schema(self) -> pa.Schema:
-        """Return schema after column pruning, UDF inference, and tensor check.
-
-        The UDF is invoked on an empty table to derive the output schema; any
-        exception is swallowed with a debug log so schema inference doesn't
-        crash on a misbehaving UDF.
-        """
+        """Return schema after column pruning and tensor check."""
         schema = super().read_schema()
         if self.include_paths and schema.get_field_index("path") == -1:
             schema = schema.append(pa.field("path", pa.string()))
-
-        if self._block_udf is not None:
-            try:
-                udf_schema = self._block_udf(schema.empty_table()).schema
-                schema = udf_schema.with_metadata(schema.metadata)
-            except Exception:
-                logger.debug(
-                    "Failed to infer schema by running block UDF on empty table.",
-                    exc_info=True,
-                )
 
         check_for_legacy_tensor_type(schema)
         return schema
@@ -74,5 +54,4 @@ class ParquetScanner(ArrowFileScanner):
             ignore_prefixes=self.ignore_prefixes,
             target_block_size=self.target_block_size,
             include_paths=self.include_paths,
-            _block_udf=self._block_udf,
         )

--- a/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
@@ -1,15 +1,22 @@
+import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Callable, Optional
 
 import pyarrow as pa
 
+from ray.data._internal.datasource.parquet_datasource import (
+    check_for_legacy_tensor_type,
+)
 from ray.data._internal.datasource_v2.readers.parquet_file_reader import (
     ParquetFileReader,
 )
 from ray.data._internal.datasource_v2.scanners.arrow_file_scanner import (
     ArrowFileScanner,
 )
+from ray.data.block import Block
 from ray.util.annotations import DeveloperAPI
+
+logger = logging.getLogger(__name__)
 
 
 @DeveloperAPI
@@ -17,19 +24,38 @@ from ray.util.annotations import DeveloperAPI
 class ParquetScanner(ArrowFileScanner):
     """Parquet-specific scanner implementation.
 
-    Inherits filter pushdown, column pruning, limit pushdown, and partition
-    pruning from ArrowFileScanner. Adds Parquet-specific reader creation
-    with adaptive batch sizing.
+    Inherits filter pushdown, column pruning, limit pushdown, partition
+    pruning, and file shuffle from ArrowFileScanner. Adds Parquet-specific
+    reader creation with adaptive batch sizing and the Parquet-only
+    legacy-tensor-type schema check.
     """
 
     target_block_size: Optional[int] = None
     include_paths: bool = False
+    _block_udf: Optional[Callable[[Block], Block]] = None
 
     def read_schema(self) -> pa.Schema:
-        """Return schema after column pruning, with path column if requested."""
+        """Return schema after column pruning, UDF inference, and tensor check.
+
+        The UDF is invoked on an empty table to derive the output schema; any
+        exception is swallowed with a debug log so schema inference doesn't
+        crash on a misbehaving UDF.
+        """
         schema = super().read_schema()
         if self.include_paths and schema.get_field_index("path") == -1:
             schema = schema.append(pa.field("path", pa.string()))
+
+        if self._block_udf is not None:
+            try:
+                udf_schema = self._block_udf(schema.empty_table()).schema
+                schema = udf_schema.with_metadata(schema.metadata)
+            except Exception:
+                logger.debug(
+                    "Failed to infer schema by running block UDF on empty table.",
+                    exc_info=True,
+                )
+
+        check_for_legacy_tensor_type(schema)
         return schema
 
     def create_reader(self) -> ParquetFileReader:
@@ -48,4 +74,5 @@ class ParquetScanner(ArrowFileScanner):
             ignore_prefixes=self.ignore_prefixes,
             target_block_size=self.target_block_size,
             include_paths=self.include_paths,
+            _block_udf=self._block_udf,
         )


### PR DESCRIPTION
## Description
Followups from https://github.com/ray-project/ray/pull/62182

Basically this ports over remaining functionality from V1 parquet datasource.

Also not porting over `block_udf`. We will be deprecating that param in DatasourceV2, since it's only used in tests.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
