### PR TITLE
[core] fix flaky test_no_process_leak_after_job_finishes

### DIFF
--- a/python/ray/tests/test_job.py
+++ b/python/ray/tests/test_job.py
@@ -414,11 +414,12 @@ def test_no_process_leak_after_job_finishes(ray_start_cluster):
     @ray.remote(num_cpus=0)
     class PidActor:
         def __init__(self):
-            self.pids = set()
-            self.pids.add(os.getpid())
+            # List (not set): parent and child may run on the same worker PID, but we
+            # still get one entry per registration (actor + parent + child == len 3).
+            self.pids = [os.getpid()]
 
         def add_pid(self, pid):
-            self.pids.add(pid)
+            self.pids.append(pid)
 
         def get_pids(self):
             return self.pids
@@ -445,7 +446,7 @@ def test_no_process_leak_after_job_finishes(ray_start_cluster):
     ray.shutdown()
     # Job finishes at this point
 
-    for pid in pids:
+    for pid in set(pids):
         wait_for_pid_to_exit(pid)
 
 


### PR DESCRIPTION
## Description

Fix the flaky `test_no_process_leak_after_job_finishes`.

The test uses a `PidActor` for tracking worker pids. There is a `wait_for_condition` waiting for 3 pids that causes flakiness. The 3 pids should be:
1. actor worker pid
2. parent task worker pid
3. child task worker pid

However, the parent task worker pid and the child task worker pid can be the same one sometimes, so we can have only 2 pids, and the `wait_for_condition` will time out.

The fix is we track pids with a normal list instead of a set.

## Related issues
Fixes https://github.com/anyscale/ray/issues/1429
