### PR TITLE
Add perf metrics for 2.55.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 155.65619199999998,
+    "_dashboard_memory_usage_mb": 97.652736,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.71,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3636\t2.2GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3050\t1.96GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n12074\t0.85GiB\tpython distributed/test_many_actors.py\n3887\t0.21GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4377\t0.18GiB\tray::DashboardAgent\n3205\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3791\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1142\t0.08GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4379\t0.08GiB\tray::RuntimeEnvAgent\n11782\t0.07GiB\tray::JobSupervisor",
-    "actors_per_second": 421.58470204328825,
+    "_peak_memory": 4.01,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3706\t1.57GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3138\t1.05GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n6374\t0.83GiB\tpython distributed/test_many_actors.py\n3932\t0.2GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4413\t0.17GiB\tray::DashboardAgent\n3177\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1440\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4415\t0.09GiB\tray::RuntimeEnvAgent\n3849\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n6514\t0.08GiB\tray::DashboardTester.run",
+    "actors_per_second": 528.8023526342919,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 421.58470204328825
+            "perf_metric_value": 528.8023526342919
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.916
+            "perf_metric_value": 9.635
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3849.811
+            "perf_metric_value": 1983.793
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 4939.24
+            "perf_metric_value": 3389.923
         }
     ],
-    "time": 23.720025777816772
+    "time": 18.910657167434692
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 95.154176,
+    "_dashboard_memory_usage_mb": 90.198016,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.4,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3647\t0.63GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3154\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3879\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n7522\t0.16GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4376\t0.12GiB\tray::DashboardAgent\n3111\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n2178\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3779\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4378\t0.08GiB\tray::RuntimeEnvAgent\n7754\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 2.36,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3547\t0.6GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2994\t0.32GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5416\t0.31GiB\taide --config=/etc/aide/aide.conf --update --after=report_url=file:/var/lib/aide/dailyaidecheck/arun\n4911\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n3762\t0.17GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4243\t0.13GiB\tray::DashboardAgent\n3105\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1364\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3680\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n5117\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 386.6133448073775
+            "perf_metric_value": 183.49078025658062
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.562
+            "perf_metric_value": 5.651
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 42.959
+            "perf_metric_value": 46.531
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 144.301
+            "perf_metric_value": 138.51
         }
     ],
-    "tasks_per_second": 386.6133448073775,
-    "time": 302.5865635871887,
+    "tasks_per_second": 183.49078025658062,
+    "time": 305.44986510276794,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 247.144448,
+    "_dashboard_memory_usage_mb": 79.745024,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.89,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3655\t1.04GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3167\t0.61GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5494\t0.38GiB\tpython distributed/test_many_pgs.py\n595\t0.2GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4399\t0.16GiB\tray::DashboardAgent\n3130\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n3904\t0.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n1141\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n2931\t0.08GiB\t/app/go/infra/activityprobe/activityprobe ray --port=5903 --metrics_server_port=9092 --raylet_addr=l\n4401\t0.08GiB\tray::RuntimeEnvAgent",
+    "_peak_memory": 2.63,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3660\t0.83GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n2982\t0.59GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5085\t0.35GiB\tpython distributed/test_many_pgs.py\n590\t0.22GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4371\t0.15GiB\tray::DashboardAgent\n3887\t0.14GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n1392\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3149\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n4373\t0.09GiB\tray::RuntimeEnvAgent\n3791\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 17.650687524827635
+            "perf_metric_value": 80.95254123918434
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.002
+            "perf_metric_value": 6.74
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 37.856
+            "perf_metric_value": 147.311
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 798.453
+            "perf_metric_value": 1879.035
         }
     ],
-    "pgs_per_second": 17.650687524827635,
-    "time": 56.65501689910889
+    "pgs_per_second": 80.95254123918434,
+    "time": 12.352916717529297
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 91.15648,
+    "_dashboard_memory_usage_mb": 98.545664,
     "_dashboard_test_success": true,
-    "_peak_memory": 5.94,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3674\t2.49GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3916\t1.04GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n6585\t0.76GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3090\t0.34GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3919\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4412\t0.15GiB\tray::DashboardAgent\n3036\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1178\t0.1GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3808\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n6805\t0.08GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 5.58,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3704\t2.15GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3925\t1.1GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n5053\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n3139\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n3928\t0.19GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4406\t0.13GiB\tray::DashboardAgent\n3143\t0.11GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/python3_9_x86_64-unknown-\n1448\t0.09GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5268\t0.09GiB\tray::StateAPIGeneratorActor.start\n4408\t0.09GiB\tray::RuntimeEnvAgent",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 594.0367087794571
+            "perf_metric_value": 373.6653345877981
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 6.859
+            "perf_metric_value": 5.121
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 272.748
+            "perf_metric_value": 241.548
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1141.131
+            "perf_metric_value": 1104.206
         }
     ],
-    "tasks_per_second": 594.0367087794571,
-    "time": 316.8339765071869,
+    "tasks_per_second": 373.6653345877981,
+    "time": 326.7619152069092,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.54.0"}
+{"release_version": "2.55.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        7527.784116619314,
-        686.70161998692
+        8396.874033285541,
+        203.90199139819524
     ],
     "1_1_actor_calls_concurrent": [
-        5055.6982704309885,
-        117.81188103317386
+        5678.956390335692,
+        50.71434424461075
     ],
     "1_1_actor_calls_sync": [
-        1645.0106136032405,
-        32.423053096719755
+        1879.6455165405484,
+        25.108186673715778
     ],
     "1_1_async_actor_calls_async": [
-        4406.2141950729665,
-        392.67069052261905
+        4616.604004176862,
+        193.83565419000846
     ],
     "1_1_async_actor_calls_sync": [
-        1403.3196936007505,
-        23.38136965997657
+        1417.1846351735794,
+        16.71205106233678
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2985.2594797119345,
-        72.10260029608293
+        2966.3149904468737,
+        176.1920125374007
     ],
     "1_n_actor_calls_async": [
-        6982.12785749039,
-        84.52093535167333
+        7370.550357182028,
+        122.44520396894765
     ],
     "1_n_async_actor_calls_async": [
-        6321.193126550936,
-        105.40625132604556
+        6907.905927393101,
+        85.84985868672779
     ],
     "client__1_1_actor_calls_async": [
-        1019.3488253694755,
-        40.97440169490378
+        1066.5581344588645,
+        25.29295730544665
     ],
     "client__1_1_actor_calls_concurrent": [
-        1013.6459203927111,
-        36.42569600106788
+        1050.5473572391506,
+        78.9131834499914
     ],
     "client__1_1_actor_calls_sync": [
-        453.03975429334184,
-        4.589809773066405
+        539.1188849292095,
+        13.207864650501818
     ],
     "client__get_calls": [
-        1119.7606509262687,
-        10.216247991847167
+        1110.3815800718512,
+        46.94010981271201
     ],
     "client__put_calls": [
-        851.7996054229982,
-        21.394281286045853
+        847.7132252307356,
+        9.482802711501769
     ],
     "client__put_gigabytes": [
-        0.09739017021478441,
-        0.0001559510533309823
+        0.09852699612927329,
+        0.0011153895982075907
     ],
     "client__tasks_and_get_batch": [
-        0.982001139120161,
-        0.007911403954563356
+        0.9637211637507427,
+        0.022560513795709242
     ],
     "client__tasks_and_put_batch": [
-        11564.646324370273,
-        197.74393620118164
+        12087.25786385043,
+        175.63310455993135
     ],
     "multi_client_put_calls_Plasma_Store": [
-        12328.429700852164,
-        65.30767292022132
+        12844.074948208083,
+        142.37580714319805
     ],
     "multi_client_put_gigabytes": [
-        42.60577675231464,
-        2.093494970352258
+        40.8627833341568,
+        2.480266729516992
     ],
     "multi_client_tasks_async": [
-        18575.069898088233,
-        1524.2708653751615
+        21137.109008698124,
+        1293.3274307575432
     ],
     "n_n_actor_calls_async": [
-        22974.891754744596,
-        801.8328425494504
+        23481.256884763905,
+        892.8391276253976
     ],
     "n_n_actor_calls_with_arg_async": [
-        3009.073515305312,
-        114.28060136202912
+        3222.5114335686285,
+        29.534933551700966
     ],
     "n_n_async_actor_calls_async": [
-        18829.374267162224,
-        451.3497379007174
+        21566.207868367015,
+        636.2725036061306
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10155.173652668069
+            "perf_metric_value": 10618.338081970585
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4552.207208625433
+            "perf_metric_value": 4632.275852502236
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12328.429700852164
+            "perf_metric_value": 12844.074948208083
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10.938074087722523
+            "perf_metric_value": 12.831166033501425
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.723101265712336
+            "perf_metric_value": 5.481786077048712
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 42.60577675231464
+            "perf_metric_value": 40.8627833341568
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 10.363904163485511
+            "perf_metric_value": 12.123293390343653
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4.273484814546707
+            "perf_metric_value": 4.933826950268857
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 751.1819830194418
+            "perf_metric_value": 813.2443700905843
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5781.3376960167725
+            "perf_metric_value": 7096.786888013178
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18575.069898088233
+            "perf_metric_value": 21137.109008698124
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1645.0106136032405
+            "perf_metric_value": 1879.6455165405484
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7527.784116619314
+            "perf_metric_value": 8396.874033285541
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5055.6982704309885
+            "perf_metric_value": 5678.956390335692
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6982.12785749039
+            "perf_metric_value": 7370.550357182028
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 22974.891754744596
+            "perf_metric_value": 23481.256884763905
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3009.073515305312
+            "perf_metric_value": 3222.5114335686285
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1403.3196936007505
+            "perf_metric_value": 1417.1846351735794
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4406.2141950729665
+            "perf_metric_value": 4616.604004176862
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2985.2594797119345
+            "perf_metric_value": 2966.3149904468737
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6321.193126550936
+            "perf_metric_value": 6907.905927393101
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 18829.374267162224
+            "perf_metric_value": 21566.207868367015
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 588.8442875974866
+            "perf_metric_value": 657.0579674498558
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1119.7606509262687
+            "perf_metric_value": 1110.3815800718512
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 851.7996054229982
+            "perf_metric_value": 847.7132252307356
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.09739017021478441
+            "perf_metric_value": 0.09852699612927329
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11564.646324370273
+            "perf_metric_value": 12087.25786385043
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 453.03975429334184
+            "perf_metric_value": 539.1188849292095
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1019.3488253694755
+            "perf_metric_value": 1066.5581344588645
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1013.6459203927111
+            "perf_metric_value": 1050.5473572391506
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.982001139120161
+            "perf_metric_value": 0.9637211637507427
         }
     ],
     "placement_group_create/removal": [
-        588.8442875974866,
-        8.24413631861294
+        657.0579674498558,
+        3.492779228356284
     ],
     "single_client_get_calls_Plasma_Store": [
-        10155.173652668069,
-        152.66450548162283
+        10618.338081970585,
+        208.9811943036501
     ],
     "single_client_get_object_containing_10k_refs": [
-        10.363904163485511,
-        0.6892780427336627
+        12.123293390343653,
+        0.09539779266926034
     ],
     "single_client_put_calls_Plasma_Store": [
-        4552.207208625433,
-        16.667769025520144
+        4632.275852502236,
+        36.084422332688135
     ],
     "single_client_put_gigabytes": [
-        10.938074087722523,
-        9.854324012193258
+        12.831166033501425,
+        9.770703025046103
     ],
     "single_client_tasks_and_get_batch": [
-        5.723101265712336,
-        0.4762480593924589
+        5.481786077048712,
+        2.8262175645089083
     ],
     "single_client_tasks_async": [
-        5781.3376960167725,
-        285.1993884608796
+        7096.786888013178,
+        236.50107313394884
     ],
     "single_client_tasks_sync": [
-        751.1819830194418,
-        13.417517883145772
+        813.2443700905843,
+        10.854662507708719
     ],
     "single_client_wait_1k_refs": [
-        4.273484814546707,
-        0.2990099139939311
+        4.933826950268857,
+        0.16035857361821815
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 16.721766646000006,
+    "broadcast_time": 16.648311011999994,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 16.721766646000006
+            "perf_metric_value": 16.648311011999994
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 11.357349357000004,
-    "get_time": 15.349179023000005,
+    "args_time": 12.265755501000008,
+    "get_time": 15.200454125999997,
     "large_object_size": 107374182400,
-    "large_object_time": 22.459637914999973,
+    "large_object_time": 24.263247010999976,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 11.357349357000004
+            "perf_metric_value": 12.265755501000008
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.577688757000004
+            "perf_metric_value": 3.7088375179999957
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15.349179023000005
+            "perf_metric_value": 15.200454125999997
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 148.61821138700003
+            "perf_metric_value": 140.07216235099997
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 22.459637914999973
+            "perf_metric_value": 24.263247010999976
         }
     ],
-    "queued_time": 148.61821138700003,
-    "returns_time": 3.577688757000004,
+    "queued_time": 140.07216235099997,
+    "returns_time": 3.7088375179999957,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 1.6285365343093872,
-    "max_iteration_time": 5.4259233474731445,
-    "min_iteration_time": 0.16121268272399902,
+    "avg_iteration_time": 1.45254629611969,
+    "max_iteration_time": 5.837781667709351,
+    "min_iteration_time": 0.07228946685791016,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.6285365343093872
+            "perf_metric_value": 1.45254629611969
         }
     ],
-    "total_time": 162.85378408432007
+    "total_time": 145.25475406646729
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.112839698791504
+            "perf_metric_value": 8.620674133300781
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 17.395077729225157
+            "perf_metric_value": 15.162811255455017
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 45.97143950462341
+            "perf_metric_value": 37.03696446418762
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2.621494770050049
+            "perf_metric_value": 3.1294972896575928
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2659.2353205680847
+            "perf_metric_value": 2621.6581025123596
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.3184540688712737
+            "perf_metric_value": 0.6704279092079272
         }
     ],
-    "stage_0_time": 7.112839698791504,
-    "stage_1_avg_iteration_time": 17.395077729225157,
-    "stage_1_max_iteration_time": 20.159411668777466,
-    "stage_1_min_iteration_time": 14.787779331207275,
-    "stage_1_time": 173.95084357261658,
-    "stage_2_avg_iteration_time": 45.97143950462341,
-    "stage_2_max_iteration_time": 47.81036567687988,
-    "stage_2_min_iteration_time": 45.03093671798706,
-    "stage_2_time": 229.85781526565552,
-    "stage_3_creation_time": 2.621494770050049,
-    "stage_3_time": 2659.2353205680847,
-    "stage_4_spread": 0.3184540688712737
+    "stage_0_time": 8.620674133300781,
+    "stage_1_avg_iteration_time": 15.162811255455017,
+    "stage_1_max_iteration_time": 17.312448978424072,
+    "stage_1_min_iteration_time": 13.779070854187012,
+    "stage_1_time": 151.62816882133484,
+    "stage_2_avg_iteration_time": 37.03696446418762,
+    "stage_2_max_iteration_time": 41.41323781013489,
+    "stage_2_min_iteration_time": 35.700154542922974,
+    "stage_2_time": 185.1853449344635,
+    "stage_3_creation_time": 3.1294972896575928,
+    "stage_3_time": 2621.6581025123596,
+    "stage_4_spread": 0.6704279092079272
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.5098637252248464,
-    "avg_pg_remove_time_ms": 1.154493106606675,
+    "avg_pg_create_time_ms": 1.6259311876874045,
+    "avg_pg_remove_time_ms": 1.7122211741741544,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.5098637252248464
+            "perf_metric_value": 1.6259311876874045
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.154493106606675
+            "perf_metric_value": 1.7122211741741544
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 52.54%: tasks_per_second (THROUGHPUT) regresses from 386.6133448073775 to 183.49078025658062 in benchmarks/many_nodes.json
REGRESSION 37.10%: tasks_per_second (THROUGHPUT) regresses from 594.0367087794571 to 373.6653345877981 in benchmarks/many_tasks.json
REGRESSION 4.22%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 5.723101265712336 to 5.481786077048712 in microbenchmark.json
REGRESSION 4.09%: multi_client_put_gigabytes (THROUGHPUT) regresses from 42.60577675231464 to 40.8627833341568 in microbenchmark.json
REGRESSION 1.86%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.982001139120161 to 0.9637211637507427 in microbenchmark.json
REGRESSION 0.84%: client__get_calls (THROUGHPUT) regresses from 1119.7606509262687 to 1110.3815800718512 in microbenchmark.json
REGRESSION 0.63%: 1_1_async_actor_calls_with_args_async (THROUGHPUT) regresses from 2985.2594797119345 to 2966.3149904468737 in microbenchmark.json
REGRESSION 0.48%: client__put_calls (THROUGHPUT) regresses from 851.7996054229982 to 847.7132252307356 in microbenchmark.json
REGRESSION 289.14%: dashboard_p95_latency_ms (LATENCY) regresses from 37.856 to 147.311 in benchmarks/many_pgs.json
REGRESSION 135.33%: dashboard_p99_latency_ms (LATENCY) regresses from 798.453 to 1879.035 in benchmarks/many_pgs.json
REGRESSION 110.53%: stage_4_spread (LATENCY) regresses from 0.3184540688712737 to 0.6704279092079272 in stress_tests/stress_test_many_tasks.json
REGRESSION 48.31%: avg_pg_remove_time_ms (LATENCY) regresses from 1.154493106606675 to 1.7122211741741544 in stress_tests/stress_test_placement_group.json
REGRESSION 34.75%: dashboard_p50_latency_ms (LATENCY) regresses from 5.002 to 6.74 in benchmarks/many_pgs.json
REGRESSION 21.20%: stage_0_time (LATENCY) regresses from 7.112839698791504 to 8.620674133300781 in stress_tests/stress_test_many_tasks.json
REGRESSION 19.38%: stage_3_creation_time (LATENCY) regresses from 2.621494770050049 to 3.1294972896575928 in stress_tests/stress_test_many_tasks.json
REGRESSION 8.31%: dashboard_p95_latency_ms (LATENCY) regresses from 42.959 to 46.531 in benchmarks/many_nodes.json
REGRESSION 8.03%: 107374182400_large_object_time (LATENCY) regresses from 22.459637914999973 to 24.263247010999976 in scalability/single_node.json
REGRESSION 8.00%: 10000_args_time (LATENCY) regresses from 11.357349357000004 to 12.265755501000008 in scalability/single_node.json
REGRESSION 7.69%: avg_pg_create_time_ms (LATENCY) regresses from 1.5098637252248464 to 1.6259311876874045 in stress_tests/stress_test_placement_group.json
REGRESSION 3.67%: 3000_returns_time (LATENCY) regresses from 3.577688757000004 to 3.7088375179999957 in scalability/single_node.json
```