### PR TITLE
[core] increase the cleanup timeout in the chaos iptable test

### DIFF
--- a/release/nightly_tests/chaos_test/actor_workload.py
+++ b/release/nightly_tests/chaos_test/actor_workload.py
@@ -70,7 +70,7 @@ def run_actor_workload(total_num_cpus, smoke):
             ray.cluster_resources().get("CPU", 0)
             == ray.available_resources().get("CPU", 0)
         ),
-        timeout=120,
+        timeout=300,
     )
     letter_set = set()
     for db_actor in db_actors:

--- a/release/nightly_tests/chaos_test/actor_workload.py
+++ b/release/nightly_tests/chaos_test/actor_workload.py
@@ -70,7 +70,7 @@ def run_actor_workload(total_num_cpus, smoke):
             ray.cluster_resources().get("CPU", 0)
             == ray.available_resources().get("CPU", 0)
         ),
-        timeout=60,
+        timeout=120,
     )
     letter_set = set()
     for db_actor in db_actors:


### PR DESCRIPTION
## Description

Increase the waiting time for the cleanup according to the cluster logs from the [failure](https://buildkite.com/ray-project/release/builds/90709#019dd2b5-f78b-47eb-aa8f-331c5c68cad3):

### Timeline
- **23:14:00**: Actor workload starts with network failure injection every 60s.
- **23:15:00**: First 5s network fault affects head + 4 workers.
- **23:16:02**: Raylet reports worker process `10563` did not register within timeout.
- **23:16:02-23:17:00**: `ReportActor.add` retries pile up after connection resets; progress stalls near 47%.
- **23:18:34-23:20:34**: Head state dumps show `128` total worker CPUs and `0` available while actor work is still running.
- **23:21:34**: Head sees `128` total CPUs, `112` available. Missing `16` CPUs are all on `10.0.45.36`.
- **23:21:43**: Worker `10.0.45.36` reports 16 `ReportActor.__init__` workers, each holding `1 CPU`.
- **23:21:47**: Those 16 `ReportActor` workers disconnect gracefully.
- **23:21:49**: `wait_for_condition` times out before observing all CPUs released; another network fault triggers at the same time.

So, increasing the cleanup consistency timeout should likely fix this specific failure.


## Related issues
Fixes: https://github.com/anyscale/ray/issues/1534

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
