### PR TITLE
[data][3/n] DataSourceV2: ParquetDatasourceV2 + read_parquet V2 dispatch

### DIFF
--- a/doc/source/data/performance-tips.rst
+++ b/doc/source/data/performance-tips.rst
@@ -226,8 +226,7 @@ calling :func:`~ray.data.Dataset.select_columns`, since column selection is push
     # Read just two of the five columns of the Iris dataset.
     ds = ray.data.read_parquet(
         "s3://anonymous@ray-example-data/iris.parquet",
-        columns=["sepal.length", "variety"],
-    )
+    ).select_columns(["sepal.length", "variety"])
     
     print(ds.schema())
 

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -54,6 +54,19 @@ py_test_module_list(
 )
 
 py_test_module_list(
+    size = "small",
+    files = glob(["_internal/logical/operators/tests/test_*.py"]),
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test_module_list(
     size = "medium",
     files = glob(["tests/block_batching/test_*.py"]),
     tags = [

--- a/python/ray/data/_internal/datasource_v2/datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/datasource_v2.py
@@ -161,3 +161,13 @@ class DataSourceV2(ABC, Generic[InputSplit]):
             Configured Scanner instance.
         """
         ...
+
+    def resolve_partitioning(self, sample: InputSplit) -> Optional[Any]:
+        """Return a partitioning descriptor derived from ``sample``, or ``None``.
+
+        Override this for file-based sources whose partition keys must be
+        discovered from a sample path (e.g. hive layouts where field names
+        are not known up front). The resolved descriptor is passed into
+        :meth:`create_scanner`.
+        """
+        return None

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -1,0 +1,268 @@
+"""Concrete ``DataSourceV2`` for Parquet files.
+
+Wires the V2 listing (`NonSamplingFileIndexer`, driven by the upstream
+`ListFiles` op), scanning (`ParquetScanner`), and reading
+(`ParquetFileReader`) components against a user-supplied path set.
+Constructed from `read_api.read_parquet` when
+`DataContext.use_datasource_v2` is set.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
+
+import pyarrow as pa
+from typing_extensions import override
+
+from ray.data._internal.datasource.parquet_datasource import (
+    ParquetDatasource,
+    check_for_legacy_tensor_type,
+)
+from ray.data._internal.datasource_v2.datasource_v2 import (
+    DatasourceCategory,
+    DataSourceV2,
+)
+from ray.data._internal.datasource_v2.listing.file_indexer import (
+    FileIndexer,
+    NonSamplingFileIndexer,
+)
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
+    ParquetInMemorySizeEstimator,
+)
+from ray.data._internal.datasource_v2.scanners.parquet_scanner import ParquetScanner
+from ray.data.context import DataContext
+from ray.data.datasource.partitioning import (
+    Partitioning,
+    PartitionStyle,
+    PathPartitionParser,
+    _partition_field_types_to_pa_schema,
+)
+from ray.data.datasource.path_util import _resolve_paths_and_filesystem
+from ray.util.annotations import DeveloperAPI
+
+if TYPE_CHECKING:
+    from pyarrow.fs import FileSystem
+
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
+
+
+@DeveloperAPI
+class ParquetDatasourceV2(DataSourceV2[FileManifest]):
+    """V2 Parquet datasource.
+
+    Listing is delegated to :class:`NonSamplingFileIndexer` driven by the
+    ``ListFiles`` logical op; scanning and reading are delegated to
+    :class:`ParquetScanner` and :class:`ParquetFileReader`. Schema
+    inference reads the first file's footer only and augments with
+    partition/path columns as configured.
+    """
+
+    def __init__(
+        self,
+        paths: List[str],
+        *,
+        filesystem: Optional["FileSystem"] = None,
+        partitioning: Optional[Partitioning] = Partitioning(PartitionStyle.HIVE),
+        file_extensions: Optional[List[str]] = None,
+        ignore_missing_paths: bool = False,
+        include_paths: bool = False,
+        shuffle: Optional[Union[Literal["files"], "FileShuffleConfig"]] = None,
+        arrow_parquet_args: Optional[dict] = None,
+        schema: Optional[pa.Schema] = None,
+    ):
+        super().__init__(name="ParquetV2", category=DatasourceCategory.FILE_BASED)
+        resolved_paths, resolved_filesystem = _resolve_paths_and_filesystem(
+            paths, filesystem
+        )
+        self._paths: List[str] = resolved_paths
+        self._filesystem = resolved_filesystem
+        self._partitioning = partitioning
+        self._file_extensions = file_extensions or ParquetDatasource._FILE_EXTENSIONS
+        self._ignore_missing_paths = ignore_missing_paths
+        self._include_paths = include_paths
+        self._shuffle = shuffle
+        self._arrow_parquet_args = arrow_parquet_args or {}
+        # User-supplied schema override. When set, ``infer_schema`` returns
+        # it verbatim (plus partition/path augmentation) rather than reading
+        # footers, and the scanner pins it on the pyarrow dataset so files
+        # are cast to these types at scan time.
+        self._user_schema = schema
+
+    @property
+    def paths(self) -> List[str]:
+        return self._paths
+
+    @property
+    def filesystem(self) -> Optional["FileSystem"]:
+        return self._filesystem
+
+    @property
+    def partitioning(self) -> Optional[Partitioning]:
+        return self._partitioning
+
+    @property
+    def file_extensions(self) -> List[str]:
+        return self._file_extensions
+
+    @property
+    def ignore_missing_paths(self) -> bool:
+        return self._ignore_missing_paths
+
+    @property
+    def include_paths(self) -> bool:
+        return self._include_paths
+
+    @property
+    def shuffle(self) -> Optional[Union[Literal["files"], "FileShuffleConfig"]]:
+        return self._shuffle
+
+    def _get_file_indexer(self) -> FileIndexer:
+        return NonSamplingFileIndexer(
+            ignore_missing_paths=self._ignore_missing_paths,
+        )
+
+    def get_size_estimator(self) -> ParquetInMemorySizeEstimator:
+        return ParquetInMemorySizeEstimator()
+
+    @override
+    def resolve_partitioning(self, sample: FileManifest) -> Optional[Partitioning]:
+        """Return ``self._partitioning`` with path-discovered field names.
+
+        Hive partitioning ships with ``field_names=None`` by default and
+        discovers keys from the file path at plan time. Directory
+        partitioning already carries ``field_names`` at construction and
+        needs no discovery. Returns a fresh ``Partitioning`` rather than
+        mutating ``self`` so schema inference stays side-effect-free.
+        """
+        import copy
+
+        if self._partitioning is None or len(sample) == 0:
+            return copy.deepcopy(self._partitioning)
+        if self._partitioning.field_names:
+            return copy.deepcopy(self._partitioning)
+
+        first_path = sample.paths.tolist()[0]
+        parser = PathPartitionParser(self._partitioning)
+        partition_kv = parser(first_path)
+        if not partition_kv:
+            return copy.deepcopy(self._partitioning)
+        return Partitioning(
+            style=self._partitioning.style,
+            base_dir=self._partitioning.base_dir,
+            field_names=list(partition_kv.keys()),
+            field_types=self._partitioning.field_types,
+            filesystem=self._partitioning.filesystem,
+        )
+
+    def infer_schema(self, sample: FileManifest) -> pa.Schema:
+        """Read Parquet footers from the sample manifest; unify and augment.
+
+        When the sample has multiple files, their schemas are unified via
+        ``unify_schemas_with_validation`` so a first file with all-null
+        columns doesn't lock in ``null`` types that can't be cast to the
+        actual types in later files.
+
+        Pure: does not mutate ``self``. Partitioning field-name discovery
+        is delegated to :meth:`resolve_partitioning` so the discovered
+        ``Partitioning`` can flow through ``_read_datasource_v2`` into
+        :meth:`create_scanner` without side effects.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        import pyarrow.parquet as pq
+
+        from ray.data._internal.util import unify_schemas_with_validation
+
+        # Empty sample — typically means the user pointed ``read_parquet``
+        # at an empty directory. Return an empty schema so the rest of
+        # the plan stays valid; downstream ops produce zero blocks and
+        # the executor runs through without error (matches V1).
+        if len(sample) == 0:
+            return self._user_schema if self._user_schema is not None else pa.schema([])
+
+        sample_paths: List[str] = sample.paths.tolist()
+        # Parquet footer reads against high-latency object stores
+        # (S3, GCS) are ~50-100 ms each. Reading the sample's footers in
+        # parallel keeps driver-side schema inference bounded by the
+        # slowest single read rather than the sum. ``executor.map``
+        # preserves input order, which matters because the unified
+        # schema's field order follows the first schema's and
+        # ``sample_paths[0]`` drives partition discovery below.
+        #
+        # NOTE: ``pq.read_schema`` only accepts a ``filesystem=`` kwarg in
+        # recent pyarrow releases; older wheels in CI don't have it. Open
+        # the file through the configured filesystem and hand the file
+        # handle to ``read_schema`` for cross-version compatibility.
+        filesystem = self._filesystem
+
+        if self._user_schema is not None:
+            # Caller pinned the schema — skip footer reads. Partition/path
+            # augmentation below still applies so downstream ops see the
+            # synthesized columns.
+            schema = self._user_schema
+        else:
+
+            def _read_schema(path: str):
+                if filesystem is None:
+                    return pq.read_schema(path)
+                with filesystem.open_input_file(path) as handle:
+                    return pq.read_schema(handle)
+
+            with ThreadPoolExecutor(max_workers=min(len(sample_paths), 16)) as executor:
+                per_file_schemas = list(executor.map(_read_schema, sample_paths))
+            schema = (
+                unify_schemas_with_validation(per_file_schemas) or per_file_schemas[0]
+            )
+            assert isinstance(schema, pa.Schema)
+
+        resolved_partitioning = self.resolve_partitioning(sample)
+        if resolved_partitioning is not None:
+            first_path = sample_paths[0]
+            parser = PathPartitionParser(resolved_partitioning)
+            partition_kv = parser(first_path)
+            # For hive partitioning the parser discovers key names from the
+            # path itself; for directory partitioning it uses ``field_names``.
+            # In both cases ``partition_kv`` is the authoritative list of
+            # partition columns for the first sample file.
+            partition_pa_schema = _partition_field_types_to_pa_schema(
+                field_names=list(partition_kv.keys()),
+                field_types=resolved_partitioning.field_types or {},
+            )
+            for field_name in partition_kv.keys():
+                if schema.get_field_index(field_name) == -1:
+                    pa_type = partition_pa_schema.field(field_name).type
+                    schema = schema.append(pa.field(field_name, pa_type))
+
+        if self._include_paths and schema.get_field_index("path") == -1:
+            schema = schema.append(pa.field("path", pa.string()))
+
+        check_for_legacy_tensor_type(schema)
+        return schema
+
+    def create_scanner(
+        self,
+        schema: pa.Schema,
+        filesystem: Optional["FileSystem"] = None,
+        **options: Any,
+    ) -> ParquetScanner:
+        # ``filter=`` in V1 read_parquet() is the legacy pyarrow-compute
+        # predicate. Stamp it on the scanner's ``predicate`` field so it's
+        # honored at scan time (V2 does not yet dispatch Ray-level
+        # predicate pushdown rules).
+        predicate = self._arrow_parquet_args.get("filter")
+        # Callers (``_read_datasource_v2``) supply the sample-resolved
+        # ``Partitioning`` via ``options["partitioning"]`` so the
+        # datasource itself stays immutable — fall back to the
+        # constructor-provided one for direct users of this API.
+        partitioning = options.get("partitioning", self._partitioning)
+        return ParquetScanner(
+            schema=schema,
+            filesystem=filesystem or self._filesystem,
+            partitioning=partitioning,
+            include_paths=self._include_paths,
+            shuffle=self._shuffle,
+            ignore_prefixes=options.get("ignore_prefixes"),
+            target_block_size=DataContext.get_current().target_max_block_size,
+            predicate=predicate,
+        )

--- a/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
@@ -1,0 +1,107 @@
+"""Unit tests for :class:`ParquetDatasourceV2`.
+
+These tests exercise schema inference, scanner/estimator creation, and
+include-paths schema augmentation against a local tmpdir — they do not
+spin up Ray.
+"""
+
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.parquet_datasource_v2 import (
+    ParquetDatasourceV2,
+)
+from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
+    ParquetInMemorySizeEstimator,
+)
+from ray.data._internal.datasource_v2.scanners.parquet_scanner import (
+    ParquetScanner,
+)
+from ray.data.datasource.partitioning import Partitioning, PartitionStyle
+
+
+def _write_parquet(path: str, table: pa.Table) -> None:
+    pq.write_table(table, path)
+
+
+def _manifest_of(paths):
+    sizes = [os.path.getsize(p) for p in paths]
+    return FileManifest.construct_manifest(paths, sizes)
+
+
+def test_infer_schema_unpartitioned(tmp_path):
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+
+    datasource = ParquetDatasourceV2([str(file_path)])
+    schema = datasource.infer_schema(_manifest_of([str(file_path)]))
+
+    assert schema.names == ["a", "b"]
+    assert schema.field("a").type == pa.int64()
+    assert schema.field("b").type == pa.string()
+
+
+def test_infer_schema_hive_partitioned(tmp_path):
+    for part in ["a", "b"]:
+        d = tmp_path / f"color={part}"
+        d.mkdir()
+        _write_parquet(str(d / "data.parquet"), pa.table({"x": [1, 2]}))
+
+    first_file = str(tmp_path / "color=a" / "data.parquet")
+    datasource = ParquetDatasourceV2(
+        [str(tmp_path)], partitioning=Partitioning(PartitionStyle.HIVE)
+    )
+    schema = datasource.infer_schema(_manifest_of([first_file]))
+
+    assert "x" in schema.names
+    assert "color" in schema.names
+    assert schema.field("color").type == pa.string()
+
+
+def test_infer_schema_with_include_paths(tmp_path):
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1, 2]}))
+
+    datasource = ParquetDatasourceV2([str(file_path)], include_paths=True)
+    schema = datasource.infer_schema(_manifest_of([str(file_path)]))
+
+    assert "path" in schema.names
+    assert schema.field("path").type == pa.string()
+
+
+def test_infer_schema_returns_empty_schema_on_empty_manifest(tmp_path):
+    datasource = ParquetDatasourceV2([str(tmp_path)])
+    empty = FileManifest.construct_manifest([], [])
+    schema = datasource.infer_schema(empty)
+    assert schema.names == []
+
+
+def test_create_scanner_returns_parquet_scanner(tmp_path):
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1]}))
+
+    datasource = ParquetDatasourceV2([str(file_path)])
+    schema = datasource.infer_schema(_manifest_of([str(file_path)]))
+    scanner = datasource.create_scanner(schema)
+
+    assert isinstance(scanner, ParquetScanner)
+    assert scanner.schema == schema
+
+
+def test_get_size_estimator_returns_parquet_estimator(tmp_path):
+    datasource = ParquetDatasourceV2([str(tmp_path)])
+    assert isinstance(datasource.get_size_estimator(), ParquetInMemorySizeEstimator)
+
+
+def test_paths_and_filesystem_resolved(tmp_path):
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1]}))
+
+    datasource = ParquetDatasourceV2([str(file_path)])
+    # _resolve_paths_and_filesystem produces a concrete filesystem even when
+    # the caller passed None.
+    assert datasource.filesystem is not None
+    assert len(datasource.paths) == 1

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     import pyarrow as pa
     from pyarrow.fs import FileSystem
 
-    from ray.data._internal.datasource_v2.datasource_v2 import DataSourceV2
     from ray.data._internal.datasource_v2.listing.file_indexer import FileIndexer
     from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
         FilePartitioner,
@@ -249,7 +248,7 @@ class ReadFiles(
     """
 
     input_op: InitVar[LogicalOperator]
-    datasource: "DataSourceV2"
+    datasource_name: str
     scanner: "Scanner"
     schema: "pa.Schema"
     parallelism: int
@@ -275,9 +274,13 @@ class ReadFiles(
             object.__setattr__(self, "compute", TaskPoolStrategy())
         if self.ray_remote_args is None:
             object.__setattr__(self, "ray_remote_args", {})
-        object.__setattr__(self, "_name", f"ReadFiles{self.datasource.name}")
+        object.__setattr__(self, "_name", f"ReadFiles{self.datasource_name}")
         object.__setattr__(self, "_input_dependencies", [input_op])
         object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def input_dependency(self) -> LogicalOperator:
+        return self.input_dependencies[0]
 
     def _apply_transform(
         self, transform: "Callable[[LogicalOperator], LogicalOperator]"

--- a/python/ray/data/_internal/logical/operators/tests/test_read_files_logical.py
+++ b/python/ray/data/_internal/logical/operators/tests/test_read_files_logical.py
@@ -1,0 +1,102 @@
+"""Unit tests for :class:`ReadFiles`.
+
+Verifies pushdown scaffolding (projection/predicate capability dispatch,
+immutable scanner substitution) and schema inference without triggering
+physical execution. Each test wires a minimal ``ListFiles`` upstream
+op so ``ReadFiles`` (which now has one input dependency) can be
+constructed.
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from ray.data._internal.datasource_v2.listing.file_indexer import (
+    NonSamplingFileIndexer,
+)
+from ray.data._internal.datasource_v2.listing.listing_utils import (
+    sample_files,
+)
+from ray.data._internal.datasource_v2.parquet_datasource_v2 import (
+    ParquetDatasourceV2,
+)
+from ray.data._internal.datasource_v2.scanners.parquet_scanner import (
+    ParquetScanner,
+)
+from ray.data._internal.logical.operators import ListFiles, ReadFiles
+from ray.data.expressions import col
+
+
+def _mk_parquet(path, table):
+    pq.write_table(table, str(path))
+
+
+def _mk_read_files(tmp_path) -> ReadFiles:
+    f = tmp_path / "data.parquet"
+    _mk_parquet(f, pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+
+    datasource = ParquetDatasourceV2([str(f)])
+    indexer = NonSamplingFileIndexer(ignore_missing_paths=False)
+    sample = sample_files(indexer, datasource.paths, datasource.filesystem)
+    schema = datasource.infer_schema(sample)
+    scanner = datasource.create_scanner(schema=schema)
+
+    list_files_op = ListFiles(
+        paths=list(datasource.paths),
+        file_indexer=indexer,
+        filesystem=datasource.filesystem,
+        source_paths=list(datasource.paths),
+        file_extensions=datasource.file_extensions,
+    )
+
+    return ReadFiles(
+        input_op=list_files_op,
+        datasource_name=datasource.name,
+        scanner=scanner,
+        schema=schema,
+        parallelism=-1,
+    )
+
+
+def test_construction_stores_schema_and_infer_schema_returns_it(tmp_path):
+    op = _mk_read_files(tmp_path)
+    assert op.infer_schema().names == ["a", "b"]
+
+
+def test_input_dependency_is_list_files(tmp_path):
+    op = _mk_read_files(tmp_path)
+    assert isinstance(op.input_dependencies[0], ListFiles)
+
+
+def test_supports_projection_pushdown_true_for_parquet_scanner(tmp_path):
+    op = _mk_read_files(tmp_path)
+    assert op.supports_projection_pushdown() is True
+
+
+def test_apply_projection_returns_new_op_with_pruned_scanner(tmp_path):
+    op = _mk_read_files(tmp_path)
+    new_op = op.apply_projection({"a": "a"})
+
+    assert new_op is not op
+    assert isinstance(new_op.scanner, ParquetScanner)
+    assert new_op.scanner.columns == ("a",)
+    # Original scanner untouched
+    assert isinstance(op.scanner, ParquetScanner)
+    assert op.scanner.columns is None
+
+
+def test_apply_projection_none_is_noop(tmp_path):
+    op = _mk_read_files(tmp_path)
+    assert op.apply_projection(None) is op
+
+
+def test_supports_and_apply_predicate_pushdown(tmp_path):
+    op = _mk_read_files(tmp_path)
+    assert op.supports_predicate_pushdown() is True
+
+    new_op = op.apply_predicate(col("a") > 1)
+    assert new_op is not op
+    assert isinstance(new_op.scanner, ParquetScanner)
+    assert new_op.scanner.predicate is not None
+    # Original scanner untouched
+    assert isinstance(op.scanner, ParquetScanner)
+    assert op.scanner.predicate is None

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -77,6 +77,8 @@ DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
 
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
+DEFAULT_USE_DATASOURCE_V2 = False
+
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
 
 DEFAULT_USE_PUSH_BASED_SHUFFLE = bool(
@@ -504,6 +506,11 @@ class DataContext:
         min_parallelism: This setting is deprecated. Use ``read_op_min_num_blocks``
             instead.
         read_op_min_num_blocks: Minimum number of read output blocks for a dataset.
+        use_datasource_v2: When True, ``ray.data.read_parquet()`` routes through
+            the DataSourceV2 pipeline (``ListFiles → ReadFiles`` logical chain,
+            driver-side first-file sampling for schema inference,
+            ``ParquetScanner`` / ``ParquetFileReader``). Defaults to False — V1
+            remains the production path while V2 bakes.
         enable_tensor_extension_casting: Whether to automatically cast NumPy ndarray
             columns in Pandas DataFrames to tensor extension columns.
         arrow_fixed_shape_tensor_format: The tensor format to use for fixed-shape tensors.
@@ -726,6 +733,7 @@ class DataContext:
     decoding_size_estimation: bool = DEFAULT_DECODING_SIZE_ESTIMATION_ENABLED
     min_parallelism: int = DEFAULT_MIN_PARALLELISM
     read_op_min_num_blocks: int = DEFAULT_READ_OP_MIN_NUM_BLOCKS
+    use_datasource_v2: bool = DEFAULT_USE_DATASOURCE_V2
     enable_tensor_extension_casting: bool = DEFAULT_ENABLE_TENSOR_EXTENSION_CASTING
     arrow_fixed_shape_tensor_format: "FixedShapeTensorFormat" = field(
         default_factory=_default_fixed_shape_tensor_format

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -74,7 +74,9 @@ from ray.data._internal.logical.operators import (
     FromItems,
     FromNumpy,
     FromPandas,
+    ListFiles,
     Read,
+    ReadFiles,
 )
 from ray.data._internal.plan import ExecutionPlan
 from ray.data._internal.remote_fn import cached_remote_fn
@@ -136,6 +138,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
+INT32_MAX = 2**31 - 1
 
 
 @DeveloperAPI
@@ -385,6 +388,156 @@ def range_tensor(
         concurrency=concurrency,
         override_num_blocks=override_num_blocks,
     )
+
+
+def _read_datasource_v2(
+    datasource,
+    *,
+    parallelism: int = -1,
+    num_cpus: Optional[float] = None,
+    num_gpus: Optional[float] = None,
+    memory: Optional[float] = None,
+    ray_remote_args: Optional[Dict[str, Any]] = None,
+    concurrency: Optional[int] = None,
+    compute: Optional[ComputeStrategy] = None,
+    partition_filter: Optional[PathPartitionFilter] = None,
+) -> Dataset:
+    """Internal entry point for ``DataSourceV2`` reads.
+
+    Wires a ``ListFiles → ReadFiles`` logical chain:
+
+    - :class:`ListFiles` owns listing (via the datasource's ``FileIndexer``),
+      optional global shuffle (``FileShuffleConfig``), and size-balanced
+      bucketing (``RoundRobinPartitioner``). Its physical planner
+      parallelizes listing across path shards and emits manifest blocks.
+    - :class:`ReadFiles` consumes the manifest blocks and reads each bucket
+      via ``scanner.create_reader().read(manifest)``.
+
+    Schema inference happens once on the driver by sampling the first
+    file — no caching layer needed.
+    """
+    import time
+
+    from ray.data._internal.datasource_v2.listing.file_pruners import (
+        FileExtensionPruner,
+        FilePruner,
+        PartitionPruner,
+    )
+    from ray.data._internal.datasource_v2.listing.listing_utils import (
+        sample_files,
+    )
+    from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner import (
+        RoundRobinPartitioner,
+    )
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
+
+    ctx = DataContext.get_current()
+
+    if ray_remote_args is None:
+        ray_remote_args = {}
+
+    if "scheduling_strategy" not in ray_remote_args and (
+        "label_selector" not in ray_remote_args
+    ):
+        ray_remote_args["scheduling_strategy"] = ctx.scheduling_strategy
+
+    ray_remote_args = merge_resources_to_ray_remote_args(
+        num_cpus,
+        num_gpus,
+        memory,
+        ray_remote_args,
+    )
+
+    pruners: List[FilePruner] = [FileExtensionPruner(datasource.file_extensions)]
+    if partition_filter is not None:
+        pruners.append(PartitionPruner(partition_filter))
+
+    indexer = datasource._get_file_indexer()
+
+    # Sample a few files for schema inference. Listed again (cheaply) during
+    # execution inside the ListFiles op — no caching layer needed.
+    sample = sample_files(indexer, datasource.paths, datasource.filesystem, pruners)
+    if len(sample) == 0:
+        raise ValueError(
+            f"no files found under {datasource.paths!r}. Check the path and any "
+            "configured `partition_filter` or `file_extensions` filters."
+        )
+    schema = datasource.infer_schema(sample)
+    # Resolve any path-discovered partitioning field names from the sample
+    # and pass the result through to the scanner. Keeping the discovery
+    # here (rather than mutating ``datasource._partitioning`` inside
+    # ``infer_schema``) leaves the datasource instance immutable across
+    # reads.
+    resolved_partitioning = datasource.resolve_partitioning(sample)
+    scanner = datasource.create_scanner(
+        schema=schema,
+        filesystem=datasource.filesystem,
+        partitioning=resolved_partitioning,
+    )
+
+    # Size-balanced bucketing for the listing output. The partitioner is
+    # captured in a pickled closure and runs inside worker tasks, so its
+    # estimator must be I/O-free and pickle-safe — use the datasource's
+    # canonical estimator (``ParquetInMemorySizeEstimator`` is a fixed
+    # encoding-ratio multiplier). ``num_buckets`` is a hint;
+    # ``RoundRobinPartitioner`` honors ``[min, max]`` block-size limits
+    # first, so the actual bucket count scales with total data size.
+    # ``target_*_block_size`` can be ``None`` (block sizing disabled); fall
+    # back to sentinel bounds so the partitioner just rolls every file
+    # into a single bucket.
+    import sys
+
+    min_bucket_size = ctx.target_min_block_size or 0
+    max_bucket_size = (
+        ctx.target_max_block_size
+        if ctx.target_max_block_size is not None
+        else sys.maxsize
+    )
+    partitioner = RoundRobinPartitioner(
+        in_memory_size_estimator=datasource.get_size_estimator(),
+        min_bucket_size=min_bucket_size,
+        max_bucket_size=max_bucket_size,
+        num_buckets=ctx.read_op_min_num_blocks,
+    )
+
+    # NOTE: We're using shuffle config factory to fix the seed at the planning
+    #       time, rather than at the composition time (for backward-compatibility)
+    shuffle = getattr(datasource, "shuffle", None)
+
+    def _shuffle_config_factory() -> Optional[FileShuffleConfig]:
+        return (
+            FileShuffleConfig(seed=time.time_ns() % INT32_MAX)
+            if shuffle == "files"
+            else shuffle
+        )
+
+    list_files_op = ListFiles(
+        paths=list(datasource.paths),
+        file_indexer=indexer,
+        filesystem=datasource.filesystem,
+        source_paths=list(datasource.paths),
+        file_partitioner=partitioner,
+        file_extensions=datasource.file_extensions,
+        partition_filter=partition_filter,
+        shuffle_config_factory=_shuffle_config_factory,
+    )
+
+    compute_strategy = get_compute_strategy_for_read_api(compute, concurrency)
+
+    read_op = ReadFiles(
+        input_op=list_files_op,
+        datasource_name=datasource.name,
+        scanner=scanner,
+        schema=schema,
+        parallelism=parallelism,
+        ray_remote_args=ray_remote_args,
+        compute=compute_strategy,
+    )
+
+    stats = DatasetStats(metadata={"Read": []}, parent=None)
+    execution_plan = ExecutionPlan(stats, DataContext.get_current().copy())
+    logical_plan = LogicalPlan(read_op, execution_plan._context)
+    return Dataset(plan=execution_plan, logical_plan=logical_plan)
 
 
 @PublicAPI
@@ -1116,6 +1269,58 @@ def read_parquet(
     dataset_kwargs = arrow_parquet_args.pop("dataset_kwargs", None)
     _block_udf = arrow_parquet_args.pop("_block_udf", None)
     schema = arrow_parquet_args.pop("schema", None)
+
+    ctx = DataContext.get_current()
+    if ctx.use_datasource_v2:
+        if _block_udf is not None:
+            raise NotImplementedError(
+                "`_block_udf` is deprecated and not supported on the DataSourceV2 path."
+            )
+        if tensor_column_schema is not None:
+            raise NotImplementedError(
+                "`tensor_column_schema` is not yet supported on the DataSourceV2 path."
+            )
+        if dataset_kwargs:
+            raise NotImplementedError(
+                "`dataset_kwargs` is not yet supported on the DataSourceV2 path."
+            )
+        if columns is not None:
+            # TODO(datasource-v2): remove `columns=` from `read_parquet` once
+            # the projection-pushdown rule dispatches to `ReadFiles`. Callers
+            # should use `ray.data.read_parquet(path).select_columns([...])`
+            # — semantically equivalent on V1, and on V2 the pushdown rule
+            # will fold the projection into the scanner once it lands.
+            raise NotImplementedError(
+                "`columns=` on `read_parquet` is deprecated on the DataSourceV2 "
+                "path. Use `ray.data.read_parquet(path).select_columns([...])` "
+                "instead."
+            )
+
+        from ray.data._internal.datasource_v2.parquet_datasource_v2 import (
+            ParquetDatasourceV2,
+        )
+
+        datasource_v2 = ParquetDatasourceV2(
+            paths=paths if isinstance(paths, list) else [paths],
+            filesystem=filesystem,
+            partitioning=partitioning,
+            file_extensions=file_extensions,
+            include_paths=include_paths,
+            shuffle=shuffle,
+            arrow_parquet_args=arrow_parquet_args,
+            schema=schema,
+        )
+        return _read_datasource_v2(
+            datasource_v2,
+            parallelism=_get_num_output_blocks(parallelism, override_num_blocks),
+            num_cpus=num_cpus,
+            num_gpus=num_gpus,
+            memory=memory,
+            ray_remote_args=ray_remote_args,
+            concurrency=concurrency,
+            partition_filter=partition_filter,
+        )
+
     datasource = ParquetDatasource(
         paths,
         columns=columns,

--- a/python/ray/data/tests/unit/datasource_v2/test_list_files_op.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_list_files_op.py
@@ -1,0 +1,78 @@
+"""Unit tests for :class:`ListFiles` logical op.
+
+Full physical-planning tests live in the CI parquet regression suite
+(they need Ray initialized for ``ray.put`` on the listing input
+bundles). Here we exercise just the logical op shape and the shuffle
+factory semantics.
+"""
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from ray.data._internal.datasource_v2.listing.file_indexer import (
+    NonSamplingFileIndexer,
+)
+from ray.data._internal.datasource_v2.listing.file_manifest import (
+    FILE_SIZE_COLUMN_NAME,
+    PATH_COLUMN_NAME,
+)
+from ray.data._internal.logical.operators import ListFiles
+from ray.data.datasource.file_based_datasource import FileShuffleConfig
+
+
+def _mk_indexer():
+    return NonSamplingFileIndexer(ignore_missing_paths=False)
+
+
+def _mk_list_files(tmp_path, num_files: int = 3, shuffle_seed=None):
+    for i in range(num_files):
+        pq.write_table(pa.table({"x": [i]}), str(tmp_path / f"f{i}.parquet"))
+    paths = [str(tmp_path / f"f{i}.parquet") for i in range(num_files)]
+
+    def _shuffle_factory():
+        if shuffle_seed is None:
+            return None
+        return FileShuffleConfig(seed=shuffle_seed)
+
+    import pyarrow.fs as pafs
+
+    return ListFiles(
+        paths=paths,
+        file_indexer=_mk_indexer(),
+        filesystem=pafs.LocalFileSystem(),
+        source_paths=paths,
+        shuffle_config_factory=_shuffle_factory,
+    )
+
+
+def test_list_files_infers_manifest_schema(tmp_path):
+    op = _mk_list_files(tmp_path, num_files=1)
+    schema = op.infer_schema()
+    assert schema.names == [PATH_COLUMN_NAME, FILE_SIZE_COLUMN_NAME]
+    assert schema.field(PATH_COLUMN_NAME).type == pa.string()
+    assert schema.field(FILE_SIZE_COLUMN_NAME).type == pa.int64()
+
+
+def test_list_files_has_no_input_dependencies(tmp_path):
+    op = _mk_list_files(tmp_path, num_files=1)
+    assert op.input_dependencies == []
+    assert op.num_outputs is None
+    assert op.output_data() is None
+
+
+def test_shuffle_config_factory_none_when_unconfigured(tmp_path):
+    op = _mk_list_files(tmp_path, num_files=1, shuffle_seed=None)
+    assert op.shuffle_config_factory() is None
+
+
+def test_shuffle_config_factory_returns_config_when_seeded(tmp_path):
+    op = _mk_list_files(tmp_path, num_files=1, shuffle_seed=42)
+    config = op.shuffle_config_factory()
+    assert isinstance(config, FileShuffleConfig)
+    assert config.seed == 42
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-xvs"]))

--- a/python/ray/data/tests/unit/datasource_v2/test_read_parquet_v2.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_read_parquet_v2.py
@@ -1,0 +1,102 @@
+"""Integration-ish tests for ``read_parquet()`` on the DataSourceV2 path.
+
+These tests exercise planning-time behavior: schema inference,
+``ListFiles → ReadFiles`` attachment to the logical plan, and
+unsupported-option gating. Physical execution (take_all) requires a
+live Ray runtime and is covered by the CI parquet regression suite;
+these tests run with no Ray cluster.
+"""
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import ray
+from ray.data._internal.logical.operators import ListFiles, ReadFiles
+from ray.data.context import DataContext
+
+
+def _write(path, table):
+    pq.write_table(table, str(path))
+
+
+@pytest.fixture
+def restore_ctx():
+    ctx = DataContext.get_current()
+    original = ctx.use_datasource_v2
+    try:
+        yield ctx
+    finally:
+        ctx.use_datasource_v2 = original
+
+
+def test_v2_flag_default():
+    # The default is driven by ``DEFAULT_USE_DATASOURCE_V2``. Asserting
+    # either direction here would be brittle, so just check that the
+    # default is a bool.
+    ctx = DataContext()
+    assert isinstance(ctx.use_datasource_v2, bool)
+
+
+def test_read_parquet_builds_list_files_read_files_chain(tmp_path, restore_ctx):
+    f = tmp_path / "data.parquet"
+    _write(f, pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet(str(tmp_path))
+
+    assert isinstance(ds._logical_plan.dag, ReadFiles)
+    assert isinstance(ds._logical_plan.dag.input_dependency, ListFiles)
+    schema = ds.schema()
+    assert schema is not None
+    assert "a" in schema.names
+    assert "b" in schema.names
+
+
+def test_read_parquet_v2_hive_partitioned(tmp_path, restore_ctx):
+    for p in ["a", "b"]:
+        d = tmp_path / f"color={p}"
+        d.mkdir()
+        _write(d / "data.parquet", pa.table({"x": [1, 2]}))
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet(str(tmp_path))
+    schema = ds.schema()
+    assert "x" in schema.names
+    assert "color" in schema.names
+
+
+def test_read_parquet_v2_include_paths(tmp_path, restore_ctx):
+    _write(tmp_path / "data.parquet", pa.table({"a": [1]}))
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet(str(tmp_path), include_paths=True)
+    schema = ds.schema()
+    assert "path" in schema.names
+
+
+def test_read_parquet_v2_block_udf_raises(tmp_path, restore_ctx):
+    _write(tmp_path / "data.parquet", pa.table({"a": [1]}))
+
+    restore_ctx.use_datasource_v2 = True
+    with pytest.raises(NotImplementedError, match="_block_udf"):
+        ray.data.read_parquet(str(tmp_path), _block_udf=lambda b: b)
+
+
+def test_read_parquet_v2_columns_raises(tmp_path, restore_ctx):
+    _write(tmp_path / "data.parquet", pa.table({"a": [1], "b": [2]}))
+
+    restore_ctx.use_datasource_v2 = True
+    with pytest.raises(NotImplementedError, match="`columns=` on `read_parquet`"):
+        ray.data.read_parquet(str(tmp_path), columns=["a"])
+
+
+def test_read_parquet_v2_empty_dir_raises(tmp_path, restore_ctx):
+    restore_ctx.use_datasource_v2 = True
+    with pytest.raises(ValueError, match="no files found"):
+        ray.data.read_parquet(str(tmp_path))
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-xvs"]))


### PR DESCRIPTION

Wires the V2 Parquet read path end-to-end. Behind the
``DataContext.use_datasource_v2`` opt-in flag (default ``False``);
``read_parquet`` continues to take the V1 path until pr-Z flips the
default.

- datasource_v2/datasource_v2.py: ``resolve_partitioning`` base
  method (default ``None``) so subclasses can derive partitioning
  field names from a sample without mutating instance state.
- datasource_v2/parquet_datasource_v2.py (new): ParquetDatasourceV2
  with file indexer, scanner factory, schema inference (parallelized
  footer reads + thread pool), ``resolve_partitioning`` override
  populating field_names from path discovery, and user-supplied
  ``schema`` overrides.
- read_api.py: ``_read_datasource_v2`` driver entry that wires the
  ListFiles → ReadFiles op pair and threads through the file pruner
  list. ``read_parquet`` dispatches to V2 when
  ``use_datasource_v2=True``. Raises ``NotImplementedError`` for
  ``_block_udf``, ``tensor_column_schema``, ``dataset_kwargs``,
  and ``columns=`` (each gets its own follow-up — pr-C, pr-G).
- context.py: ``use_datasource_v2: bool`` flag, default ``False``.
- BUILD.bazel: register the new V2 unit-test packages.
- doc/source/data/performance-tips.rst: brief mention.
- tests: parquet datasource unit tests, ListFiles-op fixture tests,
  read_files logical-op tests, V2 read_parquet end-to-end tests.

Signed-off-by: Goutam <goutam@anyscale.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
