### PR TITLE
Support multiple callbacks for the same pubsub key

### DIFF
--- a/src/ray/pubsub/subscriber.cc
+++ b/src/ray/pubsub/subscriber.cc
@@ -39,10 +39,8 @@ void SubscriberChannel::Subscribe(
   const auto publisher_id = UniqueID::FromBinary(publisher_address.worker_id());
 
   if (key_id) {
-    subscription_map_[publisher_id].per_entity_subscription.try_emplace(
-        *key_id,
-        SubscriptionInfo(std::move(subscription_callback),
-                         std::move(subscription_failure_callback)));
+    subscription_map_[publisher_id].per_entity_subscription[*key_id].emplace_back(
+        std::move(subscription_callback), std::move(subscription_failure_callback));
     return;
   }
   auto &all_entities_subscription =
@@ -131,20 +129,23 @@ void SubscriberChannel::HandlePublishedMessage(const rpc::Address &publisher_add
       << rpc::ChannelType_Name(channel_type_);
 
   auto maybe_subscription_callback =
-      GetSubscriptionItemCallback(publisher_address, key_id);
+      GetSubscriptionItemCallbacks(publisher_address, key_id);
   cum_published_messages_++;
-  if (!maybe_subscription_callback.has_value()) {
+  if (maybe_subscription_callback.empty()) {
     return;
   }
   cum_processed_messages_++;
   // If the object id is still subscribed, run a callback to the callback io service.
   const auto &channel_name =
       rpc::ChannelType_descriptor()->FindValueByNumber(channel_type_)->name();
-  callback_service_->post(
-      [subscription_callback = std::move(maybe_subscription_callback.value()),
-       msg = std::move(pub_message)]() mutable  // allow data to be moved
-      { subscription_callback(std::move(msg)); },
-      "Subscriber.HandlePublishedMessage_" + channel_name);
+  const rpc::PubMessage message = pub_message;
+  for (auto &subscription_callback : maybe_subscription_callback) {
+    callback_service_->post(
+        [subscription_callback = std::move(subscription_callback), msg = message]() mutable {
+          subscription_callback(std::move(msg));
+        },
+        "Subscriber.HandlePublishedMessage_" + channel_name);
+  }
 }
 
 void SubscriberChannel::HandlePublisherFailure(const rpc::Address &publisher_address,
@@ -193,18 +194,21 @@ bool SubscriberChannel::HandlePublisherFailureInternal(
     const rpc::Address &publisher_address,
     const std::string &key_id,
     const Status &status) {
-  auto maybe_failure_callback = GetFailureCallback(publisher_address, key_id);
-  if (maybe_failure_callback.has_value()) {
-    const auto &channel_name =
-        rpc::ChannelType_descriptor()->FindValueByNumber(channel_type_)->name();
+  auto failure_callbacks = GetFailureCallbacks(publisher_address, key_id);
+  if (failure_callbacks.empty()) {
+    return false;
+  }
+
+  const auto &channel_name =
+      rpc::ChannelType_descriptor()->FindValueByNumber(channel_type_)->name();
+  for (auto &failure_callback : failure_callbacks) {
     callback_service_->post(
-        [failure_callback = std::move(maybe_failure_callback.value()), key_id, status]() {
+        [failure_callback = std::move(failure_callback), key_id, status]() {
           failure_callback(key_id, status);
         },
         "Subscriber.HandleFailureCallback_" + channel_name);
-    return true;
   }
-  return false;
+  return true;
 }
 
 std::string SubscriberChannel::DebugString() const {

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -48,13 +48,15 @@ struct SubscriptionInfo {
   SubscriptionFailureCallback failure_cb;
 };
 
+using SubscriptionInfos = std::vector<SubscriptionInfo>;
+
 /// All subscription info for the publisher.
 struct Subscriptions {
   // Subscriptions for all entities.
   std::unique_ptr<SubscriptionInfo> all_entities_subscription;
 
   // Subscriptions for each entity.
-  absl::flat_hash_map<std::string, SubscriptionInfo> per_entity_subscription;
+  absl::flat_hash_map<std::string, SubscriptionInfos> per_entity_subscription;
 };
 
 /// Subscriber channel is an abstraction for each channel.
@@ -142,42 +144,52 @@ class SubscriberChannel {
                                       const std::string &key_id,
                                       const Status &status);
 
-  /// Returns a subscription callback; Returns a nullopt if the object id is not
+  /// Returns subscription callbacks. Returns an empty vector if the object id is not
   /// subscribed.
-  std::optional<SubscriptionItemCallback> GetSubscriptionItemCallback(
+  std::vector<SubscriptionItemCallback> GetSubscriptionItemCallbacks(
       const rpc::Address &publisher_address, const std::string &key_id) const {
     const auto publisher_id = UniqueID::FromBinary(publisher_address.worker_id());
     auto subscription_it = subscription_map_.find(publisher_id);
     if (subscription_it == subscription_map_.end()) {
-      return std::nullopt;
+      return {};
     }
     if (subscription_it->second.all_entities_subscription != nullptr) {
-      return subscription_it->second.all_entities_subscription->item_cb;
+      return {subscription_it->second.all_entities_subscription->item_cb};
     }
     auto callback_it = subscription_it->second.per_entity_subscription.find(key_id);
     if (callback_it == subscription_it->second.per_entity_subscription.end()) {
-      return std::nullopt;
+      return {};
     }
-    return callback_it->second.item_cb;
+    std::vector<SubscriptionItemCallback> callbacks;
+    callbacks.reserve(callback_it->second.size());
+    for (const auto &subscription_info : callback_it->second) {
+      callbacks.push_back(subscription_info.item_cb);
+    }
+    return callbacks;
   }
 
-  /// Returns a publisher failure callback; Returns a nullopt if the object id is not
-  /// subscribed.
-  std::optional<SubscriptionFailureCallback> GetFailureCallback(
+  /// Returns publisher failure callbacks. Returns an empty vector if the object id is
+  /// not subscribed.
+  std::vector<SubscriptionFailureCallback> GetFailureCallbacks(
       const rpc::Address &publisher_address, const std::string &key_id) const {
     const auto publisher_id = UniqueID::FromBinary(publisher_address.worker_id());
     auto subscription_it = subscription_map_.find(publisher_id);
     if (subscription_it == subscription_map_.end()) {
-      return std::nullopt;
+      return {};
     }
     if (subscription_it->second.all_entities_subscription != nullptr) {
-      return subscription_it->second.all_entities_subscription->failure_cb;
+      return {subscription_it->second.all_entities_subscription->failure_cb};
     }
     auto callback_it = subscription_it->second.per_entity_subscription.find(key_id);
     if (callback_it == subscription_it->second.per_entity_subscription.end()) {
-      return std::nullopt;
+      return {};
     }
-    return callback_it->second.failure_cb;
+    std::vector<SubscriptionFailureCallback> callbacks;
+    callbacks.reserve(callback_it->second.size());
+    for (const auto &subscription_info : callback_it->second) {
+      callbacks.push_back(subscription_info.failure_cb);
+    }
+    return callbacks;
   }
 
   const rpc::ChannelType channel_type_;

--- a/src/ray/pubsub/tests/subscriber_test.cc
+++ b/src/ray/pubsub/tests/subscriber_test.cc
@@ -431,6 +431,56 @@ TEST_F(SubscriberTest, TestMultiLongPollingWithTheSameSubscription) {
   ASSERT_GT(object_subscribed_[object_id], 0);
 }
 
+TEST_F(SubscriberTest, TestMultipleSubscriptionsOnSameKey) {
+  std::unordered_map<ObjectID, int64_t> object_subscribed_1, object_subscribed_2;
+  auto subscription_callback1 = [&](const rpc::PubMessage &msg) {
+    object_subscribed_1[ObjectID::FromBinary(msg.key_id())]++;
+  };
+  auto subscription_callback2 = [&](const rpc::PubMessage &msg) {
+    object_subscribed_2[ObjectID::FromBinary(msg.key_id())]++;
+  };
+  auto failure_callback = EMPTY_FAILURE_CALLBACK;
+
+  const auto owner_addr = GenerateOwnerAddress();
+  const auto object_id = ObjectID::FromRandom();
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
+
+  subscriber_->Subscribe(GenerateSubMessage(object_id),
+                         channel,
+                         owner_addr,
+                         object_id.Binary(),
+                         /*subscribe_done_callback=*/nullptr,
+                         subscription_callback1,
+                         failure_callback);
+  subscriber_->Subscribe(GenerateSubMessage(object_id),
+                         channel,
+                         owner_addr,
+                         object_id.Binary(),
+                         /*subscribe_done_callback=*/nullptr,
+                         subscription_callback2,
+                         failure_callback);
+  ASSERT_TRUE(owner_client->ReplyCommandBatch());
+  ASSERT_TRUE(owner_client->ReplyCommandBatch());
+  ASSERT_TRUE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
+
+  std::vector<ObjectID> objects_batched;
+  objects_batched.push_back(object_id);
+  ASSERT_TRUE(ReplyLongPolling(channel, objects_batched));
+  ASSERT_EQ(object_subscribed_1[object_id], 1);
+  ASSERT_EQ(object_subscribed_2[object_id], 1);
+
+  ASSERT_TRUE(ReplyLongPolling(channel, objects_batched));
+  ASSERT_EQ(object_subscribed_1[object_id], 2);
+  ASSERT_EQ(object_subscribed_2[object_id], 2);
+
+  subscriber_->Unsubscribe(channel, owner_addr, object_id.Binary());
+  ASSERT_TRUE(owner_client->ReplyCommandBatch());
+  ASSERT_FALSE(subscriber_->IsSubscribed(channel, owner_addr, object_id.Binary()));
+
+  ASSERT_TRUE(ReplyLongPolling(channel, objects_batched));
+  ASSERT_TRUE(subscriber_->CheckNoLeaks());
+}
+
 TEST_F(SubscriberTest, TestCallbackNotInvokedForNonSubscribedObject) {
   ///
   /// Make sure the non-subscribed object's subscription callback is not called.


### PR DESCRIPTION
Summary:
- store multiple per-key subscription callbacks instead of overwriting prior subscribers
- fan out published messages and failure callbacks to every subscriber registered for the key
- add a regression test for subscribing multiple times to the same key

Fixes #45445

Testing:
- Local Bazel validation on macOS was blocked by unrelated external upb/protobuf arm64 link failures before the subscriber test target could build.