### PR TITLE
[ci] Skip test init when RAYCI_SELECT is set on pipeline build env

### DIFF
--- a/.buildkite/release/custom-image-build-and-test-init.sh
+++ b/.buildkite/release/custom-image-build-and-test-init.sh
@@ -42,6 +42,7 @@ UV_PYTHON_BIN="$("${UV_BIN}" python find --no-project "${UV_PYTHON_VERSION}")"
 
 if [[ "${AUTOMATIC:-0}" == "1" && "${RAYCI_SELECT:-}" != "" ]]; then
   echo "Skipping custom image build and test init because RAYCI_SELECT is set"
+  echo "RAYCI_SELECT: ${RAYCI_SELECT}"
   exit 0
 fi
 

--- a/.buildkite/release/custom-image-build-and-test-init.sh
+++ b/.buildkite/release/custom-image-build-and-test-init.sh
@@ -20,6 +20,12 @@ fi
 export RAYCI_BUILD_ID="${BUILD_ID}"
 echo "RAYCI_BUILD_ID: ${RAYCI_BUILD_ID}"
 
+if [[ "${AUTOMATIC:-0}" == "1" && -n "${RAYCI_SELECT:-}" ]]; then
+  echo "Skipping custom image build and test init because RAYCI_SELECT is set"
+  echo "RAYCI_SELECT: ${RAYCI_SELECT}"
+  exit 0
+fi
+
 aws ecr get-login-password --region us-west-2 | \
     docker login --username AWS --password-stdin 029272617770.dkr.ecr.us-west-2.amazonaws.com
 
@@ -39,12 +45,6 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 UV_BIN="${HOME}/.local/bin/uv"
 "${UV_BIN}" python install "${UV_PYTHON_VERSION}"
 UV_PYTHON_BIN="$("${UV_BIN}" python find --no-project "${UV_PYTHON_VERSION}")"
-
-if [[ "${AUTOMATIC:-0}" == "1" && "${RAYCI_SELECT:-}" != "" ]]; then
-  echo "Skipping custom image build and test init because RAYCI_SELECT is set"
-  echo "RAYCI_SELECT: ${RAYCI_SELECT}"
-  exit 0
-fi
 
 echo "--- Generate custom build steps"
 

--- a/.buildkite/release/custom-image-build-and-test-init.sh
+++ b/.buildkite/release/custom-image-build-and-test-init.sh
@@ -40,6 +40,10 @@ UV_BIN="${HOME}/.local/bin/uv"
 "${UV_BIN}" python install "${UV_PYTHON_VERSION}"
 UV_PYTHON_BIN="$("${UV_BIN}" python find --no-project "${UV_PYTHON_VERSION}")"
 
+if [[ "${AUTOMATIC:-0}" == "1" && "${RAYCI_SELECT:-}" != "" ]]; then
+  echo "Skipping custom image build and test init because RAYCI_SELECT is set"
+  exit 0
+fi
 
 echo "--- Generate custom build steps"
 

--- a/ci/ray_ci/automation/push_release_test_image.py
+++ b/ci/ray_ci/automation/push_release_test_image.py
@@ -16,6 +16,7 @@ Run with --help to see all options.
 """
 
 import logging
+import os
 import subprocess
 import sys
 from typing import List
@@ -48,6 +49,25 @@ _runfiles = runfiles.Create()
 
 class PushReleaseTestImageError(Exception):
     """Error raised when pushing release test images fails."""
+
+
+def _annotate_pushed_image(image_uri: str, image_type: str) -> None:
+    if os.environ.get("BUILDKITE") != "true":
+        return
+    step_key = os.environ.get("BUILDKITE_STEP_KEY")
+    rayci_select = os.environ.get("RAYCI_SELECT")
+    if step_key and rayci_select and step_key not in rayci_select:
+        return
+    subprocess.run(
+        [
+            "buildkite-agent",
+            "annotate",
+            "--style=info",
+            f"--context=release-test-{image_type}-images",
+            "--append",
+            f"{image_uri}<br/>",
+        ],
+    )
 
 
 def _run_gcloud_docker_login() -> None:
@@ -318,6 +338,7 @@ def main(
                 dest_image = f"{registry}/anyscale/{image_type}:{tag}"
                 logger.info(f"Pushing to {name}: {dest_image}")
                 copy_image(source_tag, dest_image, dry_run=False)
+                _annotate_pushed_image(dest_image, image_type)
     except ImageTagsError as e:
         raise PushReleaseTestImageError(str(e))
 

--- a/ci/ray_ci/automation/push_release_test_image.py
+++ b/ci/ray_ci/automation/push_release_test_image.py
@@ -56,7 +56,10 @@ def _annotate_pushed_image(image_uri: str, image_type: str) -> None:
         return
     step_key = os.environ.get("BUILDKITE_STEP_KEY")
     rayci_select = os.environ.get("RAYCI_SELECT")
-    if step_key and rayci_select and step_key not in rayci_select:
+    selected_step_keys = (
+        {key.strip() for key in rayci_select.split(",")} if rayci_select else set()
+    )
+    if step_key and selected_step_keys and step_key not in selected_step_keys:
         return
     subprocess.run(
         [

--- a/ci/ray_ci/automation/test_push_release_test_image.py
+++ b/ci/ray_ci/automation/test_push_release_test_image.py
@@ -6,7 +6,10 @@ from ci.ray_ci.automation.image_tags_lib import (
     format_platform_tag,
     format_python_tag,
 )
-from ci.ray_ci.automation.push_release_test_image import ReleaseTestImagePushContext
+from ci.ray_ci.automation.push_release_test_image import (
+    ReleaseTestImagePushContext,
+    _annotate_pushed_image,
+)
 from ci.ray_ci.configs import DEFAULT_PYTHON_TAG_VERSION
 from ci.ray_ci.docker_container import GPU_PLATFORM
 
@@ -261,6 +264,51 @@ class TestDestinationTags:
         # Should have both -cpu and empty platform suffix
         assert "abc123-extra-py311-cpu" in tags
         assert "abc123-extra-py311" in tags
+
+
+class TestAnnotatePushedImage:
+    def test_skips_when_not_buildkite(self, monkeypatch):
+        monkeypatch.delenv("BUILDKITE", raising=False)
+
+        calls = []
+        monkeypatch.setattr(
+            "ci.ray_ci.automation.push_release_test_image.subprocess.run",
+            lambda args: calls.append(args),
+        )
+
+        _annotate_pushed_image("example/image:tag", "ray")
+
+        assert calls == []
+
+    def test_runs_when_exact_step_key_selected(self, monkeypatch):
+        monkeypatch.setenv("BUILDKITE", "true")
+        monkeypatch.setenv("BUILDKITE_STEP_KEY", "release-ray")
+        monkeypatch.setenv("RAYCI_SELECT", "release-ray,release-ray-ml")
+
+        calls = []
+        monkeypatch.setattr(
+            "ci.ray_ci.automation.push_release_test_image.subprocess.run",
+            lambda args: calls.append(args),
+        )
+
+        _annotate_pushed_image("example/image:tag", "ray")
+
+        assert len(calls) == 1
+
+    def test_skips_when_step_key_is_only_substring_of_selected_key(self, monkeypatch):
+        monkeypatch.setenv("BUILDKITE", "true")
+        monkeypatch.setenv("BUILDKITE_STEP_KEY", "ray")
+        monkeypatch.setenv("RAYCI_SELECT", "ray-ml,ray-data")
+
+        calls = []
+        monkeypatch.setattr(
+            "ci.ray_ci.automation.push_release_test_image.subprocess.run",
+            lambda args: calls.append(args),
+        )
+
+        _annotate_pushed_image("example/image:tag", "ray")
+
+        assert calls == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
- Allow automated pipeline triggers specifically for image builds by respecting RAYCI_SELECT env variable configured in pipeline build creation trigger
- Add published image URIs to Buildkite Annotations for the build when image is the target of the build.

## Related issues
None

## Additional information
None
