### PR TITLE
[ci] convert ml.rayci.yml matrix to array syntax

### DIFF
--- a/.buildkite/ml.rayci.yml
+++ b/.buildkite/ml.rayci.yml
@@ -6,28 +6,30 @@ depends_on:
 steps:
   # builds
   - name: minbuild-ml
-    label: "wanda: minbuild-ml-py{{matrix}}"
+    label: "wanda: minbuild-ml-py{{array.python}}"
     wanda: ci/docker/min.build.wanda.yaml
-    depends_on: oss-ci-base_test-multipy(python=3.10)
-    matrix:
-      - "3.10"
+    depends_on: oss-ci-base_test-multipy($)
+    array:
+      python:
+        - "3.10"
     env:
-      PYTHON_VERSION: "{{matrix}}"
+      PYTHON_VERSION: "{{array.python}}"
       EXTRA_DEPENDENCY: ml
     tags: cibase
 
   - name: mlbuild-multipy
-    label: "wanda: mlbuild-py{{matrix}}"
+    label: "wanda: mlbuild-py{{array.python}}"
     wanda: ci/docker/ml.build.wanda.yaml
-    depends_on: oss-ci-base_ml-multipy(*)
+    depends_on: oss-ci-base_ml-multipy($)
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "ml"
       BUILD_VARIANT: "build"
       RAYCI_IS_GPU_BUILD: "false"
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     tags: cibase
 
   - name: mllightning1gpubuild
@@ -41,17 +43,18 @@ steps:
     depends_on: oss-ci-base_gpu-multipy(python=3.10)
 
   - name: mlgpubuild-multipy
-    label: "wanda: mlgpubuild-py{{matrix}}"
+    label: "wanda: mlgpubuild-py{{array.python}}"
     wanda: ci/docker/ml.build.wanda.yaml
-    depends_on: oss-ci-base_gpu-multipy(*)
+    depends_on: oss-ci-base_gpu-multipy($)
     env:
-      PYTHON: "{{matrix}}"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "gpu"
       BUILD_VARIANT: "gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
-    matrix:
-      - "3.10"
-      - "3.12"
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     tags: cibase
 
   # tests
@@ -64,7 +67,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --except-tags gpu,minimal,tune,doctest,needs_credentials,train_v2,train_v2_gpu,data_integration
         --python-version 3.10 --build-name mlbuild-py3.10
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":bullettrain_front: ml: train v2 tests"
     tags: train
@@ -76,7 +79,7 @@ steps:
         --python-version 3.10 --build-name mlbuild-py3.10
         --only-tags train_v2
         --except-tags needs_credentials,data_integration
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":bullettrain_front: ml: train v2 gpu tests"
     tags:
@@ -89,9 +92,10 @@ steps:
         --build-name mlgpubuild-py3.10 --python-version 3.10
         --only-tags train_v2_gpu
         --except-tags data_integration
-    depends_on: [ "mlgpubuild-multipy", "forge" ]
+    depends_on: [ "mlgpubuild-multipy(python=3.10)", "forge" ]
 
-  - label: ":bullettrain_front: :python: ml: train v2 {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":bullettrain_front: :python: ml: train v2 {{array.python}} tests ({{array.worker_id}})"
+    key: ml_train_v2_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - train
@@ -100,15 +104,14 @@ steps:
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
-        --python-version {{matrix.python}} --build-name mlbuild-py{{matrix.python}}
+        --workers 2 --worker-id {{array.worker_id}} --parallelism-per-worker 3
+        --python-version {{array.python}} --build-name mlbuild-py{{array.python}}
         --only-tags train_v2
         --except-tags needs_credentials
-    depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1"]
+    depends_on: [ "mlbuild-multipy($)", "forge" ]
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1"]
 
   - label: ":train: ml: train v1 gpu tests"
     tags:
@@ -122,7 +125,7 @@ steps:
         --build-name mlgpubuild-py3.10 --python-version 3.10
         --only-tags gpu
         --except-tags data_integration
-    depends_on: [ "mlgpubuild-multipy", "forge" ]
+    depends_on: [ "mlgpubuild-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: data integration tests"
     tags:
@@ -133,9 +136,10 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... ml
         --python-version 3.10 --build-name mlgpubuild-py3.10
         --only-tags data_integration
-    depends_on: [ "mlgpubuild-multipy", "forge" ]
+    depends_on: [ "mlgpubuild-multipy(python=3.10)", "forge" ]
 
-  - label: ":bullettrain_front: :python: ml: train v2 gpu {{matrix.python}} tests ({{matrix.worker_id}})"
+  - label: ":bullettrain_front: :python: ml: train v2 gpu {{array.python}} tests ({{array.worker_id}})"
+    key: ml_train_v2_gpu_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags:
       - train_gpu
@@ -143,16 +147,15 @@ steps:
     instance_type: gpu-large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/train/... //python/ray/air/... //doc/... ml
-        --workers 2 --worker-id {{matrix.worker_id}} --parallelism-per-worker 2
-        --python-version {{matrix.python}}
-        --build-name mlgpubuild-py{{matrix.python}}
+        --workers 2 --worker-id {{array.worker_id}} --parallelism-per-worker 2
+        --python-version {{array.python}}
+        --build-name mlgpubuild-py{{array.python}}
         --only-tags train_v2_gpu
         --except-tags doctest,data_integration
-    depends_on: [ "mlgpubuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.12"]
-        worker_id: ["0", "1"]
+    depends_on: [ "mlgpubuild-multipy($)", "forge" ]
+    array:
+      python: ["3.12"]
+      worker_id: ["0", "1"]
 
   - label: ":train: ml: train authentication tests"
     tags:
@@ -168,7 +171,7 @@ steps:
         --python-version 3.10 --build-name mlbuild-py3.10
         --only-tags needs_credentials
         --test-env=WANDB_API_KEY --test-env=COMET_API_KEY
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: tune tests"
     tags: tune
@@ -178,21 +181,21 @@ steps:
         --parallelism-per-worker 3
         --python-version 3.10 --build-name mlbuild-py3.10
         --except-tags doctest,soft_imports,rllib
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
-  - label: ":bullettrain_front: :python: ml: tune {{matrix.python}} tests"
+  - label: ":bullettrain_front: :python: ml: tune {{array.python}} tests"
+    key: ml_tune_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
     tags: tune
     instance_type: large
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/tune/... ml
         --parallelism-per-worker 3
-        --python-version {{matrix.python}} --build-name mlbuild-py{{matrix.python}}
+        --python-version {{array.python}} --build-name mlbuild-py{{array.python}}
         --except-tags doctest,soft_imports,rllib
-    depends_on: [ "mlbuild-multipy", "forge" ]
-    matrix:
-      setup:
-        python: ["3.12"]
+    depends_on: [ "mlbuild-multipy($)", "forge" ]
+    array:
+      python: ["3.12"]
 
   - label: ":train: ml: tune soft import tests"
     tags: tune
@@ -216,7 +219,7 @@ steps:
         --parallelism-per-worker 3
         --only-tags ray_air
         --skip-ray-installation
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: train+tune tests"
     tags: train
@@ -227,7 +230,7 @@ steps:
         --python-version 3.10 --build-name mlbuild-py3.10
         --only-tags tune
         --except-tags ray_air,gpu,doctest,needs_credentials
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: rllib+tune tests"
     tags:
@@ -240,7 +243,7 @@ steps:
         --parallelism-per-worker 3
         --only-tags rllib
         --except-tags gpu
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: release tests"
     tags:
@@ -252,7 +255,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //release/... ml
         --python-version 3.10 --build-name mlbuild-py3.10
         --parallelism-per-worker 3
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: train minimal"
     tags:
@@ -265,7 +268,7 @@ steps:
         --parallelism-per-worker 2
         --build-name minbuild-ml-py3.10 --python-version 3.10
         --only-tags minimal
-    depends_on: [ "minbuild-ml", "forge" ]
+    depends_on: [ "minbuild-ml(python=3.10)", "forge" ]
 
   - label: ":train: ml: doc tests"
     tags:
@@ -289,7 +292,7 @@ steps:
         --except-tags gpu,post_wheel_build,doctest,highly_parallel
         --parallelism-per-worker 3
         --skip-ray-installation
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
 
   - label: ":train: ml: lightning 1.x compatibility tests"
     tags:
@@ -314,7 +317,7 @@ steps:
         --python-version 3.10 --build-name mlbuild-py3.10
         --parallelism-per-worker 2
         --except-tags gpu,needs_credentials,train_v2_gpu,data_integration
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
     soft_fail: true
 
   - label: ":train: ml: flaky authentication tests"
@@ -331,7 +334,7 @@ steps:
         --parallelism-per-worker 3
         --only-tags needs_credentials
         --test-env=WANDB_API_KEY --test-env=COMET_API_KEY
-    depends_on: [ "mlbuild-multipy", "forge" ]
+    depends_on: [ "mlbuild-multipy(python=3.10)", "forge" ]
     soft_fail: true
 
   - label: ":train: ml: train gpu flaky tests"
@@ -347,5 +350,5 @@ steps:
         --python-version 3.10 --build-name mlgpubuild-py3.10
         --only-tags gpu,train_v2_gpu
         --except-tags data_integration
-    depends_on: [ "mlgpubuild-multipy", "forge" ]
+    depends_on: [ "mlgpubuild-multipy(python=3.10)", "forge" ]
     soft_fail: true


### PR DESCRIPTION
Convert the three matrix build steps (minbuild-ml, mlbuild-multipy, mlgpubuild-multipy) and the three matrix-setup test labels ("train v2 {{python}} tests", "train v2 gpu {{python}} tests", "tune {{python}} tests") from matrix to array syntax. The three newly-array test steps use ($) against mlbuild-multipy and mlgpubuild-multipy since both sides share the python array key, and the build steps refine their oss-ci-base_* dependencies from (*) / (python=3.10) to ($) for the same reason. Every remaining plain depends_on to minbuild-ml / mlbuild-multipy / mlgpubuild-multipy becomes (python=3.10) since every consuming step pins py3.10. The non-array mllightning1gpubuild is unaffected.

Topic: convert-array-ml
Signed-off-by: andrew <andrew@anyscale.com>