### PR TITLE
Fix Kafka watermark helper indentation

### DIFF
--- a/python/ray/data/tests/datasource/test_kafka.py
+++ b/python/ray/data/tests/datasource/test_kafka.py
@@ -26,18 +26,25 @@ def _wait_for_watermark(bootstrap_server, topic, expected_count, timeout=5):
         }
     )
     try:
-        deadline = time.time() + timeout
-        total = 0
-        while time.time() < deadline:
-            metadata = consumer.list_topics(topic, timeout=5)
-            topic_meta = metadata.topics.get(topic)
-            if topic_meta and topic_meta.partitions:
-                total = 0
-                for pid in topic_meta.partitions:
-                    _, high = consumer.get_watermark_offsets(
-                        TopicPartition(topic, pid), timeout=10
-                    )
-                    total += high
+       deadline = time.monotonic() + timeout
+       total = 0
+       while True:
+           remaining = deadline - time.monotonic()
+           if remaining <= 0:
+               break
+
+           metadata = consumer.list_topics(topic, timeout=remaining)
+           topic_meta = metadata.topics.get(topic)
+           if topic_meta and topic_meta.partitions:
+               total = 0
+               for pid in topic_meta.partitions:
+                   remaining = deadline - time.monotonic()
+                   if remaining <= 0:
+                       break
+                   _, high = consumer.get_watermark_offsets(
+                       TopicPartition(topic, pid), timeout=remaining
+                   )
+                   total += high
                 if total >= expected_count:
                     return
             time.sleep(0.1)

--- a/python/ray/data/tests/datasource/test_kafka.py
+++ b/python/ray/data/tests/datasource/test_kafka.py
@@ -26,25 +26,25 @@ def _wait_for_watermark(bootstrap_server, topic, expected_count, timeout=5):
         }
     )
     try:
-       deadline = time.monotonic() + timeout
-       total = 0
-       while True:
-           remaining = deadline - time.monotonic()
-           if remaining <= 0:
-               break
+        deadline = time.monotonic() + timeout
+        total = 0
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
 
-           metadata = consumer.list_topics(topic, timeout=remaining)
-           topic_meta = metadata.topics.get(topic)
-           if topic_meta and topic_meta.partitions:
-               total = 0
-               for pid in topic_meta.partitions:
-                   remaining = deadline - time.monotonic()
-                   if remaining <= 0:
-                       break
-                   _, high = consumer.get_watermark_offsets(
-                       TopicPartition(topic, pid), timeout=remaining
-                   )
-                   total += high
+            metadata = consumer.list_topics(topic, timeout=remaining)
+            topic_meta = metadata.topics.get(topic)
+            if topic_meta and topic_meta.partitions:
+                total = 0
+                for pid in topic_meta.partitions:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    _, high = consumer.get_watermark_offsets(
+                        TopicPartition(topic, pid), timeout=remaining
+                    )
+                    total += high
                 if total >= expected_count:
                     return
             time.sleep(0.1)

--- a/python/ray/data/tests/datasource/test_kafka.py
+++ b/python/ray/data/tests/datasource/test_kafka.py
@@ -15,6 +15,40 @@ from ray.data._internal.datasource.kafka_datasource import (
 pytest.importorskip("confluent_kafka")
 
 
+def _wait_for_watermark(bootstrap_server, topic, expected_count, timeout=5):
+    """Poll until the topic's high watermark reaches expected_count messages."""
+    from confluent_kafka import Consumer, TopicPartition
+
+    consumer = Consumer(
+        {
+            "bootstrap.servers": bootstrap_server,
+            "group.id": "test-watermark-poller",
+        }
+    )
+    try:
+        deadline = time.time() + timeout
+        total = 0
+        while time.time() < deadline:
+            metadata = consumer.list_topics(topic, timeout=5)
+            topic_meta = metadata.topics.get(topic)
+            if topic_meta and topic_meta.partitions:
+                total = 0
+                for pid in topic_meta.partitions:
+                    _, high = consumer.get_watermark_offsets(
+                        TopicPartition(topic, pid), timeout=10
+                    )
+                    total += high
+                if total >= expected_count:
+                    return
+            time.sleep(0.1)
+        raise TimeoutError(
+            f"Timed out waiting for {expected_count} messages in topic {topic!r} "
+            f"(got {total})"
+        )
+    finally:
+        consumer.close()
+
+
 @pytest.fixture(scope="session")
 def kafka_container():
     from testcontainers.kafka import KafkaContainer
@@ -250,9 +284,7 @@ def test_read_kafka_basic(bootstrap_server, kafka_producer, ray_start_regular_sh
         message = {"id": i, "value": f"message-{i}"}
         kafka_producer.produce(topic, value=message, key=f"key-{i}")
     kafka_producer.flush()
-
-    # Wait a bit for messages to be committed
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 100)
 
     # Read from Kafka
     ds = ray.data.read_kafka(
@@ -311,7 +343,7 @@ def test_read_kafka_with_offsets(
         message = {"id": i, "value": f"message-{i}"}
         kafka_producer.produce(topic, value=message)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, total_messages)
 
     ds = ray.data.read_kafka(
         topics=[topic],
@@ -344,7 +376,7 @@ def test_read_kafka_multiple_partitions(
         partition = i % 3
         kafka_producer.produce(topic, value=message, partition=partition)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 150)
 
     # Read from all partitions
     ds = ray.data.read_kafka(
@@ -373,7 +405,8 @@ def test_read_kafka_multiple_topics(
         kafka_producer.produce(topic2, value=message)
 
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic1, 50)
+    _wait_for_watermark(bootstrap_server, topic2, 30)
 
     # Read from both topics
     ds = ray.data.read_kafka(
@@ -398,7 +431,7 @@ def test_read_kafka_with_message_headers(
         ]
         kafka_producer.produce(topic, value=message, headers=headers)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 10)
 
     ds = ray.data.read_kafka(
         topics=[topic],
@@ -441,7 +474,7 @@ def test_read_kafka_offset_exceeds_available_messages(
         message = {"id": i, "value": f"message-{i}"}
         kafka_producer.produce(topic, value=message)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 100)
 
     # end_offset exceeds available messages, but it gets clamped to the high
     # watermark during offset resolution, so the read completes without
@@ -467,7 +500,7 @@ def test_read_kafka_default_no_timeout(
         message = {"id": i, "value": f"message-{i}"}
         kafka_producer.produce(topic, value=message)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 50)
 
     # timeout_ms is intentionally omitted (defaults to None).
     # Verifies the no-timeout code path works correctly.
@@ -525,7 +558,7 @@ def test_read_kafka_invalid_offsets(
         message = {"id": i, "value": f"message-{i}"}
         kafka_producer.produce(topic, value=message)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 100)
 
     with pytest.raises(ValueError, match=expected_error):
         ds = ray.data.read_kafka(
@@ -551,8 +584,7 @@ def test_read_kafka_with_datetime_offsets(
     for i in range(3):
         kafka_producer.produce(topic, value={"id": i}, timestamp=msg_ts)
     kafka_producer.flush()
-    # Brief wait for consumer-side metadata propagation after flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 3)
 
     ds = ray.data.read_kafka(
         topics=[topic],
@@ -596,8 +628,7 @@ def test_read_kafka_datetime_partial_range(
         timestamp=batch2_ts,
     )
     kafka_producer.flush()
-    # Brief wait for consumer-side metadata propagation after flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 4)
 
     # Read only the second batch using boundary_time as start
     ds = ray.data.read_kafka(
@@ -628,8 +659,7 @@ def test_read_kafka_datetime_after_all_messages(
 
     kafka_producer.produce(topic, value={"id": 0})
     kafka_producer.flush()
-    # Brief wait for consumer-side metadata propagation after flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 1)
 
     future_time = datetime(2099, 1, 1)
 
@@ -651,8 +681,7 @@ def test_read_kafka_datetime_before_all_messages(
 
     kafka_producer.produce(topic, value={"id": 0})
     kafka_producer.flush()
-    # Brief wait for consumer-side metadata propagation after flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 1)
 
     past_time = datetime(1970, 1, 2)
 
@@ -1254,7 +1283,7 @@ def test_per_partition_start_offset_non_existent_partition(
         message = {"id": i, "value": f"message-{i}"}
         kafka_producer.produce(topic, value=message)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 10)
 
     with pytest.raises(
         ValueError,
@@ -1286,7 +1315,7 @@ def test_per_partition_start_offset_specific_offsets(
         kafka_producer.produce(topic, value={"id": i}, partition=0)
         kafka_producer.produce(topic, value={"id": i}, partition=1)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 100)
 
     # Read partition 0 from offset 20, partition 1 from offset 40
     # Expected: 30 messages from partition 0 + 10 messages from partition 1 = 40
@@ -1319,7 +1348,7 @@ def test_per_partition_end_offset_specific_offsets(
         kafka_producer.produce(topic, value={"id": i}, partition=0)
         kafka_producer.produce(topic, value={"id": i}, partition=1)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 100)
 
     # End partition 0 at offset 30, partition 1 at offset 20
     # Expected: 30 messages from partition 0 + 20 messages from partition 1 = 50
@@ -1352,7 +1381,7 @@ def test_per_partition_start_offset_fallback_to_earliest(
         kafka_producer.produce(topic, value={"id": i}, partition=0)
         kafka_producer.produce(topic, value={"id": i}, partition=1)
     kafka_producer.flush()
-    time.sleep(0.3)
+    _wait_for_watermark(bootstrap_server, topic, 100)
 
     # Only specify offset for partition 0; partition 1 should fall back to earliest (0)
     # Expected: 30 messages from partition 0 + 50 messages from partition 1 = 80


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Fixes mixed indentation in `_wait_for_watermark` in `python/ray/data/tests/datasource/test_kafka.py`, which caused Python parsing/pre-commit to fail with `IndentationError` on the PR branch.

## Related issues
Related to #63099.

## Additional information
The fix commit was also pushed directly to the original PR branch `owenowenisme/ray:data/unflaky-test-kafka` and amended with a valid DCO sign-off.

Validated with:
- `python3 -m py_compile python/ray/data/tests/datasource/test_kafka.py`
- `ast.parse(...)` on `python/ray/data/tests/datasource/test_kafka.py`
- `bash ci/lint/check-docstyle.sh python/ray/data/tests/datasource/test_kafka.py`

Note: `pre-commit` is not installed in this cloud environment, so I ran the repo hook script directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47583c86-d4fb-401e-bb23-4e8dbde2fd22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47583c86-d4fb-401e-bb23-4e8dbde2fd22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

