### PR TITLE
[Data] Make logical operator fields canonical

### DIFF
--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -20,21 +20,17 @@ class LogicalOperator(Operator, ABC):
     physical operator.
     """
 
-    _name: Optional[str] = field(init=False, default=None, repr=False)
-    _input_dependencies: List["LogicalOperator"] = field(
-        init=False, default_factory=list, repr=False
+    input_dependencies: List["LogicalOperator"] = field(
+        default_factory=list, repr=False, kw_only=True
     )
-    _num_outputs: Optional[int] = field(default=None, repr=False)
 
     @property
     def name(self) -> str:
-        return self._name or self.__class__.__name__
+        return self.__class__.__name__
 
     @property
-    @abstractmethod
     def num_outputs(self) -> Optional[int]:
-        """Expected number of output blocks, if known."""
-        ...
+        return None
 
     def estimated_num_outputs(self) -> Optional[int]:
         """Returns the estimated number of blocks that
@@ -51,20 +47,9 @@ class LogicalOperator(Operator, ABC):
             return self.input_dependencies[0].estimated_num_outputs()
         return None
 
-    # Override the following 3 methods to correct type hints.
-
-    @property
-    def input_dependencies(self) -> List["LogicalOperator"]:
-        value = self._input_dependencies
-        for x in value:
-            assert isinstance(x, LogicalOperator), x
-        return value
-
-    @input_dependencies.setter
-    def input_dependencies(self, value: List["LogicalOperator"]) -> None:
-        for x in value:
-            assert isinstance(x, LogicalOperator), x
-        object.__setattr__(self, "_input_dependencies", value)
+    def __post_init__(self):
+        for input_dependency in self.input_dependencies:
+            assert isinstance(input_dependency, LogicalOperator), input_dependency
 
     def post_order_iter(self) -> Iterator["LogicalOperator"]:
         return super().post_order_iter()  # type: ignore
@@ -90,11 +75,11 @@ class LogicalOperator(Operator, ABC):
     def _with_new_input_dependencies(
         self, input_dependencies: List["LogicalOperator"]
     ) -> "LogicalOperator":
-        if "input_dependencies" in {field.name for field in fields(self)}:
+        if "__dataclass_fields__" in type(self).__dict__:
             return replace(self, input_dependencies=input_dependencies)
 
         target = copy.copy(self)
-        object.__setattr__(target, "_input_dependencies", input_dependencies)
+        object.__setattr__(target, "input_dependencies", input_dependencies)
         return target
 
     def _get_args(self) -> Dict[str, Any]:
@@ -106,6 +91,7 @@ class LogicalOperator(Operator, ABC):
             # Keep underscore-prefixed keys to preserve legacy export schema.
             args[key if key.startswith("_") else f"_{key}"] = value
         args["_name"] = self.name
+        args["_num_outputs"] = self.num_outputs
         # Preserve legacy export shape even though output deps are no longer tracked.
         args["_output_dependencies"] = []
         return args

--- a/python/ray/data/_internal/logical/interfaces/operator.py
+++ b/python/ray/data/_internal/logical/interfaces/operator.py
@@ -8,11 +8,8 @@ class Operator(ABC):
     Operators live on the driver side of the Dataset only.
     """
 
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Name for this operator."""
-        ...
+    name: str
+    input_dependencies: List["Operator"]
 
     @property
     def dag_str(self) -> str:
@@ -24,12 +21,6 @@ class Operator(ABC):
             out_str = ""
         out_str += f"{self.__class__.__name__}[{self.name}]"
         return out_str
-
-    @property
-    @abstractmethod
-    def input_dependencies(self) -> List["Operator"]:
-        """List of operators that provide inputs for this operator."""
-        ...
 
     def post_order_iter(self) -> Iterator["Operator"]:
         """Depth-first traversal of this operator and its input dependencies."""

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
@@ -33,9 +33,12 @@ class AbstractAllToAll(LogicalOperator):
     AllToAllOperator.
     """
 
+    _name: Optional[str] = field(init=False, default=None, repr=False)
+    num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
     def __init__(
         self,
-        input_op: LogicalOperator,
+        input_dependencies: List[LogicalOperator],
         num_outputs: Optional[int] = None,
         sub_progress_bar_names: Optional[List[str]] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
@@ -45,8 +48,7 @@ class AbstractAllToAll(LogicalOperator):
         """Initialize an ``AbstractAllToAll`` logical operator.
 
         Args:
-            input_op: The operator preceding this operator in the plan DAG. The outputs
-                of `input_op` will be the inputs to this operator.
+            input_dependencies: The operators preceding this operator in the plan DAG.
             num_outputs: The number of expected output bundles outputted by this
                 operator.
             sub_progress_bar_names: Optional sub-stage progress bar names for this
@@ -56,17 +58,17 @@ class AbstractAllToAll(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            _num_outputs=num_outputs,
+            input_dependencies=input_dependencies,
         )
-        object.__setattr__(self, "_input_dependencies", [input_op])
+        object.__setattr__(self, "num_outputs", num_outputs)
         if name is not None:
             object.__setattr__(self, "_name", name)
         object.__setattr__(self, "ray_remote_args", ray_remote_args or {})
         object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
 
     @property
-    def num_outputs(self) -> Optional[int]:
-        return self._num_outputs
+    def name(self) -> str:
+        return self._name or super().name
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -77,14 +79,16 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.seed_config is None:
             object.__setattr__(self, "seed_config", RandomSeedConfig())
-        object.__setattr__(self, "_name", "RandomizeBlockOrder")
-        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def name(self) -> str:
+        return "RandomizeBlockOrder"
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -107,14 +111,14 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
 class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for random_shuffle."""
 
-    name: InitVar[str] = "RandomShuffle"
+    name: str = "RandomShuffle"
     seed_config: Optional[RandomSeedConfig] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
-    def __post_init__(self, name: str):
+    def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.seed_config is None:
             object.__setattr__(self, "seed_config", RandomSeedConfig())
@@ -127,13 +131,11 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
                     ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
                 ],
             )
-        object.__setattr__(self, "_name", name)
-        object.__setattr__(self, "_num_outputs", None)
 
     def _with_new_input_dependencies(
         self, input_dependencies: List[LogicalOperator]
     ) -> LogicalOperator:
-        return replace(self, input_dependencies=input_dependencies, name=self._name)
+        return replace(self, input_dependencies=input_dependencies, name=self.name)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -156,16 +158,16 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
 class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for repartition."""
 
-    num_outputs: InitVar[int]
+    num_outputs: int
     shuffle: bool = False
     keys: Optional[List[str]] = None
     sort: bool = False
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
-    _num_outputs: Optional[int] = field(init=False, repr=False)
 
-    def __post_init__(self, num_outputs: int):
+    def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.shuffle:
             sub_progress_bar_names = [
@@ -177,7 +179,6 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
                 ShuffleTaskSpec.SPLIT_REPARTITION_SUB_PROGRESS_BAR_NAME,
             ]
         object.__setattr__(self, "sub_progress_bar_names", sub_progress_bar_names)
-        object.__setattr__(self, "_num_outputs", num_outputs)
 
     def _with_new_input_dependencies(
         self, input_dependencies: List[LogicalOperator]
@@ -214,9 +215,9 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         object.__setattr__(
             self,
@@ -227,7 +228,6 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        object.__setattr__(self, "_num_outputs", None)
 
     def infer_metadata(self) -> "BlockMetadata":
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -257,9 +257,9 @@ class Aggregate(AbstractAllToAll):
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     sub_progress_bar_names: Optional[List[str]] = None
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         object.__setattr__(
             self,
@@ -270,4 +270,3 @@ class Aggregate(AbstractAllToAll):
                 ExchangeTaskSpec.REDUCE_SUB_PROGRESS_BAR_NAME,
             ],
         )
-        object.__setattr__(self, "_num_outputs", None)

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-from typing import Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
 
@@ -20,11 +19,7 @@ class Count(LogicalOperator):
     COLUMN_NAME = "__num_rows"
 
     input_dependencies: list[LogicalOperator] = field(repr=False, kw_only=True)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-
-    @property
-    def num_outputs(self) -> Optional[int]:
-        return self._num_outputs

--- a/python/ray/data/_internal/logical/operators/from_operators.py
+++ b/python/ray/data/_internal/logical/operators/from_operators.py
@@ -1,4 +1,3 @@
-import abc
 import functools
 from dataclasses import InitVar, dataclass, field
 from typing import TYPE_CHECKING, List, Optional, Union
@@ -29,22 +28,19 @@ __all__ = [
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
+class AbstractFrom(LogicalOperator, SourceOperator):
     """Abstract logical operator for `from_*`."""
 
     input_blocks: InitVar[List[ObjectRef[Block]]]
     input_metadata: InitVar[List[BlockMetadataWithSchema]]
     input_data: List[RefBundle] = field(init=False)
-    _input_dependencies: list[LogicalOperator] = field(
-        init=False, repr=False, default_factory=list
-    )
-    _num_outputs: Optional[int] = field(init=False, repr=False)
 
     def __post_init__(
         self,
         input_blocks: List[ObjectRef[Block]],
         input_metadata: List[BlockMetadataWithSchema],
     ):
+        super().__post_init__()
         assert len(input_blocks) == len(input_metadata), (
             len(input_blocks),
             len(input_metadata),
@@ -63,14 +59,13 @@ class AbstractFrom(LogicalOperator, SourceOperator, metaclass=abc.ABCMeta):
                 for i in range(len(input_blocks))
             ],
         )
-        object.__setattr__(self, "_num_outputs", len(input_blocks))
 
     def output_data(self) -> Optional[List[RefBundle]]:
         return self.input_data
 
     @property
     def num_outputs(self) -> Optional[int]:
-        return self._num_outputs
+        return len(self.input_data)
 
     @functools.cached_property
     def _cached_output_metadata(self) -> BlockMetadata:

--- a/python/ray/data/_internal/logical/operators/input_data_operator.py
+++ b/python/ray/data/_internal/logical/operators/input_data_operator.py
@@ -1,5 +1,5 @@
 import functools
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import List, Optional
 
 from ray.data._internal.execution.interfaces import RefBundle
@@ -20,20 +20,13 @@ class InputData(LogicalOperator, SourceOperator):
     """
 
     input_data: List[RefBundle]
-    _input_dependencies: list[LogicalOperator] = field(
-        init=False, repr=False, default_factory=list
-    )
-    _num_outputs: Optional[int] = field(init=False, repr=False)
-
-    def __post_init__(self):
-        object.__setattr__(self, "_num_outputs", len(self.input_data))
 
     def output_data(self) -> Optional[List[RefBundle]]:
         return self.input_data
 
     @property
     def num_outputs(self) -> Optional[int]:
-        return self._num_outputs
+        return len(self.input_data)
 
     def infer_metadata(self) -> BlockMetadata:
         return self._cached_output_metadata

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar, dataclass, field, replace
+from dataclasses import InitVar, dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -55,8 +55,6 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
     right_columns_suffix: Optional[str] = None
     partition_size_hint: Optional[int] = None
     aggregator_ray_remote_args: Optional[Dict[str, Any]] = None
-    _input_dependencies: list[LogicalOperator] = field(init=False, repr=False)
-    _num_outputs: Optional[int] = field(init=False, repr=False)
 
     def __post_init__(
         self,
@@ -73,12 +71,9 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
             )
 
         object.__setattr__(self, "join_type", join_type_enum)
-        object.__setattr__(
-            self,
-            "_input_dependencies",
-            [left_input_op, right_input_op],
-        )
-        object.__setattr__(self, "_num_outputs", num_partitions)
+        object.__setattr__(self, "input_dependencies", [left_input_op, right_input_op])
+        object.__setattr__(self, "num_outputs", num_partitions)
+        super().__post_init__()
 
     def _with_new_input_dependencies(
         self, input_dependencies: List[LogicalOperator]

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.logical.interfaces import (
@@ -38,10 +38,10 @@ class AbstractMap(AbstractOneToOne):
 
     def __init__(
         self,
-        name: Optional[str] = None,
-        input_op: Optional[LogicalOperator] = None,
-        num_outputs: Optional[int] = None,
+        input_dependencies: List[LogicalOperator],
         *,
+        name: Optional[str] = None,
+        num_outputs: Optional[int] = None,
         can_modify_num_rows: bool,
         min_rows_per_bundled_input: Optional[int] = None,
         ray_remote_args: Optional[Dict[str, Any]] = None,
@@ -52,10 +52,9 @@ class AbstractMap(AbstractOneToOne):
         be converted into a physical ``MapOperator``.
 
         Args:
+            input_dependencies: The operators preceding this operator in the plan DAG.
             name: Name for this operator. This is the name that will appear when
                 inspecting the logical plan of a Dataset.
-            input_op: The operator preceding this operator in the plan DAG. The
-                outputs of ``input_op`` will be the inputs to this operator.
             num_outputs: Number of outputs for this operator.
             can_modify_num_rows: Whether the operator can change the row count. False if
                 # of input rows = # of output rows. True otherwise.
@@ -74,7 +73,7 @@ class AbstractMap(AbstractOneToOne):
                 autoscaling actor pool.
         """
         super().__init__(
-            input_op=input_op,
+            input_dependencies=input_dependencies,
             can_modify_num_rows=can_modify_num_rows,
             num_outputs=num_outputs,
             name=name,
@@ -86,6 +85,10 @@ class AbstractMap(AbstractOneToOne):
         object.__setattr__(self, "ray_remote_args_fn", ray_remote_args_fn)
         object.__setattr__(self, "compute", compute or TaskPoolStrategy())
         object.__setattr__(self, "per_block_limit", None)
+
+    @property
+    def name(self) -> str:
+        return self._name or super().name
 
     def set_per_block_limit(self, per_block_limit: int):
         object.__setattr__(self, "per_block_limit", per_block_limit)
@@ -119,10 +122,10 @@ class AbstractUDFMap(AbstractMap):
 
     def __init__(
         self,
-        name: str,
-        input_op: LogicalOperator,
+        input_dependencies: List[LogicalOperator],
         fn: UserDefinedFunction,
         *,
+        name: str,
         can_modify_num_rows: bool,
         fn_args: Optional[Iterable[Any]] = None,
         fn_kwargs: Optional[Dict[str, Any]] = None,
@@ -136,11 +139,10 @@ class AbstractUDFMap(AbstractMap):
         """Initialize AbstractUDFMap.
 
         Args:
+            input_dependencies: The operators preceding this operator in the plan DAG.
+            fn: User-defined function to be called.
             name: Name for this operator. This is the name that will appear when
                 inspecting the logical plan of a Dataset.
-            input_op: The operator preceding this operator in the plan DAG. The outputs
-                of `input_op` will be the inputs to this operator.
-            fn: User-defined function to be called.
             can_modify_num_rows: Whether the UDF can change the row count. False if
                 # of input rows = # of output rows. True otherwise.
             fn_args: Arguments to `fn`.
@@ -163,8 +165,8 @@ class AbstractUDFMap(AbstractMap):
         """
         name = self._get_operator_name(name, fn)
         super().__init__(
-            name,
-            input_op,
+            input_dependencies=input_dependencies,
+            name=name,
             can_modify_num_rows=can_modify_num_rows,
             min_rows_per_bundled_input=min_rows_per_bundled_input,
             ray_remote_args=ray_remote_args,
@@ -226,18 +228,16 @@ class MapBatches(AbstractUDFMap):
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     per_block_limit: Optional[int] = None
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
-        object.__setattr__(
-            self,
-            "_name",
-            self._get_operator_name(self.__class__.__name__, self.fn),
-        )
-        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def name(self) -> str:
+        return self._get_operator_name(self.__class__.__name__, self.fn)
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -256,14 +256,16 @@ class MapRows(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=False)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
-        object.__setattr__(self, "_name", self._get_operator_name("Map", self.fn))
-        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def name(self) -> str:
+        return self._get_operator_name("Map", self.fn)
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -283,9 +285,9 @@ class Filter(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=True)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         provided_params = sum([self.fn is not None, self.predicate_expr is not None])
         if provided_params != 1:
@@ -295,12 +297,10 @@ class Filter(AbstractUDFMap):
             )
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
-        object.__setattr__(
-            self,
-            "_name",
-            self._get_operator_name(self.__class__.__name__, self.fn),
-        )
-        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def name(self) -> str:
+        return self._get_operator_name(self.__class__.__name__, self.fn)
 
     def is_expression_based(self) -> bool:
         return self.predicate_expr is not None
@@ -338,9 +338,9 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     batch_format: str = field(init=False, default="pyarrow")
     zero_copy_batch: bool = field(init=False, default=True)
     per_block_limit: Optional[int] = None
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(
@@ -352,7 +352,6 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
                     "All Project expressions must be named (use .alias(name) or col(name)), "
                     "or be a star() expression."
                 )
-        object.__setattr__(self, "_num_outputs", None)
 
     def _detect_and_get_compute_strategy(self, exprs: list["Expr"]) -> ComputeStrategy:
         """Detect if expressions contain callable class UDFs and return appropriate compute strategy.
@@ -424,18 +423,16 @@ class FlatMap(AbstractUDFMap):
     can_modify_num_rows: bool = field(init=False, default=True)
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
-        object.__setattr__(
-            self,
-            "_name",
-            self._get_operator_name(self.__class__.__name__, self.fn),
-        )
-        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def name(self) -> str:
+        return self._get_operator_name(self.__class__.__name__, self.fn)
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -462,9 +459,9 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
     ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]] = None
     compute: Optional[ComputeStrategy] = None
     per_block_limit: Optional[int] = None
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if self.target_num_rows_per_block <= 0:
             raise ValueError(
@@ -473,12 +470,14 @@ class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThro
             )
         if self.compute is None:
             object.__setattr__(self, "compute", TaskPoolStrategy())
-        object.__setattr__(
-            self,
-            "_name",
-            f"StreamingRepartition[num_rows_per_block={self.target_num_rows_per_block},strict={self.strict}]",
+
+    @property
+    def name(self) -> str:
+        return (
+            "StreamingRepartition["
+            f"num_rows_per_block={self.target_num_rows_per_block},"
+            f"strict={self.strict}]"
         )
-        object.__setattr__(self, "_num_outputs", None)
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # StreamingRepartition only re-bundles rows into different block sizes.

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -62,6 +62,8 @@ def estimate_num_mix_outputs(
 class NAry(LogicalOperator):
     """Base class for n-ary operators, which take multiple input operators."""
 
+    num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
     def __init__(
         self,
         *input_ops: LogicalOperator,
@@ -72,13 +74,9 @@ class NAry(LogicalOperator):
             input_ops: The input operators.
         """
         super().__init__(
-            _num_outputs=num_outputs,
+            input_dependencies=list(input_ops),
         )
-        object.__setattr__(self, "_input_dependencies", list(input_ops))
-
-    @property
-    def num_outputs(self) -> Optional[int]:
-        return self._num_outputs
+        object.__setattr__(self, "num_outputs", num_outputs)
 
     def _with_new_input_dependencies(
         self, input_dependencies: List[LogicalOperator]
@@ -90,17 +88,11 @@ class NAry(LogicalOperator):
 class Zip(NAry):
     """Logical operator for zip."""
 
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
-
     def __init__(
         self,
         *input_ops: LogicalOperator,
     ):
-        for input_op in input_ops:
-            assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_input_dependencies", list(input_ops))
-        object.__setattr__(self, "_num_outputs", None)
+        super().__init__(*input_ops)
 
     def estimated_num_outputs(self):
         total_num_outputs = 0
@@ -116,9 +108,6 @@ class Zip(NAry):
 class Mix(NAry):
     """Logical operator for weighted dataset mixing."""
 
-    _name: str = field(init=False, repr=False)
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
     weights: List[float] = field(init=False, repr=False)
     stopping_condition: MixStoppingCondition = field(init=False, repr=False)
 
@@ -136,11 +125,7 @@ class Mix(NAry):
         if any(weight <= 0 for weight in weights):
             raise ValueError(f"Weights must be positive. Got weights: {weights}")
 
-        for input_op in input_ops:
-            assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_name", self.__class__.__name__)
-        object.__setattr__(self, "_input_dependencies", list(input_ops))
-        object.__setattr__(self, "_num_outputs", None)
+        super().__init__(*input_ops)
         object.__setattr__(self, "weights", weights)
         object.__setattr__(self, "stopping_condition", stopping_condition)
 
@@ -168,17 +153,11 @@ class Mix(NAry):
 class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for union."""
 
-    _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
-
     def __init__(
         self,
         *input_ops: LogicalOperator,
     ):
-        for input_op in input_ops:
-            assert isinstance(input_op, LogicalOperator), input_op
-        object.__setattr__(self, "_input_dependencies", list(input_ops))
-        object.__setattr__(self, "_num_outputs", None)
+        super().__init__(*input_ops)
 
     def estimated_num_outputs(self):
         total_num_outputs = 0

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -26,9 +26,12 @@ class AbstractOneToOne(LogicalOperator):
     have one input and one output dependency.
     """
 
+    _name: Optional[str] = field(init=False, default=None, repr=False)
+    num_outputs: Optional[int] = field(init=False, default=None, repr=False)
+
     def __init__(
         self,
-        input_op: Optional[LogicalOperator],
+        input_dependencies: List[LogicalOperator],
         can_modify_num_rows: bool,
         num_outputs: Optional[int] = None,
         *,
@@ -37,8 +40,7 @@ class AbstractOneToOne(LogicalOperator):
         """Initialize an AbstractOneToOne operator.
 
         Args:
-            input_op: The operator preceding this operator in the plan DAG. The outputs
-                of `input_op` will be the inputs to this operator.
+            input_dependencies: The operators preceding this operator in the plan DAG.
             can_modify_num_rows: Whether the UDF can change the row count. False if
                 # of input rows = # of output rows. True otherwise.
             num_outputs: If known, the number of blocks produced by this operator.
@@ -46,16 +48,16 @@ class AbstractOneToOne(LogicalOperator):
                 inspecting the logical plan of a Dataset.
         """
         super().__init__(
-            _num_outputs=num_outputs,
+            input_dependencies=input_dependencies,
         )
-        object.__setattr__(self, "_input_dependencies", [input_op] if input_op else [])
+        object.__setattr__(self, "num_outputs", num_outputs)
         if name is not None:
             object.__setattr__(self, "_name", name)
         object.__setattr__(self, "can_modify_num_rows", can_modify_num_rows)
 
     @property
-    def num_outputs(self) -> Optional[int]:
-        return self._num_outputs
+    def name(self) -> str:
+        return self._name or super().name
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -65,12 +67,14 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
     limit: int
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     can_modify_num_rows: bool = field(init=False, default=True)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        object.__setattr__(self, "_name", f"limit={self.limit}")
-        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def name(self) -> str:
+        return f"limit={self.limit}"
 
     def infer_metadata(self) -> BlockMetadata:
         return BlockMetadata(
@@ -120,13 +124,12 @@ class Download(AbstractOneToOne):
     filesystem: Optional["pyarrow.fs.FileSystem"] = None
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
     can_modify_num_rows: bool = field(init=False, default=False)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if len(self.uri_column_names) != len(self.output_bytes_column_names):
             raise ValueError(
                 f"Number of URI columns ({len(self.uri_column_names)}) must match "
                 f"number of output columns ({len(self.output_bytes_column_names)})"
             )
-        object.__setattr__(self, "_num_outputs", None)

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,6 +1,6 @@
 import functools
 import math
-from dataclasses import InitVar, dataclass, field, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
 
 from ray.data._internal.compute import ComputeStrategy
@@ -39,7 +39,7 @@ __all__ = [
 ]
 
 
-@dataclass(frozen=True, repr=False, eq=False)
+@dataclass(frozen=True, repr=False, eq=False, init=False)
 class Read(
     AbstractMap,
     SourceOperator,
@@ -51,7 +51,7 @@ class Read(
     datasource: Datasource
     datasource_or_legacy_reader: Union[Datasource, Reader]
     parallelism: int
-    num_outputs: InitVar[Optional[int]] = None
+    num_outputs: Optional[int] = None
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     compute: Optional[ComputeStrategy] = None
     detected_parallelism: Optional[int] = None
@@ -59,19 +59,40 @@ class Read(
     min_rows_per_bundled_input: Optional[int] = field(init=False, default=None)
     ray_remote_args_fn: None = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _input_dependencies: list = field(init=False, repr=False, default_factory=list)
-    _num_outputs: Optional[int] = field(init=False, repr=False)
 
-    def __post_init__(self, num_outputs: Optional[int]):
-        if self.compute is None:
-            from ray.data._internal.compute import TaskPoolStrategy
+    def __init__(
+        self,
+        datasource: Datasource,
+        datasource_or_legacy_reader: Union[Datasource, Reader],
+        parallelism: int,
+        num_outputs: Optional[int] = None,
+        ray_remote_args: Optional[Dict[str, Any]] = None,
+        compute: Optional[ComputeStrategy] = None,
+        detected_parallelism: Optional[int] = None,
+        per_block_limit: Optional[int] = None,
+        *,
+        input_dependencies: Optional[List[LogicalOperator]] = None,
+    ):
+        super().__init__(
+            input_dependencies=input_dependencies or [],
+            can_modify_num_rows=True,
+            num_outputs=num_outputs,
+            min_rows_per_bundled_input=None,
+            ray_remote_args=ray_remote_args,
+            ray_remote_args_fn=None,
+            compute=compute,
+        )
+        object.__setattr__(self, "datasource", datasource)
+        object.__setattr__(
+            self, "datasource_or_legacy_reader", datasource_or_legacy_reader
+        )
+        object.__setattr__(self, "parallelism", parallelism)
+        object.__setattr__(self, "detected_parallelism", detected_parallelism)
+        object.__setattr__(self, "per_block_limit", per_block_limit)
 
-            object.__setattr__(self, "compute", TaskPoolStrategy())
-        if self.ray_remote_args is None:
-            object.__setattr__(self, "ray_remote_args", {})
-        object.__setattr__(self, "_name", f"Read{self.datasource.get_name()}")
-        object.__setattr__(self, "_input_dependencies", [])
-        object.__setattr__(self, "_num_outputs", num_outputs)
+    @property
+    def name(self) -> str:
+        return f"Read{self.datasource.get_name()}"
 
     def output_data(self):
         return None
@@ -91,7 +112,7 @@ class Read(
         return self.detected_parallelism
 
     def estimated_num_outputs(self) -> Optional[int]:
-        return self._num_outputs or self._estimate_num_outputs()
+        return self.num_outputs or self._estimate_num_outputs()
 
     def infer_metadata(self) -> BlockMetadata:
         """A ``BlockMetadata`` that represents the aggregate metadata of the outputs.
@@ -209,7 +230,7 @@ class Read(
             self,
             datasource=projected_datasource,
             datasource_or_legacy_reader=projected_datasource,
-            num_outputs=self._num_outputs,
+            num_outputs=self.num_outputs,
         )
 
     def supports_predicate_pushdown(self) -> bool:
@@ -232,7 +253,7 @@ class Read(
             self,
             datasource=predicated_datasource,
             datasource_or_legacy_reader=predicated_datasource,
-            num_outputs=self._num_outputs,
+            num_outputs=self.num_outputs,
         )
 
 
@@ -278,10 +299,9 @@ class ReadFiles(
     # limit pushdown is applied via ``scanner.push_limit`` (see
     # ``LimitPushdownRule._apply_per_block_limit_if_supported``), not this field.
     per_block_limit: Optional[int] = field(init=False, default=None)
-    _name: str = field(init=False, repr=False)
-    _num_outputs: Optional[int] = field(init=False, repr=False, default=None)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         assert isinstance(
             self.input_dependencies[0], LogicalOperator
@@ -292,8 +312,10 @@ class ReadFiles(
             object.__setattr__(self, "compute", TaskPoolStrategy())
         if self.ray_remote_args is None:
             object.__setattr__(self, "ray_remote_args", {})
-        object.__setattr__(self, "_name", f"ReadFiles{self.datasource_name}")
-        object.__setattr__(self, "_num_outputs", None)
+
+    @property
+    def name(self) -> str:
+        return f"ReadFiles{self.datasource_name}"
 
     def infer_schema(self) -> "pa.Schema":
         # Scanner schema reflects any applied projection pushdown
@@ -451,14 +473,9 @@ class ListFiles(LogicalOperator, SourceOperator):
     shuffle_config_factory: Callable[[], Optional["FileShuffleConfig"]] = field(
         default=lambda: None
     )
-    _name: str = field(init=False, repr=False)
-    _input_dependencies: List[LogicalOperator] = field(
-        init=False, repr=False, default_factory=list
-    )
-    _num_outputs: Optional[int] = field(init=False, repr=False, default=None)
 
     def __post_init__(self):
-        object.__setattr__(self, "_name", self.__class__.__name__)
+        super().__post_init__()
 
     def output_data(self) -> Optional[list]:
         return None

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -19,12 +19,7 @@ class StreamingSplit(LogicalOperator):
     equal: bool
     locality_hints: Optional[List["NodeIdStr"]] = None
     input_dependencies: List[LogicalOperator] = field(repr=False, kw_only=True)
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        object.__setattr__(self, "_num_outputs", None)
-
-    @property
-    def num_outputs(self) -> Optional[int]:
-        return self._num_outputs

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -25,9 +25,9 @@ class Write(AbstractMap):
     min_rows_per_bundled_input: Optional[int] = field(init=False)
     ray_remote_args_fn: None = field(init=False, default=None)
     per_block_limit: Optional[int] = None
-    _num_outputs: Optional[int] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
+        super().__post_init__()
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         if isinstance(self.datasink_or_legacy_datasource, Datasink):
             min_rows_per_bundled_input = (
@@ -42,4 +42,3 @@ class Write(AbstractMap):
         object.__setattr__(
             self, "min_rows_per_bundled_input", min_rows_per_bundled_input
         )
-        object.__setattr__(self, "_num_outputs", None)

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -243,5 +243,5 @@ class LimitPushdownRule(Rule):
 
         # Use copy and replace input dependencies approach
         new_op = copy.copy(original_op)
-        new_op.input_dependencies = [new_input]
+        object.__setattr__(new_op, "input_dependencies", [new_input])
         return new_op

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -386,9 +386,9 @@ class FuseOperators(Rule):
 
         input_op = up_logical_op.input_dependencies[0]
         logical_op = AbstractUDFMap(
-            name,
-            input_op,
+            [input_op],
             up_logical_op.fn,
+            name=name,
             can_modify_num_rows=up_logical_op.can_modify_num_rows,
             fn_args=up_logical_op.fn_args,
             fn_kwargs=up_logical_op.fn_kwargs,
@@ -560,9 +560,9 @@ class FuseOperators(Rule):
         )
         if isinstance(down_logical_op, AbstractUDFMap):
             logical_op = AbstractUDFMap(
-                name,
-                input_op,
+                [input_op],
                 down_logical_op.fn,
+                name=name,
                 fn_args=down_logical_op.fn_args,
                 fn_kwargs=down_logical_op.fn_kwargs,
                 fn_constructor_args=down_logical_op.fn_constructor_args,
@@ -576,8 +576,8 @@ class FuseOperators(Rule):
         else:
             # The downstream op is AbstractMap instead of AbstractUDFMap.
             logical_op = AbstractMap(
-                name,
-                input_op,
+                [input_op],
+                name=name,
                 can_modify_num_rows=can_modify_num_rows,
                 min_rows_per_bundled_input=min_rows_per_bundled_input,
                 ray_remote_args_fn=ray_remote_args_fn,

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -353,5 +353,5 @@ class PredicatePushdown(Rule):
         if isinstance(op, Union) and is_dataclass(op):
             return Union(*new_inputs)
         new_op = copy.copy(op)
-        new_op.input_dependencies = new_inputs
+        object.__setattr__(new_op, "input_dependencies", new_inputs)
         return new_op

--- a/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
+++ b/python/ray/data/tests/test_execution_optimizer_limit_pushdown.py
@@ -39,11 +39,14 @@ def _check_valid_plan_and_result(
 class _DummyLogicalOperator(LogicalOperator):
     def __init__(self, input_dependencies, name=None, num_outputs=None):
         super().__init__(
-            _num_outputs=num_outputs,
+            input_dependencies=input_dependencies,
         )
-        object.__setattr__(self, "_input_dependencies", input_dependencies)
-        if name is not None:
-            object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_num_outputs", num_outputs)
+
+    @property
+    def name(self):
+        return self._name or self.__class__.__name__
 
     @property
     def num_outputs(self):

--- a/python/ray/data/tests/test_state_export.py
+++ b/python/ray/data/tests/test_state_export.py
@@ -91,11 +91,6 @@ class TestDataclass:
 class DummyLogicalOperator(LogicalOperator):
     """A dummy logical operator for testing _get_logical_args with various data types."""
 
-    _name: str = field(init=False, default="DummyOperator", repr=False)
-    _input_dependencies: List[LogicalOperator] = field(
-        init=False, default_factory=list, repr=False
-    )
-    _num_outputs: None = field(init=False, default=None, repr=False)
     _string_value: str = "test_string"
     _int_value: int = 42
     _float_value: float = 3.14
@@ -151,8 +146,12 @@ class DummyLogicalOperator(LogicalOperator):
     _data_class: TestDataclass = field(default_factory=TestDataclass)
 
     @property
+    def name(self):
+        return "DummyOperator"
+
+    @property
     def num_outputs(self):
-        return self._num_outputs
+        return None
 
 
 @pytest.fixture

--- a/python/ray/data/tests/unit/test_logical_plan.py
+++ b/python/ray/data/tests/unit/test_logical_plan.py
@@ -1,15 +1,25 @@
+from typing import Optional
+
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan
+from ray.data._internal.logical.rules.limit_pushdown import LimitPushdownRule
+from ray.data._internal.logical.rules.predicate_pushdown import PredicatePushdown
 from ray.data.context import DataContext
 
 
 class DummyLogicalOperator(LogicalOperator):
+    _name: Optional[str]
+    _num_outputs: Optional[int]
+
     def __init__(self, input_dependencies, name=None, num_outputs=None):
         super().__init__(
-            _num_outputs=num_outputs,
+            input_dependencies=input_dependencies,
         )
-        object.__setattr__(self, "_input_dependencies", input_dependencies)
-        if name is not None:
-            object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_name", name)
+        object.__setattr__(self, "_num_outputs", num_outputs)
+
+    @property
+    def name(self):
+        return self._name or self.__class__.__name__
 
     @property
     def num_outputs(self):
@@ -70,6 +80,26 @@ def test_logical_operator_transform_supports_custom_subclasses():
     assert transformed is not sink
     assert transformed.name == "sink"
     assert transformed.input_dependencies == [replacement]
+    assert sink.input_dependencies == [source]
+
+
+def test_rule_copy_fallback_supports_custom_subclasses():
+    source = DummyLogicalOperator([], name="source")
+    replacement = DummyLogicalOperator([], name="replacement")
+    sink = DummyLogicalOperator([source], name="sink")
+
+    predicate_result = PredicatePushdown._clone_op_with_new_inputs(sink, [replacement])
+    assert predicate_result is not sink
+    assert predicate_result.name == "sink"
+    assert predicate_result.input_dependencies == [replacement]
+    assert sink.input_dependencies == [source]
+
+    limit_result = LimitPushdownRule()._recreate_operator_with_new_input(
+        sink, replacement
+    )
+    assert limit_result is not sink
+    assert limit_result.name == "sink"
+    assert limit_result.input_dependencies == [replacement]
     assert sink.input_dependencies == [source]
 
 


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next cleanup in the `#60312` logical plan migration stack.

After `Operator` became a thin shared base, `LogicalOperator` can own logical dependencies directly through the public `input_dependencies` contract instead of keeping a separate logical `_input_dependencies` backing field.

#### What this PR changes:

Makes `LogicalOperator.input_dependencies` the canonical dataclass field for logical inputs and removes the logical `_input_dependencies` backing field.

Keeps `name` and `num_outputs` as public logical-operator contracts on `LogicalOperator`:
- `name` defaults to the class name, with derived-name operators overriding it through properties or fields.
- `num_outputs` defaults to `None`; operators with caller-provided output counts store it as a field, while derived output counts remain properties.

Updates the abstract logical map / one-to-one / all-to-all layers to accept `input_dependencies` directly instead of accepting `input_op` and converting it in parent constructors.

Stores one-to-one output counts through the public `num_outputs` field instead of `_num_outputs`. `Read` keeps a manual constructor so the existing positional `num_outputs` argument continues to work while still participating in the new field model.

Preserves the existing `_get_args()` export key shape, including `_name`, `_num_outputs`, `_input_dependencies`, and `_output_dependencies`, for state/export compatibility.

Preserves custom logical-operator fallback rewiring in limit and predicate pushdown by updating copied operators through the frozen-safe `input_dependencies` field.

This PR does not change physical operator storage, clean up broader logical-rule special-casing, or change equality/comparability semantics. Those remain separate follow-ups in the current split plan.

## Related issues

Part of #60312.

## Additional information

This PR corresponds to the logical field-model cleanup step in the current split plan.

### Tests

- `pre-commit run --files ...`
- Targeted logical plan, state export, limit pushdown, predicate pushdown, read-files logical, and operator fusion tests

### Stack Plan

Done:
- Convert remaining concrete logical operators to frozen dataclasses.
- Make logical abstract classes frozen dataclasses.
- Derive logical operator names from the base class.
- Replace single-input `input_op` InitVars with `input_dependencies`.
- Remove the one-to-one `input_dependency` convenience property.
- Clean up logical operator args export.
- Make `Operator` a thin shared base.
- Consolidate redundant logical operator repr/string logic.

This PR:
- Make logical operator fields canonical.

Next:
- Clean up special-casing in logical rules.
- Finish equality/comparability end-state.
