### PR TITLE
[ci] convert linux_aarch64 rayci matrix to array syntax

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -445,5 +445,5 @@ steps:
       - bazel run //ci/ray_ci/automation:generate_index -- --prefix nightly
     depends_on:
       - ray_images_push(*)
-      - ray_images_push_aarch64
+      - ray_images_push_aarch64(*)
       - forge

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -29,92 +29,92 @@ steps:
     instance_type: builder-arm64
 
   - name: raycpubase-aarch64
-    label: "wanda: ray.py{{matrix}}.cpu.base (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cpu.base (aarch64)"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
 
   - name: raycpubaseextra-aarch64
-    label: "wanda: ray.py{{matrix}}.cpu.base-extra (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cpu.base-extra (aarch64)"
     wanda: docker/base-extra/cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: "-aarch64"
-    depends_on: raycpubase-aarch64
+    depends_on: raycpubase-aarch64($)
 
   - name: raycudabase-aarch64
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.base (aarch64)"
     tags:
       - python_dependencies
       - docker
     wanda: docker/base-deps/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: "-aarch64"
 
   - name: raycudabaseextra-aarch64
-    label: "wanda: ray.py{{matrix.python}}.cu{{matrix.cuda}}.base-extra (aarch64)"
+    label: "wanda: ray.py{{array.python}}.cu{{array.cuda}}.base-extra (aarch64)"
     wanda: docker/base-extra/cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     instance_type: builder-arm64
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       IMAGE_TYPE: "ray"
       ARCH_SUFFIX: "-aarch64"
-    depends_on: raycudabase-aarch64
+    depends_on: raycudabase-aarch64($)
 
   # NOTE(andrew-anyscale): dashboard is architecture agnostic, but wanda pulls
   # images for the architecture of the machine running the build. In the future,
@@ -131,34 +131,36 @@ steps:
     instance_type: builder-arm64
 
   - name: ray-core-build-aarch64
-    label: "wanda: core binary parts py{{matrix}} (aarch64)"
+    label: "wanda: core binary parts py{{array.python}} (aarch64)"
     wanda: ci/docker/ray-core.wanda.yaml
     env_file: rayci.env
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
       HOSTTYPE: "aarch64"
     tags: release_wheels
     instance_type: builder-arm64
 
   - name: ray-wheel-build-aarch64
-    label: "wanda: wheel py{{matrix}} (aarch64)"
+    label: "wanda: wheel py{{array.python}} (aarch64)"
     wanda: ci/docker/ray-wheel.wanda.yaml
     env_file: rayci.env
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
       HOSTTYPE: "aarch64"
       JDK_SUFFIX: "-jdk"
@@ -168,28 +170,29 @@ steps:
       - release_wheels
       - linux_wheels
     depends_on:
-      - ray-core-build-aarch64
+      - ray-core-build-aarch64($)
       - ray-java-build-aarch64
       - ray-dashboard-build-aarch64
     instance_type: builder-arm64
 
-  - label: ":arrow_up: upload: wheel py{{matrix}} (aarch64)"
+  - label: ":arrow_up: upload: wheel py{{array.python}} (aarch64)"
     key: linux_wheels_upload_aarch64
     instance_type: small  # x86_64 instance since crane is currently only x86_64
     commands:
       - bazel run //ci/ray_ci/automation:extract_wanda_artifact --
-        --wanda-image-name=ray-wheel-py{{matrix}}-aarch64
+        --wanda-image-name=ray-wheel-py{{array.python}}-aarch64
         --file-glob='*.whl'
         --output-dir=.whl
       - ./ci/build/copy_build_artifacts.sh wheel
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
-      - "3.14"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+        - "3.14"
     depends_on:
-      - ray-wheel-build-aarch64
+      - ray-wheel-build-aarch64($)
       - forge
     tags:
       - release_wheels
@@ -222,7 +225,7 @@ steps:
       - linux_wheels
       - oss
     depends_on:
-      - ray-core-build-aarch64
+      - ray-core-build-aarch64(python=3.10)
       - ray-cpp-core-build-aarch64
       - ray-java-build-aarch64
       - ray-dashboard-build-aarch64
@@ -247,67 +250,67 @@ steps:
       - skip-on-premerge
 
   - name: ray-image-cpu-build-aarch64
-    label: "wanda: ray py{{matrix}} cpu (aarch64)"
+    label: "wanda: ray py{{array.python}} cpu (aarch64)"
     wanda: ci/docker/ray-image-cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
       - docker
       - oss
     depends_on:
-      - ray-wheel-build-aarch64
-      - raycpubase-aarch64
+      - ray-wheel-build-aarch64($)
+      - raycpubase-aarch64($)
     instance_type: builder-arm64
 
   - name: ray-image-cuda-build-aarch64
-    label: "wanda: ray py{{matrix.python}} cu{{matrix.cuda}} (aarch64)"
+    label: "wanda: ray py{{array.python}} cu{{array.cuda}} (aarch64)"
     wanda: ci/docker/ray-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
       - docker
       - oss
     depends_on:
-      - ray-wheel-build-aarch64
-      - raycudabase-aarch64
+      - ray-wheel-build-aarch64($)
+      - raycudabase-aarch64($)
     instance_type: builder-arm64
 
-  - label: ":crane: publish: ray py{{matrix}} (aarch64)"
+  - label: ":crane: publish: ray py{{array.python}} (aarch64)"
     key: ray_images_push_aarch64
     instance_type: small  # x86_64 instance since crane is currently only x86_64
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cpu
         --platform cu11.7.1-cudnn8
         --platform cu11.8.0-cudnn8
@@ -320,14 +323,15 @@ steps:
         --platform cu12.9.1-cudnn
         --image-type ray
         --architecture aarch64
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     depends_on:
-      - ray-image-cpu-build-aarch64
-      - ray-image-cuda-build-aarch64
+      - ray-image-cpu-build-aarch64($)
+      - ray-image-cuda-build-aarch64($)
     tags:
       - python_dependencies
       - docker
@@ -335,67 +339,67 @@ steps:
       - skip-on-premerge
 
   - name: ray-extra-image-cpu-build-aarch64
-    label: "wanda: ray-extra py{{matrix}} cpu (aarch64)"
+    label: "wanda: ray-extra py{{array.python}} cpu (aarch64)"
     wanda: ci/docker/ray-extra-image-cpu.wanda.yaml
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
       - docker
       - oss
     depends_on:
-      - ray-wheel-build-aarch64
-      - raycpubaseextra-aarch64
+      - ray-wheel-build-aarch64($)
+      - raycpubaseextra-aarch64($)
     instance_type: builder-arm64
 
   - name: ray-extra-image-cuda-build-aarch64
-    label: "wanda: ray-extra py{{matrix.python}} cu{{matrix.cuda}} (aarch64)"
+    label: "wanda: ray-extra py{{array.python}} cu{{array.cuda}} (aarch64)"
     wanda: ci/docker/ray-extra-image-cuda.wanda.yaml
-    matrix:
-      setup:
-        python:
-          - "3.10"
-          - "3.11"
-          - "3.12"
-          - "3.13"
-        cuda:
-          - "11.7.1-cudnn8"
-          - "11.8.0-cudnn8"
-          - "12.1.1-cudnn8"
-          - "12.3.2-cudnn9"
-          - "12.4.1-cudnn"
-          - "12.5.1-cudnn"
-          - "12.6.3-cudnn"
-          - "12.8.1-cudnn"
-          - "12.9.1-cudnn"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
+      cuda:
+        - "11.7.1-cudnn8"
+        - "11.8.0-cudnn8"
+        - "12.1.1-cudnn8"
+        - "12.3.2-cudnn9"
+        - "12.4.1-cudnn"
+        - "12.5.1-cudnn"
+        - "12.6.3-cudnn"
+        - "12.8.1-cudnn"
+        - "12.9.1-cudnn"
     env_file: rayci.env
     env:
-      PYTHON_VERSION: "{{matrix.python}}"
-      CUDA_VERSION: "{{matrix.cuda}}"
+      PYTHON_VERSION: "{{array.python}}"
+      CUDA_VERSION: "{{array.cuda}}"
       ARCH_SUFFIX: "-aarch64"
     tags:
       - python_dependencies
       - docker
       - oss
     depends_on:
-      - ray-wheel-build-aarch64
-      - raycudabaseextra-aarch64
+      - ray-wheel-build-aarch64($)
+      - raycudabaseextra-aarch64($)
     instance_type: builder-arm64
 
-  - label: ":crane: publish: ray-extra py{{matrix}} (aarch64)"
+  - label: ":crane: publish: ray-extra py{{array.python}} (aarch64)"
     key: ray_extra_images_push_aarch64
     instance_type: small
     commands:
       - bazel run //.buildkite:copy_files -- --destination docker_login
       - bazel run //ci/ray_ci/automation:push_ray_image --
-        --python-version {{matrix}}
+        --python-version {{array.python}}
         --platform cpu
         --platform cu11.7.1-cudnn8
         --platform cu11.8.0-cudnn8
@@ -408,14 +412,15 @@ steps:
         --platform cu12.9.1-cudnn
         --image-type ray-extra
         --architecture aarch64
-    matrix:
-      - "3.10"
-      - "3.11"
-      - "3.12"
-      - "3.13"
+    array:
+      python:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - "3.13"
     depends_on:
-      - ray-extra-image-cpu-build-aarch64
-      - ray-extra-image-cuda-build-aarch64
+      - ray-extra-image-cpu-build-aarch64($)
+      - ray-extra-image-cuda-build-aarch64($)
     tags:
       - python_dependencies
       - docker
@@ -437,7 +442,7 @@ steps:
       - manylinux-aarch64
       - oss-ci-base_build-aarch64
       - forge-aarch64
-      - ray-wheel-build-aarch64
+      - ray-wheel-build-aarch64(python=3.10)
     job_env: forge-aarch64
 
   - label: ":ray-serve: serve: wheel-aarch64 tests"
@@ -455,5 +460,5 @@ steps:
       - manylinux-aarch64
       - oss-ci-base_build-aarch64
       - forge-aarch64
-      - ray-wheel-build-aarch64
+      - ray-wheel-build-aarch64(python=3.10)
     job_env: forge-aarch64


### PR DESCRIPTION
Convert all matrix and matrix-setup blocks in linux_aarch64.rayci.yml to array syntax. Use ($) for array-to-array depends_on where keys overlap (raycpubase, raycudabase, ray-core-build, ray-wheel-build, ray-image-cpu/cuda-build, ray-extra-image-cpu/cuda-build aarch64 variants). Use (python=3.10) subset for non-array steps that pin python 3.10: ray-cpp-wheel-build-aarch64 depending on ray-core-build-aarch64, and the two wheel-aarch64 test labels depending on ray-wheel-build-aarch64

Topic: convert-array-aarch64
Signed-off-by: andrew <andrew@anyscale.com>