### PR TITLE
[Data] Revert raw-modulo hash partition fast path

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -107,13 +107,7 @@ def _hash_partition(
     table: "pyarrow.Table",
     num_partitions: int,
 ) -> np.ndarray:
-    # NOTE: We special-case single column with integer type,
-    #       short-circuiting the need for hashing the column and instead
-    #       using values as-is for partitioning.
-    if len(table.columns) == 1 and pyarrow.types.is_integer(table.column(0).type):
-        target_column = table.column(0)
-        partitions = (target_column.to_numpy() % num_partitions).astype(np.int64)
-    elif _has_unhashable_pandas_types(table.schema):
+    if _has_unhashable_pandas_types(table.schema):
         # Struct/list/map columns become dicts/lists in pandas, which are
         # unhashable. Use row-by-row hashing on PyArrow scalars instead.
         partitions = np.zeros((table.num_rows,), dtype=np.int64)


### PR DESCRIPTION
## Description
- Reverts the single-integer-column shortcut from #62587 that used `value % num_partitions` instead of hashing, interger will use panda hash from #62757
- Raw modulo creates partition skew on non-uniform integer distributions (e.g., TPC-H sparse orderkeys), causing ~15% regression on TPC-H Q3 (52s → 60s)

## Result 

Runtime of TPCH q3 is back to normal, from 72.0s → 50.5s
### Before fix
```                                                                                                                                                            
(base) ray@ip-10-0-150-35:~/default$ python release/nightly_tests/dataset/tpch/tpch_q3.py --sf 100                                                             
2026-05-04 02:44:13,892 INFO streaming_executor.py:294 -- ✔️  Dataset dataset_82_0 execution finished in 46.19 seconds                                          
Result of case tpch_q3: {'time': 71.99991431299998, 'object_store_spilled_total_gb': 0.0, 'sf': 100}                                                           
Finished benchmark, metrics exported to './result.json':                                                                                                       
{                                                                                                                                                              
    "tpch_q3": {                                                                                                                                               
        "time": 71.99991431299998,                                                                                                                             
        "object_store_spilled_total_gb": 0.0,                                                                                                                  
        "sf": 100                                                                                                                                              
    }                                                                                                                                                          
}                                                                                                                                                                                                                                                                                                               
```
### After fix 
```
(base) ray@ip-10-0-150-35:~/default$ python release/nightly_tests/dataset/tpch/tpch_q3.py --sf 100                                                             
2026-05-04 02:42:18,468 INFO streaming_executor.py:294 -- ✔️  Dataset dataset_61_0 execution finished in 35.09 seconds                                          
Result of case tpch_q3: {'time': 50.5168060389999, 'object_store_spilled_total_gb': 0.0, 'sf': 100}                                                            
Finished benchmark, metrics exported to './result.json':                                                                                                       
{                                                                                                                                                              
    "tpch_q3": {                                                                                                                                               
        "time": 50.5168060389999,                                                                                                                              
        "object_store_spilled_total_gb": 0.0,                                                                                                                  
        "sf": 100                                                                                                                                              
    }                                                                                                                                                          
} 
```


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
