### PR TITLE
[ci][llm] Fix release tests' incompatibility with Ansycale SDK

### DIFF
--- a/release/llm_tests/serve/run_llm_serve_test_and_bms.py
+++ b/release/llm_tests/serve/run_llm_serve_test_and_bms.py
@@ -26,7 +26,7 @@ from benchmark.common import read_from_s3, get_llm_config
 from benchmark.firehose_utils import FirehoseRecord, RecordName
 from test_utils import (
     start_service,
-    get_current_compute_config,
+    get_service_compute_config,
     get_applications,
     get_hf_token_env_var,
     setup_client_env_vars,
@@ -55,6 +55,15 @@ SERVICE_NAME = "serve_llm_release_test_service"
 )
 @click.option("--serve-config-file", type=str, help="Serve config file for this test")
 @click.option(
+    "--compute-config",
+    type=str,
+    default=None,
+    help=(
+        "Optional Anyscale compute config name/version to use for the service. "
+        "Defaults to ANYSCALE_JOB_CLUSTER_COMPUTE_NAME from the release job."
+    ),
+)
+@click.option(
     "--run-probes",
     type=bool,
     default=True,
@@ -82,6 +91,7 @@ SERVICE_NAME = "serve_llm_release_test_service"
 def main(
     image_uri: Optional[str],
     serve_config_file: str,
+    compute_config: Optional[str],
     run_probes: bool,
     run_serve_llm_profiler: bool,
     skip_hf_token: bool,
@@ -94,7 +104,8 @@ def main(
         image_uri = f"anyscale/image/{cluster_env}:1"
 
     applications = get_applications(serve_config_file)
-    compute_config = get_current_compute_config()
+    compute_config = get_service_compute_config(compute_config)
+    logger.info("Using service compute config: %s", compute_config)
     env_vars = get_hf_token_env_var() if not skip_hf_token else {}
 
     if run_vllm_profiler:

--- a/release/llm_tests/serve/test_utils.py
+++ b/release/llm_tests/serve/test_utils.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Optional, Union
 import requests
 from openai import OpenAI
 
-import anyscale
 import boto3
 import ray
 import yaml
@@ -32,6 +31,7 @@ SECRET_NAME = "llm_release_test_hf_token"
 # Buildkite is also configured to have read access to this bucket
 S3_BUCKET = "rayllm-ci-results"
 S3_PREFIX = "vllm_perf_results"
+ANYSCALE_JOB_CLUSTER_COMPUTE_NAME_ENV_VAR = "ANYSCALE_JOB_CLUSTER_COMPUTE_NAME"
 
 
 def check_service_state(
@@ -169,11 +169,25 @@ def start_service(
         logger.info(f"Service '{service_name}' terminated successfully.")
 
 
-def get_current_compute_config():
-    """Get the compute config of the current job."""
-    job_id = os.environ["ANYSCALE_JOB_ID"]
-    job_status = anyscale.job.status(id=job_id)
-    return job_status.config.compute_config
+def get_service_compute_config(
+    compute_config: Optional[str] = None,
+) -> str:
+    """Get the compute config to use when starting the Anyscale Service.
+
+    Release jobs pass the current job's compute config name through the
+    environment. Using that name avoids querying the Jobs API from inside the
+    cluster, where only the cluster CLI token may be available.
+    """
+    service_compute_config = compute_config or os.environ.get(
+        ANYSCALE_JOB_CLUSTER_COMPUTE_NAME_ENV_VAR
+    )
+    if service_compute_config is None:
+        raise RuntimeError(
+            "No compute config was provided for the Anyscale Service. Set "
+            f"--compute-config or {ANYSCALE_JOB_CLUSTER_COMPUTE_NAME_ENV_VAR}; "
+            "release jobs should provide this automatically."
+        )
+    return service_compute_config
 
 
 def get_applications(serve_config_file: str) -> List[Any]:

--- a/release/ray_release/job_manager/anyscale_job_manager.py
+++ b/release/ray_release/job_manager/anyscale_job_manager.py
@@ -60,6 +60,10 @@ class AnyscaleJobManager:
         env_vars_for_job[
             "ANYSCALE_JOB_CLUSTER_ENV_NAME"
         ] = self.cluster_manager.cluster_env_name
+        if self.cluster_manager.cluster_compute_name:
+            env_vars_for_job[
+                "ANYSCALE_JOB_CLUSTER_COMPUTE_NAME"
+            ] = self.cluster_manager.cluster_compute_name
 
         logger.info(
             f"Executing {cmd_to_run} with {env_vars_for_job} via Anyscale job submit"

--- a/release/ray_release/tests/test_anyscale_job_manager.py
+++ b/release/ray_release/tests/test_anyscale_job_manager.py
@@ -14,9 +14,24 @@ class FakeJobStatus:
         self.state = state
 
 
+class FakeCreateJobResponse:
+    class Result:
+        id = "job_id"
+
+    result = Result()
+
+
 class FakeSDK(Anyscale):
+    def __init__(self):
+        super().__init__()
+        self.created_job = None
+
     def project_name_by_id(self, project_id: str) -> str:
         return "fake_project_name"
+
+    def create_job(self, job_request):
+        self.created_job = job_request
+        return FakeCreateJobResponse()
 
 
 def test_get_last_logs_long_running_job():
@@ -35,6 +50,26 @@ def test_get_last_logs_long_running_job():
     anyscale_job_manager._job_id = "foo"
     anyscale_job_manager.save_last_job_status(FakeJobStatus(state=JobState.SUCCEEDED))
     assert anyscale_job_manager.get_last_logs() is None
+
+
+def test_run_job_exports_cluster_compute_name():
+    fake_test = Test(name="fake_test")
+    fake_sdk = FakeSDK()
+    cluster_manager = ClusterManager(
+        test=fake_test, project_id="fake_project_id", sdk=fake_sdk
+    )
+    cluster_manager.cluster_env_name = "cluster_env"
+    cluster_manager.cluster_env_build_id = "build_id"
+    cluster_manager.cluster_compute_id = "compute_id"
+    cluster_manager.cluster_compute_name = "compute_name"
+
+    anyscale_job_manager = AnyscaleJobManager(cluster_manager=cluster_manager)
+    anyscale_job_manager._run_job("echo hi", {"USER_ENV": "1"})
+
+    env_vars = fake_sdk.created_job.config.runtime_env["env_vars"]
+    assert env_vars["USER_ENV"] == "1"
+    assert env_vars["ANYSCALE_JOB_CLUSTER_ENV_NAME"] == "cluster_env"
+    assert env_vars["ANYSCALE_JOB_CLUSTER_COMPUTE_NAME"] == "compute_name"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
`anyscale` is pinned to `0.26.97` on the `llm-cu130` image. In this version, `anyscale.job.status()` fetches job runs through a new internal endpoint (`POST /api/v2/decorated_ha_jobs/job_runs/search`) which requires an API key, but the release test is running inside an Anyscale job with only the cluster CLI token. This results in the following error ([sample log](https://console.anyscale-staging.com/cld_wy5a6nhazplvu32526ams61d98/prj_lhlrf1u5yv8qz9qg3xzw8fkiiq/jobs/prodjob_rcgpimwr11kgmr6t3w3cr6rpdn?job-logs-section-tabs=application_logs&job-tab=overview)).
```
ValueError: The endpoint POST /api/v2/decorated_ha_jobs/job_runs/search requires a different
type of authentication, please use your API key instead of the cluster CLI token.
```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
