### PR TITLE
[ci] Dedup prefix-independent work in microcheck step-id selection

### DIFF
--- a/ci/ray_ci/automation/determine_microcheck_step_ids.py
+++ b/ci/ray_ci/automation/determine_microcheck_step_ids.py
@@ -20,10 +20,9 @@ def main() -> None:
     This script determines the rayci step ids to run microcheck tests.
     """
     ci_init()
-    steps = (
-        Test.gen_microcheck_step_ids(LINUX_TEST_PREFIX, BAZEL_WORKSPACE_DIR)
-        .union(Test.gen_microcheck_step_ids(WINDOWS_TEST_PREFIX, BAZEL_WORKSPACE_DIR))
-        .union(Test.gen_microcheck_step_ids(MACOS_TEST_PREFIX, BAZEL_WORKSPACE_DIR))
+    steps = Test.gen_microcheck_step_ids_for_prefixes(
+        [LINUX_TEST_PREFIX, WINDOWS_TEST_PREFIX, MACOS_TEST_PREFIX],
+        BAZEL_WORKSPACE_DIR,
     )
 
     print(",".join(steps))

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -223,8 +223,46 @@ class Test(dict):
         with the given test prefix. This is used to determine the buildkite steps in
         the microcheck pipeline.
         """
+        return cls.gen_microcheck_step_ids_for_prefixes([prefix], bazel_workspace_dir)
+
+    @classmethod
+    def gen_microcheck_step_ids_for_prefixes(
+        cls, prefixes: List[str], bazel_workspace_dir: str
+    ) -> Set[str]:
+        """
+        Generate the union of microcheck buildkite step ids across multiple OS
+        prefixes. The git/bazel-query work that determines changed and human-specified
+        tests does not depend on the prefix, so it runs once for the whole call instead
+        of once per prefix.
+        """
+        changed_tests = cls._get_changed_tests(bazel_workspace_dir)
+        human_specified_tests = cls._get_human_specified_tests(bazel_workspace_dir)
+
         step_ids = set()
-        test_targets = cls.gen_microcheck_tests(prefix, bazel_workspace_dir)
+        for prefix in prefixes:
+            step_ids.update(
+                cls._gen_microcheck_step_ids_for_prefix(
+                    prefix, changed_tests, human_specified_tests
+                )
+            )
+        return step_ids
+
+    @classmethod
+    def _gen_microcheck_step_ids_for_prefix(
+        cls,
+        prefix: str,
+        changed_tests: Set[str],
+        human_specified_tests: Set[str],
+    ) -> Set[str]:
+        """
+        Per-prefix worker for gen_microcheck_step_ids_for_prefixes. Accepts the
+        prefix-independent test sets so callers can compute them once and reuse them
+        across prefixes.
+        """
+        high_impact_tests = cls._gen_high_impact_tests(prefix)
+        test_targets = high_impact_tests.union(changed_tests, human_specified_tests)
+
+        step_ids = set()
         for test_target in test_targets:
             test = cls.gen_from_name(f"{prefix}{test_target}")
             if not test:

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -449,6 +449,32 @@ def test_get_human_specified_tests(mock_check_output, mock_check_call) -> None:
     assert Test._get_human_specified_tests("") == {"//test01", "//test02"}
 
 
+@patch("ray_release.test.Test._gen_microcheck_step_ids_for_prefix")
+@patch("ray_release.test.Test._get_human_specified_tests")
+@patch("ray_release.test.Test._get_changed_tests")
+def test_gen_microcheck_step_ids_for_prefixes_dedups_prefix_independent_calls(
+    mock_get_changed_tests,
+    mock_get_human_specified_tests,
+    mock_gen_for_prefix,
+) -> None:
+    mock_get_changed_tests.return_value = {"//changed"}
+    mock_get_human_specified_tests.return_value = {"//human"}
+    mock_gen_for_prefix.side_effect = lambda prefix, _c, _h: {f"step-{prefix}"}
+
+    result = Test.gen_microcheck_step_ids_for_prefixes(
+        [LINUX_TEST_PREFIX, WINDOWS_TEST_PREFIX, MACOS_TEST_PREFIX], ""
+    )
+
+    assert result == {
+        f"step-{LINUX_TEST_PREFIX}",
+        f"step-{WINDOWS_TEST_PREFIX}",
+        f"step-{MACOS_TEST_PREFIX}",
+    }
+    mock_get_changed_tests.assert_called_once_with("")
+    mock_get_human_specified_tests.assert_called_once_with("")
+    assert mock_gen_for_prefix.call_count == 3
+
+
 def test_gen_microcheck_tests() -> None:
     test_harness = [
         {


### PR DESCRIPTION
determine_microcheck_step_ids ran Test.gen_microcheck_step_ids three times (linux/darwin/windows). Inside, _get_changed_tests and _get_human_specified_tests are prefix-independent, so each call repeated the same git diff and bazel query work — visible in the init log as the same three "no such target" errors recurring three times.

Add Test.gen_microcheck_step_ids_for_prefixes that computes the prefix-independent sets once and threads them into a per-prefix worker. Existing Test.gen_microcheck_step_ids delegates to the new method to keep the public API stable for ci/ray_ci/tester.py.

Topic: microcheck-dedup-prefix-deps
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>