### PR TITLE
[core] Pin legacy OOM killing policy in test_memory_pressure fixtures

### DIFF
--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -52,6 +52,10 @@ def ray_with_memory_monitor(shutdown_only):
             "task_oom_retries": task_oom_retries,
             "min_memory_free_bytes": -1,
             "task_oom_retry_delay_base_ms": 0,
+            # PR #62643 flipped the default OOM killing policy to the
+            # time-based multi-worker policy; these tests assert on
+            # single-worker, owner-group semantics.
+            "worker_killing_policy_by_group": True,
         },
     ) as addr:
         yield addr
@@ -70,6 +74,7 @@ def ray_with_memory_monitor_no_oom_retry(shutdown_only):
             "task_oom_retries": 0,
             "min_memory_free_bytes": -1,
             "task_oom_retry_delay_base_ms": 0,
+            "worker_killing_policy_by_group": True,
         },
     ) as addr:
         yield addr


### PR DESCRIPTION
PR #62643 ([Core] (Resource Isolation 12/n) Switch group killing policy to by time killing policy) flipped the default OOM killing policy from the legacy owner-group, single-worker policy to the new time-based, multi-worker policy. Two tests in test_memory_pressure.py assert on the legacy semantics:

  - test_memory_pressure_kill_newest_worker asserts exactly one named actor survives after the OOM kill
  - test_newer_task_not_retriable_kill_older_retriable_task_first asserts the older retriable task is the one chosen to be killed

Under the new policy these assertions aren't guaranteed, and the mempress CI job on compile-req-compiled-py313 fails all 3 bazel attempts (the raylet log itself prints the "RAY_worker_killing_policy _by_group" escape hatch).

Set `worker_killing_policy_by_group=True` in the `_system_config` of both `ray_with_memory_monitor` fixtures to pin the legacy policy these tests were written against. Not specific to the py3.13 dep refresh — master inherits the same regression from PR #62643; fixing here to unblock the refresh branch's CI.