### PR TITLE
[autoscaler] fix ReadOnlyProviderConfigReader max_workers counting bug

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/config.py
+++ b/python/ray/autoscaler/v2/instance_manager/config.py
@@ -542,9 +542,7 @@ class ReadOnlyProviderConfigReader(IConfigReader):
         if available_node_types:
             self._configs["available_node_types"].update(available_node_types)
             self._configs["max_workers"] = sum(
-                v["max_workers"]
-                for k, v in available_node_types.items()
-                if k != head_node_type
+                v["max_workers"] for v in available_node_types.values()
             )
             assert head_node_type, "Head node type should be found."
             self._configs["head_node_type"] = head_node_type

--- a/python/ray/autoscaler/v2/instance_manager/config.py
+++ b/python/ray/autoscaler/v2/instance_manager/config.py
@@ -541,7 +541,11 @@ class ReadOnlyProviderConfigReader(IConfigReader):
 
         if available_node_types:
             self._configs["available_node_types"].update(available_node_types)
-            self._configs["max_workers"] = len(available_node_types)
+            self._configs["max_workers"] = sum(
+                v["max_workers"]
+                for k, v in available_node_types.items()
+                if k != head_node_type
+            )
             assert head_node_type, "Head node type should be found."
             self._configs["head_node_type"] = head_node_type
 

--- a/python/ray/autoscaler/v2/tests/test_config.py
+++ b/python/ray/autoscaler/v2/tests/test_config.py
@@ -211,6 +211,7 @@ def test_readonly_node_type_name_and_fallback(monkeypatch):
         ),
         _DummyNodeState("worker.custom", b"\x02", {"CPU": 2}),
         _DummyNodeState("worker.custom", b"\x03", {"CPU": 2}),
+        _DummyNodeState("worker.custom", b"\x04", {"CPU": 2}),
         _DummyNodeState("", unnamed_worker_id, {"CPU": 3}),
     ]
     monkeypatch.setattr(
@@ -230,16 +231,17 @@ def test_readonly_node_type_name_and_fallback(monkeypatch):
     assert cfg.get_head_node_type() == "ray.head.default"
     # Preferred name aggregation
     assert "worker.custom" in node_types
-    assert node_types["worker.custom"]["max_workers"] == 2
+    assert node_types["worker.custom"]["max_workers"] == 3
     # Fallback for unnamed worker
     assert fallback_name in node_types
     assert node_types[fallback_name]["max_workers"] == 1
 
     # Global max_workers should be the sum of all worker-type max_workers,
     # NOT the count of node type names.
-    # Previously this was `len(available_node_types)` which returned 3
-    # (number of distinct type names) instead of the actual worker count.
-    assert cfg.get_config("max_workers") == 3
+    # Here: 3 distinct types (head, worker.custom, fallback), but
+    # 4 actual workers (3 x worker.custom + 1 x fallback).
+    # The old buggy `len(available_node_types)` returned 3 instead of 4.
+    assert cfg.get_config("max_workers") == 4
 
 
 if __name__ == "__main__":

--- a/python/ray/autoscaler/v2/tests/test_config.py
+++ b/python/ray/autoscaler/v2/tests/test_config.py
@@ -235,6 +235,12 @@ def test_readonly_node_type_name_and_fallback(monkeypatch):
     assert fallback_name in node_types
     assert node_types[fallback_name]["max_workers"] == 1
 
+    # Global max_workers should be the sum of all worker-type max_workers,
+    # NOT the count of node type names.
+    # Previously this was `len(available_node_types)` which returned 3
+    # (number of distinct type names) instead of the actual worker count.
+    assert cfg.get_config("max_workers") == 3
+
 
 if __name__ == "__main__":
     if os.environ.get("PARALLEL_CI"):


### PR DESCRIPTION
## Why are these changes needed?

The `ReadOnlyProviderConfigReader` in the autoscaler v2 incorrectly sets `max_workers` to the count of distinct node type names instead of the actual total number of worker nodes.

**Bug location:** `python/ray/autoscaler/v2/instance_manager/config.py` line 544

```python
# Before (bug):
self._configs["max_workers"] = len(available_node_types)
# e.g., available_node_types = {"ray.head.default": {...}, "worker": {...}}
# len() = 2 (type names), but actual worker count could be 9

# After (fix):
self._configs["max_workers"] = sum(
    v["max_workers"]
    for k, v in available_node_types.items()
    if k != head_node_type
)
# Correctly sums per-type max_workers, excluding head type
```

**Impact:** The v2 scheduler's `_enforce_max_workers_global` uses this `max_workers` value to decide how many nodes to keep. With the bug, a cluster with 9 worker pods (all of type "worker") gets `max_workers = 2` (2 distinct type names: head + worker), causing the scheduler to issue `TerminationRequest.Cause.MAX_NUM_NODES` for 7 of 9 workers. `RayStopper` then drains these raylets via GCS `DrainNode` RPC.

**Observed symptom:** K8s shows all 9 pods Running (KubeRay reports `readyWorkerReplicas: 9`), but Ray scheduler only uses 2 workers. In our case, 99 CPUs configured but only 22 utilized, causing ~4x slowdown.

**Scope:** Affects any KubeRay-managed Ray cluster where autoscaler v2 is active in readonly mode (i.e., `enableInTreeAutoscaling: false`). Related to #47578 and kuberay#2759.

## Tests added

Added assertion in `test_readonly_node_type_name_and_fallback` to verify that global `max_workers` equals the sum of all worker-type `max_workers` (3 = 2 named + 1 fallback), not the count of type names.

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the following tests are passing by adding the specified label:
  - Add `test-autoscaler` for autoscaler-related changes.