### PR TITLE
[Data] Replace logical input_op InitVars with input_dependencies

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -1,6 +1,6 @@
 import copy
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterator, List, Optional
 
@@ -21,7 +21,9 @@ class LogicalOperator(Operator, ABC):
     """
 
     _name: Optional[str] = field(init=False, default=None, repr=False)
-    _input_dependencies: List["LogicalOperator"] = field(repr=False)
+    _input_dependencies: List["LogicalOperator"] = field(
+        init=False, default_factory=list, repr=False
+    )
     _num_outputs: Optional[int] = field(default=None, repr=False)
 
     @property
@@ -88,17 +90,12 @@ class LogicalOperator(Operator, ABC):
     def _with_new_input_dependencies(
         self, input_dependencies: List["LogicalOperator"]
     ) -> "LogicalOperator":
-        if len(input_dependencies) == 1 and "input_op" in getattr(
-            self, "__dataclass_fields__", {}
-        ):
-            return self._with_new_input(input_dependencies[0])
+        if "input_dependencies" in {field.name for field in fields(self)}:
+            return replace(self, input_dependencies=input_dependencies)
 
         target = copy.copy(self)
         object.__setattr__(target, "_input_dependencies", input_dependencies)
         return target
-
-    def _with_new_input(self, input_op: "LogicalOperator") -> "LogicalOperator":
-        return replace(self, input_op=input_op)
 
     def _get_args(self) -> Dict[str, Any]:
         """This Dict must be serializable"""

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -56,9 +56,9 @@ class AbstractAllToAll(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            _input_dependencies=[input_op],
             _num_outputs=num_outputs,
         )
+        object.__setattr__(self, "_input_dependencies", [input_op])
         if name is not None:
             object.__setattr__(self, "_name", name)
         object.__setattr__(self, "ray_remote_args", ray_remote_args or {})
@@ -73,19 +73,17 @@ class AbstractAllToAll(LogicalOperator):
 class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for randomize_block_order."""
 
-    input_op: InitVar[LogicalOperator]
     seed_config: Optional[RandomSeedConfig] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.seed_config is None:
             object.__setattr__(self, "seed_config", RandomSeedConfig())
         object.__setattr__(self, "_name", "RandomizeBlockOrder")
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
     def infer_metadata(self) -> "BlockMetadata":
@@ -109,16 +107,15 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
 class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for random_shuffle."""
 
-    input_op: InitVar[LogicalOperator]
     name: InitVar[str] = "RandomShuffle"
     seed_config: Optional[RandomSeedConfig] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator, name: str):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self, name: str):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.seed_config is None:
             object.__setattr__(self, "seed_config", RandomSeedConfig())
         if self.sub_progress_bar_names is None:
@@ -131,11 +128,12 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
                 ],
             )
         object.__setattr__(self, "_name", name)
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
-    def _with_new_input(self, input_op: LogicalOperator) -> LogicalOperator:
-        return replace(self, input_op=input_op, name=self._name)
+    def _with_new_input_dependencies(
+        self, input_dependencies: List[LogicalOperator]
+    ) -> LogicalOperator:
+        return replace(self, input_dependencies=input_dependencies, name=self._name)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -158,18 +156,17 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
 class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for repartition."""
 
-    input_op: InitVar[LogicalOperator]
     num_outputs: InitVar[int]
     shuffle: bool = False
     keys: Optional[List[str]] = None
     sort: bool = False
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     _num_outputs: Optional[int] = field(init=False, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator, num_outputs: int):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self, num_outputs: int):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.shuffle:
             sub_progress_bar_names = [
                 ExchangeTaskSpec.MAP_SUB_PROGRESS_BAR_NAME,
@@ -180,13 +177,14 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
                 ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
             ]
         object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", num_outputs)
 
-    def _with_new_input(self, input_op: LogicalOperator) -> LogicalOperator:
+    def _with_new_input_dependencies(
+        self, input_dependencies: List[LogicalOperator]
+    ) -> LogicalOperator:
         return replace(
             self,
-            input_op=input_op,
+            input_dependencies=input_dependencies,
             num_outputs=self.num_outputs,
         )
 
@@ -211,16 +209,15 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
 class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for sort."""
 
-    input_op: InitVar[LogicalOperator]
     sort_key: SortKey
     batch_format: Optional[str] = "default"
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         object.__setattr__(
             self,
             "sub_progress_bar_names",
@@ -230,7 +227,6 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
     def infer_metadata(self) -> "BlockMetadata":
@@ -254,18 +250,17 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
 class Aggregate(AbstractAllToAll):
     """Logical operator for aggregate."""
 
-    input_op: InitVar[LogicalOperator]
     key: Optional[str]
     aggs: List[AggregateFn]
     num_partitions: Optional[int] = None
     batch_format: Optional[str] = "default"
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         object.__setattr__(
             self,
             "sub_progress_bar_names",
@@ -275,5 +270,4 @@ class Aggregate(AbstractAllToAll):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -19,13 +19,11 @@ class Count(LogicalOperator):
 
     COLUMN_NAME = "__num_rows"
 
-    input_op: InitVar[LogicalOperator]
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_input_dependencies", [input_op])
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
 
     @property
     def num_outputs(self) -> Optional[int]:

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -1,7 +1,7 @@
 import functools
 import inspect
 import logging
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
@@ -191,8 +191,8 @@ class AbstractUDFMap(AbstractMap):
 class MapBatches(AbstractUDFMap):
     """Logical operator for map_batches."""
 
-    input_op: InitVar[LogicalOperator]
     fn: UserDefinedFunction
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     can_modify_num_rows: bool = False
     batch_size: Union[Optional[int], Literal["auto"]] = None
     batch_format: Optional[str] = "default"
@@ -206,11 +206,10 @@ class MapBatches(AbstractUDFMap):
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     per_block_limit: Optional[int] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
         object.__setattr__(
@@ -218,7 +217,6 @@ class MapBatches(AbstractUDFMap):
             "_name",
             self._get_operator_name(self.__class__.__name__, self.fn),
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
 
@@ -226,8 +224,8 @@ class MapBatches(AbstractUDFMap):
 class MapRows(AbstractUDFMap):
     """Logical operator for map."""
 
-    input_op: InitVar[LogicalOperator]
     fn: UserDefinedFunction
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     fn_args: Optional[Iterable[Any]] = None
     fn_kwargs: Optional[Dict[str, Any]] = None
     fn_constructor_args: Optional[Iterable[Any]] = None
@@ -238,15 +236,13 @@ class MapRows(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=False)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
         object.__setattr__(self, "_name", self._get_operator_name("Map", self.fn))
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
 
@@ -254,9 +250,9 @@ class MapRows(AbstractUDFMap):
 class Filter(AbstractUDFMap):
     """Logical operator for filter."""
 
-    input_op: InitVar[LogicalOperator]
     predicate_expr: Optional[Expr] = None
     fn: Optional[UserDefinedFunction] = None
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     fn_args: Optional[Iterable[Any]] = None
     fn_kwargs: Optional[Dict[str, Any]] = None
     fn_constructor_args: Optional[Iterable[Any]] = None
@@ -267,11 +263,10 @@ class Filter(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=True)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         provided_params = sum([self.fn is not None, self.predicate_expr is not None])
         if provided_params != 1:
             raise ValueError(
@@ -285,7 +280,6 @@ class Filter(AbstractUDFMap):
             "_name",
             self._get_operator_name(self.__class__.__name__, self.fn),
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
     def is_expression_based(self) -> bool:
@@ -313,8 +307,8 @@ class Filter(AbstractUDFMap):
 class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for all Projection Operations."""
 
-    input_op: InitVar[LogicalOperator]
     exprs: list["Expr"]
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     compute: Optional[ComputeStrategy] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
@@ -324,11 +318,10 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     batch_format: str = field(init=False, default="pyarrow")
     zero_copy_batch: bool = field(init=False, default=True)
     per_block_limit: Optional[int] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(
                 self, "compute", self._detect_and_get_compute_strategy(self.exprs)
@@ -339,7 +332,6 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
                     "All Project expressions must be named (use .alias(name) or col(name)), "
                     "or be a star() expression."
                 )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
     def _detect_and_get_compute_strategy(self, exprs: list["Expr"]) -> ComputeStrategy:
@@ -400,8 +392,8 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
 class FlatMap(AbstractUDFMap):
     """Logical operator for flat_map."""
 
-    input_op: InitVar[LogicalOperator]
     fn: UserDefinedFunction
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     fn_args: Optional[Iterable[Any]] = None
     fn_kwargs: Optional[Dict[str, Any]] = None
     fn_constructor_args: Optional[Iterable[Any]] = None
@@ -412,11 +404,10 @@ class FlatMap(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=True)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
         object.__setattr__(
@@ -424,7 +415,6 @@ class FlatMap(AbstractUDFMap):
             "_name",
             self._get_operator_name(self.__class__.__name__, self.fn),
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
 
@@ -443,8 +433,8 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
             Defaults to False.
     """
 
-    input_op: InitVar[LogicalOperator]
     target_num_rows_per_block: int
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     strict: bool = False
     can_modify_num_rows: bool = field(init=False, default=False)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
@@ -452,11 +442,10 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     compute: Optional[ComputeStrategy] = None
     per_block_limit: Optional[int] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.target_num_rows_per_block <= 0:
             raise ValueError(
                 "target_num_rows_per_block must be positive for streaming repartition, "
@@ -469,7 +458,6 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
             "_name",
             f"StreamingRepartition[num_rows_per_block={self.target_num_rows_per_block},strict={self.strict}]",
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -28,9 +28,9 @@ class NAry(LogicalOperator):
             input_ops: The input operators.
         """
         super().__init__(
-            _input_dependencies=list(input_ops),
             _num_outputs=num_outputs,
         )
+        object.__setattr__(self, "_input_dependencies", list(input_ops))
 
     @property
     def num_outputs(self) -> Optional[int]:

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
@@ -46,9 +46,9 @@ class AbstractOneToOne(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            _input_dependencies=[input_op] if input_op else [],
             _num_outputs=num_outputs,
         )
+        object.__setattr__(self, "_input_dependencies", [input_op] if input_op else [])
         if name is not None:
             object.__setattr__(self, "_name", name)
         object.__setattr__(self, "can_modify_num_rows", can_modify_num_rows)
@@ -66,16 +66,14 @@ class AbstractOneToOne(LogicalOperator):
 class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for limit."""
 
-    input_op: InitVar[LogicalOperator]
     limit: int
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     can_modify_num_rows: bool = field(init=False, default=True)
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         object.__setattr__(self, "_name", f"limit={self.limit}")
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
 
     def infer_metadata(self) -> BlockMetadata:
@@ -120,21 +118,19 @@ class Download(AbstractOneToOne):
     Supports downloading from multiple URI columns in a single operation.
     """
 
-    input_op: InitVar[LogicalOperator]
     uri_column_names: List[str]
     output_bytes_column_names: List[str]
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     filesystem: Optional["pyarrow.fs.FileSystem"] = None
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     can_modify_num_rows: bool = field(init=False, default=False)
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if len(self.uri_column_names) != len(self.output_bytes_column_names):
             raise ValueError(
                 f"Number of URI columns ({len(self.uri_column_names)}) must match "
                 f"number of output columns ({len(self.output_bytes_column_names)})"
             )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
@@ -15,16 +15,14 @@ __all__ = [
 class StreamingSplit(LogicalOperator):
     """Logical operator that represents splitting the input data to `n` splits."""
 
-    input_op: InitVar[LogicalOperator]
     num_splits: int
     equal: bool
     locality_hints: Optional[List["NodeIdStr"]] = None
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
+    input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
-        assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_input_dependencies", [input_op])
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         object.__setattr__(self, "_num_outputs", None)
 
     @property

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
@@ -16,8 +16,8 @@ __all__ = [
 class Write(AbstractMap):
     """Logical operator for write."""
 
-    input_op: InitVar[LogicalOperator]
     datasink_or_legacy_datasource: Union[Datasink, Datasource]
+    input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     compute: Optional[ComputeStrategy] = None
     write_args: Dict[str, Any] = field(default_factory=dict)
@@ -25,10 +25,10 @@ class Write(AbstractMap):
     min_rows_per_bundled_input: Optional[int] = field(init=False)
     ray_remote_args_fn: None = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
     _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, input_op: LogicalOperator):
+    def __post_init__(self):
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if isinstance(self.datasink_or_legacy_datasource, Datasink):
             min_rows_per_bundled_input = (
                 self.datasink_or_legacy_datasource.min_rows_per_write
@@ -42,5 +42,4 @@ class Write(AbstractMap):
         object.__setattr__(
             self, "min_rows_per_bundled_input", min_rows_per_bundled_input
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)

--- a/python/ray/data/_internal/logical/rules/combine_shuffles.py
+++ b/python/ray/data/_internal/logical/rules/combine_shuffles.py
@@ -47,8 +47,8 @@ class CombineShuffles(Rule):
         if isinstance(input_op, Repartition) and isinstance(op, Repartition):
             shuffle = input_op.shuffle or op.shuffle
             return Repartition(
-                input_op.input_dependencies[0],
                 num_outputs=op.num_outputs,
+                input_dependencies=[input_op.input_dependencies[0]],
                 shuffle=shuffle,
                 keys=op.keys,
                 sort=op.sort,
@@ -58,30 +58,30 @@ class CombineShuffles(Rule):
         ):
             strict = input_op.strict or op.strict
             return StreamingRepartition(
-                input_op.input_dependencies[0],
                 target_num_rows_per_block=op.target_num_rows_per_block,
+                input_dependencies=[input_op.input_dependencies[0]],
                 strict=strict,
             )
         elif isinstance(input_op, Repartition) and isinstance(op, Aggregate):
             return Aggregate(
-                input_op=input_op.input_dependencies[0],
                 key=op.key,
                 aggs=op.aggs,
+                input_dependencies=[input_op.input_dependencies[0]],
                 num_partitions=op.num_partitions,
                 batch_format=op.batch_format,
             )
         elif isinstance(input_op, StreamingRepartition) and isinstance(op, Repartition):
             return Repartition(
-                input_op.input_dependencies[0],
                 num_outputs=op.num_outputs,
+                input_dependencies=[input_op.input_dependencies[0]],
                 shuffle=op.shuffle,
                 keys=op.keys,
                 sort=op.sort,
             )
         elif isinstance(input_op, Sort) and isinstance(op, Sort):
             return Sort(
-                input_op.input_dependencies[0],
                 sort_key=op.sort_key,
+                input_dependencies=[input_op.input_dependencies[0]],
                 batch_format=op.batch_format,
             )
 

--- a/python/ray/data/_internal/logical/rules/inherit_batch_format.py
+++ b/python/ray/data/_internal/logical/rules/inherit_batch_format.py
@@ -41,7 +41,7 @@ class InheritBatchFormatRule(Rule):
                     ):
                         return replace(
                             node,
-                            input_op=node.input_dependencies[0],
+                            input_dependencies=[node.input_dependencies[0]],
                             batch_format=upstream_op.batch_format,
                         )
                 upstream_op = upstream_op.input_dependencies[0]

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -50,7 +50,9 @@ class LimitPushdownRule(Rule):
                 if isinstance(upstream_op, Limit):
                     # Fuse consecutive Limits: Limit[n] -> Limit[m] becomes Limit[min(n,m)]
                     new_limit = min(node.limit, upstream_op.limit)
-                    return Limit(upstream_op.input_dependency, new_limit)
+                    return Limit(
+                        new_limit, input_dependencies=[upstream_op.input_dependency]
+                    )
 
                 # If no fusion, apply pushdown logic
                 if isinstance(upstream_op, Union):
@@ -126,7 +128,7 @@ class LimitPushdownRule(Rule):
             if _branch_has_limit(child, limit_op.limit):
                 branch_tails.append(child)
                 continue
-            raw_limit = Limit(child, limit_op.limit)  # child → limit
+            raw_limit = Limit(limit_op.limit, input_dependencies=[child])
 
             if isinstance(raw_limit.input_dependency, Union):
                 # This represents the limit operator appended after the union.
@@ -137,7 +139,7 @@ class LimitPushdownRule(Rule):
             branch_tails.append(pushed_tail)
 
         new_union = Union(*branch_tails)
-        return Limit(new_union, limit_op.limit)
+        return Limit(limit_op.limit, input_dependencies=[new_union])
 
     def _push_limit_down(self, limit_op: Limit) -> LogicalOperator:
         """Push a single limit down through compatible operators conservatively.
@@ -173,7 +175,7 @@ class LimitPushdownRule(Rule):
         )
 
         # Build the new operator chain: Chain non-preserving number of rows -> Limit -> Operators preserving number of rows
-        new_limit = Limit(limit_input, limit_op.limit)
+        new_limit = Limit(limit_op.limit, input_dependencies=[limit_input])
         result_op = new_limit
 
         # Recreate the intermediate operators and apply per-block limits
@@ -200,7 +202,7 @@ class LimitPushdownRule(Rule):
                 assert len(op.input_dependencies) == 1, len(op.input_dependencies)
                 return replace(
                     op,
-                    input_op=op.input_dependency,
+                    input_dependencies=[op.input_dependency],
                     per_block_limit=limit,
                 )
             new_op = copy.copy(op)
@@ -214,17 +216,17 @@ class LimitPushdownRule(Rule):
         """Create a new operator of the same type as original_op but with new_input as its input."""
 
         if isinstance(original_op, Limit):
-            return Limit(new_input, original_op.limit)
+            return Limit(original_op.limit, input_dependencies=[new_input])
         if isinstance(original_op, Download):
             return Download(
-                new_input,
                 uri_column_names=original_op.uri_column_names,
                 output_bytes_column_names=original_op.output_bytes_column_names,
+                input_dependencies=[new_input],
                 ray_remote_args=original_op.ray_remote_args,
                 filesystem=original_op.filesystem,
             )
         if isinstance(original_op, AbstractMap) and is_dataclass(original_op):
-            return replace(original_op, input_op=new_input)
+            return replace(original_op, input_dependencies=[new_input])
 
         # Use copy and replace input dependencies approach
         new_op = copy.copy(original_op)

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -666,14 +666,14 @@ class FuseOperators(Rule):
 
         if isinstance(down_logical_op, RandomShuffle):
             logical_op = RandomShuffle(
-                input_op,
                 name=name,
+                input_dependencies=[input_op],
                 ray_remote_args=ray_remote_args,
             )
         elif isinstance(down_logical_op, Repartition):
             logical_op = Repartition(
-                input_op,
                 num_outputs=down_logical_op.num_outputs,
+                input_dependencies=[input_op],
                 shuffle=down_logical_op.shuffle,
             )
         self._op_map[op] = logical_op

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -74,8 +74,8 @@ class PredicatePushdown(Rule):
 
         # Create new filter on the input of the lower filter
         return Filter(
-            input_op.input_dependencies[0],
             predicate_expr=combined_predicate,
+            input_dependencies=[input_op.input_dependencies[0]],
         )
 
     @classmethod
@@ -254,8 +254,8 @@ class PredicatePushdown(Rule):
 
                 # Push filter through and recursively try to push further
                 new_filter = Filter(
-                    input_op.input_dependencies[0],
                     predicate_expr=predicate_expr,
+                    input_dependencies=[input_op.input_dependencies[0]],
                 )
                 pushed_filter = cls._try_push_down_predicate(new_filter)
 
@@ -267,7 +267,9 @@ class PredicatePushdown(Rule):
                 # Apply filter to each branch and recursively push down
                 new_inputs = []
                 for branch_op in input_op.input_dependencies:
-                    branch_filter = Filter(branch_op, predicate_expr=predicate_expr)
+                    branch_filter = Filter(
+                        predicate_expr=predicate_expr, input_dependencies=[branch_op]
+                    )
                     pushed_branch = cls._try_push_down_predicate(branch_filter)
                     new_inputs.append(pushed_branch)
 
@@ -307,8 +309,8 @@ class PredicatePushdown(Rule):
         # Push to the appropriate branch
         new_inputs = list(conditional_op.input_dependencies)
         branch_filter = Filter(
-            new_inputs[branch_idx],
             predicate_expr=filter_op.predicate_expr,
+            input_dependencies=[new_inputs[branch_idx]],
         )
         new_inputs[branch_idx] = cls._try_push_down_predicate(branch_filter)
 
@@ -330,13 +332,13 @@ class PredicatePushdown(Rule):
         """
         if isinstance(op, Limit):
             assert len(new_inputs) == 1, len(new_inputs)
-            return Limit(new_inputs[0], op.limit)
+            return Limit(op.limit, input_dependencies=[new_inputs[0]])
         if isinstance(op, AbstractMap) and is_dataclass(op):
             assert len(new_inputs) == 1, len(new_inputs)
-            return replace(op, input_op=new_inputs[0])
+            return replace(op, input_dependencies=[new_inputs[0]])
         if isinstance(op, AbstractAllToAll) and is_dataclass(op):
             assert len(new_inputs) == 1, len(new_inputs)
-            kwargs = {"input_op": new_inputs[0]}
+            kwargs = {"input_dependencies": [new_inputs[0]]}
             if isinstance(op, Repartition):
                 kwargs["num_outputs"] = op.num_outputs
             if isinstance(op, RandomShuffle):

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -261,8 +261,8 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
         new_exprs = projected_upstream_output_col_exprs + rebound_downstream_exprs
 
     return Project(
-        upstream_project.input_dependency,
         exprs=new_exprs,
+        input_dependencies=[upstream_project.input_dependency],
         compute=fused_compute,
         ray_remote_args=downstream_project.ray_remote_args,
     )
@@ -404,8 +404,8 @@ class ProjectionPushdown(Rule):
 
                 # Has transformations: Keep Project on top of optimized Read
                 return Project(
-                    projected_input_op,
                     exprs=current_project.exprs,
+                    input_dependencies=[projected_input_op],
                     compute=current_project.compute,
                     ray_remote_args=current_project.ray_remote_args,
                 )

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -446,8 +446,8 @@ class Dataset:
 
         plan = self._plan.copy()
         map_op = MapRows(
-            self._logical_plan.dag,
             fn,
+            input_dependencies=[self._logical_plan.dag],
             fn_args=fn_args,
             fn_kwargs=fn_kwargs,
             fn_constructor_args=fn_constructor_args,
@@ -812,8 +812,8 @@ class Dataset:
 
         plan = self._plan.copy()
         map_batches_op = MapBatches(
-            self._logical_plan.dag,
             fn,
+            input_dependencies=[self._logical_plan.dag],
             batch_size=batch_size,
             can_modify_num_rows=udf_modifying_row_count,
             batch_format=batch_format,
@@ -913,17 +913,17 @@ class Dataset:
         plan = self._plan.copy()
         if isinstance(expr, DownloadExpr):
             download_op = Download(
-                self._logical_plan.dag,
                 uri_column_names=[expr.uri_column_name],
                 output_bytes_column_names=[column_name],
+                input_dependencies=[self._logical_plan.dag],
                 ray_remote_args=ray_remote_args,
                 filesystem=expr.filesystem,
             )
             logical_plan = LogicalPlan(download_op, self.context)
         else:
             project_op = Project(
-                self._logical_plan.dag,
                 exprs=[StarExpr(), expr.alias(column_name)],
+                input_dependencies=[self._logical_plan.dag],
                 compute=compute,
                 ray_remote_args=ray_remote_args,
             )
@@ -1194,8 +1194,8 @@ class Dataset:
 
         plan = self._plan.copy()
         select_op = Project(
-            self._logical_plan.dag,
             exprs=exprs,
+            input_dependencies=[self._logical_plan.dag],
             compute=compute,
             ray_remote_args=ray_remote_args,
         )
@@ -1322,8 +1322,8 @@ class Dataset:
 
         plan = self._plan.copy()
         select_op = Project(
-            self._logical_plan.dag,
             exprs=[StarExpr(), *exprs],
+            input_dependencies=[self._logical_plan.dag],
             compute=compute,
             ray_remote_args=ray_remote_args,
         )
@@ -1461,8 +1461,8 @@ class Dataset:
 
         plan = self._plan.copy()
         op = FlatMap(
-            input_op=self._logical_plan.dag,
             fn=fn,
+            input_dependencies=[self._logical_plan.dag],
             fn_args=fn_args,
             fn_kwargs=fn_kwargs,
             fn_constructor_args=fn_constructor_args,
@@ -1660,9 +1660,9 @@ class Dataset:
 
         # Create Filter operator with explicitly typed arguments
         filter_op = Filter(
-            input_op=input_op,
             predicate_expr=predicate_expr,
             fn=filter_fn,
+            input_dependencies=[input_op],
             fn_args=filter_fn_args,
             fn_kwargs=filter_fn_kwargs,
             fn_constructor_args=filter_fn_constructor_args,
@@ -1801,14 +1801,14 @@ class Dataset:
         plan = self._plan.copy()
         if target_num_rows_per_block is not None:
             op = StreamingRepartition(
-                self._logical_plan.dag,
                 target_num_rows_per_block=target_num_rows_per_block,
+                input_dependencies=[self._logical_plan.dag],
                 strict=strict,
             )
         else:
             op = Repartition(
-                self._logical_plan.dag,
                 num_outputs=num_blocks,
+                input_dependencies=[self._logical_plan.dag],
                 shuffle=shuffle,
                 keys=keys,
                 sort=sort,
@@ -1892,8 +1892,8 @@ class Dataset:
 
         plan = self._plan.copy()
         op = RandomShuffle(
-            self._logical_plan.dag,
             seed_config=seed_config,
+            input_dependencies=[self._logical_plan.dag],
             ray_remote_args=ray_remote_args,
         )
         logical_plan = LogicalPlan(op, self.context)
@@ -1946,8 +1946,8 @@ class Dataset:
 
         plan = self._plan.copy()
         op = RandomizeBlocks(
-            self._logical_plan.dag,
             seed_config=seed_config,
+            input_dependencies=[self._logical_plan.dag],
         )
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
@@ -2132,9 +2132,9 @@ class Dataset:
         """
         plan = self._plan.copy()
         op = StreamingSplit(
-            self._logical_plan.dag,
             num_splits=n,
             equal=equal,
+            input_dependencies=[self._logical_plan.dag],
             locality_hints=locality_hints,
         )
         logical_plan = LogicalPlan(op, self.context)
@@ -3650,8 +3650,8 @@ class Dataset:
         sort_key = SortKey(key, descending, boundaries)
         plan = self._plan.copy()
         op = Sort(
-            self._logical_plan.dag,
             sort_key=sort_key,
+            input_dependencies=[self._logical_plan.dag],
         )
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
@@ -3721,7 +3721,7 @@ class Dataset:
             The truncated dataset.
         """
         plan = self._plan.copy()
-        op = Limit(self._logical_plan.dag, limit=limit)
+        op = Limit(limit=limit, input_dependencies=[self._logical_plan.dag])
         logical_plan = LogicalPlan(op, self.context)
         return Dataset(plan, logical_plan)
 
@@ -3944,7 +3944,11 @@ class Dataset:
 
         # NOTE: Project the dataset to avoid the need to carry actual
         #       data when we're only interested in the total count
-        count_op = Count(Project(self._logical_plan.dag, exprs=[]))
+        count_op = Count(
+            input_dependencies=[
+                Project(exprs=[], input_dependencies=[self._logical_plan.dag])
+            ]
+        )
         logical_plan = LogicalPlan(count_op, self.context)
         count_ds = Dataset(plan, logical_plan)
 
@@ -5737,8 +5741,8 @@ class Dataset:
 
         plan = self._plan.copy()
         write_op = Write(
-            self._logical_plan.dag,
             datasink,
+            input_dependencies=[self._logical_plan.dag],
             ray_remote_args=ray_remote_args,
             compute=TaskPoolStrategy(concurrency),
         )

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -65,9 +65,9 @@ class GroupedData:
 
         plan = self._dataset._plan.copy()
         op = Aggregate(
-            self._dataset._logical_plan.dag,
             key=self._key,
             aggs=aggs,
+            input_dependencies=[self._dataset._logical_plan.dag],
             num_partitions=self._num_partitions,
         )
         logical_plan = LogicalPlan(op, self._dataset.context)

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -125,7 +125,7 @@ def generate_sample_physical_plan(generate_sample_data_csv, tmp_path):
 
     read_op = Read(datasource, datasource, -1, None)
     write_path = os.path.join(tmp_path, "output")
-    write_op = Write(read_op, ParquetDatasink(write_path))
+    write_op = Write(ParquetDatasink(write_path), input_dependencies=[read_op])
     logical_plan = LogicalPlan(write_op, ctx)
     physical_plan, _ = get_execution_plan(logical_plan)
     yield physical_plan

--- a/python/ray/data/tests/test_execution_optimizer_advanced.py
+++ b/python/ray/data/tests/test_execution_optimizer_advanced.py
@@ -49,8 +49,8 @@ def test_random_shuffle_operator(ray_start_regular_shared_2_cpus):
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = RandomShuffle(
-        read_op,
         seed_config=RandomSeedConfig(seed=0),
+        input_dependencies=[read_op],
     )
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)
@@ -84,7 +84,7 @@ def test_repartition_operator(ray_start_regular_shared_2_cpus, shuffle):
 
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = Repartition(read_op, num_outputs=5, shuffle=shuffle)
+    op = Repartition(num_outputs=5, shuffle=shuffle, input_dependencies=[read_op])
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)
     physical_op = physical_plan.dag
@@ -166,8 +166,8 @@ def test_write_operator(ray_start_regular_shared_2_cpus, tmp_path):
     datasink = ParquetDatasink(tmp_path)
     read_op = get_parquet_read_logical_op()
     op = Write(
-        read_op,
         datasink,
+        input_dependencies=[read_op],
         compute=TaskPoolStrategy(concurrency),
     )
     plan = LogicalPlan(op, ctx)
@@ -192,8 +192,8 @@ def test_sort_operator(
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = Sort(
-        read_op,
         sort_key=SortKey("col1"),
+        input_dependencies=[read_op],
     )
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)
@@ -268,9 +268,11 @@ def test_inherit_batch_format_rule():
     ctx = DataContext.get_current()
 
     operator1 = get_parquet_read_logical_op()
-    operator2 = MapBatches(operator1, fn=lambda g: g, batch_format="pandas")
+    operator2 = MapBatches(
+        fn=lambda g: g, batch_format="pandas", input_dependencies=[operator1]
+    )
     sort_key = SortKey("number", descending=True)
-    operator3 = Sort(operator2, sort_key)
+    operator3 = Sort(sort_key, input_dependencies=[operator2])
     original_plan = LogicalPlan(dag=operator3, context=ctx)
 
     rule = InheritBatchFormatRule()

--- a/python/ray/data/tests/test_execution_optimizer_basic.py
+++ b/python/ray/data/tests/test_execution_optimizer_basic.py
@@ -103,8 +103,8 @@ def test_split_blocks_operator(ray_start_regular_shared_2_cpus):
 
     # Test that split blocks prevents fusion.
     op = MapBatches(
-        op,
         lambda x: x,
+        input_dependencies=[op],
     )
     logical_plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(logical_plan)
@@ -190,8 +190,8 @@ def test_map_operator_udf_name(ray_start_regular_shared_2_cpus):
 
     for udf, expected_name in zip(udf_list, expected_names):
         op = MapRows(
-            get_parquet_read_logical_op(),
             udf,
+            input_dependencies=[get_parquet_read_logical_op()],
         )
         assert op.name == f"Map({expected_name})"
 
@@ -202,8 +202,8 @@ def test_map_batches_operator(ray_start_regular_shared_2_cpus):
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = MapBatches(
-        read_op,
         lambda x: x,
+        input_dependencies=[read_op],
     )
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)
@@ -231,8 +231,8 @@ def test_map_rows_operator(ray_start_regular_shared_2_cpus):
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = MapRows(
-        read_op,
         lambda x: x,
+        input_dependencies=[read_op],
     )
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)
@@ -259,8 +259,8 @@ def test_filter_operator(ray_start_regular_shared_2_cpus):
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = Filter(
-        read_op,
         fn=lambda x: x,
+        input_dependencies=[read_op],
     )
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)
@@ -336,8 +336,8 @@ def test_flat_map(ray_start_regular_shared_2_cpus):
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = FlatMap(
-        read_op,
         lambda x: x,
+        input_dependencies=[read_op],
     )
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -39,9 +39,9 @@ def _check_valid_plan_and_result(
 class _DummyLogicalOperator(LogicalOperator):
     def __init__(self, input_dependencies, name=None, num_outputs=None):
         super().__init__(
-            _input_dependencies=input_dependencies,
             _num_outputs=num_outputs,
         )
+        object.__setattr__(self, "_input_dependencies", input_dependencies)
         if name is not None:
             object.__setattr__(self, "_name", name)
 
@@ -53,11 +53,11 @@ class _DummyLogicalOperator(LogicalOperator):
 def test_limit_pushdown_recreates_frozen_download():
     input_op = _DummyLogicalOperator(input_dependencies=[], name="DummyInput")
     download_op = Download(
-        input_op=input_op,
         uri_column_names=["uri"],
         output_bytes_column_names=["bytes"],
+        input_dependencies=[input_op],
     )
-    limit_op = Limit(download_op, 1)
+    limit_op = Limit(1, input_dependencies=[download_op])
 
     result = LimitPushdownRule()._push_limit_down(limit_op)
 

--- a/python/ray/data/tests/test_gpu_shuffle.py
+++ b/python/ray/data/tests/test_gpu_shuffle.py
@@ -574,8 +574,8 @@ class TestPlanAllToAllOpRouting:
 
     def _make_repartition_op(self, keys=("user_id",), num_outputs=8):
         return Repartition(
-            input_op=MagicMock(LogicalOperator),
             num_outputs=num_outputs,
+            input_dependencies=[MagicMock(LogicalOperator)],
             shuffle=True,
             keys=list(keys),
         )

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -43,8 +43,8 @@ def test_read_map_batches_operator_fusion(ray_start_regular_shared_2_cpus):
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
     op = MapBatches(
-        read_op,
         lambda x: x,
+        input_dependencies=[read_op],
     )
     logical_plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(logical_plan)
@@ -67,10 +67,10 @@ def test_read_map_chain_operator_fusion(ray_start_regular_shared_2_cpus):
     # Test that a chain of different map operators are fused.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    map1 = MapRows(read_op, lambda x: x)
-    map2 = MapBatches(map1, lambda x: x)
-    map3 = FlatMap(map2, lambda x: x)
-    map4 = Filter(map3, fn=lambda x: x)
+    map1 = MapRows(lambda x: x, input_dependencies=[read_op])
+    map2 = MapBatches(lambda x: x, input_dependencies=[map1])
+    map3 = FlatMap(lambda x: x, input_dependencies=[map2])
+    map4 = Filter(fn=lambda x: x, input_dependencies=[map3])
     logical_plan = LogicalPlan(map4, ctx)
     physical_plan, _ = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -116,8 +116,12 @@ def test_read_map_batches_operator_fusion_compatible_remote_args(
             ray_remote_args={"resources": {"non-existent": 1}},
             parallelism=1,
         )
-        op = MapBatches(read_op, lambda x: x, ray_remote_args=up_remote_args)
-        op = MapBatches(op, lambda x: x, ray_remote_args=down_remote_args)
+        op = MapBatches(
+            lambda x: x, input_dependencies=[read_op], ray_remote_args=up_remote_args
+        )
+        op = MapBatches(
+            lambda x: x, input_dependencies=[op], ray_remote_args=down_remote_args
+        )
         logical_plan = LogicalPlan(op, ctx)
 
         physical_plan, _ = planner.plan(logical_plan)
@@ -167,8 +171,12 @@ def test_read_map_batches_operator_fusion_incompatible_remote_args(
         read_op = get_parquet_read_logical_op(
             ray_remote_args={"resources": {"non-existent": 1}}
         )
-        op = MapBatches(read_op, lambda x: x, ray_remote_args=up_remote_args)
-        op = MapBatches(op, lambda x: x, ray_remote_args=down_remote_args)
+        op = MapBatches(
+            lambda x: x, input_dependencies=[read_op], ray_remote_args=up_remote_args
+        )
+        op = MapBatches(
+            lambda x: x, input_dependencies=[op], ray_remote_args=down_remote_args
+        )
         logical_plan = LogicalPlan(op, ctx)
         physical_plan, _ = planner.plan(logical_plan)
         physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -199,8 +207,10 @@ def test_read_map_batches_operator_fusion_compute_tasks_to_actors(
     # the former comes before the latter.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(read_op, lambda x: x)
-    op = MapBatches(op, lambda x: x, compute=ray.data.ActorPoolStrategy())
+    op = MapBatches(lambda x: x, input_dependencies=[read_op])
+    op = MapBatches(
+        lambda x: x, input_dependencies=[op], compute=ray.data.ActorPoolStrategy()
+    )
     logical_plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -221,7 +231,9 @@ def test_read_map_batches_operator_fusion_compute_read_to_actors(
     # Test that reads fuse into an actor-based map operator.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(read_op, lambda x: x, compute=ray.data.ActorPoolStrategy())
+    op = MapBatches(
+        lambda x: x, input_dependencies=[read_op], compute=ray.data.ActorPoolStrategy()
+    )
     logical_plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -242,8 +254,10 @@ def test_read_map_batches_operator_fusion_incompatible_compute(
     # Test that map operators are not fused when compute strategies are incompatible.
     planner = create_planner()
     read_op = get_parquet_read_logical_op(parallelism=1)
-    op = MapBatches(read_op, lambda x: x, compute=ray.data.ActorPoolStrategy())
-    op = MapBatches(op, lambda x: x)
+    op = MapBatches(
+        lambda x: x, input_dependencies=[read_op], compute=ray.data.ActorPoolStrategy()
+    )
+    op = MapBatches(lambda x: x, input_dependencies=[op])
     logical_plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(logical_plan)
     physical_plan = PhysicalOptimizer().optimize(physical_plan)
@@ -308,27 +322,27 @@ def test_read_with_map_batches_fused_successfully(
         ),
         (
             # No fusion (could drastically reduce dataset)
-            Filter(InputData([]), fn=lambda x: False),
+            Filter(fn=lambda x: False, input_dependencies=[InputData([])]),
             False,
         ),
         (
             # No fusion (could drastically expand/reduce dataset)
-            FlatMap(InputData([]), lambda x: x),
+            FlatMap(lambda x: x, input_dependencies=[InputData([])]),
             False,
         ),
         (
             # Fusion
-            MapBatches(InputData([]), lambda x: x),
+            MapBatches(lambda x: x, input_dependencies=[InputData([])]),
             True,
         ),
         (
             # Fusion
-            MapRows(InputData([]), lambda x: x),
+            MapRows(lambda x: x, input_dependencies=[InputData([])]),
             True,
         ),
         (
             # Fusion
-            Project(InputData([]), exprs=[star()]),
+            Project(exprs=[star()], input_dependencies=[InputData([])]),
             True,
         ),
     ],
@@ -720,7 +734,7 @@ def test_zero_copy_fusion_eliminate_build_output_blocks(
     # Test the EliminateBuildOutputBlocks optimization rule.
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
-    op = MapBatches(read_op, lambda x: x)
+    op = MapBatches(lambda x: x, input_dependencies=[read_op])
     logical_plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(logical_plan)
 

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -123,7 +123,11 @@ class TestProjectionFusion:
                 named_expr = expr.alias(name)
                 exprs.append(named_expr)
 
-            current_op = Project(current_op, exprs=[star()] + exprs, ray_remote_args={})
+            current_op = Project(
+                exprs=[star()] + exprs,
+                input_dependencies=[current_op],
+                ray_remote_args={},
+            )
 
         return current_op
 

--- a/python/ray/data/tests/test_randomize_block_order.py
+++ b/python/ray/data/tests/test_randomize_block_order.py
@@ -18,8 +18,8 @@ def test_randomize_blocks_operator(ray_start_regular_shared):
     planner = create_planner()
     read_op = get_parquet_read_logical_op()
     op = RandomizeBlocks(
-        read_op,
         seed_config=RandomSeedConfig(seed=0),
+        input_dependencies=[read_op],
     )
     plan = LogicalPlan(op, ctx)
     physical_plan, _ = planner.plan(plan)

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -92,9 +92,9 @@ class DummyLogicalOperator(LogicalOperator):
 
     def __init__(self, input_op=None):
         super().__init__(
-            _input_dependencies=[],
             _num_outputs=None,
         )
+        object.__setattr__(self, "_input_dependencies", [])
         object.__setattr__(self, "_name", "DummyOperator")
 
         # Test various data types that might be returned by _get_logical_args

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -5,9 +5,9 @@ from ray.data.context import DataContext
 class DummyLogicalOperator(LogicalOperator):
     def __init__(self, input_dependencies, name=None, num_outputs=None):
         super().__init__(
-            _input_dependencies=input_dependencies,
             _num_outputs=num_outputs,
         )
+        object.__setattr__(self, "_input_dependencies", input_dependencies)
         if name is not None:
             object.__setattr__(self, "_name", name)
 


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

After deduplicating `_apply_transform`, single-input logical operators still use `input_op: InitVar` plus `__post_init__` wiring to populate `_input_dependencies`. The next step is to make `input_dependencies` the explicit constructor field, so callers pass `input_dependencies=[input_op]` directly.

#### What this PR changes:

Replaces single-input logical operator `input_op: InitVar` fields with keyword-only `input_dependencies` dataclass fields.

This updates the affected single-input logical operators, Dataset/grouped-data construction paths, logical optimizer rules, and related tests to construct those operators through `input_dependencies=[...]`.

The shared logical-operator rebuild path now uses `dataclasses.replace(self, input_dependencies=...)` when the operator exposes that field. `RandomShuffle` and `Repartition` keep small rebuild hooks because they still have InitVar-only constructor values that must be passed during replacement.

This PR does not remove `input_dependency` from `AbstractOneToOne`, clean up `_get_args`, remove redundant `__repr__` / `__str__`, clean up broader logical-rule special-casing, or change equality/comparability semantics. Those remain separate follow-ups in the current split plan.

## Related issues

Part of #60312

## Additional information

This PR corresponds to the `input_op: InitVar` replacement step in the current split plan.

### Tests

- `pre-commit run --files $(git diff --name-only)`
- Targeted logical optimizer/operator tests for map, all-to-all, limit pushdown, predicate pushdown, projection fusion, and operator fusion paths
- One local `test_pushdown_filter_lance[s3_fs-s3_path]` setup failed because the mock S3 health check timed out through a local SOCKS proxy; the other targeted test paths passed locally

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- PR-Next-0: Convert the remaining concrete logical operators to frozen dataclasses
- PR-Next-1: Convert abstract logical operator classes to frozen dataclasses
- PR-Next-2: make logical-operator names derived by default
- PR-Next-3: deduplicate `_apply_transform`
- This PR: replace `input_op: InitVar` with a real `input_dependencies` field

Next:
- remove `input_dependency` on `AbstractOneToOne`
- clean up `_get_args`
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`
