### PR TITLE
[Data] Make Operator a thin shared base

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -381,7 +381,8 @@ class PhysicalOperator(Operator):
         target_max_block_size_override: Optional[int] = None,
         num_output_splits: int = 1,
     ):
-        super().__init__(name, input_dependencies)
+        self._name = name
+        self._input_dependencies = input_dependencies
         self._output_dependencies: List["PhysicalOperator"] = []
 
         for input in input_dependencies:
@@ -436,8 +437,29 @@ class PhysicalOperator(Operator):
     # Override the following methods to correct type hints.
 
     @property
+    def name(self) -> str:
+        return self._name
+
+    @property
     def input_dependencies(self) -> List["PhysicalOperator"]:
-        return super().input_dependencies  # type: ignore
+        return self._input_dependencies
+
+    @property
+    def dag_str(self) -> str:
+        """String representation of the whole physical DAG."""
+        if self.input_dependencies:
+            out_str = ", ".join([x.dag_str for x in self.input_dependencies])
+            out_str += " -> "
+        else:
+            out_str = ""
+        out_str += f"{self.__class__.__name__}[{self._name}]"
+        return out_str
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}[{self._name}]"
+
+    def __str__(self) -> str:
+        return repr(self)
 
     @property
     def output_dependencies(self) -> List["PhysicalOperator"]:

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -55,7 +55,7 @@ class LogicalOperator(Operator, ABC):
 
     @property
     def input_dependencies(self) -> List["LogicalOperator"]:
-        value = super().input_dependencies  # type: ignore
+        value = self._input_dependencies
         for x in value:
             assert isinstance(x, LogicalOperator), x
         return value

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -1,24 +1,18 @@
-import copy
+from abc import ABC, abstractmethod
 from typing import Callable, Iterator, List
 
 
-class Operator:
+class Operator(ABC):
     """Abstract class for operators.
 
     Operators live on the driver side of the Dataset only.
     """
 
-    def __init__(
-        self,
-        name: str,
-        input_dependencies: List["Operator"],
-    ):
-        self._name = name
-        self._input_dependencies = input_dependencies
-
     @property
+    @abstractmethod
     def name(self) -> str:
-        return self._name
+        """Name for this operator."""
+        ...
 
     @property
     def dag_str(self) -> str:
@@ -28,16 +22,14 @@ class Operator:
             out_str += " -> "
         else:
             out_str = ""
-        out_str += f"{self.__class__.__name__}[{self._name}]"
+        out_str += f"{self.__class__.__name__}[{self.name}]"
         return out_str
 
     @property
+    @abstractmethod
     def input_dependencies(self) -> List["Operator"]:
         """List of operators that provide inputs for this operator."""
-        assert hasattr(
-            self, "_input_dependencies"
-        ), "Operator.__init__() was not called."
-        return self._input_dependencies
+        ...
 
     def post_order_iter(self) -> Iterator["Operator"]:
         """Depth-first traversal of this operator and its input dependencies."""
@@ -45,6 +37,7 @@ class Operator:
             yield from op.post_order_iter()
         yield self
 
+    @abstractmethod
     def _apply_transform(
         self, transform: Callable[["Operator"], "Operator"]
     ) -> "Operator":
@@ -54,28 +47,10 @@ class Operator:
               instead creating new operations whenever any operator needs to be
               updated.
         """
-
-        transformed_input_ops = []
-        has_changes = False
-
-        for input_op in self.input_dependencies:
-            transformed_input_op = input_op._apply_transform(transform)
-            transformed_input_ops.append(transformed_input_op)
-            if transformed_input_op is not input_op:
-                has_changes = True
-
-        if has_changes:
-            # Make a shallow copy to avoid modifying operators in-place
-            target = copy.copy(self)
-
-            target._input_dependencies = transformed_input_ops
-        else:
-            target = self
-
-        return transform(target)
+        ...
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}[{self._name}]"
+        return f"{self.__class__.__name__}[{self.name}]"
 
     def __str__(self) -> str:
         return repr(self)


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next PR in the `#60312` logical plan migration stack.

After cleaning up logical-operator fields and `_get_args`, the shared `Operator` base still owns concrete `_name` / `_input_dependencies` storage through a constructor. That keeps the base contract tied to mutable storage even though `LogicalOperator` now provides its own frozen dataclass-backed fields.

This PR makes the shared base contract explicit before the later `__repr__` / `__str__`, rule-cleanup, and equality/comparability steps. This removes the old shared storage model from the base class, so later cleanup PRs can reason about logical operator state through the public contract instead of working around `_name` / `_input_dependencies` ownership in `Operator`.

#### What this PR changes:

Makes `Operator` a thin shared base with no constructor-owned `_name` / `_input_dependencies` storage.

`Operator` now defines the public `name` / `input_dependencies` contract and its default methods use that public contract instead of touching `_name` / `_input_dependencies` directly.

`LogicalOperator` continues to provide the frozen dataclass-backed implementation of that contract.

`PhysicalOperator` remains stateful and keeps the existing physical execution behavior, but now owns the mutable name/dependency storage it needs instead of relying on shared `Operator` storage. This physical-side change is compatibility-only: physical operators are not being made immutable or dataclass-backed.

This PR does not make physical operators dataclasses or immutable, remove redundant `__repr__` / `__str__`, clean up broader logical-rule special-casing, or change equality/comparability semantics. Those remain separate follow-ups in the current split plan.

## Related issues

Part of #60312

## Additional information

This PR corresponds to the shared `Operator` / `LogicalOperator` base-contract cleanup step in the current split plan.

### Tests

- Ran targeted logical, physical-operator transform, operator-fusion, and state-export tests.
- Ran touched-file pre-commit checks.

### Stack Plan

Done:
- PR-A: Add a default property implementation for `LogicalOperator.name`
- PR-B: Move logical `output_dependencies` handling out of logical operators
- PR-C: Make `LogicalOperator` an ABC with abstract `num_outputs`
- PR-D1: Convert one-to-one logical operators to frozen dataclasses
- PR-D2: Convert map logical operators to frozen dataclasses
- PR-D3: Convert all-to-all, join, read, and write logical operators to frozen dataclasses
- PR-D4: Convert remaining source logical operators to frozen dataclasses
- PR-Next-0: Convert the remaining concrete logical operators to frozen dataclasses
- PR-Next-1: Convert abstract logical operator classes to frozen dataclasses
- PR-Next-2: make logical-operator names derived by default
- PR-Next-3: deduplicate `_apply_transform`
- PR-Next-4: replace `input_op: InitVar` with a real `input_dependencies` field
- PR-Next-5: remove `input_dependency` on `AbstractOneToOne`
- PR-Next-6: clean up `_get_args`
- This PR: make `Operator` a thin shared base

Next:
- remove redundant `__repr__` / `__str__`
- clean up special-casing in logical rules
- finalize equality / comparability work for `#60312`

