### PR TITLE
[Data] Fix missing f-string prefix in _concatenate_extension_column

### DIFF
--- a/python/ray/data/_internal/utils/transform_pyarrow.py
+++ b/python/ray/data/_internal/utils/transform_pyarrow.py
@@ -41,7 +41,7 @@ def _concatenate_extension_column(
     )
 
     if not _is_pa_extension_type(ca.type):
-        raise ValueError("Chunked array isn't an extension array: {ca}")
+        raise ValueError(f"Chunked array isn't an extension array: {ca.type}")
 
     tensor_extension_types = get_arrow_extension_tensor_types()
 


### PR DESCRIPTION
## Description

The `ValueError` raised by `_concatenate_extension_column` in
`python/ray/data/_internal/utils/transform_pyarrow.py` used a plain
string literal with `{ca}` as a placeholder — there was no `f` prefix
and no `.format()` call, so the placeholder was never interpolated.

As a result, whenever this error path was hit (a non-extension
`ChunkedArray` being passed into the function), users would literally
see:

```
ValueError: Chunked array isn't an extension array: {ca}
```

which carries zero diagnostic information about the offending column
and makes the failure very hard to debug.

This PR:

1. Adds the missing `f` prefix so the value is actually interpolated.
2. Prints `ca.type` instead of the full `ChunkedArray`. A
   `ChunkedArray` holds all underlying chunks and can be very large;
   `ca.type` is exactly the piece of information the user needs here
   and is safe / cheap to include in an error message.

### Before

```python
if not _is_pa_extension_type(ca.type):
    raise ValueError("Chunked array isn't an extension array: {ca}")
```

Produces:

```
ValueError: Chunked array isn't an extension array: {ca}
```

### After

```python
if not _is_pa_extension_type(ca.type):
    raise ValueError(f"Chunked array isn't an extension array: {ca.type}")
```

Produces (example):

```
ValueError: Chunked array isn't an extension array: int64
```

No behavior changes on the success path. Only the error message is
affected, so there is no functional risk to existing pipelines.

## Related issues

N/A 

## Additional information

N/A 