### PR TITLE
[WIP][Core][GPU fraction] Add per-instance availability check function for resource requests

### DIFF
--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -49,24 +49,26 @@ bool NodeResourceInstanceSet::Has(ResourceID resource_id) const {
 void NodeResourceInstanceSet::Remove(ResourceID resource_id) {
   resources_.erase(resource_id);
 
-  // Remove from the pg_indexed_resources_ as well
-  auto data = ParsePgFormattedResource(resource_id.Binary(),
-                                       /*for_wildcard_resource=*/false,
-                                       /*for_indexed_resource=*/true);
-  if (data) {
-    ResourceID original_resource_id(data->original_resource);
+  if (track_pg_index_) {
+    // Remove from the pg_indexed_resources_ as well
+    auto data = ParsePgFormattedResource(resource_id.Binary(),
+                                         /*for_wildcard_resource=*/false,
+                                         /*for_indexed_resource=*/true);
+    if (data) {
+      ResourceID original_resource_id(data->original_resource);
 
-    auto pg_resource_map_it = pg_indexed_resources_.find(original_resource_id);
-    if (pg_resource_map_it != pg_indexed_resources_.end()) {
-      auto resource_set_it = pg_resource_map_it->second.find(data->group_id);
+      auto pg_resource_map_it = pg_indexed_resources_.find(original_resource_id);
+      if (pg_resource_map_it != pg_indexed_resources_.end()) {
+        auto resource_set_it = pg_resource_map_it->second.find(data->group_id);
 
-      if (resource_set_it != pg_resource_map_it->second.end()) {
-        resource_set_it->second.erase(resource_id);
-        if (resource_set_it->second.empty()) {
-          pg_resource_map_it->second.erase(data->group_id);
-        }
-        if (pg_resource_map_it->second.empty()) {
-          pg_indexed_resources_.erase(original_resource_id);
+        if (resource_set_it != pg_resource_map_it->second.end()) {
+          resource_set_it->second.erase(resource_id);
+          if (resource_set_it->second.empty()) {
+            pg_resource_map_it->second.erase(data->group_id);
+          }
+          if (pg_resource_map_it->second.empty()) {
+            pg_indexed_resources_.erase(original_resource_id);
+          }
         }
       }
     }
@@ -98,22 +100,24 @@ NodeResourceInstanceSet &NodeResourceInstanceSet::Set(ResourceID resource_id,
   } else {
     resources_[resource_id] = std::move(instances);
 
-    // Popluate the pg_indexed_resources_map_
-    // TODO(myan): The parsing of the resource_id String can be costly and impact the
-    // task creation throughput if the parting is required every time we allocate
-    // resources for a task and updating the available resources. The current benchmark
-    // shows no observable impact for now. But in the future, ideas of improvement are:
-    // (1) to add the placement group id as well as the bundle index inside the
-    // ResourceID class. And instead of parse the String, leveraging the fields in the
-    // ResourceID class directly; (2) to update the pg resource id format to start with
-    // a special prefix so that we can do "startwith" instead of regex match which is
-    // less costly
-    auto data = ParsePgFormattedResource(resource_id.Binary(),
-                                         /*for_wildcard_resource=*/false,
-                                         /*for_indexed_resource=*/true);
-    if (data) {
-      pg_indexed_resources_[ResourceID(data->original_resource)][data->group_id].emplace(
-          resource_id);
+    if (track_pg_index_) {
+      // Populate the pg_indexed_resources_map_
+      // TODO(myan): The parsing of the resource_id String can be costly and impact the
+      // task creation throughput if the parting is required every time we allocate
+      // resources for a task and updating the available resources. The current benchmark
+      // shows no observable impact for now. But in the future, ideas of improvement are:
+      // (1) to add the placement group id as well as the bundle index inside the
+      // ResourceID class. And instead of parse the String, leveraging the fields in the
+      // ResourceID class directly; (2) to update the pg resource id format to start with
+      // a special prefix so that we can do "startwith" instead of regex match which is
+      // less costly
+      auto data = ParsePgFormattedResource(resource_id.Binary(),
+                                           /*for_wildcard_resource=*/false,
+                                           /*for_indexed_resource=*/true);
+      if (data) {
+        pg_indexed_resources_[ResourceID(data->original_resource)][data->group_id]
+            .emplace(resource_id);
+      }
     }
   }
   return *this;
@@ -136,9 +140,71 @@ bool NodeResourceInstanceSet::operator==(const NodeResourceInstanceSet &other) c
   return this->resources_ == other.resources_;
 }
 
-std::optional<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>
-NodeResourceInstanceSet::TryAllocate(const ResourceSet &resource_demands) {
-  absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> allocations;
+bool NodeResourceInstanceSet::CanAllocate(const ResourceSet &resource_demands) const {
+  for (const auto &[resource_id, demand] : resource_demands.Resources()) {
+    const std::vector<FixedPoint> &available = Get(resource_id);
+
+    if (available.empty()) {
+      return false;
+    }
+
+    if (available.size() == 1) {
+      if (available[0] >= demand) {
+        continue;
+      }
+      return false;
+    }
+
+    FixedPoint remaining_demand = demand;
+    int64_t full_instances_used = 0;
+
+    if (remaining_demand >= 1.) {
+      for (size_t i = 0; i < available.size(); i++) {
+        if (available[i] == 1.) {
+          full_instances_used++;
+          remaining_demand -= 1.;
+        }
+        if (remaining_demand < 1.) {
+          break;
+        }
+      }
+    }
+
+    if (remaining_demand >= 1.) {
+      // Not enough full-capacity instances to cover the integer part.
+      return false;
+    }
+
+    if (remaining_demand > 0.) {
+      bool found_fit = false;
+      int64_t full_instances_skipped = 0;
+
+      for (size_t i = 0; i < available.size(); i++) {
+        // Skip the exact number of full instances we previously calculated
+        if (available[i] == 1. && full_instances_skipped < full_instances_used) {
+          full_instances_skipped++;
+          continue;
+        }
+
+        // EARLY EXIT: We only need to know IF it can fit, not WHERE it fits best.
+        if (available[i] >= remaining_demand) {
+          found_fit = true;
+          break;
+        }
+      }
+
+      if (!found_fit) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+std::optional<ResourceAllocation> NodeResourceInstanceSet::TryAllocate(
+    const ResourceSet &resource_demands) {
+  ResourceAllocation allocations;
 
   // During resource allocation with a placement group, no matter whether the allocation
   // requirement specifies a bundle index, we generate the allocation on both
@@ -288,8 +354,7 @@ NodeResourceInstanceSet::TryAllocate(const ResourceSet &resource_demands) {
     allocations[*wildcard_resource_id] = std::move(*wildcard_allocation);
   }
 
-  return std::make_optional<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>(
-      std::move(allocations));
+  return std::make_optional<ResourceAllocation>(std::move(allocations));
 }
 
 std::optional<std::vector<FixedPoint>> NodeResourceInstanceSet::TryAllocate(

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -25,10 +25,19 @@
 
 namespace ray {
 
+/// Per-instance allocation result: maps each resource to its per-instance allocation
+/// vector. E.g. {"GPU": [0.3, 0.6], "NPU": [0.6, 0.7]}.
+using ResourceAllocation = absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>;
+
 /// Represents a node resource set that contains the per-instance resource values.
 class NodeResourceInstanceSet {
  public:
-  NodeResourceInstanceSet(){};
+  /// \param track_pg_index If true, parse resource names on every Set/Remove
+  /// to build a lookup table for PG bundle resources. The raylet uses this to
+  /// find which bundle can satisfy a PG resource request. The GCS passes false
+  /// because it never does local PG allocation, and the parsing overhead is large.
+  explicit NodeResourceInstanceSet(bool track_pg_index = true)
+      : track_pg_index_(track_pg_index){};
 
   /// Construct a NodeResourceInstanceSet from a node total resources.
   explicit NodeResourceInstanceSet(const NodeResourceSet &total);
@@ -56,11 +65,13 @@ class NodeResourceInstanceSet {
 
   std::string DebugString() const;
 
+  /// Checks whether the available resources can satisfy `resource_demands`
+  bool CanAllocate(const ResourceSet &resource_demands) const;
+
   /// Try to allocate resources specified by `resource_demands`.
   /// This operation is all or nothing meaning that if any single resource
   /// cannot be allocated, the entire allocation fails and std::nullopt is returned.
-  std::optional<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>> TryAllocate(
-      const ResourceSet &resource_demands);
+  std::optional<ResourceAllocation> TryAllocate(const ResourceSet &resource_demands);
 
   /// Free allocated resources and add them back to this set.
   void Free(ResourceID resource_id, const std::vector<FixedPoint> &allocation);
@@ -91,7 +102,6 @@ class NodeResourceInstanceSet {
     return resources_;
   }
 
- private:
   /// Allocate enough capacity across the instances of a resource to satisfy "demand".
   ///
   /// Allocate full unit-capacity instances until
@@ -150,6 +160,7 @@ class NodeResourceInstanceSet {
   std::optional<std::vector<FixedPoint>> TryAllocate(ResourceID resource_id,
                                                      FixedPoint demand);
 
+ private:
   /// Allocate resource to the resource_id based on a provided reference allocation.
   /// The function is used for placement group allocation. Making the allocation of
   /// the wildcard resource be identical to the indexed resource allocation.
@@ -162,6 +173,8 @@ class NodeResourceInstanceSet {
   /// \param resource_id: The id of the resource to be allocated
   void AllocateWithReference(const std::vector<FixedPoint> &ref_allocation,
                              ResourceID resource_id);
+
+  bool track_pg_index_ = true;
 
   /// Map from the resource IDs to the resource instance values.
   absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> resources_;


### PR DESCRIPTION
## Description
This PR introduces an important function and field for `NodeResourceInstanceSet`, which is a crucial class that represents the per-instance topology of a node's resources in the upcoming PR https://github.com/ray-project/ray/pull/62005

* Define a function to check the availability of a resource request at the per-instance level, which is a crucial prerequisite for the upcoming fractional scheduling logic
* Since GCS will use `NodeResourceInstanceSet` as the resource view in the upcoming PR, add a flag (`track_pg_index_`) to skip the PG index parsing overhead, as GCS never performs local PG allocation
* Introduced a new typedef to represent per-instance breakdown of allocated resources. For example `{“GPU”: [0.3, 0.6], NPU: [0.6, 0.7]}`


## Related PRs
Related to https://github.com/ray-project/ray/pull/62005

## Additional information
See the complete [Split PR Plan](https://github.com/ray-project/ray/pull/62005#issuecomment-4321349042)