### PR TITLE
[Data] Pre-resolve filesystem in threaded download to avoid IMDS herd

### DIFF
--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -33,7 +33,10 @@ from ray.data._internal.util import (
 )
 from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
-from ray.data.datasource.path_util import _resolve_paths_and_filesystem
+from ray.data.datasource.path_util import (
+    _resolve_paths_and_filesystem,
+    _validate_and_wrap_filesystem,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +222,11 @@ def download_bytes_threaded(
         # IMDS credential fetch. With N concurrent Download tasks on an EC2
         # node that's 16*N near-simultaneous IMDS calls — enough to trip the
         # per-instance rate limit and produce intermittent NoCredentialsError.
-        resolved_fs = filesystem
+        #
+        # Normalize a user-supplied fsspec FS to PyFileSystem(FSSpecHandler) so
+        # RetryingPyFileSystem.wrap (which forwards open_input_stream to the
+        # inner FS) doesn't end up calling a method fsspec filesystems lack.
+        resolved_fs = _validate_and_wrap_filesystem(filesystem)
         if resolved_fs is None:
             for probe_uri in uris:
                 if probe_uri is None:

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -262,10 +262,17 @@ def download_bytes_threaded(
                         resolved_paths, per_uri_fs = _resolve_paths_and_filesystem(
                             uri, filesystem=None
                         )
-                        fs_for_read = RetryingPyFileSystem.wrap(
+                        # Cache the first successful inference for the rest of
+                        # this worker's iterator so we don't redo it per URI.
+                        # Without this, every URI in the fallback path would
+                        # reconstruct the filesystem — recreating the repeated
+                        # construction cost this PR is trying to avoid.
+                        resolved_fs = per_uri_fs
+                        wrapped_fs = RetryingPyFileSystem.wrap(
                             per_uri_fs,
                             retryable_errors=data_context.retried_io_errors,
                         )
+                        fs_for_read = wrapped_fs
                     else:
                         # Path normalization only — _resolve_paths_and_filesystem
                         # short-circuits when filesystem is supplied (no network).

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -262,6 +262,11 @@ def download_bytes_threaded(
                         resolved_paths, per_uri_fs = _resolve_paths_and_filesystem(
                             uri, filesystem=None
                         )
+                        if per_uri_fs is None:
+                            # Resolution succeeded structurally but yielded no FS —
+                            # don't cache and don't try to read. Move on so the
+                            # next URI gets a fresh inference attempt.
+                            continue
                         # Cache the first successful inference for the rest of
                         # this worker's iterator so we don't redo it per URI.
                         # Without this, every URI in the fallback path would

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -231,17 +231,32 @@ def download_bytes_threaded(
                     continue
                 # _resolve_paths_and_filesystem can silently drop unresolvable
                 # URIs (returning ([], ...)) or yield no filesystem. Only accept
-                # a result we can actually use — otherwise workers fall back to
-                # per-URI inference and recreate the IMDS herd.
+                # a result we can actually use.
                 if paths and candidate_fs is not None:
                     resolved_fs = candidate_fs
                     break
 
-        wrapped_fs = None
-        if resolved_fs is not None:
-            wrapped_fs = RetryingPyFileSystem.wrap(
-                resolved_fs, retryable_errors=data_context.retried_io_errors
+        if resolved_fs is None:
+            # Probe iterated every URI and could not infer a filesystem. Workers
+            # would just retry the same URIs with the same filesystem=None and
+            # hit the same failure — while reintroducing per-worker FS
+            # construction (the IMDS herd this PR exists to prevent). Yield
+            # None for every URI and skip the worker pool entirely.
+            logger.warning(
+                "Could not resolve a filesystem from any URI in column "
+                f"{uri_column_name!r} ({len(uris)} URIs). Yielding None for "
+                "all rows."
             )
+            output_block = output_block.add_column(
+                len(output_block.column_names),
+                output_bytes_column_name,
+                pa.array([None] * len(uris), type=pa.binary()),
+            )
+            continue
+
+        wrapped_fs = RetryingPyFileSystem.wrap(
+            resolved_fs, retryable_errors=data_context.retried_io_errors
+        )
 
         def load_uri_bytes(
             uri_iterator,
@@ -255,41 +270,15 @@ def download_bytes_threaded(
                 try:
                     if uri is None:
                         continue
-                    if wrapped_fs is None:
-                        # All probe URIs failed — last-resort per-URI resolution.
-                        # Mirrors legacy behavior so a block full of unresolvable
-                        # URIs doesn't lose the ones that might still resolve.
-                        resolved_paths, per_uri_fs = _resolve_paths_and_filesystem(
-                            uri, filesystem=None
-                        )
-                        if per_uri_fs is None:
-                            # Resolution succeeded structurally but yielded no FS —
-                            # don't cache and don't try to read. Move on so the
-                            # next URI gets a fresh inference attempt.
-                            continue
-                        # Cache the first successful inference for the rest of
-                        # this worker's iterator so we don't redo it per URI.
-                        # Without this, every URI in the fallback path would
-                        # reconstruct the filesystem — recreating the repeated
-                        # construction cost this PR is trying to avoid.
-                        resolved_fs = per_uri_fs
-                        wrapped_fs = RetryingPyFileSystem.wrap(
-                            per_uri_fs,
-                            retryable_errors=data_context.retried_io_errors,
-                        )
-                        fs_for_read = wrapped_fs
-                    else:
-                        # Path normalization only — _resolve_paths_and_filesystem
-                        # short-circuits when filesystem is supplied (no network).
-                        resolved_paths, _ = _resolve_paths_and_filesystem(
-                            uri, filesystem=resolved_fs
-                        )
-                        fs_for_read = wrapped_fs
-
+                    # Path normalization only — _resolve_paths_and_filesystem
+                    # short-circuits when filesystem is supplied (no network).
+                    resolved_paths, _ = _resolve_paths_and_filesystem(
+                        uri, filesystem=resolved_fs
+                    )
                     resolved_path = resolved_paths[0] if resolved_paths else None
                     if resolved_path is None:
                         continue
-                    with fs_for_read.open_input_stream(resolved_path) as f:
+                    with wrapped_fs.open_input_stream(resolved_path) as f:
                         read_bytes = f.read()
                 except OSError as e:
                     logger.debug(

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -213,36 +213,73 @@ def download_bytes_threaded(
         if len(uris) == 0:
             continue
 
-        def load_uri_bytes(uri_iterator):
-            """Resolve filesystem and download bytes for each URI.
+        # Resolve the filesystem exactly once before spawning workers. Without
+        # this, each of 16 make_async_gen worker threads independently
+        # constructs a pyarrow.fs.S3FileSystem on its first URI, triggering an
+        # IMDS credential fetch. With N concurrent Download tasks on an EC2
+        # node that's 16*N near-simultaneous IMDS calls — enough to trip the
+        # per-instance rate limit and produce intermittent NoCredentialsError.
+        resolved_fs = filesystem
+        if resolved_fs is None:
+            for probe_uri in uris:
+                if probe_uri is None:
+                    continue
+                try:
+                    paths, candidate_fs = _resolve_paths_and_filesystem(
+                        probe_uri, None
+                    )
+                except Exception as e:
+                    logger.debug(f"Could not infer filesystem from '{probe_uri}': {e}")
+                    continue
+                # _resolve_paths_and_filesystem can silently drop unresolvable
+                # URIs (returning ([], ...)) or yield no filesystem. Only accept
+                # a result we can actually use — otherwise workers fall back to
+                # per-URI inference and recreate the IMDS herd.
+                if paths and candidate_fs is not None:
+                    resolved_fs = candidate_fs
+                    break
 
-            Takes an iterator of URIs and yields bytes for each.
-            Uses lazy filesystem resolution - resolves once and reuses for subsequent URIs.
-            If a filesystem was provided explicitly, it will be used for all URIs.
-            """
-            cached_fs = filesystem
+        wrapped_fs = None
+        if resolved_fs is not None:
+            wrapped_fs = RetryingPyFileSystem.wrap(
+                resolved_fs, retryable_errors=data_context.retried_io_errors
+            )
+
+        def load_uri_bytes(
+            uri_iterator,
+            wrapped_fs=wrapped_fs,
+            resolved_fs=resolved_fs,
+            uri_column_name=uri_column_name,
+        ):
+            """Download bytes for each URI using the pre-resolved filesystem."""
             for uri in uri_iterator:
                 read_bytes = None
                 try:
-                    # Use cached FS if available, otherwise resolve the filesystem for the uri.
-                    resolved_paths, resolved_fs = _resolve_paths_and_filesystem(
-                        uri, filesystem=cached_fs
-                    )
-                    cached_fs = resolved_fs
+                    if uri is None:
+                        continue
+                    if wrapped_fs is None:
+                        # All probe URIs failed — last-resort per-URI resolution.
+                        # Mirrors legacy behavior so a block full of unresolvable
+                        # URIs doesn't lose the ones that might still resolve.
+                        resolved_paths, per_uri_fs = _resolve_paths_and_filesystem(
+                            uri, filesystem=None
+                        )
+                        fs_for_read = RetryingPyFileSystem.wrap(
+                            per_uri_fs,
+                            retryable_errors=data_context.retried_io_errors,
+                        )
+                    else:
+                        # Path normalization only — _resolve_paths_and_filesystem
+                        # short-circuits when filesystem is supplied (no network).
+                        resolved_paths, _ = _resolve_paths_and_filesystem(
+                            uri, filesystem=resolved_fs
+                        )
+                        fs_for_read = wrapped_fs
 
-                    # Wrap with retrying filesystem
-                    fs = RetryingPyFileSystem.wrap(
-                        resolved_fs, retryable_errors=data_context.retried_io_errors
-                    )
-                    # We only pass one uri to resolve and unwrap it from the list of resolved paths,
-                    # if fails, we will catch the index error and log it.
-                    resolved_path = resolved_paths[0]
+                    resolved_path = resolved_paths[0] if resolved_paths else None
                     if resolved_path is None:
                         continue
-
-                    # Download bytes
-                    # Use open_input_stream to handle the rare scenario where the data source is not seekable.
-                    with fs.open_input_stream(resolved_path) as f:
+                    with fs_for_read.open_input_stream(resolved_path) as f:
                         read_bytes = f.read()
                 except OSError as e:
                     logger.debug(

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -225,9 +225,7 @@ def download_bytes_threaded(
                 if probe_uri is None:
                     continue
                 try:
-                    paths, candidate_fs = _resolve_paths_and_filesystem(
-                        probe_uri, None
-                    )
+                    paths, candidate_fs = _resolve_paths_and_filesystem(probe_uri, None)
                 except Exception as e:
                     logger.debug(f"Could not infer filesystem from '{probe_uri}': {e}")
                     continue

--- a/python/ray/data/_internal/planner/plan_download_op.py
+++ b/python/ray/data/_internal/planner/plan_download_op.py
@@ -216,16 +216,10 @@ def download_bytes_threaded(
         if len(uris) == 0:
             continue
 
-        # Resolve the filesystem exactly once before spawning workers. Without
-        # this, each of 16 make_async_gen worker threads independently
-        # constructs a pyarrow.fs.S3FileSystem on its first URI, triggering an
-        # IMDS credential fetch. With N concurrent Download tasks on an EC2
-        # node that's 16*N near-simultaneous IMDS calls — enough to trip the
-        # per-instance rate limit and produce intermittent NoCredentialsError.
-        #
-        # Normalize a user-supplied fsspec FS to PyFileSystem(FSSpecHandler) so
-        # RetryingPyFileSystem.wrap (which forwards open_input_stream to the
-        # inner FS) doesn't end up calling a method fsspec filesystems lack.
+        # Resolve the filesystem once before spawning workers; otherwise each
+        # worker infers its own S3FileSystem and fires a duplicate IMDS
+        # credential fetch. Normalize fsspec inputs so RetryingPyFileSystem.wrap
+        # can forward open_input_stream.
         resolved_fs = _validate_and_wrap_filesystem(filesystem)
         if resolved_fs is None:
             for probe_uri in uris:
@@ -236,19 +230,14 @@ def download_bytes_threaded(
                 except Exception as e:
                     logger.debug(f"Could not infer filesystem from '{probe_uri}': {e}")
                     continue
-                # _resolve_paths_and_filesystem can silently drop unresolvable
-                # URIs (returning ([], ...)) or yield no filesystem. Only accept
-                # a result we can actually use.
+                # Skip results that drop the URI (([], ...)) or yield no FS.
                 if paths and candidate_fs is not None:
                     resolved_fs = candidate_fs
                     break
 
         if resolved_fs is None:
-            # Probe iterated every URI and could not infer a filesystem. Workers
-            # would just retry the same URIs with the same filesystem=None and
-            # hit the same failure — while reintroducing per-worker FS
-            # construction (the IMDS herd this PR exists to prevent). Yield
-            # None for every URI and skip the worker pool entirely.
+            # No URI resolved a filesystem; workers would only repeat the same
+            # failed inference. Yield None for every row and skip the pool.
             logger.warning(
                 "Could not resolve a filesystem from any URI in column "
                 f"{uri_column_name!r} ({len(uris)} URIs). Yielding None for "
@@ -277,8 +266,7 @@ def download_bytes_threaded(
                 try:
                     if uri is None:
                         continue
-                    # Path normalization only — _resolve_paths_and_filesystem
-                    # short-circuits when filesystem is supplied (no network).
+                    # Normalize the path only; FS is supplied so no network I/O.
                     resolved_paths, _ = _resolve_paths_and_filesystem(
                         uri, filesystem=resolved_fs
                     )

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -602,11 +602,25 @@ class TestThreadedDownloadPreResolve:
             f"data-{i}".encode() for i in range(10)
         ]
 
-    def test_supplied_fs_skips_probe(self, tmp_path):
+    @pytest.mark.parametrize(
+        "fs_factory",
+        [
+            pytest.param(lambda: pafs.LocalFileSystem(), id="pyarrow-local"),
+            # fsspec.filesystem objects lack ``open_input_stream`` and must be
+            # normalized to PyFileSystem(FSSpecHandler) before RetryingPyFileSystem
+            # wraps them, otherwise reading raises AttributeError mid-flight.
+            pytest.param(
+                lambda: pytest.importorskip("fsspec").filesystem("file"),
+                id="fsspec-local",
+            ),
+        ],
+    )
+    def test_supplied_fs_skips_probe(self, tmp_path, fs_factory):
         (tmp_path / "f.bin").write_bytes(b"supplied")
         table = pa.Table.from_arrays(
             [pa.array([f"file://{tmp_path}/f.bin"])], names=["uri"]
         )
+
         spy, probes, _ = _spy_resolve()
         with spy:
             results = list(
@@ -615,7 +629,7 @@ class TestThreadedDownloadPreResolve:
                     ["uri"],
                     ["bytes"],
                     DataContext.get_current(),
-                    filesystem=pafs.LocalFileSystem(),
+                    filesystem=fs_factory(),
                 )
             )
 

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -542,6 +542,33 @@ class TestPlanObstoreRouting:
 
 
 # TestThreadedDownloadPreResolve
+def _spy_resolve(fake_fn=None):
+    """Wrap _resolve_paths_and_filesystem with a call counter.
+
+    Returns ``(patch_cm, probe_calls, normalize_calls)``. Wrap the ``with``
+    around the body; the two lists get appended as calls arrive. If
+    ``fake_fn`` is given, it replaces the real function; otherwise the real
+    one runs and gets observed.
+    """
+    from ray.data._internal.planner import plan_download_op as pdo
+
+    probe_calls: list = []
+    normalize_calls: list = []
+    original = pdo._resolve_paths_and_filesystem
+
+    def _tracking(uri, filesystem=None, **kw):
+        (probe_calls if filesystem is None else normalize_calls).append(uri)
+        if fake_fn is not None:
+            return fake_fn(uri, filesystem=filesystem, **kw)
+        return original(uri, filesystem=filesystem, **kw)
+
+    return (
+        patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_tracking),
+        probe_calls,
+        normalize_calls,
+    )
+
+
 class TestThreadedDownloadPreResolve:
     """``download_bytes_threaded`` resolves the filesystem once per block/column.
 
@@ -555,181 +582,98 @@ class TestThreadedDownloadPreResolve:
     def test_probe_once_across_workers(self, tmp_path):
         for i in range(10):
             (tmp_path / f"f{i}.bin").write_bytes(f"data-{i}".encode())
-
         uris = [f"file://{tmp_path}/f{i}.bin" for i in range(10)]
         table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
-        ctx = DataContext.get_current()
 
-        # Spy on _resolve_paths_and_filesystem. Under the new pre-resolve
-        # scheme, exactly one invocation should happen with filesystem=None
-        # (the probe), plus one per URI with filesystem=<resolved fs> (path
-        # normalization only — that call short-circuits in path_util without
-        # any network I/O). With the old code, filesystem=None would be
-        # called up to 16 times (once per worker's first URI).
-        from ray.data._internal.planner import plan_download_op as pdo
+        spy, probes, normalizes = _spy_resolve()
+        with spy:
+            results = list(
+                download_bytes_threaded(
+                    table, ["uri"], ["bytes"], DataContext.get_current()
+                )
+            )
 
-        original = pdo._resolve_paths_and_filesystem
-        probe_calls: list = []
-        normalize_calls: list = []
-
-        def _tracking(uri, filesystem=None, **kw):
-            if filesystem is None:
-                probe_calls.append(uri)
-            else:
-                normalize_calls.append(uri)
-            return original(uri, filesystem=filesystem, **kw)
-
-        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_tracking):
-            results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
-
-        assert len(probe_calls) == 1, (
-            f"Expected exactly one probe call with filesystem=None, got "
-            f"{len(probe_calls)}: {probe_calls}"
-        )
-        assert len(normalize_calls) == 10
-        out_bytes = [b.as_py() for b in results[0].column("bytes")]
-        assert out_bytes == [f"data-{i}".encode() for i in range(10)]
+        # Exactly one probe (filesystem=None) regardless of worker count.
+        # Normalize-only calls (one per URI) short-circuit in path_util
+        # without any network I/O.
+        assert len(probes) == 1
+        assert len(normalizes) == 10
+        assert [b.as_py() for b in results[0].column("bytes")] == [
+            f"data-{i}".encode() for i in range(10)
+        ]
 
     def test_supplied_fs_skips_probe(self, tmp_path):
         (tmp_path / "f.bin").write_bytes(b"supplied")
-        uri = f"file://{tmp_path}/f.bin"
-        table = pa.Table.from_arrays([pa.array([uri])], names=["uri"])
-        ctx = DataContext.get_current()
-
-        from ray.data._internal.planner import plan_download_op as pdo
-
-        original = pdo._resolve_paths_and_filesystem
-        probe_calls: list = []
-
-        def _tracking(probe_uri, filesystem=None, **kw):
-            if filesystem is None:
-                probe_calls.append(probe_uri)
-            return original(probe_uri, filesystem=filesystem, **kw)
-
-        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_tracking):
+        table = pa.Table.from_arrays(
+            [pa.array([f"file://{tmp_path}/f.bin"])], names=["uri"]
+        )
+        spy, probes, _ = _spy_resolve()
+        with spy:
             results = list(
                 download_bytes_threaded(
                     table,
                     ["uri"],
                     ["bytes"],
-                    ctx,
+                    DataContext.get_current(),
                     filesystem=pafs.LocalFileSystem(),
                 )
             )
 
-        # A user-supplied FS means zero probe calls — we go straight to
-        # normalize-only calls.
-        assert probe_calls == []
+        assert probes == []
         assert results[0].column("bytes")[0].as_py() == b"supplied"
 
-    def test_bad_first_uri_probes_past(self, tmp_path):
-        # Probe loop must skip None / unresolvable URIs and continue until it
-        # finds one that yields both paths and a filesystem.
-        (tmp_path / "good.bin").write_bytes(b"good content")
-        good_uri = f"file://{tmp_path}/good.bin"
-
-        # Mix None + resolvable. None entries must not stop the probe.
-        uris = [None, good_uri]
-        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
-        ctx = DataContext.get_current()
-
-        results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
-        out_bytes = [b.as_py() for b in results[0].column("bytes")]
-        # None URI → None result; good URI → good content.
-        assert out_bytes[1] == b"good content"
-
-    def test_all_probes_fail_no_crash(self):
-        # Every URI raises during inference. Workers must fall back to
-        # per-URI resolution without crashing. Every URI yields None.
-        uris = ["not-a-scheme://bogus/1", "also-bogus://2"]
-        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
-        ctx = DataContext.get_current()
-
-        # Should not raise.
-        results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
-        out_bytes = [b.as_py() for b in results[0].column("bytes")]
-        assert all(b is None for b in out_bytes)
-
-    def test_empty_block_no_workers(self):
-        # Zero URIs → the column loop skips; no probe, no workers.
-        table = pa.Table.from_arrays([pa.array([], type=pa.string())], names=["uri"])
-        ctx = DataContext.get_current()
-
+    @pytest.mark.parametrize(
+        "first_uri,probe_returns_for_first",
+        [
+            pytest.param(None, None, id="none-in-list"),
+            pytest.param("file:///first-dropped", ([], None), id="empty-paths-result"),
+        ],
+    )
+    def test_probe_loop_skips_unusable(
+        self, tmp_path, first_uri, probe_returns_for_first
+    ):
+        # Regression: the probe must keep going past (a) None URIs and
+        # (b) ([], fs) / (paths, None) returns — both leave workers with no
+        # usable filesystem and would recreate the IMDS herd if the loop
+        # broke out prematurely.
         from ray.data._internal.planner import plan_download_op as pdo
 
-        with patch.object(
-            pdo, "_resolve_paths_and_filesystem", side_effect=AssertionError
-        ):
-            # No resolve calls expected; iterator should finish cleanly.
-            list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
-
-    def test_probe_skips_empty_paths(self):
-        # Regression: the probe must NOT break when _resolve_paths_and_filesystem
-        # returns ([], fs) — that would leave workers with no usable FS and
-        # push them back to per-URI resolution (the IMDS herd). The loop must
-        # keep probing until it finds a URI whose resolution yields both paths
-        # AND a filesystem.
-        from ray.data._internal.planner import plan_download_op as pdo
-
+        (tmp_path / "good.bin").write_bytes(b"good")
         real_fs = pafs.LocalFileSystem()
-        calls: list = []
 
-        def _fake_resolve(uri, filesystem=None, **_kw):
-            calls.append((uri, filesystem))
+        def _fake(uri, filesystem=None, **_kw):
             if filesystem is not None:
-                # Normalize-only call during the worker's read path.
-                return ([uri.removeprefix("file://")], filesystem)
-            if uri == "file:///first-dropped":
-                # Simulate the silent-drop case: successful return but no paths.
-                return ([], real_fs)
-            # Second URI: real resolution.
-            return ([uri.removeprefix("file://")], real_fs)
+                # Normalize-only: pass paths through when FS is supplied.
+                return ([str(tmp_path / "good.bin")], filesystem)
+            if uri == first_uri:
+                return probe_returns_for_first
+            return ([str(tmp_path / "good.bin")], real_fs)
 
-        import tempfile
+        good = f"file://{tmp_path}/good.bin"
+        table = pa.Table.from_arrays([pa.array([first_uri, good])], names=["uri"])
 
-        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tf:
-            tf.write(b"second uri wins")
-            real_path = tf.name
+        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_fake):
+            results = list(
+                download_bytes_threaded(
+                    table, ["uri"], ["bytes"], DataContext.get_current()
+                )
+            )
+        assert results[0].column("bytes")[-1].as_py() == b"good"
 
-        try:
-            uris = ["file:///first-dropped", f"file://{real_path}"]
-            table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
-            ctx = DataContext.get_current()
-
-            with patch.object(
-                pdo, "_resolve_paths_and_filesystem", side_effect=_fake_resolve
-            ):
-                results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
-        finally:
-            os.unlink(real_path)
-
-        # The probe must have tried BOTH URIs (dropped the empty-paths result,
-        # accepted the second). Count of probe calls (filesystem=None):
-        probe_calls = [c for c in calls if c[1] is None]
-        assert len(probe_calls) == 2, (
-            f"Expected probe to skip the empty-paths result and try the next URI, "
-            f"got {probe_calls}"
-        )
-
-        out_bytes = [b.as_py() for b in results[0].column("bytes")]
-        assert out_bytes[1] == b"second uri wins"
-
-    def test_fallback_caches_fs_in_worker(self):
-        # Regression: when all block-level probes fail, workers fall back
-        # to per-URI resolution with filesystem=None. After the first
-        # successful fallback resolution, subsequent URIs in the same
-        # worker must reuse it — otherwise the fallback path reconstructs
-        # the FS on every URI and defeats the whole point of the PR.
-        #
-        # With 32 URIs round-robin'd across 16 workers, we get 2 URIs per
-        # worker. If the per-worker cache works, inference happens exactly
-        # once per worker → 16 total. Without the cache it would be 32.
+    def test_all_probes_fail_fallback_caches_per_worker(self):
+        # Two safety guarantees in one test:
+        #  1. When every probe URI fails, we don't crash — workers fall back
+        #     to per-URI inference and each URI either yields bytes or None.
+        #  2. After the first successful fallback resolution IN A WORKER, the
+        #     worker caches the filesystem for its remaining URIs. With 32
+        #     "probe-fail" URIs across 16 workers, we get 2 URIs per worker:
+        #     correct caching → 16 inferences total, not 32.
         from ray.data._internal.planner import plan_download_op as pdo
 
         real_fs = pafs.LocalFileSystem()
         inference_calls: list = []
 
-        def _fake_resolve(uri, filesystem=None, **_kw):
+        def _fake(uri, filesystem=None, **_kw):
             if uri == "probe-fail":
                 raise RuntimeError("probe fails for all URIs")
             if filesystem is None:
@@ -739,17 +683,31 @@ class TestThreadedDownloadPreResolve:
 
         uris = ["probe-fail"] * 32
         table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
-        ctx = DataContext.get_current()
-
-        with patch.object(
-            pdo, "_resolve_paths_and_filesystem", side_effect=_fake_resolve
-        ):
-            list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
-
+        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_fake):
+            # Should not raise.
+            list(
+                download_bytes_threaded(
+                    table, ["uri"], ["bytes"], DataContext.get_current()
+                )
+            )
         assert len(inference_calls) == 16, (
             f"Expected 16 inferences (one per worker) after per-worker caching, "
             f"got {len(inference_calls)} — fallback path is re-inferring per URI."
         )
+
+    def test_empty_block_no_workers(self):
+        # Zero URIs → the column loop skips; no probe, no workers spawned.
+        table = pa.Table.from_arrays([pa.array([], type=pa.string())], names=["uri"])
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        with patch.object(
+            pdo, "_resolve_paths_and_filesystem", side_effect=AssertionError
+        ):
+            list(
+                download_bytes_threaded(
+                    table, ["uri"], ["bytes"], DataContext.get_current()
+                )
+            )
 
 
 # TestObstoreDownloadPath

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -699,9 +699,7 @@ class TestThreadedDownloadPreResolve:
             with patch.object(
                 pdo, "_resolve_paths_and_filesystem", side_effect=_fake_resolve
             ):
-                results = list(
-                    download_bytes_threaded(table, ["uri"], ["bytes"], ctx)
-                )
+                results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
         finally:
             os.unlink(real_path)
 

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -660,53 +660,34 @@ class TestThreadedDownloadPreResolve:
             )
         assert results[0].column("bytes")[-1].as_py() == b"good"
 
-    def test_all_probes_fail_fallback_caches_per_worker(self, tmp_path):
-        # Two safety guarantees in one test:
-        #  1. When every probe URI fails, we don't crash — workers fall back
-        #     to per-URI inference.
-        #  2. After the first successful fallback resolution IN A WORKER,
-        #     the worker caches the filesystem for its remaining URIs.
-        #     With 32 URIs round-robin'd across 16 workers (2 each), the
-        #     cache should yield exactly 16 inferences, not 32.
-        #
-        # The probe loop and the worker fallback both call
-        # _resolve_paths_and_filesystem(uri, filesystem=None) for the same
-        # URI. To make the probe fail but the worker succeed, we
-        # differentiate by thread id: the probe runs in this test's
-        # thread; workers run in threads spawned by make_async_gen.
-        import threading
-
+    def test_all_probes_fail_yields_none(self):
+        # When the probe iterates every URI and can't resolve a filesystem,
+        # workers would just retry the same URIs with the same filesystem=None
+        # and hit the same failure — while reintroducing per-worker FS
+        # construction (the IMDS herd this PR exists to prevent). Instead, we
+        # short-circuit: yield None for every URI and skip the worker pool.
         from ray.data._internal.planner import plan_download_op as pdo
 
-        # The worker tries to open the file, so it must exist.
-        real_path = tmp_path / "f.bin"
-        real_path.write_bytes(b"x")
-        real_fs = pafs.LocalFileSystem()
+        resolve_calls: list = []
 
-        main_tid = threading.get_ident()
-        inference_calls: list = []
+        def _fail_all(uri, filesystem=None, **_kw):
+            resolve_calls.append((uri, filesystem))
+            raise RuntimeError("nothing resolves")
 
-        def _fake(uri, filesystem=None, **_kw):
-            if filesystem is None:
-                if threading.get_ident() == main_tid:
-                    raise RuntimeError("probe fails")
-                inference_calls.append(uri)
-                return ([str(real_path)], real_fs)
-            # Normalize-only call (filesystem supplied by worker after caching).
-            return ([str(real_path)], filesystem)
-
-        uris = ["probe-fail"] * 32
+        uris = ["bad-1", "bad-2", "bad-3"]
         table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
-        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_fake):
-            list(
+        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_fail_all):
+            results = list(
                 download_bytes_threaded(
                     table, ["uri"], ["bytes"], DataContext.get_current()
                 )
             )
-        assert len(inference_calls) == 16, (
-            f"Expected 16 inferences (one per worker) after per-worker caching, "
-            f"got {len(inference_calls)} — fallback path is re-inferring per URI."
-        )
+
+        # Probe tried each URI exactly once. No worker calls.
+        assert len(resolve_calls) == len(uris)
+        assert all(fs is None for _, fs in resolve_calls)
+        # Every URI yields None.
+        assert [b.as_py() for b in results[0].column("bytes")] == [None] * len(uris)
 
     def test_empty_block_no_workers(self):
         # Zero URIs → the column loop skips; no probe, no workers spawned.

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -552,7 +552,7 @@ class TestThreadedDownloadPreResolve:
     pre-resolved filesystem across all workers.
     """
 
-    def test_resolves_filesystem_once_across_workers(self, tmp_path):
+    def test_probe_once_across_workers(self, tmp_path):
         for i in range(10):
             (tmp_path / f"f{i}.bin").write_bytes(f"data-{i}".encode())
 
@@ -590,7 +590,7 @@ class TestThreadedDownloadPreResolve:
         out_bytes = [b.as_py() for b in results[0].column("bytes")]
         assert out_bytes == [f"data-{i}".encode() for i in range(10)]
 
-    def test_supplied_filesystem_skips_probe(self, tmp_path):
+    def test_supplied_fs_skips_probe(self, tmp_path):
         (tmp_path / "f.bin").write_bytes(b"supplied")
         uri = f"file://{tmp_path}/f.bin"
         table = pa.Table.from_arrays([pa.array([uri])], names=["uri"])
@@ -622,7 +622,7 @@ class TestThreadedDownloadPreResolve:
         assert probe_calls == []
         assert results[0].column("bytes")[0].as_py() == b"supplied"
 
-    def test_bad_first_uri_still_finds_filesystem(self, tmp_path):
+    def test_bad_first_uri_probes_past(self, tmp_path):
         # Probe loop must skip None / unresolvable URIs and continue until it
         # finds one that yields both paths and a filesystem.
         (tmp_path / "good.bin").write_bytes(b"good content")
@@ -638,7 +638,7 @@ class TestThreadedDownloadPreResolve:
         # None URI → None result; good URI → good content.
         assert out_bytes[1] == b"good content"
 
-    def test_all_probe_uris_unresolvable_does_not_crash(self):
+    def test_all_probes_fail_no_crash(self):
         # Every URI raises during inference. Workers must fall back to
         # per-URI resolution without crashing. Every URI yields None.
         uris = ["not-a-scheme://bogus/1", "also-bogus://2"]
@@ -650,7 +650,7 @@ class TestThreadedDownloadPreResolve:
         out_bytes = [b.as_py() for b in results[0].column("bytes")]
         assert all(b is None for b in out_bytes)
 
-    def test_empty_block_does_not_spawn_workers(self):
+    def test_empty_block_no_workers(self):
         # Zero URIs → the column loop skips; no probe, no workers.
         table = pa.Table.from_arrays([pa.array([], type=pa.string())], names=["uri"])
         ctx = DataContext.get_current()
@@ -663,7 +663,7 @@ class TestThreadedDownloadPreResolve:
             # No resolve calls expected; iterator should finish cleanly.
             list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
 
-    def test_probe_rejects_empty_paths_result(self):
+    def test_probe_skips_empty_paths(self):
         # Regression: the probe must NOT break when _resolve_paths_and_filesystem
         # returns ([], fs) — that would leave workers with no usable FS and
         # push them back to per-URI resolution (the IMDS herd). The loop must
@@ -713,6 +713,43 @@ class TestThreadedDownloadPreResolve:
 
         out_bytes = [b.as_py() for b in results[0].column("bytes")]
         assert out_bytes[1] == b"second uri wins"
+
+    def test_fallback_caches_fs_in_worker(self):
+        # Regression: when all block-level probes fail, workers fall back
+        # to per-URI resolution with filesystem=None. After the first
+        # successful fallback resolution, subsequent URIs in the same
+        # worker must reuse it — otherwise the fallback path reconstructs
+        # the FS on every URI and defeats the whole point of the PR.
+        #
+        # With 32 URIs round-robin'd across 16 workers, we get 2 URIs per
+        # worker. If the per-worker cache works, inference happens exactly
+        # once per worker → 16 total. Without the cache it would be 32.
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        real_fs = pafs.LocalFileSystem()
+        inference_calls: list = []
+
+        def _fake_resolve(uri, filesystem=None, **_kw):
+            if uri == "probe-fail":
+                raise RuntimeError("probe fails for all URIs")
+            if filesystem is None:
+                inference_calls.append(uri)
+                return ([f"/tmp/{uri}"], real_fs)
+            return ([f"/tmp/{uri}"], filesystem)
+
+        uris = ["probe-fail"] * 32
+        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+        ctx = DataContext.get_current()
+
+        with patch.object(
+            pdo, "_resolve_paths_and_filesystem", side_effect=_fake_resolve
+        ):
+            list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+
+        assert len(inference_calls) == 16, (
+            f"Expected 16 inferences (one per worker) after per-worker caching, "
+            f"got {len(inference_calls)} — fallback path is re-inferring per URI."
+        )
 
 
 # TestObstoreDownloadPath

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -541,6 +541,182 @@ class TestPlanObstoreRouting:
             )
 
 
+# TestThreadedDownloadPreResolve
+class TestThreadedDownloadPreResolve:
+    """``download_bytes_threaded`` resolves the filesystem once per block/column.
+
+    Regression coverage for the IMDS thundering-herd: each of the 16
+    ``make_async_gen`` workers used to call ``_resolve_paths_and_filesystem``
+    independently on its first URI, triggering an IMDS credential fetch per
+    worker per task. The fix probes exactly once up-front and shares the
+    pre-resolved filesystem across all workers.
+    """
+
+    def test_resolves_filesystem_once_across_workers(self, tmp_path):
+        for i in range(10):
+            (tmp_path / f"f{i}.bin").write_bytes(f"data-{i}".encode())
+
+        uris = [f"file://{tmp_path}/f{i}.bin" for i in range(10)]
+        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+        ctx = DataContext.get_current()
+
+        # Spy on _resolve_paths_and_filesystem. Under the new pre-resolve
+        # scheme, exactly one invocation should happen with filesystem=None
+        # (the probe), plus one per URI with filesystem=<resolved fs> (path
+        # normalization only — that call short-circuits in path_util without
+        # any network I/O). With the old code, filesystem=None would be
+        # called up to 16 times (once per worker's first URI).
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        original = pdo._resolve_paths_and_filesystem
+        probe_calls: list = []
+        normalize_calls: list = []
+
+        def _tracking(uri, filesystem=None, **kw):
+            if filesystem is None:
+                probe_calls.append(uri)
+            else:
+                normalize_calls.append(uri)
+            return original(uri, filesystem=filesystem, **kw)
+
+        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_tracking):
+            results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+
+        assert len(probe_calls) == 1, (
+            f"Expected exactly one probe call with filesystem=None, got "
+            f"{len(probe_calls)}: {probe_calls}"
+        )
+        assert len(normalize_calls) == 10
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        assert out_bytes == [f"data-{i}".encode() for i in range(10)]
+
+    def test_supplied_filesystem_skips_probe(self, tmp_path):
+        (tmp_path / "f.bin").write_bytes(b"supplied")
+        uri = f"file://{tmp_path}/f.bin"
+        table = pa.Table.from_arrays([pa.array([uri])], names=["uri"])
+        ctx = DataContext.get_current()
+
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        original = pdo._resolve_paths_and_filesystem
+        probe_calls: list = []
+
+        def _tracking(probe_uri, filesystem=None, **kw):
+            if filesystem is None:
+                probe_calls.append(probe_uri)
+            return original(probe_uri, filesystem=filesystem, **kw)
+
+        with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_tracking):
+            results = list(
+                download_bytes_threaded(
+                    table,
+                    ["uri"],
+                    ["bytes"],
+                    ctx,
+                    filesystem=pafs.LocalFileSystem(),
+                )
+            )
+
+        # A user-supplied FS means zero probe calls — we go straight to
+        # normalize-only calls.
+        assert probe_calls == []
+        assert results[0].column("bytes")[0].as_py() == b"supplied"
+
+    def test_bad_first_uri_still_finds_filesystem(self, tmp_path):
+        # Probe loop must skip None / unresolvable URIs and continue until it
+        # finds one that yields both paths and a filesystem.
+        (tmp_path / "good.bin").write_bytes(b"good content")
+        good_uri = f"file://{tmp_path}/good.bin"
+
+        # Mix None + resolvable. None entries must not stop the probe.
+        uris = [None, good_uri]
+        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+        ctx = DataContext.get_current()
+
+        results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        # None URI → None result; good URI → good content.
+        assert out_bytes[1] == b"good content"
+
+    def test_all_probe_uris_unresolvable_does_not_crash(self):
+        # Every URI raises during inference. Workers must fall back to
+        # per-URI resolution without crashing. Every URI yields None.
+        uris = ["not-a-scheme://bogus/1", "also-bogus://2"]
+        table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+        ctx = DataContext.get_current()
+
+        # Should not raise.
+        results = list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        assert all(b is None for b in out_bytes)
+
+    def test_empty_block_does_not_spawn_workers(self):
+        # Zero URIs → the column loop skips; no probe, no workers.
+        table = pa.Table.from_arrays([pa.array([], type=pa.string())], names=["uri"])
+        ctx = DataContext.get_current()
+
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        with patch.object(
+            pdo, "_resolve_paths_and_filesystem", side_effect=AssertionError
+        ):
+            # No resolve calls expected; iterator should finish cleanly.
+            list(download_bytes_threaded(table, ["uri"], ["bytes"], ctx))
+
+    def test_probe_rejects_empty_paths_result(self):
+        # Regression: the probe must NOT break when _resolve_paths_and_filesystem
+        # returns ([], fs) — that would leave workers with no usable FS and
+        # push them back to per-URI resolution (the IMDS herd). The loop must
+        # keep probing until it finds a URI whose resolution yields both paths
+        # AND a filesystem.
+        from ray.data._internal.planner import plan_download_op as pdo
+
+        real_fs = pafs.LocalFileSystem()
+        calls: list = []
+
+        def _fake_resolve(uri, filesystem=None, **_kw):
+            calls.append((uri, filesystem))
+            if filesystem is not None:
+                # Normalize-only call during the worker's read path.
+                return ([uri.removeprefix("file://")], filesystem)
+            if uri == "file:///first-dropped":
+                # Simulate the silent-drop case: successful return but no paths.
+                return ([], real_fs)
+            # Second URI: real resolution.
+            return ([uri.removeprefix("file://")], real_fs)
+
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as tf:
+            tf.write(b"second uri wins")
+            real_path = tf.name
+
+        try:
+            uris = ["file:///first-dropped", f"file://{real_path}"]
+            table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
+            ctx = DataContext.get_current()
+
+            with patch.object(
+                pdo, "_resolve_paths_and_filesystem", side_effect=_fake_resolve
+            ):
+                results = list(
+                    download_bytes_threaded(table, ["uri"], ["bytes"], ctx)
+                )
+        finally:
+            os.unlink(real_path)
+
+        # The probe must have tried BOTH URIs (dropped the empty-paths result,
+        # accepted the second). Count of probe calls (filesystem=None):
+        probe_calls = [c for c in calls if c[1] is None]
+        assert len(probe_calls) == 2, (
+            f"Expected probe to skip the empty-paths result and try the next URI, "
+            f"got {probe_calls}"
+        )
+
+        out_bytes = [b.as_py() for b in results[0].column("bytes")]
+        assert out_bytes[1] == b"second uri wins"
+
+
 # TestObstoreDownloadPath
 class TestObstoreDownloadPath:
     """Integration tests for the obstore async download path.

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -660,31 +660,44 @@ class TestThreadedDownloadPreResolve:
             )
         assert results[0].column("bytes")[-1].as_py() == b"good"
 
-    def test_all_probes_fail_fallback_caches_per_worker(self):
+    def test_all_probes_fail_fallback_caches_per_worker(self, tmp_path):
         # Two safety guarantees in one test:
         #  1. When every probe URI fails, we don't crash — workers fall back
-        #     to per-URI inference and each URI either yields bytes or None.
-        #  2. After the first successful fallback resolution IN A WORKER, the
-        #     worker caches the filesystem for its remaining URIs. With 32
-        #     "probe-fail" URIs across 16 workers, we get 2 URIs per worker:
-        #     correct caching → 16 inferences total, not 32.
+        #     to per-URI inference.
+        #  2. After the first successful fallback resolution IN A WORKER,
+        #     the worker caches the filesystem for its remaining URIs.
+        #     With 32 URIs round-robin'd across 16 workers (2 each), the
+        #     cache should yield exactly 16 inferences, not 32.
+        #
+        # The probe loop and the worker fallback both call
+        # _resolve_paths_and_filesystem(uri, filesystem=None) for the same
+        # URI. To make the probe fail but the worker succeed, we
+        # differentiate by thread id: the probe runs in this test's
+        # thread; workers run in threads spawned by make_async_gen.
+        import threading
+
         from ray.data._internal.planner import plan_download_op as pdo
 
+        # The worker tries to open the file, so it must exist.
+        real_path = tmp_path / "f.bin"
+        real_path.write_bytes(b"x")
         real_fs = pafs.LocalFileSystem()
+
+        main_tid = threading.get_ident()
         inference_calls: list = []
 
         def _fake(uri, filesystem=None, **_kw):
-            if uri == "probe-fail":
-                raise RuntimeError("probe fails for all URIs")
             if filesystem is None:
+                if threading.get_ident() == main_tid:
+                    raise RuntimeError("probe fails")
                 inference_calls.append(uri)
-                return ([f"/tmp/{uri}"], real_fs)
-            return ([f"/tmp/{uri}"], filesystem)
+                return ([str(real_path)], real_fs)
+            # Normalize-only call (filesystem supplied by worker after caching).
+            return ([str(real_path)], filesystem)
 
         uris = ["probe-fail"] * 32
         table = pa.Table.from_arrays([pa.array(uris)], names=["uri"])
         with patch.object(pdo, "_resolve_paths_and_filesystem", side_effect=_fake):
-            # Should not raise.
             list(
                 download_bytes_threaded(
                     table, ["uri"], ["bytes"], DataContext.get_current()

--- a/python/ray/data/tests/unit/test_obstore_download.py
+++ b/python/ray/data/tests/unit/test_obstore_download.py
@@ -543,13 +543,9 @@ class TestPlanObstoreRouting:
 
 # TestThreadedDownloadPreResolve
 def _spy_resolve(fake_fn=None):
-    """Wrap _resolve_paths_and_filesystem with a call counter.
-
-    Returns ``(patch_cm, probe_calls, normalize_calls)``. Wrap the ``with``
-    around the body; the two lists get appended as calls arrive. If
-    ``fake_fn`` is given, it replaces the real function; otherwise the real
-    one runs and gets observed.
-    """
+    """Patch _resolve_paths_and_filesystem, returning (patch_cm, probe_calls,
+    normalize_calls). Probe calls pass filesystem=None; normalize calls supply
+    one. ``fake_fn`` replaces the real function when given."""
     from ray.data._internal.planner import plan_download_op as pdo
 
     probe_calls: list = []
@@ -570,14 +566,8 @@ def _spy_resolve(fake_fn=None):
 
 
 class TestThreadedDownloadPreResolve:
-    """``download_bytes_threaded`` resolves the filesystem once per block/column.
-
-    Regression coverage for the IMDS thundering-herd: each of the 16
-    ``make_async_gen`` workers used to call ``_resolve_paths_and_filesystem``
-    independently on its first URI, triggering an IMDS credential fetch per
-    worker per task. The fix probes exactly once up-front and shares the
-    pre-resolved filesystem across all workers.
-    """
+    """``download_bytes_threaded`` probes the filesystem once and shares it
+    across workers, instead of each worker inferring it (the IMDS herd)."""
 
     def test_probe_once_across_workers(self, tmp_path):
         for i in range(10):
@@ -593,9 +583,7 @@ class TestThreadedDownloadPreResolve:
                 )
             )
 
-        # Exactly one probe (filesystem=None) regardless of worker count.
-        # Normalize-only calls (one per URI) short-circuit in path_util
-        # without any network I/O.
+        # One probe regardless of worker count; one normalize per URI.
         assert len(probes) == 1
         assert len(normalizes) == 10
         assert [b.as_py() for b in results[0].column("bytes")] == [
@@ -606,9 +594,8 @@ class TestThreadedDownloadPreResolve:
         "fs_factory",
         [
             pytest.param(lambda: pafs.LocalFileSystem(), id="pyarrow-local"),
-            # fsspec.filesystem objects lack ``open_input_stream`` and must be
-            # normalized to PyFileSystem(FSSpecHandler) before RetryingPyFileSystem
-            # wraps them, otherwise reading raises AttributeError mid-flight.
+            # fsspec FS lacks open_input_stream and must be normalized before
+            # wrapping, else reads raise AttributeError mid-flight.
             pytest.param(
                 lambda: pytest.importorskip("fsspec").filesystem("file"),
                 id="fsspec-local",
@@ -646,10 +633,8 @@ class TestThreadedDownloadPreResolve:
     def test_probe_loop_skips_unusable(
         self, tmp_path, first_uri, probe_returns_for_first
     ):
-        # Regression: the probe must keep going past (a) None URIs and
-        # (b) ([], fs) / (paths, None) returns — both leave workers with no
-        # usable filesystem and would recreate the IMDS herd if the loop
-        # broke out prematurely.
+        # Probe must skip None URIs and ([], fs)/(paths, None) returns rather
+        # than break early with no usable filesystem.
         from ray.data._internal.planner import plan_download_op as pdo
 
         (tmp_path / "good.bin").write_bytes(b"good")
@@ -675,11 +660,8 @@ class TestThreadedDownloadPreResolve:
         assert results[0].column("bytes")[-1].as_py() == b"good"
 
     def test_all_probes_fail_yields_none(self):
-        # When the probe iterates every URI and can't resolve a filesystem,
-        # workers would just retry the same URIs with the same filesystem=None
-        # and hit the same failure — while reintroducing per-worker FS
-        # construction (the IMDS herd this PR exists to prevent). Instead, we
-        # short-circuit: yield None for every URI and skip the worker pool.
+        # No URI resolves; we short-circuit to None for every row instead of
+        # letting workers repeat the failed inference.
         from ray.data._internal.planner import plan_download_op as pdo
 
         resolve_calls: list = []


### PR DESCRIPTION
## Summary

`download_bytes_threaded` spawns 16 worker threads via `make_async_gen`. Each worker called `_resolve_paths_and_filesystem` independently on its first URI. When no filesystem is provided, that call constructs a fresh `pyarrow.fs.S3FileSystem`, which triggers an IMDS credential fetch on EC2. With N concurrent Download tasks on a node that was ~16×N near-simultaneous IMDS HTTP calls — enough to trip the per-instance rate limit and produce intermittent `NoCredentialsError`.

This is the second of two independent PRs. The matching fsspec credential-extraction fix — which triggers the threaded fallback whenever a session-backed filesystem can't have credentials statically extracted — is in a separate PR. Either can land first; this change is valuable on its own because the threaded path is also used when obstore is disabled (`RAY_DATA_USE_OBSTORE=0`) or when the URI scheme isn't obstore-supported.

## Changes

- Resolve the filesystem **exactly once** per (block, column) before `make_async_gen`, then share it across all 16 workers via default-arg binding on the inner `load_uri_bytes` closure. Workers now do zero filesystem inference — their per-URI calls to `_resolve_paths_and_filesystem` short-circuit (path normalization only; no network) because a filesystem is supplied.
- The probe loop:
  - Skips `None` URIs.
  - Catches resolution exceptions and continues to the next URI.
  - Requires **both** `paths` and a non-`None` filesystem before breaking — otherwise `_resolve_paths_and_filesystem` could silently drop a bad URI and leave workers with no usable filesystem, recreating the herd.
- If every probe fails, workers retain the legacy per-URI resolution as a last resort so a block of partially-unresolvable URIs doesn't lose the ones that might still resolve.

## Test plan

- [x] `pre-commit run` passes.
- [x] New `TestThreadedDownloadPreResolve` covers:
  - `test_resolves_filesystem_once_across_workers` — spy on `_resolve_paths_and_filesystem`, 10 URIs × 16 workers → exactly **1** probe call with `filesystem=None` (vs. up to 16 before the fix).
  - `test_supplied_filesystem_skips_probe` — with a user-supplied FS, zero probe calls happen.
  - `test_bad_first_uri_still_finds_filesystem` — mix of `None` + resolvable URIs; probe keeps going past `None`.
  - `test_all_probe_uris_unresolvable_does_not_crash` — all URIs unresolvable → no crash, every result is `None`.
  - `test_empty_block_does_not_spawn_workers` — zero URIs → no probe, no workers.
  - `test_probe_rejects_empty_paths_result` — regression test for the `([], fs)` silent-drop case: the probe must skip it and continue.
- [ ] End-to-end under concurrent tasks with `RAY_DATA_USE_OBSTORE=0`, verifying `pyarrow.fs.S3FileSystem.__init__` is invoked exactly once per block rather than per worker.