### PR TITLE
Zarr datasource

### DIFF
--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -80,6 +80,7 @@ from ray.data.read_api import (  # noqa: F401
     read_unity_catalog,
     read_videos,
     read_webdataset,
+    read_zarrv2
 )
 
 # Module-level cached global functions for callable classes. It needs to be defined here
@@ -191,4 +192,5 @@ __all__ = [
     "KafkaAuthConfig",
     "Preprocessor",
     "TFXReadOptions",
+    "read_zarrv2"
 ]

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -110,13 +110,19 @@ class ZarrV2Datasource(Datasource):
     def __init__(
         self,
         path: str,
+        chunk_shape: List[int] | None = None,
         array_paths: List[str] | None = None,
     ) -> None:
         super().__init__()
         _check_import(self, module="zarr", package="zarr")
+        
+        if chunk_shape:
+            for val in chunk_shape:
+                if val <= 0 or not isinstance(val, int):
+                    raise ValueError("chunk shape must only contain positive integerse")
 
         self.paths = [str(path)]
-
+        self.chunk_shape = tuple(chunk_shape) if chunk_shape else chunk_shape
         self._metadata = self._load_consolidated_metadata()
         self._selected_arrays = self._select_array_metadata(array_paths)
         self._grid_shape_dict = self._gen_grid_shape()
@@ -143,8 +149,10 @@ class ZarrV2Datasource(Datasource):
         """Pick a single array's metadata from the consolidated metadata."""
         arrays: dict[str, dict[str, object]] = {}
         for key, value in self._metadata.items():
-            if not key.endswith(".zarray") or key == ".zarray":
+            if not key.endswith(".zarray"):
                 continue
+            elif key == ".zarray":
+                arrays[""] = value
             else:
                 arrays[key[: -len("/.zarray")]] = value
 
@@ -173,9 +181,12 @@ class ZarrV2Datasource(Datasource):
         for array, meta in self._selected_arrays.items():
             shape = tuple(meta['shape'])
             chunk_shape = tuple(meta['chunks'])
+            if self.chunk_shape:
+                chunk_shape = self.chunk_shape
+                meta['chunks'] = chunk_shape
             
             if len(shape) != len(chunk_shape):
-                raise ValueError("array dimensions must be the same as chunk dimensions")
+                raise ValueError(f"chunk shape must have same dimension length as the array: {array}")
             
             grid_shape = tuple(
                 math.ceil(size / chunk)

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -182,7 +182,7 @@ class ZarrV2Datasource(Datasource):
                 for size, chunk in zip(shape, chunk_shape)
             )
             
-            grid_shape[array] = {"meta": meta, "grid_shape": grid_shape}
+            grid_shape_dict[array] = {"meta": meta, "grid_shape": grid_shape}
         return grid_shape_dict
         
 

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -100,7 +100,7 @@ def _create_read_fn(
             full_chunk_slices.append(chunk_slices)
             arrays.append(row['array'])
             array_shapes.append(row['meta']['shape'])
-            chunk_shapes.append(chunk_shape)
+            chunk_shapes.append(tuple(chunk_shape))
             dtypes.append(row['meta']['dtype'])
             full_paddings.append(padding)
         

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -80,25 +80,37 @@ def _create_read_fn(
         chunk_shapes = []
         dtypes = []
         full_chunk_slices = []
+        full_paddings = []
         
         for row in batch:
             chunk_slices = []
-            for i, size, chunk in zip(row['chunk_index'], row['meta']['shape'], row['meta']['chunks']):
+            padding = []
+            chunk_shape = list(row["meta"]["chunks"])
+            for dim, (i, size, chunk) in enumerate(zip(row['chunk_index'], row['meta']['shape'], row['meta']['chunks'])):
                 start = i * chunk
                 stop = min((i + 1) * chunk, size)
                 chunk_slices.append((start, stop))
+                
+                if start + chunk > size:
+                    padding_slice = start + chunk - size
+                    chunk_shape[dim] = stop - start
+                else:
+                    padding_slice = 0
+                padding.append(padding_slice)
             full_chunk_slices.append(chunk_slices)
             arrays.append(row['array'])
             array_shapes.append(row['meta']['shape'])
-            chunk_shapes.append(row['meta']['chunks'])
+            chunk_shapes.append(chunk_shape)
             dtypes.append(row['meta']['dtype'])
+            full_paddings.append(padding)
         
         yield pd.DataFrame({
             "array": arrays,
             "array_shape": array_shapes,
             "chunk_shape": chunk_shapes,
             "dtype": dtypes,
-            "chunk_slices": full_chunk_slices
+            "chunk_slices": full_chunk_slices,
+            "padding": full_paddings
         })
                 
 

--- a/python/ray/data/_internal/datasource/zarr_datasource.py
+++ b/python/ray/data/_internal/datasource/zarr_datasource.py
@@ -1,0 +1,271 @@
+"""Zarr datasource for Ray Data."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable, Iterable
+from itertools import product
+from math import prod
+from pathlib import Path
+from typing import Any, List, Optional
+from urllib.parse import urlsplit
+import sys
+
+import numpy as np
+import pandas as pd
+from ray.data._internal.util import _check_import
+from ray.data.block import BlockMetadata
+from ray.data.datasource.datasource import Datasource, ReadTask
+
+from obstore.fsspec import FsspecStore
+from obstore.store import AzureStore
+import fsspec
+import fsspec.core
+
+
+def _make_azure_fs(url: str) -> tuple[FsspecStore, AzureStore]:
+    """Create an authenticated Azure FsspecStore and AzureStore from a URL.
+    Args:
+        url: The Azure Blob Storage URL (abfs://...).
+    Returns:
+        A tuple of (FsspecStore, AzureStore).
+    """
+    store = AzureStore.from_url(
+        url=url,
+    )
+    return FsspecStore(
+        config=store.config,
+        protocol="abfs",
+    ), store
+
+def _resolve_store(path: str) -> tuple[Any, str]:
+    """
+    Return a filesystem-like object and a rooted path prefix for the Zarr store.
+    Works for:
+    - Azure abfs://...
+    - local paths
+    - s3://... (including public anonymous buckets)
+    - generic fsspec-supported URLs
+    """
+    parsed = urlsplit(path)
+
+    # Azure
+    if parsed.scheme in ("abfs", "abfss", "az"):
+        fs, _ = _make_azure_fs(path)
+        return fs, path.rstrip("/")
+
+    # Local
+    if parsed.scheme in ("", "file"):
+        local = path if not parsed.scheme else parsed.path
+        root = str(Path(local).resolve())
+        return fsspec.filesystem("file"), root
+
+    # Public S3
+    if parsed.scheme == "s3":
+        fs = fsspec.filesystem("s3", anon=True)
+        return fs, path.rstrip("/")
+
+    # Generic fallback
+    fs, root = fsspec.core.url_to_fs(path)
+    return fs, root.rstrip("/")
+
+def _create_read_fn(
+    batch: list[dict[str, object]],
+) -> Callable[[], Iterable[pd.DataFrame]]:
+
+    def read_fn() -> Iterable[pd.DataFrame]:
+        arrays = []
+        array_shapes = []
+        chunk_shapes = []
+        dtypes = []
+        full_chunk_slices = []
+        
+        for row in batch:
+            chunk_slices = []
+            for i, size, chunk in zip(row['chunk_index'], row['meta']['shape'], row['meta']['chunks']):
+                start = i * chunk
+                stop = min((i + 1) * chunk, size)
+                chunk_slices.append((start, stop))
+            full_chunk_slices.append(chunk_slices)
+            arrays.append(row['array'])
+            array_shapes.append(row['meta']['shape'])
+            chunk_shapes.append(row['meta']['chunks'])
+            dtypes.append(row['meta']['dtype'])
+        
+        yield pd.DataFrame({
+            "array": arrays,
+            "array_shape": array_shapes,
+            "chunk_shape": chunk_shapes,
+            "dtype": dtypes,
+            "chunk_slices": full_chunk_slices
+        })
+                
+
+    return read_fn
+
+class ZarrV2Datasource(Datasource):
+    """Datasource for reading Zarr arrays."""
+
+    def __init__(
+        self,
+        path: str,
+        array_paths: List[str] | None = None,
+    ) -> None:
+        super().__init__()
+        _check_import(self, module="zarr", package="zarr")
+
+        self.paths = [str(path)]
+
+        self._metadata = self._load_consolidated_metadata()
+        self._selected_arrays = self._select_array_metadata(array_paths)
+        self._grid_shape_dict = self._gen_grid_shape()
+
+    def _load_consolidated_metadata(self) -> dict:
+        fs, store_path = _resolve_store(self.paths[0])
+        if store_path:
+            meta_path = f"{store_path.rstrip('/')}/.zmetadata"
+        else:
+            meta_path = ".zmetadata"
+
+        with fs.open(meta_path, "rb") as f:
+            consolidated = json.load(f)
+
+        if "metadata" not in consolidated:
+            raise ValueError("Missing 'metadata' in consolidated .zmetadata file")
+
+        return consolidated["metadata"]
+
+    def _select_array_metadata(
+        self,
+        array_paths: Iterable[str] | None
+    ) -> dict[str, dict[str, object]]:
+        """Pick a single array's metadata from the consolidated metadata."""
+        arrays: dict[str, dict[str, object]] = {}
+        for key, value in self._metadata.items():
+            if not key.endswith(".zarray") or key == ".zarray":
+                continue
+            else:
+                arrays[key[: -len("/.zarray")]] = value
+
+        if not arrays:
+            raise ValueError("No arrays found in consolidated metadata.")
+        
+        if array_paths is None:
+            requested_paths = [p.strip("/") for p in arrays.keys()]
+            normalized_paths = [p if p != "." else "" for p in requested_paths]
+            selected_paths = normalized_paths
+        else:
+            requested_paths = [p.strip("/") for p in array_paths]
+            normalized_paths = [p if p != "." else "" for p in requested_paths]
+            missing = [p for p in normalized_paths if p not in arrays]
+            if missing:
+                available = ", ".join(sorted(p or "." for p in arrays.keys()))
+                raise ValueError(
+                    f"Array(s) not found: {', '.join(missing)}. Available: {available}"
+                )
+            selected_paths = normalized_paths
+        
+        return {path: arrays[path] for path in selected_paths}
+    
+    def _gen_grid_shape(self):
+        grid_shape_dict = {}
+        for array, meta in self._selected_arrays.items():
+            shape = tuple(meta['shape'])
+            chunk_shape = tuple(meta['chunks'])
+            
+            if len(shape) != len(chunk_shape):
+                raise ValueError("array dimensions must be the same as chunk dimensions")
+            
+            grid_shape = tuple(
+                math.ceil(size / chunk)
+                for size, chunk in zip(shape, chunk_shape)
+            )
+            
+            grid_shape[array] = {"meta": meta, "grid_shape": grid_shape}
+        return grid_shape_dict
+        
+
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        full_bytes_estimate = 0
+        for _, meta in self._selected_arrays.items():
+            shape = tuple(meta['shape'])
+            dtype = np.dtype(meta["dtype"])
+            bytes_estimate = int(prod(shape) * dtype.itemsize)
+            full_bytes_estimate += bytes_estimate
+        
+        return full_bytes_estimate
+    
+    def _sizeof_batch(self, obj, seen=None):
+        if seen is None:
+            seen = set()
+
+        obj_id = id(obj)
+        if obj_id in seen:
+            return 0
+        seen.add(obj_id)
+
+        size = sys.getsizeof(obj)
+
+        if isinstance(obj, dict):
+            size += sum(self._sizeof_batch(k, seen) + self._sizeof_batch(v, seen) for k, v in obj.items())
+        elif isinstance(obj, (list, tuple, set, frozenset)):
+            size += sum(self._sizeof_batch(x, seen) for x in obj)
+
+        return size
+    
+    
+    def get_read_tasks(
+        self,
+        parallelism: int,
+        per_task_row_limit: Optional[int] = None,
+        data_context: Optional["DataContext"] = None,
+    ) -> List[ReadTask]:
+        
+        read_tasks: List[ReadTask] = []
+        batch: list[dict[str, object]] = []
+        
+        num_chunks = sum(prod(value['grid_shape']) for _, value in self._grid_shape_dict.items())
+        parallelism = min(parallelism, num_chunks) if num_chunks > 0 else 1
+        batch_size = math.ceil(num_chunks / parallelism)
+        
+        for array, data in self._grid_shape_dict.items():
+            for chunk_index in product(*(range(n) for n in data['grid_shape'])):
+                
+                batch.append({"array": array, "meta": data['meta'], "chunk_index": chunk_index})
+                
+                if len(batch) >= batch_size:
+                    read_tasks.append(
+                        ReadTask(
+                            _create_read_fn(
+                                batch
+                            ),
+                            BlockMetadata(
+                                num_rows = len(batch),
+                                size_bytes = self._sizeof_batch(batch),
+                                input_files = [self.paths[0]],
+                                exec_stats = None
+                            )
+                        )
+                    )
+                    batch = []
+        if batch:
+            read_tasks.append(
+                ReadTask(
+                    _create_read_fn(
+                        batch
+                    ),
+                    BlockMetadata(
+                        num_rows = len(batch),
+                        size_bytes = self._sizeof_batch(batch),
+                        input_files = [self.paths[0]],
+                        exec_stats = None
+                    )
+                )
+            )
+        return read_tasks
+        
+                
+        
+    
+    

--- a/python/ray/data/_internal/datasource/zarrv2_datasource.py
+++ b/python/ray/data/_internal/datasource/zarrv2_datasource.py
@@ -29,7 +29,7 @@ def _make_azure_fs(url: str) -> tuple[Any, Any]:
     Returns:
         A tuple of (FsspecStore, AzureStore).
     """
-    _check_import(_make_azure_fs, module="obstore", package="obstore")
+    _check_import(module="obstore", package="obstore")
 
     from obstore.fsspec import FsspecStore
     from obstore.store import AzureStore
@@ -66,7 +66,7 @@ def _resolve_store(path: str) -> tuple[Any, str]:
 
     # Public S3
     if parsed.scheme == "s3":
-        fs = fsspec.filesystem("s3", anon=True)
+        fs = fsspec.filesystem("s3")
         return fs, path.rstrip("/")
 
     # Generic fallback
@@ -133,7 +133,7 @@ class ZarrV2Datasource(Datasource):
         if chunk_shape:
             for val in chunk_shape:
                 if val <= 0 or not isinstance(val, int):
-                    raise ValueError("chunk shape must only contain positive integerse")
+                    raise ValueError("chunk shape must only contain positive integers")
 
         self.paths = [str(path)]
         self.chunk_shape = tuple(chunk_shape) if chunk_shape else chunk_shape
@@ -190,7 +190,7 @@ class ZarrV2Datasource(Datasource):
         
         return {path: arrays[path] for path in selected_paths}
     
-    def _gen_grid_shape(self):
+    def _gen_grid_shape(self) -> dict[str, dict[str, object]]:
         grid_shape_dict = {}
         for array, meta in self._selected_arrays.items():
             shape = tuple(meta['shape'])
@@ -212,15 +212,53 @@ class ZarrV2Datasource(Datasource):
         
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
-        full_bytes_estimate = 0
-        for _, meta in self._selected_arrays.items():
-            shape = tuple(meta['shape'])
-            dtype = np.dtype(meta["dtype"])
-            bytes_estimate = int(prod(shape) * dtype.itemsize)
-            full_bytes_estimate += bytes_estimate
-        
-        return full_bytes_estimate
+        arrays = []
+        array_shapes = []
+        chunk_shapes = []
+        dtypes = []
+        full_chunk_slices = []
+        full_paddings = []
+
+        for array, data in self._grid_shape_dict.items():
+            meta = data["meta"]
+            for chunk_index in product(*(range(n) for n in data["grid_shape"])):
+                chunk_slices = []
+                padding = []
+                chunk_shape = list(meta["chunks"])
+
+                for dim, (i, size, chunk) in enumerate(
+                    zip(chunk_index, meta["shape"], meta["chunks"])
+                ):
+                    start = i * chunk
+                    stop = min((i + 1) * chunk, size)
+                    chunk_slices.append((start, stop))
+
+                    if start + chunk > size:
+                        padding_slice = start + chunk - size
+                        chunk_shape[dim] = stop - start
+                    else:
+                        padding_slice = 0
+                    padding.append(padding_slice)
+
+                arrays.append(array)
+                array_shapes.append(meta["shape"])
+                chunk_shapes.append(tuple(chunk_shape))
+                dtypes.append(meta["dtype"])
+                full_chunk_slices.append(chunk_slices)
+                full_paddings.append(padding)
+
+        return self._sizeof_batch(
+            {
+                "array": arrays,
+                "array_shape": array_shapes,
+                "chunk_shape": chunk_shapes,
+                "dtype": dtypes,
+                "chunk_slices": full_chunk_slices,
+                "padding": full_paddings,
+            }
+        )
     
+    @staticmethod
     def _sizeof_batch(self, obj, seen=None):
         if seen is None:
             seen = set()

--- a/python/ray/data/_internal/datasource/zarrv2_datasource.py
+++ b/python/ray/data/_internal/datasource/zarrv2_datasource.py
@@ -258,7 +258,6 @@ class ZarrV2Datasource(Datasource):
             }
         )
     
-    @staticmethod
     def _sizeof_batch(self, obj, seen=None):
         if seen is None:
             seen = set()

--- a/python/ray/data/_internal/datasource/zarrv2_datasource.py
+++ b/python/ray/data/_internal/datasource/zarrv2_datasource.py
@@ -18,19 +18,22 @@ from ray.data._internal.util import _check_import
 from ray.data.block import BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
 
-from obstore.fsspec import FsspecStore
-from obstore.store import AzureStore
 import fsspec
 import fsspec.core
 
 
-def _make_azure_fs(url: str) -> tuple[FsspecStore, AzureStore]:
+def _make_azure_fs(url: str) -> tuple[Any, Any]:
     """Create an authenticated Azure FsspecStore and AzureStore from a URL.
     Args:
         url: The Azure Blob Storage URL (abfs://...).
     Returns:
         A tuple of (FsspecStore, AzureStore).
     """
+    _check_import(_make_azure_fs, module="obstore", package="obstore")
+
+    from obstore.fsspec import FsspecStore
+    from obstore.store import AzureStore
+
     store = AzureStore.from_url(
         url=url,
     )
@@ -126,7 +129,6 @@ class ZarrV2Datasource(Datasource):
         array_paths: List[str] | None = None,
     ) -> None:
         super().__init__()
-        _check_import(self, module="zarr", package="zarr")
         
         if chunk_shape:
             for val in chunk_shape:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -643,7 +643,8 @@ def read_audio(
     
 def read_zarrv2(
     path: str,
-    array_paths: List[str],
+    chunk_shape: List[int] | None = None,
+    array_paths: List[str] | None = None,
     *,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
@@ -654,6 +655,7 @@ def read_zarrv2(
 ):
     datasource = ZarrV2Datasource(
         path = path,
+        chunk_shape = chunk_shape,
         array_paths = array_paths
     )
     return read_datasource(

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -27,7 +27,7 @@ from ray.data._internal.datasource.audio_datasource import AudioDatasource
 from ray.data._internal.datasource.avro_datasource import AvroDatasource
 from ray.data._internal.datasource.bigquery_datasource import BigQueryDatasource
 from ray.data._internal.datasource.binary_datasource import BinaryDatasource
-from ray.data._internal.datasource.zarr_datasource import ZarrV2Datasource
+from ray.data._internal.datasource.zarrv2_datasource import ZarrV2Datasource
 from ray.data._internal.datasource.clickhouse_datasource import ClickHouseDatasource
 from ray.data._internal.datasource.csv_datasource import CSVDatasource
 from ray.data._internal.datasource.databricks_credentials import (
@@ -640,7 +640,8 @@ def read_audio(
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,
     )
-    
+
+@PublicAPI(stability="alpha")
 def read_zarrv2(
     path: str,
     chunk_shape: List[int] | None = None,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -653,6 +653,62 @@ def read_zarrv2(
     memory: Optional[float] = None,
     ray_remote_args: Optional[Dict[str, Any]] = None,
 ):
+    """Creates a :class:`~ray.data.Dataset` from a Zarr v2 store.
+
+    Each row in the resulting dataset describes a single chunk from one of the
+    selected arrays in the store. The returned rows contain chunk metadata and
+    per-dimension slice bounds that can be used to query the chunk, but the
+    datasource doesn't materialize any array or chunk data.
+
+    The column names are ``"array"``, ``"array_shape"``, ``"chunk_shape"``,
+    ``"dtype"``, and ``"chunk_slices"``.
+
+    Examples:
+        >>> import ray
+        >>> ds = ray.data.read_zarrv2("/path/to/store")  # doctest: +SKIP
+
+        Read specific arrays from a store.
+
+        >>> ds = ray.data.read_zarrv2(  # doctest: +SKIP
+        ...     "/path/to/store",
+        ...     array_paths=["images", "labels"],
+        ... )
+
+        Override the chunk shape used to generate chunk descriptors.
+
+        >>> ds = ray.data.read_zarrv2(  # doctest: +SKIP
+        ...     "/path/to/store",
+        ...     chunk_shape=[256, 256],
+        ... )
+
+    Args:
+        path: Path to the Zarr v2 store. The store must contain consolidated
+            metadata in a ``.zmetadata`` file.
+        chunk_shape: Optional chunk shape override to use for all selected arrays.
+            If unspecified, the datasource uses the chunk shape recorded in each
+            array's metadata. If provided, the chunk shape must have the same
+            number of dimensions as each selected array.
+        array_paths: Optional list of array paths within the Zarr store to read.
+            If unspecified, all arrays found in the store are used.
+        concurrency: The maximum number of Ray tasks to run concurrently. Set this
+            to control number of tasks to run concurrently. This doesn't change the
+            total number of tasks run or the total number of output blocks. By default,
+            concurrency is dynamically decided based on the available resources.
+        override_num_blocks: Override the number of output blocks from all read tasks.
+            By default, the number of output blocks is dynamically decided based on
+            input data size and available resources. You shouldn't manually set this
+            value in most cases.
+        num_cpus: The number of CPUs to reserve for each parallel read worker.
+        num_gpus: The number of GPUs to reserve for each parallel read worker. For
+            example, specify `num_gpus=1` to request 1 GPU for each parallel read
+            worker.
+        memory: The heap memory in bytes to reserve for each parallel read worker.
+        ray_remote_args: kwargs passed to :meth:`~ray.remote` in the read tasks.
+
+    Returns:
+        A :class:`~ray.data.Dataset` where each row contains the selected array
+        path, array metadata, and per-dimension chunk slice bounds for one chunk.
+    """
     datasource = ZarrV2Datasource(
         path = path,
         chunk_shape = chunk_shape,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -656,12 +656,13 @@ def read_zarrv2(
     """Creates a :class:`~ray.data.Dataset` from a Zarr v2 store.
 
     Each row in the resulting dataset describes a single chunk from one of the
-    selected arrays in the store. The returned rows contain chunk metadata and
-    per-dimension slice bounds that can be used to query the chunk, but the
-    datasource doesn't materialize any array or chunk data.
+    selected arrays in the store. The returned rows contain chunk metadata,
+    per-dimension slice bounds that can be used to query the chunk, and
+    per-dimension padding for truncated edge chunks, but the datasource
+    doesn't materialize any array or chunk data.
 
     The column names are ``"array"``, ``"array_shape"``, ``"chunk_shape"``,
-    ``"dtype"``, and ``"chunk_slices"``.
+    ``"dtype"``, ``"chunk_slices"``, and ``"padding"``.
 
     Examples:
         >>> import ray
@@ -707,7 +708,8 @@ def read_zarrv2(
 
     Returns:
         A :class:`~ray.data.Dataset` where each row contains the selected array
-        path, array metadata, and per-dimension chunk slice bounds for one chunk.
+        path, array metadata, per-dimension chunk slice bounds, and
+        per-dimension trailing padding for one chunk.
     """
     datasource = ZarrV2Datasource(
         path = path,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -27,6 +27,7 @@ from ray.data._internal.datasource.audio_datasource import AudioDatasource
 from ray.data._internal.datasource.avro_datasource import AvroDatasource
 from ray.data._internal.datasource.bigquery_datasource import BigQueryDatasource
 from ray.data._internal.datasource.binary_datasource import BinaryDatasource
+from ray.data._internal.datasource.zarr_datasource import ZarrV2Datasource
 from ray.data._internal.datasource.clickhouse_datasource import ClickHouseDatasource
 from ray.data._internal.datasource.csv_datasource import CSVDatasource
 from ray.data._internal.datasource.databricks_credentials import (
@@ -639,6 +640,32 @@ def read_audio(
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,
     )
+    
+def read_zarrv2(
+    path: str,
+    array_paths: List[str],
+    *,
+    concurrency: Optional[int] = None,
+    override_num_blocks: Optional[int] = None,
+    num_cpus: Optional[float] = None,
+    num_gpus: Optional[float] = None,
+    memory: Optional[float] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+):
+    datasource = ZarrV2Datasource(
+        path = path,
+        array_paths = array_paths
+    )
+    return read_datasource(
+        datasource,
+        ray_remote_args=ray_remote_args,
+        num_cpus=num_cpus,
+        num_gpus=num_gpus,
+        memory=memory,
+        concurrency=concurrency,
+        override_num_blocks=override_num_blocks,
+    )
+    
 
 
 @PublicAPI(stability="alpha")

--- a/python/ray/data/tests/datasource/test_zarrv2.py
+++ b/python/ray/data/tests/datasource/test_zarrv2.py
@@ -1,0 +1,223 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import ray.data.read_api as read_api
+from ray.data._internal.datasource import zarrv2_datasource
+
+
+def _write_zmetadata(store_path: Path, metadata: dict) -> Path:
+    store_path.mkdir()
+    (store_path / ".zmetadata").write_text(json.dumps({"metadata": metadata}))
+    return store_path
+
+
+def _execute_read_tasks(tasks) -> pd.DataFrame:
+    frames = [block for task in tasks for block in task()]
+    return pd.concat(frames, ignore_index=True)
+
+
+@pytest.fixture(autouse=True)
+def stub_optional_imports(monkeypatch):
+    monkeypatch.setattr(
+        zarrv2_datasource,
+        "_check_import",
+        lambda *args, **kwargs: None,
+    )
+
+
+@pytest.fixture
+def zarrv2_store(tmp_path) -> Path:
+    return _write_zmetadata(
+        tmp_path / "sample.zarr",
+        {
+            ".zarray": {
+                "shape": [5, 4],
+                "chunks": [2, 3],
+                "dtype": "<i4",
+            },
+            "nested/.zarray": {
+                "shape": [3],
+                "chunks": [2],
+                "dtype": "|u1",
+            },
+            ".zgroup": {"zarr_format": 2},
+        },
+    )
+
+
+def test_zarrv2_datasource_selects_all_arrays_and_estimates_size(zarrv2_store):
+    datasource = zarrv2_datasource.ZarrV2Datasource(str(zarrv2_store))
+
+    assert set(datasource._selected_arrays) == {"", "nested"}
+    assert datasource._grid_shape_dict[""]["grid_shape"] == (3, 2)
+    assert datasource._grid_shape_dict["nested"]["grid_shape"] == (2,)
+    assert datasource.estimate_inmemory_data_size() == 83
+
+
+def test_zarrv2_datasource_normalizes_requested_array_paths(zarrv2_store):
+    datasource = zarrv2_datasource.ZarrV2Datasource(
+        str(zarrv2_store),
+        array_paths=[".", "nested/"],
+    )
+
+    assert list(datasource._selected_arrays) == ["", "nested"]
+
+
+def test_zarrv2_datasource_rejects_missing_array_paths(zarrv2_store):
+    with pytest.raises(
+        ValueError,
+        match=r"Array\(s\) not found: missing\. Available: \., nested",
+    ):
+        zarrv2_datasource.ZarrV2Datasource(
+            str(zarrv2_store),
+            array_paths=["missing"],
+        )
+
+
+@pytest.mark.parametrize("chunk_shape", [[0, 2], [-1, 2], [1.5, 2]])
+def test_zarrv2_datasource_rejects_invalid_chunk_shape(zarrv2_store, chunk_shape):
+    with pytest.raises(ValueError, match="chunk shape must only contain positive"):
+        zarrv2_datasource.ZarrV2Datasource(
+            str(zarrv2_store),
+            chunk_shape=chunk_shape,
+        )
+
+
+def test_zarrv2_datasource_rejects_chunk_rank_mismatch(zarrv2_store):
+    with pytest.raises(ValueError, match="same dimension length as the array"):
+        zarrv2_datasource.ZarrV2Datasource(
+            str(zarrv2_store),
+            chunk_shape=[4, 4],
+            array_paths=["nested"],
+        )
+
+
+def test_zarrv2_datasource_applies_chunk_shape_override(zarrv2_store):
+    datasource = zarrv2_datasource.ZarrV2Datasource(
+        str(zarrv2_store),
+        chunk_shape=[4, 2],
+        array_paths=["."],
+    )
+
+    read_tasks = datasource.get_read_tasks(parallelism=8)
+    rows = _execute_read_tasks(read_tasks).to_dict("records")
+
+    assert datasource._grid_shape_dict[""]["grid_shape"] == (2, 2)
+    assert len(rows) == 4
+
+    truncated_chunk = next(
+        row
+        for row in rows
+        if row["chunk_slices"] == [(4, 5), (2, 4)]
+    )
+    assert truncated_chunk["chunk_shape"] == (1, 2)
+    assert truncated_chunk["padding"] == [3, 0]
+
+
+def test_zarrv2_datasource_requires_consolidated_metadata(tmp_path):
+    store_path = tmp_path / "broken.zarr"
+    store_path.mkdir()
+    (store_path / ".zmetadata").write_text(json.dumps({}))
+
+    with pytest.raises(ValueError, match="Missing 'metadata'"):
+        zarrv2_datasource.ZarrV2Datasource(str(store_path))
+
+
+def test_zarrv2_datasource_get_read_tasks_batches_chunks_by_parallelism(zarrv2_store):
+    datasource = zarrv2_datasource.ZarrV2Datasource(str(zarrv2_store))
+
+    read_tasks = datasource.get_read_tasks(parallelism=3)
+
+    assert len(read_tasks) == 3
+    assert [task.metadata.num_rows for task in read_tasks] == [3, 3, 2]
+    assert all(task.metadata.input_files == [str(zarrv2_store)] for task in read_tasks)
+
+
+def test_zarrv2_datasource_get_read_tasks_returns_chunk_descriptors(zarrv2_store):
+    datasource = zarrv2_datasource.ZarrV2Datasource(str(zarrv2_store))
+
+    read_tasks = datasource.get_read_tasks(parallelism=16)
+    rows = _execute_read_tasks(read_tasks).to_dict("records")
+
+    assert len(read_tasks) == 8
+    assert all(task.metadata.num_rows == 1 for task in read_tasks)
+
+    first_root_chunk = next(
+        row
+        for row in rows
+        if row["array"] == "" and row["chunk_slices"] == [(0, 2), (0, 3)]
+    )
+    assert first_root_chunk["array_shape"] == [5, 4]
+    assert first_root_chunk["chunk_shape"] == (2, 3)
+    assert first_root_chunk["dtype"] == "<i4"
+    assert first_root_chunk["padding"] == [0, 0]
+
+    truncated_root_chunk = next(
+        row
+        for row in rows
+        if row["array"] == "" and row["chunk_slices"] == [(4, 5), (3, 4)]
+    )
+    assert truncated_root_chunk["chunk_shape"] == (1, 1)
+    assert truncated_root_chunk["padding"] == [1, 2]
+
+    truncated_nested_chunk = next(
+        row
+        for row in rows
+        if row["array"] == "nested" and row["chunk_slices"] == [(2, 3)]
+    )
+    assert truncated_nested_chunk["chunk_shape"] == (1,)
+    assert truncated_nested_chunk["dtype"] == "|u1"
+    assert truncated_nested_chunk["padding"] == [1]
+
+
+def test_read_zarrv2_builds_datasource_and_delegates_to_read_datasource():
+    datasource = object()
+    dataset = object()
+
+    with patch(
+        "ray.data.read_api.ZarrV2Datasource",
+        return_value=datasource,
+    ) as mock_datasource:
+        with patch(
+            "ray.data.read_api.read_datasource",
+            return_value=dataset,
+        ) as mock_read_datasource:
+            result = read_api.read_zarrv2(
+                "/tmp/sample.zarr",
+                chunk_shape=[4, 2],
+                array_paths=["nested"],
+                concurrency=3,
+                override_num_blocks=2,
+                num_cpus=0.5,
+                num_gpus=1,
+                memory=1024,
+                ray_remote_args={"resources": {"custom": 1}},
+            )
+
+    assert result is dataset
+    mock_datasource.assert_called_once_with(
+        path="/tmp/sample.zarr",
+        chunk_shape=[4, 2],
+        array_paths=["nested"],
+    )
+    mock_read_datasource.assert_called_once()
+    args, kwargs = mock_read_datasource.call_args
+    assert args == (datasource,)
+    assert kwargs == {
+        "ray_remote_args": {"resources": {"custom": 1}},
+        "num_cpus": 0.5,
+        "num_gpus": 1,
+        "memory": 1024,
+        "concurrency": 3,
+        "override_num_blocks": 2,
+    }
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description
This PR adds a new `ray.data.read_zarrv2()` API for reading Zarr v2 stores with Ray Data.

The goal is to expose a first-class public API for Zarr v2 so it can be used consistently with the rest of the `ray.data.read_*` APIs. This includes wiring the new API into Ray Data and adding unit tests covering the new read path.

## Related issues
N/A

## Additional information
Example usage:

```python
import ray

ds = ray.data.read_zarrv2("/path/to/zarr/store")
