### PR TITLE
[data] hide local-shuffle take() behind a producer thread

### DIFF
--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -1,6 +1,8 @@
 import dataclasses
 import functools
 import logging
+import os
+import queue
 import threading
 from contextlib import nullcontext
 from typing import Any, Callable, Generic, Iterator, List, Optional, Tuple, TypeVar
@@ -19,6 +21,17 @@ from ray.data.block import Block, BlockAccessor, DataBatch
 from ray.types import ObjectRef
 
 logger = logging.getLogger(__name__)
+
+# When set, run the local-shuffle `ShufflingBatcher` add/next_batch loop on a
+# dedicated producer thread that pushes formed batches into a bounded queue,
+# so that the per-batch and pre-compaction `take` calls overlap with downstream
+# format/finalize/train work. Off by default; gated to ease A/B benchmarking.
+_RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE = bool(
+    int(os.environ.get("RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE", "0"))
+)
+_RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE_QUEUE_DEPTH = max(
+    1, int(os.environ.get("RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE_QUEUE_DEPTH", "4"))
+)
 
 I = TypeVar("I")
 O = TypeVar("O")
@@ -146,10 +159,25 @@ class _BatchingIterator(Iterator[Batch]):
         else:
             self._batcher = Batcher(batch_size=batch_size, ensure_copy=ensure_copy)
 
+        self._async_take = (
+            shuffle_buffer_min_size is not None and _RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE
+        )
+        if self._async_take:
+            self._batch_queue: "queue.Queue" = queue.Queue(
+                maxsize=_RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE_QUEUE_DEPTH
+            )
+            self._sentinel = object()
+            self._producer_thread: Optional[threading.Thread] = None
+
     def __iter__(self) -> "_BatchingIterator":
         return self
 
     def __next__(self) -> Batch:
+        if self._async_take:
+            return self._next_async()
+        return self._next_sync()
+
+    def _next_sync(self) -> Batch:
         timer = self._stats.iter_next_batch_s.timer() if self._stats else nullcontext()
 
         # Try to get a batch from current batcher state
@@ -186,6 +214,58 @@ class _BatchingIterator(Iterator[Batch]):
                 #
                 # We stop the iteration
                 raise StopIteration
+
+    def _next_async(self) -> Batch:
+        if self._producer_thread is None:
+            self._producer_thread = threading.Thread(
+                target=self._producer_loop,
+                name="ShufflingBatcherAsyncTake",
+                daemon=True,
+            )
+            self._producer_thread.start()
+
+        timer = self._stats.iter_next_batch_s.timer() if self._stats else nullcontext()
+        with timer:
+            item = self._batch_queue.get()
+        if isinstance(item, BaseException):
+            raise item
+        if item is self._sentinel:
+            raise StopIteration
+        return item
+
+    def _producer_loop(self) -> None:
+        # Mirrors the control flow of _next_sync, but runs on a dedicated thread
+        # and pushes formed batches into a bounded queue. The expensive `take`
+        # calls inside ShufflingBatcher.next_batch release the GIL, so they can
+        # run in parallel with downstream format/finalize/train work on the
+        # consumer thread.
+        try:
+            done_adding = False
+            while True:
+                can_yield = self._batcher.has_batch() or (
+                    self._batcher.has_any() and done_adding and not self._drop_last
+                )
+
+                if can_yield:
+                    next_batch = self._batcher.next_batch()
+                    res = Batch(
+                        metadata=BatchMetadata(batch_idx=self._global_counter),
+                        data=next_batch,
+                    )
+                    self._global_counter += 1
+                    self._batch_queue.put(res)
+                elif not done_adding:
+                    try:
+                        block = next(self._block_iter)
+                        self._batcher.add(block)
+                    except StopIteration:
+                        self._batcher.done_adding()
+                        done_adding = True
+                else:
+                    self._batch_queue.put(self._sentinel)
+                    return
+        except BaseException as e:
+            self._batch_queue.put(e)
 
 
 def _format_batch(

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import random
 import sys
@@ -10,6 +11,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data._internal.block_batching import util as block_batching_util
 from ray.data._internal.block_batching.interfaces import Batch, BatchMetadata
 from ray.data._internal.block_batching.util import (
     _calculate_ref_hits,
@@ -67,6 +69,62 @@ def test_blocks_to_batches(block_size, drop_last):
     assert [batch.metadata.batch_idx for batch in batch_iter] == list(
         range(len(batch_iter))
     )
+
+
+@pytest.fixture
+def async_take_enabled(monkeypatch):
+    monkeypatch.setenv("RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE", "1")
+    monkeypatch.setenv("RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE_QUEUE_DEPTH", "2")
+    importlib.reload(block_batching_util)
+    yield
+    importlib.reload(block_batching_util)
+
+
+def test_blocks_to_batches_shuffle_async_take(async_take_enabled):
+    """All rows are emitted exactly once when the async-take producer thread
+    drives the shuffling batcher."""
+    num_blocks = 8
+    block_size = 5
+    batch_size = 4
+    block_iter = (
+        pa.table({"foo": list(range(i * block_size, (i + 1) * block_size))})
+        for i in range(num_blocks)
+    )
+
+    batches = list(
+        block_batching_util.blocks_to_batches(
+            block_iter,
+            batch_size=batch_size,
+            shuffle_buffer_min_size=batch_size,
+            shuffle_seed=0,
+        )
+    )
+
+    total_rows = num_blocks * block_size
+    seen = []
+    for batch in batches:
+        seen.extend(batch.data["foo"].to_pylist())
+    assert sorted(seen) == list(range(total_rows))
+    assert [b.metadata.batch_idx for b in batches] == list(range(len(batches)))
+
+
+def test_blocks_to_batches_shuffle_async_take_propagates_errors(async_take_enabled):
+    """Errors raised by the upstream block iterator surface on the consumer."""
+
+    def failing_block_iter():
+        yield pa.table({"foo": [1, 2, 3]})
+        raise RuntimeError("upstream boom")
+
+    it = block_batching_util.blocks_to_batches(
+        failing_block_iter(),
+        batch_size=2,
+        shuffle_buffer_min_size=2,
+        shuffle_seed=0,
+    )
+
+    with pytest.raises(RuntimeError, match="upstream boom"):
+        for _ in it:
+            pass
 
 
 @pytest.mark.parametrize("batch_format", ["pandas", "numpy", "pyarrow"])


### PR DESCRIPTION
## Summary

Local-shuffle iteration is bottlenecked by `pyarrow.compute.take` in `ShufflingBatcher.next_batch`. Per-batch `take(batch_indices)` plus the pre-compaction `take(remaining_indices)` together account for ~80% of leaf CPU time in py-spy traces. They currently run on the same pipeline thread that drives format/finalize, so each compaction stalls downstream training.

This PR adds a gated path that runs the add+next_batch loop on a dedicated producer thread, pushing formed batches into a bounded queue. Since `pyarrow.compute.take` releases the GIL, the take work overlaps with format/finalize/train on the consumer thread.

- Off by default. Enable with `RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE=1`.
- Bounded queue depth via `RAY_DATA_SHUFFLE_BUFFER_ASYNC_TAKE_QUEUE_DEPTH` (default `4`).
- Sync path is unchanged.
- Errors from the upstream block iterator are propagated to the consumer via the queue.

`combine_chunks` and `permutation` still sit on the producer's critical path; with the small bounded queue they only get hidden if the queue happens to span them. This is intentional — the goal here is to hide `take(remaining_indices)`; `combine_chunks` is a follow-up.

## Test plan

- [x] `pytest python/ray/data/tests/block_batching/test_util.py` — 41 passed.
- [x] New test `test_blocks_to_batches_shuffle_async_take` verifies all rows are emitted exactly once with the producer thread driving the batcher.
- [x] New test `test_blocks_to_batches_shuffle_async_take_propagates_errors` verifies upstream `block_iter` exceptions surface on the consumer.
- [ ] Benchmark via `train_shuffling_benchmark` (synthetic + image_classification, incremental method) with and without the env var to quantify the speedup before flipping the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)