### PR TITLE
[Serve] Defer PG creation for TPU Serve deployments to accelerator backend

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -92,13 +92,13 @@ class AcceleratorBackend(ABC):
         pass
 
     @property
-    @abstractmethod
     def requires_deferred_placement_group(self) -> bool:
         """
         If True, Ray Serve will not provision a placement group for the deployment.
         Instead, creation is deferred to the replica at runtime.
+        Defaults to False.
         """
-        pass
+        return False
 
     @property
     @abstractmethod
@@ -118,10 +118,6 @@ class AcceleratorBackend(ABC):
 
 class CPUAccelerator(AcceleratorBackend):
     # stateless — no __init__
-    @property
-    def requires_deferred_placement_group(self) -> bool:
-        return False
-
     def default_bundles(
         self, *, num_devices: int, accelerator_type_str: Optional[str] = None
     ):
@@ -147,10 +143,6 @@ class CPUAccelerator(AcceleratorBackend):
 
 class GPUAccelerator(AcceleratorBackend):
     # stateless — no __init__
-    @property
-    def requires_deferred_placement_group(self) -> bool:
-        return False
-
     def default_bundles(
         self, *, num_devices: int, accelerator_type_str: Optional[str] = None
     ):
@@ -249,6 +241,12 @@ class TPUAccelerator(AcceleratorBackend):
 
     @property
     def requires_deferred_placement_group(self) -> bool:
+        """
+        If a TPU topology is specified, we defer PG creation so the replica can
+        provision a `SlicePlacementGroup` at runtime. This ensures multi-host
+        TPU slices are gang-scheduled atomically according to their physical
+        topology rather than fragmented across the cluster.
+        """
         return bool(self._config.topology)
 
     @property

--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -93,6 +93,15 @@ class AcceleratorBackend(ABC):
 
     @property
     @abstractmethod
+    def requires_deferred_placement_group(self) -> bool:
+        """
+        If True, Ray Serve will not provision a placement group for the deployment.
+        Instead, creation is deferred to the replica at runtime.
+        """
+        pass
+
+    @property
+    @abstractmethod
     def requires_remote_initialization(self) -> bool:
         """Boolean indicating whether this backend needs a remote Ray task to query hardware during init."""
         pass
@@ -109,6 +118,10 @@ class AcceleratorBackend(ABC):
 
 class CPUAccelerator(AcceleratorBackend):
     # stateless — no __init__
+    @property
+    def requires_deferred_placement_group(self) -> bool:
+        return False
+
     def default_bundles(
         self, *, num_devices: int, accelerator_type_str: Optional[str] = None
     ):
@@ -134,6 +147,10 @@ class CPUAccelerator(AcceleratorBackend):
 
 class GPUAccelerator(AcceleratorBackend):
     # stateless — no __init__
+    @property
+    def requires_deferred_placement_group(self) -> bool:
+        return False
+
     def default_bundles(
         self, *, num_devices: int, accelerator_type_str: Optional[str] = None
     ):
@@ -229,6 +246,10 @@ class TPUAccelerator(AcceleratorBackend):
             name=name,
         )
         return self._slice_pg_wrapper.placement_group
+
+    @property
+    def requires_deferred_placement_group(self) -> bool:
+        return self._config.topology is not None
 
     @property
     def requires_remote_initialization(self) -> bool:

--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -249,7 +249,7 @@ class TPUAccelerator(AcceleratorBackend):
 
     @property
     def requires_deferred_placement_group(self) -> bool:
-        return self._config.topology is not None
+        return bool(self._config.topology)
 
     @property
     def requires_remote_initialization(self) -> bool:

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -707,18 +707,19 @@ class LLMServer(LLMServerProtocol):
                 "placement_group_bundles and placement_group_strategy must not be specified in deployment_config. You can override the default values by setting the `placement_group_config` in the LLMConfig."
             )
 
-        # TODO: Move this _merge_replica_actor_and_child_actor_bundles to a
-        # more generic place.
-        pg_bundles = _merge_replica_actor_and_child_actor_bundles(
-            engine_config.placement_bundles, replica_actor_resources
-        )
+        if not engine_config.accelerator.requires_deferred_placement_group:
+            # TODO: Move this _merge_replica_actor_and_child_actor_bundles to a
+            # more generic place.
+            pg_bundles = _merge_replica_actor_and_child_actor_bundles(
+                engine_config.placement_bundles, replica_actor_resources
+            )
 
-        deployment_options.update(
-            {
-                "placement_group_bundles": pg_bundles,
-                "placement_group_strategy": engine_config.placement_strategy,
-            }
-        )
+            deployment_options.update(
+                {
+                    "placement_group_bundles": pg_bundles,
+                    "placement_group_strategy": engine_config.placement_strategy,
+                }
+            )
 
         # Handle env vars from runtime_env
         default_runtime_env = ray.get_runtime_context().runtime_env

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -691,23 +691,23 @@ class LLMServer(LLMServerProtocol):
         # deployment_options
         ray_actor_options = deployment_options.get("ray_actor_options", {})
 
-        replica_actor_resources = {
-            "CPU": ray_actor_options.get("num_cpus", 1),
-            "GPU": ray_actor_options.get("num_gpus", 0),
-            **ray_actor_options.get("resources", {}),
-        }
-        if "memory" in ray_actor_options:
-            replica_actor_resources["memory"] = ray_actor_options["memory"]
-
-        if (
-            "placement_group_bundles" in llm_config.deployment_config
-            or "placement_group_strategy" in llm_config.deployment_config
-        ):
-            raise ValueError(
-                "placement_group_bundles and placement_group_strategy must not be specified in deployment_config. You can override the default values by setting the `placement_group_config` in the LLMConfig."
-            )
-
         if not engine_config.accelerator.requires_deferred_placement_group:
+            replica_actor_resources = {
+                "CPU": ray_actor_options.get("num_cpus", 1),
+                "GPU": ray_actor_options.get("num_gpus", 0),
+                **ray_actor_options.get("resources", {}),
+            }
+            if "memory" in ray_actor_options:
+                replica_actor_resources["memory"] = ray_actor_options["memory"]
+
+            if (
+                "placement_group_bundles" in llm_config.deployment_config
+                or "placement_group_strategy" in llm_config.deployment_config
+            ):
+                raise ValueError(
+                    "placement_group_bundles and placement_group_strategy must not be specified in deployment_config. You can override the default values by setting the `placement_group_config` in the LLMConfig."
+                )
+
             # TODO: Move this _merge_replica_actor_and_child_actor_bundles to a
             # more generic place.
             pg_bundles = _merge_replica_actor_and_child_actor_bundles(

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -687,6 +687,14 @@ class LLMServer(LLMServerProtocol):
         engine_config = llm_config.get_engine_config()
         deployment_options = copy.deepcopy(llm_config.deployment_config)
 
+        if (
+            "placement_group_bundles" in llm_config.deployment_config
+            or "placement_group_strategy" in llm_config.deployment_config
+        ):
+            raise ValueError(
+                "placement_group_bundles and placement_group_strategy must not be specified in deployment_config. You can override the default values by setting the `placement_group_config` in the LLMConfig."
+            )
+
         # Handle the ray_actor_options that could be passed in to
         # deployment_options
         ray_actor_options = deployment_options.get("ray_actor_options", {})
@@ -699,14 +707,6 @@ class LLMServer(LLMServerProtocol):
             }
             if "memory" in ray_actor_options:
                 replica_actor_resources["memory"] = ray_actor_options["memory"]
-
-            if (
-                "placement_group_bundles" in llm_config.deployment_config
-                or "placement_group_strategy" in llm_config.deployment_config
-            ):
-                raise ValueError(
-                    "placement_group_bundles and placement_group_strategy must not be specified in deployment_config. You can override the default values by setting the `placement_group_config` in the LLMConfig."
-                )
 
             # TODO: Move this _merge_replica_actor_and_child_actor_bundles to a
             # more generic place.

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -5,7 +5,12 @@ import pydantic
 import pytest
 
 from ray.llm._internal.common.utils.download_utils import NodeModelDownloadable
-from ray.llm._internal.serve.core.configs.accelerators import TPUAccelerator
+from ray.llm._internal.serve.core.configs.accelerators import (
+    CPUAccelerator,
+    GPUAccelerator,
+    TPUAccelerator,
+    TPUConfig,
+)
 from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     LoraConfig,
@@ -397,6 +402,20 @@ class TestAcceleratorConfigLogic:
 
         assert isinstance(engine_config.accelerator, TPUAccelerator)
         assert engine_config.accelerator_type == "TPU-V6E"
+
+    def test_requires_deferred_placement_group(self):
+        """Test that requires_deferred_placement_group correctly identifies deferred PG requirements."""
+        cpu_accel = CPUAccelerator()
+        assert cpu_accel.requires_deferred_placement_group is False
+
+        gpu_accel = GPUAccelerator()
+        assert gpu_accel.requires_deferred_placement_group is False
+
+        tpu_accel_no_topo = TPUAccelerator(TPUConfig(kind="tpu"))
+        assert tpu_accel_no_topo.requires_deferred_placement_group is False
+
+        tpu_accel_with_topo = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
+        assert tpu_accel_with_topo.requires_deferred_placement_group is True
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 import ray
+from ray import serve
 from ray.llm._internal.serve.core.configs.accelerators import (
     CPUAccelerator,
     CPUConfig,
@@ -11,6 +12,8 @@ from ray.llm._internal.serve.core.configs.accelerators import (
     TPUAccelerator,
     TPUConfig,
 )
+from ray.llm._internal.serve.core.server.llm_server import LLMServer
+from ray.llm.tests.serve.mocks.mock_vllm_engine import PGCreationMockEngine
 from ray.serve.llm import LLMConfig, ModelLoadingConfig
 from ray.util.placement_group import PlacementGroup, placement_group_table
 
@@ -216,6 +219,95 @@ def test_tpu_slice_placement_group_creation_cpu_driver_homogeneous_tpu_bundles_p
         ray.util.remove_placement_group(pg)
     except Exception:
         pass
+
+
+def test_tpu_serve_deployment_default_chip_level_bundles(ray_tpu_cluster):
+    """
+    Verifies that a Serve deployment created for a multi-host TPU slice defaults
+    to chip-level bundles when no placement_group_config is specified.
+    """
+    llm_config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
+        accelerator_type="TPU-V6E",
+        accelerator_config={"kind": "tpu", "topology": "4x4"},
+    )
+
+    app = serve.deployment(LLMServer).bind(llm_config, engine_cls=PGCreationMockEngine)
+    serve.run(app)
+
+    pg_table = ray.util.placement_group_table()
+    active_pgs = list(
+        {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
+    )
+
+    assert (
+        len(active_pgs) == 2
+    ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
+
+    head_pgs = [
+        pg
+        for pg in active_pgs
+        if any(
+            any("head" in res.lower() for res in b.keys())
+            for b in pg["bundles"].values()
+        )
+    ]
+    assert len(head_pgs) == 1
+
+    worker_pg = [pg for pg in active_pgs if pg not in head_pgs][0]
+
+    assert worker_pg["strategy"] == "PACK"
+    # 4x4 topology = 16 chips. Default is 16 bundles of 1 TPU.
+    assert len(worker_pg["bundles"]) == 16
+    for bundle in worker_pg["bundles"].values():
+        assert bundle.get("TPU", 0) == 1
+
+    serve.shutdown()
+
+
+def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
+    """
+    Verifies that a user can explicitly request host-level bundles (4 TPUs per bundle)
+    for a Serve deployment via placement_group_config.
+    """
+    llm_config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
+        accelerator_type="TPU-V6E",
+        accelerator_config={"kind": "tpu", "topology": "4x4"},
+        placement_group_config={"bundle_per_worker": {"TPU": 4}},
+    )
+
+    app = serve.deployment(LLMServer).bind(llm_config, engine_cls=PGCreationMockEngine)
+    serve.run(app)
+
+    pg_table = ray.util.placement_group_table()
+    active_pgs = list(
+        {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
+    )
+
+    assert (
+        len(active_pgs) == 2
+    ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
+
+    head_pgs = [
+        pg
+        for pg in active_pgs
+        if any(
+            any("head" in res.lower() for res in b.keys())
+            for b in pg["bundles"].values()
+        )
+    ]
+    assert len(head_pgs) == 1
+
+    worker_pg = [pg for pg in active_pgs if pg not in head_pgs][0]
+
+    assert worker_pg["strategy"] == "PACK"
+    # 4x4 topology = 16 chips. With 4 TPUs per bundle, expect exactly 4 bundles.
+    assert len(worker_pg["bundles"]) == 4
+    for bundle in worker_pg["bundles"].values():
+        assert bundle.get("TPU", 0) == 4
+
+    serve.shutdown()
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -244,13 +244,12 @@ def test_tpu_serve_deployment_default_chip_level_bundles(ray_tpu_cluster):
         len(active_pgs) == 2
     ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
 
+    tpu_head_resource = "TPU-v6e-16-head"
     head_pgs = [
         pg
         for pg in active_pgs
-        if any(
-            any("head" in res.lower() for res in b.keys())
-            for b in pg["bundles"].values()
-        )
+        if len(pg["bundles"]) == 1
+        and tpu_head_resource in list(pg["bundles"].values())[0]
     ]
     assert len(head_pgs) == 1
 
@@ -289,13 +288,12 @@ def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
         len(active_pgs) == 2
     ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
 
+    tpu_head_resource = "TPU-v6e-16-head"
     head_pgs = [
         pg
         for pg in active_pgs
-        if any(
-            any("head" in res.lower() for res in b.keys())
-            for b in pg["bundles"].values()
-        )
+        if len(pg["bundles"]) == 1
+        and tpu_head_resource in list(pg["bundles"].values())[0]
     ]
     assert len(head_pgs) == 1
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -678,6 +678,20 @@ class TestGetDeploymentOptions:
             in serve_options["ray_actor_options"]["runtime_env"]
         )
 
+    def test_deferred_placement_group_for_tpu_topology(self):
+        """Test that Serve skips PG creation when deferred placement group is required."""
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
+            accelerator_type="TPU-V6E",
+            accelerator_config={"kind": "tpu", "topology": "4x4"},
+            llm_engine="vLLM",
+        )
+
+        serve_options = LLMServer.get_deployment_options(llm_config)
+
+        assert "placement_group_bundles" not in serve_options
+        assert "placement_group_strategy" not in serve_options
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -581,3 +581,15 @@ class FakeLoraModelLoader(LoraModelLoader):
             local_path="/fake/local/path",
             lora_assigned_int_id=random.randint(1, 100),
         )
+
+
+class PGCreationMockEngine(MockVLLMEngine):
+    """
+    A wrapper around the mock engine that forces it to create the placement
+    group on startup, simulating the real vLLM initialization sequence.
+    """
+
+    def __init__(self, llm_config, *args, **kwargs):
+        super().__init__(llm_config, *args, **kwargs)
+        self.engine_config = llm_config.get_engine_config()
+        self.engine_config.get_or_create_pg()


### PR DESCRIPTION
## Description
This PR enables the `SlicePlacementGroup` reservation logic for TPU accelerator backends to be called  in Ray Serve when creating a Serve deployment. This is a follow-up to https://github.com/ray-project/ray/pull/61906 which added the new accelerator config logic and `topology` API to Serve `LLMConfig` and `VLLMEngine`.

Specific Changes:
- Added `requires_deferred_placement_group` property to AcceleratorBackend interface, which returns True for TPU backend when `topology` is set. This is used to check whether to set `pg_bundles` in `LLMServer` which are used to create a standard Ray PG. This results in the `LLMConfig` calling our backend-specific reservation logic when the Serve deployment starts.
- Added unit tests and end-to-end mocked deployment tests to verify the two-step PG reservation works properly for Serve deployments

## Related issues
https://github.com/ray-project/ray/issues/57137

## Additional information
This comment describes the rationale for this PR in more detail: https://github.com/ray-project/ray/pull/61906#discussion_r3141052983