### PR TITLE
[Data] Fix HashAggregate duplicate group rows for AggregateFnV2

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -174,7 +174,9 @@ class ArrowBlockBuilder(TableBlockBuilder):
     @staticmethod
     def _combine_tables(tables: List[Block]) -> Block:
         if len(tables) > 1:
-            return transform_pyarrow.concat(tables, promote_types=True)
+            return transform_pyarrow.concat(
+                tables, promote_types=True, preserve_order=True
+            )
         else:
             return tables[0]
 

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -128,12 +128,11 @@ class TableBlockBuilder(BlockBuilder):
         return self._concat_would_copy() and len(self._tables) > 1
 
     def build(self) -> Block:
+        # Preserve insertion order: previously-compacted tables (older) first,
+        # then any rows added since the last compaction (newest) last.
+        tables = list(self._tables)
         if self._columns:
-            tables = [self._table_from_pydict(self._columns)]
-        else:
-            tables = []
-
-        tables.extend(self._tables)
+            tables.append(self._table_from_pydict(self._columns))
 
         if len(tables) == 0:
             return self._empty_table()

--- a/python/ray/data/tests/test_hash_shuffle.py
+++ b/python/ray/data/tests/test_hash_shuffle.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
+import pyarrow as pa
 import pytest
 
 from ray.data import DataContext, ExecutionResources
@@ -11,9 +12,10 @@ from ray.data._internal.execution.operators.hash_shuffle import HashShuffleOpera
 from ray.data._internal.execution.operators.join import JoinOperator
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.logical.operators import JoinType
+from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 from ray.data._internal.util import GiB, MiB
-from ray.data.aggregate import Count, Sum
-from ray.data.block import BlockMetadata
+from ray.data.aggregate import AggregateFnV2, Count, Sum
+from ray.data.block import BlockAccessor, BlockMetadata
 
 
 @dataclass
@@ -623,6 +625,56 @@ def test_aggregator_ray_remote_args_partial_override(ray_start_regular):
 
         # Verify that memory is still present
         assert "memory" in op._aggregator_pool._aggregator_ray_remote_args
+
+
+def test_partial_aggregate_preserves_sort_after_builder_compaction(
+    ray_start_regular,
+    monkeypatch,
+):
+    """Regression test for HashAggregate producing duplicate group rows when
+    `TableBlockBuilder.build()` reorders rows across an internal compaction.
+
+    For an `AggregateFnV2` whose accumulator can vary in size between groups
+    (here, an empty list vs. a non-empty list), the per-block partial-aggregate
+    output is built by `_aggregate` row-by-row via the table builder. If
+    `_compact_if_needed` triggered mid-loop, the legacy `build()` placed the
+    still-uncompacted (newest) rows in front of the compacted (older) tables,
+    breaking the "blocks reaching `_combine_aggregated_blocks` are sorted by
+    key" precondition that `heapq.merge` relies on. That precondition violation
+    surfaced as duplicate group rows whose count varied with the parallelism
+    arg (since parallelism changes per-block row count, and therefore whether
+    compaction triggers inside the partial-aggregate loop).
+
+    We force compaction on every row via `MAX_UNCOMPACTED_SIZE_BYTES=1` and
+    assert that the partial-aggregate output is still sorted by the group key.
+    """
+    import ray.data._internal.table_block as table_block
+
+    class EmptyAccumulatorForOddKeys(AggregateFnV2):
+        def __init__(self):
+            super().__init__(
+                name="items",
+                on=None,
+                ignore_nulls=False,
+                zero_factory=lambda: [],
+            )
+
+        def aggregate_block(self, block):
+            table = BlockAccessor.for_block(block).to_arrow()
+            group_key = table.column("A")[0].as_py()
+            return [] if group_key % 2 else ["value"]
+
+        def combine(self, current, new):
+            return current + new
+
+    monkeypatch.setattr(table_block, "MAX_UNCOMPACTED_SIZE_BYTES", 1)
+
+    source = pa.table({"A": [1, 2, 3, 4], "B": [0, 0, 0, 0]})
+    partial = BlockAccessor.for_block(source)._aggregate(
+        SortKey("A"), (EmptyAccumulatorForOddKeys(),)
+    )
+
+    assert partial.column("A").to_pylist() == [1, 2, 3, 4]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`TableBlockBuilder.build()` reordered rows across an internal compaction boundary, so `_aggregate`'s per-block partial-aggregate output could be unsorted by the group key. That violates the "inputs are sorted by key" precondition that `_combine_aggregated_blocks`' `heapq.merge` relies on, and surfaced as duplicate group rows in HashAggregate output whose count varied with the parallelism arg.

Two issues, both fixed:

1. **`TableBlockBuilder.build()`** put the still-uncompacted dict-of-lists (newest rows) in front of the previously-compacted tables. Now appends the uncompacted tail after the compacted tables — preserving insertion order.
2. **`ArrowBlockBuilder._combine_tables`** called `transform_pyarrow.concat` without `preserve_order=True`. When block schemas didn't unify exactly (common for V2 aggregators whose accumulator varies in shape between rows — e.g. an empty list vs. a non-empty list, inferring `list<null>` vs `list<string>`), `concat` took a fast path that groups schema-matching blocks together and prepends mismatched ones. Now passes `preserve_order=True` since the builder's contract is to preserve insertion order regardless of internal compaction or schema unification.

## Where `_combine_tables` sits in the hash-shuffle lifecycle

```mermaid
sequenceDiagram
    autonumber
    participant ShuffleTask as _shuffle_block (Ray task)
    participant Closure as input_block_transformer<br/>(_aggregate closure)
    participant TableAcc as TableBlockAccessor._aggregate
    participant Builder as TableBlockBuilder
    participant Combine as ArrowBlockBuilder._combine_tables
    participant Aggregator as HashShuffleAggregator
    participant Reducer as ReducingAggregation

    ShuffleTask->>Closure: block_transformer(block)
    Closure->>Closure: pruned.sort(sort_key)
    Closure->>TableAcc: target._aggregate(sort_key, aggs)
    loop for each group (sorted)
        TableAcc->>Builder: builder.add(row)
        Note over Builder: _compact_if_needed may flush<br/>_columns into _tables mid-loop
    end
    TableAcc->>Builder: builder.build()
    Builder->>Combine: _combine_tables(_tables + [_columns_partial])
    Note over Combine: ★ FIXES LIVE HERE<br/>build(): append uncompacted tail (was: prepend)<br/>_combine_tables: preserve_order=True
    Combine-->>Builder: sorted partial-aggregate block
    Builder-->>TableAcc: sorted partial-aggregate block
    TableAcc-->>Closure: sorted partial-aggregate block
    Closure-->>ShuffleTask: sorted partial-aggregate block
    ShuffleTask->>ShuffleTask: hash_partition (np.where + take, preserves order)
    ShuffleTask->>Aggregator: aggregator.submit.remote(shard)
    Aggregator->>Reducer: compact / finalize (List[Block])
    Reducer->>Reducer: _combine_aggregated_blocks<br/>(heapq.merge — now sees sorted inputs)
```

The bug was in step 8: `_combine_tables` and `build()` could permute rows across compactions, propagating unsorted blocks through steps 9–14 to the `heapq.merge` in step 15, which silently produced duplicate group rows because its consecutive-equal-key grouping only collapses adjacent rows.

## Test plan

- [x] New regression test `test_partial_aggregate_preserves_sort_after_builder_compaction` in `python/ray/data/tests/test_hash_shuffle.py` forces compaction on every row via `MAX_UNCOMPACTED_SIZE_BYTES=1` and asserts partial-aggregate output is sorted by the group key. Fails on master, passes after this change.
- [x] Full `test_hash_shuffle.py` suite (19 tests) passes.
- [x] `test_hash_shuffle_aggregator.py` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)