### PR TITLE
[llm] remove VLLM_USE_V1 from docs and examples

### DIFF
--- a/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
+++ b/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
@@ -61,7 +61,6 @@ llm_config = LLMConfig(
             },
         },
     },
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
 )
 
 app = build_openai_app({"llm_configs": [llm_config]})

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -251,13 +251,6 @@ class VLLMEngine(LLMEngine):
             raise ImportError(
                 "vLLM is not installed. Please install it with `pip install ray[llm]`."
             )
-        from vllm import envs as vllm_envs
-
-        if hasattr(vllm_envs, "VLLM_USE_V1") and not vllm_envs.VLLM_USE_V1:
-            logger.error(
-                "vLLM v0 is fully deprecated. As a result in Ray Serve LLM only v1 is supported."
-            )
-
         self.llm_config.setup_engine_backend()
 
         self._running = False

--- a/release/llm_tests/serve/benchmark/benchmark_vllm.py
+++ b/release/llm_tests/serve/benchmark/benchmark_vllm.py
@@ -242,6 +242,7 @@ def main(pargs):
         "service_name": "",
         "py_version": f"py{sys.version_info.major}{sys.version_info.minor}",
         "tag": tag,
+        "vllm_engine": "V1",
     }
 
     # Post the results to S3

--- a/release/llm_tests/serve/benchmark/benchmark_vllm.py
+++ b/release/llm_tests/serve/benchmark/benchmark_vllm.py
@@ -242,7 +242,6 @@ def main(pargs):
         "service_name": "",
         "py_version": f"py{sys.version_info.major}{sys.version_info.minor}",
         "tag": tag,
-        "vllm_engine": f"V{os.environ.get('VLLM_USE_V1', '')}",
     }
 
     # Post the results to S3

--- a/release/llm_tests/serve/test_llm_serve_fault_tolerance.py
+++ b/release/llm_tests/serve/test_llm_serve_fault_tolerance.py
@@ -27,7 +27,6 @@ def get_llm_config(
             tensor_parallel_size=tensor_parallel_size,
             enforce_eager=True,
         ),
-        runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     )
 
 


### PR DESCRIPTION
## Why

vLLM's V1 engine has been the default for a while and v0 is fully deprecated, so the `VLLM_USE_V1` references scattered across our docs, examples, and release tests are misleading at best (no-op) and at worst suggest v0 is still toggleable.

## Intentionally not touched

Versioned content tied to specific Ray releases is left as-is:

- `doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md`
- `doc/source/serve/tutorials/serve-deepseek.md`
- `doc/source/ray-overview/examples/e2e-rag/notebooks/03_Deploy_LLM_with_Ray_Serve.ipynb`
- `doc/source/ray-overview/examples/entity-recognition-with-llms/README.md` and `README.ipynb`

Closes #61892