### PR TITLE
[Data] Mismatched `multimodal-inference-benchmarks` configuration

### DIFF
--- a/release/release_multimodal_inference_benchmarks_tests.yaml
+++ b/release/release_multimodal_inference_benchmarks_tests.yaml
@@ -84,7 +84,6 @@
       runtime_env:
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_DEAD_NODES=0  # Allow node death during test
-      type: gpu
       post_build_script: byod_install_multimodal_inference_benchmarks_transcription.sh
       python_depset: audio_transcription_py3.10.lock
 


### PR DESCRIPTION
## Description
Remove extraneous `type: gpu` config in `release_multimodal_inference_benchmarks_tests.yaml`. Experimenting to check if it could cause the `audio_transcription` to not be picked up by the CI.