### PR TITLE
[Air / Train] Add `Result.get_best_checkpoint(return_metrics: bool)`

### DIFF
--- a/python/ray/air/result.py
+++ b/python/ray/air/result.py
@@ -249,8 +249,8 @@ class Result:
 
     @PublicAPI(stability="alpha")
     def get_best_checkpoint(
-        self, metric: str, mode: str
-    ) -> Optional["ray.tune.Checkpoint"]:
+        self, metric: str, mode: str, return_metrics: bool = False
+    ) -> Union["ray.tune.Checkpoint", Tuple["ray.tune.Checkpoint", Dict[str, Any]]]:
         """Get the best checkpoint from this trial based on a specific metric.
 
         Any checkpoints without an associated metric value will be filtered out.
@@ -258,10 +258,12 @@ class Result:
         Args:
             metric: The key for checkpoints to order on.
             mode: One of ["min", "max"].
+            return_metrics: If True, returns the best checkpoint and all its
+                recorded metrics.
 
         Returns:
-            :class:`Checkpoint <ray.train.Checkpoint>` object, or None if there is
-            no valid checkpoint associated with the metric.
+            :class:`Checkpoint <ray.tune.Checkpoint>` object or
+            ``(checkpoint, metrics)`` tuple if ``return_metric`` is True.
         """
         if not self.best_checkpoints:
             raise RuntimeError("No checkpoint exists in the trial directory!")
@@ -273,15 +275,17 @@ class Result:
 
         op = max if mode == "max" else min
         valid_checkpoints = [
-            ckpt_info
-            for ckpt_info in self.best_checkpoints
-            if unflattened_lookup(metric, ckpt_info[1], default=None) is not None
+            (ckpt, metrics, value)
+            for ckpt, metrics in self.best_checkpoints
+            if (value := unflattened_lookup(metric, metrics, default=None)) is not None
         ]
 
-        if not valid_checkpoints:
-            raise RuntimeError(
-                f"Invalid metric name {metric}! "
-                f"You may choose from the following metrics: {self.metrics.keys()}."
-            )
+        if len(valid_checkpoints) == 0:
+            raise RuntimeError(f"No checkpoint's metrics contain {metric} as a key.")
 
-        return op(valid_checkpoints, key=lambda x: unflattened_lookup(metric, x[1]))[0]
+        best_ckpt, best_metrics, best_value = op(
+            valid_checkpoints, key=lambda ckpt_metrics_value: ckpt_metrics_value[2]
+        )
+        if return_metrics:
+            return best_ckpt, best_metrics
+        return best_ckpt

--- a/python/ray/air/result.py
+++ b/python/ray/air/result.py
@@ -263,7 +263,7 @@ class Result:
 
         Returns:
             :class:`Checkpoint <ray.tune.Checkpoint>` object or
-            ``(checkpoint, metrics)`` tuple if ``return_metric`` is True.
+            ``(checkpoint, metrics)`` tuple if ``return_metrics`` is True.
         """
         if not self.best_checkpoints:
             raise RuntimeError("No checkpoint exists in the trial directory!")

--- a/python/ray/air/result.py
+++ b/python/ray/air/result.py
@@ -281,7 +281,12 @@ class Result:
         ]
 
         if len(valid_checkpoints) == 0:
-            raise RuntimeError(f"No checkpoint's metrics contain {metric} as a key.")
+            # this is technically missing recursive keys from "unflattened_lookup"
+            available = sorted({k for _, m in self.best_checkpoints for k in m})
+            raise RuntimeError(
+                f"No checkpoint's metrics contains {metric!r} as a key. "
+                f"Available metrics are {available}"
+            )
 
         best_ckpt, best_metrics, best_value = op(
             valid_checkpoints, key=lambda ckpt_metrics_value: ckpt_metrics_value[2]

--- a/python/ray/train/tests/test_result.py
+++ b/python/ray/train/tests/test_result.py
@@ -122,7 +122,7 @@ def test_result_restore(ray_start_4_cpus, tmpdir, mock_s3_bucket_uri, storage, m
     best_ckpt_b = result.get_best_checkpoint(metric="metric_b", mode="max")
     assert load_dict_checkpoint(best_ckpt_b)["iter"] == NUM_ITERATIONS - NUM_CHECKPOINTS
 
-    with pytest.raises(RuntimeError, match="Invalid metric name.*"):
+    with pytest.raises(RuntimeError, match="No checkpoint's metrics contains.*"):
         result.get_best_checkpoint(metric="invalid_metric", mode="max")
 
     # Check if we properly restored errors

--- a/python/ray/train/v2/api/result.py
+++ b/python/ray/train/v2/api/result.py
@@ -57,9 +57,23 @@ class Result(ResultV1):
 
     @PublicAPI(stability="alpha")
     def get_best_checkpoint(
-        self, metric: str, mode: str
-    ) -> Optional["ray.train.Checkpoint"]:
-        return super().get_best_checkpoint(metric, mode)
+        self, metric: str, mode: str, return_metrics: bool = False
+    ) -> Union["ray.train.Checkpoint", Tuple["ray.train.Checkpoint", Dict[str, Any]]]:
+        """Get the best checkpoint from this trial based on a specific metric.
+
+        Any checkpoints without an associated metric value will be filtered out.
+
+        Args:
+            metric: The key for checkpoints to order on.
+            mode: One of ["min", "max"].
+            return_metrics: If True, returns the best checkpoint and all its
+                recorded metrics.
+
+        Returns:
+            :class:`Checkpoint <ray.train.Checkpoint>` object or
+            ``(checkpoint, metrics)`` tuple if ``return_metric`` is True.
+        """
+        return super().get_best_checkpoint(metric, mode, return_metrics)
 
     @classmethod
     def from_path(

--- a/python/ray/train/v2/api/result.py
+++ b/python/ray/train/v2/api/result.py
@@ -59,9 +59,11 @@ class Result(ResultV1):
     def get_best_checkpoint(
         self, metric: str, mode: str, return_metrics: bool = False
     ) -> Union["ray.train.Checkpoint", Tuple["ray.train.Checkpoint", Dict[str, Any]]]:
-        """Get the best checkpoint from this trial based on a specific metric.
+        """Get the best checkpoint from this training result based on a specific metric.
 
         Any checkpoints without an associated metric value will be filtered out.
+        For values in a nested dictionary can be access through using a slash
+        between metrics like ``"root_key/nested_key"``.
 
         Args:
             metric: The key for checkpoints to order on.

--- a/python/ray/train/v2/api/result.py
+++ b/python/ray/train/v2/api/result.py
@@ -71,7 +71,7 @@ class Result(ResultV1):
 
         Returns:
             :class:`Checkpoint <ray.train.Checkpoint>` object or
-            ``(checkpoint, metrics)`` tuple if ``return_metric`` is True.
+            ``(checkpoint, metrics)`` tuple if ``return_metrics`` is True.
         """
         return super().get_best_checkpoint(metric, mode, return_metrics)
 

--- a/python/ray/train/v2/tests/test_result.py
+++ b/python/ray/train/v2/tests/test_result.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
@@ -129,6 +130,14 @@ def test_get_best_checkpoint():
     )
     assert metric == {"iter": 0, "metric": 1.0}
 
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "No checkpoint's metrics contains 'missing-metric' as a key. Available metrics are ['iter', 'metric']"
+        ),
+    ):
+        res.get_best_checkpoint(metric="missing-metric", mode="max")
+
 
 def test_get_best_checkpoint_nested_metrics():
     """Test that get_best_checkpoint works with nested metric dictionaries."""
@@ -227,6 +236,15 @@ def test_get_best_checkpoint_nested_metrics():
         metric="env_runners/episode_return_mean", mode="max", return_metrics=True
     )
     assert metrics == {"iter": 1, "env_runners/episode_return_mean": 200.0}
+
+    # Test if the key is missing
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "No checkpoint's metrics contains 'missing-metric' as a key. Available metrics are ['env_runners', 'iter']"
+        ),
+    ):
+        res.get_best_checkpoint(metric="missing-metric", mode="max")
 
 
 @pytest.mark.parametrize("path_type", ["str", "PathLike"])

--- a/python/ray/train/v2/tests/test_result.py
+++ b/python/ray/train/v2/tests/test_result.py
@@ -119,6 +119,16 @@ def test_get_best_checkpoint():
         == "/bucket/path/ckpt0"
     )
 
+    # Test `return_metrics=True`
+    ckpt, metric = res.get_best_checkpoint(
+        metric="metric", mode="max", return_metrics=True
+    )
+    assert metric == {"iter": 3, "metric": 4.0}
+    ckpt, metric = res.get_best_checkpoint(
+        metric="metric", mode="min", return_metrics=True
+    )
+    assert metric == {"iter": 0, "metric": 1.0}
+
 
 def test_get_best_checkpoint_nested_metrics():
     """Test that get_best_checkpoint works with nested metric dictionaries."""
@@ -167,6 +177,13 @@ def test_get_best_checkpoint_nested_metrics():
         ).path
         == "/bucket/path/ckpt3"
     )
+    ckpt, metrics = res.get_best_checkpoint(
+        metric="env_runners/episode_return_mean", mode="max", return_metrics=True
+    )
+    assert metrics == {
+        "iter": 3,
+        "env_runners": {"episode_return_mean": 400.0, "num_episodes": 10},
+    }
 
     # Test min mode with nested metric
     assert (
@@ -175,6 +192,13 @@ def test_get_best_checkpoint_nested_metrics():
         ).path
         == "/bucket/path/ckpt0"
     )
+    ckpt, metrics = res.get_best_checkpoint(
+        metric="env_runners/episode_return_mean", mode="min", return_metrics=True
+    )
+    assert metrics == {
+        "iter": 0,
+        "env_runners": {"episode_return_mean": 100.0, "num_episodes": 10},
+    }
 
     # Test that flat keys still work (backwards compatibility)
     res_flat = Result(
@@ -199,6 +223,10 @@ def test_get_best_checkpoint_nested_metrics():
         ).path
         == "/bucket/path/ckpt1"
     )
+    ckpt, metrics = res_flat.get_best_checkpoint(
+        metric="env_runners/episode_return_mean", mode="max", return_metrics=True
+    )
+    assert metrics == {"iter": 1, "env_runners/episode_return_mean": 200.0}
 
 
 @pytest.mark.parametrize("path_type", ["str", "PathLike"])

--- a/python/ray/train/v2/tests/test_result.py
+++ b/python/ray/train/v2/tests/test_result.py
@@ -321,7 +321,7 @@ def test_result_restore(
     best_ckpt_b = result.get_best_checkpoint(metric="metric_b", mode="max")
     assert load_dict_checkpoint(best_ckpt_b)["iter"] == num_iterations - num_checkpoints
 
-    with pytest.raises(RuntimeError, match="Invalid metric name.*"):
+    with pytest.raises(RuntimeError, match="No checkpoint's metrics contains.*"):
         result.get_best_checkpoint(metric="invalid_metric", mode="max")
 
 


### PR DESCRIPTION
## Description
`Result.get_best_checkpoint` allows users to get the best checkpoint according to a metric and if they want the max or min of it. However, there isn't a simple way of getting that respective checkpoint's metrics as `best_checkpoints` is a `list[tuple[Checkpoint, Metrics]]`.
Therefore, this PR adds `return_metrics: bool = False` to the method allowing the checkpoint's corresponding metrics to returned alongside the checkpoint. 
To preserve backwards compatibility, `return_metrics` defaults to false. 