### PR TITLE
[serve] Retry build_serve_application task on failure

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional, Tuple
 import ray
 from ray import cloudpickle
 from ray._common.utils import import_attr, import_module_and_attr
-from ray.exceptions import RuntimeEnvSetupError
+from ray.exceptions import RayTaskError, RuntimeEnvSetupError
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.build_app import BuiltApplication, build_app
 from ray.serve._private.common import (
@@ -862,6 +862,14 @@ class ApplicationState:
                 + traceback.format_exc()
             )
             return None, None, BuildAppStatus.FAILED, error_msg
+        except RayTaskError:
+            return (
+                None,
+                None,
+                BuildAppStatus.FAILED,
+                f"Deploying app '{self._name}' failed with exception:\n"
+                f"{traceback.format_exc()}",
+            )
         except Exception:
             error_msg = (
                 f"Unexpected error occurred while deploying application "
@@ -1676,9 +1684,9 @@ def build_serve_application(
         )
         return None, None, None
     except Exception:
-        logger.error(
-            f"Exception importing application '{name}'.\n{traceback.format_exc()}"
-        )
+        # Ray's task retry machinery already logs the full traceback on each
+        # attempt, so emit a brief warning here to avoid 4× duplicate tracebacks.
+        logger.warning(f"Exception importing application '{name}'.")
         # Re-raise so Ray's max_retries / retry_exceptions on the decorator apply.
         raise
 

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1684,11 +1684,13 @@ def build_serve_application(
         )
         return None, None, None
     except Exception:
-        # Ray's task retry machinery already logs the full traceback on each
-        # attempt, so emit a brief warning here to avoid 4× duplicate tracebacks.
+        # Wrap the user traceback in a RuntimeError so that user exceptions
+        # which are unpickleable (e.g. NonserializableException) or lose detail
+        # through Ray's serialization round-trip (e.g. SyntaxError) still
+        # propagate their original traceback intact through Ray's retry path.
+        err_str = traceback.format_exc()
         logger.warning(f"Exception importing application '{name}'.")
-        # Re-raise so Ray's max_retries / retry_exceptions on the decorator apply.
-        raise
+        raise RuntimeError(err_str) from None
 
 
 def override_deployment_info(

--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -1536,7 +1536,7 @@ class ApplicationStateManager:
         )
 
 
-@ray.remote(num_cpus=0, max_calls=1)
+@ray.remote(num_cpus=0, max_calls=1, max_retries=3, retry_exceptions=True)
 def build_serve_application(
     import_path: str,
     code_version: str,
@@ -1679,7 +1679,8 @@ def build_serve_application(
         logger.error(
             f"Exception importing application '{name}'.\n{traceback.format_exc()}"
         )
-        return None, None, traceback.format_exc()
+        # Re-raise so Ray's max_retries / retry_exceptions on the decorator apply.
+        raise
 
 
 def override_deployment_info(

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -203,6 +203,7 @@ py_test_module_list(
 # Large tests.
 py_test_module_list(
     size = "enormous",
+    data = glob(["test_config_files/**/*"]),
     files = [
         "test_autoscaling_policy.py",
         "test_deploy.py",

--- a/python/ray/serve/tests/test_config_files/flaky_build.py
+++ b/python/ray/serve/tests/test_config_files/flaky_build.py
@@ -1,0 +1,29 @@
+"""Test fixture: raises on first FLAKY_BUILD_FAIL_COUNT imports, then succeeds.
+
+A counter file persists state across the fresh worker processes that
+``build_serve_application``'s ``max_calls=1`` decorator spawns on each retry.
+"""
+
+import os
+
+from ray import serve
+
+_COUNTER_FILE = os.environ["FLAKY_BUILD_COUNTER_FILE"]
+_FAIL_COUNT = int(os.environ.get("FLAKY_BUILD_FAIL_COUNT", "3"))
+
+with open(_COUNTER_FILE, "r") as f:
+    _attempts = int(f.read().strip() or "0")
+with open(_COUNTER_FILE, "w") as f:
+    f.write(str(_attempts + 1))
+
+if _attempts < _FAIL_COUNT:
+    raise RuntimeError(f"flaky build failure on attempt {_attempts + 1}")
+
+
+@serve.deployment
+class FlakyApp:
+    def __call__(self):
+        return "ok"
+
+
+node = FlakyApp.bind()

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -587,6 +587,66 @@ def test_build_app_task_uses_zero_cpus(ray_shutdown):
     ray.shutdown()
 
 
+def _call_build_serve_application(import_path: str):
+    from ray.serve._private.application_state import build_serve_application
+    from ray.serve.schema import LoggingConfig
+
+    return build_serve_application.remote(
+        import_path,
+        "test-code-version",
+        "test_app",
+        {},
+        LoggingConfig(),
+        None,
+        {},
+        {},
+        {},
+    )
+
+
+def test_build_serve_application_retries_on_failure(ray_shutdown, tmp_path):
+    """Application errors raised during the build task are retried up to 3 times."""
+    counter_file = tmp_path / "counter.txt"
+    counter_file.write_text("0")
+
+    os.environ["FLAKY_BUILD_COUNTER_FILE"] = str(counter_file)
+    os.environ["FLAKY_BUILD_FAIL_COUNT"] = "3"
+    try:
+        ray.init(num_cpus=1)
+        obj_ref = _call_build_serve_application(
+            "ray.serve.tests.test_config_files.flaky_build.node"
+        )
+        _, deploy_args, err = ray.get(obj_ref)
+        assert err is None, f"expected success after retries, got {err!r}"
+        assert deploy_args is not None
+        assert int(counter_file.read_text()) == 4
+    finally:
+        os.environ.pop("FLAKY_BUILD_COUNTER_FILE", None)
+        os.environ.pop("FLAKY_BUILD_FAIL_COUNT", None)
+
+
+def test_build_serve_application_propagates_after_retries_exhausted(
+    ray_shutdown, tmp_path
+):
+    """If the build task keeps failing, the exception propagates after 3 retries."""
+    counter_file = tmp_path / "counter.txt"
+    counter_file.write_text("0")
+
+    os.environ["FLAKY_BUILD_COUNTER_FILE"] = str(counter_file)
+    os.environ["FLAKY_BUILD_FAIL_COUNT"] = "10"
+    try:
+        ray.init(num_cpus=1)
+        obj_ref = _call_build_serve_application(
+            "ray.serve.tests.test_config_files.flaky_build.node"
+        )
+        with pytest.raises(Exception, match="flaky build failure"):
+            ray.get(obj_ref)
+        assert int(counter_file.read_text()) == 4
+    finally:
+        os.environ.pop("FLAKY_BUILD_COUNTER_FILE", None)
+        os.environ.pop("FLAKY_BUILD_FAIL_COUNT", None)
+
+
 @pytest.mark.parametrize(
     "options",
     [

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -639,7 +639,7 @@ def test_build_serve_application_propagates_after_retries_exhausted(
         obj_ref = _call_build_serve_application(
             "ray.serve.tests.test_config_files.flaky_build.node"
         )
-        with pytest.raises(Exception, match="flaky build failure"):
+        with pytest.raises(RuntimeError, match="flaky build failure"):
             ray.get(obj_ref)
         assert int(counter_file.read_text()) == 4
     finally:

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -587,60 +587,50 @@ def test_build_app_task_uses_zero_cpus(ray_shutdown):
     ray.shutdown()
 
 
-def _call_build_serve_application(import_path: str):
-    from ray.serve._private.application_state import build_serve_application
-    from ray.serve.schema import LoggingConfig
-
-    return build_serve_application.remote(
-        import_path,
-        "test-code-version",
-        "test_app",
-        {},
-        LoggingConfig(),
-        None,
-        {},
-        {},
-        {},
+def _deploy_flaky_app(counter_file, fail_count: int):
+    os.environ["FLAKY_BUILD_COUNTER_FILE"] = str(counter_file)
+    os.environ["FLAKY_BUILD_FAIL_COUNT"] = str(fail_count)
+    counter_file.write_text("0")
+    ray.init(num_cpus=1)
+    serve.start()
+    _get_global_client().deploy_apps(
+        ServeDeploySchema(
+            applications=[
+                ServeApplicationSchema(
+                    name="flaky_app",
+                    route_prefix="/flaky",
+                    import_path="ray.serve.tests.test_config_files.flaky_build.node",
+                )
+            ]
+        )
     )
 
 
-def test_build_serve_application_retries_on_failure(ray_shutdown, tmp_path):
-    """Application errors raised during the build task are retried up to 3 times."""
+def test_build_app_retries_until_success(ray_shutdown, tmp_path):
+    """A flaky build that succeeds on the 4th attempt deploys cleanly."""
     counter_file = tmp_path / "counter.txt"
-    counter_file.write_text("0")
-
-    os.environ["FLAKY_BUILD_COUNTER_FILE"] = str(counter_file)
-    os.environ["FLAKY_BUILD_FAIL_COUNT"] = "3"
     try:
-        ray.init(num_cpus=1)
-        obj_ref = _call_build_serve_application(
-            "ray.serve.tests.test_config_files.flaky_build.node"
+        _deploy_flaky_app(counter_file, fail_count=3)
+        wait_for_condition(
+            lambda: serve.status().applications["flaky_app"].status == "RUNNING",
+            timeout=60,
         )
-        _, deploy_args, err = ray.get(obj_ref)
-        assert err is None, f"expected success after retries, got {err!r}"
-        assert deploy_args is not None
         assert int(counter_file.read_text()) == 4
     finally:
         os.environ.pop("FLAKY_BUILD_COUNTER_FILE", None)
         os.environ.pop("FLAKY_BUILD_FAIL_COUNT", None)
 
 
-def test_build_serve_application_propagates_after_retries_exhausted(
-    ray_shutdown, tmp_path
-):
-    """If the build task keeps failing, the exception propagates after 3 retries."""
+def test_build_app_fails_after_retries_exhausted(ray_shutdown, tmp_path):
+    """If the build keeps failing, the app status surfaces the user error."""
     counter_file = tmp_path / "counter.txt"
-    counter_file.write_text("0")
-
-    os.environ["FLAKY_BUILD_COUNTER_FILE"] = str(counter_file)
-    os.environ["FLAKY_BUILD_FAIL_COUNT"] = "10"
     try:
-        ray.init(num_cpus=1)
-        obj_ref = _call_build_serve_application(
-            "ray.serve.tests.test_config_files.flaky_build.node"
+        _deploy_flaky_app(counter_file, fail_count=10)
+        wait_for_condition(
+            lambda: serve.status().applications["flaky_app"].status == "DEPLOY_FAILED",
+            timeout=60,
         )
-        with pytest.raises(RuntimeError, match="flaky build failure"):
-            ray.get(obj_ref)
+        assert "flaky build failure" in serve.status().applications["flaky_app"].message
         assert int(counter_file.read_text()) == 4
     finally:
         os.environ.pop("FLAKY_BUILD_COUNTER_FILE", None)


### PR DESCRIPTION
## Summary

- `build_serve_application` is the Ray task the controller uses to import and build a user app. It ran with no retry on application errors: any exception during the user import / build was caught inside the task and surfaced as `DEPLOY_FAILED` on the first attempt, even for transient failures.
- Add `max_retries=3, retry_exceptions=True` to the task decorator and re-raise from the catch-all `except Exception:` so Ray's retry machinery actually sees the failure. After 3 retries (4 total attempts) the exception propagates out of `ray.get()` and is surfaced as `DEPLOY_FAILED` as before.
- The `KeyboardInterrupt` branch (raised by `ray.cancel()` during redeploy) is unchanged and still returns cleanly without retry.