### PR TITLE
[Data] Fix silent credential drop for fsspec-S3 in download expression

### DIFF
--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import logging
 import os
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
@@ -113,6 +114,16 @@ def _is_obstore_supported_url(path: str) -> bool:
 
 
 # Credential extraction & store management
+async def _await(awaitable):
+    """Drive an arbitrary awaitable (coroutine, Task, Future, ...) to a value.
+
+    ``asyncio.run`` only accepts coroutines, but ``inspect.isawaitable``
+    matches a wider set (Task, Future, custom ``__await__`` objects).
+    Wrapping with ``await`` here lets ``asyncio.run`` drive any of them.
+    """
+    return await awaitable
+
+
 def _frozen_s3fs_credentials(fsspec_fs) -> Optional[Dict[str, str]]:
     """Snapshot credentials from an s3fs-style session.
 
@@ -135,17 +146,20 @@ def _frozen_s3fs_credentials(fsspec_fs) -> Optional[Dict[str, str]]:
     try:
         get_creds = session.get_credentials
         creds = get_creds()
-        if asyncio.iscoroutine(creds):
+        # Use inspect.isawaitable rather than asyncio.iscoroutine — sessions
+        # backed by aiobotocore / custom wrappers can return Tasks, Futures,
+        # or other awaitables that ``iscoroutine`` does not recognize.
+        if inspect.isawaitable(creds):
             try:
-                creds = asyncio.run(creds)
+                creds = asyncio.run(_await(creds))
             except RuntimeError:
                 return None
         if creds is None:
             return None
         frozen = creds.get_frozen_credentials()
-        if asyncio.iscoroutine(frozen):
+        if inspect.isawaitable(frozen):
             try:
-                frozen = asyncio.run(frozen)
+                frozen = asyncio.run(_await(frozen))
             except RuntimeError:
                 return None
     except Exception as e:

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -354,43 +354,65 @@ def _obstore_filesystem_requires_threaded_download(
     return True
 
 
+def _is_fsspec_s3_filesystem(filesystem: "pyarrow.fs.FileSystem") -> bool:
+    """True if *filesystem* is a PyFileSystem wrapping an fsspec s3/s3a handler."""
+    if isinstance(filesystem, RetryingPyFileSystem):
+        filesystem = filesystem.unwrap()
+    PyFileSystem = getattr(pyarrow.fs, "PyFileSystem", None)
+    FSSpecHandler = getattr(pyarrow.fs, "FSSpecHandler", None)
+    if (
+        PyFileSystem is None
+        or FSSpecHandler is None
+        or not isinstance(filesystem, PyFileSystem)
+        or not isinstance(filesystem.handler, FSSpecHandler)
+    ):
+        return False
+    fsspec_fs = getattr(filesystem.handler, "fs", None)
+    if fsspec_fs is None:
+        return False
+    protocol = getattr(fsspec_fs, "protocol", None)
+    if isinstance(protocol, tuple):
+        protocol = protocol[0] if protocol else None
+    return protocol in ("s3", "s3a")
+
+
 # Per-process dedup for credential-extraction warnings. Keyed by ``id(fs)`` so
 # each distinct filesystem object warns exactly once in a worker.
 _warned_credential_fs_ids: set = set()
 
 
-def _warn_credential_extraction_failed(
+def _warn_fsspec_s3_credentials_unextractable(
     filesystem: "pyarrow.fs.FileSystem",
 ) -> None:
-    """Emit a one-shot WARNING per filesystem object when creds can't be extracted."""
+    """Emit a one-shot WARNING for fsspec-S3 filesystems with unextractable creds.
+
+    Only call this for filesystems where ``_is_fsspec_s3_filesystem`` is True —
+    the message hardcodes fsspec-specific advice (``storage_options``) and
+    would be misleading for native filesystems like ``LocalFileSystem`` or
+    ``HdfsFileSystem``.
+    """
     fs_id = id(filesystem)
     if fs_id in _warned_credential_fs_ids:
         return
     _warned_credential_fs_ids.add(fs_id)
 
-    fs_class = type(filesystem).__name__
-    inner_class: Optional[str] = None
     unwrapped = (
         filesystem.unwrap()
         if isinstance(filesystem, RetryingPyFileSystem)
         else filesystem
     )
-    PyFileSystem = getattr(pyarrow.fs, "PyFileSystem", None)
-    if PyFileSystem is not None and isinstance(unwrapped, PyFileSystem):
-        handler = getattr(unwrapped, "handler", None)
-        inner = getattr(handler, "fs", None)
-        if inner is not None:
-            inner_class = type(inner).__name__
+    handler = getattr(unwrapped, "handler", None)
+    inner = getattr(handler, "fs", None)
+    inner_class = type(inner).__name__ if inner is not None else "unknown"
 
-    detail = f" (inner fsspec: {inner_class})" if inner_class else ""
     logger.warning(
-        "Could not extract S3 credentials from user-supplied filesystem %s%s; "
-        "falling back to the PyArrow threaded download path so the filesystem's "
-        "own credential resolution stays authoritative. If this is unexpected, "
-        "pass credentials via fsspec ``storage_options`` "
-        "(e.g. key/secret/token) so they can be forwarded to obstore.",
-        fs_class,
-        detail,
+        "Could not extract S3 credentials from user-supplied fsspec "
+        "filesystem (inner: %s); falling back to the PyArrow threaded "
+        "download path so the filesystem's own credential resolution stays "
+        "authoritative. If this is unexpected, pass credentials via fsspec "
+        "``storage_options`` (e.g. key/secret/token) so they can be "
+        "forwarded to obstore.",
+        inner_class,
     )
 
 
@@ -400,14 +422,24 @@ def _plan_obstore_routing(
     """Decide whether to use obstore and return the kwargs to forward.
 
     Returns ``(True, fs_kwargs)`` if obstore should be used, or ``(False, {})``
-    if the caller must route to the threaded path (emits a warning).
+    if the caller must route to the threaded path. Emits a ``WARNING`` only
+    when an fsspec-S3 filesystem was supplied but its credentials couldn't be
+    extracted — routing native / unrecognized filesystems to the threaded
+    path is the expected behavior and is logged at ``DEBUG``.
     """
     if _obstore_filesystem_requires_threaded_download(filesystem):
         return False, {}
     fs_kwargs = _extract_credentials_from_filesystem(filesystem)
     if fs_kwargs is None:
-        assert filesystem is not None  # only fsspec-S3 branch can return None
-        _warn_credential_extraction_failed(filesystem)
+        assert filesystem is not None  # None filesystem always returns {}
+        if _is_fsspec_s3_filesystem(filesystem):
+            _warn_fsspec_s3_credentials_unextractable(filesystem)
+        else:
+            logger.debug(
+                "Routing filesystem %s to the PyArrow threaded download path "
+                "(obstore cannot forward credentials for this filesystem type).",
+                type(filesystem).__name__,
+            )
         return False, {}
     return True, fs_kwargs
 

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -113,9 +113,60 @@ def _is_obstore_supported_url(path: str) -> bool:
 
 
 # Credential extraction & store management
+def _frozen_s3fs_credentials(fsspec_fs) -> Optional[Dict[str, str]]:
+    """Snapshot credentials from an s3fs-style session.
+
+    s3fs with Okta / STS / profile-based auth resolves credentials lazily via
+    ``fs.session.get_credentials()`` — the ``key`` / ``secret`` / ``token``
+    instance attributes are ``None`` in that setup. We call
+    ``get_frozen_credentials()`` to capture the currently-valid set.
+
+    Returns a dict with ``access_key``, ``secret_key``, ``token`` keys, or
+    ``None`` if a session isn't available or credentials can't be retrieved
+    (e.g. expired, retrieval error). The caller must tolerate ``None`` and
+    route to the threaded path so the user's filesystem stays authoritative.
+    """
+    session = getattr(fsspec_fs, "session", None) or getattr(
+        fsspec_fs, "_session", None
+    )
+    if session is None:
+        return None
+
+    try:
+        get_creds = session.get_credentials
+        creds = get_creds()
+        if asyncio.iscoroutine(creds):
+            try:
+                creds = asyncio.run(creds)
+            except RuntimeError:
+                return None
+        if creds is None:
+            return None
+        frozen = creds.get_frozen_credentials()
+        if asyncio.iscoroutine(frozen):
+            try:
+                frozen = asyncio.run(frozen)
+            except RuntimeError:
+                return None
+    except Exception as e:
+        logger.debug("Could not snapshot fsspec session credentials: %r", e)
+        return None
+
+    access_key = getattr(frozen, "access_key", None)
+    secret_key = getattr(frozen, "secret_key", None)
+    token = getattr(frozen, "token", None)
+    if not access_key:
+        return None
+    return {
+        "access_key": access_key,
+        "secret_key": secret_key or "",
+        "token": token or "",
+    }
+
+
 def _extract_credentials_from_filesystem(
     filesystem: Optional["pyarrow.fs.FileSystem"],
-) -> Dict[str, Any]:
+) -> Optional[Dict[str, Any]]:
     """Extract credentials from a PyArrow filesystem for use with obstore.
 
     Maps PyArrow filesystem configuration to obstore keyword arguments.
@@ -131,9 +182,11 @@ def _extract_credentials_from_filesystem(
 
     **fsspec S3 (``PyFileSystem`` + ``FSSpecHandler``):** For ``s3`` / ``s3a``
     (e.g. ``s3fs`` with STS/Okta/custom endpoints), credentials are read from
-    ``storage_options`` / common instance attributes so obstore can use the
-    same keys the user passed to fsspec. ``anon`` maps to ``skip_signature``;
-    ``region_name`` may appear in ``storage_options`` or ``client_kwargs``.
+    ``storage_options`` / common instance attributes first; if no static key is
+    present, we snapshot ``fs.session.get_credentials().get_frozen_credentials()``
+    to handle session-backed (Okta/STS/profile) auth. If both passes come up
+    empty we return ``None`` so the caller routes to the threaded path, keeping
+    the user's fsspec filesystem authoritative.
 
     Other ``PyFileSystem`` handlers (non-fsspec or non-S3 fsspec protocols) are
     not converted here; see :func:`_obstore_filesystem_requires_threaded_download`.
@@ -142,7 +195,9 @@ def _extract_credentials_from_filesystem(
         filesystem: A PyArrow filesystem instance.
 
     Returns:
-        A dict of keyword arguments to pass to obstore's ``from_url``.
+        A dict of keyword arguments for ``obstore.store.from_url``, or
+        ``None`` when the filesystem was recognized as fsspec-S3 but we
+        couldn't pull usable credentials (caller must fall back).
     """
     if filesystem is None:
         return {}
@@ -174,8 +229,9 @@ def _extract_credentials_from_filesystem(
                 kwargs[ob_key] = val
         if getattr(filesystem, "anonymous", False):
             kwargs["skip_signature"] = True
+        return kwargs
 
-    elif GcsFileSystem is not None and isinstance(filesystem, GcsFileSystem):
+    if GcsFileSystem is not None and isinstance(filesystem, GcsFileSystem):
         # obstore GCSConfig does not have a project_id field. The only useful
         # attribute PyArrow exposes on GcsFileSystem is `anonymous`, which maps
         # to obstore's `skip_signature`. All other credentials (service account,
@@ -183,14 +239,16 @@ def _extract_credentials_from_filesystem(
         # environment automatically.
         if getattr(filesystem, "anonymous", False):
             kwargs["skip_signature"] = True
+        return kwargs
 
-    elif AzureFileSystem is not None and isinstance(filesystem, AzureFileSystem):
+    if AzureFileSystem is not None and isinstance(filesystem, AzureFileSystem):
         for attr in ("account_name", "account_key"):
             val = getattr(filesystem, attr, None)
             if val:
                 kwargs[attr] = val
+        return kwargs
 
-    elif (
+    if (
         PyFileSystem is not None
         and FSSpecHandler is not None
         and isinstance(filesystem, PyFileSystem)
@@ -199,42 +257,62 @@ def _extract_credentials_from_filesystem(
         # fsspec-backed FS (e.g. s3fs with Okta/STS) wrapped for PyArrow.
         fsspec_fs = getattr(filesystem.handler, "fs", None)
         if fsspec_fs is None:
-            return {}
+            return None
         protocol = getattr(fsspec_fs, "protocol", None)
         if isinstance(protocol, tuple):
             protocol = protocol[0] if protocol else None
-        if protocol in ("s3", "s3a"):
-            opts = getattr(fsspec_fs, "storage_options", None) or {}
-            if not isinstance(opts, dict):
-                opts = {}
-            key = opts.get("key") or getattr(fsspec_fs, "key", None)
-            secret = opts.get("secret") or getattr(fsspec_fs, "secret", None)
-            token = opts.get("token") or getattr(fsspec_fs, "token", None)
-            endpoint = opts.get("endpoint_url") or getattr(
-                fsspec_fs, "endpoint_url", None
-            )
-            client_kwargs = opts.get("client_kwargs") or getattr(
-                fsspec_fs, "client_kwargs", None
-            )
-            if isinstance(client_kwargs, dict):
-                endpoint = endpoint or client_kwargs.get("endpoint_url")
-                region_name = client_kwargs.get("region_name")
-                if region_name:
-                    kwargs["region"] = region_name
-            region_opt = opts.get("region_name")
-            if region_opt:
-                kwargs["region"] = region_opt
-            if key:
-                kwargs["access_key_id"] = key
-            if secret:
-                kwargs["secret_access_key"] = secret
-            if token:
-                kwargs["session_token"] = token
-            if endpoint:
-                kwargs["endpoint"] = endpoint
-            if opts.get("anon") or getattr(fsspec_fs, "anon", False):
-                kwargs["skip_signature"] = True
-    return kwargs
+        if protocol not in ("s3", "s3a"):
+            # Non-S3 fsspec — obstore can't use these. Callers usually filter
+            # this out via _obstore_filesystem_requires_threaded_download, but
+            # direct callers must also route to the threaded path.
+            return None
+        opts = getattr(fsspec_fs, "storage_options", None) or {}
+        if not isinstance(opts, dict):
+            opts = {}
+        key = opts.get("key") or getattr(fsspec_fs, "key", None)
+        secret = opts.get("secret") or getattr(fsspec_fs, "secret", None)
+        token = opts.get("token") or getattr(fsspec_fs, "token", None)
+        endpoint = opts.get("endpoint_url") or getattr(fsspec_fs, "endpoint_url", None)
+        client_kwargs = opts.get("client_kwargs") or getattr(
+            fsspec_fs, "client_kwargs", None
+        )
+        if isinstance(client_kwargs, dict):
+            endpoint = endpoint or client_kwargs.get("endpoint_url")
+            region_name = client_kwargs.get("region_name")
+            if region_name:
+                kwargs["region"] = region_name
+        region_opt = opts.get("region_name")
+        if region_opt:
+            kwargs["region"] = region_opt
+        if key:
+            kwargs["access_key_id"] = key
+        if secret:
+            kwargs["secret_access_key"] = secret
+        if token:
+            kwargs["session_token"] = token
+        if endpoint:
+            kwargs["endpoint"] = endpoint
+        anon = opts.get("anon") or getattr(fsspec_fs, "anon", False)
+        if anon:
+            kwargs["skip_signature"] = True
+
+        # Static attrs didn't yield an access key and the user didn't opt into
+        # anonymous — snapshot the session (Okta/STS/profile-based auth).
+        if "access_key_id" not in kwargs and not anon:
+            frozen = _frozen_s3fs_credentials(fsspec_fs)
+            if frozen is None:
+                return None
+            kwargs["access_key_id"] = frozen["access_key"]
+            if frozen["secret_key"]:
+                kwargs["secret_access_key"] = frozen["secret_key"]
+            if frozen["token"]:
+                kwargs["session_token"] = frozen["token"]
+        return kwargs
+
+    # Unrecognized non-None filesystem — route to threaded so the user's FS
+    # stays authoritative. Obstore with empty kwargs would silently use its
+    # own credential chain, dropping any configuration on the user's FS.
+    return None
 
 
 def _obstore_filesystem_requires_threaded_download(
@@ -274,6 +352,64 @@ def _obstore_filesystem_requires_threaded_download(
     if protocol in ("s3", "s3a"):
         return False
     return True
+
+
+# Per-process dedup for credential-extraction warnings. Keyed by ``id(fs)`` so
+# each distinct filesystem object warns exactly once in a worker.
+_warned_credential_fs_ids: set = set()
+
+
+def _warn_credential_extraction_failed(
+    filesystem: "pyarrow.fs.FileSystem",
+) -> None:
+    """Emit a one-shot WARNING per filesystem object when creds can't be extracted."""
+    fs_id = id(filesystem)
+    if fs_id in _warned_credential_fs_ids:
+        return
+    _warned_credential_fs_ids.add(fs_id)
+
+    fs_class = type(filesystem).__name__
+    inner_class: Optional[str] = None
+    unwrapped = (
+        filesystem.unwrap()
+        if isinstance(filesystem, RetryingPyFileSystem)
+        else filesystem
+    )
+    PyFileSystem = getattr(pyarrow.fs, "PyFileSystem", None)
+    if PyFileSystem is not None and isinstance(unwrapped, PyFileSystem):
+        handler = getattr(unwrapped, "handler", None)
+        inner = getattr(handler, "fs", None)
+        if inner is not None:
+            inner_class = type(inner).__name__
+
+    detail = f" (inner fsspec: {inner_class})" if inner_class else ""
+    logger.warning(
+        "Could not extract S3 credentials from user-supplied filesystem %s%s; "
+        "falling back to the PyArrow threaded download path so the filesystem's "
+        "own credential resolution stays authoritative. If this is unexpected, "
+        "pass credentials via fsspec ``storage_options`` "
+        "(e.g. key/secret/token) so they can be forwarded to obstore.",
+        fs_class,
+        detail,
+    )
+
+
+def _plan_obstore_routing(
+    filesystem: Optional["pyarrow.fs.FileSystem"],
+) -> "tuple[bool, Dict[str, Any]]":
+    """Decide whether to use obstore and return the kwargs to forward.
+
+    Returns ``(True, fs_kwargs)`` if obstore should be used, or ``(False, {})``
+    if the caller must route to the threaded path (emits a warning).
+    """
+    if _obstore_filesystem_requires_threaded_download(filesystem):
+        return False, {}
+    fs_kwargs = _extract_credentials_from_filesystem(filesystem)
+    if fs_kwargs is None:
+        assert filesystem is not None  # only fsspec-S3 branch can return None
+        _warn_credential_extraction_failed(filesystem)
+        return False, {}
+    return True, fs_kwargs
 
 
 class StoreRegistry:
@@ -401,11 +537,12 @@ def download_bytes_async(
         )
         return
 
-    if _obstore_filesystem_requires_threaded_download(filesystem):
-        logger.debug(
-            "PyArrow PyFileSystem with a non-S3 fsspec backend (or unknown handler); "
-            "using threaded PyArrow download to preserve user filesystem credentials."
-        )
+    # Resolve credentials up front in sync context. This is the only safe place
+    # to call ``_extract_credentials_from_filesystem`` for fsspec sessions that
+    # need ``asyncio.run`` internally — once we're inside ``_download_uris_with_obstore``
+    # we're already in an event loop and that path is unavailable.
+    use_obstore, fs_kwargs = _plan_obstore_routing(filesystem)
+    if not use_obstore:
         yield from _yield_threaded_download_bytes(
             block,
             uri_column_names,
@@ -433,7 +570,10 @@ def download_bytes_async(
 
         uri_bytes = asyncio.run(
             _download_uris_with_obstore(
-                uris, uri_column_name, filesystem=filesystem, file_sizes=file_sizes
+                uris,
+                uri_column_name,
+                fs_kwargs=fs_kwargs,
+                file_sizes=file_sizes,
             )
         )
 
@@ -461,6 +601,7 @@ async def _download_uris_with_obstore(
     uri_column_name: str,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     file_sizes: Optional[List[Optional[int]]] = None,
+    fs_kwargs: Optional[Dict[str, Any]] = None,
 ) -> List[Optional[bytes]]:
     """Download URIs concurrently using obstore's async API.
 
@@ -479,16 +620,36 @@ async def _download_uris_with_obstore(
         uris: URIs to download.
         uri_column_name: Column name (used only for error logging).
         filesystem: Optional PyArrow filesystem whose credentials are
-            forwarded to the obstore store.
+            forwarded to the obstore store. Ignored when *fs_kwargs* is given.
         file_sizes: Optional per-URI file sizes from AsyncPartitionActor.
             ``0`` or ``None`` entries trigger a HEAD request when range
             splitting is enabled.
+        fs_kwargs: Pre-extracted obstore kwargs from the planner. Preferred
+            over *filesystem* because it sidesteps re-extracting credentials
+            from inside the event loop (aiobotocore sessions need ``asyncio.run``).
 
     Returns:
         Downloaded bytes in the same order as *uris*.  ``None`` entries
         indicate failed downloads.
     """
-    fs_kwargs = _extract_credentials_from_filesystem(filesystem)
+    if fs_kwargs is None:
+        # Direct-caller path (tests, internal helpers). Session-backed fsspec
+        # may fail here because we may already be inside an event loop; the
+        # planner path avoids this by pre-extracting upfront and passing
+        # ``fs_kwargs``. Re-extract best-effort, but fail closed if the
+        # filesystem is non-None and extraction signals "not extractable" —
+        # silently handing obstore the ambient credential chain is exactly
+        # the bug the new routing was designed to prevent.
+        extracted = _extract_credentials_from_filesystem(filesystem)
+        if extracted is None:
+            raise RuntimeError(
+                "_download_uris_with_obstore was called with a filesystem whose "
+                f"credentials cannot be statically extracted ({type(filesystem).__name__}). "
+                "Pass ``fs_kwargs`` explicitly, or route through "
+                "``_plan_obstore_routing`` / ``download_bytes_async`` so "
+                "non-extractable filesystems take the threaded PyArrow path."
+            )
+        fs_kwargs = extracted
 
     range_threshold = RAY_DATA_OBSTORE_RANGE_THRESHOLD
     range_chunk_size = RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -2,9 +2,13 @@ import asyncio
 import inspect
 import logging
 import os
+import threading
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional
 
 if TYPE_CHECKING:
+    import s3fs  # noqa: F401
+
     from ray.data.context import DataContext
 
 import pyarrow as pa
@@ -114,68 +118,100 @@ def _is_obstore_supported_url(path: str) -> bool:
 
 
 # Credential extraction & store management
-async def _await(awaitable):
-    """Drive an arbitrary awaitable (coroutine, Task, Future, ...) to a value.
-
-    ``asyncio.run`` only accepts coroutines, but ``inspect.isawaitable``
-    matches a wider set (Task, Future, custom ``__await__`` objects).
-    Wrapping with ``await`` here lets ``asyncio.run`` drive any of them.
-    """
-    return await awaitable
-
-
-def _frozen_s3fs_credentials(fsspec_fs) -> Optional[Dict[str, str]]:
-    """Snapshot credentials from an s3fs-style session.
+class _S3FSSessionCredentialProvider:
+    """Obstore credential provider backed by an fsspec s3fs session.
 
     s3fs with Okta / STS / profile-based auth resolves credentials lazily via
-    ``fs.session.get_credentials()`` — the ``key`` / ``secret`` / ``token``
-    instance attributes are ``None`` in that setup. We call
-    ``get_frozen_credentials()`` to capture the currently-valid set.
+    ``fs.session.get_credentials()`` and rotates them on expiry. A single
+    snapshot becomes stale during long-running jobs, so we install this as
+    obstore's ``credential_provider`` callable instead — obstore will invoke
+    it whenever it needs fresh keys.
 
-    Returns a dict with ``access_key``, ``secret_key``, ``token`` keys, or
-    ``None`` if a session isn't available or credentials can't be retrieved
-    (e.g. expired, retrieval error). The caller must tolerate ``None`` and
-    route to the threaded path so the user's filesystem stays authoritative.
+    Cached in memory until ``expires_at`` so we don't re-enter the session on
+    every request. Thread-safe via an ``RLock`` because obstore may call this
+    concurrently from its async runtime.
     """
-    session = getattr(fsspec_fs, "session", None) or getattr(
-        fsspec_fs, "_session", None
-    )
-    if session is None:
-        return None
 
-    try:
-        get_creds = session.get_credentials
-        creds = get_creds()
-        # Use inspect.isawaitable rather than asyncio.iscoroutine — sessions
-        # backed by aiobotocore / custom wrappers can return Tasks, Futures,
-        # or other awaitables that ``iscoroutine`` does not recognize.
-        if inspect.isawaitable(creds):
-            try:
-                creds = asyncio.run(_await(creds))
-            except RuntimeError:
-                return None
-        if creds is None:
+    _DEFAULT_TTL = timedelta(minutes=30)
+
+    def __init__(
+        self, session: Any, ttl: Optional[timedelta] = None
+    ) -> None:
+        self._session = session
+        self._ttl = ttl if ttl is not None else self._DEFAULT_TTL
+        self._lock = threading.RLock()
+        self._cached: Optional[Dict[str, Any]] = None
+
+    @classmethod
+    def from_fsspec_fs(
+        cls, fsspec_fs: "s3fs.S3FileSystem"
+    ) -> Optional["_S3FSSessionCredentialProvider"]:
+        """Build a provider from an s3fs filesystem, or ``None`` if no session."""
+        session = getattr(fsspec_fs, "session", None) or getattr(
+            fsspec_fs, "_session", None
+        )
+        if session is None or not hasattr(session, "get_credentials"):
             return None
-        frozen = creds.get_frozen_credentials()
-        if inspect.isawaitable(frozen):
-            try:
-                frozen = asyncio.run(_await(frozen))
-            except RuntimeError:
-                return None
-    except Exception as e:
-        logger.debug("Could not snapshot fsspec session credentials: %r", e)
-        return None
+        return cls(session)
 
-    access_key = getattr(frozen, "access_key", None)
-    secret_key = getattr(frozen, "secret_key", None)
-    token = getattr(frozen, "token", None)
-    if not access_key:
-        return None
-    return {
-        "access_key": access_key,
-        "secret_key": secret_key or "",
-        "token": token or "",
-    }
+    async def __call__(self) -> Dict[str, Any]:
+        """Return obstore-compatible S3 credentials, refreshing past expiry."""
+        now = datetime.now(timezone.utc)
+        with self._lock:
+            if self._cached is not None and self._cached["expires_at"] > now:
+                return dict(self._cached)
+
+        session_creds = await self._await_maybe(self._session.get_credentials())
+        if session_creds is None:
+            raise RuntimeError("fsspec S3 session returned no credentials")
+        frozen = await self._await_maybe(session_creds.get_frozen_credentials())
+        access_key = getattr(frozen, "access_key", None)
+        if not access_key:
+            raise RuntimeError("fsspec S3 session returned no access key")
+
+        creds: Dict[str, Any] = {
+            "access_key_id": access_key,
+            "secret_access_key": getattr(frozen, "secret_key", None) or "",
+            "expires_at": self._compute_expires_at(session_creds),
+        }
+        token = getattr(frozen, "token", None)
+        if token:
+            creds["token"] = token
+
+        with self._lock:
+            self._cached = creds
+        return dict(creds)
+
+    @staticmethod
+    async def _await_maybe(value: Any) -> Any:
+        """Await *value* if it's awaitable (coroutine, Task, Future, custom)."""
+        if inspect.isawaitable(value):
+            return await value
+        return value
+
+    def _compute_expires_at(self, session_creds: Any) -> datetime:
+        """Read the session's expiry, falling back to now + TTL."""
+        for attr in ("expiry_time", "_expiry_time"):
+            exp = getattr(session_creds, attr, None)
+            if isinstance(exp, datetime):
+                return exp if exp.tzinfo else exp.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) + self._ttl
+
+    def can_fetch_credentials(self) -> bool:
+        """Return True if a credential fetch succeeds from sync code right now.
+
+        Used by the planner during routing decisions: if the session can't
+        produce a credential set, fall back to the threaded path rather than
+        installing a provider that would fail on first request. Logs at DEBUG
+        so legitimate failures (expired creds, transient session errors) are
+        diagnosable without spamming the user.
+        """
+        try:
+            asyncio.run(self())
+        except Exception as e:
+            logger.debug("Could not fetch fsspec session credentials: %r", e)
+            return False
+        return True
 
 
 def _extract_credentials_from_filesystem(
@@ -196,11 +232,12 @@ def _extract_credentials_from_filesystem(
 
     **fsspec S3 (``PyFileSystem`` + ``FSSpecHandler``):** For ``s3`` / ``s3a``
     (e.g. ``s3fs`` with STS/Okta/custom endpoints), credentials are read from
-    ``storage_options`` / common instance attributes first; if no static key is
-    present, we snapshot ``fs.session.get_credentials().get_frozen_credentials()``
-    to handle session-backed (Okta/STS/profile) auth. If both passes come up
-    empty we return ``None`` so the caller routes to the threaded path, keeping
-    the user's fsspec filesystem authoritative.
+    ``storage_options`` / common instance attributes first; if no static key
+    is present, we install a :class:`_S3FSSessionCredentialProvider` callback
+    so obstore can refresh session-backed (Okta/STS/profile) credentials on
+    expiry instead of using a stale snapshot. If both passes come up empty we
+    return ``None`` so the caller routes to the threaded path, keeping the
+    user's fsspec filesystem authoritative.
 
     Other ``PyFileSystem`` handlers (non-fsspec or non-S3 fsspec protocols) are
     not converted here; see :func:`_obstore_filesystem_requires_threaded_download`.
@@ -311,16 +348,14 @@ def _extract_credentials_from_filesystem(
             kwargs["skip_signature"] = True
 
         # Static attrs didn't yield an access key and the user didn't opt into
-        # anonymous — snapshot the session (Okta/STS/profile-based auth).
+        # anonymous — install a credential_provider so obstore refreshes the
+        # session-backed keys (Okta/STS/profile-based) on expiry instead of
+        # using a stale snapshot.
         if "access_key_id" not in kwargs and not anon:
-            frozen = _frozen_s3fs_credentials(fsspec_fs)
-            if frozen is None:
+            provider = _S3FSSessionCredentialProvider.from_fsspec_fs(fsspec_fs)
+            if provider is None or not provider.can_fetch_credentials():
                 return None
-            kwargs["access_key_id"] = frozen["access_key"]
-            if frozen["secret_key"]:
-                kwargs["secret_access_key"] = frozen["secret_key"]
-            if frozen["token"]:
-                kwargs["session_token"] = frozen["token"]
+            kwargs["credential_provider"] = provider
         return kwargs
 
     # Unrecognized non-None filesystem — route to threaded so the user's FS
@@ -369,25 +404,18 @@ def _obstore_filesystem_requires_threaded_download(
 
 
 def _is_fsspec_s3_filesystem(filesystem: "pyarrow.fs.FileSystem") -> bool:
-    """True if *filesystem* is a PyFileSystem wrapping an fsspec s3/s3a handler."""
+    """True if *filesystem* is a PyFileSystem wrapping an s3fs ``S3FileSystem``."""
     if isinstance(filesystem, RetryingPyFileSystem):
         filesystem = filesystem.unwrap()
-    PyFileSystem = getattr(pyarrow.fs, "PyFileSystem", None)
-    FSSpecHandler = getattr(pyarrow.fs, "FSSpecHandler", None)
-    if (
-        PyFileSystem is None
-        or FSSpecHandler is None
-        or not isinstance(filesystem, PyFileSystem)
-        or not isinstance(filesystem.handler, FSSpecHandler)
-    ):
+    if not isinstance(filesystem, pyarrow.fs.PyFileSystem):
         return False
-    fsspec_fs = getattr(filesystem.handler, "fs", None)
-    if fsspec_fs is None:
+    if not isinstance(filesystem.handler, pyarrow.fs.FSSpecHandler):
         return False
-    protocol = getattr(fsspec_fs, "protocol", None)
-    if isinstance(protocol, tuple):
-        protocol = protocol[0] if protocol else None
-    return protocol in ("s3", "s3a")
+    try:
+        from s3fs import S3FileSystem
+    except ImportError:
+        return False
+    return isinstance(filesystem.handler.fs, S3FileSystem)
 
 
 # Per-process dedup for credential-extraction warnings. Keyed by ``id(fs)`` so

--- a/python/ray/data/_internal/planner/_obstore_download.py
+++ b/python/ray/data/_internal/planner/_obstore_download.py
@@ -134,9 +134,7 @@ class _S3FSSessionCredentialProvider:
 
     _DEFAULT_TTL = timedelta(minutes=30)
 
-    def __init__(
-        self, session: Any, ttl: Optional[timedelta] = None
-    ) -> None:
+    def __init__(self, session: Any, ttl: Optional[timedelta] = None) -> None:
         self._session = session
         self._ttl = ttl if ttl is not None else self._DEFAULT_TTL
         self._lock = threading.RLock()

--- a/python/ray/data/_internal/planner/download_partition_actor.py
+++ b/python/ray/data/_internal/planner/download_partition_actor.py
@@ -207,6 +207,20 @@ class AsyncPartitionActor(PartitionActor):
     ):
         super().__init__(uri_column_names, data_context, filesystem)
         fs_kwargs = _extract_credentials_from_filesystem(filesystem)
+        if fs_kwargs is None:
+            # Fail closed. ``plan_download_op`` routes filesystems we can't
+            # extract credentials from to ``PartitionActor`` (PyArrow path),
+            # so reaching ``AsyncPartitionActor`` with an unextractable FS is
+            # a bug. Silently seeding an empty kwargs dict would hand the
+            # user's filesystem over to obstore's ambient credential chain
+            # (IMDS / env), which is exactly the silent-drop behavior the
+            # routing was designed to prevent.
+            raise RuntimeError(
+                "AsyncPartitionActor was constructed with a filesystem whose "
+                f"credentials cannot be statically extracted ({type(filesystem).__name__}). "
+                "This indicates a dispatch bug: use PartitionActor for such "
+                "filesystems so the user's credentials are not silently dropped."
+            )
         self._registry = StoreRegistry(retry_config={"max_retries": 10}, **fs_kwargs)
 
     def __call__(self, block: pa.Table) -> Iterator[pa.Table]:

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -18,6 +18,7 @@ from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.planner._obstore_download import (
     OBSTORE_AVAILABLE,
     _log_fallback_warning,
+    _plan_obstore_routing,
     download_bytes_async,
 )
 from ray.data._internal.planner.download_partition_actor import (
@@ -68,9 +69,18 @@ def plan_download_op(
     # at the start of the chain. This is primarily done to prevent partition actors from bottlenecking
     # the chain becuase the interleaved operators would be a single actor. As a result, the
     # URIDownloader physical operator is responsible for outputting appropriately sized blocks.
+    # Decide obstore vs threaded upfront. For fsspec-S3 filesystems backed by
+    # a session we can't statically introspect (Okta / STS / profile-based),
+    # _plan_obstore_routing emits a warning and returns use_obstore=False so
+    # we fall back to the threaded PyArrow path — which uses the user's
+    # filesystem directly and resolves credentials correctly.
+    use_obstore_path = False
+    if OBSTORE_AVAILABLE:
+        use_obstore_path, _ = _plan_obstore_routing(filesystem)
+
     partition_map_operator = None
     if not upstream_op_is_download:
-        partition_cls = AsyncPartitionActor if OBSTORE_AVAILABLE else PartitionActor
+        partition_cls = AsyncPartitionActor if use_obstore_path else PartitionActor
         # PartitionActor / AsyncPartitionActor are callable classes, so we need
         # ActorPoolStrategy.
         partition_compute = ActorPoolStrategy(
@@ -117,9 +127,12 @@ def plan_download_op(
             ray_actor_task_remote_args={"_generator_backpressure_num_objects": -1},
         )
 
-    if OBSTORE_AVAILABLE:
+    if use_obstore_path:
         download_fn = download_bytes_async
         logger.debug("Using obstore async download path.")
+    elif OBSTORE_AVAILABLE:
+        # Warning already emitted by _plan_obstore_routing.
+        download_fn = download_bytes_threaded
     else:
         download_fn = download_bytes_threaded
         _log_fallback_warning()

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -130,12 +130,14 @@ def plan_download_op(
     if use_obstore_path:
         download_fn = download_bytes_async
         logger.debug("Using obstore async download path.")
-    elif OBSTORE_AVAILABLE:
-        # Warning already emitted by _plan_obstore_routing.
-        download_fn = download_bytes_threaded
     else:
         download_fn = download_bytes_threaded
-        _log_fallback_warning()
+        # The "obstore not installed" warning is only relevant when obstore is
+        # missing entirely. When obstore is available but the filesystem can't
+        # be routed through it, _plan_obstore_routing already logged the reason
+        # (a WARNING for fsspec-S3-unextractable, DEBUG otherwise).
+        if not OBSTORE_AVAILABLE:
+            _log_fallback_warning()
 
     fn, init_fn = _get_udf(
         download_fn,

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -11,8 +11,10 @@ from ray.data._internal.planner._obstore_download import (
     _FILE_SIZE_COLUMN_PREFIX,
     _download_uris_with_obstore,
     _extract_credentials_from_filesystem,
+    _frozen_s3fs_credentials,
     _is_obstore_supported_url,
     _obstore_filesystem_requires_threaded_download,
+    _plan_obstore_routing,
     download_bytes_async,
 )
 from ray.data._internal.planner.plan_download_op import (
@@ -63,15 +65,19 @@ class TestDownloadHelpers:
         assert _extract_credentials_from_filesystem(None) == {}
 
     def test_extract_credentials_unrecognized_fs(self):
-        # LocalFileSystem is not S3/GCS/Azure, so no credentials extracted.
-        assert _extract_credentials_from_filesystem(pafs.LocalFileSystem()) == {}
+        # Unrecognized non-None filesystems (LocalFileSystem, custom FS) return
+        # None so the planner routes to the threaded path, keeping the user's
+        # filesystem authoritative instead of handing control to obstore's
+        # default credential chain.
+        assert _extract_credentials_from_filesystem(pafs.LocalFileSystem()) is None
 
     def test_extract_credentials_unwraps_retrying_fs(self):
         # RetryingPyFileSystem must be unwrapped before the isinstance checks,
-        # otherwise an S3/GCS/Azure branch would never be reached.
+        # otherwise an S3/GCS/Azure branch would never be reached. After
+        # unwrapping to an unrecognized FS, extraction returns None.
         inner = pafs.LocalFileSystem()
         retrying = RetryingPyFileSystem.wrap(inner, retryable_errors=[])
-        assert _extract_credentials_from_filesystem(retrying) == {}
+        assert _extract_credentials_from_filesystem(retrying) is None
 
     def test_extract_credentials_unwraps_retrying_fs_over_s3(self):
         # Even when an S3FileSystem is wrapped, credentials must still be
@@ -250,6 +256,342 @@ class TestDownloadHelpers:
             )
         with ctx:
             assert _is_obstore_supported_url(uri) is expected
+
+
+# TestSessionBackedFsspecCredentials
+class TestSessionBackedFsspecCredentials:
+    """Covers session-backed s3fs (Okta / STS / profile-based) credential paths.
+
+    Static attrs like ``fs.key`` are ``None`` in those setups; the helper must
+    fall through to ``session.get_credentials().get_frozen_credentials()`` and
+    return ``None`` when that also fails so the caller can route to the
+    threaded path with the user's filesystem intact.
+    """
+
+    def _make_fsspec_wrapper(
+        self, session, storage_options=None, protocol="s3", anon=False
+    ):
+        """Build a PyFileSystem(FSSpecHandler(...)) around a minimal stub.
+
+        ``s3fs`` can't be instantiated in unit tests without live AWS config,
+        so we mimic just the attributes that the extraction code reads.
+        """
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        inner = MagicMock()
+        inner.protocol = protocol
+        inner.storage_options = storage_options or {}
+        inner.session = session
+        inner.key = None
+        inner.secret = None
+        inner.token = None
+        inner.endpoint_url = None
+        inner.client_kwargs = None
+        inner.anon = anon
+        # PyArrow's FSSpecHandler calls fs._strip_protocol for normalization.
+        inner._strip_protocol = lambda p: p.split("://", 1)[-1] if "://" in p else p
+        wrapped = PyFileSystem(FSSpecHandler(inner))
+        return wrapped, inner
+
+    def _make_session(self, access_key, secret_key, token):
+        """Build a sync (botocore-style) session that returns frozen creds."""
+        frozen = MagicMock()
+        frozen.access_key = access_key
+        frozen.secret_key = secret_key
+        frozen.token = token
+        creds = MagicMock()
+        creds.get_frozen_credentials = MagicMock(return_value=frozen)
+        session = MagicMock()
+        session.get_credentials = MagicMock(return_value=creds)
+        return session
+
+    def test_frozen_credentials_sync_session(self):
+        session = self._make_session("AKIA_OKTA", "sstoken_secret", "sts_token")
+        inner = MagicMock()
+        inner.session = session
+        result = _frozen_s3fs_credentials(inner)
+        assert result == {
+            "access_key": "AKIA_OKTA",
+            "secret_key": "sstoken_secret",
+            "token": "sts_token",
+        }
+
+    def test_frozen_credentials_missing_session_returns_none(self):
+        inner = MagicMock()
+        inner.session = None
+        # Ensure both fallbacks miss.
+        inner._session = None
+        assert _frozen_s3fs_credentials(inner) is None
+
+    def test_frozen_credentials_session_raises_returns_none(self):
+        session = MagicMock()
+        session.get_credentials = MagicMock(side_effect=RuntimeError("token expired"))
+        inner = MagicMock()
+        inner.session = session
+        assert _frozen_s3fs_credentials(inner) is None
+
+    def test_frozen_credentials_no_access_key_returns_none(self):
+        # session.get_credentials() succeeds but returns empty creds (e.g. an
+        # unconfigured aws profile). Must return None, not an empty dict.
+        session = self._make_session(access_key=None, secret_key=None, token=None)
+        inner = MagicMock()
+        inner.session = session
+        assert _frozen_s3fs_credentials(inner) is None
+
+    def test_frozen_credentials_async_session(self):
+        # aiobotocore returns coroutines from get_credentials and
+        # get_frozen_credentials. The helper must drive those to completion.
+        async def _async_frozen():
+            frozen = MagicMock()
+            frozen.access_key = "AKIA_AIO"
+            frozen.secret_key = "aio_secret"
+            frozen.token = "aio_tok"
+            return frozen
+
+        async def _async_creds():
+            creds = MagicMock()
+            creds.get_frozen_credentials = MagicMock(return_value=_async_frozen())
+            return creds
+
+        session = MagicMock()
+        session.get_credentials = MagicMock(return_value=_async_creds())
+        inner = MagicMock()
+        inner.session = session
+        result = _frozen_s3fs_credentials(inner)
+        assert result == {
+            "access_key": "AKIA_AIO",
+            "secret_key": "aio_secret",
+            "token": "aio_tok",
+        }
+
+    def test_frozen_credentials_underscore_session_fallback(self):
+        # Older s3fs versions exposed `_session` instead of `session`.
+        session = self._make_session("AKIA_OLD", "old_sec", "")
+        inner = MagicMock(spec=["_session"])  # no `session` attr on the spec
+        inner._session = session
+        result = _frozen_s3fs_credentials(inner)
+        assert result == {
+            "access_key": "AKIA_OLD",
+            "secret_key": "old_sec",
+            "token": "",
+        }
+
+    def test_extract_credentials_uses_session_when_static_empty(self):
+        # The critical bug: fsspec s3fs with Okta has static attrs as None
+        # but credentials resolvable via session. Extraction must recover them.
+        session = self._make_session("AKIA_STS", "secret_sts", "token_sts")
+        wrapped, _ = self._make_fsspec_wrapper(session=session)
+        result = _extract_credentials_from_filesystem(wrapped)
+        assert result == {
+            "access_key_id": "AKIA_STS",
+            "secret_access_key": "secret_sts",
+            "session_token": "token_sts",
+        }
+
+    def test_extract_credentials_session_preferred_only_when_static_missing(self):
+        # Static storage_options wins over session — we don't override explicit
+        # user intent. The session (which would yield different values) is not
+        # consulted at all.
+        session = self._make_session("AKIA_FROM_SESSION", "x", "y")
+        wrapped, _ = self._make_fsspec_wrapper(
+            session=session,
+            storage_options={
+                "key": "AKIA_EXPLICIT",
+                "secret": "explicit_secret",
+            },
+        )
+        result = _extract_credentials_from_filesystem(wrapped)
+        assert result is not None
+        assert result["access_key_id"] == "AKIA_EXPLICIT"
+        assert result["secret_access_key"] == "explicit_secret"
+        # Session was never invoked because static attrs produced an access key.
+        session.get_credentials.assert_not_called()
+
+    def test_extract_credentials_unresolvable_session_returns_none(self):
+        # No static attrs AND session raises — function must return None so the
+        # planner routes to the threaded path with the user's fsspec FS intact.
+        session = MagicMock()
+        session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
+        wrapped, _ = self._make_fsspec_wrapper(session=session)
+        assert _extract_credentials_from_filesystem(wrapped) is None
+
+    def test_extract_credentials_anon_skips_session(self):
+        # Anonymous s3fs — no credentials needed, don't poke the session.
+        session = MagicMock()
+        session.get_credentials = MagicMock(
+            side_effect=AssertionError("must not be called when anon=True")
+        )
+        wrapped, _ = self._make_fsspec_wrapper(session=session, anon=True)
+        result = _extract_credentials_from_filesystem(wrapped)
+        assert result == {"skip_signature": True}
+
+
+# TestPlanObstoreRouting
+class TestPlanObstoreRouting:
+    """``_plan_obstore_routing`` picks obstore vs threaded with one-shot warning."""
+
+    def setup_method(self):
+        # Clear the module-level dedup so each test sees a fresh warning.
+        from ray.data._internal.planner import _obstore_download as m
+
+        m._warned_credential_fs_ids.clear()
+
+    def test_routing_none_filesystem_uses_obstore(self):
+        use_obstore, kwargs = _plan_obstore_routing(None)
+        assert use_obstore is True
+        assert kwargs == {}
+
+    def test_routing_non_s3_fsspec_routes_to_threaded(self):
+        import fsspec
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        class _GcsStub(fsspec.AbstractFileSystem):
+            protocol = "gcs"
+
+        wrapped = PyFileSystem(FSSpecHandler(_GcsStub()))
+        use_obstore, kwargs = _plan_obstore_routing(wrapped)
+        assert use_obstore is False
+        assert kwargs == {}
+
+    def test_routing_unextractable_fsspec_s3_routes_to_threaded_with_warning(
+        self, caplog
+    ):
+        import logging
+
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        session = MagicMock()
+        session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
+        inner = MagicMock()
+        inner.protocol = "s3"
+        inner.storage_options = {}
+        inner.session = session
+        inner.key = None
+        inner.secret = None
+        inner.token = None
+        inner.endpoint_url = None
+        inner.client_kwargs = None
+        inner.anon = False
+        inner._strip_protocol = lambda p: p
+        wrapped = PyFileSystem(FSSpecHandler(inner))
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="ray.data._internal.planner._obstore_download",
+        ):
+            use_obstore, kwargs = _plan_obstore_routing(wrapped)
+
+        assert use_obstore is False
+        assert kwargs == {}
+        # Warning emitted exactly once.
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "Could not extract S3 credentials" in r.getMessage()
+        ]
+        assert len(warning_records) == 1
+
+    def test_routing_warns_once_per_filesystem(self, caplog):
+        import logging
+
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        def _make_wrapper():
+            session = MagicMock()
+            session.get_credentials = MagicMock(side_effect=RuntimeError("x"))
+            inner = MagicMock()
+            inner.protocol = "s3"
+            inner.storage_options = {}
+            inner.session = session
+            inner.key = None
+            inner.secret = None
+            inner.token = None
+            inner.endpoint_url = None
+            inner.client_kwargs = None
+            inner.anon = False
+            inner._strip_protocol = lambda p: p
+            return PyFileSystem(FSSpecHandler(inner))
+
+        fs_a = _make_wrapper()
+        fs_b = _make_wrapper()
+
+        with caplog.at_level(
+            logging.WARNING,
+            logger="ray.data._internal.planner._obstore_download",
+        ):
+            _plan_obstore_routing(fs_a)
+            _plan_obstore_routing(fs_a)  # same FS — no new warning
+            _plan_obstore_routing(fs_b)  # different FS — new warning
+
+        warning_records = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "Could not extract S3 credentials" in r.getMessage()
+        ]
+        assert len(warning_records) == 2
+
+    def test_async_partition_actor_fails_closed_on_unextractable_creds(self):
+        # AsyncPartitionActor must raise (not silently use obstore's ambient
+        # credential chain) when it's constructed with a filesystem whose
+        # credentials can't be extracted. In the normal plan flow,
+        # _plan_obstore_routing directs such filesystems to PartitionActor.
+        # Reaching AsyncPartitionActor anyway indicates a dispatch bug.
+        pytest.importorskip("obstore")
+        from ray.data._internal.planner.download_partition_actor import (
+            AsyncPartitionActor,
+        )
+
+        # Unrecognized filesystem → extraction returns None.
+        bad_fs = pafs.LocalFileSystem()
+        ctx = DataContext.get_current()
+
+        with pytest.raises(RuntimeError, match="cannot be statically extracted"):
+            AsyncPartitionActor(["uri"], ctx, filesystem=bad_fs)
+
+    def test_download_uris_with_obstore_fails_closed_on_unextractable_fs(self):
+        # Direct-caller guard: _download_uris_with_obstore with a filesystem
+        # whose credentials can't be extracted must raise rather than coerce
+        # to {} and hand obstore the ambient credential chain. Preserves the
+        # fail-closed contract for any internal/test caller that bypasses
+        # _plan_obstore_routing.
+        pytest.importorskip("obstore")
+
+        bad_fs = pafs.LocalFileSystem()  # unrecognized → extraction returns None
+
+        with pytest.raises(RuntimeError, match="cannot be statically extracted"):
+            asyncio.run(
+                _download_uris_with_obstore(
+                    ["file:///tmp/does-not-matter.bin"],
+                    "uri",
+                    filesystem=bad_fs,
+                )
+            )
+
+    def test_routing_extractable_fsspec_s3_uses_obstore(self):
+        from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+        inner = MagicMock()
+        inner.protocol = "s3"
+        inner.storage_options = {"key": "AKIA", "secret": "sec", "token": "tok"}
+        inner.session = None
+        inner.key = None
+        inner.secret = None
+        inner.token = None
+        inner.endpoint_url = None
+        inner.client_kwargs = None
+        inner.anon = False
+        inner._strip_protocol = lambda p: p
+        wrapped = PyFileSystem(FSSpecHandler(inner))
+
+        use_obstore, kwargs = _plan_obstore_routing(wrapped)
+        assert use_obstore is True
+        assert kwargs == {
+            "access_key_id": "AKIA",
+            "secret_access_key": "sec",
+            "session_token": "tok",
+        }
 
 
 # TestObstoreDownloadPath
@@ -434,12 +776,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "big.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/big.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size * 2,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size * 2,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             results = asyncio.run(
                 _download_uris_with_obstore([uri], "uri", file_sizes=[len(content)])
@@ -453,12 +798,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "big2.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/big2.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             results = asyncio.run(
                 _download_uris_with_obstore([uri], "uri", file_sizes=None)
@@ -488,15 +836,19 @@ class TestObstoreRangeSplitDownload:
         def _fail_ranged(*_args, **_kwargs):
             raise AssertionError("_fetch_ranged must not be called")
 
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            100,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            -512,
-        ), patch(
-            "ray.data._internal.planner._obstore_download._fetch_ranged",
-            side_effect=_fail_ranged,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                100,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                -512,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download._fetch_ranged",
+                side_effect=_fail_ranged,
+            ),
         ):
             results2 = asyncio.run(
                 _download_uris_with_obstore([uri2], "uri", file_sizes=[len(content2)])
@@ -515,12 +867,15 @@ class TestObstoreRangeSplitDownload:
             f"file://{tmp_path}/large.bin",
             f"file://{tmp_path}/small.bin",
         ]
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size * 2,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size * 2,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             results = asyncio.run(
                 _download_uris_with_obstore(
@@ -629,12 +984,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "f.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/f.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             import obstore as obs
 
@@ -648,9 +1006,10 @@ class TestObstoreRangeSplitDownload:
                 range_calls.append(args)
                 return await original_get_range(*args, **kwargs)
 
-            with patch.object(
-                obs, "head_async", side_effect=_failing_head
-            ), patch.object(obs, "get_range_async", side_effect=_tracking_range):
+            with (
+                patch.object(obs, "head_async", side_effect=_failing_head),
+                patch.object(obs, "get_range_async", side_effect=_tracking_range),
+            ):
                 results = asyncio.run(
                     _download_uris_with_obstore([uri], "uri", file_sizes=[0])
                 )
@@ -678,12 +1037,15 @@ class TestObstoreRangeSplitDownload:
         ]
         file_sizes: list[Optional[int]] = [len(large_content), len(small_content), 0]
 
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size * 2,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size * 2,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             import obstore as obs
 
@@ -710,12 +1072,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "exact.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/exact.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            threshold,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            256,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                threshold,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                256,
+            ),
         ):
             import obstore as obs
 
@@ -742,12 +1107,15 @@ class TestObstoreRangeSplitDownload:
         (tmp_path / "fail.bin").write_bytes(content)
 
         uri = f"file://{tmp_path}/fail.bin"
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
-            chunk_size,
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_CHUNK_SIZE",
+                chunk_size,
+            ),
         ):
             import obstore as obs
 
@@ -783,15 +1151,17 @@ class TestObstoreRangeSplitDownload:
 
         uri = f"file://{tmp_path}/f.bin"
         # Simulate misconfiguration: range splitting on, but concurrency = 0.
-        with patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
-            chunk_size,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_MAX_CONCURRENCY",
-            0,
-        ), patch(
-            "ray.data._internal.planner._obstore_download.logger"
-        ) as mock_logger:
+        with (
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_RANGE_THRESHOLD",
+                chunk_size,
+            ),
+            patch(
+                "ray.data._internal.planner._obstore_download.RAY_DATA_OBSTORE_MAX_CONCURRENCY",
+                0,
+            ),
+            patch("ray.data._internal.planner._obstore_download.logger") as mock_logger,
+        ):
             import obstore as obs
 
             # Spy on get_range_async to verify it is never called.

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -96,6 +96,7 @@ class TestDownloadHelpers:
         with patch("pyarrow.fs.S3FileSystem", type(mock_fs)):
             result = _extract_credentials_from_filesystem(mock_retrying)
 
+        assert result is not None
         assert result.get("region") == "eu-west-1"
 
     # _extract_credentials_from_filesystem with S3
@@ -108,6 +109,7 @@ class TestDownloadHelpers:
         except Exception:
             pytest.skip("Cannot instantiate S3FileSystem in this environment")
         result = _extract_credentials_from_filesystem(fs)
+        assert result is not None
         assert result.get("region") == "us-west-2"
         assert "access_key_id" not in result
         assert "skip_signature" not in result
@@ -123,6 +125,7 @@ class TestDownloadHelpers:
         mock_fs.region = None
         with patch("pyarrow.fs.S3FileSystem", type(mock_fs)):
             result = _extract_credentials_from_filesystem(mock_fs)
+        assert result is not None
         assert result.get("skip_signature") is True
         assert "access_key_id" not in result
 
@@ -136,6 +139,7 @@ class TestDownloadHelpers:
         mock_fs.region = "us-west-2"
         with patch("pyarrow.fs.S3FileSystem", type(mock_fs)):
             result = _extract_credentials_from_filesystem(mock_fs)
+        assert result is not None
         assert result["access_key_id"] == "AKID"
         assert result["secret_access_key"] == "SECRET"
         assert result["session_token"] == "TOKEN"
@@ -361,6 +365,7 @@ class TestFsspecSessionCreds:
             session, storage_options={"key": "AKIA_EXPLICIT", "secret": "e"}
         )
         result = _extract_credentials_from_filesystem(wrapped)
+        assert result is not None
         assert result["access_key_id"] == "AKIA_EXPLICIT"
         assert result["secret_access_key"] == "e"
         session.get_credentials.assert_not_called()

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -259,88 +259,72 @@ class TestDownloadHelpers:
 
 
 # TestSessionBackedFsspecCredentials
-class TestSessionBackedFsspecCredentials:
-    """Covers session-backed s3fs (Okta / STS / profile-based) credential paths.
+def _make_sync_session(access_key, secret_key, token):
+    """Build a sync (botocore-style) session returning the given frozen creds."""
+    frozen = MagicMock()
+    frozen.access_key = access_key
+    frozen.secret_key = secret_key
+    frozen.token = token
+    creds = MagicMock()
+    creds.get_frozen_credentials = MagicMock(return_value=frozen)
+    session = MagicMock()
+    session.get_credentials = MagicMock(return_value=creds)
+    return session
 
-    Static attrs like ``fs.key`` are ``None`` in those setups; the helper must
-    fall through to ``session.get_credentials().get_frozen_credentials()`` and
-    return ``None`` when that also fails so the caller can route to the
-    threaded path with the user's filesystem intact.
-    """
 
-    def _make_fsspec_wrapper(
-        self, session, storage_options=None, protocol="s3", anon=False
-    ):
-        """Build a PyFileSystem(FSSpecHandler(...)) around a minimal stub.
+def _wrap_fsspec(session, storage_options=None, protocol="s3", anon=False):
+    """Wrap a minimal fsspec-like stub in PyFileSystem(FSSpecHandler(...))."""
+    from pyarrow.fs import FSSpecHandler, PyFileSystem
 
-        ``s3fs`` can't be instantiated in unit tests without live AWS config,
-        so we mimic just the attributes that the extraction code reads.
-        """
-        from pyarrow.fs import FSSpecHandler, PyFileSystem
+    inner = MagicMock()
+    inner.protocol = protocol
+    inner.storage_options = storage_options or {}
+    inner.session = session
+    inner.key = None
+    inner.secret = None
+    inner.token = None
+    inner.endpoint_url = None
+    inner.client_kwargs = None
+    inner.anon = anon
+    inner._strip_protocol = lambda p: p.split("://", 1)[-1] if "://" in p else p
+    return PyFileSystem(FSSpecHandler(inner))
 
-        inner = MagicMock()
-        inner.protocol = protocol
-        inner.storage_options = storage_options or {}
-        inner.session = session
-        inner.key = None
-        inner.secret = None
-        inner.token = None
-        inner.endpoint_url = None
-        inner.client_kwargs = None
-        inner.anon = anon
-        # PyArrow's FSSpecHandler calls fs._strip_protocol for normalization.
-        inner._strip_protocol = lambda p: p.split("://", 1)[-1] if "://" in p else p
-        wrapped = PyFileSystem(FSSpecHandler(inner))
-        return wrapped, inner
 
-    def _make_session(self, access_key, secret_key, token):
-        """Build a sync (botocore-style) session that returns frozen creds."""
-        frozen = MagicMock()
-        frozen.access_key = access_key
-        frozen.secret_key = secret_key
-        frozen.token = token
-        creds = MagicMock()
-        creds.get_frozen_credentials = MagicMock(return_value=frozen)
-        session = MagicMock()
-        session.get_credentials = MagicMock(return_value=creds)
-        return session
+class TestFsspecSessionCreds:
+    """Session-backed s3fs (Okta / STS / profile-based) credential paths."""
 
-    def test_frozen_credentials_sync_session(self):
-        session = self._make_session("AKIA_OKTA", "sstoken_secret", "sts_token")
+    def test_sync_session(self):
+        session = _make_sync_session("AKIA_OKTA", "sstoken_secret", "sts_token")
         inner = MagicMock()
         inner.session = session
-        result = _frozen_s3fs_credentials(inner)
-        assert result == {
+        assert _frozen_s3fs_credentials(inner) == {
             "access_key": "AKIA_OKTA",
             "secret_key": "sstoken_secret",
             "token": "sts_token",
         }
 
-    def test_frozen_credentials_missing_session_returns_none(self):
+    def test_missing_session(self):
         inner = MagicMock()
         inner.session = None
-        # Ensure both fallbacks miss.
         inner._session = None
         assert _frozen_s3fs_credentials(inner) is None
 
-    def test_frozen_credentials_session_raises_returns_none(self):
+    def test_session_raises(self):
         session = MagicMock()
-        session.get_credentials = MagicMock(side_effect=RuntimeError("token expired"))
+        session.get_credentials = MagicMock(side_effect=RuntimeError("expired"))
         inner = MagicMock()
         inner.session = session
         assert _frozen_s3fs_credentials(inner) is None
 
-    def test_frozen_credentials_no_access_key_returns_none(self):
-        # session.get_credentials() succeeds but returns empty creds (e.g. an
-        # unconfigured aws profile). Must return None, not an empty dict.
-        session = self._make_session(access_key=None, secret_key=None, token=None)
+    def test_empty_access_key(self):
+        # session returns creds but access_key is None → return None.
         inner = MagicMock()
-        inner.session = session
+        inner.session = _make_sync_session(None, None, None)
         assert _frozen_s3fs_credentials(inner) is None
 
-    def test_frozen_credentials_async_session(self):
+    def test_async_session(self):
         # aiobotocore returns coroutines from get_credentials and
-        # get_frozen_credentials. The helper must drive those to completion.
+        # get_frozen_credentials. The helper must drive them to completion.
         async def _async_frozen():
             frozen = MagicMock()
             frozen.access_key = "AKIA_AIO"
@@ -357,76 +341,86 @@ class TestSessionBackedFsspecCredentials:
         session.get_credentials = MagicMock(return_value=_async_creds())
         inner = MagicMock()
         inner.session = session
-        result = _frozen_s3fs_credentials(inner)
-        assert result == {
+        assert _frozen_s3fs_credentials(inner) == {
             "access_key": "AKIA_AIO",
             "secret_key": "aio_secret",
             "token": "aio_tok",
         }
 
-    def test_frozen_credentials_underscore_session_fallback(self):
+    def test_underscore_session_fallback(self):
         # Older s3fs versions exposed `_session` instead of `session`.
-        session = self._make_session("AKIA_OLD", "old_sec", "")
-        inner = MagicMock(spec=["_session"])  # no `session` attr on the spec
+        session = _make_sync_session("AKIA_OLD", "old_sec", "")
+        inner = MagicMock(spec=["_session"])
         inner._session = session
-        result = _frozen_s3fs_credentials(inner)
-        assert result == {
+        assert _frozen_s3fs_credentials(inner) == {
             "access_key": "AKIA_OLD",
             "secret_key": "old_sec",
             "token": "",
         }
 
-    def test_extract_credentials_uses_session_when_static_empty(self):
-        # The critical bug: fsspec s3fs with Okta has static attrs as None
-        # but credentials resolvable via session. Extraction must recover them.
-        session = self._make_session("AKIA_STS", "secret_sts", "token_sts")
-        wrapped, _ = self._make_fsspec_wrapper(session=session)
-        result = _extract_credentials_from_filesystem(wrapped)
-        assert result == {
+    def test_extract_uses_session_when_static_empty(self):
+        # The target bug: fsspec s3fs with Okta has static attrs None but
+        # credentials resolvable via session. Extraction must recover them.
+        session = _make_sync_session("AKIA_STS", "secret_sts", "token_sts")
+        wrapped = _wrap_fsspec(session)
+        assert _extract_credentials_from_filesystem(wrapped) == {
             "access_key_id": "AKIA_STS",
             "secret_access_key": "secret_sts",
             "session_token": "token_sts",
         }
 
-    def test_extract_credentials_session_preferred_only_when_static_missing(self):
-        # Static storage_options wins over session — we don't override explicit
-        # user intent. The session (which would yield different values) is not
-        # consulted at all.
-        session = self._make_session("AKIA_FROM_SESSION", "x", "y")
-        wrapped, _ = self._make_fsspec_wrapper(
-            session=session,
-            storage_options={
-                "key": "AKIA_EXPLICIT",
-                "secret": "explicit_secret",
-            },
+    def test_static_wins_over_session(self):
+        # Static storage_options wins — explicit user config is not overridden.
+        session = _make_sync_session("AKIA_SESSION", "x", "y")
+        wrapped = _wrap_fsspec(
+            session,
+            storage_options={"key": "AKIA_EXPLICIT", "secret": "explicit_secret"},
         )
         result = _extract_credentials_from_filesystem(wrapped)
         assert result is not None
         assert result["access_key_id"] == "AKIA_EXPLICIT"
         assert result["secret_access_key"] == "explicit_secret"
-        # Session was never invoked because static attrs produced an access key.
         session.get_credentials.assert_not_called()
 
-    def test_extract_credentials_unresolvable_session_returns_none(self):
-        # No static attrs AND session raises — function must return None so the
-        # planner routes to the threaded path with the user's fsspec FS intact.
+    def test_unresolvable_session_returns_none(self):
         session = MagicMock()
         session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
-        wrapped, _ = self._make_fsspec_wrapper(session=session)
-        assert _extract_credentials_from_filesystem(wrapped) is None
+        assert _extract_credentials_from_filesystem(_wrap_fsspec(session)) is None
 
-    def test_extract_credentials_anon_skips_session(self):
-        # Anonymous s3fs — no credentials needed, don't poke the session.
+    def test_anon_skips_session(self):
         session = MagicMock()
         session.get_credentials = MagicMock(
             side_effect=AssertionError("must not be called when anon=True")
         )
-        wrapped, _ = self._make_fsspec_wrapper(session=session, anon=True)
-        result = _extract_credentials_from_filesystem(wrapped)
-        assert result == {"skip_signature": True}
+        wrapped = _wrap_fsspec(session, anon=True)
+        assert _extract_credentials_from_filesystem(wrapped) == {"skip_signature": True}
 
 
 # TestPlanObstoreRouting
+def _make_fsspec_s3_wrapper(*, session=None, storage_options=None, anon=False):
+    """Build a PyFileSystem(FSSpecHandler(stub)) for s3 protocol."""
+    from pyarrow.fs import FSSpecHandler, PyFileSystem
+
+    inner = MagicMock()
+    inner.protocol = "s3"
+    inner.storage_options = storage_options or {}
+    inner.session = session
+    inner.key = None
+    inner.secret = None
+    inner.token = None
+    inner.endpoint_url = None
+    inner.client_kwargs = None
+    inner.anon = anon
+    inner._strip_protocol = lambda p: p
+    return PyFileSystem(FSSpecHandler(inner))
+
+
+def _make_raising_session():
+    session = MagicMock()
+    session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
+    return session
+
+
 class TestPlanObstoreRouting:
     """``_plan_obstore_routing`` picks obstore vs threaded with one-shot warning."""
 
@@ -436,12 +430,12 @@ class TestPlanObstoreRouting:
 
         m._warned_credential_fs_ids.clear()
 
-    def test_routing_none_filesystem_uses_obstore(self):
+    def test_none_fs_uses_obstore(self):
         use_obstore, kwargs = _plan_obstore_routing(None)
         assert use_obstore is True
         assert kwargs == {}
 
-    def test_routing_non_s3_fsspec_routes_to_threaded(self):
+    def test_non_s3_fsspec_to_threaded(self):
         import fsspec
         from pyarrow.fs import FSSpecHandler, PyFileSystem
 
@@ -453,138 +447,76 @@ class TestPlanObstoreRouting:
         assert use_obstore is False
         assert kwargs == {}
 
-    def test_routing_unextractable_fsspec_s3_routes_to_threaded_with_warning(
-        self, caplog
-    ):
-        import logging
+    def test_fsspec_s3_unextractable_warns(self):
+        # Patch the module logger directly instead of relying on caplog —
+        # Ray's internal loggers don't always propagate in test environments,
+        # so caplog.records can come back empty even when the warning fires.
+        wrapped = _make_fsspec_s3_wrapper(session=_make_raising_session())
 
-        from pyarrow.fs import FSSpecHandler, PyFileSystem
-
-        session = MagicMock()
-        session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
-        inner = MagicMock()
-        inner.protocol = "s3"
-        inner.storage_options = {}
-        inner.session = session
-        inner.key = None
-        inner.secret = None
-        inner.token = None
-        inner.endpoint_url = None
-        inner.client_kwargs = None
-        inner.anon = False
-        inner._strip_protocol = lambda p: p
-        wrapped = PyFileSystem(FSSpecHandler(inner))
-
-        with caplog.at_level(
-            logging.WARNING,
-            logger="ray.data._internal.planner._obstore_download",
-        ):
+        with patch(
+            "ray.data._internal.planner._obstore_download.logger"
+        ) as mock_logger:
             use_obstore, kwargs = _plan_obstore_routing(wrapped)
 
         assert use_obstore is False
         assert kwargs == {}
-        # Warning emitted exactly once.
-        warning_records = [
-            r
-            for r in caplog.records
-            if r.levelno == logging.WARNING
-            and "Could not extract S3 credentials" in r.getMessage()
-        ]
-        assert len(warning_records) == 1
+        # Exactly one warning, with the S3-specific advice.
+        assert mock_logger.warning.call_count == 1
+        msg = mock_logger.warning.call_args[0][0]
+        assert "S3 credentials" in msg and "storage_options" in msg
 
-    def test_routing_warns_once_per_filesystem(self, caplog):
-        import logging
+    def test_warns_once_per_fs(self):
+        fs_a = _make_fsspec_s3_wrapper(session=_make_raising_session())
+        fs_b = _make_fsspec_s3_wrapper(session=_make_raising_session())
 
-        from pyarrow.fs import FSSpecHandler, PyFileSystem
-
-        def _make_wrapper():
-            session = MagicMock()
-            session.get_credentials = MagicMock(side_effect=RuntimeError("x"))
-            inner = MagicMock()
-            inner.protocol = "s3"
-            inner.storage_options = {}
-            inner.session = session
-            inner.key = None
-            inner.secret = None
-            inner.token = None
-            inner.endpoint_url = None
-            inner.client_kwargs = None
-            inner.anon = False
-            inner._strip_protocol = lambda p: p
-            return PyFileSystem(FSSpecHandler(inner))
-
-        fs_a = _make_wrapper()
-        fs_b = _make_wrapper()
-
-        with caplog.at_level(
-            logging.WARNING,
-            logger="ray.data._internal.planner._obstore_download",
-        ):
+        with patch(
+            "ray.data._internal.planner._obstore_download.logger"
+        ) as mock_logger:
             _plan_obstore_routing(fs_a)
             _plan_obstore_routing(fs_a)  # same FS — no new warning
             _plan_obstore_routing(fs_b)  # different FS — new warning
 
-        warning_records = [
-            r
-            for r in caplog.records
-            if r.levelno == logging.WARNING
-            and "Could not extract S3 credentials" in r.getMessage()
-        ]
-        assert len(warning_records) == 2
+        assert mock_logger.warning.call_count == 2
 
-    def test_async_partition_actor_fails_closed_on_unextractable_creds(self):
-        # AsyncPartitionActor must raise (not silently use obstore's ambient
-        # credential chain) when it's constructed with a filesystem whose
-        # credentials can't be extracted. In the normal plan flow,
-        # _plan_obstore_routing directs such filesystems to PartitionActor.
-        # Reaching AsyncPartitionActor anyway indicates a dispatch bug.
+    def test_native_fs_silent_routing(self):
+        # LocalFileSystem / HdfsFileSystem / etc. are unrecognized non-None
+        # filesystems. Routing to threaded is correct, but the WARNING is
+        # hardcoded with S3/fsspec advice and would be misleading for these
+        # — the routing must be silent (DEBUG only).
+        with patch(
+            "ray.data._internal.planner._obstore_download.logger"
+        ) as mock_logger:
+            use_obstore, kwargs = _plan_obstore_routing(pafs.LocalFileSystem())
+
+        assert use_obstore is False
+        assert kwargs == {}
+        mock_logger.warning.assert_not_called()
+        # A debug message is fine — just verifying no WARN noise.
+
+    def test_async_partition_actor_fails_closed(self):
         pytest.importorskip("obstore")
         from ray.data._internal.planner.download_partition_actor import (
             AsyncPartitionActor,
         )
 
-        # Unrecognized filesystem → extraction returns None.
-        bad_fs = pafs.LocalFileSystem()
+        bad_fs = pafs.LocalFileSystem()  # extraction → None
         ctx = DataContext.get_current()
-
         with pytest.raises(RuntimeError, match="cannot be statically extracted"):
             AsyncPartitionActor(["uri"], ctx, filesystem=bad_fs)
 
-    def test_download_uris_with_obstore_fails_closed_on_unextractable_fs(self):
-        # Direct-caller guard: _download_uris_with_obstore with a filesystem
-        # whose credentials can't be extracted must raise rather than coerce
-        # to {} and hand obstore the ambient credential chain. Preserves the
-        # fail-closed contract for any internal/test caller that bypasses
-        # _plan_obstore_routing.
+    def test_download_uris_fails_closed(self):
         pytest.importorskip("obstore")
-
-        bad_fs = pafs.LocalFileSystem()  # unrecognized → extraction returns None
-
         with pytest.raises(RuntimeError, match="cannot be statically extracted"):
             asyncio.run(
                 _download_uris_with_obstore(
-                    ["file:///tmp/does-not-matter.bin"],
-                    "uri",
-                    filesystem=bad_fs,
+                    ["file:///tmp/x.bin"], "uri", filesystem=pafs.LocalFileSystem()
                 )
             )
 
-    def test_routing_extractable_fsspec_s3_uses_obstore(self):
-        from pyarrow.fs import FSSpecHandler, PyFileSystem
-
-        inner = MagicMock()
-        inner.protocol = "s3"
-        inner.storage_options = {"key": "AKIA", "secret": "sec", "token": "tok"}
-        inner.session = None
-        inner.key = None
-        inner.secret = None
-        inner.token = None
-        inner.endpoint_url = None
-        inner.client_kwargs = None
-        inner.anon = False
-        inner._strip_protocol = lambda p: p
-        wrapped = PyFileSystem(FSSpecHandler(inner))
-
+    def test_extractable_fsspec_s3_uses_obstore(self):
+        wrapped = _make_fsspec_s3_wrapper(
+            storage_options={"key": "AKIA", "secret": "sec", "token": "tok"}
+        )
         use_obstore, kwargs = _plan_obstore_routing(wrapped)
         assert use_obstore is True
         assert kwargs == {

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -310,8 +310,11 @@ class TestFsspecSessionCreds:
         assert _frozen_s3fs_credentials(legacy) == expected
 
     def test_frozen_async_session(self):
-        # aiobotocore returns coroutines from get_credentials and
-        # get_frozen_credentials. The helper must drive them to completion.
+        # aiobotocore returns coroutines from get_credentials /
+        # get_frozen_credentials; the helper must drive them. Internally
+        # we use ``inspect.isawaitable`` (not ``asyncio.iscoroutine``) so
+        # custom wrappers returning Tasks / Futures / other awaitables
+        # also work.
         async def _frozen():
             return MagicMock(access_key="AKIA_AIO", secret_key="s", token="t")
 

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -258,13 +258,10 @@ class TestDownloadHelpers:
             assert _is_obstore_supported_url(uri) is expected
 
 
-# TestSessionBackedFsspecCredentials
-def _make_sync_session(access_key, secret_key, token):
-    """Build a sync (botocore-style) session returning the given frozen creds."""
-    frozen = MagicMock()
-    frozen.access_key = access_key
-    frozen.secret_key = secret_key
-    frozen.token = token
+# Test helpers for fsspec-S3 credential extraction & routing.
+def _sync_session(access_key, secret_key="sk", token="tk"):
+    """Build a botocore-style sync session returning frozen creds."""
+    frozen = MagicMock(access_key=access_key, secret_key=secret_key, token=token)
     creds = MagicMock()
     creds.get_frozen_credentials = MagicMock(return_value=frozen)
     session = MagicMock()
@@ -272,20 +269,27 @@ def _make_sync_session(access_key, secret_key, token):
     return session
 
 
-def _wrap_fsspec(session, storage_options=None, protocol="s3", anon=False):
-    """Wrap a minimal fsspec-like stub in PyFileSystem(FSSpecHandler(...))."""
+def _raising_session(exc=RuntimeError("no creds")):
+    session = MagicMock()
+    session.get_credentials = MagicMock(side_effect=exc)
+    return session
+
+
+def _wrap_s3fs(session=None, storage_options=None, protocol="s3", anon=False):
+    """Build a PyFileSystem(FSSpecHandler(stub)) with the given session."""
     from pyarrow.fs import FSSpecHandler, PyFileSystem
 
-    inner = MagicMock()
-    inner.protocol = protocol
-    inner.storage_options = storage_options or {}
-    inner.session = session
-    inner.key = None
-    inner.secret = None
-    inner.token = None
-    inner.endpoint_url = None
-    inner.client_kwargs = None
-    inner.anon = anon
+    inner = MagicMock(
+        protocol=protocol,
+        storage_options=storage_options or {},
+        session=session,
+        key=None,
+        secret=None,
+        token=None,
+        endpoint_url=None,
+        client_kwargs=None,
+        anon=anon,
+    )
     inner._strip_protocol = lambda p: p.split("://", 1)[-1] if "://" in p else p
     return PyFileSystem(FSSpecHandler(inner))
 
@@ -293,132 +297,76 @@ def _wrap_fsspec(session, storage_options=None, protocol="s3", anon=False):
 class TestFsspecSessionCreds:
     """Session-backed s3fs (Okta / STS / profile-based) credential paths."""
 
-    def test_sync_session(self):
-        session = _make_sync_session("AKIA_OKTA", "sstoken_secret", "sts_token")
+    def test_frozen_sync_and_underscore_fallback(self):
+        # Modern s3fs uses ``session``; older versions used ``_session``.
+        # Both must work and produce identical frozen-credential output.
+        expected = {"access_key": "AKIA", "secret_key": "sk", "token": "tk"}
+
+        modern = MagicMock(session=_sync_session("AKIA"))
+        assert _frozen_s3fs_credentials(modern) == expected
+
+        legacy = MagicMock(spec=["_session"])
+        legacy._session = _sync_session("AKIA")
+        assert _frozen_s3fs_credentials(legacy) == expected
+
+    def test_frozen_async_session(self):
+        # aiobotocore returns coroutines from get_credentials and
+        # get_frozen_credentials. The helper must drive them to completion.
+        async def _frozen():
+            return MagicMock(access_key="AKIA_AIO", secret_key="s", token="t")
+
+        async def _creds():
+            return MagicMock(get_frozen_credentials=MagicMock(return_value=_frozen()))
+
         inner = MagicMock()
-        inner.session = session
+        inner.session = MagicMock()
+        inner.session.get_credentials = MagicMock(return_value=_creds())
         assert _frozen_s3fs_credentials(inner) == {
-            "access_key": "AKIA_OKTA",
-            "secret_key": "sstoken_secret",
-            "token": "sts_token",
+            "access_key": "AKIA_AIO",
+            "secret_key": "s",
+            "token": "t",
         }
 
-    def test_missing_session(self):
+    @pytest.mark.parametrize(
+        "session_factory",
+        [
+            pytest.param(lambda: None, id="no-session"),
+            pytest.param(_raising_session, id="session-raises"),
+            pytest.param(lambda: _sync_session(None, None, None), id="empty-creds"),
+        ],
+    )
+    def test_frozen_returns_none_on_failure(self, session_factory):
         inner = MagicMock()
-        inner.session = None
+        inner.session = session_factory()
         inner._session = None
         assert _frozen_s3fs_credentials(inner) is None
 
-    def test_session_raises(self):
-        session = MagicMock()
-        session.get_credentials = MagicMock(side_effect=RuntimeError("expired"))
-        inner = MagicMock()
-        inner.session = session
-        assert _frozen_s3fs_credentials(inner) is None
-
-    def test_empty_access_key(self):
-        # session returns creds but access_key is None → return None.
-        inner = MagicMock()
-        inner.session = _make_sync_session(None, None, None)
-        assert _frozen_s3fs_credentials(inner) is None
-
-    def test_async_session(self):
-        # aiobotocore returns coroutines from get_credentials and
-        # get_frozen_credentials. The helper must drive them to completion.
-        async def _async_frozen():
-            frozen = MagicMock()
-            frozen.access_key = "AKIA_AIO"
-            frozen.secret_key = "aio_secret"
-            frozen.token = "aio_tok"
-            return frozen
-
-        async def _async_creds():
-            creds = MagicMock()
-            creds.get_frozen_credentials = MagicMock(return_value=_async_frozen())
-            return creds
-
-        session = MagicMock()
-        session.get_credentials = MagicMock(return_value=_async_creds())
-        inner = MagicMock()
-        inner.session = session
-        assert _frozen_s3fs_credentials(inner) == {
-            "access_key": "AKIA_AIO",
-            "secret_key": "aio_secret",
-            "token": "aio_tok",
-        }
-
-    def test_underscore_session_fallback(self):
-        # Older s3fs versions exposed `_session` instead of `session`.
-        session = _make_sync_session("AKIA_OLD", "old_sec", "")
-        inner = MagicMock(spec=["_session"])
-        inner._session = session
-        assert _frozen_s3fs_credentials(inner) == {
-            "access_key": "AKIA_OLD",
-            "secret_key": "old_sec",
-            "token": "",
-        }
-
-    def test_extract_uses_session_when_static_empty(self):
+    def test_extract_recovers_via_session(self):
         # The target bug: fsspec s3fs with Okta has static attrs None but
         # credentials resolvable via session. Extraction must recover them.
-        session = _make_sync_session("AKIA_STS", "secret_sts", "token_sts")
-        wrapped = _wrap_fsspec(session)
+        wrapped = _wrap_s3fs(_sync_session("AKIA_STS", "s_sts", "t_sts"))
         assert _extract_credentials_from_filesystem(wrapped) == {
             "access_key_id": "AKIA_STS",
-            "secret_access_key": "secret_sts",
-            "session_token": "token_sts",
+            "secret_access_key": "s_sts",
+            "session_token": "t_sts",
         }
 
-    def test_static_wins_over_session(self):
+    def test_extract_static_wins_over_session(self):
         # Static storage_options wins — explicit user config is not overridden.
-        session = _make_sync_session("AKIA_SESSION", "x", "y")
-        wrapped = _wrap_fsspec(
-            session,
-            storage_options={"key": "AKIA_EXPLICIT", "secret": "explicit_secret"},
+        session = _sync_session("AKIA_SESSION")
+        wrapped = _wrap_s3fs(
+            session, storage_options={"key": "AKIA_EXPLICIT", "secret": "e"}
         )
         result = _extract_credentials_from_filesystem(wrapped)
-        assert result is not None
         assert result["access_key_id"] == "AKIA_EXPLICIT"
-        assert result["secret_access_key"] == "explicit_secret"
+        assert result["secret_access_key"] == "e"
         session.get_credentials.assert_not_called()
 
-    def test_unresolvable_session_returns_none(self):
-        session = MagicMock()
-        session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
-        assert _extract_credentials_from_filesystem(_wrap_fsspec(session)) is None
-
-    def test_anon_skips_session(self):
-        session = MagicMock()
-        session.get_credentials = MagicMock(
-            side_effect=AssertionError("must not be called when anon=True")
-        )
-        wrapped = _wrap_fsspec(session, anon=True)
+    def test_extract_anon_skips_session(self):
+        # Anonymous → no creds needed; session must not be invoked.
+        session = _raising_session(AssertionError("must not be called"))
+        wrapped = _wrap_s3fs(session, anon=True)
         assert _extract_credentials_from_filesystem(wrapped) == {"skip_signature": True}
-
-
-# TestPlanObstoreRouting
-def _make_fsspec_s3_wrapper(*, session=None, storage_options=None, anon=False):
-    """Build a PyFileSystem(FSSpecHandler(stub)) for s3 protocol."""
-    from pyarrow.fs import FSSpecHandler, PyFileSystem
-
-    inner = MagicMock()
-    inner.protocol = "s3"
-    inner.storage_options = storage_options or {}
-    inner.session = session
-    inner.key = None
-    inner.secret = None
-    inner.token = None
-    inner.endpoint_url = None
-    inner.client_kwargs = None
-    inner.anon = anon
-    inner._strip_protocol = lambda p: p
-    return PyFileSystem(FSSpecHandler(inner))
-
-
-def _make_raising_session():
-    session = MagicMock()
-    session.get_credentials = MagicMock(side_effect=RuntimeError("no creds"))
-    return session
 
 
 class TestPlanObstoreRouting:
@@ -431,67 +379,61 @@ class TestPlanObstoreRouting:
         m._warned_credential_fs_ids.clear()
 
     def test_none_fs_uses_obstore(self):
-        use_obstore, kwargs = _plan_obstore_routing(None)
-        assert use_obstore is True
-        assert kwargs == {}
+        assert _plan_obstore_routing(None) == (True, {})
 
-    def test_non_s3_fsspec_to_threaded(self):
+    def test_extractable_fsspec_s3_uses_obstore(self):
+        wrapped = _wrap_s3fs(
+            storage_options={"key": "AKIA", "secret": "sec", "token": "tok"}
+        )
+        assert _plan_obstore_routing(wrapped) == (
+            True,
+            {
+                "access_key_id": "AKIA",
+                "secret_access_key": "sec",
+                "session_token": "tok",
+            },
+        )
+
+    def test_fsspec_s3_unextractable_warns_once(self):
+        # Patch module logger directly — Ray's internal loggers don't always
+        # propagate to pytest's caplog in sandboxed test runners. This also
+        # covers the dedup path: same FS twice = one warning, different FS =
+        # new warning.
+        fs_a = _wrap_s3fs(_raising_session())
+        fs_b = _wrap_s3fs(_raising_session())
+
+        with patch(
+            "ray.data._internal.planner._obstore_download.logger"
+        ) as mock_logger:
+            assert _plan_obstore_routing(fs_a) == (False, {})
+            _plan_obstore_routing(fs_a)  # dedup — no new warning
+            _plan_obstore_routing(fs_b)  # different FS — new warning
+
+        assert mock_logger.warning.call_count == 2
+        msg = mock_logger.warning.call_args_list[0][0][0]
+        assert "S3 credentials" in msg and "storage_options" in msg
+
+    def test_silent_routing_for_unrecognized_fs(self):
+        # Both non-S3 fsspec and native unrecognized filesystems must route
+        # to the threaded path WITHOUT a S3-specific warning. The hardcoded
+        # "pass credentials via fsspec storage_options" advice only makes
+        # sense for fsspec-S3.
         import fsspec
         from pyarrow.fs import FSSpecHandler, PyFileSystem
 
         class _GcsStub(fsspec.AbstractFileSystem):
             protocol = "gcs"
 
-        wrapped = PyFileSystem(FSSpecHandler(_GcsStub()))
-        use_obstore, kwargs = _plan_obstore_routing(wrapped)
-        assert use_obstore is False
-        assert kwargs == {}
-
-    def test_fsspec_s3_unextractable_warns(self):
-        # Patch the module logger directly instead of relying on caplog —
-        # Ray's internal loggers don't always propagate in test environments,
-        # so caplog.records can come back empty even when the warning fires.
-        wrapped = _make_fsspec_s3_wrapper(session=_make_raising_session())
-
-        with patch(
-            "ray.data._internal.planner._obstore_download.logger"
-        ) as mock_logger:
-            use_obstore, kwargs = _plan_obstore_routing(wrapped)
-
-        assert use_obstore is False
-        assert kwargs == {}
-        # Exactly one warning, with the S3-specific advice.
-        assert mock_logger.warning.call_count == 1
-        msg = mock_logger.warning.call_args[0][0]
-        assert "S3 credentials" in msg and "storage_options" in msg
-
-    def test_warns_once_per_fs(self):
-        fs_a = _make_fsspec_s3_wrapper(session=_make_raising_session())
-        fs_b = _make_fsspec_s3_wrapper(session=_make_raising_session())
-
-        with patch(
-            "ray.data._internal.planner._obstore_download.logger"
-        ) as mock_logger:
-            _plan_obstore_routing(fs_a)
-            _plan_obstore_routing(fs_a)  # same FS — no new warning
-            _plan_obstore_routing(fs_b)  # different FS — new warning
-
-        assert mock_logger.warning.call_count == 2
-
-    def test_native_fs_silent_routing(self):
-        # LocalFileSystem / HdfsFileSystem / etc. are unrecognized non-None
-        # filesystems. Routing to threaded is correct, but the WARNING is
-        # hardcoded with S3/fsspec advice and would be misleading for these
-        # — the routing must be silent (DEBUG only).
-        with patch(
-            "ray.data._internal.planner._obstore_download.logger"
-        ) as mock_logger:
-            use_obstore, kwargs = _plan_obstore_routing(pafs.LocalFileSystem())
-
-        assert use_obstore is False
-        assert kwargs == {}
-        mock_logger.warning.assert_not_called()
-        # A debug message is fine — just verifying no WARN noise.
+        filesystems = [
+            PyFileSystem(FSSpecHandler(_GcsStub())),
+            pafs.LocalFileSystem(),
+        ]
+        for fs in filesystems:
+            with patch(
+                "ray.data._internal.planner._obstore_download.logger"
+            ) as mock_logger:
+                assert _plan_obstore_routing(fs) == (False, {})
+                mock_logger.warning.assert_not_called()
 
     def test_async_partition_actor_fails_closed(self):
         pytest.importorskip("obstore")
@@ -499,10 +441,10 @@ class TestPlanObstoreRouting:
             AsyncPartitionActor,
         )
 
-        bad_fs = pafs.LocalFileSystem()  # extraction → None
-        ctx = DataContext.get_current()
         with pytest.raises(RuntimeError, match="cannot be statically extracted"):
-            AsyncPartitionActor(["uri"], ctx, filesystem=bad_fs)
+            AsyncPartitionActor(
+                ["uri"], DataContext.get_current(), filesystem=pafs.LocalFileSystem()
+            )
 
     def test_download_uris_fails_closed(self):
         pytest.importorskip("obstore")
@@ -512,18 +454,6 @@ class TestPlanObstoreRouting:
                     ["file:///tmp/x.bin"], "uri", filesystem=pafs.LocalFileSystem()
                 )
             )
-
-    def test_extractable_fsspec_s3_uses_obstore(self):
-        wrapped = _make_fsspec_s3_wrapper(
-            storage_options={"key": "AKIA", "secret": "sec", "token": "tok"}
-        )
-        use_obstore, kwargs = _plan_obstore_routing(wrapped)
-        assert use_obstore is True
-        assert kwargs == {
-            "access_key_id": "AKIA",
-            "secret_access_key": "sec",
-            "session_token": "tok",
-        }
 
 
 # TestObstoreDownloadPath

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -1,5 +1,7 @@
 import asyncio
 import os
+import time
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from unittest.mock import MagicMock, patch
 
@@ -11,10 +13,10 @@ from ray.data._internal.planner._obstore_download import (
     _FILE_SIZE_COLUMN_PREFIX,
     _download_uris_with_obstore,
     _extract_credentials_from_filesystem,
-    _frozen_s3fs_credentials,
     _is_obstore_supported_url,
     _obstore_filesystem_requires_threaded_download,
     _plan_obstore_routing,
+    _S3FSSessionCredentialProvider,
     download_bytes_async,
 )
 from ray.data._internal.planner.plan_download_op import (
@@ -263,10 +265,10 @@ class TestDownloadHelpers:
 
 
 # Test helpers for fsspec-S3 credential extraction & routing.
-def _sync_session(access_key, secret_key="sk", token="tk"):
+def _sync_session(access_key, secret_key="sk", token="tk", expiry_time=None):
     """Build a botocore-style sync session returning frozen creds."""
     frozen = MagicMock(access_key=access_key, secret_key=secret_key, token=token)
-    creds = MagicMock()
+    creds = MagicMock(expiry_time=expiry_time)
     creds.get_frozen_credentials = MagicMock(return_value=frozen)
     session = MagicMock()
     session.get_credentials = MagicMock(return_value=creds)
@@ -279,87 +281,151 @@ def _raising_session(exc=RuntimeError("no creds")):
     return session
 
 
-def _wrap_s3fs(session=None, storage_options=None, protocol="s3", anon=False):
-    """Build a PyFileSystem(FSSpecHandler(stub)) with the given session."""
+def _wrap_s3fs(session=None, storage_options=None, anon=False):
+    """Build a PyFileSystem(FSSpecHandler(stub)) backed by an s3fs.S3FileSystem mock.
+
+    ``_is_fsspec_s3_filesystem`` is strict about the inner class being
+    ``s3fs.S3FileSystem``, so we use ``spec=`` to ensure the mock passes
+    ``isinstance(inner, S3FileSystem)``.
+    """
+    s3fs = pytest.importorskip("s3fs")
     from pyarrow.fs import FSSpecHandler, PyFileSystem
 
-    inner = MagicMock(
-        protocol=protocol,
-        storage_options=storage_options or {},
-        session=session,
-        key=None,
-        secret=None,
-        token=None,
-        endpoint_url=None,
-        client_kwargs=None,
-        anon=anon,
-    )
+    inner = MagicMock(spec=s3fs.S3FileSystem)
+    inner.protocol = "s3"
+    inner.storage_options = storage_options or {}
+    inner.session = session
+    inner._session = None
+    inner.key = None
+    inner.secret = None
+    inner.token = None
+    inner.endpoint_url = None
+    inner.client_kwargs = None
+    inner.anon = anon
     inner._strip_protocol = lambda p: p.split("://", 1)[-1] if "://" in p else p
     return PyFileSystem(FSSpecHandler(inner))
 
 
-class TestFsspecSessionCreds:
-    """Session-backed s3fs (Okta / STS / profile-based) credential paths."""
+class TestS3FSSessionCredentialProvider:
+    """``_S3FSSessionCredentialProvider`` — obstore callback for session-backed s3fs."""
 
-    def test_frozen_sync_and_underscore_fallback(self):
-        # Modern s3fs uses ``session``; older versions used ``_session``.
-        # Both must work and produce identical frozen-credential output.
-        expected = {"access_key": "AKIA", "secret_key": "sk", "token": "tk"}
+    def test_returns_obstore_dict_sync_session(self):
+        # Botocore sessions return non-awaitable Credentials objects; the
+        # provider must still produce the obstore-shaped dict.
+        provider = _S3FSSessionCredentialProvider(_sync_session("AKIA"))
+        result = asyncio.run(provider())
+        assert result["access_key_id"] == "AKIA"
+        assert result["secret_access_key"] == "sk"
+        assert result["token"] == "tk"
+        assert isinstance(result["expires_at"], datetime)
 
-        modern = MagicMock(session=_sync_session("AKIA"))
-        assert _frozen_s3fs_credentials(modern) == expected
-
-        legacy = MagicMock(spec=["_session"])
-        legacy._session = _sync_session("AKIA")
-        assert _frozen_s3fs_credentials(legacy) == expected
-
-    def test_frozen_async_session(self):
+    def test_returns_obstore_dict_async_session(self):
         # aiobotocore returns coroutines from get_credentials /
-        # get_frozen_credentials; the helper must drive them. Internally
-        # we use ``inspect.isawaitable`` (not ``asyncio.iscoroutine``) so
-        # custom wrappers returning Tasks / Futures / other awaitables
-        # also work.
+        # get_frozen_credentials; the provider must drive them. We use
+        # ``inspect.isawaitable`` so Tasks / Futures / custom awaitables
+        # work too, not just bare coroutines.
         async def _frozen():
             return MagicMock(access_key="AKIA_AIO", secret_key="s", token="t")
 
         async def _creds():
-            return MagicMock(get_frozen_credentials=MagicMock(return_value=_frozen()))
+            return MagicMock(
+                get_frozen_credentials=MagicMock(return_value=_frozen()),
+                expiry_time=None,
+            )
 
-        inner = MagicMock()
-        inner.session = MagicMock()
-        inner.session.get_credentials = MagicMock(return_value=_creds())
-        assert _frozen_s3fs_credentials(inner) == {
-            "access_key": "AKIA_AIO",
-            "secret_key": "s",
-            "token": "t",
-        }
+        session = MagicMock()
+        session.get_credentials = MagicMock(return_value=_creds())
+        result = asyncio.run(_S3FSSessionCredentialProvider(session)())
+        assert result["access_key_id"] == "AKIA_AIO"
+        assert result["token"] == "t"
+
+    def test_caches_until_expiry(self):
+        # Repeated calls within the TTL must not re-enter the session — obstore
+        # may invoke the provider on every request and the session can be
+        # expensive (HTTP / token refresh).
+        session = _sync_session("AKIA")
+        provider = _S3FSSessionCredentialProvider(session)
+        first = asyncio.run(provider())
+        second = asyncio.run(provider())
+        assert session.get_credentials.call_count == 1
+        assert second == first
+
+    def test_refreshes_after_expiry(self):
+        # Once expires_at passes, the next call must re-enter the session so
+        # rotated keys propagate to obstore. Use a tiny TTL to test quickly.
+        session = _sync_session("AKIA")
+        provider = _S3FSSessionCredentialProvider(
+            session, ttl=timedelta(microseconds=1)
+        )
+        asyncio.run(provider())
+        time.sleep(0.005)
+        asyncio.run(provider())
+        assert session.get_credentials.call_count == 2
+
+    def test_uses_session_expiry_time(self):
+        # When the session exposes its own expiry_time (typical for STS /
+        # AssumeRole), use that instead of TTL — obstore will refresh on
+        # the real expiry, not a wall-clock window.
+        future = datetime.now(timezone.utc) + timedelta(hours=2)
+        provider = _S3FSSessionCredentialProvider(
+            _sync_session("AKIA", expiry_time=future)
+        )
+        assert asyncio.run(provider())["expires_at"] == future
+
+    @pytest.mark.parametrize("attr", ["session", "_session"])
+    def test_from_fsspec_fs_picks_session_or_underscore(self, attr):
+        # Modern s3fs uses ``session``; older versions used ``_session``.
+        # Both must be picked up.
+        fs = MagicMock(session=None, _session=None)
+        setattr(fs, attr, _sync_session("AKIA"))
+        provider = _S3FSSessionCredentialProvider.from_fsspec_fs(fs)
+        assert provider is not None
+        assert asyncio.run(provider())["access_key_id"] == "AKIA"
+
+    def test_from_fsspec_fs_returns_none_when_no_session(self):
+        fs = MagicMock(session=None, _session=None)
+        assert _S3FSSessionCredentialProvider.from_fsspec_fs(fs) is None
+
+    def test_can_fetch_credentials_true(self):
+        provider = _S3FSSessionCredentialProvider(_sync_session("AKIA"))
+        assert provider.can_fetch_credentials() is True
 
     @pytest.mark.parametrize(
         "session_factory",
         [
-            pytest.param(lambda: None, id="no-session"),
             pytest.param(_raising_session, id="session-raises"),
-            pytest.param(lambda: _sync_session(None, None, None), id="empty-creds"),
+            pytest.param(
+                lambda: _sync_session(None, None, None), id="empty-access-key"
+            ),
         ],
     )
-    def test_frozen_returns_none_on_failure(self, session_factory):
-        inner = MagicMock()
-        inner.session = session_factory()
-        inner._session = None
-        assert _frozen_s3fs_credentials(inner) is None
+    def test_can_fetch_credentials_false(self, session_factory):
+        provider = _S3FSSessionCredentialProvider(session_factory())
+        assert provider.can_fetch_credentials() is False
 
-    def test_extract_recovers_via_session(self):
+
+class TestExtractCredentialsFromFilesystemFsspecSession:
+    """``_extract_credentials_from_filesystem`` installs the provider for fsspec-S3."""
+
+    def test_installs_provider_for_session_backed_fs(self):
         # The target bug: fsspec s3fs with Okta has static attrs None but
-        # credentials resolvable via session. Extraction must recover them.
-        wrapped = _wrap_s3fs(_sync_session("AKIA_STS", "s_sts", "t_sts"))
-        assert _extract_credentials_from_filesystem(wrapped) == {
-            "access_key_id": "AKIA_STS",
-            "secret_access_key": "s_sts",
-            "session_token": "t_sts",
-        }
+        # credentials resolvable via session. Extraction must install a
+        # credential_provider so obstore can refresh on expiry — not snapshot
+        # the keys into static kwargs, which would go stale mid-job.
+        wrapped = _wrap_s3fs(_sync_session("AKIA_STS"))
+        result = _extract_credentials_from_filesystem(wrapped)
+        assert result is not None
+        assert isinstance(
+            result["credential_provider"], _S3FSSessionCredentialProvider
+        )
+        # Static keys are NOT in kwargs — they come from the provider on demand.
+        assert "access_key_id" not in result
+        assert "secret_access_key" not in result
 
-    def test_extract_static_wins_over_session(self):
-        # Static storage_options wins — explicit user config is not overridden.
+    def test_static_keys_skip_provider(self):
+        # Explicit static keys win — no provider needed and the session must
+        # not be entered (avoids accidental session calls for users who
+        # provided keys directly).
         session = _sync_session("AKIA_SESSION")
         wrapped = _wrap_s3fs(
             session, storage_options={"key": "AKIA_EXPLICIT", "secret": "e"}
@@ -368,13 +434,22 @@ class TestFsspecSessionCreds:
         assert result is not None
         assert result["access_key_id"] == "AKIA_EXPLICIT"
         assert result["secret_access_key"] == "e"
+        assert "credential_provider" not in result
         session.get_credentials.assert_not_called()
 
-    def test_extract_anon_skips_session(self):
-        # Anonymous → no creds needed; session must not be invoked.
+    def test_anon_skips_provider(self):
+        # Anonymous → no creds needed; session must not be invoked even if
+        # it would raise.
         session = _raising_session(AssertionError("must not be called"))
         wrapped = _wrap_s3fs(session, anon=True)
         assert _extract_credentials_from_filesystem(wrapped) == {"skip_signature": True}
+
+    def test_unresolvable_session_returns_none(self):
+        # Session present but get_credentials raises — provider validation
+        # fails, and we return None so the planner routes to the threaded
+        # path (keeping the user's filesystem authoritative).
+        wrapped = _wrap_s3fs(_raising_session())
+        assert _extract_credentials_from_filesystem(wrapped) is None
 
 
 class TestPlanObstoreRouting:

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -281,6 +281,23 @@ def _raising_session(exc=RuntimeError("no creds")):
     return session
 
 
+def _async_session(access_key="AKIA_AIO", secret_key="s", token="t"):
+    """Build an aiobotocore-style session returning a credentials coroutine."""
+
+    async def _frozen():
+        return MagicMock(access_key=access_key, secret_key=secret_key, token=token)
+
+    async def _creds():
+        return MagicMock(
+            get_frozen_credentials=MagicMock(return_value=_frozen()),
+            expiry_time=None,
+        )
+
+    session = MagicMock()
+    session.get_credentials = MagicMock(return_value=_creds())
+    return session
+
+
 def _wrap_s3fs(session=None, storage_options=None, anon=False):
     """Build a PyFileSystem(FSSpecHandler(stub)) backed by an s3fs.S3FileSystem mock.
 
@@ -309,35 +326,23 @@ def _wrap_s3fs(session=None, storage_options=None, anon=False):
 class TestS3FSSessionCredentialProvider:
     """``_S3FSSessionCredentialProvider`` — obstore callback for session-backed s3fs."""
 
-    def test_returns_obstore_dict_sync_session(self):
-        # Botocore sessions return non-awaitable Credentials objects; the
-        # provider must still produce the obstore-shaped dict.
-        provider = _S3FSSessionCredentialProvider(_sync_session("AKIA"))
+    @pytest.mark.parametrize(
+        "session_factory,expected_key",
+        [
+            # Botocore returns plain Credentials objects.
+            pytest.param(lambda: _sync_session("AKIA"), "AKIA", id="sync-botocore"),
+            # aiobotocore returns coroutines from get_credentials and
+            # get_frozen_credentials; the provider drives either via
+            # ``inspect.isawaitable``, which also covers Tasks / Futures / custom
+            # awaitables, not just bare coroutines.
+            pytest.param(_async_session, "AKIA_AIO", id="async-aiobotocore"),
+        ],
+    )
+    def test_returns_obstore_dict(self, session_factory, expected_key):
+        provider = _S3FSSessionCredentialProvider(session_factory())
         result = asyncio.run(provider())
-        assert result["access_key_id"] == "AKIA"
-        assert result["secret_access_key"] == "sk"
-        assert result["token"] == "tk"
+        assert result["access_key_id"] == expected_key
         assert isinstance(result["expires_at"], datetime)
-
-    def test_returns_obstore_dict_async_session(self):
-        # aiobotocore returns coroutines from get_credentials /
-        # get_frozen_credentials; the provider must drive them. We use
-        # ``inspect.isawaitable`` so Tasks / Futures / custom awaitables
-        # work too, not just bare coroutines.
-        async def _frozen():
-            return MagicMock(access_key="AKIA_AIO", secret_key="s", token="t")
-
-        async def _creds():
-            return MagicMock(
-                get_frozen_credentials=MagicMock(return_value=_frozen()),
-                expiry_time=None,
-            )
-
-        session = MagicMock()
-        session.get_credentials = MagicMock(return_value=_creds())
-        result = asyncio.run(_S3FSSessionCredentialProvider(session)())
-        assert result["access_key_id"] == "AKIA_AIO"
-        assert result["token"] == "t"
 
     def test_caches_until_expiry(self):
         # Repeated calls within the TTL must not re-enter the session — obstore
@@ -386,22 +391,21 @@ class TestS3FSSessionCredentialProvider:
         fs = MagicMock(session=None, _session=None)
         assert _S3FSSessionCredentialProvider.from_fsspec_fs(fs) is None
 
-    def test_can_fetch_credentials_true(self):
-        provider = _S3FSSessionCredentialProvider(_sync_session("AKIA"))
-        assert provider.can_fetch_credentials() is True
-
     @pytest.mark.parametrize(
-        "session_factory",
+        "session_factory,expected",
         [
-            pytest.param(_raising_session, id="session-raises"),
+            pytest.param(lambda: _sync_session("AKIA"), True, id="success"),
+            pytest.param(_raising_session, False, id="session-raises"),
             pytest.param(
-                lambda: _sync_session(None, None, None), id="empty-access-key"
+                lambda: _sync_session(None, None, None),
+                False,
+                id="empty-access-key",
             ),
         ],
     )
-    def test_can_fetch_credentials_false(self, session_factory):
+    def test_can_fetch_credentials(self, session_factory, expected):
         provider = _S3FSSessionCredentialProvider(session_factory())
-        assert provider.can_fetch_credentials() is False
+        assert provider.can_fetch_credentials() is expected
 
 
 class TestExtractCredentialsFromFilesystemFsspecSession:
@@ -415,9 +419,7 @@ class TestExtractCredentialsFromFilesystemFsspecSession:
         wrapped = _wrap_s3fs(_sync_session("AKIA_STS"))
         result = _extract_credentials_from_filesystem(wrapped)
         assert result is not None
-        assert isinstance(
-            result["credential_provider"], _S3FSSessionCredentialProvider
-        )
+        assert isinstance(result["credential_provider"], _S3FSSessionCredentialProvider)
         # Static keys are NOT in kwargs — they come from the provider on demand.
         assert "access_key_id" not in result
         assert "secret_access_key" not in result


### PR DESCRIPTION
## Summary

When a user passes an fsspec `S3FileSystem` with Okta/STS/profile-based auth (wrapped as `PyFileSystem(FSSpecHandler(s3fs_fs))`), `_extract_credentials_from_filesystem` read only static attrs (`key`/`secret`/`token`, `storage_options`). Those attrs are `None` for session-backed s3fs — credentials live on `fs.session.get_credentials()` and may rotate. The function returned `{}`, obstore's `from_url` got no keys, and obstore silently fell back to its own credential chain (IMDS on EC2). Under concurrent S3 workloads this manifested as intermittent `NoCredentialsError` — users never saw a warning, and their Okta credentials had been silently dropped.

This is the first of two independent PRs addressing related bugs in the `download` expression pipeline. The matching threaded-path pre-resolve fix (which avoids an IMDS thundering herd on the PyArrow fallback path, and is triggered whenever this PR routes an unextractable filesystem to threaded) is in a separate PR. Either can land first.

## Changes

- **`_extract_credentials_from_filesystem`** now returns `Optional[Dict]`. `None` signals "route to threaded" so the user's filesystem stays authoritative. Unrecognized non-`None` filesystems also return `None` per the new contract.
- **`_frozen_s3fs_credentials`** (new helper) snapshots credentials via `session.get_credentials().get_frozen_credentials()` for both sync (botocore) and async (aiobotocore) sessions.
- **`_plan_obstore_routing(fs) -> (use_obstore, fs_kwargs)`** (new helper) centralizes dispatch at plan time with a one-shot `WARNING` per filesystem when credentials can't be extracted.
- **`plan_download_op`** wires the routing helper so both the partition actor choice (`AsyncPartitionActor` vs `PartitionActor`) and the download function choice (`download_bytes_async` vs `download_bytes_threaded`) use the same gate.
- **`download_bytes_async`** extracts credentials once in sync context and threads the kwargs through to `_download_uris_with_obstore`. Fixes a latent correctness issue where aiobotocore's async `get_credentials` can't run from inside an already-running event loop.
- **`AsyncPartitionActor`** and **`_download_uris_with_obstore`** both fail closed with a clear `RuntimeError` when constructed / called with a filesystem whose credentials can't be statically extracted. Dispatch should route such filesystems to the PyArrow path; reaching these code paths anyway indicates a dispatch bug and the guard prevents regressions back to the silent-drop behavior.

## Test plan

- [x] `pre-commit run` passes (ruff, pydoclint, black, docstyle, semgrep, import order, mock-method / logger checks).
- [x] New unit tests in `test_obstore_download.py`:
  - `TestSessionBackedFsspecCredentials` — sync botocore session, aiobotocore async session, `_session` fallback for older s3fs, unresolvable-session → `None`, no-access-key → `None`, `anon=True` skips the session, static attrs win over session.
  - `TestPlanObstoreRouting` — `None` filesystem → obstore, non-S3 fsspec → threaded, unextractable fsspec-S3 → threaded with warning, warning dedup (same FS twice = one warning), extractable fsspec-S3 → obstore, `AsyncPartitionActor` raises on unextractable creds, `_download_uris_with_obstore` raises on unextractable creds.
- [ ] End-to-end against moto/minio with Okta-style fsspec `S3FileSystem` over ~100 URIs (no `NoCredentialsError`, moto sees signed requests with the session's current keys).