### PR TITLE
[Core] Add host vs container memory usage distinction to memory panels

### DIFF
--- a/doc/source/ray-observability/reference/system-metrics.rst
+++ b/doc/source/ray-observability/reference/system-metrics.rst
@@ -81,6 +81,18 @@ Ray exports a number of system metrics, which provide introspection into the sta
    * - `ray_node_mem_total`
      - `instance`
      - The amount of physical memory available per node, in bytes.
+   * - `ray_node_mem_used_host`
+     - `instance`
+     - The host (OS-level) physical memory used per node, in bytes.
+   * - `ray_node_mem_total_host`
+     - `instance`
+     - The host (OS-level) total physical memory per node, in bytes.
+   * - `ray_node_cgroup_mem_used`
+     - `instance`
+     - The container memory usage per node (from cgroup), in bytes. Only emitted when cgroup memory limits are present.
+   * - `ray_node_cgroup_mem_total`
+     - `instance`
+     - The container memory limit per node (from cgroup), in bytes. Only emitted when cgroup memory limits are present.
    * - `ray_component_uss_mb`
      - `Component`, `instance`
      - The measured unique set size in megabytes, broken down by logical Ray component. Ray components consist of system components (e.g., raylet, gcs, dashboard, or agent) and the method names of running tasks/actors.

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -524,40 +524,56 @@ def get_cgroup_used_memory(
 
 
 def get_cgroup_mem_stats() -> Optional[Tuple[int, int]]:
-    """Return (used_bytes, total_bytes) from cgroups, or None if unavailable.
+    """
+    Return (used_bytes, total_bytes) from cgroups, or None if unavailable.
 
     Supports both cgroups v1 and v2. Total is capped at the host physical
-    memory so callers always get a sensible upper bound.
+    memory.
     """
-    mem_usage_v1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
-    mem_stat_v1 = "/sys/fs/cgroup/memory/memory.stat"
-    mem_limit_v1 = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-    mem_usage_v2 = "/sys/fs/cgroup/memory.current"
-    mem_stat_v2 = "/sys/fs/cgroup/memory.stat"
-    mem_limit_v2 = "/sys/fs/cgroup/memory.max"
+    mem_usage_v1_file = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+    mem_stat_v1_file = "/sys/fs/cgroup/memory/memory.stat"
+    mem_limit_v1_file = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    mem_usage_v2_file = "/sys/fs/cgroup/memory.current"
+    mem_stat_v2_file = "/sys/fs/cgroup/memory.stat"
+    mem_limit_v2_file = "/sys/fs/cgroup/memory.max"
 
     cgroup_used = None
     cgroup_total = None
     system_total = get_system_memory()
 
-    if os.path.exists(mem_usage_v1) and os.path.exists(mem_stat_v1):
+    if os.path.exists(mem_usage_v1_file) and os.path.exists(mem_stat_v1_file):
         cgroup_used = get_cgroup_used_memory(
-            mem_stat_v1, mem_usage_v1, "total_inactive_file", "total_active_file"
+            mem_stat_v1_file,
+            mem_usage_v1_file,
+            "total_inactive_file",
+            "total_active_file",
         )
-        if os.path.exists(mem_limit_v1):
-            with open(mem_limit_v1, "r") as f:
+        try:
+            with open(mem_limit_v1_file, "r") as f:
                 cgroup_total = min(int(f.read().strip()), system_total)
-    elif os.path.exists(mem_usage_v2) and os.path.exists(mem_stat_v2):
+        except Exception as exception:
+            logger.warning(
+                f"Failed to obtain current container memory limit from {mem_limit_v1_file}: {repr(exception)}"
+                "Falling back to system total memory."
+            )
+            cgroup_total = system_total
+    elif os.path.exists(mem_usage_v2_file) and os.path.exists(mem_stat_v2_file):
         cgroup_used = get_cgroup_used_memory(
-            mem_stat_v2, mem_usage_v2, "inactive_file", "active_file"
+            mem_stat_v2_file, mem_usage_v2_file, "inactive_file", "active_file"
         )
-        if os.path.exists(mem_limit_v2):
-            with open(mem_limit_v2, "r") as f:
+        try:
+            with open(mem_limit_v2_file, "r") as f:
                 max_val = f.read().strip()
             if max_val.isnumeric():
                 cgroup_total = min(int(max_val), system_total)
             else:
                 cgroup_total = system_total
+        except Exception as exception:
+            logger.warning(
+                f"Failed to obtain current container memory limit from {mem_limit_v2_file}: {repr(exception)}"
+                "Falling back to system total memory."
+            )
+            cgroup_total = system_total
 
     if cgroup_used is not None and cgroup_total is not None:
         return cgroup_used, cgroup_total
@@ -623,13 +639,14 @@ def resolve_object_store_memory(
 
 
 def get_used_memory():
-    """Return the currently used system memory in bytes
+    """
+    Return the currently used system memory in bytes
+    If cgroup memory utilization files (e.g. memory.stat) are available,
+    we are in a container/cgroup. Use the cgroup memory usage instead.
 
     Returns:
         The total amount of used memory
     """
-    # Try to accurately figure out the memory usage if we are in a docker
-    # container.
     cgroup_stats = get_cgroup_mem_stats()
     if cgroup_stats is not None:
         return cgroup_stats[0]

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -553,7 +553,7 @@ def get_cgroup_mem_stats() -> Optional[Tuple[int, int]]:
                 cgroup_total = min(int(f.read().strip()), system_total)
         except Exception as exception:
             logger.warning(
-                f"Failed to obtain current container memory limit from {mem_limit_v1_file}: {repr(exception)}"
+                f"Failed to obtain current container memory limit from {mem_limit_v1_file}: {repr(exception)}. "
                 "Falling back to system total memory."
             )
             cgroup_total = system_total

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -523,6 +523,47 @@ def get_cgroup_used_memory(
     return cgroup_usage_in_bytes - inactive_file_bytes - active_file_bytes
 
 
+def get_cgroup_mem_stats() -> Optional[Tuple[int, int]]:
+    """Return (used_bytes, total_bytes) from cgroups, or None if unavailable.
+
+    Supports both cgroups v1 and v2. Total is capped at the host physical
+    memory so callers always get a sensible upper bound.
+    """
+    mem_usage_v1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
+    mem_stat_v1 = "/sys/fs/cgroup/memory/memory.stat"
+    mem_limit_v1 = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+    mem_usage_v2 = "/sys/fs/cgroup/memory.current"
+    mem_stat_v2 = "/sys/fs/cgroup/memory.stat"
+    mem_limit_v2 = "/sys/fs/cgroup/memory.max"
+
+    cgroup_used = None
+    cgroup_total = None
+    system_total = get_system_memory()
+
+    if os.path.exists(mem_usage_v1) and os.path.exists(mem_stat_v1):
+        cgroup_used = get_cgroup_used_memory(
+            mem_stat_v1, mem_usage_v1, "total_inactive_file", "total_active_file"
+        )
+        if os.path.exists(mem_limit_v1):
+            with open(mem_limit_v1, "r") as f:
+                cgroup_total = min(int(f.read().strip()), system_total)
+    elif os.path.exists(mem_usage_v2) and os.path.exists(mem_stat_v2):
+        cgroup_used = get_cgroup_used_memory(
+            mem_stat_v2, mem_usage_v2, "inactive_file", "active_file"
+        )
+        if os.path.exists(mem_limit_v2):
+            with open(mem_limit_v2, "r") as f:
+                max_val = f.read().strip()
+            if max_val.isnumeric():
+                cgroup_total = min(int(max_val), system_total)
+            else:
+                cgroup_total = system_total
+
+    if cgroup_used is not None and cgroup_total is not None:
+        return cgroup_used, cgroup_total
+    return None
+
+
 def resolve_object_store_memory(
     available_memory_bytes: int,
     object_store_memory: Optional[int] = None,
@@ -589,34 +630,9 @@ def get_used_memory():
     """
     # Try to accurately figure out the memory usage if we are in a docker
     # container.
-    docker_usage = None
-    # For cgroups v1:
-    memory_usage_filename_v1 = "/sys/fs/cgroup/memory/memory.usage_in_bytes"
-    memory_stat_filename_v1 = "/sys/fs/cgroup/memory/memory.stat"
-    # For cgroups v2:
-    memory_usage_filename_v2 = "/sys/fs/cgroup/memory.current"
-    memory_stat_filename_v2 = "/sys/fs/cgroup/memory.stat"
-    if os.path.exists(memory_usage_filename_v1) and os.path.exists(
-        memory_stat_filename_v1
-    ):
-        docker_usage = get_cgroup_used_memory(
-            memory_stat_filename_v1,
-            memory_usage_filename_v1,
-            "total_inactive_file",
-            "total_active_file",
-        )
-    elif os.path.exists(memory_usage_filename_v2) and os.path.exists(
-        memory_stat_filename_v2
-    ):
-        docker_usage = get_cgroup_used_memory(
-            memory_stat_filename_v2,
-            memory_usage_filename_v2,
-            "inactive_file",
-            "active_file",
-        )
-
-    if docker_usage is not None:
-        return docker_usage
+    cgroup_stats = get_cgroup_mem_stats()
+    if cgroup_stats is not None:
+        return cgroup_stats[0]
     return psutil.virtual_memory().used
 
 

--- a/python/ray/_private/utils.py
+++ b/python/ray/_private/utils.py
@@ -570,7 +570,7 @@ def get_cgroup_mem_stats() -> Optional[Tuple[int, int]]:
                 cgroup_total = system_total
         except Exception as exception:
             logger.warning(
-                f"Failed to obtain current container memory limit from {mem_limit_v2_file}: {repr(exception)}"
+                f"Failed to obtain current container memory limit from {mem_limit_v2_file}: {repr(exception)}. "
                 "Falling back to system total memory."
             )
             cgroup_total = system_total

--- a/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
+++ b/python/ray/autoscaler/aws/cloudwatch/example-cloudwatch-agent-config.json
@@ -26,6 +26,8 @@
               "ray_node_mem_available": "Bytes",
               "ray_node_mem_total": "Bytes",
               "ray_node_mem_used": "Bytes",
+              "ray_node_mem_total_host": "Bytes",
+              "ray_node_mem_used_host": "Bytes",
               "ray_node_network_receive_speed": "Bytes",
               "ray_node_network_received": "Bytes",
               "ray_node_network_send_speed": "Bytes",

--- a/python/ray/dashboard/modules/metrics/dashboards/common.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/common.py
@@ -184,6 +184,18 @@ GRAPH_PANEL_TEMPLATE = {
             "fill": 0,
             "stack": False,
         },
+        {
+            "alias": "/Container /",
+            "hiddenSeries": True,
+        },
+        {
+            "alias": "Container MAX",
+            "dashes": True,
+            "color": "#73BF69",
+            "fill": 0,
+            "stack": False,
+            "hiddenSeries": True,
+        },
     ],
     "spaceLength": 10,
     "stack": True,

--- a/python/ray/dashboard/modules/metrics/dashboards/common.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/common.py
@@ -185,7 +185,7 @@ GRAPH_PANEL_TEMPLATE = {
             "stack": False,
         },
         {
-            "alias": "/Container /",
+            "alias": "/Container/",
             "hiddenSeries": True,
         },
         {

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -415,7 +415,7 @@ NODE_HARDWARE_UTILIZATION_BY_RAY_COMPONENT_PANELS = [
                 legend="shared_memory",
             ),
             Target(
-                expr='sum(ray_node_mem_total{{instance=~"$Instance",{global_filters}}})',
+                expr='sum(ray_node_mem_total_host{{instance=~"$Instance",{global_filters}}})',
                 legend="MAX",
             ),
         ],
@@ -484,7 +484,10 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
     Panel(
         id=4,
         title="Node Memory Usage (heap + object store)",
-        description="The physical (hardware) memory usage for each node. The dotted line means the total amount of memory from the cluster. Node memory is a sum of object store memory (shared memory) and heap memory.\n\nHost targets reflect memory as reported by the OS (meminfo/psutil) and are always present. Container targets reflect cgroup-limited memory and are only emitted when cgroups are available on the host; they are hidden by default.",
+        description="The physical (hardware) memory usage for each node. The dotted line means the total amount of memory from the cluster. "
+        "Node memory is a sum of object store memory (shared memory) and heap memory.\n\n"
+        "Host targets reflect memory as reported by the host machine. "
+        "Container targets reflect cgroup-limited memory and are only emitted when the ray node reside within a cgroup.",
         unit="bytes",
         targets=[
             Target(
@@ -497,7 +500,7 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
             ),
             Target(
                 expr='sum(ray_node_cgroup_mem_used{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
-                legend="Container Memory Used: {{instance}} ({{RayNodeType}})",
+                legend="Memory Used (Container): {{instance}} ({{RayNodeType}})",
             ),
             Target(
                 expr='sum(ray_node_cgroup_mem_total{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}})',
@@ -508,7 +511,9 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
     Panel(
         id=48,
         title="Node Memory Usage % (heap + object store)",
-        description="The percentage of physical (hardware) memory usage for each node.\n\nHost targets reflect memory as reported by the OS (meminfo/psutil) and are always present. Container targets reflect cgroup-limited memory and are only emitted when cgroups are available on the host; they are hidden by default.",
+        description="The percentage of physical (hardware) memory usage for each node.\n\n"
+        "Host targets reflect memory as reported by the host machine. "
+        "Container targets reflect cgroup-limited memory and are only emitted when the ray node reside within a cgroup.",
         unit="%",
         targets=[
             Target(
@@ -517,7 +522,7 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
             ),
             Target(
                 expr='sum(ray_node_cgroup_mem_used{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType) * 100 / sum(ray_node_cgroup_mem_total{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
-                legend="Container Memory Used: {{instance}} ({{RayNodeType}})",
+                legend="Memory Used (Container): {{instance}} ({{RayNodeType}})",
             ),
         ],
         fill=0,

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -415,7 +415,7 @@ NODE_HARDWARE_UTILIZATION_BY_RAY_COMPONENT_PANELS = [
                 legend="shared_memory",
             ),
             Target(
-                expr='sum(ray_node_mem_total_host{{instance=~"$Instance",{global_filters}}})',
+                expr='min(label_replace(sum(ray_node_mem_total_host{{instance=~"$Instance",{global_filters}}}), "mem_cap_source", "host", "", "") or label_replace(sum(ray_node_cgroup_mem_total{{instance=~"$Instance",{global_filters}}}), "mem_cap_source", "cgroup", "", ""))',
                 legend="MAX",
             ),
         ],

--- a/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/default_dashboard_panels.py
@@ -78,7 +78,7 @@ OVERVIEW_AND_HEALTH_PANELS = [
             ),
             # Memory
             Target(
-                expr='sum(ray_node_mem_used{{instance=~"$Instance",{global_filters}}}) / on() (sum(ray_node_mem_total{{instance=~"$Instance",{global_filters}}})) * 100',
+                expr='sum(ray_node_mem_used_host{{instance=~"$Instance",{global_filters}}}) / on() (sum(ray_node_mem_total_host{{instance=~"$Instance",{global_filters}}})) * 100',
                 legend="Memory (RAM)",
             ),
             # GRAM
@@ -484,28 +484,40 @@ NODE_HARDWARE_UTILIZATION_PANELS = [
     Panel(
         id=4,
         title="Node Memory Usage (heap + object store)",
-        description="The physical (hardware) memory usage for each node. The dotted line means the total amount of memory from the cluster. Node memory is a sum of object store memory (shared memory) and heap memory.\n\nNote: If Ray is deployed within a container, the total memory could be lower than the host machine because Ray may reserve some additional memory space outside the container.",
+        description="The physical (hardware) memory usage for each node. The dotted line means the total amount of memory from the cluster. Node memory is a sum of object store memory (shared memory) and heap memory.\n\nHost targets reflect memory as reported by the OS (meminfo/psutil) and are always present. Container targets reflect cgroup-limited memory and are only emitted when cgroups are available on the host; they are hidden by default.",
         unit="bytes",
         targets=[
             Target(
-                expr='sum(ray_node_mem_used{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
-                legend="Memory Used: {{instance}} ({{RayNodeType}})",
+                expr='sum(ray_node_mem_used_host{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
+                legend="Memory Used (Host): {{instance}} ({{RayNodeType}})",
             ),
             Target(
-                expr='sum(ray_node_mem_total{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}})',
+                expr='sum(ray_node_mem_total_host{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}})',
                 legend="MAX",
+            ),
+            Target(
+                expr='sum(ray_node_cgroup_mem_used{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
+                legend="Container Memory Used: {{instance}} ({{RayNodeType}})",
+            ),
+            Target(
+                expr='sum(ray_node_cgroup_mem_total{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}})',
+                legend="Container MAX",
             ),
         ],
     ),
     Panel(
         id=48,
         title="Node Memory Usage % (heap + object store)",
-        description="The percentage of physical (hardware) memory usage for each node.",
+        description="The percentage of physical (hardware) memory usage for each node.\n\nHost targets reflect memory as reported by the OS (meminfo/psutil) and are always present. Container targets reflect cgroup-limited memory and are only emitted when cgroups are available on the host; they are hidden by default.",
         unit="%",
         targets=[
             Target(
-                expr='sum(ray_node_mem_used{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType) * 100 / sum(ray_node_mem_total{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
-                legend="Memory Used: {{instance}} ({{RayNodeType}})",
+                expr='sum(ray_node_mem_used_host{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType) * 100 / sum(ray_node_mem_total_host{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
+                legend="Memory Used (Host): {{instance}} ({{RayNodeType}})",
+            ),
+            Target(
+                expr='sum(ray_node_cgroup_mem_used{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType) * 100 / sum(ray_node_cgroup_mem_total{{instance=~"$Instance", RayNodeType=~"$RayNodeType", {global_filters}}}) by (instance, RayNodeType)',
+                legend="Container Memory Used: {{instance}} ({{RayNodeType}})",
             ),
         ],
         fill=0,

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -168,25 +168,25 @@ METRICS_GAUGES = {
     ),
     "node_mem_used_host": Gauge(
         "node_mem_used_host",
-        "Host (meminfo/psutil) memory usage on a ray node",
+        "Host memory usage on a ray node",
         "bytes",
         NODE_TAG_KEYS,
     ),
     "node_mem_total_host": Gauge(
         "node_mem_total_host",
-        "Total host (meminfo/psutil) memory on a ray node",
+        "Total host memory on a ray node",
         "bytes",
         NODE_TAG_KEYS,
     ),
     "node_cgroup_mem_used": Gauge(
         "node_cgroup_mem_used",
-        "Container (cgroup) memory usage on a ray node",
+        "Container memory usage on a ray node",
         "bytes",
         NODE_TAG_KEYS,
     ),
     "node_cgroup_mem_total": Gauge(
         "node_cgroup_mem_total",
-        "Container (cgroup) memory limit on a ray node",
+        "Container memory limit on a ray node",
         "bytes",
         NODE_TAG_KEYS,
     ),
@@ -918,6 +918,11 @@ class ReporterAgent(
         return total, available, percent, used
 
     @staticmethod
+    def _get_host_mem_usage():
+        vmem = psutil.virtual_memory()
+        return vmem.used, vmem.total
+
+    @staticmethod
     def _get_disk_usage(temp_dir: str):
         if IN_KUBERNETES_POD and not ENABLE_K8S_DISK_USAGE:
             # If in a K8s pod, disable disk display by passing in dummy values.
@@ -1168,7 +1173,7 @@ class ReporterAgent(
             "mem": self._get_mem_usage(),
             # Unit is in bytes. None if
             "shm": self._get_shm_usage(),
-            "host_mem": psutil.virtual_memory(),
+            "host_mem": self._get_host_mem_usage(),
             "cgroup_mem": utils.get_cgroup_mem_stats(),
             "workers": await self._async_get_workers_and_agents(gpus),
             "raylet": raylet,
@@ -1540,24 +1545,22 @@ class ReporterAgent(
             )
             records_reported.append(node_mem_shared)
 
-        # -- Host mem (always psutil/meminfo) --
-        host_vmem = stats["host_mem"]
+        host_mem_used, host_mem_total = stats["host_mem"]
         records_reported.extend(
             [
                 Record(
                     gauge=METRICS_GAUGES["node_mem_used_host"],
-                    value=host_vmem.used,
+                    value=host_mem_used,
                     tags=node_tags,
                 ),
                 Record(
                     gauge=METRICS_GAUGES["node_mem_total_host"],
-                    value=host_vmem.total,
+                    value=host_mem_total,
                     tags=node_tags,
                 ),
             ]
         )
 
-        # -- Cgroup mem (only emitted when cgroups are available) --
         cgroup_stats = stats["cgroup_mem"]
         if cgroup_stats is not None:
             cgroup_used, cgroup_total = cgroup_stats

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -166,6 +166,30 @@ METRICS_GAUGES = {
         "bytes",
         NODE_TAG_KEYS,
     ),
+    "node_mem_used_host": Gauge(
+        "node_mem_used_host",
+        "Host (meminfo/psutil) memory usage on a ray node",
+        "bytes",
+        NODE_TAG_KEYS,
+    ),
+    "node_mem_total_host": Gauge(
+        "node_mem_total_host",
+        "Total host (meminfo/psutil) memory on a ray node",
+        "bytes",
+        NODE_TAG_KEYS,
+    ),
+    "node_cgroup_mem_used": Gauge(
+        "node_cgroup_mem_used",
+        "Container (cgroup) memory usage on a ray node",
+        "bytes",
+        NODE_TAG_KEYS,
+    ),
+    "node_cgroup_mem_total": Gauge(
+        "node_cgroup_mem_total",
+        "Container (cgroup) memory limit on a ray node",
+        "bytes",
+        NODE_TAG_KEYS,
+    ),
     # GPU metrics
     "node_gpus_available": Gauge(
         "node_gpus_available",
@@ -1144,6 +1168,8 @@ class ReporterAgent(
             "mem": self._get_mem_usage(),
             # Unit is in bytes. None if
             "shm": self._get_shm_usage(),
+            "host_mem": psutil.virtual_memory(),
+            "cgroup_mem": utils.get_cgroup_mem_stats(),
             "workers": await self._async_get_workers_and_agents(gpus),
             "raylet": raylet,
             "agent": self._get_agent(),
@@ -1513,6 +1539,42 @@ class ReporterAgent(
                 tags=node_tags,
             )
             records_reported.append(node_mem_shared)
+
+        # -- Host mem (always psutil/meminfo) --
+        host_vmem = stats["host_mem"]
+        records_reported.extend(
+            [
+                Record(
+                    gauge=METRICS_GAUGES["node_mem_used_host"],
+                    value=host_vmem.used,
+                    tags=node_tags,
+                ),
+                Record(
+                    gauge=METRICS_GAUGES["node_mem_total_host"],
+                    value=host_vmem.total,
+                    tags=node_tags,
+                ),
+            ]
+        )
+
+        # -- Cgroup mem (only emitted when cgroups are available) --
+        cgroup_stats = stats["cgroup_mem"]
+        if cgroup_stats is not None:
+            cgroup_used, cgroup_total = cgroup_stats
+            records_reported.extend(
+                [
+                    Record(
+                        gauge=METRICS_GAUGES["node_cgroup_mem_used"],
+                        value=cgroup_used,
+                        tags=node_tags,
+                    ),
+                    Record(
+                        gauge=METRICS_GAUGES["node_cgroup_mem_total"],
+                        value=cgroup_total,
+                        tags=node_tags,
+                    ),
+                ]
+            )
 
         # The output example of GpuUtilizationInfo.
         """

--- a/python/ray/dashboard/modules/reporter/reporter_models.py
+++ b/python/ray/dashboard/modules/reporter/reporter_models.py
@@ -163,6 +163,10 @@ if PYDANTIC_INSTALLED:
         cpu: float  # CPU usage percentage
         cpus: Tuple[int, int]  # (logicalCpuCount, physicalCpuCount)
         mem: MemoryUsage  # (total, available, percent, used) in bytes
+        hostMem: Tuple[int, int]  # host physical memory (used, totall) in bytes
+        cgroupMem: Optional[
+            Tuple[int, int]
+        ] = None  # (used, total) from cgroup, or None
         shm: Optional[int] = None  # shared memory in bytes, None if not available
         workers: List[ProcessInfo]
         raylet: Optional[ProcessInfo] = None

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -136,6 +136,8 @@ STATS_TEMPLATE = {
     "network": (13621160960, 11914936320),
     "network_speed": (8.435062128545095, 7.378462703142336),
     "cmdline": ["fake raylet cmdline"],
+    "host_mem": (10737418240, 17179869184),
+    "cgroup_mem": None,
 }
 
 
@@ -229,7 +231,8 @@ def test_prometheus_physical_stats_record(
             "ray_node_mem_used" in metric_names,
             "ray_node_mem_available" in metric_names,
             "ray_node_mem_total" in metric_names,
-            "ray_node_mem_total" in metric_names,
+            "ray_node_mem_used_host" in metric_names,
+            "ray_node_mem_total_host" in metric_names,
             "ray_component_rss_mb" in metric_names,
             "ray_component_uss_mb" in metric_names,
             "ray_component_num_fds" in metric_names,
@@ -337,7 +340,7 @@ def test_report_stats(tmp_path):
             assert val == stats["shm"]
         print(record.gauge.name)
         print(record)
-    assert len(records) == 41
+    assert len(records) == 43
     # Verify RayNodeType and IsHeadNode tags
     for record in records:
         if record.gauge.name.startswith("node_"):
@@ -345,10 +348,31 @@ def test_report_stats(tmp_path):
             assert record.tags["RayNodeType"] == "head"
             assert "IsHeadNode" in record.tags
             assert record.tags["IsHeadNode"] == "true"
+    # Verify host memory metrics are reported
+    host_mem_used = [r for r in records if r.gauge.name == "node_mem_used_host"]
+    host_mem_total = [r for r in records if r.gauge.name == "node_mem_total_host"]
+    assert len(host_mem_used) == 1
+    assert host_mem_used[0].value == stats["host_mem"][0]
+    assert len(host_mem_total) == 1
+    assert host_mem_total[0].value == stats["host_mem"][1]
+    # Verify no cgroup records when cgroup_mem is None
+    assert not any(r.gauge.name == "node_cgroup_mem_used" for r in records)
+    assert not any(r.gauge.name == "node_cgroup_mem_total" for r in records)
+
+    # Test cgroup memory metrics when cgroup_mem is populated
+    stats["cgroup_mem"] = (5368709120, 10737418240)
+    records = agent._to_records(stats, cluster_stats)
+    cgroup_used = [r for r in records if r.gauge.name == "node_cgroup_mem_used"]
+    cgroup_total = [r for r in records if r.gauge.name == "node_cgroup_mem_total"]
+    assert len(cgroup_used) == 1
+    assert cgroup_used[0].value == 5368709120
+    assert len(cgroup_total) == 1
+    assert cgroup_total[0].value == 10737418240
+
     # Test stats without raylets
     stats["raylet"] = None
     records = agent._to_records(stats, cluster_stats)
-    assert len(records) == 37
+    assert len(records) == 41
     # Test stats with gpus
     stats["gpus"] = [
         {
@@ -375,11 +399,11 @@ def test_report_stats(tmp_path):
         }
     ]
     records = agent._to_records(stats, cluster_stats)
-    assert len(records) == 46
+    assert len(records) == 50
     # Test stats without autoscaler report
     cluster_stats = {}
     records = agent._to_records(stats, cluster_stats)
-    assert len(records) == 44
+    assert len(records) == 48
 
     stats_payload = agent._generate_stats_payload(stats)
     assert stats_payload is not None

--- a/python/ray/tests/test_metrics_agent.py
+++ b/python/ray/tests/test_metrics_agent.py
@@ -67,6 +67,8 @@ _METRICS = [
     "ray_node_disk_usage",
     "ray_node_mem_used",
     "ray_node_mem_total",
+    "ray_node_mem_used_host",
+    "ray_node_mem_total_host",
     "ray_node_cpu_utilization",
     # TODO(rickyx): refactoring the below 3 metric seem to be a bit involved
     # , e.g. need to see how users currently depend on them.
@@ -167,6 +169,8 @@ _NODE_METRICS = [
     "ray_node_mem_used",
     "ray_node_mem_available",
     "ray_node_mem_total",
+    "ray_node_mem_total_host",
+    "ray_node_mem_used_host",
     "ray_node_disk_io_read",
     "ray_node_disk_io_write",
     "ray_node_disk_io_read_count",

--- a/release/ray_release/command_runner/_prometheus_metrics.py
+++ b/release/ray_release/command_runner/_prometheus_metrics.py
@@ -82,9 +82,15 @@ async def _get_prometheus_metrics(
             **kwargs,
         ),
         "memory_usage": client.query_prometheus(
-            query=f"ray_node_mem_used_host{sf}", **kwargs
+            query=f"ray_node_mem_used{sf}", **kwargs
         ),
         "total_memory": client.query_prometheus(
+            query=f"ray_node_mem_total{sf}", **kwargs
+        ),
+        "memory_usage_host": client.query_prometheus(
+            query=f"ray_node_mem_used_host{sf}", **kwargs
+        ),
+        "total_memory_host": client.query_prometheus(
             query=f"ray_node_mem_total_host{sf}", **kwargs
         ),
         "memory_usage_cgroup": client.query_prometheus(

--- a/release/ray_release/command_runner/_prometheus_metrics.py
+++ b/release/ray_release/command_runner/_prometheus_metrics.py
@@ -82,10 +82,10 @@ async def _get_prometheus_metrics(
             **kwargs,
         ),
         "memory_usage": client.query_prometheus(
-            query=f"ray_node_mem_used{sf}", **kwargs
+            query=f"ray_node_mem_used_host{sf}", **kwargs
         ),
         "total_memory": client.query_prometheus(
-            query=f"ray_node_mem_total{sf}", **kwargs
+            query=f"ray_node_mem_total_host{sf}", **kwargs
         ),
         "gpu_memory_usage": client.query_prometheus(
             query=f"ray_node_gram_used{sf} * 1024 * 1024", **kwargs

--- a/release/ray_release/command_runner/_prometheus_metrics.py
+++ b/release/ray_release/command_runner/_prometheus_metrics.py
@@ -87,6 +87,12 @@ async def _get_prometheus_metrics(
         "total_memory": client.query_prometheus(
             query=f"ray_node_mem_total_host{sf}", **kwargs
         ),
+        "memory_usage_cgroup": client.query_prometheus(
+            query=f"ray_node_cgroup_mem_used{sf}", **kwargs
+        ),
+        "total_memory_cgroup": client.query_prometheus(
+            query=f"ray_node_cgroup_mem_total{sf}", **kwargs
+        ),
         "gpu_memory_usage": client.query_prometheus(
             query=f"ray_node_gram_used{sf} * 1024 * 1024", **kwargs
         ),


### PR DESCRIPTION
## Description
Our existing dashboard only tracks memory utilization at the container level when we detect that the node is running within a container. This can be potentially misleading as the container memory utilization can be considerably lower than the actual host memory utilization when there are non-negligible processes running outside the container on the host. Under such scenarios, we have observed the system to experience kernel OOMs even when the memory utilization metric looked healthy as it was not reflective of the entire system's memory utilization. 

This PR emits both the host and container level memory utilization to provide a more comprehensive view of the system memory utilization. This way, we will be more accurately determine when the system is under memory pressure at both the container and host layer.

This image below shows an example of the change. As we can see, the memory utilization panels now provide us with the ability to view either the container or host level memory usage stats. 
<img width="1903" height="645" alt="image" src="https://github.com/user-attachments/assets/b0f45272-c079-4512-8e1a-832dfa15706a" />


## Related issues


## Additional information

