### PR TITLE
[deps][ci] adding python_dependencies tag and setting dependency test rules

### DIFF
--- a/.buildkite/dependencies.rayci.yml
+++ b/.buildkite/dependencies.rayci.yml
@@ -5,7 +5,7 @@ steps:
   # dependencies
   - label: ":tapioca: build: pip-compile dependencies"
     key: pip_compile_dependencies
-    tags: always
+    tags: python_dependencies
     instance_type: small
     commands:
       # uncomment the following line to update the pinned versions of pip dependencies
@@ -21,7 +21,7 @@ steps:
 
   - label: ":tapioca: build: raydepsets: compile all dependencies"
     key: raydepsets_compile_all_dependencies
-    tags: always
+    tags: python_dependencies
     instance_type: small
     commands:
       - bazel run //ci/raydepsets:raydepsets -- build --all-configs --check

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -33,9 +33,12 @@ rllib/rllib.py: rllib rllib_gpu rllib_directly
 python/core.py: ml tune train data python dashboard linux_wheels macos_wheels java
 python/setup.py: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/requirements/test-requirements.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
+python/requirements_compiled.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
+python/requirements_compiled_py3.10.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
+python/requirements_compiled_py3.13.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/_raylet.pyx: ml tune train data python dashboard linux_wheels macos_wheels java
 
-# === Raydepsets lock files ===
+# === Raydepsets lock files and configs ===
 # macos_depset lock is consumed by the mac smoke test, so it must emit macos_wheels.
 python/deplocks/ci/macos_depset_py3.10.lock: macos_wheels
 # Other deplock updates should NOT trigger the mac smoke test (no macos_wheels).
@@ -43,6 +46,12 @@ python/deplocks/base_deps/ray_base_deps_py3.10.lock: ml tune train serve workflo
 python/deplocks/ci/data-base-ci_depset_py3.10.lock: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
 # LLM deplocks still hit the earlier llm rule block.
 python/deplocks/llm/ray_py311_cpu.lock: llm
+# Raydepsets config changes drive lock regeneration, so they get the same
+# tag set as deplock updates (no macos_wheels).
+ci/raydepsets/configs/ci_core.depsets.yaml: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
+ci/raydepsets/configs/rayimg.depsets.yaml: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
+# Other raydepsets files (the tool itself) are tools changes.
+ci/raydepsets/raydepsets.py: tools
 
 # === Buildkite Configs ===
 

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -34,7 +34,6 @@ python/core.py: ml tune train data python dashboard linux_wheels macos_wheels ja
 python/setup.py: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/requirements/test-requirements.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/requirements_compiled.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
-python/requirements_compiled_py3.10.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/requirements_compiled_py3.13.txt: ml tune train serve workflow data python dashboard linux_wheels macos_wheels java python_dependencies min_build
 python/_raylet.pyx: ml tune train data python dashboard linux_wheels macos_wheels java
 

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -38,19 +38,22 @@ python/requirements_compiled_py3.13.txt: ml tune train serve workflow data pytho
 python/_raylet.pyx: ml tune train data python dashboard linux_wheels macos_wheels java
 
 # === Raydepsets lock files and configs ===
-# macos_depset lock is consumed by the mac smoke test, so it must emit macos_wheels.
-python/deplocks/ci/macos_depset_py3.10.lock: macos_wheels
+# macos_depset lock is consumed by the mac smoke test (macos_wheels) AND
+# also needs to run the raydepsets --check verification (python_dependencies).
+python/deplocks/ci/macos_depset_py3.10.lock: macos_wheels python_dependencies
 # Other deplock updates should NOT trigger the mac smoke test (no macos_wheels).
 python/deplocks/base_deps/ray_base_deps_py3.10.lock: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
 python/deplocks/ci/data-base-ci_depset_py3.10.lock: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
-# LLM deplocks still hit the earlier llm rule block.
-python/deplocks/llm/ray_py311_cpu.lock: llm
+# LLM deplocks hit the dedicated llm-lock rule block and also emit
+# python_dependencies so lock updates run the raydepsets --check verification.
+python/deplocks/llm/ray_py311_cpu.lock: llm python_dependencies
 # Raydepsets config changes drive lock regeneration, so they get the same
 # tag set as deplock updates (no macos_wheels).
 ci/raydepsets/configs/ci_core.depsets.yaml: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
 ci/raydepsets/configs/rayimg.depsets.yaml: ml tune train serve workflow data python dashboard linux_wheels java python_dependencies min_build
-# Other raydepsets files (the tool itself) are tools changes.
-ci/raydepsets/raydepsets.py: tools
+# Raydepsets tool code changes can alter compiled lock output, so they
+# emit python_dependencies in addition to tools.
+ci/raydepsets/raydepsets.py: tools python_dependencies
 
 # === Buildkite Configs ===
 

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -24,12 +24,15 @@ python/ray/air/
 @ ml train train_gpu tune data linux_wheels
 ;
 
+python/deplocks/llm/*.lock
+@ llm python_dependencies
+;
+
 python/ray/llm/
 doc/source/llm/
 doc/source/data/doc_code/working-with-llms/
 .buildkite/llm.rayci.yml
 ci/docker/llm.build.Dockerfile
-python/deplocks/llm/*.lock
 @ llm
 ;
 
@@ -88,8 +91,10 @@ python/ray/dashboard/
 # The macOS smoke test installs this specific lock file
 # (ci/ray_ci/macos/macos_ci.sh), so changes here must still trigger
 # macos_wheels. Must precede the general python/deplocks/ rule below.
+# Also emits python_dependencies so lock file changes still run the
+# raydepsets --check verification in dependencies.rayci.yml.
 python/deplocks/ci/macos_depset_py*
-@ macos_wheels
+@ macos_wheels python_dependencies
 ;
 
 # Raydepsets-generated lock files and raydepsets configs that drive
@@ -213,9 +218,15 @@ ci/lint/
 ci/fossa/
 ci/docker/fossa.Dockerfile
 ci/docker/fossa.wanda.yaml
-ci/raydepsets/
 bazel/tests/
 @ tools
+;
+
+# Raydepsets tool code. Changes here can alter what gets compiled into
+# lock files, so emit python_dependencies to re-run the compile/check.
+# The configs/ subdir is handled earlier with the deplock rule block.
+ci/raydepsets/
+@ tools python_dependencies
 ;
 
 .buildkite/macos.rayci.yml

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -92,12 +92,14 @@ python/deplocks/ci/macos_depset_py*
 @ macos_wheels
 ;
 
-# Raydepsets-generated lock files. These do NOT affect the macOS smoke
-# test (which only consumes macos_depset_py*, handled above), so we
-# deliberately omit macos_wheels here to avoid running mac tests on
-# unrelated lock updates. Otherwise mirrors the python/setup.py rule's
-# tag set so general dependency changes still fan out across CI.
+# Raydepsets-generated lock files and raydepsets configs that drive
+# their generation. These do NOT affect the macOS smoke test (which
+# only consumes macos_depset_py*, handled above), so we deliberately
+# omit macos_wheels here to avoid running mac tests on unrelated lock
+# updates. Otherwise mirrors the python/setup.py rule's tag set so
+# general dependency changes still fan out across CI.
 python/deplocks/
+ci/raydepsets/configs/
 @ ml tune train serve workflow data min_build
 @ python dashboard linux_wheels java
 @ python_dependencies
@@ -106,6 +108,7 @@ python/deplocks/
 python/setup.py
 python/requirements.txt
 python/requirements_compiled.txt
+python/requirements_compiled_py*
 python/requirements/
 @ ml tune train serve workflow data min_build
 @ python dashboard linux_wheels macos_wheels java


### PR DESCRIPTION
## Changes

### `.buildkite/dependencies.rayci.yml` (lines 8, 24)
- Changed both `tags: always` → `tags: python_dependencies`, so the pip-compile and raydepsets compile steps only fire when `python_dependencies` is emitted.

### `.buildkite/test.rules.txt`
- Added `ci/raydepsets/configs/` to the `python/deplocks/` rule block, emitting `python_dependencies` plus the broader dependency fan-out tags but not `macos_wheels`. Placed before the `ci/raydepsets/` tools rule so first-match-wins picks the new rule.
- Added `python/requirements_compiled_py*` pattern to the `python/setup.py` / `python/requirements.txt` rule block so the per-Python-version lock files emit the same tags as the generic `requirements_compiled.txt`.
- Added `python_dependencies` to the `python/deplocks/ci/macos_depset_py*` block so macOS lock file changes still run the raydepsets `--check` verification (previously only emitted `macos_wheels`, which would have skipped dependency verification once `dependencies.rayci.yml` was gated on `python_dependencies`).
- Split `python/deplocks/llm/*.lock` out of the combined LLM rule block into its own block emitting `llm python_dependencies`. Keeps LLM source/docs/Dockerfile/buildkite changes on just `@ llm`, but ensures LLM lock updates run the dependency verification.
- Split `ci/raydepsets/` out of the combined tools rule block into its own block emitting `tools python_dependencies`. Tool code changes can alter compiled lock output, so they should re-run the compile/check — but the split avoids pulling `ci/lint/`, `ci/fossa/`, `bazel/tests/`, etc. into dependency jobs.

### `.buildkite/test.rules.test.txt`
- Added test cases for:
  - `python/requirements_compiled.txt`
  - `python/requirements_compiled_py3.13.txt` (py3.10/3.11/3.12 are symlinks to `requirements_compiled.txt`, so they never appear in git diffs — only py3.13 is a real file)
  - `ci/raydepsets/configs/ci_core.depsets.yaml`
  - `ci/raydepsets/configs/rayimg.depsets.yaml`
  - `ci/raydepsets/raydepsets.py` → `tools python_dependencies` (also guards rule ordering so `configs/` still matches the deplock block first).
- Updated existing assertions to match the review-driven rule changes:
  - `python/deplocks/ci/macos_depset_py3.10.lock` → `macos_wheels python_dependencies`
  - `python/deplocks/llm/ray_py311_cpu.lock` → `llm python_dependencies`

## Paths that now trigger `dependencies.rayci.yml`

Via the `python_dependencies` tag:
- `python/requirements/`
- `python/requirements_compiled_py*` (new)
- `python/deplocks/` (including `python/deplocks/ci/macos_depset_py*` and `python/deplocks/llm/*.lock`)
- `ci/raydepsets/configs/` (new)
- `ci/raydepsets/` tool code (new)
- `python/setup.py`, `python/requirements.txt`, `python/requirements_compiled.txt` (pre-existing)

## Validation

Parsed `test.rules.txt` via `ci/pipeline/determine_tests_to_run.py` and ran all 53 assertions from `test.rules.test.txt` — all pass.
