### PR TITLE
fix(core): raise helpful ImportError for missing psutil C extensions

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -52,6 +52,26 @@ def _configure_system():
     )
     sys.path.insert(0, thirdparty_files)
 
+    try:
+        import psutil  # noqa: F401
+    except ImportError as e:
+        _psutil_cext_names = ("_psutil_osx", "_psutil_linux", "_psutil_windows")
+        if os.path.exists(thirdparty_files) and any(
+            name in str(e) for name in _psutil_cext_names
+        ):
+            raise ImportError(
+                f"Ray failed to import psutil: {e}\n\n"
+                "This usually happens when building Ray from source and the "
+                "thirdparty_files directory is incomplete or stale. "
+                "To fix this, run:\n\n"
+                "    rm -rf python/ray/thirdparty_files/\n"
+                "    python3 -m pip install psutil\n\n"
+                "Then rebuild Ray from source. "
+                "See https://docs.ray.io/en/latest/ray-contribute/development.html"
+                " for full build instructions."
+            ) from e
+        raise
+
     if (
         platform.system() == "Linux"
         and "Microsoft".lower() in platform.release().lower()


### PR DESCRIPTION
When building Ray from source, psutil's C extensions (_psutil_osx, _psutil_linux) can fail to import if thirdparty_files is incomplete or stale. Previously this surfaced as a cryptic 'partially initialized module / circular import' error with no actionable guidance.

This wraps the psutil import in ray/__init__.py in a targeted try/except: if thirdparty_files exists and a known C extension name appears in the error, a clear message is raised with the exact commands needed to resolve the issue.

Fixes #28903

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
