### PR TITLE
[Core] Fix misleading docstrings on drain_node APIs

### DIFF
--- a/python/ray/includes/gcs_client.pxi
+++ b/python/ray/includes/gcs_client.pxi
@@ -639,9 +639,26 @@ cdef class InnerGcsClient:
             reason: int32_t,
             reason_message: c_string,
             deadline_timestamp_ms: int64_t):
-        """Send the DrainNode request to GCS.
+        """Send a DrainNode request to GCS to gracefully terminate a node.
 
-        This is only for testing.
+        Used by the `ray drain-node` CLI command and by autoscaler v2's
+        ray_stopper for idle and preemption-based node termination.
+
+        Args:
+            node_id: Binary node ID of the target node.
+            reason: A `DrainNodeReason` enum value. `IDLE_TERMINATION`
+                requests are rejectable by the raylet; `PREEMPTION`
+                requests are non-rejectable.
+            reason_message: Human-readable explanation, used for
+                observability.
+            deadline_timestamp_ms: Timestamp (ms) when the node will be
+                force-killed. Used as a hint so workloads can drain
+                before the deadline.
+
+        Returns:
+            Tuple of (is_accepted, rejection_reason_message). When
+            `is_accepted` is False, `rejection_reason_message` describes
+            why the raylet rejected the request.
         """
         cdef:
             int64_t timeout_ms = -1

--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -2640,10 +2640,14 @@ def drain_node(
     reason_message: str,
     deadline_remaining_seconds: int,
 ):
-    """
-    This is NOT a public API.
+    """Manually drain a worker node.
 
-    Manually drain a worker node.
+    This is a developer-facing command used to request that GCS gracefully
+    drain a node (e.g., before manual termination). The same underlying API
+    is invoked by autoscaler v2 for idle and preemption-based termination.
+
+    The command is hidden from the top-level `ray --help` output and its
+    interface is not covered by Ray's public API stability guarantees.
     """
     # This should be before get_runtime_context() so get_runtime_context()
     # doesn't start a new worker here.


### PR DESCRIPTION
## Description
I ran into these docstrings while trying to drain a Ray worker via the GCS API for a specific operational case. The wording made me second-guess whether I was using the right API at all, so I traced the call sites to see who actually uses them.

GcsClient.drain_node() in python/ray/includes/gcs_client.pxi says "This is only for testing." The same method is called from the ray drain-node CLI in python/ray/scripts/scripts.py and from autoscaler v2's ray_stopper in python/ray/autoscaler/v2/instance_manager/subscribers/ray_stopper.py, which uses it for idle and preemption-based termination.

The ray drain-node CLI itself says "This is NOT a public API." It is hidden from ray --help, but it is the developer-facing entry point that talks to the same GCS API autoscaler v2 uses.

Replace both docstrings with descriptions of what the function does, who calls it, and what each parameter and return value means.

## Related issues

## Additional information

Call sites I confirmed for GcsClient.drain_node():

- python/ray/scripts/scripts.py: implements the `ray drain-node` CLI command.
  https://github.com/ray-project/ray/blob/master/python/ray/scripts/scripts.py#L2636-L2675
- python/ray/autoscaler/v2/instance_manager/subscribers/ray_stopper.py: invoked by autoscaler v2 with `DRAIN_NODE_REASON_IDLE_TERMINATION` and `DRAIN_NODE_REASON_PREEMPTION`.
  https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/v2/instance_manager/subscribers/ray_stopper.py#L108

For the CLI, @cli.command(hidden=True) only suppresses it from the ray --help listing. It does not mark the command as test-only, so the original "NOT a public API" wording overstates its restriction. The new docstring keeps the stability caveat without implying the command is internal-only.