### PR TITLE
[Data] Move `requester_id` in `DefaultAutoscalingCoordinator` from Method Signatures into the Constructor

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
@@ -17,7 +17,6 @@ class AutoscalingCoordinator(abc.ABC):
     @abc.abstractmethod
     def request_resources(
         self,
-        requester_id: str,
         resources: List[ResourceDict],
         expire_after_s: float,
         request_remaining: bool = False,
@@ -28,10 +27,7 @@ class AutoscalingCoordinator(abc.ABC):
         The requested resources should represent the full set of resources needed,
         not just the incremental amount.
 
-        A request with the same `requester_id` overwrites the previous one.
-
         Args:
-            requester_id: A unique identifier for the component making the request.
             resources: The requested resources. This should match the format accepted
                 by `ray.autoscaler.sdk.request_resources`.
             expire_after_s: Time in seconds after which this request will expire.
@@ -44,20 +40,13 @@ class AutoscalingCoordinator(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def cancel_request(self, requester_id: str):
-        """Cancel the resource request from the given requester.
-
-        Args:
-            requester_id: The unique identifier of the requester.
-        """
+    def cancel_request(self) -> None:
+        """Cancel the resource request from the requester."""
         ...
 
     @abc.abstractmethod
-    def get_allocated_resources(self, requester_id: str) -> List[ResourceDict]:
-        """Get the allocated resources for the given requester.
-
-        Args:
-            requester_id: The unique identifier of the requester.
+    def get_allocated_resources(self) -> List[ResourceDict]:
+        """Get the allocated resources for the requester.
 
         Returns:
             A list of dictionaries representing the allocated resources bundles.

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -58,7 +58,6 @@ class OngoingRequest:
 def handle_timeout_errors(
     failure_counter_attr: str,
     operation_name: str,
-    requester_id_param: str = "requester_id",
     error_msg_suffix: Optional[str] = None,
     on_error_return: Optional[Callable] = None,
 ):
@@ -69,13 +68,10 @@ def handle_timeout_errors(
             consecutive failures.
         operation_name: Name of the operation for error messages (e.g.,
             "send resource request", "cancel resource request").
-        requester_id_param: Name of the parameter that contains the
-            requester_id.
         error_msg_suffix: Optional suffix to append to the error message.
             If None, uses a default message.
-        on_error_return: Optional callable that takes (self, requester_id)
-            and returns a value to return on error. If None, no value is
-            returned (method should return None).
+        on_error_return: Optional callable that takes ``self`` and returns a
+            value to return on error. If None, no value is returned.
 
     Returns:
         A decorator that wraps methods to handle timeout errors.
@@ -84,19 +80,7 @@ def handle_timeout_errors(
     def decorator(func):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
-            # Extract requester_id from args or kwargs
-            requester_id = kwargs.get(requester_id_param)
-            if requester_id is None:
-                # Try to get from args by checking function signature
-                import inspect
-
-                sig = inspect.signature(func)
-                param_names = list(sig.parameters.keys())
-                if requester_id_param in param_names:
-                    param_index = param_names.index(requester_id_param) - 1
-                    if param_index < len(args):
-                        requester_id = args[param_index]
-
+            requester_id = self._requester_id
             failure_counter = getattr(self, failure_counter_attr)
 
             try:
@@ -145,7 +129,7 @@ def handle_timeout_errors(
 
                 # Return value on error if callback provided
                 if on_error_return is not None:
-                    return on_error_return(self, requester_id)
+                    return on_error_return(self)
 
         return wrapper
 
@@ -160,7 +144,8 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
         "RAY_DATA_AUTOSCALING_COORDINATOR_MAX_CONSECUTIVE_FAILURES", 10
     )
 
-    def __init__(self):
+    def __init__(self, requester_id: str):
+        self._requester_id = requester_id
         self._cached_allocated_resources: Dict[str, List[ResourceDict]] = {}
         self._consecutive_failures_request_resources: int = 0
         self._consecutive_failures_cancel_request: int = 0
@@ -182,7 +167,6 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
     )
     def request_resources(
         self,
-        requester_id: str,
         resources: List[ResourceDict],
         expire_after_s: float,
         request_remaining: bool = False,
@@ -190,7 +174,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
     ) -> None:
         ray.get(
             self._autoscaling_coordinator.request_resources.remote(
-                requester_id=requester_id,
+                requester_id=self._requester_id,
                 resources=resources,
                 expire_after_s=expire_after_s,
                 request_remaining=request_remaining,
@@ -208,10 +192,10 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
             " If this error persists, file a GitHub issue."
         ),
     )
-    def cancel_request(self, requester_id: str):
+    def cancel_request(self) -> None:
         ray.get(
             self._autoscaling_coordinator.cancel_request.remote(
-                requester_id,
+                self._requester_id,
             ),
             timeout=self.AUTOSCALING_REQUEST_GET_TIMEOUT_S,
         )
@@ -225,18 +209,18 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
             " or CPU being overloaded, it's safe to ignore this error."
             " If this error persists, file a GitHub issue."
         ),
-        on_error_return=lambda self, requester_id: self._cached_allocated_resources.get(
-            requester_id, []
+        on_error_return=lambda self: self._cached_allocated_resources.get(
+            self._requester_id, []
         ),
     )
-    def get_allocated_resources(self, requester_id: str) -> List[ResourceDict]:
+    def get_allocated_resources(self) -> List[ResourceDict]:
         result = ray.get(
             self._autoscaling_coordinator.get_allocated_resources.remote(
-                requester_id,
+                self._requester_id,
             ),
             timeout=self.AUTOSCALING_REQUEST_GET_TIMEOUT_S,
         )
-        self._cached_allocated_resources[requester_id] = result
+        self._cached_allocated_resources[self._requester_id] = result
         return result
 
 

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -146,7 +146,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
 
     def __init__(self, requester_id: str):
         self._requester_id = requester_id
-        self._cached_allocated_resources: Dict[str, List[ResourceDict]] = {}
+        self._cached_allocated_resources: List[ResourceDict] = []
         self._consecutive_failures_request_resources: int = 0
         self._consecutive_failures_cancel_request: int = 0
         self._consecutive_failures_get_allocated_resources: int = 0
@@ -209,9 +209,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
             " or CPU being overloaded, it's safe to ignore this error."
             " If this error persists, file a GitHub issue."
         ),
-        on_error_return=lambda self: self._cached_allocated_resources.get(
-            self._requester_id, []
-        ),
+        on_error_return=lambda self: self._cached_allocated_resources,
     )
     def get_allocated_resources(self) -> List[ResourceDict]:
         result = ray.get(
@@ -220,7 +218,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
             ),
             timeout=self.AUTOSCALING_REQUEST_GET_TIMEOUT_S,
         )
-        self._cached_allocated_resources[self._requester_id] = result
+        self._cached_allocated_resources = result
         return result
 
 

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -179,9 +179,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
                 execution_id=execution_id,
             )
 
-        if autoscaling_coordinator is None:
-            autoscaling_coordinator = DefaultAutoscalingCoordinator()
-
         self._resource_limits = resource_limits
         self._resource_utilization_calculator = resource_utilization_calculator
         # Threshold of cluster utilization to trigger scaling up.
@@ -198,7 +195,13 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         # resources into explicit autoscaler demand.
         self._last_non_empty_resource_request: List[ResourceDict] = []
         self._last_non_empty_request_time: Optional[float] = None
+        # Unique identifier for the cluster autoscaler as a requester for
+        # the autoscaling coordinator.
         self._requester_id = f"data-{execution_id}"
+        if autoscaling_coordinator is None:
+            autoscaling_coordinator = DefaultAutoscalingCoordinator(
+                requester_id=self._requester_id
+            )
         self._autoscaling_coordinator = autoscaling_coordinator
         self._get_node_counts = get_node_counts
         self._get_time = get_time
@@ -316,7 +319,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
 
         # Make autoscaler resource request.
         self._autoscaling_coordinator.request_resources(
-            requester_id=self._requester_id,
             resources=resource_request,
             expire_after_s=self.AUTOSCALING_REQUEST_EXPIRE_TIME_S,
             request_remaining=True,
@@ -334,7 +336,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
     def on_executor_shutdown(self):
         # Cancel the resource request when the executor is shutting down.
         try:
-            self._autoscaling_coordinator.cancel_request(self._requester_id)
+            self._autoscaling_coordinator.cancel_request()
         except Exception:
             msg = (
                 f"Failed to cancel resource request for {self._requester_id}."
@@ -345,9 +347,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
 
     def get_total_resources(self) -> ExecutionResources:
         """Get total resources available from the autoscaling coordinator."""
-        resources = self._autoscaling_coordinator.get_allocated_resources(
-            requester_id=self._requester_id
-        )
+        resources = self._autoscaling_coordinator.get_allocated_resources()
         total = ExecutionResources.zero()
         for res in resources:
             total = total.add(ExecutionResources.from_resource_dict(res))

--- a/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
@@ -1,6 +1,6 @@
 import time
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 from .base_autoscaling_coordinator import (
     AutoscalingCoordinator,
@@ -26,6 +26,7 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
         self,
         get_time: Callable[[], float] = time.time,
         initial_cluster_resources: Optional[List[ResourceDict]] = None,
+        requester_id: str = "default",
     ):
         """Initialize the coordinator.
 
@@ -36,18 +37,19 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
                 ``request_remaining`` is True, the coordinator allocates these resources
                 to the requester. Otherwise, the coordinator allocates the requested
                 resources.
+            requester_id: Identifier for this single requester. Defaults to
+                "default" for convenience in tests.
         """
         if initial_cluster_resources is None:
             initial_cluster_resources = []
 
+        self._requester_id = requester_id
         self._get_time = get_time
         self._initial_cluster_resources = initial_cluster_resources
-
-        self._allocations: Dict[str, FakeAutoscalingCoordinator.Allocation] = {}
+        self._allocation: Optional[FakeAutoscalingCoordinator.Allocation] = None
 
     def request_resources(
         self,
-        requester_id: str,
         resources: List[ResourceDict],
         expire_after_s: float,
         request_remaining: bool = False,
@@ -62,27 +64,22 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
             resources = [r.copy() for r in self._initial_cluster_resources]
 
         # Always accept the request and record it.
-        self._allocations[requester_id] = self.Allocation(
+        self._allocation = self.Allocation(
             resources=resources,
             expiration_time_s=self._get_time() + expire_after_s,
             request_remaining=request_remaining,
         )
 
-    def cancel_request(self, requester_id: str):
-        if requester_id in self._allocations:
-            del self._allocations[requester_id]
+    def cancel_request(self) -> None:
+        self._allocation = None
 
-    def get_allocated_resources(self, requester_id: str) -> List[ResourceDict]:
+    def get_allocated_resources(self) -> List[ResourceDict]:
         """Return the allocated resources if they haven't expired."""
-        allocation = self._allocations.get(requester_id)
-
-        # Case 1: no allocation.
-        if allocation is None:
+        if self._allocation is None:
             return []
 
-        # Case 2: request expired.
-        if allocation.expiration_time_s < self._get_time():
-            del self._allocations[requester_id]
+        if self._allocation.expiration_time_s < self._get_time():
+            self._allocation = None
             return []
 
-        return [r.copy() for r in allocation.resources]
+        return [r.copy() for r in self._allocation.resources]

--- a/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
@@ -26,7 +26,6 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
         self,
         get_time: Callable[[], float] = time.time,
         initial_cluster_resources: Optional[List[ResourceDict]] = None,
-        requester_id: str = "default",
     ):
         """Initialize the coordinator.
 
@@ -37,13 +36,10 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
                 ``request_remaining`` is True, the coordinator allocates these resources
                 to the requester. Otherwise, the coordinator allocates the requested
                 resources.
-            requester_id: Identifier for this single requester. Defaults to
-                "default" for convenience in tests.
         """
         if initial_cluster_resources is None:
             initial_cluster_resources = []
 
-        self._requester_id = requester_id
         self._get_time = get_time
         self._initial_cluster_resources = initial_cluster_resources
         self._allocation: Optional[FakeAutoscalingCoordinator.Allocation] = None

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -386,11 +386,11 @@ def test_get_allocated_resources_handles_timeout_error(
     teardown_autoscaling_coordinator,
 ):
     """Test get_allocated_resources handles timeout error."""
-    coordinator = DefaultAutoscalingCoordinator()
+    coordinator = DefaultAutoscalingCoordinator("test")
     coordinator._cached_allocated_resources["test"] = [{"CPU": 1}]
 
     def call_method():
-        return coordinator.get_allocated_resources("test")
+        return coordinator.get_allocated_resources()
 
     max_failures = coordinator.MAX_CONSECUTIVE_FAILURES
     timeout_error = ray.exceptions.GetTimeoutError("timeout")
@@ -422,11 +422,11 @@ def test_get_allocated_resources_handles_timeout_error(
 
 def test_cancel_request_handles_timeout_error(teardown_autoscaling_coordinator):
     """Test cancel_request handles timeout error."""
-    coordinator = DefaultAutoscalingCoordinator()
+    coordinator = DefaultAutoscalingCoordinator("test")
 
     _test_consecutive_failures(
         coordinator=coordinator,
-        call_method=lambda: coordinator.cancel_request("test"),
+        call_method=lambda: coordinator.cancel_request(),
         counter_attr="_consecutive_failures_cancel_request",
         error_msg_prefix="Failed to cancel resource request for test",
     )
@@ -434,12 +434,12 @@ def test_cancel_request_handles_timeout_error(teardown_autoscaling_coordinator):
 
 def test_request_resources_handles_timeout_error(teardown_autoscaling_coordinator):
     """Test request_resources handles timeout error."""
-    coordinator = DefaultAutoscalingCoordinator()
+    coordinator = DefaultAutoscalingCoordinator("test")
 
     _test_consecutive_failures(
         coordinator=coordinator,
         call_method=lambda: coordinator.request_resources(
-            "test", [{"CPU": 1}], expire_after_s=1
+            [{"CPU": 1}], expire_after_s=1
         ),
         counter_attr="_consecutive_failures_request_resources",
         error_msg_prefix="Failed to send resource request for test",
@@ -451,13 +451,11 @@ def test_coordinator_accepts_zero_resource_for_missing_resource_type(
 ):
     # This is a regression test for a bug where the coordinator crashes when you request
     # a resource type (e.g., GPU: 0) that doesn't exist on the cluster.
-    coordinator = DefaultAutoscalingCoordinator()
+    coordinator = DefaultAutoscalingCoordinator("spam")
 
-    coordinator.request_resources(
-        requester_id="spam", resources=[{"CPU": 1, "GPU": 0}], expire_after_s=1
-    )
+    coordinator.request_resources(resources=[{"CPU": 1, "GPU": 0}], expire_after_s=1)
 
-    assert coordinator.get_allocated_resources("spam") == [{"CPU": 1, "GPU": 0}]
+    assert coordinator.get_allocated_resources() == [{"CPU": 1, "GPU": 0}]
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -387,7 +387,7 @@ def test_get_allocated_resources_handles_timeout_error(
 ):
     """Test get_allocated_resources handles timeout error."""
     coordinator = DefaultAutoscalingCoordinator("test")
-    coordinator._cached_allocated_resources["test"] = [{"CPU": 1}]
+    coordinator._cached_allocated_resources = [{"CPU": 1}]
 
     def call_method():
         return coordinator.get_allocated_resources()


### PR DESCRIPTION
##  Description
The client wrapper `DefaultAutoscalingCoordinator` is always tied to a single requester for its entire lifetime—it is constructed once per execution with a fixed `requester_id` and never shared across multiple requesters. Despite this, `requester_id` was threaded through every method call (`request_resources`, `cancel_request`, `get_allocated_resources`), adding noise to both call sites and the abstract base class interface.

This PR moves `requester_id` from the method signatures into the constructor, making the single-requester ownership explicit in the type. The abstract base class (`AutoscalingCoordinator`) and testing implementation (`FakeAutoscalingCoordinator`) are updated to match. `FakeAutoscalingCoordinator` is also simplified from a Dict-keyed multi-tenant structure to a single `Optional[Allocation]`, reflecting its single-tenant usage.

## Additional information
API changes:
- `AutoscalingCoordinator` abstract methods no longer take `requester_id`:
```python
# Before
def request_resources(self, requester_id: str, resources, ...) -> None: ...
def cancel_request(self, requester_id: str) -> None: ...
def get_allocated_resources(self, requester_id: str) -> List[ResourceDict]: ...

# After
def request_resources(self, resources, ...) -> None: ...
def cancel_request(self) -> None: ...
def get_allocated_resources(self) -> List[ResourceDict]: ...
```
- `DefaultAutoscalingCoordinator.__init__` now requires `requester_id`:
```python
# Before
DefaultAutoscalingCoordinator()

# After
DefaultAutoscalingCoordinator(requester_id="data-<execution_id>")
```

The `_AutoscalingCoordinatorActor` (underlying Ray actor that actually coordinates across multiple datasets) is unchanged. It still takes `requester_id` per call, as it genuinely serves multiple requesters.