### PR TITLE
[RLlib] Example: clearing ema

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -4728,13 +4728,13 @@ py_test(
 )
 
 py_test(
-    name = "examples/metrics/persistent_ema",
+    name = "examples/metrics/clearing_ema",
     size = "medium",
-    srcs = ["examples/metrics/persistent_ema.py"],
+    srcs = ["examples/metrics/clearing_ema.py"],
     args = [
         "--stop-iters=3",
     ],
-    main = "examples/metrics/persistent_ema.py",
+    main = "examples/metrics/clearing_ema.py",
     tags = [
         "examples",
         "exclusive",

--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -4727,6 +4727,21 @@ py_test(
     ],
 )
 
+py_test(
+    name = "examples/metrics/persistent_ema",
+    size = "medium",
+    srcs = ["examples/metrics/persistent_ema.py"],
+    args = [
+        "--stop-iters=3",
+    ],
+    main = "examples/metrics/persistent_ema.py",
+    tags = [
+        "examples",
+        "exclusive",
+        "team:rllib",
+    ],
+)
+
 # subdirectory: multi_agent/
 # ....................................
 py_test(

--- a/rllib/examples/metrics/clearing_ema.py
+++ b/rllib/examples/metrics/clearing_ema.py
@@ -11,29 +11,34 @@ add a new key (referenced via ``log_value(..., reduce="<your_key>")``) or
 replace an existing key to change RLlib's default reduction behaviour for
 all metrics that internally use that reduction.
 
-This example replaces the default ``"ema"`` key with ``PersistentEmaStats``,
+This example replaces the default ``"ema"`` key with ``ClearingEmaStats``,
 a subclass of :py:class:`~ray.rllib.utils.metrics.stats.ema.EmaStats` that
-keeps its running value across ``reduce()`` calls. The default ``EmaStats``
-resets the running value to ``NaN`` after every reduce, so the next
-iteration's EMA starts from scratch; ``PersistentEmaStats`` instead carries
-the value forward, producing a metric that smoothly tracks across training
-iterations. Because RLlib's internal timers (and other ``reduce="ema"``
+resets its running value to ``NaN`` after every ``reduce()`` call. The
+default ``EmaStats`` carries the running value forward across reduces so a
+metric smoothly tracks across training iterations; ``ClearingEmaStats``
+instead restarts each iteration's EMA from scratch. This reproduces the
+short-lived behaviour from Ray 2.53/2.54 and is useful when you want each
+reported value to reflect only the data observed within a single
+iteration. Because RLlib's internal timers (and other ``reduce="ema"``
 metrics) go through the lookup, swapping the key is enough -- no per-metric
 plumbing required.
 
-A small ``VerifyPersistentEmaCallback`` is attached purely as a sanity
+A small ``VerifyClearingEmaCallback`` is attached purely as a sanity
 check: every ``on_train_result`` it asserts that RLlib's built-in
-training-iteration timer is now an instance of ``PersistentEmaStats`` and
-that its internal ``_value`` survives the reduce that just happened.
+training-iteration timer is now an instance of ``ClearingEmaStats`` and
+that its internal ``_value`` was reset to ``NaN`` by the reduce that just
+happened.
 
 How to run this script
 ----------------------
-``python persistent_ema.py --stop-iters=3``
+``python clearing_ema.py --stop-iters=3``
 
 For debugging:
-``python persistent_ema.py --no-tune --num-env-runners=0 --stop-iters=3``
+``python clearing_ema.py --no-tune --num-env-runners=0 --stop-iters=3``
 """
 import math
+
+import numpy as np
 
 from ray.rllib.callbacks.callbacks import RLlibCallback
 from ray.rllib.examples.utils import (
@@ -46,22 +51,21 @@ from ray.rllib.utils.metrics.stats.ema import EmaStats
 from ray.tune.registry import get_trainable_cls
 
 
-class PersistentEmaStats(EmaStats):
+class ClearingEmaStats(EmaStats):
     # This is required such that RLlib can correctly restore metrics from checkpoints
     stats_cls_identifier = "ema"
 
     def reduce(self, compile: bool = True):
-        saved_value = self._value
         result = super().reduce(compile=compile)
-        self._value = saved_value
+        self._value = np.nan
         return result
 
 
-class VerifyPersistentEmaCallback(RLlibCallback):
+class VerifyClearingEmaCallback(RLlibCallback):
     def on_train_result(self, *, algorithm, metrics_logger, result, **kwargs) -> None:
         timer_stats = metrics_logger.stats[TIMERS][TRAINING_ITERATION_TIMER]
-        # Only check that our value is persisted
-        assert not math.isnan(timer_stats._value)
+        # Only check that our value was cleared
+        assert math.isnan(timer_stats._value)
 
 
 parser = add_rllib_example_script_args(default_reward=50.0, default_iters=5)
@@ -72,15 +76,15 @@ if __name__ == "__main__":
 
     # Override the default "ema" key in the lookup. Every metric RLlib logs
     # with `reduce="ema"` (e.g. all of its built-in timers) will now use
-    # `PersistentEmaStats`.
-    custom_stats_lookup = {**DEFAULT_STATS_CLS_LOOKUP, "ema": PersistentEmaStats}
+    # `ClearingEmaStats`.
+    custom_stats_lookup = {**DEFAULT_STATS_CLS_LOOKUP, "ema": ClearingEmaStats}
 
     base_config = (
         get_trainable_cls(args.algo)
         .get_default_config()
         .environment("CartPole-v1")
         .reporting(custom_stats_cls_lookup=custom_stats_lookup)
-        .callbacks(VerifyPersistentEmaCallback)
+        .callbacks(VerifyClearingEmaCallback)
     )
 
     run_rllib_example_script_experiment(base_config, args)

--- a/rllib/examples/metrics/clearing_ema.py
+++ b/rllib/examples/metrics/clearing_ema.py
@@ -23,7 +23,7 @@ iteration. Because RLlib's internal timers (and other ``reduce="ema"``
 metrics) go through the lookup, swapping the key is enough -- no per-metric
 plumbing required.
 
-A small ``VerifyClearingEmaCallback`` is attached purely as a sanity
+``VerifyClearingEmaCallback`` is attached purely as a sanity
 check: every ``on_train_result`` it asserts that RLlib's built-in
 training-iteration timer is now an instance of ``ClearingEmaStats`` and
 that its internal ``_value`` was reset to ``NaN`` by the reduce that just
@@ -52,9 +52,6 @@ from ray.tune.registry import get_trainable_cls
 
 
 class ClearingEmaStats(EmaStats):
-    # This is required such that RLlib can correctly restore metrics from checkpoints
-    stats_cls_identifier = "ema"
-
     def reduce(self, compile: bool = True):
         result = super().reduce(compile=compile)
         self._value = np.nan

--- a/rllib/examples/metrics/persistent_ema.py
+++ b/rllib/examples/metrics/persistent_ema.py
@@ -1,0 +1,86 @@
+"""Example of plugging a custom EMA Stats class into the MetricsLogger via
+``AlgorithmConfig.reporting(custom_stats_cls_lookup=...)``.
+
+RLlib aggregates metrics through Stats objects (see
+:py:class:`~ray.rllib.utils.metrics.stats.base.StatsBase`). A ``reduce=...``
+keyword (e.g. ``"ema"``, ``"mean"``) maps to a Stats class via
+:py:data:`~ray.rllib.utils.metrics.metrics_logger.DEFAULT_STATS_CLS_LOOKUP`.
+By passing your own dictionary to
+``AlgorithmConfig.reporting(custom_stats_cls_lookup=...)`` you can either
+add a new key (referenced via ``log_value(..., reduce="<your_key>")``) or
+replace an existing key to change RLlib's default reduction behaviour for
+all metrics that internally use that reduction.
+
+This example replaces the default ``"ema"`` key with ``PersistentEmaStats``,
+a subclass of :py:class:`~ray.rllib.utils.metrics.stats.ema.EmaStats` that
+keeps its running value across ``reduce()`` calls. The default ``EmaStats``
+resets the running value to ``NaN`` after every reduce, so the next
+iteration's EMA starts from scratch; ``PersistentEmaStats`` instead carries
+the value forward, producing a metric that smoothly tracks across training
+iterations. Because RLlib's internal timers (and other ``reduce="ema"``
+metrics) go through the lookup, swapping the key is enough -- no per-metric
+plumbing required.
+
+A small ``VerifyPersistentEmaCallback`` is attached purely as a sanity
+check: every ``on_train_result`` it asserts that RLlib's built-in
+training-iteration timer is now an instance of ``PersistentEmaStats`` and
+that its internal ``_value`` survives the reduce that just happened.
+
+How to run this script
+----------------------
+``python persistent_ema.py --stop-iters=3``
+
+For debugging:
+``python persistent_ema.py --no-tune --num-env-runners=0 --stop-iters=3``
+"""
+import math
+
+from ray.rllib.callbacks.callbacks import RLlibCallback
+from ray.rllib.examples.utils import (
+    add_rllib_example_script_args,
+    run_rllib_example_script_experiment,
+)
+from ray.rllib.utils.metrics import TIMERS, TRAINING_ITERATION_TIMER
+from ray.rllib.utils.metrics.metrics_logger import DEFAULT_STATS_CLS_LOOKUP
+from ray.rllib.utils.metrics.stats.ema import EmaStats
+from ray.tune.registry import get_trainable_cls
+
+
+class PersistentEmaStats(EmaStats):
+    # This is required such that RLlib can correctly restore metrics from checkpoints
+    stats_cls_identifier = "ema"
+
+    def reduce(self, compile: bool = True):
+        saved_value = self._value
+        result = super().reduce(compile=compile)
+        self._value = saved_value
+        return result
+
+
+class VerifyPersistentEmaCallback(RLlibCallback):
+    def on_train_result(self, *, algorithm, metrics_logger, result, **kwargs) -> None:
+        timer_stats = metrics_logger.stats[TIMERS][TRAINING_ITERATION_TIMER]
+        # Only check that our value is persisted
+        assert not math.isnan(timer_stats._value)
+
+
+parser = add_rllib_example_script_args(default_reward=50.0, default_iters=5)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    # Override the default "ema" key in the lookup. Every metric RLlib logs
+    # with `reduce="ema"` (e.g. all of its built-in timers) will now use
+    # `PersistentEmaStats`.
+    custom_stats_lookup = {**DEFAULT_STATS_CLS_LOOKUP, "ema": PersistentEmaStats}
+
+    base_config = (
+        get_trainable_cls(args.algo)
+        .get_default_config()
+        .environment("CartPole-v1")
+        .reporting(custom_stats_cls_lookup=custom_stats_lookup)
+        .callbacks(VerifyPersistentEmaCallback)
+    )
+
+    run_rllib_example_script_experiment(base_config, args)

--- a/rllib/utils/metrics/metrics_logger.py
+++ b/rllib/utils/metrics/metrics_logger.py
@@ -124,7 +124,7 @@ class MetricsLogger:
     The MetricsLogger supports logging anything that has a corresponding reduction method.
     These are defined natively in the Stats classes, which are used to log the metrics.
     Please take a look ray.rllib.utils.metrics.metrics_logger.DEFAULT_STATS_CLS_LOOKUP for the available reduction methods.
-    You can provide your own reduce methods by extending ray.rllib.utils.metrics.metrics_logger.DEFAULT_STATS_CLS_LOOKUP and passing it to AlgorithmConfig.logging().
+    You can provide your own reduce methods by extending ray.rllib.utils.metrics.metrics_logger.DEFAULT_STATS_CLS_LOOKUP and passing it to AlgorithmConfig.reporting().
 
     Notes on architecture:
     In our docstrings we make heavy use of the phrase 'parallel components'.


### PR DESCRIPTION
## Description

Example script to show how to override the default EMA stat behavior (which carries the running value over across reduces) with a clearing variant that resets the value to NaN after each reduce — i.e. how to opt back into the Ray 2.53/2.54 short-lived behavior.