### PR TITLE
[train][doc] Fix flaky doc test for TorchDetectionPredictor

### DIFF
--- a/python/deplocks/ci/docgpu_depset_py3.10.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.10.lock
@@ -701,6 +701,8 @@ boto3==1.29.7 \
     --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
+    #   -r python/requirements/ml/py313/tune-test-requirements.txt
     #   -r python/requirements/py313/test-requirements.txt
     #   aim
     #   aiobotocore

--- a/python/deplocks/ci/docgpu_depset_py3.12.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.12.lock
@@ -576,6 +576,8 @@ boto3==1.29.7 \
     --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
+    #   -r python/requirements/ml/py313/tune-test-requirements.txt
     #   -r python/requirements/py313/test-requirements.txt
     #   aiobotocore
     #   aws-sam-translator

--- a/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
@@ -530,13 +530,15 @@ bleach==6.1.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   nbconvert
-boto3==1.29.7 ; python_full_version < '3.12' \
+boto3==1.29.7 \
     --hash=sha256:1eb4c548118b5fc5e018dee956fd33e6fb249cd1f2def85f1bba816aef4d9f3e \
     --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
+    #   -r python/requirements/ml/py313/tune-test-requirements.txt
     #   aim
-botocore==1.32.7 ; python_full_version < '3.12' \
+botocore==1.32.7 \
     --hash=sha256:58b33d02cafa23461c8a9d211b30e8cded992380a84de409379fd02811fa3e11 \
     --hash=sha256:c6795c731b04c8e3635588c44cfd1a4462fc5987859195522c96812cf3eceff9
     # via
@@ -1896,7 +1898,7 @@ jinja2==3.1.6 \
     #   nbconvert
     #   torch
     #   torch-geometric
-jmespath==1.0.1 ; python_full_version < '3.12' \
+jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
     --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
     # via
@@ -5102,7 +5104,7 @@ s3torchconnectorclient==1.4.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   s3torchconnector
-s3transfer==0.8.0 ; python_full_version < '3.12' \
+s3transfer==0.8.0 \
     --hash=sha256:baa479dc2e63e5c2ed51611b4d46cdf0295e2070d8d0b86b22f335ee5b954986 \
     --hash=sha256:e8d6bd52ffd99841e3a57b34370a54841f12d3aab072af862cdcc50955288002
     # via

--- a/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
@@ -376,6 +376,20 @@ bleach==6.1.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   nbconvert
+boto3==1.29.7 \
+    --hash=sha256:1eb4c548118b5fc5e018dee956fd33e6fb249cd1f2def85f1bba816aef4d9f3e \
+    --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
+    #   -r python/requirements/ml/py313/tune-test-requirements.txt
+botocore==1.32.7 \
+    --hash=sha256:58b33d02cafa23461c8a9d211b30e8cded992380a84de409379fd02811fa3e11 \
+    --hash=sha256:c6795c731b04c8e3635588c44cfd1a4462fc5987859195522c96812cf3eceff9
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   boto3
+    #   s3transfer
 botorch==0.16.1 \
     --hash=sha256:1c06d4af942120be6cbface266e01422c33f27e8d44b565d0c7e308589a1937b \
     --hash=sha256:2a9ec7e43f1acddcf0c170ba084443e128696bc02f0ef9a48cc720f13f71713b
@@ -1675,6 +1689,13 @@ jinja2==3.1.6 \
     #   nbconvert
     #   torch
     #   torch-geometric
+jmespath==1.0.1 \
+    --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
+    --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   boto3
+    #   botocore
 joblib==1.2.0 \
     --hash=sha256:091138ed78f800342968c523bdde947e7a305b8594b910a0fea2ab83c3c6d385 \
     --hash=sha256:e1cee4a79e4af22881164f218d4311f60074197fb707e082e803b61f6d137018
@@ -4184,6 +4205,7 @@ python-dateutil==2.8.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   arrow
+    #   botocore
     #   celery
     #   freezegun
     #   holidays
@@ -4683,6 +4705,12 @@ s3torchconnectorclient==1.4.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   s3torchconnector
+s3transfer==0.8.0 \
+    --hash=sha256:baa479dc2e63e5c2ed51611b4d46cdf0295e2070d8d0b86b22f335ee5b954986 \
+    --hash=sha256:e8d6bd52ffd99841e3a57b34370a54841f12d3aab072af862cdcc50955288002
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   boto3
 safetensors==0.4.3 \
     --hash=sha256:018b691383026a2436a22b648873ed11444a364324e7088b99cd2503dd828400 \
     --hash=sha256:01e4b22e3284cd866edeabe4f4d896229495da457229408d2e1e4810c5187121 \
@@ -5610,6 +5638,7 @@ urllib3==1.26.19 \
     --hash=sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   botocore
     #   requests
 utilsforecast==0.2.0 \
     --hash=sha256:3db4245da4e361f26c8eaeef216c2d1206b20defbb033bf11d3e66ce2b1d6ef8 \

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
@@ -505,13 +505,15 @@ bleach==6.1.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   nbconvert
-boto3==1.29.7 ; python_full_version < '3.12' \
+boto3==1.29.7 \
     --hash=sha256:1eb4c548118b5fc5e018dee956fd33e6fb249cd1f2def85f1bba816aef4d9f3e \
     --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
+    #   -r python/requirements/ml/py313/tune-test-requirements.txt
     #   aim
-botocore==1.32.7 ; python_full_version < '3.12' \
+botocore==1.32.7 \
     --hash=sha256:58b33d02cafa23461c8a9d211b30e8cded992380a84de409379fd02811fa3e11 \
     --hash=sha256:c6795c731b04c8e3635588c44cfd1a4462fc5987859195522c96812cf3eceff9
     # via
@@ -1878,7 +1880,7 @@ jinja2==3.1.6 \
     #   nbconvert
     #   torch
     #   torch-geometric
-jmespath==1.0.1 ; python_full_version < '3.12' \
+jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
     --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
     # via
@@ -5159,7 +5161,7 @@ s3torchconnectorclient==1.4.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   s3torchconnector
-s3transfer==0.8.0 ; python_full_version < '3.12' \
+s3transfer==0.8.0 \
     --hash=sha256:baa479dc2e63e5c2ed51611b4d46cdf0295e2070d8d0b86b22f335ee5b954986 \
     --hash=sha256:e8d6bd52ffd99841e3a57b34370a54841f12d3aab072af862cdcc50955288002
     # via

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
@@ -376,6 +376,20 @@ bleach==6.1.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   nbconvert
+boto3==1.29.7 \
+    --hash=sha256:1eb4c548118b5fc5e018dee956fd33e6fb249cd1f2def85f1bba816aef4d9f3e \
+    --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
+    #   -r python/requirements/ml/py313/tune-test-requirements.txt
+botocore==1.32.7 \
+    --hash=sha256:58b33d02cafa23461c8a9d211b30e8cded992380a84de409379fd02811fa3e11 \
+    --hash=sha256:c6795c731b04c8e3635588c44cfd1a4462fc5987859195522c96812cf3eceff9
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   boto3
+    #   s3transfer
 botorch==0.16.1 \
     --hash=sha256:1c06d4af942120be6cbface266e01422c33f27e8d44b565d0c7e308589a1937b \
     --hash=sha256:2a9ec7e43f1acddcf0c170ba084443e128696bc02f0ef9a48cc720f13f71713b
@@ -1756,6 +1770,13 @@ jinja2==3.1.6 \
     #   nbconvert
     #   torch
     #   torch-geometric
+jmespath==1.0.1 \
+    --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
+    --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   boto3
+    #   botocore
 joblib==1.2.0 \
     --hash=sha256:091138ed78f800342968c523bdde947e7a305b8594b910a0fea2ab83c3c6d385 \
     --hash=sha256:e1cee4a79e4af22881164f218d4311f60074197fb707e082e803b61f6d137018
@@ -4444,6 +4465,7 @@ python-dateutil==2.8.2 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   arrow
+    #   botocore
     #   celery
     #   freezegun
     #   holidays
@@ -4955,6 +4977,12 @@ s3torchconnectorclient==1.4.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   s3torchconnector
+s3transfer==0.8.0 \
+    --hash=sha256:baa479dc2e63e5c2ed51611b4d46cdf0295e2070d8d0b86b22f335ee5b954986 \
+    --hash=sha256:e8d6bd52ffd99841e3a57b34370a54841f12d3aab072af862cdcc50955288002
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   boto3
 safetensors==0.4.3 \
     --hash=sha256:018b691383026a2436a22b648873ed11444a364324e7088b99cd2503dd828400 \
     --hash=sha256:01e4b22e3284cd866edeabe4f4d896229495da457229408d2e1e4810c5187121 \
@@ -5879,6 +5907,7 @@ urllib3==1.26.19 \
     --hash=sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   botocore
     #   requests
 utilsforecast==0.2.0 \
     --hash=sha256:3db4245da4e361f26c8eaeef216c2d1206b20defbb033bf11d3e66ce2b1d6ef8 \

--- a/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
@@ -505,13 +505,15 @@ bleach==6.1.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
     #   nbconvert
-boto3==1.29.7 ; python_full_version < '3.12' \
+boto3==1.29.7 \
     --hash=sha256:1eb4c548118b5fc5e018dee956fd33e6fb249cd1f2def85f1bba816aef4d9f3e \
     --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
+    #   -r /tmp/ray-deps/tune-test-requirements-no-lightning.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
     #   aim
-botocore==1.32.7 ; python_full_version < '3.12' \
+botocore==1.32.7 \
     --hash=sha256:58b33d02cafa23461c8a9d211b30e8cded992380a84de409379fd02811fa3e11 \
     --hash=sha256:c6795c731b04c8e3635588c44cfd1a4462fc5987859195522c96812cf3eceff9
     # via
@@ -1877,7 +1879,7 @@ jinja2==3.1.6 \
     #   nbconvert
     #   torch
     #   torch-geometric
-jmespath==1.0.1 ; python_full_version < '3.12' \
+jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \
     --hash=sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe
     # via
@@ -5131,7 +5133,7 @@ s3torchconnectorclient==1.4.3 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
     #   s3torchconnector
-s3transfer==0.8.0 ; python_full_version < '3.12' \
+s3transfer==0.8.0 \
     --hash=sha256:baa479dc2e63e5c2ed51611b4d46cdf0295e2070d8d0b86b22f335ee5b954986 \
     --hash=sha256:e8d6bd52ffd99841e3a57b34370a54841f12d3aab072af862cdcc50955288002
     # via

--- a/python/ray/train/torch/torch_detection_predictor.py
+++ b/python/ray/train/torch/torch_detection_predictor.py
@@ -29,6 +29,10 @@ class TorchDetectionPredictor(TorchPredictor):
 
             from ray.train.torch import TorchDetectionPredictor
 
+            # In real use, load pretrained COCO weights for meaningful predictions:
+            #   from torchvision.models.detection import FasterRCNN_ResNet50_FPN_V2_Weights
+            #   weights = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT
+            #   model = models.detection.fasterrcnn_resnet50_fpn_v2(weights=weights)
             model = models.detection.fasterrcnn_resnet50_fpn_v2(weights=None)
 
             predictor = TorchDetectionPredictor(model=model)

--- a/python/ray/train/torch/torch_detection_predictor.py
+++ b/python/ray/train/torch/torch_detection_predictor.py
@@ -29,7 +29,7 @@ class TorchDetectionPredictor(TorchPredictor):
 
             from ray.train.torch import TorchDetectionPredictor
 
-            # In real use, load pretrained COCO weights for meaningful predictions:
+            # In real use case, load pretrained weights for meaningful predictions:
             #   from torchvision.models.detection import FasterRCNN_ResNet50_FPN_V2_Weights
             #   weights = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT
             #   model = models.detection.fasterrcnn_resnet50_fpn_v2(weights=weights)

--- a/python/ray/train/torch/torch_detection_predictor.py
+++ b/python/ray/train/torch/torch_detection_predictor.py
@@ -29,7 +29,7 @@ class TorchDetectionPredictor(TorchPredictor):
 
             from ray.train.torch import TorchDetectionPredictor
 
-            model = models.detection.fasterrcnn_resnet50_fpn_v2(pretrained=True)
+            model = models.detection.fasterrcnn_resnet50_fpn_v2(weights=None)
 
             predictor = TorchDetectionPredictor(model=model)
             predictions = predictor.predict(np.zeros((4, 3, 32, 32), dtype=np.float32))

--- a/python/requirements/ml/py313/train-test-requirements.txt
+++ b/python/requirements/ml/py313/train-test-requirements.txt
@@ -1,3 +1,4 @@
+boto3==1.29.7
 evaluate==0.4.3
 freezegun==1.1.0
 mosaicml; python_version < "3.12"

--- a/python/requirements/ml/py313/tune-test-requirements.txt
+++ b/python/requirements/ml/py313/tune-test-requirements.txt
@@ -1,4 +1,5 @@
 aim==3.23.0; python_version < "3.12"
+boto3==1.29.7
 
 jupyterlab
 matplotlib!=3.4.3


### PR DESCRIPTION
## Description
1. fix one doc flaky test, if the weights is not there, if will first download, which prints additional log in the test output. 
```
[2026-04-21T00:39:11Z] Expected:
[2026-04-21T00:39:11Z]     dict_keys(['pred_boxes', 'pred_labels', 'pred_scores'])
[2026-04-21T00:39:11Z] Got:
[2026-04-21T00:39:11Z]     Downloading: "https://download.pytorch.org/models/fasterrcnn_resnet50_fpn_v2_coco-dd69338a.pth" to /root/.cache/torch/hub/checkpoints/fasterrcnn_resnet50_fpn_v2_coco-dd69338a.pth
[2026-04-21T00:39:11Z]     dict_keys(['pred_boxes', 'pred_labels', 'pred_scores'])
```
2. add real use case comment
3. also the original pretrained arg is deprecated per: https://pytorch.org/blog/introducing-torchvision-new-multi-weight-support-api/
4. add missing boto3 requirement in depset, previously, it is installed with https://github.com/liulehui/ray/blob/master/python/requirements/test-requirements.txt#L13



