### PR TITLE
[core] rename InternalPubSub* to ControlPlanePubSub*

### DIFF
--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -106,7 +106,7 @@ class _AioSubscriber(_SubscriberBase):
         if pubsub_channel_type in _OBSERVABILITY_PUBSUB_CHANNELS:
             self._stub = gcs_service_pb2_grpc.ObservabilityPubSubServiceStub(channel)
         else:
-            self._stub = gcs_service_pb2_grpc.InternalPubSubGcsServiceStub(channel)
+            self._stub = gcs_service_pb2_grpc.ControlPlanePubSubGcsServiceStub(channel)
 
         # Type of the channel.
         self._channel = pubsub_channel_type

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -704,10 +704,11 @@ void GcsServer::InitKVService() {
 
 void GcsServer::InitPubSubHandler() {
   auto &io_context = io_context_provider_.GetIOContext<pubsub::GcsPublisher>();
-  pubsub_handler_ = std::make_unique<InternalPubSubHandler>(io_context, *gcs_publisher_);
+  pubsub_handler_ =
+      std::make_unique<ControlPlanePubSubHandler>(io_context, *gcs_publisher_);
 
   // This service is used to handle long poll requests, so we don't limit active RPCs.
-  rpc_server_.RegisterService(std::make_unique<rpc::InternalPubSubGrpcService>(
+  rpc_server_.RegisterService(std::make_unique<rpc::ControlPlanePubSubGrpcService>(
       io_context, *pubsub_handler_, /*max_active_rpcs_per_handler_=*/-1));
 
   auto &obs_io = io_context_provider_.GetIOContext<pubsub::ObservabilityPublisher>();

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -305,7 +305,7 @@ class GcsServer {
   /// Runtime env handler.
   std::unique_ptr<RuntimeEnvHandler> runtime_env_handler_;
   /// GCS PubSub handler (control-plane).
-  std::unique_ptr<InternalPubSubHandler> pubsub_handler_;
+  std::unique_ptr<ControlPlanePubSubHandler> pubsub_handler_;
   /// Observability pubsub handler.
   std::unique_ptr<ObservabilityPubSubHandler> observability_pubsub_handler_;
   /// GCS Task info manager for managing task states change events.

--- a/src/ray/gcs/grpc_service_interfaces.h
+++ b/src/ray/gcs/grpc_service_interfaces.h
@@ -132,7 +132,7 @@ class NodeResourceInfoGcsServiceHandler {
                                          SendReplyCallback send_reply_callback) = 0;
 };
 
-/// Shared handler surface for GCS Internal and Observability pubsub gRPC services.
+/// Shared handler surface for GCS control-plane and observability pubsub gRPC services.
 class PubSubGcsServiceHandlerBase {
  public:
   virtual ~PubSubGcsServiceHandlerBase() = default;
@@ -150,7 +150,7 @@ class PubSubGcsServiceHandlerBase {
                                                SendReplyCallback send_reply_callback) = 0;
 };
 
-class InternalPubSubGcsServiceHandler : public PubSubGcsServiceHandlerBase {};
+class ControlPlanePubSubGcsServiceHandler : public PubSubGcsServiceHandlerBase {};
 
 class ObservabilityPubSubServiceHandler : public PubSubGcsServiceHandlerBase {
  public:

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -76,16 +76,18 @@ void NodeResourceInfoGrpcService::InitServerCallFactories(
       NodeResourceInfoGcsService, GetAllResourceUsage, max_active_rpcs_per_handler_)
 }
 
-void InternalPubSubGrpcService::InitServerCallFactories(
+void ControlPlanePubSubGrpcService::InitServerCallFactories(
     const std::unique_ptr<grpc::ServerCompletionQueue> &cq,
     std::vector<std::unique_ptr<ServerCallFactory>> *server_call_factories,
     const ClusterID &cluster_id,
     std::shared_ptr<const AuthenticationToken> auth_token) {
-  RPC_SERVICE_HANDLER(InternalPubSubGcsService, GcsPublish, max_active_rpcs_per_handler_);
   RPC_SERVICE_HANDLER(
-      InternalPubSubGcsService, GcsSubscriberPoll, max_active_rpcs_per_handler_);
+      ControlPlanePubSubGcsService, GcsPublish, max_active_rpcs_per_handler_);
   RPC_SERVICE_HANDLER(
-      InternalPubSubGcsService, GcsSubscriberCommandBatch, max_active_rpcs_per_handler_);
+      ControlPlanePubSubGcsService, GcsSubscriberPoll, max_active_rpcs_per_handler_);
+  RPC_SERVICE_HANDLER(ControlPlanePubSubGcsService,
+                      GcsSubscriberCommandBatch,
+                      max_active_rpcs_per_handler_);
 }
 
 void ObservabilityPubSubGrpcService::InitServerCallFactories(

--- a/src/ray/gcs/grpc_services.h
+++ b/src/ray/gcs/grpc_services.h
@@ -111,11 +111,11 @@ class NodeResourceInfoGrpcService : public GrpcService {
   int64_t max_active_rpcs_per_handler_;
 };
 
-class InternalPubSubGrpcService : public GrpcService {
+class ControlPlanePubSubGrpcService : public GrpcService {
  public:
-  InternalPubSubGrpcService(instrumented_io_context &io_service,
-                            InternalPubSubGcsServiceHandler &handler,
-                            int64_t max_active_rpcs_per_handler)
+  ControlPlanePubSubGrpcService(instrumented_io_context &io_service,
+                                ControlPlanePubSubGcsServiceHandler &handler,
+                                int64_t max_active_rpcs_per_handler)
       : GrpcService(io_service),
         service_handler_(handler),
         max_active_rpcs_per_handler_(max_active_rpcs_per_handler) {}
@@ -130,8 +130,8 @@ class InternalPubSubGrpcService : public GrpcService {
       std::shared_ptr<const AuthenticationToken> auth_token) override;
 
  private:
-  InternalPubSubGcsService::AsyncService service_;
-  InternalPubSubGcsServiceHandler &service_handler_;
+  ControlPlanePubSubGcsService::AsyncService service_;
+  ControlPlanePubSubGcsServiceHandler &service_handler_;
   int64_t max_active_rpcs_per_handler_;
 };
 

--- a/src/ray/gcs/pubsub_handler.cc
+++ b/src/ray/gcs/pubsub_handler.cc
@@ -126,8 +126,8 @@ void PubSubHandlerBase::AsyncRemoveSubscriberFrom(const std::string &sender_id) 
       "RemoveSubscriberFrom");
 }
 
-InternalPubSubHandler::InternalPubSubHandler(instrumented_io_context &io_service,
-                                             pubsub::GcsPublisher &gcs_publisher)
+ControlPlanePubSubHandler::ControlPlanePubSubHandler(instrumented_io_context &io_service,
+                                                     pubsub::GcsPublisher &gcs_publisher)
     : PubSubHandlerBase(io_service, gcs_publisher.GetPublisher()) {}
 
 ObservabilityPubSubHandler::ObservabilityPubSubHandler(

--- a/src/ray/gcs/pubsub_handler.h
+++ b/src/ray/gcs/pubsub_handler.h
@@ -26,7 +26,7 @@
 namespace ray {
 namespace gcs {
 
-/// Shared implementation for Internal and Observability GCS pubsub handlers
+/// Shared implementation for control-plane and observability GCS pubsub handlers
 /// (publish, subscriber poll, subscribe/unsubscribe batch).
 class PubSubHandlerBase {
  public:
@@ -57,13 +57,13 @@ class PubSubHandlerBase {
   absl::flat_hash_map<std::string, absl::flat_hash_set<UniqueID>> sender_to_subscribers_;
 };
 
-/// Implementation of `InternalPubSubGcsServiceHandler`: long-poll subscribe and
+/// Implementation of `ControlPlanePubSubGcsServiceHandler`: long-poll subscribe and
 /// register / unregister subscribers against a `GcsPublisher`.
-class InternalPubSubHandler : public PubSubHandlerBase,
-                              public rpc::InternalPubSubGcsServiceHandler {
+class ControlPlanePubSubHandler : public PubSubHandlerBase,
+                                  public rpc::ControlPlanePubSubGcsServiceHandler {
  public:
-  InternalPubSubHandler(instrumented_io_context &io_service,
-                        pubsub::GcsPublisher &gcs_publisher);
+  ControlPlanePubSubHandler(instrumented_io_context &io_service,
+                            pubsub::GcsPublisher &gcs_publisher);
 
   using PubSubHandlerBase::AsyncRemoveSubscriberFrom;
 
@@ -90,7 +90,8 @@ class InternalPubSubHandler : public PubSubHandlerBase,
 };
 
 /// Observability pubsub (`ObservabilityPubSubService`): same publish/subscriber
-/// behavior as internal pubsub, plus `ReportJobError`, on an `ObservabilityPublisher`.
+/// behavior as control-plane pubsub, plus `ReportJobError`, on an
+/// `ObservabilityPublisher`.
 class ObservabilityPubSubHandler : public PubSubHandlerBase,
                                    public rpc::ObservabilityPubSubServiceHandler {
  public:

--- a/src/ray/gcs/tests/pubsub_handler_test.cc
+++ b/src/ray/gcs/tests/pubsub_handler_test.cc
@@ -68,13 +68,13 @@ class PubSubHandlerTest : public ::testing::Test {
         std::make_unique<pubsub::ObservabilityPublisher>(std::move(obs_inner));
 
     pubsub_handler_ =
-        std::make_unique<InternalPubSubHandler>(io_service_, *gcs_publisher_);
+        std::make_unique<ControlPlanePubSubHandler>(io_service_, *gcs_publisher_);
     observability_pubsub_handler_ = std::make_unique<ObservabilityPubSubHandler>(
         io_service_, *observability_publisher_);
   }
 
  protected:
-  std::unique_ptr<InternalPubSubHandler> pubsub_handler_;
+  std::unique_ptr<ControlPlanePubSubHandler> pubsub_handler_;
   std::unique_ptr<ObservabilityPubSubHandler> observability_pubsub_handler_;
 
  private:

--- a/src/ray/gcs_rpc_client/rpc_client.h
+++ b/src/ray/gcs_rpc_client/rpc_client.h
@@ -172,8 +172,9 @@ class GcsRpcClient {
             channel_, client_call_manager, address);
     internal_kv_grpc_client_ = std::make_shared<GrpcClient<InternalKVGcsService>>(
         channel_, client_call_manager, address);
-    internal_pubsub_grpc_client_ = std::make_shared<GrpcClient<InternalPubSubGcsService>>(
-        channel_, client_call_manager, address);
+    control_plane_pubsub_grpc_client_ =
+        std::make_shared<GrpcClient<ControlPlanePubSubGcsService>>(
+            channel_, client_call_manager, address);
     task_info_grpc_client_ = std::make_shared<GrpcClient<TaskInfoGcsService>>(
         channel_, client_call_manager, address);
     ray_event_export_grpc_client_ =
@@ -513,17 +514,17 @@ class GcsRpcClient {
                              /*method_timeout_ms*/ -1, )
 
   /// Operations for pubsub
-  VOID_GCS_RPC_CLIENT_METHOD(InternalPubSubGcsService,
+  VOID_GCS_RPC_CLIENT_METHOD(ControlPlanePubSubGcsService,
                              GcsPublish,
-                             internal_pubsub_grpc_client_,
+                             control_plane_pubsub_grpc_client_,
                              /*method_timeout_ms*/ -1, )
-  VOID_GCS_RPC_CLIENT_METHOD(InternalPubSubGcsService,
+  VOID_GCS_RPC_CLIENT_METHOD(ControlPlanePubSubGcsService,
                              GcsSubscriberPoll,
-                             internal_pubsub_grpc_client_,
+                             control_plane_pubsub_grpc_client_,
                              /*method_timeout_ms*/ -1, )
-  VOID_GCS_RPC_CLIENT_METHOD(InternalPubSubGcsService,
+  VOID_GCS_RPC_CLIENT_METHOD(ControlPlanePubSubGcsService,
                              GcsSubscriberCommandBatch,
-                             internal_pubsub_grpc_client_,
+                             control_plane_pubsub_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
   /// Operations for autoscaler
@@ -610,7 +611,8 @@ class GcsRpcClient {
   std::shared_ptr<GrpcClient<PlacementGroupInfoGcsService>>
       placement_group_info_grpc_client_;
   std::shared_ptr<GrpcClient<InternalKVGcsService>> internal_kv_grpc_client_;
-  std::shared_ptr<GrpcClient<InternalPubSubGcsService>> internal_pubsub_grpc_client_;
+  std::shared_ptr<GrpcClient<ControlPlanePubSubGcsService>>
+      control_plane_pubsub_grpc_client_;
   std::shared_ptr<GrpcClient<TaskInfoGcsService>> task_info_grpc_client_;
   std::shared_ptr<GrpcClient<RayEventExportGcsService>> ray_event_export_grpc_client_;
   std::shared_ptr<GrpcClient<RuntimeEnvGcsService>> runtime_env_grpc_client_;

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -704,7 +704,7 @@ message GcsSubscriberCommandBatchReply {
 
 /// Control-plane pubsub (GCS table deltas, node liveness, worker failures).
 /// Runs on the `pubsub_io_context` thread in GcsServer.
-service InternalPubSubGcsService {
+service ControlPlanePubSubGcsService {
   /// The request to sent to GCS to publish messages for control-plane channels only.
   rpc GcsPublish(GcsPublishRequest) returns (GcsPublishReply);
   /// The long polling request sent to GCS for pubsub operations.
@@ -717,8 +717,9 @@ service InternalPubSubGcsService {
 }
 
 /// Observability pubsub (logs, errors, node resource usage JSON for the dashboard).
-/// Same RPC and message names as `InternalPubSubGcsService`, plus `ReportJobError`, on a
-/// separate gRPC service and a dedicated `observability_pubsub_io_context` in GcsServer.
+/// Same RPC and message names as `ControlPlanePubSubGcsService`, plus `ReportJobError`,
+/// on a separate gRPC service and a dedicated `observability_pubsub_io_context` in
+/// GcsServer.
 service ObservabilityPubSubService {
   rpc GcsPublish(GcsPublishRequest) returns (GcsPublishReply);
   rpc ReportJobError(ReportJobErrorRequest) returns (ReportJobErrorReply);


### PR DESCRIPTION

## Description
Renaming `InternalPubSub*` to `ControlPlanePubSub*` for clarity. Following up to https://github.com/ray-project/ray/pull/62806#pullrequestreview-4207199543

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
