### PR TITLE
[Serve][1/N] Add schema, CLI flag, and checkpoint data structures - Auto-rollback

### DIFF
--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1054,3 +1054,35 @@ class AsyncInferenceTaskQueueMetricReport:
     deployment_id: DeploymentID
     queue_length: int
     timestamp_s: float
+
+
+class RolloutState(str, Enum):
+    """The states the RolloutSupervisor transitions through."""
+
+    IDLE = "IDLE"
+    WATCHING = "WATCHING"
+    ROLLING_BACK = "ROLLING_BACK"
+    ROLLED_BACK = "ROLLED_BACK"
+    ROLLBACK_FAILED = "ROLLBACK_FAILED"
+
+
+@dataclass
+class ConfigSnapshot:
+    """Snapshot of a single config submission."""
+
+    deployment_time: float = 0.0
+    target_capacity: Optional[float] = None
+    target_capacity_direction: Optional[TargetCapacityDirection] = None
+    config_dict: Dict[str, Any] = field(default_factory=dict)
+    auto_rollback_enabled: bool = False
+
+
+@dataclass
+class ServeConfigCheckpoint:
+    """Versioned checkpoint for the Serve cluster config and rollout state."""
+
+    version: int = 2
+    current: ConfigSnapshot = field(default_factory=ConfigSnapshot)
+    last_good: Optional[ConfigSnapshot] = None
+    rollout_state: RolloutState = RolloutState.IDLE
+    rollout_started_at: Optional[float] = None

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -983,6 +983,19 @@ class HTTPOptionsSchema(BaseModel):
         return v
 
 
+@PublicAPI(stability="alpha")
+class RolloutStrategySchema(BaseModel):
+    """Options controlling rollout behavior for Serve cluster config."""
+
+    auto_rollback: bool = Field(
+        default=False,
+        description=(
+            "If True, automatically roll back to the last known good config "
+            "when any application reaches DEPLOY_FAILED status."
+        ),
+    )
+
+
 @PublicAPI(stability="stable")
 class ServeDeploySchema(BaseModel):
     """
@@ -1017,6 +1030,13 @@ class ServeDeploySchema(BaseModel):
         ..., description="The set of applications to run on the Ray cluster."
     )
     target_capacity: Optional[float] = TARGET_CAPACITY_FIELD
+    rollout_strategy: Optional[RolloutStrategySchema] = Field(
+        default=None,
+        description=(
+            "Options controlling rollout behavior. If not specified, no "
+            "automatic rollback is performed on deployment failure."
+        ),
+    )
 
     @field_validator("applications")
     @classmethod

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -39,6 +39,7 @@ from ray.serve.deployment import Application, deployment_to_schema
 from ray.serve.exceptions import RayServeException
 from ray.serve.schema import (
     LoggingConfig,
+    RolloutStrategySchema,
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
@@ -240,6 +241,7 @@ def _generate_config_from_file_or_import_path(
     name: Optional[str],
     arguments: Dict[str, str],
     runtime_env: Optional[Dict[str, Any]],
+    rollback_on_failure: bool = False,
 ) -> ServeDeploySchema:
     """Generates a deployable config schema for the passed application(s)."""
     if pathlib.Path(config_or_import_path).is_file():
@@ -273,6 +275,8 @@ def _generate_config_from_file_or_import_path(
         if name is not None:
             app.name = name
         config = ServeDeploySchema(applications=[app])
+    if rollback_on_failure:
+        config.rollout_strategy = RolloutStrategySchema(auto_rollback=True)
 
     return config
 
@@ -338,6 +342,15 @@ def _generate_config_from_file_or_import_path(
     type=str,
     help=RAY_DASHBOARD_ADDRESS_HELP_STR,
 )
+@click.option(
+    "--rollback-on-failure",
+    is_flag=True,
+    default=False,
+    help=(
+        "Rollback cluster config to the last known good config if there are any failures "
+        "on applying the current config."
+    ),
+)
 def deploy(
     config_or_import_path: str,
     arguments: Tuple[str],
@@ -346,6 +359,7 @@ def deploy(
     working_dir: str,
     name: Optional[str],
     address: str,
+    rollback_on_failure: bool,
 ):
     args_dict = convert_args_to_dict(arguments)
     final_runtime_env = parse_runtime_env_args(
@@ -359,6 +373,7 @@ def deploy(
         name=name,
         arguments=args_dict,
         runtime_env=final_runtime_env,
+        rollback_on_failure=rollback_on_failure,
     )
 
     ServeSubmissionClient(address).deploy_applications(

--- a/python/ray/serve/tests/unit/test_cli.py
+++ b/python/ray/serve/tests/unit/test_cli.py
@@ -133,6 +133,36 @@ class TestDeploy:
             ).model_dump(exclude_unset=True)
         ]
 
+    def test_rollback_on_failure(self, fake_serve_client):
+        runner = CliRunner()
+        result = runner.invoke(deploy, ["my_module:my_app", "--rollback-on-failure"])
+        assert result.exit_code == 0, result.output
+        assert fake_serve_client.deployed_config["rollout_strategy"] == {
+            "auto_rollback": True,
+        }
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Tempfile not working.")
+    def test_deploy_yaml_rollback_on_failure(self, fake_serve_client):
+        runner = CliRunner()
+        config = {
+            "applications": [
+                {
+                    "name": "app1",
+                    "import_path": "module.app",
+                    "route_prefix": "/app1",
+                }
+            ]
+        }
+        with NamedTemporaryFile("w", suffix=".yaml") as f:
+            yaml.dump(config, f)
+            f.flush()
+            result = runner.invoke(deploy, [f.name, "--rollback-on-failure"])
+
+        assert result.exit_code == 0, result.output
+        assert fake_serve_client.deployed_config["rollout_strategy"] == {
+            "auto_rollback": True,
+        }
+
 
 class TestEnumSerialization:
     """Test that enum representer correctly serializes enums in YAML dumps."""

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -24,6 +24,7 @@ from ray.serve.schema import (
     DeploymentSchema,
     LoggingConfig,
     RayActorOptionsSchema,
+    RolloutStrategySchema,
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
@@ -991,6 +992,44 @@ class TestServeDeploySchema:
         else:
             s = ServeDeploySchema.model_validate(deploy_config_dict)
             assert s.target_capacity == output_val
+
+    @pytest.mark.parametrize(
+        "input_val,expected_auto_rollback",
+        [
+            # Can be omitted,defaults to None.
+            (None, None),
+            # Accepts auto_rollback: true.
+            ({"auto_rollback": True}, True),
+            # Accepts auto_rollback: false.
+            ({"auto_rollback": False}, False),
+        ],
+    )
+    def test_rollout_strategy(self, input_val, expected_auto_rollback):
+        """Test validation of rollout_strategy field."""
+
+        deploy_config_dict = {"applications": []}
+        if input_val is not None:
+            deploy_config_dict["rollout_strategy"] = input_val
+
+        s = ServeDeploySchema.model_validate(deploy_config_dict)
+        if expected_auto_rollback is None:
+            assert s.rollout_strategy is None
+        else:
+            assert s.rollout_strategy.auto_rollback == expected_auto_rollback
+
+
+class TestRolloutStrategySchema:
+    """
+    Tests RolloutStrategySchema
+    """
+
+    def test_defaults_to_false(self):
+        s = RolloutStrategySchema()
+        assert s.auto_rollback is False
+
+    def test_accepts_true(self):
+        s = RolloutStrategySchema(auto_rollback=True)
+        assert s.auto_rollback is True
 
 
 class TestLoggingConfig:


### PR DESCRIPTION

### Description
This is the first PR towards implementing auto-rollback for `serve deploy` ([#63016](https://github.com/ray-project/ray/issues/63016)). It adds the schema definitions, CLI wiring, and internal data structures needed for the feature.

## Changes

- **`schema.py`**: Add `RolloutStrategySchema` and an optional `rollout_strategy` field on `ServeDeploySchema`.
- **`scripts.py`**: Add `--rollback-on-failure` flag to `serve deploy`.
- **`common.py`**: Add `RolloutState` enum, `ConfigSnapshot` dataclass, and `ServeConfigCheckpoint` dataclass for the new checkpoint format.
### Tests
- **`test_schema.py`**: Tests for `RolloutStrategySchema` and the `rollout_strategy` field on `ServeDeploySchema`.
- **`test_cli.py`**: Tests for `--rollback-on-failure` with both import paths and YAML config files.

## Related issues

Part of #63016

## Follow up PRs

This is the first PR to get `auto-rollback` feature in. 
The next PR will add the `RolloutSupervisor` core logic and controller wiring that consumes these checkpoint structures during deploy/rollback handling.