### PR TITLE
[Data] Name the ray.wait timeout in `process_completed_tasks`

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -51,6 +51,9 @@ logger = logging.getLogger(__name__)
 # operator to tracked streaming exec state.
 Topology = Dict[PhysicalOperator, "OpState"]
 
+# Maximum time `process_completed_tasks` will block in `ray.wait()` waiting
+WAIT_FOR_TASK_COMPLETION_TIMEOUT_S = 0.1
+
 
 class OpBufferQueue:
     """A FIFO queue to buffer RefBundles between upstream and downstream operators.
@@ -482,7 +485,7 @@ def process_completed_tasks(
             list(active_tasks.keys()),
             num_returns=len(active_tasks),
             fetch_local=False,
-            timeout=0.1,
+            timeout=WAIT_FOR_TASK_COMPLETION_TIMEOUT_S,
         )
 
         # Organize tasks by the operator they belong to, and sort them by task index.

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 # operator to tracked streaming exec state.
 Topology = Dict[PhysicalOperator, "OpState"]
 
-# Maximum time `process_completed_tasks` will block in `ray.wait()` waiting
+# Maximum time `process_completed_tasks` will block in `ray.wait()` waiting for tasks to complete.
 WAIT_FOR_TASK_COMPLETION_TIMEOUT_S = 0.1
 
 


### PR DESCRIPTION
## Description
Replace magic timeout=0.1 in process_completed_tasks with a named constant.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
