### PR TITLE
[Data] Remove one-to-one logical input_dependency

### DIFF
--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -57,10 +57,6 @@ class AbstractOneToOne(LogicalOperator):
     def num_outputs(self) -> Optional[int]:
         return self._num_outputs
 
-    @property
-    def input_dependency(self) -> LogicalOperator:
-        return self.input_dependencies[0]
-
 
 @dataclass(frozen=True, repr=False, eq=False)
 class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -46,12 +46,13 @@ class LimitPushdownRule(Rule):
         def transform(node: LogicalOperator) -> LogicalOperator:
             if isinstance(node, Limit):
                 # First, try to fuse with upstream Limit if possible (reuse fusion logic)
-                upstream_op = node.input_dependency
+                upstream_op = node.input_dependencies[0]
                 if isinstance(upstream_op, Limit):
                     # Fuse consecutive Limits: Limit[n] -> Limit[m] becomes Limit[min(n,m)]
                     new_limit = min(node.limit, upstream_op.limit)
                     return Limit(
-                        new_limit, input_dependencies=[upstream_op.input_dependency]
+                        new_limit,
+                        input_dependencies=[upstream_op.input_dependencies[0]],
                     )
 
                 # If no fusion, apply pushdown logic
@@ -75,7 +76,7 @@ class LimitPushdownRule(Rule):
 
         def transform(node: LogicalOperator) -> LogicalOperator:
             if isinstance(node, Limit):
-                if isinstance(node.input_dependency, Union):
+                if isinstance(node.input_dependencies[0], Union):
                     return self._push_limit_into_union(node)
                 return self._push_limit_down(node)
             return node
@@ -103,7 +104,7 @@ class LimitPushdownRule(Rule):
             after:
                 child -> Limit(n) -> Union -> Limit(n)   (no extra branch limit inserted)
         """
-        union_op = limit_op.input_dependency
+        union_op = limit_op.input_dependencies[0]
         assert isinstance(union_op, Union)
 
         def _branch_has_limit(op: LogicalOperator, limit: int) -> bool:
@@ -115,8 +116,8 @@ class LimitPushdownRule(Rule):
             ):
                 if isinstance(current, Limit):
                     return current.limit == limit
-                # Safe to use input_dependency: current is an AbstractOneToOne here.
-                current = current.input_dependency
+                # Safe to use the first dependency: current is one-to-one here.
+                current = current.input_dependencies[0]
 
             return isinstance(current, Limit) and current.limit == limit
 
@@ -130,7 +131,7 @@ class LimitPushdownRule(Rule):
                 continue
             raw_limit = Limit(limit_op.limit, input_dependencies=[child])
 
-            if isinstance(raw_limit.input_dependency, Union):
+            if isinstance(raw_limit.input_dependencies[0], Union):
                 # This represents the limit operator appended after the union.
                 pushed_tail = self._push_limit_into_union(raw_limit)
             else:
@@ -148,7 +149,7 @@ class LimitPushdownRule(Rule):
         """
         # Traverse up the DAG until we reach the first operator that meets
         # one of the stopping conditions
-        current_op = limit_op.input_dependency
+        current_op = limit_op.input_dependencies[0]
         num_rows_preserving_ops: List[LogicalOperator] = []
         while (
             isinstance(current_op, AbstractOneToOne)
@@ -164,7 +165,7 @@ class LimitPushdownRule(Rule):
                     )
                     break
             num_rows_preserving_ops.append(current_op)
-            current_op = current_op.input_dependency
+            current_op = current_op.input_dependencies[0]
 
         # If we couldn't push through any operators, return original
         if not num_rows_preserving_ops:
@@ -202,7 +203,7 @@ class LimitPushdownRule(Rule):
                 assert len(op.input_dependencies) == 1, len(op.input_dependencies)
                 return replace(
                     op,
-                    input_dependencies=[op.input_dependency],
+                    input_dependencies=[op.input_dependencies[0]],
                     per_block_limit=limit,
                 )
             new_op = copy.copy(op)

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -384,7 +384,7 @@ class FuseOperators(Rule):
         ):
             op.add_map_task_kwargs_fn(map_task_kwargs_fn)
 
-        input_op = up_logical_op.input_dependency
+        input_op = up_logical_op.input_dependencies[0]
         logical_op = AbstractUDFMap(
             name,
             input_op,
@@ -550,7 +550,7 @@ class FuseOperators(Rule):
         # TODO(Scott): This is hacky, remove this once we push fusion to be purely based
         # on a lower-level operator spec.
         if isinstance(up_logical_op, AbstractUDFMap):
-            input_op = up_logical_op.input_dependency
+            input_op = up_logical_op.input_dependencies[0]
         else:
             # Bottom out at the source logical op (e.g. Read()).
             input_op = up_logical_op

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -262,7 +262,7 @@ def _try_fuse(upstream_project: Project, downstream_project: Project) -> Project
 
     return Project(
         exprs=new_exprs,
-        input_dependencies=[upstream_project.input_dependency],
+        input_dependencies=[upstream_project.input_dependencies[0]],
         compute=fused_compute,
         ray_remote_args=downstream_project.ray_remote_args,
     )
@@ -304,12 +304,11 @@ class ProjectionPushdown(Rule):
         # Step 1: Iteratively fuse with upstream Project operations
         current_project: Project = op
 
-        if not isinstance(current_project.input_dependency, Project):
+        upstream_op = current_project.input_dependencies[0]
+        if not isinstance(upstream_op, Project):
             return op
 
-        upstream_project: Project = current_project.input_dependency  # type: ignore[assignment]
-
-        fused = _try_fuse(upstream_project, current_project)
+        fused = _try_fuse(upstream_op, current_project)
 
         return fused
 
@@ -322,7 +321,7 @@ class ProjectionPushdown(Rule):
         current_project: Project = op
 
         # Step 2: Push projection into the data source if supported
-        input_op = current_project.input_dependency
+        input_op = current_project.input_dependencies[0]
         if (
             isinstance(input_op, LogicalOperatorSupportsProjectionPushdown)
             and input_op.supports_projection_pushdown()

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -62,9 +62,9 @@ def test_limit_pushdown_recreates_frozen_download():
     result = LimitPushdownRule()._push_limit_down(limit_op)
 
     assert isinstance(result, Download)
-    assert isinstance(result.input_dependency, Limit)
-    assert result.input_dependency.limit == 1
-    assert result.input_dependency.input_dependency is input_op
+    assert isinstance(result.input_dependencies[0], Limit)
+    assert result.input_dependencies[0].limit == 1
+    assert result.input_dependencies[0].input_dependencies[0] is input_op
 
 
 def test_limit_pushdown_basic_limit_fusion(ray_start_regular_shared_2_cpus):

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -141,7 +141,7 @@ class TestProjectionFusion:
             levels.append(
                 {expr.name for expr in current.exprs if not isinstance(expr, StarExpr)}
             )
-            current = current.input_dependency
+            current = current.input_dependencies[0]
 
         return list(reversed(levels))  # Return bottom-up order
 
@@ -153,7 +153,9 @@ class TestProjectionFusion:
         while current:
             if isinstance(current, Project):
                 count += 1
-            current = getattr(current, "input_dependency", None)
+            current = (
+                current.input_dependencies[0] if current.input_dependencies else None
+            )
 
         return count
 
@@ -168,7 +170,9 @@ class TestProjectionFusion:
                 operators.append(f"Project({expr_count} exprs)")
             else:
                 operators.append(current.__class__.__name__)
-            current = getattr(current, "input_dependency", None)
+            current = (
+                current.input_dependencies[0] if current.input_dependencies else None
+            )
 
         return " -> ".join(operators)
 

--- a/python/ray/data/tests/test_projection_fusion.py
+++ b/python/ray/data/tests/test_projection_fusion.py
@@ -10,6 +10,7 @@ import ray
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators.input_data_operator import InputData
 from ray.data._internal.logical.operators.map_operator import Project
+from ray.data._internal.logical.operators.one_to_one_operator import AbstractOneToOne
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.logical.rules import (
     ProjectionPushdown,
@@ -154,7 +155,9 @@ class TestProjectionFusion:
             if isinstance(current, Project):
                 count += 1
             current = (
-                current.input_dependencies[0] if current.input_dependencies else None
+                current.input_dependencies[0]
+                if isinstance(current, AbstractOneToOne)
+                else None
             )
 
         return count
@@ -171,7 +174,9 @@ class TestProjectionFusion:
             else:
                 operators.append(current.__class__.__name__)
             current = (
-                current.input_dependencies[0] if current.input_dependencies else None
+                current.input_dependencies[0]
+                if isinstance(current, AbstractOneToOne)
+                else None
             )
 
         return " -> ".join(operators)


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

After replacing single-input logical operators with explicit `input_dependencies` constructor fields, the one-off `AbstractOneToOne.input_dependency` convenience property is no longer needed. Removing it keeps logical operator access aligned on the canonical `input_dependencies` field before the later `_get_args`, base-contract, and rule-cleanup steps.

#### What this PR changes:

Removes the `input_dependency` property from `AbstractOneToOne`.

This updates logical optimizer rules and tests that previously used `input_dependency` to access the single input through `input_dependencies[0]` instead.

This PR does not clean up `_get_args`, change the shared `Operator` storage contract, remove redundant `__repr__` / `__str__`, clean up broader logical-rule special-casing, or change equality/comparability semantics. Those remain separate follow-ups in the current split plan.

## Related issues

Part of #60312

## Additional information

This PR corresponds to the `AbstractOneToOne.input_dependency` removal step in the current split plan.

### Tests

- `python -m py_compile ...`
- `git diff --check`
- `pre-commit run --files ...`
- `PYTHONPATH=python python -m pytest python/ray/data/tests/test_execution_optimizer_limit_pushdown.py::test_limit_pushdown_recreates_frozen_download python/ray/data/tests/test_projection_fusion.py -q`
- `PYTHONPATH=python python -m pytest python/ray/data/tests/test_execution_optimizer_limit_pushdown.py -q`
- `PYTHONPATH=python python -m pytest python/ray/data/tests/test_operator_fusion.py -q`

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- PR-Next-0: Convert the remaining concrete logical operators to frozen dataclasses
- PR-Next-1: Convert abstract logical operator classes to frozen dataclasses
- PR-Next-2: make logical-operator names derived by default
- PR-Next-3: deduplicate `_apply_transform`
- PR-Next-4: replace `input_op: InitVar` with a real `input_dependencies` field
- This PR: remove `input_dependency` on `AbstractOneToOne`

Next:
- clean up `_get_args`
- make `Operator` a thin shared base
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`
