### PR TITLE
[deps] Pin datasets==3.6.0 in py313 train-requirements

### DIFF
--- a/python/requirements/ml/py313/train-requirements.txt
+++ b/python/requirements/ml/py313/train-requirements.txt
@@ -1,6 +1,6 @@
 accelerate>=0.20.1
 deepspeed>=0.12.3
-datasets
+datasets==3.6.0
 huggingface-hub>=0.24.0
 numexpr>=2.8.4
 accelerate


### PR DESCRIPTION
requirements_compiled_py3.13.txt resolved `datasets` to 4.8.4 on this branch; master's py3.13 compiled file resolves 3.6.0. HF datasets 4.0 (July 2025) was a major break — removed script-based dataset support and changed schema/dtype behavior that cascades into ray.data.from_huggingface → iter_torch_batches → accelerate's gather_for_metrics.

traingputests / traingpu2tests shards fail deterministically on //python/ray/train:accelerate_torch_trainer and
:accelerate_torch_trainer_no_raydata with:

    File ".../evaluate_modules/.../glue.py", line 84, in simple_accuracy
        return float((preds == labels).mean())
    AttributeError: 'bool' object has no attribute 'mean'

This surfaces when `metric.add_batch` is never called (or preds and refs end up as scalars), so `[] == []` in the glue accuracy fn returns a Python bool instead of an ndarray. Pinning datasets to 3.6.0 matches the last-known-good CI baseline on master.