### PR TITLE
[depsets] regenerate doctest depset lock for boto3 provenance

### DIFF
--- a/python/deplocks/docs/doctest_depset_py3.10.lock
+++ b/python/deplocks/docs/doctest_depset_py3.10.lock
@@ -726,6 +726,8 @@ boto3==1.29.7 \
     --hash=sha256:96e9890ebe7cd823b5f4976dd676e112c000c6528c28e20a2f274590589dd18b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/py313/train-test-requirements.txt
+    #   -r python/requirements/ml/py313/tune-test-requirements.txt
     #   -r python/requirements/py313/test-requirements.txt
     #   aim
     #   aiobotocore


### PR DESCRIPTION
Commit 6634f273bf generated doctest_depset_py3.10.lock from a tree that predated commit 8b6c71e660 ("[train][doc] Fix flaky doc test for TorchDetectionPredictor"), which added boto3==1.29.7 to python/requirements/ml/py313/{train,tune}-test-requirements.txt. The boto3 entry in the lock file was missing the two "# via -r ..." provenance comments, causing raydepsets --check to fail in premerge CI.

Topic: fix-raydepset-doc
Signed-off-by: andrew <andrew@anyscale.com>