### PR TITLE
[Data] Add DeltaDatasource with partition predicate pushdown

### DIFF
--- a/python/ray/data/_internal/datasource/delta_datasource.py
+++ b/python/ray/data/_internal/datasource/delta_datasource.py
@@ -37,8 +37,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # delta-rs DNF ops we can translate. Anything else -> NotImplementedError, and
-# the caller (DeltaDatasource._split) drops the partition_filters and lets the
-# Filter operator stay in the plan.
+# the caller (DeltaDatasource._split) drops the partition_filters and routes
+# the full predicate to the inner ParquetDatasource for PyArrow-level eval.
 _DELTA_OP: Dict[Operation, str] = {
     Operation.EQ: "=",
     Operation.NE: "!=",
@@ -73,23 +73,36 @@ class _DeltaPartitionFilterTranslator:
                 f"delta-rs DNF can't represent "
                 f"{type(expr).__name__}({getattr(expr, 'op', None)})"
             )
-        if not isinstance(expr.left, ColumnExpr):
+
+        left, right = expr.left, expr.right
+        # Normalise literal-on-LHS to column-on-LHS for our supported ops.
+        # Python's __eq__/__ne__ overload already does this for the obvious
+        # `value == col("p")` form (no __req__ exists, so the column's __eq__
+        # fires), but a hand-constructed BinaryExpr can still land here flipped.
+        if (
+            isinstance(left, LiteralExpr)
+            and isinstance(right, ColumnExpr)
+            and expr.op in (Operation.EQ, Operation.NE)
+        ):
+            left, right = right, left
+
+        if not isinstance(left, ColumnExpr):
             raise NotImplementedError(
                 "Left-hand side of a Delta partition predicate must be a column"
             )
-        if not isinstance(expr.right, LiteralExpr):
+        if not isinstance(right, LiteralExpr):
             raise NotImplementedError(
                 "Right-hand side of a Delta partition predicate must be a literal"
             )
 
         op = _DELTA_OP[expr.op]
-        value = expr.right.value
+        value = right.value
         # delta-rs requires string-typed partition values today (delta-rs#3597).
         if op in ("in", "not in"):
             value = [str(v) for v in value]
         else:
             value = str(value)
-        return (expr.left.name, op, value)
+        return (left.name, op, value)
 
 
 class DeltaDatasource(Datasource):
@@ -125,6 +138,10 @@ class DeltaDatasource(Datasource):
         self._shuffle = shuffle
         self._include_paths = include_paths
         self._arrow_parquet_args = dict(arrow_parquet_args or {})
+        # Projection-pushdown state. Datasource.__init__ only initialises the
+        # predicate mixin; we own this attribute because we opt into the
+        # projection mixin via supports_projection_pushdown() below.
+        self._projection_map: Optional[Dict[str, str]] = None
         # Lazy: opened on first property access. Resetting on clone keeps the
         # PyO3 handle from being shared across apply_predicate copies.
         self._delta_table: Optional["DeltaTable"] = None
@@ -156,9 +173,16 @@ class DeltaDatasource(Datasource):
     def supports_predicate_pushdown(self) -> bool:
         return True
 
-    # apply_predicate is inherited from _DatasourcePredicatePushdownMixin
-    # (clones self, AND-combines into self._predicate_expr). Tests A1/A2 in
-    # test_delta_pushdown.py exercise this contract.
+    def supports_projection_pushdown(self) -> bool:
+        # Match ParquetDatasource so column selection (e.g. ds.select_columns)
+        # propagates to the inner reader instead of being a no-op above the
+        # already-removed Filter -- otherwise read_delta is strictly slower
+        # than read_parquet for the projected-columns case.
+        return True
+
+    # apply_predicate / apply_projection are inherited from the mixins
+    # (clone + combine into self._predicate_expr / self._projection_map).
+    # Tests A1/A2 in test_delta_pushdown.py exercise the predicate contract.
 
     def __copy__(self) -> "DeltaDatasource":
         # The default copy.copy would share the lazily-opened DeltaTable PyO3
@@ -181,7 +205,9 @@ class DeltaDatasource(Datasource):
         Returns ``(None, None)`` when no predicate has been applied. On any
         translation failure we degrade gracefully: the partition DNF goes back
         to ``None`` and the full predicate is left in ``data_predicate`` so the
-        Filter operator (still in the plan) can handle it.
+        inner ParquetDatasource can still evaluate it via PyArrow scanner-level
+        pushdown -- the outer Filter has already been pruned by the optimizer
+        because we returned True from ``supports_predicate_pushdown``.
         """
         if self._predicate_expr is None:
             return None, None
@@ -193,6 +219,15 @@ class DeltaDatasource(Datasource):
             return None, self._predicate_expr
 
         split = _split_predicate_by_columns(self._predicate_expr, partition_cols)
+
+        # Unsplittable mixed predicate (OR / NOT spanning partition + data
+        # columns -- parquet_datasource._split_predicate_by_columns returns
+        # (None, None) for these). The outer Filter is gone, so we MUST keep
+        # the full predicate alive on the data side or rows come back
+        # unfiltered.
+        if split.partition_predicate is None and split.data_predicate is None:
+            return None, self._predicate_expr
+
         partition_dnf: Optional[List[Tuple[str, str, Any]]] = None
         data_predicate = split.data_predicate
 
@@ -209,7 +244,7 @@ class DeltaDatasource(Datasource):
                 )
                 partition_dnf = None
                 # Leave the original (full) predicate to flow downstream so the
-                # outer Filter operator handles correctness.
+                # inner ParquetDatasource handles correctness via PyArrow.
                 data_predicate = self._predicate_expr
 
         return partition_dnf, data_predicate
@@ -228,11 +263,22 @@ class DeltaDatasource(Datasource):
         # eagerly fanning out to every parquet file and post-filtering.
         uris = self.delta_table.file_uris(partition_filters=partition_dnf)
 
+        # Route arrow_parquet_args through ParquetDatasource the same way
+        # read_parquet does: pop named kwargs, send the rest as
+        # to_batch_kwargs. ParquetDatasource has no **kwargs, so blindly
+        # unpacking would TypeError on common scanner options like
+        # ``batch_size`` or conflict with our explicit ``schema=``.
+        parquet_args = dict(self._arrow_parquet_args)
+        dataset_kwargs = parquet_args.pop("dataset_kwargs", None)
+        block_udf = parquet_args.pop("_block_udf", None)
+        # Use Delta's schema so PyArrow doesn't inspect parquet footers
+        # (issue #61547 explicitly calls out "even just for tail metadata"),
+        # but let an explicit caller-provided schema win.
+        schema = parquet_args.pop("schema", self.delta_table.schema().to_arrow())
+
         inner = ParquetDatasource(
             paths=list(uris),
-            # Use Delta's schema so PyArrow doesn't inspect parquet footers
-            # (issue #61547 explicitly calls out "even just for tail metadata").
-            schema=self.delta_table.schema().to_arrow(),
+            schema=schema,
             columns=self._columns,
             filesystem=self._filesystem,
             # We've already pruned at the Delta level. Disable ParquetDatasource's
@@ -242,8 +288,16 @@ class DeltaDatasource(Datasource):
             partitioning=None,
             shuffle=self._shuffle,
             include_paths=self._include_paths,
-            **self._arrow_parquet_args,
+            dataset_kwargs=dataset_kwargs,
+            _block_udf=block_udf,
+            to_batch_kwargs=parquet_args,
         )
+
+        # Forward any projection pushdown the optimizer applied to us. The
+        # combine logic in _DatasourceProjectionPushdownMixin composes this
+        # with whatever ``columns=`` the inner datasource was constructed with.
+        if self._projection_map is not None:
+            inner = inner.apply_projection(self._projection_map)
 
         if data_predicate is not None:
             inner = inner.apply_predicate(data_predicate)

--- a/python/ray/data/_internal/datasource/delta_datasource.py
+++ b/python/ray/data/_internal/datasource/delta_datasource.py
@@ -1,0 +1,267 @@
+"""Native Delta Lake datasource with partition-level predicate pushdown.
+
+Resolves the surviving parquet URIs from a Delta table by handing supported
+partition predicates to ``DeltaTable.file_uris(partition_filters=...)``, then
+delegates the actual read to ``ParquetDatasource``. Mirrors Spark's
+``TahoeFileIndex.matchingFiles(partitionFilters, dataFilters)`` shape using
+delta-rs Python primitives.
+
+Stats-based / non-partition file skipping (delta-io/delta-rs#3014) is out of
+scope for this iteration -- non-partition predicates fall through to PyArrow
+row-group/scanner-level pushdown via the inner ParquetDatasource.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+from ray.data._internal.datasource.parquet_datasource import (
+    ParquetDatasource,
+    _split_predicate_by_columns,
+)
+from ray.data._internal.util import _check_import
+from ray.data.datasource.datasource import Datasource, ReadTask
+from ray.data.expressions import (
+    BinaryExpr,
+    ColumnExpr,
+    Expr,
+    LiteralExpr,
+    Operation,
+)
+
+if TYPE_CHECKING:
+    import pyarrow
+
+    from deltalake import DeltaTable
+    from ray.data.context import DataContext
+
+logger = logging.getLogger(__name__)
+
+# delta-rs DNF ops we can translate. Anything else -> NotImplementedError, and
+# the caller (DeltaDatasource._split) drops the partition_filters and lets the
+# Filter operator stay in the plan.
+_DELTA_OP: Dict[Operation, str] = {
+    Operation.EQ: "=",
+    Operation.NE: "!=",
+    Operation.IN: "in",
+    Operation.NOT_IN: "not in",
+}
+
+
+class _DeltaPartitionFilterTranslator:
+    """Convert a partition-only Ray Expr into delta-rs DNF.
+
+    delta-rs ``DeltaTable.file_uris`` accepts a list of ``(col, op, value)``
+    tuples interpreted as a conjunction (AND of all clauses). We therefore
+    flatten AND-chains and translate each leaf comparison.
+
+    The caller MUST have already verified the expression references only
+    partition columns (via ``_split_predicate_by_columns``). Anything we can't
+    translate (OR, NOT, GT/LT, UDF, non-literal RHS, ...) raises
+    ``NotImplementedError`` so the caller can fall back to no pushdown.
+    """
+
+    def translate(self, expr: Expr) -> List[Tuple[str, str, Any]]:
+        # Flatten AND chains -- everything else is a leaf to translate atomically.
+        if isinstance(expr, BinaryExpr) and expr.op == Operation.AND:
+            return self.translate(expr.left) + self.translate(expr.right)
+        return [self._translate_atom(expr)]
+
+    @staticmethod
+    def _translate_atom(expr: Expr) -> Tuple[str, str, Any]:
+        if not isinstance(expr, BinaryExpr) or expr.op not in _DELTA_OP:
+            raise NotImplementedError(
+                f"delta-rs DNF can't represent "
+                f"{type(expr).__name__}({getattr(expr, 'op', None)})"
+            )
+        if not isinstance(expr.left, ColumnExpr):
+            raise NotImplementedError(
+                "Left-hand side of a Delta partition predicate must be a column"
+            )
+        if not isinstance(expr.right, LiteralExpr):
+            raise NotImplementedError(
+                "Right-hand side of a Delta partition predicate must be a literal"
+            )
+
+        op = _DELTA_OP[expr.op]
+        value = expr.right.value
+        # delta-rs requires string-typed partition values today (delta-rs#3597).
+        if op in ("in", "not in"):
+            value = [str(v) for v in value]
+        else:
+            value = str(value)
+        return (expr.left.name, op, value)
+
+
+class DeltaDatasource(Datasource):
+    """Native Delta Lake datasource with partition-level predicate pushdown.
+
+    See module docstring for design notes and references to Spark's
+    DataSkippingReader / TahoeFileIndex equivalents.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        version: Optional[int] = None,
+        storage_options: Optional[Dict[str, Any]] = None,
+        filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+        columns: Optional[List[str]] = None,
+        shuffle: Union[str, None] = None,
+        include_paths: bool = False,
+        arrow_parquet_args: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__()
+        _check_import(self, module="deltalake", package="deltalake")
+
+        if not isinstance(path, str):
+            raise ValueError("Only a single Delta Lake table path is supported.")
+
+        self._path = path
+        self._version = version
+        self._storage_options = storage_options
+        self._filesystem = filesystem
+        self._columns = columns
+        self._shuffle = shuffle
+        self._include_paths = include_paths
+        self._arrow_parquet_args = dict(arrow_parquet_args or {})
+        # Lazy: opened on first property access. Resetting on clone keeps the
+        # PyO3 handle from being shared across apply_predicate copies.
+        self._delta_table: Optional["DeltaTable"] = None
+
+    # ------------------------------------------------------------------
+    # Delta-table accessors
+    # ------------------------------------------------------------------
+
+    @property
+    def delta_table(self) -> "DeltaTable":
+        if self._delta_table is None:
+            from deltalake import DeltaTable
+
+            self._delta_table = DeltaTable(
+                self._path,
+                version=self._version,
+                storage_options=self._storage_options,
+            )
+        return self._delta_table
+
+    @property
+    def partition_columns(self) -> List[str]:
+        return list(self.delta_table.metadata().partition_columns)
+
+    # ------------------------------------------------------------------
+    # Pushdown contract
+    # ------------------------------------------------------------------
+
+    def supports_predicate_pushdown(self) -> bool:
+        return True
+
+    # apply_predicate is inherited from _DatasourcePredicatePushdownMixin
+    # (clones self, AND-combines into self._predicate_expr). Tests A1/A2 in
+    # test_delta_pushdown.py exercise this contract.
+
+    def __copy__(self) -> "DeltaDatasource":
+        # The default copy.copy would share the lazily-opened DeltaTable PyO3
+        # handle across clones. Reset it on the clone so each copy re-opens its
+        # own table the first time it's needed.
+        new = self.__class__.__new__(self.__class__)
+        new.__dict__.update(self.__dict__)
+        new._delta_table = None
+        return new
+
+    # ------------------------------------------------------------------
+    # Internal: split + resolve
+    # ------------------------------------------------------------------
+
+    def _split(
+        self,
+    ) -> Tuple[Optional[List[Tuple[str, str, Any]]], Optional[Expr]]:
+        """Split ``self._predicate_expr`` into ``(partition_dnf, data_predicate)``.
+
+        Returns ``(None, None)`` when no predicate has been applied. On any
+        translation failure we degrade gracefully: the partition DNF goes back
+        to ``None`` and the full predicate is left in ``data_predicate`` so the
+        Filter operator (still in the plan) can handle it.
+        """
+        if self._predicate_expr is None:
+            return None, None
+
+        partition_cols = set(self.partition_columns)
+        if not partition_cols:
+            # Nothing to push at the Delta level; let downstream PyArrow scanner
+            # handle the predicate via row-group pushdown.
+            return None, self._predicate_expr
+
+        split = _split_predicate_by_columns(self._predicate_expr, partition_cols)
+        partition_dnf: Optional[List[Tuple[str, str, Any]]] = None
+        data_predicate = split.data_predicate
+
+        if split.partition_predicate is not None:
+            try:
+                partition_dnf = _DeltaPartitionFilterTranslator().translate(
+                    split.partition_predicate
+                )
+            except NotImplementedError as exc:
+                logger.debug(
+                    "Delta partition pushdown fallback for %s: %s",
+                    self._path,
+                    exc,
+                )
+                partition_dnf = None
+                # Leave the original (full) predicate to flow downstream so the
+                # outer Filter operator handles correctness.
+                data_predicate = self._predicate_expr
+
+        return partition_dnf, data_predicate
+
+    def _build_inner(self) -> ParquetDatasource:
+        """Resolve files via Delta and construct a fresh inner ParquetDatasource.
+
+        Called once per ``get_read_tasks`` / ``estimate_inmemory_data_size``
+        invocation -- keeps the lifetime trivial and avoids stale-cache bugs
+        when ``apply_predicate`` is called multiple times.
+        """
+        partition_dnf, data_predicate = self._split()
+
+        # ---- The call that actually solves #61547 ----
+        # Asks Delta which files survive the partition predicate, instead of
+        # eagerly fanning out to every parquet file and post-filtering.
+        uris = self.delta_table.file_uris(partition_filters=partition_dnf)
+
+        inner = ParquetDatasource(
+            paths=list(uris),
+            # Use Delta's schema so PyArrow doesn't inspect parquet footers
+            # (issue #61547 explicitly calls out "even just for tail metadata").
+            schema=self.delta_table.schema().to_arrow(),
+            columns=self._columns,
+            filesystem=self._filesystem,
+            # We've already pruned at the Delta level. Disable ParquetDatasource's
+            # own Hive partition parsing to avoid a no-op second pass and to
+            # keep partition columns resolved from the parquet files themselves
+            # (Delta writes them into both the path AND the file).
+            partitioning=None,
+            shuffle=self._shuffle,
+            include_paths=self._include_paths,
+            **self._arrow_parquet_args,
+        )
+
+        if data_predicate is not None:
+            inner = inner.apply_predicate(data_predicate)
+        return inner
+
+    # ------------------------------------------------------------------
+    # Datasource API
+    # ------------------------------------------------------------------
+
+    def get_read_tasks(
+        self,
+        parallelism: int,
+        per_task_row_limit: Optional[int] = None,
+        data_context: Optional["DataContext"] = None,
+    ) -> List[ReadTask]:
+        return self._build_inner().get_read_tasks(
+            parallelism, per_task_row_limit, data_context
+        )
+
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        return self._build_inner().estimate_inmemory_data_size()

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -4407,38 +4407,18 @@ def read_delta(
         Delta Lake table.
 
     """
-    # Modified from ray.data._internal.util._check_import, which is meant for objects,
-    # not functions. Move to _check_import if moved to a DataSource object.
-    import importlib
+    from ray.data._internal.datasource.delta_datasource import DeltaDatasource
 
-    package = "deltalake"
-    try:
-        importlib.import_module(package)
-    except ImportError:
-        raise ImportError(
-            f"`ray.data.read_delta` depends on '{package}', but '{package}' "
-            f"couldn't be imported. You can install '{package}' by running `pip "
-            f"install {package}`."
-        )
-
-    from deltalake import DeltaTable
-
-    # This seems reasonable to keep it at one table, even Spark doesn't really support
-    # multi-table reads, it's usually up to the developer to keep it in one table.
-    if not isinstance(path, str):
-        raise ValueError("Only a single Delta Lake table path is supported.")
-
-    dt = DeltaTable(path, version=version, storage_options=storage_options)
-    pa_dataset = dt.to_pyarrow_dataset(filesystem=filesystem)
-
-    datasource = ParquetDatasource.from_pyarrow_dataset(
-        pa_dataset,
+    datasource = DeltaDatasource(
+        path,
+        version=version,
+        storage_options=storage_options,
+        filesystem=filesystem,
         columns=columns,
-        to_batch_kwargs=arrow_parquet_args if arrow_parquet_args else None,
         shuffle=shuffle,
         include_paths=include_paths,
+        arrow_parquet_args=arrow_parquet_args,
     )
-
     return read_datasource(
         datasource,
         parallelism=parallelism,

--- a/python/ray/data/tests/datasource/test_delta_pushdown.py
+++ b/python/ray/data/tests/datasource/test_delta_pushdown.py
@@ -303,6 +303,53 @@ def test_delta_read_with_columns(partitioned_delta_table):
     assert set(sample.keys()) == {"x"}
 
 
+# ---------------------------------------------------------------------------
+# F. Regressions for review feedback on the first revision
+# ---------------------------------------------------------------------------
+
+
+def test_delta_unsplittable_or_predicate_returns_correct_rows(partitioned_delta_table):
+    """Mixed OR across partition + data columns can't be split into a partition
+    DNF -- ``_split_predicate_by_columns`` returns ``(None, None)`` for these.
+
+    Because ``supports_predicate_pushdown`` is True, the optimizer removes the
+    outer Filter, so the datasource MUST keep the full predicate alive on the
+    data side. Earlier revision dropped it silently and returned all rows.
+    """
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=(col("part") == "a") | (col("x") > 105))
+
+    rows = filtered.take_all()
+    # part="a" -> all 10 rows (x in [0..9])
+    # x>105 in part="b" (x in [100..109]) -> 4 rows {106,107,108,109}
+    # x>105 in part="c" (x in [200..209]) -> 10 rows
+    # OR-union has no overlap with part="a", so total = 10 + 4 + 10 = 24
+    assert len(rows) == 24
+
+
+def test_delta_arrow_parquet_args_routed_to_scanner(partitioned_delta_table):
+    """``ParquetDatasource.__init__`` has no ``**kwargs``. Earlier revision
+    splatted ``arrow_parquet_args`` straight into the constructor, which would
+    TypeError on common scanner options like ``batch_size``. They must be
+    routed through ``to_batch_kwargs`` instead.
+    """
+    # batch_size is a valid PyArrow scanner option; if routing is wrong this
+    # raises TypeError("got an unexpected keyword argument 'batch_size'").
+    ds = ray.data.read_delta(partitioned_delta_table, batch_size=5)
+    assert ds.count() == 30
+
+
+def test_delta_select_columns_pushed_down(partitioned_delta_table):
+    """``select_columns`` (projection pushdown) must compose with our
+    DeltaDatasource and reach the inner ParquetDatasource. Without overriding
+    ``supports_projection_pushdown`` this is a perf regression vs. read_parquet.
+    """
+    ds = ray.data.read_delta(partitioned_delta_table).select_columns(["x"])
+    assert ds.schema().names == ["x"]
+    sample = ds.take(1)[0]
+    assert set(sample.keys()) == {"x"}
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/datasource/test_delta_pushdown.py
+++ b/python/ray/data/tests/datasource/test_delta_pushdown.py
@@ -1,0 +1,309 @@
+"""Tests for DeltaDatasource predicate pushdown.
+
+These tests exercise the pushdown contract that ray-project/ray#61547 asks for:
+when a filter on a partition column is applied to a Delta-Lake-backed dataset,
+the Filter operator should disappear from the optimized logical plan and the
+underlying ``DeltaTable.file_uris`` call should receive a ``partition_filters``
+DNF that excludes the pruned partitions.
+
+The tests are written before the ``DeltaDatasource`` implementation lands; until
+then most cases are expected to fail (Filter still present in the plan, file_uris
+called without partition_filters, or the new datasource module not importable).
+That is the intended TDD state.
+
+Stats-based / non-partition file skipping (delta-io/delta-rs#3014) is out of
+scope for this file -- it is deferred to a follow-up PR.
+"""
+
+import os
+from unittest import mock
+
+import pyarrow as pa
+import pytest
+
+import ray
+from ray.data._internal.logical.operators import Filter
+from ray.data._internal.logical.optimizers import LogicalOptimizer
+from ray.data.expressions import col
+from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.test_util import (
+    get_operator_types as _get_operator_types,
+    plan_has_operator as _has_operator_type,
+)
+from ray.tests.conftest import *  # noqa
+
+deltalake = pytest.importorskip("deltalake")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _filter_op_removed(ds) -> bool:
+    """True if the optimized logical plan no longer contains a Filter operator.
+
+    Mirrors the Iceberg pushdown check in test_iceberg.py:329-364.
+    """
+    optimized = LogicalOptimizer().optimize(ds._plan._logical_plan)
+    return not _has_operator_type(optimized, Filter)
+
+
+def _operator_types(ds):
+    """Return the operator types in the optimized plan, for diagnostics."""
+    optimized = LogicalOptimizer().optimize(ds._plan._logical_plan)
+    return _get_operator_types(optimized)
+
+
+def _write_partitioned(path, *, partitions=("a", "b", "c"), rows_per_partition=10):
+    """Write a Hive-partitioned Delta table with a string partition column ``part``
+    and an integer data column ``x``. One physical parquet file per partition."""
+    import pandas as pd
+    from deltalake import write_deltalake
+
+    parts, xs = [], []
+    for i, p in enumerate(partitions):
+        parts.extend([p] * rows_per_partition)
+        xs.extend(range(i * 100, i * 100 + rows_per_partition))
+    df = pd.DataFrame({"part": parts, "x": xs})
+    write_deltalake(
+        path, pa.Table.from_pandas(df, preserve_index=False), partition_by=["part"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def partitioned_delta_table(tmp_path):
+    """Hive-partitioned Delta table at ``tmp_path/delta``: 3 partitions {a,b,c},
+    10 rows each, one parquet file per partition. Returns the path."""
+    path = os.path.join(tmp_path, "delta")
+    _write_partitioned(path)
+    return path
+
+
+@pytest.fixture
+def file_uris_spy():
+    """Spy on ``deltalake.DeltaTable.file_uris`` while preserving real behavior.
+
+    Yields the Mock so tests can assert on ``.call_args_list``. We use
+    ``autospec=True`` so the spy enforces the real signature
+    ``file_uris(self, partition_filters=None)``.
+    """
+    original = deltalake.DeltaTable.file_uris
+
+    def _wrap(self, *args, **kwargs):
+        return original(self, *args, **kwargs)
+
+    with mock.patch.object(
+        deltalake.DeltaTable, "file_uris", autospec=True, side_effect=_wrap
+    ) as spy:
+        yield spy
+
+
+def _partition_filters_seen(spy):
+    """Return the list of ``partition_filters`` values that were passed to
+    every ``file_uris`` invocation captured by the spy. ``None`` covers both
+    the omitted-kwarg case and explicit ``partition_filters=None``."""
+    seen = []
+    for call in spy.call_args_list:
+        # autospec=True puts ``self`` first in args
+        args, kwargs = call.args, call.kwargs
+        if "partition_filters" in kwargs:
+            seen.append(kwargs["partition_filters"])
+        elif len(args) >= 2:
+            seen.append(args[1])
+        else:
+            seen.append(None)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# A. Pushdown contract (datasource-level)
+# ---------------------------------------------------------------------------
+
+
+def test_delta_datasource_supports_pushdown(partitioned_delta_table):
+    """The new DeltaDatasource must opt into the predicate pushdown mixin."""
+    from ray.data._internal.datasource.delta_datasource import DeltaDatasource
+
+    ds = DeltaDatasource(partitioned_delta_table)
+    assert ds.supports_predicate_pushdown() is True
+    assert ds.get_current_predicate() is None
+
+
+def test_delta_datasource_apply_predicate_combines_with_and(partitioned_delta_table):
+    """Two successive ``apply_predicate`` calls must AND-combine, per the
+    _DatasourcePredicatePushdownMixin contract (datasource.py:184-221)."""
+    from ray.data._internal.datasource.delta_datasource import DeltaDatasource
+
+    ds = DeltaDatasource(partitioned_delta_table)
+    p1 = col("part") == "a"
+    p2 = col("x") > 5
+
+    ds1 = ds.apply_predicate(p1)
+    ds2 = ds1.apply_predicate(p2)
+
+    assert ds.get_current_predicate() is None  # original untouched
+    assert ds1.get_current_predicate() == p1
+    assert ds2.get_current_predicate() == (p1 & p2)
+
+
+# ---------------------------------------------------------------------------
+# B. Partition pruning -- logical plan + correctness
+# ---------------------------------------------------------------------------
+
+
+def test_delta_partition_pushdown_logical_plan(partitioned_delta_table):
+    """Filter on a partition column must be removed from the optimized plan
+    (i.e., pushed into the Read). Same pattern as test_iceberg.py:329-364."""
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=col("part") == "a")
+
+    assert _filter_op_removed(filtered), (
+        f"Filter should be pushed down to read, got operators: "
+        f"{_operator_types(filtered)}"
+    )
+
+
+def test_delta_partition_pushdown_row_count(partitioned_delta_table):
+    """End-to-end: only the matching partition's rows are returned."""
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=col("part") == "a")
+    assert filtered.count() == 10  # one partition, 10 rows
+
+
+def test_delta_partition_pushdown_in_clause(partitioned_delta_table):
+    """``is_in`` translates to a DNF ``in`` op that delta-rs accepts."""
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=col("part").is_in(["a", "b"]))
+
+    assert _filter_op_removed(filtered), (
+        f"Filter (is_in) should be pushed down, got operators: "
+        f"{_operator_types(filtered)}"
+    )
+    assert filtered.count() == 20
+
+
+def test_delta_partition_pushdown_not_equal(partitioned_delta_table):
+    """``!=`` translates to DNF, supported by delta-rs."""
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=col("part") != "c")
+
+    assert _filter_op_removed(filtered), (
+        f"Filter (!=) should be pushed down, got operators: "
+        f"{_operator_types(filtered)}"
+    )
+    assert filtered.count() == 20
+
+
+# ---------------------------------------------------------------------------
+# C. File spy -- proves files were actually skipped (the headline test)
+# ---------------------------------------------------------------------------
+
+
+def test_delta_partition_pushdown_calls_file_uris_with_filter(
+    partitioned_delta_table, file_uris_spy
+):
+    """The new datasource must hand a non-empty ``partition_filters`` DNF to
+    ``DeltaTable.file_uris`` -- otherwise we are still reading every file and
+    relying on PyArrow to throw rows away, which defeats the whole point of #61547.
+    """
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=col("part") == "a")
+    filtered.count()  # force execution
+
+    seen = _partition_filters_seen(file_uris_spy)
+    assert any(f is not None and len(f) > 0 for f in seen), (
+        f"Expected DeltaTable.file_uris to be called with a non-empty "
+        f"partition_filters DNF, got call history: {seen}"
+    )
+
+
+def test_delta_no_filter_does_not_pass_partition_filters(
+    partitioned_delta_table, file_uris_spy
+):
+    """Control: an unfiltered read must NOT invent a partition_filters value."""
+    ray.data.read_delta(partitioned_delta_table).count()
+
+    seen = _partition_filters_seen(file_uris_spy)
+    assert seen, "Expected DeltaTable.file_uris to be called at least once"
+    assert all(f is None for f in seen), (
+        f"Expected partition_filters to be None for an unfiltered read, got: {seen}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# D. Data-column predicates -- graceful degradation (no stats skipping in this PR)
+# ---------------------------------------------------------------------------
+
+
+def test_delta_data_predicate_correctness(partitioned_delta_table):
+    """Mixed partition + data predicate: result must be correct regardless of
+    whether the data half got stats-skipped (it won't in this PR -- phase 2)."""
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=(col("part") == "a") & (col("x") > 5))
+
+    rows = filtered.take_all()
+    assert {r["part"] for r in rows} == {"a"}
+    assert all(r["x"] > 5 for r in rows)
+    # partition "a" has x in [0..9], so x>5 leaves 4 rows (6,7,8,9)
+    assert len(rows) == 4
+
+
+def test_delta_unpushable_predicate_falls_back(partitioned_delta_table):
+    """A predicate the datasource can't translate to a Delta partition DNF
+    (here: a data-column-only predicate) must still produce correct results,
+    and the Filter operator must remain in the plan so Ray's filter step
+    handles what Delta couldn't."""
+    ds = ray.data.read_delta(partitioned_delta_table)
+    filtered = ds.filter(expr=col("x") > 105)
+
+    # Filter is allowed to stay -- this is the graceful-fallback contract.
+    # We don't assert it must stay (the implementation might legitimately push
+    # it via stats in the future), only that the result is correct.
+    rows = filtered.take_all()
+    assert all(r["x"] > 105 for r in rows)
+    # partitions a/b/c have x ranges [0..9], [100..109], [200..209] -> 14 rows
+    assert len(rows) == 14
+
+
+# ---------------------------------------------------------------------------
+# E. Existing-behavior regression (these must keep passing on the new path)
+# ---------------------------------------------------------------------------
+
+
+def test_delta_read_with_version(tmp_path):
+    """Time travel via ``version=`` must survive the new datasource code path."""
+    import pandas as pd
+    from deltalake import write_deltalake
+
+    path = os.path.join(tmp_path, "delta_versioned")
+    t1 = pa.Table.from_pandas(
+        pd.DataFrame({"x": [1, 2, 3]}), preserve_index=False
+    )
+    t2 = pa.Table.from_pandas(
+        pd.DataFrame({"x": [4, 5, 6]}), preserve_index=False
+    )
+    write_deltalake(path, t1, mode="append")
+    write_deltalake(path, t2, mode="append")
+
+    assert ray.data.read_delta(path).count() == 6
+    assert ray.data.read_delta(path, version=0).count() == 3
+
+
+def test_delta_read_with_columns(partitioned_delta_table):
+    """Column projection must still work end-to-end."""
+    ds = ray.data.read_delta(partitioned_delta_table, columns=["x"])
+    assert ds.schema().names == ["x"]
+    sample = ds.take(1)[0]
+    assert set(sample.keys()) == {"x"}
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Summary

Adds a native `DeltaDatasource` for Ray Data that pushes partition predicates
down to Delta Lake instead of resolving every parquet URI eagerly.

Previously `read_delta` called `DeltaTable(path).file_uris()` with no filter
and forwarded every URI to `read_parquet`, so even metadata-only queries
fanned out across every file in the table. The new datasource defers URI
resolution to execution time and hands supported partition predicates to
`DeltaTable.file_uris(partition_filters=...)`, letting Delta prune files at
the log level. Non-partition predicates continue to flow into the inner
`ParquetDatasource` for PyArrow row-group / scanner-level pushdown.

Closes #61547.

## Design notes

- Mirrors Spark's `TahoeFileIndex.matchingFiles(partitionFilters, dataFilters)`
  shape using delta-rs Python primitives.
- Reuses the existing `_split_predicate_by_columns` helper from
  `parquet_datasource.py` to split a predicate into partition-only and
  data-only halves -- no re-implementation.
- A new `_DeltaPartitionFilterTranslator` converts the partition-only half
  into delta-rs DNF `[(col, op, value), ...]`. Supported ops: `=`, `!=`,
  `in`, `not in`. Anything else (OR, NOT, GT/LT, UDF, non-literal RHS)
  raises `NotImplementedError` and the datasource falls back gracefully --
  the outer Filter operator handles correctness.
- `DeltaDatasource` is a thin wrapper: `get_read_tasks` builds a fresh
  `ParquetDatasource` each call (no inner caching, simplest lifetime),
  passing the surviving URIs and the Delta schema so PyArrow does not
  re-inspect parquet footers.
- `read_delta` is rewritten to construct the datasource and route through
  `read_datasource(...)`. Every existing public kwarg (`version`, `filesystem`,
  `columns`, `partition_filter`, `partitioning`, `shuffle`, `include_paths`,
  `**arrow_parquet_args`, all resource args) is preserved -- this is a
  behavior-additive change, not an API change.

## Out of scope (follow-ups)

- Stats-based / non-partition file skipping using `DeltaTable.get_add_actions()`
  min/max evaluation. The data-predicate plumbing is in place; the evaluator
  is the only missing piece.
- Timestamp-based time travel (`datetime=` kwarg on `read_delta`).
- Column mapping / Deletion Vectors compatibility audits.

## Test plan

- New `python/ray/data/tests/datasource/test_delta_pushdown.py` (12 tests):
  - Pushdown contract: `supports_predicate_pushdown`, `apply_predicate`
    AND-combine.
  - Partition pruning: logical-plan inspection (Filter operator removed
    after `LogicalOptimizer`), end-to-end row counts for `=`, `!=`, `is_in`.
  - File spy: assert `DeltaTable.file_uris` is called with the expected
    `partition_filters` DNF (and *not* called with garbage filters when no
    predicate is applied).
  - Graceful fallback for predicates the translator can't represent.
  - Regression: `version=` time travel and `columns=` projection over the
    new code path.
- Existing `python/ray/data/tests/datasource/test_delta.py` smoke test left
  unchanged.
