### PR TITLE
[Serve][LLM] Don't fetch LLMConfig from replicas at ingress startup

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -11,6 +11,7 @@ from ray.llm._internal.common.dict_utils import (
 )
 from ray.llm._internal.common.utils.import_utils import load_class
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
 from ray.llm._internal.serve.core.ingress.ingress import (
     OpenAiIngress,
     make_fastapi_ingress,
@@ -27,7 +28,7 @@ logger = get_logger(__name__)
 class IngressClsConfig(BaseModelExtended):
     ingress_cls: Union[str, Type[OpenAiIngress]] = Field(
         default=OpenAiIngress,
-        description="The class name of the ingress to use. It can be in form of `module_name.class_name` or `module_name:class_name` or the class itself. The class constructor should take the following arguments: `(llm_deployments: List[DeploymentHandle], **extra_kwargs)` where `llm_deployments` is a list of DeploymentHandle objects from `LLMServer` deployments.",
+        description="The class name of the ingress to use. It can be in form of `module_name.class_name` or `module_name:class_name` or the class itself. The class constructor should take the following arguments: `(llm_deployments: Dict[str, DeploymentHandle], model_cards: Dict[str, ModelCard], lora_paths: Optional[Dict[str, str]] = None, **extra_kwargs)` where the dicts are keyed by base model ID.",
     )
 
     ingress_extra_kwargs: Optional[dict] = Field(
@@ -118,7 +119,13 @@ def build_openai_app(builder_config: dict) -> Application:
     builder_config = LLMServingArgs.model_validate(builder_config)
     llm_configs = builder_config.llm_configs
 
-    llm_deployments = [build_llm_deployment(c) for c in llm_configs]
+    llm_deployments = {c.model_id: build_llm_deployment(c) for c in llm_configs}
+    model_cards = {c.model_id: to_model_metadata(c.model_id, c) for c in llm_configs}
+    lora_paths = {
+        c.model_id: c.lora_config.dynamic_lora_loading_path
+        for c in llm_configs
+        if c.lora_config is not None
+    }
 
     ingress_cls_config = builder_config.ingress_cls_config
     default_ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(
@@ -135,5 +142,8 @@ def build_openai_app(builder_config: dict) -> Application:
     logger.info(pprint.pformat(ingress_options))
 
     return serve.deployment(ingress_cls, **ingress_options).bind(
-        llm_deployments=llm_deployments, **ingress_cls_config.ingress_extra_kwargs
+        llm_deployments=llm_deployments,
+        model_cards=model_cards,
+        lora_paths=lora_paths,
+        **ingress_cls_config.ingress_extra_kwargs,
     )

--- a/python/ray/llm/_internal/serve/core/ingress/dev_ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/dev_ingress.py
@@ -23,6 +23,7 @@ from ray import serve
 from ray.llm._internal.common.dict_utils import (
     maybe_apply_llm_deployment_config_defaults,
 )
+from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
 from ray.llm._internal.serve.core.ingress.builder import LLMServingArgs
 from ray.llm._internal.serve.core.ingress.ingress import (
     DEFAULT_ENDPOINTS,
@@ -109,7 +110,13 @@ def build_dev_openai_app(builder_config: Dict) -> Application:
     config = LLMServingArgs.model_validate(builder_config)
     llm_configs = config.llm_configs
 
-    llm_deployments = [build_llm_deployment(c) for c in llm_configs]
+    llm_deployments = {c.model_id: build_llm_deployment(c) for c in llm_configs}
+    model_cards = {c.model_id: to_model_metadata(c.model_id, c) for c in llm_configs}
+    lora_paths = {
+        c.model_id: c.lora_config.dynamic_lora_loading_path
+        for c in llm_configs
+        if c.lora_config is not None
+    }
 
     ingress_cls_config = config.ingress_cls_config
     default_ingress_options = DevIngress.get_deployment_options(llm_configs)
@@ -124,5 +131,8 @@ def build_dev_openai_app(builder_config: Dict) -> Application:
     logger.info(pprint.pformat(ingress_options))
 
     return serve.deployment(ingress_cls, **ingress_options).bind(
-        llm_deployments=llm_deployments, **ingress_cls_config.ingress_extra_kwargs
+        llm_deployments=llm_deployments,
+        model_cards=model_cards,
+        lora_paths=lora_paths,
+        **ingress_cls_config.ingress_extra_kwargs,
     )

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -24,7 +24,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse, Response, StreamingResponse
 
 from ray import serve
-from ray._common.utils import get_or_create_event_loop
 from ray.llm._internal.common.utils.lora_utils import (
     get_base_model_id,
     get_lora_model_ids,
@@ -62,7 +61,6 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     TranscriptionRequest,
     TranscriptionResponse,
     TranscriptionStreamResponse,
-    to_model_metadata,
 )
 from ray.llm._internal.serve.core.ingress.middleware import (
     SetRequestIdMiddleware,
@@ -376,14 +374,24 @@ async def router_request_timeout(timeout_duration: float):
 class OpenAiIngress(DeploymentProtocol):
     def __init__(
         self,
-        llm_deployments: List[DeploymentHandle],
+        llm_deployments: Dict[str, DeploymentHandle],
+        model_cards: Dict[str, ModelCard],
         *,
+        lora_paths: Optional[Dict[str, str]] = None,
         _get_lora_model_metadata_func: Optional[
-            Callable[[str, LLMConfig], Awaitable[Dict[str, Any]]]
+            Callable[[str, str], Awaitable[Dict[str, Any]]]
         ] = None,
     ):
-        self._default_serve_handles: Dict[str, DeploymentHandle] = {}
-        self._llm_configs: Dict[str, LLMConfig] = {}
+        if set(llm_deployments) != set(model_cards):
+            raise ValueError(
+                "llm_deployments and model_cards must have the same model IDs. "
+                f"Got llm_deployments={sorted(llm_deployments)}, "
+                f"model_cards={sorted(model_cards)}."
+            )
+
+        self._default_serve_handles: Dict[str, DeploymentHandle] = dict(llm_deployments)
+        self._model_cards: Dict[str, ModelCard] = dict(model_cards)
+        self._lora_paths: Dict[str, str] = dict(lora_paths or {})
 
         # Configuring a ServeHandle with .options() creates a new ServeHandle
         # object, which contains a new metrics pusher and long-polling call.
@@ -394,36 +402,13 @@ class OpenAiIngress(DeploymentProtocol):
             _get_lora_model_metadata_func or self._default_get_lora_model_metadata_func
         )
 
-        # Setup _default_serve_handles and _llm_configs asynchronously.
-        self._init_completed = asyncio.Event()
-        self.running_setup_task = get_or_create_event_loop().create_task(
-            self._setup_handle_and_config_maps(llm_deployments=llm_deployments)
-        )
-
     async def _default_get_lora_model_metadata_func(
-        self, model_id: str, llm_config: LLMConfig
+        self, model_id: str, base_path: str
     ) -> Dict[str, Any]:
-        return await get_lora_model_metadata(model_id, llm_config)
-
-    async def _setup_handle_and_config_maps(
-        self, llm_deployments: List[DeploymentHandle]
-    ):
-        for handle in llm_deployments:
-            llm_config = await handle.llm_config.remote()
-            self._default_serve_handles[llm_config.model_id] = handle
-            self._llm_configs[llm_config.model_id] = llm_config
-
-        # Note (genesu): Even though we have already checked model id uniqueness in
-        # `router_application()` under run.py. When we OSS this router component, users
-        # would be able to directly use the lower level api and bypass that check. We
-        # check it again here to ensure all the model ids are unique.
-        if len(llm_deployments) != len(self._llm_configs):
-            raise ValueError("Duplicate models found. Make sure model ids are unique.")
-
-        self._init_completed.set()
+        return await get_lora_model_metadata(model_id, base_path)
 
     async def check_health(self):
-        await self._init_completed.wait()
+        pass
 
     def _get_configured_serve_handle(self, model_id: str):
         """Gets a ServeHandle to a model deployment.
@@ -468,17 +453,17 @@ class OpenAiIngress(DeploymentProtocol):
     async def _get_model_id(self, model: Optional[str]) -> str:
         # Default to the only configured model if no model specified
         if model is None:
-            if len(self._llm_configs) == 1:
-                model = next(iter(self._llm_configs.keys()))
+            if len(self._model_cards) == 1:
+                model = next(iter(self._model_cards.keys()))
             else:
                 raise HTTPException(
                     status.HTTP_400_BAD_REQUEST,
                     "Model parameter is required when multiple models are configured. "
-                    f"Available models: {list(self._llm_configs.keys())}",
+                    f"Available models: {list(self._model_cards.keys())}",
                 )
 
         base_model_id = get_base_model_id(model)
-        if base_model_id not in self._llm_configs:
+        if base_model_id not in self._model_cards:
             raise HTTPException(
                 status.HTTP_404_NOT_FOUND,
                 f'Got request for model "{model}". '
@@ -530,23 +515,23 @@ class OpenAiIngress(DeploymentProtocol):
             yield response
 
     async def model(self, model_id: str) -> Optional[ModelCard]:
-        if model_id in self._llm_configs:
-            return to_model_metadata(model_id, self._llm_configs[model_id])
+        if model_id in self._model_cards:
+            return self._model_cards[model_id]
 
         base_model_id = get_base_model_id(model_id)
-        if (
-            base_model_id in self._llm_configs
-            and self._llm_configs[base_model_id].lora_config
-        ):
+        base_path = self._lora_paths.get(base_model_id)
+        if base_path is not None:
             try:
                 overrides = await self._get_lora_model_metadata_func(
-                    model_id, self._llm_configs[base_model_id]
+                    model_id, base_path
                 )
-
-                return to_model_metadata(
-                    model_id=model_id,
-                    model_config=self._llm_configs[base_model_id],
-                    overrides=overrides,
+                base_card = self._model_cards[base_model_id]
+                return ModelCard(
+                    id=model_id,
+                    object="model",
+                    owned_by=base_card.owned_by,
+                    permission=list(base_card.permission),
+                    metadata={**base_card.metadata, **overrides},
                 )
             except HTTPException:
                 logger.exception(
@@ -558,14 +543,15 @@ class OpenAiIngress(DeploymentProtocol):
     async def models(self) -> ModelList:
         """OpenAI API-compliant endpoint to get all rayllm models."""
         all_models = dict()
-        for base_model_id, llm_config in self._llm_configs.items():
+        for base_model_id in self._model_cards:
             # Add the base model.
             all_models[base_model_id] = await self.model(base_model_id)
 
-            if llm_config.lora_config is not None:
+            base_path = self._lora_paths.get(base_model_id)
+            if base_path is not None:
                 # Add all the fine-tuned models.
                 lora_model_ids = get_lora_model_ids(
-                    dynamic_lora_loading_path=llm_config.lora_config.dynamic_lora_loading_path,
+                    dynamic_lora_loading_path=base_path,
                     base_model_id=base_model_id,
                 )
                 for lora_id in lora_model_ids:

--- a/python/ray/llm/_internal/serve/serving_patterns/data_parallel/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/data_parallel/builder.py
@@ -7,6 +7,7 @@ from ray import serve
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.dict_utils import deep_merge_dicts
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
 from ray.llm._internal.serve.core.ingress.builder import IngressClsConfig
 from ray.llm._internal.serve.core.ingress.ingress import (
     make_fastapi_ingress,
@@ -119,7 +120,15 @@ def build_dp_openai_app(builder_config: dict) -> Application:
     logger.info("============== Ingress Options ==============")
     logger.info(pprint.pformat(ingress_options))
 
+    model_id = llm_config.model_id
+    lora_config = llm_config.lora_config
     return serve.deployment(ingress_cls, **ingress_options).bind(
-        llm_deployments=[dp_deployment],
+        llm_deployments={model_id: dp_deployment},
+        model_cards={model_id: to_model_metadata(model_id, llm_config)},
+        lora_paths=(
+            {model_id: lora_config.dynamic_lora_loading_path}
+            if lora_config is not None
+            else {}
+        ),
         **ingress_cls_config.ingress_extra_kwargs,
     )

--- a/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/prefill_decode/builder.py
@@ -14,6 +14,7 @@ from ray.llm._internal.common.dict_utils import (
     maybe_apply_llm_deployment_config_defaults,
 )
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
 from ray.llm._internal.serve.core.ingress.builder import (
     IngressClsConfig,
     load_class,
@@ -218,7 +219,17 @@ def build_pd_openai_app(pd_serving_args: dict) -> Application:
     )
 
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
+    # Prefill and decode share the same model_id (validated in PDServingArgs).
+    # Ingress binds to decode only (the "model" the client sees).
+    model_id = pd_config.decode_config.model_id
+    lora_config = pd_config.decode_config.lora_config
     return serve.deployment(ingress_cls, **ingress_options).bind(
-        llm_deployments=[decode_deployment],
+        llm_deployments={model_id: decode_deployment},
+        model_cards={model_id: to_model_metadata(model_id, pd_config.decode_config)},
+        lora_paths=(
+            {model_id: lora_config.dynamic_lora_loading_path}
+            if lora_config is not None
+            else {}
+        ),
         **ingress_cls_config.ingress_extra_kwargs,
     )

--- a/python/ray/llm/_internal/serve/utils/broadcast.py
+++ b/python/ray/llm/_internal/serve/utils/broadcast.py
@@ -74,13 +74,17 @@ def broadcast(
     if router is None:
         raise RuntimeError("DeploymentHandle router is None.")
 
-    # Access the request router and replica set
-    # Handle different potential internal structures
+    # Access the request router and replica set. Use the public `request_router`
+    # property when available — it lazily initializes `_request_router` from the
+    # populated replica set, which the underscore-prefixed field does not.
+    # Without this, a handle that has only ever been .options()-cloned (never
+    # called as a coroutine) sees `_request_router is None` even after replicas
+    # are populated.
     request_router = None
     if hasattr(router, "_asyncio_router"):
-        request_router = router._asyncio_router._request_router
-    elif hasattr(router, "_request_router"):
-        request_router = router._request_router
+        request_router = router._asyncio_router.request_router
+    elif hasattr(router, "request_router"):
+        request_router = router.request_router
 
     if request_router is None:
         raise RuntimeError("Request router not initialized. No replicas accessible.")

--- a/python/ray/llm/_internal/serve/utils/broadcast.py
+++ b/python/ray/llm/_internal/serve/utils/broadcast.py
@@ -60,34 +60,36 @@ def broadcast(
         # waiting.
         handle._init(_run_router_in_separate_loop=True)
 
-    # Wait for the router to be populated with replicas
-    # We add a timeout to prevent infinite hanging
-    start_time = time.time()
-    while not handle.running_replicas_populated():
-        if time.time() - start_time > BROADCAST_REPLICA_POPULATION_TIMEOUT_S:
-            raise TimeoutError(
-                "Timed out waiting for deployment replicas to be populated."
-            )
-        time.sleep(0.1)
-
     router = handle._router
     if router is None:
         raise RuntimeError("DeploymentHandle router is None.")
 
-    # Access the request router and replica set. Use the public `request_router`
-    # property when available — it lazily initializes `_request_router` from the
-    # populated replica set, which the underscore-prefixed field does not.
-    # Without this, a handle that has only ever been .options()-cloned (never
-    # called as a coroutine) sees `_request_router is None` even after replicas
-    # are populated.
-    request_router = None
-    if hasattr(router, "_asyncio_router"):
-        request_router = router._asyncio_router.request_router
-    elif hasattr(router, "request_router"):
-        request_router = router.request_router
+    # Wait for both the replica set AND the request router to be populated.
+    # `running_replicas_populated()` flips when DEPLOYMENT_TARGETS long-poll
+    # arrives; `request_router` becomes non-None only after DEPLOYMENT_CONFIG
+    # long-poll arrives and sets `_request_router_class`. These are independent
+    # long-polls, so polling only the former races with the latter.
+    #
+    # In normal request flow this is hidden because `assign_request` awaits
+    # `_request_router_initialized` before routing — but `broadcast()` bypasses
+    # `assign_request` and pokes `_replica_id_set` directly, so it has to
+    # synchronize itself.
+    def _get_request_router():
+        if hasattr(router, "_asyncio_router"):
+            return router._asyncio_router.request_router
+        if hasattr(router, "request_router"):
+            return router.request_router
+        return None
 
-    if request_router is None:
-        raise RuntimeError("Request router not initialized. No replicas accessible.")
+    start_time = time.time()
+    while not handle.running_replicas_populated() or _get_request_router() is None:
+        if time.time() - start_time > BROADCAST_REPLICA_POPULATION_TIMEOUT_S:
+            raise TimeoutError(
+                "Timed out waiting for deployment router/replicas to initialize."
+            )
+        time.sleep(0.1)
+
+    request_router = _get_request_router()
 
     replica_set = request_router._replica_id_set
 

--- a/python/ray/llm/_internal/serve/utils/lora_serve_utils.py
+++ b/python/ray/llm/_internal/serve/utils/lora_serve_utils.py
@@ -83,18 +83,20 @@ async def download_multiplex_config_info(
     return bucket_uri, ft_context_length
 
 
-async def get_lora_model_metadata(
-    model_id: str, llm_config: LLMConfig
-) -> Dict[str, Any]:
-    """Get the lora model metadata for a given model id and llm config.
+async def get_lora_model_metadata(model_id: str, base_path: str) -> Dict[str, Any]:
+    """Get the lora model metadata for a given model id and base path.
 
-    This is used to get the metadata for the model with the given model id.
+    Args:
+        model_id: A lora model id of the form ``base_model_id:suffix:id``.
+        base_path: The cloud storage path under which LoRA adapters are stored
+            (typically ``llm_config.lora_config.dynamic_lora_loading_path``).
+
+    Returns:
+        A dict with keys ``model_id``, ``base_model_id``,
+        ``max_request_context_length``, and ``bucket_uri``.
     """
-    # Note (genesu): `model_id` passed is a lora model id where it's in a form of
-    #     base_model_id:suffix:id
     base_model_id = get_base_model_id(model_id)
     lora_id = get_lora_id(model_id)
-    base_path = llm_config.lora_config.dynamic_lora_loading_path
 
     # Examples of the variables:
     #   model_id: "meta-llama/Meta-Llama-3.1-8B-Instruct:my_suffix:aBc1234"
@@ -120,7 +122,9 @@ async def get_lora_mirror_config(
     llm_config: LLMConfig,
 ) -> LoraMirrorConfig:
     """Get LoRA mirror configuration for serve-specific LLM config."""
-    metadata = await get_lora_model_metadata(model_id, llm_config)
+    metadata = await get_lora_model_metadata(
+        model_id, llm_config.lora_config.dynamic_lora_loading_path
+    )
 
     return LoraMirrorConfig(
         lora_model_id=model_id,

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/multiplex/test_lora_deployment_base_client.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/multiplex/test_lora_deployment_base_client.py
@@ -6,7 +6,10 @@ import pytest
 from fastapi import HTTPException
 
 from ray import serve
-from ray.llm._internal.serve.core.configs.openai_api_models import ModelCard
+from ray.llm._internal.serve.core.configs.openai_api_models import (
+    ModelCard,
+    to_model_metadata,
+)
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
 from ray.serve.handle import DeploymentHandle
@@ -66,10 +69,22 @@ def get_mocked_llm_deployments(llm_configs) -> List[DeploymentHandle]:
 def make_ingress_app(llm_deployments, llm_configs, **kwargs):
     ingress_options = OpenAiIngress.get_deployment_options(llm_configs)
     ingress_cls = make_fastapi_ingress(OpenAiIngress)
+    deployments_by_id = {c.model_id: d for c, d in zip(llm_configs, llm_deployments)}
+    model_cards = {c.model_id: to_model_metadata(c.model_id, c) for c in llm_configs}
+    lora_paths = {
+        c.model_id: c.lora_config.dynamic_lora_loading_path
+        for c in llm_configs
+        if c.lora_config is not None
+    }
     return (
         serve.deployment(ingress_cls)
         .options(**ingress_options)
-        .bind(llm_deployments=llm_deployments, **kwargs)
+        .bind(
+            llm_deployments=deployments_by_id,
+            model_cards=model_cards,
+            lora_paths=lora_paths,
+            **kwargs,
+        )
     )
 
 

--- a/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/prefill_decode_disagg/test_prefill_decode_disagg.py
@@ -268,7 +268,10 @@ class TestBuildPDOpenaiApp:
 
         # The app should have an ingress deployment bound to the decode deployment
         ingress_deployment = app._bound_deployment
-        decode_app = ingress_deployment.init_kwargs["llm_deployments"][0]
+        llm_deployments = ingress_deployment.init_kwargs["llm_deployments"]
+        # Single model id -> single decode app (P/D shares the same model_id).
+        assert len(llm_deployments) == 1
+        decode_app = next(iter(llm_deployments.values()))
         decode_deployment = decode_app._bound_deployment
 
         assert decode_deployment.func_or_class is PDDecodeServer

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_dev_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_dev_ingress.py
@@ -18,6 +18,7 @@ import pytest
 
 import ray
 from ray import serve
+from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
 from ray.llm._internal.serve.core.ingress.dev_ingress import DEV_ENDPOINTS, DevIngress
 from ray.llm._internal.serve.core.ingress.ingress import make_fastapi_ingress
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
@@ -54,7 +55,8 @@ def single_model_dev_ingress(ray_instance, disable_placement_bundles):
     ingress_cls = make_fastapi_ingress(DevIngress, endpoint_map=DEV_ENDPOINTS)
     ingress_options = DevIngress.get_deployment_options([llm_config])
     ingress_app = serve.deployment(ingress_cls, **ingress_options).bind(
-        llm_deployments=[llm_deployment],
+        llm_deployments={model_id: llm_deployment},
+        model_cards={model_id: to_model_metadata(model_id, llm_config)},
     )
 
     serve.run(ingress_app, name="single-model-app")
@@ -91,7 +93,14 @@ def two_model_dev_ingress(ray_instance, disable_placement_bundles):
     ingress_cls = make_fastapi_ingress(DevIngress, endpoint_map=DEV_ENDPOINTS)
     ingress_options = DevIngress.get_deployment_options([llm_config_1, llm_config_2])
     ingress_app = serve.deployment(ingress_cls, **ingress_options).bind(
-        llm_deployments=[llm_deployment_1, llm_deployment_2],
+        llm_deployments={
+            model_id_1: llm_deployment_1,
+            model_id_2: llm_deployment_2,
+        },
+        model_cards={
+            model_id_1: to_model_metadata(model_id_1, llm_config_1),
+            model_id_2: to_model_metadata(model_id_2, llm_config_2),
+        },
     )
 
     serve.run(ingress_app, name="two-model-app")

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -10,6 +10,7 @@ from ray.llm._internal.serve.core.configs.llm_config import (
     LLMConfig,
     ModelLoadingConfig,
 )
+from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
 from ray.llm._internal.serve.core.ingress.ingress import (
     OpenAiIngress,
     make_fastapi_ingress,
@@ -46,7 +47,12 @@ def create_oai_client(llm_config: LLMConfig):
     ingress_cls = make_fastapi_ingress(OpenAiIngress)
     RouterDeployment = serve.deployment(ingress_cls, **ingress_options)
     server = ServerDeployment.bind(llm_config, engine_cls=MockVLLMEngine)
-    router = RouterDeployment.bind(llm_deployments=[server])
+    router = RouterDeployment.bind(
+        llm_deployments={llm_config.model_id: server},
+        model_cards={
+            llm_config.model_id: to_model_metadata(llm_config.model_id, llm_config)
+        },
+    )
     serve.run(router)
 
     client = openai.Client(base_url="http://localhost:8000/v1", api_key="foo")
@@ -172,12 +178,15 @@ class TestOpenAiIngress:
         """Test health check functionality."""
 
         server = MagicMock()
-        server.llm_config = MagicMock()
-        server.llm_config.remote = AsyncMock(return_value=llm_config)
         server.check_health = MagicMock()
         server.check_health.remote = AsyncMock()
 
-        router = OpenAiIngress(llm_deployments=[server])
+        router = OpenAiIngress(
+            llm_deployments={llm_config.model_id: server},
+            model_cards={
+                llm_config.model_id: to_model_metadata(llm_config.model_id, llm_config)
+            },
+        )
 
         await router.check_health()
 
@@ -218,16 +227,18 @@ class TestOpenAiIngress:
             )
 
         mock_handle = MagicMock()
-        mock_handle.llm_config = MagicMock()
-        mock_handle.llm_config.remote = AsyncMock(return_value=llm_config)
         mock_handle.chat = MagicMock()
         mock_handle.chat.remote = mock_chat_generator
         # Make options() return the same mock so chat.remote is preserved
         mock_handle.options.return_value = mock_handle
 
         # Create router with mock handle
-        router = OpenAiIngress(llm_deployments=[mock_handle])
-        await router._init_completed.wait()
+        router = OpenAiIngress(
+            llm_deployments={llm_config.model_id: mock_handle},
+            model_cards={
+                llm_config.model_id: to_model_metadata(llm_config.model_id, llm_config)
+            },
+        )
 
         # Create a mock FastAPI request
         from starlette.datastructures import Headers

--- a/python/ray/serve/llm/ingress.py
+++ b/python/ray/serve/llm/ingress.py
@@ -26,6 +26,9 @@ class OpenAiIngress(_OpenAiIngress):
 
 
             from ray import serve
+            from ray.llm._internal.serve.core.configs.openai_api_models import (
+                to_model_metadata,
+            )
             from ray.serve.llm import LLMConfig
             from ray.serve.llm.deployment import LLMServer
             from ray.serve.llm.ingress import OpenAiIngress, make_fastapi_ingress
@@ -66,12 +69,28 @@ class OpenAiIngress(_OpenAiIngress):
             server_deployment2 = serve.deployment(LLMServer).options(
                 **server_options2).bind(llm_config2)
 
-            # ingress
+            # ingress: pass dicts keyed by model_id; no remote llm_config fetch.
             ingress_options = OpenAiIngress.get_deployment_options(
                 llm_configs=[llm_config1, llm_config2])
             ingress_cls = make_fastapi_ingress(OpenAiIngress)
-            ingress_deployment = serve.deployment(ingress_cls).options(
-                **ingress_options).bind([server_deployment1, server_deployment2])
+            ingress_deployment = (
+                serve.deployment(ingress_cls)
+                .options(**ingress_options)
+                .bind(
+                    llm_deployments={
+                        llm_config1.model_id: server_deployment1,
+                        llm_config2.model_id: server_deployment2,
+                    },
+                    model_cards={
+                        llm_config1.model_id: to_model_metadata(
+                            llm_config1.model_id, llm_config1
+                        ),
+                        llm_config2.model_id: to_model_metadata(
+                            llm_config2.model_id, llm_config2
+                        ),
+                    },
+                )
+            )
 
             # run
             serve.run(ingress_deployment, blocking=True)


### PR DESCRIPTION
## Bug
With `min_replicas: 0`, deploying an OpenAI ingress force-starts every `LLMServer` at deploy time, defeating scale-to-zero. The ingress also can't pass `check_health` until every model has successfully started at least once, so one broken model blocks the whole service from becoming healthy.

## Root cause
`OpenAiIngress.__init__` schedules `_setup_handle_and_config_maps`, which awaits `handle.llm_config.remote()` for each deployment. With 0 replicas the call queues at the router, bumps `ongoing_requests` to 1, and the autoscaler scales 0 → 1. The fetched `LLMConfig` is byte-identical to what `build_openai_app` already holds in memory.

## Fix
Pass static metadata into the ingress directly. `OpenAiIngress.__init__` now takes:
- `llm_deployments: Dict[str, DeploymentHandle]`
- `model_cards: Dict[str, ModelCard]`
- `lora_paths: Optional[Dict[str, str]] = None`

`build_openai_app`, `build_dev_openai_app`, `build_pd_openai_app`, and `build_dp_openai_app` build these dicts up front. `get_lora_model_metadata` takes `base_path: str` instead of `LLMConfig`. No remote `llm_config()` call at startup; `check_health` is a no-op.

## Test plan
- [x] `pytest python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py`
- [x] `pytest python/ray/llm/tests/serve/cpu/deployments/routers/test_dev_ingress.py`
- [x] `pytest python/ray/llm/tests/serve/cpu/deployments/llm/multiplex/test_lora_deployment_base_client.py`
- [x] Manually deploy multi-model app with `min_replicas: 0`, send no traffic, verify no replicas start and service reports healthy.