### PR TITLE
[llm][serve] Materialize chat completion message `content` in sanitizer

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -132,8 +132,10 @@ def _sanitize_chat_completion_request(
 ) -> ChatCompletionRequest:
     """Sanitize ChatCompletionRequest to fix Pydantic ValidatorIterator serialization issue.
 
-    This addresses a known Pydantic bug where tool_calls fields become ValidatorIterator
-    objects that cannot be pickled for Ray remote calls.
+    This addresses a known Pydantic bug where fields typed as ``Iterable[...]``
+    on OpenAI message TypedDicts (notably ``content`` on every message variant
+    and ``tool_calls`` on assistant messages) become ValidatorIterator objects
+    that cannot be pickled for Ray remote calls.
 
     Workaround logic adapted from vLLM (credits: @gcalmettes):
     - vLLM PR: https://github.com/vllm-project/vllm/pull/9951
@@ -141,13 +143,28 @@ def _sanitize_chat_completion_request(
     - Related Issue: https://github.com/pydantic/pydantic/issues/9541
     - Official Workaround: https://github.com/pydantic/pydantic/issues/9467#issuecomment-2442097291
 
-    TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix.
+    Note: still reproducible on Pydantic 2.12 for the ``Iterable[...]`` arm of
+    a ``Union``, so this sanitizer is required regardless of Pydantic version.
     """
     for i, message in enumerate(request.messages):
         # SGLang messages are Pydantic BaseModels (no .get()); convert to dicts
         # so the same logic works for both vLLM (TypedDict) and SGLang.
         if not isinstance(message, dict):
             request.messages[i] = message = message.model_dump()
+
+        # `content` is typed `Union[str, Iterable[ContentPart], None]` on every
+        # OpenAI message variant. When the iterable arm matches, Pydantic stores
+        # a non-picklable ValidatorIterator. Materialize it for any role.
+        content_val = message.get("content")
+        if content_val is not None and not isinstance(content_val, str):
+            try:
+                request.messages[i]["content"] = list(content_val)
+            except (TypeError, ValueError) as e:
+                raise ValueError(
+                    "Validating message `content` raised an error. Please "
+                    "ensure `content` is a string, None, or an iterable of "
+                    "content parts."
+                ) from e
 
         if message.get("role") == "assistant":
             tool_calls_val = message.get("tool_calls")

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -158,7 +158,7 @@ def _sanitize_chat_completion_request(
         content_val = message.get("content")
         if content_val is not None and not isinstance(content_val, str):
             try:
-                request.messages[i]["content"] = list(content_val)
+                message["content"] = list(content_val)
             except (TypeError, ValueError) as e:
                 raise ValueError(
                     "Validating message `content` raised an error. Please "
@@ -170,7 +170,7 @@ def _sanitize_chat_completion_request(
             tool_calls_val = message.get("tool_calls")
             if tool_calls_val is not None:
                 try:
-                    request.messages[i]["tool_calls"] = list(tool_calls_val)
+                    message["tool_calls"] = list(tool_calls_val)
                 except (TypeError, ValueError) as e:
                     raise ValueError(
                         "Validating messages' `tool_calls` raised an error. "

--- a/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
@@ -134,6 +134,44 @@ class TestSanitizeChatCompletionRequest:
         else:
             assert getattr(assistant_msg, "tool_calls", None) is None
 
+    def test_serializes_content_iterator(self):
+        """When `content` is sent as a list of content parts on any message,
+        Pydantic stores it as a ValidatorIterator against the `Iterable[...]`
+        arm and the request becomes unpicklable until sanitized."""
+        import pickle
+
+        from ray.llm._internal.serve.core.configs.openai_api_models import (
+            ChatCompletionRequest,
+        )
+        from ray.llm._internal.serve.core.ingress.ingress import (
+            _sanitize_chat_completion_request,
+        )
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[
+                {"role": "system", "content": [{"text": "sys", "type": "text"}]},
+                {"role": "user", "content": [{"text": "hi", "type": "text"}]},
+                {
+                    "role": "assistant",
+                    "content": [{"text": "step", "type": "text"}],
+                },
+                {
+                    "role": "tool",
+                    "content": [{"text": "r", "type": "text"}],
+                    "tool_call_id": "c0",
+                },
+            ],
+        )
+
+        result = _sanitize_chat_completion_request(request)
+        for msg in result.messages:
+            assert isinstance(msg, dict)
+            assert isinstance(msg["content"], list)
+            assert type(msg["content"]).__name__ != "ValidatorIterator"
+
+        pickle.dumps(result)
+
 
 class TestLLMServerLazyImport:
     def test_default_engine_cls_is_none(self):


### PR DESCRIPTION
## Summary

`_sanitize_chat_completion_request` (in `ray/llm/_internal/serve/core/ingress/ingress.py`) only materialized `tool_calls` on assistant messages, leaving `content` as a Pydantic `ValidatorIterator` whenever the request matched the `Iterable[ContentPart]` arm of the `Union[str, Iterable[...], None]` field type that OpenAI's TypedDicts use on every message variant. Cloudpickle then failed when the ingress forwarded the request to the LLM replica via `model_handle.chat.remote(...)`, returning 500s for any payload that sends `content` as a list of content parts (e.g. `[{"text": "...", "type": "text"}]`).

Plain-string `content` requests were unaffected, which is why this slipped through earlier.

This PR extends the sanitizer to also materialize `content` to a list on every message variant (system, user, assistant, tool). The existing `tool_calls` handling is unchanged.

It also drops the optimistic `TODO(seiji): Remove when we update to Pydantic v2.11+` — the `Iterable[...]` Union-arm bug is still reproducible on Pydantic 2.12, so this workaround is required regardless of Pydantic version.

### Repro (before)

```python
from ray.llm._internal.serve.core.configs.openai_api_models import ChatCompletionRequest
import pickle

body = ChatCompletionRequest.model_validate({
    "model": "qwen35-9b",
    "messages": [
        {"role": "user", "content": [{"text": "hi", "type": "text"}]},
        {"role": "assistant", "content": [{"text": "ok", "type": "text"}]},
    ],
})
pickle.dumps(body)
# TypeError: cannot pickle 'pydantic_core._pydantic_core.ValidatorIterator' object
```

After this PR (running through `_sanitize_chat_completion_request`), the request pickles successfully.

## Related

- vLLM PR: https://github.com/vllm-project/vllm/pull/9951
- Pydantic Issue: https://github.com/pydantic/pydantic/issues/9467
- Related Issue: https://github.com/pydantic/pydantic/issues/9541
- Original Ray fix (assistant `tool_calls` only): #55538 / #55294

## Test plan

- [x] New unit test `test_serializes_content_iterator` exercises a payload with list-of-content-parts on every role and asserts the result pickles.
- [x] Existing tests `test_serializes_tool_calls_iterator` and `test_handles_no_tool_calls` still pass.
- [x] `bash ci/lint/lint.sh pre_commit` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)