### PR TITLE
[Docs] Replace deprecated busyboxplus curl image in Kubernetes examples (fixes #61538)

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
@@ -114,7 +114,7 @@ Below is a screenshot example of the Serve page in the Ray dashboard.
 ```sh
 # Step 6.1: Run a curl Pod.
 # If you already have a curl Pod, you can use `kubectl exec -it <curl-pod> -- sh` to access the Pod.
-kubectl run curl --image=radial/busyboxplus:curl -i --tty
+kubectl run curl --image=curlimages/curl:latest -i --tty -- sh
 
 # Step 6.2: Send a request to the fruit stand app.
 curl -X POST -H 'Content-Type: application/json' rayservice-sample-serve-svc:8000/fruit/ -d '["MANGO", 2]'

--- a/doc/source/cluster/kubernetes/user-guides/rayservice-no-ray-serve-replica.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice-no-ray-serve-replica.md
@@ -139,7 +139,7 @@ Although one worker Pod is unready, Ray Serve can still route the traffic to the
 ```sh
 # Step 6.1: Run a curl Pod.
 # If you already have a curl Pod, you can use `kubectl exec -it <curl-pod> -- sh` to access the Pod.
-kubectl run curl --image=radial/busyboxplus:curl -i --tty
+kubectl run curl --image=curlimages/curl:latest -i --tty -- sh
 
 # Step 6.2: Send a request to the simple_app.
 curl -X POST -H 'Content-Type: application/json' rayservice-no-ray-serve-replica-serve-svc:8000/basic

--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -182,7 +182,7 @@ Below is a screenshot example of the Serve page in the Ray dashboard.
 ```sh
 # Step 6.1: Run a curl Pod.
 # If you already have a curl Pod, you can use `kubectl exec -it <curl-pod> -- sh` to access the Pod.
-kubectl run curl --image=curlimages/curl:latest -i --tty -- sh
+kubectl run curl --image=curlimages/curl:8.8.0 -i --tty -- sh
 
 # Step 6.2: Send a request to the fruit stand app.
 curl -X POST -H 'Content-Type: application/json' rayservice-sample-serve-svc:8000/fruit/ -d '["MANGO", 2]'

--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -182,7 +182,7 @@ Below is a screenshot example of the Serve page in the Ray dashboard.
 ```sh
 # Step 6.1: Run a curl Pod.
 # If you already have a curl Pod, you can use `kubectl exec -it <curl-pod> -- sh` to access the Pod.
-kubectl run curl --image=radial/busyboxplus:curl -i --tty
+kubectl run curl --image=curlimages/curl:latest -i --tty -- sh
 
 # Step 6.2: Send a request to the fruit stand app.
 curl -X POST -H 'Content-Type: application/json' rayservice-sample-serve-svc:8000/fruit/ -d '["MANGO", 2]'

--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -182,7 +182,7 @@ Below is a screenshot example of the Serve page in the Ray dashboard.
 ```sh
 # Step 6.1: Run a curl Pod.
 # If you already have a curl Pod, you can use `kubectl exec -it <curl-pod> -- sh` to access the Pod.
-kubectl run curl --image=curlimages/curl:8.8.0 -i --tty -- sh
+kubectl run curl --image=curlimages/curl:latest -i --tty -- sh
 
 # Step 6.2: Send a request to the fruit stand app.
 curl -X POST -H 'Content-Type: application/json' rayservice-sample-serve-svc:8000/fruit/ -d '["MANGO", 2]'


### PR DESCRIPTION
## Summary

Fixes broken Kubernetes example in RayService quickstart docs.

The image `radial/busyboxplus:curl` is no longer usable due to deprecated
Docker manifest format, causing ImagePullBackOff errors.

## Changes

- Replaced `radial/busyboxplus:curl` with `curlimages/curl:latest`

## Testing

- Verified the new image works with `kubectl run`
- Confirmed curl commands execute successfully inside the pod

## Issue

Closes #61538