### PR TITLE
[core][autoscaler][v2] Fix invalid default stats factory in ClusterStatus

### DIFF
--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -175,7 +175,7 @@ class Stats:
     # How long it took to get the GCS request.
     # This is required when initializing the Stats since it should be calculated before
     # the request was made.
-    gcs_request_time_s: float
+    gcs_request_time_s: float = 0.0
     # How long it took to get all live instances from node provider.
     none_terminated_node_request_time_s: Optional[float] = None
     # How long for autoscaler to process the scaling decision.
@@ -209,7 +209,7 @@ class ClusterStatus:
         default_factory=ResourceDemandSummary
     )
     # Query metics
-    stats: Stats = field(default_factory=lambda: Stats(gcs_request_time_s=0.0))
+    stats: Stats = field(default_factory=Stats)
 
     def total_resources(self) -> Dict[str, float]:
         return {r.resource_name: r.total for r in self.cluster_resource_usage}

--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -209,7 +209,7 @@ class ClusterStatus:
         default_factory=ResourceDemandSummary
     )
     # Query metics
-    stats: Stats = field(default_factory=Stats)
+    stats: Stats = field(default_factory=lambda: Stats(gcs_request_time_s=0.0))
 
     def total_resources(self) -> Dict[str, float]:
         return {r.resource_name: r.total for r in self.cluster_resource_usage}

--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -173,8 +173,6 @@ class ResourceDemandSummary:
 @dataclass
 class Stats:
     # How long it took to get the GCS request.
-    # This is required when initializing the Stats since it should be calculated before
-    # the request was made.
     gcs_request_time_s: float = 0.0
     # How long it took to get all live instances from node provider.
     none_terminated_node_request_time_s: Optional[float] = None

--- a/python/ray/autoscaler/v2/tests/test_schema.py
+++ b/python/ray/autoscaler/v2/tests/test_schema.py
@@ -14,7 +14,6 @@ from ray.core.generated.autoscaler_pb2 import NodeState, NodeStatus
 from ray.core.generated.instance_manager_pb2 import Instance
 
 
-
 def test_cluster_status_default_stats():
     status = ClusterStatus()
 
@@ -27,6 +26,7 @@ def test_cluster_status_default_stats():
     assert status.cluster_resource_usage == []
     assert status.stats.gcs_request_time_s == 0.0
     assert status.stats.request_ts_s is None
+
 
 def _make_ippr_status() -> IPPRStatus:
     return IPPRStatus(

--- a/python/ray/autoscaler/v2/tests/test_schema.py
+++ b/python/ray/autoscaler/v2/tests/test_schema.py
@@ -4,10 +4,29 @@ import time
 
 import pytest
 
-from ray.autoscaler.v2.schema import AutoscalerInstance, IPPRGroupSpec, IPPRStatus
+from ray.autoscaler.v2.schema import (
+    AutoscalerInstance,
+    ClusterStatus,
+    IPPRGroupSpec,
+    IPPRStatus,
+)
 from ray.core.generated.autoscaler_pb2 import NodeState, NodeStatus
 from ray.core.generated.instance_manager_pb2 import Instance
 
+
+
+def test_cluster_status_default_stats():
+    status = ClusterStatus()
+
+    assert status.active_nodes == []
+    assert status.idle_nodes == []
+    assert status.pending_launches == []
+    assert status.failed_launches == []
+    assert status.pending_nodes == []
+    assert status.failed_nodes == []
+    assert status.cluster_resource_usage == []
+    assert status.stats.gcs_request_time_s == 0.0
+    assert status.stats.request_ts_s is None
 
 def _make_ippr_status() -> IPPRStatus:
     return IPPRStatus(


### PR DESCRIPTION

## Description

`ClusterStatus.stats` currently uses `field(default_factory=Stats)`, but
`Stats` requires the positional argument `gcs_request_time_s`.

As a result, `ClusterStatus()` cannot be default-constructed and raises:

```text
TypeError: Stats.__init__() missing 1 required positional argument: 'gcs_request_time_s'
```

This PR fixes the invalid default by making ClusterStatus construct a valid default Stats object, and adds a regression test to cover the empty/default construction path.

This is a small schema-level fix and does not change the normal populated paths where callers already pass an explicit Stats(...) instance.


## Related issues
#62933 

## Additional information

Implementation notes:
update ClusterStatus.stats to use a valid default Stats value add a regression test for ClusterStatus()
