### PR TITLE
[Data] Incrementally update resource usage after task dispatch

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -263,6 +263,75 @@ class ResourceManager:
         if self._op_resource_allocator is not None:
             self._update_allocated_budgets()
 
+    def update_usages_incremental(self, op: PhysicalOperator) -> None:
+        """Incrementally refresh usage state for the given operator and its upstreams.
+
+        Recomputes per-op usages only for the given operator and its upstreams.
+        Global aggregates are patched by delta.
+
+        Allocator budgets (`_update_allocated_budgets`) are intentionally left
+        frozen during the inner dispatch loop. Recomputing them after every
+        dispatched task is expensive, and the next full `update_usages` call
+        refreshes budgets before the next scheduling-loop step.
+
+        Pre-condition: `update_usages` has been called at least once so
+        the per-op usage caches are populated.
+        """
+        affected_ops = set[PhysicalOperator]([op])
+        for upstream in op.input_dependencies:
+            if upstream in self._topology:
+                affected_ops.add(upstream)
+
+        for op in affected_ops:
+            state = self._topology[op]
+
+            # Subtract this op's previous contribution from globals.
+            old_usage = self._op_usages.get(op)
+            old_running = self._op_running_usages.get(op)
+            old_pending = self._op_pending_usages.get(op)
+            if old_usage is not None:
+                self._global_usage = self._global_usage.subtract(old_usage)
+            if old_running is not None:
+                self._global_running_usage = self._global_running_usage.subtract(
+                    old_running
+                )
+            if old_pending is not None:
+                self._global_pending_usage = self._global_pending_usage.subtract(
+                    old_pending
+                )
+
+            op_usage = op.current_logical_usage()
+            op_running_usage = op.running_logical_usage()
+            op_pending_usage = op.pending_logical_usage()
+
+            assert not op_usage.object_store_memory
+            assert not op_running_usage.object_store_memory
+            assert not op_pending_usage.object_store_memory
+
+            used_object_store = self._estimate_object_store_memory_usage(op, state)
+
+            op_usage = op_usage.copy(object_store_memory=used_object_store)
+            op_running_usage = op_running_usage.copy(
+                object_store_memory=used_object_store
+            )
+
+            if isinstance(op, ReportsExtraResourceUsage):
+                op_usage.add(op.extra_resource_usage())
+
+            self._op_usages[op] = op_usage
+            self._op_running_usages[op] = op_running_usage
+            self._op_pending_usages[op] = op_pending_usage
+
+            self._global_usage = self._global_usage.add(op_usage)
+            self._global_running_usage = self._global_running_usage.add(
+                op_running_usage
+            )
+            self._global_pending_usage = self._global_pending_usage.add(
+                op_pending_usage
+            )
+
+            op._metrics.obj_store_mem_used = op_usage.object_store_memory
+
     def _update_allocated_budgets(self):
         completed_ops_usage = self._get_completed_ops_usage()
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -465,7 +465,7 @@ class StreamingExecutor(Executor, threading.Thread):
 
             topology[op].dispatch_next_task()
 
-            self._resource_manager.update_usages()
+            self._resource_manager.update_usages_incremental(op)
 
             i += 1
             if i % self._progress_manager.TOTAL_PROGRESS_REFRESH_EVERY_N_STEPS == 0:

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -764,6 +764,71 @@ class TestResourceManager:
             not can_submit
         ), "Task should be blocked: requires 2000 bytes but only 1000 bytes memory available"
 
+    def test_update_usages_incremental_matches_full_recompute(self):
+        ctx = DataContext.get_current()
+        o1 = InputDataBuffer(ctx, [])
+        o2 = mock_map_op(o1, ray_remote_args={"num_cpus": 1}, name="Map1")
+        o3 = mock_map_op(o2, ray_remote_args={"num_cpus": 1}, name="Map2")
+        topo = build_streaming_topology(o3, ExecutionOptions())
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            lambda: ExecutionResources(cpu=4, object_store_memory=1000),
+            ctx,
+        )
+        ops = [o1, o2, o3]
+        current = {op: ExecutionResources.zero() for op in ops}
+        running = {op: ExecutionResources.zero() for op in ops}
+        pending = {op: ExecutionResources.zero() for op in ops}
+        pending_outputs = {op: 0 for op in ops}
+        internal_outqueue = {op: 0 for op in ops}
+        pending_inputs = {op: 0 for op in ops}
+        internal_inqueue = {op: 0 for op in ops}
+        for op in ops:
+            op.current_logical_usage = MagicMock(side_effect=lambda op=op: current[op])
+            op.running_logical_usage = MagicMock(side_effect=lambda op=op: running[op])
+            op.pending_logical_usage = MagicMock(side_effect=lambda op=op: pending[op])
+            op._metrics = MagicMock()
+            op._metrics.obj_store_mem_max_pending_output_per_task = 0
+            op._metrics.obj_store_mem_internal_inqueue_for_input = MagicMock(
+                side_effect=lambda _input_index, op=op: internal_inqueue[op]
+            )
+
+        def apply_metrics():
+            for op in ops:
+                op._metrics.obj_store_mem_pending_task_outputs = pending_outputs[op]
+                op._metrics.obj_store_mem_internal_outqueue = internal_outqueue[op]
+                op._metrics.obj_store_mem_pending_task_inputs = pending_inputs[op]
+
+        def usage_snapshot():
+            return {
+                "global": resource_manager.get_global_usage(),
+                "running": resource_manager.get_global_running_usage(),
+                "pending": resource_manager.get_global_pending_usage(),
+                "op_usages": {op: resource_manager.get_op_usage(op) for op in ops},
+                "mem_internal": {
+                    op: resource_manager.get_mem_op_internal(op) for op in ops
+                },
+                "mem_outputs": {
+                    op: resource_manager.get_mem_op_outputs(op) for op in ops
+                },
+            }
+
+        apply_metrics()
+        resource_manager.update_usages()
+        budgets_before = {op: resource_manager.get_budget(op) for op in ops}
+        current[o3] = ExecutionResources(cpu=1)
+        running[o3] = ExecutionResources(cpu=1)
+        pending_outputs[o3] = 100
+        pending_inputs[o3] = 50
+        internal_inqueue[o3] = 25
+        apply_metrics()
+        resource_manager.update_usages_incremental(o3)
+        assert {op: resource_manager.get_budget(op) for op in ops} == budgets_before
+        incremental_snapshot = usage_snapshot()
+        resource_manager.update_usages()
+        assert incremental_snapshot == usage_snapshot()
+
 
 class TestResourceAllocatorUnblockingStreamingOutputBackpressure:
     """Tests for OpResourceAllocator._should_unblock_streaming_output_backpressure."""


### PR DESCRIPTION
## Description
This PR updates the Ray Data streaming executor to avoid doing a full resource usage recomputation after every task dispatch.
Previously, each dispatch in the scheduling loop called `ResourceManager.update_usages()`, which walks the full topology and recomputes usage for every operator. This can be expensive in the hot path. With this change, after dispatching a task, we only refresh usage for the dispatched operator and its immediate upstream operators, since those are the operators whose accounting can change from moving an input bundle into the operator.
Allocator budgets are intentionally left frozen during the inner dispatch loop to keep the hot path cheap. They are refreshed by the next full `update_usages()` call before the next scheduling-loop step.

Key changes:
- Adding `ResourceManager.update_usages_incremental()` to update per-op and global resource usage by delta.
- Updating the streaming executor dispatch loop to call `update_usages_incremental` instead of `update_usages`.
- Adding a unit test that compares incremental refresh against a full recompute.

## Related issues

## Additional information
TODO: test was done with 2.55.0-release. Need to test with latest main
