### PR TITLE
[ci] Parallelize per-test S3 fetches in microcheck step-id selection

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -266,17 +266,32 @@ class Test(dict):
         """
         Per-prefix worker for gen_microcheck_step_ids_for_prefixes. Accepts the
         prefix-independent test sets so callers can compute them once and reuse them
-        across prefixes.
+        across prefixes. Per-test S3 fetches run in parallel; the dedup logic that
+        depends on running step_ids state stays serial.
         """
         high_impact_tests = cls._gen_high_impact_tests(prefix)
-        test_targets = high_impact_tests.union(changed_tests, human_specified_tests)
+        test_targets = list(
+            high_impact_tests.union(changed_tests, human_specified_tests)
+        )
 
-        step_ids = set()
-        for test_target in test_targets:
+        def _fetch_recent_results(test_target: str):
             test = cls.gen_from_name(f"{prefix}{test_target}")
             if not test:
-                continue
-            recent_results = test.get_test_results()
+                return None
+            return test.get_test_results(use_async=True)
+
+        if test_targets:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=min(16, len(test_targets))
+            ) as executor:
+                all_recent_results = list(
+                    executor.map(_fetch_recent_results, test_targets)
+                )
+        else:
+            all_recent_results = []
+
+        step_ids: Set[str] = set()
+        for recent_results in all_recent_results:
             if not recent_results:
                 continue
             test_step_ids = {

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -44,7 +44,7 @@ class MockTest(dict):
     def get_name(self) -> str:
         return self.get("name", "")
 
-    def get_test_results(self, limit: int) -> List[TestResult]:
+    def get_test_results(self, *args, **kwargs) -> List[TestResult]:
         return self.get("test_results", [])
 
     def is_high_impact(self) -> bool:
@@ -473,6 +473,41 @@ def test_gen_microcheck_step_ids_for_prefixes_dedups_prefix_independent_calls(
     mock_get_changed_tests.assert_called_once_with("")
     mock_get_human_specified_tests.assert_called_once_with("")
     assert mock_gen_for_prefix.call_count == 3
+
+
+@patch("ray_release.test.Test.gen_from_name")
+@patch("ray_release.test.Test._gen_high_impact_tests")
+def test_gen_microcheck_step_ids_for_prefix_parallel_fetches(
+    mock_gen_high_impact_tests,
+    mock_gen_from_name,
+) -> None:
+    mock_gen_high_impact_tests.return_value = {"//a", "//b", "//c"}
+
+    a = MockTest(
+        {
+            "name": "linux://a",
+            "test_results": [_stub_test_result(rayci_step_id="step-a", commit="c1")],
+        }
+    )
+    b = MockTest(
+        {
+            "name": "linux://b",
+            "test_results": [_stub_test_result(rayci_step_id="step-b", commit="c1")],
+        }
+    )
+    c = MockTest(
+        {
+            "name": "linux://c",
+            "test_results": [_stub_test_result(rayci_step_id="step-a", commit="c1")],
+        }
+    )
+    by_name = {t.get_name(): t for t in (a, b, c)}
+    mock_gen_from_name.side_effect = lambda name: by_name.get(name)
+
+    result = Test._gen_microcheck_step_ids_for_prefix(LINUX_TEST_PREFIX, set(), set())
+
+    assert result == {"step-a", "step-b"}
+    assert mock_gen_from_name.call_count == 3
 
 
 def test_gen_microcheck_tests() -> None:


### PR DESCRIPTION
Inside each prefix worker, the loop over test_targets serially called gen_from_name + get_test_results — both are S3-bound and dominated runtime once dedup landed. Split the worker into a parallel I/O phase (executor.map fans out across test_targets, with use_async=True so the inner test-result GETs run concurrently too) and a serial dedup phase that still depends on running step_ids state. ThreadPoolExecutor caps at 16 workers to bound concurrent S3 requests.

Topic: microcheck-async-test-results
Relative: microcheck-parallel-prefixes
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>