### PR TITLE
[Serve] Allow user-supplied HAProxy config fragment

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -689,6 +689,16 @@ RAY_SERVE_HAPROXY_CONFIG_FILE_LOC = os.environ.get(
     "RAY_SERVE_HAPROXY_CONFIG_FILE_LOC", "/tmp/haproxy-serve/haproxy.cfg"
 )
 
+# Optional path to a user-supplied HAProxy config fragment. When set, the
+# file's contents are spliced into the generated config right after Ray's
+# `defaults ray_defaults` block. Users typically declare
+# `defaults user_overrides from ray_defaults` and override any directive
+# there; Ray-owned frontends/backends inherit from `user_overrides` so user
+# values win. Empty string disables.
+RAY_SERVE_HAPROXY_USER_CONFIG_PATH = os.environ.get(
+    "RAY_SERVE_HAPROXY_USER_CONFIG_PATH", ""
+)
+
 # HAProxy admin socket path
 RAY_SERVE_HAPROXY_SOCKET_PATH = os.environ.get(
     "RAY_SERVE_HAPROXY_SOCKET_PATH", "/tmp/haproxy-serve/admin.sock"

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -49,6 +49,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_HAPROXY_TIMEOUT_CLIENT_S,
     RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S,
     RAY_SERVE_HAPROXY_TIMEOUT_SERVER_S,
+    RAY_SERVE_HAPROXY_USER_CONFIG_PATH,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
@@ -724,6 +725,20 @@ class HAProxyApi(ProxyApi):
                 }
             )
 
+            # When RAY_SERVE_HAPROXY_USER_CONFIG_PATH is set, the file's
+            # contents are spliced into the generated config right after
+            # `defaults ray_defaults`. Users typically declare
+            # `defaults user_overrides from ray_defaults` in that fragment and
+            # Ray-owned frontends/backends inherit from `user_overrides`,
+            # letting user-specified directives win over Ray's baseline.
+            user_config_content = ""
+            if RAY_SERVE_HAPROXY_USER_CONFIG_PATH:
+                with open(RAY_SERVE_HAPROXY_USER_CONFIG_PATH, "r") as f:
+                    user_config_content = f.read()
+            parent_defaults = (
+                "user_overrides" if user_config_content else "ray_defaults"
+            )
+
             config_template = env.from_string(HAPROXY_CONFIG_TEMPLATE)
             config_content = config_template.render(
                 {
@@ -732,6 +747,9 @@ class HAProxyApi(ProxyApi):
                     "backends_with_health_config": backends_with_health_config,
                     "healthz_rules": healthz_rules,
                     "route_info": health_route_info,
+                    "parent_defaults": parent_defaults,
+                    "user_config_content": user_config_content,
+                    "user_config_path": RAY_SERVE_HAPROXY_USER_CONFIG_PATH,
                 }
             )
 

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -33,7 +33,7 @@ HAPROXY_CONFIG_TEMPLATE = """global
     {%- if config.hard_stop_after_s is not none %}
     hard-stop-after {{ config.hard_stop_after_s }}s
     {%- endif %}
-defaults
+defaults ray_defaults
     mode http
     option log-health-checks
     {% if config.timeout_connect_s is not none %}timeout connect {{ config.timeout_connect_s }}s{% endif %}
@@ -61,12 +61,17 @@ defaults
     load-server-state-from-file global
     {%- endif %}
     balance {{ config.balance_algorithm }}
-frontend prometheus
+{%- if user_config_content %}
+# Begin user-supplied config fragment ({{ user_config_path }})
+{{ user_config_content }}
+# End user-supplied config fragment
+{%- endif %}
+frontend prometheus from ray_defaults
     bind :{{ config.metrics_port }}
     mode http
     http-request use-service prometheus-exporter if { path {{ config.metrics_uri }} }
     no log
-frontend http_frontend
+frontend http_frontend from {{ parent_defaults }}
     bind {{ config.frontend_host }}:{{ config.frontend_port }}
 {{ healthz_rules|safe }}
     # Routes endpoint
@@ -84,12 +89,12 @@ frontend http_frontend
     use_backend {{ backend.name or 'unknown' }} if is_{{ backend.name or 'unknown' }}
 {%- endfor %}
     default_backend default_backend
-backend default_backend
+backend default_backend from {{ parent_defaults }}
     http-request return status 404 content-type text/plain lf-string "Path \'%[path]\' not found. Ping http://.../-/routes for available routes."
 {%- for item in backends_with_health_config %}
 {%- set backend = item.backend %}
 {%- set hc = item.health_config %}
-backend {{ backend.name or 'unknown' }}
+backend {{ backend.name or 'unknown' }} from {{ parent_defaults }}
     log global
     # Enable HTTP connection reuse for better performance
     http-reuse always
@@ -132,7 +137,7 @@ backend {{ backend.name or 'unknown' }}
     server {{ backend.fallback_server.name }} {{ backend.fallback_server.host }}:{{ backend.fallback_server.port }} check backup
     {%- endif %}
 {%- endfor %}
-listen stats
+listen stats from ray_defaults
   bind *:{{ config.stats_port }}
   stats enable
   stats uri {{ config.stats_uri }}

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -275,7 +275,7 @@ global
     server-state-base /tmp/haproxy-serve
     server-state-file /tmp/haproxy-serve/server-state
     hard-stop-after 120s
-defaults
+defaults ray_defaults
     mode http
     option log-health-checks
     timeout connect 5s
@@ -293,12 +293,12 @@ defaults
     errorfile 504 {temp_dir}/500.http
     load-server-state-from-file global
     balance random(2)
-frontend prometheus
+frontend prometheus from ray_defaults
     bind :9101
     mode http
     http-request use-service prometheus-exporter if {{ path /metrics }}
     no log
-frontend http_frontend
+frontend http_frontend from ray_defaults
     bind *:8000
     # Health check endpoint
     acl healthcheck path -i /-/healthz
@@ -322,9 +322,9 @@ frontend http_frontend
     acl is_web_backend path /web
     use_backend web_backend if is_web_backend
     default_backend default_backend
-backend default_backend
+backend default_backend from ray_defaults
     http-request return status 404 content-type text/plain lf-string "Path \'%[path]\' not found. Ping http://.../-/routes for available routes."
-backend api_backend
+backend api_backend from ray_defaults
     log global
     # Enable HTTP connection reuse for better performance
     http-reuse always
@@ -342,7 +342,7 @@ backend api_backend
     server api_server2 127.0.0.1:8002 check
     # Fallback to head node's Serve proxy when no ingress replicas are available
     server api_fallback_server 127.0.0.1:8500 check backup
-backend web_backend
+backend web_backend from ray_defaults
     log global
     # Enable HTTP connection reuse for better performance
     http-reuse always
@@ -359,7 +359,7 @@ backend web_backend
     default-server fastinter 250ms downinter 250ms fall 3 rise 2 inter 2s check
     # Servers in this backend
     server web_server1 127.0.0.1:8003 check
-listen stats
+listen stats from ray_defaults
   bind *:8080
   stats enable
   stats uri /mystats
@@ -377,6 +377,59 @@ listen stats
                             os.remove(temp_file)
                     except (FileNotFoundError, OSError):
                         pass  # File already removed or doesn't exist
+
+
+def test_generate_config_with_user_override(haproxy_api_cleanup):
+    """When RAY_SERVE_HAPROXY_USER_CONFIG_PATH is set, the file's contents are
+    spliced after `defaults ray_defaults` and Ray's frontends/backends inherit
+    from `user_overrides` so user-supplied directives win for last-defined
+    directives."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_file_path = os.path.join(temp_dir, "haproxy.cfg")
+        user_config_path = os.path.join(temp_dir, "user.cfg")
+        user_fragment = (
+            "defaults user_overrides from ray_defaults\n"
+            "    timeout http-request 5s\n"
+            "    retries 3\n"
+            "    option redispatch\n"
+        )
+        with open(user_config_path, "w") as f:
+            f.write(user_fragment)
+
+        backend_config_stub = {
+            "api_backend": BackendConfig(
+                name="api_backend",
+                path_prefix="/api",
+                app_name="api_backend",
+                servers=[ServerConfig(name="s1", host="127.0.0.1", port=8001)],
+            ),
+        }
+
+        with mock.patch(
+            "ray.serve._private.haproxy.RAY_SERVE_HAPROXY_USER_CONFIG_PATH",
+            user_config_path,
+        ):
+            api = HAProxyApi(
+                cfg=HAProxyConfig(),
+                config_file_path=config_file_path,
+                backend_configs=backend_config_stub,
+            )
+            api._generate_config_file_internal()
+
+        with open(config_file_path, "r") as f:
+            content = f.read()
+
+        # User fragment is spliced verbatim.
+        assert "defaults user_overrides from ray_defaults" in content
+        assert "timeout http-request 5s" in content
+        # Ray-owned frontend/backend inherit from user_overrides, not ray_defaults.
+        assert "frontend http_frontend from user_overrides" in content
+        assert "backend default_backend from user_overrides" in content
+        assert "backend api_backend from user_overrides" in content
+        # ray_defaults is still the root parent and other sections still use it.
+        assert "defaults ray_defaults" in content
+        assert "frontend prometheus from ray_defaults" in content
+        assert "listen stats from ray_defaults" in content
 
 
 def test_generate_backends_in_order(haproxy_api_cleanup):


### PR DESCRIPTION
## Summary

Adds `RAY_SERVE_HAPROXY_USER_CONFIG_PATH`. When set, the file's contents are spliced into the generated HAProxy config immediately after Ray's `defaults` block. This gives operators an escape hatch to tune HAProxy without forking the template or running an external proxy in front.

## Design

Ray's unnamed `defaults` block is renamed to **named** `defaults ray_defaults`. All Ray-owned sections gain `from <parent>` inheritance:

|                          | no user config       | with user config        |
| ------------------------ | -------------------- | ----------------------- |
| `defaults`               | `ray_defaults`       | `ray_defaults`          |
| `frontend prometheus`    | `from ray_defaults`  | `from ray_defaults`     |
| `frontend http_frontend` | `from ray_defaults`  | `from user_overrides`   |
| `backend default_backend`| `from ray_defaults`  | `from user_overrides`   |
| `backend <app>`          | `from ray_defaults`  | `from user_overrides`   |
| `listen stats`           | `from ray_defaults`  | `from ray_defaults`     |

Users declare `defaults user_overrides from ray_defaults` in their fragment and override any directive there. Last-defined wins via HAProxy chained-defaults inheritance.

### Why splicing, not `!include` or multi-`-f`?

- HAProxy 2.4+ does not have an `!include`/`.include` directive (verified against 2.8.18).
- Multiple `-f` files are parsed sequentially; forward references like `defaults user_overrides from ray_defaults` (where `ray_defaults` lives in a later file) fail with `defaults section 'ray_defaults' not found`.
- Splicing in Python at config-render time is the simplest single-file approach and behaves like `!include` would.

## Example user fragment

```
defaults user_overrides from ray_defaults
    timeout http-request 5s
    timeout queue 30s
    retries 3
    option redispatch
```

## Out of scope

- Customizing the per-server `maxconn` on Ray's auto-generated `server` lines
- A typed schema / strongly-validated config — users write standard HAProxy syntax and `haproxy -c` validates at startup

## Test plan

- [x] Existing `test_generate_config_file_internal` updated for the renamed defaults block; passes locally via direct rendering + `haproxy -c` validation
- [x] New `test_generate_config_with_user_override` asserts user fragment is spliced and Ray-owned sections inherit from `user_overrides`
- [x] Spliced output validated with `haproxy -c` against HAProxy 2.8.18

Reference: [discuss.ray.io/t/haproxy-config-customization/23516](https://discuss.ray.io/t/haproxy-config-customization/23516)