### PR TITLE
[tune] Expose progress reporter heartbeat cadence via RunConfig

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1892,9 +1892,6 @@ python/ray/tune/experimental/output.py
     DOC103: Function `_max_len`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [wrap: bool].
     DOC201: Function `_max_len` does not have a return section in docstring
     DOC201: Function `_get_trial_info` does not have a return section in docstring
-    DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
-    DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
-    DOC101: Method `ProgressReporter.__init__`: Docstring contains fewer arguments than in function signature.
 --------------------
 python/ray/tune/impl/tuner_internal.py
     DOC101: Method `TunerInternal.__init__`: Docstring contains fewer arguments than in function signature.

--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1895,7 +1895,6 @@ python/ray/tune/experimental/output.py
     DOC001: Method `__init__` Potential formatting errors in docstring. Error message: No specification for "Args": ""
     DOC001: Function/method `__init__`: Potential formatting errors in docstring. Error message: No specification for "Args": "" (Note: DOC001 could trigger other unrelated violations under this function/method too. Please fix the docstring formatting first.)
     DOC101: Method `ProgressReporter.__init__`: Docstring contains fewer arguments than in function signature.
-    DOC103: Method `ProgressReporter.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]], verbosity: AirVerbosity].
 --------------------
 python/ray/tune/impl/tuner_internal.py
     DOC101: Method `TunerInternal.__init__`: Docstring contains fewer arguments than in function signature.

--- a/doc/source/tune/api/reporters.rst
+++ b/doc/source/tune/api/reporters.rst
@@ -23,9 +23,24 @@ By default, Tune reports experiment progress periodically to the command-line as
     | MyTrainable_a826b7bc | RUNNING  | 10.234.98.164:31112 | 0.729127  | 0.0748 | 0.1784 | 0.1797 | 1.7161 |          7.05715 |    14 |
     +----------------------+----------+---------------------+-----------+--------+--------+--------+--------+------------------+-------+
 
-Note that columns will be hidden if they are completely empty. The output can be configured in various ways by
-instantiating a ``CLIReporter`` instance (or ``JupyterNotebookReporter`` if you're using jupyter notebook).
-Here's an example:
+Note that columns will be hidden if they are completely empty. To reduce the
+cadence at which the status table is reprinted (useful for long-running sweeps
+where the default 30s refresh floods the console), set
+``RunConfig(progress_report_interval_s=...)``:
+
+.. code-block:: python
+
+    import ray.tune
+
+    tuner = ray.tune.Tuner(
+        my_trainable,
+        run_config=ray.tune.RunConfig(progress_report_interval_s=300),
+    )
+    results = tuner.fit()
+
+The output can also be configured in various ways by instantiating a
+``CLIReporter`` instance (or ``JupyterNotebookReporter`` if you're using jupyter
+notebook). Here's an example:
 
 .. TODO: test these snippets
 

--- a/python/ray/air/config.py
+++ b/python/ray/air/config.py
@@ -564,6 +564,13 @@ class RunConfig:
             both streams are written. If this is a Sequence (e.g. a Tuple),
             it has to have length 2 and the elements indicate the files to
             which stdout and stderr are written, respectively.
+        progress_report_interval_s: Minimum interval in seconds between
+            consecutive status-table heartbeats printed to the console. When
+            unset (default), the built-in reporter refreshes every 30 seconds
+            under the AIR output engine and every 5 seconds under the legacy
+            ``CLIReporter``/``JupyterNotebookReporter`` path. Raise this value
+            to reduce log noise for long-running sweeps; lower it for more
+            responsive feedback during short runs.
 
     """
 
@@ -577,6 +584,7 @@ class RunConfig:
     stop: Optional[Union[Mapping, "Stopper", Callable[[str, Mapping], bool]]] = None
     callbacks: Optional[List["Callback"]] = None
     progress_reporter: Optional["ray.tune.progress_reporter.ProgressReporter"] = None
+    progress_report_interval_s: Optional[float] = None
     log_to_file: Union[bool, str, Tuple[str, str]] = False
 
     # Deprecated

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -581,7 +581,10 @@ def _print_dict_as_table(
 class ProgressReporter(Callback):
     """Periodically prints out status update."""
 
-    # TODO: Make this configurable
+    # Default heartbeat cadence in seconds. Subclasses may override this
+    # class attribute; individual instances can further override via the
+    # ``heartbeat_freq`` ctor argument (plumbed from
+    # ``RunConfig.progress_report_interval_s``).
     _heartbeat_freq = 30  # every 30 sec
     # to be updated by subclasses.
     _heartbeat_threshold = None
@@ -593,11 +596,18 @@ class ProgressReporter(Callback):
         self,
         verbosity: AirVerbosity,
         progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
+        heartbeat_freq: Optional[float] = None,
     ):
         """
 
         Args:
             verbosity: AirVerbosity level.
+            progress_metrics: Optional list of metrics to include in the
+                intermediate progress output.
+            heartbeat_freq: Minimum interval in seconds between status-table
+                heartbeats. If ``None`` (the default), falls back to the
+                class-level ``_heartbeat_freq`` (30s) so existing subclass
+                overrides are preserved.
         """
         self._verbosity = verbosity
         self._start_time = time.time()
@@ -605,6 +615,8 @@ class ProgressReporter(Callback):
         self._start_time = time.time()
         self._progress_metrics = progress_metrics
         self._trial_last_printed_results = {}
+        if heartbeat_freq is not None:
+            self._heartbeat_freq = heartbeat_freq
 
         self._in_block = None
 
@@ -802,6 +814,7 @@ def _detect_reporter(
     mode: Optional[str] = None,
     config: Optional[Dict] = None,
     progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
+    heartbeat_freq: Optional[float] = None,
 ):
     if entrypoint in {
         AirEntrypoint.TUNE_RUN,
@@ -815,9 +828,14 @@ def _detect_reporter(
             mode=mode,
             config=config,
             progress_metrics=progress_metrics,
+            heartbeat_freq=heartbeat_freq,
         )
     else:
-        reporter = TrainReporter(verbosity, progress_metrics=progress_metrics)
+        reporter = TrainReporter(
+            verbosity,
+            progress_metrics=progress_metrics,
+            heartbeat_freq=heartbeat_freq,
+        )
     return reporter
 
 
@@ -836,6 +854,7 @@ class TuneReporterBase(ProgressReporter):
         mode: Optional[str] = None,
         config: Optional[Dict] = None,
         progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
+        heartbeat_freq: Optional[float] = None,
     ):
         self._num_samples = num_samples
         self._metric = metric
@@ -844,7 +863,9 @@ class TuneReporterBase(ProgressReporter):
         self._inferred_metric = None
         self._inferred_params = _infer_params(config or {})
         super(TuneReporterBase, self).__init__(
-            verbosity=verbosity, progress_metrics=progress_metrics
+            verbosity=verbosity,
+            progress_metrics=progress_metrics,
+            heartbeat_freq=heartbeat_freq,
         )
 
     def setup(

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -581,11 +581,6 @@ def _print_dict_as_table(
 class ProgressReporter(Callback):
     """Periodically prints out status update."""
 
-    # Default heartbeat cadence in seconds. Subclasses may override this
-    # class attribute; individual instances can further override via the
-    # ``heartbeat_freq`` ctor argument (plumbed from
-    # ``RunConfig.progress_report_interval_s``).
-    _heartbeat_freq = 30  # every 30 sec
     # to be updated by subclasses.
     _heartbeat_threshold = None
     _start_end_verbosity = None
@@ -596,7 +591,7 @@ class ProgressReporter(Callback):
         self,
         verbosity: AirVerbosity,
         progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
-        heartbeat_freq: Optional[float] = None,
+        heartbeat_freq: float = 30,
     ):
         """
 
@@ -605,18 +600,14 @@ class ProgressReporter(Callback):
             progress_metrics: Optional list of metrics to include in the
                 intermediate progress output.
             heartbeat_freq: Minimum interval in seconds between status-table
-                heartbeats. If ``None`` (the default), falls back to the
-                class-level ``_heartbeat_freq`` (30s) so existing subclass
-                overrides are preserved.
+                heartbeats. Defaults to 30 seconds.
         """
         self._verbosity = verbosity
         self._start_time = time.time()
         self._last_heartbeat_time = float("-inf")
-        self._start_time = time.time()
         self._progress_metrics = progress_metrics
         self._trial_last_printed_results = {}
-        if heartbeat_freq is not None:
-            self._heartbeat_freq = heartbeat_freq
+        self._heartbeat_freq = heartbeat_freq
 
         self._in_block = None
 
@@ -814,7 +805,7 @@ def _detect_reporter(
     mode: Optional[str] = None,
     config: Optional[Dict] = None,
     progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
-    heartbeat_freq: Optional[float] = None,
+    heartbeat_freq: float = 30,
 ):
     if entrypoint in {
         AirEntrypoint.TUNE_RUN,
@@ -854,7 +845,7 @@ class TuneReporterBase(ProgressReporter):
         mode: Optional[str] = None,
         config: Optional[Dict] = None,
         progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
-        heartbeat_freq: Optional[float] = None,
+        heartbeat_freq: float = 30,
     ):
         self._num_samples = num_samples
         self._metric = metric

--- a/python/ray/tune/experimental/output.py
+++ b/python/ray/tune/experimental/output.py
@@ -98,6 +98,9 @@ ORDER = [
     Trial.ERROR,
 ]
 
+# Default minimum interval (seconds) between status-table heartbeats.
+DEFAULT_HEARTBEAT_FREQ_S = 30
+
 
 class AirVerbosity(IntEnum):
     SILENT = 0
@@ -591,16 +594,16 @@ class ProgressReporter(Callback):
         self,
         verbosity: AirVerbosity,
         progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
-        heartbeat_freq: float = 30,
+        heartbeat_freq: float = DEFAULT_HEARTBEAT_FREQ_S,
     ):
-        """
+        """Initialize the progress reporter.
 
         Args:
             verbosity: AirVerbosity level.
             progress_metrics: Optional list of metrics to include in the
                 intermediate progress output.
             heartbeat_freq: Minimum interval in seconds between status-table
-                heartbeats. Defaults to 30 seconds.
+                heartbeats. Defaults to ``DEFAULT_HEARTBEAT_FREQ_S`` (30s).
         """
         self._verbosity = verbosity
         self._start_time = time.time()
@@ -805,7 +808,7 @@ def _detect_reporter(
     mode: Optional[str] = None,
     config: Optional[Dict] = None,
     progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
-    heartbeat_freq: float = 30,
+    heartbeat_freq: float = DEFAULT_HEARTBEAT_FREQ_S,
 ):
     if entrypoint in {
         AirEntrypoint.TUNE_RUN,
@@ -845,7 +848,7 @@ class TuneReporterBase(ProgressReporter):
         mode: Optional[str] = None,
         config: Optional[Dict] = None,
         progress_metrics: Optional[Union[List[str], List[Dict[str, str]]]] = None,
-        heartbeat_freq: float = 30,
+        heartbeat_freq: float = DEFAULT_HEARTBEAT_FREQ_S,
     ):
         self._num_samples = num_samples
         self._metric = metric

--- a/python/ray/tune/impl/tuner_internal.py
+++ b/python/ray/tune/impl/tuner_internal.py
@@ -592,6 +592,7 @@ class TunerInternal:
             raise_on_failed_trial=False,
             fail_fast=(self._run_config.failure_config.fail_fast),
             progress_reporter=self._run_config.progress_reporter,
+            progress_report_interval_s=self._run_config.progress_report_interval_s,
             verbose=self._run_config.verbose,
             reuse_actors=self._tune_config.reuse_actors,
             max_concurrent_trials=self._tune_config.max_concurrent_trials,

--- a/python/ray/tune/progress_reporter.py
+++ b/python/ray/tune/progress_reporter.py
@@ -203,7 +203,7 @@ class TuneReporterBase(ProgressReporter):
         else:
             self._print_intermediate_tables = print_intermediate_tables
 
-        self._max_report_freqency = max_report_frequency
+        self._max_report_frequency = max_report_frequency
         self._last_report_time = 0
 
         self._start_time = time.time()
@@ -254,7 +254,7 @@ class TuneReporterBase(ProgressReporter):
             self._start_time = timestamp
 
     def should_report(self, trials: List[Trial], done: bool = False):
-        if time.time() - self._last_report_time > self._max_report_freqency:
+        if time.time() - self._last_report_time > self._max_report_frequency:
             self._last_report_time = time.time()
             return True
         return done

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -347,5 +347,46 @@ def test_heartbeat_reset(progress_reporter_cls):
             raise RuntimeError("Test faulty.")
 
 
+@pytest.mark.parametrize("progress_reporter_cls", [TrainReporter, TuneTerminalReporter])
+def test_heartbeat_freq_configurable(progress_reporter_cls):
+    """A per-instance ``heartbeat_freq`` overrides the class-level default."""
+    default_reporter = progress_reporter_cls(verbosity=AirVerbosity.VERBOSE)
+    class_default = type(default_reporter)._heartbeat_freq
+
+    # Shorter-than-default cadence: second tick must flush.
+    fast_reporter = progress_reporter_cls(
+        verbosity=AirVerbosity.VERBOSE, heartbeat_freq=0.5
+    )
+    fast_reporter._print_heartbeat = mock.MagicMock()
+    assert fast_reporter._heartbeat_freq == 0.5
+
+    with freeze_time() as frozen:
+        fast_reporter.print_heartbeat([])
+        assert fast_reporter._print_heartbeat.call_count == 1
+        frozen.tick(0.5)
+        fast_reporter.print_heartbeat([])
+        assert fast_reporter._print_heartbeat.call_count == 2
+
+    # Much-longer-than-default cadence: ticking past the class default
+    # should not trigger a second heartbeat.
+    slow_reporter = progress_reporter_cls(
+        verbosity=AirVerbosity.VERBOSE, heartbeat_freq=class_default * 10
+    )
+    slow_reporter._print_heartbeat = mock.MagicMock()
+
+    with freeze_time() as frozen:
+        slow_reporter.print_heartbeat([])
+        assert slow_reporter._print_heartbeat.call_count == 1
+        frozen.tick(class_default + 1)
+        slow_reporter.print_heartbeat([])
+        assert slow_reporter._print_heartbeat.call_count == 1
+
+    # ``heartbeat_freq=None`` preserves the class-level default.
+    noop_reporter = progress_reporter_cls(
+        verbosity=AirVerbosity.VERBOSE, heartbeat_freq=None
+    )
+    assert noop_reporter._heartbeat_freq == class_default
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tune/tests/output/test_output.py
+++ b/python/ray/tune/tests/output/test_output.py
@@ -349,9 +349,9 @@ def test_heartbeat_reset(progress_reporter_cls):
 
 @pytest.mark.parametrize("progress_reporter_cls", [TrainReporter, TuneTerminalReporter])
 def test_heartbeat_freq_configurable(progress_reporter_cls):
-    """A per-instance ``heartbeat_freq`` overrides the class-level default."""
+    """A per-instance ``heartbeat_freq`` overrides the 30s default."""
     default_reporter = progress_reporter_cls(verbosity=AirVerbosity.VERBOSE)
-    class_default = type(default_reporter)._heartbeat_freq
+    assert default_reporter._heartbeat_freq == 30
 
     # Shorter-than-default cadence: second tick must flush.
     fast_reporter = progress_reporter_cls(
@@ -367,25 +367,19 @@ def test_heartbeat_freq_configurable(progress_reporter_cls):
         fast_reporter.print_heartbeat([])
         assert fast_reporter._print_heartbeat.call_count == 2
 
-    # Much-longer-than-default cadence: ticking past the class default
-    # should not trigger a second heartbeat.
+    # Much-longer-than-default cadence: ticking past the default should not
+    # trigger a second heartbeat.
     slow_reporter = progress_reporter_cls(
-        verbosity=AirVerbosity.VERBOSE, heartbeat_freq=class_default * 10
+        verbosity=AirVerbosity.VERBOSE, heartbeat_freq=300
     )
     slow_reporter._print_heartbeat = mock.MagicMock()
 
     with freeze_time() as frozen:
         slow_reporter.print_heartbeat([])
         assert slow_reporter._print_heartbeat.call_count == 1
-        frozen.tick(class_default + 1)
+        frozen.tick(31)
         slow_reporter.print_heartbeat([])
         assert slow_reporter._print_heartbeat.call_count == 1
-
-    # ``heartbeat_freq=None`` preserves the class-level default.
-    noop_reporter = progress_reporter_cls(
-        verbosity=AirVerbosity.VERBOSE, heartbeat_freq=None
-    )
-    assert noop_reporter._heartbeat_freq == class_default
 
 
 if __name__ == "__main__":

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -805,6 +805,15 @@ class ProgressReporterTest(unittest.TestCase):
             self.assertFalse(isinstance(trainer_reporter, JupyterNotebookReporter))
             self.assertTrue(isinstance(trainer_reporter, CLIReporter))
 
+    def testReporterDetectionMaxReportFrequency(self):
+        """``_detect_reporter`` forwards ``max_report_frequency`` to ctor."""
+        reporter = _detect_reporter(max_report_frequency=42)
+        self.assertEqual(reporter._max_report_freqency, 42)
+
+        with patch("ray.tune.progress_reporter.IS_NOTEBOOK", True):
+            reporter = _detect_reporter(max_report_frequency=17)
+            self.assertEqual(reporter._max_report_freqency, 17)
+
     def testProgressReporterAPI(self):
         class CustomReporter(ProgressReporter):
             def should_report(self, trials, done=False):

--- a/python/ray/tune/tests/test_progress_reporter.py
+++ b/python/ray/tune/tests/test_progress_reporter.py
@@ -415,7 +415,7 @@ class ProgressReporterTest(unittest.TestCase):
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self._max_report_freqency = 0
+                self._max_report_frequency = 0
 
             def report(self, *args, **kwargs):
                 progress_str = self._progress_str(*args, **kwargs)
@@ -592,7 +592,7 @@ class ProgressReporterTest(unittest.TestCase):
 
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self._max_report_freqency = 0
+                self._max_report_frequency = 0
 
             def report(self, *args, **kwargs):
                 progress_str = self._progress_str(*args, **kwargs)
@@ -633,7 +633,7 @@ class ProgressReporterTest(unittest.TestCase):
         class TestReporter(CLIReporter):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self._max_report_freqency = 0
+                self._max_report_frequency = 0
                 self._output = ""
 
             def report(self, *args, **kwargs):
@@ -808,11 +808,11 @@ class ProgressReporterTest(unittest.TestCase):
     def testReporterDetectionMaxReportFrequency(self):
         """``_detect_reporter`` forwards ``max_report_frequency`` to ctor."""
         reporter = _detect_reporter(max_report_frequency=42)
-        self.assertEqual(reporter._max_report_freqency, 42)
+        self.assertEqual(reporter._max_report_frequency, 42)
 
         with patch("ray.tune.progress_reporter.IS_NOTEBOOK", True):
             reporter = _detect_reporter(max_report_frequency=17)
-            self.assertEqual(reporter._max_report_freqency, 17)
+            self.assertEqual(reporter._max_report_frequency, 17)
 
     def testProgressReporterAPI(self):
         class CustomReporter(ProgressReporter):

--- a/python/ray/tune/tests/test_tuner.py
+++ b/python/ray/tune/tests/test_tuner.py
@@ -267,6 +267,10 @@ class TunerTest(unittest.TestCase):
             {"tune_config": TuneConfig(time_budget_s=60)},
             lambda kw: kw["time_budget_s"] == 60,
         ),
+        (
+            {"run_config": RunConfig(progress_report_interval_s=12.5)},
+            lambda kw: kw["progress_report_interval_s"] == 12.5,
+        ),
     ],
 )
 def test_tuner_api_kwargs(shutdown_only, params_expected):

--- a/python/ray/tune/tune.py
+++ b/python/ray/tune/tune.py
@@ -284,6 +284,7 @@ def run(
     checkpoint_config: Optional[CheckpointConfig] = None,
     verbose: Optional[Union[int, AirVerbosity, Verbosity]] = None,
     progress_reporter: Optional[ProgressReporter] = None,
+    progress_report_interval_s: Optional[float] = None,
     log_to_file: bool = False,
     trial_name_creator: Optional[Callable[[Trial], str]] = None,
     trial_dirname_creator: Optional[Callable[[Trial], str]] = None,
@@ -412,6 +413,12 @@ def run(
             intermediate experiment progress. Defaults to CLIReporter if
             running in command-line, or JupyterNotebookReporter if running in
             a Jupyter notebook.
+        progress_report_interval_s: Minimum interval in seconds between
+            consecutive status-table heartbeats printed to the console. If
+            ``None`` (default), uses 30s for the AIR output engine and 5s for
+            the legacy ``CLIReporter``/``JupyterNotebookReporter`` path. Only
+            applies to the default reporter; ignored when a custom
+            ``progress_reporter`` instance is supplied.
         log_to_file: Log stdout and stderr to files in
             Tune's trial directories. If this is `False` (default), no files
             are written. If `true`, outputs are written to `trialdir/stdout`
@@ -865,6 +872,7 @@ def run(
         metric=metric,
         mode=mode,
         progress_metrics=progress_metrics,
+        progress_report_interval_s=progress_report_interval_s,
     )
 
     # User Warning for GPUs
@@ -898,8 +906,11 @@ def run(
 
     if air_verbosity is None:
         is_trainer = _entrypoint == AirEntrypoint.TRAINER
+        legacy_reporter_kwargs = {}
+        if progress_report_interval_s is not None:
+            legacy_reporter_kwargs["max_report_frequency"] = progress_report_interval_s
         progress_reporter = progress_reporter or _detect_reporter(
-            _trainer_api=is_trainer
+            _trainer_api=is_trainer, **legacy_reporter_kwargs
         )
 
     if resume is not None:

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -41,6 +41,7 @@ def _create_default_callbacks(
     mode: Optional[str] = None,
     config: Optional[dict] = None,
     progress_metrics: Optional[Collection[str]] = None,
+    progress_report_interval_s: Optional[float] = None,
 ) -> List[Callback]:
     """Create default callbacks for `Tuner.fit()`.
 
@@ -102,6 +103,7 @@ def _create_default_callbacks(
             mode=mode,
             config=config,
             progress_metrics=progress_metrics,
+            heartbeat_freq=progress_report_interval_s,
         )
         callbacks.append(air_progress_reporter)
     elif not has_trial_progress_callback:  # old flow

--- a/python/ray/tune/utils/callback.py
+++ b/python/ray/tune/utils/callback.py
@@ -95,6 +95,9 @@ def _create_default_callbacks(
             _detect_reporter as _detect_air_reporter,
         )
 
+        air_reporter_kwargs = {}
+        if progress_report_interval_s is not None:
+            air_reporter_kwargs["heartbeat_freq"] = progress_report_interval_s
         air_progress_reporter = _detect_air_reporter(
             air_verbosity,
             num_samples=1,  # Update later with setup()
@@ -103,7 +106,7 @@ def _create_default_callbacks(
             mode=mode,
             config=config,
             progress_metrics=progress_metrics,
-            heartbeat_freq=progress_report_interval_s,
+            **air_reporter_kwargs,
         )
         callbacks.append(air_progress_reporter)
     elif not has_trial_progress_callback:  # old flow


### PR DESCRIPTION
## Description

Expose the AIR progress reporter's 30s refresh cadence as `RunConfig(progress_report_interval_s=...)`. The hardcoded `_heartbeat_freq = 30` in `python/ray/tune/experimental/output.py` has had a `# TODO: Make this configurable` comment since the AIR output path landed in #33609 (March 2023).

`CLIReporter(max_report_frequency=...)` on `RunConfig.progress_reporter` is silently dropped in AIR mode (the `"AIR_VERBOSITY is set, ignoring passed-in ProgressReporter for now."` warning). So long-running sweeps have no public way to slow the status-table reprint — only private workarounds (monkey-patching `_heartbeat_freq`, or `RAY_AIR_NEW_OUTPUT=0`).

No default behavior change: when the field is `None`, each reporter falls back to its class-level default (30s AIR, 5s legacy). Subclass overrides of `_heartbeat_freq` still work.

## Related issues

Related to #49078 (progress reporter not configurable under AIR) and #38202 (custom progress reporter ignored since 2.6.0). Does not fully fix either — honoring a user-supplied custom reporter in AIR mode is a larger refactor and out of scope. This PR covers the most commonly-cited need (cadence) with a narrow public knob.

## Additional information

Usage:

```python
from ray import tune
from ray.train import RunConfig

tune.Tuner(
    my_trainable,
    run_config=RunConfig(progress_report_interval_s=300),
).fit()
```

Plumbing: `RunConfig` → `tune.run` → `_create_default_callbacks` → `_detect_reporter` → reporter ctor (`heartbeat_freq` for AIR, `max_report_frequency` for legacy). Class attr `_heartbeat_freq = 30` kept as fallback.

Tests:
- `test_output.py::test_heartbeat_freq_configurable` — short freq flushes, long freq suppresses, `None` preserves class default. Parameterized over `TrainReporter` and `TuneTerminalReporter`.
- `test_progress_reporter.py::testReporterDetectionMaxReportFrequency` — `_detect_reporter` forwards `max_report_frequency`.
- `test_tuner.py::test_tuner_api_kwargs` — `RunConfig(progress_report_interval_s=12.5)` reaches `tune.run` unchanged.

Docs: `RunConfig` and `tune.run` docstrings; snippet added to `doc/source/tune/api/reporters.rst`.

Out of scope: AIR/legacy unification, default cadence change, `TrialProgressCallback.DEBUG_PRINT_INTERVAL`, new env vars.

Note: the same original commit left two sibling TODOs in `output.py` — line 350 (`max_row`) and line 387 (`max_trial_num_to_show`, `max_column_length`) — mirroring other `CLIReporter` ctor args. Not touching them here; can open a follow-up RFC on whether those should be mirror knobs or whether AIR mode should honor custom `progress_reporter` instances directly.