### PR TITLE
[runtime_env] Support .tar.gz archives for remote working_dir URIs

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -490,8 +490,8 @@ API Reference
 
 The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime_env.RuntimeEnv <ray.runtime_env.RuntimeEnv>` including one or more of the following fields:
 
-- ``working_dir`` (str): Specifies the working directory for the Ray workers. This must either be (1) an local existing directory with total size at most 500 MiB, (2) a local existing zipped file with total unzipped size at most 500 MiB (Note: ``excludes`` has no effect), or (3) a URI to a remotely-stored zip file containing the working directory for your job (no file size limit is enforced by Ray). See :ref:`remote-uris` for details.
-  The specified directory will be downloaded to each node on the cluster, and Ray workers will be started in their node's copy of this directory.
+- ``working_dir`` (str): Specifies the working directory for the Ray workers. This must either be (1) a local existing directory with total size at most 500 MiB, (2) a local existing archive file (``.zip``, ``.tar.gz``, or ``.tgz``) with total uncompressed size at most 500 MiB (Note: ``excludes`` has no effect), or (3) a URI to a remotely-stored archive (``.zip``, ``.tar.gz``, or ``.tgz``) containing the working directory for your job (no file size limit is enforced by Ray). See :ref:`remote-uris` for details.
+  The specified directory is downloaded to each node on the cluster, and Ray workers start in their node's copy of this directory.
 
   - Examples
 
@@ -503,6 +503,8 @@ The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime
 
     - ``"s3://path/to/my_dir.zip"``
 
+    - ``"s3://path/to/my_dir.tar.gz"``
+
   Note: Setting a local directory per-task or per-actor is currently unsupported; it can only be set per-job (i.e., in ``ray.init()``).
 
   Note: By default, if the local directory contains a ``.gitignore`` and/or ``.rayignore`` file, the specified files are not uploaded to the cluster. To disable the ``.gitignore`` from being considered, set ``RAY_RUNTIME_ENV_IGNORE_GITIGNORE=1`` on the machine doing the uploading.
@@ -512,7 +514,7 @@ The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime
   Note: If the local directory contains symbolic links, Ray follows the links and the files they point to are uploaded to the cluster.
 
 - ``py_modules`` (List[str|module]): Specifies Python modules to be available for import in the Ray workers.  (For more ways to specify packages, see also the ``pip`` and ``conda`` fields below.)
-  Each entry must be either (1) a path to a local file or directory, (2) a URI to a remote zip or wheel file (see :ref:`remote-uris` for details), (3) a Python module object, or (4) a path to a local `.whl` file.
+  Each entry must be either (1) a path to a local file or directory, (2) a URI to a remote archive (``.zip``, ``.tar.gz``, ``.tgz``) or wheel (``.whl``) file (see :ref:`remote-uris` for details), (3) a Python module object, or (4) a path to a local ``.whl`` file.
 
   - Examples of entries in the list:
 
@@ -818,25 +820,31 @@ If you want to specify this directory as a local path, your ``runtime_env`` dict
   runtime_env = {..., "working_dir": "/some_path/example_dir", ...}
 
 Suppose instead you want to host your files in your ``/some_path/example_dir`` directory remotely and provide a remote URI.
-You would need to first compress the ``example_dir`` directory into a zip file.
+You need to first compress the ``example_dir`` directory into a ``.zip`` or ``.tar.gz`` archive.
 
-There should be no other files or directories at the top level of the zip file, other than ``example_dir``.
-You can use the following command in the Terminal to do this:
+There should be no other files or directories at the top level of the archive, other than ``example_dir``.
+You can use one of the following commands in the Terminal:
 
 .. code-block:: bash
 
     cd /some_path
-    zip -r zip_file_name.zip example_dir
+    # Using zip:
+    zip -r archive.zip example_dir
+    # Using tar.gz:
+    tar -czf archive.tar.gz example_dir
 
-Note that this command must be run from the *parent directory* of the desired ``working_dir`` to ensure that the resulting zip file contains a single top-level directory.
-In general, the zip file's name and the top-level directory's name can be anything.
-The top-level directory's contents will be used as the ``working_dir`` (or ``py_module``).
+Run this command from the *parent directory* of the desired ``working_dir`` to ensure that the resulting archive contains a single top-level directory.
+In general, the archive's name and the top-level directory's name can be anything.
+The top-level directory's contents are used as the ``working_dir`` (or ``py_module``).
 
-You can check that the zip file contains a single top-level directory by running the following command in the Terminal:
+You can check that the archive contains a single top-level directory by running one of the following commands in the Terminal:
 
 .. code-block:: bash
 
-  zipinfo -1 zip_file_name.zip
+  # For zip:
+  zipinfo -1 archive.zip
+  # For tar.gz:
+  tar -tzf archive.tar.gz
   # example_dir/
   # example_dir/my_file_1.txt
   # example_dir/subdir/my_file_2.txt
@@ -849,15 +857,22 @@ Your ``runtime_env`` dictionary should contain:
 
   runtime_env = {..., "working_dir": "s3://example_bucket/example.zip", ...}
 
+You can also use ``.tar.gz`` or ``.tgz`` archives:
+
+.. testcode::
+  :skipif: True
+
+  runtime_env = {..., "working_dir": "s3://example_bucket/example.tar.gz", ...}
+
 .. warning::
 
-  Check for hidden files and metadata directories in zipped dependencies.
-  You can inspect a zip file's contents by running the ``zipinfo -1 zip_file_name.zip`` command in the Terminal.
-  Some zipping methods can cause hidden files or metadata directories to appear in the zip file at the top level.
-  To avoid this, use the ``zip -r`` command directly on the directory you want to compress from its parent's directory. For example, if you have a directory structure such as: ``a/b`` and you want to compress ``b``, issue the ``zip -r b`` command from the directory ``a.``
-  If Ray detects more than a single directory at the top level, it will use the entire zip file instead of the top-level directory, which may lead to unexpected behavior.
+  Check for hidden files and metadata directories in archived dependencies.
+  You can inspect an archive's contents by running ``zipinfo -1 archive.zip`` or ``tar -tzf archive.tar.gz`` in the Terminal.
+  Some archiving methods can cause hidden files or metadata directories to appear at the top level.
+  To avoid this, use ``zip -r`` or ``tar -czf`` directly on the directory you want to compress from its parent's directory. For example, if you have a directory structure such as: ``a/b`` and you want to compress ``b``, issue the command from the directory ``a``.
+  If Ray detects more than a single directory at the top level, it uses the entire archive instead of the top-level directory, which may lead to unexpected behavior.
 
-Currently, four types of remote URIs are supported for hosting ``working_dir`` and ``py_modules`` packages:
+Remote URIs support ``.zip``, ``.tar.gz``, and ``.tgz`` archive formats. Four types of remote URIs are supported for hosting ``working_dir`` and ``py_modules`` packages:
 
 - ``HTTPS``: ``HTTPS`` refers to URLs that start with ``https``.
   These are particularly useful because remote Git providers (e.g. GitHub, Bitbucket, GitLab, etc.) use ``https`` URLs as download links for repository archives.

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import sys
+import tarfile
 import time
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -283,9 +284,24 @@ def parse_uri(pkg_uri: str) -> Tuple[Protocol, str]:
             for disallowed_char in disallowed_chars:
                 package_name = package_name.replace(disallowed_char, "_")
 
-            # Remove all periods except the last, which is part of the
-            # file extension
-            package_name = package_name.replace(".", "_", package_name.count(".") - 1)
+            # Preserve compound extensions like .tar.gz before replacing dots
+            compound_ext = None
+            if package_name.endswith(".tar.gz"):
+                compound_ext = ".tar.gz"
+                package_name = package_name[: -len(".tar.gz")]
+            elif package_name.endswith(".tar.bz2"):
+                compound_ext = ".tar.bz2"
+                package_name = package_name[: -len(".tar.bz2")]
+
+            if compound_ext:
+                package_name = package_name.replace(".", "_")
+                package_name += compound_ext
+            else:
+                # Remove all periods except the last, which is part of the
+                # file extension
+                package_name = package_name.replace(
+                    ".", "_", package_name.count(".") - 1
+                )
     else:
         package_name = uri.netloc
     return (protocol, package_name)
@@ -316,6 +332,15 @@ def is_jar_uri(uri: str) -> bool:
         return False
 
     return Path(path).suffix == ".jar"
+
+
+def is_tar_gz_uri(uri: str) -> bool:
+    try:
+        _, path = parse_uri(uri)
+    except ValueError:
+        return False
+
+    return path.endswith(".tar.gz") or Path(path).suffix == ".tgz"
 
 
 def _get_excludes(path: Path, excludes: List[str]) -> Callable:
@@ -768,7 +793,13 @@ def upload_package_if_needed(
 def get_local_dir_from_uri(uri: str, base_directory: str) -> Path:
     """Return the local directory corresponding to this URI."""
     pkg_file = Path(_get_local_path(base_directory, uri))
-    local_dir = pkg_file.with_suffix("")
+    pkg_name = pkg_file.name
+    if pkg_name.endswith(".tar.gz"):
+        local_dir = pkg_file.parent / pkg_name[: -len(".tar.gz")]
+    elif pkg_name.endswith(".tar.bz2"):
+        local_dir = pkg_file.parent / pkg_name[: -len(".tar.bz2")]
+    else:
+        local_dir = pkg_file.with_suffix("")
     return local_dir
 
 
@@ -780,8 +811,9 @@ async def download_and_unpack_package(
     logger: Optional[logging.Logger] = default_logger,
     overwrite: bool = False,
 ) -> str:
-    """Download the package corresponding to this URI and unpack it if zipped.
+    """Download the package corresponding to this URI and unpack it.
 
+    Supports .zip, .jar, .tar.gz, and .tgz archives for remote protocols.
     Will be written to a file or directory named {base_directory}/{uri}.
     Returns the path to this file or directory.
 
@@ -886,6 +918,18 @@ async def download_and_unpack_package(
                     )
                 elif pkg_file.suffix == ".whl":
                     return str(pkg_file)
+                elif (
+                    str(pkg_file).endswith(".tar.gz")
+                    or pkg_file.suffix == ".tgz"
+                    or str(pkg_file).endswith(".tar.bz2")
+                ):
+                    untar_package(
+                        package_path=pkg_file,
+                        target_dir=local_dir,
+                        remove_top_level_directory=True,
+                        unlink_tar=True,
+                        logger=logger,
+                    )
                 else:
                     raise NotImplementedError(
                         f"Package format {pkg_file.suffix} is ",
@@ -1074,6 +1118,88 @@ def unzip_package(
         Path(package_path).unlink()
 
 
+def get_top_level_dir_from_tar_package(package_path: str):
+    """
+    If tar package at package_path contains a single top-level
+    directory, returns the name of the top-level directory. Otherwise,
+    returns None.
+    """
+    with tarfile.open(package_path, "r:*") as tar:
+        top_level_directory = None
+        for member in tar.getmembers():
+            parts = member.name.split("/")
+            if len(parts) == 1 and not member.isdir():
+                return None
+            dir_name = parts[0]
+            if top_level_directory is None:
+                top_level_directory = dir_name
+            elif dir_name != top_level_directory:
+                return None
+        return top_level_directory
+
+
+def untar_package(
+    package_path: str,
+    target_dir: str,
+    remove_top_level_directory: bool,
+    unlink_tar: bool,
+    logger: Optional[logging.Logger] = default_logger,
+) -> None:
+    """
+    Extract the tar archive at package_path to target_dir.
+
+    If remove_top_level_directory is True and the archive contains a single
+    top-level directory, the contents are extracted directly into target_dir
+    without the top-level wrapper.
+
+    Args:
+        package_path: String path of the tar archive to extract.
+        target_dir: String path of the directory to store the extracted contents.
+        remove_top_level_directory: Whether to strip the top-level directory.
+        unlink_tar: Whether to delete the tar file after extraction.
+        logger: Optional logger to use for logging.
+    """
+    try:
+        os.mkdir(target_dir)
+    except FileExistsError:
+        logger.info(f"Directory at {target_dir} already exists")
+
+    logger.debug(f"Unpacking {package_path} to {target_dir}")
+
+    with tarfile.open(package_path, "r:*") as tar:
+        for member in tar.getmembers():
+            member_path = os.path.join(target_dir, member.name)
+            resolved = os.path.realpath(member_path)
+            target_real = os.path.realpath(target_dir)
+            if not resolved.startswith(target_real + os.sep) and resolved != target_real:
+                logger.warning(f"Skipping unsafe path in tar: {member.name}")
+                continue
+
+            if member.issym() or member.islnk():
+                logger.warning(f"Skipping link in tar: {member.name}")
+                continue
+
+            if member.isdir():
+                os.makedirs(member_path, exist_ok=True)
+            elif member.isfile():
+                parent_dir = os.path.dirname(member_path)
+                if parent_dir:
+                    os.makedirs(parent_dir, exist_ok=True)
+                with tar.extractfile(member) as source, open(
+                    member_path, "wb"
+                ) as target:
+                    shutil.copyfileobj(source, target)
+                os.chmod(member_path, member.mode)
+
+    if remove_top_level_directory:
+        top_level_directory = get_top_level_dir_from_tar_package(package_path)
+        if top_level_directory is not None:
+            remove_dir_from_filepaths(target_dir, top_level_directory)
+
+    if unlink_tar:
+        Path(package_path).unlink()
+
+
 def delete_package(pkg_uri: str, base_directory: str) -> Tuple[bool, int]:
     """Deletes a specific URI from the local filesystem.
 
@@ -1085,14 +1211,14 @@ def delete_package(pkg_uri: str, base_directory: str) -> Tuple[bool, int]:
     """
 
     deleted = False
-    path = Path(_get_local_path(base_directory, pkg_uri))
-    with FileLock(str(path) + ".lock"):
-        path = path.with_suffix("")
-        if path.exists():
-            if path.is_dir() and not path.is_symlink():
-                shutil.rmtree(str(path))
+    pkg_path = Path(_get_local_path(base_directory, pkg_uri))
+    with FileLock(str(pkg_path) + ".lock"):
+        local_dir = get_local_dir_from_uri(pkg_uri, base_directory)
+        if local_dir.exists():
+            if local_dir.is_dir() and not local_dir.is_symlink():
+                shutil.rmtree(str(local_dir))
             else:
-                path.unlink()
+                local_dir.unlink()
             deleted = True
 
     return deleted

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -587,8 +587,14 @@ def get_uri_for_package(package: Path) -> str:
         )
     else:
         hash_val = hashlib.sha1(package.read_bytes()).hexdigest()
-        return "{protocol}://{pkg_name}.zip".format(
-            protocol=Protocol.GCS.value, pkg_name=RAY_PKG_PREFIX + hash_val
+        if package.name.endswith(".tar.gz"):
+            ext = ".tar.gz"
+        elif package.suffix == ".tgz":
+            ext = ".tar.gz"
+        else:
+            ext = ".zip"
+        return "{protocol}://{pkg_name}{ext}".format(
+            protocol=Protocol.GCS.value, pkg_name=RAY_PKG_PREFIX + hash_val, ext=ext
         )
 
 
@@ -901,6 +907,14 @@ async def download_and_unpack_package(
                         target_dir=local_dir,
                         remove_top_level_directory=False,
                         unlink_zip=True,
+                        logger=logger,
+                    )
+                elif is_tar_gz_uri(pkg_uri):
+                    untar_package(
+                        package_path=pkg_file,
+                        target_dir=local_dir,
+                        remove_top_level_directory=False,
+                        unlink_tar=True,
                         logger=logger,
                     )
                 else:

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -1141,7 +1141,14 @@ def get_top_level_dir_from_tar_package(package_path: str):
     with tarfile.open(package_path, "r:*") as tar:
         top_level_directory = None
         for member in tar.getmembers():
-            parts = member.name.split("/")
+            # GNU tar commonly prefixes members with "./" — strip it so
+            # we don't treat "." as the top-level directory name.
+            name = member.name
+            while name.startswith("./"):
+                name = name[2:]
+            if not name or name == ".":
+                continue
+            parts = name.split("/")
             if len(parts) == 1 and not member.isdir():
                 return None
             dir_name = parts[0]

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -1192,7 +1192,10 @@ def untar_package(
             member_path = os.path.join(target_dir, member.name)
             resolved = os.path.realpath(member_path)
             target_real = os.path.realpath(target_dir)
-            if not resolved.startswith(target_real + os.sep) and resolved != target_real:
+            if (
+                not resolved.startswith(target_real + os.sep)
+                and resolved != target_real
+            ):
                 logger.warning(f"Skipping unsafe path in tar: {member.name}")
                 continue
 
@@ -1206,9 +1209,10 @@ def untar_package(
                 parent_dir = os.path.dirname(member_path)
                 if parent_dir:
                     os.makedirs(parent_dir, exist_ok=True)
-                with tar.extractfile(member) as source, open(
-                    member_path, "wb"
-                ) as target:
+                with (
+                    tar.extractfile(member) as source,
+                    open(member_path, "wb") as target,
+                ):
                     shutil.copyfileobj(source, target)
                 os.chmod(member_path, member.mode)
 

--- a/python/ray/_private/runtime_env/protocol.py
+++ b/python/ray/_private/runtime_env/protocol.py
@@ -298,7 +298,8 @@ Protocol = enum.Enum(
 @classmethod
 def _remote_protocols(cls):
     # Returns a list of protocols that support remote storage
-    # These protocols should only be used with paths that end in ".zip" or ".whl"
+    # These protocols should only be used with paths that end in
+    # ".zip", ".whl", ".tar.gz", or ".tgz"
     return [
         cls[protocol.upper()] for protocol in ProtocolsProvider.get_remote_protocols()
     ]

--- a/python/ray/_private/runtime_env/py_modules.py
+++ b/python/ray/_private/runtime_env/py_modules.py
@@ -36,12 +36,13 @@ def _check_is_uri(s: str) -> bool:
     except ValueError:
         protocol, path = None, None
 
-    if (
-        protocol in Protocol.remote_protocols()
-        and not path.endswith(".zip")
-        and not path.endswith(".whl")
+    supported_extensions = (".zip", ".whl", ".tar.gz", ".tgz")
+    if protocol in Protocol.remote_protocols() and not any(
+        path.endswith(ext) for ext in supported_extensions
     ):
-        raise ValueError("Only .zip or .whl files supported for remote URIs.")
+        raise ValueError(
+            "Only .zip, .whl, .tar.gz, and .tgz files supported for remote URIs."
+        )
 
     return protocol is not None
 

--- a/python/ray/_private/runtime_env/validation.py
+++ b/python/ray/_private/runtime_env/validation.py
@@ -29,12 +29,13 @@ def validate_uri(uri: str):
             "(i.e., passed to `ray.init`)."
         )
 
-    if (
-        protocol in Protocol.remote_protocols()
-        and not path.endswith(".zip")
-        and not path.endswith(".whl")
+    supported_extensions = (".zip", ".whl", ".tar.gz", ".tgz")
+    if protocol in Protocol.remote_protocols() and not any(
+        path.endswith(ext) for ext in supported_extensions
     ):
-        raise ValueError("Only .zip or .whl files supported for remote URIs.")
+        raise ValueError(
+            "Only .zip, .whl, .tar.gz, and .tgz files supported for remote URIs."
+        )
 
 
 def _handle_local_deps_requirement_file(requirements_file: str):

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -67,8 +67,13 @@ def upload_working_dir_if_needed(
         protocol, path = None, None
 
     if protocol is not None:
-        if protocol in Protocol.remote_protocols() and not path.endswith(".zip"):
-            raise ValueError("Only .zip files supported for remote URIs.")
+        supported_extensions = (".zip", ".tar.gz", ".tgz")
+        if protocol in Protocol.remote_protocols() and not any(
+            path.endswith(ext) for ext in supported_extensions
+        ):
+            raise ValueError(
+                "Only .zip, .tar.gz, and .tgz files supported for remote URIs."
+            )
         return runtime_env
 
     default_excludes = ray_constants.get_runtime_env_default_excludes()
@@ -98,10 +103,15 @@ def upload_working_dir_if_needed(
         )
     except ValueError:  # working_dir is not a directory
         package_path = Path(working_dir)
-        if not package_path.exists() or package_path.suffix != ".zip":
+        supported_local = (
+            package_path.suffix == ".zip"
+            or package_path.suffix == ".tgz"
+            or package_path.name.endswith(".tar.gz")
+        )
+        if not package_path.exists() or not supported_local:
             raise ValueError(
                 f"directory {package_path} must be an existing "
-                "directory or a zip package"
+                "directory or a supported archive (.zip, .tar.gz, .tgz)"
             )
 
         pkg_uri = get_uri_for_package(package_path)

--- a/python/ray/_private/runtime_env/working_dir.py
+++ b/python/ray/_private/runtime_env/working_dir.py
@@ -167,7 +167,6 @@ def set_pythonpath_in_context(python_path: str, context: RuntimeEnvContext):
 
 
 class WorkingDirPlugin(RuntimeEnvPlugin):
-
     name = "working_dir"
 
     # Note working_dir is not following the priority order of other plugins. Instead

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -430,7 +430,7 @@ def test_http_bad_request(job_sdk_client):
 
 def test_invalid_runtime_env(job_sdk_client):
     client = job_sdk_client
-    with pytest.raises(ValueError, match="Only .zip files supported"):
+    with pytest.raises(ValueError, match="Only .zip, .tar.gz, and .tgz files"):
         client.submit_job(
             entrypoint="echo hello", runtime_env={"working_dir": "s3://not_a_zip"}
         )

--- a/python/ray/runtime_env/runtime_env.py
+++ b/python/ray/runtime_env/runtime_env.py
@@ -232,10 +232,12 @@ class RuntimeEnv(dict):
 
     Args:
         py_modules: List of local paths or remote URIs (either in the GCS or external
-            storage), each of which is a zip file that Ray unpacks and
-            inserts into the PYTHONPATH of the workers.
-        working_dir: Local path or remote URI (either in the GCS or external storage) of a zip
-            file that Ray unpacks in the directory of each task/actor.
+            storage), each of which is an archive that Ray unpacks and
+            inserts into the PYTHONPATH of the workers. Supported formats for
+            remote URIs: ``.zip``, ``.whl``, ``.tar.gz``, and ``.tgz``.
+        working_dir: Local path or remote URI (either in the GCS or external storage) of an
+            archive that Ray unpacks in the directory of each task/actor.
+            Supported formats for remote URIs: ``.zip``, ``.tar.gz``, and ``.tgz``.
         pip: Either a list of pip packages, a string
             containing the path to a pip requirements.txt file, or a Python
             dictionary that has three fields: 1) ``packages`` (required, List[str]): a

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -5,6 +5,7 @@ import shutil
 import socket
 import string
 import sys
+import tarfile
 import tempfile
 import types
 import uuid
@@ -31,13 +32,16 @@ from ray._private.runtime_env.packaging import (
     get_excludes_from_ignore_files,
     get_local_dir_from_uri,
     get_top_level_dir_from_compressed_package,
+    get_top_level_dir_from_tar_package,
     get_uri_for_directory,
     get_uri_for_file,
     get_uri_for_package,
+    is_tar_gz_uri,
     is_whl_uri,
     is_zip_uri,
     parse_uri,
     remove_dir_from_filepaths,
+    untar_package,
     unzip_package,
     upload_package_if_needed,
     upload_package_to_gcs,
@@ -999,6 +1003,33 @@ class TestDownloadAndUnpackPackage:
             # Check that the file was extracted to the destination directory
             assert (Path(local_dir) / "file.txt").exists()
 
+    async def test_download_and_unpack_package_with_file_uri_tar_gz(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tar_path = Path(temp_dir) / "test-tar-file.tar.gz"
+            with tarfile.open(tar_path, "w:gz") as tar:
+                file_content = b"Hello from tar!"
+                info = tarfile.TarInfo(name="top_level/file.txt")
+                info.size = len(file_content)
+                tar.addfile(info, io.BytesIO(file_content))
+
+                dir_info = tarfile.TarInfo(name="top_level/")
+                dir_info.type = tarfile.DIRTYPE
+                tar.addfile(dir_info)
+
+            from urllib.parse import urljoin
+            from urllib.request import pathname2url
+
+            file_path = pathname2url(str(tar_path))
+            pkg_uri = urljoin("file:", file_path[1:])
+
+            dest_dir = tempfile.mkdtemp()
+            local_dir = await download_and_unpack_package(
+                pkg_uri=pkg_uri, base_directory=dest_dir
+            )
+
+            assert (Path(local_dir) / "file.txt").exists()
+            assert (Path(local_dir) / "file.txt").read_text() == "Hello from tar!"
+
     @pytest.mark.parametrize(
         "protocol",
         [
@@ -1177,6 +1208,121 @@ def test_get_local_dir_from_uri():
     assert get_local_dir_from_uri(uri, "base_dir") == Path(
         "base_dir/<working_dir_content_hash>"
     )
+
+
+def test_get_local_dir_from_uri_tar_gz():
+    uri = "s3://bucket/archive.tar.gz"
+    local_dir = get_local_dir_from_uri(uri, "base_dir")
+    assert "tar" not in str(local_dir.name)
+    assert not str(local_dir).endswith(".gz")
+
+
+def test_is_tar_gz_uri():
+    assert is_tar_gz_uri("s3://bucket/archive.tar.gz")
+    assert is_tar_gz_uri("https://example.com/pkg.tar.gz")
+    assert is_tar_gz_uri("s3://bucket/archive.tgz")
+    assert not is_tar_gz_uri("s3://bucket/archive.zip")
+    assert not is_tar_gz_uri("gcs://archive.whl")
+    assert not is_tar_gz_uri("invalid_format")
+
+
+def test_parse_uri_tar_gz():
+    protocol, package_name = parse_uri("s3://bucket/archive.tar.gz")
+    assert package_name.endswith(".tar.gz")
+    assert protocol == Protocol.S3
+
+    protocol, package_name = parse_uri("https://example.com/path/my.pkg.tar.gz")
+    assert package_name.endswith(".tar.gz")
+    assert "_" in package_name
+
+
+def test_untar_package_without_top_level_dir(tmp_path):
+    tar_path = tmp_path / "test.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        file_content = b"Hello, world!"
+        info = tarfile.TarInfo(name="file.txt")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    target_dir = str(tmp_path / "extracted")
+    untar_package(
+        package_path=str(tar_path),
+        target_dir=target_dir,
+        remove_top_level_directory=False,
+        unlink_tar=False,
+    )
+    assert (Path(target_dir) / "file.txt").exists()
+    assert (Path(target_dir) / "file.txt").read_text() == "Hello, world!"
+
+
+def test_untar_package_with_top_level_dir(tmp_path):
+    tar_path = tmp_path / "test.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        dir_info = tarfile.TarInfo(name="top_level/")
+        dir_info.type = tarfile.DIRTYPE
+        tar.addfile(dir_info)
+
+        file_content = b"Hello from tar!"
+        info = tarfile.TarInfo(name="top_level/file.txt")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    target_dir = str(tmp_path / "extracted")
+    untar_package(
+        package_path=str(tar_path),
+        target_dir=target_dir,
+        remove_top_level_directory=True,
+        unlink_tar=True,
+    )
+    assert (Path(target_dir) / "file.txt").exists()
+    assert (Path(target_dir) / "file.txt").read_text() == "Hello from tar!"
+    assert not tar_path.exists()
+
+
+def test_untar_package_path_traversal(tmp_path):
+    """Verify that path traversal attacks are blocked."""
+    tar_path = tmp_path / "malicious.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        file_content = b"malicious"
+        info = tarfile.TarInfo(name="../../../etc/passwd")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    target_dir = str(tmp_path / "extracted")
+    untar_package(
+        package_path=str(tar_path),
+        target_dir=target_dir,
+        remove_top_level_directory=False,
+        unlink_tar=False,
+    )
+    assert not (Path(target_dir) / "../../../etc/passwd").exists()
+    assert len(os.listdir(target_dir)) == 0
+
+
+def test_get_top_level_dir_from_tar_package(tmp_path):
+    tar_path = tmp_path / "test.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        dir_info = tarfile.TarInfo(name="myproject/")
+        dir_info.type = tarfile.DIRTYPE
+        tar.addfile(dir_info)
+
+        file_content = b"content"
+        info = tarfile.TarInfo(name="myproject/main.py")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    assert get_top_level_dir_from_tar_package(str(tar_path)) == "myproject"
+
+
+def test_get_top_level_dir_from_tar_package_no_top_level(tmp_path):
+    tar_path = tmp_path / "test.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        file_content = b"content"
+        info = tarfile.TarInfo(name="file.txt")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    assert get_top_level_dir_from_tar_package(str(tar_path)) is None
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -1340,6 +1340,54 @@ def test_get_top_level_dir_from_tar_package(tmp_path):
     assert get_top_level_dir_from_tar_package(str(tar_path)) == "myproject"
 
 
+def test_get_top_level_dir_from_tar_package_dot_slash_prefix(tmp_path):
+    """GNU tar commonly prefixes members with ./ — must not return '.'."""
+    tar_path = tmp_path / "test.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        dir_info = tarfile.TarInfo(name="./myproject/")
+        dir_info.type = tarfile.DIRTYPE
+        tar.addfile(dir_info)
+
+        file_content = b"content"
+        info = tarfile.TarInfo(name="./myproject/main.py")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    assert get_top_level_dir_from_tar_package(str(tar_path)) == "myproject"
+
+
+def test_get_top_level_dir_from_tar_package_dot_slash_no_top_level(tmp_path):
+    """./file.txt at the root means no single top-level directory."""
+    tar_path = tmp_path / "test.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        file_content = b"content"
+        info = tarfile.TarInfo(name="./file.txt")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    assert get_top_level_dir_from_tar_package(str(tar_path)) is None
+
+
+def test_get_top_level_dir_from_tar_package_bare_dot_entry(tmp_path):
+    """Archives with a bare '.' entry should handle it gracefully."""
+    tar_path = tmp_path / "test.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        dot_info = tarfile.TarInfo(name=".")
+        dot_info.type = tarfile.DIRTYPE
+        tar.addfile(dot_info)
+
+        dir_info = tarfile.TarInfo(name="./myproject/")
+        dir_info.type = tarfile.DIRTYPE
+        tar.addfile(dir_info)
+
+        file_content = b"content"
+        info = tarfile.TarInfo(name="./myproject/main.py")
+        info.size = len(file_content)
+        tar.addfile(info, io.BytesIO(file_content))
+
+    assert get_top_level_dir_from_tar_package(str(tar_path)) == "myproject"
+
+
 def test_get_top_level_dir_from_tar_package_no_top_level(tmp_path):
     tar_path = tmp_path / "test.tar.gz"
     with tarfile.open(tar_path, "w:gz") as tar:

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -1203,6 +1203,32 @@ def test_get_uri_for_package():
     assert get_uri_for_package(Path("/tmp/my-pkg.whl")) == "gcs://my-pkg.whl"
 
 
+def test_get_uri_for_package_tar_gz(tmp_path):
+    tar_path = tmp_path / "my-pkg.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        info = tarfile.TarInfo(name="file.txt")
+        info.size = 5
+        tar.addfile(info, io.BytesIO(b"hello"))
+
+    uri = get_uri_for_package(tar_path)
+    assert uri.startswith("gcs://")
+    assert uri.endswith(".tar.gz")
+    assert not uri.endswith(".zip")
+
+
+def test_get_uri_for_package_tgz(tmp_path):
+    tgz_path = tmp_path / "my-pkg.tgz"
+    with tarfile.open(tgz_path, "w:gz") as tar:
+        info = tarfile.TarInfo(name="file.txt")
+        info.size = 5
+        tar.addfile(info, io.BytesIO(b"hello"))
+
+    uri = get_uri_for_package(tgz_path)
+    assert uri.startswith("gcs://")
+    assert uri.endswith(".tar.gz")
+    assert not uri.endswith(".zip")
+
+
 def test_get_local_dir_from_uri():
     uri = "gcs://<working_dir_content_hash>.zip"
     assert get_local_dir_from_uri(uri, "base_dir") == Path(

--- a/python/ray/tests/unit/test_runtime_env_validation.py
+++ b/python/ray/tests/unit/test_runtime_env_validation.py
@@ -86,7 +86,8 @@ class TestValidateWorkingDir:
             "gs://bucket/file",
         ]:
             with pytest.raises(
-                ValueError, match="Only .zip or .whl files supported for remote URIs."
+                ValueError,
+                match="Only .zip, .tar.gz, and .tgz files supported for remote URIs.",
             ):
                 parse_and_validate_working_dir(uri)
 
@@ -95,6 +96,9 @@ class TestValidateWorkingDir:
             "https://some_domain.com/path/file.zip",
             "s3://bucket/file.zip",
             "gs://bucket/file.zip",
+            "https://some_domain.com/path/file.tar.gz",
+            "s3://bucket/file.tar.gz",
+            "gs://bucket/file.tgz",
         ]:
             working_dir = parse_and_validate_working_dir(uri)
             assert working_dir == uri
@@ -130,7 +134,8 @@ class TestValidatePyModules:
             "gs://bucket/file",
         ]
         with pytest.raises(
-            ValueError, match="Only .zip or .whl files supported for remote URIs."
+            ValueError,
+            match="Only .zip, .whl, .tar.gz, and .tgz files supported for remote URIs.",
         ):
             parse_and_validate_py_modules(uris)
 
@@ -142,6 +147,9 @@ class TestValidatePyModules:
             "https://some_domain.com/path/file.whl",
             "s3://bucket/file.whl",
             "gs://bucket/file.whl",
+            "https://some_domain.com/path/file.tar.gz",
+            "s3://bucket/file.tar.gz",
+            "gs://bucket/file.tgz",
         ]
         py_modules = parse_and_validate_py_modules(uris)
         assert py_modules == uris

--- a/python/ray/tests/unit/test_runtime_env_validation.py
+++ b/python/ray/tests/unit/test_runtime_env_validation.py
@@ -87,7 +87,7 @@ class TestValidateWorkingDir:
         ]:
             with pytest.raises(
                 ValueError,
-                match="Only .zip, .tar.gz, and .tgz files supported for remote URIs.",
+                match=r"Only \.zip, \.whl, \.tar\.gz, and \.tgz files supported for remote URIs\.",
             ):
                 parse_and_validate_working_dir(uri)
 


### PR DESCRIPTION
## Summary

- Extends `working_dir` (and `py_modules`) remote URI support to accept `.tar.gz` and `.tgz` archives in addition to `.zip`
- Adds `untar_package` with path traversal protection (skips symlinks, validates resolved paths stay within target)
- Updates `parse_uri` to preserve compound extensions (`.tar.gz`, `.tar.bz2`) so that local directory naming and suffix detection work correctly

## Why is this change needed?

Many CI/build systems (Bazel, pip, conda) produce `.tar.gz` archives as their primary artifact format. The previous `.zip`-only restriction forced users to add a costly conversion step (download tar.gz → repackage as zip → re-upload), adding latency, storage overhead, and complexity — especially in KubeRay/RayJob workflows.

Closes #62811

## Changes

| File | Change |
|------|--------|
| `packaging.py` | Add `import tarfile`, `is_tar_gz_uri`, `untar_package`, `get_top_level_dir_from_tar_package`; update `parse_uri` for compound extensions; update `download_and_unpack_package` to handle tar; fix `get_local_dir_from_uri` and `delete_package` for double extensions |
| `working_dir.py` | Accept `.tar.gz`/`.tgz` in remote URI validation and local archive detection |
| `py_modules.py` | Accept `.tar.gz`/`.tgz` in remote URI validation |
| `validation.py` | Accept `.tar.gz`/`.tgz` in generic URI validation |
| `protocol.py` | Update comment to reflect new supported formats |
| Tests | Add unit tests for `untar_package`, `parse_uri` with tar.gz, `is_tar_gz_uri`, `get_local_dir_from_uri` with tar.gz, `download_and_unpack_package` with `file://` tar.gz URI, path traversal protection; update error message assertions |

## Test plan

- [x] `test_parse_uri_tar_gz` — verifies compound extension preservation
- [x] `test_is_tar_gz_uri` — verifies URI detection
- [x] `test_get_local_dir_from_uri_tar_gz` — verifies directory naming
- [x] `test_untar_package_without_top_level_dir` — basic extraction
- [x] `test_untar_package_with_top_level_dir` — top-level directory stripping
- [x] `test_untar_package_path_traversal` — security: blocks `../` attacks
- [x] `test_get_top_level_dir_from_tar_package` — top-level detection
- [x] `test_download_and_unpack_package_with_file_uri_tar_gz` — end-to-end with `file://` protocol
- [x] Updated validation tests pass with new error messages and `.tar.gz`/`.tgz` as valid inputs


Made with [Cursor](https://cursor.com)