### PR TITLE
[ci] Cache prefix S3 listing and share boto3 client across microcheck threads

### DIFF
--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import enum
+import functools
 import json
 import os
 import platform
@@ -52,6 +53,13 @@ WINDOWS_BISECT_DAILY_RATE_LIMIT = 3
 BISECT_DAILY_RATE_LIMIT = 10
 
 _asyncio_thread_pool = concurrent.futures.ThreadPoolExecutor()
+
+
+@functools.lru_cache(maxsize=1)
+def _get_s3_client():
+    """Return a process-wide boto3 S3 client. Clients are thread-safe per AWS docs;
+    sharing avoids re-running IAM credential discovery on every call."""
+    return boto3.client("s3")
 
 
 def _convert_env_list_to_dict(env_list: List[str]) -> Dict[str, str]:
@@ -197,7 +205,7 @@ class Test(dict):
         Obtain all tests whose names start with the given prefix from s3
         """
         bucket = get_read_state_machine_aws_bucket()
-        s3_client = boto3.client("s3")
+        s3_client = _get_s3_client()
         pages = s3_client.get_paginator("list_objects_v2").paginate(
             Bucket=bucket,
             Prefix=f"{AWS_TEST_KEY}/{prefix}",
@@ -264,18 +272,27 @@ class Test(dict):
         human_specified_tests: Set[str],
     ) -> Set[str]:
         """
-        Per-prefix worker for gen_microcheck_step_ids_for_prefixes. Accepts the
-        prefix-independent test sets so callers can compute them once and reuse them
-        across prefixes. Per-test S3 fetches run in parallel; the dedup logic that
-        depends on running step_ids state stays serial.
+        Per-prefix worker for gen_microcheck_step_ids_for_prefixes. Loads every Test
+        for the prefix in a single S3 listing pass and reuses the loaded objects to
+        derive both high-impact targets and per-target lookups. gen_from_name is only
+        consulted on cache miss (e.g. a brand-new changed test not yet in S3). Per-
+        test S3 fetches run in parallel; the dedup logic that depends on running
+        step_ids state stays serial.
         """
-        high_impact_tests = cls._gen_high_impact_tests(prefix)
+        prefix_tests = cls.gen_from_s3(prefix)
+        tests_by_full_name: Dict[str, "Test"] = {
+            test.get_name(): test for test in prefix_tests
+        }
+        high_impact_targets = {
+            test.get_target() for test in prefix_tests if test.is_high_impact()
+        }
         test_targets = list(
-            high_impact_tests.union(changed_tests, human_specified_tests)
+            high_impact_targets.union(changed_tests, human_specified_tests)
         )
 
         def _fetch_recent_results(test_target: str):
-            test = cls.gen_from_name(f"{prefix}{test_target}")
+            full_name = f"{prefix}{test_target}"
+            test = tests_by_full_name.get(full_name) or cls.gen_from_name(full_name)
             if not test:
                 return None
             return test.get_test_results(use_async=True)
@@ -719,7 +736,7 @@ class Test(dict):
             return self.test_results
 
         bucket = aws_bucket or get_read_state_machine_aws_bucket()
-        s3_client = boto3.client("s3")
+        s3_client = _get_s3_client()
         pages = s3_client.get_paginator("list_objects_v2").paginate(
             Bucket=bucket,
             Prefix=f"{AWS_TEST_RESULT_KEY}/{self._get_s3_name(self.get_name())}-",
@@ -758,6 +775,10 @@ class Test(dict):
         bucket: str,
         keys: List[str],
     ) -> Awaitable[List[TestResult]]:
+        # A fresh aioboto3.Session per call keeps the credentials provider's
+        # IMDS sockets bound to the current asyncio.run() event loop. Reusing
+        # one Session across asyncio.run() invocations leaks loop-bound futures
+        # at process exit ("Future ... attached to a different loop").
         session = aioboto3.Session()
         async with session.client("s3") as s3_client:
             return await asyncio.gather(

--- a/release/ray_release/tests/test_test.py
+++ b/release/ray_release/tests/test_test.py
@@ -44,6 +44,13 @@ class MockTest(dict):
     def get_name(self) -> str:
         return self.get("name", "")
 
+    def get_target(self) -> str:
+        name = self.get_name()
+        for prefix in (LINUX_TEST_PREFIX, MACOS_TEST_PREFIX, WINDOWS_TEST_PREFIX):
+            if name.startswith(prefix):
+                return name[len(prefix) :]
+        return name
+
     def get_test_results(self, *args, **kwargs) -> List[TestResult]:
         return self.get("test_results", [])
 
@@ -476,38 +483,71 @@ def test_gen_microcheck_step_ids_for_prefixes_dedups_prefix_independent_calls(
 
 
 @patch("ray_release.test.Test.gen_from_name")
-@patch("ray_release.test.Test._gen_high_impact_tests")
-def test_gen_microcheck_step_ids_for_prefix_parallel_fetches(
-    mock_gen_high_impact_tests,
+@patch("ray_release.test.Test.gen_from_s3")
+def test_gen_microcheck_step_ids_for_prefix_uses_single_s3_load(
+    mock_gen_from_s3,
     mock_gen_from_name,
 ) -> None:
-    mock_gen_high_impact_tests.return_value = {"//a", "//b", "//c"}
-
     a = MockTest(
         {
             "name": "linux://a",
+            Test.KEY_IS_HIGH_IMPACT: "true",
             "test_results": [_stub_test_result(rayci_step_id="step-a", commit="c1")],
         }
     )
     b = MockTest(
         {
             "name": "linux://b",
+            Test.KEY_IS_HIGH_IMPACT: "true",
             "test_results": [_stub_test_result(rayci_step_id="step-b", commit="c1")],
         }
     )
     c = MockTest(
         {
             "name": "linux://c",
+            Test.KEY_IS_HIGH_IMPACT: "true",
             "test_results": [_stub_test_result(rayci_step_id="step-a", commit="c1")],
         }
     )
-    by_name = {t.get_name(): t for t in (a, b, c)}
-    mock_gen_from_name.side_effect = lambda name: by_name.get(name)
+    not_high_impact = MockTest(
+        {
+            "name": "linux://skip",
+            Test.KEY_IS_HIGH_IMPACT: "false",
+            "test_results": [_stub_test_result(rayci_step_id="step-skip", commit="c1")],
+        }
+    )
+    mock_gen_from_s3.return_value = [a, b, c, not_high_impact]
 
     result = Test._gen_microcheck_step_ids_for_prefix(LINUX_TEST_PREFIX, set(), set())
 
     assert result == {"step-a", "step-b"}
-    assert mock_gen_from_name.call_count == 3
+    mock_gen_from_s3.assert_called_once_with(LINUX_TEST_PREFIX)
+    mock_gen_from_name.assert_not_called()
+
+
+@patch("ray_release.test.Test.gen_from_name")
+@patch("ray_release.test.Test.gen_from_s3")
+def test_gen_microcheck_step_ids_for_prefix_falls_back_for_unknown_target(
+    mock_gen_from_s3,
+    mock_gen_from_name,
+) -> None:
+    mock_gen_from_s3.return_value = []
+    new_test = MockTest(
+        {
+            "name": "linux://new_target",
+            "test_results": [_stub_test_result(rayci_step_id="step-new", commit="c1")],
+        }
+    )
+    mock_gen_from_name.side_effect = lambda name: (
+        new_test if name == "linux://new_target" else None
+    )
+
+    result = Test._gen_microcheck_step_ids_for_prefix(
+        LINUX_TEST_PREFIX, {"//new_target"}, set()
+    )
+
+    assert result == {"step-new"}
+    mock_gen_from_name.assert_called_once_with("linux://new_target")
 
 
 def test_gen_microcheck_tests() -> None:


### PR DESCRIPTION
The prior stack still produced ~420 IAM credential-discovery logs per init run, one per fresh boto3.client("s3") call. Two sources:

1. _gen_microcheck_step_ids_for_prefix called _gen_high_impact_tests (which loaded every Test for the prefix from S3, kept only the high-impact target names) and then for each target ran gen_from_name, which redundantly re-listed and re-fetched a single Test from S3 — discarding the full Test objects we'd just loaded.

2. gen_from_s3 and get_test_results each created their own boto3 client per call. With ~140 high-impact tests × 3 prefixes that's hundreds of client constructions, each running credential discovery from scratch.

Refactor the per-prefix worker to call gen_from_s3 once, build a name→Test index, derive high-impact targets in-memory, and only fall back to gen_from_name for genuine cache misses (e.g. a brand-new changed test not yet in S3). Add a module-level lru_cache helper _get_s3_client and route gen_from_s3 / get_test_results through it. The aioboto3 path stays per-call: sharing one Session across asyncio.run() invocations leaks credentials-provider futures bound to the previous event loop ("Future ... attached to a different loop" at exit), and the sync sharing alone already drops credentials.py logs from 421 to 1 in practice.

Topic: microcheck-cache-s3-loads
Relative: microcheck-async-test-results
Labels: draft
Signed-off-by: andrew <andrew@anyscale.com>