### PR TITLE
[serve][3/n] deflake test_direct_ingress

### DIFF
--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -927,9 +927,21 @@ def test_crashed_replica_port_is_released_and_reused(
     assert len(after_crash_http_ports) == 4
     assert len(after_crash_grpc_ports) == 4
 
-    # show that smart port selection is working even with crashed ports
-    assert set(after_crash_http_ports) == set(http_ports)
-    assert set(after_crash_grpc_ports) == set(grpc_ports)
+    # Show that smart port selection is working even with crashed ports.
+    # We expect the used ports to be within 4 ports of the original ports since
+    # we have 4 replicas and they can all be in TIME_WAIT state after deletion.
+    assert set(after_crash_http_ports).issubset(
+        range(
+            RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT,
+            RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT + 8,
+        )
+    )
+    assert set(after_crash_grpc_ports).issubset(
+        range(
+            RAY_SERVE_DIRECT_INGRESS_MIN_GRPC_PORT,
+            RAY_SERVE_DIRECT_INGRESS_MIN_GRPC_PORT + 8,
+        )
+    )
 
     # make requests to the application
     for http_port in http_ports:

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -521,28 +521,36 @@ def test_health_check(_skip_if_ff_not_enabled, serve_instance):
 
 
 def _occupy_ports(ports: list) -> list:
-    """Wait for ports to be free, then bind and return the sockets.
-
-    Previous tests' replica actors may still be shutting down (the Serve
-    application status transitions to NOT_STARTED before the OS releases the
-    socket), so we wait for all ports to be bindable first.
     """
-    wait_for_condition(all_ports_can_be_bound, ports=ports, timeout=120)
-    sockets = []
-    for port in ports:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.bind(("localhost", port))
-        sock.listen(1)
-        sockets.append(sock)
-    return sockets
+    Waits up to 120s for all ports to become bindable (previous replicas may
+    still be shutting down). If some ports remain occupied (e.g. by Ray
+    internal services that were assigned random ephemeral ports), we proceed
+    anyway and bind what we can — those ports are equally blocked for replicas.
+    """
+    deadline = time.monotonic() + 120
+    while True:
+        sockets = []
+        for port in ports:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("localhost", port))
+                sock.listen(1)
+                sockets.append(sock)
+            except OSError:
+                sock.close()
+        if len(sockets) == len(ports) or time.monotonic() >= deadline:
+            return sockets
+        for s in sockets:
+            s.close()
+        time.sleep(1)
 
 
 def test_port_retry_logic(_skip_if_ff_not_enabled, serve_instance):
     """Test that replicas retry port allocation when ports are in use."""
 
     # Start occupying the min HTTP and gRPC ports
-    http_sock, grpc_sock = _occupy_ports(
+    sockets = _occupy_ports(
         [RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT, RAY_SERVE_DIRECT_INGRESS_MIN_GRPC_PORT]
     )
 
@@ -577,9 +585,8 @@ def test_port_retry_logic(_skip_if_ff_not_enabled, serve_instance):
         assert r.text == "Hello world!"
 
     finally:
-        # Clean up the sockets
-        http_sock.close()
-        grpc_sock.close()
+        for s in sockets:
+            s.close()
 
 
 def test_replica_gives_up_after_max_port_retries_for_http(

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -944,11 +944,11 @@ def test_crashed_replica_port_is_released_and_reused(
     )
 
     # make requests to the application
-    for http_port in http_ports:
+    for http_port in after_crash_http_ports:
         req = httpx.get(f"http://localhost:{http_port}/")
         assert req.status_code == 200
         assert req.text == "Hello world!"
-    for grpc_port in grpc_ports:
+    for grpc_port in after_crash_grpc_ports:
         channel = grpc.insecure_channel(f"localhost:{grpc_port}")
         stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
         assert stub.Method1(serve_pb2.UserDefinedMessage()).greeting == "Hello world!"


### PR DESCRIPTION
we forcefully shut down the replica processes. serve will restart them on the lowest available ports, however it may not always match the original ports in case they enter TIME_WAIT. this PR relaxes the constraint

also instead of requiring the `_occupy_ports` function to guarantee all ports can be bound, it optimistically does so and assumes any port that can't be bound within 120 seconds to already be occupied.