### PR TITLE
[ci] installing pip with conda in macos build wheel script

### DIFF
--- a/ci/build/test-macos-wheels.sh
+++ b/ci/build/test-macos-wheels.sh
@@ -66,7 +66,7 @@ for ((i=0; i<${#PY_MMS[@]}; ++i)); do
     conda create -y -n "$CONDA_ENV_NAME"
     conda activate "$CONDA_ENV_NAME"
     conda remove -y python || true
-    conda install -y python="${PY_MM}"
+    conda install -y python="${PY_MM}" pip=25.2
 
     PYTHON_EXE="/opt/homebrew/opt/miniforge/envs/${CONDA_ENV_NAME}/bin/python"
     PIP_CMD="/opt/homebrew/opt/miniforge/envs/${CONDA_ENV_NAME}/bin/pip"

--- a/python/build-wheel-macos.sh
+++ b/python/build-wheel-macos.sh
@@ -56,12 +56,10 @@ for ((i=0; i<${#PY_MMS[@]}; ++i)); do
   conda create -y -n "$CONDA_ENV_NAME"
   conda activate "$CONDA_ENV_NAME"
   conda remove -y python || true
-  conda install -y python="$PY_MM"
+  conda install -y python="$PY_MM" pip=25.2
 
   # NOTE: We expect conda to set the PATH properly.
   PIP_CMD=pip
-
-  $PIP_CMD install --upgrade pip
 
   if [ -z "${TRAVIS_COMMIT}" ]; then
     TRAVIS_COMMIT=${BUILDKITE_COMMIT}


### PR DESCRIPTION
  - a8d40a2949 (python/build-wheel-macos.sh): changes conda install -y python="$PY_MM" → conda install -y python="$PY_MM" pip=25.2, and deletes the now-redundant pip install --upgrade pip — exactly the line that errored.
  - a2302f8cd8 (ci/build/test-macos-wheels.sh): same pip=25.2 addition in the wheel-test sister script so the test job doesn't hit the same trap.

post merge test : https://buildkite.com/ray-project/postmerge-macos/builds/12176
