### PR TITLE
[Data][LLM] Fix wrong documented default for max_tasks_in_flight_per_actor

### DIFF
--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -57,7 +57,7 @@ class ProcessorConfig(BaseModelExtended):
         default_factory=dict,
         description="[Experimental] Experimental configurations."
         "Supported keys:\n"
-        "`max_tasks_in_flight_per_actor`: The maximum number of tasks in flight per actor. Default to 4.",
+        "`max_tasks_in_flight_per_actor`: The maximum number of tasks in flight per actor. Default to 16.",
     )
 
     @field_validator("concurrency")


### PR DESCRIPTION
## Summary
- The experimental field description in `ProcessorConfig` (`python/ray/llm/_internal/batch/processor/base.py`) said `max_tasks_in_flight_per_actor` defaults to 4, but the actual default — `DEFAULT_MAX_TASKS_IN_FLIGHT = 16` in the same file — is used in both `vllm_engine_proc.py` and `sglang_engine_proc.py`.
- This is a pure docstring fix to match the code. The user-facing RST docs in `doc/source/data/working-with-llms.rst` already correctly state `default: 16`, so only `base.py` was out of sync.

## Why it matters
Users tuning multi-replica pipelines may rely on the documented default of 4 when reasoning about actor greediness and queue behavior, but the actual value is 4x higher. This affects how aggressively each actor pulls blocks from the input queue.

## Test plan
- [x] No behavior change; docstring-only fix. Existing tests in `test_vllm_engine_proc.py` and `test_sglang_engine_proc.py` already assert the default equals `DEFAULT_MAX_TASKS_IN_FLIGHT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)