### PR TITLE
[DatasourceV2][data][2/n] add ListFiles + ReadFiles logical ops + planner

### DIFF
--- a/python/ray/data/_internal/datasource_v2/logical_optimizers.py
+++ b/python/ray/data/_internal/datasource_v2/logical_optimizers.py
@@ -52,6 +52,17 @@ class SupportsColumnPruning(ABC):
         """
         ...
 
+    @abstractmethod
+    def pruned_column_names(self) -> Optional[Tuple[str, ...]]:
+        """Physical column names selected after pruning, if any.
+
+        Returns:
+            ``None`` when no pruning has been applied (read all columns).
+            A tuple (possibly empty) after :meth:`prune_columns` has been
+            applied, listing on-disk / reader column names in read order.
+        """
+        ...
+
 
 @DeveloperAPI
 class SupportsLimitPushdown(ABC):

--- a/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
@@ -129,6 +129,10 @@ class ArrowFileScanner(
         return replace(self, columns=tuple(columns))
 
     @override
+    def pruned_column_names(self) -> Optional[Tuple[str, ...]]:
+        return self.columns
+
+    @override
     def push_limit(self, limit: int) -> "ArrowFileScanner":
         """Push row limit down to the scanner.
 

--- a/python/ray/data/_internal/logical/operators/__init__.py
+++ b/python/ray/data/_internal/logical/operators/__init__.py
@@ -35,7 +35,11 @@ from ray.data._internal.logical.operators.one_to_one_operator import (
     Download,
     Limit,
 )
-from ray.data._internal.logical.operators.read_operator import Read
+from ray.data._internal.logical.operators.read_operator import (
+    ListFiles,
+    Read,
+    ReadFiles,
+)
 from ray.data._internal.logical.operators.streaming_split_operator import StreamingSplit
 from ray.data._internal.logical.operators.write_operator import Write
 
@@ -60,6 +64,7 @@ __all__ = [
     "JoinSide",
     "JoinType",
     "Limit",
+    "ListFiles",
     "MapBatches",
     "MapRows",
     "NAry",
@@ -67,6 +72,7 @@ __all__ = [
     "RandomShuffle",
     "RandomizeBlocks",
     "Read",
+    "ReadFiles",
     "Repartition",
     "Sort",
     "StreamingRepartition",

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,10 +1,11 @@
 import functools
 import math
 from dataclasses import InitVar, dataclass, field, replace
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.logical.interfaces import (
+    LogicalOperator,
     LogicalOperatorSupportsPredicatePushdown,
     LogicalOperatorSupportsProjectionPushdown,
     SourceOperator,
@@ -18,8 +19,23 @@ from ray.data.context import DataContext
 from ray.data.datasource.datasource import Datasource, Reader
 from ray.data.expressions import Expr
 
+if TYPE_CHECKING:
+    import pyarrow as pa
+    from pyarrow.fs import FileSystem
+
+    from ray.data._internal.datasource_v2.datasource_v2 import DataSourceV2
+    from ray.data._internal.datasource_v2.listing.file_indexer import FileIndexer
+    from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
+        FilePartitioner,
+    )
+    from ray.data._internal.datasource_v2.scanners.scanner import Scanner
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
+    from ray.data.datasource.partitioning import PathPartitionFilter
+
 __all__ = [
+    "ListFiles",
     "Read",
+    "ReadFiles",
 ]
 
 
@@ -214,4 +230,254 @@ class Read(
             datasource=predicated_datasource,
             datasource_or_legacy_reader=predicated_datasource,
             num_outputs=self._num_outputs,
+        )
+
+
+@dataclass(frozen=True, repr=False, eq=False)
+class ReadFiles(
+    AbstractMap,
+    LogicalOperatorSupportsProjectionPushdown,
+    LogicalOperatorSupportsPredicatePushdown,
+):
+    """Logical operator for DataSourceV2 reads.
+
+    Consumes ``FileManifest`` blocks produced by a :class:`ListFiles`
+    source operator upstream. Owns the :class:`Scanner` (with any pushed
+    column/predicate/limit state), schema, and ``column_renames`` map.
+    Listing, shuffling, and size-balanced bucketing happen in the
+    upstream op; this op's physical planner just reads each manifest
+    bucket via ``scanner.create_reader().read(manifest)``.
+    """
+
+    input_op: InitVar[LogicalOperator]
+    datasource: "DataSourceV2"
+    scanner: "Scanner"
+    schema: "pa.Schema"
+    parallelism: int
+    ray_remote_args: Dict[str, Any] = field(default_factory=dict)
+    compute: Optional[ComputeStrategy] = None
+    detected_parallelism: Optional[int] = None
+    # ``old_name → new_name`` for any columns the projection pushdown rule
+    # renamed. The scanner only knows original names; renames are applied
+    # in ``plan_read_files_op`` after each block is read.
+    column_renames: Optional[Dict[str, str]] = None
+    can_modify_num_rows: bool = field(init=False, default=True)
+    min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
+    ray_remote_args_fn: None = field(init=False, default=None)
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    _num_outputs: Optional[int] = field(init=False, repr=False, default=None)
+
+    def __post_init__(self, input_op: LogicalOperator):
+        assert isinstance(input_op, LogicalOperator), input_op
+        if self.compute is None:
+            from ray.data._internal.compute import TaskPoolStrategy
+
+            object.__setattr__(self, "compute", TaskPoolStrategy())
+        if self.ray_remote_args is None:
+            object.__setattr__(self, "ray_remote_args", {})
+        object.__setattr__(self, "_name", f"ReadFiles{self.datasource.name}")
+        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "_num_outputs", None)
+
+    def _apply_transform(
+        self, transform: "Callable[[LogicalOperator], LogicalOperator]"
+    ) -> LogicalOperator:
+        transformed_input = self.input_dependency._apply_transform(transform)
+        target: LogicalOperator
+        if transformed_input is self.input_dependency:
+            target = self
+        else:
+            target = replace(self, input_op=transformed_input)
+        return transform(target)
+
+    def set_detected_parallelism(self, parallelism: int) -> "ReadFiles":
+        return replace(
+            self, input_op=self.input_dependency, detected_parallelism=parallelism
+        )
+
+    def get_detected_parallelism(self) -> Optional[int]:
+        return self.detected_parallelism
+
+    def infer_schema(self) -> "pa.Schema":
+        # Scanner schema reflects any applied projection pushdown
+        # (``scanner.prune_columns`` / empty projection from
+        # ``select_columns([])``); the stored ``self.schema`` is the
+        # unprojected one and only used for construction.
+        schema = self.scanner.read_schema()
+        if self.column_renames:
+            import pyarrow as pa
+
+            renamed_fields = [
+                pa.field(self.column_renames.get(f.name, f.name), f.type, f.nullable)
+                for f in schema
+            ]
+            schema = pa.schema(renamed_fields)
+        return schema
+
+    def infer_metadata(self) -> BlockMetadata:
+        """Return empty metadata; downstream callers fall back to materialization.
+
+        Prior ``ReadFiles`` versions reached into a driver-side file cache to
+        compute size hints. With listing owned by an upstream
+        ``ListFiles`` op, metadata-for-sizing is computed from the
+        materialized manifest at execution time — the logical op doesn't
+        try to pre-estimate.
+        """
+        return BlockMetadata(None, None, None, None)
+
+    def estimate_in_memory_size(self) -> Optional[int]:
+        """Used by ``SetReadParallelismRule``. Returns ``None`` now — the
+        upstream ``ListFiles`` op computes balanced buckets via
+        ``RoundRobinPartitioner`` at execution time, so the rule's
+        size-based parallelism heuristic is no longer load-bearing."""
+        return None
+
+    def supports_projection_pushdown(self) -> bool:
+        from ray.data._internal.datasource_v2.logical_optimizers import (
+            SupportsColumnPruning,
+        )
+
+        return isinstance(self.scanner, SupportsColumnPruning)
+
+    def get_projection_map(self) -> Optional[Dict[str, str]]:
+        if not self.supports_projection_pushdown():
+            return None
+        columns = self.scanner.pruned_column_names()
+        if columns is None:
+            return None
+        renames = self.column_renames or {}
+        return {name: renames.get(name, name) for name in columns}
+
+    def get_column_renames(self) -> Optional[Dict[str, str]]:
+        return self.column_renames
+
+    def apply_projection(
+        self,
+        projection_map: Optional[Dict[str, str]],
+    ) -> "ReadFiles":
+        if projection_map is None:
+            return self
+        from ray.data._internal.datasource_v2.logical_optimizers import (
+            SupportsColumnPruning,
+        )
+
+        assert isinstance(self.scanner, SupportsColumnPruning)
+
+        # ``projection_map`` is ``{input_name: output_name}`` where the
+        # input names are what this op's current output produces — which
+        # includes any renames applied on a prior pushdown. Translate
+        # input names back to the ORIGINAL on-disk column names via the
+        # existing ``column_renames`` map, then hand those originals to
+        # the scanner. The new rename map is composed on top of the old
+        # so a chain like ``sepal.length → a → b`` collapses to
+        # ``sepal.length → b``.
+        existing = self.column_renames or {}
+        reverse = {out: orig for orig, out in existing.items()}
+
+        original_to_new: Dict[str, str] = {}
+        for input_name, output_name in projection_map.items():
+            original = reverse.get(input_name, input_name)
+            original_to_new[original] = output_name
+
+        new_scanner = self.scanner.prune_columns(list(original_to_new.keys()))
+        merged = {orig: out for orig, out in original_to_new.items() if orig != out}
+        return replace(
+            self,
+            input_op=self.input_dependency,
+            scanner=new_scanner,
+            column_renames=merged or None,
+        )
+
+    def supports_predicate_pushdown(self) -> bool:
+        from ray.data._internal.datasource_v2.logical_optimizers import (
+            SupportsFilterPushdown,
+        )
+
+        return isinstance(self.scanner, SupportsFilterPushdown)
+
+    def get_current_predicate(self) -> Optional[Expr]:
+        return getattr(self.scanner, "predicate", None)
+
+    def apply_predicate(self, predicate_expr: Expr) -> "ReadFiles":
+        from ray.data._internal.datasource_v2.logical_optimizers import (
+            SupportsFilterPushdown,
+            SupportsPartitionPruning,
+        )
+        from ray.data._internal.planner.plan_expression.expression_visitors import (
+            get_column_references,
+        )
+
+        assert isinstance(self.scanner, SupportsFilterPushdown)
+
+        # Skip pushdown if the predicate references any partition column:
+        # ``push_filters`` passes the expression to pyarrow's scanner, which
+        # can only bind on-disk columns. Splitting the predicate into
+        # data- and partition-column conjuncts (then routing each through
+        # ``push_filters`` / ``prune_partitions``) is a follow-up; for
+        # now the rule keeps the ``Filter`` above ``ReadFiles`` when we
+        # return ``self`` unchanged, so correctness is preserved.
+        if isinstance(self.scanner, SupportsPartitionPruning):
+            referenced = set(get_column_references(predicate_expr))
+            if referenced & self.scanner.partition_columns:
+                return self
+
+        new_scanner, _residual = self.scanner.push_filters(predicate_expr)
+        return replace(self, input_op=self.input_dependency, scanner=new_scanner)
+
+
+@dataclass(frozen=True, repr=False, eq=False)
+class ListFiles(LogicalOperator, SourceOperator):
+    """Logical source op that lists files and yields ``FileManifest`` blocks.
+
+    Extracted from the prior monolithic ``ReadFiles`` so listing, shuffling,
+    and size-balanced bucketing live in one place (see
+    :func:`ray.data._internal.planner.plan_list_files_op.plan_list_files_op`).
+    Downstream, ``ReadFiles`` consumes the manifest blocks produced here.
+    """
+
+    paths: List[str]
+    file_indexer: "FileIndexer"
+    filesystem: "FileSystem"
+    # Original user-supplied paths. Lineage-tracking pins this to the
+    # caller's intent rather than the resolved absolute paths.
+    source_paths: List[str]
+    file_partitioner: Optional["FilePartitioner"] = None
+    file_extensions: Optional[List[str]] = None
+    partition_filter: Optional["PathPartitionFilter"] = None
+    # A factory (not a stored config) so the shuffle seed is re-sampled
+    # per execution when the config asks for it.
+    shuffle_config_factory: Callable[[], Optional["FileShuffleConfig"]] = field(
+        default=lambda: None
+    )
+    _name: str = field(init=False, repr=False)
+    _input_dependencies: List[LogicalOperator] = field(
+        init=False, repr=False, default_factory=list
+    )
+    _num_outputs: Optional[int] = field(init=False, repr=False, default=None)
+
+    def __post_init__(self):
+        object.__setattr__(self, "_name", self.__class__.__name__)
+
+    def output_data(self) -> Optional[list]:
+        return None
+
+    @property
+    def num_outputs(self) -> Optional[int]:
+        return None
+
+    def infer_schema(self) -> "pa.Schema":
+        # ``FileManifest`` columns are fixed: __path, __file_size.
+        import pyarrow as pa
+
+        from ray.data._internal.datasource_v2.listing.file_manifest import (
+            FILE_SIZE_COLUMN_NAME,
+            PATH_COLUMN_NAME,
+        )
+
+        return pa.schema(
+            [
+                pa.field(PATH_COLUMN_NAME, pa.string()),
+                pa.field(FILE_SIZE_COLUMN_NAME, pa.int64()),
+            ]
         )

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -10,6 +10,7 @@ from ray.data._internal.logical.operators import (
     Download,
     Limit,
     Read,
+    ReadFiles,
     Union,
 )
 
@@ -197,6 +198,18 @@ class LimitPushdownRule(Rule):
                         per_block_limit=limit,
                         num_outputs=op.num_outputs,
                     )
+                if isinstance(op, ReadFiles):
+                    from ray.data._internal.datasource_v2.logical_optimizers import (
+                        SupportsLimitPushdown,
+                    )
+
+                    if isinstance(op.scanner, SupportsLimitPushdown):
+                        return replace(
+                            op,
+                            input_op=op.input_dependency,
+                            scanner=op.scanner.push_limit(limit),
+                        )
+                    return op
                 assert len(op.input_dependencies) == 1, len(op.input_dependencies)
                 return replace(
                     op,

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -6,7 +6,7 @@ from ray import available_resources as ray_available_resources
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.logical.interfaces import PhysicalPlan, Rule
-from ray.data._internal.logical.operators import Read
+from ray.data._internal.logical.operators import Read, ReadFiles
 from ray.data._internal.util import _autodetect_parallelism
 from ray.data.context import WARN_PREFIX, DataContext
 from ray.data.datasource.datasource import Datasource, Reader
@@ -106,11 +106,45 @@ class SetReadParallelismRule(Rule):
             if isinstance(op, InputDataBuffer):
                 continue
             logical_op = plan.op_map[op]
-            if isinstance(logical_op, Read):
+            if isinstance(logical_op, ReadFiles):
+                self._apply_v2(plan, op, logical_op)
+            elif isinstance(logical_op, Read):
                 self._apply(plan, op, logical_op)
             ops += op.input_dependencies
 
         return plan
+
+    def _apply_v2(
+        self, plan: PhysicalPlan, op: PhysicalOperator, logical_op: ReadFiles
+    ):
+        """Set parallelism for a ``ReadFiles`` op using sample-extrapolated size.
+
+        ``ReadFiles`` defers file listing to physical execution, so we don't
+        know the true file count here. The driver has already cached a
+        sample via ``_read_datasource_v2``; we use it plus
+        ``ParquetInMemorySizeEstimator`` to produce an upper-bound
+        in-memory size, then let ``_autodetect_parallelism`` pick a block
+        count. ``scanner.plan()`` rebalances at execution time, so this is
+        a planning-time approximation.
+        """
+        ctx = DataContext.get_current()
+        mem_size = logical_op.estimate_in_memory_size()
+
+        detected_parallelism, reason, _ = _autodetect_parallelism(
+            logical_op.parallelism,
+            op.target_max_block_size_override or ctx.target_max_block_size,
+            ctx,
+            datasource_or_legacy_reader=None,
+            mem_size=mem_size,
+        )
+
+        if logical_op.parallelism == -1:
+            assert reason != ""
+            logger.debug(
+                f"Using autodetected parallelism={detected_parallelism} "
+                f"for operator {logical_op.name} to satisfy {reason}."
+            )
+        plan.op_map[op] = logical_op.set_detected_parallelism(detected_parallelism)
 
     def _apply(self, plan: PhysicalPlan, op: PhysicalOperator, logical_op: Read):
         estimated_in_mem_bytes = logical_op.infer_metadata().size_bytes

--- a/python/ray/data/_internal/planner/plan_list_files_op.py
+++ b/python/ray/data/_internal/planner/plan_list_files_op.py
@@ -1,0 +1,166 @@
+"""Physical planner for the V2 ``ListFiles`` source operator.
+
+Emits ``FileManifest`` blocks by (a) sharding user-supplied paths into
+parallel listing tasks, (b) invoking the configured ``FileIndexer``, and
+optionally (c) globally shuffling + size-balanced bucketing before the
+downstream ``ReadFiles`` physical op consumes them.
+
+Checkpoint filtering is not attached here — it's wrapped around the
+downstream ``ReadFiles`` physical op by
+:func:`plan_read_files_op_with_checkpoint_filter`, matching V1's
+dispatch pattern.
+"""
+from __future__ import annotations
+
+import logging
+from functools import partial
+from typing import List
+
+import numpy as np
+import pyarrow as pa
+
+import ray
+from ray.data._internal.datasource_v2.listing.file_manifest import (
+    PATH_COLUMN_NAME,
+)
+from ray.data._internal.datasource_v2.listing.listing_utils import (
+    list_files_for_each_block,
+    partition_files,
+    shuffle_files,
+)
+from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
+from ray.data._internal.execution.operators.input_data_buffer import (
+    InputDataBuffer,
+)
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_transformer import (
+    BlockMapTransformFn,
+    MapTransformer,
+    MapTransformFn,
+)
+from ray.data._internal.logical.operators import ListFiles
+from ray.data.block import Block, BlockAccessor
+from ray.data.context import DataContext
+
+logger = logging.getLogger(__name__)
+
+# Cap on the number of parallel listing tasks. In practice most reads
+# pass a single directory (one task); this matters when users hand in
+# thousands of explicit paths.
+DEFAULT_MAX_NUM_LIST_FILES_TASKS = 200
+
+
+def plan_list_files_op(
+    op: ListFiles,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
+) -> MapOperator:
+    assert len(physical_children) == 0
+
+    # NOTE: Avoid capturing ``op`` inside closures — only its field values.
+    file_extensions = op.file_extensions
+    partition_filter = op.partition_filter
+    filesystem = op.filesystem
+    indexer = op.file_indexer
+    partitioner = op.file_partitioner
+
+    shuffle_config = op.shuffle_config_factory()
+
+    transform_fns: List[MapTransformFn] = [
+        BlockMapTransformFn(
+            partial(
+                list_files_for_each_block,
+                indexer=indexer,
+                filesystem=filesystem,
+                file_extensions=file_extensions,
+                partition_filter=partition_filter,
+                preserve_order=data_context.execution_options.preserve_order,
+            ),
+            # Disable block-shaping: produce manifest blocks as-is.
+            disable_block_shaping=True,
+        ),
+    ]
+
+    if shuffle_config is not None:
+        transform_fns.append(
+            BlockMapTransformFn(
+                partial(
+                    shuffle_files,
+                    shuffle_config=shuffle_config,
+                    execution_idx=data_context._execution_idx,
+                ),
+                disable_block_shaping=True,
+            )
+        )
+
+    if partitioner is not None:
+        transform_fns.append(
+            BlockMapTransformFn(
+                partial(partition_files, partitioner=partitioner),
+                disable_block_shaping=True,
+            )
+        )
+
+    map_transformer = MapTransformer(transform_fns)
+
+    map_op = MapOperator.create(
+        map_transformer,
+        _create_input_data_buffer(
+            op,
+            data_context,
+            # Shuffle needs every manifest on a single task to compute one
+            # global RNG over the full listing.
+            should_parallelize=shuffle_config is None,
+        ),
+        data_context,
+        name="ListFiles",
+        # Listing is extremely fast; default backpressure would starve the
+        # downstream reader of inputs.
+        ray_remote_args={"_generator_backpressure_num_objects": -1},
+        # Don't fuse into the downstream ``ReadFiles`` — listing and reading
+        # have different resource profiles.
+        supports_fusion=False,
+    )
+    map_op.throttling_disabled = lambda: True
+    return map_op
+
+
+def _create_input_data_buffer(
+    op: ListFiles,
+    data_context: DataContext,
+    *,
+    should_parallelize: bool,
+) -> InputDataBuffer:
+    """Wrap ``op.paths`` into listing-input RefBundles.
+
+    Each bundle's block is a 1-column arrow table ``{"__path": [paths...]}``
+    that :func:`list_files_for_each_block` expands into manifest blocks.
+    """
+    if should_parallelize and op.paths:
+        path_splits = np.array_split(
+            list(op.paths),
+            min(DEFAULT_MAX_NUM_LIST_FILES_TASKS, len(op.paths)),
+        )
+    else:
+        path_splits = [list(op.paths)]
+
+    input_data: List[RefBundle] = []
+    for path_split in path_splits:
+        paths = list(path_split)
+        if not paths:
+            continue
+        block = pa.Table.from_pydict({PATH_COLUMN_NAME: paths})
+        metadata = BlockAccessor.for_block(block).get_metadata(
+            input_files=None, block_exec_stats=None
+        )
+        block_ref: ray.ObjectRef[Block] = ray.put(block)
+        ref_bundle = RefBundle(
+            ((block_ref, metadata),),  # pyrefly: ignore[bad-argument-type]
+            # ``owns_blocks=False``: these are the root of the DAG and
+            # must not be freed eagerly, or the DAG can't be reconstructed.
+            owns_blocks=False,
+            schema=BlockAccessor.for_block(block).schema(),
+        )
+        input_data.append(ref_bundle)
+
+    return InputDataBuffer(data_context, input_data=input_data)

--- a/python/ray/data/_internal/planner/plan_read_files_op.py
+++ b/python/ray/data/_internal/planner/plan_read_files_op.py
@@ -1,0 +1,91 @@
+"""Physical planner for the V2 ``ReadFiles`` logical operator.
+
+``ReadFiles`` now consumes ``FileManifest`` blocks from an upstream
+``ListFiles`` physical op. This planner wires one map transform —
+``do_read`` — that calls ``scanner.create_reader().read(manifest)`` for
+each incoming bucket and applies any recorded column renames.
+
+Listing, shuffling, and size-balanced bucketing previously lived here;
+they've moved to :func:`plan_list_files_op` where they belong.
+
+Checkpoint wrapping (when ``data_context.checkpoint_config`` is set) is
+handled by the companion
+:func:`ray.data._internal.planner.checkpoint.plan_read_files_op.plan_read_files_op_with_checkpoint_filter`,
+registered via the planner's ``_get_plan_fns_for_checkpointing`` hook —
+same dispatch shape V1 uses for ``plan_read_op_with_checkpoint_filter``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List
+
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.scanners.file_scanner import FileScanner
+from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.execution.interfaces.task_context import TaskContext
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_transformer import (
+    BlockMapTransformFn,
+    MapTransformer,
+)
+from ray.data._internal.logical.operators import ReadFiles
+from ray.data._internal.output_buffer import OutputBlockSizeOption
+from ray.data.block import Block
+from ray.data.context import DataContext
+from ray.data.datasource.datasource import _DatasourceProjectionPushdownMixin
+
+logger = logging.getLogger(__name__)
+
+
+def plan_read_files_op(
+    op: ReadFiles,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
+) -> MapOperator:
+    """Convert a ``ReadFiles`` logical op into a reader ``MapOperator``.
+
+    Expects exactly one physical child: the upstream ``ListFiles`` op,
+    which produces balanced manifest blocks via its transform chain.
+    """
+    assert len(physical_children) == 1
+    upstream = physical_children[0]
+
+    # NOTE: Avoid capturing the whole ``op`` in closures — only field values.
+    scanner = op.scanner
+    renames = op.column_renames
+
+    def do_read(blocks: Iterable[Block], _: TaskContext) -> Iterable[Block]:
+        reader = scanner.create_reader()
+        # File-level predicate pruning (partition predicates pushed down
+        # onto the scanner) runs per incoming manifest block. Only
+        # ``FileScanner`` subclasses expose ``prune_manifest``; the base
+        # implementation is an identity no-op, and ``ArrowFileScanner``
+        # overrides it to evaluate ``partition_predicate``.
+        for block in blocks:
+            manifest = FileManifest(block)
+            if isinstance(scanner, FileScanner):
+                manifest = scanner.prune_manifest(manifest)
+            if len(manifest) == 0:
+                continue
+            for table in reader.read(manifest):
+                yield _DatasourceProjectionPushdownMixin._apply_rename(table, renames)
+
+    return MapOperator.create(
+        MapTransformer(
+            [
+                BlockMapTransformFn(
+                    do_read,
+                    is_udf=False,
+                    output_block_size_option=OutputBlockSizeOption.of(
+                        target_max_block_size=data_context.target_max_block_size,
+                    ),
+                ),
+            ]
+        ),
+        upstream,
+        data_context,
+        name=op.name,
+        compute_strategy=op.compute,
+        ray_remote_args=op.ray_remote_args,
+    )

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -33,8 +33,10 @@ from ray.data._internal.logical.operators import (
     InputData,
     Join,
     Limit,
+    ListFiles,
     Project,
     Read,
+    ReadFiles,
     StreamingRepartition,
     StreamingSplit,
     Union,
@@ -47,6 +49,8 @@ from ray.data._internal.planner.checkpoint import (
 )
 from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
 from ray.data._internal.planner.plan_download_op import plan_download_op
+from ray.data._internal.planner.plan_list_files_op import plan_list_files_op
+from ray.data._internal.planner.plan_read_files_op import plan_read_files_op
 from ray.data._internal.planner.plan_read_op import plan_read_op
 from ray.data._internal.planner.plan_udf_map_op import (
     plan_filter_op,
@@ -155,6 +159,8 @@ class Planner:
 
     _DEFAULT_PLAN_FNS = {
         Read: plan_read_op,
+        ReadFiles: plan_read_files_op,
+        ListFiles: plan_list_files_op,
         InputData: plan_input_data_op,
         Write: plan_write_op,
         AbstractFrom: plan_from_op,


### PR DESCRIPTION

The two-op shape: a ListFiles source op (listing + shuffle + bucketing
via RoundRobinPartitioner) feeds a ReadFiles op (scanner-only). No
caller constructs the ops yet — that wiring is in PR-A3.

- logical/operators/read_operator.py: ListFiles, ReadFiles classes.
  ReadFiles consumes FileManifest blocks via a single input_dependency
  and only runs the scanner; ListFiles owns the path-listing transform
  chain.
- logical/operators/__init__.py: re-export.
- planner/plan_list_files_op.py (new): listing/shuffle/bucket transform
  chain emitting balanced FileManifest blocks.
- planner/plan_read_files_op.py (new): builds one map operator per
  manifest block.
- planner/planner.py: register ListFiles → plan_list_files_op,
  ReadFiles → plan_read_files_op in _DEFAULT_PLAN_FNS. Checkpoint
  filter dispatch is intentionally deferred to PR-B.
- logical/rules/limit_pushdown.py: ReadFiles branch.
- logical/rules/set_read_parallelism.py: _apply_v2 for ReadFiles.

Signed-off-by: Goutam <goutam@anyscale.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
