### PR TITLE
docs(serve): fix broken MCP template link

### DIFF
--- a/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb
+++ b/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb
@@ -154,7 +154,7 @@
         "**Additional resources:**\n",
         "- [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)\n",
         "- [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)\n",
-        "- [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve)\n"
+        "- [MCP Ray Serve example](https://docs.ray.io/en/latest/ray-overview/examples/mcp-ray-serve/README.html)\n"
       ]
     },
     {
@@ -631,7 +631,7 @@
         "### Extend your agent\n",
         "\n",
         "**Add more tools**  \n",
-        "Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve).\n",
+        "Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [MCP Ray Serve example](https://docs.ray.io/en/latest/ray-overview/examples/mcp-ray-serve/README.html).\n",
         "\n",
         "**Swap or upgrade LLMs**  \n",
         "Replace the Qwen model with other tool-calling models such as GPT-4, Claude, or Llama variants. Since the LLM runs as a separate service, you can A/B test different models or perform zero-downtime upgrades. For deployment patterns, see the [Anyscale LLM Serving Template](https://console.anyscale.com/template-preview/deployment-serve-llm).\n",

--- a/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
+++ b/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
@@ -124,7 +124,7 @@ mcp = FastMCP("weather", stateless_http=True)
 **Additional resources:**
 - [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)
 - [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)
-- [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve)
+- [MCP Ray Serve example](https://docs.ray.io/en/latest/ray-overview/examples/mcp-ray-serve/README.html)
 
 
 ### Step 3: Create the agent logic
@@ -513,7 +513,7 @@ You've successfully built, deployed, and tested a multi-tool agent using Ray Ser
 ### Extend your agent
 
 **Add more tools**  
-Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve).
+Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [MCP Ray Serve example](https://docs.ray.io/en/latest/ray-overview/examples/mcp-ray-serve/README.html).
 
 **Swap or upgrade LLMs**  
 Replace the Qwen model with other tool-calling models such as GPT-4, Claude, or Llama variants. Since the LLM runs as a separate service, you can A/B test different models or perform zero-downtime upgrades. For deployment patterns, see the [Anyscale LLM Serving Template](https://console.anyscale.com/template-preview/deployment-serve-llm).


### PR DESCRIPTION
Fix the broken Anyscale MCP template link in the Ray Serve agent example.

- Replace the console template preview URL with the public Ray docs example page.
- Update both the notebook source and generated markdown to keep them in sync.

Verification:
- Parsed doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb with json.load().
- Confirmed the updated link appears in both README.ipynb and README.md.