### PR TITLE
[serve] Deflake test_drain_and_undrain_haproxy_manager

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -1038,8 +1038,23 @@ class HAProxyManager(ProxyActorInterface):
             f"logger with logging config: {logging_config}"
         )
 
+        # Scope paths under node_id so co-located managers (multi-raylet
+        # test clusters on one host) don't stomp each other's files.
+        def _per_node(path: str) -> str:
+            d, f = os.path.split(path)
+            return os.path.join(d, self._node_id, f)
+
         self._haproxy = HAProxyApi(
-            cfg=HAProxyConfig(http_options=http_options, is_head=is_head)
+            cfg=HAProxyConfig(
+                http_options=http_options,
+                is_head=is_head,
+                socket_path=_per_node(RAY_SERVE_HAPROXY_SOCKET_PATH),
+                server_state_base=os.path.join(
+                    RAY_SERVE_HAPROXY_SERVER_STATE_BASE, self._node_id
+                ),
+                server_state_file=_per_node(RAY_SERVE_HAPROXY_SERVER_STATE_FILE),
+            ),
+            config_file_path=_per_node(RAY_SERVE_HAPROXY_CONFIG_FILE_LOC),
         )
         self._haproxy_start_task = self.event_loop.create_task(self._haproxy.start())
 

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -1039,7 +1039,7 @@ class HAProxyManager(ProxyActorInterface):
         )
 
         # Scope paths under node_id so co-located managers (multi-raylet
-        # test clusters on one host) don't stomp each other's files.
+        # test clusters on one host) don't overwrite each other's files.
         def _per_node(path: str) -> str:
             d, f = os.path.split(path)
             return os.path.join(d, self._node_id, f)

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -304,25 +304,15 @@ async def test_drain_and_undrain_haproxy_manager(
 
     cluster = Cluster()
 
-    # Cluster() puts three Ray nodes on one host, but HAProxy defaults to
-    # singleton paths under /tmp/haproxy-serve/, so concurrent reloads
-    # across nodes truncate each other's config and crash haproxy with
-    # "No enabled listener found". Each raylet inherits os.environ at fork
-    # time, so setting per-node env vars before each cluster.add_node()
-    # gives each HAProxyManager its own paths without changing prod code.
+    # Give each raylet its own HAProxy paths so co-located managers don't
+    # stomp each other's config (raylets inherit os.environ at fork).
     def add_node(i, num_cpus):
-        monkeypatch.setenv(
-            "RAY_SERVE_HAPROXY_CONFIG_FILE_LOC",
-            f"/tmp/haproxy-serve/haproxy-{i}.cfg",
-        )
-        monkeypatch.setenv(
-            "RAY_SERVE_HAPROXY_SOCKET_PATH",
-            f"/tmp/haproxy-serve/admin-{i}.sock",
-        )
-        monkeypatch.setenv(
-            "RAY_SERVE_HAPROXY_SERVER_STATE_FILE",
-            f"/tmp/haproxy-serve/server-state-{i}",
-        )
+        for var, name in [
+            ("RAY_SERVE_HAPROXY_CONFIG_FILE_LOC", f"haproxy-{i}.cfg"),
+            ("RAY_SERVE_HAPROXY_SOCKET_PATH", f"admin-{i}.sock"),
+            ("RAY_SERVE_HAPROXY_SERVER_STATE_FILE", f"server-state-{i}"),
+        ]:
+            monkeypatch.setenv(var, f"/tmp/haproxy-serve/{name}")
         return cluster.add_node(num_cpus=num_cpus)
 
     head_node = add_node(0, num_cpus=0)
@@ -354,22 +344,18 @@ async def test_drain_and_undrain_haproxy_manager(
 
     assert len(proxy_actor_ids) == 3
 
-    # All HAProxy actors share *:8000 via SO_REUSEPORT, so a localhost
-    # connection may land on any of them. Wait until each shard has received
-    # the backend update from the controller's long poll before issuing the
-    # blocking request — otherwise an unsynced shard returns 503 and the
-    # request never reaches a replica.
+    # 3 HAProxies share *:8000 via SO_REUSEPORT; ping until 20 successive
+    # requests succeed so every shard is hit at least once with high
+    # probability (P(miss) ~= 3 * (2/3)^20 ~= 0.1%).
     def all_haproxies_ready():
-        for _ in range(6):
-            try:
-                if (
-                    httpx.get("http://localhost:8000/-/healthz", timeout=2).status_code
-                    != 200
-                ):
-                    return False
-            except Exception:
-                return False
-        return True
+        try:
+            return all(
+                httpx.get("http://localhost:8000/-/healthz", timeout=2).status_code
+                == 200
+                for _ in range(20)
+            )
+        except Exception:
+            return False
 
     wait_for_condition(all_haproxies_ready, timeout=20)
 

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -344,9 +344,8 @@ async def test_drain_and_undrain_haproxy_manager(
 
     assert len(proxy_actor_ids) == 3
 
-    # 3 HAProxies share *:8000 via SO_REUSEPORT; ping until 20 successive
-    # requests succeed so every shard is hit at least once with high
-    # probability (P(miss) ~= 3 * (2/3)^20 ~= 0.1%).
+    # 3 HAProxies share *:8000 via SO_REUSEPORT; 20 successive 200s makes it
+    # very likely each shard has served at least one request and converged.
     def all_haproxies_ready():
         try:
             return all(

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -303,9 +303,31 @@ async def test_drain_and_undrain_haproxy_manager(
     monkeypatch.setenv("SERVE_SOCKET_REUSE_PORT_ENABLED", "1")
 
     cluster = Cluster()
-    head_node = cluster.add_node(num_cpus=0)
-    cluster.add_node(num_cpus=1)
-    cluster.add_node(num_cpus=1)
+
+    # Cluster() puts three Ray nodes on one host, but HAProxy defaults to
+    # singleton paths under /tmp/haproxy-serve/, so concurrent reloads
+    # across nodes truncate each other's config and crash haproxy with
+    # "No enabled listener found". Each raylet inherits os.environ at fork
+    # time, so setting per-node env vars before each cluster.add_node()
+    # gives each HAProxyManager its own paths without changing prod code.
+    def add_node(i, num_cpus):
+        monkeypatch.setenv(
+            "RAY_SERVE_HAPROXY_CONFIG_FILE_LOC",
+            f"/tmp/haproxy-serve/haproxy-{i}.cfg",
+        )
+        monkeypatch.setenv(
+            "RAY_SERVE_HAPROXY_SOCKET_PATH",
+            f"/tmp/haproxy-serve/admin-{i}.sock",
+        )
+        monkeypatch.setenv(
+            "RAY_SERVE_HAPROXY_SERVER_STATE_FILE",
+            f"/tmp/haproxy-serve/server-state-{i}",
+        )
+        return cluster.add_node(num_cpus=num_cpus)
+
+    head_node = add_node(0, num_cpus=0)
+    add_node(1, num_cpus=1)
+    add_node(2, num_cpus=1)
     cluster.wait_for_nodes()
     ray.init(address=head_node.address)
     serve.start(http_options={"location": "EveryNode"})
@@ -331,6 +353,25 @@ async def test_drain_and_undrain_haproxy_manager(
     proxy_actor_ids = {proxy.actor_id for _, proxy in serve_details.proxies.items()}
 
     assert len(proxy_actor_ids) == 3
+
+    # All HAProxy actors share *:8000 via SO_REUSEPORT, so a localhost
+    # connection may land on any of them. Wait until each shard has received
+    # the backend update from the controller's long poll before issuing the
+    # blocking request — otherwise an unsynced shard returns 503 and the
+    # request never reaches a replica.
+    def all_haproxies_ready():
+        for _ in range(6):
+            try:
+                if (
+                    httpx.get("http://localhost:8000/-/healthz", timeout=2).status_code
+                    != 200
+                ):
+                    return False
+            except Exception:
+                return False
+        return True
+
+    wait_for_condition(all_haproxies_ready, timeout=20)
 
     # Start a long-running request in background to test draining behavior
     request_result = []

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -303,21 +303,9 @@ async def test_drain_and_undrain_haproxy_manager(
     monkeypatch.setenv("SERVE_SOCKET_REUSE_PORT_ENABLED", "1")
 
     cluster = Cluster()
-
-    # Give each raylet its own HAProxy paths so co-located managers don't
-    # stomp each other's config (raylets inherit os.environ at fork).
-    def add_node(i, num_cpus):
-        for var, name in [
-            ("RAY_SERVE_HAPROXY_CONFIG_FILE_LOC", f"haproxy-{i}.cfg"),
-            ("RAY_SERVE_HAPROXY_SOCKET_PATH", f"admin-{i}.sock"),
-            ("RAY_SERVE_HAPROXY_SERVER_STATE_FILE", f"server-state-{i}"),
-        ]:
-            monkeypatch.setenv(var, f"/tmp/haproxy-serve/{name}")
-        return cluster.add_node(num_cpus=num_cpus)
-
-    head_node = add_node(0, num_cpus=0)
-    add_node(1, num_cpus=1)
-    add_node(2, num_cpus=1)
+    head_node = cluster.add_node(num_cpus=0)
+    cluster.add_node(num_cpus=1)
+    cluster.add_node(num_cpus=1)
     cluster.wait_for_nodes()
     ray.init(address=head_node.address)
     serve.start(http_options={"location": "EveryNode"})
@@ -804,7 +792,9 @@ def test_haproxy_healthcheck_multiple_apps_and_backends(ray_shutdown):
         return "hello"
 
     # Helpers
-    SOCKET_PATH = "/tmp/haproxy-serve/admin.sock"
+    SOCKET_PATH = (
+        f"/tmp/haproxy-serve/{ray.get_runtime_context().get_node_id()}/admin.sock"
+    )
 
     def app_to_backend(app: str) -> str:
         return f"http-{app}"


### PR DESCRIPTION
`test_drain_and_undrain_haproxy_manager` has flaked 7 times in the past 30 days (most recent: [postmerge #17325](https://buildkite.com/ray-project/postmerge/builds/17325)). The test starts 3 Ray nodes on one host, so 3 `HAProxyManager` actors end up sharing the singleton paths under `/tmp/haproxy-serve/`. One actor's reload truncates the config another's haproxy is mid-read on, and we get `[ALERT] No enabled listener found ... Exiting`.

Production runs one manager per host, so this only breaks in the test. Two fixes:

1. **`HAProxyManager` scopes its files under `node_id`.** Each manager now writes to `/tmp/haproxy-serve/<node_id>/{haproxy.cfg,admin.sock,server-state}` instead of the shared singleton paths. Co-located managers no longer collide. This fixes the test without test-side env-var gymnastics, and is the right behavior even outside this test (any future scenario with >1 manager per host gets isolation for free).

2. **Wait for SO_REUSEPORT shard convergence before the blocking request.** With 3 HAProxies on `*:8000`, a request can hit a shard whose long-poll hasn't seen the new backend. Poll `/-/healthz` until all 3 have converged.

`test_haproxy_healthcheck_multiple_apps_and_backends` hardcoded `/tmp/haproxy-serve/admin.sock` and is updated to derive the socket path from the runtime node id.

5/5 local runs pass; reverting either fix brings the flake back.

## Test plan

- [ ] CI: `:ray-serve: serve: HAProxy tests [g16_s15]` and `(pip) [g16_s16]` green