### PR TITLE
[data] Defer hash-shuffle schema broadcast to first row-bearing block

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -68,7 +68,9 @@ from ray.data.block import (
     BlockMetadataWithSchema,
     BlockStats,
     BlockType,
+    Schema,
     TaskExecWorkerStats,
+    _is_empty_schema,
     to_stats,
 )
 from ray.data.context import (
@@ -221,6 +223,14 @@ def _combine(partition_shards: List[Block]) -> Block:
     for block in partition_shards:
         builder.add_block(block)
     return builder.build()
+
+
+def _has_broadcastable_schema(
+    block_metadata: BlockMetadata, bundle_schema: Optional["Schema"]
+) -> bool:
+    if (block_metadata.num_rows or 0) > 0:
+        return True
+    return bundle_schema is not None and not _is_empty_schema(bundle_schema)
 
 
 @ray.remote
@@ -679,8 +689,11 @@ class HashShufflingOperatorBase(PhysicalOperator, SubProgressBarMixin):
         for block_ref, block_metadata in zip(input_blocks_refs, input_blocks_metadata):
             # If operator hasn't propagated schemas (for this sequence) to its
             # aggregator pool, it will need to do that upon receiving of the
-            # first block
-            should_broadcast_schemas = not self._has_schemas_broadcasted[input_index]
+            # first block that actually carries a schema (skip column-less
+            # marker blocks that would broadcast an empty schema).
+            should_broadcast_schemas = not self._has_schemas_broadcasted[
+                input_index
+            ] and _has_broadcastable_schema(block_metadata, input_bundle.schema)
             input_key_column_names = self._key_column_names[input_index]
             # Compose shuffling task resource bundle
             shuffle_task_resource_bundle = {

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -983,6 +983,108 @@ def test_overlapping_non_key_columns_without_suffixes(
         )
 
 
+def test_join_after_upstream_groupby_map_groups(
+    ray_start_regular_shared_2_cpus,
+):
+    """Regression test for empty-schema hash-shuffle broadcast.
+
+    When the upstream of a Dataset.join() is itself a hash shuffle (here,
+    groupby.map_groups), the first input block reaching the join's hash
+    shuffle can be a zero-row, zero-column marker block. Prior to the fix
+    in HashShufflingOperatorBase, that block was used to broadcast the
+    schema, causing _create_empty_table to propagate a column-less block
+    to every aggregator. Aggregators with no row-bearing data on a side
+    then failed at finalize with `ArrowInvalid: No match or multiple
+    matches for key field reference FieldRef.Name(<key>) on left side
+    of the join`.
+
+    With the fix, schema broadcast is deferred to the first row-bearing
+    block, and the join completes correctly.
+    """
+    DataContext.get_current().default_hash_shuffle_parallelism = 20
+
+    def noop(df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    left = (
+        ray.data.from_pandas(
+            pd.DataFrame({"key": ["a", "b", "c", "d", "e"], "lval": [1, 2, 3, 4, 5]})
+        )
+        .groupby("key")
+        .map_groups(noop, batch_format="pandas")
+    )
+    right = (
+        ray.data.from_pandas(
+            pd.DataFrame(
+                {"key": ["a", "b", "c", "d", "e"], "rval": [10, 20, 30, 40, 50]}
+            )
+        )
+        .groupby("key")
+        .map_groups(noop, batch_format="pandas")
+    )
+
+    result = left.join(
+        right, on=("key",), join_type="inner", num_partitions=5
+    ).to_pandas()
+
+    expected = pd.DataFrame(
+        {
+            "key": ["a", "b", "c", "d", "e"],
+            "lval": [1, 2, 3, 4, 5],
+            "rval": [10, 20, 30, 40, 50],
+        }
+    )
+    assert rows_same(result, expected)
+
+
+def test_join_with_empty_first_block_carrying_schema(
+    ray_start_regular_shared_2_cpus,
+):
+    """The first input block to a side is a zero-row block that does carry a
+    schema (e.g. from `from_arrow` of an empty-but-typed table, then unioned
+    with row-bearing data). The broadcast must still seed every aggregator
+    with the correct schema so the join completes successfully.
+
+    Exercises the metadata-schema path in `_has_broadcastable_schema`.
+    """
+    import pyarrow as pa
+
+    schema = pa.schema([("key", pa.large_string()), ("lval", pa.int64())])
+    empty_left = ray.data.from_arrow(pa.Table.from_pylist([], schema=schema))
+    populated_left = ray.data.from_arrow(
+        pa.Table.from_pylist(
+            [{"key": "a", "lval": 1}, {"key": "b", "lval": 2}, {"key": "c", "lval": 3}],
+            schema=schema,
+        )
+    )
+    left = empty_left.union(populated_left)
+
+    right_schema = pa.schema([("key", pa.large_string()), ("rval", pa.int64())])
+    right = ray.data.from_arrow(
+        pa.Table.from_pylist(
+            [
+                {"key": "a", "rval": 10},
+                {"key": "b", "rval": 20},
+                {"key": "c", "rval": 30},
+            ],
+            schema=right_schema,
+        )
+    )
+
+    result = left.join(
+        right, on=("key",), join_type="inner", num_partitions=5
+    ).to_pandas()
+
+    expected = pd.DataFrame(
+        {
+            "key": ["a", "b", "c"],
+            "lval": [1, 2, 3],
+            "rval": [10, 20, 30],
+        }
+    )
+    assert rows_same(result, expected)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?

The hash shuffle used by `Dataset.join()` broadcasts the input schema to aggregators. When the upstream step is itself a hash shuffle (e.g. `groupby.map_groups`) it can emit empty / zero-column blocks. If an empty block is the first to reach the join's hash shuffle,  the empty schema is broadcast to the aggregators. Aggregators end up with schema-less blocks, and `pa.Table.join` fails resolving the join key:

```
pyarrow.lib.ArrowInvalid: No match or multiple matches for key field reference
FieldRef.Name(<key>) on left side of the join
```

This is reproducible on the latest stable (Ray 2.55.1) with a `from_pandas → groupby.map_groups → join` where `default_hash_shuffle_parallelism` is high enough relative to the distinct key cardinality to leave partitions empty.

The fix defers the broadcast to the first row-bearing block. Zero-row marker blocks fall through with `send_empty_blocks=False` and are filtered as before; a row-bearing block with a real schema will arrive whenever the dataset is non-empty, and the broadcast then propagates the correct schema to every aggregator.

### Minimal repro (fails on master, passes with this PR)

```python
import pandas as pd
import ray

ray.data.DataContext.get_current().default_hash_shuffle_parallelism = 20

def noop(df: pd.DataFrame) -> pd.DataFrame:
    return df

left = (
    ray.data.from_pandas(pd.DataFrame({"key": list("abcde"), "lval": [1, 2, 3, 4, 5]}))
    .groupby("key").map_groups(noop, batch_format="pandas")
)
right = (
    ray.data.from_pandas(pd.DataFrame({"key": list("abcde"), "rval": [10, 20, 30, 40, 50]}))
    .groupby("key").map_groups(noop, batch_format="pandas")
)

left.join(right, on=("key",), join_type="inner", num_partitions=5).show()
```

## Related issue number

N/A.

## Checks

- [x] I've signed off every commit (by using the `-s` flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` under the corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
