### PR TITLE
core(uv): Fix uv existence check in UVProcessor

### DIFF
--- a/python/ray/_private/runtime_env/uv.py
+++ b/python/ray/_private/runtime_env/uv.py
@@ -112,6 +112,7 @@ class UvProcessor:
             python,
             "-m",
             "uv",
+            "self",
             "version",
         ]
 

--- a/python/ray/_private/runtime_env/uv.py
+++ b/python/ray/_private/runtime_env/uv.py
@@ -1,5 +1,4 @@
-"""Util class to install packages via uv.
-"""
+"""Util class to install packages via uv."""
 
 import asyncio
 import hashlib
@@ -112,8 +111,7 @@ class UvProcessor:
             python,
             "-m",
             "uv",
-            "self",
-            "version",
+            "--version",
         ]
 
         try:


### PR DESCRIPTION

## Description
Recent versions of uv require a `pyproject.toml` to exist in the current directory for the command below to work:
```bash
python -m uv version
```

This command is currently used in the uv existence check performed by the UVProcessor. The uv existence check fails even if uv is installed, because the command returns with an exception due to the missing `pyproject.toml`.
When ray is installed in a python environment that contains pip this falls back to ray trying to "reinstall uv",  while it makes the creation of any environment fail completely in those cases where pip is not installed (i.e., uv native python environments).

To guarantee the uv existence check works in all cases and across all uv versions, regardless of the presence of a pyproject, one should use the command shown below:

```bash
python -m uv --version
```

This PR fixes the uv existence check in the UVProcessor, by updating the command used for performing the check according to the above description.

## Related issues
Fixes #60570 

## Additional information
