### PR TITLE
[Data] only scale up related node-type

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import sys
 import time
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -69,9 +70,26 @@ class _NodeResourceSpec:
         return {"CPU": self.cpu, "GPU": self.gpu, "memory": self.mem}
 
 
-def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
-    """Get the unique node resource specs and their count in the cluster."""
-    nodes_resource_spec_count = defaultdict(int)
+@dataclass(frozen=True)
+class _NodeGroupInfo:
+    """Per-node-type bookkeeping: current count and max replicas."""
+
+    count: int
+    max_count: int  # -1 means unlimited
+
+    @property
+    def available(self) -> int:
+        """Number of additional nodes that can still be launched."""
+        if self.max_count == -1:
+            return sys.maxsize
+        return max(0, self.max_count - self.count)
+
+
+def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, _NodeGroupInfo]:
+    """Get the unique node resource specs, their running count, and max
+    replicas from the cluster config."""
+    nodes_resource_spec_count: Dict[_NodeResourceSpec, int] = defaultdict(int)
+    nodes_resource_spec_max: Dict[_NodeResourceSpec, int] = {}
 
     cluster_config = ray._private.state.state.get_cluster_config()
     if cluster_config and cluster_config.node_group_configs:
@@ -83,6 +101,13 @@ def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
                 node_group_config.resources
             )
             nodes_resource_spec_count[node_resource_spec] = 0
+            # Sum max_count across groups that share the same resource spec
+            prev = nodes_resource_spec_max.get(node_resource_spec, 0)
+            cur = node_group_config.max_count
+            if cur == -1 or prev == -1:
+                nodes_resource_spec_max[node_resource_spec] = -1
+            else:
+                nodes_resource_spec_max[node_resource_spec] = prev + cur
 
     # Filter out the head node.
     node_resources = [
@@ -95,7 +120,13 @@ def _get_node_resource_spec_and_count() -> Dict[_NodeResourceSpec, int]:
         node_resource_spec = _NodeResourceSpec.from_bundle(r)
         nodes_resource_spec_count[node_resource_spec] += 1
 
-    return nodes_resource_spec_count
+    default_max_count = -1 if cluster_config is None else 0
+    result: Dict[_NodeResourceSpec, _NodeGroupInfo] = {}
+    for spec, count in nodes_resource_spec_count.items():
+        max_count = nodes_resource_spec_max.get(spec, default_max_count)
+        result[spec] = _NodeGroupInfo(count=count, max_count=max_count)
+
+    return result
 
 
 class DefaultClusterAutoscalerV2(ClusterAutoscaler):
@@ -162,7 +193,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         min_gap_between_autoscaling_requests_s: float = MIN_GAP_BETWEEN_AUTOSCALING_REQUESTS,  # noqa: E501
         low_util_request_release_delay_s: float = DEFAULT_LOW_UTIL_REQUEST_RELEASE_DELAY_S,  # noqa: E501
         autoscaling_coordinator: Optional[AutoscalingCoordinator] = None,
-        get_node_counts: Callable[[], Dict[_NodeResourceSpec, int]] = (
+        get_node_counts: Callable[[], Dict[_NodeResourceSpec, _NodeGroupInfo]] = (
             _get_node_resource_spec_and_count
         ),
         get_time: Callable[[], float] = time.time,
@@ -238,20 +269,43 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             self._send_resource_request(None)
             return
 
+        # Determine which resource dimensions are bottlenecks.
+        bottleneck_cpu = util.cpu >= self._cluster_scaling_up_util_threshold
+        bottleneck_gpu = util.gpu >= self._cluster_scaling_up_util_threshold
+        bottleneck_memory = (
+            util.memory >= self._cluster_scaling_up_util_threshold
+            or util.object_store_memory >= self._cluster_scaling_up_util_threshold
+        )
+
         # We separate active bundles (existing nodes) from pending bundles (scale-up delta)
         # to ensure existing nodes' resources are never crowded out by scale-up requests.
-        # TODO(hchen): We scale up all nodes by the same delta for now.
+        # TODO(hchen): We only scale node types that are related to a bottleneck
+        # resource, applying the same delta to all selected types.
         # We may want to distinguish different node types based on their individual
         # utilization.
         active_bundles = []
         pending_bundles = []
-        node_resource_spec_count = self._get_node_counts()
-        for node_resource_spec, count in node_resource_spec_count.items():
+        node_resource_spec_info = self._get_node_counts()
+        for node_resource_spec, group_info in node_resource_spec_info.items():
             bundle = node_resource_spec.to_bundle()
-            # Bundles for existing nodes -> active (must include)
-            active_bundles.extend([bundle] * count)
-            # Bundles for scale-up delta -> pending (best-effort)
-            pending_bundles.extend([bundle] * self._cluster_scaling_up_delta)
+            # Bundles for existing nodes -> active (always include)
+            active_bundles.extend([bundle] * group_info.count)
+
+            # Only request scale-up for node types that carry the bottleneck
+            # resource. A node is relevant if it provides a resource whose
+            # utilization exceeds the threshold.
+            has_bottleneck_resource = (
+                (bottleneck_gpu and node_resource_spec.gpu > 0)
+                or (bottleneck_cpu and node_resource_spec.cpu > 0)
+                or (bottleneck_memory and node_resource_spec.mem > 0)
+            )
+            if not has_bottleneck_resource:
+                continue
+
+            # Cap the delta by the remaining capacity (maxReplicas - current).
+            delta = min(self._cluster_scaling_up_delta, group_info.available)
+            if delta > 0:
+                pending_bundles.extend([bundle] * delta)
 
         # Cap the resource request to respect user-configured limits.
         # Active bundles (existing nodes) are always included; pending bundles
@@ -277,7 +331,8 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             f"CPU={current_utilization.cpu:.0%}, GPU={current_utilization.gpu:.0%}, "
             f"memory={current_utilization.memory:.0%}, "
             f"object_store_memory={current_utilization.object_store_memory:.0%}. "
-            f"Requesting {self._cluster_scaling_up_delta} node(s) of each shape:"
+            f"Requesting up to {self._cluster_scaling_up_delta} node(s) "
+            f"of bottleneck-resource shapes (capped by maxReplicas):"
         )
 
         current_node_counts = Counter(

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -8,6 +8,7 @@ from ray.core.generated import autoscaler_pb2
 from ray.data._internal.cluster_autoscaler.default_cluster_autoscaler_v2 import (
     DefaultClusterAutoscalerV2,
     _get_node_resource_spec_and_count,
+    _NodeGroupInfo,
     _NodeResourceSpec,
 )
 from ray.data._internal.cluster_autoscaler.fake_autoscaling_coordinator import (
@@ -103,17 +104,17 @@ class TestClusterAutoscaling:
                 cpu=self._node_type1["CPU"],
                 gpu=self._node_type1.get("GPU", 0),
                 mem=self._node_type1["memory"],
-            ): 2,
+            ): _NodeGroupInfo(count=2, max_count=-1),
             _NodeResourceSpec.of(
                 cpu=self._node_type2["CPU"],
                 gpu=self._node_type2.get("GPU", 0),
                 mem=self._node_type2["memory"],
-            ): 1,
+            ): _NodeGroupInfo(count=1, max_count=-1),
             _NodeResourceSpec.of(
                 cpu=self._node_type3["CPU"],
                 gpu=self._node_type3.get("GPU", 0),
                 mem=self._node_type3["memory"],
-            ): 1,
+            ): _NodeGroupInfo(count=1, max_count=-1),
         }
 
         # Patch cluster config to return None
@@ -137,8 +138,8 @@ class TestClusterAutoscaling:
             cpu=cpu_util, gpu=gpu_util, object_store_memory=mem_util
         )
         fake_coordinator = FakeAutoscalingCoordinator()
-        resource_spec1 = _NodeResourceSpec.of(cpu=4, gpu=0, mem=1000)
-        resource_spec2 = _NodeResourceSpec.of(cpu=8, gpu=1, mem=1000)
+        resource_spec1 = _NodeResourceSpec.of(cpu=4, gpu=0, mem=8 * GiB)
+        resource_spec2 = _NodeResourceSpec.of(cpu=8, gpu=1, mem=8 * GiB)
 
         autoscaler = DefaultClusterAutoscalerV2(
             resource_manager=MagicMock(),
@@ -149,7 +150,10 @@ class TestClusterAutoscaling:
             cluster_scaling_up_util_threshold=scale_up_threshold,
             min_gap_between_autoscaling_requests_s=0,
             autoscaling_coordinator=fake_coordinator,
-            get_node_counts=lambda: {resource_spec1: 2, resource_spec2: 1},
+            get_node_counts=lambda: {
+                resource_spec1: _NodeGroupInfo(count=2, max_count=-1),
+                resource_spec2: _NodeGroupInfo(count=1, max_count=-1),
+            },
         )
 
         autoscaler.try_trigger_scaling()
@@ -164,20 +168,38 @@ class TestClusterAutoscaling:
         if not should_scale_up:
             assert resources_allocated == ExecutionResources.zero()
         else:
-            expected_num_resource_spec1_requested = 2 + scale_up_delta
-            expected_num_resource_spec2_requested = 1 + scale_up_delta
+            # With bottleneck-aware scaling, only node types carrying the
+            # bottleneck resource get the delta.  resource_spec1 has cpu
+            # only; resource_spec2 has both cpu and gpu.
+            #
+            # - cpu bottleneck  → both specs get delta (both have cpu > 0)
+            # - gpu bottleneck  → only spec2 gets delta (spec1 has gpu == 0)
+            # - mem bottleneck (object_store_memory mapped to memory dim)
+            #                   → both specs get delta (both have mem > 0)
+            spec1_requested = 2  # existing count always included
+            spec2_requested = 1
+
+            if cpu_util >= scale_up_threshold or mem_util >= scale_up_threshold:
+                spec1_requested += scale_up_delta
+            if (
+                gpu_util >= scale_up_threshold
+                or cpu_util >= scale_up_threshold
+                or mem_util >= scale_up_threshold
+            ):
+                spec2_requested += scale_up_delta
+
             expected_resources = ExecutionResources(
                 cpu=(
-                    resource_spec1.cpu * expected_num_resource_spec1_requested
-                    + resource_spec2.cpu * expected_num_resource_spec2_requested
+                    resource_spec1.cpu * spec1_requested
+                    + resource_spec2.cpu * spec2_requested
                 ),
                 gpu=(
-                    resource_spec1.gpu * expected_num_resource_spec1_requested
-                    + resource_spec2.gpu * expected_num_resource_spec2_requested
+                    resource_spec1.gpu * spec1_requested
+                    + resource_spec2.gpu * spec2_requested
                 ),
                 memory=(
-                    resource_spec1.mem * expected_num_resource_spec1_requested
-                    + resource_spec2.mem * expected_num_resource_spec2_requested
+                    resource_spec1.mem * spec1_requested
+                    + resource_spec2.mem * spec2_requested
                 ),
             )
 
@@ -213,8 +235,12 @@ class TestClusterAutoscaling:
         cluster_config.node_group_configs.append(node_group_config2)
 
         expected = {
-            _NodeResourceSpec.of(cpu=4, gpu=0, mem=1000): 0,
-            _NodeResourceSpec.of(cpu=8, gpu=2, mem=2000): 0,
+            _NodeResourceSpec.of(cpu=4, gpu=0, mem=1000): _NodeGroupInfo(
+                count=0, max_count=10
+            ),
+            _NodeResourceSpec.of(cpu=8, gpu=2, mem=2000): _NodeGroupInfo(
+                count=0, max_count=5
+            ),
         }
 
         with patch("ray.nodes", return_value=node_table):
@@ -247,8 +273,8 @@ class TestClusterAutoscaling:
             min_gap_between_autoscaling_requests_s=0,
             autoscaling_coordinator=fake_coordinator,
             get_node_counts=lambda: {
-                resource_spec1: 0,
-                resource_spec2: 0,
+                resource_spec1: _NodeGroupInfo(count=0, max_count=-1),
+                resource_spec2: _NodeGroupInfo(count=0, max_count=-1),
             },
         )
 
@@ -292,7 +318,9 @@ class TestClusterAutoscaling:
             resource_utilization_calculator=FakeUtilizationGauge(),
             min_gap_between_autoscaling_requests_s=0,
             autoscaling_coordinator=FakeAutoscalingCoordinator(),
-            get_node_counts=lambda: {node_resource_spec: 0},
+            get_node_counts=lambda: {
+                node_resource_spec: _NodeGroupInfo(count=0, max_count=-1),
+            },
         )
 
         # Trigger scaling with high utilization. The cluster autoscaler should request
@@ -341,7 +369,9 @@ class TestClusterAutoscaling:
             min_gap_between_autoscaling_requests_s=0,
             low_util_request_release_delay_s=100,
             autoscaling_coordinator=fake_coordinator,
-            get_node_counts=lambda: {node_resource_spec: 0},
+            get_node_counts=lambda: {
+                node_resource_spec: _NodeGroupInfo(count=0, max_count=-1),
+            },
             get_time=get_time,
         )
         autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
@@ -386,7 +416,9 @@ class TestClusterAutoscaling:
             min_gap_between_autoscaling_requests_s=0,
             low_util_request_release_delay_s=100,
             autoscaling_coordinator=fake_coordinator,
-            get_node_counts=lambda: {node_resource_spec: 0},
+            get_node_counts=lambda: {
+                node_resource_spec: _NodeGroupInfo(count=0, max_count=-1),
+            },
             get_time=get_time,
         )
         autoscaler.AUTOSCALING_REQUEST_EXPIRE_TIME_S = 3600
@@ -430,7 +462,9 @@ class TestClusterAutoscaling:
 
         # Only the first node type should be discovered
         expected = {
-            _NodeResourceSpec.of(cpu=4, gpu=0, mem=1000): 0,
+            _NodeResourceSpec.of(cpu=4, gpu=0, mem=1000): _NodeGroupInfo(
+                count=0, max_count=10
+            ),
         }
 
         with patch("ray.nodes", return_value=node_table):
@@ -461,7 +495,11 @@ class TestClusterAutoscaling:
         ]
 
         # Expect everything to default to 0
-        expected = {_NodeResourceSpec.of(cpu=0, gpu=0, mem=0): 1}
+        expected = {
+            _NodeResourceSpec.of(cpu=0, gpu=0, mem=0): _NodeGroupInfo(
+                count=1, max_count=-1
+            ),
+        }
 
         with (
             patch("ray.nodes", return_value=node_table),
@@ -533,7 +571,9 @@ class TestClusterAutoscaling:
             cluster_scaling_up_util_threshold=scale_up_threshold,
             min_gap_between_autoscaling_requests_s=0,
             autoscaling_coordinator=fake_coordinator,
-            get_node_counts=lambda: {node_spec: existing_nodes},
+            get_node_counts=lambda: {
+                node_spec: _NodeGroupInfo(count=existing_nodes, max_count=-1),
+            },
         )
 
         autoscaler.try_trigger_scaling()
@@ -566,8 +606,8 @@ class TestClusterAutoscaling:
         # Node types available: large (8 CPUs) and small (4 CPUs)
         def get_heterogeneous_nodes():
             return {
-                large_node_spec: 0,  # 0 existing large nodes
-                small_node_spec: 1,  # 1 existing small node (4 CPUs)
+                large_node_spec: _NodeGroupInfo(count=0, max_count=-1),
+                small_node_spec: _NodeGroupInfo(count=1, max_count=-1),
             }
 
         autoscaler = DefaultClusterAutoscalerV2(
@@ -629,8 +669,8 @@ class TestClusterAutoscaling:
         # Scale-up delta: 2 (want to add 2 of each node type)
         def get_node_counts():
             return {
-                large_node_spec: 1,  # 1 existing large node (6 CPUs)
-                small_node_spec: 0,  # 0 existing small nodes
+                large_node_spec: _NodeGroupInfo(count=1, max_count=-1),
+                small_node_spec: _NodeGroupInfo(count=0, max_count=-1),
             }
 
         autoscaler = DefaultClusterAutoscalerV2(
@@ -678,7 +718,9 @@ class TestClusterAutoscaling:
                 resource_utilization_calculator=StubUtilizationGauge(utilization),
                 min_gap_between_autoscaling_requests_s=0,
                 autoscaling_coordinator=fake_coordinator,
-                get_node_counts=lambda: {node_spec: 1},
+                get_node_counts=lambda: {
+                    node_spec: _NodeGroupInfo(count=1, max_count=-1),
+                },
             )
 
         with caplog.at_level(logging.INFO):
@@ -687,7 +729,8 @@ class TestClusterAutoscaling:
         expected_message = (
             "The utilization of one or more logical resource is higher than the "
             "specified threshold of 75%: CPU=100%, GPU=100%, memory=0%, "
-            "object_store_memory=100%. Requesting 1 node(s) of each shape: "
+            "object_store_memory=100%. Requesting up to 1 node(s) "
+            "of bottleneck-resource shapes (capped by maxReplicas): "
             "[{CPU: 1, GPU: 0, memory: 8.0GiB}: 1 -> 2]"
         )
         log_messages = [record.message for record in caplog.records]
@@ -721,7 +764,9 @@ class TestClusterAutoscaling:
                 resource_utilization_calculator=StubUtilizationGauge(utilization),
                 min_gap_between_autoscaling_requests_s=0,
                 autoscaling_coordinator=fake_coordinator,
-                get_node_counts=lambda: {node_spec: 2},
+                get_node_counts=lambda: {
+                    node_spec: _NodeGroupInfo(count=2, max_count=-1),
+                },
             )
 
         with caplog.at_level(logging.DEBUG):


### PR DESCRIPTION
### Background

I'm running a Ray Data job with two types of worker nodes:

- GPU nodes: logical resources CPU\*32, GPU\*1, maxReplicas=500, currently 1 node
- CPU nodes: logical resources CPU\*32, GPU\*0, maxReplicas=10, currently 10 nodes

`default_cluster_autoscaler_v2.py` continuously monitors cluster resource utilization. When it detects that GPU resources are insufficient, it triggers scale-up. Unfortunately, the current implementation scales up **all** node types, because of this line: https://github.com/ray-project/ray/blob/8c5f8f8d69aaff5b2f2725136225adc609931b31/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py#L243

This causes `default_cluster_autoscaler_v2.py` to send a request to the autoscaler pod like:
`{'CPU': 8, 'GPU': 1} × 1, {'CPU': 16, 'GPU': 0} × 1`

Since the CPU nodes have already reached their maxReplicas, the autoscaler considers the request infeasible and fails with:
> No available node types can fulfill cluster constraint: {'CPU': 8.0, 'GPU': 1.0}\*1, {'CPU': 16.0, 'GPU': 0.0}\*1. Add suitable node types to this cluster to resolve this issue.

In this CR, I made changes so that `default_cluster_autoscaler_v2.py` only scales up node types that are related to the resource bottleneck. For example, when GPU resources are the bottleneck, only GPU nodes will be scaled up.


---
### Related PR
During testing, i found had issues during scaling up. After investigation, I discovered this was because the `cluster_config` retrieved from GCS is `None`:

https://github.com/ray-project/ray/blob/f229d5376eb87b09a3fa0b991323450de84df890/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py#L76

So I looked into it and found that this function is responsible for writing the `cluster_config` to GCS:

https://github.com/ray-project/ray/blob/f229d5376eb87b09a3fa0b991323450de84df890/python/ray/includes/gcs_client.pxi#L753

But this function was never actually called.

Therefore, in PR https://github.com/ray-project/ray/pull/63012 , I modified autoscaler v2 to make it write the `cluster_config` to GCS.

