### PR TITLE
[core] fix AttributeError: 'NoneType' object has no attribute 'trace' in client mode

### DIFF
--- a/python/ray/tests/test_tracing.py
+++ b/python/ray/tests/test_tracing.py
@@ -10,7 +10,8 @@ import pytest
 
 import ray
 from ray._private.test_utils import check_call_ray
-from ray.util.tracing.setup_local_tmp_tracing import spans_dir
+from ray.util.tracing.setup_local_tmp_tracing import setup_tracing, spans_dir
+from ray.util.tracing.tracing_helper import _enable_tracing
 
 setup_tracing_path = "ray.util.tracing.setup_local_tmp_tracing:setup_tracing"
 
@@ -54,6 +55,24 @@ def ray_start_cli_predefined_actor_tracing(scope="function"):
         ["start", "--head", "--tracing-startup-hook", setup_tracing_path],
     )
     yield
+    ray.shutdown()
+    check_call_ray(["stop", "--force"])
+
+
+@pytest.fixture()
+def ray_start_cli_tracing_with_client(scope="function"):
+    """Start ray with tracing startup hook and Ray Client server."""
+    check_call_ray(["stop", "--force"])
+    check_call_ray(
+        [
+            "start",
+            "--head",
+            "--ray-client-server-port=50057",
+            "--tracing-startup-hook",
+            setup_tracing_path,
+        ],
+    )
+    yield "ray://localhost:50057"
     ray.shutdown()
     check_call_ray(["stop", "--force"])
 
@@ -197,6 +216,47 @@ def test_tracing_async_actor_start_workflow(cleanup_dirs, ray_start_cli_tracing)
 
 def test_tracing_predefined_actor(cleanup_dirs, ray_start_cli_predefined_actor_tracing):
     sync_actor_helper()
+
+
+def test_tracing_actor_client_mode(cleanup_dirs, ray_start_cli_tracing_with_client):
+    ray.init(ray_start_cli_tracing_with_client)
+    assert ray.util.client.ray.is_connected()
+    setup_tracing()
+    _enable_tracing()
+
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.value = 0
+
+        def increment(self):
+            self.value += 1
+            return self.value
+
+    counter = Counter.remote()
+    assert ray.get(counter.increment.remote()) == 1
+
+    span_list = get_span_list()
+    span_names = get_span_dict(span_list)
+    assert span_names == {
+        "test_tracing_actor_client_mode.<locals>.Counter.__init__ ray.remote": 1,
+        "Counter.__init__ ray.remote": 1,
+        "Counter.increment ray.remote": 1,
+        "Counter.__init__ ray.remote_worker": 1,
+        "Counter.increment ray.remote_worker": 1,
+    }, span_names
+
+    actor_creation_spans = [
+        span
+        for span in span_list
+        if span["name"].endswith("Counter.__init__ ray.remote")
+    ]
+    actor_method_span = next(
+        span for span in span_list if span["name"] == "Counter.increment ray.remote"
+    )
+    actor_id = counter._actor_id.hex()
+    for span in actor_creation_spans + [actor_method_span]:
+        assert span["attributes"]["ray.actor_id"] == actor_id
 
 
 def test_wrapping(ray_start_init_tracing):

--- a/python/ray/util/tracing/tracing_helper.py
+++ b/python/ray/util/tracing/tracing_helper.py
@@ -102,6 +102,22 @@ def _enable_tracing():
     _opentelemetry.try_all()
 
 
+def _get_opentelemetry() -> "_OpenTelemetryProxy":
+    """Avoids pickling a stale `_opentelemetry` value into closures."""
+    return _opentelemetry
+
+
+def _get_actor_id_hex(actor_ref: Any) -> Optional[str]:
+    """Actor id extraction across core and client actor refs."""
+    ray_actor_id = getattr(actor_ref, "_ray_actor_id", None)
+    if ray_actor_id is not None:
+        return ray_actor_id.hex()
+    client_actor_id = getattr(actor_ref, "_actor_id", None)
+    if client_actor_id is not None:
+        return client_actor_id.hex()
+    return None
+
+
 def _sort_params_list(params_list: List[Parameter]):
     """Given a list of Parameters, if a kwargs Parameter exists,
     move it to the end of the list."""
@@ -166,13 +182,15 @@ class _DictPropagator:
     def inject_current_context() -> Dict[Any, Any]:
         """Inject trace context into otel propagator."""
         context_dict: Dict[Any, Any] = {}
-        _opentelemetry.propagate.inject(context_dict)
+        opentelemetry = _get_opentelemetry()
+        opentelemetry.propagate.inject(context_dict)
         return context_dict
 
     def extract(context_dict: Dict[Any, Any]) -> "_opentelemetry.Context":
         """Given a trace context, extract as a Context."""
+        opentelemetry = _get_opentelemetry()
         return cast(
-            _opentelemetry.Context, _opentelemetry.propagate.extract(context_dict)
+            opentelemetry.Context, opentelemetry.propagate.extract(context_dict)
         )
 
 
@@ -181,15 +199,16 @@ def _use_context(
     parent_context: "_opentelemetry.Context",
 ) -> Generator[None, None, None]:
     """Uses the Ray trace context for the span."""
+    opentelemetry = _get_opentelemetry()
     if parent_context is not None:
         new_context = parent_context
     else:
-        new_context = _opentelemetry.Context()
-    token = _opentelemetry.context.attach(new_context)
+        new_context = opentelemetry.Context()
+    token = opentelemetry.context.attach(new_context)
     try:
         yield
     finally:
-        _opentelemetry.context.detach(token)
+        opentelemetry.context.detach(token)
 
 
 def _function_hydrate_span_args(function_name: str):
@@ -310,10 +329,11 @@ def _tracing_task_invocation(method):
             return method(self, args, kwargs, *_args, **_kwargs)
 
         assert "_ray_trace_ctx" not in kwargs
-        tracer = _opentelemetry.trace.get_tracer(__name__)
+        opentelemetry = _get_opentelemetry()
+        tracer = opentelemetry.trace.get_tracer(__name__)
         with tracer.start_as_current_span(
             _function_span_producer_name(self._function_name),
-            kind=_opentelemetry.trace.SpanKind.PRODUCER,
+            kind=opentelemetry.trace.SpanKind.PRODUCER,
             attributes=_function_hydrate_span_args(self._function_name),
         ):
             # Inject a _ray_trace_ctx as a dictionary
@@ -347,7 +367,8 @@ def _inject_tracing_into_function(function):
         if _ray_trace_ctx is None:
             return function(*args, **kwargs)
 
-        tracer = _opentelemetry.trace.get_tracer(__name__)
+        opentelemetry = _get_opentelemetry()
+        tracer = opentelemetry.trace.get_tracer(__name__)
         function_name = function.__module__ + "." + function.__name__
 
         # Retrieves the context from the _ray_trace_ctx dictionary we injected
@@ -355,7 +376,7 @@ def _inject_tracing_into_function(function):
             _DictPropagator.extract(_ray_trace_ctx)
         ), tracer.start_as_current_span(
             _function_span_consumer_name(function_name),
-            kind=_opentelemetry.trace.SpanKind.CONSUMER,
+            kind=opentelemetry.trace.SpanKind.CONSUMER,
             attributes=_function_hydrate_span_args(function_name),
         ):
             return function(*args, **kwargs)
@@ -386,18 +407,20 @@ def _tracing_actor_creation(method):
         class_name = self.__ray_metadata__.class_name
         method_name = "__init__"
         assert "_ray_trace_ctx" not in _kwargs
-        tracer = _opentelemetry.trace.get_tracer(__name__)
+        opentelemetry = _get_opentelemetry()
+        tracer = opentelemetry.trace.get_tracer(__name__)
         with tracer.start_as_current_span(
             name=_actor_span_producer_name(class_name, method_name),
-            kind=_opentelemetry.trace.SpanKind.PRODUCER,
+            kind=opentelemetry.trace.SpanKind.PRODUCER,
             attributes=_actor_hydrate_span_args(class_name, method_name),
         ) as span:
             # Inject a _ray_trace_ctx as a dictionary
             kwargs["_ray_trace_ctx"] = _DictPropagator.inject_current_context()
 
             result = method(self, args, kwargs, *_args, **_kwargs)
-
-            span.set_attribute("ray.actor_id", result._ray_actor_id.hex())
+            actor_id = _get_actor_id_hex(result)
+            if actor_id:
+                span.set_attribute("ray.actor_id", actor_id)
 
             return result
 
@@ -425,16 +448,19 @@ def _tracing_actor_method_invocation(method):
         method_name = self._method_name
         assert "_ray_trace_ctx" not in _kwargs
 
-        tracer = _opentelemetry.trace.get_tracer(__name__)
+        opentelemetry = _get_opentelemetry()
+        tracer = opentelemetry.trace.get_tracer(__name__)
         with tracer.start_as_current_span(
             name=_actor_span_producer_name(class_name, method_name),
-            kind=_opentelemetry.trace.SpanKind.PRODUCER,
+            kind=opentelemetry.trace.SpanKind.PRODUCER,
             attributes=_actor_hydrate_span_args(class_name, method_name),
         ) as span:
             # Inject a _ray_trace_ctx as a dictionary
             kwargs["_ray_trace_ctx"] = _DictPropagator.inject_current_context()
 
-            span.set_attribute("ray.actor_id", self._actor._ray_actor_id.hex())
+            actor_id = _get_actor_id_hex(self._actor)
+            if actor_id:
+                span.set_attribute("ray.actor_id", actor_id)
 
             return method(self, args, kwargs, *_args, **_kwargs)
 
@@ -460,7 +486,8 @@ def _inject_tracing_into_class(_cls):
             if not _is_tracing_enabled() or _ray_trace_ctx is None:
                 return method(self, *_args, **_kwargs)
 
-            tracer: _opentelemetry.trace.Tracer = _opentelemetry.trace.get_tracer(
+            opentelemetry = _get_opentelemetry()
+            tracer: opentelemetry.trace.Tracer = opentelemetry.trace.get_tracer(
                 __name__
             )
 
@@ -470,7 +497,7 @@ def _inject_tracing_into_class(_cls):
                 _DictPropagator.extract(_ray_trace_ctx)
             ), tracer.start_as_current_span(
                 _actor_span_consumer_name(self.__class__.__name__, method),
-                kind=_opentelemetry.trace.SpanKind.CONSUMER,
+                kind=opentelemetry.trace.SpanKind.CONSUMER,
                 attributes=_actor_hydrate_span_args(self.__class__.__name__, method),
             ):
                 return method(self, *_args, **_kwargs)
@@ -492,7 +519,8 @@ def _inject_tracing_into_class(_cls):
             if not _is_tracing_enabled() or _ray_trace_ctx is None:
                 return await method(self, *_args, **_kwargs)
 
-            tracer = _opentelemetry.trace.get_tracer(__name__)
+            opentelemetry = _get_opentelemetry()
+            tracer = opentelemetry.trace.get_tracer(__name__)
 
             # Retrieves the context from the _ray_trace_ctx dictionary we
             # injected, or starts a new context
@@ -500,7 +528,7 @@ def _inject_tracing_into_class(_cls):
                 _DictPropagator.extract(_ray_trace_ctx)
             ), tracer.start_as_current_span(
                 _actor_span_consumer_name(self.__class__.__name__, method.__name__),
-                kind=_opentelemetry.trace.SpanKind.CONSUMER,
+                kind=opentelemetry.trace.SpanKind.CONSUMER,
                 attributes=_actor_hydrate_span_args(
                     self.__class__.__name__, method.__name__
                 ),


### PR DESCRIPTION
## Description
This PR fixes a regression introduced in 2.54.0, where actor method wrappers can carry a stale `_opentelemetry=None` captured on the client driver and cause `None.trace` accesses on the worker side. This PR fixes it by using a `_get_opentelemetry` reader function so that we don't capture `_opentelemetry` on the client.

Additionally, Ray Client actor method results are ClientActorHandle objects that do not expose _ray_actor_id but expose an _actor_id attribute, so this PR also adds `_get_actor_id_hex` helper to retrieve the actor id accordingly for the`ray.actor_id` span attribute in client mode.

## Related issues
Original issue report: https://discuss.ray.io/t/attributeerror-nonetype-object-has-no-attribute-trace-in-2-54-0/23519
Fixes: https://github.com/ray-project/ray/issues/62952

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
