### PR TITLE
[CI] Map docs-infra files to the `doc` tag

### DIFF
--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -87,6 +87,9 @@ doc/tutorial.rst: doc
 .readthedocs.yaml: doc
 .vale.ini: doc
 .vale/styles/config/vocabularies/Core/accept.txt: doc
+doc/requirements-doc.txt: doc
+python/deplocks/docs/docbuild_depset_py3.10.lock: doc python_dependencies
+ci/raydepsets/configs/docs.depsets.yaml: doc python_dependencies
 
 # === Release ===
 

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -181,6 +181,9 @@ doc/*.ipynb
 doc/BUILD
 doc/*/BUILD
 doc/*.rst
+doc/requirements-doc.txt
+python/deplocks/docs/*.lock
+ci/raydepsets/configs/docs.depsets.yaml
 .vale.ini
 .vale/
 .buildkite/doc.rayci.yml

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -97,6 +97,12 @@ python/deplocks/ci/macos_depset_py*
 @ macos_wheels python_dependencies
 ;
 
+# Short-circuit deps handling for docs-specific.
+python/deplocks/docs/*.lock
+ci/raydepsets/configs/docs.depsets.yaml
+@ doc python_dependencies
+;
+
 # Raydepsets-generated lock files and raydepsets configs that drive
 # their generation. These do NOT affect the macOS smoke test (which
 # only consumes macos_depset_py*, handled above), so we deliberately
@@ -182,8 +188,6 @@ doc/BUILD
 doc/*/BUILD
 doc/*.rst
 doc/requirements-doc.txt
-python/deplocks/docs/*.lock
-ci/raydepsets/configs/docs.depsets.yaml
 .vale.ini
 .vale/
 .buildkite/doc.rayci.yml

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -178,6 +178,7 @@ docker/
 
 doc/*.py
 doc/*.ipynb
+doc/*.md
 doc/BUILD
 doc/*/BUILD
 doc/*.rst

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -178,7 +178,6 @@ docker/
 
 doc/*.py
 doc/*.ipynb
-doc/*.md
 doc/BUILD
 doc/*/BUILD
 doc/*.rst


### PR DESCRIPTION
## Why

Three docs-infra paths don't currently match any rule in `.buildkite/test.rules.txt` and fall through to broader tag sets, triggering test runs that aren't relevant to docs-only changes:

- `doc/requirements-doc.txt` — Python dependencies for the docs build.
- `python/deplocks/docs/*.lock` — compiled dependency locks for the docs build.
- `ci/raydepsets/configs/docs.depsets.yaml` — `raydepsets` configuration for the docs deplocks.

Recent docs-infra PRs (#63115 sitemap fix, #63130 llms.txt) touch these files and pull in test runs that don't need to fire. REEf flagged this and asked for the rule update; once this lands, those PRs benefit on their next CI run.

## What

Adds the three patterns to the existing doc rule block (lines 179-188 of `test.rules.txt`). Three new lines, no changes to existing rules or other tag mappings.

## Test plan

- Verify the diff is exactly three added lines, no other changes.
- A follow-up docs-infra-only PR (or a rebase of #63115 / #63130 onto this) should show reduced test invocation in CI versus the current state.

## Context

Tracked under `DOC-877` in the anyscale/docs Jira (private). Unblocks the in-flight sitemap fix (#63115) and llms.txt PR (#63130) which both touch the docs deplock and hit broader test sets without this change. Part of a docs CI right-sizing effort.
