### PR TITLE
[Train] Increase `test_elastic_e2e` test timeout length

### DIFF
--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -204,7 +204,7 @@ py_test(
 
 py_test(
     name = "test_elastic_e2e",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_elastic_e2e.py"],
     env = {"RAY_TRAIN_V2_ENABLED": "1"},
     tags = [


### PR DESCRIPTION
## Description
Reviewing logs for a flaky `test_elastic_e2e.py` after https://github.com/ray-project/ray/pull/63039 is merged, [example](https://buildkite.com/ray-project/postmerge/builds/17345#019de1ee-b07d-441b-8ccc-7024028e8fb0) then the test still fails occasionally. 

A deeper dive into the logs show that the tests finish within the 180 second test limit

> [elapsed=171.6s] cluster_resources={'GPU': 36.0, 'CPU': 24.0}
> Training finished with result:

However it seems like the teardown / cluster clean up is taking over 8 seconds to run which causes the test to time out. 
I suspect that this is downstream of issues related to core / cluster teardown taking longer than expected. 

This PR just increases the time given to run and will talk to core team about if this is related to a deeper problem