### PR TITLE
[ci] narrow pre-existing (*) fan-ins to (python=3.10) subsets

### DIFF
--- a/.buildkite/build.rayci.yml
+++ b/.buildkite/build.rayci.yml
@@ -49,7 +49,7 @@ steps:
       - linux_wheels
       - oss
     depends_on:
-      - ray-core-build(*)
+      - ray-core-build(python=3.10)
       - ray-cpp-core-build
       - ray-java-build
       - ray-dashboard-build
@@ -139,7 +139,7 @@ steps:
         "$${RAYCI_WORK_REPO}":"$${RAYCI_BUILD_ID}"-ray-py3.10-tpu
         /bin/bash -c "python -c \"import ray; print('ray', ray.__version__); import jax; print('jax', jax.__version__)\""
     depends_on:
-      - ray-image-tpu-build(*)
+      - ray-image-tpu-build(python=3.10)
       - forge
 
   - name: ray-image-cuda-build

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -5,7 +5,7 @@ steps:
     wanda: ci/docker/doc.build.wanda.yaml
     depends_on:
       - oss-ci-base_build-multipy(python=3.10)
-      - ray-core-build(*)
+      - ray-core-build(python=3.10)
       - ray-dashboard-build
     matrix:
       - "3.10"

--- a/.buildkite/kuberay.rayci.yml
+++ b/.buildkite/kuberay.rayci.yml
@@ -18,8 +18,8 @@ steps:
       - k8sbuild
       - manylinux-x86_64
       - forge
-      - raycpubase(*)
-      - ray-core-build(*)
+      - raycpubase(python=3.10)
+      - ray-core-build(python=3.10)
       - ray-dashboard-build
 
   - label: ":kubernetes: chaos {{matrix.workload}} under {{matrix.fault}}"
@@ -46,6 +46,6 @@ steps:
     depends_on:
       - manylinux-x86_64
       - forge
-      - raycpubase(*)
-      - ray-core-build(*)
+      - raycpubase(python=3.10)
+      - ray-core-build(python=3.10)
       - ray-dashboard-build

--- a/.buildkite/others.rayci.yml
+++ b/.buildkite/others.rayci.yml
@@ -23,7 +23,7 @@ steps:
         --python-version 3.10
     depends_on:
       - doctestbuild
-      - ray-core-build(*)
+      - ray-core-build(python=3.10)
       - ray-dashboard-build
 
   # java

--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,7 +1,7 @@
 group: rllib tests
 depends_on:
   - forge
-  - ray-core-build(*)
+  - ray-core-build(python=3.10)
   - ray-dashboard-build
 steps:
   # builds


### PR DESCRIPTION
Tighten pre-existing (*) depends_on references that were never touched by the recent matrix-to-array conversion work. Each narrowed step pins python 3.10 in its commands or wanda env, so the (*) fan-in across every python variant is wider than necessary: rllib top-level (ray-core-build), doc docbuild (ray-core-build), others doc-tests (ray-core-build), build cpp wheel (ray-core-build — uses PYTHON_VERSION=3.10 for upstream images), build tpu smoke test (ray-image-tpu-build — pulls ray-py3.10-tpu), and both kuberay operator and chaos steps (raycpubase + ray-core-build — the k8s scripts default PYTHON_VERSION=3.10). Remaining top-level (*) in core / llm / ml / data / serve and the nightly-indexes ray_images_push(*) are left intact because each truly spans multiple python variants or needs every image push to complete

Topic: narrow-preexisting-stars
Signed-off-by: andrew <andrew@anyscale.com>