### PR TITLE
[Data] Fix credential drop and IMDS herd in download expression

### DIFF
--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -633,11 +633,23 @@ async def _download_uris_with_obstore(
         indicate failed downloads.
     """
     if fs_kwargs is None:
-        # Best-effort re-extraction for direct callers (e.g. tests). Session-
-        # backed fsspec may fail here because we're already in an event loop;
-        # the sync planner path avoids this by pre-extracting upfront.
+        # Direct-caller path (tests, internal helpers). Session-backed fsspec
+        # may fail here because we may already be inside an event loop; the
+        # planner path avoids this by pre-extracting upfront and passing
+        # ``fs_kwargs``. Re-extract best-effort, but fail closed if the
+        # filesystem is non-None and extraction signals "not extractable" —
+        # silently handing obstore the ambient credential chain is exactly
+        # the bug the new routing was designed to prevent.
         extracted = _extract_credentials_from_filesystem(filesystem)
-        fs_kwargs = extracted if extracted is not None else {}
+        if extracted is None:
+            raise RuntimeError(
+                "_download_uris_with_obstore was called with a filesystem whose "
+                f"credentials cannot be statically extracted ({type(filesystem).__name__}). "
+                "Pass ``fs_kwargs`` explicitly, or route through "
+                "``_plan_obstore_routing`` / ``download_bytes_async`` so "
+                "non-extractable filesystems take the threaded PyArrow path."
+            )
+        fs_kwargs = extracted
 
     range_threshold = RAY_DATA_OBSTORE_RANGE_THRESHOLD
     range_chunk_size = RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -113,9 +113,60 @@ def _is_obstore_supported_url(path: str) -> bool:
 
 
 # Credential extraction & store management
+def _frozen_s3fs_credentials(fsspec_fs) -> Optional[Dict[str, str]]:
+    """Snapshot credentials from an s3fs-style session.
+
+    s3fs with Okta / STS / profile-based auth resolves credentials lazily via
+    ``fs.session.get_credentials()`` — the ``key`` / ``secret`` / ``token``
+    instance attributes are ``None`` in that setup. We call
+    ``get_frozen_credentials()`` to capture the currently-valid set.
+
+    Returns a dict with ``access_key``, ``secret_key``, ``token`` keys, or
+    ``None`` if a session isn't available or credentials can't be retrieved
+    (e.g. expired, retrieval error). The caller must tolerate ``None`` and
+    route to the threaded path so the user's filesystem stays authoritative.
+    """
+    session = getattr(fsspec_fs, "session", None) or getattr(
+        fsspec_fs, "_session", None
+    )
+    if session is None:
+        return None
+
+    try:
+        get_creds = session.get_credentials
+        creds = get_creds()
+        if asyncio.iscoroutine(creds):
+            try:
+                creds = asyncio.run(creds)
+            except RuntimeError:
+                return None
+        if creds is None:
+            return None
+        frozen = creds.get_frozen_credentials()
+        if asyncio.iscoroutine(frozen):
+            try:
+                frozen = asyncio.run(frozen)
+            except RuntimeError:
+                return None
+    except Exception as e:
+        logger.debug("Could not snapshot fsspec session credentials: %r", e)
+        return None
+
+    access_key = getattr(frozen, "access_key", None)
+    secret_key = getattr(frozen, "secret_key", None)
+    token = getattr(frozen, "token", None)
+    if not access_key:
+        return None
+    return {
+        "access_key": access_key,
+        "secret_key": secret_key or "",
+        "token": token or "",
+    }
+
+
 def _extract_credentials_from_filesystem(
     filesystem: Optional["pyarrow.fs.FileSystem"],
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Extract credentials from a PyArrow filesystem for use with obstore.
 
     Maps PyArrow filesystem configuration to obstore keyword arguments.
@@ -131,9 +182,11 @@ def _extract_credentials_from_filesystem(
 
     **fsspec S3 (``PyFileSystem`` + ``FSSpecHandler``):** For ``s3`` / ``s3a``
     (e.g. ``s3fs`` with STS/Okta/custom endpoints), credentials are read from
-    ``storage_options`` / common instance attributes so obstore can use the
-    same keys the user passed to fsspec. ``anon`` maps to ``skip_signature``;
-    ``region_name`` may appear in ``storage_options`` or ``client_kwargs``.
+    ``storage_options`` / common instance attributes first; if no static key is
+    present, we snapshot ``fs.session.get_credentials().get_frozen_credentials()``
+    to handle session-backed (Okta/STS/profile) auth. If both passes come up
+    empty we return ``None`` so the caller routes to the threaded path, keeping
+    the user's fsspec filesystem authoritative.
 
     Other ``PyFileSystem`` handlers (non-fsspec or non-S3 fsspec protocols) are
     not converted here; see :func:`_obstore_filesystem_requires_threaded_download`.
@@ -142,7 +195,9 @@ def _extract_credentials_from_filesystem(
         filesystem: A PyArrow filesystem instance.
 
     Returns:
-        A dict of keyword arguments to pass to obstore's ``from_url``.
+        A dict of keyword arguments for ``obstore.store.from_url``, or
+        ``None`` when the filesystem was recognized as fsspec-S3 but we
+        couldn't pull usable credentials (caller must fall back).
     """
     if filesystem is None:
         return {}
@@ -174,8 +229,9 @@ def _extract_credentials_from_filesystem(
                 kwargs[ob_key] = val
         if getattr(filesystem, "anonymous", False):
             kwargs["skip_signature"] = True
+        return kwargs
 
-    elif GcsFileSystem is not None and isinstance(filesystem, GcsFileSystem):
+    if GcsFileSystem is not None and isinstance(filesystem, GcsFileSystem):
         # obstore GCSConfig does not have a project_id field. The only useful
         # attribute PyArrow exposes on GcsFileSystem is `anonymous`, which maps
         # to obstore's `skip_signature`. All other credentials (service account,
@@ -183,14 +239,16 @@ def _extract_credentials_from_filesystem(
         # environment automatically.
         if getattr(filesystem, "anonymous", False):
             kwargs["skip_signature"] = True
+        return kwargs
 
-    elif AzureFileSystem is not None and isinstance(filesystem, AzureFileSystem):
+    if AzureFileSystem is not None and isinstance(filesystem, AzureFileSystem):
         for attr in ("account_name", "account_key"):
             val = getattr(filesystem, attr, None)
             if val:
                 kwargs[attr] = val
+        return kwargs
 
-    elif (
+    if (
         PyFileSystem is not None
         and FSSpecHandler is not None
         and isinstance(filesystem, PyFileSystem)
@@ -199,42 +257,62 @@ def _extract_credentials_from_filesystem(
         # fsspec-backed FS (e.g. s3fs with Okta/STS) wrapped for PyArrow.
         fsspec_fs = getattr(filesystem.handler, "fs", None)
         if fsspec_fs is None:
-            return {}
+            return None
         protocol = getattr(fsspec_fs, "protocol", None)
         if isinstance(protocol, tuple):
             protocol = protocol[0] if protocol else None
-        if protocol in ("s3", "s3a"):
-            opts = getattr(fsspec_fs, "storage_options", None) or {}
-            if not isinstance(opts, dict):
-                opts = {}
-            key = opts.get("key") or getattr(fsspec_fs, "key", None)
-            secret = opts.get("secret") or getattr(fsspec_fs, "secret", None)
-            token = opts.get("token") or getattr(fsspec_fs, "token", None)
-            endpoint = opts.get("endpoint_url") or getattr(
-                fsspec_fs, "endpoint_url", None
-            )
-            client_kwargs = opts.get("client_kwargs") or getattr(
-                fsspec_fs, "client_kwargs", None
-            )
-            if isinstance(client_kwargs, dict):
-                endpoint = endpoint or client_kwargs.get("endpoint_url")
-                region_name = client_kwargs.get("region_name")
-                if region_name:
-                    kwargs["region"] = region_name
-            region_opt = opts.get("region_name")
-            if region_opt:
-                kwargs["region"] = region_opt
-            if key:
-                kwargs["access_key_id"] = key
-            if secret:
-                kwargs["secret_access_key"] = secret
-            if token:
-                kwargs["session_token"] = token
-            if endpoint:
-                kwargs["endpoint"] = endpoint
-            if opts.get("anon") or getattr(fsspec_fs, "anon", False):
-                kwargs["skip_signature"] = True
-    return kwargs
+        if protocol not in ("s3", "s3a"):
+            # Non-S3 fsspec — obstore can't use these. Callers usually filter
+            # this out via _obstore_filesystem_requires_threaded_download, but
+            # direct callers must also route to the threaded path.
+            return None
+        opts = getattr(fsspec_fs, "storage_options", None) or {}
+        if not isinstance(opts, dict):
+            opts = {}
+        key = opts.get("key") or getattr(fsspec_fs, "key", None)
+        secret = opts.get("secret") or getattr(fsspec_fs, "secret", None)
+        token = opts.get("token") or getattr(fsspec_fs, "token", None)
+        endpoint = opts.get("endpoint_url") or getattr(fsspec_fs, "endpoint_url", None)
+        client_kwargs = opts.get("client_kwargs") or getattr(
+            fsspec_fs, "client_kwargs", None
+        )
+        if isinstance(client_kwargs, dict):
+            endpoint = endpoint or client_kwargs.get("endpoint_url")
+            region_name = client_kwargs.get("region_name")
+            if region_name:
+                kwargs["region"] = region_name
+        region_opt = opts.get("region_name")
+        if region_opt:
+            kwargs["region"] = region_opt
+        if key:
+            kwargs["access_key_id"] = key
+        if secret:
+            kwargs["secret_access_key"] = secret
+        if token:
+            kwargs["session_token"] = token
+        if endpoint:
+            kwargs["endpoint"] = endpoint
+        anon = opts.get("anon") or getattr(fsspec_fs, "anon", False)
+        if anon:
+            kwargs["skip_signature"] = True
+
+        # Static attrs didn't yield an access key and the user didn't opt into
+        # anonymous — snapshot the session (Okta/STS/profile-based auth).
+        if "access_key_id" not in kwargs and not anon:
+            frozen = _frozen_s3fs_credentials(fsspec_fs)
+            if frozen is None:
+                return None
+            kwargs["access_key_id"] = frozen["access_key"]
+            if frozen["secret_key"]:
+                kwargs["secret_access_key"] = frozen["secret_key"]
+            if frozen["token"]:
+                kwargs["session_token"] = frozen["token"]
+        return kwargs
+
+    # Unrecognized non-None filesystem — route to threaded so the user's FS
+    # stays authoritative. Obstore with empty kwargs would silently use its
+    # own credential chain, dropping any configuration on the user's FS.
+    return None
 
 
 def _obstore_filesystem_requires_threaded_download(
@@ -274,6 +352,64 @@ def _obstore_filesystem_requires_threaded_download(
     if protocol in ("s3", "s3a"):
         return False
     return True
+
+
+# Per-process dedup for credential-extraction warnings. Keyed by ``id(fs)`` so
+# each distinct filesystem object warns exactly once in a worker.
+_warned_credential_fs_ids: set = set()
+
+
+def _warn_credential_extraction_failed(
+    filesystem: "pyarrow.fs.FileSystem",
+) -> None:
+    """Emit a one-shot WARNING per filesystem object when creds can't be extracted."""
+    fs_id = id(filesystem)
+    if fs_id in _warned_credential_fs_ids:
+        return
+    _warned_credential_fs_ids.add(fs_id)
+
+    fs_class = type(filesystem).__name__
+    inner_class: Optional[str] = None
+    unwrapped = (
+        filesystem.unwrap()
+        if isinstance(filesystem, RetryingPyFileSystem)
+        else filesystem
+    )
+    PyFileSystem = getattr(pyarrow.fs, "PyFileSystem", None)
+    if PyFileSystem is not None and isinstance(unwrapped, PyFileSystem):
+        handler = getattr(unwrapped, "handler", None)
+        inner = getattr(handler, "fs", None)
+        if inner is not None:
+            inner_class = type(inner).__name__
+
+    detail = f" (inner fsspec: {inner_class})" if inner_class else ""
+    logger.warning(
+        "Could not extract S3 credentials from user-supplied filesystem %s%s; "
+        "falling back to the PyArrow threaded download path so the filesystem's "
+        "own credential resolution stays authoritative. If this is unexpected, "
+        "pass credentials via fsspec ``storage_options`` "
+        "(e.g. key/secret/token) so they can be forwarded to obstore.",
+        fs_class,
+        detail,
+    )
+
+
+def _plan_obstore_routing(
+    filesystem: Optional["pyarrow.fs.FileSystem"],
+) -> "tuple[bool, Dict[str, Any]]":
+    """Decide whether to use obstore and return the kwargs to forward.
+
+    Returns ``(True, fs_kwargs)`` if obstore should be used, or ``(False, {})``
+    if the caller must route to the threaded path (emits a warning).
+    """
+    if _obstore_filesystem_requires_threaded_download(filesystem):
+        return False, {}
+    fs_kwargs = _extract_credentials_from_filesystem(filesystem)
+    if fs_kwargs is None:
+        assert filesystem is not None  # only fsspec-S3 branch can return None
+        _warn_credential_extraction_failed(filesystem)
+        return False, {}
+    return True, fs_kwargs
 
 
 class StoreRegistry:
@@ -401,11 +537,12 @@ def download_bytes_async(
         )
         return
 
-    if _obstore_filesystem_requires_threaded_download(filesystem):
-        logger.debug(
-            "PyArrow PyFileSystem with a non-S3 fsspec backend (or unknown handler); "
-            "using threaded PyArrow download to preserve user filesystem credentials."
-        )
+    # Resolve credentials up front in sync context. This is the only safe place
+    # to call ``_extract_credentials_from_filesystem`` for fsspec sessions that
+    # need ``asyncio.run`` internally — once we're inside ``_download_uris_with_obstore``
+    # we're already in an event loop and that path is unavailable.
+    use_obstore, fs_kwargs = _plan_obstore_routing(filesystem)
+    if not use_obstore:
         yield from _yield_threaded_download_bytes(
             block,
             uri_column_names,
@@ -433,7 +570,10 @@ def download_bytes_async(
 
         uri_bytes = asyncio.run(
             _download_uris_with_obstore(
-                uris, uri_column_name, filesystem=filesystem, file_sizes=file_sizes
+                uris,
+                uri_column_name,
+                fs_kwargs=fs_kwargs,
+                file_sizes=file_sizes,
             )
         )
 
@@ -461,6 +601,7 @@ async def _download_uris_with_obstore(
     uri_column_name: str,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     file_sizes: Optional[List[Optional[int]]] = None,
+    fs_kwargs: Optional[Dict[str, Any]] = None,
 ) -> List[Optional[bytes]]:
     """Download URIs concurrently using obstore's async API.
 
@@ -479,16 +620,24 @@ async def _download_uris_with_obstore(
         uris: URIs to download.
         uri_column_name: Column name (used only for error logging).
         filesystem: Optional PyArrow filesystem whose credentials are
-            forwarded to the obstore store.
+            forwarded to the obstore store. Ignored when *fs_kwargs* is given.
         file_sizes: Optional per-URI file sizes from AsyncPartitionActor.
             ``0`` or ``None`` entries trigger a HEAD request when range
             splitting is enabled.
+        fs_kwargs: Pre-extracted obstore kwargs from the planner. Preferred
+            over *filesystem* because it sidesteps re-extracting credentials
+            from inside the event loop (aiobotocore sessions need ``asyncio.run``).
 
     Returns:
         Downloaded bytes in the same order as *uris*.  ``None`` entries
         indicate failed downloads.
     """
-    fs_kwargs = _extract_credentials_from_filesystem(filesystem)
+    if fs_kwargs is None:
+        # Best-effort re-extraction for direct callers (e.g. tests). Session-
+        # backed fsspec may fail here because we're already in an event loop;
+        # the sync planner path avoids this by pre-extracting upfront.
+        extracted = _extract_credentials_from_filesystem(filesystem)
+        fs_kwargs = extracted if extracted is not None else {}
 
     range_threshold = RAY_DATA_OBSTORE_RANGE_THRESHOLD
     range_chunk_size = RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -207,6 +207,20 @@ class AsyncPartitionActor(PartitionActor):
     ):
         super().__init__(uri_column_names, data_context, filesystem)
         fs_kwargs = _extract_credentials_from_filesystem(filesystem)
+        if fs_kwargs is None:
+            # Fail closed. ``plan_download_op`` routes filesystems we can't
+            # extract credentials from to ``PartitionActor`` (PyArrow path),
+            # so reaching ``AsyncPartitionActor`` with an unextractable FS is
+            # a bug. Silently seeding an empty kwargs dict would hand the
+            # user's filesystem over to obstore's ambient credential chain
+            # (IMDS / env), which is exactly the silent-drop behavior the
+            # routing was designed to prevent.
+            raise RuntimeError(
+                "AsyncPartitionActor was constructed with a filesystem whose "
+                f"credentials cannot be statically extracted ({type(filesystem).__name__}). "
+                "This indicates a dispatch bug: use PartitionActor for such "
+                "filesystems so the user's credentials are not silently dropped."
+            )
         self._registry = StoreRegistry(retry_config={"max_retries": 10}, **fs_kwargs)
 
     def __call__(self, block: pa.Table) -> Iterator[pa.Table]:

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -18,6 +18,7 @@ from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.planner._obstore_download import (
     OBSTORE_AVAILABLE,
     _log_fallback_warning,
+    _plan_obstore_routing,
     download_bytes_async,
 )
 from ray.data._internal.planner.download_partition_actor import (
@@ -68,9 +69,18 @@ def plan_download_op(
     # at the start of the chain. This is primarily done to prevent partition actors from bottlenecking
     # the chain becuase the interleaved operators would be a single actor. As a result, the
     # URIDownloader physical operator is responsible for outputting appropriately sized blocks.
+    # Decide obstore vs threaded upfront. For fsspec-S3 filesystems backed by
+    # a session we can't statically introspect (Okta / STS / profile-based),
+    # _plan_obstore_routing emits a warning and returns use_obstore=False so
+    # we fall back to the threaded PyArrow path — which uses the user's
+    # filesystem directly and resolves credentials correctly.
+    use_obstore_path = False
+    if OBSTORE_AVAILABLE:
+        use_obstore_path, _ = _plan_obstore_routing(filesystem)
+
     partition_map_operator = None
     if not upstream_op_is_download:
-        partition_cls = AsyncPartitionActor if OBSTORE_AVAILABLE else PartitionActor
+        partition_cls = AsyncPartitionActor if use_obstore_path else PartitionActor
         # PartitionActor / AsyncPartitionActor are callable classes, so we need
         # ActorPoolStrategy.
         partition_compute = ActorPoolStrategy(
@@ -117,9 +127,12 @@ def plan_download_op(
             ray_actor_task_remote_args={"_generator_backpressure_num_objects": -1},
         )
 
-    if OBSTORE_AVAILABLE:
+    if use_obstore_path:
         download_fn = download_bytes_async
         logger.debug("Using obstore async download path.")
+    elif OBSTORE_AVAILABLE:
+        # Warning already emitted by _plan_obstore_routing.
+        download_fn = download_bytes_threaded
     else:
         download_fn = download_bytes_threaded
         _log_fallback_warning()
@@ -198,36 +211,71 @@ def download_bytes_threaded(
         if len(uris) == 0:
             continue
 
-        def load_uri_bytes(uri_iterator):
-            """Resolve filesystem and download bytes for each URI.
+        # Resolve the filesystem exactly once before spawning workers. Without
+        # this, each of 16 make_async_gen worker threads independently
+        # constructs a pyarrow.fs.S3FileSystem on its first URI, triggering an
+        # IMDS credential fetch. With N concurrent Download tasks on an EC2
+        # node that's 16*N near-simultaneous IMDS calls — enough to trip the
+        # per-instance rate limit and produce intermittent NoCredentialsError.
+        resolved_fs = filesystem
+        if resolved_fs is None:
+            for probe_uri in uris:
+                if probe_uri is None:
+                    continue
+                try:
+                    paths, candidate_fs = _resolve_paths_and_filesystem(probe_uri, None)
+                except Exception as e:
+                    logger.debug(f"Could not infer filesystem from '{probe_uri}': {e}")
+                    continue
+                # _resolve_paths_and_filesystem can silently drop unresolvable
+                # URIs (returning ([], ...)) or yield no filesystem. Only accept
+                # a result we can actually use — otherwise workers fall back to
+                # per-URI inference and recreate the IMDS herd.
+                if paths and candidate_fs is not None:
+                    resolved_fs = candidate_fs
+                    break
 
-            Takes an iterator of URIs and yields bytes for each.
-            Uses lazy filesystem resolution - resolves once and reuses for subsequent URIs.
-            If a filesystem was provided explicitly, it will be used for all URIs.
-            """
-            cached_fs = filesystem
+        wrapped_fs = None
+        if resolved_fs is not None:
+            wrapped_fs = RetryingPyFileSystem.wrap(
+                resolved_fs, retryable_errors=data_context.retried_io_errors
+            )
+
+        def load_uri_bytes(
+            uri_iterator,
+            wrapped_fs=wrapped_fs,
+            resolved_fs=resolved_fs,
+            uri_column_name=uri_column_name,
+        ):
+            """Download bytes for each URI using the pre-resolved filesystem."""
             for uri in uri_iterator:
                 read_bytes = None
                 try:
-                    # Use cached FS if available, otherwise resolve the filesystem for the uri.
-                    resolved_paths, resolved_fs = _resolve_paths_and_filesystem(
-                        uri, filesystem=cached_fs
-                    )
-                    cached_fs = resolved_fs
+                    if uri is None:
+                        continue
+                    if wrapped_fs is None:
+                        # All probe URIs failed — last-resort per-URI resolution.
+                        # Mirrors legacy behavior so a block full of unresolvable
+                        # URIs doesn't lose the ones that might still resolve.
+                        resolved_paths, per_uri_fs = _resolve_paths_and_filesystem(
+                            uri, filesystem=None
+                        )
+                        fs_for_read = RetryingPyFileSystem.wrap(
+                            per_uri_fs,
+                            retryable_errors=data_context.retried_io_errors,
+                        )
+                    else:
+                        # Path normalization only — _resolve_paths_and_filesystem
+                        # short-circuits when filesystem is supplied (no network).
+                        resolved_paths, _ = _resolve_paths_and_filesystem(
+                            uri, filesystem=resolved_fs
+                        )
+                        fs_for_read = wrapped_fs
 
-                    # Wrap with retrying filesystem
-                    fs = RetryingPyFileSystem.wrap(
-                        resolved_fs, retryable_errors=data_context.retried_io_errors
-                    )
-                    # We only pass one uri to resolve and unwrap it from the list of resolved paths,
-                    # if fails, we will catch the index error and log it.
-                    resolved_path = resolved_paths[0]
+                    resolved_path = resolved_paths[0] if resolved_paths else None
                     if resolved_path is None:
                         continue
-
-                    # Download bytes
-                    # Use open_input_stream to handle the rare scenario where the data source is not seekable.
-                    with fs.open_input_stream(resolved_path) as f:
+                    with fs_for_read.open_input_stream(resolved_path) as f:
                         read_bytes = f.read()
                 except OSError as e:
                     logger.debug(

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -11,8 +11,10 @@ from ray.data._internal.planner._obstore_download import (
     _FILE_SIZE_COLUMN_PREFIX,
     _download_uris_with_obstore,
     _extract_credentials_from_filesystem,
+    _frozen_s3fs_credentials,
     _is_obstore_supported_url,
     _obstore_filesystem_requires_threaded_download,
+    _plan_obstore_routing,
     download_bytes_async,
 )
 from ray.data._internal.planner.plan_download_op import (
@@ -63,15 +65,19 @@ class TestDownloadHelpers:
         assert _extract_credentials_from_filesystem(None) == {}
 
     def test_extract_credentials_unrecognized_fs(self):
-        # LocalFileSystem is not S3/GCS/Azure, so no credentials extracted.
-        assert _extract_credentials_from_filesystem(pafs.LocalFileSystem()) == {}
+        # Unrecognized non-None filesystems (LocalFileSystem, custom FS) return
+        # None so the planner routes to the threaded path, keeping the user's
+        # filesystem authoritative instead of handing control to obstore's
+        # default credential chain.
+        assert _extract_credentials_from_filesystem(pafs.LocalFileSystem()) is None
 
     def test_extract_credentials_unwraps_retrying_fs(self):
         # RetryingPyFileSystem must be unwrapped before the isinstance checks,
-        # otherwise an S3/GCS/Azure branch would never be reached.
+        # otherwise an S3/GCS/Azure branch would never be reached. After
+        # unwrapping to an unrecognized FS, extraction returns None.
         inner = pafs.LocalFileSystem()
         retrying = RetryingPyFileSystem.wrap(inner, retryable_errors=[])
-        assert _extract_credentials_from_filesystem(retrying) == {}
+        assert _extract_credentials_from_filesystem(retrying) is None
 
     def test_extract_credentials_unwraps_retrying_fs_over_s3(self):
         # Even when an S3FileSystem is wrapped, credentials must still be
@@ -250,6 +256,497 @@ class TestDownloadHelpers:
             )
         with ctx:
             assert _is_obstore_supported_url(uri) is expected
+
+
+# TestSessionBackedFsspecCredentials
+class TestSessionBackedFsspecCredentials:
+    """Covers session-backed s3fs (Okta / STS / profile-based) credential paths.
+
+    Static attrs like ``fs.key`` are ``None`` in those setups; the helper must
+    fall through to ``session.get_credentials().get_frozen_credentials()`` and
+    return ``None`` when that also fails so the caller can route to the
+    threaded path with the user's filesystem intact.
+    """
+
+    def _make_fsspec_wrapper(
+        self, session, storage_options=None, protocol="s3", anon=False
+    ):
+        """Build a PyFileSystem(FSSpecHandler(...)) around a minimal stub.
+
+        ``s3fs`` can't be instantiated in unit tests without live AWS config,
+        so we mimic just the attributes that the extraction code reads.
+        """
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        inner = MagicMock()
+        inner.protocol = protocol
+        inner.storage_options = storage_options or {}
+        inner.session = session
+        inner.key = None
+        inner.secret = None
+        inner.token = None
+        inner.endpoint_url = None
+        inner.client_kwargs = None
+        inner.anon = anon
+        # PyArrow's FSSpecHandler calls fs._strip_protocol for normalization.
+        inner._strip_protocol = lambda p: p.split("://", 1)[-1] if "://" in p else p
+        wrapped = PyFileSystem(FSSpecHandler(inner))
+        return wrapped, inner
+
+    def _make_session(self, access_key, secret_key, token):
+        """Build a sync (botocore-style) session that returns frozen creds."""
+        frozen = MagicMock()
+        frozen.access_key = access_key
+        frozen.secret_key = secret_key
+        frozen.token = token
+        creds = MagicMock()
+        creds.get_frozen_credentials = MagicMock(return_value=frozen)
+        session = MagicMock()
+        session.get_credentials = MagicMock(return_value=creds)
+        return session
+
+    def test_frozen_credentials_sync_session(self):
+        session = self._make_session("AKIA_OKTA", "sstoken_secret", "sts_token")
+        inner = MagicMock()
+        inner.session = session
+        result = _frozen_s3fs_credentials(inner)
+        assert result == {
+            "access_key": "AKIA_OKTA",
+            "secret_key": "sstoken_secret",
+            "token": "sts_token",
+        }
+
+    def test_frozen_credentials_missing_session_returns_none(self):
+        inner = MagicMock()
+        inner.session = None
+        # Ensure both fallbacks miss.
+        inner._session = None
+        assert _frozen_s3fs_credentials(inner) is None
+
+    def test_frozen_credentials_session_raises_returns_none(self):
+        session = MagicMock()
+        session.get_credentials = MagicMock(side_effect=RuntimeError("token expired"))
+        inner = MagicMock()
+        inner.session = session
+        assert _frozen_s3fs_credentials(inner) is None
+
+    def test_frozen_credentials_no_access_key_returns_none(self):
+        # session.get_credentials() succeeds but returns empty creds (e.g. an
+        # unconfigured aws profile). Must return None, not an empty dict.
+        session = self._make_session(access_key=None, secret_key=None, token=None)
+        inner = MagicMock()
+        inner.session = session
+        assert _frozen_s3fs_credentials(inner) is None
+
+    def test_frozen_credentials_async_session(self):
+        # aiobotocore returns coroutines from get_credentials and
+        # get_frozen_credentials. The helper must drive those to completion.
+        async def _async_frozen():
+            frozen = MagicMock()
+            frozen.access_key = "AKIA_AIO"
+            frozen.secret_key = "aio_secret"
+            frozen.token = "aio_tok"
+            return frozen
+
+        async def _async_creds():
+            creds = MagicMock()
+            creds.get_frozen_credentials = MagicMock(return_value=_async_frozen())
+            return creds
+
+        session = MagicMock()
+        session.get_credentials = MagicMock(return_value=_async_creds())
+        inner = MagicMock()
+        inner.session = session
+        result = _frozen_s3fs_credentials(inner)
+        assert result == {
+            "access_key": "AKIA_AIO",
+            "secret_key": "aio_secret",
+            "token": "aio_tok",
+        }
+
+    def test_frozen_credentials_underscore_session_fallback(self):
+        # Older s3fs versions exposed `_session` instead of `session`.
+        session = self._make_session("AKIA_OLD", "old_sec", "")
+        inner = MagicMock(spec=["_session"])  # no `session` attr on the spec
+        inner._session = session
+        result = _frozen_s3fs_credentials(inner)
+        assert result == {
+            "access_key": "AKIA_OLD",
+            "secret_key": "old_sec",
+            "token": "",
+        }
+
+    def test_extract_credentials_uses_session_when_static_empty(self):
+        # The critical bug: fsspec s3fs with Okta has static attrs as None
+        # but credentials resolvable via session. Extraction must recover them.
+        session = self._make_session("AKIA_STS", "secret_sts", "token_sts")
+        wrapped, _ = self._make_fsspec_wrapper(session=session)
+        result = _extract_credentials_from_filesystem(wrapped)
+        assert result == {
+            "access_key_id": "AKIA_STS",
+            "secret_access_key": "secret_sts",
+            "session_token": "token_sts",
+        }
+
+    def test_extract_credentials_session_preferred_only_when_static_missing(self):
+        # Static storage_options wins over session — we don't override explicit
+        # user intent. The session (which would yield different values) is not
+        # consulted at all.
+        session = self._make_session("AKIA_FROM_SESSION", "x", "y")
+        wrapped, _ = self._make_fsspec_wrapper(
+            session=session,
+            storage_options={
+                "key": "AKIA_EXPLICIT",
+                "secret": "explicit_secret",
+            },
+        )
+        result = _extract_credentials_from_filesystem(wrapped)
+        assert result is not None
+        assert result["access_key_id"] == "AKIA_EXPLICIT"
+        assert result["secret_access_key"] == "explicit_secret"
+        # Session was never invoked because static attrs produced an access key.
+        session.get_credentials.assert_not_called()
+
+    def test_extract_credentials_unresolvable_session_returns_none(self):
+        # No static attrs AND session raises — function must return None so the
+        # planner routes to the threaded path with the user's fsspec FS intact.
+        session = MagicMock()
+        session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
+        wrapped, _ = self._make_fsspec_wrapper(session=session)
+        assert _extract_credentials_from_filesystem(wrapped) is None
+
+    def test_extract_credentials_anon_skips_session(self):
+        # Anonymous s3fs — no credentials needed, don't poke the session.
+        session = MagicMock()
+        session.get_credentials = MagicMock(
+            side_effect=AssertionError("must not be called when anon=True")
+        )
+        wrapped, _ = self._make_fsspec_wrapper(session=session, anon=True)
+        result = _extract_credentials_from_filesystem(wrapped)
+        assert result == {"skip_signature": True}
+
+
+# TestPlanObstoreRouting
+class TestPlanObstoreRouting:
+    """``_plan_obstore_routing`` picks obstore vs threaded with one-shot warning."""
+
+    def setup_method(self):
+        # Clear the module-level dedup so each test sees a fresh warning.
+        from ray.data._internal.planner import _obstore_download as m
+
+        m._warned_credential_fs_ids.clear()
+
+    def test_routing_none_filesystem_uses_obstore(self):
+        use_obstore, kwargs = _plan_obstore_routing(None)
+        assert use_obstore is True
+        assert kwargs == {}
+
+    def test_routing_non_s3_fsspec_routes_to_threaded(self):
+        import fsspec
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        class _GcsStub(fsspec.AbstractFileSystem):
+            protocol = "gcs"
+
+        wrapped = PyFileSystem(FSSpecHandler(_GcsStub()))
+        use_obstore, kwargs = _plan_obstore_routing(wrapped)
+        assert use_obstore is False
+        assert kwargs == {}
+
+    def test_routing_unextractable_fsspec_s3_routes_to_threaded_with_warning(
+        self, caplog
+    ):
+        import logging
+
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        session = MagicMock()
+        session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
+        inner = MagicMock()
+        inner.protocol = "s3"
+        inner.storage_options = {}
+        inner.session = session
+        inner.key = None
+        inner.secret = None
+        inner.token = None
+        inner.endpoint_url = None
+        inner.client_kwargs = None
+        inner.anon = False
+        inner._strip_protocol = lambda p: p
+        wrapped = PyFileSystem(FSSpecHandler(inner))
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="ray.data._internal.planner._obstore_download",
+        ):
+            use_obstore, kwargs = _plan_obstore_routing(wrapped)
+
+        assert use_obstore is False
+        assert kwargs == {}
+        # Warning emitted exactly once.
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "Could not extract S3 credentials" in r.getMessage()
+        ]
+        assert len(warning_records) == 1
+
+    def test_routing_warns_once_per_filesystem(self, caplog):
+        import logging
+
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        def _make_wrapper():
+            session = MagicMock()
+            session.get_credentials = MagicMock(side_effect=RuntimeError("x"))
+            inner = MagicMock()
+            inner.protocol = "s3"
+            inner.storage_options = {}
+            inner.session = session
+            inner.key = None
+            inner.secret = None
+            inner.token = None
+            inner.endpoint_url = None
+            inner.client_kwargs = None
+            inner.anon = False
+            inner._strip_protocol = lambda p: p
+            return PyFileSystem(FSSpecHandler(inner))
+
+        fs_a = _make_wrapper()
+        fs_b = _make_wrapper()
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="ray.data._internal.planner._obstore_download",
+        ):
+            _plan_obstore_routing(fs_a)
+            _plan_obstore_routing(fs_a)  # same FS — no new warning
+            _plan_obstore_routing(fs_b)  # different FS — new warning
+
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "Could not extract S3 credentials" in r.getMessage()
+        ]
+        assert len(warning_records) == 2
+
+    def test_async_partition_actor_fails_closed_on_unextractable_creds(self):
+        # AsyncPartitionActor must raise (not silently use obstore's ambient
+        # credential chain) when it's constructed with a filesystem whose
+        # credentials can't be extracted. In the normal plan flow,
+        # _plan_obstore_routing directs such filesystems to PartitionActor.
+        # Reaching AsyncPartitionActor anyway indicates a dispatch bug.
+        pytest.importorskip("obstore")
+        from ray.data._internal.planner.download_partition_actor import (
+            AsyncPartitionActor,
+        )
+
+        # Unrecognized filesystem → extraction returns None.
+        bad_fs = pafs.LocalFileSystem()
+        ctx = DataContext.get_current()
+
+        with pytest.raises(RuntimeError, match="cannot be statically extracted"):
+            AsyncPartitionActor(["uri"], ctx, filesystem=bad_fs)
+
+    def test_routing_extractable_fsspec_s3_uses_obstore(self):
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        inner = MagicMock()
+        inner.protocol = "s3"
+        inner.storage_options = {"key": "AKIA", "secret": "sec", "token": "tok"}
+        inner.session = None
+        inner.key = None
+        inner.secret = None
+        inner.token = None
+        inner.endpoint_url = None
+        inner.client_kwargs = None
+        inner.anon = False
+        inner._strip_protocol = lambda p: p
+        wrapped = PyFileSystem(FSSpecHandler(inner))
+
+        use_obstore, kwargs = _plan_obstore_routing(wrapped)
+        assert use_obstore is True
+        assert kwargs == {
+            "access_key_id": "AKIA",
+            "secret_access_key": "sec",
+            "session_token": "tok",
+        }
+
+
+# TestThreadedDownloadPreResolve
+class TestThreadedDownloadPreResolve:
+    """``download_bytes_threaded`` resolves the filesystem once per block/column.
+
+    Regression coverage for the IMDS thundering-herd: each of the 16
+    ``make_async_gen`` workers used to call ``_resolve_paths_and_filesystem``
+    independently on its first URI, triggering an IMDS credential fetch per
+    worker per task. The fix probes exactly once up-front and shares the
+    pre-resolved filesystem across all workers.
+    """
+
+    def test_resolves_filesystem_once_across_workers(self, tmp_path):
+        for i in range(10):
+            (tmp_path / f"f{i}.bin").write_bytes(f"data-{i}".encode())
+
+        uris = [f"file://{tmp_path}/f{i}.bin" for i in range(10)]
+        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+        ctx = DataContext.get_current()
+
+        # Spy on _resolve_paths_and_filesystem. Under the new pre-resolve
+        # scheme, exactly one invocation should happen with filesystem=None
+        # (the probe), plus one per URI with filesystem=<resolved fs> (path
+        # normalization only — that call short-circuits in path_util without
+        # any network I/O). With the old code, filesystem=None would be
+        # called up to 16 times (once per worker's first URI).
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        original = pdo._resolve_paths_and_filesystem
+        probe_calls: list = []
+        normalize_calls: list = []
+
+        def _tracking(uri, filesystem=None, **kw):
+            if filesystem is None:
+                probe_calls.append(uri)
+            else:
+                normalize_calls.append(uri)
+            return original(uri, filesystem=filesystem, **kw)
+
+        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_tracking):
+            results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+
+        assert len(probe_calls) == 1, (
+            f"Expected exactly one probe call with filesystem=None, got "
+            f"{len(probe_calls)}: {probe_calls}"
+        )
+        assert len(normalize_calls) == 10
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        assert out_bytes == [f"data-{i}".encode() for i in range(10)]
+
+    def test_supplied_filesystem_skips_probe(self, tmp_path):
+        (tmp_path / "f.bin").write_bytes(b"supplied")
+        uri = f"file://{tmp_path}/f.bin"
+        table = pa.Table.from_arrays([pa.array([uri])], names=["uri"])
+        ctx = DataContext.get_current()
+
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        original = pdo._resolve_paths_and_filesystem
+        probe_calls: list = []
+
+        def _tracking(probe_uri, filesystem=None, **kw):
+            if filesystem is None:
+                probe_calls.append(probe_uri)
+            return original(probe_uri, filesystem=filesystem, **kw)
+
+        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_tracking):
+            results = list(
+                download_bytes_threaded(
+                    table,
+                    ["uri"],
+                    ["bytes"],
+                    ctx,
+                    filesystem=pafs.LocalFileSystem(),
+                )
+            )
+
+        # A user-supplied FS means zero probe calls — we go straight to
+        # normalize-only calls.
+        assert probe_calls == []
+        assert results[0].column("bytes")[0].as_py() == b"supplied"
+
+    def test_bad_first_uri_still_finds_filesystem(self, tmp_path):
+        # Probe loop must skip None / unresolvable URIs and continue until it
+        # finds one that yields both paths and a filesystem.
+        (tmp_path / "good.bin").write_bytes(b"good content")
+        good_uri = f"file://{tmp_path}/good.bin"
+
+        # Mix None + resolvable. None entries must not stop the probe.
+        uris = [None, good_uri]
+        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+        ctx = DataContext.get_current()
+
+        results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        # None URI → None result; good URI → good content.
+        assert out_bytes[1] == b"good content"
+
+    def test_all_probe_uris_unresolvable_does_not_crash(self):
+        # Every URI raises during inference. Workers must fall back to
+        # per-URI resolution without crashing. Every URI yields None.
+        uris = ["not-a-scheme://bogus/1", "also-bogus://2"]
+        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+        ctx = DataContext.get_current()
+
+        # Should not raise.
+        results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        assert all(b is None for b in out_bytes)
+
+    def test_empty_block_does_not_spawn_workers(self):
+        # Zero URIs → the column loop skips; no probe, no workers.
+        table = pa.Table.from_arrays([pa.array([], type=pa.string())], names=["uri"])
+        ctx = DataContext.get_current()
+
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        with patch.object(
+            pdo, "_resolve_paths_and_filesystem", side_effect=AssertionError
+        ):
+            # No resolve calls expected; iterator should finish cleanly.
+            list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+
+    def test_probe_rejects_empty_paths_result(self):
+        # Regression: the probe must NOT break when _resolve_paths_and_filesystem
+        # returns ([], fs) — that would leave workers with no usable FS and
+        # push them back to per-URI resolution (the IMDS herd). The loop must
+        # keep probing until it finds a URI whose resolution yields both paths
+        # AND a filesystem.
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        real_fs = pafs.LocalFileSystem()
+        calls: list = []
+
+        def _fake_resolve(uri, filesystem=None, **_kw):
+            calls.append((uri, filesystem))
+            if filesystem is not None:
+                # Normalize-only call during the worker's read path.
+                return ([uri.removeprefix("file://")], filesystem)
+            if uri == "file:///first-dropped":
+                # Simulate the silent-drop case: successful return but no paths.
+                return ([], real_fs)
+            # Second URI: real resolution.
+            return ([uri.removeprefix("file://")], real_fs)
+
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tf:
+            tf.write(b"second uri wins")
+            real_path = tf.name
+
+        try:
+            uris = ["file:///first-dropped", f"file://{real_path}"]
+            table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+            ctx = DataContext.get_current()
+
+            with patch.object(
+                pdo, "_resolve_paths_and_filesystem", side_effect=_fake_resolve
+            ):
+                results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+        finally:
+            os.unlink(real_path)
+
+        # The probe must have tried BOTH URIs (dropped the empty-paths result,
+        # accepted the second). Count of probe calls (filesystem=None):
+        probe_calls = [c for c in calls if c[1] is None]
+        assert len(probe_calls) == 2, (
+            f"Expected probe to skip the empty-paths result and try the next URI, "
+            f"got {probe_calls}"
+        )
+
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        assert out_bytes[1] == b"second uri wins"
 
 
 # TestObstoreDownloadPath
@@ -434,12 +931,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "big.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/big.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size * 2,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size * 2,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             results = asyncio.run(
                 _download_uris_with_obstore([uri], "uri", file_sizes=[len(content)])
@@ -453,12 +953,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "big2.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/big2.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             results = asyncio.run(
                 _download_uris_with_obstore([uri], "uri", file_sizes=None)
@@ -488,15 +991,19 @@ class TestObstoreRangeSplitDownload:
         def _fail_ranged(*_args, **_kwargs):
             raise AssertionError("_fetch_ranged must not be called")
 
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            100,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            -512,
-        ), patch(
-            "ray.data._internal.planner._obstore_download._fetch_ranged",
-            side_effect=_fail_ranged,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                100,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                -512,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download._fetch_ranged",
+                side_effect=_fail_ranged,
+            ),
         ):
             results2 = asyncio.run(
                 _download_uris_with_obstore([uri2], "uri", file_sizes=[len(content2)])
@@ -515,12 +1022,15 @@ class TestObstoreRangeSplitDownload:
             f"file://{tmp_path}/large.bin",
             f"file://{tmp_path}/small.bin",
         ]
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size * 2,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size * 2,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             results = asyncio.run(
                 _download_uris_with_obstore(
@@ -629,12 +1139,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "f.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/f.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             import obstore as obs
 
@@ -648,9 +1161,10 @@ class TestObstoreRangeSplitDownload:
                 range_calls.append(args)
                 return await original_get_range(*args, **kwargs)
 
-            with patch.object(
-                obs, "head_async", side_effect=_failing_head
-            ), patch.object(obs, "get_range_async", side_effect=_tracking_range):
+            with (
+                patch.object(obs, "head_async", side_effect=_failing_head),
+                patch.object(obs, "get_range_async", side_effect=_tracking_range),
+            ):
                 results = asyncio.run(
                     _download_uris_with_obstore([uri], "uri", file_sizes=[0])
                 )
@@ -678,12 +1192,15 @@ class TestObstoreRangeSplitDownload:
         ]
         file_sizes: list[Optional[int]] = [len(large_content), len(small_content), 0]
 
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size * 2,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size * 2,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             import obstore as obs
 
@@ -710,12 +1227,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "exact.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/exact.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            threshold,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            256,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                threshold,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                256,
+            ),
         ):
             import obstore as obs
 
@@ -742,12 +1262,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "fail.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/fail.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             import obstore as obs
 
@@ -783,15 +1306,17 @@ class TestObstoreRangeSplitDownload:
 
         uri = f"file://{tmp_path}/f.bin"
         # Simulate misconfiguration: range splitting on, but concurrency = 0.
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_MAX_CONCURRENCY",
-            0,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.logger"
-        ) as mock_logger:
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_MAX_CONCURRENCY",
+                0,
+            ),
+            patch("ray.data._internal.planner._obstore_download.logger") as mock_logger,
+        ):
             import obstore as obs
 
             # Spy on get_range_async to verify it is never called.

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -550,6 +550,25 @@ class TestPlanObstoreRouting:
         with pytest.raises(RuntimeError, match="cannot be statically extracted"):
             AsyncPartitionActor(["uri"], ctx, filesystem=bad_fs)
 
+    def test_download_uris_with_obstore_fails_closed_on_unextractable_fs(self):
+        # Direct-caller guard: _download_uris_with_obstore with a filesystem
+        # whose credentials can't be extracted must raise rather than coerce
+        # to {} and hand obstore the ambient credential chain. Preserves the
+        # fail-closed contract for any internal/test caller that bypasses
+        # _plan_obstore_routing.
+        pytest.importorskip("obstore")
+
+        bad_fs = pafs.LocalFileSystem()  # unrecognized → extraction returns None
+
+        with pytest.raises(RuntimeError, match="cannot be statically extracted"):
+            asyncio.run(
+                _download_uris_with_obstore(
+                    ["file:///tmp/does-not-matter.bin"],
+                    "uri",
+                    filesystem=bad_fs,
+                )
+            )
+
     def test_routing_extractable_fsspec_s3_uses_obstore(self):
         from pyarrow.fs import FSSpecHandler, PyFileSystem
 


### PR DESCRIPTION
## Summary

Fixes two independent bugs in the `download` expression pipeline that compound under concurrent S3 workloads on EC2.

### Bug 1 — Silent credential drop (obstore path)

When a user passes an fsspec `S3FileSystem` with Okta/STS/profile-based auth (wrapped as `PyFileSystem(FSSpecHandler(s3fs_fs))`), `_extract_credentials_from_filesystem` read only static attrs (`key`/`secret`/`token`, `storage_options`). Those attrs are `None` for session-backed s3fs — credentials live on `fs.session.get_credentials()` and may rotate. The function returned `{}`, obstore's `from_url` got no keys, and obstore silently fell back to its own credential chain (IMDS on EC2). Users never saw a warning.

### Bug 2 — IMDS thundering herd (threaded fallback)

`download_bytes_threaded` spawned 16 worker threads via `make_async_gen`. Each worker independently called `_resolve_paths_and_filesystem(uri, cached_fs=None)` on its first URI, constructing a fresh `pyarrow.fs.S3FileSystem` → triggering an IMDS credential fetch. With N concurrent Download tasks on a node that was ~16×N near-simultaneous IMDS HTTP calls — enough to trip the per-instance rate limit and produce intermittent `NoCredentialsError`.

## Changes

- **`_extract_credentials_from_filesystem`** now returns `Optional[Dict]`. `None` signals "route to threaded" so the user's filesystem stays authoritative. New `_frozen_s3fs_credentials` helper snapshots via `session.get_credentials().get_frozen_credentials()` for both sync (botocore) and async (aiobotocore) sessions. Unrecognized non-`None` filesystems also return `None` per the new contract.
- **`_plan_obstore_routing(fs) -> (use_obstore, fs_kwargs)`** centralizes dispatch with a one-shot `WARNING` per filesystem when credentials can't be extracted.
- **`plan_download_op`** pre-decides obstore-vs-threaded at plan time and routes `AsyncPartitionActor` accordingly — no silent downgrade.
- **`download_bytes_threaded`** resolves the filesystem exactly once per (block, column) before `make_async_gen` and shares it across all 16 workers via closure default-arg binding. Probe loop requires both `paths` **and** `fs` to be usable before breaking, avoiding leak-through when `_resolve_paths_and_filesystem` silently drops a bad URI.
- **`download_bytes_async`** extracts credentials once in sync context and threads kwargs through to `_download_uris_with_obstore`. Fixes a correctness issue where aiobotocore's async `get_credentials` couldn't run from inside an existing event loop.
- **`AsyncPartitionActor`** fails closed with a clear `RuntimeError` if it's ever constructed with an unextractable filesystem (dispatch-bug guard).

## Test plan

- [x] `pre-commit run` passes on all changed files (ruff, pydoclint, black, docstyle, semgrep, import order, mock-method / logger checks).
- [x] Added unit tests in `test_obstore_download.py`:
  - `TestSessionBackedFsspecCredentials` — boto3 sync session, aiobotocore async session, `_session` fallback for older s3fs, unresolvable session returns `None`, no-access-key returns `None`, `anon=True` skips session, static attrs win over session.
  - `TestPlanObstoreRouting` — `None` filesystem → obstore, non-S3 fsspec → threaded, unextractable fsspec-S3 → threaded with warning, warning dedup (same FS twice = one warning), extractable fsspec-S3 → obstore, `AsyncPartitionActor` raises on unextractable creds.
  - `TestThreadedDownloadPreResolve` — exactly one probe across 16 workers, supplied-FS skips probe, bad-first-URI still finds FS, all-bad URIs don't crash, empty block doesn't spawn workers, regression test for `([], fs)` probe-break bug.
- [ ] End-to-end against moto/minio with Okta-style fsspec `S3FileSystem` over ~100 URIs (no `NoCredentialsError`, moto sees signed requests).
- [ ] Run with `RAY_DATA_USE_OBSTORE=0` over concurrent tasks, verifying `S3FileSystem.__init__` is invoked exactly once per block rather than per worker.