### PR TITLE
[docs][llm] Remove VLLM_USE_V1 from DeepSeek and batch LLM examples

### DIFF
--- a/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayserve-deepseek-example.md
@@ -80,9 +80,6 @@ serveConfigV2: |
             autoscaling_config:
               min_replicas: 1
               max_replicas: 1
-          runtime_env:
-            env_vars:
-              VLLM_USE_V1: "1"
           engine_kwargs:
             tensor_parallel_size: 8
             pipeline_parallel_size: 2

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.ipynb
@@ -1203,7 +1203,6 @@
     }
    ],
    "source": [
-    "import os\n",
     "import ray\n",
     "from ray.data.llm import vLLMEngineProcessorConfig"
    ]
@@ -1216,12 +1215,6 @@
    "source": [
     "config = vLLMEngineProcessorConfig(\n",
     "    model_source=model_source,\n",
-    "    runtime_env={\n",
-    "        \"env_vars\": {\n",
-    "            \"VLLM_USE_V1\": \"0\",  # v1 doesn't support lora adapters yet\n",
-    "            # \"HF_TOKEN\": os.environ.get(\"HF_TOKEN\"),\n",
-    "        },\n",
-    "    },\n",
     "    engine_kwargs={\n",
     "        \"enable_lora\": True,\n",
     "        \"max_lora_rank\": 8,\n",

--- a/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
+++ b/doc/source/ray-overview/examples/entity-recognition-with-llms/README.md
@@ -753,7 +753,6 @@ Start by defining the [vLLM engine processor config](https://docs.ray.io/en/late
 
 
 ```python
-import os
 import ray
 from ray.data.llm import vLLMEngineProcessorConfig
 ```
@@ -765,12 +764,6 @@ from ray.data.llm import vLLMEngineProcessorConfig
 ```python
 config = vLLMEngineProcessorConfig(
     model_source=model_source,
-    runtime_env={
-        "env_vars": {
-            "VLLM_USE_V1": "0",  # v1 doesn't support lora adapters yet
-            # "HF_TOKEN": os.environ.get("HF_TOKEN"),
-        },
-    },
     engine_kwargs={
         "enable_lora": True,
         "max_lora_rank": 8,

--- a/doc/source/serve/tutorials/serve-deepseek.md
+++ b/doc/source/serve/tutorials/serve-deepseek.md
@@ -42,7 +42,6 @@ llm_config = LLMConfig(
     },
     # Change to the accelerator type of the node
     accelerator_type="H100",
-    runtime_env={"env_vars": {"VLLM_USE_V1": "1"}},
     # Customize engine arguments as needed (e.g. vLLM engine kwargs)
     engine_kwargs={
         "tensor_parallel_size": 8,
@@ -78,9 +77,6 @@ applications:
           autoscaling_config:
             min_replicas: 1
             max_replicas: 1
-        runtime_env:
-          env_vars:
-            VLLM_USE_V1: "1"
         engine_kwargs:
           tensor_parallel_size: 8
           pipeline_parallel_size: 2


### PR DESCRIPTION
## Summary
Removes obsolete \VLLM_USE_V1\ settings from user-facing docs and examples. This aligns documentation with #63001, which removed \VLLM_USE_V1\ from the Ray LLM vLLM engine and related code paths.

## Changes
- \serve-deepseek.md\: drop \untime_env\ from Python and YAML snippets
- \ayserve-deepseek-example.md\: drop \untime_env\ from the \serveConfigV2\ excerpt
- Entity recognition example (\README.md\, \README.ipynb\): remove \untime_env\ from \LLMEngineProcessorConfig\ and unused \import os\ in that cell

## Testing
- Doc-only change; no code paths modified.

cc: follow-up to https://github.com/ray-project/ray/pull/63001

Made with [Cursor](https://cursor.com)