### PR TITLE
[ci] convert core.rayci.yml build steps to array syntax

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -6,62 +6,66 @@ depends_on:
 steps:
   # builds
   - name: corebuild-multipy
-    label: "wanda: corebuild-py{{matrix}}"
+    label: "wanda: corebuild-py{{array.python}}"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "build"
       BUILD_VARIANT: "build"
-    depends_on: oss-ci-base_build-multipy(*)
+    depends_on: oss-ci-base_build-multipy($)
 
   - name: coregpubuild-multipy
-    label: "wanda: coregpubuild-py{{matrix}}"
+    label: "wanda: coregpubuild-py{{array.python}}"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
-    depends_on: oss-ci-base_gpu-multipy(*)
+    depends_on: oss-ci-base_gpu-multipy($)
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "gpu"
       BUILD_VARIANT: "gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
 
   - name: coregpu-cu130-build-multipy
-    label: "wanda: coregpu-cu130-build-py{{matrix}}"
+    label: "wanda: coregpu-cu130-build-py{{array.python}}"
     wanda: ci/docker/core.build.wanda.yaml
     tags: cibase
-    depends_on: oss-ci-base_cu130-multipy(*)
+    depends_on: oss-ci-base_cu130-multipy($)
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "cu130"
       BUILD_VARIANT: "gpu-cu130-build"
       RAYCI_IS_GPU_BUILD: "true"
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
 
   - name: minbuild-core
-    label: "wanda: minbuild-core-py{{matrix}}"
+    label: "wanda: minbuild-core-py{{array.python}}"
     wanda: ci/docker/min.build.wanda.yaml
-    depends_on: oss-ci-base_test-multipy(*)
+    depends_on: oss-ci-base_test-multipy($)
     tags: cibase
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       EXTRA_DEPENDENCY: core
 
   - wait: ~
     depends_on:
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   # tests
   - label: ":ray: core: python tests"
@@ -79,6 +83,7 @@ steps:
         --install-mask all-ray-libraries
 
   - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
+    key: core_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - python
@@ -90,7 +95,7 @@ steps:
         --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
         --python-version {{matrix.python}} --build-name corebuild-py{{matrix.python}}
         --except-tags custom_setup
-    depends_on: corebuild-multipy
+    depends_on: corebuild-multipy(*)
     matrix:
       setup:
         python: ["3.12"]
@@ -266,11 +271,12 @@ steps:
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
     depends_on:
       - manylinux-x86_64
-      - corebuild-multipy
+      - corebuild-multipy(*)
       - forge
       - ray-wheel-build(*)
 
   - label: ":ray: core: minimal tests {{matrix}}"
+    key: core_minimal_tests
     tags:
       - python
       - dashboard
@@ -319,7 +325,7 @@ steps:
         --only-tags minimal
         --skip-ray-installation
     depends_on:
-      - minbuild-core
+      - minbuild-core(*)
     matrix:
       - "3.10"
       - "3.11"
@@ -370,7 +376,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
@@ -382,7 +388,7 @@ steps:
         --cache-test-results --parallelism-per-worker 2
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
@@ -394,7 +400,7 @@ steps:
         --cache-test-results --parallelism-per-worker 2
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   - label: ":ray: core: flaky tests"
     key: core_flaky_tests
@@ -411,7 +417,7 @@ steps:
         --run-flaky-tests
         --except-tags multi_gpu,cgroup
     depends_on:
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   - label: ":ray: core: flaky gpu tests"
     key: core_flaky_gpu_tests
@@ -429,7 +435,7 @@ steps:
         --build-name coregpubuild-py3.10
         --python-version 3.10
         --only-tags multi_gpu
-    depends_on: coregpubuild-multipy
+    depends_on: coregpubuild-multipy(*)
 
   - label: ":ray: core: cpp worker tests"
     tags:
@@ -457,7 +463,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --build-type java
         --only-tags needs_java
-    depends_on: corebuild-multipy
+    depends_on: corebuild-multipy(*)
 
   - label: ":ray: core: HA integration tests"
     tags:
@@ -473,7 +479,7 @@ steps:
       - manylinux-x86_64
       - forge
       - raycpubase(*)
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   - label: ":ray: core: runtime env container tests"
     tags:
@@ -495,7 +501,7 @@ steps:
       - manylinux-x86_64
       - forge
       - raycpubase(*)
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   - label: ":core: core: spark-on-ray tests"
     # NOTE: The Spark-on-Ray tests intentionally aren't triggered by the `java` tag to
@@ -511,7 +517,7 @@ steps:
         --only-tags spark_on_ray
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
-      - corebuild-multipy
+      - corebuild-multipy(*)
 
   # block gpu tests on premerge and microcheck
   - block: "run multi gpu tests"
@@ -535,7 +541,7 @@ steps:
         --install-mask all-ray-libraries
     depends_on:
       - block-core-gpu-tests
-      - coregpubuild-multipy
+      - coregpubuild-multipy(*)
 
   - label: ":ray: core: multi gpu cu130 tests"
     key: core-multi-gpu-cu130-tests
@@ -552,4 +558,4 @@ steps:
         --install-mask all-ray-libraries
     depends_on:
       - block-core-gpu-tests
-      - coregpu-cu130-build-multipy
+      - coregpu-cu130-build-multipy(*)

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -37,7 +37,7 @@ steps:
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
         "./java/test.sh"
-    depends_on: corebuild-multipy
+    depends_on: corebuild-multipy(*)
 
   # bot
   - label: ":robot_face: CI weekly green metric"


### PR DESCRIPTION
Convert the four core build steps (corebuild-multipy, coregpubuild-multipy, coregpu-cu130-build-multipy, minbuild-core) in core.rayci.yml from matrix to array syntax. Their oss-ci-base_*-multipy dependencies refine from the (*) fan-in used during the base conversion commit to ($), since both sides now have a python array key. Every other plain depends_on reference to these four core build steps — within core.rayci.yml itself and in others.rayci.yml — becomes the explicit (*) fan-in; subset narrowing is deferred.

Topic: convert-array-core-builds
Signed-off-by: andrew <andrew@anyscale.com>