### PR TITLE
[Data] Clean logical operator args export

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -100,12 +100,11 @@ class LogicalOperator(Operator, ABC):
     def _get_args(self) -> Dict[str, Any]:
         """This Dict must be serializable"""
         args: Dict[str, Any] = {}
-        for key, value in vars(self).items():
-            if key.startswith("_"):
-                args[key] = value
-            else:
-                # Keep underscore-prefixed keys to preserve legacy export schema.
-                args[f"_{key}"] = value
+        for dataclass_field in fields(self):
+            key = dataclass_field.name
+            value = getattr(self, key)
+            # Keep underscore-prefixed keys to preserve legacy export schema.
+            args[key if key.startswith("_") else f"_{key}"] = value
         args["_name"] = self.name
         # Preserve legacy export shape even though output deps are no longer tracked.
         args["_output_dependencies"] = []

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -90,12 +90,32 @@ class AbstractMap(AbstractOneToOne):
     def set_per_block_limit(self, per_block_limit: int):
         object.__setattr__(self, "per_block_limit", per_block_limit)
 
+    def _get_args(self) -> Dict[str, Any]:
+        args = super()._get_args()
+        for key in [
+            "can_modify_num_rows",
+            "min_rows_per_bundled_input",
+            "ray_remote_args",
+            "ray_remote_args_fn",
+            "compute",
+            "per_block_limit",
+        ]:
+            args[f"_{key}"] = getattr(self, key)
+        return args
+
 
 @dataclass(frozen=True, repr=False, eq=False, init=False)
 class AbstractUDFMap(AbstractMap):
     """Abstract class for logical operators performing a UDF that should be converted
     to physical MapOperator.
     """
+
+    fn: UserDefinedFunction
+    fn_args: Optional[Iterable[Any]] = None
+    fn_kwargs: Optional[Dict[str, Any]] = None
+    fn_constructor_args: Optional[Iterable[Any]] = None
+    fn_constructor_kwargs: Optional[Dict[str, Any]] = None
+    ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
 
     def __init__(
         self,

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -1,7 +1,7 @@
 import json
 import os
-from dataclasses import asdict, dataclass
-from typing import Tuple
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -87,79 +87,68 @@ class TestDataclass:
         self.tuple_field = (1, 2, 3)
 
 
+@dataclass(frozen=True, repr=False, eq=False)
 class DummyLogicalOperator(LogicalOperator):
     """A dummy logical operator for testing _get_logical_args with various data types."""
 
-    def __init__(self, input_op=None):
-        super().__init__(
-            _num_outputs=None,
-        )
-        object.__setattr__(self, "_input_dependencies", [])
-        object.__setattr__(self, "_name", "DummyOperator")
-
-        # Test various data types that might be returned by _get_logical_args
-        object.__setattr__(self, "_string_value", "test_string")
-        object.__setattr__(self, "_int_value", 42)
-        object.__setattr__(self, "_float_value", 3.14)
-        object.__setattr__(self, "_bool_value", True)
-        object.__setattr__(self, "_none_value", None)
-        object.__setattr__(self, "_list_value", [1, 2, 3, "string", None])
-        object.__setattr__(
-            self, "_dict_value", {"key1": "value1", "key2": 123, "key3": None}
-        )
-        object.__setattr__(
-            self,
-            "_nested_dict",
-            {
-                "level1": {
-                    "level2": {
-                        "level3": "deep_value",
-                        "numbers": [1, 2, 3],
-                        "mixed": {"a": 1, "b": "string", "c": None},
-                    }
+    _name: str = field(init=False, default="DummyOperator", repr=False)
+    _input_dependencies: List[LogicalOperator] = field(
+        init=False, default_factory=list, repr=False
+    )
+    _num_outputs: None = field(init=False, default=None, repr=False)
+    _string_value: str = "test_string"
+    _int_value: int = 42
+    _float_value: float = 3.14
+    _bool_value: bool = True
+    _none_value: None = None
+    _list_value: List[Any] = field(default_factory=lambda: [1, 2, 3, "string", None])
+    _dict_value: Dict[str, Any] = field(
+        default_factory=lambda: {"key1": "value1", "key2": 123, "key3": None}
+    )
+    _nested_dict: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "level1": {
+                "level2": {
+                    "level3": "deep_value",
+                    "numbers": [1, 2, 3],
+                    "mixed": {"a": 1, "b": "string", "c": None},
                 }
-            },
-        )
-        object.__setattr__(self, "_tuple_value", (1, "string", None, 3.14))
-        object.__setattr__(self, "_set_value", {1})
-        object.__setattr__(self, "_bytes_value", b"binary_data")
-        object.__setattr__(
-            self,
-            "_complex_dict",
-            {
-                "string_keys": {"a": 1, "b": 2},
-                "int_keys": {
-                    1: "one",
-                    2: "two",
-                },  # This should cause issues if not handled
-                "mixed_keys": {"str": "value", 1: "int_key", None: "none_key"},
-            },
-        )
-        object.__setattr__(
-            self,
-            "_empty_containers",
-            {
-                "empty_list": [],
-                "empty_dict": {},
-                "empty_tuple": (),
-                "empty_set": set(),
-            },
-        )
-        object.__setattr__(
-            self,
-            "_special_values",
-            {
-                "zero": 0,
-                "negative": -1,
-                "large_int": 999999999999999999,
-                "small_float": 0.0000001,
-                "inf": float("inf"),
-                "neg_inf": float("-inf"),
-                "nan": float("nan"),
-            },
-        )
-
-        object.__setattr__(self, "_data_class", TestDataclass())
+            }
+        }
+    )
+    _tuple_value: Tuple[Any, ...] = (1, "string", None, 3.14)
+    _set_value: set = field(default_factory=lambda: {1})
+    _bytes_value: bytes = b"binary_data"
+    _complex_dict: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "string_keys": {"a": 1, "b": 2},
+            "int_keys": {
+                1: "one",
+                2: "two",
+            },  # This should cause issues if not handled
+            "mixed_keys": {"str": "value", 1: "int_key", None: "none_key"},
+        }
+    )
+    _empty_containers: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "empty_list": [],
+            "empty_dict": {},
+            "empty_tuple": (),
+            "empty_set": set(),
+        }
+    )
+    _special_values: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "zero": 0,
+            "negative": -1,
+            "large_int": 999999999999999999,
+            "small_float": 0.0000001,
+            "inf": float("inf"),
+            "neg_inf": float("-inf"),
+            "nan": float("nan"),
+        }
+    )
+    _data_class: TestDataclass = field(default_factory=TestDataclass)
 
     @property
     def num_outputs(self):


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

Logical operators are now consistently modeled as dataclasses, but `_get_args` still builds export args by scanning `vars(self)` and applying an underscore-prefix heuristic. The next cleanup is to make `_get_args` use the dataclass field model directly while preserving the legacy exported key shape.

#### What this PR changes:

Updates `LogicalOperator._get_args` to iterate over `dataclasses.fields(self)` instead of `vars(self)`.

The exported argument keys still use the existing underscore-prefixed schema, and `_name` / `_output_dependencies` are still populated explicitly for compatibility with the current state export shape.

The state export dummy logical operator now declares its exported test values as dataclass fields, so the existing serialization coverage for nested dictionaries, collections, bytes, and dataclasses remains intact under the field-based implementation.

There is one transitional map-layer case preserved explicitly: operator fusion still materializes `AbstractMap` / `AbstractUDFMap` directly as logical references for fused physical map operators. Those abstract classes assign map/UDF args in `__init__`, so this PR keeps the base `_get_args` field-based while adding owner-layer overrides that preserve the existing fused-map export shape for args like `fn`, `compute`, and `ray_remote_args` without changing their constructor or dataclass field model here.

This PR is stacked on #63107. It does not change the shared `Operator` storage contract, remove redundant `__repr__` / `__str__`, clean up broader logical-rule special-casing, or change equality/comparability semantics. Those remain separate follow-ups in the current split plan.

## Related issues

Part of #60312

## Additional information

This PR corresponds to the `_get_args` cleanup step in the current split plan.

### Tests

- `python -m py_compile python/ray/data/_internal/logical/interfaces/logical_operator.py python/ray/data/_internal/logical/operators/map_operator.py python/ray/data/tests/test_state_export.py`
- `git diff --check`
- `pre-commit run --files python/ray/data/_internal/logical/interfaces/logical_operator.py python/ray/data/_internal/logical/operators/map_operator.py python/ray/data/tests/test_state_export.py`
- `PYTHONPATH=python python -m pytest python/ray/data/tests/test_state_export.py -q`

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- PR-Next-0: Convert the remaining concrete logical operators to frozen dataclasses
- PR-Next-1: Convert abstract logical operator classes to frozen dataclasses
- PR-Next-2: make logical-operator names derived by default
- PR-Next-3: deduplicate `_apply_transform`
- PR-Next-4: replace `input_op: InitVar` with a real `input_dependencies` field
- PR-Next-5: remove `input_dependency` on `AbstractOneToOne`
- This PR: clean up `_get_args`

Next:
- make `Operator` a thin shared base
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`
