### PR TITLE
[Serve] Skip test_haproxy_binary on Windows

### DIFF
--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -9,9 +9,23 @@ py_library(
 py_test_run_all_subdirectory(
     size = "small",
     include = glob(["test_*.py"]),
-    exclude = [],
+    exclude = ["test_haproxy_binary.py"],
     extra_srcs = [],
     tags = ["team:serve"],
+    deps = [
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+        "//python/ray/serve/tests:common",
+    ],
+)
+
+py_test_module_list(
+    size = "small",
+    files = ["test_haproxy_binary.py"],
+    tags = [
+        "no_windows",
+        "team:serve",
+    ],
     deps = [
         ":conftest",
         "//python/ray/serve:serve_lib",


### PR DESCRIPTION
## Summary

`test_haproxy_binary.py::test_explicit_path_validates_executable` fails on Windows: `Path.chmod(0o644)` only toggles the read-only attribute there, and `os.access(path, os.X_OK)` returns `True` for any regular file, so the assertion that a non-executable file is rejected with `FileNotFoundError` never fires.

HAProxy isn't supported on Windows. Exclude the file from the subdirectory glob and give it a dedicated target with `no_windows`, matching the convention already used by `test_haproxy.py`, `test_haproxy_api.py`, and `test_metrics_haproxy.py`.

Failure observed in postmerge 17208, job `flaky :windows: serve tests [g19_s10]` (commit `6db3b34b0e`): https://buildkite.com/ray-project/postmerge/builds/17208#019dbc13-86f6-42f4-bedf-4c1b8313da41

```
FAILED python/ray/serve/tests/unit/test_haproxy_binary.py::test_explicit_path_validates_executable - Failed: DID NOT RAISE <class 'FileNotFoundError'>
```