### PR TITLE
[Data] Update Hudi datasource for hudi 0.5

### DIFF
--- a/python/ray/data/_internal/datasource/hudi_datasource.py
+++ b/python/ray/data/_internal/datasource/hudi_datasource.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from enum import Enum
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
 from ray.data._internal.util import _check_import
@@ -8,38 +7,107 @@ from ray.data.block import BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
 
 if TYPE_CHECKING:
+    import pyarrow
+
     from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
 
+_MIN_HUDI_VERSION = "0.5.0.dev0"
 
-class HudiQueryType(Enum):
-    SNAPSHOT = "snapshot"
-    INCREMENTAL = "incremental"
 
-    @classmethod
-    def supported_types(cls) -> List[str]:
-        return [e.value for e in cls]
+def _check_hudi_version() -> None:
+    import hudi
+    from packaging.version import parse as parse_version
+
+    version = getattr(hudi, "__version__", "0")
+    if parse_version(version) < parse_version(_MIN_HUDI_VERSION):
+        raise ImportError(
+            f"Ray Data's Hudi datasource requires hudi >= {_MIN_HUDI_VERSION}, "
+            f"but found {version}. Run "
+            f"`pip install -U 'hudi>={_MIN_HUDI_VERSION}'`."
+        )
+
+
+def _bin_pack_by_size(slices, n_bins):
+    sorted_slices = sorted(slices, key=lambda fs: fs.total_size_bytes(), reverse=True)
+    bins: List[list] = [[] for _ in range(n_bins)]
+    bin_sizes = [0] * n_bins
+    for fs in sorted_slices:
+        lightest = min(range(n_bins), key=lambda i: bin_sizes[i])
+        bins[lightest].append(fs)
+        bin_sizes[lightest] += fs.total_size_bytes()
+    return [b for b in bins if b]
 
 
 class HudiDatasource(Datasource):
-    """Hudi datasource, for reading Apache Hudi table."""
+    """Hudi datasource, for reading Apache Hudi tables.
+
+    Backed by `hudi-rs <https://github.com/apache/hudi-rs>`_ via the ``hudi``
+    Python package (>= 0.5).
+    """
 
     def __init__(
         self,
         table_uri: str,
-        query_type: str,
+        query_type: str = "snapshot",
+        *,
         filters: Optional[List[Tuple[str, str, str]]] = None,
+        columns: Optional[List[str]] = None,
+        as_of_timestamp: Optional[str] = None,
+        start_timestamp: Optional[str] = None,
+        end_timestamp: Optional[str] = None,
         hudi_options: Optional[Dict[str, str]] = None,
         storage_options: Optional[Dict[str, str]] = None,
     ):
-        _check_import(self, module="hudi", package="hudi-python")
+        _check_import(self, module="hudi", package="hudi")
+        _check_hudi_version()
 
+        from hudi import HudiQueryType
+
+        try:
+            self._query_type = getattr(HudiQueryType, query_type.capitalize())
+        except AttributeError:
+            raise ValueError(f"Unsupported query type: {query_type!r}.")
         self._table_uri = table_uri
-        self._query_type = HudiQueryType(query_type.lower())
-        self._filters = filters or []
-        self._hudi_options = hudi_options or {}
+        self._filters = list(filters) if filters else []
+        self._columns = list(columns) if columns else None
+        self._as_of_timestamp = as_of_timestamp
+        self._start_timestamp = start_timestamp
+        self._end_timestamp = end_timestamp
+        self._hudi_options = dict(hudi_options) if hudi_options else {}
         self._storage_options = storage_options or {}
+        self._hudi_table = None
+
+    def _build_table(self):
+        if self._hudi_table is None:
+            from hudi import HudiTableBuilder
+
+            self._hudi_table = (
+                HudiTableBuilder.from_base_uri(self._table_uri)
+                .with_hudi_options(self._hudi_options)
+                .with_storage_options(self._storage_options)
+                .build()
+            )
+        return self._hudi_table
+
+    def _build_read_options(self):
+        """Build a ``HudiReadOptions`` via the chainable builders."""
+        from hudi import HudiReadOptions
+
+        options = HudiReadOptions(
+            filters=self._filters or None,
+            projection=self._columns,
+            hudi_options=self._hudi_options or None,
+        ).with_query_type(self._query_type)
+
+        if self._as_of_timestamp is not None:
+            options = options.with_as_of_timestamp(self._as_of_timestamp)
+        if self._start_timestamp is not None:
+            options = options.with_start_timestamp(self._start_timestamp)
+        if self._end_timestamp is not None:
+            options = options.with_end_timestamp(self._end_timestamp)
+        return options
 
     def get_read_tasks(
         self,
@@ -47,108 +115,119 @@ class HudiDatasource(Datasource):
         per_task_row_limit: Optional[int] = None,
         data_context: Optional["DataContext"] = None,
     ) -> List["ReadTask"]:
-        import numpy as np
         import pyarrow
-        from hudi import HudiTableBuilder
 
-        def _perform_read(
-            table_uri: str,
-            base_file_paths: List[str],
-            options: Dict[str, str],
-        ) -> Iterator["pyarrow.Table"]:
-            from hudi import HudiFileGroupReader
+        hudi_table = self._build_table()
+        read_options = self._build_read_options()
 
-            for p in base_file_paths:
-                file_group_reader = HudiFileGroupReader(table_uri, options)
-                batch = file_group_reader.read_file_slice_by_base_file_path(p)
-                yield pyarrow.Table.from_batches([batch])
-
-        hudi_table = (
-            HudiTableBuilder.from_base_uri(self._table_uri)
-            .with_hudi_options(self._hudi_options)
-            .with_storage_options(self._storage_options)
-            # Although hudi-rs supports MOR snapshot, we need to add an API in
-            # the next release to allow file group reader to take in a list of
-            # files. Hence, setting this config for now to restrain reading
-            # only on parquet files (read optimized mode).
-            # This won't affect reading COW.
-            .with_hudi_option("hoodie.read.use.read_optimized.mode", "true")
-            .build()
+        logger.info(
+            "Planning Hudi %s read on %s with parallelism=%d",
+            self._query_type.value,
+            self._table_uri,
+            parallelism,
         )
 
-        logger.info("Collecting file slices for Hudi table at: %s", self._table_uri)
+        flat_slices = list(hudi_table.get_file_slices(read_options))
+        if not flat_slices:
+            return []
+        n_bins = max(1, min(parallelism, len(flat_slices)))
+        file_slices_splits = _bin_pack_by_size(flat_slices, n_bins)
 
-        if self._query_type == HudiQueryType.SNAPSHOT:
-            file_slices_splits = hudi_table.get_file_slices_splits(
-                parallelism, self._filters
-            )
-        elif self._query_type == HudiQueryType.INCREMENTAL:
-            start_ts = self._hudi_options.get("hoodie.read.file_group.start_timestamp")
-            end_ts = self._hudi_options.get("hoodie.read.file_group.end_timestamp")
-            # TODO(xushiyan): add table API to return splits of file slices
-            file_slices = hudi_table.get_file_slices_between(start_ts, end_ts)
-            file_slices_splits = np.array_split(file_slices, parallelism)
-        else:
-            raise ValueError(
-                f"Unsupported query type: {self._query_type}. Supported types are: {HudiQueryType.supported_types()}."
-            )
+        schema = hudi_table.get_schema_with_meta_fields()
+        if self._columns:
+            available = set(schema.names)
+            unknown = [c for c in self._columns if c not in available]
+            if unknown:
+                raise ValueError(
+                    f"Columns {unknown} not found in schema. "
+                    f"Available columns: {sorted(available)}"
+                )
+            schema = pyarrow.schema([schema.field(c) for c in self._columns])
 
-        logger.info("Creating read tasks for Hudi table at: %s", self._table_uri)
+        table_uri = self._table_uri
+        hudi_opts = dict(self._hudi_options)
+        storage_opts = dict(self._storage_options)
+        worker_opts_dict = dict(read_options.hudi_options)
+        worker_filters = list(read_options.filters)
+        worker_projection = (
+            list(read_options.projection) if read_options.projection else None
+        )
 
-        reader_options = {
-            **hudi_table.storage_options(),
-            **hudi_table.hudi_options(),
-        }
+        def _make_read_fn(slice_paths: List[Tuple[str, List[str]]]):
+            def _read() -> Iterator["pyarrow.Table"]:
+                from hudi import HudiReadOptions, HudiTableBuilder
 
-        schema = hudi_table.get_schema()
-        read_tasks = []
+                table = (
+                    HudiTableBuilder.from_base_uri(table_uri)
+                    .with_hudi_options(hudi_opts)
+                    .with_storage_options(storage_opts)
+                    .build()
+                )
+                read_opts = HudiReadOptions(
+                    filters=worker_filters or None,
+                    projection=worker_projection,
+                    hudi_options=worker_opts_dict,
+                )
+                reader = table.create_file_group_reader_with_options(
+                    read_options=read_opts,
+                )
+                for base_path, log_paths in slice_paths:
+                    stream = reader.read_file_slice_from_paths_stream(
+                        base_path, log_paths, read_opts
+                    )
+                    for batch in stream:
+                        yield pyarrow.Table.from_batches([batch])
 
-        for file_slices_split in file_slices_splits:
-            num_rows = 0
-            relative_paths = []
-            input_files = []
+            return _read
+
+        read_tasks: List[ReadTask] = []
+        for split in file_slices_splits:
+            slice_paths: List[Tuple[str, List[str]]] = []
+            num_rows: Optional[int] = 0
             size_bytes = 0
-            for file_slice in file_slices_split:
-                # A file slice in a Hudi table is a logical group of data files
-                # within a physical partition. Records stored in a file slice
-                # are associated with a commit on the Hudi table's timeline.
-                # For more info, see https://hudi.apache.org/docs/file_layouts
-                num_rows += file_slice.num_records
-                relative_path = file_slice.base_file_relative_path()
-                relative_paths.append(relative_path)
-                full_path = os.path.join(self._table_uri, relative_path)
-                input_files.append(full_path)
-                size_bytes += file_slice.base_file_size
+            input_files: List[str] = []
+            for fs in split:
+                base_rel = fs.base_file_relative_path()
+                log_rels = list(fs.log_files_relative_paths())
+                slice_paths.append((base_rel, log_rels))
+                inmem = fs.base_file_byte_size
+                size_bytes += inmem if inmem > 0 else fs.total_size_bytes()
+                if num_rows is not None:
+                    if fs.num_records > 0:
+                        num_rows += fs.num_records
+                    else:
+                        num_rows = None
+                input_files.append(os.path.join(table_uri, base_rel))
+                input_files.extend(os.path.join(table_uri, p) for p in log_rels)
 
-            if self._query_type == HudiQueryType.SNAPSHOT:
-                metadata = BlockMetadata(
-                    num_rows=num_rows,
-                    input_files=input_files,
-                    size_bytes=size_bytes,
-                    exec_stats=None,
-                )
-            elif self._query_type == HudiQueryType.INCREMENTAL:
-                # need the check due to
-                # https://github.com/apache/hudi-rs/issues/401
-                metadata = BlockMetadata(
-                    num_rows=None,
-                    input_files=input_files,
-                    size_bytes=None,
-                    exec_stats=None,
-                )
+            if not slice_paths:
+                continue
 
-            read_task = ReadTask(
-                read_fn=lambda paths=relative_paths: _perform_read(
-                    self._table_uri, paths, reader_options
-                ),
-                metadata=metadata,
-                schema=schema,
-                per_task_row_limit=per_task_row_limit,
+            metadata = BlockMetadata(
+                num_rows=num_rows or None,
+                input_files=input_files,
+                size_bytes=size_bytes or None,
+                exec_stats=None,
             )
-            read_tasks.append(read_task)
+
+            read_tasks.append(
+                ReadTask(
+                    read_fn=_make_read_fn(slice_paths),
+                    metadata=metadata,
+                    schema=schema,
+                    per_task_row_limit=per_task_row_limit,
+                )
+            )
 
         return read_tasks
 
     def estimate_inmemory_data_size(self) -> Optional[int]:
-        # TODO(xushiyan) add APIs to provide estimated in-memory size
-        return None
+        try:
+            stats = self._build_table().compute_table_stats(self._build_read_options())
+            if stats is None:
+                return None
+            _, byte_size = stats
+            return byte_size
+        except Exception as e:
+            logger.debug("compute_table_stats() failed: %s", e)
+            return None

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -2896,6 +2896,10 @@ def read_hudi(
     *,
     query_type: str = "snapshot",
     filters: Optional[List[Tuple[str, str, str]]] = None,
+    columns: Optional[List[str]] = None,
+    as_of_timestamp: Optional[str] = None,
+    start_timestamp: Optional[str] = None,
+    end_timestamp: Optional[str] = None,
     hudi_options: Optional[Dict[str, str]] = None,
     storage_options: Optional[Dict[str, str]] = None,
     num_cpus: Optional[float] = None,
@@ -2909,35 +2913,57 @@ def read_hudi(
     Create a :class:`~ray.data.Dataset` from an
     `Apache Hudi table <https://hudi.apache.org>`_.
 
+    Requires ``hudi >= 0.5.0``.
+
     Examples:
+        Snapshot read with a partition filter and column projection:
+
         >>> import ray
         >>> ds = ray.data.read_hudi( # doctest: +SKIP
         ...     table_uri="/hudi/trips",
-        ...     query_type="snapshot",
         ...     filters=[("city", "=", "san_francisco")],
+        ...     columns=["ts", "rider", "fare"],
         ... )
+
+        Time-travel snapshot at a specific commit:
+
+        >>> ds = ray.data.read_hudi( # doctest: +SKIP
+        ...     table_uri="/hudi/trips",
+        ...     as_of_timestamp="20230115123456789",
+        ... )
+
+        Incremental read between two commits:
 
         >>> ds = ray.data.read_hudi( # doctest: +SKIP
         ...     table_uri="/hudi/trips",
         ...     query_type="incremental",
-        ...     hudi_options={
-        ...         "hoodie.read.file_group.start_timestamp": "20230101123456789",
-        ...         "hoodie.read.file_group.end_timestamp": "20230201123456789",
-        ...     },
+        ...     start_timestamp="20230101123456789",
+        ...     end_timestamp="20230201123456789",
         ... )
 
     Args:
         table_uri: The URI of the Hudi table to read from. Local file paths, S3, and GCS are supported.
         query_type: The Hudi query type to use. Supported values are ``snapshot`` and ``incremental``.
-        filters: Optional list of filters to apply to the Hudi table when the
-            ``query_type`` is ``snapshot``. Each filter is a tuple of the form
-            ``(column_name, operator, value)``. The operator can be
-            one of ``"="``, ``"!="``, ``"<"``, ``"<="``, ``">"``, ``">="``.
-            Currently, only filters on partition columns will be effective.
-        hudi_options: A dictionary of Hudi options to pass to the Hudi reader.
-        storage_options: Extra options that make sense for a particular storage
-            connection. This is used to store connection parameters like credentials,
-            endpoint, etc. See more explanation
+        filters: Optional list of filters to apply. Each filter is a tuple of
+            ``(column_name, operator, value)``. The operator can be one of
+            ``"="``, ``"!="``, ``"<"``, ``"<="``, ``">"``, ``">="``, ``"IN"``,
+            ``"NOT IN"``. Filters drive partition pruning when the column is a
+            partition column, file-level statistics pruning when the column has
+            statistics, and row-level filtering otherwise. Applies to both
+            snapshot and incremental queries.
+        columns: Optional list of column names to read (projection pushdown).
+            If unset, all columns are read.
+        as_of_timestamp: For snapshot queries, the timestamp to read at. If
+            unset, the latest commit is used.
+        start_timestamp: For incremental queries, the lower-bound timestamp
+            (exclusive). If unset, defaults to the earliest commit.
+        end_timestamp: For incremental queries, the upper-bound timestamp
+            (inclusive). If unset, defaults to the latest commit.
+        hudi_options: Advanced Hudi options passed to both the
+            ``HudiTableBuilder`` (table construction) and ``HudiReadOptions``
+            (per-read behavior such as ``hoodie.read.use.read_optimized.mode``).
+        storage_options: Extra options for a particular storage connection
+            (credentials, endpoint, etc). See
             `here <https://github.com/apache/hudi-rs?tab=readme-ov-file#work-with-cloud-storage>`_.
         num_cpus: The number of CPUs to reserve for each parallel read worker.
         num_gpus: The number of GPUs to reserve for each parallel read worker. For
@@ -2961,6 +2987,10 @@ def read_hudi(
         table_uri=table_uri,
         query_type=query_type,
         filters=filters,
+        columns=columns,
+        as_of_timestamp=as_of_timestamp,
+        start_timestamp=start_timestamp,
+        end_timestamp=end_timestamp,
         hudi_options=hudi_options,
         storage_options=storage_options,
     )

--- a/python/ray/data/tests/datasource/test_hudi.py
+++ b/python/ray/data/tests/datasource/test_hudi.py
@@ -24,6 +24,10 @@ PYARROW_HUDI_TEST_SKIP_REASON = (
     f"Hudi only supported if pyarrow >= {MIN_PYARROW_VERSION_FOR_HUDI}"
 )
 
+# Commit timestamps baked into the v6_trips_8i1u test fixture.
+FIRST_COMMIT = "20250715043008154"
+SECOND_COMMIT = "20250715043011090"
+
 
 def _extract_testing_table(fixture_path: str, table_dir: str, target_dir: str) -> str:
     with zipfile.ZipFile(fixture_path, "r") as zip_ref:
@@ -75,29 +79,27 @@ def test_hudi_snapshot_query_v6_trips_table(ray_start_regular_shared, fs, data_p
         .sort("fare")
         .take_all()
     )
-    first_commit = "20250715043008154"
-    second_commit = "20250715043011090"
     assert rows == [
         {
-            "_hoodie_commit_time": first_commit,
+            "_hoodie_commit_time": FIRST_COMMIT,
             "ts": 1695159649087,
             "rider": "rider-A",
             "fare": 19.10,
         },
         {
-            "_hoodie_commit_time": second_commit,
+            "_hoodie_commit_time": SECOND_COMMIT,
             "ts": 1695046462179,
             "rider": "rider-D",
             "fare": 25.0,
         },
         {
-            "_hoodie_commit_time": first_commit,
+            "_hoodie_commit_time": FIRST_COMMIT,
             "ts": 1695091554788,
             "rider": "rider-C",
             "fare": 27.70,
         },
         {
-            "_hoodie_commit_time": first_commit,
+            "_hoodie_commit_time": FIRST_COMMIT,
             "ts": 1695332066204,
             "rider": "rider-E",
             "fare": 93.50,
@@ -119,15 +121,11 @@ def test_hudi_snapshot_query_v6_trips_table(ray_start_regular_shared, fs, data_p
 def test_hudi_incremental_query_v6_trips_table(ray_start_regular_shared, fs, data_path):
     table_path = _get_hudi_table_path(fs, data_path, "v6_trips_8i1u")
 
-    first_commit = "20250715043008154"
-    second_commit = "20250715043011090"
     ds = ray.data.read_hudi(
         table_path,
         query_type="incremental",
-        hudi_options={
-            "hoodie.read.file_group.start_timestamp": first_commit,
-            "hoodie.read.file_group.end_timestamp": second_commit,
-        },
+        start_timestamp=FIRST_COMMIT,
+        end_timestamp=SECOND_COMMIT,
     )
 
     assert ds.schema().names == [
@@ -147,12 +145,68 @@ def test_hudi_incremental_query_v6_trips_table(ray_start_regular_shared, fs, dat
     rows = ds.select_columns(["_hoodie_commit_time", "ts", "rider", "fare"]).take_all()
     assert rows == [
         {
-            "_hoodie_commit_time": second_commit,
+            "_hoodie_commit_time": SECOND_COMMIT,
             "ts": 1695046462179,
             "rider": "rider-D",
             "fare": 25.0,
         },
     ]
+
+
+@pytest.mark.skipif(
+    not PYARROW_VERSION_MEETS_REQUIREMENT,
+    reason=PYARROW_HUDI_TEST_SKIP_REASON,
+)
+def test_hudi_snapshot_as_of_with_columns_projection(
+    ray_start_regular_shared, local_path
+):
+    """Time-travel snapshot at the first commit, with projection.
+
+    At ``FIRST_COMMIT``, rider-D's fare is the original 33.90 (the update to
+    25.0 lands in the second commit). Projection should narrow the schema and
+    the data.
+    """
+    table_path = _get_hudi_table_path(None, local_path, "v6_trips_8i1u")
+
+    ds = ray.data.read_hudi(
+        table_path,
+        as_of_timestamp=FIRST_COMMIT,
+        filters=[("city", "=", "san_francisco")],
+        columns=["rider", "fare"],
+    )
+
+    assert ds.schema().names == ["rider", "fare"]
+    rows = ds.sort("rider").take_all()
+    assert rows == [
+        {"rider": "rider-A", "fare": 19.10},
+        {"rider": "rider-C", "fare": 27.70},
+        {"rider": "rider-D", "fare": 33.90},
+        {"rider": "rider-E", "fare": 93.50},
+    ]
+
+
+@pytest.mark.skipif(
+    not PYARROW_VERSION_MEETS_REQUIREMENT,
+    reason=PYARROW_HUDI_TEST_SKIP_REASON,
+)
+def test_hudi_incremental_query_honors_filters(ray_start_regular_shared, local_path):
+    """Filters now apply to incremental queries (previously silently ignored).
+
+    The only changed row in the (FIRST_COMMIT, SECOND_COMMIT] range is rider-D
+    in san_francisco, so filtering ``city != san_francisco`` must return 0
+    rows.
+    """
+    table_path = _get_hudi_table_path(None, local_path, "v6_trips_8i1u")
+
+    ds = ray.data.read_hudi(
+        table_path,
+        query_type="incremental",
+        start_timestamp=FIRST_COMMIT,
+        end_timestamp=SECOND_COMMIT,
+        filters=[("city", "!=", "san_francisco")],
+    )
+
+    assert ds.count() == 0
 
 
 if __name__ == "__main__":

--- a/python/requirements/data/pyarrow-latest.txt
+++ b/python/requirements/data/pyarrow-latest.txt
@@ -1,5 +1,5 @@
 pyarrow==23.0.1
-hudi
+hudi @ git+https://github.com/xushiyan/hudi-rs.git@023625379f33254a88032f120328697f1cb8296f#subdirectory=python
 pylance
 modin==0.37.1
 pandas==2.3.3

--- a/python/requirements/data/pyarrow-nightly.txt
+++ b/python/requirements/data/pyarrow-nightly.txt
@@ -1,5 +1,5 @@
 # not including pyarrow as nightly versions will break depset compilation too frequently
-hudi
+hudi @ git+https://github.com/xushiyan/hudi-rs.git@023625379f33254a88032f120328697f1cb8296f#subdirectory=python
 pylance
 modin
 pandas

--- a/python/requirements/data/pyarrow-v17.txt
+++ b/python/requirements/data/pyarrow-v17.txt
@@ -1,7 +1,7 @@
 pyarrow==17.0.0
 numpy
 datasets
-hudi
+hudi @ git+https://github.com/xushiyan/hudi-rs.git@023625379f33254a88032f120328697f1cb8296f#subdirectory=python
 pylance
 modin==0.31.0
 pandas==2.2.3

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -23,6 +23,6 @@ pyiceberg[sql-sqlite]==0.11.0
 clickhouse-connect
 confluent-kafka
 pybase64
-hudi==0.4.0
+hudi @ git+https://github.com/xushiyan/hudi-rs.git@023625379f33254a88032f120328697f1cb8296f#subdirectory=python
 datasketches
 testcontainers[kafka]

--- a/python/requirements/ml/py313/data-test-requirements.txt
+++ b/python/requirements/ml/py313/data-test-requirements.txt
@@ -23,7 +23,7 @@ pyiceberg[sql-sqlite]==0.11.0
 clickhouse-connect
 confluent-kafka
 pybase64
-hudi==0.4.0
+hudi @ git+https://github.com/xushiyan/hudi-rs.git@023625379f33254a88032f120328697f1cb8296f#subdirectory=python
 datasketches
 testcontainers[kafka]
 pyarrow

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -784,7 +784,7 @@ httpx==0.28.1
     #   gradio-client
     #   jupyterlab
     #   openlineage-python
-hudi==0.4.0
+hudi @ git+https://github.com/xushiyan/hudi-rs.git@023625379f33254a88032f120328697f1cb8296f#subdirectory=python
     # via -r python/requirements/ml/data-test-requirements.txt
 huggingface-hub==0.27.0
     # via

--- a/python/requirements_compiled_py3.13.txt
+++ b/python/requirements_compiled_py3.13.txt
@@ -805,7 +805,7 @@ httpx==0.28.1
     #   jupyterlab
     #   openlineage-python
     #   safehttpx
-hudi==0.4.0
+hudi @ git+https://github.com/xushiyan/hudi-rs.git@023625379f33254a88032f120328697f1cb8296f#subdirectory=python
     # via -r python/requirements/ml/py313/data-test-requirements.txt
 huey==2.6.0
     # via mlflow


### PR DESCRIPTION
## Summary

Adopts the new hudi-rs 0.5 Python API surface in Ray's Hudi datasource, fixing a silent data-loss bug on MOR incremental reads, adding several missing capabilities, and populating `BlockMetadata` accurately for both query types.

Pins the `hudi` Python dependency to apache/hudi-rs main HEAD until `0.5.0` publishes to PyPI. The pinned commit is the head of [apache/hudi-rs#592](https://github.com/apache/hudi-rs/pull/592).

## Changes

- **Correctness.** Drop the `hoodie.read.use.read_optimized.mode=true` workaround. `HudiFileGroupReader.read_file_slice_from_paths()` now merges base + log files via the new API, so MOR incremental reads return updates that previously got silently dropped.
- **Capability.** New first-class kwargs on `ray.data.read_hudi()`:
  - `columns` — projection pushdown.
  - `as_of_timestamp` — time-travel snapshots.
  - `start_timestamp` / `end_timestamp` — incremental range (was hidden inside `hudi_options`).
  - `filters` now apply to incremental queries (were silently ignored).
- **Metadata fidelity.** Sum `FileSlice.total_size_bytes()` (base + log) for `BlockMetadata.size_bytes`. Pass `HudiReadOptions` to `HudiTable.compute_table_stats()` so `estimate_inmemory_data_size()` returns real values for both snapshot and incremental queries.
- **Internal.** Migrated to `HudiReadOptions(filters, projection, hudi_options)` and `HudiTable.get_file_slices(options)`. Worker closures capture only primitives (path strings + option-bag dict) since PyO3 pyclass types don't yet implement `__reduce__`. Manual `numpy.array_split` for parallelism since hudi-rs 0.5 unified the splits APIs into a single flat-list call.

## Test plan

- [ ] `pytest python/ray/data/tests/datasource/test_hudi.py -v` against an env with the pinned hudi dev wheel installed (e.g., `cd /path/to/hudi-rs/python && maturin develop --release`)
- [ ] Verify CI data-test lane after lock regeneration + Rust toolchain in image
- [ ] Cover paths: snapshot + filters, snapshot + projection + as-of, incremental + filters, legacy `hudi_options` deprecation warning (all included in `test_hudi.py`)