### PR TITLE
[Data][DatasourceV2][5/n] Add LazyFileIndex for driver/worker split file listing

### DIFF
--- a/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
@@ -58,6 +58,26 @@ class FileManifest:
         """
         return self._block
 
+    @classmethod
+    def concat(cls, manifests: List["FileManifest"]) -> "FileManifest":
+        """Return a new `FileManifest` whose rows are the concatenation of
+        ``manifests`` in order.
+
+        Row alignment of ``paths``/``file_sizes`` is preserved because each
+        input already satisfies it.
+        """
+        assert len(manifests) > 0, "concat requires at least one manifest"
+        if len(manifests) == 1:
+            return manifests[0]
+
+        merged = pa.concat_tables(
+            [
+                BlockAccessor.for_block(manifest._block).to_arrow()
+                for manifest in manifests
+            ]
+        )
+        return cls(merged)
+
     def shuffle(self, seed: Optional[int]) -> "FileManifest":
         """Return a new `FileManifest` with rows permuted.
 
@@ -86,8 +106,8 @@ class FileManifest:
 
         block = pa.table(
             {
-                PATH_COLUMN_NAME: paths,
-                FILE_SIZE_COLUMN_NAME: sizes,
+                PATH_COLUMN_NAME: pa.array(paths, type=pa.string()),
+                FILE_SIZE_COLUMN_NAME: pa.array(sizes, type=pa.int64()),
             }
         )
         return cls(block)

--- a/python/ray/data/_internal/datasource_v2/listing/lazy_file_index.py
+++ b/python/ray/data/_internal/datasource_v2/listing/lazy_file_index.py
@@ -1,0 +1,191 @@
+from typing import Iterable, Iterator, List, Optional, Set, Union, overload
+
+import pyarrow as pa
+from pyarrow.fs import FileSystem
+
+from ray.data._internal.datasource_v2.listing.file_indexer import FileIndexer
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
+
+
+class LazyFileIndex:
+    """Lazy file index with caching and early-exit sampling.
+
+    Provides a caching wrapper around FileIndexer:
+    - list_files(): Streams all manifests, caching for subsequent calls
+    - list_files(sample=N): Returns merged manifest of up to N files (early exit)
+
+    Both modes share the same cache - sampling caches manifests as it iterates,
+    and subsequent list_files() calls continue from where sampling stopped.
+
+    Usage:
+        index = LazyFileIndex(indexer, paths, filesystem, pruners)
+
+        # Planning: sample for schema inference (early exit, caches as it goes)
+        sample = index.list_files(sample=10)
+        schema = infer_schema(sample)
+
+        # Execution: continues from cache, then lists remaining files
+        for manifest in index.list_files():
+            process(manifest)
+
+    Workers receive a pickled index; the in-flight iterator is not preserved
+    across pickle boundaries. Two-stage reads are expected to hand each worker
+    a fresh `LazyFileIndex` over its own disjoint path shard, so workers never
+    resume a partially-consumed iterator.
+    """
+
+    def __init__(
+        self,
+        indexer: FileIndexer,
+        paths: List[str],
+        filesystem: "FileSystem",
+        pruners: Optional[List[FilePruner]] = None,
+        preserve_order: bool = False,
+    ):
+        """Initialize the lazy file index.
+
+        Args:
+            indexer: The underlying FileIndexer to use.
+            paths: List of paths to index.
+            filesystem: PyArrow filesystem for file operations.
+            pruners: Optional file pruners applied during listing.
+            preserve_order: If True, preserve deterministic listing order.
+        """
+        self._indexer = indexer
+        self._paths = paths
+        self._filesystem = filesystem
+        self._pruners = pruners
+        self._cached_manifests: List[FileManifest] = []
+        self._cached_paths: Set[str] = set()
+        self._listing_iterator: Optional[Iterator[FileManifest]] = None
+        self._is_fully_cached: bool = False
+        self._preserve_order = preserve_order
+
+    @property
+    def is_fully_cached(self) -> bool:
+        return self._is_fully_cached
+
+    @overload
+    def list_files(self, *, sample: None = None) -> Iterable[FileManifest]:
+        ...
+
+    @overload
+    def list_files(self, *, sample: int) -> FileManifest:
+        ...
+
+    def list_files(
+        self, *, sample: Optional[int] = None
+    ) -> Union[Iterable[FileManifest], FileManifest]:
+        """List files, caching results for subsequent calls.
+
+        Args:
+            sample: If provided, return a merged FileManifest with up to this
+                many files (early exit). If None, return an iterable of all
+                manifests.
+
+        Returns:
+            If sample is None: Iterable[FileManifest] streaming all files.
+            If sample is int: Single FileManifest with up to ``sample`` files.
+
+        Raises:
+            ValueError: If sample is provided but no files are found.
+        """
+        if sample is not None:
+            return self._sample(sample)
+        return self._iter_manifests()
+
+    def _iter_manifests(self) -> Iterable[FileManifest]:
+        """Yield cached manifests, then stream remaining manifests, caching
+        each new manifest as it arrives.
+
+        When the indexer iterator is re-created (e.g. on a worker after
+        unpickling), paths already present in the cache are filtered out so
+        they are never re-listed.
+        """
+        yield from self._cached_manifests
+
+        if self._is_fully_cached:
+            return
+
+        if self._listing_iterator is None:
+            self._listing_iterator = self._indexer.list_files(
+                pa.array(self._paths),
+                filesystem=self._filesystem,
+                pruners=self._pruners,
+                preserve_order=self._preserve_order,
+            )
+
+        for manifest in self._listing_iterator:
+            filtered = self._dedup_and_cache(manifest)
+            if filtered is not None:
+                yield filtered
+
+        self._is_fully_cached = True
+        self._listing_iterator = None
+
+    def _dedup_and_cache(self, manifest: FileManifest) -> Optional[FileManifest]:
+        paths = manifest.paths.tolist()
+        sizes = manifest.file_sizes.tolist()
+
+        new_paths: List[str] = []
+        new_sizes: List[int] = []
+        for path, size in zip(paths, sizes):
+            if path in self._cached_paths:
+                continue
+            self._cached_paths.add(path)
+            new_paths.append(path)
+            new_sizes.append(size)
+
+        if not new_paths:
+            return None
+
+        if len(new_paths) == len(paths):
+            to_cache = manifest
+        else:
+            to_cache = FileManifest.construct_manifest(new_paths, new_sizes)
+
+        self._cached_manifests.append(to_cache)
+        return to_cache
+
+    def _sample(self, n: int) -> FileManifest:
+        collected: List[FileManifest] = []
+        total = 0
+
+        for manifest in self._iter_manifests():
+            remaining = n - total
+            if remaining <= 0:
+                break
+
+            if len(manifest) > remaining:
+                collected.append(FileManifest(manifest.as_block().slice(0, remaining)))
+                break
+
+            collected.append(manifest)
+            total += len(manifest)
+
+        if not collected:
+            raise ValueError(f"No files found in {self._paths}")
+
+        return FileManifest.concat(collected)
+
+    def __getstate__(self) -> dict:
+        return {
+            "_indexer": self._indexer,
+            "_paths": self._paths,
+            "_filesystem": self._filesystem,
+            "_pruners": self._pruners,
+            "_cached_manifests": self._cached_manifests,
+            "_cached_paths": self._cached_paths,
+            "_is_fully_cached": self._is_fully_cached,
+        }
+
+    def __setstate__(self, state: dict) -> None:
+        self._indexer = state["_indexer"]
+        self._paths = state["_paths"]
+        self._filesystem = state["_filesystem"]
+        self._pruners = state["_pruners"]
+        self._cached_manifests = state["_cached_manifests"]
+        self._cached_paths = state["_cached_paths"]
+        self._is_fully_cached = state["_is_fully_cached"]
+        self._listing_iterator = None

--- a/python/ray/data/_internal/datasource_v2/listing/lazy_file_index.py
+++ b/python/ray/data/_internal/datasource_v2/listing/lazy_file_index.py
@@ -49,10 +49,11 @@ class LazyFileIndex:
     Concurrency: only one active iteration per instance; a second
     ``list_files`` call while an iterator is live raises.
 
-    Pickle: the in-flight iterator is dropped; only the cache survives.
-    After unpickling, cached manifests replay first and the indexer is
-    re-invoked for the remainder, filtering paths already cached. Assumes
-    the filesystem listing is stable across pickle boundaries.
+    Pickle: the in-flight iterator is dropped; only cached manifests
+    survive. After unpickling, cached manifests replay first and the
+    indexer is re-invoked for the remainder; a dedup set built lazily
+    from the cached prefix filters paths already emitted by the driver.
+    Assumes the filesystem listing is stable across pickle boundaries.
     """
 
     def __init__(
@@ -138,27 +139,50 @@ class LazyFileIndex:
                 return
 
             if self._listing_iterator is None:
+                # On worker-side resumption after unpickle, build the dedup
+                # set once from the driver-listed prefix. The re-invoked
+                # indexer lists from scratch and would re-emit cached paths;
+                # we filter them out below. On the driver's initial listing
+                # the cache is empty and the set stays empty — the indexer
+                # yields each path at most once, so dedup is unnecessary.
+                # Cap memory at the driver prefix (bounded by
+                # ``planning_file_listing_budget``); worker-discovered paths
+                # are not added to the set.
+                if self._cached_manifests:
+                    self._cached_paths = set()
+                    for cached in self._cached_manifests:
+                        self._cached_paths.update(cached.paths.tolist())
                 self._listing_iterator = self._indexer.list_files(
-                    pa.array(self._paths),
+                    pa.array(self._paths, type=pa.string()),
                     filesystem=self._filesystem,
                     pruners=self._pruners,
                     preserve_order=self._preserve_order,
                 )
 
             for manifest in self._listing_iterator:
-                filtered = self._dedup_and_cache(manifest)
+                filtered = self._filter_and_cache(manifest)
                 if filtered is not None:
                     yield filtered
 
             self._fully_listed = True
             self._listing_iterator = None
-            # Dedup set is only consulted when re-listing; once fully cached
-            # it is no longer needed and can be large for big listings.
             self._cached_paths = set()
         finally:
             self._iterating = False
 
-    def _dedup_and_cache(self, manifest: FileManifest) -> Optional[FileManifest]:
+    def _filter_and_cache(self, manifest: FileManifest) -> Optional[FileManifest]:
+        """Filter a manifest against the dedup set and append to the cache.
+
+        The dedup set is populated only on worker-side resumption (see
+        ``_iter_manifests``); on the driver it stays empty and the manifest
+        passes through unchanged. Worker-discovered paths are not added to
+        the set — every path the indexer re-emits is compared against the
+        fixed driver-listed prefix, so the set never grows past that bound.
+        """
+        if not self._cached_paths:
+            self._cached_manifests.append(manifest)
+            return manifest
+
         paths = manifest.paths.tolist()
         sizes = manifest.file_sizes.tolist()
 
@@ -167,7 +191,6 @@ class LazyFileIndex:
         for path, size in zip(paths, sizes):
             if path in self._cached_paths:
                 continue
-            self._cached_paths.add(path)
             new_paths.append(path)
             new_sizes.append(size)
 
@@ -217,4 +240,7 @@ class LazyFileIndex:
         # runtime guard that doesn't carry meaning across processes.
         state["_listing_iterator"] = None
         state["_iterating"] = False
+        # Rebuilt lazily from ``_cached_manifests`` on worker resumption; no
+        # need to pay the pickle cost for a set we can reconstruct on demand.
+        state["_cached_paths"] = set()
         return state

--- a/python/ray/data/_internal/datasource_v2/listing/lazy_file_index.py
+++ b/python/ray/data/_internal/datasource_v2/listing/lazy_file_index.py
@@ -7,32 +7,52 @@ from ray.data._internal.datasource_v2.listing.file_indexer import FileIndexer
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
 
+DEFAULT_PLANNING_SAMPLE_SIZE = 10
+
 
 class LazyFileIndex:
-    """Lazy file index with caching and early-exit sampling.
+    """Lazy, caching view over a ``FileIndexer``.
 
-    Provides a caching wrapper around FileIndexer:
-    - list_files(): Streams all manifests, caching for subsequent calls
-    - list_files(sample=N): Returns merged manifest of up to N files (early exit)
+    ``list_files()`` streams every manifest; ``list_files(sample=N)`` returns
+    a merged manifest of up to ``N`` files and stops early. Both modes share
+    one cache: manifests yielded by either call are replayed on subsequent
+    calls without re-invoking the indexer, so a planning-time sample is
+    reused when execution later streams the full listing.
 
-    Both modes share the same cache - sampling caches manifests as it iterates,
-    and subsequent list_files() calls continue from where sampling stopped.
+    Driver-side listing yields balanced buckets but blocks planning;
+    worker-side listing hides cost behind read I/O but loses balance.
+    ``DataContext.planning_file_listing_budget`` caps driver-side work and
+    flips to worker-side for very large listings (e.g. millions of files).
 
-    Usage:
-        index = LazyFileIndex(indexer, paths, filesystem, pruners)
+    The planner samples on the driver for schema and size estimation, then
+    continues listing on the driver up to the budget. If ``fully_listed``,
+    the scanner produces balanced buckets; otherwise the planner splits
+    remaining paths into shards that workers list and read in a pipeline::
 
-        # Planning: sample for schema inference (early exit, caches as it goes)
-        sample = index.list_files(sample=10)
-        schema = infer_schema(sample)
+        Driver                                               Workers
+        ──────                                               ───────
+        sample = lfi.list_files(sample=N)   ──▶ schema + size estimate
+              │
+              ▼
+        for chunk in lfi.list_files():      # warm cache on driver
+            if total >= ctx.planning_file_listing_budget:
+                break
+              │
+              ▼
+        if lfi.fully_listed:                # single-stage
+            buckets = scanner.plan(         ─────────────▶  reader.read(bucket)
+                lfi.cached_manifest)
+        else:                               # two-stage
+            shards = split_paths(           ─────────────▶  shard.list_files()
+                lfi.remaining_paths)                        + reader.read(manifest)
 
-        # Execution: continues from cache, then lists remaining files
-        for manifest in index.list_files():
-            process(manifest)
+    Concurrency: only one active iteration per instance; a second
+    ``list_files`` call while an iterator is live raises.
 
-    Workers receive a pickled index; the in-flight iterator is not preserved
-    across pickle boundaries. Two-stage reads are expected to hand each worker
-    a fresh `LazyFileIndex` over its own disjoint path shard, so workers never
-    resume a partially-consumed iterator.
+    Pickle: the in-flight iterator is dropped; only the cache survives.
+    After unpickling, cached manifests replay first and the indexer is
+    re-invoked for the remainder, filtering paths already cached. Assumes
+    the filesystem listing is stable across pickle boundaries.
     """
 
     def __init__(
@@ -52,6 +72,8 @@ class LazyFileIndex:
             pruners: Optional file pruners applied during listing.
             preserve_order: If True, preserve deterministic listing order.
         """
+
+        # If some of these properties are not pickleable, we need to remove them from the __dict__ before pickling.
         self._indexer = indexer
         self._paths = paths
         self._filesystem = filesystem
@@ -59,12 +81,13 @@ class LazyFileIndex:
         self._cached_manifests: List[FileManifest] = []
         self._cached_paths: Set[str] = set()
         self._listing_iterator: Optional[Iterator[FileManifest]] = None
-        self._is_fully_cached: bool = False
+        self._fully_listed: bool = False
         self._preserve_order = preserve_order
+        self._iterating: bool = False
 
     @property
-    def is_fully_cached(self) -> bool:
-        return self._is_fully_cached
+    def fully_listed(self) -> bool:
+        return self._fully_listed
 
     @overload
     def list_files(self, *, sample: None = None) -> Iterable[FileManifest]:
@@ -82,7 +105,8 @@ class LazyFileIndex:
         Args:
             sample: If provided, return a merged FileManifest with up to this
                 many files (early exit). If None, return an iterable of all
-                manifests.
+                manifests. Must be positive if provided. Planning-time callers
+                should pass ``DEFAULT_PLANNING_SAMPLE_SIZE``.
 
         Returns:
             If sample is None: Iterable[FileManifest] streaming all files.
@@ -103,26 +127,36 @@ class LazyFileIndex:
         unpickling), paths already present in the cache are filtered out so
         they are never re-listed.
         """
-        yield from self._cached_manifests
+        assert (
+            not self._iterating
+        ), "LazyFileIndex does not support concurrent iteration"
+        self._iterating = True
+        try:
+            yield from self._cached_manifests
 
-        if self._is_fully_cached:
-            return
+            if self._fully_listed:
+                return
 
-        if self._listing_iterator is None:
-            self._listing_iterator = self._indexer.list_files(
-                pa.array(self._paths),
-                filesystem=self._filesystem,
-                pruners=self._pruners,
-                preserve_order=self._preserve_order,
-            )
+            if self._listing_iterator is None:
+                self._listing_iterator = self._indexer.list_files(
+                    pa.array(self._paths),
+                    filesystem=self._filesystem,
+                    pruners=self._pruners,
+                    preserve_order=self._preserve_order,
+                )
 
-        for manifest in self._listing_iterator:
-            filtered = self._dedup_and_cache(manifest)
-            if filtered is not None:
-                yield filtered
+            for manifest in self._listing_iterator:
+                filtered = self._dedup_and_cache(manifest)
+                if filtered is not None:
+                    yield filtered
 
-        self._is_fully_cached = True
-        self._listing_iterator = None
+            self._fully_listed = True
+            self._listing_iterator = None
+            # Dedup set is only consulted when re-listing; once fully cached
+            # it is no longer needed and can be large for big listings.
+            self._cached_paths = set()
+        finally:
+            self._iterating = False
 
     def _dedup_and_cache(self, manifest: FileManifest) -> Optional[FileManifest]:
         paths = manifest.paths.tolist()
@@ -149,20 +183,28 @@ class LazyFileIndex:
         return to_cache
 
     def _sample(self, n: int) -> FileManifest:
+        assert n > 0, f"sample must be positive, got {n}"
+
         collected: List[FileManifest] = []
         total = 0
 
-        for manifest in self._iter_manifests():
-            remaining = n - total
-            if remaining <= 0:
-                break
+        gen = self._iter_manifests()
+        try:
+            for manifest in gen:
+                remaining = n - total
+                if remaining <= 0:
+                    break
 
-            if len(manifest) > remaining:
-                collected.append(FileManifest(manifest.as_block().slice(0, remaining)))
-                break
+                if len(manifest) > remaining:
+                    collected.append(
+                        FileManifest(manifest.as_block().slice(0, remaining))
+                    )
+                    break
 
-            collected.append(manifest)
-            total += len(manifest)
+                collected.append(manifest)
+                total += len(manifest)
+        finally:
+            gen.close()
 
         if not collected:
             raise ValueError(f"No files found in {self._paths}")
@@ -170,22 +212,9 @@ class LazyFileIndex:
         return FileManifest.concat(collected)
 
     def __getstate__(self) -> dict:
-        return {
-            "_indexer": self._indexer,
-            "_paths": self._paths,
-            "_filesystem": self._filesystem,
-            "_pruners": self._pruners,
-            "_cached_manifests": self._cached_manifests,
-            "_cached_paths": self._cached_paths,
-            "_is_fully_cached": self._is_fully_cached,
-        }
-
-    def __setstate__(self, state: dict) -> None:
-        self._indexer = state["_indexer"]
-        self._paths = state["_paths"]
-        self._filesystem = state["_filesystem"]
-        self._pruners = state["_pruners"]
-        self._cached_manifests = state["_cached_manifests"]
-        self._cached_paths = state["_cached_paths"]
-        self._is_fully_cached = state["_is_fully_cached"]
-        self._listing_iterator = None
+        state = self.__dict__.copy()
+        # The in-flight iterator can't be pickled; ``_iterating`` is a
+        # runtime guard that doesn't carry meaning across processes.
+        state["_listing_iterator"] = None
+        state["_iterating"] = False
+        return state

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -506,10 +506,14 @@ class DataContext:
         min_parallelism: This setting is deprecated. Use ``read_op_min_num_blocks``
             instead.
         read_op_min_num_blocks: Minimum number of read output blocks for a dataset.
-        planning_file_listing_budget: Upper bound on how many files the DataSourceV2
-            ``LazyFileIndex`` will list on the driver during planning. Once this
-            count is reached, remaining files are listed on workers at execution
-            time. Defaults to 1000.
+        planning_file_listing_budget: Threshold above which DataSourceV2 switches
+            from driver-side full listing to runtime listing on workers. During
+            planning, a small sample is always listed on the driver for schema
+            inference and size estimation; if the extrapolated total file count
+            stays within this budget, the driver lists the rest and hands
+            workers balanced ``FileManifest`` buckets. Above the budget, the
+            driver hands workers unlisted path shards and listing happens at
+            execution time. Defaults to 1000.
         enable_tensor_extension_casting: Whether to automatically cast NumPy ndarray
             columns in Pandas DataFrames to tensor extension columns.
         arrow_fixed_shape_tensor_format: The tensor format to use for fixed-shape tensors.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -77,6 +77,8 @@ DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
 
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
+DEFAULT_PLANNING_FILE_LISTING_BUDGET = 1000
+
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
 
 DEFAULT_USE_PUSH_BASED_SHUFFLE = bool(
@@ -504,6 +506,10 @@ class DataContext:
         min_parallelism: This setting is deprecated. Use ``read_op_min_num_blocks``
             instead.
         read_op_min_num_blocks: Minimum number of read output blocks for a dataset.
+        planning_file_listing_budget: Upper bound on how many files the DataSourceV2
+            ``LazyFileIndex`` will list on the driver during planning. Once this
+            count is reached, remaining files are listed on workers at execution
+            time. Defaults to 1000.
         enable_tensor_extension_casting: Whether to automatically cast NumPy ndarray
             columns in Pandas DataFrames to tensor extension columns.
         arrow_fixed_shape_tensor_format: The tensor format to use for fixed-shape tensors.
@@ -726,6 +732,7 @@ class DataContext:
     decoding_size_estimation: bool = DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED
     min_parallelism: int = DEFAULT_MIN_PARALLELISM
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
+    planning_file_listing_budget: int = DEFAULT_PLANNING_FILE_LISTING_BUDGET
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
     arrow_fixed_shape_tensor_format: "FixedShapeTensorFormat" = field(
         default_factory=_default_fixed_shape_tensor_format

--- a/python/ray/data/tests/unit/datasource_v2/test_lazy_file_index.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_lazy_file_index.py
@@ -128,9 +128,19 @@ class TestLazyFileIndexStreaming:
         second = _collect_paths(idx.list_files())
         assert second == ["a", "b", "c"]
 
-    def test_dedup_set_freed_when_fully_listed(self):
+    def test_driver_listing_does_not_populate_dedup_set(self):
+        # On the driver's initial listing, the indexer yields each path at
+        # most once, so the dedup set is unnecessary and must stay empty.
+        # This bounds memory for very large listings (millions of files):
+        # ``_cached_paths`` only grows on worker-side resumption, capped by
+        # the driver-listed prefix.
         idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
-        _collect_paths(idx.list_files())
+        it = iter(idx.list_files())
+        next(it)
+        assert idx._cached_paths == set()
+        # Drain the rest — dedup set must still be empty mid-stream.
+        for _ in it:
+            assert idx._cached_paths == set()
         assert idx.fully_listed is True
         assert idx._cached_paths == set()
 
@@ -196,6 +206,17 @@ class TestLazyFileIndexPickle:
         assert restored.fully_listed is True
         assert _collect_paths(restored.list_files()) == ["a", "b", "c"]
 
+    def test_pickle_drops_dedup_set(self):
+        # The dedup set is rebuilt lazily from _cached_manifests on the
+        # worker; it should not be carried through pickle.
+        idx = _make_index(
+            [_manifest(["a", "b"]), _manifest(["c", "d"]), _manifest(["e"])]
+        )
+        _ = idx.list_files(sample=2)
+
+        restored = pickle.loads(pickle.dumps(idx))
+        assert restored._cached_paths == set()
+
     def test_worker_resume_does_not_relist_cached_paths(self):
         # Driver samples partially, pickles to worker. On the worker, the
         # indexer iterator is re-created from scratch and would yield paths
@@ -220,6 +241,36 @@ class TestLazyFileIndexPickle:
         cached_indices = [full.index(p) for p in cached_paths]
         new_indices = [full.index(p) for p in set(full) - cached_paths]
         assert max(cached_indices) < min(new_indices)
+
+    def test_worker_dedup_set_bounded_by_driver_prefix(self):
+        # The dedup set must only contain the driver-listed prefix — paths
+        # the worker newly discovers must not be added. This bounds memory
+        # to the driver prefix, which is capped by
+        # ``planning_file_listing_budget``, rather than growing with the
+        # full dataset size.
+        manifests = [_manifest(["a", "b"]), _manifest(["c", "d"]), _manifest(["e"])]
+        idx = LazyFileIndex(_FakeIndexer(manifests), paths=[], filesystem=None)
+        _ = idx.list_files(sample=2)
+        driver_prefix = {p for m in idx._cached_manifests for p in m.paths.tolist()}
+
+        restored = pickle.loads(pickle.dumps(idx))
+        restored._indexer = _FakeIndexer(manifests)
+
+        # Drive iteration to completion.
+        _collect_paths(restored.list_files())
+
+        # After full listing the set is released, so capture it mid-stream
+        # instead: re-prime and inspect before the final manifest.
+        idx2 = LazyFileIndex(_FakeIndexer(manifests), paths=[], filesystem=None)
+        _ = idx2.list_files(sample=2)
+        restored2 = pickle.loads(pickle.dumps(idx2))
+        restored2._indexer = _FakeIndexer(manifests)
+        it = iter(restored2.list_files())
+        # Advance past the cached prefix; the next pull triggers the indexer.
+        for _ in range(len(idx2._cached_manifests)):
+            next(it)
+        next(it)
+        assert restored2._cached_paths == driver_prefix
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/datasource_v2/test_lazy_file_index.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_lazy_file_index.py
@@ -1,0 +1,190 @@
+import pickle
+from typing import Iterable, List, Optional
+
+import pytest
+
+from ray.data._internal.datasource_v2.listing.file_indexer import FileIndexer
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
+from ray.data._internal.datasource_v2.listing.lazy_file_index import LazyFileIndex
+
+
+class _FakeIndexer(FileIndexer):
+    """Indexer that yields pre-canned manifests, one iterator per call."""
+
+    def __init__(self, manifests: List[FileManifest]):
+        self._manifests = manifests
+        self.call_count = 0
+        self.last_pruners: Optional[List[FilePruner]] = None
+
+    def list_files(
+        self,
+        paths,
+        *,
+        filesystem,
+        pruners: Optional[List[FilePruner]] = None,
+        preserve_order: bool = False,
+    ) -> Iterable[FileManifest]:
+        self.call_count += 1
+        self.last_pruners = pruners
+        return iter(self._manifests)
+
+
+class _AcceptAllPruner(FilePruner):
+    def should_include(self, path: str) -> bool:
+        return True
+
+
+def _manifest(paths: List[str], sizes: Optional[List[int]] = None) -> FileManifest:
+    if sizes is None:
+        sizes = [len(p) for p in paths]
+    return FileManifest.construct_manifest(paths, sizes)
+
+
+def _make_index(manifests: List[FileManifest]) -> LazyFileIndex:
+    return LazyFileIndex(_FakeIndexer(manifests), paths=[], filesystem=None)
+
+
+def _collect_paths(manifests_iter) -> List[str]:
+    out: List[str] = []
+    for m in manifests_iter:
+        out.extend(m.paths.tolist())
+    return out
+
+
+class TestFileManifestConcat:
+    def test_concat_preserves_order(self):
+        a = _manifest(["a", "b"], [1, 2])
+        b = _manifest(["c", "d"], [3, 4])
+        merged = FileManifest.concat([a, b])
+        assert merged.paths.tolist() == ["a", "b", "c", "d"]
+        assert merged.file_sizes.tolist() == [1, 2, 3, 4]
+        assert len(merged) == 4
+
+    def test_concat_single_returns_same_instance(self):
+        a = _manifest(["a"], [1])
+        assert FileManifest.concat([a]) is a
+
+
+class TestLazyFileIndexSampling:
+    def test_sample_less_than_first_manifest_truncates(self):
+        idx = _make_index([_manifest(["a", "b", "c", "d", "e"]), _manifest(["f", "g"])])
+        sampled = idx.list_files(sample=3)
+        assert sampled.paths.tolist() == ["a", "b", "c"]
+        assert len(sampled) == 3
+
+    def test_sample_crosses_manifest_boundary(self):
+        idx = _make_index([_manifest(["a", "b"]), _manifest(["c", "d", "e"])])
+        sampled = idx.list_files(sample=4)
+        assert sampled.paths.tolist() == ["a", "b", "c", "d"]
+
+    def test_sample_greater_than_total_returns_all(self):
+        idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
+        sampled = idx.list_files(sample=100)
+        assert sampled.paths.tolist() == ["a", "b", "c"]
+        assert idx.is_fully_cached is True
+
+    def test_sample_empty_paths_raises(self):
+        idx = _make_index([])
+        with pytest.raises(ValueError):
+            idx.list_files(sample=5)
+
+    def test_repeat_sample_reuses_cache(self):
+        indexer = _FakeIndexer([_manifest(["a", "b"]), _manifest(["c", "d"])])
+        idx = LazyFileIndex(indexer, paths=[], filesystem=None)
+
+        first = idx.list_files(sample=2)
+        assert first.paths.tolist() == ["a", "b"]
+        assert indexer.call_count == 1
+
+        second = idx.list_files(sample=2)
+        assert second.paths.tolist() == ["a", "b"]
+        assert indexer.call_count == 1
+
+
+class TestLazyFileIndexStreaming:
+    def test_full_stream_after_sample_continues_from_cache(self):
+        idx = _make_index(
+            [_manifest(["a", "b"]), _manifest(["c", "d"]), _manifest(["e"])]
+        )
+        sampled = idx.list_files(sample=2)
+        assert sampled.paths.tolist() == ["a", "b"]
+
+        full = _collect_paths(idx.list_files())
+        assert full == ["a", "b", "c", "d", "e"]
+        assert idx.is_fully_cached is True
+
+    def test_full_stream_twice_uses_cache(self):
+        idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
+        first = _collect_paths(idx.list_files())
+        assert first == ["a", "b", "c"]
+        second = _collect_paths(idx.list_files())
+        assert second == ["a", "b", "c"]
+
+
+class TestLazyFileIndexPruners:
+    def test_pruners_are_passed_through_to_indexer(self):
+        pruner = _AcceptAllPruner()
+        indexer = _FakeIndexer([_manifest(["a"])])
+        idx = LazyFileIndex(indexer, paths=[], filesystem=None, pruners=[pruner])
+
+        _ = idx.list_files(sample=1)
+        assert indexer.last_pruners == [pruner]
+
+
+class TestLazyFileIndexPickle:
+    def test_pickle_drops_iterator_preserves_cache(self):
+        indexer = _FakeIndexer(
+            [_manifest(["a", "b"]), _manifest(["c", "d"]), _manifest(["e"])]
+        )
+        idx = LazyFileIndex(indexer, paths=[], filesystem=None)
+        _ = idx.list_files(sample=2)
+        assert idx._listing_iterator is not None
+        cached_before = [m.paths.tolist() for m in idx._cached_manifests]
+
+        restored = pickle.loads(pickle.dumps(idx))
+
+        assert restored._listing_iterator is None
+        assert [m.paths.tolist() for m in restored._cached_manifests] == cached_before
+        assert restored.is_fully_cached is False
+
+    def test_pickle_when_fully_cached(self):
+        indexer = _FakeIndexer([_manifest(["a", "b", "c"])])
+        idx = LazyFileIndex(indexer, paths=[], filesystem=None)
+        _collect_paths(idx.list_files())
+        assert idx.is_fully_cached is True
+
+        restored = pickle.loads(pickle.dumps(idx))
+        assert restored.is_fully_cached is True
+        assert _collect_paths(restored.list_files()) == ["a", "b", "c"]
+
+    def test_worker_resume_does_not_relist_cached_paths(self):
+        # Driver samples partially, pickles to worker. On the worker, the
+        # indexer iterator is re-created from scratch and would yield paths
+        # already cached; the index must dedup so the remainder comes
+        # through exactly once.
+        manifests = [_manifest(["a", "b"]), _manifest(["c", "d"]), _manifest(["e"])]
+        driver_indexer = _FakeIndexer(manifests)
+        idx = LazyFileIndex(driver_indexer, paths=[], filesystem=None)
+        _ = idx.list_files(sample=2)
+        cached_paths = {p for m in idx._cached_manifests for p in m.paths.tolist()}
+
+        restored = pickle.loads(pickle.dumps(idx))
+        # Simulate the worker seeing the same source files via a fresh iterator.
+        restored._indexer = _FakeIndexer(manifests)
+
+        full = _collect_paths(restored.list_files())
+        # Cache is yielded first, then only un-cached files from the re-listed
+        # iterator.
+        assert len(full) == len(set(full)), f"duplicates in {full}"
+        assert set(full) == {"a", "b", "c", "d", "e"}
+        # The originally cached paths appear before any newly listed paths.
+        cached_indices = [full.index(p) for p in cached_paths]
+        new_indices = [full.index(p) for p in set(full) - cached_paths]
+        assert max(cached_indices) < min(new_indices)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/unit/datasource_v2/test_lazy_file_index.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_lazy_file_index.py
@@ -82,12 +82,19 @@ class TestLazyFileIndexSampling:
         idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
         sampled = idx.list_files(sample=100)
         assert sampled.paths.tolist() == ["a", "b", "c"]
-        assert idx.is_fully_cached is True
+        assert idx.fully_listed is True
 
     def test_sample_empty_paths_raises(self):
         idx = _make_index([])
         with pytest.raises(ValueError):
             idx.list_files(sample=5)
+
+    def test_sample_non_positive_raises(self):
+        idx = _make_index([_manifest(["a"])])
+        with pytest.raises(AssertionError):
+            idx.list_files(sample=0)
+        with pytest.raises(AssertionError):
+            idx.list_files(sample=-1)
 
     def test_repeat_sample_reuses_cache(self):
         indexer = _FakeIndexer([_manifest(["a", "b"]), _manifest(["c", "d"])])
@@ -112,7 +119,7 @@ class TestLazyFileIndexStreaming:
 
         full = _collect_paths(idx.list_files())
         assert full == ["a", "b", "c", "d", "e"]
-        assert idx.is_fully_cached is True
+        assert idx.fully_listed is True
 
     def test_full_stream_twice_uses_cache(self):
         idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
@@ -120,6 +127,37 @@ class TestLazyFileIndexStreaming:
         assert first == ["a", "b", "c"]
         second = _collect_paths(idx.list_files())
         assert second == ["a", "b", "c"]
+
+    def test_dedup_set_freed_when_fully_listed(self):
+        idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
+        _collect_paths(idx.list_files())
+        assert idx.fully_listed is True
+        assert idx._cached_paths == set()
+
+    def test_partial_iteration_then_restart(self):
+        # Breaking out of an iteration must release the internal ``_iterating``
+        # guard so a subsequent call to ``list_files`` is allowed.
+        idx = _make_index([_manifest(["a", "b"]), _manifest(["c", "d"])])
+        for _ in idx.list_files():
+            break
+        # Second call must not raise and must still produce all files.
+        assert _collect_paths(idx.list_files()) == ["a", "b", "c", "d"]
+
+
+class TestLazyFileIndexConcurrency:
+    def test_overlapping_iteration_raises(self):
+        idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
+        first = iter(idx.list_files())
+        next(first)  # start iteration, do not finish
+        with pytest.raises(AssertionError):
+            list(idx.list_files())
+
+    def test_sample_during_iteration_raises(self):
+        idx = _make_index([_manifest(["a", "b"]), _manifest(["c"])])
+        first = iter(idx.list_files())
+        next(first)
+        with pytest.raises(AssertionError):
+            idx.list_files(sample=1)
 
 
 class TestLazyFileIndexPruners:
@@ -146,16 +184,16 @@ class TestLazyFileIndexPickle:
 
         assert restored._listing_iterator is None
         assert [m.paths.tolist() for m in restored._cached_manifests] == cached_before
-        assert restored.is_fully_cached is False
+        assert restored.fully_listed is False
 
-    def test_pickle_when_fully_cached(self):
+    def test_pickle_when_fully_listed(self):
         indexer = _FakeIndexer([_manifest(["a", "b", "c"])])
         idx = LazyFileIndex(indexer, paths=[], filesystem=None)
         _collect_paths(idx.list_files())
-        assert idx.is_fully_cached is True
+        assert idx.fully_listed is True
 
         restored = pickle.loads(pickle.dumps(idx))
-        assert restored.is_fully_cached is True
+        assert restored.fully_listed is True
         assert _collect_paths(restored.list_files()) == ["a", "b", "c"]
 
     def test_worker_resume_does_not_relist_cached_paths(self):


### PR DESCRIPTION
## Description
Adds abstraction to perform lazy file indexing, meaning it lists lazily both on driver (up to a limit) and worker with some caching to avoid re-listing already listed paths. We first sample 10 files on the driver for schema inference. Then there's a budget of up to 1k that we list on the driver. Beyond that budget the listing occurs on the worker process (ex: a 1 million image files in the dataset)

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
