### PR TITLE
[train][torchft][data] Replacement worker gets replaced worker’s data split

### DIFF
--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -1,6 +1,6 @@
 import abc
-from dataclasses import dataclass
-from typing import Any, List
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
 
 from ray.data.block import Block, DataBatch
 from ray.types import ObjectRef
@@ -25,10 +25,17 @@ class Batch:
     Attributes:
         metadata: Metadata associated with this batch.
         data: The batch of data.
+        provenance: Optional list of (block_id, rows_taken) describing which
+            source blocks contributed how many rows to this batch's data.
+            Populated only when the batching pipeline is run in
+            replacement-capable mode (see BatchIterator.block_iter_with_ids).
+            The list is ordered by source-block insertion order, and the row
+            counts sum to the number of rows in ``data``.
     """
 
     metadata: BatchMetadata
     data: DataBatch
+    provenance: Optional[List[Tuple[str, int]]] = field(default=None)
 
 
 class CollatedBatch(Batch):

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -9,6 +9,7 @@ from ray.data._internal.block_batching.interfaces import Batch, BlockPrefetcher
 from ray.data._internal.block_batching.util import (
     ActorBlockPrefetcher,
     WaitBlockPrefetcher,
+    _BatchingIteratorWithProvenance,
     blocks_to_batches,
     collate,
     finalize_batches,
@@ -98,6 +99,19 @@ class BatchIterator:
             formatting to be overlapped with the UDF. Defaults to 1.
         prefetch_bytes_callback: A callback to report prefetched bytes to the executor's
             resource manager.
+        block_iter_with_ids: If True, run in replacement-capable mode: the block
+            iterator yields ``(block_ref_hex, block)`` tuples instead of bare
+            blocks, and the batcher attaches per-batch source-block provenance to
+            each emitted ``Batch.provenance``. Used by streaming_split under Ray
+            Train when ``backend_config.has_replica_groups=True`` (e.g., torchft)
+            so the consumer can ack rows back to the SplitCoordinator before
+            yielding each batch. Incompatible with ``shuffle_buffer_min_size``.
+            Defaults to False.
+        on_yield: Optional callback invoked synchronously with each ``Batch``
+            right before its data is yielded to user code. Used by 2PC
+            consumption tracking to fire ``coord.ack(...)`` for the rows in the
+            imminent batch; the yield only happens once the callback returns.
+            Defaults to None (no callback).
     """
 
     UPDATE_METRICS_INTERVAL_S: float = 5.0
@@ -119,7 +133,27 @@ class BatchIterator:
         ensure_copy: bool = False,
         prefetch_batches: int = 1,
         prefetch_bytes_callback: Optional[Callable[[int], None]] = None,
+        block_iter_with_ids: bool = False,
+        on_yield: Optional[Callable[["Batch"], None]] = None,
     ):
+        # Replacement-capable iteration (used by streaming_split with
+        # DataConfig.enable_2pc_batch_consumption_tracking=True, automatically
+        # enabled by Ray Train when backend_config.has_replica_groups=True
+        # (e.g., torchft) requires per-block provenance to flow through the
+        # pipeline. The local-shuffle path reorders rows out of FIFO block
+        # order and breaks the provenance invariant, so reject the
+        # combination at construction time.
+        if block_iter_with_ids and shuffle_buffer_min_size is not None:
+            raise ValueError(
+                "local_shuffle_buffer_size is incompatible with "
+                "DataConfig.enable_2pc_batch_consumption_tracking=True "
+                "(automatically enabled when backend_config.has_replica_groups="
+                "True, e.g., for torchft replacement-capable iteration). The "
+                "shuffle buffer reorders rows out of source-block order, which "
+                "breaks the FIFO row provenance the SplitCoordinator's "
+                "reservation tracking relies on. Disable one of the two flags."
+            )
+
         self._ref_bundles = ref_bundles
         self._stats = stats
         self._dataset_tag = dataset_tag
@@ -133,6 +167,8 @@ class BatchIterator:
         self._ensure_copy = ensure_copy
         self._prefetch_batches = prefetch_batches
         self._prefetch_bytes_callback = prefetch_bytes_callback
+        self._block_iter_with_ids = block_iter_with_ids
+        self._on_yield = on_yield
         self._eager_free = (
             clear_block_after_read and DataContext.get_current().eager_free
         )
@@ -168,10 +204,30 @@ class BatchIterator:
 
     def _resolve_block_refs(
         self, block_refs: Iterator[ObjectRef[Block]]
-    ) -> Iterator[Block]:
-        return resolve_block_refs(block_ref_iter=block_refs, stats=self._stats)
+    ) -> Iterator[Any]:
+        # When 2PC consumption tracking is on, we yield (block_id, block)
+        # tuples downstream instead of bare blocks; the matching batcher in
+        # `_blocks_to_batches` knows how to consume both shapes.
+        return resolve_block_refs(
+            block_ref_iter=block_refs,
+            stats=self._stats,
+            with_id=self._block_iter_with_ids,
+        )
 
-    def _blocks_to_batches(self, blocks: Iterator[Block]) -> Iterator[Batch]:
+    def _blocks_to_batches(self, blocks: Iterator[Any]) -> Iterator[Batch]:
+        # Two batchers, one selected by the 2PC flag. The provenance batcher
+        # consumes (block_id, block) pairs and attaches per-batch provenance;
+        # the default batcher consumes bare blocks and is unchanged.
+        if self._block_iter_with_ids:
+            return _BatchingIteratorWithProvenance(
+                blocks,
+                stats=self._stats,
+                batch_size=self._batch_size,
+                drop_last=self._drop_last,
+                shuffle_buffer_min_size=self._shuffle_buffer_min_size,
+                shuffle_seed=self._shuffle_seed,
+                ensure_copy=self._ensure_copy,
+            )
         return blocks_to_batches(
             block_iter=blocks,
             stats=self._stats,
@@ -250,6 +306,14 @@ class BatchIterator:
                     batch = next(async_batch_iter)
                 except StopIteration:
                     break
+            # Replacement-capable mode: notify the consumer of the imminent
+            # yield so it can synchronously commit (ack) the rows in this
+            # batch back to the SplitCoordinator BEFORE user code sees them.
+            # This gives at-most-once semantics: a worker dying after the
+            # ack but before yield drops the batch (no replay), keeping the
+            # cursor consistent with what live peers' allreduce expects.
+            if self._on_yield is not None:
+                self._on_yield(batch)
             with self.yield_batch_context(batch):
                 yield batch.data
 

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -1,9 +1,20 @@
+import collections
 import dataclasses
 import functools
 import logging
 import threading
 from contextlib import nullcontext
-from typing import Any, Callable, Generic, Iterator, List, Optional, Tuple, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Deque,
+    Generic,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 
 import ray
 from ray.actor import ActorHandle
@@ -64,18 +75,27 @@ def _calculate_ref_hits(refs: List[ObjectRef[Any]]) -> Tuple[int, int, int]:
 def resolve_block_refs(
     block_ref_iter: Iterator[ObjectRef[Block]],
     stats: Optional[DatasetStats] = None,
-) -> Iterator[Block]:
+    with_id: bool = False,
+) -> Iterator[Any]:
     """Resolves the block references for each logical batch.
 
     Args:
         block_ref_iter: An iterator over block object references.
         stats: An optional stats object to recording block hits and misses.
+        with_id: If True, yield ``(block_ref_hex, block)`` pairs instead of
+            bare blocks. Used by replacement-capable streaming_split
+            iteration so the downstream batcher can record per-batch
+            provenance and the consumer can ack rows back to the
+            SplitCoordinator. The hex is captured before ``ray.get`` so it
+            survives even though the original ObjectRef is dropped after
+            resolution.
     """
     hits = 0
     misses = 0
     unknowns = 0
 
     for block_ref in block_ref_iter:
+        block_id = block_ref.hex() if with_id else None
         current_hit, current_miss, current_unknown = _calculate_ref_hits([block_ref])
         hits += current_hit
         misses += current_miss
@@ -85,7 +105,7 @@ def resolve_block_refs(
         # `ray.get()` call.
         with stats.iter_get_s.timer() if stats else nullcontext():
             block = ray.get(block_ref)
-        yield block
+        yield (block_id, block) if with_id else block
 
     if stats:
         stats.iter_blocks_local = hits
@@ -186,6 +206,58 @@ class _BatchingIterator(Iterator[Batch]):
                 #
                 # We stop the iteration
                 raise StopIteration
+
+
+class _BatchingIteratorWithProvenance(_BatchingIterator):
+    """Variant of ``_BatchingIterator`` that records per-batch provenance.
+
+    Wraps an iterator of ``(block_id, block)`` tuples. As blocks are added to
+    the underlying ``Batcher``, a parallel ``_block_contribs`` deque tracks
+    how many rows from each block remain unyielded. Each emitted ``Batch``
+    has its ``provenance`` field populated with a list of
+    ``(block_id, rows_taken)`` entries that sums to ``len(batch.data)`` and
+    preserves source-block insertion order.
+
+    Correctness invariant: the underlying ``Batcher`` is FIFO over ``add``
+    order; rows leave the batcher in the same block-by-block order they
+    entered. The contribs deque is also FIFO. We drain it in lockstep with
+    the row count of each emitted batch. ``ShufflingBatcher`` breaks this
+    invariant and is rejected by ``BatchIterator.__init__`` when
+    ``block_iter_with_ids`` is enabled.
+    """
+
+    def __init__(
+        self,
+        block_iter_with_ids: Iterator[Tuple[str, Block]],
+        **kwargs,
+    ):
+        # Save the raw (id, block) iterator and feed the parent only plain
+        # blocks, recording each add in the contribs deque.
+        self._raw_iter = block_iter_with_ids
+        self._block_contribs: Deque[List] = collections.deque()
+        super().__init__(self._unwrap_block_iter(), **kwargs)
+
+    def _unwrap_block_iter(self) -> Iterator[Block]:
+        for block_id, block in self._raw_iter:
+            self._block_contribs.append(
+                [block_id, BlockAccessor.for_block(block).num_rows()]
+            )
+            yield block
+
+    def __next__(self) -> Batch:
+        batch = super().__next__()
+        rows_remaining = BlockAccessor.for_block(batch.data).num_rows()
+        provenance: List[Tuple[str, int]] = []
+        while rows_remaining > 0:
+            head = self._block_contribs[0]
+            take = min(head[1], rows_remaining)
+            provenance.append((head[0], take))
+            head[1] -= take
+            rows_remaining -= take
+            if head[1] == 0:
+                self._block_contribs.popleft()
+        batch.provenance = provenance
+        return batch
 
 
 def _format_batch(

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -1,8 +1,9 @@
+import collections
+import dataclasses
 import logging
-import os
 import threading
 import time
-from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Deque, Dict, Iterator, List, Optional, Tuple
 
 import ray
 from ray.data._internal.execution.interfaces import (
@@ -11,6 +12,7 @@ from ray.data._internal.execution.interfaces import (
 )
 from ray.data._internal.execution.legacy_compat import execute_to_legacy_bundle_iterator
 from ray.data._internal.stats import DatasetStats
+from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
 from ray.data.iterator import DataIterator
 from ray.types import ObjectRef
@@ -36,6 +38,7 @@ class StreamSplitDataIterator(DataIterator):
         base_dataset: "Dataset",
         n: int,
         locality_hints: Optional[List[NodeIdStr]],
+        enable_2pc_batch_consumption_tracking: bool = False,
     ) -> List["StreamSplitDataIterator"]:
         """Create a split iterator from the given base Dataset and options.
 
@@ -48,15 +51,26 @@ class StreamSplitDataIterator(DataIterator):
             label_selector={
                 ray._raylet.RAY_NODE_ID_KEY: ray.get_runtime_context().get_node_id()
             },
-        ).remote(base_dataset, n, locality_hints)
+        ).remote(
+            base_dataset,
+            n,
+            locality_hints,
+            enable_2pc_batch_consumption_tracking,
+        )
 
-        return [StreamSplitDataIterator(coord_actor, i, n) for i in range(n)]
+        return [
+            StreamSplitDataIterator(
+                coord_actor, i, n, enable_2pc_batch_consumption_tracking
+            )
+            for i in range(n)
+        ]
 
     def __init__(
         self,
         coord_actor: ray.actor.ActorHandle,
         output_split_idx: int,
         world_size: int,
+        enable_2pc_batch_consumption_tracking: bool = False,
     ):
         self._coord_actor = coord_actor
         self._output_split_idx = output_split_idx
@@ -70,8 +84,23 @@ class StreamSplitDataIterator(DataIterator):
         # Cleared after the first iter_batches() call so subsequent epochs
         # follow the normal barrier path.
         self._is_replacement = False
+        # 2PC mode: when True, gen_blocks tells the coord to reserve each
+        # served block under our split_idx, and the BatchIterator fires a
+        # synchronous coord.ack right before each yield via _ack_callback.
+        # When False, get/ack/abort are no-ops at the coord side and the
+        # BatchIterator runs in legacy (untracked) mode.
+        self._enable_2pc_batch_consumption_tracking = (
+            enable_2pc_batch_consumption_tracking
+        )
+        # Cumulative per-block (hex -> rows-acked-so-far). Updated by
+        # _ack_callback as batches flow out; sent to coord on each ack.
+        self._pending_offsets: Dict[str, int] = {}
+        # Per-block num_rows cache so _ack_callback can prune fully-acked
+        # entries from _pending_offsets without an extra coord round-trip.
+        self._block_num_rows: Dict[str, int] = {}
         logger.debug(
-            f"StreamSplitDataIterator created: split={output_split_idx}, {world_size=}"
+            f"StreamSplitDataIterator created: split={output_split_idx}, "
+            f"{world_size=}, 2pc={enable_2pc_batch_consumption_tracking}"
         )
 
     def _to_ref_bundle_iterator(
@@ -79,15 +108,6 @@ class StreamSplitDataIterator(DataIterator):
     ) -> Tuple[Iterator[RefBundle], Optional[DatasetStats], bool, None]:
         is_replacement = self._is_replacement
         self._is_replacement = False
-        # Opt-out of the 1-block lookahead in gen_blocks. Useful for
-        # failure-tolerant consumers (e.g., Ray Train torchft-style
-        # replacement) where an in-flight prefetched block would be lost if
-        # the consumer dies: the coordinator has already popped the block
-        # from this split's queue, but the dead consumer never received it.
-        # With lookahead disabled, the coordinator only pops a block when
-        # the consumer is actively asking for it. Default (lookahead
-        # enabled) preserves throughput for the common no-failure path.
-        no_prefetch = os.environ.get("RAY_STREAM_SPLIT_NO_LOOKAHEAD") == "1"
 
         def gen_blocks() -> Iterator[RefBundle]:
             if is_replacement:
@@ -107,36 +127,10 @@ class StreamSplitDataIterator(DataIterator):
             logger.debug(f"Split {self._output_split_idx}: epoch {cur_epoch} started")
 
             last_log_time = 0.0
-            if no_prefetch:
-                # Dispatch each coord.get only when the consumer comes back
-                # for another block. One outstanding future at a time, no
-                # in-RAM block the consumer hasn't asked for yet.
-                while True:
-                    block_ref_and_md: Optional[RefBundle] = ray.get(
-                        self._coord_actor.get.remote(
-                            cur_epoch, self._output_split_idx, 0
-                        )
-                    )
-                    if not block_ref_and_md:
-                        break
-                    yield RefBundle(
-                        blocks=block_ref_and_md.blocks,
-                        owns_blocks=False,
-                        schema=block_ref_and_md.schema,
-                    )
-                    now = time.time()
-                    if now - last_log_time >= self.YIELD_LOG_INTERVAL_S:
-                        last_log_time = now
-                        logger.debug(
-                            f"Split {self._output_split_idx} epoch {cur_epoch}: "
-                            f"consumer resumed after yield"
-                        )
-                logger.debug(
-                    f"Split {self._output_split_idx}: epoch {cur_epoch} exhausted"
-                )
-                return
 
-            # Initial get with 0 prefetched bytes.
+            # Initial get with 0 prefetched bytes. (When 2PC is on, the
+            # coord registers each served block under our split_idx; when
+            # off, get() is the legacy immediate-commit path.)
             future: ObjectRef[Optional[RefBundle]] = self._coord_actor.get.remote(
                 cur_epoch, self._output_split_idx, 0
             )
@@ -145,6 +139,13 @@ class StreamSplitDataIterator(DataIterator):
                 if not block_ref_and_md:
                     break
                 else:
+                    # Cache per-block num_rows so the ack callback can prune
+                    # fully-acked entries from _pending_offsets without
+                    # another coord round-trip.
+                    if self._enable_2pc_batch_consumption_tracking:
+                        for block_ref, md in block_ref_and_md.blocks:
+                            self._block_num_rows[block_ref.hex()] = md.num_rows or 0
+
                     # Calculate prefetched bytes: BatchIterator's current prefetch
                     # plus the block we just received (which will be added to
                     # BatchIterator's sliding window when we yield it).
@@ -177,6 +178,62 @@ class StreamSplitDataIterator(DataIterator):
         # Return None for executor since StreamSplitDataIterator has its own
         # mechanism for reporting prefetched bytes via SplitCoordinator.
         return gen_blocks(), self._iter_stats, False, None
+
+    def _create_batch_iterator(
+        self,
+        ref_bundles_iter: Iterator[RefBundle],
+        prefetch_bytes_callback=None,
+        **kwargs,
+    ):
+        """Construct a BatchIterator with 2PC instrumentation when enabled.
+
+        When ``enable_2pc_batch_consumption_tracking`` is on, the iterator
+        runs in provenance mode (each emitted Batch carries source-block
+        provenance) and registers ``_ack_callback`` as ``on_yield`` so each
+        batch is synchronously committed at the coord before user code sees
+        it. When off, this matches the base ``DataIterator``-level
+        construction.
+        """
+        # Local import to avoid an import cycle at module load.
+        from ray.data._internal.block_batching.iter_batches import BatchIterator
+
+        return BatchIterator(
+            ref_bundles_iter,
+            prefetch_bytes_callback=prefetch_bytes_callback,
+            block_iter_with_ids=self._enable_2pc_batch_consumption_tracking,
+            on_yield=(
+                self._ack_callback
+                if self._enable_2pc_batch_consumption_tracking
+                else None
+            ),
+            **kwargs,
+        )
+
+    def _ack_callback(self, batch) -> None:
+        """Synchronously commit a batch's rows to the SplitCoordinator before
+        the batch is yielded to user code. (At-most-once delivery.)
+
+        Reads the per-batch ``provenance``, accumulates per-block cumulative
+        offsets into ``self._pending_offsets``, fires ``coord.ack`` blocking
+        on confirmation, and prunes fully-acked entries from the local
+        cache to keep ack payloads small.
+        """
+        provenance = getattr(batch, "provenance", None) or []
+        for block_id, rows_taken in provenance:
+            self._pending_offsets[block_id] = (
+                self._pending_offsets.get(block_id, 0) + rows_taken
+            )
+        if self._pending_offsets:
+            ray.get(
+                self._coord_actor.ack.remote(
+                    self._output_split_idx,
+                    list(self._pending_offsets.items()),
+                )
+            )
+        for bid in list(self._pending_offsets.keys()):
+            if self._pending_offsets[bid] >= self._block_num_rows.get(bid, 0):
+                del self._pending_offsets[bid]
+                self._block_num_rows.pop(bid, None)
 
     def stats(self) -> str:
         """Implements DataIterator."""
@@ -221,6 +278,7 @@ class SplitCoordinator:
         dataset: "Dataset",
         n: int,
         locality_hints: Optional[List[NodeIdStr]],
+        enable_2pc_batch_consumption_tracking: bool = False,
     ):
 
         # Set current DataContext.
@@ -257,7 +315,27 @@ class SplitCoordinator:
         # Store the error raised from the `gen_epoch` call.
         self._gen_epoch_error: Optional[Exception] = None
 
-        logger.debug(f"SplitCoordinator created: {n=}, {locality_hints=}")
+        # ---- 2PC reservation/abort state (guarded by self._lock) ----
+        # When enabled, every served block is added to _reserved[split_idx]
+        # as a [block_ref_hex, offset, RefBundle] entry. Acks update the
+        # offset in place; fully-acked entries are popped from the front.
+        # On abort(split_idx), the unconsumed tail of each reservation is
+        # sliced and pushed onto _requeue[split_idx]; subsequent get() calls
+        # for that split drain _requeue first. When disabled, all three
+        # methods (get's reservation step, ack, abort) are no-ops and the
+        # coord behaves as it did before this change.
+        self._enable_2pc_batch_consumption_tracking = (
+            enable_2pc_batch_consumption_tracking
+        )
+        self._reserved: Dict[int, Deque[List[Any]]] = {}
+        self._requeue: Dict[int, Deque[RefBundle]] = {
+            i: collections.deque() for i in range(n)
+        }
+
+        logger.debug(
+            f"SplitCoordinator created: {n=}, {locality_hints=}, "
+            f"2pc={enable_2pc_batch_consumption_tracking}"
+        )
 
     def get_dataset_context(self) -> DataContext:
         return self._data_context
@@ -363,6 +441,11 @@ class SplitCoordinator:
         self._gen_epoch_error = None
         # Reset per-split dispatch counters for the new epoch.
         self._num_rows_dispatched = dict.fromkeys(range(self._n), 0)
+        # 2PC state does not carry across epochs: any reservations or
+        # requeued blocks from the just-finished epoch are stale.
+        self._reserved.clear()
+        for split_idx in range(self._n):
+            self._requeue[split_idx].clear()
 
     def get(
         self,
@@ -381,7 +464,14 @@ class SplitCoordinator:
                 client's BatchIterator, used for resource accounting.
 
         Returns:
-            The next RefBundle for this split, or None if the epoch is done.
+            The next single-block RefBundle for this split, or ``None`` if
+            the epoch is done.
+
+            When ``enable_2pc_batch_consumption_tracking`` is on, the
+            returned block is also registered as a reservation under
+            ``output_split_idx``; the consumer is expected to later
+            ``ack(...)`` the rows it consumes from this block (or to be
+            ``abort(...)``-ed by Ray Train on worker death).
         """
         start_time = time.perf_counter()
         if epoch_id != self._cur_epoch:
@@ -391,44 +481,24 @@ class SplitCoordinator:
 
         returned_normally = False
         try:
-            # Ensure there is at least one bundle.
+            served_bundle = self._produce_single_block_bundle(output_split_idx)
+            if served_bundle is None:
+                # Caller path treats StopIteration as "epoch finished" by
+                # producing None; mirror that here.
+                return None
+
+            block_ref, metadata = served_bundle.blocks[0]
             with self._lock:
-                if output_split_idx in self._next_bundle:
-                    next_bundle = self._next_bundle[output_split_idx]
-                else:
-                    next_bundle = None
-
-            # Fetch next bundle if needed.
-            while next_bundle is None or not next_bundle.blocks:
-                # This is a BLOCKING call, so do it outside the lock.
-                next_bundle = self._output_iterator.get_next(output_split_idx)
-
-            schema = next_bundle.schema
-            block, metadata = next_bundle.blocks[-1]
-            next_bundle = RefBundle(
-                blocks=next_bundle.blocks[:-1],
-                schema=next_bundle.schema,
-                owns_blocks=next_bundle.owns_blocks,
-                output_split_idx=next_bundle.output_split_idx,
-            )
-
-            # Accumulate any remaining blocks in next_bundle map as needed.
-            with self._lock:
-                self._next_bundle[output_split_idx] = next_bundle
-                if not next_bundle.blocks:
-                    del self._next_bundle[output_split_idx]
-
-                # Update client prefetched bytes and report to resource manager.
                 self._client_prefetched_bytes[
                     output_split_idx
                 ] = client_prefetched_bytes
                 self._report_prefetched_bytes_to_executor()
-
-                # Track per-split row dispatch count.
                 self._num_rows_dispatched[output_split_idx] += (
                     metadata.num_rows if metadata.num_rows else 0
                 )
                 num_rows_dispatched = self._num_rows_dispatched[output_split_idx]
+                if self._enable_2pc_batch_consumption_tracking:
+                    self._reserve_block(output_split_idx, served_bundle)
 
             self._maybe_log_dispatch(
                 split_idx=output_split_idx,
@@ -438,9 +508,7 @@ class SplitCoordinator:
             )
 
             returned_normally = True
-            return RefBundle(
-                [(block, metadata)], schema=schema, owns_blocks=next_bundle.owns_blocks
-            )
+            return served_bundle
         except StopIteration:
             with self._lock:
                 num_rows = self._num_rows_dispatched[output_split_idx]
@@ -466,6 +534,58 @@ class SplitCoordinator:
                     self._report_prefetched_bytes_to_executor()
             # Track overhead time in the instance variable
             self._coordinator_overhead_s += time.perf_counter() - start_time
+
+    def _produce_single_block_bundle(
+        self, output_split_idx: int
+    ) -> Optional[RefBundle]:
+        """Produce the next single-block RefBundle for this split.
+
+        Cascades through three sources in order:
+          1. ``_requeue[split_idx]`` — sliced remainders from a dead
+             consumer's aborted reservations.
+          2. ``_next_bundle[split_idx]`` — leftover blocks from a previous
+             upstream pull.
+          3. ``self._output_iterator.get_next(split_idx)`` — pull a fresh
+             multi-block bundle from upstream and stash the leftover.
+
+        May raise ``StopIteration`` if the upstream pipeline is drained for
+        this split. Returns ``None`` only via that exception path; callers
+        currently rely on the surrounding ``try/except StopIteration`` in
+        ``get`` to translate to ``None`` for the user.
+        """
+        # Source 1: per-split requeue (drained one block per get, FIFO).
+        with self._lock:
+            if self._requeue[output_split_idx]:
+                return self._requeue[output_split_idx].popleft()
+
+        # Source 2 + 3: cached leftover bundle, pulling from upstream when
+        # empty. We pop one block off the tail and stash the rest back.
+        with self._lock:
+            next_bundle = self._next_bundle.get(output_split_idx)
+
+        while next_bundle is None or not next_bundle.blocks:
+            # Blocking call; do it outside the lock.
+            next_bundle = self._output_iterator.get_next(output_split_idx)
+
+        block, metadata = next_bundle.blocks[-1]
+        leftover = RefBundle(
+            blocks=next_bundle.blocks[:-1],
+            schema=next_bundle.schema,
+            owns_blocks=next_bundle.owns_blocks,
+            output_split_idx=next_bundle.output_split_idx,
+        )
+
+        with self._lock:
+            if leftover.blocks:
+                self._next_bundle[output_split_idx] = leftover
+            else:
+                self._next_bundle.pop(output_split_idx, None)
+
+        return RefBundle(
+            [(block, metadata)],
+            schema=next_bundle.schema,
+            owns_blocks=next_bundle.owns_blocks,
+        )
 
     def _get_total_prefetched_bytes(self) -> int:
         """Get the total prefetched bytes including coordinator buffer and clients.
@@ -514,6 +634,112 @@ class SplitCoordinator:
         logger.debug(
             f"Split {split_idx} epoch {epoch_id} returned block: "
             f"{num_rows_dispatched=}, {client_prefetched_bytes=}"
+        )
+
+    # ------------------------------------------------------------------
+    # 2PC: reserve / ack / abort
+    # ------------------------------------------------------------------
+
+    def _reserve_block(self, split_idx: int, bundle: RefBundle) -> None:
+        """Append a single-block RefBundle as a reservation for this split.
+
+        Caller must hold ``self._lock``. The bundle is expected to carry
+        exactly one block (which is what ``coord.get`` returns).
+        """
+        block_ref, _md = bundle.blocks[0]
+        deque_ = self._reserved.setdefault(split_idx, collections.deque())
+        deque_.append([block_ref.hex(), 0, bundle])
+
+    def ack(self, split_idx: int, acks: List[Tuple[str, int]]) -> None:
+        """Commit row offsets for blocks reserved against this split.
+
+        Called synchronously by the consumer just before yielding each
+        batch to user code. ``acks`` is a list of
+        ``(block_ref_hex, cumulative_offset)`` tuples covering the source
+        blocks contributing to the imminent batch. The consumer drains
+        from the front of the deque in FIFO order, so we update offsets
+        in-place and pop fully-acked entries from the front in one pass.
+        """
+        with self._lock:
+            deque_ = self._reserved.get(split_idx)
+            if not deque_:
+                return
+            new_offsets = dict(acks)
+            for entry in deque_:
+                if entry[0] in new_offsets:
+                    entry[1] = new_offsets[entry[0]]
+            while deque_:
+                _hex, offset, bundle = deque_[0]
+                num_rows = bundle.blocks[0][1].num_rows
+                if num_rows is not None and offset >= num_rows:
+                    deque_.popleft()
+                else:
+                    break
+            if not deque_:
+                del self._reserved[split_idx]
+
+    def abort(self, split_idx: int) -> None:
+        """Rewind a dead consumer's unconsumed reservations into the requeue.
+
+        For each remaining reservation entry on this split (in original
+        insertion order), slice the block at the last-acked offset and push
+        the unconsumed remainder onto ``_requeue[split_idx]``. The
+        replacement consumer's ``get(split_idx)`` will drain those
+        remainders before any new upstream blocks, so it picks up exactly
+        where the dead consumer's ack stream left off — no duplicates, no
+        gaps (modulo the microsecond ack/yield window documented in the
+        design).
+        """
+        with self._lock:
+            entries = self._reserved.pop(split_idx, None)
+        if not entries:
+            return
+
+        for entry in entries:
+            _hex, offset, bundle = entry
+            block_ref, md = bundle.blocks[0]
+            num_rows = md.num_rows or 0
+            if offset >= num_rows:
+                # Already fully consumed; nothing to requeue. (Defensive;
+                # should have been dropped on the final ack.)
+                continue
+
+            if offset == 0:
+                # Nothing acked yet for this block — push the original
+                # bundle as-is. No need for a ray.put round-trip.
+                requeue_bundle = bundle
+            else:
+                # Slice off the unconsumed tail and ray.put it as a new
+                # block. Arrow slice is a zero-copy view; the ray.put cost
+                # is the failure-path price of at-most-once recovery.
+                #
+                # We carry forward exec_stats / task_exec_stats / input_files
+                # from the original block — the slice doesn't have its own
+                # producing task, and these fields are accounting/lineage
+                # only (not load-bearing for correctness). num_rows and
+                # size_bytes are recomputed from the actual sliced bytes.
+                full_block = ray.get(block_ref)
+                sliced_block = BlockAccessor.for_block(full_block).slice(
+                    offset, num_rows, copy=False
+                )
+                sliced_accessor = BlockAccessor.for_block(sliced_block)
+                new_md = dataclasses.replace(
+                    md,
+                    num_rows=sliced_accessor.num_rows(),
+                    size_bytes=sliced_accessor.size_bytes(),
+                )
+                new_ref = ray.put(sliced_block)
+                requeue_bundle = RefBundle(
+                    [(new_ref, new_md)],
+                    schema=bundle.schema,
+                    owns_blocks=True,
+                )
+
+            with self._lock:
+                self._requeue[split_idx].append(requeue_bundle)
+
+        logger.debug(
+            f"abort(split={split_idx}) requeued {len(entries)} reservation(s)."
         )
 
     def shutdown_executor(self):

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -114,11 +114,7 @@ class StreamSplitDataIterator(DataIterator):
                 logger.debug(
                     f"Split {self._output_split_idx}: rejoining in-progress epoch."
                 )
-                cur_epoch = ray.get(
-                    self._coord_actor.rejoin_current_epoch.remote(
-                        self._output_split_idx
-                    )
-                )
+                cur_epoch = ray.get(self._coord_actor.rejoin_current_epoch.remote())
             else:
                 logger.debug(f"Split {self._output_split_idx}: requesting new epoch.")
                 cur_epoch = ray.get(
@@ -379,7 +375,7 @@ class SplitCoordinator:
         epoch_id = self._barrier(split_idx)
         return epoch_id
 
-    def rejoin_current_epoch(self, split_idx: int) -> int:
+    def rejoin_current_epoch(self) -> int:
         """Returns the in-progress epoch id without arriving at the start barrier.
 
         Used by a Ray Train replacement worker (e.g., torchft replica

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -83,7 +83,7 @@ class StreamSplitDataIterator(DataIterator):
         # the predecessor already counted toward the current epoch's barrier).
         # Cleared after the first iter_batches() call so subsequent epochs
         # follow the normal barrier path.
-        self._is_replacement = False
+        self._rejoined_epoch = False
         # 2PC mode: when True, gen_blocks tells the coord to reserve each
         # served block under our split_idx, and the BatchIterator fires a
         # synchronous coord.ack right before each yield via _ack_callback.
@@ -106,11 +106,11 @@ class StreamSplitDataIterator(DataIterator):
     def _to_ref_bundle_iterator(
         self,
     ) -> Tuple[Iterator[RefBundle], Optional[DatasetStats], bool, None]:
-        is_replacement = self._is_replacement
-        self._is_replacement = False
+        rejoined_epoch = self._rejoined_epoch
+        self._rejoined_epoch = False
 
         def gen_blocks() -> Iterator[RefBundle]:
-            if is_replacement:
+            if rejoined_epoch:
                 logger.debug(
                     f"Split {self._output_split_idx}: rejoining in-progress epoch."
                 )
@@ -230,6 +230,10 @@ class StreamSplitDataIterator(DataIterator):
             if self._pending_offsets[bid] >= self._block_num_rows.get(bid, 0):
                 del self._pending_offsets[bid]
                 self._block_num_rows.pop(bid, None)
+
+    def set_rejoined_epoch(self, rejoined_epoch: bool) -> None:
+        """Set whether this iterator rejoined this epoch."""
+        self._rejoined_epoch = rejoined_epoch
 
     def stats(self) -> str:
         """Implements DataIterator."""

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import threading
 import time
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
@@ -61,6 +62,14 @@ class StreamSplitDataIterator(DataIterator):
         self._output_split_idx = output_split_idx
         self._world_size = world_size
         self._iter_stats = DatasetStats(metadata={}, parent=None)
+        # One-shot flag: when True, the next iter_batches() call rejoins the
+        # in-progress epoch via rejoin_current_epoch() instead of arriving at
+        # the start-of-epoch barrier. Used when this iterator is handed to a
+        # Ray Train replacement worker whose predecessor died mid-epoch (so
+        # the predecessor already counted toward the current epoch's barrier).
+        # Cleared after the first iter_batches() call so subsequent epochs
+        # follow the normal barrier path.
+        self._is_replacement = False
         logger.debug(
             f"StreamSplitDataIterator created: split={output_split_idx}, {world_size=}"
         )
@@ -68,18 +77,69 @@ class StreamSplitDataIterator(DataIterator):
     def _to_ref_bundle_iterator(
         self,
     ) -> Tuple[Iterator[RefBundle], Optional[DatasetStats], bool, None]:
+        is_replacement = self._is_replacement
+        self._is_replacement = False
+        # Opt-out of the 1-block lookahead in gen_blocks. Useful for
+        # failure-tolerant consumers (e.g., Ray Train torchft-style
+        # replacement) where an in-flight prefetched block would be lost if
+        # the consumer dies: the coordinator has already popped the block
+        # from this split's queue, but the dead consumer never received it.
+        # With lookahead disabled, the coordinator only pops a block when
+        # the consumer is actively asking for it. Default (lookahead
+        # enabled) preserves throughput for the common no-failure path.
+        no_prefetch = os.environ.get("RAY_STREAM_SPLIT_NO_LOOKAHEAD") == "1"
+
         def gen_blocks() -> Iterator[RefBundle]:
-            logger.debug(f"Split {self._output_split_idx}: requesting new epoch.")
-            cur_epoch = ray.get(
-                self._coord_actor.start_epoch.remote(self._output_split_idx)
-            )
+            if is_replacement:
+                logger.debug(
+                    f"Split {self._output_split_idx}: rejoining in-progress epoch."
+                )
+                cur_epoch = ray.get(
+                    self._coord_actor.rejoin_current_epoch.remote(
+                        self._output_split_idx
+                    )
+                )
+            else:
+                logger.debug(f"Split {self._output_split_idx}: requesting new epoch.")
+                cur_epoch = ray.get(
+                    self._coord_actor.start_epoch.remote(self._output_split_idx)
+                )
             logger.debug(f"Split {self._output_split_idx}: epoch {cur_epoch} started")
+
+            last_log_time = 0.0
+            if no_prefetch:
+                # Dispatch each coord.get only when the consumer comes back
+                # for another block. One outstanding future at a time, no
+                # in-RAM block the consumer hasn't asked for yet.
+                while True:
+                    block_ref_and_md: Optional[RefBundle] = ray.get(
+                        self._coord_actor.get.remote(
+                            cur_epoch, self._output_split_idx, 0
+                        )
+                    )
+                    if not block_ref_and_md:
+                        break
+                    yield RefBundle(
+                        blocks=block_ref_and_md.blocks,
+                        owns_blocks=False,
+                        schema=block_ref_and_md.schema,
+                    )
+                    now = time.time()
+                    if now - last_log_time >= self.YIELD_LOG_INTERVAL_S:
+                        last_log_time = now
+                        logger.debug(
+                            f"Split {self._output_split_idx} epoch {cur_epoch}: "
+                            f"consumer resumed after yield"
+                        )
+                logger.debug(
+                    f"Split {self._output_split_idx}: epoch {cur_epoch} exhausted"
+                )
+                return
 
             # Initial get with 0 prefetched bytes.
             future: ObjectRef[Optional[RefBundle]] = self._coord_actor.get.remote(
                 cur_epoch, self._output_split_idx, 0
             )
-            last_log_time = 0.0
             while True:
                 block_ref_and_md: Optional[RefBundle] = ray.get(future)
                 if not block_ref_and_md:
@@ -240,6 +300,26 @@ class SplitCoordinator:
         # Wait for all clients to arrive at the barrier before starting a new epoch.
         epoch_id = self._barrier(split_idx)
         return epoch_id
+
+    def rejoin_current_epoch(self, split_idx: int) -> int:
+        """Returns the in-progress epoch id without arriving at the start barrier.
+
+        Used by a Ray Train replacement worker (e.g., torchft replica
+        replacement) to rejoin the epoch its dead predecessor was in the
+        middle of. The predecessor already counted toward this epoch's
+        barrier, so the replacement must not decrement
+        ``_unfinished_clients_in_epoch`` again. The replacement then drains
+        whatever blocks remain in this split's per-split buffer for the
+        current epoch via ``get(...)``, and proceeds to subsequent epochs
+        via the normal ``start_epoch`` path.
+        """
+        with self._lock:
+            if self._cur_epoch < 0:
+                raise ValueError(
+                    "rejoin_current_epoch called before any epoch has started; "
+                    "no in-progress epoch to rejoin."
+                )
+            return self._cur_epoch
 
     def _try_start_new_epoch(self, starting_epoch: int):
         with self._lock:

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -2046,6 +2046,7 @@ class Dataset:
         *,
         equal: bool = False,
         locality_hints: Optional[List["NodeIdStr"]] = None,
+        enable_2pc_batch_consumption_tracking: bool = False,
     ) -> List[DataIterator]:
         """Returns ``n`` :class:`DataIterators <ray.data.DataIterator>` that can
         be used to read disjoint subsets of the dataset in parallel.
@@ -2119,6 +2120,14 @@ class Dataset:
                 iterator output locations. This list must have length ``n``. You can
                 get the current node id of a task or actor by calling
                 ``ray.get_runtime_context().get_node_id()``.
+            enable_2pc_batch_consumption_tracking: If True, the underlying
+                ``SplitCoordinator`` runs in replacement-capable mode: blocks served
+                via ``coord.get`` are reserved per split until the consumer acks
+                them with row-level offsets, and ``coord.abort(split)`` rewinds the
+                unconsumed remainder into a per-split requeue for a replacement
+                consumer. Required for torchft-style replacement-resilient
+                iteration in Ray Train. Defaults to False (legacy semantics: each
+                ``coord.get`` commits the cursor immediately).
 
         Returns:
             The output iterator splits. These iterators are Ray-serializable and can
@@ -2141,7 +2150,14 @@ class Dataset:
         split_dataset = Dataset(plan, logical_plan)
         split_dataset._set_uuid(self._uuid)
 
-        return StreamSplitDataIterator.create(split_dataset, n, locality_hints)
+        return StreamSplitDataIterator.create(
+            split_dataset,
+            n,
+            locality_hints,
+            enable_2pc_batch_consumption_tracking=(
+                enable_2pc_batch_consumption_tracking
+            ),
+        )
 
     @ConsumptionAPI
     @PublicAPI(api_group=SMJ_API_GROUP)

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -434,6 +434,104 @@ def test_calculate_ref_hits(ray_start_regular_shared):
         )
 
 
+# ---------------------------------------------------------------------
+# Provenance tests for _BatchingIteratorWithProvenance.
+#
+# The provenance pipeline emits Batch objects whose `provenance` field is
+# `[(block_id, rows_from_block), ...]`, summing to the batch row count
+# and preserving source-block insertion order. Used by streaming_split
+# replacement-capable iteration to ack rows back to the SplitCoordinator.
+# ---------------------------------------------------------------------
+
+
+def _id_block_iter(blocks):
+    """Yield (block_id, block) pairs from a list of pyarrow tables."""
+    for i, blk in enumerate(blocks):
+        yield (f"blk{i}", blk)
+
+
+def test_provenance_batch_iterator_single_block():
+    """Batches that fit within one block carry provenance entries that
+    name only that block."""
+    from ray.data._internal.block_batching.util import (
+        _BatchingIteratorWithProvenance,
+    )
+
+    block = pa.table({"x": list(range(8))})
+    it = _BatchingIteratorWithProvenance(
+        _id_block_iter([block]),
+        batch_size=4,
+        drop_last=False,
+    )
+    batches = list(it)
+    assert len(batches) == 2
+    for batch in batches:
+        assert batch.provenance is not None
+        # All rows came from the single block.
+        assert batch.provenance == [("blk0", 4)]
+
+
+def test_provenance_batch_iterator_spans_multiple_blocks():
+    """A batch that spans multiple blocks emits one provenance entry per
+    contributing block, in source order, with row counts summing to the
+    batch size."""
+    from ray.data._internal.block_batching.util import (
+        _BatchingIteratorWithProvenance,
+    )
+
+    blocks = [
+        pa.table({"x": list(range(0, 4))}),  # 4 rows
+        pa.table({"x": list(range(4, 8))}),  # 4 rows
+        pa.table({"x": list(range(8, 12))}),  # 4 rows
+    ]
+    it = _BatchingIteratorWithProvenance(
+        _id_block_iter(blocks),
+        batch_size=10,
+        drop_last=False,
+    )
+    batches = list(it)
+    # 12 rows / batch_size=10 → 1 batch of 10 + 1 trailing batch of 2.
+    assert len(batches) == 2
+    # First batch: 4 from blk0 + 4 from blk1 + 2 from blk2.
+    assert batches[0].provenance == [("blk0", 4), ("blk1", 4), ("blk2", 2)]
+    # Trailing batch: remaining 2 rows from blk2.
+    assert batches[1].provenance == [("blk2", 2)]
+
+
+def test_provenance_batch_iterator_partial_last_batch():
+    """drop_last=False: the trailing partial batch's provenance still sums
+    to its actual row count (not batch_size)."""
+    from ray.data._internal.block_batching.util import (
+        _BatchingIteratorWithProvenance,
+    )
+
+    block = pa.table({"x": list(range(7))})
+    it = _BatchingIteratorWithProvenance(
+        _id_block_iter([block]),
+        batch_size=3,
+        drop_last=False,
+    )
+    batches = list(it)
+    assert len(batches) == 3
+    assert batches[0].provenance == [("blk0", 3)]
+    assert batches[1].provenance == [("blk0", 3)]
+    assert batches[2].provenance == [("blk0", 1)]
+
+
+def test_batch_iterator_block_iter_with_ids_rejects_local_shuffle():
+    """When the replacement-capable provenance pipeline is enabled,
+    local_shuffle_buffer_size must be unset; otherwise the FIFO row
+    invariant the SplitCoordinator's ack tracking depends on is broken."""
+    from ray.data._internal.block_batching.iter_batches import BatchIterator
+
+    with pytest.raises(ValueError, match="local_shuffle_buffer_size"):
+        BatchIterator(
+            ref_bundles=iter([]),
+            block_iter_with_ids=True,
+            shuffle_buffer_min_size=10,
+        )
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -1035,6 +1035,175 @@ def test_streaming_splits_schema_access(ray_start_regular_shared_2_cpus):
     assert expected_schema.equals(iter_1.schema().base_schema)
 
 
+# ---------------------------------------------------------------------
+# 2PC reservation/ack/abort tests for SplitCoordinator.
+#
+# These instantiate SplitCoordinator's underlying class directly (not as
+# a Ray actor) so we can inspect its state precisely. The actor wrapper
+# is exercised end-to-end via the Ray Train integration test.
+# ---------------------------------------------------------------------
+
+
+def _drain_block(ref_bundle):
+    """Helper: ray.get a single-block RefBundle's payload as a Python list."""
+    block_ref, _ = ref_bundle.blocks[0]
+    block = ray.get(block_ref)
+    return block.column("id").to_pylist()
+
+
+def _new_coord_local(ds, n, enable_2pc=True):
+    """Instantiate SplitCoordinator's underlying class directly (bypassing
+    the @ray.remote wrapper). State methods can then be inspected
+    synchronously.
+    """
+    from ray.data._internal.iterator.stream_split_iterator import (
+        SplitCoordinator,
+    )
+
+    cls = SplitCoordinator.__ray_actor_class__
+    return cls(ds, n, None, enable_2pc)
+
+
+def test_streaming_split_2pc_reserve_and_ack_drops_reservation(
+    ray_start_regular_shared_2_cpus,
+):
+    """get reserves under split_idx; ack with offset==num_rows drops the
+    entry from the front of the reservation deque."""
+    ds = ray.data.range(20, override_num_blocks=4)
+    coord = _new_coord_local(ds, n=1)
+
+    # Single client → barrier passes immediately.
+    epoch_id = coord.start_epoch(0)
+    bundle = coord.get(epoch_id, 0)
+    assert bundle is not None
+    block_hex = bundle.blocks[0][0].hex()
+    num_rows = bundle.blocks[0][1].num_rows
+
+    # Reservation recorded for split 0.
+    assert 0 in coord._reserved
+    assert len(coord._reserved[0]) == 1
+    assert coord._reserved[0][0][0] == block_hex
+    assert coord._reserved[0][0][1] == 0  # offset starts at 0
+
+    # Full ack drops the reservation.
+    coord.ack(0, [(block_hex, num_rows)])
+    assert 0 not in coord._reserved
+
+
+def test_streaming_split_2pc_partial_ack_advances_offset(
+    ray_start_regular_shared_2_cpus,
+):
+    """ack with offset<num_rows updates the entry's offset in place
+    without dropping it; the front-of-deque entry's offset reflects
+    cumulative consumption."""
+    ds = ray.data.range(20, override_num_blocks=4)
+    coord = _new_coord_local(ds, n=1)
+
+    epoch_id = coord.start_epoch(0)
+    bundle = coord.get(epoch_id, 0)
+    block_hex = bundle.blocks[0][0].hex()
+    num_rows = bundle.blocks[0][1].num_rows
+    assert num_rows >= 2
+
+    # Ack 1 row of partial consumption.
+    coord.ack(0, [(block_hex, 1)])
+    assert 0 in coord._reserved
+    assert len(coord._reserved[0]) == 1
+    assert coord._reserved[0][0][1] == 1  # offset updated
+
+    # Ack one more row.
+    coord.ack(0, [(block_hex, 2)])
+    assert coord._reserved[0][0][1] == 2
+
+    # Idempotency: re-ack the same offset shouldn't change anything.
+    coord.ack(0, [(block_hex, 2)])
+    assert coord._reserved[0][0][1] == 2
+
+
+def test_streaming_split_2pc_abort_slices_at_offset_and_pushes_to_requeue(
+    ray_start_regular_shared_2_cpus,
+):
+    """Aborting a partial reservation pushes the unconsumed remainder onto the
+    requeue, sliced at the last-acked offset. The next get() returns exactly
+    those rows for whichever consumer asks next."""
+    ds = ray.data.range(40, override_num_blocks=4)
+    coord = _new_coord_local(ds, n=1)
+
+    epoch_id = coord.start_epoch(0)
+    bundle = coord.get(epoch_id, 0)
+    rows_in_block = _drain_block(bundle)
+    block_hex = bundle.blocks[0][0].hex()
+    num_rows = len(rows_in_block)
+    assert num_rows >= 4
+
+    # Pretend the consumer ack'd only the first half of the block, then died.
+    half = num_rows // 2
+    coord.ack(0, [(block_hex, half)])
+    assert coord._reserved[0][0][1] == half  # offset reflected before abort
+
+    coord.abort(0)
+    assert 0 not in coord._reserved
+    assert len(coord._requeue[0]) == 1
+
+    # Replacement's first get drains the requeue. Rows match the unconsumed
+    # tail of the original block.
+    requeued_bundle = coord.get(epoch_id, 0)
+    assert requeued_bundle is not None
+    requeued_rows = _drain_block(requeued_bundle)
+    assert requeued_rows == rows_in_block[half:]
+    # Requeue is empty post-drain; the new reservation was created for the
+    # replacement under the same split key.
+    assert len(coord._requeue[0]) == 0
+    assert 0 in coord._reserved
+    assert coord._reserved[0][0][1] == 0  # fresh reservation, offset=0
+
+
+def test_streaming_split_2pc_get_drains_requeue_before_next_bundle(
+    ray_start_regular_shared_2_cpus,
+):
+    """When the requeue is non-empty, get() returns from it before pulling
+    new blocks from the upstream pipeline."""
+    ds = ray.data.range(40, override_num_blocks=4)
+    coord = _new_coord_local(ds, n=1)
+
+    epoch_id = coord.start_epoch(0)
+
+    # Pull and abort one full block (offset=0 → original bundle goes to
+    # the requeue without re-slicing).
+    pulled = coord.get(epoch_id, 0)
+    pulled_rows = _drain_block(pulled)
+    coord.abort(0)
+    assert len(coord._requeue[0]) == 1
+
+    # Replacement's first get returns the requeued bundle, NOT a fresh
+    # upstream block.
+    first = coord.get(epoch_id, 0)
+    first_rows = _drain_block(first)
+    assert first_rows == pulled_rows
+    assert len(coord._requeue[0]) == 0
+
+
+def test_streaming_split_2pc_disabled_preserves_old_get_semantics(
+    ray_start_regular_shared_2_cpus,
+):
+    """Backward compat: with enable_2pc=False, get() commits the cursor
+    immediately and never registers a reservation. ack/abort are no-ops."""
+    ds = ray.data.range(20, override_num_blocks=4)
+    coord = _new_coord_local(ds, n=1, enable_2pc=False)
+
+    epoch_id = coord.start_epoch(0)
+    bundle = coord.get(epoch_id, 0)
+    assert bundle is not None
+
+    # No reservation tracked.
+    assert coord._reserved == {}
+    # ack/abort are safe no-ops.
+    coord.ack(0, [(bundle.blocks[0][0].hex(), bundle.blocks[0][1].num_rows)])
+    coord.abort(0)
+    assert coord._reserved == {}
+    assert len(coord._requeue[0]) == 0
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -25,6 +25,7 @@ class DataConfig:
             Union["ExecutionOptions", Dict[str, "ExecutionOptions"]]
         ] = None,
         enable_shard_locality: bool = True,
+        enable_2pc_batch_consumption_tracking: bool = False,
     ):
         """Construct a DataConfig.
 
@@ -40,6 +41,16 @@ class DataConfig:
                 base your options off ``DataConfig.default_ingest_options()``.
             enable_shard_locality: If true, dataset sharding across Train workers will
                 consider locality to minimize cross-node data transfer. Enabled by default.
+            enable_2pc_batch_consumption_tracking: If true, the streaming_split
+                ``SplitCoordinator`` runs in replacement-capable mode: each block it
+                hands to a worker is reserved against that worker's split until the
+                worker synchronously acks the rows it consumed (right before yielding
+                each batch to user code). On worker death, ``DatasetsCallback``
+                aborts the dead split's outstanding reservations and the unconsumed
+                remainder is requeued for the replacement worker. Required for
+                torchft-style replacement (and auto-enabled by ``DataParallelTrainer``
+                when ``backend_config.has_replica_groups=True``); incompatible with
+                ``local_shuffle_buffer_size``. Defaults to False.
         """
         from ray.data import ExecutionOptions
 
@@ -64,9 +75,20 @@ class DataConfig:
             self._execution_options.update(execution_options)
 
         self._enable_shard_locality = enable_shard_locality
+        self._enable_2pc_batch_consumption_tracking = (
+            enable_2pc_batch_consumption_tracking
+        )
 
         self._num_train_cpus = 0.0
         self._num_train_gpus = 0.0
+
+    @property
+    def enable_2pc_batch_consumption_tracking(self) -> bool:
+        return self._enable_2pc_batch_consumption_tracking
+
+    @enable_2pc_batch_consumption_tracking.setter
+    def enable_2pc_batch_consumption_tracking(self, value: bool) -> None:
+        self._enable_2pc_batch_consumption_tracking = value
 
     def set_train_total_resources(self, num_train_cpus: float, num_train_gpus: float):
         """Set the total number of CPUs and GPUs used by training.
@@ -140,7 +162,12 @@ class DataConfig:
             if name in datasets_to_split:
                 for i, split in enumerate(
                     ds.streaming_split(
-                        world_size, equal=True, locality_hints=locality_hints
+                        world_size,
+                        equal=True,
+                        locality_hints=locality_hints,
+                        enable_2pc_batch_consumption_tracking=(
+                            self._enable_2pc_batch_consumption_tracking
+                        ),
                     )
                 ):
                     output[i][name] = split

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -218,6 +218,10 @@ class DatasetsCallback(WorkerGroupCallback, ReplicaGroupCallback, ControllerCall
         # workers. The underlying DataIterator (and its coordinator actor) is
         # preserved across the replacement, so the replacement picks up where
         # the failed worker left off.
+        from ray.data._internal.iterator.stream_split_iterator import (
+            StreamSplitDataIterator,
+        )
+
         providers = []
         for w in workers:
             rank = w.distributed_context.world_rank
@@ -231,7 +235,16 @@ class DatasetsCallback(WorkerGroupCallback, ReplicaGroupCallback, ControllerCall
                 "outgoing replica."
             )
             self._shard_provider_active[rank] = True
-            providers.append(self._shard_providers[rank])
+            provider = self._shard_providers[rank]
+            # Mark each StreamSplitDataIterator so the replacement worker
+            # rejoins the in-progress epoch instead of arriving at the
+            # start_epoch barrier the predecessor already passed (which would
+            # deadlock the SplitCoordinator). Flag is one-shot: the iterator
+            # auto-clears it after the first iter_batches() call.
+            for ds_iter in provider._dataset_iterators.values():
+                if isinstance(ds_iter, StreamSplitDataIterator):
+                    ds_iter._is_replacement = True
+            providers.append(provider)
         return {"dataset_shard_provider": providers}
 
     # --------------------------

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -12,12 +12,16 @@ from ray.train.v2._internal.data_integration.interfaces import (
 )
 from ray.train.v2._internal.execution.callback import (
     ControllerCallback,
+    ReplicaGroupCallback,
     WorkerGroupCallback,
 )
 from ray.train.v2._internal.execution.context import TrainRunContext
+from ray.train.v2._internal.execution.worker_group.execution_group import (
+    ExecutionGroup,
+    ReplicaGroup,
+)
 from ray.train.v2._internal.execution.worker_group.worker_group import (
     Worker,
-    WorkerGroup,
     WorkerGroupContext,
 )
 from ray.types import ObjectRef
@@ -47,7 +51,7 @@ class RayDatasetShardProvider:
         return self._dataset_iterators[dataset_info.dataset_name]
 
 
-class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
+class DatasetsCallback(WorkerGroupCallback, ReplicaGroupCallback, ControllerCallback):
     """A callback for managing Ray Datasets for the worker group."""
 
     def __init__(
@@ -60,6 +64,16 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
         self._scaling_config = train_run_context.scaling_config
         self._coordinator_actors: List[ActorHandle] = []
         self._shutdown_refs: List[ObjectRef] = []
+        # Populated in before_init_train_context_on_worker_group. Indexed by
+        # world rank. Shard providers are kept alive across replica group
+        # replacement so that a replacement worker picks up the same
+        # DataIterator (and its cursor) its predecessor was using.
+        self._shard_providers: List[RayDatasetShardProvider] = []
+        # Parallel to _shard_providers. Flipped to False when a replica group
+        # is shut down (so we can confirm the shard is free before reassigning
+        # it to a replacement worker), and back to True when the replacement
+        # starts.
+        self._shard_provider_active: List[bool] = []
 
         # Capture the current DataContext to propagate it to
         # the Train workers later.
@@ -118,7 +132,7 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
     # WorkerGroupCallback
     # --------------------------
 
-    def before_init_train_context(
+    def before_init_train_context_on_worker_group(
         self, workers: List[Worker]
     ) -> Dict[str, List[DatasetShardProvider]]:
         world_size = len(workers)
@@ -145,19 +159,9 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
             RayDatasetShardProvider(ds_iterators=ds_iterators_per_rank[rank])
             for rank in range(world_size)
         ]
+        self._shard_providers = shard_providers_per_rank
+        self._shard_provider_active = [True] * world_size
         return {"dataset_shard_provider": shard_providers_per_rank}
-
-    def after_worker_group_start(self, worker_group: WorkerGroup):
-        # Propagate DataContext
-        from ray.data.context import DataContext
-
-        def _propagate_data_context(ctx: "DataContext"):
-            DataContext._set_current(ctx)
-
-        worker_group.execute(
-            _propagate_data_context,
-            self._data_context,
-        )
 
     def after_worker_group_shutdown(
         self, worker_group_context: WorkerGroupContext
@@ -168,6 +172,67 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
         self, worker_group_context: WorkerGroupContext
     ) -> None:
         self._shutdown_data_executors()
+
+    # --------------------------
+    # ExecutionGroupCallback (fires on both worker group and replica group start)
+    # --------------------------
+
+    def after_execution_group_start(self, execution_group: ExecutionGroup):
+        # Propagate DataContext to all workers in the (possibly partial)
+        # execution group. This runs on full worker group startup and also on
+        # replica group replacement so that replacement workers see the same
+        # DataContext as their predecessors.
+        from ray.data.context import DataContext
+
+        def _propagate_data_context(ctx: "DataContext"):
+            DataContext._set_current(ctx)
+
+        execution_group.execute(
+            _propagate_data_context,
+            self._data_context,
+        )
+
+    # --------------------------
+    # ReplicaGroupCallback
+    # --------------------------
+
+    def before_replica_group_shutdown(self, replica_group: ReplicaGroup):
+        # Mark the shard provider slots for this replica's ranks as inactive
+        # so they can be handed to replacement workers.
+        for w in replica_group.get_workers():
+            assert w.distributed_context is not None, (
+                "Worker in replica group is missing distributed_context in "
+                "before_replica_group_shutdown."
+            )
+            rank = w.distributed_context.world_rank
+            assert 0 <= rank < len(self._shard_provider_active), (
+                f"Outgoing worker has world_rank={rank} outside of the "
+                f"range [0, {len(self._shard_provider_active)})."
+            )
+            self._shard_provider_active[rank] = False
+
+    def before_init_train_context_on_replica_group(
+        self, workers: List[Worker]
+    ) -> Dict[str, List[DatasetShardProvider]]:
+        # Reuse the existing per-rank shard providers for the replacement
+        # workers. The underlying DataIterator (and its coordinator actor) is
+        # preserved across the replacement, so the replacement picks up where
+        # the failed worker left off.
+        providers = []
+        for w in workers:
+            rank = w.distributed_context.world_rank
+            assert 0 <= rank < len(self._shard_providers), (
+                f"Replacement worker has world_rank={rank} outside of the "
+                f"range [0, {len(self._shard_providers)})."
+            )
+            assert not self._shard_provider_active[rank], (
+                f"Shard provider for rank {rank} is still marked active; "
+                "before_replica_group_shutdown was not called for the "
+                "outgoing replica."
+            )
+            self._shard_provider_active[rank] = True
+            providers.append(self._shard_providers[rank])
+        return {"dataset_shard_provider": providers}
 
     # --------------------------
     # ControllerCallback

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -198,7 +198,14 @@ class DatasetsCallback(WorkerGroupCallback, ReplicaGroupCallback, ControllerCall
 
     def before_replica_group_shutdown(self, replica_group: ReplicaGroup):
         # Mark the shard provider slots for this replica's ranks as inactive
-        # so they can be handed to replacement workers.
+        # so they can be handed to replacement workers, and abort each
+        # streaming_split iterator's reservations on the SplitCoordinator
+        # so any blocks the predecessor pulled-but-didn't-fully-ack are
+        # sliced into the requeue for the replacement to consume.
+        from ray.data._internal.iterator.stream_split_iterator import (
+            StreamSplitDataIterator,
+        )
+
         for w in replica_group.get_workers():
             assert w.distributed_context is not None, (
                 "Worker in replica group is missing distributed_context in "
@@ -209,6 +216,18 @@ class DatasetsCallback(WorkerGroupCallback, ReplicaGroupCallback, ControllerCall
                 f"Outgoing worker has world_rank={rank} outside of the "
                 f"range [0, {len(self._shard_provider_active)})."
             )
+            provider = self._shard_providers[rank]
+            for ds_iter in provider._dataset_iterators.values():
+                if isinstance(ds_iter, StreamSplitDataIterator):
+                    # Synchronous so the requeue is populated before the
+                    # replacement comes online and calls coord.get. The
+                    # coord ignores abort() when 2PC tracking is off, so
+                    # this is safe to call unconditionally.
+                    ray.get(
+                        ds_iter._coord_actor.abort.remote(
+                            ds_iter._output_split_idx,
+                        )
+                    )
             self._shard_provider_active[rank] = False
 
     def before_init_train_context_on_replica_group(

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -194,6 +194,10 @@ class DatasetsCallback(WorkerGroupCallback, ReplicaGroupCallback, ControllerCall
 
     # --------------------------
     # ReplicaGroupCallback
+    # We should only call these methods if we are replacing worker(s) in a fixed
+    # size training group. If the number of workers changes, we need to shift from
+    # "handing a dataset shard to the replacement worker" to
+    # "having multiple workers pull from a common queue."
     # --------------------------
 
     def before_replica_group_shutdown(self, replica_group: ReplicaGroup):
@@ -262,7 +266,7 @@ class DatasetsCallback(WorkerGroupCallback, ReplicaGroupCallback, ControllerCall
             # auto-clears it after the first iter_batches() call.
             for ds_iter in provider._dataset_iterators.values():
                 if isinstance(ds_iter, StreamSplitDataIterator):
-                    ds_iter._is_replacement = True
+                    ds_iter.set_rejoined_epoch(True)
             providers.append(provider)
         return {"dataset_shard_provider": providers}
 

--- a/python/ray/train/v2/_internal/execution/callback.py
+++ b/python/ray/train/v2/_internal/execution/callback.py
@@ -40,6 +40,18 @@ class ExecutionGroupCallback(RayTrainCallback):
         """
         return {}
 
+    def before_init_train_context_on_worker_group(
+        self, workers: List["Worker"]
+    ) -> Dict[str, List[Any]]:
+        """Variant of before_init_train_context invoked on full worker group startup."""
+        return self.before_init_train_context(workers)
+
+    def before_init_train_context_on_replica_group(
+        self, workers: List["Worker"]
+    ) -> Dict[str, List[Any]]:
+        """Variant of before_init_train_context invoked on replica group replacement."""
+        return self.before_init_train_context(workers)
+
     def after_execution_group_start(self, execution_group: "ExecutionGroup"):
         """Called after an execution group is started or replaced.
         All workers in the execution group should be ready to execute tasks."""

--- a/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker_group.py
@@ -505,6 +505,7 @@ class WorkerGroup(ExecutionGroup):
         self,
         workers: List[Worker],
         sync_actor: ActorHandle,
+        is_replica_replacement: bool = False,
     ) -> None:
         """Collect train context args from callbacks and initialize train context.
 
@@ -514,11 +515,21 @@ class WorkerGroup(ExecutionGroup):
         Args:
             workers: The workers to initialize.
             sync_actor: The synchronization actor.
+            is_replica_replacement: Whether this call is for replacing a
+                subset of workers in an already-running worker group (as
+                opposed to starting the whole worker group from scratch).
+                Callbacks that need different behavior for the two paths can
+                implement ``before_init_train_context_on_worker_group`` and
+                ``before_init_train_context_on_replica_group``; otherwise
+                ``before_init_train_context`` is used in both cases.
         """
         before_init_train_context_cb_start = time_monotonic()
         train_context_args: Dict[str, List[Any]] = {}
         for cb in self._execution_group_callbacks:
-            args = cb.before_init_train_context(workers)
+            if is_replica_replacement:
+                args = cb.before_init_train_context_on_replica_group(workers)
+            else:
+                args = cb.before_init_train_context_on_worker_group(workers)
             for arg, arg_values in args.items():
                 assert len(arg_values) == len(workers), (
                     f"Callback {cb} returned {arg} with "
@@ -858,7 +869,9 @@ class WorkerGroup(ExecutionGroup):
         # Initialize train context on new workers.
         sync_actor = self._worker_group_state.sync_actor
         try:
-            self._init_train_context(new_workers, sync_actor)
+            self._init_train_context(
+                new_workers, sync_actor, is_replica_replacement=True
+            )
         except RayActorError as actor_error:
             error_msg = (
                 "At least one replacement worker failed to initialize "

--- a/python/ray/train/v2/api/data_parallel_trainer.py
+++ b/python/ray/train/v2/api/data_parallel_trainer.py
@@ -95,6 +95,24 @@ class DataParallelTrainer:
         self.datasets = datasets or {}
         self.data_config = dataset_config or DataConfig()
 
+        # Auto-link DataConfig.enable_2pc_batch_consumption_tracking to the
+        # backend's has_replica_groups: replacement-capable backends (e.g.,
+        # torchft) need the SplitCoordinator running in 2PC mode so a dead
+        # worker's pulled-but-unacked blocks can be requeued for the
+        # replacement instead of silently dropped. Other backends keep the
+        # default fast-path. We set it then assert as a sanity check, in
+        # case a user passed a custom DataConfig that pre-set the flag.
+        has_replica_groups = self.backend_config.backend_cls.has_replica_groups
+        self.data_config.enable_2pc_batch_consumption_tracking = has_replica_groups
+        assert (
+            self.data_config.enable_2pc_batch_consumption_tracking == has_replica_groups
+        ), (
+            "DataConfig.enable_2pc_batch_consumption_tracking must match "
+            "backend_config.backend_cls.has_replica_groups: "
+            f"{self.data_config.enable_2pc_batch_consumption_tracking} != "
+            f"{has_replica_groups}"
+        )
+
         self.running_in_local_mode = self.scaling_config.num_workers == 0
 
         self.train_run_context = TrainRunContext(

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -26,7 +26,6 @@ from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 from ray.train.v2.tests.util import (
     DummyObjectRefWrapper,
     DummyWorkerGroup,
-    MockReplicaGroupBackendConfig,
     create_dummy_run_context,
 )
 
@@ -834,84 +833,6 @@ def test_fixed_scaling_policy_coordinator_lifecycle():
         mock_coordinator.cancel_request.remote.assert_called_once_with(
             requester_id="train-test-run-123",
         )
-
-
-def test_shard_provider_reused_across_replica_group_replacement(ray_start_4_cpus):
-    """When a replica group is replaced (torchft-style), the replacement worker
-    resumes data delivery exactly where the predecessor's last ack landed —
-    no duplicates ever reach user code (at-most-once contract).
-
-    Backed by the SplitCoordinator's 2PC reservation/ack/abort protocol:
-    each batch yielded synchronously commits its rows via coord.ack before
-    user code sees them, and DatasetsCallback.before_replica_group_shutdown
-    aborts the predecessor's outstanding reservations into a per-split
-    requeue that the replacement drains first.
-    """
-    import os
-
-    import ray
-
-    NUM_ROWS = 100
-    NUM_WORKERS = 2
-
-    @ray.remote(num_cpus=0)
-    class Collector:
-        def __init__(self):
-            self._rows = []
-
-        def add(self, worker_tag, row):
-            self._rows.append((worker_tag, row))
-
-        def get_rows(self):
-            return list(self._rows)
-
-    collector = Collector.remote()
-
-    # Default block sizes; no overrides needed. With 2PC, prefetched-but-not-
-    # yet-yielded blocks become reservations that the abort path slices into
-    # the requeue, so any layer of in-worker buffering is safe.
-    train_ds = ray.data.range(NUM_ROWS)
-
-    def train_fn():
-        worker_tag = os.getpid()
-        shard = ray.train.get_dataset_shard("train")
-        for batch in shard.iter_batches(batch_size=1):
-            row = int(batch["id"][0])
-            ray.get(collector.add.remote(worker_tag, row))
-            # Only 1 worker should see row 50 and fail once. With 2PC's
-            # sync-ack-before-yield, this row has already been committed at
-            # the coord by the time the raise fires; the replacement
-            # resumes from row 51's block onward.
-            if row == 50:
-                raise RuntimeError("Injected failure after consuming row 50.")
-
-    trainer = DataParallelTrainer(
-        train_fn,
-        datasets={"train": train_ds},
-        backend_config=MockReplicaGroupBackendConfig(),
-        scaling_config=ray.train.ScalingConfig(num_workers=NUM_WORKERS),
-        run_config=ray.train.RunConfig(
-            failure_config=ray.train.FailureConfig(max_failures=1),
-        ),
-    )
-    trainer.fit()
-
-    entries = ray.get(collector.get_rows.remote())
-    by_worker = {}
-    for worker_tag, row in entries:
-        by_worker.setdefault(worker_tag, []).append(row)
-    for tag in by_worker:
-        by_worker[tag].sort()
-    rows = sorted(r for _, r in entries)
-    attribution = "\n".join(
-        f"  worker pid={tag}: {len(rs)} rows {rs}"
-        for tag, rs in sorted(by_worker.items())
-    )
-    assert sorted(rows) == list(range(NUM_ROWS)), (
-        f"Expected all {NUM_ROWS} rows to be collected exactly once after "
-        f"replica replacement, got {len(rows)} rows: {sorted(rows)}\n"
-        f"Per-worker attribution:\n{attribution}"
-    )
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -209,6 +209,7 @@ def test_configure_locality(enable_shard_locality):
         world_size,
         equal=True,
         locality_hints=worker_node_ids if enable_shard_locality else None,
+        enable_2pc_batch_consumption_tracking=False,
     )
 
 
@@ -837,9 +838,14 @@ def test_fixed_scaling_policy_coordinator_lifecycle():
 
 def test_shard_provider_reused_across_replica_group_replacement(ray_start_4_cpus):
     """When a replica group is replaced (torchft-style), the replacement worker
-    should inherit the same per-rank RayDatasetShardProvider as its predecessor,
-    so that the DataIterator's cursor on the shared coordinator actor is
-    preserved and no rows are dropped or duplicated.
+    resumes data delivery exactly where the predecessor's last ack landed —
+    no duplicates ever reach user code (at-most-once contract).
+
+    Backed by the SplitCoordinator's 2PC reservation/ack/abort protocol:
+    each batch yielded synchronously commits its rows via coord.ack before
+    user code sees them, and DatasetsCallback.before_replica_group_shutdown
+    aborts the predecessor's outstanding reservations into a per-split
+    requeue that the replacement drains first.
     """
     import os
 
@@ -861,38 +867,23 @@ def test_shard_provider_reused_across_replica_group_replacement(ray_start_4_cpus
 
     collector = Collector.remote()
 
-    # One-row blocks so the atomic unit the SplitCoordinator hands out matches
-    # what the consumer processes synchronously. Combined with no-lookahead
-    # below, this guarantees a dying worker has at most the row it's currently
-    # processing in memory (and that row is already in the collector by the
-    # time the raise fires).
-    train_ds = ray.data.range(NUM_ROWS, override_num_blocks=NUM_ROWS)
+    # Default block sizes; no overrides needed. With 2PC, prefetched-but-not-
+    # yet-yielded blocks become reservations that the abort path slices into
+    # the requeue, so any layer of in-worker buffering is safe.
+    train_ds = ray.data.range(NUM_ROWS)
 
     def train_fn():
-        # Disable all lookahead between the SplitCoordinator and the consumer
-        # so rows stay in the coord's queue until the consumer explicitly
-        # asks for them; anything the worker has pulled into RAM would
-        # otherwise be lost if the worker dies (the coord has already popped
-        # it off the split's queue).
-        # - RAY_STREAM_SPLIT_NO_LOOKAHEAD=1: skip gen_blocks' 1-block
-        #   prefetch of the NEXT block (SplitCoordinator layer).
-        # - We bypass iter_batches entirely and iterate the raw ref-bundle
-        #   stream by hand, because iter_batches wraps the pipeline in
-        #   make_async_gen which eagerly pulls batches in a background
-        #   thread even with prefetch_batches=0.
-        os.environ["RAY_STREAM_SPLIT_NO_LOOKAHEAD"] = "1"
         worker_tag = os.getpid()
         shard = ray.train.get_dataset_shard("train")
-        ref_bundles, _, _, _ = shard._to_ref_bundle_iterator()
-        for bundle in ref_bundles:
-            for block_ref in bundle.block_refs:
-                block = ray.get(block_ref)
-                for row_idx in range(block.num_rows):
-                    row = int(block.column("id")[row_idx].as_py())
-                    ray.get(collector.add.remote(worker_tag, row))
-                    # Only 1 worker should see row 50 and fail once.
-                    if row == 50:
-                        raise RuntimeError("Injected failure after consuming row 50.")
+        for batch in shard.iter_batches(batch_size=1):
+            row = int(batch["id"][0])
+            ray.get(collector.add.remote(worker_tag, row))
+            # Only 1 worker should see row 50 and fail once. With 2PC's
+            # sync-ack-before-yield, this row has already been committed at
+            # the coord by the time the raise fires; the replacement
+            # resumes from row 51's block onward.
+            if row == 50:
+                raise RuntimeError("Injected failure after consuming row 50.")
 
     trainer = DataParallelTrainer(
         train_fn,

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -841,6 +841,8 @@ def test_shard_provider_reused_across_replica_group_replacement(ray_start_4_cpus
     so that the DataIterator's cursor on the shared coordinator actor is
     preserved and no rows are dropped or duplicated.
     """
+    import os
+
     import ray
 
     NUM_ROWS = 100
@@ -851,24 +853,46 @@ def test_shard_provider_reused_across_replica_group_replacement(ray_start_4_cpus
         def __init__(self):
             self._rows = []
 
-        def add(self, row):
-            self._rows.append(row)
+        def add(self, worker_tag, row):
+            self._rows.append((worker_tag, row))
 
         def get_rows(self):
             return list(self._rows)
 
     collector = Collector.remote()
 
-    train_ds = ray.data.range(NUM_ROWS)
+    # One-row blocks so the atomic unit the SplitCoordinator hands out matches
+    # what the consumer processes synchronously. Combined with no-lookahead
+    # below, this guarantees a dying worker has at most the row it's currently
+    # processing in memory (and that row is already in the collector by the
+    # time the raise fires).
+    train_ds = ray.data.range(NUM_ROWS, override_num_blocks=NUM_ROWS)
 
     def train_fn():
+        # Disable all lookahead between the SplitCoordinator and the consumer
+        # so rows stay in the coord's queue until the consumer explicitly
+        # asks for them; anything the worker has pulled into RAM would
+        # otherwise be lost if the worker dies (the coord has already popped
+        # it off the split's queue).
+        # - RAY_STREAM_SPLIT_NO_LOOKAHEAD=1: skip gen_blocks' 1-block
+        #   prefetch of the NEXT block (SplitCoordinator layer).
+        # - We bypass iter_batches entirely and iterate the raw ref-bundle
+        #   stream by hand, because iter_batches wraps the pipeline in
+        #   make_async_gen which eagerly pulls batches in a background
+        #   thread even with prefetch_batches=0.
+        os.environ["RAY_STREAM_SPLIT_NO_LOOKAHEAD"] = "1"
+        worker_tag = os.getpid()
         shard = ray.train.get_dataset_shard("train")
-        for batch in shard.iter_batches(batch_size=1):
-            row = int(batch["id"][0])
-            ray.get(collector.add.remote(row))
-            # Only 1 worker should see row 50 and fail once.
-            if row == 50:
-                raise RuntimeError("Injected failure after consuming row 50.")
+        ref_bundles, _, _, _ = shard._to_ref_bundle_iterator()
+        for bundle in ref_bundles:
+            for block_ref in bundle.block_refs:
+                block = ray.get(block_ref)
+                for row_idx in range(block.num_rows):
+                    row = int(block.column("id")[row_idx].as_py())
+                    ray.get(collector.add.remote(worker_tag, row))
+                    # Only 1 worker should see row 50 and fail once.
+                    if row == 50:
+                        raise RuntimeError("Injected failure after consuming row 50.")
 
     trainer = DataParallelTrainer(
         train_fn,
@@ -881,10 +905,21 @@ def test_shard_provider_reused_across_replica_group_replacement(ray_start_4_cpus
     )
     trainer.fit()
 
-    rows = ray.get(collector.get_rows.remote())
+    entries = ray.get(collector.get_rows.remote())
+    by_worker = {}
+    for worker_tag, row in entries:
+        by_worker.setdefault(worker_tag, []).append(row)
+    for tag in by_worker:
+        by_worker[tag].sort()
+    rows = sorted(r for _, r in entries)
+    attribution = "\n".join(
+        f"  worker pid={tag}: {len(rs)} rows {rs}"
+        for tag, rs in sorted(by_worker.items())
+    )
     assert sorted(rows) == list(range(NUM_ROWS)), (
         f"Expected all {NUM_ROWS} rows to be collected exactly once after "
-        f"replica replacement, got {len(rows)} rows: {sorted(rows)}"
+        f"replica replacement, got {len(rows)} rows: {sorted(rows)}\n"
+        f"Per-worker attribution:\n{attribution}"
     )
 
 

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -26,6 +26,7 @@ from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
 from ray.train.v2.tests.util import (
     DummyObjectRefWrapper,
     DummyWorkerGroup,
+    MockReplicaGroupBackendConfig,
     create_dummy_run_context,
 )
 
@@ -57,7 +58,7 @@ def test_dataset_sharding_across_workers(ray_start_4_cpus, num_workers):
 
 @pytest.mark.parametrize("datasets_to_split", ["all", ["train"], []])
 def test_multiple_datasets(ray_start_4_cpus, datasets_to_split):
-    """Tests that the dataset is sharded across a variety of num_workers."""
+    """Tests that multiple datasets can be sharded across workers."""
     NUM_ROWS = 1000
     NUM_WORKERS = 2
 
@@ -125,9 +126,11 @@ def test_datasets_callback(ray_start_4_cpus):
         train_run_context=train_run_context,
         datasets={"train": train_ds, "valid": valid_ds},
     )
-    dataset_manager_for_each_worker = callback.before_init_train_context(
-        worker_group.get_workers()
-    )["dataset_shard_provider"]
+    dataset_manager_for_each_worker = (
+        callback.before_init_train_context_on_worker_group(worker_group.get_workers())[
+            "dataset_shard_provider"
+        ]
+    )
     assert len(dataset_manager_for_each_worker) == NUM_WORKERS
 
     dataset_manager = dataset_manager_for_each_worker[0]
@@ -652,9 +655,11 @@ def test_datasets_callback_v1_uses_exclude_resources(ray_start_4_cpus, monkeypat
         train_run_context=train_run_context,
         datasets={"train": train_ds, "valid": valid_ds},
     )
-    dataset_manager_for_each_worker = callback.before_init_train_context(
-        worker_group.get_workers()
-    )["dataset_shard_provider"]
+    dataset_manager_for_each_worker = (
+        callback.before_init_train_context_on_worker_group(worker_group.get_workers())[
+            "dataset_shard_provider"
+        ]
+    )
 
     dataset_manager = dataset_manager_for_each_worker[0]
     processed_train_ds = dataset_manager.get_dataset_shard(
@@ -714,9 +719,11 @@ def test_v2_no_negative_exclude_resources(ray_start_4_cpus):
         train_run_context=train_run_context,
         datasets={"train": train_ds, "valid": valid_ds},
     )
-    dataset_manager_for_each_worker = callback.before_init_train_context(
-        worker_group.get_workers()
-    )["dataset_shard_provider"]
+    dataset_manager_for_each_worker = (
+        callback.before_init_train_context_on_worker_group(worker_group.get_workers())[
+            "dataset_shard_provider"
+        ]
+    )
 
     dataset_manager = dataset_manager_for_each_worker[0]
     processed_train_ds = dataset_manager.get_dataset_shard(
@@ -826,6 +833,59 @@ def test_fixed_scaling_policy_coordinator_lifecycle():
         mock_coordinator.cancel_request.remote.assert_called_once_with(
             requester_id="train-test-run-123",
         )
+
+
+def test_shard_provider_reused_across_replica_group_replacement(ray_start_4_cpus):
+    """When a replica group is replaced (torchft-style), the replacement worker
+    should inherit the same per-rank RayDatasetShardProvider as its predecessor,
+    so that the DataIterator's cursor on the shared coordinator actor is
+    preserved and no rows are dropped or duplicated.
+    """
+    import ray
+
+    NUM_ROWS = 100
+    NUM_WORKERS = 2
+
+    @ray.remote(num_cpus=0)
+    class Collector:
+        def __init__(self):
+            self._rows = []
+
+        def add(self, row):
+            self._rows.append(row)
+
+        def get_rows(self):
+            return list(self._rows)
+
+    collector = Collector.remote()
+
+    train_ds = ray.data.range(NUM_ROWS)
+
+    def train_fn():
+        shard = ray.train.get_dataset_shard("train")
+        for batch in shard.iter_batches(batch_size=1):
+            row = int(batch["id"][0])
+            ray.get(collector.add.remote(row))
+            # Only 1 worker should see row 50 and fail once.
+            if row == 50:
+                raise RuntimeError("Injected failure after consuming row 50.")
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        datasets={"train": train_ds},
+        backend_config=MockReplicaGroupBackendConfig(),
+        scaling_config=ray.train.ScalingConfig(num_workers=NUM_WORKERS),
+        run_config=ray.train.RunConfig(
+            failure_config=ray.train.FailureConfig(max_failures=1),
+        ),
+    )
+    trainer.fit()
+
+    rows = ray.get(collector.get_rows.remote())
+    assert sorted(rows) == list(range(NUM_ROWS)), (
+        f"Expected all {NUM_ROWS} rows to be collected exactly once after "
+        f"replica replacement, got {len(rows)} rows: {sorted(rows)}"
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/tests/test_data_integration_replica_replacement.py
+++ b/python/ray/train/v2/tests/test_data_integration_replica_replacement.py
@@ -1,0 +1,326 @@
+"""End-to-end tests for the streaming_split + replica-replacement code
+path used by Ray Train V2 backends with ``has_replica_groups=True``
+(e.g., torchft).
+
+Two test surfaces are covered here:
+
+1. ``DatasetsCallback`` lifecycle (unit, no trainer): verifies the
+   provider hand-off across ``before_replica_group_shutdown`` /
+   ``before_init_train_context_on_replica_group``, plus the defensive
+   asserts on out-of-range / not-shut-down ranks.
+
+2. ``test_replica_replacement_recovery`` (parametrized, integration):
+   spins up a real DataParallelTrainer with the mock replica-group
+   backend and a configurable failure injector; asserts each user-visible
+   epoch sees every row exactly once (or, for the simultaneous-failure
+   scenario where the controller falls through to a full worker-group
+   restart, every row at least once).
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+from unittest.mock import MagicMock
+
+import pytest
+
+import ray
+import ray.data
+import ray.train
+from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
+from ray.train.v2._internal.callbacks.datasets import DatasetsCallback
+from ray.train.v2.api.data_parallel_trainer import DataParallelTrainer
+from ray.train.v2.tests.util import (
+    MockReplicaGroupBackendConfig,
+    create_dummy_run_context,
+)
+
+# ---------------------------------------------------------------------
+# DatasetsCallback lifecycle (unit tests, no trainer involved).
+# ---------------------------------------------------------------------
+
+
+def _mock_worker(world_rank: int, node_id: str = "node-x"):
+    """A MagicMock worker with explicitly-set
+    ``distributed_context.world_rank`` and ``metadata.node_id``
+    (DatasetsCallback reads both).
+    """
+    w = MagicMock()
+    w.distributed_context.world_rank = world_rank
+    w.metadata.node_id = node_id
+    return w
+
+
+def _build_callback_with_workers(num_workers: int, num_rows: int = 40):
+    """Construct a DatasetsCallback + mock worker list ready for the
+    callback round-trip tests."""
+    train_ds = ray.data.range(num_rows)
+    data_config = ray.train.DataConfig(datasets_to_split=["train"])
+    scaling_config = ray.train.ScalingConfig(num_workers=num_workers)
+    train_run_context = create_dummy_run_context(
+        dataset_config=data_config, scaling_config=scaling_config
+    )
+    workers = [_mock_worker(rank) for rank in range(num_workers)]
+    callback = DatasetsCallback(
+        train_run_context=train_run_context,
+        datasets={"train": train_ds},
+    )
+    return callback, workers
+
+
+def test_datasets_callback_replacement_round_trip(ray_start_4_cpus):
+    """Walks the full lifecycle."""
+    NUM_WORKERS = 2
+    callback, workers = _build_callback_with_workers(NUM_WORKERS)
+
+    # Init worker group
+    providers = callback.before_init_train_context_on_worker_group(workers)[
+        "dataset_shard_provider"
+    ]
+    assert len(providers) == NUM_WORKERS
+    assert callback._shard_provider_active == [True, True]
+    original_provider_0 = providers[0]
+    iter_0 = original_provider_0._dataset_iterators["train"]
+    assert isinstance(iter_0, StreamSplitDataIterator)
+    assert iter_0._is_replacement is False
+
+    # Shut down replica group
+    fake_replica = MagicMock()
+    fake_replica.get_workers.return_value = [workers[0]]
+    callback.before_replica_group_shutdown(fake_replica)
+    assert callback._shard_provider_active == [False, True]
+
+    # Replace replica group
+    repl_workers = [_mock_worker(0)]
+    repl_providers = callback.before_init_train_context_on_replica_group(repl_workers)[
+        "dataset_shard_provider"
+    ]
+    assert len(repl_providers) == 1
+    assert repl_providers[0] is original_provider_0
+    assert callback._shard_provider_active == [True, True]
+    assert iter_0._is_replacement is True
+
+
+def test_datasets_callback_replacement_before_shutdown_raises(ray_start_4_cpus):
+    """Calling before_init_train_context_on_replica_group for a rank that
+    is still marked active (no shutdown happened) is an error."""
+    callback, workers = _build_callback_with_workers(num_workers=2)
+    callback.before_init_train_context_on_worker_group(workers)
+    assert callback._shard_provider_active == [True, True]
+
+    with pytest.raises(AssertionError, match="still marked active"):
+        callback.before_init_train_context_on_replica_group([_mock_worker(0)])
+
+
+def test_datasets_callback_shutdown_out_of_range_rank_raises(ray_start_4_cpus):
+    """Defensive: a worker whose world_rank is outside the configured
+    world size triggers an assertion in before_replica_group_shutdown."""
+    callback, workers = _build_callback_with_workers(num_workers=2)
+    callback.before_init_train_context_on_worker_group(workers)
+
+    fake_replica = MagicMock()
+    fake_replica.get_workers.return_value = [_mock_worker(world_rank=99)]
+    with pytest.raises(AssertionError, match="outside of the range"):
+        callback.before_replica_group_shutdown(fake_replica)
+
+
+# ---------------------------------------------------------------------
+# Parametrized end-to-end recovery test.
+# ---------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FailurePoint:
+    """A single failure to inject into the train_fn. The gate fires each
+    point at most once — over the lifetime of the test (across all
+    worker-process attempts), not per-process.
+
+    Mid-batch trigger: ``after_n_rows`` fires when the worker has consumed
+    that many rows in its current process attempt.
+
+    End-of-epoch trigger: ``after_epoch`` fires after the inner
+    iter_batches loop finishes for that epoch index.
+    """
+
+    rank: int
+    after_n_rows: Optional[int] = None
+    after_epoch: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class _Scenario:
+    name: str
+    num_epochs: int
+    max_failures: int
+    failures: Tuple[_FailurePoint, ...]
+    # When True, the controller is expected to fall through to a full
+    # worker-group restart (e.g., simultaneous failure of all replicas);
+    # the dataset replays from scratch, so per-epoch row duplicates are
+    # OK and we only assert completeness.
+    expects_full_restart: bool = False
+
+
+_SCENARIOS = [
+    _Scenario(
+        name="single_failure_rank_0_mid_epoch",
+        num_epochs=1,
+        max_failures=1,
+        failures=(_FailurePoint(rank=0, after_n_rows=20),),
+    ),
+    _Scenario(
+        name="rank_0_failure_at_epoch_boundary",
+        num_epochs=3,
+        max_failures=1,
+        failures=(_FailurePoint(rank=0, after_epoch=0),),
+    ),
+    _Scenario(
+        name="two_failures_same_rank",
+        num_epochs=1,
+        max_failures=2,
+        failures=(
+            _FailurePoint(rank=0, after_n_rows=10),
+            _FailurePoint(rank=0, after_n_rows=10),
+        ),
+    ),
+    _Scenario(
+        name="simultaneous_failures_two_ranks_full_restart",
+        num_epochs=1,
+        max_failures=1,
+        # Both ranks fail at the same row count; both deaths land in the
+        # same controller poll, so failing_rgs == all_rgs and the
+        # controller falls through to a full worker-group restart.
+        failures=(
+            _FailurePoint(rank=0, after_n_rows=10),
+            _FailurePoint(rank=1, after_n_rows=10),
+        ),
+        expects_full_restart=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("scenario", _SCENARIOS, ids=lambda s: s.name)
+def test_replica_replacement_recovery(ray_start_4_cpus, scenario):
+    """End-to-end recovery test under the various failure scenarios in
+    ``_SCENARIOS``. Each scenario configures one or more
+    ``_FailurePoint``s; the gate fires each at most once. After fit(),
+    the test asserts that every row in [0, NUM_ROWS) is delivered to
+    user code in each epoch:
+
+    - exactly-once if the controller is expected to take the
+      replica-replacement path (the data cursor is preserved across
+      worker death);
+    - at-least-once if a full worker-group restart is expected (the
+      streaming pipeline is rebuilt and may replay rows).
+    """
+    NUM_ROWS = 100
+    NUM_WORKERS = 2
+
+    @ray.remote(num_cpus=0)
+    class Collector:
+        def __init__(self):
+            self._rows = []
+
+        def add(self, epoch, row):
+            self._rows.append((epoch, row))
+
+        def get_rows(self):
+            return list(self._rows)
+
+    @ray.remote(num_cpus=0)
+    class FailureGate:
+        """Tracks failure points; fires each at most once.
+        ``maybe_fail`` returns True when a matching point fires (caller
+        should raise), False otherwise.
+
+        Points come in as ``(rank, after_n_rows, after_epoch)`` tuples
+        — plain primitives so cross-process serialization doesn't pull
+        in this test module's classes.
+        """
+
+        def __init__(self, points):
+            self._points = list(points)
+            self._fired = [False] * len(points)
+
+        def maybe_fail(self, rank, rows_seen=None, epoch_just_finished=None):
+            for i, (p_rank, p_after_n_rows, p_after_epoch) in enumerate(self._points):
+                if (
+                    self._fired[i]
+                    or p_rank != rank
+                    or (p_after_n_rows is not None and rows_seen != p_after_n_rows)
+                    or (
+                        p_after_epoch is not None
+                        and epoch_just_finished != p_after_epoch
+                    )
+                ):
+                    continue
+                self._fired[i] = True
+                return True
+            return False
+
+    failure_tuples = [
+        (fp.rank, fp.after_n_rows, fp.after_epoch) for fp in scenario.failures
+    ]
+
+    collector = Collector.remote()
+    gate = FailureGate.remote(failure_tuples)
+    train_ds = ray.data.range(NUM_ROWS)
+
+    num_epochs = scenario.num_epochs
+
+    def train_fn():
+        rank = ray.train.get_context().get_world_rank()
+        rows_seen = 0
+        shard = ray.train.get_dataset_shard("train")
+        for epoch in range(num_epochs):
+            for batch in shard.iter_batches(batch_size=10):
+                for row_obj in batch["id"]:
+                    row = int(row_obj)
+                    ray.get(collector.add.remote(epoch, row))
+                    rows_seen += 1
+                    if ray.get(gate.maybe_fail.remote(rank=rank, rows_seen=rows_seen)):
+                        raise RuntimeError(
+                            f"Injected mid-batch failure at rank={rank} "
+                            f"rows_seen={rows_seen}"
+                        )
+            # End-of-epoch failure check.
+            if ray.get(gate.maybe_fail.remote(rank=rank, epoch_just_finished=epoch)):
+                raise RuntimeError(
+                    f"Injected boundary failure at rank={rank} after epoch={epoch}"
+                )
+
+    trainer = DataParallelTrainer(
+        train_fn,
+        datasets={"train": train_ds},
+        backend_config=MockReplicaGroupBackendConfig(),
+        scaling_config=ray.train.ScalingConfig(num_workers=NUM_WORKERS),
+        run_config=ray.train.RunConfig(
+            failure_config=ray.train.FailureConfig(max_failures=scenario.max_failures),
+        ),
+    )
+    trainer.fit()
+
+    entries = ray.get(collector.get_rows.remote())
+    by_epoch = {}
+    for epoch, row in entries:
+        by_epoch.setdefault(epoch, []).append(row)
+
+    for epoch in range(num_epochs):
+        rows = sorted(by_epoch.get(epoch, []))
+        if scenario.expects_full_restart:
+            # Full restart replays the dataset; tolerate duplicates but
+            # every row must appear at least once.
+            assert set(rows) == set(range(NUM_ROWS)), (
+                f"Epoch {epoch}: missing rows after full worker-group "
+                f"restart. Got: {rows}"
+            )
+        else:
+            # Replica replacement preserves the cursor; exactly-once.
+            assert rows == list(range(NUM_ROWS)), (
+                f"Epoch {epoch}: expected exactly-once delivery via "
+                f"replica replacement, got: {rows}"
+            )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/python/ray/train/v2/tests/test_data_integration_replica_replacement.py
+++ b/python/ray/train/v2/tests/test_data_integration_replica_replacement.py
@@ -81,7 +81,7 @@ def test_datasets_callback_replacement_round_trip(ray_start_4_cpus):
     original_provider_0 = providers[0]
     iter_0 = original_provider_0._dataset_iterators["train"]
     assert isinstance(iter_0, StreamSplitDataIterator)
-    assert iter_0._is_replacement is False
+    assert iter_0._rejoined_epoch is False
 
     # Shut down replica group
     fake_replica = MagicMock()
@@ -97,7 +97,7 @@ def test_datasets_callback_replacement_round_trip(ray_start_4_cpus):
     assert len(repl_providers) == 1
     assert repl_providers[0] is original_provider_0
     assert callback._shard_provider_active == [True, True]
-    assert iter_0._is_replacement is True
+    assert iter_0._rejoined_epoch is True
 
 
 def test_datasets_callback_replacement_before_shutdown_raises(ray_start_4_cpus):

--- a/python/ray/train/v2/tests/test_data_integration_replica_replacement.py
+++ b/python/ray/train/v2/tests/test_data_integration_replica_replacement.py
@@ -184,14 +184,12 @@ _SCENARIOS = [
     _Scenario(
         name="simultaneous_failures_two_ranks_full_restart",
         num_epochs=1,
-        max_failures=1,
-        # Both ranks fail at the same row count; both deaths land in the
-        # same controller poll, so failing_rgs == all_rgs and the
-        # controller falls through to a full worker-group restart.
+        max_failures=2,
         failures=(
             _FailurePoint(rank=0, after_n_rows=10),
             _FailurePoint(rank=1, after_n_rows=10),
         ),
+        # Failure can happen in same or different poll cycles.
         expects_full_restart=True,
     ),
 ]

--- a/python/ray/train/v2/tests/util.py
+++ b/python/ray/train/v2/tests/util.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import ray
 from ray.train import Checkpoint
+from ray.train.backend import Backend, BackendConfig
 from ray.train.context import TrainContext
 from ray.train.v2._internal.execution.context import (
     DistributedContext,
@@ -49,6 +50,16 @@ from ray.train.v2._internal.state.schema import (
 from ray.train.v2._internal.util import ObjectRefWrapper, time_monotonic
 from ray.train.v2.api.exceptions import TrainingFailedError
 from ray.train.v2.api.validation_config import ValidationTaskConfig
+
+
+class MockReplicaGroupBackend(Backend):
+    has_replica_groups = True
+
+
+class MockReplicaGroupBackendConfig(BackendConfig):
+    @property
+    def backend_cls(self):
+        return MockReplicaGroupBackend
 
 
 class DummyWorkerGroup(WorkerGroup):


### PR DESCRIPTION
# Summary

This is a continuation of the ray train + torchft integration (https://docs.google.com/document/d/1phjJanIPv5JSD-_B-iPp4Afa4cRV_sEBLeW6q_Z26Xc/edit?tab=t.0#heading=h.mm9jf5hqeinp) to also work seamlessly with Ray Data. When a training worker dies, the train controller spins up a replacement worker that loads the model from another worker (already works with train + torchft integration) and loads the dataloader state from the train controller (this PR) - all without restarting the worker group or saving/loading checkpoints.

It works on three levels:
1) Pass "live" dataset shard to replacement worker. `DatasetsCallback` holds a reference to each worker's `RayDatasetShardProvider`, so it can simply use `before_init_train_context_on_replica_group` to give the replacement worker that shard.
2) Rejoin epoch. Ray Data's `SplitCoordinator` has an "epoch barrier" such that we only begin dataset execution for an epoch after every worker has joined the barrier. `before_init_train_context_on_replica_group` calls the new `set_rejoined_epoch` method to avoid starting a new epoch barrier on joining.
3) 2 phase commit to avoid data loss. Right now, as soon as the `SplitCoordinator` sends a block to the worker, it marks that block as "done." However, you can get into a situation where a worker prefetches more blocks than it has processed and dies, so those blocks are lost. We get around this problem with 2 phase commit, which I explain below.

2 phase commit can be summarized by this diagram:

  queue ──get──► reserved(consumer_id, offset=0) ──ack(k)──► committed up to row k
                         │
                         └── disconnect/abort ──► returned to queue with offset=k

It is implemented at the following levels:
1) 2pc methods on `SplitCoordinator`: `reserve` moves blocks from `_next_bundle` to the `_reserved` queue, `ack` pops/updates blocks and their offsets (we care about the number of rows that have been read for each block) from the `_reserved` queue, and `abort` moves the dead consumer's (block, offset)'s from `_reserved` to `_requeue` (it also slices partially consumed blocks and `ray.put`'s the sliced block)
2) `RefBundle` state management. `iter_batches` creates a `RefBundle` iterator where each `RefBundle` is populated by `gen_blocks` which in turn calls gets the blocks from `SplitCoordinator.get`. Now, `SplitCoordinator.get` tries to get the `RefBundle` from `requeue` (basically, the previously aborted bundles) before getting it from `next_bundle`/`get_next` like it does today. Then, after getting the bundle, `SplitCoordinator` calls `reserve` on it (as opposed to discarding it like it does today). Finally, when the train controller detects that a worker has died, it calls the `abort` method above, which populates `requeue` in the first place.
3) Batch provenance on `StreamSplitDataIterator`. The `StreamSplitDataIterator` formats the `RefBundle`s from the iterator above into batches. The `Batch` dataclass now contains provenance (block_id, rows taken) information. The worker forms batches with `_BatchIteratorWithProvenance` (basically the same as `_BatchIterator` except it also tracks provenance - this occurs within `_pipeline`) and calls the `ack` method (we call `_ack_callback` after getting the batch) above with this provenance information right before yielding the batch. This achieves at most once semantics - if the worker yields the batch and dies before using it, the batch will not be replayed, which is preferable to nccl hanging at the end of training due to an uneven number of batches. We can consider supporting exactly once semantics with dataset rewinding in the future.

We raise an error if the user uses both `local_shuffle_buffer_size` and `enable_2pc_batch_consumption_tracking`. This is fine because we are advising users to use `map_batches` for shuffling instead - CC @xinyuangui2 

# Testing

TODO: Running a benchmark in RayTurbo.