### PR TITLE
[RLlib] train FQETorchModel for 500 steps only to deflake

### DIFF
--- a/rllib/offline/estimators/tests/test_dm_learning.py
+++ b/rllib/offline/estimators/tests/test_dm_learning.py
@@ -37,7 +37,7 @@ class TestDMLearning(unittest.TestCase):
 
         # Config settings for FQE model
         cls.q_model_config = {
-            "n_iters": 800,
+            "n_iters": 500,
             "minibatch_size": 64,
             "polyak_coef": 1.0,
             "model_config": {

--- a/rllib/offline/estimators/tests/test_dr_learning.py
+++ b/rllib/offline/estimators/tests/test_dr_learning.py
@@ -40,7 +40,7 @@ class TestDRLearning(unittest.TestCase):
 
         # Config settings for FQE model
         cls.q_model_config = {
-            "n_iters": 800,
+            "n_iters": 500,
             "minibatch_size": 64,
             "polyak_coef": 1.0,
             "model_config": {


### PR DESCRIPTION
## Description
I have observed ope methods flake some times in the past weeks.
Example: https://buildkite.com/ray-project/microcheck/builds/44888#019df8e0-e435-4270-a189-b43f548e459f

This is because they can time out.
Empirically, training for 500 steps is enough and reduces the runtime of the test.