### PR TITLE
[Data] Deduplicate logical operator apply transform

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -1,3 +1,4 @@
+import copy
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, replace
 from enum import Enum
@@ -87,12 +88,14 @@ class LogicalOperator(Operator, ABC):
     def _with_new_input_dependencies(
         self, input_dependencies: List["LogicalOperator"]
     ) -> "LogicalOperator":
-        if len(input_dependencies) != 1:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} must define how to replace "
-                "multiple input dependencies."
-            )
-        return self._with_new_input(input_dependencies[0])
+        if len(input_dependencies) == 1 and "input_op" in getattr(
+            self, "__dataclass_fields__", {}
+        ):
+            return self._with_new_input(input_dependencies[0])
+
+        target = copy.copy(self)
+        object.__setattr__(target, "_input_dependencies", input_dependencies)
+        return target
 
     def _with_new_input(self, input_op: "LogicalOperator") -> "LogicalOperator":
         return replace(self, input_op=input_op)

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
@@ -69,7 +69,33 @@ class LogicalOperator(Operator, ABC):
     def _apply_transform(
         self, transform: Callable[["LogicalOperator"], "LogicalOperator"]
     ) -> "LogicalOperator":
-        return super()._apply_transform(transform)  # type: ignore
+        input_dependencies = self.input_dependencies
+        transformed_inputs = [
+            input_op._apply_transform(transform) for input_op in input_dependencies
+        ]
+        if all(
+            transformed_input is input_op
+            for transformed_input, input_op in zip(
+                transformed_inputs, input_dependencies
+            )
+        ):
+            target = self
+        else:
+            target = self._with_new_input_dependencies(transformed_inputs)
+        return transform(target)
+
+    def _with_new_input_dependencies(
+        self, input_dependencies: List["LogicalOperator"]
+    ) -> "LogicalOperator":
+        if len(input_dependencies) != 1:
+            raise NotImplementedError(
+                f"{self.__class__.__name__} must define how to replace "
+                "multiple input dependencies."
+            )
+        return self._with_new_input(input_dependencies[0])
+
+    def _with_new_input(self, input_op: "LogicalOperator") -> "LogicalOperator":
+        return replace(self, input_op=input_op)
 
     def _get_args(self) -> Dict[str, Any]:
         """This Dict must be serializable"""

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar, dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -88,18 +88,6 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        input_op = self.input_dependencies[0]
-        transformed_input = input_op._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is input_op:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
-
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         assert isinstance(self.input_dependencies[0], LogicalOperator)
@@ -146,17 +134,8 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        input_op = self.input_dependencies[0]
-        transformed_input = input_op._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is input_op:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input, name=self.name)
-        return transform(target)
+    def _with_new_input(self, input_op: LogicalOperator) -> LogicalOperator:
+        return replace(self, input_op=input_op, name=self._name)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -204,21 +183,12 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", num_outputs)
 
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        input_op = self.input_dependencies[0]
-        transformed_input = input_op._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is input_op:
-            target = self
-        else:
-            target = replace(
-                self,
-                input_op=transformed_input,
-                num_outputs=self.num_outputs,
-            )
-        return transform(target)
+    def _with_new_input(self, input_op: LogicalOperator) -> LogicalOperator:
+        return replace(
+            self,
+            input_op=input_op,
+            num_outputs=self.num_outputs,
+        )
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -262,18 +232,6 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
         )
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        input_op = self.input_dependencies[0]
-        transformed_input = input_op._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is input_op:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -319,15 +277,3 @@ class Aggregate(AbstractAllToAll):
         )
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        input_op = self.input_dependencies[0]
-        transformed_input = input_op._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is input_op:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar, dataclass, field
-from typing import Callable, Optional
+from typing import Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
 
@@ -30,14 +30,3 @@ class Count(LogicalOperator):
     @property
     def num_outputs(self) -> Optional[int]:
         return self._num_outputs
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependencies[0]._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependencies[0]:
-            target = self
-        else:
-            target = Count(transformed_input)
-        return transform(target)

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -1,6 +1,6 @@
-from dataclasses import InitVar, dataclass, field
+from dataclasses import InitVar, dataclass, field, replace
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Sequence, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -80,30 +80,15 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
         )
         object.__setattr__(self, "_num_outputs", num_partitions)
 
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
+    def _with_new_input_dependencies(
+        self, input_dependencies: List[LogicalOperator]
     ) -> LogicalOperator:
-        left_input = self.input_dependencies[0]
-        right_input = self.input_dependencies[1]
-        transformed_left = left_input._apply_transform(transform)
-        transformed_right = right_input._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_left is left_input and transformed_right is right_input:
-            target = self
-        else:
-            target = Join(
-                transformed_left,
-                transformed_right,
-                self.join_type,
-                self.left_key_columns,
-                self.right_key_columns,
-                num_partitions=self.num_outputs,
-                left_columns_suffix=self.left_columns_suffix,
-                right_columns_suffix=self.right_columns_suffix,
-                partition_size_hint=self.partition_size_hint,
-                aggregator_ray_remote_args=self.aggregator_ray_remote_args,
-            )
-        return transform(target)
+        return replace(
+            self,
+            left_input_op=input_dependencies[0],
+            right_input_op=input_dependencies[1],
+            num_partitions=self.num_outputs,
+        )
 
     @staticmethod
     def _validate_schemas(

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import logging
-from dataclasses import InitVar, dataclass, field, replace
+from dataclasses import InitVar, dataclass, field
 from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
@@ -221,17 +221,6 @@ class MapBatches(AbstractUDFMap):
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
-
 
 @dataclass(frozen=True, repr=False, eq=False)
 class MapRows(AbstractUDFMap):
@@ -259,17 +248,6 @@ class MapRows(AbstractUDFMap):
         object.__setattr__(self, "_name", self._get_operator_name("Map", self.fn))
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -309,17 +287,6 @@ class Filter(AbstractUDFMap):
         )
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
 
     def is_expression_based(self) -> bool:
         return self.predicate_expr is not None
@@ -374,17 +341,6 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
                 )
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
 
     def _detect_and_get_compute_strategy(self, exprs: list["Expr"]) -> ComputeStrategy:
         """Detect if expressions contain callable class UDFs and return appropriate compute strategy.
@@ -471,17 +427,6 @@ class FlatMap(AbstractUDFMap):
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
-
 
 @dataclass(frozen=True, repr=False, eq=False)
 class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
@@ -526,17 +471,6 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
         )
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # StreamingRepartition only re-bundles rows into different block sizes.

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional
+from typing import List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -36,6 +36,11 @@ class NAry(LogicalOperator):
     def num_outputs(self) -> Optional[int]:
         return self._num_outputs
 
+    def _with_new_input_dependencies(
+        self, input_dependencies: List[LogicalOperator]
+    ) -> LogicalOperator:
+        return self.__class__(*input_dependencies)
+
 
 @dataclass(frozen=True, repr=False, eq=False, init=False)
 class Zip(NAry):
@@ -52,24 +57,6 @@ class Zip(NAry):
             assert isinstance(input_op, LogicalOperator), input_op
         object.__setattr__(self, "_input_dependencies", list(input_ops))
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_inputs = [
-            input_op._apply_transform(transform) for input_op in self.input_dependencies
-        ]
-        target: LogicalOperator
-        if all(
-            transformed_input is input_op
-            for transformed_input, input_op in zip(
-                transformed_inputs, self.input_dependencies
-            )
-        ):
-            target = self
-        else:
-            target = Zip(*transformed_inputs)
-        return transform(target)
 
     def estimated_num_outputs(self):
         total_num_outputs = 0
@@ -96,24 +83,6 @@ class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
             assert isinstance(input_op, LogicalOperator), input_op
         object.__setattr__(self, "_input_dependencies", list(input_ops))
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_inputs = [
-            input_op._apply_transform(transform) for input_op in self.input_dependencies
-        ]
-        target: LogicalOperator
-        if all(
-            transformed_input is input_op
-            for transformed_input, input_op in zip(
-                transformed_inputs, self.input_dependencies
-            )
-        ):
-            target = self
-        else:
-            target = Union(*transformed_inputs)
-        return transform(target)
 
     def estimated_num_outputs(self):
         total_num_outputs = 0

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar, dataclass, field
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -78,17 +78,6 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = Limit(transformed_input, self.limit)
-        return transform(target)
-
     def infer_metadata(self) -> BlockMetadata:
         return BlockMetadata(
             num_rows=self._num_rows(),
@@ -149,20 +138,3 @@ class Download(AbstractOneToOne):
             )
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        transformed_input = self.input_dependency._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is self.input_dependency:
-            target = self
-        else:
-            target = Download(
-                transformed_input,
-                uri_column_names=self.uri_column_names,
-                output_bytes_column_names=self.output_bytes_column_names,
-                ray_remote_args=self.ray_remote_args,
-                filesystem=self.filesystem,
-            )
-        return transform(target)

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar, dataclass, field
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
 
@@ -26,23 +26,6 @@ class StreamingSplit(LogicalOperator):
         assert isinstance(input_op, LogicalOperator), input_op
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        input_op = self.input_dependencies[0]
-        transformed_input = input_op._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is input_op:
-            target = self
-        else:
-            target = StreamingSplit(
-                transformed_input,
-                num_splits=self.num_splits,
-                equal=self.equal,
-                locality_hints=self.locality_hints,
-            )
-        return transform(target)
 
     @property
     def num_outputs(self) -> Optional[int]:

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -1,5 +1,5 @@
-from dataclasses import InitVar, dataclass, field, replace
-from typing import Any, Callable, Dict, Optional, Union
+from dataclasses import InitVar, dataclass, field
+from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -44,15 +44,3 @@ class Write(AbstractMap):
         )
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
-
-    def _apply_transform(
-        self, transform: Callable[[LogicalOperator], LogicalOperator]
-    ) -> LogicalOperator:
-        input_op = self.input_dependencies[0]
-        transformed_input = input_op._apply_transform(transform)
-        target: LogicalOperator
-        if transformed_input is input_op:
-            target = self
-        else:
-            target = replace(self, input_op=transformed_input)
-        return transform(target)

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -60,6 +60,19 @@ def test_logical_operator_does_not_track_output_dependencies():
     assert not hasattr(sink, "_output_dependencies")
 
 
+def test_logical_operator_transform_supports_custom_subclasses():
+    source = DummyLogicalOperator([], name="source")
+    replacement = DummyLogicalOperator([], name="replacement")
+    sink = DummyLogicalOperator([source], name="sink")
+
+    transformed = sink._apply_transform(lambda op: replacement if op is source else op)
+
+    assert transformed is not sink
+    assert transformed.name == "sink"
+    assert transformed.input_dependencies == [replacement]
+    assert sink.input_dependencies == [source]
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

After making logical operators frozen dataclasses and moving logical operator names to the base layer, most concrete operators still carry near-identical `_apply_transform` implementations. Each implementation recursively transforms its input operator, keeps `self` when the input is unchanged, and rebuilds the operator when the input changes.

#### What this PR changes:

Adds a frozen-safe default `_apply_transform` implementation to `LogicalOperator` and moves operator-specific rebuild details into small `_with_new_input` / `_with_new_input_dependencies` hooks.

For single-input operators, the default rebuild path uses `dataclasses.replace(self, input_op=...)`. `RandomShuffle` and `Repartition` keep small hooks because they still have InitVar-only constructor values that must be passed during replacement. `NAry` owns the common n-ary rebuild path for `Zip` and `Union`, and `Join` keeps the multi-input rebuild hook for its left and right inputs.

This PR does not replace `input_op: InitVar` with a real `input_dependencies` field, remove `input_dependency` from `AbstractOneToOne`, clean up `_get_args`, or clean up logical-rule special-casing. Those remain separate follow-ups in the current split plan.

## Related issues

Part of #60312

## Additional information

This PR corresponds to the `_apply_transform` deduplication step in the current split plan and is stacked on top of the derived logical-operator name change.

### Tests

- `python -m pre_commit run --files python/ray/data/_internal/logical/interfaces/logical_operator.py python/ray/data/_internal/logical/operators/all_to_all_operator.py python/ray/data/_internal/logical/operators/count_operator.py python/ray/data/_internal/logical/operators/join_operator.py python/ray/data/_internal/logical/operators/map_operator.py python/ray/data/_internal/logical/operators/n_ary_operator.py python/ray/data/_internal/logical/operators/one_to_one_operator.py python/ray/data/_internal/logical/operators/streaming_split_operator.py python/ray/data/_internal/logical/operators/write_operator.py`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/unit/test_logical_plan.py python/ray/data/tests/test_execution_optimizer_limit_pushdown.py::test_limit_pushdown_recreates_frozen_download`
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_execution_optimizer_limit_pushdown.py python/ray/data/tests/test_execution_optimizer_advanced.py python/ray/data/tests/test_union.py python/ray/data/tests/test_split.py -k 'limit_pushdown_recreates_frozen_download or zip_e2e or union or split or project or join'`

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- PR-Next-0: Convert the remaining concrete logical operators to frozen dataclasses
- PR-Next-1: Convert abstract logical operator classes to frozen dataclasses
- PR-Next-2: make logical-operator names derived by default
- This PR: deduplicate `_apply_transform`

Next:
- replace `input_op: InitVar` with a real `input_dependencies` field
- remove `input_dependency` on `AbstractOneToOne`
- clean up `_get_args`
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`
