### PR TITLE
[Core] Match expected resource isolation integration test constraint to new cgroup constraint

### DIFF
--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -326,9 +326,8 @@ def assert_cgroup_hierarchy_exists_for_node(
     assert non_ray_cgroup.is_dir()
 
     # 2) Verify the constraints are applied correctly.
-    # Verify memory.max for default mode.
     total_memory = ray._common.utils.get_system_memory()
-    with open(user_cgroup / "memory.max", "r") as memory_max_file:
+    with open(user_cgroup / "memory.high", "r") as memory_max_file:
         contents = memory_max_file.read().strip()
         assert contents == str(
             total_memory

--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -327,8 +327,8 @@ def assert_cgroup_hierarchy_exists_for_node(
 
     # 2) Verify the constraints are applied correctly.
     total_memory = ray._common.utils.get_system_memory()
-    with open(user_cgroup / "memory.high", "r") as memory_max_file:
-        contents = memory_max_file.read().strip()
+    with open(user_cgroup / "memory.high", "r") as memory_high_file:
+        contents = memory_high_file.read().strip()
         assert contents == str(
             total_memory
             - resource_isolation_config.system_reserved_memory


### PR DESCRIPTION
## Description
The resource isolation python integration tests are currently failing because the resource isolation upper bound constraint has been adjusted from `memory.max` to `memory.high` in the latest resource isolation changes without updating the integration test. This PR adjust the resource isolation integration test to match the latest changes in to use `memory.high` upper bound constraint. 

The resource isolation PR that updated the memory constraint without updating the test: https://github.com/ray-project/ray/pull/62705/changes#diff-60b34dab728b2e51426a465dd712767a8735682e137e52ebfe030123aeeb56d5L69-R77

## Related issues
Fixes failing core: cgroup tests

## Additional information