### PR TITLE
[Serve][LLM] Introduce SGLang wideEP into ray serve

### DIFF
--- a/python/ray/llm/_internal/serve/engines/sglang/__init__.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/__init__.py
@@ -1,3 +1,4 @@
 from ray.llm._internal.serve.engines.sglang.sglang_engine import SGLangServer
+from ray.llm._internal.serve.engines.sglang.sglang_models import SGLangEngineConfig
 
-__all__ = ["SGLangServer"]
+__all__ = ["SGLangServer", "SGLangEngineConfig"]

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -44,7 +44,14 @@ from ray.llm._internal.serve.core.server.llm_server import (
 
 
 class SGLangServer:
-    def __init__(self, llm_config: LLMConfig):
+    def __init__(self, llm_config: LLMConfig, engine_cls: Optional[type] = None):
+        """Initialize SGLang server.
+
+        Args:
+            llm_config: The LLM configuration.
+            engine_cls: Optional engine class to use. Defaults to sglang.Engine.
+                Can be sglang.RayEngine for distributed execution.
+        """
 
         self._llm_config = llm_config
         self.engine_kwargs = llm_config.engine_kwargs
@@ -68,7 +75,8 @@ class SGLangServer:
         try:
             # Override signal.signal with our no-op function
             signal.signal = noop_signal_handler
-            self.engine = sglang.Engine(**self.engine_kwargs)
+            engine_cls = engine_cls or sglang.Engine
+            self.engine = engine_cls(**self.engine_kwargs)
         finally:
             signal.signal = original_signal_func
 

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_models.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_models.py
@@ -1,0 +1,152 @@
+"""SGLang engine configuration models for Ray Serve LLM."""
+
+import dataclasses
+from typing import Any, Dict, Optional
+
+from pydantic import ConfigDict, Field, model_validator
+
+from ray.llm._internal.common.base_pydantic import BaseModelExtended
+from ray.llm._internal.common.utils.import_utils import try_import
+from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+from ray.llm._internal.serve.observability.logging import get_logger
+
+logger = get_logger(__name__)
+sglang = try_import("sglang")
+
+
+class SGLangEngineConfig(BaseModelExtended):
+    """Configuration model for SGLang engine.
+
+    Validates engine_kwargs against SGLang ServerArgs and provides
+    WideEP-specific validation.
+    """
+
+    model_config = ConfigDict(
+        use_enum_values=True,
+    )
+
+    model_id: str = Field(
+        description="The identifier for the model.",
+    )
+    hf_model_id: Optional[str] = Field(
+        None, description="The Hugging Face model identifier."
+    )
+    engine_kwargs: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Engine kwargs to pass to SGLang Engine.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_engine_kwargs(self):
+        """Validate engine_kwargs against SGLang ServerArgs."""
+        if sglang is None:
+            logger.warning(
+                "SGLang is not installed. Skipping engine_kwargs validation."
+            )
+            return self
+
+        # Get valid ServerArgs field names
+        try:
+            from sglang.srt.server_args import ServerArgs
+
+            server_args_fields = {f.name for f in dataclasses.fields(ServerArgs)}
+        except ImportError:
+            logger.warning("Could not import ServerArgs for validation.")
+            return self
+
+        # Validate that all engine_kwargs are valid ServerArgs fields
+        for key in self.engine_kwargs:
+            if key not in server_args_fields and key != "placement_group":
+                logger.warning(
+                    f"engine_kwargs contains unknown field '{key}' not in ServerArgs."
+                )
+
+        return self
+
+    @property
+    def tp_size(self) -> int:
+        """Tensor parallel size."""
+        return self.engine_kwargs.get("tp_size", 1)
+
+    @property
+    def pp_size(self) -> int:
+        """Pipeline parallel size."""
+        return self.engine_kwargs.get("pp_size", 1)
+
+    @property
+    def dp_size(self) -> int:
+        """Data parallel size."""
+        return self.engine_kwargs.get("dp_size", 1)
+
+    @property
+    def nnodes(self) -> int:
+        """Number of nodes."""
+        return self.engine_kwargs.get("nnodes", 1)
+
+    @property
+    def moe_a2a_backend(self) -> Optional[str]:
+        """MoE all-to-all backend."""
+        return self.engine_kwargs.get("moe_a2a_backend")
+
+    @property
+    def enable_dp_attention(self) -> bool:
+        """Whether DP attention is enabled."""
+        return self.engine_kwargs.get("enable_dp_attention", False)
+
+    @property
+    def is_wideep(self) -> bool:
+        """Whether WideEP is enabled (moe_a2a_backend='deepep')."""
+        return self.moe_a2a_backend == "deepep"
+
+    @property
+    def num_devices(self) -> int:
+        """Total number of GPUs needed."""
+        return self.tp_size * self.pp_size
+
+    def validate_wideep_config(self) -> None:
+        """Validate WideEP-specific configuration constraints.
+
+        Raises:
+            ValueError: If WideEP configuration is invalid.
+        """
+        if not self.is_wideep:
+            return
+
+        moe_dp_size = self.engine_kwargs.get("moe_dp_size", 1)
+
+        # Pure WideEP (without DPA) requires moe_dp_size=1
+        if not self.enable_dp_attention and moe_dp_size != 1:
+            raise ValueError(
+                f"WideEP without DPA requires moe_dp_size=1. "
+                f"Got moe_dp_size={moe_dp_size}. "
+                f"For DPA+WideEP, set enable_dp_attention=True."
+            )
+
+        # Multi-node validation
+        if self.nnodes > 1:
+            total_gpus = self.num_devices
+            if total_gpus % self.nnodes != 0:
+                raise ValueError(
+                    f"total_gpus (tp_size * pp_size = {total_gpus}) must be "
+                    f"divisible by nnodes ({self.nnodes})."
+                )
+
+        logger.info(
+            f"WideEP config validated: tp_size={self.tp_size}, "
+            f"nnodes={self.nnodes}, moe_a2a_backend={self.moe_a2a_backend}"
+        )
+
+    @classmethod
+    def from_llm_config(cls, llm_config: LLMConfig) -> "SGLangEngineConfig":
+        """Convert LLMConfig to SGLangEngineConfig."""
+        hf_model_id = None
+        if llm_config.model_loading_config.model_source is None:
+            hf_model_id = llm_config.model_id
+        elif isinstance(llm_config.model_loading_config.model_source, str):
+            hf_model_id = llm_config.model_loading_config.model_source
+
+        return cls(
+            model_id=llm_config.model_id,
+            hf_model_id=hf_model_id,
+            engine_kwargs=llm_config.engine_kwargs.copy(),
+        )

--- a/python/ray/llm/_internal/serve/serving_patterns/sglang/__init__.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/sglang/__init__.py
@@ -1,0 +1,7 @@
+"""SGLang serving patterns for Ray Serve LLM."""
+
+from ray.llm._internal.serve.serving_patterns.sglang.builder import (
+    build_sglang_wideep_deployment,
+)
+
+__all__ = ["build_sglang_wideep_deployment"]

--- a/python/ray/llm/_internal/serve/serving_patterns/sglang/builder.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/sglang/builder.py
@@ -1,0 +1,45 @@
+"""Builder for SGLang WideEP deployment."""
+
+from typing import Optional
+
+from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+from ray.llm._internal.serve.core.server.builder import build_llm_deployment
+from ray.llm._internal.serve.observability.logging import get_logger
+from ray.llm._internal.serve.serving_patterns.sglang.sglang_wideep_server import (
+    SGLangWideEPServer,
+)
+from ray.serve.deployment import Application
+
+logger = get_logger(__name__)
+
+
+def build_sglang_wideep_deployment(
+    llm_config: LLMConfig,
+    *,
+    name_prefix: Optional[str] = None,
+    bind_kwargs: Optional[dict] = None,
+    override_serve_options: Optional[dict] = None,
+) -> Application:
+    """Build a SGLang WideEP LLM deployment.
+
+    WideEP is enabled via moe_a2a_backend="deepep" which automatically sets
+    ep_size = tp_size. Uses gang scheduling with gang_size=1 (single engine
+    per gang, internally manages all DP/TP/EP ranks).
+
+    Args:
+        llm_config: The LLM configuration. Must include moe_a2a_backend="deepep"
+            in engine_kwargs to enable WideEP.
+        name_prefix: The prefix to add to the deployment name.
+        bind_kwargs: Optional extra kwargs to pass to the deployment constructor.
+        override_serve_options: Optional serve options to override defaults.
+
+    Returns:
+        The Ray Serve Application for the SGLang WideEP deployment.
+    """
+    return build_llm_deployment(
+        llm_config,
+        name_prefix=name_prefix,
+        bind_kwargs=bind_kwargs,
+        override_serve_options=override_serve_options,
+        deployment_cls=SGLangWideEPServer,
+    )

--- a/python/ray/llm/_internal/serve/serving_patterns/sglang/sglang_wideep_server.py
+++ b/python/ray/llm/_internal/serve/serving_patterns/sglang/sglang_wideep_server.py
@@ -1,0 +1,155 @@
+"""SGLang WideEP Server for Ray Serve LLM.
+
+Gang-scheduled WideEP server wrapping SGLang RayEngine with gang_size=1.
+WideEP is enabled via moe_a2a_backend="deepep" which automatically sets
+ep_size = tp_size.
+"""
+
+import copy
+import os
+
+from ray import serve
+from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
+from ray.llm._internal.serve.engines.sglang.sglang_engine import SGLangServer
+from ray.llm._internal.serve.engines.sglang.sglang_models import SGLangEngineConfig
+from ray.llm._internal.serve.observability.logging import get_logger
+from ray.llm._internal.serve.utils.pg_utils import get_bundle_indices_sorted_by_node
+from ray.serve.config import (
+    GangPlacementStrategy,
+    GangRuntimeFailurePolicy,
+    GangSchedulingConfig,
+)
+from ray.util.placement_group import get_placement_group
+
+logger = get_logger(__name__)
+
+
+class SGLangWideEPServer(SGLangServer):
+    """Gang-scheduled WideEP server wrapping SGLang RayEngine with gang_size=1.
+
+    Inherits all API methods (chat, completions, embeddings, etc.) from SGLangServer.
+    Only overrides __init__ for WideEP-specific setup and get_deployment_options
+    for gang scheduling configuration.
+    """
+
+    def __init__(self, llm_config: LLMConfig):
+        """Initialize WideEP server with gang scheduling and RayEngine.
+
+        Args:
+            llm_config: LLM configuration with moe_a2a_backend="deepep" to enable WideEP.
+
+        Raises:
+            RuntimeError: If gang scheduling is not enabled.
+            ValueError: If WideEP configuration constraints are violated.
+        """
+        # Validate WideEP configuration
+        engine_config = SGLangEngineConfig.from_llm_config(llm_config)
+        engine_config.validate_wideep_config()
+
+        ctx = serve.get_replica_context()
+        gang_context = ctx.gang_context
+
+        if gang_context is None:
+            raise RuntimeError(
+                "SGLangWideEPServer requires gang scheduling to be enabled. "
+                "Set gang_scheduling_config in the deployment options."
+            )
+
+        self.gang_id = gang_context.gang_id
+        logger.info(
+            f"SGLangWideEPServer replica initialized: gang_id={self.gang_id}, "
+            f"gang_size={gang_context.world_size}"
+        )
+
+        # Get gang placement group and pass to RayEngine
+        pg = get_placement_group(gang_context.pg_name)
+
+        # Sort bundle indices by node to ensure TP ranks are co-located
+        sorted_indices = get_bundle_indices_sorted_by_node(pg)
+        tp_size = llm_config.engine_kwargs.get("tp_size", 1)
+        pp_size = llm_config.engine_kwargs.get("pp_size", 1)
+        num_devices = tp_size * pp_size
+
+        # Set SGLANG_RAY_BUNDLE_INDICES for RayEngine to place SchedulerActors
+        os.environ["SGLANG_RAY_BUNDLE_INDICES"] = ",".join(
+            str(idx) for idx in sorted_indices[:num_devices]
+        )
+        logger.info(
+            f"SGLANG_RAY_BUNDLE_INDICES set to: {os.environ['SGLANG_RAY_BUNDLE_INDICES']}"
+        )
+
+        # Pass placement_group to RayEngine for SchedulerActor placement
+        llm_config.engine_kwargs["placement_group"] = pg
+
+        # Import SGLang and call parent with RayEngine class
+        try:
+            import sglang
+        except ImportError as e:
+            raise ImportError(
+                "SGLang is not installed or failed to import. Please run "
+                "`pip install sglang[all]` to install required dependencies."
+            ) from e
+
+        super().__init__(llm_config, engine_cls=sglang.RayEngine)
+
+        logger.info(
+            f"SGLang RayEngine initialized with tp_size={tp_size}, "
+            f"nnodes={llm_config.engine_kwargs.get('nnodes', 1)}, "
+            f"moe_a2a_backend={llm_config.engine_kwargs.get('moe_a2a_backend')}"
+        )
+
+    @classmethod
+    def get_deployment_options(cls, llm_config: "LLMConfig"):
+        """Get deployment options for SGLang WideEP.
+
+        Returns gang_scheduling_config with gang_size=1 and placement_group_bundles
+        based on tp_size/pp_size/nnodes.
+
+        Args:
+            llm_config: LLM configuration.
+
+        Returns:
+            dict with placement_group_bundles, placement_group_strategy,
+            and gang_scheduling_config.
+        """
+        # Start with user's deployment_config to preserve settings like autoscaling_config
+        deployment_options = copy.deepcopy(llm_config.deployment_config)
+
+        tp_size = llm_config.engine_kwargs.get("tp_size", 1)
+        pp_size = llm_config.engine_kwargs.get("pp_size", 1)
+        nnodes = llm_config.engine_kwargs.get("nnodes", 1)
+        num_devices = tp_size * pp_size
+
+        if tp_size < 1 or pp_size < 1:
+            raise ValueError(
+                f"Invalid configuration: tp_size={tp_size} and pp_size={pp_size}. "
+                f"Both must be >= 1."
+            )
+
+        # Placement group bundles
+        if nnodes > 1:
+            gpus_per_node = num_devices // nnodes
+            pg_bundles = [{"GPU": gpus_per_node} for _ in range(nnodes)]
+        else:
+            pg_bundles = [{"GPU": 1} for _ in range(num_devices)]
+
+        deployment_options["placement_group_bundles"] = pg_bundles
+
+        deployment_options["gang_scheduling_config"] = GangSchedulingConfig(
+            gang_size=1,
+            gang_placement_strategy=(
+                GangPlacementStrategy.SPREAD
+                if nnodes > 1
+                else GangPlacementStrategy.PACK
+            ),
+            runtime_failure_policy=GangRuntimeFailurePolicy.RESTART_GANG,
+        )
+
+        deployment_options.pop("placement_group_strategy", None)
+
+        logger.info(
+            f"SGLangWideEPServer deployment options: "
+            f"gang_size=1, pg_bundles={len(pg_bundles)}"
+        )
+
+        return deployment_options

--- a/release/llm_tests/serve/test_llm_serve_sglang.py
+++ b/release/llm_tests/serve/test_llm_serve_sglang.py
@@ -481,5 +481,182 @@ class TestSGLangProtocolDecoupling:
         assert issubclass(ScoreRequest, ScoringRequest)
 
 
+# ---------------------------------------------------------------------------
+# SGLang WideEP Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cleanup_wideep():
+    """Cleanup Ray Serve resources after WideEP tests."""
+    yield
+    serve.shutdown()
+
+
+def test_sglang_wideep_config_validation():
+    """Verify WideEP configuration constraints are validated.
+
+    - moe_a2a_backend must be 'deepep'
+    - moe_dp_size must be 1 for pure WideEP
+    - nnodes must divide total_gpus evenly
+    """
+    from ray.llm._internal.serve.engines.sglang.sglang_models import SGLangEngineConfig
+    from ray.llm._internal.serve.serving_patterns.sglang.sglang_wideep_server import (
+        SGLangWideEPServer,
+    )
+
+    # Valid config: moe_a2a_backend='deepep', moe_dp_size=1
+    valid_config = LLMConfig(
+        model_loading_config={"model_id": "test-model"},
+        engine_kwargs={
+            "moe_a2a_backend": "deepep",
+            "tp_size": 8,
+            "nnodes": 2,
+        },
+    )
+    engine_config = SGLangEngineConfig.from_llm_config(valid_config)
+    engine_config.validate_wideep_config()  # Should not raise
+
+    # Invalid: moe_a2a_backend != 'deepep'
+    invalid_config = LLMConfig(
+        model_loading_config={"model_id": "test-model"},
+        engine_kwargs={
+            "moe_a2a_backend": "none",
+            "tp_size": 8,
+        },
+    )
+    deployment_options = SGLangWideEPServer.get_deployment_options(invalid_config)
+    # get_deployment_options should work, but __init__ should validate
+    assert deployment_options["gang_scheduling_config"].gang_size == 1
+
+    # Invalid: moe_dp_size != 1 without DPA
+    invalid_dp_config = LLMConfig(
+        model_loading_config={"model_id": "test-model"},
+        engine_kwargs={
+            "moe_a2a_backend": "deepep",
+            "tp_size": 8,
+            "moe_dp_size": 2,  # Invalid for pure WideEP
+        },
+    )
+    engine_config = SGLangEngineConfig.from_llm_config(invalid_dp_config)
+    with pytest.raises(ValueError, match="moe_dp_size=1"):
+        engine_config.validate_wideep_config()
+
+    # Valid: moe_dp_size != 1 with DPA enabled
+    valid_dpa_config = LLMConfig(
+        model_loading_config={"model_id": "test-model"},
+        engine_kwargs={
+            "moe_a2a_backend": "deepep",
+            "tp_size": 16,
+            "dp_size": 8,
+            "enable_dp_attention": True,  # DPA + WideEP
+            "moe_dp_size": 1,
+        },
+    )
+    engine_config = SGLangEngineConfig.from_llm_config(valid_dpa_config)
+    engine_config.validate_wideep_config()  # Should not raise
+
+
+def test_sglang_wideep_deployment_options():
+    """Verify SGLangWideEPServer.get_deployment_options returns correct values.
+
+    - gang_size=1 (single Engine per gang)
+    - Placement group bundles based on tp_size/pp_size/nnodes
+    - SPREAD strategy for multi-node, PACK for single-node
+    """
+    from ray.llm._internal.serve.serving_patterns.sglang.sglang_wideep_server import (
+        SGLangWideEPServer,
+    )
+    from ray.serve.config import GangPlacementStrategy
+
+    # Single-node WideEP
+    single_node_config = LLMConfig(
+        model_loading_config={"model_id": "test-model"},
+        engine_kwargs={
+            "moe_a2a_backend": "deepep",
+            "tp_size": 8,
+            "nnodes": 1,
+        },
+    )
+    options = SGLangWideEPServer.get_deployment_options(single_node_config)
+    assert options["gang_scheduling_config"].gang_size == 1
+    assert len(options["placement_group_bundles"]) == 8
+    assert options["placement_group_strategy"] == "PACK"
+    assert (
+        options["gang_scheduling_config"].gang_placement_strategy
+        == GangPlacementStrategy.PACK
+    )
+
+    # Multi-node WideEP
+    multi_node_config = LLMConfig(
+        model_loading_config={"model_id": "test-model"},
+        engine_kwargs={
+            "moe_a2a_backend": "deepep",
+            "tp_size": 16,
+            "nnodes": 2,
+        },
+    )
+    options = SGLangWideEPServer.get_deployment_options(multi_node_config)
+    assert options["gang_scheduling_config"].gang_size == 1
+    assert len(options["placement_group_bundles"]) == 2
+    assert options["placement_group_bundles"][0] == {"GPU": 8}
+    assert options["placement_group_strategy"] == "SPREAD"
+    assert (
+        options["gang_scheduling_config"].gang_placement_strategy
+        == GangPlacementStrategy.SPREAD
+    )
+
+
+@pytest.mark.skip(reason="Requires SGLang WideEP support and 2 GPUs")
+def test_sglang_wideep_gang_scheduling(cleanup_wideep):
+    """Verify WideEP deployment uses gang scheduling with gang_size=1.
+
+    This test requires at least 2 GPUs and SGLang with WideEP support to run.
+    Skipped by default until WideEP support is fully integrated.
+    """
+    from ray.llm._internal.serve.serving_patterns.sglang import (
+        build_sglang_wideep_deployment,
+    )
+
+    llm_config = LLMConfig(
+        model_loading_config={
+            "model_id": RAY_MODEL_ID,
+            "model_source": MODEL_ID,
+        },
+        deployment_config={
+            "autoscaling_config": {
+                "min_replicas": 1,
+                "max_replicas": 1,
+            }
+        },
+        engine_kwargs={
+            "model_path": MODEL_ID,
+            "moe_a2a_backend": "deepep",
+            "tp_size": 2,
+            "nnodes": 1,
+            "mem_fraction_static": 0.8,
+        },
+    )
+
+    app = build_sglang_wideep_deployment(llm_config)
+    serve.run(app, blocking=False)
+
+    wait_for_condition(_app_is_running, timeout=300)
+
+    # Verify deployment has gang scheduling enabled
+    status = serve.status()
+    deployment_name = f"SGLangWideEPServer:{RAY_MODEL_ID}"
+    assert deployment_name in status.applications[SERVE_DEFAULT_APP_NAME].deployments
+
+    client = OpenAI(base_url="http://localhost:8000/v1", api_key="fake-key")
+    chat_resp = client.chat.completions.create(
+        model=RAY_MODEL_ID,
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        max_tokens=64,
+        temperature=0.0,
+    )
+    assert chat_resp.choices[0].message.content.strip()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-xvs", __file__]))


### PR DESCRIPTION
## Description
Add `SGLangWideEPServer` to support SGLang's WideEP (Expert Parallelism) for Ray Serve LLM. WideEP is enabled via `moe_a2a_backend="deepep"` and uses gang scheduling with `gang_size=1` (single Engine per gang, internally manages all DP/TP/EP ranks).

## Changes

**New Files:**
- `engines/sglang/sglang_models.py` - SGLangEngineConfig validates engine_kwargs and WideEP constraints
- `serving_patterns/sglang/__init__.py` - Package init, exports `build_sglang_wideep_deployment`
- `serving_patterns/sglang/builder.py` - `build_sglang_wideep_deployment()` builder function
- `serving_patterns/sglang/sglang_wideep_server.py` - SGLangWideEPServer inherits SGLangServer (~160 lines)
- `release/llm_tests/serve/test_llm_serve_sglang.py` - WideEP config validation and deployment tests

**Modified:**
- `engines/sglang/__init__.py` - Export SGLangEngineConfig
- `engines/sglang/sglang_engine.py` - Add `engine_cls` parameter to SGLangServer.__init__ (supports RayEngine)

**Implementation:**
- `SGLangWideEPServer` inherits from `SGLangServer`, only overriding `__init__` and `get_deployment_options`
- Uses `sglang.RayEngine` with `placement_group` parameter for SchedulerActor placement
- Sets `SGLANG_RAY_BUNDLE_INDICES` from sorted bundle indices (ensures TP ranks co-located on same node)
- `gang_size=1` means single Engine per gang (unlike vLLM DPServer's `gang_size=dp_size`)
- Validates WideEP constraints: `moe_a2a_backend="deepep"`, `moe_dp_size=1` for pure WideEP

## Related issues
Closes #62910