### PR TITLE
[data][1/n] DataSourceV2: refactor V2 listing/scanner/reader infrastructure

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -60,6 +60,10 @@ _MIN_PYARROW_VERSION_TO_NUMPY_ZERO_COPY_ONLY = parse_version("13.0.0")
 _BATCH_SIZE_PRESERVING_STUB_COL_NAME = "__bsp_stub"
 
 
+def _is_user_visible_column(name: str) -> bool:
+    return name != _BATCH_SIZE_PRESERVING_STUB_COL_NAME
+
+
 # Set the max chunk size in bytes for Arrow to Batches conversion in
 # ArrowBlockAccessor.iter_rows(). Default to 4MB, to optimize for image
 # datasets in parquet format.
@@ -387,9 +391,18 @@ class ArrowBlockAccessor(TableBlockAccessor):
                 f"Arrow blocks, but got: {columns}."
             )
         if len(columns) == 0:
-            # Applicable for count which does an empty projection.
-            # Pyarrow returns a table with 0 columns and num_rows rows.
-            return self.fill_column(_BATCH_SIZE_PRESERVING_STUB_COL_NAME, None)
+            # Empty projection (e.g. count or ``select_columns([])``).
+            # Drop every existing column, then append the stub so row
+            # counts survive downstream ``pa.concat_tables`` calls (which
+            # collapse num_rows to 0 when all inputs have 0 columns).
+            # ``pa.Table`` tracks num_rows as metadata independent of
+            # columns, so ``select([])`` preserves it here. The stub is
+            # filtered out of the user-visible schema; it's a physical
+            # placeholder only.
+            narrowed = self._table.select([])
+            return ArrowBlockAccessor(narrowed).fill_column(
+                _BATCH_SIZE_PRESERVING_STUB_COL_NAME, None
+            )
         return self._table.select(columns)
 
     def rename_columns(self, columns_rename: Dict[str, str]) -> "pyarrow.Table":

--- a/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
@@ -58,11 +58,34 @@ class FileManifest:
         """
         return self._block
 
+    @classmethod
+    def concat(cls, manifests: List["FileManifest"]) -> "FileManifest":
+        """Return a new `FileManifest` whose rows are the concatenation of
+        ``manifests`` in order.
+
+        Row alignment of ``paths`` / ``file_sizes`` is preserved because
+        each input already satisfies it.
+        """
+        assert len(manifests) > 0, "concat requires at least one manifest"
+        if len(manifests) == 1:
+            return manifests[0]
+
+        merged = pa.concat_tables(
+            [
+                BlockAccessor.for_block(manifest._block).to_arrow()
+                for manifest in manifests
+            ]
+        )
+        return cls(merged)
+
     def shuffle(self, seed: Optional[int]) -> "FileManifest":
         """Return a new `FileManifest` with rows permuted.
 
         Args:
             seed: Random seed. ``None`` for non-deterministic shuffling.
+                When set, input rows are first sorted by path so the shuffle
+                is reproducible regardless of upstream listing order
+                (the threaded ``FileIndexer`` doesn't preserve order).
 
         Returns:
             A new `FileManifest` with the same rows in a shuffled order. The
@@ -73,8 +96,15 @@ class FileManifest:
         n = len(self)
         if n <= 1:
             return self
+        block = self._block
+        if seed is not None:
+            sort_indices = pa.compute.sort_indices(
+                BlockAccessor.for_block(block).to_arrow(),
+                sort_keys=[(PATH_COLUMN_NAME, "ascending")],
+            )
+            block = block.take(sort_indices)
         permutation = np.random.default_rng(seed).permutation(n)
-        return FileManifest(self._block.take(permutation))
+        return FileManifest(block.take(permutation))
 
     @classmethod
     def construct_manifest(

--- a/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
@@ -1,11 +1,29 @@
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable, List, Optional
 
-from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+import pyarrow as pa
+
+from ray.data._internal.datasource_v2.listing.file_manifest import (
+    PATH_COLUMN_NAME,
+    FileManifest,
+)
+from ray.data._internal.datasource_v2.listing.file_pruners import (
+    FileExtensionPruner,
+    FilePruner,
+    PartitionPruner,
+)
 from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
     FilePartitioner,
 )
+from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces.task_context import TaskContext
-from ray.data.block import Block
+from ray.data.block import Block, BlockAccessor
+
+if TYPE_CHECKING:
+    from pyarrow.fs import FileSystem
+
+    from ray.data._internal.datasource_v2.listing.file_indexer import FileIndexer
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
+    from ray.data.datasource.partitioning import PathPartitionFilter
 
 
 def partition_files(
@@ -21,3 +39,121 @@ def partition_files(
     partitioner.finalize()
     while partitioner.has_partition():
         yield partitioner.next_partition().as_block()
+
+
+def _build_pruners(
+    file_extensions: Optional[List[str]],
+    partition_filter: Optional["PathPartitionFilter"],
+) -> List[FilePruner]:
+    pruners: List[FilePruner] = []
+    if file_extensions is not None:
+        pruners.append(FileExtensionPruner(file_extensions))
+    if partition_filter is not None:
+        pruners.append(PartitionPruner(partition_filter))
+    return pruners
+
+
+def list_files_for_each_block(
+    blocks: Iterable[Block],
+    _: TaskContext,
+    *,
+    indexer: "FileIndexer",
+    filesystem: "FileSystem",
+    file_extensions: Optional[List[str]] = None,
+    partition_filter: Optional["PathPartitionFilter"] = None,
+    preserve_order: bool = False,
+) -> Iterable[Block]:
+    """Expand path blocks into ``FileManifest`` blocks.
+
+    Each input block carries a single ``__path`` column of path strings.
+    For every path, the indexer is invoked to produce a stream of
+    ``FileManifest`` objects; each manifest's backing block is yielded.
+    Pruners are constructed once per task from ``file_extensions`` /
+    ``partition_filter`` — keeps pruner construction out of the
+    ``_read_datasource_v2`` entry point.
+    """
+    pruners = _build_pruners(file_extensions, partition_filter)
+    for block in blocks:
+        for manifest in indexer.list_files(
+            block[PATH_COLUMN_NAME],
+            filesystem=filesystem,
+            pruners=pruners,
+            preserve_order=preserve_order,
+        ):
+            if len(manifest) > 0:
+                yield manifest.as_block()
+
+
+def shuffle_files(
+    blocks: Iterable[Block],
+    _: TaskContext,
+    *,
+    shuffle_config: "FileShuffleConfig",
+    execution_idx: int,
+) -> Iterable[Block]:
+    """Concatenate manifest blocks and shuffle rows with the seeded RNG.
+
+    Runs in a single task (`plan_list_files_op` sets `should_parallelize=False`
+    when shuffle is requested) so we have the full manifest before
+    shuffling. Emits one merged manifest block. Determinism comes from
+    ``FileManifest.shuffle`` which sorts by path before applying the
+    permutation — this protects against non-deterministic upstream
+    indexer yield order.
+    """
+    builder = DelegatingBlockBuilder()
+    for block in blocks:
+        if len(block) > 0:
+            builder.add_block(block)
+
+    combined = builder.build()
+    if len(combined) == 0:
+        return
+
+    seed = shuffle_config.get_seed(execution_idx)
+    yield FileManifest(combined).shuffle(seed).as_block()
+
+
+def sample_files(
+    indexer: "FileIndexer",
+    paths: List[str],
+    filesystem: "FileSystem",
+    pruners: Optional[List[FilePruner]] = None,
+    max_files: int = 16,
+) -> FileManifest:
+    """Drive the indexer until up to ``max_files`` files arrive; return them.
+
+    Used for driver-side schema inference in ``_read_datasource_v2``.
+    Sampling more than one file lets callers unify schemas (e.g., if the
+    first file has an all-null column, later files' non-null types can
+    promote it). No caching — the returned manifest is discarded after
+    schema inference, and the ``ListFiles`` op lists the same paths
+    again on workers at execution time.
+    """
+    assert max_files >= 1
+    paths_column = pa.array(paths, type=pa.string())
+    collected: List[FileManifest] = []
+    collected_rows = 0
+    for manifest in indexer.list_files(
+        paths_column,
+        filesystem=filesystem,
+        pruners=pruners or [],
+        preserve_order=True,
+    ):
+        if len(manifest) == 0:
+            continue
+        remaining = max_files - collected_rows
+        if len(manifest) <= remaining:
+            collected.append(manifest)
+            collected_rows += len(manifest)
+        else:
+            collected.append(
+                FileManifest(
+                    BlockAccessor.for_block(manifest.as_block()).slice(0, remaining)
+                )
+            )
+            collected_rows = max_files
+        if collected_rows >= max_files:
+            break
+    if not collected:
+        return FileManifest.construct_manifest(paths=[], sizes=[])
+    return FileManifest.concat(collected)

--- a/python/ray/data/_internal/datasource_v2/logical_optimizers.py
+++ b/python/ray/data/_internal/datasource_v2/logical_optimizers.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple
 
 from ray.data.expressions import Expr
 from ray.util.annotations import DeveloperAPI
@@ -81,6 +81,18 @@ class SupportsPartitionPruning(ABC):
     Partition pruning allows skipping entire files/partitions based on
     predicates that reference partition columns.
     """
+
+    @property
+    @abstractmethod
+    def partition_columns(self) -> Set[str]:
+        """Names of columns that are partition keys.
+
+        Callers (e.g. the predicate-pushdown rule) use this to decide
+        whether a predicate should be routed through :meth:`push_filters`
+        (data columns) or :meth:`prune_partitions` (partition columns).
+        Must be fully populated by schema inference at planning time.
+        """
+        ...
 
     @abstractmethod
     def prune_partitions(self, predicate: "Expr") -> "Scanner":

--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -1,5 +1,6 @@
 from enum import Enum
-from typing import Iterator, List, Optional
+from functools import cached_property
+from typing import Any, Iterator, List, Optional, Set, Tuple
 
 import pyarrow as pa
 import pyarrow.dataset as pds
@@ -11,6 +12,7 @@ from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.readers.base_reader import Reader
 from ray.data._internal.util import iterate_with_retry
 from ray.data.context import DataContext
+from ray.data.datasource.partitioning import Partitioning, PathPartitionParser
 from ray.util.annotations import DeveloperAPI
 
 # https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html#pyarrow.dataset.Scanner.from_batches
@@ -45,9 +47,10 @@ class FileReader(Reader[FileManifest]):
         predicate: Optional[pc.Expression] = None,
         limit: Optional[int] = None,
         filesystem: Optional[FileSystem] = None,
-        partitioning: Optional[pds.Partitioning] = None,
+        partitioning: Optional[Partitioning] = None,
         ignore_prefixes: Optional[List[str]] = None,
         include_paths: bool = False,
+        schema: Optional[pa.Schema] = None,
     ):
         """Initialize the reader.
         Refer to https://arrow.apache.org/docs/python/generated/pyarrow.dataset.dataset.html for more details.
@@ -59,10 +62,17 @@ class FileReader(Reader[FileManifest]):
             predicate: PyArrow compute expression for filtering.
             limit: Maximum number of rows to read.
             filesystem: Filesystem for reading files.
-            partitioning: Partitioning to use for reading files.
+            partitioning: Ray ``Partitioning`` object. Partition columns are
+                synthesized per-path via ``PathPartitionParser`` after each
+                batch is read, producing string-typed columns (V1 parity).
             ignore_prefixes: Prefixes to ignore when reading files. Default is ['.', '_'] set by PyArrow.
             include_paths: If True, include the source file path in a
                 ``'path'`` column for each row.
+            schema: Caller-supplied unified schema used both to override
+                pyarrow's per-fragment inference (so a file whose column
+                is all-null doesn't pin the type to ``null``) and to cast
+                path-derived partition values to their target types when
+                ``Partitioning(field_types=...)`` is set.
 
         """
         self._format = format
@@ -71,9 +81,53 @@ class FileReader(Reader[FileManifest]):
         self._batch_size = batch_size
         self._limit = limit
         self._filesystem = filesystem
-        self._partitioning = partitioning
+        self._partition_parser: Optional[PathPartitionParser] = (
+            PathPartitionParser(partitioning) if partitioning is not None else None
+        )
         self._ignore_prefixes = ignore_prefixes
         self._include_paths = include_paths
+        self._schema = schema
+
+    @cached_property
+    def _file_dataset_schema(self) -> Optional[pa.Schema]:
+        """Schema passed to ``pds.dataset`` — partition keys and ``path``
+        stripped out since those are synthesized post-read.
+
+        A caller-supplied schema overrides pyarrow's per-fragment
+        inference — without it, a file with all-null values in column X
+        pins X to ``null`` type and pyarrow can't cast string → null in
+        later files.
+        """
+        if self._schema is None:
+            return None
+        partition_keys = (
+            set(self._partition_parser._scheme.field_names or [])
+            if self._partition_parser is not None
+            else set()
+        )
+        fields = [
+            f for f in self._schema if f.name not in partition_keys and f.name != "path"
+        ]
+        return pa.schema(fields) if fields else None
+
+    def _broadcast_partition_value(
+        self, name: str, value: Any, num_rows: int
+    ) -> pa.Array:
+        """Broadcast a single path-derived partition value to ``num_rows``,
+        casting to the caller-supplied schema's field type if set.
+
+        Values are stringified first (``PathPartitionParser`` in
+        ``explicit`` mode can return arrow-scalar-like non-strings) and
+        then cast to the target type, so ``Partitioning(field_types=
+        {"year": int})`` still promotes them correctly.
+        """
+        str_val = None if value is None else str(value)
+        arr = pa.repeat(pa.scalar(str_val, type=pa.string()), num_rows)
+        if self._schema is not None:
+            idx = self._schema.get_field_index(name)
+            if idx != -1 and self._schema.field(idx).type != pa.string():
+                arr = arr.cast(self._schema.field(idx).type)
+        return arr
 
     def read(self, input_split: FileManifest) -> Iterator[pa.Table]:
         """Read data from the input bucket and yield Arrow tables.
@@ -87,62 +141,104 @@ class FileReader(Reader[FileManifest]):
         Yields:
             pa.Table: PyArrow Tables containing the read data.
         """
-        if len(input_split) > 0:
-            paths = list(input_split.paths)
-            filesystem = self._filesystem or LocalFileSystem()
+        if len(input_split) == 0:
+            return
 
-            dataset = pds.dataset(
-                source=paths,
-                format=self._format.value,
-                filesystem=filesystem,
-                partitioning=self._partitioning,
-                ignore_prefixes=self._ignore_prefixes,
-            )
+        paths = list(input_split.paths)
+        filesystem = self._filesystem or LocalFileSystem()
+        dataset = pds.dataset(
+            source=paths,
+            format=self._format.value,
+            filesystem=filesystem,
+            schema=self._file_dataset_schema,
+            ignore_prefixes=self._ignore_prefixes,
+        )
 
-            batch_size = self._resolve_batch_size(dataset)
+        # Split the requested columns into ones the on-disk file has
+        # (pyarrow reads these) and ones we need to synthesize post-read
+        # (hive partition keys, "path"). ``self._columns is None`` means
+        # "no projection" — read every file column and synthesize every
+        # available partition/path column.
+        on_disk_column_names = set(dataset.schema.names)
+        if self._columns is None:
+            columns_to_read_from_file: Optional[List[str]] = None
+            columns_to_synthesize: Optional[Set[str]] = None
+        else:
+            columns_to_read_from_file = [
+                c for c in self._columns if c in on_disk_column_names
+            ]
+            columns_to_synthesize = set(self._columns) - on_disk_column_names
 
-            scanner_kwargs = dict(
-                columns=self._columns,
-                filter=self._predicate,
-                batch_size=batch_size,
-                batch_readahead=1,
-            )
-            scanner_kwargs.update(self._arrow_scanner_kwargs())
-            scanner = dataset.scanner(**scanner_kwargs)
+        scanner_kwargs = dict(
+            columns=columns_to_read_from_file,
+            filter=self._predicate,
+            batch_size=self._resolve_batch_size(dataset),
+            batch_readahead=1,
+        )
+        scanner_kwargs.update(self._arrow_scanner_kwargs())
+        scanner = dataset.scanner(**scanner_kwargs)
 
-            ctx = DataContext.get_current()
-            rows_read = 0
-            for table, fragment_path in iterate_with_retry(
-                lambda: self._read_batches(scanner),
-                "read batches",
-                match=ctx.retried_io_errors,
-            ):
-                if self._limit is not None:
-                    remaining = self._limit - rows_read
-                    if remaining <= 0:
-                        break
-                    if len(table) > remaining:
-                        table = table.slice(0, remaining)
+        ctx = DataContext.get_current()
+        rows_read = 0
+        for table, fragment_path in iterate_with_retry(
+            lambda: self._read_batches(scanner),
+            "read batches",
+            match=ctx.retried_io_errors,
+        ):
+            if self._limit is not None:
+                if rows_read >= self._limit:
+                    break
+                if len(table) > self._limit - rows_read:
+                    table = table.slice(0, self._limit - rows_read)
 
-                if self._include_paths:
-                    table = table.append_column(
-                        "path",
-                        pa.array([fragment_path] * table.num_rows, type=pa.string()),
-                    )
+            # Build the list of (name, value) pairs to synthesize from
+            # the fragment path: hive partitions + optional ``path``.
+            derived_items: List[Tuple[str, Any]] = []
+            if self._partition_parser is not None:
+                derived_items.extend(self._partition_parser(fragment_path).items())
+            if self._include_paths:
+                derived_items.append(("path", fragment_path))
 
-                if table.num_columns == 0 and table.num_rows > 0:
-                    # Guards against ``pa.concat_tables`` collapsing rows when
-                    # a batch has zero columns (e.g., empty projection for a
-                    # count query). The stub column is dropped by downstream
-                    # projections.
-                    table = table.append_column(
-                        _BATCH_SIZE_PRESERVING_STUB_COL_NAME,
-                        pa.nulls(table.num_rows),
-                    )
+            for name, value in derived_items:
+                if (
+                    columns_to_synthesize is not None
+                    and name not in columns_to_synthesize
+                ):
+                    continue
+                if name in table.column_names:
+                    # When the caller schema names a partition key, pyarrow
+                    # expects it in every file and fills it with nulls when
+                    # absent (the hive-typical case). Drop that placeholder
+                    # so the path-derived value below replaces it.
+                    table = table.drop([name])
+                table = table.append_column(
+                    name,
+                    self._broadcast_partition_value(name, value, table.num_rows),
+                )
 
-                self._on_batch_read(table)
-                rows_read += len(table)
-                yield table
+            if self._columns is not None:
+                # Project/reorder to the caller's requested column order;
+                # drop any that weren't produced (matches V1's lenient
+                # behavior). Always select — an empty projection must
+                # narrow the table to zero columns so the stub-column
+                # guard below handles row preservation.
+                produced = set(table.column_names)
+                projected = [c for c in self._columns if c in produced]
+                table = table.select(projected)
+
+            if table.num_columns == 0 and table.num_rows > 0:
+                # Guards against ``pa.concat_tables`` collapsing rows
+                # when a batch has zero columns (e.g., empty projection
+                # for a count query). The stub column is dropped by
+                # downstream projections.
+                table = table.append_column(
+                    _BATCH_SIZE_PRESERVING_STUB_COL_NAME,
+                    pa.nulls(table.num_rows),
+                )
+
+            self._on_batch_read(table)
+            rows_read += len(table)
+            yield table
 
     def _resolve_batch_size(self, dataset: pds.Dataset) -> int:
         """Return the batch size to use for scanning.

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -1,6 +1,6 @@
 import logging
 import math
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import pyarrow as pa
 import pyarrow.dataset as pds
@@ -8,6 +8,9 @@ import pyarrow.parquet as pq
 from pyarrow import compute as pc
 from pyarrow.fs import FileSystem
 from typing_extensions import override
+
+if TYPE_CHECKING:
+    from ray.data.datasource.partitioning import Partitioning
 
 from ray.data._internal.datasource_v2.readers.file_reader import (
     _ARROW_DEFAULT_BATCH_SIZE,
@@ -135,10 +138,11 @@ class ParquetFileReader(FileReader):
         predicate: Optional[pc.Expression] = None,
         limit: Optional[int] = None,
         filesystem: Optional[FileSystem] = None,
-        partitioning: Optional[pds.Partitioning] = None,
+        partitioning: "Optional[Partitioning]" = None,
         ignore_prefixes: Optional[List[str]] = None,
         target_block_size: Optional[int] = None,
         include_paths: bool = False,
+        schema: Optional[pa.Schema] = None,
     ):
         """Initialize the Parquet reader.
 
@@ -149,12 +153,16 @@ class ParquetFileReader(FileReader):
             predicate: PyArrow compute expression for filtering.
             limit: Maximum number of rows to read.
             filesystem: Filesystem for reading files.
-            partitioning: PyArrow partitioning for reading files.
+            partitioning: Ray ``Partitioning`` for synthesizing partition
+                columns from file paths.
             ignore_prefixes: Prefixes to ignore when reading files.
             target_block_size: Target in-memory size per batch in bytes.
                 Used for adaptive batch sizing when ``batch_size`` is not set.
             include_paths: If True, include the source file path in a
                 ``'path'`` column for each row.
+            schema: Caller-supplied unified schema forwarded to the base
+                :class:`FileReader` for per-fragment inference override
+                and partition-column type casting.
         """
         super().__init__(
             format=FileFormat.PARQUET,
@@ -166,6 +174,7 @@ class ParquetFileReader(FileReader):
             partitioning=partitioning,
             ignore_prefixes=ignore_prefixes,
             include_paths=include_paths,
+            schema=schema,
         )
         self._explicit_batch_size = batch_size
         self._target_block_size = target_block_size

--- a/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
@@ -15,7 +15,6 @@ from ray.data._internal.datasource_v2.logical_optimizers import (
     SupportsPartitionPruning,
 )
 from ray.data._internal.datasource_v2.scanners.file_scanner import FileScanner
-from ray.data.context import DataContext
 from ray.data.datasource.partitioning import Partitioning, PathPartitionParser
 from ray.data.expressions import Expr
 from ray.util.annotations import DeveloperAPI
@@ -62,8 +61,18 @@ class ArrowFileScanner(
         return set(self.partitioning.field_names or [])
 
     def read_schema(self) -> pa.Schema:
-        """Return schema after column pruning."""
-        if not self.columns:
+        """Return the logical schema after column pruning.
+
+        ``columns is None`` → no projection applied, return the full schema.
+        ``columns = ()`` → empty projection (``ds.select_columns([])``),
+        return an empty schema.
+
+        The physical read may still inject a stub column (see
+        ``_BATCH_SIZE_PRESERVING_STUB_COL_NAME``) so that row counts
+        survive a zero-column scan; that stub is an execution-layer detail
+        and is deliberately not reflected in this logical schema.
+        """
+        if self.columns is None:
             return self.schema
         fields = []
         for name in self.columns:
@@ -156,45 +165,18 @@ class ArrowFileScanner(
         return replace(self, partition_predicate=combined)
 
     @override
-    def plan(
-        self,
-        manifest: FileManifest,
-        parallelism: int,
-        data_context: Optional["DataContext"] = None,
-    ) -> List[FileManifest]:
-        """Plan parallel work units, pruning files by partition predicate first.
+    def prune_manifest(self, manifest: FileManifest) -> FileManifest:
+        """Filter manifest to only files matching ``self.partition_predicate``.
 
-        If a partition predicate is set, files whose partition values do not
-        satisfy the predicate are removed from the manifest. The pruned
-        manifest is then handed to ``FileScanner.plan``, which applies the
-        shuffle (if configured) before splitting.
-
-        Args:
-            manifest: FileManifest to partition.
-            parallelism: Target number of parallel tasks.
-            data_context: Optional data context.
-
-        Returns:
-            List of FileManifest objects for parallel execution.
+        Called by :func:`plan_read_files_op.do_read` for every incoming
+        manifest block. No-op when either the predicate or the
+        partitioning spec is absent. Uses
+        :class:`PathPartitionParser` to parse partition values from
+        each file path and evaluate the predicate.
         """
-        if self.partition_predicate is not None and self.partitioning is not None:
-            manifest = self._prune_manifest(manifest)
-        return super().plan(manifest, parallelism, data_context)
+        if self.partition_predicate is None or self.partitioning is None:
+            return manifest
 
-    def _prune_manifest(self, manifest: FileManifest) -> FileManifest:
-        """Filter manifest to only files matching the partition predicate.
-
-        Uses :class:`PathPartitionParser` to parse partition values from each
-        file path and evaluate the partition predicate against them.
-
-        Args:
-            manifest: The full file manifest.
-
-        Returns:
-            A new FileManifest containing only matching files.
-        """
-        assert self.partitioning is not None
-        assert self.partition_predicate is not None
         parser = PathPartitionParser(self.partitioning)
         keep_indices = []
 

--- a/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, List, Literal, Optional, Union
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.scanners.scanner import Scanner
 from ray.data._internal.util import _is_local_scheme
-from ray.data.context import DataContext
 from ray.data.datasource.file_based_datasource import (
     FileShuffleConfig,
     _validate_shuffle_arg,
@@ -20,13 +19,13 @@ if TYPE_CHECKING:
 class FileScanner(Scanner[FileManifest]):
     """Base scanner for file-based datasources.
 
-    Provides a default plan() implementation that shuffles (if configured)
-    and splits a FileManifest by files. Subclasses implement format-specific
-    read_schema() and create_reader().
+    Subclasses implement format-specific ``read_schema()`` and
+    ``create_reader()``. Shuffling and parallel bucketing are handled
+    upstream in the ``ListFiles`` transform chain (``shuffle_files`` +
+    ``RoundRobinPartitioner`` via ``plan_list_files_op``), not here.
 
-    PyArrow Dataset-based scanners should subclass ``ArrowFileScanner``; use
-    ``FileScanner`` directly for non-Arrow file formats that only share
-    splitting and shuffling.
+    PyArrow Dataset-based scanners should subclass ``ArrowFileScanner``;
+    use ``FileScanner`` directly for non-Arrow file formats.
     """
 
     # kw_only so subclass dataclasses can declare their own required fields
@@ -39,61 +38,16 @@ class FileScanner(Scanner[FileManifest]):
     def __post_init__(self) -> None:
         _validate_shuffle_arg(self.shuffle)
 
-    def plan(
-        self,
-        manifest: FileManifest,
-        parallelism: int,
-        data_context: Optional["DataContext"] = None,
-    ) -> List[FileManifest]:
-        """Shuffle (if configured) and split a manifest into parallel work units.
+    def prune_manifest(self, manifest: FileManifest) -> FileManifest:
+        """Return a filtered view of ``manifest``.
 
-        When file listing is adaptive (``LazyFileIndex``), only the files
-        known at plan time participate in the shuffle; files streamed in at
-        execution time are not reordered.
-
-        Args:
-            manifest: FileManifest to partition.
-            parallelism: Target number of parallel tasks.
-            data_context: Optional data context.
-
-        Returns:
-            List of FileManifest objects for parallel execution.
+        Default: identity. Subclasses that support file-level predicate
+        pruning (e.g. :class:`ArrowFileScanner`'s ``partition_predicate``)
+        override this to drop rows whose partition values fail the
+        predicate. Invoked per-block from
+        :func:`plan_read_files_op.do_read`.
         """
-        if self.shuffle is not None:
-            execution_idx = (
-                data_context._execution_idx if data_context is not None else 0
-            )
-            if self.shuffle == "files":
-                seed = None
-            else:
-                assert isinstance(self.shuffle, FileShuffleConfig)
-                seed = self.shuffle.get_seed(execution_idx)
-            manifest = manifest.shuffle(seed)
-
-        num_files = len(manifest)
-        if parallelism <= 0 or num_files == 0:
-            return [manifest] if num_files > 0 else []
-
-        # Ensure we don't create more splits than files
-        actual_splits = min(parallelism, num_files)
-        partitions = []
-
-        # Distribute files as evenly as possible
-        base_size = num_files // actual_splits
-        remainder = num_files % actual_splits
-
-        start = 0
-        for i in range(actual_splits):
-            # Add one extra file to the first 'remainder' splits
-            size = base_size + (1 if i < remainder else 0)
-            if size > 0:
-                # Slice the underlying block
-                block = manifest.as_block()
-                sliced_block = block.slice(start, size)  # pyrefly: ignore[not-callable]
-                partitions.append(FileManifest(sliced_block))
-                start += size
-
-        return partitions
+        return manifest
 
     @staticmethod
     def compute_local_scheduling(

--- a/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
@@ -50,8 +50,9 @@ class ParquetScanner(ArrowFileScanner):
             predicate=self.predicate,
             limit=self.limit,
             filesystem=self.filesystem,
-            partitioning=self.partitioning.to_pyarrow() if self.partitioning else None,
+            partitioning=self.partitioning,
             ignore_prefixes=self.ignore_prefixes,
             target_block_size=self.target_block_size,
             include_paths=self.include_paths,
+            schema=self.schema,
         )

--- a/python/ray/data/_internal/datasource_v2/scanners/scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/scanner.py
@@ -1,11 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import Generic, List, Optional
+from typing import Generic
 
 import pyarrow as pa
 
 from ray.data._internal.datasource_v2 import InputSplit
 from ray.data._internal.datasource_v2.readers.base_reader import Reader
-from ray.data.context import DataContext
 from ray.util.annotations import DeveloperAPI
 
 
@@ -20,8 +19,12 @@ class Scanner(ABC, Generic[InputSplit]):
 
     The Scanner is responsible for:
     1. Determining the output schema after all projections
-    2. Planning input partitions for parallel execution
-    3. Creating Reader instances configured with all pushdowns
+    2. Creating Reader instances configured with all pushdowns
+
+    Splitting the input into parallel work units used to live here as a
+    ``plan()`` method. That responsibility now belongs to the listing-side
+    pipeline (``ListFiles`` + ``FilePartitioner``); scanners only
+    need to answer "what schema?" and "give me a reader."
     """
 
     @abstractmethod
@@ -32,28 +35,6 @@ class Scanner(ABC, Generic[InputSplit]):
 
         Returns:
             PyArrow Schema describing the output data.
-        """
-        ...
-
-    @abstractmethod
-    def plan(
-        self,
-        manifest: InputSplit,
-        parallelism: int,
-        data_context: Optional["DataContext"] = None,
-    ) -> List[InputSplit]:
-        """Split the input into parallel work units.
-
-        This method determines how to divide the work for parallel execution.
-        The resulting partitions should be roughly balanced in terms of work.
-
-        Args:
-            manifest: The full input to partition.
-            parallelism: Target number of parallel tasks.
-            data_context: Optional data context for configuration.
-
-        Returns:
-            List of InputSplit objects, one per parallel task.
         """
         ...
 

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -7478,7 +7478,14 @@ class Schema:
     @property
     def names(self) -> List[str]:
         """Lists the columns of this Dataset."""
-        return list(self.base_schema.names)
+        from ray.data._internal.arrow_block import _is_user_visible_column
+
+        # ``__bsp_stub`` is a physical placeholder the read path injects
+        # into zero-column blocks so ``pa.concat_tables`` doesn't collapse
+        # the row count. It's not part of the user-visible schema.
+        return [
+            name for name in self.base_schema.names if _is_user_visible_column(name)
+        ]
 
     @property
     def types(self) -> List[Union[type[object], "pyarrow.lib.DataType"]]:
@@ -7490,6 +7497,7 @@ class Schema:
         import pyarrow as pa
         from pandas.core.dtypes.dtypes import BaseMaskedDtype
 
+        from ray.data._internal.arrow_block import _is_user_visible_column
         from ray.data._internal.tensor_extensions.arrow import (
             create_arrow_fixed_shape_tensor_type,
         )
@@ -7508,10 +7516,16 @@ class Schema:
             return pa.from_numpy_dtype(dtype)
 
         if isinstance(self.base_schema, pa.lib.Schema):
-            return list(self.base_schema.types)
+            return [
+                t
+                for name, t in zip(self.base_schema.names, self.base_schema.types)
+                if _is_user_visible_column(name)
+            ]
 
         arrow_types = []
-        for dtype in self.base_schema.types:
+        for name, dtype in zip(self.base_schema.names, self.base_schema.types):
+            if not _is_user_visible_column(name):
+                continue
             if isinstance(dtype, TensorDtype):
                 pa_dtype = _convert_to_pa_type(dtype._dtype)
                 if any(dim is None for dim in dtype._shape):


### PR DESCRIPTION

Internal refactor of V2 listing/scanner/reader infrastructure to prep
for the upcoming ListFiles/ReadFiles op split. No public API change.

- Listing: partition-column helpers on FileManifest, sample_files +
  _build_pruners helpers in listing_utils.
- FileReader.read(manifest): cached_property file_dataset_schema,
  _broadcast_partition_value helper, derived_items synthesis loop,
  early-return on empty manifest. Caller-supplied schema overrides
  pyarrow's per-fragment inference for the all-null first-file case.
- FileScanner: drop bucketing helper plan() (moved upstream to
  plan_list_files_op in PR-A2), add prune_manifest hook, keep
  compute_local_scheduling (used by V1 dispatch until PR-D).
- ArrowFileScanner / ParquetFileReader / Scanner: simplifications
  aligned with the new manifest-driven read path.
- arrow_block.py + dataset.py: Schema.names hides _bsp_stub stub
  column produced when the scanner emits zero-column batches.

This is breaking up PR: #62880
