### PR TITLE
[Data] Make logical operator names derived by default

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -19,9 +19,13 @@ class LogicalOperator(Operator, ABC):
     physical operator.
     """
 
-    _name: str = field(repr=False)
+    _name: Optional[str] = field(init=False, default=None, repr=False)
     _input_dependencies: List["LogicalOperator"] = field(repr=False)
     _num_outputs: Optional[int] = field(default=None, repr=False)
+
+    @property
+    def name(self) -> str:
+        return self._name or self.__class__.__name__
 
     @property
     @abstractmethod
@@ -76,6 +80,7 @@ class LogicalOperator(Operator, ABC):
             else:
                 # Keep underscore-prefixed keys to preserve legacy export schema.
                 args[f"_{key}"] = value
+        args["_name"] = self.name
         # Preserve legacy export shape even though output deps are no longer tracked.
         args["_output_dependencies"] = []
         return args

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -56,10 +56,11 @@ class AbstractAllToAll(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            _name=name or self.__class__.__name__,
             _input_dependencies=[input_op],
             _num_outputs=num_outputs,
         )
+        if name is not None:
+            object.__setattr__(self, "_name", name)
         object.__setattr__(self, "ray_remote_args", ray_remote_args or {})
         object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
 
@@ -76,7 +77,6 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
     seed_config: Optional[RandomSeedConfig] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -126,7 +126,6 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
     seed_config: Optional[RandomSeedConfig] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -187,7 +186,6 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
     sort: bool = False
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, repr=False)
 
@@ -203,7 +201,6 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
                 ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
             ]
         object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", num_outputs)
 
@@ -249,7 +246,6 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     batch_format: Optional[str] = "default"
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -264,7 +260,6 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
@@ -308,7 +303,6 @@ class Aggregate(AbstractAllToAll):
     batch_format: Optional[str] = "default"
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -323,7 +317,6 @@ class Aggregate(AbstractAllToAll):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -20,13 +20,11 @@ class Count(LogicalOperator):
     COLUMN_NAME = "__num_rows"
 
     input_op: InitVar[LogicalOperator]
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self, input_op: LogicalOperator):
         assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
 
     @property

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -35,7 +35,6 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
     input_blocks: InitVar[List[ObjectRef[Block]]]
     input_metadata: InitVar[List[BlockMetadataWithSchema]]
     input_data: List[RefBundle] = field(init=False)
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(
         init=False, repr=False, default_factory=list
     )
@@ -64,7 +63,6 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
                 for i in range(len(input_blocks))
             ],
         )
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_num_outputs", len(input_blocks))
 
     def output_data(self) -> Optional[List[RefBundle]]:

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -20,14 +20,12 @@ class InputData(LogicalOperator, SourceOperator):
     """
 
     input_data: List[RefBundle]
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(
         init=False, repr=False, default_factory=list
     )
     _num_outputs: Optional[int] = field(init=False, repr=False)
 
     def __post_init__(self):
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_num_outputs", len(self.input_data))
 
     def output_data(self) -> Optional[List[RefBundle]]:

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -55,7 +55,6 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
     right_columns_suffix: Optional[str] = None
     partition_size_hint: Optional[int] = None
     aggregator_ray_remote_args: Optional[Dict[str, Any]] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, repr=False)
 
@@ -74,7 +73,6 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
             )
 
         object.__setattr__(self, "join_type", join_type_enum)
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(
             self,
             "_input_dependencies",

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -206,7 +206,6 @@ class MapBatches(AbstractUDFMap):
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -250,7 +249,6 @@ class MapRows(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=False)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -291,7 +289,6 @@ class Filter(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=True)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -360,7 +357,6 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     batch_format: str = field(init=False, default="pyarrow")
     zero_copy_batch: bool = field(init=False, default=True)
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -376,7 +372,6 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
                     "All Project expressions must be named (use .alias(name) or col(name)), "
                     "or be a star() expression."
                 )
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
@@ -461,7 +456,6 @@ class FlatMap(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=True)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -513,7 +507,6 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     compute: Optional[ComputeStrategy] = None
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -28,7 +28,6 @@ class NAry(LogicalOperator):
             input_ops: The input operators.
         """
         super().__init__(
-            _name=self.__class__.__name__,
             _input_dependencies=list(input_ops),
             _num_outputs=num_outputs,
         )
@@ -42,7 +41,6 @@ class NAry(LogicalOperator):
 class Zip(NAry):
     """Logical operator for zip."""
 
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -52,7 +50,6 @@ class Zip(NAry):
     ):
         for input_op in input_ops:
             assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", list(input_ops))
         object.__setattr__(self, "_num_outputs", None)
 
@@ -88,7 +85,6 @@ class Zip(NAry):
 class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for union."""
 
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -98,7 +94,6 @@ class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
     ):
         for input_op in input_ops:
             assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", list(input_ops))
         object.__setattr__(self, "_num_outputs", None)
 

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -46,10 +46,11 @@ class AbstractOneToOne(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            _name=name or self.__class__.__name__,
             _input_dependencies=[input_op] if input_op else [],
             _num_outputs=num_outputs,
         )
+        if name is not None:
+            object.__setattr__(self, "_name", name)
         object.__setattr__(self, "can_modify_num_rows", can_modify_num_rows)
 
     @property
@@ -68,7 +69,6 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
     input_op: InitVar[LogicalOperator]
     limit: int
     can_modify_num_rows: bool = field(init=False, default=True)
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -137,7 +137,6 @@ class Download(AbstractOneToOne):
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     filesystem: Optional["pyarrow.fs.FileSystem"] = None
     can_modify_num_rows: bool = field(init=False, default=False)
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -148,7 +147,6 @@ class Download(AbstractOneToOne):
                 f"Number of URI columns ({len(self.uri_column_names)}) must match "
                 f"number of output columns ({len(self.output_bytes_column_names)})"
             )
-        object.__setattr__(self, "_name", "Download")
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -43,7 +43,6 @@ class Read(
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     ray_remote_args_fn: None = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list = field(init=False, repr=False, default_factory=list)
     _num_outputs: Optional[int] = field(init=False, repr=False)
 

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -19,13 +19,11 @@ class StreamingSplit(LogicalOperator):
     num_splits: int
     equal: bool
     locality_hints: Optional[List["NodeIdStr"]] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self, input_op: LogicalOperator):
         assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -25,7 +25,6 @@ class Write(AbstractMap):
     min_rows_per_bundled_input: Optional[int] = field(init=False)
     ray_remote_args_fn: None = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _name: str = field(init=False, repr=False)
     _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
@@ -43,7 +42,6 @@ class Write(AbstractMap):
         object.__setattr__(
             self, "min_rows_per_bundled_input", min_rows_per_bundled_input
         )
-        object.__setattr__(self, "_name", self.__class__.__name__)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -39,10 +39,11 @@ def _check_valid_plan_and_result(
 class _DummyLogicalOperator(LogicalOperator):
     def __init__(self, input_dependencies, name=None, num_outputs=None):
         super().__init__(
-            _name=name or self.__class__.__name__,
             _input_dependencies=input_dependencies,
             _num_outputs=num_outputs,
         )
+        if name is not None:
+            object.__setattr__(self, "_name", name)
 
     @property
     def num_outputs(self):

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -92,10 +92,10 @@ class DummyLogicalOperator(LogicalOperator):
 
     def __init__(self, input_op=None):
         super().__init__(
-            _name="DummyOperator",
             _input_dependencies=[],
             _num_outputs=None,
         )
+        object.__setattr__(self, "_name", "DummyOperator")
 
         # Test various data types that might be returned by _get_logical_args
         object.__setattr__(self, "_string_value", "test_string")

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -5,10 +5,11 @@ from ray.data.context import DataContext
 class DummyLogicalOperator(LogicalOperator):
     def __init__(self, input_dependencies, name=None, num_outputs=None):
         super().__init__(
-            _name=name or self.__class__.__name__,
             _input_dependencies=input_dependencies,
             _num_outputs=num_outputs,
         )
+        if name is not None:
+            object.__setattr__(self, "_name", name)
 
     @property
     def num_outputs(self):


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

After moving the shared logical-operator backing fields to the abstract-class layer, `_name` is still wired manually in many concrete operators. Most of those assignments are just the operator class name, so the next step is to make that default behavior come from the base logical-operator layer.

#### What this PR changes:

Makes logical-operator names derived by default from the base logical-operator layer. For operators without a special naming rule, `name` now defaults to `self.__class__.__name__`.

This PR removes concrete `_name` wiring where the assigned value was only the class name, while preserving the special naming cases that still need explicit values, such as `Read`, `Limit`, `RandomShuffle`, `RandomizeBlocks`, and UDF-based map operators.

This PR does not include the later `_apply_transform` deduplication, `input_op: InitVar` replacement, `_get_args` cleanup, or broader logical-rule cleanup follow-ups.

## Related issues

Part of #60312

## Additional information

This PR corresponds to the `_name` derived-field step in the current split plan.

### Tests

- `python -m pre_commit run --files python/ray/data/_internal/logical/interfaces/logical_operator.py python/ray/data/_internal/logical/operators/one_to_one_operator.py python/ray/data/_internal/logical/operators/n_ary_operator.py python/ray/data/_internal/logical/operators/all_to_all_operator.py python/ray/data/_internal/logical/operators/count_operator.py python/ray/data/_internal/logical/operators/input_data_operator.py python/ray/data/_internal/logical/operators/from_operators.py python/ray/data/_internal/logical/operators/streaming_split_operator.py python/ray/data/_internal/logical/operators/join_operator.py python/ray/data/_internal/logical/operators/write_operator.py python/ray/data/_internal/logical/operators/map_operator.py`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_state_export.py python/ray/data/tests/unit/test_logical_plan.py python/ray/data/tests/test_execution_optimizer_basic.py -k 'Project or Count or InputData or Union or Zip or split or join or write or read or map'`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_execution_optimizer_advanced.py python/ray/data/tests/test_union.py python/ray/data/tests/test_split.py -k 'zip or union or split or project or read or write or join'`

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- PR-Next-0: Convert the remaining concrete logical operators to frozen dataclasses
- PR-Next-1: Convert abstract logical operator classes to frozen dataclasses
- This PR: make logical-operator names derived by default

Next:
- deduplicate `_apply_transform`
- replace `input_op: InitVar` with a real `input_dependencies` field
- remove `input_dependency` on `AbstractOneToOne`
- clean up `_get_args`
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`
