### PR TITLE
[core] Remove GCS resource updates during PG scheduling

### DIFF
--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -33,7 +33,6 @@ GcsPlacementGroupScheduler::GcsPlacementGroupScheduler(
     ClusterResourceScheduler &cluster_resource_scheduler,
     rpc::RayletClientPool &raylet_client_pool)
     : io_context_(io_context),
-      return_timer_(io_context),
       gcs_table_storage_(gcs_table_storage),
       gcs_node_manager_(gcs_node_manager),
       cluster_resource_scheduler_(cluster_resource_scheduler),
@@ -131,10 +130,6 @@ void GcsPlacementGroupScheduler::ScheduleUnplacedBundles(
                 .emplace(placement_group->GetPlacementGroupID(), lease_status_tracker)
                 .second);
 
-  // Acquire resources from gcs resources manager to reserve bundle resources.
-  const auto &bundle_locations = lease_status_tracker->GetBundleLocations();
-  AcquireBundleResources(bundle_locations);
-
   // Convert to a set of bundle specifications grouped by the node.
   std::unordered_map<NodeID, std::vector<std::shared_ptr<const BundleSpecification>>>
       node_to_bundles;
@@ -183,9 +178,6 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupBundleResourcesIfExists(
     // bundles at the same time.
     DestroyPlacementGroupPreparedBundleResources(placement_group_id);
     DestroyPlacementGroupCommittedBundleResources(placement_group_id);
-
-    // Return destroyed bundles resources to the cluster resource.
-    ReturnBundleResources(bundle_locations.value());
   }
 }
 
@@ -325,7 +317,6 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
   if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
     DestroyPlacementGroupCommittedBundleResources(
         lease_status_tracker->GetPlacementGroup()->GetPlacementGroupID());
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
     schedule_failure_handler(lease_status_tracker->GetPlacementGroup(),
                              /*is_feasible=*/true);
     return;
@@ -355,17 +346,8 @@ void GcsPlacementGroupScheduler::CommitAllBundles(
                                       node_id,
                                       schedule_failure_handler,
                                       schedule_success_handler](const Status &status) {
-      auto commited_bundle_locations = std::make_shared<BundleLocations>();
       for (const auto &bundle : bundles_per_node) {
         lease_status_tracker->MarkCommitRequestReturned(node_id, bundle, status);
-        (*commited_bundle_locations)[bundle->BundleId()] = {node_id, bundle};
-      }
-
-      if (status.ok()) {
-        // Commit the bundle resources on the remote node to the cluster resources.
-        // If status is not OK, no need to call ReturnBundleResources because the
-        // OnAllBundleCommitRequestReturned function calls it.
-        CommitBundleResources(commited_bundle_locations);
       }
 
       if (lease_status_tracker->AllCommitRequestReturned()) {
@@ -405,7 +387,6 @@ void GcsPlacementGroupScheduler::OnAllBundlePrepareRequestReturned(
     auto it = placement_group_leasing_in_progress_.find(placement_group_id);
     RAY_CHECK(it != placement_group_leasing_in_progress_.end());
     placement_group_leasing_in_progress_.erase(it);
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -459,7 +440,6 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
   // to destroy them separately.
   if (lease_status_tracker->GetLeasingState() == LeasingState::CANCELLED) {
     DestroyPlacementGroupCommittedBundleResources(placement_group_id);
-    ReturnBundleResources(lease_status_tracker->GetBundleLocations());
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
     return;
   }
@@ -473,7 +453,6 @@ void GcsPlacementGroupScheduler::OnAllBundleCommitRequestReturned(
       placement_group->GetMutableBundle(bundle.first.second)->clear_node_id();
     }
     placement_group->UpdateState(rpc::PlacementGroupTableData::RESCHEDULING);
-    ReturnBundleResources(uncommitted_bundle_locations);
     schedule_failure_handler(placement_group, /*is_feasible*/ true);
   } else {
     schedule_success_handler(placement_group);
@@ -671,31 +650,6 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
   }
 }
 
-void GcsPlacementGroupScheduler::AcquireBundleResources(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
-  // Acquire bundle resources from gcs resources manager.
-  auto &cluster_resource_manager =
-      cluster_resource_scheduler_.GetClusterResourceManager();
-  for (auto &bundle : *bundle_locations) {
-    cluster_resource_manager.SubtractNodeAvailableResources(
-        scheduling::NodeID(bundle.second.first.Binary()),
-        bundle.second.second->GetRequiredResources());
-  }
-}
-
-absl::flat_hash_map<scheduling::NodeID, ResourceRequest> ToNodeBundleResourcesMap(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
-  absl::flat_hash_map<scheduling::NodeID, ResourceRequest> node_bundle_resources_map;
-  for (const auto &bundle : *bundle_locations) {
-    auto node_id = scheduling::NodeID(bundle.second.first.Binary());
-    const auto &bundle_spec = *bundle.second.second;
-    auto bundle_resource_request = ResourceMapToResourceRequest(
-        bundle_spec.GetFormattedResources(), /*requires_object_store_memory=*/false);
-    node_bundle_resources_map[node_id] += bundle_resource_request;
-  }
-  return node_bundle_resources_map;
-}
-
 bool GcsPlacementGroupScheduler::IsPlacementGroupWildcardResource(
     const std::string &resource_name) {
   std::string_view resource_name_view(resource_name);
@@ -709,126 +663,6 @@ bool GcsPlacementGroupScheduler::IsPlacementGroupWildcardResource(
 
   auto idx = resource_name_view.size() - (pattern.size() + 2 * PlacementGroupID::Size());
   return resource_name_view.substr(idx, pattern.size()) == pattern;
-}
-
-void GcsPlacementGroupScheduler::CommitBundleResources(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
-  // Acquire bundle resources from gcs resources manager.
-  auto &cluster_resource_manager =
-      cluster_resource_scheduler_.GetClusterResourceManager();
-  auto node_bundle_resources_map = ToNodeBundleResourcesMap(bundle_locations);
-  for (const auto &[node_id, node_bundle_resources] : node_bundle_resources_map) {
-    for (const auto &resource_id : node_bundle_resources.ResourceIds()) {
-      // A placement group's wildcard resource has to be the sum of all related bundles.
-      // Even though `ToNodeBundleResourcesMap` has already considered this,
-      // it misses the scenario in which single (or subset of) bundle is rescheduled.
-      // When commiting this single bundle, its wildcard resource would wrongly overwrite
-      // the existing value, unless using the following additive operation.
-      auto capacity = node_bundle_resources.Get(resource_id);
-      if (IsPlacementGroupWildcardResource(resource_id.Binary())) {
-        auto new_capacity =
-            capacity +
-            cluster_resource_manager.GetNodeResources(node_id).total.Get(resource_id);
-        cluster_resource_manager.UpdateResourceCapacity(
-            node_id, resource_id, new_capacity.Double());
-      } else {
-        cluster_resource_manager.UpdateResourceCapacity(
-            node_id, resource_id, capacity.Double());
-      }
-    }
-  }
-
-  for (const auto &listener : resources_changed_listeners_) {
-    listener();
-  }
-}
-
-void GcsPlacementGroupScheduler::ReturnBundleResources(
-    const std::shared_ptr<BundleLocations> &bundle_locations) {
-  // Return bundle resources to gcs resources manager should contains the following steps.
-  // 1. Remove related bundle resources from nodes.
-  // 2. Add resources allocated for bundles back to nodes.
-  for (auto &bundle : *bundle_locations) {
-    if (!TryReleasingBundleResources(bundle.second)) {
-      waiting_removed_bundles_.push_back(bundle.second);
-    }
-  }
-
-  for (const auto &listener : resources_changed_listeners_) {
-    listener();
-  }
-}
-
-void GcsPlacementGroupScheduler::AddResourcesChangedListener(
-    std::function<void()> listener) {
-  RAY_CHECK(listener != nullptr);
-  resources_changed_listeners_.emplace_back(std::move(listener));
-}
-
-bool GcsPlacementGroupScheduler::TryReleasingBundleResources(
-    const std::pair<NodeID, std::shared_ptr<const BundleSpecification>> &bundle) {
-  auto &cluster_resource_manager =
-      cluster_resource_scheduler_.GetClusterResourceManager();
-  auto node_id = scheduling::NodeID(bundle.first.Binary());
-  const auto &bundle_spec = bundle.second;
-  std::vector<scheduling::ResourceID> bundle_resource_ids;
-  absl::flat_hash_map<std::string, FixedPoint> wildcard_resources;
-
-  if (!cluster_resource_manager.HasNode(node_id)) {
-    // If the node is dead, we do not need to release the bundle resources.
-    // The bundle resources will be released when the node is removed by
-    // the cluster resource manager.
-    return true;
-  }
-
-  // Subtract wildcard resources and delete bundle resources.
-  for (const auto &entry : bundle_spec->GetFormattedResources()) {
-    auto resource_id = scheduling::ResourceID(entry.first);
-    auto capacity =
-        cluster_resource_manager.GetNodeResources(node_id).total.Get(resource_id);
-    if (IsPlacementGroupWildcardResource(entry.first)) {
-      wildcard_resources[entry.first] = capacity - entry.second;
-    } else {
-      bundle_resource_ids.emplace_back(resource_id);
-    }
-  }
-
-  // This bundle is not ready for returning.
-  if (bundle_resource_ids.empty()) {
-    return false;
-  }
-
-  for (const auto &[resource_name, capacity] : wildcard_resources) {
-    if (capacity == 0) {
-      bundle_resource_ids.emplace_back(scheduling::ResourceID(resource_name));
-    } else {
-      cluster_resource_manager.UpdateResourceCapacity(
-          node_id, scheduling::ResourceID(resource_name), capacity.Double());
-    }
-  }
-
-  // It will affect nothing if the resource_id to be deleted does not exist in the
-  // cluster_resource_manager_.
-  cluster_resource_manager.DeleteResources(node_id, bundle_resource_ids);
-  // Add reserved bundle resources back to the node.
-  cluster_resource_manager.AddNodeAvailableResources(
-      node_id, bundle_spec->GetRequiredResources().GetResourceSet());
-  return true;
-}
-
-void GcsPlacementGroupScheduler::HandleWaitingRemovedBundles() {
-  for (auto iter = waiting_removed_bundles_.begin();
-       iter != waiting_removed_bundles_.end();) {
-    auto current = iter++;
-    auto bundle = *current;
-    if (TryReleasingBundleResources(bundle)) {
-      // Release bundle successfully.
-      waiting_removed_bundles_.erase(current);
-    }
-  }
-  for (const auto &listener : resources_changed_listeners_) {
-    listener();
-  }
 }
 
 LeaseStatusTracker::LeaseStatusTracker(

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -357,11 +357,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
           &group_to_bundles,
       const std::vector<SchedulePgRequest> &prepared_pgs) override;
 
-  /// Add resources changed listener.
-  void AddResourcesChangedListener(std::function<void()> listener);
-
-  void HandleWaitingRemovedBundles();
-
  protected:
   /// Send bundles PREPARE requests to a node. The PREPARE requests will lock resources
   /// on a node until COMMIT or CANCEL requests are sent to a node.
@@ -444,16 +439,6 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   void DestroyPlacementGroupCommittedBundleResources(
       const PlacementGroupID &placement_group_id);
 
-  /// Acquire the bundle resources from the cluster resources.
-  void AcquireBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
-
-  /// Commit the bundle resources to the cluster resources.
-  void CommitBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
-
-  /// Return the bundle resources to the cluster resources.
-  /// It will remove bundle resources AND also add original resources back.
-  void ReturnBundleResources(const std::shared_ptr<BundleLocations> &bundle_locations);
-
   /// Create scheduling context.
   std::unique_ptr<BundleSchedulingContext> CreateSchedulingContext(
       const PlacementGroupID &placement_group_id);
@@ -462,23 +447,12 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   SchedulingOptions CreateSchedulingOptions(const GcsPlacementGroup &placement_group,
                                             rpc::PlacementStrategy strategy);
 
-  /// Try to release bundle resource to cluster resource manager.
-  ///
-  /// \param bundle The node to which the bundle is scheduled and the bundle's
-  /// specification.
-  /// \return True if the bundle is successfully released. False otherwise.
-  bool TryReleasingBundleResources(
-      const std::pair<NodeID, std::shared_ptr<const BundleSpecification>> &bundle);
-
   /// Help function to check if the resource_name has the pattern
   /// {original_resource_name}_group_{placement_group_id}, which means
   /// wildcard resource.
   bool IsPlacementGroupWildcardResource(const std::string &resource_name);
 
   instrumented_io_context &io_context_;
-
-  /// A timer that ticks every cancel resource failure milliseconds.
-  boost::asio::deadline_timer return_timer_;
 
   /// Used to update placement group information upon creation, deletion, etc.
   gcs::GcsTableStorage &gcs_table_storage_;
@@ -502,17 +476,8 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   /// The nodes which are releasing unused bundles.
   absl::flat_hash_set<NodeID> nodes_of_releasing_unused_bundles_;
 
-  /// The resources changed listeners.
-  std::vector<std::function<void()>> resources_changed_listeners_;
-
-  /// The bundles that waiting to be destroyed and release resources.
-  std::list<std::pair<NodeID, std::shared_ptr<const BundleSpecification>>>
-      waiting_removed_bundles_;
-
   friend class GcsPlacementGroupSchedulerTest;
   FRIEND_TEST(GcsPlacementGroupSchedulerTest, TestCheckingWildcardResource);
-  FRIEND_TEST(GcsPlacementGroupSchedulerTest, TestWaitingRemovedBundles);
-  FRIEND_TEST(GcsPlacementGroupSchedulerTest, TestBundlesRemovedWhenNodeDead);
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -895,7 +895,6 @@ void GcsServer::InstallEventListeners() {
                                          worker_failure_data->exit_type(),
                                          worker_failure_data->exit_detail(),
                                          creation_task_exception);
-        gcs_placement_group_scheduler_->HandleWaitingRemovedBundles();
         pubsub_handler_->AsyncRemoveSubscriberFrom(worker_id.Binary());
         gcs_task_manager_->OnWorkerDead(worker_id, worker_failure_data);
       });

--- a/src/ray/gcs/tests/gcs_server_test_util.h
+++ b/src/ray/gcs/tests/gcs_server_test_util.h
@@ -342,8 +342,6 @@ struct GcsServerMocker {
    public:
     using gcs::GcsPlacementGroupScheduler::GcsPlacementGroupScheduler;
 
-    size_t GetWaitingRemovedBundlesSize() { return waiting_removed_bundles_.size(); }
-
     using gcs::GcsPlacementGroupScheduler::ScheduleUnplacedBundles;
     // Extra conveinence overload for the mock tests to keep using the old interface.
     void ScheduleUnplacedBundles(


### PR DESCRIPTION
Following up on #62858 there's a race condition between the ray syncer resource view updates and the GCS directly modifying it's own resource view during PG scheduling. The GCS in general shouldn't directly modify it's own resource view since the raylet's ray syncer view updates are the source of truth. The main reason why I think we allow the GCS to do this currently is to prevent the next PG from mistakenly scheduling using an out of date resource view. Testing to see what impact this actually has on PG throughput. If it does have an impact, we could do something similar to normal task spillback where we temporarily just subtract the resources, and don't add them back and rely on ray_syncer_message_refresh_interval_ms to correct them later on.  