### PR TITLE
[train][Docs] Document S3-compatible storage

### DIFF
--- a/doc/source/train/user-guides/persistent-storage.rst
+++ b/doc/source/train/user-guides/persistent-storage.rst
@@ -215,13 +215,13 @@ You can use any of these implementations by wrapping the ``fsspec`` filesystem w
 
 
 
-MinIO and other S3-compatible storage
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+S3-compatible storage (Backblaze B2, MinIO, etc.)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can follow the :ref:`examples shown above <custom-storage-filesystem>` to configure
-a custom S3 filesystem to work with MinIO.
-
-Note that including these as query parameters in the ``storage_path`` URI directly is another option:
+For S3-compatible stores like `Backblaze B2 <https://www.backblaze.com/cloud-storage>`_
+or `MinIO <https://min.io/>`_, follow the
+:ref:`custom-filesystem examples above <custom-storage-filesystem>`, or pass
+the endpoint as a query parameter in the ``storage_path`` URI:
 
 .. testcode::
     :skipif: True
@@ -232,10 +232,22 @@ Note that including these as query parameters in the ``storage_path`` URI direct
     trainer = TorchTrainer(
         ...,
         run_config=train.RunConfig(
-            storage_path="s3://bucket-name/sub-path?endpoint_override=http://localhost:9000",
+            # Backblaze B2 (substitute your bucket's region):
+            storage_path="s3://bucket-name/sub-path?endpoint_override=https://s3.us-west-001.backblazeb2.com",
+            # MinIO running locally:
+            # storage_path="s3://bucket-name/sub-path?endpoint_override=http://localhost:9000",
             name="unique-run-id",
         )
     )
+
+Alternatively, configure the endpoint and credentials through the environment
+variables Arrow reads (see
+`Arrow's S3 environment variables <https://arrow.apache.org/docs/cpp/env_vars.html>`_)
+and use a plain ``storage_path="s3://bucket/path"``. For Backblaze B2, set
+``AWS_ENDPOINT_URL_S3`` to your bucket's endpoint, and ``AWS_ACCESS_KEY_ID`` /
+``AWS_SECRET_ACCESS_KEY`` to your B2 application key ID and key.
+
+See `this end-to-end notebook <https://github.com/backblaze-b2-samples/notebooks/tree/main/ray-train-tune-checkpoints>`_ for a worked Backblaze B2 example.
 
 
 Overview of Ray Train outputs


### PR DESCRIPTION
## Why are these changes needed?

Ray Train already works with any S3-compatible object store through pyarrow's `S3FileSystem` (via `endpoint_override` in the `storage_path` URI, or the standard `AWS_*` environment variables). This PR documents that path in the Train persistent-storage guide and adds the Backblaze B2 specifics.

**Docs-only, no code changes.** (An earlier revision added an env-var aliasing helper; per review feedback it was removed in favor of documenting the setup users perform themselves.)

Changes to `doc/source/train/user-guides/persistent-storage.rst`:

- Retitles the section to "S3-compatible storage (Backblaze B2, MinIO, etc.)".
- Shows the `endpoint_override` query-parameter form for Backblaze B2 and MinIO (local).
- Notes that the standard AWS environment variables (`AWS_ENDPOINT_URL_S3`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) work with a plain `s3://bucket/path`.
- Documents that Backblaze B2 publishes credentials as `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY`; users set `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` to those values, since pyarrow reads only the AWS-named variables.
- Links a complete end-to-end Backblaze B2 notebook example.

## Related issue number

Related to #63104

## Checks

- [x] Change is contained to `doc/source/train/user-guides/persistent-storage.rst`.
- [x] No code paths changed; existing tests unaffected.
