### PR TITLE
fix test python object leak pyarrow abcmeta

### DIFF
--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -336,6 +336,11 @@ def test_python_object_leak(shutdown_only):
             # Clear any existing circular references
             # before testing leaks in actor tasks.
             gc.collect()
+            # Exempt import-time cycles (e.g. pyarrow's ABCMeta-based
+            # ListScalar/StructScalar introduced in pyarrow 21) from
+            # DEBUG_SAVEALL — the test measures only leaks produced by the
+            # workload below, not class-definition cycles in dependencies.
+            gc.freeze()
             self.gc_garbage_len = 0
 
         def get_gc_garbage_len(self):
@@ -367,6 +372,11 @@ def test_python_object_leak(shutdown_only):
             # Clear any existing circular references
             # before testing leaks in actor tasks.
             gc.collect()
+            # Exempt import-time cycles (e.g. pyarrow's ABCMeta-based
+            # ListScalar/StructScalar introduced in pyarrow 21) from
+            # DEBUG_SAVEALL — the test measures only leaks produced by the
+            # workload below, not class-definition cycles in dependencies.
+            gc.freeze()
             self.gc_garbage_len = 0
 
         def get_gc_garbage_len(self):

--- a/python/ray/tests/test_streaming_generator_2.py
+++ b/python/ray/tests/test_streaming_generator_2.py
@@ -333,6 +333,13 @@ def test_python_object_leak(shutdown_only):
     @ray.remote
     class AsyncActor:
         def __init__(self):
+            # Force pyarrow (and its ABCMeta-based ListScalar/StructScalar
+            # classes introduced in pyarrow 21) to import before we freeze,
+            # so its one-shot class-definition cycle is captured in the
+            # permanent generation. On py3.10 workers pyarrow is imported
+            # lazily and a freeze here would otherwise miss it.
+            import pyarrow  # noqa: F401
+
             # Clear any existing circular references
             # before testing leaks in actor tasks.
             gc.collect()
@@ -369,6 +376,13 @@ def test_python_object_leak(shutdown_only):
     @ray.remote
     class A:
         def __init__(self):
+            # Force pyarrow (and its ABCMeta-based ListScalar/StructScalar
+            # classes introduced in pyarrow 21) to import before we freeze,
+            # so its one-shot class-definition cycle is captured in the
+            # permanent generation. On py3.10 workers pyarrow is imported
+            # lazily and a freeze here would otherwise miss it.
+            import pyarrow  # noqa: F401
+
             # Clear any existing circular references
             # before testing leaks in actor tasks.
             gc.collect()


### PR DESCRIPTION
## Summary

`test_python_object_leak` asserts `len(gc.garbage) == 0` after 100 exception-raising actor tasks, but once pyarrow ≥ 21 is installed the test fails deterministically with `assert 6 == 0`. The 6 objects are a one-shot class-definition cycle from pyarrow's ABCMeta-based `ListScalar` / `StructScalar` / `MapScalar`, not a workload leak. This PR exempts the import-time cycle so the test measures what it was always meant to — cycles created by the workload.

## Root cause

- The test enables `gc.set_debug(gc.DEBUG_SAVEALL)`, which tells `gc.collect()` to append **every** unreachable cycle it finds to `gc.garbage` — including one-shot cycles formed during dependency imports.
- pyarrow 21 ([apache/arrow#45818](https://github.com/apache/arrow/pull/45818)) added `collections.abc.Sequence` / `Mapping` / `ABCMeta` bases to `ListScalar` / `StructScalar` / `MapScalar`. Cython's class-construction leaves behind a 6-object cycle (class + MRO tuple + `__dict__` + `__abstractmethods__` frozenset + `_abc_data` + getset_descriptor) that every Ray worker inherits when pyarrow is imported.
- The test is older than pyarrow 21; its `== 0` assertion never anticipated a dependency forming import-time cycles.

## Fix

Two commits:

1. **`[tests] Freeze GC baseline in test_python_object_leak`** — add `gc.collect()` + `gc.freeze()` in both actor `__init__` methods (`AsyncActor` and `A`). `gc.freeze()` moves all currently-tracked objects into a permanent generation that `gc.collect()` never re-scans, exempting any import-time cycles from `DEBUG_SAVEALL`.

2. **`[tests] Force pyarrow import before gc.freeze in test_python_object_leak`** — on py3.10 Ray workers pyarrow is imported lazily, so the initial `gc.freeze()` ran before pyarrow's ABCMeta cycle existed and the 6-object cycle was still detected at workload time. Force `import pyarrow  # noqa: F401` at the very top of both `__init__` methods so the cycle materializes before the freeze.

The strict `== 0` assertion is preserved; the test still catches workload-created cycles, which is what it was designed to do.

## Why not pin pyarrow back to 19.x

- Pinning would mask the latent over-strictness without fixing it; the next ABCMeta-adopting dep (`attrs`, `wrapt`, `opentelemetry`, etc.) would reintroduce the same failure mode.
- Downgrading pyarrow cascades through the lock into many transitive downgrades.
- `gc.freeze()` is the minimal, future-proof surface for this problem — any library that creates import-time cycles gets exempted automatically.
