### PR TITLE
[chore] Fix typo 'overriden' -> 'overridden' in comments

### DIFF
--- a/python/ray/autoscaler/_private/updater.py
+++ b/python/ray/autoscaler/_private/updater.py
@@ -93,7 +93,7 @@ class NodeUpdater:
         # 1) use_internal_ip arg is True -> use_internal_ip is True
         # 2) worker node -> use value of provider_config["use_internal_ips"]
         # 3) head node -> use value of provider_config["use_internal_ips"] unless
-        #                 overriden by provider_config["use_external_head_ip"]
+        #                 overridden by provider_config["use_external_head_ip"]
         use_internal_ip = use_internal_ip or (
             provider_config.get("use_internal_ips", False)
             and not (

--- a/python/ray/dashboard/modules/aggregator/publisher/configs.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/configs.py
@@ -43,7 +43,7 @@ HTTP_EXPOSABLE_EVENT_TYPES = os.environ.get(
 )
 
 # GCS Publisher specific configurations
-# List of event types that are allowed to be exposed to GCS, not overriden by environment variable
+# List of event types that are allowed to be exposed to GCS, not overridden by environment variable
 # as GCS only supports Task event types
 GCS_EXPOSABLE_EVENT_TYPES = [
     "TASK_DEFINITION_EVENT",

--- a/python/ray/data/_internal/datasource/huggingface_datasource.py
+++ b/python/ray/data/_internal/datasource/huggingface_datasource.py
@@ -142,7 +142,7 @@ class HuggingFaceDatasource(Datasource):
             # HuggingFace IterableDatasets do not fully support methods like
             # `set_format`, `with_format`, and `formatted_as`, so the dataset
             # can return whatever is the default configured batch type, even if
-            # the format is manually overriden before iterating above.
+            # the format is manually overridden before iterating above.
             # Therefore, we limit support to batch formats which have native
             # block types in Ray Data (pyarrow.Table, pd.DataFrame),
             # or can easily be converted to such (dict, np.array).

--- a/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py
@@ -134,7 +134,7 @@ async def test_vllm_engine_udf_basic(mock_vllm_wrapper, model_llama_3_2_216M):
         engine_kwargs={
             # Test that this should be overridden by the stage.
             "model": "random-model",
-            # This is overriden in the processor, so it remains unchanged when we bypass
+            # This is overridden in the processor, so it remains unchanged when we bypass
             # the processor and pass it directly to the stage via vLLMEngineStageUDF.
             "task_type": vLLMTaskType.EMBED,
             "max_num_seqs": 100,

--- a/python/ray/tune/experiment/trial.py
+++ b/python/ray/tune/experiment/trial.py
@@ -1018,7 +1018,7 @@ class Trial:
             if key in state:
                 state[key] = cloudpickle.loads(hex_to_binary(state[key]))
 
-        # Ensure that stub doesn't get overriden
+        # Ensure that stub doesn't get overridden
         stub = state.pop("stub", True)
         self.__dict__.update(state)
         self.stub = stub or getattr(self, "stub", False)

--- a/rllib/algorithms/appo/appo_learner.py
+++ b/rllib/algorithms/appo/appo_learner.py
@@ -44,7 +44,7 @@ class APPOLearner(IMPALALearner):
             # For APPO use a large queue.
             self._learner_thread_in_queue = Queue(maxsize=self.config.simple_queue_size)
 
-        # Now build the super class. Otherwise the learner-queue would overriden.
+        # Now build the super class. Otherwise the learner-queue would be overridden.
         super().build()
 
         # Make target networks.

--- a/src/ray/gcs/tests/gcs_task_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_task_manager_test.cc
@@ -1383,7 +1383,7 @@ TEST_F(GcsTaskManagerTest, TestJobFinishesFailAllRunningTasks) {
     }
   }
 
-  // Failed tasks from job1 failed timestamp not overriden
+  // Failed tasks from job1 failed timestamp not overridden
   {
     google::protobuf::RepeatedPtrField<rpc::TaskEvents> mergedEvents;
     for (const auto &task_id : tasks_failed_job1) {

--- a/src/ray/gcs/tests/usage_stats_client_test.cc
+++ b/src/ray/gcs/tests/usage_stats_client_test.cc
@@ -50,7 +50,7 @@ TEST_F(UsageStatsClientTest, TestRecordExtraUsageTag) {
                    ASSERT_EQ(value.value(), "value1");
                  },
                  io_context_->GetIoService()});
-  // Make sure the value is overriden for the same key.
+  // Make sure the value is overridden for the same key.
   usage_stats_client.RecordExtraUsageTag(usage::TagKey::_TEST2, "value2");
   fake_kv_->Get("usage_stats",
                 "extra_usage_tag__test2",


### PR DESCRIPTION
Fix a minor spelling mistake of 'overriden' in code comments across multiple modules (autoscaler, dashboard aggregator, data, llm tests, tune, rllib and GCS tests). No functional changes.

## Description

This PR fixes a minor spelling mistake of `overriden` (correct spelling: `overridden`) found in code comments across multiple modules. No functional changes — comments only.

Affected files:

- `python/ray/autoscaler/_private/updater.py`
- `python/ray/dashboard/modules/aggregator/publisher/configs.py`
- `python/ray/data/_internal/datasource/huggingface_datasource.py`
- `python/ray/llm/tests/batch/gpu/stages/test_vllm_engine_stage.py`
- `python/ray/tune/experiment/trial.py`
- `rllib/algorithms/appo/appo_learner.py`
- `src/ray/gcs/tests/gcs_task_manager_test.cc`
- `src/ray/gcs/tests/usage_stats_client_test.cc`

Also fixes a small related grammar issue in `rllib/algorithms/appo/appo_learner.py` (`would overriden` → `would be overridden`).

## Related issues

N/A

## Additional information

N/A

