### PR TITLE
[deps] Pin redis==4.5.4 in py313 test-requirements

### DIFF
--- a/python/requirements/py313/test-requirements.txt
+++ b/python/requirements/py313/test-requirements.txt
@@ -59,7 +59,7 @@ pytest-timeout==2.1.0
 pytest-virtualenv==1.8.1; python_version < "3.12"
 pytest-sphinx @ git+https://github.com/ray-project/pytest-sphinx
 pytest-mock==3.14.0
-redis
+redis==4.5.4
 scikit-learn>=1.5.2
 smart_open[s3]==6.2.0
 tqdm==4.67.1


### PR DESCRIPTION
requirements_compiled_py3.13.txt resolved `redis` to 7.4.0 on this branch; master's py3.13 compiled file and the legacy requirements_compiled.txt both still pin 4.5.4. The 4.x → 7.x jump crosses the redis-py 5.x and 6.x majors (multiple async/pubsub API changes).

core redis tests shard fails deterministically on
test_worker_graceful_shutdown.py::test_ray_get_during_graceful_shutdown[asyncio] — the asyncio actor receives SIGTERM but the in-flight ray.get doesn't complete, and the worker exits with SYSTEM_ERROR / SIGTERM code 1. redis-py 7.x is the most plausible culprit on the shutdown path.

Pin in the py313 source file per the source-only pinning workflow, so the next recompile can't drift above 4.5.4.