### PR TITLE
[ci] convert core.rayci.yml test steps to array and narrow subsets

### DIFF
--- a/.buildkite/cicd.rayci.yml
+++ b/.buildkite/cicd.rayci.yml
@@ -40,12 +40,12 @@ steps:
           --build-type cgroup
           --privileged
     instance_type: small
-    depends_on: oss-ci-base_test-multipy(*)
+    depends_on: oss-ci-base_test-multipy(python=3.10)
     tags: tools
   - label: ":coral: reef: iwyu tests"
     commands:
       - bazel test --config iwyu //bazel/tests/cpp:example_test
     instance_type: small
-    depends_on: oss-ci-base_build-multipy(*)
+    depends_on: oss-ci-base_build-multipy(python=3.10)
     job_env: oss-ci-base_build-py3.10
     tags: tools

--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -65,7 +65,7 @@ steps:
 
   - wait: ~
     depends_on:
-      - corebuild-multipy(*)
+      - corebuild-multipy(python=3.10)
 
   # tests
   - label: ":ray: core: python tests"
@@ -82,7 +82,7 @@ steps:
         --except-tags custom_setup
         --install-mask all-ray-libraries
 
-  - label: ":ray: core: python {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":ray: core: python {{array.python}} tests ({{array.worker_id}})"
     key: core_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
@@ -92,14 +92,13 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dag/... //python/ray/autoscaler/v2/... core
         --install-mask all-ray-libraries
-        --workers 4 --worker-id "{{matrix.worker_id}}" --parallelism-per-worker 3
-        --python-version {{matrix.python}} --build-name corebuild-py{{matrix.python}}
+        --workers 4 --worker-id "{{array.worker_id}}" --parallelism-per-worker 3
+        --python-version {{array.python}} --build-name corebuild-py{{array.python}}
         --except-tags custom_setup
-    depends_on: corebuild-multipy(*)
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1", "2", "3"]
+    depends_on: corebuild-multipy($)
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1", "2", "3"]
 
   - label: ":ray: core: ray client tests"
     tags:
@@ -271,11 +270,11 @@ steps:
         --test-env=RAY_CI_POST_WHEEL_TESTS=True
     depends_on:
       - manylinux-x86_64
-      - corebuild-multipy(*)
+      - corebuild-multipy(python=3.10)
       - forge
-      - ray-wheel-build(*)
+      - ray-wheel-build(python=3.10)
 
-  - label: ":ray: core: minimal tests {{matrix}}"
+  - label: ":ray: core: minimal tests {{array.python}}"
     key: core_minimal_tests
     tags:
       - python
@@ -289,49 +288,50 @@ steps:
       # core tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
-        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --test-env=EXPECTED_PYTHON_VERSION={{array.python}}
         --only-tags minimal
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --except-tags basic_test,manual,cgroup
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
-        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --test-env=EXPECTED_PYTHON_VERSION={{array.python}}
         --only-tags minimal
         --except-tags no_basic_test,manual
         --skip-ray-installation
       # core redis tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... core
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
         --test-env=TEST_EXTERNAL_REDIS=1
-        --test-env=EXPECTED_PYTHON_VERSION={{matrix}}
+        --test-env=EXPECTED_PYTHON_VERSION={{array.python}}
         --only-tags minimal
         --except-tags no_basic_test,manual
         --skip-ray-installation
       # serve tests
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tests/... //python/ray/dashboard/... serve
         --parallelism-per-worker 3
-        --python-version {{matrix}}
-        --build-name minbuild-core-py{{matrix}}
+        --python-version {{array.python}}
+        --build-name minbuild-core-py{{array.python}}
         --test-env=RAY_MINIMAL=1
         --only-tags minimal
         --skip-ray-installation
     depends_on:
-      - minbuild-core(*)
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+      - minbuild-core($)
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
 
   - label: ":ray: core: cgroup tests"
     tags:
@@ -376,7 +376,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild-multipy(*)
+      - corebuild-multipy(python=3.10)
 
   - label: ":ray: core: cpp ubsan tests"
     tags: core_cpp
@@ -388,7 +388,7 @@ steps:
         --cache-test-results --parallelism-per-worker 2
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild-multipy(*)
+      - corebuild-multipy(python=3.10)
 
   - label: ":ray: core: cpp tsan tests"
     tags: core_cpp
@@ -400,7 +400,7 @@ steps:
         --cache-test-results --parallelism-per-worker 2
     depends_on:
       - block-core-cpp-sanitizer-tests
-      - corebuild-multipy(*)
+      - corebuild-multipy(python=3.10)
 
   - label: ":ray: core: flaky tests"
     key: core_flaky_tests
@@ -417,7 +417,7 @@ steps:
         --run-flaky-tests
         --except-tags multi_gpu,cgroup
     depends_on:
-      - corebuild-multipy(*)
+      - corebuild-multipy(python=3.10)
 
   - label: ":ray: core: flaky gpu tests"
     key: core_flaky_gpu_tests
@@ -435,7 +435,7 @@ steps:
         --build-name coregpubuild-py3.10
         --python-version 3.10
         --only-tags multi_gpu
-    depends_on: coregpubuild-multipy(*)
+    depends_on: coregpubuild-multipy(python=3.10)
 
   - label: ":ray: core: cpp worker tests"
     tags:
@@ -450,7 +450,7 @@ steps:
       # cpp worker tests has one that tests cross-language with Java.
       - RAY_INSTALL_JAVA=1 ci/ci.sh build
       - ci/ci.sh test_cpp
-    depends_on: oss-ci-base_build-multipy(*)
+    depends_on: oss-ci-base_build-multipy(python=3.10)
     job_env: oss-ci-base_build-py3.10
 
   - label: ":ray: core: java worker tests"
@@ -463,7 +463,7 @@ steps:
         --python-version 3.10 --build-name corebuild-py3.10
         --build-type java
         --only-tags needs_java
-    depends_on: corebuild-multipy(*)
+    depends_on: corebuild-multipy(python=3.10)
 
   - label: ":ray: core: HA integration tests"
     tags:
@@ -478,8 +478,8 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase(*)
-      - corebuild-multipy(*)
+      - raycpubase(python=3.10)
+      - corebuild-multipy(python=3.10)
 
   - label: ":ray: core: runtime env container tests"
     tags:
@@ -500,8 +500,8 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase(*)
-      - corebuild-multipy(*)
+      - raycpubase(python=3.10)
+      - corebuild-multipy(python=3.10)
 
   - label: ":core: core: spark-on-ray tests"
     # NOTE: The Spark-on-Ray tests intentionally aren't triggered by the `java` tag to
@@ -517,7 +517,7 @@ steps:
         --only-tags spark_on_ray
         --python-version 3.10 --build-name corebuild-py3.10
     depends_on:
-      - corebuild-multipy(*)
+      - corebuild-multipy(python=3.10)
 
   # block gpu tests on premerge and microcheck
   - block: "run multi gpu tests"
@@ -541,7 +541,7 @@ steps:
         --install-mask all-ray-libraries
     depends_on:
       - block-core-gpu-tests
-      - coregpubuild-multipy(*)
+      - coregpubuild-multipy(python=3.10)
 
   - label: ":ray: core: multi gpu cu130 tests"
     key: core-multi-gpu-cu130-tests
@@ -558,4 +558,4 @@ steps:
         --install-mask all-ray-libraries
     depends_on:
       - block-core-gpu-tests
-      - coregpu-cu130-build-multipy(*)
+      - coregpu-cu130-build-multipy(python=3.10)

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -55,7 +55,7 @@ steps:
     wanda: ci/docker/docgpu.build.wanda.yaml
     env:
       PYTHON: "3.12"
-    depends_on: oss-ci-base_gpu-multipy(*)
+    depends_on: oss-ci-base_gpu-multipy(python=3.12)
     tags: cibase
 
   # type check

--- a/.buildkite/dependencies.rayci.yml
+++ b/.buildkite/dependencies.rayci.yml
@@ -17,7 +17,7 @@ steps:
       - cp -f ./python/requirements_compiled.txt /artifact-mount/
       - diff ./python/requirements_compiled.txt requirements_compiled_backup.txt || (echo "requirements_compiled.txt is not up to date. Please download it from Artifacts tab and git push the changes." && exit 1)
     job_env: oss-ci-base_test-py3.11
-    depends_on: oss-ci-base_test-multipy(*)
+    depends_on: oss-ci-base_test-multipy(python=3.11)
 
   - label: ":tapioca: build: pip-compile py3.13 dependencies"
     key: pip_compile_313_dependencies

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -4,7 +4,7 @@ steps:
     label: "wanda: docbuild-py{{matrix}}"
     wanda: ci/docker/doc.build.wanda.yaml
     depends_on:
-      - oss-ci-base_build-multipy(*)
+      - oss-ci-base_build-multipy(python=3.10)
       - ray-core-build(*)
       - ray-dashboard-build
     matrix:
@@ -17,7 +17,7 @@ steps:
   - name: docgpubuild
     label: "wanda: docgpubuild-py3.10"
     wanda: ci/docker/docgpu.build.wanda.yaml
-    depends_on: oss-ci-base_gpu-multipy(*)
+    depends_on: oss-ci-base_gpu-multipy(python=3.10)
     env:
       PYTHON: "3.10"
     tags: cibase

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -3,7 +3,7 @@ steps:
   - name: k8sbuild
     wanda: ci/docker/k8s.build.wanda.yaml
     depends_on:
-      - oss-ci-base_build-multipy(*)
+      - oss-ci-base_build-multipy(python=3.10)
     tags: cibase
 
   - label: ":kubernetes: operator"

--- a/.buildkite/llm.rayci.yml
+++ b/.buildkite/llm.rayci.yml
@@ -7,7 +7,7 @@ steps:
   - name: llmbuild
     wanda: ci/docker/llm.build.wanda.yaml
     depends_on:
-      - oss-ci-base_build-multipy(*)
+      - oss-ci-base_build-multipy(python=3.11)
     env:
       PYTHON: "3.11"
       BASE_TYPE: "build"
@@ -18,7 +18,7 @@ steps:
   - name: llmbuild-py312
     wanda: ci/docker/llm.build.wanda.yaml
     depends_on:
-      - oss-ci-base_build-multipy(*)
+      - oss-ci-base_build-multipy(python=3.12)
     env:
       PYTHON: "3.12"
       BASE_TYPE: "build"
@@ -40,7 +40,7 @@ steps:
   - name: llmgpubuild-py312
     wanda: ci/docker/llm.build.wanda.yaml
     depends_on:
-      - oss-ci-base_cu130-multipy(*)
+      - oss-ci-base_cu130-multipy(python=3.12)
     env:
       PYTHON: "3.12"
       BASE_TYPE: "cu130"

--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -8,7 +8,7 @@ steps:
   - name: minbuild-ml
     label: "wanda: minbuild-ml-py{{matrix}}"
     wanda: ci/docker/min.build.wanda.yaml
-    depends_on: oss-ci-base_test-multipy(*)
+    depends_on: oss-ci-base_test-multipy(python=3.10)
     matrix:
       - "3.10"
     env:
@@ -38,7 +38,7 @@ steps:
       BUILD_VARIANT: "lightning1gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
     tags: cibase
-    depends_on: oss-ci-base_gpu-multipy(*)
+    depends_on: oss-ci-base_gpu-multipy(python=3.10)
 
   - name: mlgpubuild-multipy
     label: "wanda: mlgpubuild-py{{matrix}}"
@@ -201,7 +201,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tune/... ml
         --only-tags soft_imports
         --build-name oss-ci-base_build-py3.10 --python-version 3.10
-    depends_on: [ "oss-ci-base_build-multipy(*)", "forge" ]
+    depends_on: [ "oss-ci-base_build-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: air tests"
     tags: ml

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -5,7 +5,7 @@ steps:
   # docs
   - name: doctestbuild
     wanda: ci/docker/doctest.build.wanda.yaml
-    depends_on: oss-ci-base_build-multipy(*)
+    depends_on: oss-ci-base_build-multipy(python=3.10)
     env:
       PYTHON: "3.10"
     tags: cibase
@@ -37,7 +37,7 @@ steps:
       - docker run -i --rm --volume /tmp/artifacts:/artifact-mount --shm-size=2.5gb
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-corebuild-py3.10 /bin/bash -iecuo pipefail
         "./java/test.sh"
-    depends_on: corebuild-multipy(*)
+    depends_on: corebuild-multipy(python=3.10)
 
   # bot
   - label: ":robot_face: CI weekly green metric"

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -7,7 +7,7 @@ steps:
   # builds
   - name: rllibbuild
     wanda: ci/docker/rllib.build.wanda.yaml
-    depends_on: oss-ci-base_ml-multipy(*)
+    depends_on: oss-ci-base_ml-multipy(python=3.10)
     env:
       PYTHON: "3.10"
       BASE_TYPE: "ml"
@@ -17,7 +17,7 @@ steps:
 
   - name: rllibgpubuild
     wanda: ci/docker/rllib.build.wanda.yaml
-    depends_on: oss-ci-base_gpu-multipy(*)
+    depends_on: oss-ci-base_gpu-multipy(python=3.10)
     env:
       PYTHON: "3.10"
       BASE_TYPE: "gpu"

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -23,7 +23,7 @@ steps:
   - name: minbuild-serve
     label: "wanda: minbuild-{{matrix.extra}}-py{{matrix.python}}"
     wanda: ci/docker/min.build.wanda.yaml
-    depends_on: oss-ci-base_test-multipy(*)
+    depends_on: oss-ci-base_test-multipy(python=3.10)
     matrix:
       setup:
         python: ["3.10"]


### PR DESCRIPTION
Convert the two remaining matrix test steps in core.rayci.yml — "core: python {{matrix.python}} tests" (matrix setup with python + worker_id) and "core: minimal tests" — to array syntax; their corebuild-multipy and minbuild-core depends_on refine from (*) to ($). Narrow three (*) fan-ins in core.rayci.yml down to (python=3.10) subsets for the wheel tests, HA integration, and runtime env container steps that only exercise python 3.10. Across cicd, data, dependencies, doc, kuberay, llm, ml, others, rllib, and serve, narrow each oss-ci-base_* (*) dependency to (python=X.Y) where the consuming step pins a single python version; leave (*) in place where the step truly spans multiple versions (data top-level ml base, ml mlbuild-multipy / mlgpubuild-multipy, serve top-level build base).

Relative: convert-array-core-builds
Topic: convert-array-core-tests
Signed-off-by: andrew <andrew@anyscale.com>