### PR TITLE
[dashboard][History Server] Add schema validation for ray dashboard APIs

### DIFF
--- a/python/ray/dashboard/BUILD.bazel
+++ b/python/ray/dashboard/BUILD.bazel
@@ -135,6 +135,28 @@ py_test(
 )
 
 py_test(
+    name = "test_node_schemas",
+    size = "small",
+    srcs = ["modules/node/tests/test_schemas.py"],
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+    deps = [":conftest"],
+)
+
+py_test(
+    name = "test_state_schemas",
+    size = "small",
+    srcs = ["modules/state/tests/test_schemas.py"],
+    tags = [
+        "exclusive",
+        "team:core",
+    ],
+    deps = [":conftest"],
+)
+
+py_test(
     name = "test_dashboard",
     size = "large",
     srcs = ["tests/test_dashboard.py"],

--- a/python/ray/dashboard/modules/job/pydantic_models.py
+++ b/python/ray/dashboard/modules/job/pydantic_models.py
@@ -1,108 +1,11 @@
-from enum import Enum
-from typing import Any, Dict, Optional
-
-from ray._common.pydantic_compat import PYDANTIC_INSTALLED, BaseModel, Field
-from ray.dashboard.modules.job.common import JobStatus
-from ray.util.annotations import PublicAPI
+from ray._common.pydantic_compat import PYDANTIC_INSTALLED
 
 # Pydantic is not part of the minimal Ray installation.
+# TODO(chiayi): This file is kept for backward compatibility because many files still import from here.
+# The actual definitions have been moved to ray.dashboard.schemas.
+# Once all importers are updated to use ray.dashboard.schemas, this file can be removed.
 if PYDANTIC_INSTALLED:
-
-    @PublicAPI(stability="beta")
-    class DriverInfo(BaseModel):
-        """A class for recording information about the driver related to the job."""
-
-        id: str = Field(..., description="The id of the driver")
-        node_ip_address: str = Field(
-            ..., description="The IP address of the node the driver is running on."
-        )
-        pid: str = Field(
-            ..., description="The PID of the worker process the driver is using."
-        )
-        # TODO(aguo): Add node_id as a field.
-
-    @PublicAPI(stability="beta")
-    class JobType(str, Enum):
-        """An enumeration for describing the different job types.
-
-        NOTE:
-            This field is still experimental and may change in the future.
-        """
-
-        #: A job that was initiated by the Ray Jobs API.
-        SUBMISSION = "SUBMISSION"
-        #: A job that was initiated by a driver script.
-        DRIVER = "DRIVER"
-
-    @PublicAPI(stability="beta")
-    class JobDetails(BaseModel):
-        """
-        Job data with extra details about its driver and its submission.
-        """
-
-        type: JobType = Field(..., description="The type of job.")
-        job_id: Optional[str] = Field(
-            None,
-            description="The job ID. An ID that is created for every job that is "
-            "launched in Ray. This can be used to fetch data about jobs using Ray "
-            "Core APIs.",
-        )
-        submission_id: Optional[str] = Field(
-            None,
-            description="A submission ID is an ID created for every job submitted via"
-            "the Ray Jobs API. It can "
-            "be used to fetch data about jobs using the Ray Jobs API.",
-        )
-        driver_info: Optional[DriverInfo] = Field(
-            None,
-            description="The driver related to this job. For jobs submitted via "
-            "the Ray Jobs API, "
-            "it is the last driver launched by that job submission, "
-            "or None if there is no driver.",
-        )
-
-        # The following fields are copied from JobInfo.
-        # TODO(aguo): Inherit from JobInfo once it's migrated to pydantic.
-        status: JobStatus = Field(..., description="The status of the job.")
-        entrypoint: str = Field(..., description="The entrypoint command for this job.")
-        message: Optional[str] = Field(
-            None, description="A message describing the status in more detail."
-        )
-        error_type: Optional[str] = Field(
-            None, description="Internal error or user script error."
-        )
-        start_time: Optional[int] = Field(
-            None,
-            description="The time when the job was started. A Unix timestamp in ms.",
-        )
-        end_time: Optional[int] = Field(
-            None,
-            description="The time when the job moved into a terminal state. "
-            "A Unix timestamp in ms.",
-        )
-        metadata: Optional[Dict[str, str]] = Field(
-            None, description="Arbitrary user-provided metadata for the job."
-        )
-        runtime_env: Optional[Dict[str, Any]] = Field(
-            None, description="The runtime environment for the job."
-        )
-        # the node info where the driver running on.
-        #     - driver_agent_http_address: this node's agent http address
-        #     - driver_node_id: this node's id.
-        driver_agent_http_address: Optional[str] = Field(
-            None,
-            description="The HTTP address of the JobAgent on the node the job "
-            "entrypoint command is running on.",
-        )
-        driver_node_id: Optional[str] = Field(
-            None,
-            description="The ID of the node the job entrypoint command is running on.",
-        )
-        driver_exit_code: Optional[int] = Field(
-            None,
-            description="The driver process exit code after the driver executed. "
-            "Return None if driver doesn't finish executing.",
-        )
+    from ray.dashboard.pydantic_models import DriverInfo, JobDetails, JobType
 
 else:
     DriverInfo = None

--- a/python/ray/dashboard/modules/node/datacenter.py
+++ b/python/ray/dashboard/modules/node/datacenter.py
@@ -2,12 +2,14 @@ import copy
 from typing import List, Optional
 
 import ray.dashboard.consts as dashboard_consts
+from ray._common.pydantic_compat import PYDANTIC_INSTALLED, ValidationError
 from ray._common.utils import (
     get_or_create_event_loop,
 )
 from ray._private.utils import (
     parse_pg_formatted_resources_to_original,
 )
+from ray.dashboard.pydantic_models import NodeDetailSchema
 from ray.dashboard.utils import (
     async_loop_forever,
     compose_state_message,
@@ -174,6 +176,15 @@ class DataOrganizer:
 
             # Update workers to node physical stats
             node_info["workers"] = DataSource.node_workers.get(node_id, [])
+
+        # Validate against schema (logging only)
+        # The node data seems pretty complex, so it might be better for now to just log
+        # when it fails validation.
+        if PYDANTIC_INSTALLED and NodeDetailSchema is not None:
+            try:
+                NodeDetailSchema.parse_obj(node_info)
+            except ValidationError as e:
+                logger.warning(f"Schema validation failed for node {node_id}: {e}")
 
         return node_info
 

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -13,6 +13,7 @@ import grpc
 import ray._private.utils
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
+from ray._common.pydantic_compat import PYDANTIC_INSTALLED, ValidationError
 from ray._common.utils import get_or_create_event_loop
 from ray._private import ray_constants
 from ray._private.collections_utils import split
@@ -41,6 +42,7 @@ from ray.dashboard.consts import (
 from ray.dashboard.modules.node import actor_consts, node_consts
 from ray.dashboard.modules.node.datacenter import DataOrganizer, DataSource
 from ray.dashboard.modules.reporter.reporter_models import StatsPayload
+from ray.dashboard.pydantic_models import ActorSchema
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 from ray.dashboard.utils import async_loop_forever
@@ -703,6 +705,19 @@ class NodeHead(SubprocessModule):
         if "ids" in req.query:
             actor_ids = req.query["ids"].split(",")
         actors = await DataOrganizer.get_actor_infos(actor_ids=actor_ids)
+
+        # Validate against schema (logging only)
+        # Keep it as just logging for the time being.
+        if PYDANTIC_INSTALLED and ActorSchema is not None:
+            for actor_id, actor_info in actors.items():
+                if actor_info is not None:
+                    try:
+                        ActorSchema.parse_obj(actor_info)
+                    except ValidationError as e:
+                        logger.warning(
+                            f"Schema validation failed for actor {actor_id}: {e}"
+                        )
+
         return dashboard_optional_utils.rest_response(
             status_code=dashboard_utils.HTTPStatusCode.OK,
             message="All actors fetched.",

--- a/python/ray/dashboard/modules/node/tests/test_schemas.py
+++ b/python/ray/dashboard/modules/node/tests/test_schemas.py
@@ -1,0 +1,110 @@
+import pytest
+
+from ray._common.pydantic_compat import PYDANTIC_INSTALLED, ValidationError
+from ray.dashboard.pydantic_models import ActorSchema, NodeDetailSchema, RayletSchema
+
+pytestmark = pytest.mark.skipif(
+    not PYDANTIC_INSTALLED, reason="Pydantic is not installed (minimal installation)"
+)
+
+
+def test_raylet_schema_validation():
+    # Valid data using aliases or direct names
+    valid_raylet_data = {
+        "nodeId": "node_123",
+        "state": "ALIVE",
+        "numWorkers": 5,
+        "pid": 1234,
+        "nodeManagerPort": 54321,
+        "startTime": 1600000000,
+        "object_store_available_memory": 1000,
+        "object_store_used_memory": 500,
+        "isHeadNode": True,
+        "labels": {"key": "value"},
+    }
+    raylet = RayletSchema.parse_obj(valid_raylet_data)
+    assert raylet.nodeId == "node_123"
+    assert raylet.state == "ALIVE"
+
+    # Invalid data (missing required field nodeId)
+    invalid_raylet_data = {
+        "state": "ALIVE",
+        "numWorkers": 5,
+    }
+    with pytest.raises(ValidationError):
+        RayletSchema.parse_obj(invalid_raylet_data)
+
+
+def test_node_detail_schema_validation():
+    valid_node_data = {
+        "hostname": "host-1",
+        "ip": "127.0.0.1",
+        "cpu": 50.5,
+        "raylet": {
+            "nodeId": "node_123",
+            "state": "ALIVE",
+            "numWorkers": 5,
+            "pid": 1234,
+            "nodeManagerPort": 54321,
+            "startTime": 1600000000,
+            "object_store_available_memory": 1000,
+            "object_store_used_memory": 500,
+            "isHeadNode": True,
+            "labels": {},
+        },
+    }
+    node_detail = NodeDetailSchema.parse_obj(valid_node_data)
+    assert node_detail.hostname == "host-1"
+    assert node_detail.raylet.nodeId == "node_123"
+
+    # Invalid data (wrong type for cpu)
+    invalid_node_data = {
+        "hostname": "host-1",
+        "ip": "127.0.0.1",
+        "cpu": "high",  # Should be float
+        "raylet": {
+            "nodeId": "node_123",
+            "state": "ALIVE",
+            "numWorkers": 5,
+            "pid": 1234,
+            "nodeManagerPort": 54321,
+            "startTime": 1600000000,
+            "object_store_available_memory": 1000,
+            "object_store_used_memory": 500,
+            "isHeadNode": True,
+            "labels": {},
+        },
+    }
+    with pytest.raises(ValidationError):
+        NodeDetailSchema.parse_obj(invalid_node_data)
+
+
+def test_actor_schema_validation():
+    valid_actor_data = {
+        "actorId": "actor_123",
+        "jobId": "job_123",
+        "state": "ALIVE",
+        "address": {
+            "nodeId": "node_123",
+            "ipAddress": "127.0.0.1",
+            "port": 1234,
+            "workerId": "worker_123",
+        },
+        "name": "my_actor",
+        "numRestarts": "0",
+        "actorClass": "MyActor",
+        "exitDetail": "",
+        "reprName": "MyActor",
+    }
+    actor = ActorSchema.parse_obj(valid_actor_data)
+    assert actor.actorId == "actor_123"
+    assert actor.state == "ALIVE"
+
+    # Invalid data (missing required field address)
+    invalid_actor_data = {
+        "actorId": "actor_123",
+        "jobId": "job_123",
+        "state": "ALIVE",
+    }
+    with pytest.raises(ValidationError):
+        ActorSchema.parse_obj(invalid_actor_data)

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -20,6 +20,7 @@ from ray.dashboard.consts import (
     RAY_STATE_SERVER_MAX_HTTP_REQUEST_ENV_NAME,
 )
 from ray.dashboard.modules.log.log_manager import LogsManager
+from ray.dashboard.pydantic_models import PlacementGroupSchema, TaskSchema
 from ray.dashboard.state_aggregator import StateAPIManager
 from ray.dashboard.state_api_utils import (
     do_reply,
@@ -133,7 +134,9 @@ class StateHead(SubprocessModule, RateLimitedModule):
         self, req: aiohttp.web.Request
     ) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_PLACEMENT_GROUPS, "1")
-        return await handle_list_api(self._state_api.list_placement_groups, req)
+        return await handle_list_api(
+            self._state_api.list_placement_groups, req, schema=PlacementGroupSchema
+        )
 
     @routes.get("/api/v0/workers")
     @RateLimitedModule.enforce_max_concurrent_calls
@@ -145,7 +148,7 @@ class StateHead(SubprocessModule, RateLimitedModule):
     @RateLimitedModule.enforce_max_concurrent_calls
     async def list_tasks(self, req: aiohttp.web.Request) -> aiohttp.web.Response:
         record_extra_usage_tag(TagKey.CORE_STATE_API_LIST_TASKS, "1")
-        return await handle_list_api(self._state_api.list_tasks, req)
+        return await handle_list_api(self._state_api.list_tasks, req, schema=TaskSchema)
 
     @routes.get("/api/v0/objects")
     @RateLimitedModule.enforce_max_concurrent_calls

--- a/python/ray/dashboard/modules/state/tests/test_schemas.py
+++ b/python/ray/dashboard/modules/state/tests/test_schemas.py
@@ -1,0 +1,139 @@
+from unittest.mock import patch
+
+import pytest
+
+from ray._common.pydantic_compat import PYDANTIC_INSTALLED, ValidationError
+from ray.dashboard.pydantic_models import BundleSchema, PlacementGroupSchema, TaskSchema
+from ray.dashboard.state_api_utils import handle_list_api
+from ray.util.state.common import ListApiOptions, ListApiResponse
+
+pytestmark = pytest.mark.skipif(
+    not PYDANTIC_INSTALLED, reason="Pydantic is not installed (minimal installation)"
+)
+
+
+def test_bundle_schema_validation():
+    # Valid data
+    valid_bundle_data = {
+        "bundle_id": "bundle_123",
+        "node_id": "node_123",
+        "unit_resources": {"CPU": 1.0},
+        "label_selector": {"key": "value"},
+    }
+    bundle = BundleSchema.parse_obj(valid_bundle_data)
+    assert bundle.bundle_id == "bundle_123"
+
+    # Invalid data (missing required field bundle_id)
+    invalid_bundle_data = {
+        "node_id": "node_123",
+    }
+    with pytest.raises(ValidationError):
+        BundleSchema.parse_obj(invalid_bundle_data)
+
+
+def test_placement_group_schema_validation():
+    valid_pg_data = {
+        "placement_group_id": "pg_123",
+        "name": "my_pg",
+        "creator_job_id": "job_123",
+        "state": "CREATED",
+        "stats": {"created_at": 1600000000},
+        "bundles": [
+            {
+                "bundle_id": "bundle_123",
+                "node_id": "node_123",
+                "unit_resources": {"CPU": 1.0},
+            }
+        ],
+    }
+    pg = PlacementGroupSchema.parse_obj(valid_pg_data)
+    assert pg.placement_group_id == "pg_123"
+    assert len(pg.bundles) == 1
+
+    # Invalid data (wrong type for bundles)
+    invalid_pg_data = {
+        "placement_group_id": "pg_123",
+        "name": "my_pg",
+        "creator_job_id": "job_123",
+        "state": "CREATED",
+        "bundles": "not_a_list",
+    }
+    with pytest.raises(ValidationError):
+        PlacementGroupSchema.parse_obj(invalid_pg_data)
+
+
+def test_task_schema_validation():
+    valid_task_data = {
+        "task_id": "task_123",
+        "attempt_number": 0,
+        "name": "my_task",
+        "state": "RUNNING",
+        "job_id": "job_123",
+        "type": "NORMAL_TASK",
+        "func_or_class_name": "my_func",
+        "parent_task_id": "parent_123",
+    }
+    task = TaskSchema.parse_obj(valid_task_data)
+    assert task.task_id == "task_123"
+    assert task.state == "RUNNING"
+
+    # Invalid data (missing required field task_id)
+    invalid_task_data = {
+        "attempt_number": 0,
+        "name": "my_task",
+    }
+    with pytest.raises(ValidationError):
+        TaskSchema.parse_obj(invalid_task_data)
+
+
+@pytest.mark.asyncio
+async def test_handle_list_api_enforcement():
+    """Test that handle_list_api correctly enforces the schema and applies defaults.
+
+    Specifically, it verifies that if a placement group is missing the 'bundles'
+    field, the returned dictionary will have 'bundles' filled in with an empty
+    list [].
+    """
+    # Mock API function that returns data missing placement group 'bundles'
+    async def mock_list_api(option: ListApiOptions):
+        return ListApiResponse(
+            total=1,
+            num_after_truncation=1,
+            num_filtered=1,
+            result=[
+                {
+                    "placement_group_id": "pg_123",
+                    "name": "my_pg",
+                    "creator_job_id": "job_123",
+                    "state": "CREATED",
+                    # 'bundles' is missing!
+                }
+            ],
+        )
+
+    # Mock request
+    class MockQuery(dict):
+        def getall(self, key, default=None):
+            return self.get(key, default or [])
+
+    class MockRequest:
+        def __init__(self):
+            self.query = MockQuery()
+
+    req = MockRequest()
+
+    # Mock do_reply to return the result_dict directly
+    with patch("ray.dashboard.state_api_utils.do_reply") as mock_reply:
+        mock_reply.side_effect = (
+            lambda status_code, error_message, result, **kwargs: result
+        )
+
+        response_dict = await handle_list_api(
+            mock_list_api, req, schema=PlacementGroupSchema
+        )
+
+        # Verify that 'bundles' was filled in with the default empty list
+        assert "result" in response_dict
+        assert len(response_dict["result"]) == 1
+        assert "bundles" in response_dict["result"][0]
+        assert response_dict["result"][0]["bundles"] == []

--- a/python/ray/dashboard/pydantic_models.py
+++ b/python/ray/dashboard/pydantic_models.py
@@ -1,0 +1,204 @@
+from enum import Enum
+from typing import Any, Dict, List, Optional, Union
+
+from ray._common.pydantic_compat import PYDANTIC_INSTALLED, BaseModel, Field
+from ray.dashboard.modules.job.common import JobStatus
+from ray.util.annotations import PublicAPI
+
+if PYDANTIC_INSTALLED:
+
+    class RayletSchema(BaseModel):
+        """
+        Pydantic schema matching the frontend Raylet TypeScript interface.
+        Ensures backend changes don't break the UI or History Server.
+        """
+
+        nodeId: str = Field(..., description="Unique ID of the node")
+        state: str = Field(..., description="Node state (e.g., ALIVE, DEAD)")
+        stateMessage: Optional[str] = Field(
+            None, description="Optional reason for state"
+        )
+
+        numWorkers: int = Field(..., description="Number of workers")
+        pid: int = Field(..., description="Process ID of raylet")
+        nodeManagerPort: int = Field(..., description="Port of node manager")
+        startTime: int = Field(..., description="Start time timestamp")
+        terminateTime: Optional[int] = Field(
+            None, description="Terminate time timestamp"
+        )
+        objectStoreAvailableMemory: int = Field(
+            ...,
+            description="Available object store memory",
+            alias="object_store_available_memory",
+        )
+        objectStoreUsedMemory: int = Field(
+            ...,
+            description="Used object store memory",
+            alias="object_store_used_memory",
+        )
+        isHeadNode: bool = Field(..., description="Whether this is the head node")
+
+        labels: Dict[str, str] = Field(
+            default_factory=dict, description="Labels associated with the node"
+        )
+
+        class Config:
+            allow_population_by_field_name = True
+
+    class NodeDetailSchema(BaseModel):
+        """
+        Schema for the top-level node object returned by the API.
+        Matches structure expected by frontend NodeDetail type.
+        """
+
+        hostname: str = Field(..., description="Hostname of the node")
+        ip: str = Field(..., description="IP address of the node")
+        cpu: float = Field(..., description="CPU usage percentage")
+        raylet: RayletSchema = Field(..., description="Enforced raylet schema")
+
+    class AddressSchema(BaseModel):
+        nodeId: str
+        ipAddress: str
+        port: int
+        workerId: str
+
+    class ActorSchema(BaseModel):
+        """
+        Pydantic schema matching the frontend Actor TypeScript interface.
+        """
+
+        actorId: str
+        jobId: str
+        placementGroupId: Optional[str] = None
+        state: str
+        pid: Optional[int] = None
+        address: AddressSchema
+        name: str
+        numRestarts: str
+        actorClass: str
+        startTime: Optional[int] = None
+        endTime: Optional[int] = None
+        requiredResources: Dict[str, float] = Field(default_factory=dict)
+        exitDetail: str
+        reprName: str
+        callSite: Optional[str] = None
+        labelSelector: Optional[Dict[str, str]] = None
+
+    class BundleSchema(BaseModel):
+        bundle_id: str
+        node_id: Optional[str] = None
+        unit_resources: Dict[str, float] = Field(default_factory=dict)
+        label_selector: Optional[Dict[str, str]] = None
+
+    class PlacementGroupSchema(BaseModel):
+        """
+        Pydantic schema matching the frontend PlacementGroup TypeScript interface.
+        """
+
+        placement_group_id: str
+        name: str
+        creator_job_id: str
+        state: str
+        stats: Optional[Dict[str, Union[int, float, str]]] = None
+        bundles: List[BundleSchema] = Field(default_factory=list)
+
+    class TaskSchema(BaseModel):
+        """
+        Pydantic schema matching the TaskState dataclass.
+        """
+
+        task_id: str
+        attempt_number: int
+        name: str
+        state: str
+        job_id: str
+        actor_id: Optional[str] = None
+        type: str
+        func_or_class_name: str
+        parent_task_id: str
+        node_id: Optional[str] = None
+        worker_id: Optional[str] = None
+        worker_pid: Optional[int] = None
+        error_type: Optional[str] = None
+        language: Optional[str] = None
+        required_resources: Optional[Dict[str, float]] = None
+        runtime_env_info: Optional[Dict[str, Any]] = None
+        placement_group_id: Optional[str] = None
+        events: Optional[List[Dict[str, Any]]] = None
+        profiling_data: Optional[Dict[str, Any]] = None
+        creation_time_ms: Optional[int] = None
+        start_time_ms: Optional[int] = None
+        end_time_ms: Optional[int] = None
+        task_log_info: Optional[Dict[str, Any]] = None
+        error_message: Optional[str] = None
+        is_debugger_paused: Optional[bool] = None
+        call_site: Optional[str] = None
+        label_selector: Optional[Dict[str, str]] = None
+        fallback_strategy: Optional[Dict[str, Any]] = None
+
+    @PublicAPI(stability="beta")
+    class DriverInfo(BaseModel):
+        id: str = Field(..., description="The id of the driver")
+        node_ip_address: str = Field(
+            ..., description="The IP address of the node the driver is running on."
+        )
+        pid: str = Field(
+            ..., description="The PID of the worker process the driver is using."
+        )
+
+    @PublicAPI(stability="beta")
+    class JobType(str, Enum):
+        SUBMISSION = "SUBMISSION"
+        DRIVER = "DRIVER"
+
+    @PublicAPI(stability="beta")
+    class JobDetails(BaseModel):
+        type: JobType = Field(..., description="The type of job.")
+        job_id: Optional[str] = Field(None, description="The job ID.")
+        submission_id: Optional[str] = Field(None, description="A submission ID.")
+        driver_info: Optional[DriverInfo] = Field(
+            None, description="The driver related to this job."
+        )
+        status: JobStatus = Field(..., description="The status of the job.")
+        entrypoint: str = Field(..., description="The entrypoint command for this job.")
+        message: Optional[str] = Field(
+            None, description="A message describing the status in more detail."
+        )
+        error_type: Optional[str] = Field(
+            None, description="Internal error or user script error."
+        )
+        start_time: Optional[int] = Field(
+            None, description="The time when the job was started."
+        )
+        end_time: Optional[int] = Field(
+            None, description="The time when the job moved into a terminal state."
+        )
+        metadata: Optional[Dict[str, str]] = Field(
+            None, description="Arbitrary user-provided metadata for the job."
+        )
+        runtime_env: Optional[Dict[str, Any]] = Field(
+            None, description="The runtime environment for the job."
+        )
+        driver_agent_http_address: Optional[str] = Field(
+            None, description="The HTTP address of the JobAgent."
+        )
+        driver_node_id: Optional[str] = Field(
+            None,
+            description="The ID of the node the job entrypoint command is running on.",
+        )
+        driver_exit_code: Optional[int] = Field(
+            None, description="The driver process exit code."
+        )
+
+else:
+    # Fallbacks for minimal install
+    RayletSchema = None
+    NodeDetailSchema = None
+    AddressSchema = None
+    ActorSchema = None
+    BundleSchema = None
+    PlacementGroupSchema = None
+    TaskSchema = None
+    DriverInfo = None
+    JobType = None
+    JobDetails = None

--- a/python/ray/dashboard/state_api_utils.py
+++ b/python/ray/dashboard/state_api_utils.py
@@ -1,9 +1,11 @@
 import dataclasses
+import logging
 from dataclasses import asdict, fields
-from typing import Awaitable, Callable, List, Tuple
+from typing import Awaitable, Callable, List, Optional, Tuple
 
 import aiohttp.web
 
+from ray._common.pydantic_compat import PYDANTIC_INSTALLED, BaseModel, ValidationError
 from ray.dashboard.optional_utils import rest_response
 from ray.dashboard.utils import HTTPStatusCode
 from ray.util.state.common import (
@@ -22,6 +24,8 @@ from ray.util.state.common import (
 from ray.util.state.exception import DataSourceUnavailable
 from ray.util.state.util import convert_string_to_type
 
+logger = logging.getLogger(__name__)
+
 
 def do_reply(
     status_code: HTTPStatusCode, error_message: str, result: ListApiResponse, **kwargs
@@ -38,13 +42,27 @@ def do_reply(
 async def handle_list_api(
     list_api_fn: Callable[[ListApiOptions], Awaitable[ListApiResponse]],
     req: aiohttp.web.Request,
+    schema: Optional[BaseModel] = None,
 ):
     try:
         result = await list_api_fn(option=options_from_req(req))
+        result_dict = asdict(result)
+
+        if PYDANTIC_INSTALLED and schema is not None:
+            validated_results = []
+            for item in result_dict.get("result", []):
+                try:
+                    validated_item = schema.parse_obj(item)
+                    validated_results.append(validated_item.dict())
+                except ValidationError as e:
+                    logger.warning(f"Schema validation failed for item in list: {e}")
+                    validated_results.append(item)
+            result_dict["result"] = validated_results
+
         return do_reply(
             status_code=HTTPStatusCode.OK,
             error_message="",
-            result=asdict(result),
+            result=result_dict,
         )
     except ValueError as e:
         return do_reply(


### PR DESCRIPTION
## Description
As part of validation and schema enforcement for Ray Dashboard APIs this PR consolidates the schemas into a central location and ensure compatibility with current and hopefully future changes. 

Important note: validation will only work if Pydantic is installed. It does have a fallback in case it isn't

The schemas for the following are centralized into `python/ray/dashboard/pydantic_models.py`:
- Nodes - derived from [NodeDetails](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/client/src/type/node.d.ts) and [Raylet](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/client/src/type/raylet.d.ts)
- Actors - derived from [Actor](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/client/src/type/actor.ts)
- Placement Groups - derived from [PlacementGroup](https://github.com/ray-project/ray/blob/master/python/ray/dashboard/client/src/type/placementGroup.ts)
- Tasks - derived from the existing [TaskState](https://github.com/ray-project/ray/blob/master/python/ray/util/state/common.py)
- Jobs - moved from `ray/dashboard/modules/job/pydantic_models.py`

For Placement group and tasks (state module), there is runtime enforcement and will raise error if schema does not match. For Nodes and actors (node module), it will only perform detection during runtime due to the complexity of the objects. 

## Related issues
This is aimed address kuberay#4713 

## Additional information