### PR TITLE
[core] use 2x machine for complying `RAY_DEFAULT_MIN_SYSTEM_RESERVED_MEMORY_BYTES`

### DIFF
--- a/release/autoscaling_tests/aws.yaml
+++ b/release/autoscaling_tests/aws.yaml
@@ -12,6 +12,6 @@ head_node_type:
 
 worker_node_types:
   - name: worker_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
     min_workers: 0
     max_workers: 20

--- a/release/autoscaling_tests/test_core.py
+++ b/release/autoscaling_tests/test_core.py
@@ -7,9 +7,9 @@ from typing import Dict
 
 ray.init("auto")
 
-# Sync with the compute config.
+# Sync with the compute config (release/autoscaling_tests/aws.yaml).
 HEAD_NODE_CPU = 0
-WORKER_NODE_CPU = 4
+WORKER_NODE_CPU = 8
 IDLE_TERMINATION_S = 60 * 5  # 5 min
 DEFAULT_RETRY_INTERVAL_MS = 15 * 1000  # 15 sec
 

--- a/release/benchmarks/distributed/many_nodes_tests/compute_config.yaml
+++ b/release/benchmarks/distributed/many_nodes_tests/compute_config.yaml
@@ -19,7 +19,9 @@ head_node:
   instance_type: m5.16xlarge
 
 worker_nodes:
-  - instance_type: m6i.large
+  - instance_type: m5.2xlarge
     min_nodes: 500
     max_nodes: 2000
     market_type: ON_DEMAND
+    resources:
+      CPU: 2

--- a/release/cluster_tests/cpt_autoscaling_1-3_aws.yaml
+++ b/release/cluster_tests/cpt_autoscaling_1-3_aws.yaml
@@ -1,12 +1,14 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
-    instance_type: m5.xlarge  # 4 CPUs
+    instance_type: m5.2xlarge
     resources:
       CPU: 4
 
 worker_nodes:
-    - instance_type: m5.xlarge
+    - instance_type: m5.2xlarge
       min_nodes: 0
       max_nodes: 2
       market_type: ON_DEMAND
+      resources:
+        CPU: 4

--- a/release/cluster_tests/cpt_autoscaling_1-3_gce.yaml
+++ b/release/cluster_tests/cpt_autoscaling_1-3_gce.yaml
@@ -3,12 +3,14 @@ zones:
     - us-west1-b
 
 head_node:
-    instance_type: n2-standard-4  # 4 CPUs
+    instance_type: n2-standard-8  # 8 CPUs
     resources:
       CPU: 4
 
 worker_nodes:
-    - instance_type: n2-standard-4
+    - instance_type: n2-standard-8
       min_nodes: 0
       max_nodes: 2
       market_type: ON_DEMAND
+      resources:
+        CPU: 4

--- a/release/cluster_tests/cpt_autoscaling_1-3_kuberay.yaml
+++ b/release/cluster_tests/cpt_autoscaling_1-3_kuberay.yaml
@@ -1,7 +1,7 @@
 
 head_node_type:
     name: head_node
-    instance_type: n2-standard-4  # 4 CPUs
+    instance_type: n2-standard-8  # 8 CPUs
     resources:
       limits:
         cpu: "4"
@@ -12,7 +12,7 @@ head_node_type:
 
 worker_node_types:
     - name: worker_node
-      instance_type: n2-standard-4
+      instance_type: n2-standard-8
       resources:
         limits:
           cpu: "4"

--- a/release/golden_notebook_tests/gpu_tpl_aws.yaml
+++ b/release/golden_notebook_tests/gpu_tpl_aws.yaml
@@ -5,7 +5,7 @@ max_workers: 2
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
 
 worker_node_types:
     - name: worker_node

--- a/release/hello_world_tests/hello_world_compute_config.yaml
+++ b/release/hello_world_tests/hello_world_compute_config.yaml
@@ -1,6 +1,6 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
 
 worker_nodes: []

--- a/release/hello_world_tests/hello_world_compute_config_gce.yaml
+++ b/release/hello_world_tests/hello_world_compute_config_gce.yaml
@@ -3,6 +3,6 @@ zones:
     - us-west1-c
 
 head_node:
-    instance_type: n2-standard-4
+    instance_type: n2-standard-8
 
 worker_nodes: []

--- a/release/jobs_tests/compute_tpl_4_xlarge.yaml
+++ b/release/jobs_tests/compute_tpl_4_xlarge.yaml
@@ -1,12 +1,12 @@
 cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 
 head_node:
-  # 4 cpus, x86, 32G mem, 10Gb NIC
-  instance_type: m5.xlarge
+  # 8 cpus, x86, 32G mem, 10Gb NIC
+  instance_type: m5.2xlarge
 
 worker_nodes:
-  - # 4 cpus, x86, 32G mem, 10Gb NIC
-    instance_type: m5.xlarge
+  - # 8 cpus, x86, 32G mem, 10Gb NIC
+    instance_type: m5.2xlarge
     min_nodes: 4
     max_nodes: 4
     market_type: ON_DEMAND

--- a/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
+++ b/release/jobs_tests/compute_tpl_gce_4_xlarge.yaml
@@ -2,10 +2,10 @@ cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
 zones: [us-west1-c]
 
 head_node:
-  instance_type: n2-standard-4 # m5.xlarge
+  instance_type: n2-standard-8 # m5.2xlarge
 
 worker_nodes:
-  - instance_type: n2-standard-4 # m5.xlarge
+  - instance_type: n2-standard-8 # m5.2xlarge
     min_nodes: 4
     max_nodes: 4
     market_type: ON_DEMAND

--- a/release/ml_user_tests/horovod/compute_tpl_aws.yaml
+++ b/release/ml_user_tests/horovod/compute_tpl_aws.yaml
@@ -5,7 +5,7 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
 
 worker_node_types:
     - name: worker_node

--- a/release/nightly_tests/dataset/single_worker_node_0_head_node_benchmark_compute.yaml
+++ b/release/nightly_tests/dataset/single_worker_node_0_head_node_benchmark_compute.yaml
@@ -5,7 +5,7 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
     resources:
         cpu: 0
 

--- a/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/placement_group_tests_compute.yaml
@@ -18,7 +18,7 @@ head_node_type:
 
 worker_node_types:
    - name: worker_node
-     instance_type: m6i.large
+     instance_type: m5.2xlarge
      min_workers: 5
      max_workers: 5
      use_spot: false

--- a/release/nightly_tests/stress_tests/smoke_test_compute.yaml
+++ b/release/nightly_tests/stress_tests/smoke_test_compute.yaml
@@ -16,7 +16,7 @@ head_node_type:
 
 worker_node_types:
    - name: worker_node
-     instance_type: m6i.large
+     instance_type: m5.2xlarge
      min_workers: 4
      max_workers: 4
      use_spot: false

--- a/release/nightly_tests/stress_tests/stress_tests_compute.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_compute.yaml
@@ -18,7 +18,7 @@ head_node_type:
 
 worker_node_types:
    - name: worker_node
-     instance_type: m6i.large
+     instance_type: m5.2xlarge
      min_workers: 100
      max_workers: 100
      use_spot: false

--- a/release/nightly_tests/stress_tests/stress_tests_single_node_oom_compute.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_single_node_oom_compute.yaml
@@ -5,6 +5,6 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
 
 worker_node_types: []

--- a/release/nightly_tests/stress_tests/stress_tests_single_node_oom_compute_gce.yaml
+++ b/release/nightly_tests/stress_tests/stress_tests_single_node_oom_compute_gce.yaml
@@ -7,6 +7,6 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: n2-standard-4
+    instance_type: n2-standard-8
 
 worker_node_types: []

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -33,7 +33,7 @@ TEST_CLUSTER_COMPUTE = {
     "worker_node_types": [
         {
             "name": "worker_node",
-            "instance_type": "m5.xlarge",
+            "instance_type": "m5.2xlarge",
             "min_workers": 0,
             "max_workers": 0,
             "use_spot": False,
@@ -49,7 +49,7 @@ TEST_CLUSTER_COMPUTE_NEW_SCHEMA = {
     },
     "worker_nodes": [
         {
-            "instance_type": "m5.xlarge",
+            "instance_type": "m5.2xlarge",
             "min_nodes": 0,
             "max_nodes": 4,
         }

--- a/release/runtime_env_tests/rte_gce_minimal.yaml
+++ b/release/runtime_env_tests/rte_gce_minimal.yaml
@@ -7,6 +7,6 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: n2-standard-4 # aws m5.xlarge
+    instance_type: n2-standard-8 # aws m5.2xlarge
 
 worker_node_types: []

--- a/release/runtime_env_tests/rte_gce_small.yaml
+++ b/release/runtime_env_tests/rte_gce_small.yaml
@@ -7,11 +7,11 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: n2-standard-4 # aws m5.xlarge
+    instance_type: n2-standard-8 # aws m5.2xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: n2-standard-4 # aws m5.xlarge
+      instance_type: n2-standard-8 # aws m5.2xlarge
       min_workers: 3
       max_workers: 3
       use_spot: false

--- a/release/runtime_env_tests/rte_minimal.yaml
+++ b/release/runtime_env_tests/rte_minimal.yaml
@@ -5,6 +5,6 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
 
 worker_node_types: []

--- a/release/runtime_env_tests/rte_small.yaml
+++ b/release/runtime_env_tests/rte_small.yaml
@@ -5,11 +5,11 @@ max_workers: 3
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.xlarge
+      instance_type: m5.2xlarge
       min_workers: 3
       max_workers: 3
       use_spot: false

--- a/release/serve_tests/workloads/replica_scalability.py
+++ b/release/serve_tests/workloads/replica_scalability.py
@@ -57,7 +57,7 @@ def main(
         head_node=HeadNodeConfig(instance_type="m5.8xlarge"),
         worker_nodes=[
             WorkerNodeGroupConfig(
-                instance_type="m5.xlarge",
+                instance_type="m5.2xlarge",
                 min_nodes=0,
                 max_nodes=1000,
                 resources={"worker_resource": 1},

--- a/release/train_tests/horovod/compute_tpl_aws.yaml
+++ b/release/train_tests/horovod/compute_tpl_aws.yaml
@@ -5,12 +5,12 @@ max_workers: 1
 
 head_node_type:
     name: head_node
-    # 4 cpus, 16G mem, $0.224/hr on demand
-    instance_type: m5.xlarge
+    # 8 cpus, 32G mem, $0.448/hr on demand
+    instance_type: m5.2xlarge
 
 worker_node_types:
     - name: worker_node
-      instance_type: m5.xlarge
+      instance_type: m5.2xlarge
       max_workers: 1
       min_workers: 1
       use_spot: false

--- a/release/tune_tests/cloud_tests/tpl_aws_1x4.yaml
+++ b/release/tune_tests/cloud_tests/tpl_aws_1x4.yaml
@@ -5,7 +5,7 @@ max_workers: 0
 
 head_node_type:
     name: head_node
-    instance_type: m5.xlarge
+    instance_type: m5.2xlarge
 
 worker_node_types: []
 


### PR DESCRIPTION

## Description
> Briefly describe what this PR accomplishes and why it's needed.

We bumped `RAY_DEFAULT_MIN_SYSTEM_RESERVED_MEMORY_BYTES` to 1 GiB, so now we need a bigger machine in tests.

## Related issues
Fixes
https://github.com/anyscale/ray/issues/1514
https://github.com/anyscale/ray/issues/1515
https://github.com/anyscale/ray/issues/1517
https://github.com/anyscale/ray/issues/1519
https://github.com/anyscale/ray/issues/1525
https://github.com/anyscale/ray/issues/1526
https://github.com/anyscale/ray/issues/1527

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
