### PR TITLE
[ci] Fix doc build failing on broken pytorch intersphinx inventory

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -856,7 +856,10 @@ intersphinx_mapping = {
         "https://www.tensorflow.org/api_docs/python",
         "https://raw.githubusercontent.com/GPflow/tensorflow-intersphinx/master/tf2_py_objects.inv",
     ),
-    "torch": ("https://pytorch.org/docs/stable/", None),
+    "torch": (
+        "https://docs.pytorch.org/docs/stable/",
+        "https://docs.pytorch.org/docs/2.7/objects.inv",
+    ),
     "torchvision": ("https://pytorch.org/vision/stable/", None),
     "transformers": ("https://huggingface.co/docs/transformers/main/en/", None),
 }


### PR DESCRIPTION
- The doc build (`make -C doc html`, which runs `sphinx-build -W --keep-going`) is failing with `build finished with problems, 1 warning`. The single Sphinx warning is an intersphinx fetch failure: `https://pytorch.org/docs/stable/objects.inv` 301s to `https://docs.pytorch.org/docs/stable/objects.inv`, which currently 404s upstream. With `-W`, that one warning fails CI.
- Repoint the `torch` intersphinx mapping in `doc/source/conf.py` to bypass the broken `/stable/objects.inv`. The base URL stays at the canonical `https://docs.pytorch.org/docs/stable/` so generated cross-reference links still target /stable/, but the inventory is fetched from a working pinned version: `https://docs.pytorch.org/docs/2.7/objects.inv`.
- Pin matches Ray's runtime torch version (`torch==2.7.0` in `python/requirements/ml/dl-{cpu,gpu}-requirements.txt`), so cross-refs only resolve to symbols that actually exist in the torch users get.

## Why pin to 2.7 and not /stable/ or /main/

- `/stable/objects.inv` is the upstream-broken URL we're routing around, so it can't be the source.
- `/main/objects.inv` works but tracks the development branch, which can index APIs that don't exist in 2.7 — leading to cross-refs resolving to symbols Ray users can't actually call.
- `/2.7/objects.inv` matches the runtime exactly. Tradeoff: when Ray bumps torch, this URL needs to bump alongside the requirements pin.

Post merge run: https://buildkite.com/ray-project/postmerge/builds/17329
