### PR TITLE
[Core] Fix BaseContext.__exit__ signature so 'with ray.init():' type-checks

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1241,7 +1241,9 @@ class BaseContext(metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def __exit__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
+        # Signature matches the context manager protocol:
+        # https://docs.python.org/3/reference/datamodel.html#object.__exit__
         pass
 
     def _context_table_template(self):

--- a/python/ray/tests/typing_files/check_typing_good.py
+++ b/python/ray/tests/typing_files/check_typing_good.py
@@ -6,6 +6,14 @@ from ray import ObjectRef
 ray.init()
 
 
+# Regression check for https://github.com/ray-project/ray/issues/62971:
+# `ray.init()` returns a `BaseContext`, which must support the standard
+# context-manager protocol so `with ray.init(...):` type-checks.
+def _check_ray_init_context_manager() -> None:
+    with ray.init(num_cpus=1, num_gpus=0):  # type-check only, never executed
+        pass
+
+
 @ray.remote
 def int_task() -> int:
     return 1


### PR DESCRIPTION
## Repro

Since ray 2.55.0, `with ray.init(...):` produces a mypy error in user code:

```bash
cat > use_ray.py <<EOF2
import ray

with ray.init(num_cpus=1, num_gpus=0):
    pass
EOF2

# OK
uvx --quiet --python 3.12 --with 'ray==2.54.1' --from 'mypy==1.20.2' mypy use_ray.py

# error: Too many arguments for "__exit__" of "BaseContext"  [call-arg]
uvx --quiet --python 3.12 --with 'ray==2.55.1' --from 'mypy==1.20.2' mypy use_ray.py
```

`BaseContext.__exit__` is declared as `__exit__(self)`, which violates the
Python context-manager protocol's three-argument signature
(<https://docs.python.org/3/reference/datamodel.html#object.__exit__>).

Until 2.55.0 this was masked by an untyped `client_mode_hook` decorator on
`ray.init` that caused mypy to infer `Any` and skip the call. #60995 retyped
that decorator with a proper TypeVar, which exposed `ray.init`'s real
`-> BaseContext` return type and surfaced the latent bug.

## Fix

Change the abstract signature in `python/ray/_private/worker.py` to match
the context-manager protocol:

```python
@abstractmethod
def __exit__(self, exc_type, exc_value, traceback):
    ...
```

Concrete overrides (`RayContext.__exit__(self, *exc)`, `ClientContext.__exit__(self, *exc)`)
are already variadic and remain compatible with the new abstract signature.

3 lines added, 1 deleted in `python/ray/_private/worker.py`.

## Test

Adds the regression line to `python/ray/tests/typing_files/check_typing_good.py`:

```python
def _check_ray_init_context_manager() -> None:
    with ray.init(num_cpus=1, num_gpus=0):  # type-check only, never executed
        pass
```

`python/ray/tests/test_typing.py::test_typing_good` runs mypy against this
file and asserts the exit code is 0. Without the fix this assertion fails
(mypy reports `[call-arg]`).

Verified locally with a minimal reproduction:

```python
# Old (broken) abstract signature
class BaseContext:
    def __exit__(self): ...
def init() -> BaseContext: ...
with init(): pass
# mypy --strict: error: Too many arguments for "__exit__" of "BaseContext"

# New (fixed) abstract signature
class BaseContext:
    def __exit__(self, exc_type, exc_value, traceback): ...
def init() -> BaseContext: ...
with init(): pass
# mypy --strict: no [call-arg] error
```

Closes #62971
