### PR TITLE
[Serve] Fix  replica constructor failure tests

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1133,13 +1133,22 @@ class FailedReplicaStore:
     def __init__(self, fail_first: bool = False):
         self._fail_first = fail_first
         self._first_caller = False
+        self._fail_count = 0
+
+    def get_fail_count(self) -> int:
+        """Returns the number replica startup failures"""
+        return self._fail_count
 
     def should_fail(self) -> bool:
         """Returns whether this replica should raise in its constructor."""
         if not self._first_caller:
             self._first_caller = True
-            return self._fail_first
-        return not self._fail_first
+            result = self._fail_first
+        else:
+            result = not self._fail_first
+        if result:
+            self._fail_count += 1
+        return result
 
 
 @ray.remote(num_cpus=0)
@@ -1171,13 +1180,17 @@ class FailedGangReplicaStore:
 
     def mark_retry_failing_gang(self, gang_id: str) -> bool:
         """Flags the first replica of each new retry gang.
-        This is called after `mark_first_failing_gang"""
+        This is called after ``mark_first_failing_gang``."""
         if gang_id == self._successful_gang_id:
             return False
         if gang_id not in self._failed_gang_ids:
             self._failed_gang_ids.add(gang_id)
             return True
         return False
+
+    def get_failed_gang_count(self) -> int:
+        """Returns the number of distinct gangs that failed."""
+        return len(self._failed_gang_ids)
 
 
 @ray.remote(num_cpus=0)

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1120,19 +1120,40 @@ class Accumulator:
 
 @ray.remote(num_cpus=0)
 class FailedReplicaStore:
-    """Stores the first replica ID that failed, for constructor failure tests."""
+    """
+    Controls replica constructor failure behavior for gang scheduling tests.
+        - The first gang seen is allowed to run.
+        - The next gang has first replica flagged to fail.
+        - Retry gangs after the first failed gang have first replica flagged.
+    """
 
     def __init__(self):
-        self.failed_replica_id = None
+        self._good_gang_chosen = False
+        self._successful_gang_id = None
+        self._failed_gang_ids = set()
 
-    def set_if_first(self, replica_id: str) -> bool:
-        if self.failed_replica_id is None:
-            self.failed_replica_id = replica_id
+    def mark_first_failing_gang(self, gang_id: str) -> bool:
+        """Picks the good gang on the first call and flags the first replica of the next gang to fail."""
+        if not self._good_gang_chosen:
+            self._good_gang_chosen = True
+            self._successful_gang_id = gang_id
+            return False
+        if gang_id == self._successful_gang_id:
+            return False
+        if len(self._failed_gang_ids) == 0:
+            self._failed_gang_ids.add(gang_id)
             return True
         return False
 
-    def get(self):
-        return self.failed_replica_id
+    def mark_retry_failing_gang(self, gang_id: str) -> bool:
+        """Flags the first replica of each new retry gang.
+        This is called after `mark_first_failing_gang"""
+        if gang_id == self._successful_gang_id:
+            return False
+        if gang_id not in self._failed_gang_ids:
+            self._failed_gang_ids.add(gang_id)
+            return True
+        return False
 
 
 @ray.remote(num_cpus=0)

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1120,6 +1120,30 @@ class Accumulator:
 
 @ray.remote(num_cpus=0)
 class FailedReplicaStore:
+    """Controls replica constructor failure behavior for constructor failure tests.
+
+    Behavior is determined by ``fail_first``:
+      - ``fail_first=True``  (transient): first caller fails, rest succeed.
+      - ``fail_first=False`` (partial):   first caller succeeds, rest fail.
+
+    All decisions are made in a single atomic actor call to avoid races
+    between concurrent replicas.
+    """
+
+    def __init__(self, fail_first: bool = False):
+        self._fail_first = fail_first
+        self._first_caller = False
+
+    def should_fail(self) -> bool:
+        """Returns whether this replica should raise in its constructor."""
+        if not self._first_caller:
+            self._first_caller = True
+            return self._fail_first
+        return not self._fail_first
+
+
+@ray.remote(num_cpus=0)
+class FailedGangReplicaStore:
     """
     Controls replica constructor failure behavior for gang scheduling tests.
         - The first gang seen is allowed to run.

--- a/python/ray/serve/tests/test_constructor_failure.py
+++ b/python/ray/serve/tests/test_constructor_failure.py
@@ -1,5 +1,4 @@
 import sys
-import time
 
 import pytest
 
@@ -73,9 +72,15 @@ def test_deploy_with_partial_constructor_failure(serve_instance):
         return len(deployment_dict.get(deployment_id, [])) == 1
 
     wait_for_condition(_one_replica_running, timeout=30)
-    # Re-check after a few retry cycles to confirm only 1 replica stays running.
-    time.sleep(10)
-    assert _one_replica_running()
+
+    # Wait well past the failed-to-start threshold
+    # (max(num_replicas * 3, 6) = 6 for 2 replicas)
+    # to prove the deployment stays stuck and never transitions.
+    def _enough_retries_and_still_stable() -> bool:
+        fail_count = ray.get(failed_store.get_fail_count.remote())
+        return fail_count >= 8 and _one_replica_running()
+
+    wait_for_condition(_enough_retries_and_still_stable, timeout=90)
 
 
 def test_deploy_with_transient_constructor_failure(serve_instance):

--- a/python/ray/serve/tests/test_constructor_failure.py
+++ b/python/ray/serve/tests/test_constructor_failure.py
@@ -1,9 +1,11 @@
 import sys
+import time
 
 import pytest
 
 import ray
 from ray import serve
+from ray._common.test_utils import wait_for_condition
 from ray.serve._private.common import DeploymentID
 from ray.serve._private.test_utils import FailedReplicaStore
 
@@ -54,36 +56,37 @@ def test_deploy_with_partial_constructor_failure(serve_instance):
     @serve.deployment(num_replicas=2)
     class PartialConstructorFailureDeployment:
         def __init__(self, store):
-            replica_id = serve.get_replica_context().replica_id.unique_id
-            is_first = ray.get(store.set_if_first.remote(replica_id))
-            if is_first:
-                raise RuntimeError("Consistently throwing on same replica.")
-            failed_id = ray.get(store.get.remote())
-            if replica_id == failed_id:
+            if ray.get(store.should_fail.remote()):
                 raise RuntimeError("Consistently throwing on same replica.")
 
         async def serve(self, request):
             return "hi"
 
-    serve.run(PartialConstructorFailureDeployment.bind(failed_store))
+    serve._run(PartialConstructorFailureDeployment.bind(failed_store), _blocking=False)
 
-    # Assert 2 replicas are running in deployment deployment after partially
-    # successful deploy call
-    deployment_dict = ray.get(serve_instance._controller._all_running_replicas.remote())
     deployment_id = DeploymentID(name="PartialConstructorFailureDeployment")
-    assert len(deployment_dict[deployment_id]) == 2
+
+    def _one_replica_running() -> bool:
+        deployment_dict = ray.get(
+            serve_instance._controller._all_running_replicas.remote()
+        )
+        return len(deployment_dict.get(deployment_id, [])) == 1
+
+    wait_for_condition(_one_replica_running, timeout=30)
+    # Re-check after a few retry cycles to confirm only 1 replica stays running.
+    time.sleep(10)
+    assert _one_replica_running()
 
 
 def test_deploy_with_transient_constructor_failure(serve_instance):
     # Test failed to deploy with total of 2 replicas,
     # but first constructor call fails.
-    failed_store = FailedReplicaStore.remote()
+    failed_store = FailedReplicaStore.remote(fail_first=True)
 
     @serve.deployment(num_replicas=2)
     class TransientConstructorFailureDeployment:
         def __init__(self, store):
-            is_first = ray.get(store.set_if_first.remote("ONE"))
-            if is_first:
+            if ray.get(store.should_fail.remote()):
                 raise RuntimeError("Intentionally throw on first try.")
 
         async def serve(self, request):

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -727,10 +727,14 @@ class TestGangConstructorFailure:
 
         wait_for_condition(_one_gang_running_and_updating, timeout=30)
 
-        # Re-check after a few retry cycles to confirm the deployment stays
-        # stuck in UPDATING and doesn't transition to HEALTHY or DEPLOY_FAILED.
-        time.sleep(10)
-        assert _one_gang_running_and_updating()
+        # Wait well past the failed-to-start threshold
+        # (max(num_replicas * 3, 6) = 12 for 4 replicas) to prove the
+        # deployment stays stuck in UPDATING.
+        def _enough_retries_and_still_stable() -> bool:
+            failed_gangs = ray.get(failed_replica_store.get_failed_gang_count.remote())
+            return failed_gangs >= 15 and _one_gang_running_and_updating()
+
+        wait_for_condition(_enough_retries_and_still_stable, timeout=90)
         assert serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "DEPLOYING"
 
     def test_transient_constructor_failure(self, ray_shutdown):

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -700,28 +700,38 @@ class TestGangConstructorFailure:
         )
         class GangPartialConstructorFailure:
             def __init__(self, store):
-                replica_id = serve.get_replica_context().replica_id.unique_id
-                is_first = ray.get(store.set_if_first.remote(replica_id))
-                if is_first:
+                gang_id = serve.get_replica_context().gang_context.gang_id
+                is_first_fail = ray.get(store.mark_first_failing_gang.remote(gang_id))
+                if is_first_fail:
                     raise RuntimeError("Consistently throwing on same replica.")
-                failed_id = ray.get(store.get.remote())
-                if replica_id == failed_id:
-                    raise RuntimeError("Consistently throwing on same replica.")
+                should_fail = ray.get(store.mark_retry_failing_gang.remote(gang_id))
+                if should_fail:
+                    raise RuntimeError("Keep failing the replica")
 
             async def __call__(self, request):
                 return "hi"
 
-        serve.run(GangPartialConstructorFailure.bind(failed_replica_store))
-
-        client = serve.context._get_global_client()
-        deployment_id = DeploymentID(name="GangPartialConstructorFailure")
-        deployment_dict = ray.get(client._controller._all_running_replicas.remote())
-        assert len(deployment_dict[deployment_id]) == 4
-        app_status = serve.status().applications[SERVE_DEFAULT_APP_NAME]
-        assert app_status.status == "RUNNING"
-        assert (
-            app_status.deployments["GangPartialConstructorFailure"].status == "HEALTHY"
+        serve._run(
+            GangPartialConstructorFailure.bind(failed_replica_store),
+            _blocking=False,
         )
+
+        deployment_name = "GangPartialConstructorFailure"
+
+        def _one_gang_running_and_updating() -> bool:
+            app_status = serve.status().applications[SERVE_DEFAULT_APP_NAME]
+            dep = app_status.deployments[deployment_name]
+            return (
+                dep.replica_states.get("RUNNING", 0) == 2 and dep.status == "UPDATING"
+            )
+
+        wait_for_condition(_one_gang_running_and_updating, timeout=30)
+
+        # Re-check after a few retry cycles to confirm the deployment stays
+        # stuck in UPDATING and doesn't transition to HEALTHY or DEPLOY_FAILED.
+        time.sleep(10)
+        assert _one_gang_running_and_updating()
+        assert serve.status().applications[SERVE_DEFAULT_APP_NAME].status == "DEPLOYING"
 
     def test_transient_constructor_failure(self, ray_shutdown):
         """Validates gang deployment where the first constructor call fails then succeeds."""
@@ -737,9 +747,9 @@ class TestGangConstructorFailure:
         )
         class GangTransientConstructorFailure:
             def __init__(self, store):
-                replica_id = serve.get_replica_context().replica_id.unique_id
-                is_first = ray.get(store.set_if_first.remote(replica_id))
-                if is_first:
+                gang_id = serve.get_replica_context().gang_context.gang_id
+                is_first_fail = ray.get(store.mark_first_failing_gang.remote(gang_id))
+                if is_first_fail:
                     raise RuntimeError("Intentionally throw on first try.")
 
             async def __call__(self, request):
@@ -774,15 +784,16 @@ class TestGangFailureRecovery:
         )
         class StartupFailureDeployment:
             def __init__(self, failed_replica_store, recovery_signal):
-                replica_id = serve.get_replica_context().replica_id.unique_id
+                gang_id = serve.get_replica_context().gang_context.gang_id
                 is_first_failure = ray.get(
-                    failed_replica_store.set_if_first.remote(replica_id)
+                    failed_replica_store.mark_first_failing_gang.remote(gang_id)
                 )
                 if is_first_failure:
                     raise RuntimeError("Fail one startup to trigger gang cleanup.")
-
-                failed_replica_id = ray.get(failed_replica_store.get.remote())
-                if replica_id == failed_replica_id:
+                should_hold = ray.get(
+                    failed_replica_store.mark_retry_failing_gang.remote(gang_id)
+                )
+                if should_hold:
                     # Hold failed replica retry until the intermediate state is asserted.
                     ray.get(recovery_signal.wait.remote())
 

--- a/python/ray/serve/tests/test_gang_scheduling.py
+++ b/python/ray/serve/tests/test_gang_scheduling.py
@@ -12,7 +12,7 @@ from ray.serve._private.common import GANG_PG_NAME_PREFIX, DeploymentID, Replica
 from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve._private.test_utils import (
     Accumulator,
-    FailedReplicaStore,
+    FailedGangReplicaStore,
     check_apps_running,
     check_num_replicas_eq,
 )
@@ -691,7 +691,7 @@ class TestGangConstructorFailure:
         ray.init(num_cpus=1)
         serve.start()
 
-        failed_replica_store = FailedReplicaStore.remote()
+        failed_replica_store = FailedGangReplicaStore.remote()
 
         @serve.deployment(
             num_replicas=4,
@@ -738,7 +738,7 @@ class TestGangConstructorFailure:
         ray.init(num_cpus=1)
         serve.start()
 
-        failed_replica_store = FailedReplicaStore.remote()
+        failed_replica_store = FailedGangReplicaStore.remote()
 
         @serve.deployment(
             num_replicas=4,
@@ -774,7 +774,7 @@ class TestGangFailureRecovery:
         """Startup failure stops both replicas in the affected gang."""
         ray.init(num_cpus=1)
         serve.start()
-        failed_replica_store = FailedReplicaStore.remote()
+        failed_replica_store = FailedGangReplicaStore.remote()
         recovery_signal = SignalActor.remote()
 
         @serve.deployment(


### PR DESCRIPTION
## Description
Changes to fix constructor replica failure tests for both gang scheduling and normal tests:
Gang Scheduling:
- Added `FailedGangReplicaStore` to use gang_id  instead of replica_id . The old set_if_first / get API is replaced with mark_first_failing_gang and mark_retry_failing_gang, which let each test precisely control which gangs fail and which succeed.
- Rewrote `test_partial_constructor_failure` to actually test consistent failure.
- Update `test_transient_constructor_failure` and `test_startup_failure_stops_entire_gang` to use the new gang_id based API

Normal constructor failure tests:
- Rewrote `FailedReplicaStore `to remove replica_id entirely. The old set_if_first / get API is replaced with a single atomic helper `should_fail` to prevent race conditions due to concurrent replica calls. 
- The store also takes a boolean `fail_first` argument in its constructor to differentiate between partial and transient constructor failure tests and raises accordingly.
- Rewrote `test_partial_constructor_failure` and `test_transient_constructor_failure` tests to pass the appropriate argument when calling the store.

## Related issues
Fixes #62829
