### PR TITLE
Improve dashboard guidance when memray attach lacks debugger

### DIFF
--- a/python/ray/dashboard/modules/reporter/profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/profile_manager.py
@@ -31,6 +31,10 @@ Install one of the following and retry:
   - Linux: `gdb`
   - macOS: `lldb`
 
+Install the debugger in the runtime image where Ray jobs/workers run (the
+repository that defines the Dockerfile for that image), not only on the
+developer machine.
+
 If this runs in a container, also ensure process-attach permissions are enabled
 (for example, ptrace/SYS_PTRACE).
 """

--- a/python/ray/dashboard/modules/reporter/profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/profile_manager.py
@@ -24,6 +24,25 @@ Alternatively, you can start Ray with passwordless sudo / root permissions.
 
 """
 
+MEMRAY_MISSING_DEBUGGER_ERROR_MESSAGE = """
+Dashboard memory profiling uses `memray attach`, which depends on a supported
+debugger on the node where the target process runs.
+Install one of the following and retry:
+  - Linux: `gdb`
+  - macOS: `lldb`
+
+If this runs in a container, also ensure process-attach permissions are enabled
+(for example, ptrace/SYS_PTRACE).
+"""
+
+
+def _memray_debugger_not_found(stderr_str: str) -> bool:
+    stderr_lower = stderr_str.lower()
+    return (
+        "cannot find a supported lldb or gdb executable" in stderr_lower
+        and "sys.remote_exec is not available" in stderr_lower
+    )
+
 
 def decode(string: Union[str, bytes]):
     if isinstance(string, bytes):
@@ -33,7 +52,7 @@ def decode(string: Union[str, bytes]):
 
 def _format_failed_profiler_command(cmd, profiler, stdout, stderr) -> str:
     stderr_str = decode(stderr)
-    extra_message = ""
+    extra_messages = []
 
     # If some sort of permission error returned, show a message about how
     # to set up permissions correctly.
@@ -43,9 +62,16 @@ def _format_failed_profiler_command(cmd, profiler, stdout, stderr) -> str:
             if sys.platform == "darwin"
             else LINUX_SET_CHOWN_CMD.format(profiler=profiler)
         )
-        extra_message = PROFILER_PERMISSIONS_ERROR_MESSAGE.format(
-            profiler=profiler, set_chown_command=set_chown_command
+        extra_messages.append(
+            PROFILER_PERMISSIONS_ERROR_MESSAGE.format(
+                profiler=profiler, set_chown_command=set_chown_command
+            )
         )
+
+    if profiler == "memray" and _memray_debugger_not_found(stderr_str):
+        extra_messages.append(MEMRAY_MISSING_DEBUGGER_ERROR_MESSAGE)
+
+    extra_message = "".join(extra_messages)
 
     return f"""Failed to execute `{cmd}`.
 {extra_message}

--- a/python/ray/dashboard/modules/reporter/tests/test_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_profile_manager.py
@@ -51,6 +51,7 @@ def test_format_failed_profiler_command_memray_missing_debugger_message():
     assert MEMRAY_MISSING_DEBUGGER_ERROR_MESSAGE.strip() in message
     assert "Linux: `gdb`" in message
     assert "macOS: `lldb`" in message
+    assert "runtime image where Ray jobs/workers run" in message
 
 
 @pytest.mark.asyncio

--- a/python/ray/dashboard/modules/reporter/tests/test_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_profile_manager.py
@@ -7,7 +7,11 @@ from unittest.mock import patch
 import pytest
 
 import ray
-from ray.dashboard.modules.reporter.profile_manager import MemoryProfilingManager
+from ray.dashboard.modules.reporter.profile_manager import (
+    MEMRAY_MISSING_DEBUGGER_ERROR_MESSAGE,
+    MemoryProfilingManager,
+    _format_failed_profiler_command,
+)
 from ray.dashboard.tests.conftest import *  # noqa
 
 
@@ -29,6 +33,24 @@ def setup_memory_profiler():
         actor = Actor.remote()
 
         yield actor, memory_profiler
+
+
+def test_format_failed_profiler_command_memray_missing_debugger_message():
+    stderr = (
+        "Cannot find a supported lldb or gdb executable and "
+        "sys.remote_exec is not available."
+    )
+
+    message = _format_failed_profiler_command(
+        cmd=["memray", "attach", "123"],
+        profiler="memray",
+        stdout="",
+        stderr=stderr,
+    )
+
+    assert MEMRAY_MISSING_DEBUGGER_ERROR_MESSAGE.strip() in message
+    assert "Linux: `gdb`" in message
+    assert "macOS: `lldb`" in message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
This PR improves Ray dashboard memory profiling failure output when `memray attach` cannot find a supported debugger (`gdb`/`lldb`) and `sys.remote_exec` is unavailable.

Changes:
- Extend profiler command failure formatting to detect the specific memray missing-debugger error.
- Append actionable remediation guidance to the returned error:
  - Install `gdb` on Linux or `lldb` on macOS.
  - Install the debugger in the runtime image where Ray jobs/workers run (the repo that defines that Dockerfile), not only on a developer machine.
  - Ensure process attach permissions are available in containerized environments (e.g., ptrace / `SYS_PTRACE`).
- Keep existing permission guidance behavior and combine guidance blocks when relevant.
- Add a focused unit test to verify the missing-debugger guidance is included in formatted output.

This makes the dashboard "Memory Profiling" UX more actionable by explaining why attach fails and what to do next.

## Related issues
Related to dashboard memory profiling failures surfaced as:
`Cannot find a supported lldb or gdb executable and sys.remote_exec is not available.`

## Additional information
This is intentionally a messaging/diagnostics improvement; it does not change attach mechanics or fallback behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://anysphere.slack.com/archives/C08QH2EAD51/p1776876204447159?thread_ts=1776876204.447159&cid=C08QH2EAD51)

<div><a href="https://cursor.com/agents/bc-4ec14523-02f3-5a56-91a4-7bdcb2e1a7b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ec14523-02f3-5a56-91a4-7bdcb2e1a7b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

