### PR TITLE
[LLM] Replace GPUType alias with AcceleratorType

### DIFF
--- a/python/ray/llm/_internal/serve/config_generator/inputs.py
+++ b/python/ray/llm/_internal/serve/config_generator/inputs.py
@@ -14,7 +14,6 @@ from ray.llm._internal.serve.config_generator.utils.files import (
 )
 from ray.llm._internal.serve.config_generator.utils.gpu import (
     DEFAULT_MODEL_ID_TO_GPU,
-    GPUType,
     get_available_gpu_types,
 )
 from ray.llm._internal.serve.config_generator.utils.input_converter import (
@@ -33,9 +32,10 @@ from ray.llm._internal.serve.config_generator.utils.prompt import (
 from ray.llm._internal.serve.config_generator.utils.text_completion import (
     get_default_llm_config,
 )
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
 
-def _get_user_input_from_list(prompt: str, options: List[GPUType]):
+def _get_user_input_from_list(prompt: str, options: List[AcceleratorType]):
     while True:
         user_input = BoldPrompt.ask(
             f"{prompt}",
@@ -134,7 +134,7 @@ def _get_validated_model_info():
             )
 
 
-def _get_default_tensor_parallelism(model_id: str, gpu_type: GPUType) -> int:
+def _get_default_tensor_parallelism(model_id: str, gpu_type: AcceleratorType) -> int:
     if model_id in DEFAULT_MODEL_ID_TO_GPU:
         llm_config = get_default_llm_config(model_id=model_id, gpu_type=gpu_type)
         return llm_config.engine_kwargs.setdefault("tensor_parallel_size", 1)
@@ -148,7 +148,7 @@ _DEFAULT_NUM_LORA_PER_REPLICA = 16
 def get_input_model_via_args(
     model_id: str,
     hf_token: Optional[str],
-    gpu_type: GPUType,
+    gpu_type: AcceleratorType,
     tensor_parallelism: int,
     enable_lora: Optional[bool],
     num_loras_per_replica: Optional[int],

--- a/python/ray/llm/_internal/serve/config_generator/start.py
+++ b/python/ray/llm/_internal/serve/config_generator/start.py
@@ -19,8 +19,8 @@ from ray.llm._internal.serve.config_generator.inputs import (
 )
 from ray.llm._internal.serve.config_generator.utils.gpu import (
     DEFAULT_MODEL_ID_TO_GPU,
-    GPUType,
 )
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
 
 def _format_yaml_dumper():
@@ -76,7 +76,7 @@ def _write_config_to_disk(serve_config: Dict[str, Any], timestamp: str):
 def _get_model_with_validation(
     model_id: Optional[str],
     hf_token: Optional[str],
-    gpu_type: Optional[GPUType],
+    gpu_type: Optional[AcceleratorType],
     tensor_parallelism: Optional[int],
     enable_lora: Optional[bool],
     num_loras_per_replica: Optional[int],
@@ -113,7 +113,7 @@ def gen_config(
         Optional[str], typer.Option(help="Huggingface token", hidden=True)
     ] = None,
     gpu_type: Annotated[
-        Optional[GPUType], typer.Option(help="Type of GPU", hidden=True)
+        Optional[AcceleratorType], typer.Option(help="Type of GPU", hidden=True)
     ] = None,
     tensor_parallelism: Annotated[
         Optional[int], typer.Option(help="Number of tensor parallelism", hidden=True)

--- a/python/ray/llm/_internal/serve/config_generator/utils/gpu.py
+++ b/python/ray/llm/_internal/serve/config_generator/utils/gpu.py
@@ -7,16 +7,16 @@ from ray.llm._internal.serve.config_generator.utils.constants import (
     DEFAULT_DEPLOYMENT_CONFIGS_FILE,
     TEMPLATE_DIR,
 )
-from ray.llm._internal.serve.core.configs.llm_config import GPUType
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
 # All practical GPUs
 ALL_GPU_TYPES = [
-    GPUType.NVIDIA_L4,
-    GPUType.NVIDIA_L40S,
-    GPUType.NVIDIA_TESLA_A10G,
-    GPUType.NVIDIA_A100_40G,
-    GPUType.NVIDIA_A100_80G,
-    GPUType.NVIDIA_H100,
+    AcceleratorType.NVIDIA_L4,
+    AcceleratorType.NVIDIA_L40S,
+    AcceleratorType.NVIDIA_TESLA_A10G,
+    AcceleratorType.NVIDIA_A100_40G,
+    AcceleratorType.NVIDIA_A100_80G,
+    AcceleratorType.NVIDIA_H100,
 ]
 
 
@@ -34,12 +34,12 @@ def read_model_id_to_gpu_mapping() -> Dict[str, List[str]]:
 DEFAULT_MODEL_ID_TO_GPU: Dict[str, str] = read_model_id_to_gpu_mapping()
 
 
-def get_available_gpu_types(model_id: str) -> List[GPUType]:
+def get_available_gpu_types(model_id: str) -> List[AcceleratorType]:
     """
     If we know the models run only on larger GPUs, we exclude the smaller GPUs from the options.
     """
     if model_id in DEFAULT_MODEL_ID_TO_GPU:
-        gpus = [GPUType(gpu) for gpu in DEFAULT_MODEL_ID_TO_GPU[model_id]]
+        gpus = [AcceleratorType(gpu) for gpu in DEFAULT_MODEL_ID_TO_GPU[model_id]]
     else:
         gpus = ALL_GPU_TYPES
     return gpus

--- a/python/ray/llm/_internal/serve/config_generator/utils/input_converter.py
+++ b/python/ray/llm/_internal/serve/config_generator/utils/input_converter.py
@@ -1,16 +1,16 @@
 from typing import Optional
 
-from ray.llm._internal.serve.config_generator.utils.gpu import GPUType
 from ray.llm._internal.serve.config_generator.utils.models import (
     TextCompletionLoraModelConfig,
     TextCompletionModelConfig,
 )
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
 
 def convert_inputs_to_text_completion_model(
     *,
     model_id: str,
-    gpu_type: GPUType,
+    gpu_type: AcceleratorType,
     tensor_parallelism: int,
     hf_token: Optional[str] = None,
     remote_storage_uri: Optional[str] = None,

--- a/python/ray/llm/_internal/serve/config_generator/utils/models.py
+++ b/python/ray/llm/_internal/serve/config_generator/utils/models.py
@@ -2,7 +2,7 @@ from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
-from ray.llm._internal.serve.config_generator.utils.gpu import GPUType
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
 TEXT_COMPLETION_MODEL_TYPE: Literal["TextCompletion"] = "TextCompletion"
 
@@ -13,7 +13,7 @@ class ServeModel(BaseModel):
     id: str
     hf_token: Optional[str] = None
     remote_storage_uri: Optional[str] = None
-    gpu_type: GPUType
+    gpu_type: AcceleratorType
 
 
 class TextCompletionLoraModelConfig(BaseModel):

--- a/python/ray/llm/_internal/serve/config_generator/utils/text_completion.py
+++ b/python/ray/llm/_internal/serve/config_generator/utils/text_completion.py
@@ -10,11 +10,11 @@ from ray.llm._internal.serve.config_generator.utils.constants import (
 )
 from ray.llm._internal.serve.config_generator.utils.gpu import (
     DEFAULT_MODEL_ID_TO_GPU,
-    GPUType,
 )
 from ray.llm._internal.serve.config_generator.utils.models import (
     TextCompletionModelConfig,
 )
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 
 
@@ -27,7 +27,7 @@ def get_model_default_config(model_id: str) -> Dict[str, Any]:
 
 
 @cache
-def get_default_llm_config(model_id: str, gpu_type: GPUType) -> LLMConfig:
+def get_default_llm_config(model_id: str, gpu_type: AcceleratorType) -> LLMConfig:
     file_path = os.path.join(TEMPLATE_DIR, DEFAULT_DEPLOYMENT_CONFIGS_FILE)
     with open(file_path, "r") as stream:
         configs = yaml.safe_load(stream)

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -52,9 +52,6 @@ from ray.serve._private.config import DeploymentConfig, handle_num_replicas_auto
 
 transformers = try_import("transformers")
 
-# TODO(ryanaoleary@): Remove this alias once all downstream files are migrated
-# to use AcceleratorType.
-GPUType = AcceleratorType
 ModelT = TypeVar("ModelT", bound=BaseModel)
 
 logger = get_logger(__name__)

--- a/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
+++ b/python/ray/llm/_internal/serve/observability/usage_telemetry/usage.py
@@ -250,14 +250,10 @@ class HardwareUsage:
     def infer_gpu_from_hardware(self) -> str:
         """Infer the GPU type from the hardware when the accelerator type on llm config is
         not specified.
-
-        Iterate through all the hardware recorded on the cluster and return the first
-        ray-compatible accelerator as the GPU type used for the deployment. If not, return
-        `UNSPECIFIED` as the default GPU type.
         """
-        from ray.llm._internal.serve.core.configs.llm_config import GPUType
+        from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
-        all_accelerator_types = [t.value for t in GPUType]
+        all_accelerator_types = [t.value for t in AcceleratorType]
         gcs_client = ray.experimental.internal_kv.internal_kv_get_gcs_client()
         hardwares = self._get_hardware_fn(gcs_client)
         for hardware in hardwares:

--- a/python/ray/llm/tests/serve/cpu/config_generator/test_input_converter.py
+++ b/python/ray/llm/tests/serve/cpu/config_generator/test_input_converter.py
@@ -3,13 +3,14 @@ from typing import Optional
 
 import pytest
 
-from ray.llm._internal.serve.config_generator.utils.gpu import ALL_GPU_TYPES, GPUType
+from ray.llm._internal.serve.config_generator.utils.gpu import ALL_GPU_TYPES
 from ray.llm._internal.serve.config_generator.utils.input_converter import (
     convert_inputs_to_text_completion_model,
 )
 from ray.llm._internal.serve.config_generator.utils.models import (
     TextCompletionLoraModelConfig,
 )
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
 _MODEL_ID = "test-model-id"
 
@@ -30,7 +31,7 @@ class TestTextCompletionModelConverter:
         self,
         hf_token: Optional[str],
         remote_storage_uri: Optional[str],
-        gpu_type: GPUType,
+        gpu_type: AcceleratorType,
         tensor_parallelism: int,
         lora_config: Optional[TextCompletionLoraModelConfig],
         reference_model_id: Optional[str],

--- a/python/ray/llm/tests/serve/cpu/config_generator/test_text_completion.py
+++ b/python/ray/llm/tests/serve/cpu/config_generator/test_text_completion.py
@@ -9,7 +9,6 @@ from ray.llm._internal.serve.config_generator.generator import (
 from ray.llm._internal.serve.config_generator.utils.gpu import (
     ALL_GPU_TYPES,
     DEFAULT_MODEL_ID_TO_GPU,
-    GPUType,
 )
 from ray.llm._internal.serve.config_generator.utils.models import (
     TextCompletionLoraModelConfig,
@@ -18,6 +17,7 @@ from ray.llm._internal.serve.config_generator.utils.models import (
 from ray.llm._internal.serve.config_generator.utils.text_completion import (
     populate_text_completion_model_config,
 )
+from ray.llm._internal.serve.core.configs.accelerators import AcceleratorType
 
 
 class TestTextCompletionModelConfig:
@@ -26,27 +26,48 @@ class TestTextCompletionModelConfig:
     def test_populate_default_models(
         self,
         model_id: str,
-        gpu_type: GPUType,
+        gpu_type: AcceleratorType,
     ):
         """
         We know a list of (model_id, gpu_type) combos that are not supported. So we skip testing them.
         """
         skipped_cases = {
-            ("meta-llama/Meta-Llama-3.1-70B-Instruct", GPUType.NVIDIA_TESLA_A10G),
-            ("meta-llama/Meta-Llama-3.1-70B-Instruct", GPUType.NVIDIA_L4),
-            ("meta-llama/Meta-Llama-3.1-70B-Instruct", GPUType.NVIDIA_L40S),
-            ("meta-llama/Meta-Llama-3.1-405B-Instruct-FP8", GPUType.NVIDIA_TESLA_A10G),
-            ("meta-llama/Meta-Llama-3.1-405B-Instruct-FP8", GPUType.NVIDIA_L4),
-            ("meta-llama/Meta-Llama-3.1-405B-Instruct-FP8", GPUType.NVIDIA_L40S),
-            ("meta-llama/Meta-Llama-3.1-405B-Instruct-FP8", GPUType.NVIDIA_A100_40G),
-            ("meta-llama/Meta-Llama-3.1-405B-Instruct-FP8", GPUType.NVIDIA_A100_80G),
-            ("mistral-community/pixtral-12b", GPUType.NVIDIA_TESLA_A10G),
-            ("mistral-community/pixtral-12b", GPUType.NVIDIA_L4),
-            ("meta-llama/Llama-3.2-11B-Vision-Instruct", GPUType.NVIDIA_TESLA_A10G),
-            ("meta-llama/Llama-3.2-11B-Vision-Instruct", GPUType.NVIDIA_L4),
-            ("meta-llama/Llama-3.2-90B-Vision-Instruct", GPUType.NVIDIA_TESLA_A10G),
-            ("meta-llama/Llama-3.2-90B-Vision-Instruct", GPUType.NVIDIA_L4),
-            ("meta-llama/Llama-3.2-90B-Vision-Instruct", GPUType.NVIDIA_L40S),
+            (
+                "meta-llama/Meta-Llama-3.1-70B-Instruct",
+                AcceleratorType.NVIDIA_TESLA_A10G,
+            ),
+            ("meta-llama/Meta-Llama-3.1-70B-Instruct", AcceleratorType.NVIDIA_L4),
+            ("meta-llama/Meta-Llama-3.1-70B-Instruct", AcceleratorType.NVIDIA_L40S),
+            (
+                "meta-llama/Meta-Llama-3.1-405B-Instruct-FP8",
+                AcceleratorType.NVIDIA_TESLA_A10G,
+            ),
+            ("meta-llama/Meta-Llama-3.1-405B-Instruct-FP8", AcceleratorType.NVIDIA_L4),
+            (
+                "meta-llama/Meta-Llama-3.1-405B-Instruct-FP8",
+                AcceleratorType.NVIDIA_L40S,
+            ),
+            (
+                "meta-llama/Meta-Llama-3.1-405B-Instruct-FP8",
+                AcceleratorType.NVIDIA_A100_40G,
+            ),
+            (
+                "meta-llama/Meta-Llama-3.1-405B-Instruct-FP8",
+                AcceleratorType.NVIDIA_A100_80G,
+            ),
+            ("mistral-community/pixtral-12b", AcceleratorType.NVIDIA_TESLA_A10G),
+            ("mistral-community/pixtral-12b", AcceleratorType.NVIDIA_L4),
+            (
+                "meta-llama/Llama-3.2-11B-Vision-Instruct",
+                AcceleratorType.NVIDIA_TESLA_A10G,
+            ),
+            ("meta-llama/Llama-3.2-11B-Vision-Instruct", AcceleratorType.NVIDIA_L4),
+            (
+                "meta-llama/Llama-3.2-90B-Vision-Instruct",
+                AcceleratorType.NVIDIA_TESLA_A10G,
+            ),
+            ("meta-llama/Llama-3.2-90B-Vision-Instruct", AcceleratorType.NVIDIA_L4),
+            ("meta-llama/Llama-3.2-90B-Vision-Instruct", AcceleratorType.NVIDIA_L40S),
         }
         if (model_id, gpu_type) in skipped_cases:
             return
@@ -71,7 +92,7 @@ class TestTextCompletionModelConfig:
     )
     def test_populate_custom_model(
         self,
-        gpu_type: GPUType,
+        gpu_type: AcceleratorType,
         tensor_parallelism: int,
         hf_token: Optional[str],
         max_num_lora_per_replica: Optional[int],


### PR DESCRIPTION
## Description
This PR addresses a TODO comment from https://github.com/ray-project/ray/pull/61906 to replace `GPUType` across files with `AcceleratorType`. We currently alias the type and made the switch to the latter since multiple accelerator types (GPU, TPU, etc.) are now supported with Ray LLM through extensible `AcceleratorBackend`s.

## Related issues

## Additional information
