### PR TITLE
[LLM] Fix Multi-Host TPU gang-scheduling and replica lifecycle

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -8,7 +8,11 @@ from typing_extensions import Annotated
 import ray.util.accelerators.accelerators as accelerators
 from ray.llm._internal.serve.observability.logging import get_logger
 from ray.util.placement_group import PlacementGroup, placement_group
-from ray.util.tpu import get_tpu_version_from_type, slice_placement_group
+from ray.util.tpu import (
+    get_chips_per_host,
+    get_tpu_version_from_type,
+    slice_placement_group,
+)
 
 logger = get_logger(__name__)
 
@@ -91,14 +95,38 @@ class AcceleratorBackend(ABC):
     ) -> PlacementGroup:
         pass
 
-    @property
-    def requires_deferred_placement_group(self) -> bool:
-        """
-        If True, Ray Serve will not provision a placement group for the deployment.
-        Instead, creation is deferred to the replica at runtime.
-        Defaults to False.
-        """
-        return False
+    def get_placement_group_labels(
+        self, accelerator_type_str: Optional[str] = None
+    ) -> Optional[Dict[str, str]]:
+        """Returns labels to be applied to the placement group bundles."""
+        return None
+
+    def apply_placement_group_bundle_labels(
+        self,
+        deployment_options: Dict[str, Any],
+        accelerator_type_str: Optional[str],
+        num_bundles: int,
+    ) -> None:
+        """Safely applies hardware-specific labels to the deployment options."""
+        accel_labels = self.get_placement_group_labels(accelerator_type_str)
+        if not accel_labels:
+            return
+
+        existing_selectors = (
+            deployment_options.get("placement_group_bundle_label_selector") or []
+        )
+        merged_selectors = []
+
+        for i in range(num_bundles):
+            labels = (
+                existing_selectors[i].copy()
+                if i < len(existing_selectors) and existing_selectors[i]
+                else {}
+            )
+            labels.update(accel_labels)
+            merged_selectors.append(labels)
+
+        deployment_options["placement_group_bundle_label_selector"] = merged_selectors
 
     @property
     @abstractmethod
@@ -180,10 +208,21 @@ class TPUAccelerator(AcceleratorBackend):
     def default_bundles(
         self, *, num_devices: int, accelerator_type_str: Optional[str] = None
     ):
-        bundle = {"TPU": 1}
+        if self._config.topology and accelerator_type_str:
+            version = get_tpu_version_from_type(accelerator_type_str)
+            chips_per_host = get_chips_per_host(self._config.topology, version)
+
+            num_bundles = max(1, num_devices // chips_per_host)
+            bundle = {"TPU": chips_per_host}
+        else:
+            # Fallback to single-chip/single-host scheduling
+            num_bundles = num_devices
+            bundle = {"TPU": 1}
+
         if accelerator_type_str:
             bundle[format_ray_accelerator_resource(accelerator_type_str)] = 0.001
-        return [bundle.copy() for _ in range(num_devices)]
+
+        return [bundle.copy() for _ in range(num_bundles)]
 
     def create_placement_group(
         self,
@@ -239,15 +278,15 @@ class TPUAccelerator(AcceleratorBackend):
         )
         return self._slice_pg_wrapper.placement_group
 
-    @property
-    def requires_deferred_placement_group(self) -> bool:
-        """
-        If a TPU topology is specified, we defer PG creation so the replica can
-        provision a `SlicePlacementGroup` at runtime. This ensures multi-host
-        TPU slices are gang-scheduled atomically according to their physical
-        topology rather than fragmented across the cluster.
-        """
-        return bool(self._config.topology)
+    def get_placement_group_labels(
+        self, accelerator_type_str: Optional[str] = None
+    ) -> Optional[Dict[str, str]]:
+        if self._config.topology and accelerator_type_str:
+            return {
+                "ray.io/tpu-topology": self._config.topology,
+                "ray.io/accelerator-type": accelerator_type_str,
+            }
+        return None
 
     @property
     def requires_remote_initialization(self) -> bool:

--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -98,7 +98,7 @@ class AcceleratorBackend(ABC):
     def get_placement_group_bundle_label_selector(
         self, accelerator_type_str: Optional[str] = None
     ) -> Optional[Dict[str, str]]:
-        """Returns labels to be applied to the placement group bundles."""
+        """Returns label selectors to apply to the placement group bundles."""
         return None
 
     def apply_placement_group_bundle_label_selector(
@@ -107,11 +107,11 @@ class AcceleratorBackend(ABC):
         accelerator_type_str: Optional[str],
         num_bundles: int,
     ) -> None:
-        """Safely applies hardware-specific labels to the deployment options."""
-        accel_labels = self.get_placement_group_bundle_label_selector(
+        """Safely applies hardware-specific label selectors to the deployment options."""
+        accel_selectors = self.get_placement_group_bundle_label_selector(
             accelerator_type_str
         )
-        if not accel_labels:
+        if not accel_selectors:
             return
 
         existing_selectors = (
@@ -120,13 +120,13 @@ class AcceleratorBackend(ABC):
         merged_selectors = []
 
         for i in range(num_bundles):
-            labels = (
+            selector = (
                 existing_selectors[i].copy()
                 if i < len(existing_selectors) and existing_selectors[i]
                 else {}
             )
-            labels.update(accel_labels)
-            merged_selectors.append(labels)
+            selector.update(accel_selectors)
+            merged_selectors.append(selector)
 
         deployment_options["placement_group_bundle_label_selector"] = merged_selectors
 

--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -95,20 +95,22 @@ class AcceleratorBackend(ABC):
     ) -> PlacementGroup:
         pass
 
-    def get_placement_group_labels(
+    def get_placement_group_bundle_label_selector(
         self, accelerator_type_str: Optional[str] = None
     ) -> Optional[Dict[str, str]]:
         """Returns labels to be applied to the placement group bundles."""
         return None
 
-    def apply_placement_group_bundle_labels(
+    def apply_placement_group_bundle_label_selector(
         self,
         deployment_options: Dict[str, Any],
         accelerator_type_str: Optional[str],
         num_bundles: int,
     ) -> None:
         """Safely applies hardware-specific labels to the deployment options."""
-        accel_labels = self.get_placement_group_labels(accelerator_type_str)
+        accel_labels = self.get_placement_group_bundle_label_selector(
+            accelerator_type_str
+        )
         if not accel_labels:
             return
 
@@ -279,7 +281,7 @@ class TPUAccelerator(AcceleratorBackend):
         )
         return self._slice_pg_wrapper.placement_group
 
-    def get_placement_group_labels(
+    def get_placement_group_bundle_label_selector(
         self, accelerator_type_str: Optional[str] = None
     ) -> Optional[Dict[str, str]]:
         if self._config.topology and accelerator_type_str:

--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -250,7 +250,8 @@ class TPUAccelerator(AcceleratorBackend):
             if not tpu_bundles:
                 worker_bundle = {"TPU": 1}
             else:
-                worker_bundle = tpu_bundles[0]
+                # Use the last bundle to avoid picking up merged CPU driver resources
+                worker_bundle = tpu_bundles[-1]
 
                 # Ensure all TPU bundles are homogeneous
                 if any(b != worker_bundle for b in tpu_bundles):

--- a/python/ray/llm/_internal/serve/core/configs/accelerators.py
+++ b/python/ray/llm/_internal/serve/core/configs/accelerators.py
@@ -254,23 +254,24 @@ class TPUAccelerator(AcceleratorBackend):
         return True
 
     def get_remote_options(self, accelerator_type_str: str = None):
-        # TPUs use custom resource strings rather than a native kwarg
-        options: Dict[str, Any] = {"resources": {"TPU": 0.001}}
-
+        # The PlacementGroupSchedulingStrategy natively handles routing the task to
+        # the correct hardware. We omit TPU resource requests to avoid consuming
+        # chips that the model engine workers must use.
+        options: Dict[str, Any] = {"resources": {}}
         if accelerator_type_str:
-            options["accelerator_type"] = accelerator_type_str
+            # Pin the task to the TPU accelerator to avoid scheduling on a CPU bundle.
+            options["label_selector"] = {
+                "ray.io/accelerator-type": accelerator_type_str
+            }
         return options
 
     def shutdown(self):
-        if self._slice_pg_wrapper is not None:
+        slice_pg_wrapper = getattr(self, "_slice_pg_wrapper", None)
+        if slice_pg_wrapper is not None:
             try:
                 logger.info("Shutting down TPU slice PG for server replica.")
-                self._slice_pg_wrapper.shutdown()
+                slice_pg_wrapper.shutdown()
             except Exception as e:
                 logger.warning(f"Failed to shut down TPU slice PG: {e}")
             finally:
                 self._slice_pg_wrapper = None
-
-    def __del__(self):
-        """Ensure placement groups are cleaned up when this backend is garbage collected."""
-        self.shutdown()

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -706,27 +706,40 @@ class LLMServer(LLMServerProtocol):
         # deployment_options
         ray_actor_options = deployment_options.get("ray_actor_options", {})
 
-        if not engine_config.accelerator.requires_deferred_placement_group:
-            replica_actor_resources = {
-                "CPU": ray_actor_options.get("num_cpus", 1),
-                "GPU": ray_actor_options.get("num_gpus", 0),
-                **ray_actor_options.get("resources", {}),
+        replica_actor_resources = {
+            "CPU": ray_actor_options.get("num_cpus", 1),
+            "GPU": ray_actor_options.get("num_gpus", 0),
+            **ray_actor_options.get("resources", {}),
+        }
+        if "memory" in ray_actor_options:
+            replica_actor_resources["memory"] = ray_actor_options["memory"]
+
+        # TODO: Move this _merge_replica_actor_and_child_actor_bundles to a
+        # more generic place.
+        pg_bundles = _merge_replica_actor_and_child_actor_bundles(
+            engine_config.placement_bundles, replica_actor_resources
+        )
+
+        deployment_options.update(
+            {
+                "placement_group_bundles": pg_bundles,
+                "placement_group_strategy": engine_config.placement_strategy,
             }
-            if "memory" in ray_actor_options:
-                replica_actor_resources["memory"] = ray_actor_options["memory"]
+        )
 
-            # TODO: Move this _merge_replica_actor_and_child_actor_bundles to a
-            # more generic place.
-            pg_bundles = _merge_replica_actor_and_child_actor_bundles(
-                engine_config.placement_bundles, replica_actor_resources
+        # Append hardware-specific `bundle_label_selectors` to the deployment options if needed
+        accelerator_type_str = (
+            getattr(
+                llm_config.accelerator_type, "value", str(llm_config.accelerator_type)
             )
-
-            deployment_options.update(
-                {
-                    "placement_group_bundles": pg_bundles,
-                    "placement_group_strategy": engine_config.placement_strategy,
-                }
-            )
+            if llm_config.accelerator_type
+            else None
+        )
+        engine_config.accelerator.apply_placement_group_bundle_labels(
+            deployment_options=deployment_options,
+            accelerator_type_str=accelerator_type_str,
+            num_bundles=len(pg_bundles),
+        )
 
         # Handle env vars from runtime_env
         default_runtime_env = ray.get_runtime_context().runtime_env
@@ -735,7 +748,6 @@ class LLMServer(LLMServerProtocol):
                 "worker_process_setup_hook"
             ] = "ray.llm._internal.serve._worker_process_setup_hook"
 
-        ray_actor_options = deployment_options.get("ray_actor_options", {})
         ray_actor_options["runtime_env"] = {
             **default_runtime_env,
             # Existing runtime_env should take precedence over the default.

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -270,7 +270,14 @@ class LLMServer(LLMServerProtocol):
         """Add the request id to the request."""
         request_id = get_serve_request_id()
         if request_id:
-            request.request_id = request_id
+            if hasattr(request, "request_id"):
+                return
+            try:
+                request.request_id = request_id
+            except ValueError:
+                # Pydantic v2 strict schemas reject unknown fields.
+                # Safely ignore as request_id is only used for internal Ray Serve logging.
+                pass
 
     async def _maybe_resolve_lora_from_multiplex(self) -> None:
         """Handle the lora model for the request."""

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -735,7 +735,7 @@ class LLMServer(LLMServerProtocol):
             if llm_config.accelerator_type
             else None
         )
-        engine_config.accelerator.apply_placement_group_bundle_labels(
+        engine_config.accelerator.apply_placement_group_bundle_label_selector(
             deployment_options=deployment_options,
             accelerator_type_str=accelerator_type_str,
             num_bundles=len(pg_bundles),

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -279,6 +279,10 @@ class VLLMEngine(LLMEngine):
         from vllm.entrypoints.openai.api_server import init_app_state
 
         callback = self.llm_config.get_or_create_callback()
+        if callback.ctx.placement_group:
+            # Ensure existing PG for the Serve deployment is scheduled
+            # before attempting to initialize the engine.
+            await callback.ctx.placement_group.ready()
         await callback.run_callback("on_before_node_init")
         if callback.ctx.run_init_node:
             await initialize_node(self.llm_config)

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -6,8 +6,6 @@ import pytest
 
 from ray.llm._internal.common.utils.download_utils import NodeModelDownloadable
 from ray.llm._internal.serve.core.configs.accelerators import (
-    CPUAccelerator,
-    GPUAccelerator,
     TPUAccelerator,
     TPUConfig,
 )
@@ -403,19 +401,16 @@ class TestAcceleratorConfigLogic:
         assert isinstance(engine_config.accelerator, TPUAccelerator)
         assert engine_config.accelerator_type == "TPU-V6E"
 
-    def test_requires_deferred_placement_group(self):
-        """Test that requires_deferred_placement_group correctly identifies deferred PG requirements."""
-        cpu_accel = CPUAccelerator()
-        assert cpu_accel.requires_deferred_placement_group is False
+    def test_tpu_accelerator_get_placement_group_labels(self):
+        """Test that TPUAccelerator correctly generates topology labels for Serve."""
+        tpu_accel_no_topology = TPUAccelerator(TPUConfig(kind="tpu"))
+        assert tpu_accel_no_topology.get_placement_group_labels("TPU-V6E") is None
 
-        gpu_accel = GPUAccelerator()
-        assert gpu_accel.requires_deferred_placement_group is False
-
-        tpu_accel_no_topo = TPUAccelerator(TPUConfig(kind="tpu"))
-        assert tpu_accel_no_topo.requires_deferred_placement_group is False
-
-        tpu_accel_with_topo = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
-        assert tpu_accel_with_topo.requires_deferred_placement_group is True
+        tpu_accel_with_topology = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
+        assert tpu_accel_with_topology.get_placement_group_labels("TPU-V6E") == {
+            "ray.io/tpu-topology": "4x4",
+            "ray.io/accelerator-type": "TPU-V6E",
+        }
 
     def test_tpu_accelerator_get_remote_options(self):
         """Test that TPUAccelerator get_remote_options returns an empty resources dict and label selector."""
@@ -427,7 +422,6 @@ class TestAcceleratorConfigLogic:
         options_with_type = tpu_accel.get_remote_options("TPU-V6E")
         assert options_with_type == {
             "resources": {},
-            "accelerator_type": "TPU-V6E",
             "label_selector": {"ray.io/accelerator-type": "TPU-V6E"},
         }
 

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -401,13 +401,18 @@ class TestAcceleratorConfigLogic:
         assert isinstance(engine_config.accelerator, TPUAccelerator)
         assert engine_config.accelerator_type == "TPU-V6E"
 
-    def test_tpu_accelerator_get_placement_group_labels(self):
+    def test_tpu_accelerator_get_placement_group_bundle_label_selector(self):
         """Test that TPUAccelerator correctly generates topology labels for Serve."""
         tpu_accel_no_topology = TPUAccelerator(TPUConfig(kind="tpu"))
-        assert tpu_accel_no_topology.get_placement_group_labels("TPU-V6E") is None
+        assert (
+            tpu_accel_no_topology.get_placement_group_bundle_label_selector("TPU-V6E")
+            is None
+        )
 
         tpu_accel_with_topology = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
-        assert tpu_accel_with_topology.get_placement_group_labels("TPU-V6E") == {
+        assert tpu_accel_with_topology.get_placement_group_bundle_label_selector(
+            "TPU-V6E"
+        ) == {
             "ray.io/tpu-topology": "4x4",
             "ray.io/accelerator-type": "TPU-V6E",
         }

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -417,6 +417,20 @@ class TestAcceleratorConfigLogic:
         tpu_accel_with_topo = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
         assert tpu_accel_with_topo.requires_deferred_placement_group is True
 
+    def test_tpu_accelerator_get_remote_options(self):
+        """Test that TPUAccelerator get_remote_options returns an empty resources dict and label selector."""
+        tpu_accel = TPUAccelerator(TPUConfig(kind="tpu"))
+
+        options_no_type = tpu_accel.get_remote_options()
+        assert options_no_type == {"resources": {}}
+
+        options_with_type = tpu_accel.get_remote_options("TPU-V6E")
+        assert options_with_type == {
+            "resources": {},
+            "accelerator_type": "TPU-V6E",
+            "label_selector": {"ray.io/accelerator-type": "TPU-V6E"},
+        }
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/conftest.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 
 import ray
-from ray import serve
 from ray.tests.conftest import _ray_start_cluster
 
 
@@ -14,19 +13,6 @@ def llm_config_with_mock_engine(llm_config):
         "RAYLLM_VLLM_ENGINE_CLS"
     ] = "ray.llm.tests.serve.mocks.mock_vllm_engine.MockVLLMEngine"
     yield llm_config
-
-
-@pytest.fixture(autouse=True)
-def isolated_serve_state(ray_tpu_cluster):
-    """
-    Automatically runs before and after every test to ensure Serve
-    starts on a random port and wipes its state, while reusing the
-    module scoped cluster.
-    """
-    serve.shutdown()
-    serve.start(http_options={"port": 0})
-    yield
-    serve.shutdown()
 
 
 @pytest.fixture(scope="module")
@@ -65,6 +51,6 @@ def ray_tpu_cluster():
                 env_vars=env_vars,
             )
 
-        ray.init(address=cluster.address)
+        ray.init(address=cluster.address, ignore_reinit_error=True)
         yield cluster
         ray.shutdown()

--- a/python/ray/llm/tests/serve/cpu/deployments/conftest.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 import ray
+from ray import serve
 from ray.tests.conftest import _ray_start_cluster
 
 
@@ -13,6 +14,19 @@ def llm_config_with_mock_engine(llm_config):
         "RAYLLM_VLLM_ENGINE_CLS"
     ] = "ray.llm.tests.serve.mocks.mock_vllm_engine.MockVLLMEngine"
     yield llm_config
+
+
+@pytest.fixture(autouse=True)
+def isolated_serve_state(ray_tpu_cluster):
+    """
+    Automatically runs before and after every test to ensure Serve
+    starts on a random port and wipes its state, while reusing the
+    module scoped cluster.
+    """
+    serve.shutdown()
+    serve.start(http_options={"port": 0})
+    yield
+    serve.shutdown()
 
 
 @pytest.fixture(scope="module")
@@ -36,6 +50,7 @@ def ray_tpu_cluster():
                 "ray.io/tpu-slice-name": "test-slice",
                 "ray.io/tpu-worker-id": str(i),
                 "ray.io/tpu-pod-type": pod_type,
+                "ray.io/accelerator-type": "TPU-V6E",
             }
             resources = {"TPU": 4, "accelerator_type:TPU-V6E": 4}
 

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -176,17 +176,19 @@ def test_tpu_deployment_options_bundle_selector_injection():
 
 def test_tpu_slice_kwargs_ignores_cpu_driver_bundle():
     """
-    Verifies that CPU-only driver bundles are safely ignored by the Serve helper
-    if subsequent TPU bundles are homogeneous.
+    Verifies that resolve_tpu_slice_kwargs correctly ignores the merged CPU 
+    resources from the replica actor in the first bundle, and extracts the 
+    TPU requirement from the remaining bundles.
     """
     labels = [{"ray.io/tpu-topology": "4x4", "ray.io/accelerator-type": "TPU-V6E"}]
-    bundles = [{"CPU": 1}, {"TPU": 4}, {"TPU": 4, "CPU": 1}]
+    bundles = [{"TPU": 4, "CPU": 1}, {"TPU": 4}, {"TPU": 4}, {"TPU": 4}]
 
     topology, version, worker_bundle = resolve_tpu_slice_kwargs(labels, bundles)
 
     assert topology == "4x4"
     assert version == "v6e"
-    assert worker_bundle.get("TPU") == 4
+    assert worker_bundle == {"TPU": 4}
+    assert "CPU" not in worker_bundle
 
 
 def test_tpu_slice_kwargs_rejects_heterogeneous_bundles():

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -176,8 +176,8 @@ def test_tpu_deployment_options_bundle_selector_injection():
 
 def test_tpu_slice_kwargs_ignores_cpu_driver_bundle():
     """
-    Verifies that resolve_tpu_slice_kwargs correctly ignores the merged CPU 
-    resources from the replica actor in the first bundle, and extracts the 
+    Verifies that resolve_tpu_slice_kwargs correctly ignores the merged CPU
+    resources from the replica actor in the first bundle, and extracts the
     TPU requirement from the remaining bundles.
     """
     labels = [{"ray.io/tpu-topology": "4x4", "ray.io/accelerator-type": "TPU-V6E"}]

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -14,134 +14,35 @@ from ray.llm._internal.serve.core.configs.accelerators import (
 )
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm.tests.serve.mocks.mock_vllm_engine import PGCreationMockEngine
+from ray.serve._private.utils import get_tpu_slice_kwargs
 from ray.serve.llm import LLMConfig, ModelLoadingConfig
-from ray.util.placement_group import PlacementGroup, placement_group_table
 
 
-def test_tpu_slice_placement_group_creation_default_resources(ray_tpu_cluster):
+def test_tpu_accelerator_remote_options_scheduling(ray_tpu_cluster):
     """
-    Verifies that requesting a multi-host TPU topology correctly intercepts
-    standard PG creation and returns a PACK SlicePlacementGroup.
-    """
-    llm_config = LLMConfig(
-        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
-        accelerator_type="TPU-V6E",
-        accelerator_config={"kind": "tpu", "topology": "4x4"},
-    )
-
-    engine_config = llm_config.get_engine_config()
-    pg = engine_config.get_or_create_pg()
-
-    assert isinstance(pg, PlacementGroup)
-
-    pg_table = placement_group_table(pg)
-    assert pg_table["strategy"] == "PACK"
-
-    # 4x4 v6e = 16 chips. We default to 1 TPU chip per bundle.
-    assert len(pg_table["bundles"]) == 16
-    for bundle in pg_table["bundles"].values():
-        assert "TPU" in bundle
-        assert bundle["TPU"] == 1
-
-    # Let the backend tear down its own resources if it has any
-    engine_config.accelerator.shutdown()
-    try:
-        ray.util.remove_placement_group(pg)
-    except Exception:
-        pass  # Already cleaned up by the wrapper
-
-
-def test_tpu_slice_placement_group_creation_host_resources(ray_tpu_cluster):
-    """
-    Verifies that explicitly providing host-level bundles via
-    placement_group_config correctly overrides the 1-chip default.
+    Verifies that TPUAccelerator.get_remote_options returns a label_selector,
+    and successfully schedules a task without causing Ray Core validation errors.
     """
     llm_config = LLMConfig(
         model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
         accelerator_type="TPU-V6E",
-        accelerator_config={"kind": "tpu", "topology": "4x4"},
-        placement_group_config={
-            "strategy": "STRICT_SPREAD",
-            "bundles": [{"TPU": 4}],
-        },
+        accelerator_config={"kind": "tpu"},
     )
-
-    engine_config = llm_config.get_engine_config()
-    pg = engine_config.get_or_create_pg()
-
-    assert isinstance(pg, PlacementGroup)
-
-    pg_table = placement_group_table(pg)
-    assert pg_table["strategy"] == "STRICT_SPREAD"
-    # We should provision 4 host-level bundles instead of the default 16 chip-level bundles.
-    assert len(pg_table["bundles"]) == 4
-    for bundle in pg_table["bundles"].values():
-        assert "TPU" in bundle
-        assert bundle["TPU"] == 4
-
-    # Let the backend tear down its own resources if it has any
-    engine_config.accelerator.shutdown()
-    try:
-        ray.util.remove_placement_group(pg)
-    except Exception:
-        pass  # Already cleaned up by the wrapper
-
-
-def test_single_tpu_fallback(ray_tpu_cluster):
-    """
-    Verifies that requesting a TPU without a topology gracefully
-    falls back to standard single-host bundle packing.
-    """
-    llm_config = LLMConfig(
-        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
-        accelerator_type="TPU-V6E",
-    )
-
-    engine_config = llm_config.get_engine_config()
-    pg = engine_config.get_or_create_pg()
-
-    pg_table = placement_group_table(pg)
-
-    # Verify it falls back to the default PACK strategy for 1 GPU/TPU
-    assert len(pg_table["bundles"]) == 1
-    assert pg_table["strategy"] == "PACK"
-
-    # Let the backend tear down its own resources if it has any
-    engine_config.accelerator.shutdown()
-    try:
-        ray.util.remove_placement_group(pg)
-    except Exception:
-        pass  # Already cleaned up by the wrapper
-
-
-def test_tpu_slice_placement_group_creation_bundle_per_worker(ray_tpu_cluster):
-    """
-    Verifies that specifying bundle_per_worker correctly expands to bundles,
-    includes the accelerator hint for TPU, and correctly identifies TPU usage.
-    """
-    llm_config = LLMConfig(
-        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
-        accelerator_type="TPU-V6E",
-        accelerator_config={"kind": "tpu", "topology": "4x4"},
-        placement_group_config={
-            "bundle_per_worker": {"TPU": 1},
-        },
-        engine_kwargs={
-            "tensor_parallel_size": 2,
-        },
-    )
-
     engine_config = llm_config.get_engine_config()
 
-    # Validate the accelerator backend was correctly inferred
-    assert isinstance(engine_config.accelerator, TPUAccelerator)
+    options = engine_config.accelerator.get_remote_options("TPU-V6E")
 
-    bundles = engine_config.placement_bundles
-    assert len(bundles) == 2
-    for bundle in bundles:
-        assert bundle["TPU"] == 1
-        assert "accelerator_type:TPU-V6E" in bundle
-        assert bundle["accelerator_type:TPU-V6E"] == 0.001
+    # Ensure it returns the expected options (i.e. label_selector only)
+    assert options == {
+        "resources": {},
+        "label_selector": {"ray.io/accelerator-type": "TPU-V6E"},
+    }
+
+    @ray.remote(**options)
+    def probe_metadata():
+        return True
+
+    assert ray.get(probe_metadata.remote()) is True
 
 
 def test_accelerator_inference_logic():
@@ -150,7 +51,6 @@ def test_accelerator_inference_logic():
     when no explicit accelerator_config is provided, and passes it
     correctly to the engine.
     """
-    # TPU string correctly infers TPUConfig and TPUAccelerator
     cfg1 = LLMConfig(
         model_loading_config={"model_id": "test"},
         accelerator_type="TPU-V6E",
@@ -180,88 +80,118 @@ def test_accelerator_inference_logic():
     assert isinstance(cfg4.get_engine_config().accelerator, CPUAccelerator)
 
 
-def test_tpu_slice_placement_group_creation_heterogeneous_tpu_bundles_fail():
+def test_tpu_deployment_options_bundle_selector_injection():
     """
-    Verifies that a ValueError is raised when heterogeneous TPU bundles are provided.
-    """
-    accelerator = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
-
-    with pytest.raises(ValueError, match="Heterogeneous TPU bundles are not supported"):
-        accelerator.create_placement_group(
-            bundles=[{"TPU": 4}, {"TPU": 2}],
-            strategy="PACK",
-            name="test-pg",
-            accelerator_type_str="TPU-V6E",
-        )
-
-
-def test_tpu_slice_placement_group_creation_cpu_driver_homogeneous_tpu_bundles_pass(
-    ray_tpu_cluster,
-):
-    """
-    Verifies that CPU-only driver bundles are ignored and do not trigger an error
-    if subsequent TPU bundles are homogeneous.
-    """
-    accelerator = TPUAccelerator(TPUConfig(kind="tpu", topology="4x4"))
-
-    pg = accelerator.create_placement_group(
-        bundles=[{"CPU": 2}, {"TPU": 4}, {"TPU": 4}],
-        strategy="PACK",
-        name="test-pg",
-        accelerator_type_str="TPU-V6E",
-    )
-
-    # Verify valid PG creation
-    assert isinstance(pg, PlacementGroup)
-
-    accelerator.shutdown()
-    try:
-        ray.util.remove_placement_group(pg)
-    except Exception:
-        pass
-
-
-def test_tpu_serve_deployment_default_chip_level_bundles(ray_tpu_cluster):
-    """
-    Verifies that a Serve deployment created for a multi-host TPU slice defaults
-    to chip-level bundles when no placement_group_config is specified.
+    Verifies that LLMServer.get_deployment_options correctly injects TPU topology
+    labels into the placement group bundle selectors and creates the expected bundles.
     """
     llm_config = LLMConfig(
         model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
         accelerator_type="TPU-V6E",
         accelerator_config={"kind": "tpu", "topology": "4x4"},
+        engine_kwargs={"tensor_parallel_size": 16},
+    )
+
+    options = LLMServer.get_deployment_options(llm_config)
+
+    # Ensure PG creation is no longer deferred
+    assert "placement_group_bundles" in options
+    assert "placement_group_bundle_label_selector" in options
+
+    pg_bundles = options["placement_group_bundles"]
+    selectors = options["placement_group_bundle_label_selector"]
+
+    # 4x4 topology = 16 chips
+    # Default is 4 bundles of 4 TPUs
+    assert len(pg_bundles) == 4
+    assert len(selectors) == 4
+
+    # The first bundle should contain the TPU allocation and the replica actor's CPU
+    assert pg_bundles[0].get("TPU") == 4
+    assert pg_bundles[0].get("CPU", 0) >= 1
+
+    # The remaining worker bundles should strictly be for the TPU host
+    for i in range(1, 4):
+        assert pg_bundles[i].get("TPU") == 4
+        assert pg_bundles[i].get("CPU", 0) == 0
+
+    for selector in selectors:
+        assert selector["ray.io/tpu-topology"] == "4x4"
+        assert selector["ray.io/accelerator-type"] == "TPU-V6E"
+
+
+def test_tpu_slice_kwargs_ignores_cpu_driver_bundle():
+    """
+    Verifies that CPU-only driver bundles are safely ignored by the Serve helper
+    if subsequent TPU bundles are homogeneous.
+    """
+    labels = [{"ray.io/tpu-topology": "4x4", "ray.io/accelerator-type": "TPU-V6E"}]
+    bundles = [{"CPU": 1}, {"TPU": 4}, {"TPU": 4, "CPU": 1}]
+
+    topology, version, worker_bundle = get_tpu_slice_kwargs(labels, bundles)
+
+    assert topology == "4x4"
+    assert version == "v6e"
+    assert worker_bundle.get("TPU") == 4
+
+
+def test_tpu_slice_kwargs_rejects_heterogeneous_bundles():
+    """
+    Verifies that a ValueError is raised when heterogeneous TPU bundles are provided
+    to the Serve gang-scheduler helper.
+    """
+    labels = [{"ray.io/tpu-topology": "4x4", "ray.io/accelerator-type": "TPU-V6E"}]
+    bundles = [{"TPU": 4}, {"TPU": 2}]
+
+    with pytest.raises(ValueError, match="Heterogeneous TPU bundles are not supported"):
+        get_tpu_slice_kwargs(labels, bundles)
+
+
+def test_tpu_serve_deployment_default_host_level_bundles(ray_tpu_cluster):
+    """
+    Verifies that a Serve deployment created for a multi-host TPU slice intercepts
+    the default creation and provisions the SlicePlacementGroup correctly.
+    """
+    llm_config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
+        accelerator_type="TPU-V6E",
+        accelerator_config={"kind": "tpu", "topology": "4x4"},
+        engine_kwargs={"tensor_parallel_size": 16},
     )
 
     app = serve.deployment(LLMServer).bind(llm_config, engine_cls=PGCreationMockEngine)
-    serve.run(app)
 
-    pg_table = ray.util.placement_group_table()
-    active_pgs = list(
-        {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
-    )
+    serve.run(app, name="default_host_app", route_prefix="/default_host")
 
-    assert (
-        len(active_pgs) == 2
-    ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
+    try:
+        pg_table = ray.util.placement_group_table()
+        active_pgs = list(
+            {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
+        )
 
-    tpu_head_resource = "TPU-v6e-16-head"
-    head_pgs = [
-        pg
-        for pg in active_pgs
-        if len(pg["bundles"]) == 1
-        and tpu_head_resource in list(pg["bundles"].values())[0]
-    ]
-    assert len(head_pgs) == 1
+        assert (
+            len(active_pgs) == 2
+        ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
 
-    worker_pg = [pg for pg in active_pgs if pg not in head_pgs][0]
+        tpu_head_resource = "TPU-v6e-16-head"
+        head_pgs = [
+            pg
+            for pg in active_pgs
+            if len(pg["bundles"]) == 1
+            and tpu_head_resource in list(pg["bundles"].values())[0]
+        ]
+        assert len(head_pgs) == 1
 
-    assert worker_pg["strategy"] == "PACK"
-    # 4x4 topology = 16 chips. Default is 16 bundles of 1 TPU.
-    assert len(worker_pg["bundles"]) == 16
-    for bundle in worker_pg["bundles"].values():
-        assert bundle.get("TPU", 0) == 1
+        worker_pg = [pg for pg in active_pgs if pg not in head_pgs][0]
 
-    serve.shutdown()
+        assert worker_pg["strategy"] == "PACK"
+
+        # 4x4 topology = 16 chips. Default is 4 bundles of 4 TPUs.
+        assert len(worker_pg["bundles"]) == 4
+        for bundle in worker_pg["bundles"].values():
+            assert bundle.get("TPU", 0) == 4
+    finally:
+        serve.delete("default_host_app")
 
 
 def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
@@ -274,67 +204,40 @@ def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
         accelerator_type="TPU-V6E",
         accelerator_config={"kind": "tpu", "topology": "4x4"},
         placement_group_config={"bundle_per_worker": {"TPU": 4}},
+        engine_kwargs={"tensor_parallel_size": 4},
     )
 
     app = serve.deployment(LLMServer).bind(llm_config, engine_cls=PGCreationMockEngine)
-    serve.run(app)
 
-    pg_table = ray.util.placement_group_table()
-    active_pgs = list(
-        {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
-    )
+    serve.run(app, name="explicit_host_app", route_prefix="/explicit_host")
 
-    assert (
-        len(active_pgs) == 2
-    ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
+    try:
+        pg_table = ray.util.placement_group_table()
+        active_pgs = list(
+            {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
+        )
 
-    tpu_head_resource = "TPU-v6e-16-head"
-    head_pgs = [
-        pg
-        for pg in active_pgs
-        if len(pg["bundles"]) == 1
-        and tpu_head_resource in list(pg["bundles"].values())[0]
-    ]
-    assert len(head_pgs) == 1
+        assert (
+            len(active_pgs) == 2
+        ), "Expected 2 PGs - one for TPU Head, one for worker bundles"
 
-    worker_pg = [pg for pg in active_pgs if pg not in head_pgs][0]
+        tpu_head_resource = "TPU-v6e-16-head"
+        head_pgs = [
+            pg
+            for pg in active_pgs
+            if len(pg["bundles"]) == 1
+            and tpu_head_resource in list(pg["bundles"].values())[0]
+        ]
+        assert len(head_pgs) == 1
 
-    assert worker_pg["strategy"] == "PACK"
-    # 4x4 topology = 16 chips. With 4 TPUs per bundle, expect exactly 4 bundles.
-    assert len(worker_pg["bundles"]) == 4
-    for bundle in worker_pg["bundles"].values():
-        assert bundle.get("TPU", 0) == 4
+        worker_pg = [pg for pg in active_pgs if pg not in head_pgs][0]
 
-    serve.shutdown()
-
-
-def test_tpu_accelerator_remote_options_scheduling(ray_tpu_cluster):
-    """
-    Verifies that TPUAccelerator.get_remote_options returns resources, accelerator_type and label_selector,
-    and successfully schedules a task without causing Ray Core validation errors.
-    """
-    llm_config = LLMConfig(
-        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
-        accelerator_type="TPU-V6E",
-        accelerator_config={"kind": "tpu"},
-    )
-    engine_config = llm_config.get_engine_config()
-
-    options = engine_config.accelerator.get_remote_options("TPU-V6E")
-
-    # Ensure it returns the expected options
-    assert options == {
-        "resources": {},
-        "accelerator_type": "TPU-V6E",
-        "label_selector": {"ray.io/accelerator-type": "TPU-V6E"},
-    }
-
-    @ray.remote(**options)
-    def probe_metadata():
-        return True
-
-    # The task should successfully schedule and run without throwing a validation error.
-    assert ray.get(probe_metadata.remote()) is True
+        assert worker_pg["strategy"] == "PACK"
+        assert len(worker_pg["bundles"]) == 4
+        for bundle in worker_pg["bundles"].values():
+            assert bundle.get("TPU", 0) == 4
+    finally:
+        serve.delete("explicit_host_app")
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -308,5 +308,34 @@ def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
     serve.shutdown()
 
 
+def test_tpu_accelerator_remote_options_scheduling(ray_tpu_cluster):
+    """
+    Verifies that TPUAccelerator.get_remote_options returns resources, accelerator_type and label_selector,
+    and successfully schedules a task without causing Ray Core validation errors.
+    """
+    llm_config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
+        accelerator_type="TPU-V6E",
+        accelerator_config={"kind": "tpu"},
+    )
+    engine_config = llm_config.get_engine_config()
+
+    options = engine_config.accelerator.get_remote_options("TPU-V6E")
+
+    # Ensure it returns the expected options
+    assert options == {
+        "resources": {},
+        "accelerator_type": "TPU-V6E",
+        "label_selector": {"ray.io/accelerator-type": "TPU-V6E"},
+    }
+
+    @ray.remote(**options)
+    def probe_metadata():
+        return True
+
+    # The task should successfully schedule and run without throwing a validation error.
+    assert ray.get(probe_metadata.remote()) is True
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -289,6 +289,7 @@ def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
         worker_pg = [pg for pg in active_pgs if pg not in head_pgs][0]
 
         assert worker_pg["strategy"] == "PACK"
+
         assert len(worker_pg["bundles"]) == 4
         for bundle in worker_pg["bundles"].values():
             assert bundle.get("TPU", 0) == 4

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_engine_tpu.py
@@ -14,8 +14,62 @@ from ray.llm._internal.serve.core.configs.accelerators import (
 )
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm.tests.serve.mocks.mock_vllm_engine import PGCreationMockEngine
-from ray.serve._private.utils import get_tpu_slice_kwargs
+from ray.serve._private.utils import resolve_tpu_slice_kwargs
 from ray.serve.llm import LLMConfig, ModelLoadingConfig
+
+
+def test_tpu_serve_deployment_single_tpu_fallback(ray_tpu_cluster):
+    """
+    Verifies that requesting a TPU without a topology gracefully
+    falls back to standard single-host bundle packing without
+    triggering the slice placement group interception.
+    """
+    llm_config = LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
+        accelerator_type="TPU-V6E",
+        # Explicitly omit topology
+        accelerator_config={"kind": "tpu"},
+        engine_kwargs={"tensor_parallel_size": 1},
+    )
+
+    app = serve.deployment(LLMServer).bind(llm_config, engine_cls=PGCreationMockEngine)
+
+    serve.start(http_options={"port": 0})
+    try:
+        serve.run(app, name="single_tpu_app", route_prefix="/single_tpu")
+        pg_table = ray.util.placement_group_table()
+        active_pgs = list(
+            {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
+        )
+
+        # Ensure we only have standard PGs, no TPU Head PGs
+        tpu_head_resource = "TPU-v6e-16-head"
+        head_pgs = [
+            pg
+            for pg in active_pgs
+            if len(pg["bundles"]) == 1
+            and tpu_head_resource in list(pg["bundles"].values())[0]
+        ]
+        assert len(head_pgs) == 0
+
+        # Verify the deployment PG has the default PACK strategy and 1 TPU
+        deployment_pgs = [
+            pg
+            for pg in active_pgs
+            if any("TPU" in bundle for bundle in pg["bundles"].values())
+        ]
+        assert len(deployment_pgs) >= 1
+
+        target_pg = deployment_pgs[0]
+        assert target_pg["strategy"] == "PACK"
+
+        # Verify it allocated 1 TPU per bundle
+        for bundle in target_pg["bundles"].values():
+            if "TPU" in bundle:
+                assert bundle["TPU"] == 1
+
+    finally:
+        serve.shutdown()
 
 
 def test_tpu_accelerator_remote_options_scheduling(ray_tpu_cluster):
@@ -128,7 +182,7 @@ def test_tpu_slice_kwargs_ignores_cpu_driver_bundle():
     labels = [{"ray.io/tpu-topology": "4x4", "ray.io/accelerator-type": "TPU-V6E"}]
     bundles = [{"CPU": 1}, {"TPU": 4}, {"TPU": 4, "CPU": 1}]
 
-    topology, version, worker_bundle = get_tpu_slice_kwargs(labels, bundles)
+    topology, version, worker_bundle = resolve_tpu_slice_kwargs(labels, bundles)
 
     assert topology == "4x4"
     assert version == "v6e"
@@ -144,7 +198,7 @@ def test_tpu_slice_kwargs_rejects_heterogeneous_bundles():
     bundles = [{"TPU": 4}, {"TPU": 2}]
 
     with pytest.raises(ValueError, match="Heterogeneous TPU bundles are not supported"):
-        get_tpu_slice_kwargs(labels, bundles)
+        resolve_tpu_slice_kwargs(labels, bundles)
 
 
 def test_tpu_serve_deployment_default_host_level_bundles(ray_tpu_cluster):
@@ -161,9 +215,9 @@ def test_tpu_serve_deployment_default_host_level_bundles(ray_tpu_cluster):
 
     app = serve.deployment(LLMServer).bind(llm_config, engine_cls=PGCreationMockEngine)
 
-    serve.run(app, name="default_host_app", route_prefix="/default_host")
-
+    serve.start(http_options={"port": 0})
     try:
+        serve.run(app, name="default_host_app", route_prefix="/default_host")
         pg_table = ray.util.placement_group_table()
         active_pgs = list(
             {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
@@ -191,7 +245,7 @@ def test_tpu_serve_deployment_default_host_level_bundles(ray_tpu_cluster):
         for bundle in worker_pg["bundles"].values():
             assert bundle.get("TPU", 0) == 4
     finally:
-        serve.delete("default_host_app")
+        serve.shutdown()
 
 
 def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
@@ -209,9 +263,9 @@ def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
 
     app = serve.deployment(LLMServer).bind(llm_config, engine_cls=PGCreationMockEngine)
 
-    serve.run(app, name="explicit_host_app", route_prefix="/explicit_host")
-
+    serve.start(http_options={"port": 0})
     try:
+        serve.run(app, name="explicit_host_app", route_prefix="/explicit_host")
         pg_table = ray.util.placement_group_table()
         active_pgs = list(
             {k: v for k, v in pg_table.items() if v["state"] == "CREATED"}.values()
@@ -237,7 +291,22 @@ def test_tpu_serve_deployment_explicit_host_level_bundles(ray_tpu_cluster):
         for bundle in worker_pg["bundles"].values():
             assert bundle.get("TPU", 0) == 4
     finally:
-        serve.delete("explicit_host_app")
+        serve.shutdown()
+
+
+def test_tpu_slice_kwargs_rejects_missing_accelerator_type():
+    """
+    Verifies that a ValueError is raised when a TPU topology is requested
+    but the accelerator type label is missing from the bundle labels.
+    """
+    labels = [{"ray.io/tpu-topology": "4x4"}]
+    bundles = [{"TPU": 4}]
+
+    with pytest.raises(
+        ValueError,
+        match="A TPU topology was requested, but 'ray.io/accelerator-type' was not found",
+    ):
+        resolve_tpu_slice_kwargs(labels, bundles)
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -28,6 +28,7 @@ def serve_handle(mock_llm_config, stream_batching_interval_ms=0):
     }
 
     app = serve.deployment(LLMServer).bind(mock_llm_config, engine_cls=MockVLLMEngine)
+    serve.start(http_options={"port": 0})
     handle = serve.run(app)
     # We set stream=True because the interfaces are async generators regardless
     # of the stream flag on request.
@@ -53,6 +54,7 @@ def multiplexed_serve_handle(mock_llm_config, stream_batching_interval_ms=0):
         engine_cls=MockVLLMEngine,
         model_downloader=FakeLoraModelLoader,
     )
+    serve.start(http_options={"port": 0})
     handle = serve.run(app)
     handle = handle.options(stream=True, multiplexed_model_id="test_model_id")
     yield handle
@@ -430,7 +432,11 @@ class TestLLMServer:
             chunks.append(chunk)
 
         assert len(chunks) == 1
-        assert chunks[0].id == "test_request_id"
+        # Ray Serve intentionally drops internal request IDs to comply with strict
+        # OpenAI schemas (Pydantic v2). Verify the engine successfully processed
+        # the request and generated its own valid OpenAI-style ID instead.
+        assert isinstance(chunks[0].id, str)
+        assert chunks[0].id.startswith("chatcmpl-")
 
     @pytest.mark.parametrize("api_type", ["chat", "completion"])
     @pytest.mark.parametrize("stream", [False, True])

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -678,19 +678,44 @@ class TestGetDeploymentOptions:
             in serve_options["ray_actor_options"]["runtime_env"]
         )
 
-    def test_deferred_placement_group_for_tpu_topology(self):
-        """Test that Serve skips PG creation when deferred placement group is required."""
+    def test_tpu_placement_group_label_selector_injection(self):
+        """Test that Serve requests a placement group with TPU topology labels."""
         llm_config = LLMConfig(
             model_loading_config=ModelLoadingConfig(model_id="test-tpu-model"),
             accelerator_type="TPU-V6E",
             accelerator_config={"kind": "tpu", "topology": "4x4"},
+            engine_kwargs={"tensor_parallel_size": 16},
             llm_engine="vLLM",
         )
 
         serve_options = LLMServer.get_deployment_options(llm_config)
 
-        assert "placement_group_bundles" not in serve_options
-        assert "placement_group_strategy" not in serve_options
+        assert "placement_group_bundles" in serve_options
+        assert serve_options["placement_group_strategy"] == "PACK"
+
+        pg_bundles = serve_options["placement_group_bundles"]
+
+        # 4x4 topology = 16 chips. Default is 4 host-level bundles of 4 TPUs.
+        assert len(pg_bundles) == 4
+
+        # Verify the first bundle successfully merged the replica actor's CPU
+        assert pg_bundles[0].get("TPU") == 4
+        assert pg_bundles[0].get("CPU", 0) >= 1
+
+        # Verify the remaining worker bundles are strictly TPU hosts
+        for i in range(1, 4):
+            assert pg_bundles[i].get("TPU") == 4
+            assert pg_bundles[i].get("CPU", 0) == 0
+
+        # Verify the PG bundle label selector is injected for TPU topology
+        assert "placement_group_bundle_label_selector" in serve_options
+
+        selectors = serve_options["placement_group_bundle_label_selector"]
+        assert len(selectors) == 4
+
+        for selector in selectors:
+            assert selector.get("ray.io/tpu-topology") == "4x4"
+            assert selector.get("ray.io/accelerator-type") == "TPU-V6E"
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -162,7 +162,10 @@ class MockVLLMEngine(LLMEngine):
 
         # Generate streaming response
         async for response in self._generate_chat_response(
-            request=request, prompt_text=prompt_text.strip(), max_tokens=max_tokens
+            request=request,
+            prompt_text=prompt_text.strip(),
+            max_tokens=max_tokens,
+            raw_request_info=raw_request_info,
         ):
             yield response
 
@@ -324,11 +327,19 @@ class MockVLLMEngine(LLMEngine):
         yield response
 
     async def _generate_chat_response(
-        self, request: ChatCompletionRequest, prompt_text: str, max_tokens: int
+        self,
+        request: ChatCompletionRequest,
+        prompt_text: str,
+        max_tokens: int,
+        raw_request_info: Optional[RawRequestInfo] = None,
     ) -> AsyncGenerator[Union[str, ChatCompletionResponse], None]:
         """Generate mock chat completion response."""
 
-        request_id = request.request_id or f"chatcmpl-{random.randint(1000, 9999)}"
+        request_id = (
+            (raw_request_info.request_id if raw_request_info else None)
+            or getattr(request, "request_id", None)
+            or f"chatcmpl-{random.randint(1000, 9999)}"
+        )
         # # Use request.model if provided, otherwise fall back to llm_config.model_id
         model_name = request.model or self.llm_config.model_id
         lora_prefix = (

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -39,9 +39,9 @@ from ray.serve._private.utils import (
     generate_request_id,
     get_current_actor_id,
     get_head_node_id,
-    get_tpu_slice_kwargs,
     inside_ray_client_context,
     resolve_deployment_response,
+    resolve_tpu_slice_kwargs,
 )
 from ray.util.placement_group import PlacementGroup
 from ray.util.tpu import slice_placement_group
@@ -64,7 +64,9 @@ def _default_create_placement_group(
     request: CreatePlacementGroupRequest,
 ) -> PlacementGroup:
     """Creates a placement group for the given request."""
-    tpu_kwargs = get_tpu_slice_kwargs(request.bundle_label_selector, request.bundles)
+    tpu_kwargs = resolve_tpu_slice_kwargs(
+        request.bundle_label_selector, request.bundles
+    )
     if tpu_kwargs is not None:
         # If TPU-related bundle label selectors are present, we utilize
         # TPU specific PG creation logic to ensure atomic scheduling of co-located slices.

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -68,8 +68,8 @@ def _default_create_placement_group(
         request.bundle_label_selector, request.bundles
     )
     if tpu_kwargs is not None:
-        # If TPU-related bundle label selectors are present, we utilize
-        # TPU specific PG creation logic to ensure atomic scheduling of co-located slices.
+        # If TPU-specific bundle label selectors are present, we utilize
+        # Slice PG utility to ensure atomic scheduling of co-located slices.
         tpu_topology, tpu_version, worker_bundle = tpu_kwargs
         slice_pg = slice_placement_group(
             topology=tpu_topology,
@@ -77,6 +77,7 @@ def _default_create_placement_group(
             resources_per_bundle=worker_bundle,
             strategy=request.strategy,
             name=request.name,
+            lifetime="detached",
         )
         return slice_pg.placement_group
 

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -39,10 +39,12 @@ from ray.serve._private.utils import (
     generate_request_id,
     get_current_actor_id,
     get_head_node_id,
+    get_tpu_slice_kwargs,
     inside_ray_client_context,
     resolve_deployment_response,
 )
 from ray.util.placement_group import PlacementGroup
+from ray.util.tpu import slice_placement_group
 
 # NOTE: Please read carefully before changing!
 #
@@ -61,6 +63,21 @@ CreatePlacementGroupFn = Callable[[CreatePlacementGroupRequest], PlacementGroup]
 def _default_create_placement_group(
     request: CreatePlacementGroupRequest,
 ) -> PlacementGroup:
+    """Creates a placement group for the given request."""
+    tpu_kwargs = get_tpu_slice_kwargs(request.bundle_label_selector, request.bundles)
+    if tpu_kwargs is not None:
+        # If TPU-related bundle label selectors are present, we utilize
+        # TPU specific PG creation logic to ensure atomic scheduling of co-located slices.
+        tpu_topology, tpu_version, worker_bundle = tpu_kwargs
+        slice_pg = slice_placement_group(
+            topology=tpu_topology,
+            accelerator_version=tpu_version,
+            resources_per_bundle=worker_bundle,
+            strategy=request.strategy,
+            name=request.name,
+        )
+        return slice_pg.placement_group
+
     return ray.util.placement_group(
         request.bundles,
         request.strategy,

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -864,7 +864,7 @@ def resolve_tpu_slice_kwargs(
         raise ValueError(
             "A TPU topology was requested, but 'ray.io/accelerator-type' "
             "was not found in the placement group bundle labels. The accelerator type "
-            "(e.g., 'TPU-V6E') is required to provision a multi-host slice."
+            "(e.g. 'TPU-V6E') is required to provision a multi-host slice."
         )
 
     raw_version = first_bundle_labels["ray.io/accelerator-type"]

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -837,11 +837,15 @@ class Semaphore:
                 return
 
 
-def get_tpu_slice_kwargs(
+def resolve_tpu_slice_kwargs(
     labels: Optional[List[Dict[str, str]]],
     bundles: Optional[List[Dict[str, float]]] = None,
 ) -> Optional[Tuple[str, str, Dict[str, float]]]:
     """Parses TPU topology, version, and validates bundles for a TPU slice.
+
+    Args:
+        labels: A list of label selector dictionaries applied to the placement group bundles.
+        bundles: An optional list of resource dictionaries defining the placement group bundles.
 
     Returns:
         A tuple of (topology, accelerator_version, worker_bundle) if this is

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -13,7 +13,7 @@ import zlib
 from decimal import ROUND_HALF_UP, Decimal
 from enum import Enum
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Set, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union
 
 import requests
 
@@ -835,3 +835,46 @@ class Semaphore:
                 self._value += 1
                 fut.set_result(True)
                 return
+
+
+def get_tpu_slice_kwargs(
+    labels: Optional[List[Dict[str, str]]],
+    bundles: Optional[List[Dict[str, float]]] = None,
+) -> Optional[Tuple[str, str, Dict[str, float]]]:
+    """Parses TPU topology, version, and validates bundles for a TPU slice.
+
+    Returns:
+        A tuple of (topology, accelerator_version, worker_bundle) if this is
+        a TPU slice request, otherwise None.
+    """
+    if not labels or not isinstance(labels, list):
+        return None
+
+    first_bundle_labels = labels[0]
+    if "ray.io/tpu-topology" not in first_bundle_labels:
+        return None
+
+    tpu_topology = first_bundle_labels["ray.io/tpu-topology"]
+
+    if "ray.io/accelerator-type" not in first_bundle_labels:
+        raise ValueError(
+            "A TPU topology was requested, but 'ray.io/accelerator-type' "
+            "was not found in the placement group bundle labels. The accelerator type "
+            "(e.g., 'TPU-V6E') is required to provision a multi-host slice."
+        )
+
+    raw_version = first_bundle_labels["ray.io/accelerator-type"]
+    tpu_version = raw_version.lower().replace("tpu-", "")
+
+    worker_bundle = {"TPU": 1}
+    if bundles:
+        tpu_bundles = [b for b in bundles if b.get("TPU", 0) > 0]
+        if tpu_bundles:
+            worker_bundle = tpu_bundles[0]
+            if any(b.get("TPU") != worker_bundle.get("TPU") for b in tpu_bundles):
+                raise ValueError(
+                    "Heterogeneous TPU bundles are not supported when a TPU topology is requested. "
+                    "A multi-host TPU slice requires homogeneous resource bundles across all workers."
+                )
+
+    return tpu_topology, tpu_version, worker_bundle

--- a/python/ray/serve/_private/utils.py
+++ b/python/ray/serve/_private/utils.py
@@ -874,7 +874,7 @@ def resolve_tpu_slice_kwargs(
     if bundles:
         tpu_bundles = [b for b in bundles if b.get("TPU", 0) > 0]
         if tpu_bundles:
-            worker_bundle = tpu_bundles[0]
+            worker_bundle = tpu_bundles[-1].copy()
             if any(b.get("TPU") != worker_bundle.get("TPU") for b in tpu_bundles):
                 raise ValueError(
                     "Heterogeneous TPU bundles are not supported when a TPU topology is requested. "


### PR DESCRIPTION
## Description
This PR is a follow-up to #62941. I realized we don't need explicit resource requests in the ray remote options for TPU because the PG is already provisioned, and the ray.remote call in `_prepare_engine_config` uses `PlacementGroupSchedulingStrategy`. The current code requests fractional TPUs which triggers Ray Core validation errors, and it can cause a resource conflict/deadlock if the remote task doesn't release the TPU resource before the workers start to schedule. We now pass an empty resource dict and pin the task using a `label_selector`.

This PR also includes several other structural fixes I found necessary when testing the latest vllm-tpu image with Ray and Gemma 4. These are:

- Removed deferred placement groups logic for TPUs in favor of appending required `bundle_label_selectors` for TPU. Deferring the PG meant the replica actor could schedule on the head node, which broke node-local model loading and env var assumptions in [tpu_inference](https://github.com/vllm-project/tpu-inference). In some runs, the Serve replica would schedule to the CPU head pod - causing errors. We now instead inject `ray.io/tpu-topology` and `ray.io/accelerator-type` labels into the deployment options, and `_default_create_placement_group` intercepts these to provision a `SlicePlacementGroup` upfront.

 - Fixed libtpu lockfile crashes via per-host bundles - `TPUAccelerator.default_bundles()` was previously defaulting to 1 TPU per bundle. It now dynamically calculates and returns bundles grouped by `chips_per_host` - per the examples I see in `tpu_inference` this will be the common pattern. Users can still request chip-level bundles by overriding `bundle_per_worker`.

- Pydantic v2 incompatibility in llm_server: I was seeing `ValueError: "ChatCompletionRequest" object has no field "request_id"` when sending a request to the model server. It was fixed by wrapping the request.request_id = request_id injection in a `try/except ValueError: pass` block to respect strict OpenAI API schemas.

- Removed `__del__` from `TPUAccelerator` because it resulted in nondeterministic garbage collection of the Slice PG when it was still being used (e.g., during child download tasks). We should just rely on shutdown being called when the replica scales down gracefully.

- Update `SlicePlacementGroup` to respect user passed in `bundle_label_selector` and merge it with the dynamic TPU slice specific selectors.

## Related issues

## Additional information
