### PR TITLE
[Serve] Support per request timeout and disconnect in http proxy path

### DIFF
--- a/ci/ray_ci/serve_di_test_names.txt
+++ b/ci/ray_ci/serve_di_test_names.txt
@@ -34,7 +34,7 @@
 //python/ray/serve/tests:test_replica_sync_methods_with_run_sync_in_threadpool
 //python/ray/serve/tests:test_replica_request_context
 //python/ray/serve/tests:test_direct_ingress
-//python/ray/serve/tests:test_direct_ingress_standalone
+//python/ray/serve/tests:test_per_request_headers
 //python/ray/serve/tests:test_direct_ingress_with_grpc
-//python/ray/serve/tests:test_direct_ingress_standalone_with_grpc
+//python/ray/serve/tests:test_per_request_headers_with_grpc
 //python/ray/serve/tests:test_handle

--- a/ci/ray_ci/serve_hap_test_names.txt
+++ b/ci/ray_ci/serve_hap_test_names.txt
@@ -2,8 +2,8 @@
 //python/ray/serve/tests:test_haproxy_api
 //python/ray/serve/tests:test_metrics_haproxy
 //python/ray/serve/tests:test_direct_ingress
-//python/ray/serve/tests:test_direct_ingress_standalone
-//python/ray/serve/tests:test_direct_ingress_standalone_with_grpc
+//python/ray/serve/tests:test_per_request_headers
+//python/ray/serve/tests:test_per_request_headers_with_grpc
 //python/ray/serve/tests:test_direct_ingress_with_grpc
 //python/ray/serve/tests:test_grpc_e2e
 //python/ray/serve/tests:test_grpc_replica_wrapper

--- a/doc/source/serve/advanced-guides/performance.md
+++ b/doc/source/serve/advanced-guides/performance.md
@@ -65,6 +65,32 @@ to retry requests that time out due to transient failures.
 Serve returns a response with status code `408` when a request times out. Clients can retry when they receive this `408` response.
 :::
 
+(serve-performance-per-request-headers)=
+### Override timeout and disconnect behavior per request
+
+Two request headers let callers override the global `request_timeout_s` and client-disconnect policy on a per-request basis.
+
+`x-request-timeout-seconds`
+: Overrides `request_timeout_s` for this single request.
+  - A **positive float** sets the timeout in seconds (for example, `x-request-timeout-seconds: 30`).
+  - A **non-positive value** (for example, `0` or `-1`) disables the timeout for this request regardless of the global setting.
+  - An **absent or non-numeric value** falls back to the global `request_timeout_s`.
+
+`x-request-disconnect-disabled`
+: Controls whether Serve monitors for client disconnects on this request.
+  - `?1` — disables disconnect detection; Serve continues processing even if the client closes the connection.
+  - `?0` or absent — disconnect detection is enabled (default behavior).
+
+**Performance impact of disabling both headers together**
+
+Setting `x-request-timeout-seconds` to a non-positive value *and* `x-request-disconnect-disabled: ?1` on the same request enables a fast path in the direct-ingress handler that yields a meaningful throughput improvement:
+
+- Serve skips wrapping the user handler in an `asyncio.create_task()` call.
+- Serve skips the `asyncio.wait()` call that would otherwise coordinate the handler task, the disconnect-monitoring task, and the timeout watcher.
+- Instead, Serve directly `await`s the user handler, eliminating all per-request event-loop scheduling overhead for monitoring.
+
+In the proxy path the gain is more modest: `asyncio.wait()` is called per response chunk with one fewer task and no timeout handle, which reduces event-loop overhead at high request rates.
+
 
 ### Set backoff time when choosing replica
 

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -12,6 +12,7 @@ from typing import (
     AsyncGenerator,
     Awaitable,
     Callable,
+    Dict,
     List,
     Optional,
     Tuple,
@@ -37,7 +38,9 @@ from ray.serve._private.constants import (
     RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S,
     RAY_SERVE_HTTP_PROXY_CALLBACK_IMPORT_PATH,
     RAY_SERVE_REQUEST_PROCESSING_TIMEOUT_S,
+    SERVE_HTTP_REQUEST_DISCONNECT_DISABLED_HEADER,
     SERVE_HTTP_REQUEST_ID_HEADER,
+    SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER,
     SERVE_LOGGER_NAME,
 )
 from ray.serve._private.constants_utils import warn_if_deprecated_env_var_set
@@ -760,6 +763,43 @@ async def start_asgi_http_server(
     server.install_signal_handlers = lambda: None
 
     return event_loop.create_task(server.serve(sockets=[sock]))
+
+
+def parse_request_timeout_header(
+    headers: Dict[bytes, bytes],
+    default_timeout_s: Optional[float],
+) -> Optional[float]:
+    """Parse the per-request timeout from the ``x-request-timeout-seconds`` header.
+
+    Returns the header value when valid and positive, ``None`` when the header is
+    present but non-positive (meaning "disable the timeout"), or ``default_timeout_s``
+    when the header is absent or malformed.
+    """
+    header_name = SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER.encode("utf-8")
+    if header_name not in headers:
+        return default_timeout_s
+
+    value = headers[header_name].decode("utf-8")
+    try:
+        timeout = float(value)
+        if timeout > 0:
+            return timeout
+        return None  # non-positive → disable timeout
+    except ValueError:
+        return default_timeout_s
+
+
+def parse_disconnect_disabled_header(headers: Dict[bytes, bytes]) -> bool:
+    """Return True if the ``x-request-disconnect-disabled`` header equals ``?1``.
+
+    When True, the caller should not monitor for client disconnects.
+    """
+    return (
+        headers.get(
+            SERVE_HTTP_REQUEST_DISCONNECT_DISABLED_HEADER.encode("utf-8"), b"?0"
+        ).decode("utf-8")
+        == "?1"
+    )
 
 
 def get_http_response_status(

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -803,13 +803,16 @@ def parse_disconnect_disabled_header(headers: Dict[bytes, bytes]) -> bool:
 
 
 def get_http_response_status(
-    exc: BaseException, request_timeout_s: float, request_id: str
+    exc: BaseException, request_timeout_s: Optional[float], request_id: str
 ) -> ResponseStatus:
     if isinstance(exc, TimeoutError):
+        timeout_str = (
+            f"after {request_timeout_s}s" if request_timeout_s is not None else ""
+        )
         return ResponseStatus(
             code=408,
             is_error=True,
-            message=f"Request {request_id} timed out after {request_timeout_s}s.",
+            message=f"Request {request_id} timed out {timeout_str}.".strip(),
         )
 
     elif isinstance(exc, asyncio.CancelledError):

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -55,6 +55,8 @@ from ray.serve._private.http_util import (
     configure_http_middlewares,
     convert_object_to_asgi_messages,
     get_http_response_status,
+    parse_disconnect_disabled_header,
+    parse_request_timeout_header,
     receive_http_body,
     send_http_response_on_exception,
     start_asgi_http_server,
@@ -1346,10 +1348,20 @@ class HTTPProxy(GenericProxy):
             self.proxy_asgi_receive(proxy_request.receive, receive_queue)
         )
 
+        # Per-request headers override the global HTTPOptions timeout and disconnect
+        # policy, enabling HAProxy (or other callers) to pass per-request hints.
+        request_headers = dict(proxy_request.headers)
+        request_timeout_s = parse_request_timeout_header(
+            request_headers, self.request_timeout_s
+        )
+        request_disconnect_disabled = parse_disconnect_disabled_header(request_headers)
+
         response_generator = ProxyResponseGenerator(
             handle.remote(handle_arg_bytes),
-            timeout_s=self.request_timeout_s,
-            disconnected_task=proxy_asgi_receive_task,
+            timeout_s=request_timeout_s,
+            disconnected_task=(
+                None if request_disconnect_disabled else proxy_asgi_receive_task
+            ),
             result_callback=result_callback,
         )
 
@@ -1407,7 +1419,7 @@ class HTTPProxy(GenericProxy):
                     yield asgi_message
                     response_started = True
         except BaseException as e:
-            status = get_http_response_status(e, self.request_timeout_s, request_id)
+            status = get_http_response_status(e, request_timeout_s, request_id)
             for asgi_message in send_http_response_on_exception(
                 status, response_started
             ):

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -84,9 +84,7 @@ from ray.serve._private.constants import (
     REQUEST_LATENCY_BUCKETS_MS,
     REQUEST_ROUTING_STATS_METHOD,
     SERVE_CONTROLLER_NAME,
-    SERVE_HTTP_REQUEST_DISCONNECT_DISABLED_HEADER,
     SERVE_HTTP_REQUEST_ID_HEADER,
-    SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER,
     SERVE_LOG_APPLICATION,
     SERVE_LOG_COMPONENT,
     SERVE_LOG_DEPLOYMENT,
@@ -116,6 +114,8 @@ from ray.serve._private.http_util import (
     configure_http_middlewares,
     configure_http_options_with_defaults,
     convert_object_to_asgi_messages,
+    parse_disconnect_disabled_header,
+    parse_request_timeout_header,
     start_asgi_http_server,
 )
 from ray.serve._private.logging_utils import (
@@ -2463,23 +2463,14 @@ class Replica:
 
         return route
 
-    def _parse_request_timeout(self, headers: Dict[str, str]) -> Optional[float]:
+    def _parse_request_timeout(self, headers: Dict[bytes, bytes]) -> Optional[float]:
         """Gets the desired request timeout from the headers.
         If the header is missing or invalid, returns the default request timeout
         from HttpOptions. If the header is non-positive, timeout is disabled.
         """
-        header_name = SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER.encode("utf-8")
-        if header_name not in headers:
-            return self._http_options.request_timeout_s
-
-        value = headers.get(header_name).decode("utf-8")
-        try:
-            timeout = float(value)
-            if timeout > 0:
-                return timeout
-            return None
-        except ValueError:
-            return self._http_options.request_timeout_s
+        return parse_request_timeout_header(
+            headers, self._http_options.request_timeout_s
+        )
 
     async def _direct_ingress_asgi(
         self,
@@ -2548,11 +2539,7 @@ class Replica:
             headers.get(SERVE_HTTP_REQUEST_ID_HEADER.encode("utf-8")).decode("utf-8")
             or generate_request_id()
         )
-        request_disconnect_disabled = (
-            headers.get(
-                SERVE_HTTP_REQUEST_DISCONNECT_DISABLED_HEADER.encode("utf-8"), b"?0"
-            ).decode("utf-8")
-        ) == "?1"
+        request_disconnect_disabled = parse_disconnect_disabled_header(headers)
         request_timeout_s = self._parse_request_timeout(headers)
 
         request_metadata = RequestMetadata(

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -754,10 +754,9 @@ py_test_module_list(
 py_test_module_list(
     size = "large",
     files = [
-        "test_direct_ingress_standalone.py",
+        "test_per_request_headers.py",
     ],
     tags = [
-        "direct_ingress",
         "exclusive",
         "team:serve",
     ],
@@ -791,11 +790,10 @@ py_test_module_list(
     size = "large",
     env = {"RAY_SERVE_USE_GRPC_BY_DEFAULT": "1"},
     files = [
-        "test_direct_ingress_standalone.py",
+        "test_per_request_headers.py",
     ],
     name_suffix = "_with_grpc",
     tags = [
-        "direct_ingress",
         "exclusive",
         "team:serve",
     ],

--- a/python/ray/serve/tests/test_per_request_headers.py
+++ b/python/ray/serve/tests/test_per_request_headers.py
@@ -6,7 +6,6 @@ import pytest
 from ray import serve
 from ray._common.test_utils import SignalActor
 from ray.serve._private.constants import (
-    RAY_SERVE_ENABLE_DIRECT_INGRESS,
     SERVE_HTTP_REQUEST_DISCONNECT_DISABLED_HEADER,
     SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER,
 )
@@ -15,20 +14,11 @@ from ray.serve.config import HTTPOptions
 from ray.serve.tests.conftest import *  # noqa
 
 
-@pytest.fixture
-def _skip_if_ff_not_enabled():
-    if not RAY_SERVE_ENABLE_DIRECT_INGRESS:
-        pytest.skip(
-            reason="RAY_SERVE_ENABLE_DIRECT_INGRESS not set.",
-        )
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("set_http_options_timeout", [False, True])
 @pytest.mark.parametrize("timeout_header", [None, "abc", "0", "1"])
 @pytest.mark.parametrize("disconnect_header", [None, "?0", "?1"])
 async def test_http_request_timeout_disconnect_headers(
-    _skip_if_ff_not_enabled,
     ray_instance,
     ray_shutdown,
     set_http_options_timeout,


### PR DESCRIPTION
`x-request-timeout-seconds` and `x-request-disconnect-disabled` were only handled by the direct-ingress code path (`replica.py`). The regular Serve HTTP proxy (`proxy.py`) ignored both headers and always used the global `HTTPOptions.request_timeout_s`.

This caused `test_direct_ingress_standalone` to fail intermittently under the HAProxy CI suite. When HAProxy is enabled, a newly deployed replica starts as `DOWN` and HAProxy falls back to the regular Serve proxy for ~500 ms while health checks complete. Requests sent during that window went through the proxy, which silently ignored the per-request headers, producing wrong status codes and missing timeouts.
