### PR TITLE
[RLlib] Fix ValueError in MultiAgentEpisode.get_rewards() when agent inactive for all requested env steps

### DIFF
--- a/rllib/env/multi_agent_episode.py
+++ b/rllib/env/multi_agent_episode.py
@@ -2750,13 +2750,19 @@ class MultiAgentEpisode:
                 for i in indices_incl_lookback
                 if i != self.SKIP_ENV_TS_TAG
             ]
-            ret = inf_lookback_buffer.get(
-                indices=indices,
-                neg_index_as_lookback=True,
-                fill=fill,
-                _add_last_ts_value=hanging_val,
-                **one_hot_discrete,
-            )
+            # If all indices were SKIP_ENV_TS_TAG (agent was inactive for all
+            # requested env steps), return an empty list. The caller already
+            # checks `if len(agent_values) > 0` before using this result.
+            if not indices:
+                ret = []
+            else:
+                ret = inf_lookback_buffer.get(
+                    indices=indices,
+                    neg_index_as_lookback=True,
+                    fill=fill,
+                    _add_last_ts_value=hanging_val,
+                    **one_hot_discrete,
+                )
         return ret
 
     def _get_hanging_value(self, what: str, agent_id: AgentID) -> Any:

--- a/rllib/env/tests/test_multi_agent_episode.py
+++ b/rllib/env/tests/test_multi_agent_episode.py
@@ -1510,6 +1510,41 @@ class TestMultiAgentEpisode(unittest.TestCase):
         rew = episode.get_rewards(env_steps=False)
         self.assertTrue(rew == {})
 
+        # Regression test for https://github.com/ray-project/ray/issues/62903
+        # get_rewards() on a finalized (numpy) episode should not crash when
+        # an agent was inactive during all requested env steps.
+        observations = [
+            {"a0": 0, "a1": 0},  # env step 0: both agents
+            {"a0": 1},           # env step 1: only a0 (a1 inactive)
+            {"a0": 2},           # env step 2: only a0 (a1 inactive)
+            {"a0": 3, "a1": 3},  # env step 3: both agents (terminal)
+        ]
+        actions = [{"a0": 0, "a1": 0}, {"a0": 1}, {"a0": 2}]
+        rewards = [
+            {"a0": 0.1, "a1": 0.1},
+            {"a0": 0.2},
+            {"a0": 0.3},
+            {"a0": 0.4, "a1": 0.4},
+        ]
+        episode = MultiAgentEpisode(
+            observations=observations,
+            actions=actions,
+            rewards=rewards,
+            len_lookback_buffer=0,
+            terminateds={"a0": True, "a1": True, "__all__": True},
+        )
+        episode.to_numpy()
+
+        # Full range: a1 has data at env steps 0 and 3, should work.
+        rew = episode.get_rewards()
+        check(rew, {"a0": [0.1, 0.2, 0.3], "a1": [0.1]})
+
+        # Slice covering only env steps where a1 was inactive.
+        # Before fix: ValueError("Input `list_of_structs` does not contain any items.")
+        rew = episode.get_rewards(indices=slice(1, 3))
+        check(rew, {"a0": [0.2, 0.3]})
+        self.assertNotIn("a1", rew)
+
     def test_other_getters(self):
         # TODO (simon): Revisit this test and the MultiAgentEpisode.episode_concat API.
         return

--- a/rllib/env/tests/test_multi_agent_episode.py
+++ b/rllib/env/tests/test_multi_agent_episode.py
@@ -1545,6 +1545,24 @@ class TestMultiAgentEpisode(unittest.TestCase):
         check(rew, {"a0": [0.2, 0.3]})
         self.assertNotIn("a1", rew)
 
+        # The fix is in the shared path _get_single_agent_data_by_env_step_indices,
+        # so get_actions should also work for the same slice.
+        act = episode.get_actions(indices=slice(1, 3))
+        check(act, {"a0": [1, 2]})
+        self.assertNotIn("a1", act)
+
+        # Non-finalized (list-based) episodes should behave the same way.
+        episode_list = MultiAgentEpisode(
+            observations=observations,
+            actions=actions,
+            rewards=rewards,
+            len_lookback_buffer=0,
+            terminateds={"a0": True, "a1": True, "__all__": True},
+        )
+        rew_list = episode_list.get_rewards(indices=slice(1, 3))
+        check(rew_list, {"a0": [0.2, 0.3]})
+        self.assertNotIn("a1", rew_list)
+
     def test_other_getters(self):
         # TODO (simon): Revisit this test and the MultiAgentEpisode.episode_concat API.
         return

--- a/rllib/env/tests/test_multi_agent_episode.py
+++ b/rllib/env/tests/test_multi_agent_episode.py
@@ -1515,8 +1515,8 @@ class TestMultiAgentEpisode(unittest.TestCase):
         # an agent was inactive during all requested env steps.
         observations = [
             {"a0": 0, "a1": 0},  # env step 0: both agents
-            {"a0": 1},           # env step 1: only a0 (a1 inactive)
-            {"a0": 2},           # env step 2: only a0 (a1 inactive)
+            {"a0": 1},  # env step 1: only a0 (a1 inactive)
+            {"a0": 2},  # env step 2: only a0 (a1 inactive)
             {"a0": 3, "a1": 3},  # env step 3: both agents (terminal)
         ]
         actions = [{"a0": 0, "a1": 0}, {"a0": 1}, {"a0": 2}]


### PR DESCRIPTION
## Summary

Fixes #62903 - `MultiAgentEpisode.get_rewards()` (and other `get_*` methods) no longer crashes with `ValueError` when called on a finalized multi-agent episode where an agent was inactive during the requested env steps.

When retrieving per-agent data by env step indices, `_get_single_agent_data_by_env_step_indices` filters out `SKIP_ENV_TS_TAG` entries for agents that didn't participate in certain env steps. If an agent was inactive for **all** requested env steps, the filtered indices list became empty, causing `InfiniteLookbackBuffer.get(indices=[])` → `batch([])` → `ValueError: Input list_of_structs does not contain any items`.

This PR adds an early return of an empty list when all indices are filtered out, allowing the caller's existing `if len(agent_values) > 0` guard to correctly exclude the inactive agent from the result dict.

<details>
<summary>Before</summary>

```
episode.get_rewards(indices=slice(1, 3))

ValueError: Input `list_of_structs` does not contain any items.

  File "ray/rllib/env/multi_agent_episode.py", line 2554, in _get_data_by_env_steps
    agent_values = self._get_single_agent_data_by_env_step_indices(
  File "ray/rllib/env/multi_agent_episode.py", line 2753, in _get_single_agent_data_by_env_step_indices
    ret = inf_lookback_buffer.get(
  File "ray/rllib/env/utils/infinite_lookback_buffer.py", line 243, in get
    data = batch(data)
  File "ray/rllib/utils/spaces/space_utils.py", line 315, in batch
    raise ValueError("Input `list_of_structs` does not contain any items.")
```

</details>

<details>
<summary>After</summary>

```python
episode.get_rewards(indices=slice(1, 3))
# {'a0': array([0.2, 0.3])}
# a1 correctly excluded — it was inactive during env steps 1 and 2
```

</details>

<details>
<summary>Test results</summary>

```
$ python -m pytest test_multi_agent_episode.py -v -x

test_multi_agent_episode.py::TestMultiAgentEpisode::test_add_env_reset PASSED [  5%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_add_env_step PASSED [ 11%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_cut PASSED [ 17%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_get_actions PASSED [ 23%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_get_infos PASSED [ 29%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_get_observations PASSED [ 35%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_get_return PASSED [ 41%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_get_rewards PASSED [ 47%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_get_sample_batch PASSED [ 52%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_get_state_and_from_state PASSED [ 58%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_init PASSED [ 64%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_len PASSED [ 70%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_other_getters PASSED [ 76%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_setters PASSED [ 82%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_slice PASSED [ 88%]
test_multi_agent_episode.py::TestMultiAgentEpisode::test_slice_with_lookback PASSED [ 94%]
test_multi_agent_episode.py::test_multi_agent_episode_functionality PASSED [100%]

======================== 17 passed, 3 warnings in 5.03s ========================
```

</details>

## Test plan
- [x] Reproduced the bug: `get_rewards(indices=slice(1,3))` raises `ValueError` on a finalized episode with an inactive agent
- [x] Verified the fix: same call now returns `{'a0': array([0.2, 0.3])}` with the inactive agent correctly excluded
- [x] Verified `get_rewards()` without indices still works as before
- [x] Added regression test to `test_get_rewards` in `test_multi_agent_episode.py` covering:
  - Finalized (numpy) episode with `get_rewards(indices=slice(1,3))` — the exact crash scenario
  - `get_actions(indices=slice(1,3))` — proves the fix covers all `get_*` methods (shared code path)
  - Non-finalized episode with same scenario — proves finalized/non-finalized behavior is consistent
- [x] All 17 tests in `test_multi_agent_episode.py` pass (regression test is inside existing `test_get_rewards`)
