### PR TITLE
[doc][2.0.0] fix sitemap URL leak; unblock docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,31 @@
+# .readthedocs.yaml
+# Read the Docs configuration for the Ray 2.0.0 release branch.
+#
+# Added because Read the Docs now requires this file explicitly, even
+# on previously-built archives. This file is scoped to the
+# releases/2.0.0 branch only; current Ray (master) maintains its own
+# .readthedocs.yaml.
+#
+# Backported in DOC-850 alongside the sitemap fix in doc/source/conf.py
+# and the setuptools<81 pin in doc/requirements-doc.txt.
+#
+# Schema reference:
+#   https://docs.readthedocs.com/platform/stable/config-file/v2.html
+
+version: 2
+
+build:
+  # Older Ubuntu image to give 2.0.0-era dependencies a better chance
+  # of resolving cleanly. Master uses ubuntu-24.04.
+  os: ubuntu-22.04
+  tools:
+    # Python 3.10 is the newest version Ray 2.0.0 originally supported.
+    # Older Pythons (3.6-3.9) may no longer be available on RtD images.
+    python: "3.10"
+
+sphinx:
+  configuration: doc/source/conf.py
+
+python:
+  install:
+    - requirements: doc/requirements-doc.txt

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -41,6 +41,12 @@ git+https://github.com/ray-project/ray_lightning@6aed848f757a03c03166c1a9bddfeea
 # Syntax highlighting
 Pygments==2.11.2
 
+# Pin setuptools below 81 so `pkg_resources` is still available for
+# sphinxemoji 0.2.0, which imports it at module load. setuptools 81+
+# removed pkg_resources, breaking the docs build on Read the Docs'
+# current build images. Backport of ray-project/ray#60887.
+setuptools<81
+
 # Sphinx
 sphinx==4.3.2
 sphinx-click==3.0.2

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -41,11 +41,13 @@ git+https://github.com/ray-project/ray_lightning@6aed848f757a03c03166c1a9bddfeea
 # Syntax highlighting
 Pygments==2.11.2
 
-# Pin setuptools below 81 so `pkg_resources` is still available for
-# sphinxemoji 0.2.0, which imports it at module load. setuptools 81+
-# removed pkg_resources, breaking the docs build on Read the Docs'
-# current build images. Backport of ray-project/ray#60887.
-setuptools<81
+# Pin setuptools to a version that still ships `pkg_resources`.
+# setuptools 82.0.0 (Feb 2026) removed pkg_resources, which
+# sphinxemoji 0.2.0 imports at module load. Without this pin,
+# Read the Docs installs the latest setuptools (currently 82+) and
+# the docs build fails on extension load before Sphinx ever runs.
+# Mirrors the master-branch pin from ray-project/ray#60887.
+setuptools==80.9.0
 
 # Sphinx
 sphinx==4.3.2

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -59,7 +59,6 @@ sphinx-panels==0.6.0
 sphinx-version-warning==1.1.2
 sphinx-book-theme==0.1.7
 sphinx-external-toc==0.2.3
-sphinxcontrib.yt==0.2.2
 sphinx-sitemap==2.2.0
 sphinx-thebe==0.1.1
 autodoc_pydantic==1.6.1

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -80,6 +80,19 @@ external_toc_path = "_toc.yml"
 
 html_extra_path = ["robots.txt"]
 
+# Set the canonical base URL to the version's published path on docs.ray.io.
+# Without this, sphinx-sitemap falls back to Read the Docs' internal hostname
+# and produces sitemap.xml entries like
+#   https://anyscale-ray.readthedocs-hosted.com/en/latest/en/2.0.0/<page>
+# instead of the public docs.ray.io URLs.
+html_baseurl = "https://docs.ray.io/en/releases-2.0.0/"
+
+# `html_baseurl` already encodes the language and version path, so override
+# sphinx-sitemap's default `{lang}{version}{link}` scheme to just `{link}`.
+# Otherwise the extension prepends the language again, producing doubled
+# paths in the sitemap.
+sitemap_url_scheme = "{link}"
+
 
 # There's a flaky autodoc import for "TensorFlowVariables" that fails depending on the doc structure / order
 # of imports.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -40,7 +40,6 @@ extensions = [
     "sphinx-jsonschema",
     "sphinxemoji.sphinxemoji",
     "sphinx_copybutton",
-    "sphinxcontrib.yt",
     "versionwarning.extension",
     "sphinx_sitemap",
     "myst_nb",


### PR DESCRIPTION
## Why

Ray 2.0.0's published sitemap leaks the internal Read the Docs hostname into every `<loc>` entry:

```
https://anyscale-ray.readthedocs-hosted.com/en/latest/en/2.0.0/<page>
```

Verified live: `https://docs.ray.io/en/releases-2.0.0/sitemap.xml` returns 200 with this corruption on every entry. Result: agents and crawlers that follow the sitemap get pointed at an internal hostname that's not meant to be public, instead of the canonical `docs.ray.io` URL.

The leak comes from two compounding bugs:

1. `html_baseurl` is unset in `conf.py`, so sphinx-sitemap falls back to Read the Docs' internal canonical base.
2. sphinx-sitemap's default `sitemap_url_scheme = "{lang}{version}{link}"` prepends the language to every page path. Combined with the internal-hostname fallback, paths get doubled.

## What

Two-file fix:

- `doc/source/conf.py`: set `html_baseurl = "https://docs.ray.io/en/releases-2.0.0/"` and override `sitemap_url_scheme = "{link}"`. Same shape as the master-side fix in [#63115](https://github.com/ray-project/ray/pull/63115), scoped to this version.
- `doc/requirements-doc.txt`: pin `setuptools<81`. setuptools 81+ removed `pkg_resources`, which `sphinxemoji==0.2.0` (already pinned in this branch) imports at module load. Without this pin, the docs build fails on Read the Docs' current build images before Sphinx ever runs. Backport of the equivalent requirements fix in [#60887](https://github.com/ray-project/ray/pull/60887).

Docs-only change. No effect on Ray runtime, Docker images, PyPI artifacts, or any release-branch surface beyond the docs build.

## Verification

After this lands, an `anyscale-ray:releases-2.0.0` build on Read the Docs should produce a sitemap with URLs that resolve under `docs.ray.io`. Spot-check expected post-merge:

- `https://docs.ray.io/en/releases-2.0.0/sitemap.xml` — every `<loc>` should start with `https://docs.ray.io/en/releases-2.0.0/` and resolve.
- 5-10 random `<loc>` entries — should return 200, not 404 and not the leaked internal hostname.

## Context

Tracked under `DOC-850` in the anyscale/docs Jira (private). Strategy context for the legacy-version cleanup campaign lives in `anyscale/docs:strategy/ray-docs/legacy-versions-aeo.md` sections 3 (sitemap audit) and 12 (rebuild-vs-no-rebuild dispatch). The DOC-855 probe rebuild on `releases-2.46.0` confirmed that deplock-install on legacy archives is healthy — the only build-time gate is the Sphinx-side `sphinxemoji`/`pkg_resources` interaction addressed by the `setuptools<81` pin here.

This is a one-off targeted backport for 2.0.0 specifically (not a sweep across legacy versions). The broader rebuild-required campaign for other versions sits in DOC-849 and the Pre-#60887 rebuild prerequisite in `legacy-versions-aeo.md` §12.
