### PR TITLE
[release] add unit test validating new-SDK cluster_compute YAMLs

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -831,6 +831,26 @@ py_test(
 )
 
 py_test(
+    name = "test_new_sdk_compute_configs",
+    size = "small",
+    srcs = ["ray_release/tests/test_new_sdk_compute_configs.py"],
+    data = glob(
+        ["**/*.yaml"],
+        exclude = ["ray_release/**/*.yaml"],
+    ),
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_release",
+        bk_require("anyscale"),
+        bk_require("pytest"),
+    ],
+)
+
+py_test(
     name = "test_result",
     size = "small",
     srcs = ["ray_release/tests/test_result.py"],

--- a/release/ray_release/tests/test_new_sdk_compute_configs.py
+++ b/release/ray_release/tests/test_new_sdk_compute_configs.py
@@ -1,0 +1,111 @@
+import os
+import sys
+
+import pytest
+import yaml
+
+from ray_release.bazel import bazel_runfile
+from ray_release.config import (
+    DEFAULT_CLOUD_ID,
+    DEFAULT_CLOUD_NAME,
+    RELEASE_TEST_CONFIG_FILES,
+    parse_test_definition,
+)
+from ray_release.template import (
+    _load_and_render_yaml_template,
+    load_test_cluster_compute,
+)
+
+_COMPUTE_CONFIG_FILE_ENV = "COMPUTE_CONFIG_FILE"
+_COMPUTE_CONFIG_FILE_FLAG = "--compute-config-file"
+
+
+def _extract_compute_config_file_arg(argv):
+    """Extract ``--compute-config-file[=VALUE]`` from argv.
+
+    Returns (override_path, remaining_argv). pytest's ``pytest_addoption``
+    hook is only collected from conftest.py or plugins — not test modules —
+    so we parse the flag ourselves and pass the value via an env var that
+    ``pytest_generate_tests`` reads.
+    """
+    override = None
+    remaining = []
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg.startswith(f"{_COMPUTE_CONFIG_FILE_FLAG}="):
+            override = arg.split("=", 1)[1]
+        elif arg == _COMPUTE_CONFIG_FILE_FLAG and i + 1 < len(argv):
+            override = argv[i + 1]
+            i += 1
+        else:
+            remaining.append(arg)
+        i += 1
+    return override, remaining
+
+
+def _collect_new_sdk_tests():
+    """Flattened list of release-collection tests with anyscale_sdk_2026=true."""
+    tests = []
+    for config_file in RELEASE_TEST_CONFIG_FILES:
+        with open(bazel_runfile(config_file)) as fp:
+            tests += parse_test_definition(yaml.safe_load(fp))
+    return [t for t in tests if t.uses_anyscale_sdk_2026()]
+
+
+def pytest_generate_tests(metafunc):
+    if "target" not in metafunc.fixturenames:
+        return
+    path = os.environ.get(_COMPUTE_CONFIG_FILE_ENV)
+    if path:
+        metafunc.parametrize(
+            "target",
+            [("path", os.path.abspath(path))],
+            ids=[os.path.basename(path)],
+        )
+    else:
+        tests = _collect_new_sdk_tests()
+        metafunc.parametrize(
+            "target",
+            [("test", t) for t in tests],
+            ids=[t["name"] for t in tests],
+        )
+
+
+def _load_single_file(path):
+    env = {
+        "ANYSCALE_CLOUD_ID": str(DEFAULT_CLOUD_ID),
+        "ANYSCALE_CLOUD_NAME": str(DEFAULT_CLOUD_NAME),
+    }
+    return _load_and_render_yaml_template(path, env=env)
+
+
+def test_new_sdk_compute_config_is_valid(target):
+    from anyscale.compute_config import ComputeConfig
+
+    kind, payload = target
+    if kind == "test":
+        cluster_compute = load_test_cluster_compute(payload)
+        label = (
+            f"test {payload['name']!r} "
+            f"(cluster_compute={payload['cluster']['cluster_compute']!r})"
+        )
+    else:
+        cluster_compute = _load_single_file(payload)
+        label = f"file {payload!r}"
+
+    assert cluster_compute is not None, f"{label}: failed to load/render YAML"
+
+    try:
+        ComputeConfig.from_dict(cluster_compute)
+    except Exception as e:
+        pytest.fail(
+            f"ComputeConfig.from_dict failed for {label}: {type(e).__name__}: {e}"
+        )
+
+
+if __name__ == "__main__":
+    override, remaining = _extract_compute_config_file_arg(sys.argv[1:])
+    if override:
+        os.environ[_COMPUTE_CONFIG_FILE_ENV] = override
+    sys.exit(pytest.main(remaining + ["-v", __file__]))

--- a/release/ray_release/tests/test_new_sdk_compute_configs.py
+++ b/release/ray_release/tests/test_new_sdk_compute_configs.py
@@ -35,7 +35,11 @@ def _extract_compute_config_file_arg(argv):
         arg = argv[i]
         if arg.startswith(f"{_COMPUTE_CONFIG_FILE_FLAG}="):
             override = arg.split("=", 1)[1]
-        elif arg == _COMPUTE_CONFIG_FILE_FLAG and i + 1 < len(argv):
+        elif (
+            arg == _COMPUTE_CONFIG_FILE_FLAG
+            and i + 1 < len(argv)
+            and not argv[i + 1].startswith("-")
+        ):
             override = argv[i + 1]
             i += 1
         else:

--- a/release/ray_release/tests/test_new_sdk_compute_configs.py
+++ b/release/ray_release/tests/test_new_sdk_compute_configs.py
@@ -65,6 +65,15 @@ def pytest_generate_tests(metafunc):
         )
     else:
         tests = _collect_new_sdk_tests()
+        if not tests:
+            raise RuntimeError(
+                "No tests with anyscale_sdk_2026=true found across "
+                f"{RELEASE_TEST_CONFIG_FILES}. Parametrizing on an empty "
+                "list would cause this validation gate to pass silently. "
+                "If the anyscale_sdk_2026 flag has been retired, update "
+                "this test to discover the right compute-config files via "
+                "the new mechanism — do not leave the gate empty."
+            )
         metafunc.parametrize(
             "target",
             [("test", t) for t in tests],


### PR DESCRIPTION
## Summary

Adds a release-unit test that validates every `anyscale_sdk_2026=true` release test's `cluster_compute` YAML by constructing `anyscale.compute_config.ComputeConfig.from_dict(...)` on the rendered content. Catches schema bugs (unknown fields, wrong types, invalid enums, duplicate worker names) at CI time instead of deep inside a release run.

- Iterates all three test-collection files (`release_tests.yaml`, `release_data_tests.yaml`, `release_multimodal_inference_benchmarks_tests.yaml`) so future additions are auto-covered.
- Rendering reuses `ray_release.template.load_test_cluster_compute`, so Jinja vars (`{{env["ANYSCALE_CLOUD_NAME"]}}` is the only one referenced today) are resolved the same way a real release run resolves them.
- Also accepts `--compute-config-file=PATH` to validate a single YAML in isolation (renders Jinja with `DEFAULT_CLOUD_ID` / `DEFAULT_CLOUD_NAME` fallbacks).
- Tagged `release_unit` so it's picked up automatically by the existing `:coral: reef: ci+release tooling tests` step in `.buildkite/cicd.rayci.yml` — no CI YAML edits needed.

Collects 61 parametrized cases today (every `anyscale_sdk_2026=true` test across all variations). `pytest_generate_tests` raises a `RuntimeError` if that list is ever empty, so the gate cannot silently disappear if the flag is retired.

**Notable design choices**:
- No `COMPUTE_CONFIG_MODEL_FIELDS` filter before `from_dict()`. The production code path filters because `set_cluster_compute()` adds runtime-only keys after YAML load; this test loads the raw YAML, so filtering would silently strip typos like `head_nod` and defeat the gate.
- `pytest_addoption` is **not** used because pytest only collects that hook from conftest.py or registered plugins, not test modules. To keep the test self-contained in one file, `--compute-config-file` is parsed out of `sys.argv` in `__main__` and passed through the `COMPUTE_CONFIG_FILE` env var.

## Test plan

- [x] `bazel test //release:test_new_sdk_compute_configs` — 61/61 pass
- [x] `bazel test //release:test_new_sdk_compute_configs --test_arg=--compute-config-file=release/hello_world_tests/hello_world_compute_config.yaml` — collects 1 case by file basename, passes
- [x] Bug-injection check: renaming `head_node` → `head_nod` in a new-SDK compute-config YAML fails the relevant case with `TypeError: ComputeConfig.__init__() got an unexpected keyword argument 'head_nod'`. Reverted.
- [x] Lint: `ruff check` + `ruff format --check` + repo buildifier script all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)