### PR TITLE
[serve][1/n] deflake test_metrics

### DIFF
--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1419,9 +1419,11 @@ class HTTPProxy(GenericProxy):
                     yield asgi_message
                     response_started = True
         except BaseException as e:
-            status = get_http_response_status(e, request_timeout_s, request_id)
+            error_status = get_http_response_status(e, request_timeout_s, request_id)
+            if status is None:
+                status = error_status
             for asgi_message in send_http_response_on_exception(
-                status, response_started
+                error_status, response_started
             ):
                 yield asgi_message
             exc = e

--- a/python/ray/serve/tests/test_metrics.py
+++ b/python/ray/serve/tests/test_metrics.py
@@ -869,7 +869,8 @@ def test_replica_metrics_fields(metrics_start_shutdown):
         lambda: len(
             get_metric_dictionaries("ray_serve_replica_processing_queries", wait=False)
         )
-        == 2
+        == 2,
+        timeout=40,
     )
     processing_queries = get_metric_dictionaries("ray_serve_replica_processing_queries")
     expected_output = {("f", "app1"), ("g", "app2")}


### PR DESCRIPTION
300 response can cause client to disconnect the connection, which would cause server to handle that connection and change the status to a 499 (which is an error). don't override the status if it's already been set.

also increase the wait_for_condition in `test_replica_metrics_fields` to match the other timeouts in the test.

there are other failures in test_metrics that needs deflaking