### PR TITLE
[ci][deps] Add explicit pip to conda env in backwards_compatibility script

### DIFF
--- a/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -36,7 +36,14 @@ do
     echo "========================================================================================="
     printf "\n\n\n"
 
-    conda create -y -n "${env_name}" python="${PYTHON_VERSION}"
+    # Include `pip` explicitly: conda-forge's `python` package stopped
+    # bundling pip as a dep, and without it `conda activate` puts us in
+    # an env with python but no pip, so subsequent `pip install` falls
+    # back to the base miniforge env's pip. That clobbers the editable
+    # ray 3.0.0.dev0 in base with ray 2.0.1, and every subsequent
+    # dashboard test that imports `ray._common` fails because 2.0.1
+    # predates that module.
+    conda create -y -n "${env_name}" python="${PYTHON_VERSION}" pip
     conda activate "${env_name}"
 
     # Pin pydantic version due to: https://github.com/ray-project/ray/issues/36990.

--- a/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
+++ b/python/ray/dashboard/modules/job/tests/backwards_compatibility_scripts/test_backwards_compatibility.sh
@@ -43,7 +43,7 @@ do
     # ray 3.0.0.dev0 in base with ray 2.0.1, and every subsequent
     # dashboard test that imports `ray._common` fails because 2.0.1
     # predates that module.
-    conda create -y -n "${env_name}" python="${PYTHON_VERSION}" pip
+    conda create -y -n "${env_name}" python="${PYTHON_VERSION}" pip=25.2
     conda activate "${env_name}"
 
     # Pin pydantic version due to: https://github.com/ray-project/ray/issues/36990.


### PR DESCRIPTION
`test_backwards_compatibility.sh:39` was `conda create -y -n <env> python=<version>` without listing `pip`. conda-forge's `python` package stopped bundling `pip` as a dep, so after `conda activate <env>` the shell has python from the new env but `pip` falls through PATH to the base miniforge env's pip. That base pip sees the editable ray==3.0.0.dev0 in base site-packages, uninstalls it, and installs ray==2.0.1 into base. Meanwhile `python -c "import ray"` runs against the new conda env (which has neither pip nor ray) and fails with ModuleNotFoundError.

The cascade breaks every subsequent dashboard test in the same shard that does `from ray._common.test_utils import ...`: ray 2.0.1 now sits in base and predates the `ray._common` module, so the import fails with ModuleNotFoundError: No module named 'ray._common' across test_ray_actor_events and friends.

Commit 93802b93b3 ([ci] uninstall ray in corebuild after depset install) addressed a related but distinct symptom (stale PyPI ray==2.55.1 leaking into the corebuild layer) and wasn't enough on its own — the conda subprocess clobbers the editable install at test runtime regardless of which ray the image ships with.

Adding `pip` to the `conda create` arg list keeps pip inside the new env, so `pip install` operates on the new env instead of base. The editable ray in base is preserved for the rest of the shard.