### PR TITLE
[Core] Fix OpenTelemetryMetricRecorder Singleton init Guard

### DIFF
--- a/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
+++ b/python/ray/_private/telemetry/open_telemetry_metric_recorder.py
@@ -96,13 +96,13 @@ class OpenTelemetryMetricRecorder:
         # Initialize the global metrics provider and meter. We only do this once on
         # the first initialization of the class, because re-setting the meter provider
         # can result in loss of metrics.
-        with self._metrics_initialized_lock:
-            if self._metrics_initialized:
+        with OpenTelemetryMetricRecorder._metrics_initialized_lock:
+            if OpenTelemetryMetricRecorder._metrics_initialized:
                 return
             prometheus_reader = PrometheusMetricReader()
             provider = MeterProvider(metric_readers=[prometheus_reader])
             metrics.set_meter_provider(provider)
-            self._metrics_initialized = True
+            OpenTelemetryMetricRecorder._metrics_initialized = True
 
     def register_gauge_metric(self, name: str, description: str) -> None:
         with self._lock:

--- a/python/ray/tests/test_open_telemetry_metric_recorder.py
+++ b/python/ray/tests/test_open_telemetry_metric_recorder.py
@@ -302,5 +302,39 @@ def test_record_histogram_aggregated_batch(
     mock_logger_warning.assert_not_called()
 
 
+@patch("ray._private.telemetry.open_telemetry_metric_recorder.MeterProvider")
+@patch("ray._private.telemetry.open_telemetry_metric_recorder.PrometheusMetricReader")
+@patch("opentelemetry.metrics.set_meter_provider")
+@patch("opentelemetry.metrics.get_meter")
+def test_init_metrics_runs_only_once_per_class(
+    mock_get_meter,
+    mock_set_meter_provider,
+    mock_prometheus_reader,
+    mock_meter_provider,
+):
+    """
+    Regression test: _init_metrics must run exactly once per process, regardless of
+    how many OpenTelemetryMetricRecorder instances are created. Previously the guard
+    flag was written via `self._metrics_initialized = True`, which created an
+    instance attribute and left the class attribute as False, so each new instance
+    re-ran the body and registered another PrometheusMetricReader on the global
+    prometheus_client REGISTRY. That produced duplicate `target_info` series.
+    """
+    mock_get_meter.return_value = MagicMock()
+    # Reset the class-level flag so the test is hermetic regardless of order.
+    original_flag = OpenTelemetryMetricRecorder._metrics_initialized
+    OpenTelemetryMetricRecorder._metrics_initialized = False
+    try:
+        for _ in range(3):
+            OpenTelemetryMetricRecorder()
+
+        assert mock_prometheus_reader.call_count == 1
+        assert mock_meter_provider.call_count == 1
+        assert mock_set_meter_provider.call_count == 1
+        assert OpenTelemetryMetricRecorder._metrics_initialized is True
+    finally:
+        OpenTelemetryMetricRecorder._metrics_initialized = original_flag
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-svv", __file__]))


### PR DESCRIPTION
## Description

Today, `OpenTelemetryMetricRecorder._init_metrics` writes its singleton flag via the instance attribute `self._metrics_initialized = True` and leaves the class attribute as `False`. So every new `OpenTelemetryMetricRecorder()` re-runs the body and registers another `PrometheusMetricReader` which defeats the purpose of the singleton flag. 

The following warning will be seen due to the issue when running a Prometheus server scraping the metrics:
```
WARN msg="Error on ingesting samples with different value but same timestamp"
     target=http://.../metrics num_dropped=4
```

The fix is to directly use the class level flag `OpenTelemetryMetricRecorder._metrics_initialized`. And PR also added a regression test to verify the behavior. 

## Related issues
N/A

## Additional information
N/A
