### PR TITLE
[data] Fix type hint for `config` parameter in `build_processor` and `build_processor`

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from ray._common.deprecation import Deprecated
 from ray.data.block import UserDefinedFunction
@@ -561,7 +561,13 @@ class PrepareImageStageConfig(_PrepareImageStageConfig):
 
 @Deprecated(new="build_processor", error=False)
 def build_llm_processor(
-    config: ProcessorConfig,
+    config: Union[
+        ProcessorConfig,
+        vLLMEngineProcessorConfig,
+        SGLangEngineProcessorConfig,
+        HttpRequestProcessorConfig,
+        ServeDeploymentProcessorConfig,
+    ],
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
     preprocess_map_kwargs: Optional[Dict[str, Any]] = None,
@@ -583,7 +589,13 @@ def build_llm_processor(
 
 @PublicAPI(stability="beta")
 def build_processor(
-    config: ProcessorConfig,
+    config: Union[
+        ProcessorConfig,
+        vLLMEngineProcessorConfig,
+        SGLangEngineProcessorConfig,
+        HttpRequestProcessorConfig,
+        ServeDeploymentProcessorConfig,
+    ],
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
     preprocess_map_kwargs: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
## Description

The `build_processor` and `build_processor` functions in `ray/data/processor.py` typed the `config` parameter as `ProcessorConfig`, but the public `VLLMEngineProcessorConfig`, `SGLangEngineProcessorConfig`, `HttpRequestProcessorConfig`, and `ServeDeploymentProcessorConfig` classes each inherit from their respective internal base classes (e.g. `_VLLMEngineProcessorConfig`) rather than from the public `ProcessorConfig` wrapper class. This caused type checkers (pyright, mypy, IDE linters) to flag valid calls—such as passing a `VLLMEngineProcessorConfig` instance—as type errors, even though the code worked correctly at runtime.

The fix updates the `config` parameter type annotation in both functions to `Union[ProcessorConfig, VLLMEngineProcessorConfig, SGLangEngineProcessorConfig, HttpRequestProcessorConfig, ServeDeploymentProcessorConfig]`, which accurately reflects all supported config types and eliminates the false type errors. No runtime behavior is changed.

## Related issues

Fixes #57981