### PR TITLE
[RLlib] Handle the all-evaluation-workers-unhealthy + parallel-to-training case

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -1685,6 +1685,18 @@ py_test(
     deps = [":conftest"],
 )
 
+py_test(
+    name = "test_eval_workers_all_unhealthy",
+    size = "medium",
+    srcs = ["algorithms/tests/test_eval_workers_all_unhealthy.py"],
+    tags = [
+        "algorithms",
+        "exclusive",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
 # Specific Algorithms
 
 # APPO

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -1464,6 +1464,12 @@ class Algorithm(Checkpointable, Trainable):
             env_steps = agent_steps = 0
             batches = []
 
+            # If `evaluation_parallel_to_training=True` and *all* eval
+            # EnvRunners are currently unhealthy, falling back to the local
+            # eval EnvRunner is unsafe (it raises). Optionally poll for
+            # recovery before deciding what to do.
+            self._maybe_wait_for_eval_env_runner_recovery()
+
             # We will use a user provided evaluation function.
             if self.config.custom_evaluation_function:
                 if self.config.enable_env_runner_and_connector_v2:
@@ -1482,14 +1488,33 @@ class Algorithm(Checkpointable, Trainable):
                     agent_steps,
                     batches,
                 ) = self._evaluate_on_local_env_runner(self.env_runner)
-            # There is only a local eval EnvRunner -> Run on that.
-            elif self.eval_env_runner_group.num_healthy_remote_workers() == 0:
+            # No healthy remote eval workers and we *can* fall back to the
+            # local eval EnvRunner (i.e. not running parallel to training).
+            elif (
+                self.eval_env_runner_group.num_healthy_remote_workers() == 0
+                and not self.config.evaluation_parallel_to_training
+            ):
                 (
                     eval_results,
                     env_steps,
                     agent_steps,
                     batches,
                 ) = self._evaluate_on_local_env_runner(self.eval_env_runner)
+            # No healthy remote eval workers and `evaluation_parallel_to_training=True`,
+            # so local fallback would raise. User asked us to fail loudly.
+            elif (
+                self.eval_env_runner_group.num_healthy_remote_workers() == 0
+                and self.config.evaluation_error_on_no_workers
+            ):
+                raise RuntimeError(
+                    "All evaluation EnvRunners are unhealthy and "
+                    "`evaluation_parallel_to_training=True`, so RLlib can't "
+                    "fall back to the local eval EnvRunner. Set "
+                    "`evaluation_error_on_no_workers=False` (default) to "
+                    "skip evaluation for this iteration instead of raising, "
+                    "and/or `evaluation_unhealthy_workers_timeout_s` > 0 to "
+                    "wait for recovery before deciding."
+                )
             # There are healthy remote evaluation workers -> Run on these.
             elif self.eval_env_runner_group.num_healthy_remote_workers() > 0:
                 # Running in automatic duration mode (parallel with training step).
@@ -1615,6 +1640,54 @@ class Algorithm(Checkpointable, Trainable):
             [results],
             key=(EVALUATION_RESULTS, OFFLINE_EVAL_RUNNER_RESULTS),
         )
+
+    def _maybe_wait_for_eval_env_runner_recovery(self) -> None:
+        """Poll for at least one healthy eval EnvRunner if the user asked to.
+
+        When `evaluation_parallel_to_training=True` and *all* remote eval
+        EnvRunners are unhealthy, the only "run eval" branch falls back to
+        the local eval EnvRunner, which raises in this mode. Before deciding
+        to skip / raise, wait up to
+        `evaluation_unhealthy_workers_timeout_s` seconds for recovery.
+        """
+        timeout_s = self.config.evaluation_unhealthy_workers_timeout_s
+        if not timeout_s or timeout_s <= 0:
+            return
+        if (
+            self.eval_env_runner_group is None
+            or not self.config.evaluation_parallel_to_training
+        ):
+            return
+        if self.eval_env_runner_group.num_healthy_remote_workers() > 0:
+            return
+
+        start = time.monotonic()
+        deadline = start + timeout_s
+        # Heartbeat every 60s so long waits show up in logs without spamming.
+        next_log = start + 60.0
+        logger.warning(
+            "All %d remote eval EnvRunner(s) are unhealthy; waiting up to "
+            "%.0fs for at least one to recover before "
+            "deciding to skip evaluation or raise (controlled by "
+            "`evaluation_error_on_no_workers`).",
+            self.eval_env_runner_group.num_remote_env_runners(),
+            timeout_s,
+        )
+        while (
+            self.eval_env_runner_group.num_healthy_remote_workers() == 0
+            and time.monotonic() < deadline
+        ):
+            time.sleep(0.01)
+            now = time.monotonic()
+            if now >= next_log:
+                logger.warning(
+                    "Still 0/%d eval EnvRunners healthy after %.0fs "
+                    "(timeout %.0fs).",
+                    self.eval_env_runner_group.num_remote_env_runners(),
+                    now - start,
+                    timeout_s,
+                )
+                next_log = now + 60.0
 
     def _evaluate_on_local_env_runner(self, env_runner):
         if hasattr(env_runner, "input_reader") and env_runner.input_reader is None:

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -520,6 +520,15 @@ class AlgorithmConfig(_Config):
         self.evaluation_auto_duration_min_env_steps_per_sample = 100
         self.evaluation_auto_duration_max_env_steps_per_sample = 2000
         self.evaluation_parallel_to_training = False
+        # How long to wait for at least one remote eval EnvRunner to recover
+        # when *all* of them are unhealthy at the start of an evaluation step
+        # (and `evaluation_parallel_to_training=True`, so the local-eval
+        # fallback isn't usable). Default 0: don't wait.
+        self.evaluation_unhealthy_workers_timeout_s = 0.0
+        # If still no eval EnvRunners are healthy after the wait above,
+        # raise a clear `RuntimeError` (True) or skip evaluation for this
+        # iteration (False, default).
+        self.evaluation_error_on_no_workers = False
         self.evaluation_force_reset_envs_before_iteration = True
         self.evaluation_config = None
         self.off_policy_estimation_methods = {}
@@ -2744,6 +2753,8 @@ class AlgorithmConfig(_Config):
         evaluation_auto_duration_max_env_steps_per_sample: Optional[int] = NotProvided,
         evaluation_sample_timeout_s: Optional[float] = NotProvided,
         evaluation_parallel_to_training: Optional[bool] = NotProvided,
+        evaluation_unhealthy_workers_timeout_s: Optional[float] = NotProvided,
+        evaluation_error_on_no_workers: Optional[bool] = NotProvided,
         evaluation_force_reset_envs_before_iteration: Optional[bool] = NotProvided,
         evaluation_config: Optional[
             Union["AlgorithmConfig", PartialAlgorithmConfigDict]
@@ -2827,6 +2838,20 @@ class AlgorithmConfig(_Config):
                 reports a good evaluation `episode_return_mean`, be aware that these
                 results were achieved on the weights trained in iteration 41, so you
                 should probably pick the iteration 41 checkpoint instead.
+            evaluation_unhealthy_workers_timeout_s: How long (in seconds) to
+                wait for at least one remote eval EnvRunner to recover when
+                *all* of them are unhealthy at the start of an evaluation
+                step and `evaluation_parallel_to_training=True` (so the
+                local-eval fallback isn't usable). Default 0: don't wait.
+                Combine with `evaluation_error_on_no_workers` to choose what
+                happens if recovery doesn't arrive in time.
+            evaluation_error_on_no_workers: If still no remote eval
+                EnvRunners are healthy after waiting
+                `evaluation_unhealthy_workers_timeout_s` seconds, raise a
+                clear `RuntimeError` (True) or skip evaluation for this
+                iteration (False, default). Only takes effect when
+                `evaluation_parallel_to_training=True` (in non-parallel
+                mode the local-eval fallback handles this case).
             evaluation_force_reset_envs_before_iteration: Whether all environments
                 should be force-reset (even if they are not done yet) right before
                 the evaluation step of the iteration begins. Setting this to True
@@ -3000,6 +3025,12 @@ class AlgorithmConfig(_Config):
             self.evaluation_sample_timeout_s = evaluation_sample_timeout_s
         if evaluation_parallel_to_training is not NotProvided:
             self.evaluation_parallel_to_training = evaluation_parallel_to_training
+        if evaluation_unhealthy_workers_timeout_s is not NotProvided:
+            self.evaluation_unhealthy_workers_timeout_s = (
+                evaluation_unhealthy_workers_timeout_s
+            )
+        if evaluation_error_on_no_workers is not NotProvided:
+            self.evaluation_error_on_no_workers = evaluation_error_on_no_workers
         if evaluation_force_reset_envs_before_iteration is not NotProvided:
             self.evaluation_force_reset_envs_before_iteration = (
                 evaluation_force_reset_envs_before_iteration

--- a/rllib/algorithms/tests/test_eval_workers_all_unhealthy.py
+++ b/rllib/algorithms/tests/test_eval_workers_all_unhealthy.py
@@ -1,0 +1,141 @@
+"""Tests for evaluating when *all* eval EnvRunners are unhealthy and
+``evaluation_parallel_to_training=True``.
+
+Previously, ``Algorithm.evaluate()`` fell back to
+``_evaluate_on_local_env_runner(self.eval_env_runner)`` in this case, which
+raises ``ValueError: Cannot run on local evaluation worker parallel to
+training!``. Now controlled by two orthogonal config knobs:
+
+- ``evaluation_unhealthy_workers_timeout_s``: how long to wait for at least
+  one eval EnvRunner to recover before deciding what to do (default 0:
+  don't wait).
+- ``evaluation_error_on_no_workers``: if still no healthy eval EnvRunners
+  after the wait, raise ``RuntimeError`` (True) or skip evaluation for
+  this iteration (False, default).
+"""
+import time
+
+import pytest
+
+import ray
+from ray.rllib.algorithms.ppo import PPOConfig
+
+
+def _algo_with_killed_eval_workers(
+    *,
+    timeout_s=0,
+    error_on_no_workers=False,
+):
+    """Build a PPO algo, kill every eval worker, mark them all unhealthy.
+
+    Returns the live ``Algorithm`` ready for an ``algo.train()`` call.
+    """
+    config = (
+        PPOConfig()
+        .environment("CartPole-v1")
+        .env_runners(num_env_runners=2)
+        .training(
+            train_batch_size=200,
+            num_epochs=1,
+            minibatch_size=200,
+        )
+        .evaluation(
+            evaluation_num_env_runners=2,
+            evaluation_interval=1,
+            evaluation_parallel_to_training=True,
+            evaluation_duration="auto",
+            evaluation_duration_unit="timesteps",
+            evaluation_unhealthy_workers_timeout_s=timeout_s,
+            evaluation_error_on_no_workers=error_on_no_workers,
+        )
+        .fault_tolerance(restart_failed_env_runners=False)
+        .reporting(min_train_timesteps_per_iteration=1)
+    )
+    algo = config.build()
+
+    # Kill every eval worker and mark them all unhealthy. Mirrors
+    # losing every eval node at once.
+    eval_grp = algo.eval_env_runner_group
+    for a in list(eval_grp._worker_manager._actors.values()):
+        ray.kill(a, no_restart=True)
+    for actor_id in list(eval_grp._worker_manager.actor_ids()):
+        eval_grp._worker_manager.set_actor_state(actor_id, healthy=False)
+    assert eval_grp.num_healthy_remote_workers() == 0
+    return algo
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ray_cluster():
+    # `num_cpus=8` bounds the cluster; each test needs 4 train + 2 eval
+    # EnvRunner actors plus the driver. Module scope avoids paying ~4s of
+    # ray.init/shutdown per test (the four tests are independent — actors
+    # are torn down by algo.stop() / ray.kill within each test).
+    ray.init(num_cpus=8, include_dashboard=False)
+    yield
+    ray.shutdown()
+
+
+def test_default_skips_eval_silently():
+    """Defaults (timeout=0, error=False): train() must succeed even though
+    every eval worker is dead. Eval is just skipped."""
+    algo = _algo_with_killed_eval_workers()
+    try:
+        result = algo.train()  # must not raise
+        assert result is not None
+    finally:
+        algo.stop()
+
+
+def test_error_on_no_workers_raises():
+    """error_on_no_workers=True with no recovery: train() must raise a clear,
+    actionable error rather than silently skipping."""
+    algo = _algo_with_killed_eval_workers(error_on_no_workers=True)
+    try:
+        with pytest.raises(RuntimeError, match="evaluation_error_on_no_workers"):
+            algo.train()
+    finally:
+        algo.stop()
+
+
+def test_timeout_waits_then_skips_when_no_recovery():
+    """timeout_s>0 with workers that never come back: train() should take at
+    least roughly that long (waiting for recovery), then skip silently
+    because error_on_no_workers defaults to False."""
+    timeout_s = 2.0
+    algo = _algo_with_killed_eval_workers(timeout_s=timeout_s)
+    try:
+        start = time.monotonic()
+        result = algo.train()  # must not raise
+        elapsed = time.monotonic() - start
+        # At least ~timeout_s elapsed because we polled for recovery.
+        assert elapsed >= timeout_s * 0.8, (
+            f"train() returned in {elapsed:.2f}s; expected at least "
+            f"{timeout_s * 0.8:.2f}s for the recovery wait."
+        )
+        assert result is not None
+    finally:
+        algo.stop()
+
+
+def test_timeout_then_error_when_no_recovery():
+    """timeout_s>0 + error_on_no_workers=True with no recovery: wait the
+    timeout, then raise."""
+    timeout_s = 1.0
+    algo = _algo_with_killed_eval_workers(timeout_s=timeout_s, error_on_no_workers=True)
+    try:
+        start = time.monotonic()
+        with pytest.raises(RuntimeError, match="evaluation_error_on_no_workers"):
+            algo.train()
+        elapsed = time.monotonic() - start
+        assert elapsed >= timeout_s * 0.8, (
+            f"train() raised in {elapsed:.2f}s; expected at least "
+            f"{timeout_s * 0.8:.2f}s for the recovery wait."
+        )
+    finally:
+        algo.stop()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

When `evaluation_parallel_to_training=True` and every remote evaluation EnvRunner is unhealthy at the start of an evaluation step, `Algorithm.evaluate()`'s `num_healthy_remote_workers() == 0` branch fell into `_evaluate_on_local_env_runner(self.eval_env_runner)`, which unconditionally raises in `parallel_to_training` mode. There was no way to recover gracefully -- the only "good" branch (skipping evaluation) was unreachable.

Fix: split that branch by `evaluation_parallel_to_training` and gate the parallel-mode case on a new config knob,
`AlgorithmConfig.evaluation_unhealthy_workers_timeout_s`:

- `None` (default): skip evaluation this iteration. Most lenient.
- `0`: fail fast with a clear `RuntimeError` pointing at the new option.
- `int > 0`: poll up to that many seconds for at least one evaluation EnvRunner to recover; if one comes back, run evaluation as usual, otherwise skip.

The non-parallel branch keeps the existing local-eval fallback, which is still safe there.