### PR TITLE
[Train] Make `test_trainer_restore` manual

### DIFF
--- a/python/ray/train/BUILD.bazel
+++ b/python/ray/train/BUILD.bazel
@@ -1051,6 +1051,7 @@ py_test(
     deps = [":train_lib"],
 )
 
+# TODO(Mark) - Disabled while resolving issues due to #63017
 py_test(
     name = "test_trainer_restore",
     size = "large",

--- a/python/ray/train/BUILD.bazel
+++ b/python/ray/train/BUILD.bazel
@@ -1058,6 +1058,7 @@ py_test(
     env = {"RAY_TRAIN_V2_ENABLED": "0"},
     tags = [
         "exclusive",
+        "manual",
         "team:ml",
     ],
     deps = [


### PR DESCRIPTION
## Description
https://github.com/ray-project/ray/pull/63017 updated pyarrow types for ray data however the LightGBM trainer wasn't updated and is raising errors in `test_trainer_restore`. 
While we work out the best solution, this PR disables the test to allow others to continue working