### PR TITLE
[ci] convert data.rayci.yml matrix to array syntax

### DIFF
--- a/.buildkite/core.rayci.yml
+++ b/.buildkite/core.rayci.yml
@@ -198,7 +198,7 @@ steps:
         --python-version 3.12
         --build-name datalbuild-py3.12
     depends_on:
-      - datalbuild-multipy
+      - datalbuild-multipy(python=3.12)
       - forge
 
   - label: ":ray: core: modin tests"
@@ -211,7 +211,7 @@ steps:
         --python-version 3.10
         --build-name datalbuild-py3.10
     depends_on:
-      - datalbuild-multipy
+      - datalbuild-multipy(python=3.10)
       - forge
 
   - label: ":ray: core: dashboard tests"

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -7,20 +7,24 @@ depends_on:
 steps:
   # builds
   - name: data17build-multipy
-    label: "wanda: data17build-py{{matrix}}"
+    label: "wanda: data17build-py{{array.python}}"
     wanda: ci/docker/data17.build.wanda.yaml
-    matrix:
-      - "3.10"
+    array:
+      python:
+        - "3.10"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     tags: cibase
 
   - name: datalbuild-multipy
-    label: "wanda: datalbuild-py{{matrix}}"
+    label: "wanda: datalbuild-py{{array.python}}"
     wanda: ci/docker/datal.build.wanda.yaml
-    matrix: ["3.10", "3.12"]
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
     tags: cibase
 
   - name: datanbuild-multipy
@@ -65,7 +69,7 @@ steps:
     instance_type: small
     commands:
       - bash ci/lint/pyrefly-check.sh
-    depends_on: data17build-multipy
+    depends_on: data17build-multipy(python=3.10)
     job_env: data17build-py3.10
 
   # tests
@@ -80,7 +84,7 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name data17build-py3.10 --python-version 3.10
         --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
-    depends_on: data17build-multipy
+    depends_on: data17build-multipy(python=3.10)
 
   - label: ":database: data: tensorflow-datasets tests"
     key: data_tensorflow_datasets_tests
@@ -107,7 +111,7 @@ steps:
         --build-name data17build-py3.10 --python-version 3.10
         --only-tags data_non_parallel
         --except-tags data_non_parallel_postmerge_only,cudf
-    depends_on: data17build-multipy
+    depends_on: data17build-multipy(python=3.10)
 
   - label: ":database: data: arrow v23 tests"
     tags:
@@ -121,7 +125,7 @@ steps:
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name datalbuild-py3.10 --python-version 3.10
         --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.10)
 
   - label: ":database: data: arrow v23 tests (data_non_parallel)"
     tags:
@@ -137,9 +141,9 @@ steps:
         --build-name datalbuild-py3.10 --python-version 3.10
         --only-tags data_non_parallel
         --except-tags data_non_parallel_postmerge_only,cudf
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.10)
 
-  - label: ":database: data: arrow v23 py{{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":database: data: arrow v23 py{{array.python}} tests ({{array.worker_id}})"
     key: datal_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
@@ -147,16 +151,15 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
-        --build-name datalbuild-py{{matrix.python}} --python-version {{matrix.python}}
+        --workers 2 --worker-id {{array.worker_id}} --parallelism-per-worker 3
+        --build-name datalbuild-py{{array.python}} --python-version {{array.python}}
         --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
-    depends_on: datalbuild-multipy
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1"]
+    depends_on: datalbuild-multipy($)
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1"]
 
-  - label: ":database: data: arrow v23 py{{matrix.python}} tests (data_non_parallel)"
+  - label: ":database: data: arrow v23 py{{array.python}} tests (data_non_parallel)"
     key: datal_python_non_parallel_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
@@ -164,13 +167,12 @@ steps:
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
-        --build-name datalbuild-py{{matrix.python}} --python-version {{matrix.python}}
+        --build-name datalbuild-py{{array.python}} --python-version {{array.python}}
         --only-tags data_non_parallel
         --except-tags data_non_parallel_postmerge_only,cudf
-    depends_on: datalbuild-multipy
-    matrix:
-      setup:
-        python: ["3.12"]
+    depends_on: datalbuild-multipy($)
+    array:
+      python: ["3.12"]
 
   - label: ":database: data: arrow nightly tests"
     tags:
@@ -213,7 +215,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
         --build-name data17build-py3.10 --python-version 3.10
         --only-tags data_non_parallel_postmerge_only
-    depends_on: data17build-multipy
+    depends_on: data17build-multipy(python=3.10)
 
   - label: ":database: data: postmerge arrow v23 tests"
     tags:
@@ -224,7 +226,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
         --build-name datalbuild-py3.10 --python-version 3.10
         --only-tags data_non_parallel_postmerge_only
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.10)
 
   - label: ":database: data: dask tests"
     tags:
@@ -235,7 +237,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... data
         --build-name datalbuild-py3.12 --python-version 3.12
         --only-tags dask
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.12)
 
   - label: ":database: data: TFRecords (tfx-bsl) tests"
     tags:
@@ -267,7 +269,7 @@ steps:
         --except-tags gpu,post_wheel_build,doctest,dask
         --parallelism-per-worker 2
         --skip-ray-installation
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.10)
 
   - label: ":database: data: dask doc tests"
     tags:
@@ -280,7 +282,7 @@ steps:
         --python-version 3.12
         --only-tags dask
         --parallelism-per-worker 2
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.12)
 
   - label: ":database: data: doc gpu tests"
     tags:
@@ -343,7 +345,7 @@ steps:
         --build-name datalbuild-py3.10
         --python-version 3.10
         --parallelism-per-worker 3
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.10)
 
   - label: ":database: data: flaky tests"
     key: data_flaky_tests
@@ -360,7 +362,7 @@ steps:
         --build-name datalbuild-py3.10
         --python-version 3.10
         --except-tags gpu_only,gpu
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.10)
 
   - label: ":database: data: flaky gpu tests"
     key: data_flaky_gpu_tests
@@ -394,4 +396,4 @@ steps:
         --test-env=SNOWFLAKE_USER --test-env=SNOWFLAKE_ACCOUNT
         --test-env=SNOWFLAKE_DATABASE --test-env=SNOWFLAKE_SCHEMA
         --test-env=SNOWFLAKE_WAREHOUSE --test-env=SNOWFLAKE_PRIVATE_KEY
-    depends_on: datalbuild-multipy
+    depends_on: datalbuild-multipy(python=3.10)


### PR DESCRIPTION
Convert data9build-multipy, datalbuild-multipy, and the two matrix-setup "arrow v23" test labels from matrix to array syntax. The two array test steps use ($) against datalbuild-multipy since both sides now share the python array key. Every remaining plain depends_on to data9build-multipy or datalbuild-multipy is replaced with (python=3.10) or (python=3.12) based on the python version each consuming step pins. The core.rayci.yml dask and modin test steps — which reference datalbuild-multipy cross-file — are narrowed to (python=3.12) and (python=3.10) respectively. The non-array datan/datamongo/datatfxbsl/datatfds builds are unaffected

Topic: convert-array-data
Signed-off-by: andrew <andrew@anyscale.com>