### PR TITLE
[ci] Remove duplicate extract_wanda_artifact BUILD rules

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -378,34 +378,6 @@ py_test(
 )
 
 py_binary(
-    name = "extract_wanda_artifact",
-    srcs = ["extract_wanda_artifact.py"],
-    exec_compatible_with = ["//bazel:py3"],
-    deps = [
-        ":crane_lib",
-        "//ci/ray_ci:ray_ci_lib",
-        ci_require("click"),
-    ],
-)
-
-py_test(
-    name = "test_extract_wanda_artifact",
-    size = "small",
-    srcs = ["test_extract_wanda_artifact.py"],
-    exec_compatible_with = ["//bazel:py3"],
-    tags = [
-        "ci_unit",
-        "team:ci",
-    ],
-    deps = [
-        ":crane_lib",
-        ":extract_wanda_artifact",
-        ci_require("click"),
-        ci_require("pytest"),
-    ],
-)
-
-py_binary(
     name = "push_ray_image",
     srcs = ["push_ray_image.py"],
     exec_compatible_with = ["//bazel:py3"],


### PR DESCRIPTION
Commits 5de85a63f8 and e78dd3f5a5 both added `extract_wanda_artifact` py_binary and `test_extract_wanda_artifact` py_test rules to ci/ray_ci/automation/BUILD.bazel, resulting in duplicate definitions that cause Bazel to fail loading the package:

    Error in py_binary: py_binary rule 'extract_wanda_artifact' in package 'ci/ray_ci/automation' conflicts with existing py_binary rule

Remove the duplicate block so the package loads.

Topic: fix-extract-wanda-artifact-duplicate
Signed-off-by: andrew <andrew@anyscale.com>