### PR TITLE
[Serve] Drop and replace replicas that survive a controller crash without rank assignment

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -728,7 +728,7 @@ class ActorReplicaWrapper:
         # finished its initial setup). The reconciler treats this case as a
         # silent drop / replace rather than a deploy failure, since the
         # underlying cause is a controller-side crash, not user code.
-        self._recovery_unrecoverable: bool = False
+        self._unrecoverable: bool = False
 
         self._actor_resources: Dict[str, float] = None
         # If the replica is being started, this will be the true version
@@ -834,8 +834,8 @@ class ActorReplicaWrapper:
         return self._gang_context
 
     @property
-    def recovery_unrecoverable(self) -> bool:
-        return self._recovery_unrecoverable
+    def unrecoverable(self) -> bool:
+        return self._unrecoverable
 
     @property
     def app_name(self) -> str:
@@ -1374,7 +1374,7 @@ class ActorReplicaWrapper:
                 )
                 logger.warning(msg)
                 self._kill_unrecoverable_actor()
-                self._recovery_unrecoverable = True
+                self._unrecoverable = True
                 return ReplicaStartupStatus.FAILED, msg
 
             if not was_initialized:
@@ -1386,7 +1386,7 @@ class ActorReplicaWrapper:
                 )
                 logger.warning(msg)
                 self._kill_unrecoverable_actor()
-                self._recovery_unrecoverable = True
+                self._unrecoverable = True
                 return ReplicaStartupStatus.FAILED, msg
 
             # Probe succeeded; safe to drive the actor through recovery.
@@ -1971,14 +1971,14 @@ class DeploymentReplica:
         return self._actor.gang_context
 
     @property
-    def recovery_unrecoverable(self) -> bool:
+    def unrecoverable(self) -> bool:
         """Whether `check_ready()` determined the actor cannot be recovered.
 
         When True, the reconciler should drop and replace the replica
         without counting it as a deploy failure (the underlying cause is a
         previous controller crash, not user code).
         """
-        return self._actor.recovery_unrecoverable
+        return self._actor.unrecoverable
 
     def check_started(
         self,
@@ -4221,7 +4221,7 @@ class DeploymentState:
                 # already killed in `check_ready()`, so force-stop to avoid
                 # issuing a graceful shutdown RPC to a dead actor. We still
                 # propagate gang failure tracking so siblings get cleaned up.
-                if replica.recovery_unrecoverable:
+                if replica.unrecoverable:
                     self._stop_replica(replica, graceful_stop=False)
                     if replica.gang_context is not None:
                         failed_gang_ids.add(replica.gang_context.gang_id)

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -719,6 +719,16 @@ class ActorReplicaWrapper:
         # Populated in either self.start() or self.recover()
         self._allocated_obj_ref: ObjectRef = None
         self._ready_obj_ref: ObjectRef = None
+        # Populated in self.recover() for non-cross-language replicas to
+        # asynchronously verify the actor finished its initial setup before
+        # we trigger `initialize_and_get_metadata`.
+        self._was_initialized_obj_ref: Optional[ObjectRef] = None
+        # Set to True when `check_ready()` determines the actor cannot be
+        # recovered (e.g., the previous controller crashed before the actor
+        # finished its initial setup). The reconciler treats this case as a
+        # silent drop / replace rather than a deploy failure, since the
+        # underlying cause is a controller-side crash, not user code.
+        self._recovery_unrecoverable: bool = False
 
         self._actor_resources: Dict[str, float] = None
         # If the replica is being started, this will be the true version
@@ -822,6 +832,10 @@ class ActorReplicaWrapper:
     @property
     def gang_context(self) -> Optional[GangContext]:
         return self._gang_context
+
+    @property
+    def recovery_unrecoverable(self) -> bool:
+        return self._recovery_unrecoverable
 
     @property
     def app_name(self) -> str:
@@ -1213,14 +1227,19 @@ class ActorReplicaWrapper:
 
         Also confirm that actor is allocated and initialized before marking as running.
 
+        This call is non-blocking: any RPCs needed to query the actor are
+        fired here as ObjectRefs and observed in `check_ready()` from the
+        reconcile loop.
+
         Args:
             ingress: Whether this replica is an ingress replica.
 
         Returns:
-            False if the replica actor is no longer alive; the
-            actor could have been killed in the time between when the
-            controller fetching all Serve actors in the cluster and when
-            the controller tries to recover it. Otherwise, return True.
+            False if the replica actor is no longer alive; the caller drops
+            the replica from tracking. Otherwise True. Replicas that are
+            alive but never finished their initial setup are detected
+            asynchronously in `check_ready()` rather than here so that
+            controller recovery does not block.
         """
         logger.info(f"Recovering {self.replica_id}.")
         self._ingress = ingress
@@ -1251,11 +1270,36 @@ class ActorReplicaWrapper:
         if self._is_cross_language:
             self._ready_obj_ref = self._actor_handle.check_health.remote()
         else:
-            self._ready_obj_ref = (
-                self._actor_handle.initialize_and_get_metadata.remote()
-            )
+            # For non-cross-language replicas, asynchronously probe whether
+            # the actor finished its initial setup before triggering
+            # `initialize_and_get_metadata`. If the previous controller
+            # crashed between actor creation and the first
+            # `initialize_and_get_metadata(rank=...)` call, the actor has
+            # neither a rank nor an initialized user callable. Recovering it
+            # would silently complete its initialization with `rank=None`,
+            # leaving rank tracking permanently broken for that replica.
+            # `check_ready()` waits for this probe and replaces the replica
+            # if it reports `False`. We defer firing
+            # `initialize_and_get_metadata` until the probe passes so we
+            # don't accidentally drive the bad actor through initialization
+            # only to kill it afterwards.
+            self._was_initialized_obj_ref = self._actor_handle.was_initialized.remote()
 
         return True
+
+    def _kill_unrecoverable_actor(self) -> None:
+        """Force-kill an actor that cannot be recovered.
+
+        Best-effort: any failure to kill the actor is
+        logged but ignored.
+        """
+        try:
+            ray.kill(self._actor_handle, no_restart=True)
+        except Exception:
+            logger.exception(
+                f"Failed to kill unrecoverable replica actor "
+                f"{self._replica_id} during controller recovery."
+            )
 
     def check_ready(self) -> Tuple[ReplicaStartupStatus, Optional[str]]:
         """
@@ -1308,6 +1352,47 @@ class ActorReplicaWrapper:
                 )
                 logger.exception(msg)
                 return ReplicaStartupStatus.FAILED, msg
+
+        # If we issued a `was_initialized` probe in `recover()`, wait for it
+        # before triggering `initialize_and_get_metadata`. If the actor was
+        # never initialized previously (the previous controller crashed
+        # mid-startup), kill it and signal an unrecoverable drop so the
+        # reconciler replaces it without counting a deploy failure.
+        if self._was_initialized_obj_ref is not None:
+            if not check_obj_ref_ready_nowait(self._was_initialized_obj_ref):
+                return ReplicaStartupStatus.PENDING_INITIALIZATION, None
+
+            probe_ref = self._was_initialized_obj_ref
+            self._was_initialized_obj_ref = None
+            try:
+                was_initialized = ray.get(probe_ref)
+            except Exception as e:
+                msg = (
+                    f"Failed to probe initialization state of "
+                    f"{self._replica_id} during controller recovery ({e!r}). "
+                    "Replacing with a fresh replica."
+                )
+                logger.warning(msg)
+                self._kill_unrecoverable_actor()
+                self._recovery_unrecoverable = True
+                return ReplicaStartupStatus.FAILED, msg
+
+            if not was_initialized:
+                msg = (
+                    f"{self._replica_id} was found alive but never finished "
+                    "its initial setup; the previous controller likely "
+                    "crashed during replica startup. Replacing with a fresh "
+                    "replica."
+                )
+                logger.warning(msg)
+                self._kill_unrecoverable_actor()
+                self._recovery_unrecoverable = True
+                return ReplicaStartupStatus.FAILED, msg
+
+            # Probe succeeded; safe to drive the actor through recovery.
+            self._ready_obj_ref = (
+                self._actor_handle.initialize_and_get_metadata.remote()
+            )
 
         if self._ready_obj_ref is None:
             # Perform auto method name translation for java handles.
@@ -1884,6 +1969,16 @@ class DeploymentReplica:
     def gang_context(self) -> Optional[GangContext]:
         """Get the gang context for this replica."""
         return self._actor.gang_context
+
+    @property
+    def recovery_unrecoverable(self) -> bool:
+        """Whether `check_ready()` determined the actor cannot be recovered.
+
+        When True, the reconciler should drop and replace the replica
+        without counting it as a deploy failure (the underlying cause is a
+        previous controller crash, not user code).
+        """
+        return self._actor.recovery_unrecoverable
 
     def check_started(
         self,
@@ -4118,6 +4213,20 @@ class DeploymentState:
 
             elif start_status == ReplicaStartupStatus.FAILED:
                 # Replica reconfigure (deploy / upgrade) failed.
+                # When `check_ready()` flagged the replica as unrecoverable
+                # (e.g., the previous controller crashed before assigning a
+                # rank to it), don't bump the deploy failure counter -- the
+                # underlying cause is controller-side, not user code, and a
+                # fresh replica will be started in its place. The actor was
+                # already killed in `check_ready()`, so force-stop to avoid
+                # issuing a graceful shutdown RPC to a dead actor. We still
+                # propagate gang failure tracking so siblings get cleaned up.
+                if replica.recovery_unrecoverable:
+                    self._stop_replica(replica, graceful_stop=False)
+                    if replica.gang_context is not None:
+                        failed_gang_ids.add(replica.gang_context.gang_id)
+                    continue
+
                 # For gang replicas, count the failure once per gang and not per replica so the
                 # retry counter isn't inflated by gang_size on every cycle.
                 if (

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2777,6 +2777,20 @@ class ReplicaActor:
             get_component_logger_file_path(),
         )
 
+    async def was_initialized(self) -> bool:
+        """Whether this replica's user callable has finished initializing.
+
+        Used by the controller during recovery to detect actors that were
+        created but never received their initial
+        ``initialize_and_get_metadata(rank=...)`` call (e.g., because the
+        previous controller crashed mid-startup). Such an actor has neither a
+        rank nor a fully-initialized user callable, and recovering it would
+        silently complete its initialization with ``rank=None``, breaking
+        rank tracking. The controller can call this method first and skip /
+        kill the actor when it returns False.
+        """
+        return self._replica_impl._user_callable_initialized
+
     def list_outbound_deployments(self) -> Optional[List[DeploymentID]]:
         return self._replica_impl.list_outbound_deployments()
 

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -395,7 +395,7 @@ class MockReplicaActorWrapper:
         self._ingress = False
         self._gang_context = None
         self._gang_pg_index = None
-        self._recovery_unrecoverable = False
+        self._unrecoverable = False
 
     @property
     def is_cross_language(self) -> bool:
@@ -585,14 +585,14 @@ class MockReplicaActorWrapper:
         # Mirror production: the `was_initialized` probe is fired here and
         # observed asynchronously in `check_ready()`. Tests register
         # uninitialized replicas via `uninitialized_replicas_context`.
-        self._recovery_unrecoverable = self.replica_id in uninitialized_replicas_context
+        self._unrecoverable = self.replica_id in uninitialized_replicas_context
         return True
 
     def check_ready(self) -> ReplicaStartupStatus:
         # If the controller's async `was_initialized` probe came back False,
         # report a failed-but-unrecoverable startup so the reconciler drops
         # and replaces the replica without recording a deploy failure.
-        if self.recovering and self._recovery_unrecoverable:
+        if self.recovering and self._unrecoverable:
             return (
                 ReplicaStartupStatus.FAILED,
                 f"{self._replica_id} was found alive but never finished "
@@ -653,8 +653,8 @@ class MockReplicaActorWrapper:
         return self._gang_context
 
     @property
-    def recovery_unrecoverable(self) -> bool:
-        return self._recovery_unrecoverable
+    def unrecoverable(self) -> bool:
+        return self._unrecoverable
 
 
 @serve.deployment

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -65,6 +65,10 @@ PROMETHEUS_METRICS_TIMEOUT_S = 5
 # loop, so we can't "mark" a replica dead through a method. This global
 # state is cleared after each test that uses the fixtures in this file.
 dead_replicas_context = set()
+# Replicas registered in this set will report `was_initialized() == False` to
+# the controller during recovery, simulating the case where a previous
+# controller crashed before the actor finished its initial setup.
+uninitialized_replicas_context = set()
 replica_rank_context: Dict[str, ReplicaRank] = {}
 
 
@@ -391,6 +395,7 @@ class MockReplicaActorWrapper:
         self._ingress = False
         self._gang_context = None
         self._gang_pg_index = None
+        self._recovery_unrecoverable = False
 
     @property
     def is_cross_language(self) -> bool:
@@ -577,9 +582,23 @@ class MockReplicaActorWrapper:
         self.recovering = True
         self.started = False
         self._rank = replica_rank_context.get(self._replica_id.unique_id, None)
+        # Mirror production: the `was_initialized` probe is fired here and
+        # observed asynchronously in `check_ready()`. Tests register
+        # uninitialized replicas via `uninitialized_replicas_context`.
+        self._recovery_unrecoverable = self.replica_id in uninitialized_replicas_context
         return True
 
     def check_ready(self) -> ReplicaStartupStatus:
+        # If the controller's async `was_initialized` probe came back False,
+        # report a failed-but-unrecoverable startup so the reconciler drops
+        # and replaces the replica without recording a deploy failure.
+        if self.recovering and self._recovery_unrecoverable:
+            return (
+                ReplicaStartupStatus.FAILED,
+                f"{self._replica_id} was found alive but never finished "
+                "its initial setup.",
+            )
+
         ready = self.status
         self.status = ReplicaStartupStatus.PENDING_INITIALIZATION
         if ready == ReplicaStartupStatus.SUCCEEDED and self.recovering:
@@ -602,7 +621,10 @@ class MockReplicaActorWrapper:
         return {}
 
     def graceful_stop(self) -> None:
-        assert self.started
+        # `started` is only set after a successful `check_ready` transition
+        # to RUNNING. A replica force-stopped while still RECOVERING (e.g.,
+        # because the `was_initialized` probe failed) is a legitimate stop.
+        assert self.started or self.recovering
         self.stopped = True
         return self.graceful_shutdown_timeout_s
 
@@ -629,6 +651,10 @@ class MockReplicaActorWrapper:
     @property
     def gang_context(self) -> Optional[GangContext]:
         return self._gang_context
+
+    @property
+    def recovery_unrecoverable(self) -> bool:
+        return self._recovery_unrecoverable
 
 
 @serve.deployment

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -210,21 +210,30 @@ def test_recover_rolling_update_from_replica_actor_names(serve_instance):
 
 
 def test_controller_recover_initializing_actor(serve_instance):
-    """Recover the actor which is under PENDING_INITIALIZATION"""
+    """Controller crash while a replica is still in `__init__`.
+
+    The previous controller never finished sending the replica its initial
+    `initialize_and_get_metadata(rank=...)` call, so the live actor has
+    neither a rank nor a fully-initialized user callable. The new
+    controller must detect this via the `was_initialized` probe and
+    replace the half-initialized actor with a fresh one rather than try to
+    recover it (which would silently complete its initialization with
+    `rank=None` and break rank tracking).
+    """
 
     signal = SignalActor.remote()
-    signal2 = SignalActor.remote()
+    init_started = SignalActor.remote()
     client = serve_instance
 
     @ray.remote
     def pending_init_indicator():
-        ray.get(signal2.wait.remote())
+        ray.get(init_started.wait.remote())
         return True
 
     @serve.deployment
     class V1:
         async def __init__(self):
-            ray.get(signal2.send.remote())
+            ray.get(init_started.send.remote())
             await signal.wait.remote()
 
         def __call__(self, request):
@@ -239,21 +248,44 @@ def test_controller_recover_initializing_actor(serve_instance):
             if SERVE_PROXY_NAME in actor["name"]:
                 continue
             if name in actor["name"]:
-                print(actor)
                 return actor["name"], actor["pid"]
 
-    actor_tag, _ = get_actor_info(f"app#{V1.name}")
+    original_actor_tag, _ = get_actor_info(f"app#{V1.name}")
     _, controller1_pid = get_actor_info(SERVE_CONTROLLER_NAME)
     ray.kill(serve.context._global_client._controller, no_restart=False)
-    # wait for controller is alive again
-    wait_for_condition(get_actor_info, name=SERVE_CONTROLLER_NAME)
-    assert controller1_pid != get_actor_info(SERVE_CONTROLLER_NAME)[1]
 
-    # Let the actor proceed initialization
+    # Wait for the controller to be replaced. `list_actors` can briefly
+    # report the killed controller as ALIVE (and any new controller as
+    # PENDING_CREATION) right after `ray.kill`, so wait specifically for
+    # the pid to change.
+    def controller_replaced():
+        info = get_actor_info(SERVE_CONTROLLER_NAME)
+        return info is not None and info[1] != controller1_pid
+
+    wait_for_condition(controller_replaced)
+
+    # The new controller's `was_initialized` probe will report False for
+    # the half-initialized actor, so it is killed and replaced. Wait for
+    # the replacement replica to start and report it has reached its
+    # constructor. Unblock its `__init__` once it has.
+    ray.get(pending_init_indicator.remote())
     ray.get(signal.send.remote())
     client._wait_for_application_running("app")
-    # Make sure the actor before controller dead is staying alive.
-    assert actor_tag == get_actor_info(f"app#{V1.name}")[0]
+
+    # The original half-initialized actor should have been replaced with a
+    # fresh one (different replica id baked into the actor name).
+    new_actor_tag, _ = get_actor_info(f"app#{V1.name}")
+    assert new_actor_tag != original_actor_tag
+
+    # And the original actor should actually be dead -- not just hidden by
+    # the ALIVE filter on a different replica id. `list_actors` may take a
+    # moment to reflect the kill in its state.
+    def original_actor_dead():
+        matching = list_actors(filters=[("name", "=", original_actor_tag)])
+        # Either the entry has been pruned entirely, or it is reported DEAD.
+        return not matching or all(a["state"] == "DEAD" for a in matching)
+
+    wait_for_condition(original_actor_dead)
 
 
 def test_replica_deletion_after_controller_recover(serve_instance):

--- a/python/ray/serve/tests/unit/conftest.py
+++ b/python/ray/serve/tests/unit/conftest.py
@@ -15,6 +15,7 @@ from ray.serve._private.test_utils import (
     MockTimer,
     dead_replicas_context,
     replica_rank_context,
+    uninitialized_replicas_context,
 )
 
 
@@ -90,3 +91,4 @@ def mock_deployment_state_manager(
 
         dead_replicas_context.clear()
         replica_rank_context.clear()
+        uninitialized_replicas_context.clear()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -59,6 +59,7 @@ from ray.serve._private.test_utils import (
     MockPlacementGroup,
     dead_replicas_context,
     replica_rank_context,
+    uninitialized_replicas_context,
 )
 from ray.serve._private.utils import (
     get_capacity_adjusted_num_replicas,
@@ -3889,6 +3890,76 @@ def test_recover_during_rolling_update(mock_deployment_state_manager):
     check_counts(new_ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v2)])
     # Make sure replica name is different, meaning a different "actor" was started
     assert mocked_replica.replica_id != new_mocked_replica_version2.replica_id
+
+
+def test_actor_uninitialized_before_recover(mock_deployment_state_manager):
+    """Test replica actor was found alive but never finished initialization.
+
+    Mirrors the production scenario where the previous controller crashed
+    between actor creation and the first
+    `initialize_and_get_metadata(rank=...)` call. `recover()` is non-
+    blocking: the new controller fires `was_initialized` asynchronously,
+    `check_ready()` observes the False response in the reconcile loop,
+    kills the actor, and the reconciler replaces it with a fresh replica.
+    The controller-side deploy-failure counter must NOT be bumped, since
+    the underlying cause is a previous controller crash, not user code.
+    """
+
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+
+    info1, v1 = deployment_info(version="1")
+    target_state_changed = dsm.deploy(TEST_DEPLOYMENT_ID, info1)
+    assert target_state_changed
+    dsm.save_checkpoint()
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
+    mocked_replica = ds._replicas.get()[0]
+    replica_id = mocked_replica.replica_id
+
+    mocked_replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, v1)])
+
+    # Mark this replica as not-yet-initialized so that the new controller's
+    # async `was_initialized` probe will return False.
+    uninitialized_replicas_context.add(replica_id)
+
+    new_dsm = create_dsm([replica_id.to_full_id_str()])
+    new_ds = new_dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    # `recover()` is non-blocking: the replica enters RECOVERING and the
+    # probe is observed in the reconcile loop.
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.RECOVERING, 1, v1)])
+    starting_failures_before = new_ds._replica_constructor_retry_counter
+
+    # Next update cycle: probe says False -> the replica is force-stopped
+    # (STOPPING) and a fresh replica is started in its place (STARTING) in
+    # the same reconcile pass.
+    new_dsm.update()
+    check_counts(
+        new_ds,
+        total=2,
+        by_state=[(ReplicaState.STOPPING, 1, v1), (ReplicaState.STARTING, 1, v1)],
+    )
+    # The drop must not bump the deploy-failure counter -- the underlying
+    # cause is a previous controller crash, not user code.
+    assert new_ds._replica_constructor_retry_counter == starting_failures_before
+    # The fresh replica should have a new replica id.
+    starting_replicas = new_ds._replicas.get(states=[ReplicaState.STARTING])
+    assert len(starting_replicas) == 1
+    assert starting_replicas[0].replica_id != replica_id
+
+    # Drain the STOPPING replica and confirm we're left with just the
+    # replacement.
+    stopping_replica = new_ds._replicas.get(states=[ReplicaState.STOPPING])[0]
+    stopping_replica._actor.set_done_stopping()
+    new_dsm.update()
+    check_counts(new_ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
+
+    uninitialized_replicas_context.remove(replica_id)
 
 
 def test_actor_died_before_recover(mock_deployment_state_manager):


### PR DESCRIPTION
related to https://github.com/ray-project/ray/issues/63118

After a controller restart, the controller occasionally floods its log with:

```
ERROR controller -- Error executing function _recover_rank_impl: 'NoneType' object has no attribute 'rank'
```

Trace: `recover_current_state_from_replica_actor_names → ActorReplicaWrapper.recover → check_ready` reads metadata back from the live actor and sets `self._rank = None`. The next reconcile cycle then calls `RankManager.recover_rank(replica_id, node_id, None)` and crashes when the impl dereferences `rank.rank`.

### Root cause

Ranks are not checkpointed; they live only in controller memory and on the actor side via `ray.serve.context._INTERNAL_REPLICA_CONTEXT`. The actor's context starts as `rank=None` and is only set when `initialize_and_get_metadata` is called *with* a rank.

If the previous controller crashes between actor creation and the first `initialize_and_get_metadata(rank=R, …)` call, the actor is alive but uninitialized. On recovery, `ActorReplicaWrapper.recover()` calls `initialize_and_get_metadata.remote()` with no args — which silently completes the actor's first init with `rank=None`, returns metadata containing `rank=None`, and breaks rank tracking for that replica permanently. Once an actor is in this state, every future controller restart hits the same crash, and the rank-related deploy retry counter eventually pushes the deployment to `DEPLOY_FAILED`.

### Fix

Detect uninitialized actors during recovery and replace them with fresh replicas, without bumping the deploy-failure counter.