### PR TITLE
[Core] Release plasma mmap pages from worker RSS via madvise

### DIFF
--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -532,6 +532,69 @@ def test_reconstruction_generator_out_of_scope(
     assert_no_leak()
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="MADV_DONTNEED only drops pages on Linux"
+)
+def test_streaming_generator_plasma_rss_bounded(shutdown_only):
+    """Verify that worker RSS doesn't grow linearly when yielding many large
+    plasma blocks in a streaming generator.
+
+    After each block is sealed in plasma, its pages should be released from
+    the worker's page table via madvise(MADV_DONTNEED). Without this fix,
+    a task yielding N blocks accumulates ~N * block_size of RSS. With the
+    fix, RSS stays bounded because sealed blocks' pages are reclaimed.
+    """
+    NUM_BLOCKS = 10
+    BLOCK_SIZE_BYTES = 50_000_000  # 50 MB each, well above plasma inlining threshold
+
+    ray.init(
+        num_cpus=1,
+        object_store_memory=1_000_000_000,  # 1 GB
+    )
+
+    @ray.remote
+    def streaming_gen():
+        import os
+
+        rss_measurements = []
+        for i in range(NUM_BLOCKS):
+            yield np.ones(BLOCK_SIZE_BYTES, dtype=np.int8) * (i % 128)
+            # Brief pause to allow async PinObjectIDs callback to fire,
+            # which triggers the second Release() -> madvise(MADV_DONTNEED).
+            time.sleep(0.2)
+            # Read current RSS from /proc/self/statm (column 1 = resident pages)
+            with open(f"/proc/{os.getpid()}/statm") as f:
+                rss_pages = int(f.read().split()[1])
+            rss_bytes = rss_pages * os.sysconf("SC_PAGE_SIZE")
+            rss_measurements.append(rss_bytes)
+        yield rss_measurements
+
+    gen = streaming_gen.remote()
+    block_refs = []
+    for ref in gen:
+        block_refs.append(ref)
+
+    # Last item is the RSS measurements list (small, inlined)
+    rss_values = ray.get(block_refs[-1])
+    assert len(rss_values) == NUM_BLOCKS
+
+    # Verify data integrity: first and last data blocks
+    assert np.all(ray.get(block_refs[0]) == 0)
+    assert np.all(ray.get(block_refs[NUM_BLOCKS - 1]) == ((NUM_BLOCKS - 1) % 128))
+
+    # Check RSS growth between first and last yield.
+    # Without the fix: growth ≈ (NUM_BLOCKS - 1) * BLOCK_SIZE_BYTES ≈ 450 MB
+    # With the fix: growth should be much less (bounded by 1-2 blocks of lag)
+    rss_growth = rss_values[-1] - rss_values[0]
+    max_allowed_growth = 3 * BLOCK_SIZE_BYTES  # 150 MB — generous for async timing
+    assert rss_growth < max_allowed_growth, (
+        f"Worker RSS grew by {rss_growth / 1e6:.0f} MB after yielding "
+        f"{NUM_BLOCKS} x {BLOCK_SIZE_BYTES / 1e6:.0f} MB blocks. "
+        f"Expected < {max_allowed_growth / 1e6:.0f} MB with madvise fix. "
+        f"RSS trace (MB): {[round(v / 1e6) for v in rss_values]}"
+    )
+
+
 if __name__ == "__main__":
 
     sys.exit(pytest.main(["-sv", __file__]))

--- a/src/ray/object_manager/plasma/client.cc
+++ b/src/ray/object_manager/plasma/client.cc
@@ -513,6 +513,19 @@ Status PlasmaClient::Release(const ObjectID &object_id) {
     //    about the object.
     const MEMFD_TYPE fd = object_entry->second->object.store_fd;
     bool may_unmap = object_entry->second->object.fallback_allocated;
+    // For primary-allocated objects (not fallback), we cannot unmap the entire
+    // shared region since other objects may share it. Instead, use
+    // madvise(MADV_DONTNEED) to release this object's pages from the worker's
+    // page table, reducing RSS. The data stays in the tmpfs/shm backing store
+    // and remains accessible to other processes (raylet, consumers).
+    if (!may_unmap) {
+      auto mmap_entry = mmap_table_.find(fd);
+      if (mmap_entry != mmap_table_.end()) {
+        auto &obj = object_entry->second->object;
+        mmap_entry->second->MadviseRelease(
+            obj.header_offset, obj.data_offset - obj.header_offset + obj.allocated_size);
+      }
+    }
     // Tell the store that the client no longer needs the object.
     RAY_RETURN_NOT_OK(MarkObjectUnused(object_id));
     RAY_RETURN_NOT_OK(SendReleaseRequest(store_conn_, object_id, may_unmap));

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -78,16 +78,16 @@ void ClientMmapTableEntry::MaybeMadviseDontdump() {
 
 void ClientMmapTableEntry::MadviseRelease(ptrdiff_t offset, int64_t length) {
 #ifndef _WIN32
-  if (length <= 0) {
+  static const long page_size = sysconf(_SC_PAGESIZE);
+  if (page_size <= 0 || length <= 0) {
     return;
   }
-  long page_size = sysconf(_SC_PAGESIZE);
+  const uintptr_t page_mask = static_cast<uintptr_t>(page_size) - 1;
   // Page-align conservatively: round start up and end down so we never
   // touch pages that may contain adjacent objects' data.
   uintptr_t region_start = reinterpret_cast<uintptr_t>(pointer_) + offset;
-  uintptr_t aligned_start = (region_start + page_size - 1) & ~(page_size - 1);
-  uintptr_t aligned_end =
-      (region_start + length) & ~(static_cast<uintptr_t>(page_size) - 1);
+  uintptr_t aligned_start = (region_start + page_mask) & ~page_mask;
+  uintptr_t aligned_end = (region_start + length) & ~page_mask;
   if (aligned_end <= aligned_start) {
     return;
   }

--- a/src/ray/object_manager/plasma/shared_memory.cc
+++ b/src/ray/object_manager/plasma/shared_memory.cc
@@ -76,6 +76,34 @@ void ClientMmapTableEntry::MaybeMadviseDontdump() {
 #endif
 }
 
+void ClientMmapTableEntry::MadviseRelease(ptrdiff_t offset, int64_t length) {
+#ifndef _WIN32
+  if (length <= 0) {
+    return;
+  }
+  long page_size = sysconf(_SC_PAGESIZE);
+  // Page-align conservatively: round start up and end down so we never
+  // touch pages that may contain adjacent objects' data.
+  uintptr_t region_start = reinterpret_cast<uintptr_t>(pointer_) + offset;
+  uintptr_t aligned_start = (region_start + page_size - 1) & ~(page_size - 1);
+  uintptr_t aligned_end =
+      (region_start + length) & ~(static_cast<uintptr_t>(page_size) - 1);
+  if (aligned_end <= aligned_start) {
+    return;
+  }
+  size_t advise_length = aligned_end - aligned_start;
+  int rval =
+      madvise(reinterpret_cast<void *>(aligned_start), advise_length, MADV_DONTNEED);
+  if (rval != 0) {
+    RAY_LOG(WARNING) << "madvise(MADV_DONTNEED) failed for offset " << offset
+                     << ", length " << length << ": " << strerror(errno);
+  } else {
+    RAY_LOG(DEBUG) << "madvise(MADV_DONTNEED) released " << advise_length
+                   << " bytes at offset " << offset << " from fd " << fd_.first;
+  }
+#endif
+}
+
 ClientMmapTableEntry::~ClientMmapTableEntry() {
   // At this point it is safe to unmap the memory, as the PlasmaBuffer
   // keeps the PlasmaClient (and therefore the ClientMmapTableEntry)

--- a/src/ray/object_manager/plasma/shared_memory.h
+++ b/src/ray/object_manager/plasma/shared_memory.h
@@ -36,6 +36,12 @@ class ClientMmapTableEntry {
 
   MEMFD_TYPE fd() const { return fd_; }
 
+  /// Release pages in the range [offset, offset+length) from this process's
+  /// page table via madvise(MADV_DONTNEED). Safe for MAP_SHARED mappings:
+  /// data stays in the tmpfs/shm backing store, only this process's RSS is
+  /// reduced. Pages fault back in transparently on re-access.
+  void MadviseRelease(ptrdiff_t offset, int64_t length);
+
  private:
   /// The associated file descriptor on the client.
   MEMFD_TYPE fd_;


### PR DESCRIPTION
## Description

### Why

When a worker serializes objects into the plasma store, it writes into a `MAP_SHARED` mmap region backed by `/dev/shm`. The faulted pages remain in the worker's page table after the object is sealed, even though the worker no longer needs them. Worker RSS grows by ~block_size per yielded object and never drops.

For `ReadParquet` workloads yielding ~7 blocks of ~143MB each, a single worker reaches 2-3GB RSS. With 8 workers on a 30GB node, this exceeds node memory and causes OOM.

Root cause: all primary-allocated plasma objects share one mmap region (the initial dlmalloc pool). The existing code only unmaps fallback-allocated objects (which each get their own fd). For primary allocations, `Release()` does nothing — acknowledged by a [TODO](https://github.com/ray-project/ray/blob/master/src/ray/object_manager/plasma/client.h#L335).

### How I find that:
Tracing a single worker reading one parquet file that yields 7 blocks:
```
           anon(heap)  shmem(plasma)   rss
  yield 1:  1053 MB      136 MB      1285 MB
  yield 2:  1085 MB      272 MB      1452 MB   shmem +136
  yield 3:  1111 MB      408 MB      1614 MB   shmem +136
  yield 4:  1116 MB      544 MB      1755 MB   shmem +136
  yield 5:  1082 MB      679 MB      1857 MB   shmem +136
  yield 6:  1082 MB      815 MB      1993 MB   shmem +136
  yield 7:  1082 MB      829 MB      2007 MB   shmem +14 (small last block)
```

### What

In `PlasmaClient::Release()`, after an object's refcount drops to 0, call `madvise(MADV_DONTNEED)` on the object's page-aligned region within the shared mmap. This drops pages from the worker's page table (reducing RSS) without affecting the data in `/dev/shm` — other processes are unaffected, and pages fault back in on re-access.

### Changes
- `shared_memory.h/.cc` — Add `ClientMmapTableEntry::MadviseRelease(offset, length)`
- `client.cc` — Call `MadviseRelease()` in `Release()` when refcount reaches 0
- `test_streaming_generator_2.py` — Integration test: assert worker RSS stays bounded

### Result

Streaming generator yielding 15 × 16MB blocks on Linux:

```
Without fix:  RSS = [195, 246, 272, 288, 305, 323, 325, 348, 365, 382, 399, 410, 430, 447]  (+318 MB)
With fix:     RSS = [179, 214, 223, 224, 225, 227, 213, 220, 221, 222, 223, 218, 222, 223]  (flat)
```

## Test plan
- [x] Integration test on Linux: RSS stays bounded (failed on stock Ray, passed with fix)
- [x] Existing plasma tests pass (`object_store_test`, `fallback_allocator_test`)
- [ ] Cluster test with ReadParquet at scale

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
