### PR TITLE
[Train / Doc] Uncomment `Result.from_path` in docs

### DIFF
--- a/doc/source/train/doc_code/key_concepts.py
+++ b/doc/source/train/doc_code/key_concepts.py
@@ -108,7 +108,7 @@ print(f"Results location (fs, path) = ({result_filesystem}, {result_path})")
 from ray.train import Result
 
 restored_result = Result.from_path(result_path)
-print("Restored loss", result.metrics["loss"])
+print("Restored loss", restored_result.metrics["loss"])
 # __result_restore_end__
 
 

--- a/doc/source/train/doc_code/key_concepts.py
+++ b/doc/source/train/doc_code/key_concepts.py
@@ -104,12 +104,11 @@ print(f"Results location (fs, path) = ({result_filesystem}, {result_path})")
 # __result_path_end__
 
 
-# TODO(justinvyu): Result.from_path is not supported in Train V2 yet.
 # __result_restore_start__
-# from ray.train import Result
+from ray.train import Result
 
-# restored_result = Result.from_path(result_path)
-# print("Restored loss", result.metrics["loss"])
+restored_result = Result.from_path(result_path)
+print("Restored loss", result.metrics["loss"])
 # __result_restore_end__
 
 

--- a/doc/source/train/user-guides/results.rst
+++ b/doc/source/train/user-guides/results.rst
@@ -115,13 +115,12 @@ access the storage location, which is useful if the path is on cloud storage.
     :end-before: __result_path_end__
 
 
-.. You can restore a result with :meth:`Result.from_path <ray.train.Result.from_path>`:
+You can restore a result with :meth:`Result.from_path <ray.train.Result.from_path>`:
 
-.. .. literalinclude:: ../doc_code/key_concepts.py
-..     :language: python
-..     :start-after: __result_restore_start__
-..     :end-before: __result_restore_end__
-
+.. literalinclude:: ../doc_code/key_concepts.py
+    :language: python
+    :start-after: __result_restore_start__
+    :end-before: __result_restore_end__
 
 
 Catching Errors


### PR DESCRIPTION
## Description
This PR uncomment documentation about `Result.from_path` due to being at the time unsupported by Train v2 API. Now that it has been implemented https://github.com/ray-project/ray/pull/58216, we can uncomment this documentation for users. 