### PR TITLE
[data] copy for hash array in transform_pyarrow

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -131,7 +131,7 @@ def _hash_partition(
         # blocks depending on whether the block contains nulls.
         hashes = pd.util.hash_pandas_object(
             table.to_pandas(types_mapper=pd.ArrowDtype), index=False
-        ).values.copy()
+        ).to_numpy(copy=True)
         np.mod(hashes, num_partitions, out=hashes)
         partitions = hashes
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -131,7 +131,7 @@ def _hash_partition(
         # blocks depending on whether the block contains nulls.
         hashes = pd.util.hash_pandas_object(
             table.to_pandas(types_mapper=pd.ArrowDtype), index=False
-        ).values
+        ).values.copy()
         np.mod(hashes, num_partitions, out=hashes)
         partitions = hashes
 

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -493,6 +493,11 @@ def _backfill_missing_fields(
     if isinstance(column, pa.ChunkedArray):
         column = pa.concat_arrays(column.chunks)
 
+    # If the column is not a struct type but the unified type expects a struct,
+    # replace with nulls of the target struct type.
+    if not pa.types.is_struct(column.type):
+        return pa.nulls(block_length, type=unified_struct_type)
+
     # Extract the current struct field names and their corresponding data
     current_fields = {
         field.name: column.field(i) for i, field in enumerate(column.type)

--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -131,9 +131,8 @@ def _hash_partition(
         # blocks depending on whether the block contains nulls.
         hashes = pd.util.hash_pandas_object(
             table.to_pandas(types_mapper=pd.ArrowDtype), index=False
-        ).to_numpy(copy=True)
-        np.mod(hashes, num_partitions, out=hashes)
-        partitions = hashes
+        ).to_numpy()
+        partitions = hashes % num_partitions
 
     return partitions
 
@@ -492,11 +491,6 @@ def _backfill_missing_fields(
     # Flatten chunked arrays into a single array if necessary
     if isinstance(column, pa.ChunkedArray):
         column = pa.concat_arrays(column.chunks)
-
-    # If the column is not a struct type but the unified type expects a struct,
-    # replace with nulls of the target struct type.
-    if not pa.types.is_struct(column.type):
-        return pa.nulls(block_length, type=unified_struct_type)
 
     # Extract the current struct field names and their corresponding data
     current_fields = {


### PR DESCRIPTION
## Description
This pull request updates the hash partitioning logic in transform_pyarrow.py to ensure the hash array is writable for in-place operations by creating a copy. The review feedback suggests using .to_numpy(copy=True) instead of .values.copy() to align with modern pandas best practices and maintain consistency within the codebase.

## Related issues
Closes #63043
