### PR TITLE
[deps] installing nightly pyarrow on top of nightly image

### DIFF
--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -19,6 +19,15 @@ set -ex
 
 uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
 
+if [[ "$IMAGE_TYPE" == "pyarrow-nightly" ]]; then
+  uv pip install \
+    --system \
+    --pre \
+    --prefer-binary \
+    --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
+    pyarrow
+fi
+
 curl -fsSL https://pgp.mongodb.com/server-8.0.asc | \
   sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
 echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] \

--- a/ci/docker/data.build.Dockerfile
+++ b/ci/docker/data.build.Dockerfile
@@ -25,6 +25,7 @@ if [[ "$IMAGE_TYPE" == "pyarrow-nightly" ]]; then
     --pre \
     --prefer-binary \
     --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
+    --upgrade-package pyarrow
     pyarrow
 fi
 

--- a/ci/raydepsets/configs/ci_data.depsets.yaml
+++ b/ci/raydepsets/configs/ci_data.depsets.yaml
@@ -106,11 +106,9 @@ depsets:
       - python/requirements/data/pyarrow-nightly.txt
     output: python/deplocks/ci/data-pyarrow-nightly-ci_depset_py${PYTHON_VERSION}.lock
     append_flags:
-      - --extra-index-url https://pypi.fury.io/arrow-nightlies/
       - --python-version=${PYTHON_VERSION}
       - --python-platform=linux
       - --unsafe-package ray
-      - --upgrade-package pyarrow
     build_arg_sets:
       - py310
 

--- a/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
@@ -1,5 +1,4 @@
 --index-url https://pypi.org/simple
---extra-index-url https://pypi.fury.io/arrow-nightlies/
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.7.0+cpu.html
@@ -3402,7 +3401,6 @@ pyarrow==23.0.1 \
     --hash=sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1 \
     --hash=sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd
     # via
-    #   -r python/requirements/data/pyarrow-nightly.txt
     #   delta-sharing
     #   getdaft
     #   hudi

--- a/python/requirements/data/pyarrow-nightly.txt
+++ b/python/requirements/data/pyarrow-nightly.txt
@@ -1,4 +1,4 @@
-pyarrow
+# not including pyarrow as nightly versions will break depset compilation too frequently
 hudi
 pylance
 modin


### PR DESCRIPTION
## Summary

- Removed `pyarrow` from `python/requirements/data/pyarrow-nightly.txt` so the compiled lockfile no longer pins a specific pyarrow version.
- Added a conditional branch to `ci/docker/data.build.Dockerfile` that, when `IMAGE_TYPE=pyarrow-nightly`, runs `uv pip install --pre --prefer-binary --extra-index-url https://pypi.fury.io/arrow-nightlies/ pyarrow` after the lockfile install, pulling the freshest nightly wheel at image build time instead of whatever was resolved when the lock was generated.

## Motivation

The pinned pyarrow entry in the nightly depset defeats the purpose of a nightly image — it baked in a stale version whenever the lock was regenerated. Installing pyarrow directly from the arrow-nightlies index at docker build time ensures `datanbuild-py$PYTHON` actually tests against current pyarrow nightlies.

## Testing

postmerge run: https://buildkite.com/ray-project/postmerge/builds/17158