### PR TITLE
[ci] uninstall ray in corebuild after depset install

### DIFF
--- a/ci/docker/core.build.Dockerfile
+++ b/ci/docker/core.build.Dockerfile
@@ -18,4 +18,6 @@ set -euo pipefail
 
 uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
 
+uv pip uninstall --system ray
+
 EOF

--- a/python/ray/dashboard/BUILD.bazel
+++ b/python/ray/dashboard/BUILD.bazel
@@ -48,10 +48,7 @@ py_test_run_all_subdirectory(
         "exclusive",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -62,10 +59,7 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -76,10 +70,7 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -90,10 +81,7 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -112,10 +100,7 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -134,10 +119,7 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -148,10 +130,7 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -163,10 +142,7 @@ py_test(
         "minimal",
         "team:core",
     ],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -207,10 +183,7 @@ py_test(
         "modules/serve/tests/test_serve_dashboard.py",
     ],
     tags = ["team:serve"],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(
@@ -218,10 +191,7 @@ py_test(
     size = "enormous",
     srcs = ["modules/serve/tests/test_serve_dashboard_2.py"],
     tags = ["team:serve"],
-    deps = [
-        ":conftest",
-        "//:ray_lib",
-    ],
+    deps = [":conftest"],
 )
 
 py_test(

--- a/python/ray/dashboard/BUILD.bazel
+++ b/python/ray/dashboard/BUILD.bazel
@@ -48,7 +48,10 @@ py_test_run_all_subdirectory(
         "exclusive",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -59,7 +62,10 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -70,7 +76,10 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -81,7 +90,10 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -100,7 +112,10 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -119,7 +134,10 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -130,7 +148,10 @@ py_test(
         "exclusive",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -142,7 +163,10 @@ py_test(
         "minimal",
         "team:core",
     ],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -183,7 +207,10 @@ py_test(
         "modules/serve/tests/test_serve_dashboard.py",
     ],
     tags = ["team:serve"],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(
@@ -191,7 +218,10 @@ py_test(
     size = "enormous",
     srcs = ["modules/serve/tests/test_serve_dashboard_2.py"],
     tags = ["team:serve"],
-    deps = [":conftest"],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
 )
 
 py_test(


### PR DESCRIPTION
Base_build installs ray via test-requirements.txt's `ray>=2.47.1` floor, which leaks into the corebuild layer. When PyPI shipped ray 2.55.1 (2026-04-22 20:09 UTC) the next base_build rebuild picked it up and broke the `:ray: core: dashboard tests [g6_s15]` postmerge job starting at build #17201 (last green #17195). Even though ci/ray_ci/tests.env.Dockerfile force-reinstalls editable ray 3.0.0.dev0, the stale 2.55.1 tree was leaving enough behind to fail ray._common imports and the backwards-compat conda script.

Drop the inherited wheel at the end of core.build so tests.env lands editable ray on a clean slot, independent of whatever version the base_build image happens to carry.
