### PR TITLE
[Core]Fix actor creation race condition of #59642

### DIFF
--- a/src/ray/gcs/actor/gcs_actor.h
+++ b/src/ray/gcs/actor/gcs_actor.h
@@ -208,6 +208,16 @@ class GcsActor {
   void UpdateAddress(const rpc::Address &address);
   /// Get the `Address` of this actor.
   const rpc::Address &GetAddress() const;
+  /// Set the borrowed references of this actor at the time of creation.
+  void SetBorrowedRefsAtCreation(
+      const google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount> &refs) {
+    borrowed_refs_at_creation_ = refs;
+  }
+  /// Get the borrowed references of this actor at the time of creation.
+  const google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount>
+      &GetBorrowedRefsAtCreation() const {
+    return borrowed_refs_at_creation_;
+  }
 
   /// Update the state of this actor and refreshes metrics. Do not update the
   /// state of the underlying proto directly via set_state(), otherwise metrics
@@ -335,6 +345,12 @@ class GcsActor {
   std::string session_name_;
   /// Address of the local raylet of the worker where this actor is running
   std::optional<rpc::Address> local_raylet_address_;
+  /// The borrowed references at the time of successful creation.
+  /// These are saved so that if the actor restarts and there is a pending
+  /// creation callback, we can correctly invoke the callback early with the
+  /// valid borrowed_refs.
+  google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount>
+      borrowed_refs_at_creation_;
 };
 
 using RestartActorForLineageReconstructionCallback =

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1514,6 +1514,26 @@ void GcsActorManager::RestartActor(
     }
     auto new_num_restarts = num_restarts + 1;
     mutable_actor_table_data->set_num_restarts(new_num_restarts);
+
+    // Invoke creation callbacks early for actors that are already created.
+    // This enforces the strict sequence that the callback is invoked with the
+    // original created actor's address and borrowed_refs, before clearing the address.
+    // Note that only borrowed_refs needs to be populated in the reconstructed
+    // PushTaskReply because the callback implementation extracts other fields
+    // (like actor_address) directly from the GcsActor instance.
+    auto create_callback_iter = actor_to_create_callbacks_.find(actor_id);
+    if (create_callback_iter != actor_to_create_callbacks_.end() &&
+        actor->GetState() == rpc::ActorTableData::ALIVE) {
+      RAY_LOG(INFO).WithField(actor_id.JobId()).WithField(actor_id)
+          << "Invoking pending creation callbacks early in RestartActor before "
+             "clearing the actor address to enforce the strict sequence that the "
+             "callback is invoked with the original created actor's address and "
+             "borrowed_refs.";
+      rpc::PushTaskReply reply;
+      reply.mutable_borrowed_refs()->CopyFrom(actor->GetBorrowedRefsAtCreation());
+      RunAndClearActorCreationCallbacks(actor, reply, Status::OK());
+    }
+
     actor->UpdateState(rpc::ActorTableData::RESTARTING);
     actor->GetMutableTaskSpec()->set_attempt_number(new_num_restarts);
     // Make sure to reset the address before flushing to GCS. Otherwise,
@@ -1667,6 +1687,7 @@ void GcsActorManager::OnActorCreationSuccess(const std::shared_ptr<GcsActor> &ac
     mutable_actor_table_data->set_start_time(time);
   }
   actor->UpdateState(rpc::ActorTableData::ALIVE);
+  actor->SetBorrowedRefsAtCreation(reply.borrowed_refs());
 
   // We should register the entry to the in-memory index before flushing them to
   // GCS because otherwise, there could be timing problems due to asynchronous Put.

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -419,6 +419,125 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::DEAD, ""), 20);
 }
 
+TEST_F(GcsActorManagerTest, TestActorCreationRaceWithRestart) {
+  auto job_id = JobID::FromInt(1);
+
+  // Register and Create Actor.
+  auto request = GenRegisterActorRequest(job_id, /*max_restarts=*/1, /*detached=*/false);
+  auto actor_id =
+      ActorID::FromBinary(request.task_spec().actor_creation_task_spec().actor_id());
+
+  rpc::RegisterActorReply register_reply;
+  gcs_actor_manager_->HandleRegisterActor(
+      request, &register_reply, [](auto, auto, auto) {});
+  drain_io_context();
+
+  rpc::CreateActorRequest create_request;
+  create_request.mutable_task_spec()->CopyFrom(request.task_spec());
+  rpc::CreateActorReply create_reply;
+
+  bool callback_invoked = false;
+  gcs_actor_manager_->HandleCreateActor(
+      create_request, &create_reply, [&callback_invoked](Status status, auto, auto) {
+        callback_invoked = true;
+        ASSERT_TRUE(status.ok());
+      });
+
+  // Get the actor instance from the scheduler.
+  ASSERT_FALSE(mock_actor_scheduler_->actors.empty());
+  auto actor = mock_actor_scheduler_->actors.back();
+
+  // Manually simulate success state (ALIVE) without triggering storage write.
+  auto address = RandomAddress();
+  auto object_id = "test_object_id";
+  actor->UpdateAddress(address);
+  actor->UpdateState(rpc::ActorTableData::ALIVE);
+  google::protobuf::RepeatedPtrField<rpc::ObjectReferenceCount> borrowed_refs;
+  borrowed_refs.Add()->mutable_reference()->set_object_id(object_id);
+  actor->SetBorrowedRefsAtCreation(borrowed_refs);
+
+  // Verify it hasn't been invoked yet since OnActorCreationSuccess is not called.
+  ASSERT_FALSE(callback_invoked);
+
+  // Mock CancelOnWorker to return the actor_id, simulating worker death during creation.
+  EXPECT_CALL(*mock_actor_scheduler_,
+              CancelOnWorker(NodeID::FromBinary(address.node_id()),
+                             WorkerID::FromBinary(address.worker_id())))
+      .WillOnce(testing::Return(actor_id));
+
+  // Trigger worker death.
+  gcs_actor_manager_->OnWorkerDead(NodeID::FromBinary(address.node_id()),
+                                   WorkerID::FromBinary(address.worker_id()),
+                                   "127.0.0.1",
+                                   rpc::WorkerExitType::SYSTEM_ERROR,
+                                   "worker process has died.");
+
+  // Verify that callbacks are invoked.
+  ASSERT_TRUE(callback_invoked);
+  // Verify that the reply is correctly populated with the original created address and
+  // borrowed_refs.
+  ASSERT_EQ(create_reply.actor_address().worker_id(), address.worker_id());
+  ASSERT_EQ(create_reply.actor_address().node_id(), address.node_id());
+  ASSERT_EQ(create_reply.borrowed_refs().size(), 1);
+  ASSERT_EQ(create_reply.borrowed_refs(0).reference().object_id(), object_id);
+}
+
+TEST_F(GcsActorManagerTest, TestActorCreationRaceWithRestartActorNotAlive) {
+  auto job_id = JobID::FromInt(1);
+
+  // Register and Create Actor.
+  auto request = GenRegisterActorRequest(job_id, /*max_restarts=*/1, /*detached=*/false);
+  auto actor_id =
+      ActorID::FromBinary(request.task_spec().actor_creation_task_spec().actor_id());
+
+  rpc::RegisterActorReply register_reply;
+  gcs_actor_manager_->HandleRegisterActor(
+      request, &register_reply, [](auto, auto, auto) {});
+  drain_io_context();
+
+  rpc::CreateActorRequest create_request;
+  create_request.mutable_task_spec()->CopyFrom(request.task_spec());
+  rpc::CreateActorReply create_reply;
+
+  bool callback_invoked = false;
+  gcs_actor_manager_->HandleCreateActor(
+      create_request, &create_reply, [&callback_invoked](Status status, auto, auto) {
+        callback_invoked = true;
+        ASSERT_TRUE(status.ok());
+      });
+
+  // Get the actor instance from the scheduler.
+  ASSERT_FALSE(mock_actor_scheduler_->actors.empty());
+  auto actor = mock_actor_scheduler_->actors.back();
+
+  // Simulate a state where the actor is in PENDING_CREATION (not ALIVE yet).
+  auto address = RandomAddress();
+  actor->UpdateAddress(address);
+  actor->UpdateState(rpc::ActorTableData::PENDING_CREATION);
+
+  // Verify it hasn't been invoked yet.
+  ASSERT_FALSE(callback_invoked);
+
+  // Mock CancelOnWorker to return the actor_id, simulating worker death during creation.
+  EXPECT_CALL(*mock_actor_scheduler_,
+              CancelOnWorker(NodeID::FromBinary(address.node_id()),
+                             WorkerID::FromBinary(address.worker_id())))
+      .WillOnce(testing::Return(actor_id));
+
+  // Trigger worker death.
+  gcs_actor_manager_->OnWorkerDead(NodeID::FromBinary(address.node_id()),
+                                   WorkerID::FromBinary(address.worker_id()),
+                                   "127.0.0.1",
+                                   rpc::WorkerExitType::SYSTEM_ERROR,
+                                   "worker process has died.");
+
+  // Verify that the creation callback is NOT invoked early when the actor is not ALIVE.
+  ASSERT_FALSE(callback_invoked);
+  // Verify that the reply remains empty and unpopulated.
+  ASSERT_FALSE(create_reply.has_actor_address());
+  ASSERT_EQ(create_reply.borrowed_refs().size(), 0);
+}
+
 TEST_F(GcsActorManagerTest, TestSchedulingFailed) {
   auto job_id = JobID::FromInt(1);
   auto registered_actor = RegisterActor(job_id);


### PR DESCRIPTION
## Description
Run and clear the actor creation callback before actor recreation to avoid race condition.

A race condition occurs when an actor is successfully created on a worker, but the worker dies before GCS completes the asynchronous write of the actor's ALIVE state to storage. While waiting for the storage write, GCS processes the worker death and clears the actor's address in memory. When the storage write finally completes, its callback reads the cleared (Nil) address and sends it to the client, causing a crash.

With the [suggestion](https://github.com/ray-project/ray/issues/59642#issuecomment-4272088511) from @MengjinYan, in RestartActor, before clearing the actor's address in memory, we check if the actor was already successfully created (ALIVE) and has pending creation callbacks. If so, we invoke the callbacks early with the valid address still in memory and the stored `borrowed_refs`. This ensures the client receives a valid address and avoids the crash.



## Related issues
Fixes #59642

## Tested
- added a new unit test
- reproduce the issue and verify the fix
