### PR TITLE
[core] fix test_ray_actor_events and test_backwards_compatibility

### DIFF
--- a/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -41,7 +41,7 @@ do
 
     # Pin pydantic version due to: https://github.com/ray-project/ray/issues/36990.
     # ray<2.9 is only compatible with pydantic<2 and setuptools < 70.
-    pip install -U "pydantic<2" ray=="${RAY_VERSION}" ray[default]=="${RAY_VERSION}" setuptools==69.5.1
+    python -m pip install -U "pydantic<2" ray=="${RAY_VERSION}" "ray[default]==${RAY_VERSION}" setuptools==69.5.1
 
     printf "\n\n\n"
     echo "========================================================="

--- a/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -36,7 +36,7 @@ do
     echo "========================================================================================="
     printf "\n\n\n"
 
-    conda create -y -n "${env_name}" python="${PYTHON_VERSION}"
+    conda create -y -n "${env_name}" python="${PYTHON_VERSION}" pip
     conda activate "${env_name}"
 
     # Pin pydantic version due to: https://github.com/ray-project/ray/issues/36990.

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -11,6 +11,7 @@ py_library(
         "//python/ray/data:__pkg__",
         "//python/ray/tests:__subpackages__",
     ],
+    deps = ["//:ray_lib"],
 )
 
 py_test_module_list(


### PR DESCRIPTION


## Description
Fix the following test errors:

```

[2026-04-23T21:00:06Z] ==================== Test output for //python/ray/dashboard:modules/aggregator/tests/test_ray_actor_events:
--
[2026-04-23T21:00:06Z] Traceback (most recent call last):
[2026-04-23T21:00:06Z]   File "/root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/bin/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.runfiles/io_ray/python/ray/dashboard/modules/aggregator/tests/test_ray_actor_events.py", line 8, in <module>
[2026-04-23T21:00:06Z]     from ray._common.test_utils import wait_for_condition
[2026-04-23T21:00:06Z] ModuleNotFoundError: No module named 'ray._common'

```

and
 
```

[2026-04-23T21:00:04Z] ==================== Test output for //python/ray/dashboard:modules/job/tests/test_backwards_compatibility:
--
[2026-04-23T21:00:04Z] Traceback (most recent call last):
[2026-04-23T21:00:04Z]   File "/root/.cache/bazel/_bazel_root/1df605deb6d24fc8068f6e25793ec703/execroot/io_ray/bazel-out/k8-opt/bin/python/ray/dashboard/modules/job/tests/test_backwards_compatibility.runfiles/io_ray/python/ray/dashboard/modules/job/tests/test_backwards_compatibility.py", line 10, in <module>
[2026-04-23T21:00:04Z]     from ray._common.test_utils import wait_for_condition
[2026-04-23T21:00:04Z] ModuleNotFoundError: No module named 'ray._common'


```

## Related issues
Fixes https://github.com/anyscale/ray/issues/1510 and https://github.com/anyscale/ray/issues/1509

## Additional information

[Test passes](https://buildkite.com/ray-project/premerge/builds/65250#019dcc12-1907-4279-9e3b-abfbb6b90af7):

<img width="1015" height="311" alt="image" src="https://github.com/user-attachments/assets/e3f0bbbb-96fa-4580-a7c1-a834cf673f1c" />

<img width="1032" height="315" alt="image" src="https://github.com/user-attachments/assets/ae87da6d-6dad-4121-a925-1d98c6655bb5" />

