### PR TITLE
[RLlib] Expand case-insensitive activation function lookup

### DIFF
--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -41,16 +41,29 @@ def get_activation_fn(
         if fn is not None:
             return fn
 
-        if name_lower in ["swish", "silu"]:
-            return nn.SiLU
-        elif name_lower == "relu":
-            return nn.ReLU
-        elif name_lower == "tanh":
-            return nn.Tanh
-        elif name_lower == "elu":
-            return nn.ELU
-        elif name_lower == "softmax":
-            return nn.Softmax
+        # Case-insensitive lookup for common activation functions.
+        # This allows users to specify e.g. "leakyrelu" or "gelu" without
+        # worrying about PyTorch's PascalCase naming convention.  #61076.
+        _TORCH_ACTIVATIONS = {
+            "relu": nn.ReLU,
+            "leakyrelu": nn.LeakyReLU,
+            "leaky_relu": nn.LeakyReLU,
+            "prelu": nn.PReLU,
+            "elu": nn.ELU,
+            "selu": nn.SELU,
+            "gelu": nn.GELU,
+            "tanh": nn.Tanh,
+            "sigmoid": nn.Sigmoid,
+            "softmax": nn.Softmax,
+            "softplus": nn.Softplus,
+            "mish": nn.Mish,
+            "swish": nn.SiLU,
+            "silu": nn.SiLU,
+            "hardswish": nn.Hardswish,
+            "hardsigmoid": nn.Hardsigmoid,
+        }
+        if name_lower in _TORCH_ACTIVATIONS:
+            return _TORCH_ACTIVATIONS[name_lower]
     elif framework == "jax":
         if name_lower in ["linear", None]:
             return None

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -37,6 +37,7 @@ def get_activation_fn(
         _, nn = try_import_torch()
         # First try getting the correct activation function from nn directly.
         # Note that torch activation functions are not all lower case.
+        assert nn is not None, "`torch` not installed. Try `pip install torch`."
         fn = getattr(nn, name, None)
         if fn is not None:
             return fn
@@ -44,26 +45,31 @@ def get_activation_fn(
         # Case-insensitive lookup for common activation functions.
         # This allows users to specify e.g. "leakyrelu" or "gelu" without
         # worrying about PyTorch's PascalCase naming convention.  #61076.
-        _TORCH_ACTIVATIONS = {
-            "relu": nn.ReLU,
-            "leakyrelu": nn.LeakyReLU,
-            "leaky_relu": nn.LeakyReLU,
-            "prelu": nn.PReLU,
-            "elu": nn.ELU,
-            "selu": nn.SELU,
-            "gelu": nn.GELU,
-            "tanh": nn.Tanh,
-            "sigmoid": nn.Sigmoid,
-            "softmax": nn.Softmax,
-            "softplus": nn.Softplus,
-            "mish": nn.Mish,
-            "swish": nn.SiLU,
-            "silu": nn.SiLU,
-            "hardswish": nn.Hardswish,
-            "hardsigmoid": nn.Hardsigmoid,
-        }
-        if name_lower in _TORCH_ACTIVATIONS:
-            return _TORCH_ACTIVATIONS[name_lower]
+        # Cache the mapping on the function object so we don't rebuild it on
+        # every call while still avoiding module-level import side effects.
+        if not hasattr(get_activation_fn, "_TORCH_ACTIVATIONS"):
+            get_activation_fn._TORCH_ACTIVATIONS = {
+                "relu": nn.ReLU,
+                "leakyrelu": nn.LeakyReLU,
+                "leaky_relu": nn.LeakyReLU,
+                "prelu": nn.PReLU,
+                "elu": nn.ELU,
+                "selu": nn.SELU,
+                "gelu": nn.GELU,
+                "tanh": nn.Tanh,
+                "sigmoid": nn.Sigmoid,
+                "softmax": nn.Softmax,
+                "softplus": nn.Softplus,
+                "mish": nn.Mish,
+                "swish": nn.SiLU,
+                "silu": nn.SiLU,
+                "hardswish": nn.Hardswish,
+                "hard_swish": nn.Hardswish,
+                "hardsigmoid": nn.Hardsigmoid,
+                "hard_sigmoid": nn.Hardsigmoid,
+            }
+        if name_lower in get_activation_fn._TORCH_ACTIVATIONS:
+            return get_activation_fn._TORCH_ACTIVATIONS[name_lower]
     elif framework == "jax":
         if name_lower in ["linear", None]:
             return None

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -37,7 +37,6 @@ def get_activation_fn(
         _, nn = try_import_torch()
         # First try getting the correct activation function from nn directly.
         # Note that torch activation functions are not all lower case.
-        assert nn is not None, "`torch` not installed. Try `pip install torch`."
         fn = getattr(nn, name, None)
         if fn is not None:
             return fn


### PR DESCRIPTION
Fixes #61076.

## Problem

\`get_activation_fn\` (torch branch) only recognizes a small set of lowercase aliases: \`relu\`, \`tanh\`, \`elu\`, \`swish\`/\`silu\`, and \`softmax\`. Users passing common activations like \`"leakyrelu"\` or \`"gelu"\` in lowercase get an error, even though these are standard PyTorch activations. The existing \`getattr(nn, name)\` fallback works but is case-sensitive, requiring users to know PyTorch's exact PascalCase naming.

As the reporter notes, LeakyReLU is particularly relevant for RL (improves plasticity in nonstationary tasks), and GELU is standard in modern transformers.

## Fix

Replace the \`elif\` chain with a comprehensive dict mapping lowercase names to \`nn.Module\` classes:

| lowercase key | nn class |
|---|---|
| \`relu\` | \`nn.ReLU\` |
| \`leakyrelu\`, \`leaky_relu\` | \`nn.LeakyReLU\` |
| \`prelu\` | \`nn.PReLU\` |
| \`elu\` | \`nn.ELU\` |
| \`selu\` | \`nn.SELU\` |
| \`gelu\` | \`nn.GELU\` |
| \`tanh\` | \`nn.Tanh\` |
| \`sigmoid\` | \`nn.Sigmoid\` |
| \`softmax\` | \`nn.Softmax\` |
| \`softplus\` | \`nn.Softplus\` |
| \`mish\` | \`nn.Mish\` |
| \`swish\`, \`silu\` | \`nn.SiLU\` |
| \`hardswish\` | \`nn.Hardswish\` |
| \`hardsigmoid\` | \`nn.Hardsigmoid\` |

The \`getattr(nn, name)\` exact-case path is preserved as the first check, so passing e.g. \`"LeakyReLU"\` still resolves directly without hitting the dict.

## Impact

- Users can now pass \`"leakyrelu"\`, \`"gelu"\`, \`"mish"\`, etc. in any casing to RLlib configs
- No breaking changes — all existing string values continue to work
- The dict is declared inline (not at module level) to avoid import-time side effects