### PR TITLE
[data] DataSourceV2: V2 predicate splitting + consistency fixes

### DIFF
--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -27,6 +27,9 @@ from ray.data._internal.datasource_v2.listing.file_indexer import (
     NonSamplingFileIndexer,
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.readers.file_reader import (
+    INCLUDE_PATHS_COLUMN_NAME,
+)
 from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
     ParquetInMemorySizeEstimator,
 )
@@ -244,8 +247,11 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
                     pa_type = partition_pa_schema.field(field_name).type
                     schema = schema.append(pa.field(field_name, pa_type))
 
-        if self._include_paths and schema.get_field_index("path") == -1:
-            schema = schema.append(pa.field("path", pa.string()))
+        if (
+            self._include_paths
+            and schema.get_field_index(INCLUDE_PATHS_COLUMN_NAME) == -1
+        ):
+            schema = schema.append(pa.field(INCLUDE_PATHS_COLUMN_NAME, pa.string()))
 
         if self._include_row_hash:
             # ``row_hash`` is synthesized post-read as ``uint64``. Replace

--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -16,6 +16,11 @@ from ray.data.context import DataContext
 from ray.data.datasource.partitioning import Partitioning, PathPartitionParser
 from ray.util.annotations import DeveloperAPI
 
+# Synthetic column name produced when ``include_paths=True``. Shared with
+# the V2 datasource and scanner layers so all references are spelled the
+# same way.
+INCLUDE_PATHS_COLUMN_NAME = "path"
+
 # https://arrow.apache.org/docs/python/generated/pyarrow.dataset.Scanner.html#pyarrow.dataset.Scanner.from_batches
 # Default is specified by PyArrow.
 _ARROW_DEFAULT_BATCH_SIZE = 131_072
@@ -26,7 +31,7 @@ _ARROW_DEFAULT_BATCH_SIZE = 131_072
 # them).
 _ARROW_SCANNER_BATCH_READAHEAD = 1
 
-_ROW_HASH_COLUMN_NAME = "row_hash"
+ROW_HASH_COLUMN_NAME = "row_hash"
 
 
 class FileFormat(str, Enum):
@@ -138,13 +143,13 @@ class FileReader(Reader[FileManifest]):
             if self._partition_parser is not None
             else set()
         )
-        synthesized = {"path"}
+        synthesized = {INCLUDE_PATHS_COLUMN_NAME}
         if self._include_row_hash:
             # ``row_hash`` is synthesized post-read, and the schema's type
             # (``uint64``) may not match the on-disk column's type when a
             # file already carries a ``row_hash`` column. Strip it from the
             # dataset schema so pyarrow doesn't try to cast.
-            synthesized.add(_ROW_HASH_COLUMN_NAME)
+            synthesized.add(ROW_HASH_COLUMN_NAME)
         fields = [
             f
             for f in self._schema
@@ -246,7 +251,7 @@ class FileReader(Reader[FileManifest]):
             if self._partition_parser is not None:
                 derived_items.extend(self._partition_parser(fragment_path).items())
             if self._include_paths:
-                derived_items.append(("path", fragment_path))
+                derived_items.append((INCLUDE_PATHS_COLUMN_NAME, fragment_path))
 
             for name, value in derived_items:
                 if (
@@ -269,15 +274,15 @@ class FileReader(Reader[FileManifest]):
             # exclude ``row_hash`` — the projection below would just drop it.
             if self._include_row_hash and (
                 columns_to_synthesize is None
-                or _ROW_HASH_COLUMN_NAME in columns_to_synthesize
+                or ROW_HASH_COLUMN_NAME in columns_to_synthesize
             ):
                 hashes = _compute_row_hashes(
                     fragment_path, fragment_row_offset, table.num_rows
                 )
-                if _ROW_HASH_COLUMN_NAME in table.column_names:
-                    table = table.drop([_ROW_HASH_COLUMN_NAME])
+                if ROW_HASH_COLUMN_NAME in table.column_names:
+                    table = table.drop([ROW_HASH_COLUMN_NAME])
                 table = table.append_column(
-                    _ROW_HASH_COLUMN_NAME, pa.array(hashes, type=pa.uint64())
+                    ROW_HASH_COLUMN_NAME, pa.array(hashes, type=pa.uint64())
                 )
 
             if self._columns is not None:

--- a/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
@@ -6,6 +6,10 @@ import pyarrow as pa
 from ray.data._internal.datasource.parquet_datasource import (
     check_for_legacy_tensor_type,
 )
+from ray.data._internal.datasource_v2.readers.file_reader import (
+    INCLUDE_PATHS_COLUMN_NAME,
+    ROW_HASH_COLUMN_NAME,
+)
 from ray.data._internal.datasource_v2.readers.parquet_file_reader import (
     ParquetFileReader,
 )
@@ -31,12 +35,28 @@ class ParquetScanner(ArrowFileScanner):
     include_row_hash: bool = False
 
     def read_schema(self) -> pa.Schema:
-        """Return schema after column pruning and tensor check."""
+        """Return schema after column pruning and tensor check.
+
+        ``path`` and ``row_hash`` are synthesized post-read by the file
+        reader, but only for columns listed in ``self.columns`` (see
+        ``file_reader.read``'s ``columns_to_synthesize`` filter). When a
+        projection has pruned a synthesized column away, advertising it
+        here would put the schema out of sync with the actual blocks — so
+        only append when no projection is active or when it survives.
+        """
         schema = super().read_schema()
-        if self.include_paths and schema.get_field_index("path") == -1:
-            schema = schema.append(pa.field("path", pa.string()))
-        if self.include_row_hash and schema.get_field_index("row_hash") == -1:
-            schema = schema.append(pa.field("row_hash", pa.uint64()))
+        synthesized = (
+            (self.include_paths, INCLUDE_PATHS_COLUMN_NAME, pa.string()),
+            (self.include_row_hash, ROW_HASH_COLUMN_NAME, pa.uint64()),
+        )
+        for enabled, name, dtype in synthesized:
+            if not enabled:
+                continue
+            if self.columns is not None and name not in self.columns:
+                continue
+            if schema.get_field_index(name) != -1:
+                continue
+            schema = schema.append(pa.field(name, dtype))
 
         check_for_legacy_tensor_type(schema)
         return schema

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -1,7 +1,7 @@
 import functools
 import math
 from dataclasses import InitVar, dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Union
 
 from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.logical.interfaces import (
@@ -262,7 +262,6 @@ class ReadFiles(
     parallelism: int
     ray_remote_args: Dict[str, Any] = field(default_factory=dict)
     compute: Optional[ComputeStrategy] = None
-    detected_parallelism: Optional[int] = None
     # ``old_name → new_name`` for any columns the projection pushdown rule
     # renamed. The scanner only knows original names; renames are applied
     # in ``plan_read_files_op`` after each block is read.
@@ -307,14 +306,6 @@ class ReadFiles(
             target = replace(self, input_op=transformed_input)
         return transform(target)
 
-    def set_detected_parallelism(self, parallelism: int) -> "ReadFiles":
-        return replace(
-            self, input_op=self.input_dependency, detected_parallelism=parallelism
-        )
-
-    def get_detected_parallelism(self) -> Optional[int]:
-        return self.detected_parallelism
-
     def infer_schema(self) -> "pa.Schema":
         # Scanner schema reflects any applied projection pushdown
         # (``scanner.prune_columns`` / empty projection from
@@ -353,13 +344,6 @@ class ReadFiles(
         try to pre-estimate.
         """
         return BlockMetadata(None, None, None, None)
-
-    def estimate_in_memory_size(self) -> Optional[int]:
-        """Used by ``SetReadParallelismRule``. Returns ``None`` now — the
-        upstream ``ListFiles`` op computes balanced buckets via
-        ``RoundRobinPartitioner`` at execution time, so the rule's
-        size-based parallelism heuristic is no longer load-bearing."""
-        return None
 
     def supports_projection_pushdown(self) -> bool:
         from ray.data._internal.datasource_v2.logical_optimizers import (
@@ -427,31 +411,56 @@ class ReadFiles(
     def get_current_predicate(self) -> Optional[Expr]:
         return getattr(self.scanner, "predicate", None)
 
-    def apply_predicate(self, predicate_expr: Expr) -> "ReadFiles":
+    def apply_predicate(self, predicate_expr: Expr) -> LogicalOperator:
+        from ray.data._internal.datasource.parquet_datasource import (
+            _split_predicate_by_columns,
+        )
         from ray.data._internal.datasource_v2.logical_optimizers import (
             SupportsFilterPushdown,
             SupportsPartitionPruning,
         )
-        from ray.data._internal.planner.plan_expression.expression_visitors import (
-            get_column_references,
-        )
+        from ray.data._internal.logical.operators.map_operator import Filter
 
         assert isinstance(self.scanner, SupportsFilterPushdown)
 
-        # Skip pushdown if the predicate references any partition column:
-        # ``push_filters`` passes the expression to pyarrow's scanner, which
-        # can only bind on-disk columns. Splitting the predicate into
-        # data- and partition-column conjuncts (then routing each through
-        # ``push_filters`` / ``prune_partitions``) is a follow-up; for
-        # now the rule keeps the ``Filter`` above ``ReadFiles`` when we
-        # return ``self`` unchanged, so correctness is preserved.
-        if isinstance(self.scanner, SupportsPartitionPruning):
-            referenced = set(get_column_references(predicate_expr))
-            if referenced & self.scanner.partition_columns:
-                return self
+        partition_cols: Set[str] = (
+            self.scanner.partition_columns
+            if isinstance(self.scanner, SupportsPartitionPruning)
+            else set()
+        )
 
-        new_scanner, _residual = self.scanner.push_filters(predicate_expr)
-        return replace(self, input_op=self.input_dependency, scanner=new_scanner)
+        if not partition_cols:
+            new_scanner, _residual = self.scanner.push_filters(predicate_expr)
+            return replace(self, input_op=self.input_dependency, scanner=new_scanner)
+
+        split = _split_predicate_by_columns(predicate_expr, partition_cols)
+
+        if split.data_predicate is None and split.partition_predicate is None:
+            # Entire predicate is residual (e.g. a single mixed-column
+            # ``OR``); nothing safe to push. Returning ``self`` tells
+            # ``PredicatePushdown`` to keep the ``Filter`` above us.
+            return self
+
+        new_scanner = self.scanner
+        if split.partition_predicate is not None:
+            new_scanner = new_scanner.prune_partitions(split.partition_predicate)
+        if split.data_predicate is not None:
+            new_scanner, _residual = new_scanner.push_filters(split.data_predicate)
+
+        new_op = replace(self, input_op=self.input_dependency, scanner=new_scanner)
+
+        if split.residual_predicate is None:
+            return new_op
+
+        # Residual conjuncts can't be pushed through either ``push_filters``
+        # (pyarrow only binds data columns) or ``prune_partitions`` (path
+        # parser only binds partition columns), so re-emit them as a
+        # ``Filter`` above the new ``ReadFiles``. Without this, we'd keep
+        # the splittable parts and silently drop the residual — letting
+        # rows through that the original predicate would have rejected.
+        return Filter(
+            predicate_expr=split.residual_predicate, input_dependencies=[new_op]
+        )
 
 
 @dataclass(frozen=True, repr=False, eq=False)

--- a/python/ray/data/_internal/logical/operators/tests/test_read_files_logical.py
+++ b/python/ray/data/_internal/logical/operators/tests/test_read_files_logical.py
@@ -7,8 +7,14 @@ op so ``ReadFiles`` (which now has one input dependency) can be
 constructed.
 """
 
+import os
+from pathlib import Path
+from typing import Optional, Union
+
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
+import pytest
 
 from ray.data._internal.datasource_v2.listing.file_indexer import (
     NonSamplingFileIndexer,
@@ -22,15 +28,16 @@ from ray.data._internal.datasource_v2.parquet_datasource_v2 import (
 from ray.data._internal.datasource_v2.scanners.parquet_scanner import (
     ParquetScanner,
 )
-from ray.data._internal.logical.operators import ListFiles, ReadFiles
-from ray.data.expressions import col
+from ray.data._internal.logical.operators import Filter, ListFiles, ReadFiles
+from ray.data.datasource.partitioning import Partitioning, PartitionStyle
+from ray.data.expressions import Expr, col
 
 
-def _mk_parquet(path, table):
+def _mk_parquet(path: Path, table: pa.Table) -> None:
     pq.write_table(table, str(path))
 
 
-def _mk_read_files(tmp_path) -> ReadFiles:
+def _mk_read_files(tmp_path: Path) -> ReadFiles:
     f = tmp_path / "data.parquet"
     _mk_parquet(f, pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]}))
 
@@ -39,6 +46,39 @@ def _mk_read_files(tmp_path) -> ReadFiles:
     sample = sample_files(indexer, datasource.paths, datasource.filesystem)
     schema = datasource.infer_schema(sample)
     scanner = datasource.create_scanner(schema=schema)
+
+    list_files_op = ListFiles(
+        paths=list(datasource.paths),
+        file_indexer=indexer,
+        filesystem=datasource.filesystem,
+        source_paths=list(datasource.paths),
+        file_extensions=datasource.file_extensions,
+    )
+
+    return ReadFiles(
+        input_op=list_files_op,
+        datasource_name=datasource.name,
+        scanner=scanner,
+        schema=schema,
+        parallelism=-1,
+    )
+
+
+def _mk_partitioned_read_files(tmp_path: Path) -> ReadFiles:
+    """Hive-partitioned dataset with partition column ``country``."""
+    for country, value in (("US", 1), ("CA", 2)):
+        d = tmp_path / f"country={country}"
+        os.makedirs(d, exist_ok=True)
+        _mk_parquet(d / "data.parquet", pa.table({"a": [value], "b": [str(value)]}))
+
+    partitioning = Partitioning(
+        PartitionStyle.HIVE, base_dir=str(tmp_path), field_names=["country"]
+    )
+    datasource = ParquetDatasourceV2([str(tmp_path)], partitioning=partitioning)
+    indexer = NonSamplingFileIndexer(ignore_missing_paths=False)
+    sample = sample_files(indexer, datasource.paths, datasource.filesystem)
+    schema = datasource.infer_schema(sample)
+    scanner = datasource.create_scanner(schema=schema, partitioning=partitioning)
 
     list_files_op = ListFiles(
         paths=list(datasource.paths),
@@ -89,14 +129,88 @@ def test_apply_projection_none_is_noop(tmp_path):
     assert op.apply_projection(None) is op
 
 
-def test_supports_and_apply_predicate_pushdown(tmp_path):
-    op = _mk_read_files(tmp_path)
-    assert op.supports_predicate_pushdown() is True
+def test_supports_predicate_pushdown(tmp_path):
+    assert _mk_read_files(tmp_path).supports_predicate_pushdown() is True
 
-    new_op = op.apply_predicate(col("a") > 1)
-    assert new_op is not op
-    assert isinstance(new_op.scanner, ParquetScanner)
-    assert new_op.scanner.predicate is not None
-    # Original scanner untouched
-    assert isinstance(op.scanner, ParquetScanner)
-    assert op.scanner.predicate is None
+
+def _assert_pred_equals(
+    actual: Optional[Union[Expr, pc.Expression]], expected: Optional[Expr]
+) -> None:
+    if expected is None:
+        assert actual is None
+        return
+    assert actual is not None
+    # ``ArrowFileScanner.push_filters`` stores the data predicate as a
+    # ``pc.Expression`` (via ``.to_pyarrow()``), while ``partition_predicate``
+    # stays a Ray ``Expr``. Dispatch on which we got.
+    if isinstance(actual, Expr):
+        assert actual.structurally_equals(expected)
+    else:
+        assert actual.equals(expected.to_pyarrow())
+
+
+@pytest.mark.parametrize(
+    "partitioned,predicate,expected_data,expected_partition",
+    [
+        (False, col("a") > 1, col("a") > 1, None),
+        (True, col("country") == "US", None, col("country") == "US"),
+        (
+            True,
+            (col("a") > 0) & (col("country") == "US"),
+            col("a") > 0,
+            col("country") == "US",
+        ),
+    ],
+    ids=["data_only", "partition_only", "mixed_and"],
+)
+def test_apply_predicate_splits_data_and_partition(
+    tmp_path, partitioned, predicate, expected_data, expected_partition
+):
+    op = (_mk_partitioned_read_files if partitioned else _mk_read_files)(tmp_path)
+
+    new_op = op.apply_predicate(predicate)
+
+    assert isinstance(new_op, ReadFiles) and new_op is not op
+    new_scanner = new_op.scanner
+    assert isinstance(new_scanner, ParquetScanner)
+    _assert_pred_equals(new_scanner.predicate, expected_data)
+    _assert_pred_equals(new_scanner.partition_predicate, expected_partition)
+    # Original scanner untouched.
+    orig_scanner = op.scanner
+    assert isinstance(orig_scanner, ParquetScanner)
+    assert orig_scanner.predicate is None
+    assert orig_scanner.partition_predicate is None
+
+
+def test_apply_predicate_mixed_or_keeps_filter_above(tmp_path):
+    op = _mk_partitioned_read_files(tmp_path)
+
+    # Mixed-column ``OR`` can't be safely split — neither bucket is
+    # populated, so ``apply_predicate`` returns ``self`` and the rule
+    # leaves the ``Filter`` above ``ReadFiles`` untouched.
+    result = op.apply_predicate((col("a") > 0) | (col("country") == "US"))
+    assert result is op
+
+
+def test_apply_predicate_mixed_and_with_unsplittable_residual(tmp_path):
+    op = _mk_partitioned_read_files(tmp_path)
+
+    # Top-level ``AND`` of one pure-data, one pure-partition, and one
+    # mixed-OR conjunct: the first two push, the OR stays as a residual
+    # ``Filter`` so we don't silently drop it.
+    pure_data = col("a") > 0
+    pure_partition = col("country") == "US"
+    mixed_or = (col("a") < 100) | (col("country") == "CA")
+
+    result = op.apply_predicate(pure_data & pure_partition & mixed_or)
+
+    assert isinstance(result, Filter)
+    new_read = result.input_dependencies[0]
+    assert isinstance(new_read, ReadFiles)
+    new_scanner = new_read.scanner
+    assert isinstance(new_scanner, ParquetScanner)
+    _assert_pred_equals(new_scanner.predicate, pure_data)
+    _assert_pred_equals(new_scanner.partition_predicate, pure_partition)
+    # The residual carried by the new Filter is exactly the mixed-OR
+    # conjunct that couldn't be pushed.
+    _assert_pred_equals(result.predicate_expr, mixed_or)

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -216,6 +216,21 @@ class PredicatePushdown(Rule):
             if result_op is input_op:
                 return filter_op
 
+            # If apply_predicate wrapped a residual in a Filter above the pushed-down
+            # op, that residual is in the original column namespace (we rewrote the
+            # whole predicate into it above). The pushed-down op still applies
+            # ``column_renames`` to its output blocks, so the Filter sees renamed
+            # columns at runtime — rebind the residual back to the renamed namespace.
+            if rename_map and isinstance(result_op, Filter):
+                inverse_rename_map = {new: old for old, new in rename_map.items()}
+                rebound = cls._substitute_predicate_columns(
+                    result_op.predicate_expr, inverse_rename_map
+                )
+                result_op = Filter(
+                    predicate_expr=rebound,
+                    input_dependencies=result_op.input_dependencies,
+                )
+
             # Otherwise, return the result without the filter (predicate was pushed down)
             return result_op
 

--- a/python/ray/data/_internal/logical/rules/set_read_parallelism.py
+++ b/python/ray/data/_internal/logical/rules/set_read_parallelism.py
@@ -6,7 +6,7 @@ from ray import available_resources as ray_available_resources
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.logical.interfaces import PhysicalPlan, Rule
-from ray.data._internal.logical.operators import Read, ReadFiles
+from ray.data._internal.logical.operators import Read
 from ray.data._internal.util import _autodetect_parallelism
 from ray.data.context import WARN_PREFIX, DataContext
 from ray.data.datasource.datasource import Datasource, Reader
@@ -40,7 +40,7 @@ def compute_additional_split_factor(
     if mem_size:
         expected_block_size = mem_size / num_read_tasks
         logger.debug(
-            f"Expected in-memory size {mem_size}," f" block size {expected_block_size}"
+            f"Expected in-memory size {mem_size}, block size {expected_block_size}"
         )
         if target_max_block_size is None:
             # Unlimited block size -> no extra splits
@@ -106,45 +106,11 @@ class SetReadParallelismRule(Rule):
             if isinstance(op, InputDataBuffer):
                 continue
             logical_op = plan.op_map[op]
-            if isinstance(logical_op, ReadFiles):
-                self._apply_v2(plan, op, logical_op)
-            elif isinstance(logical_op, Read):
+            if isinstance(logical_op, Read):
                 self._apply(plan, op, logical_op)
             ops += op.input_dependencies
 
         return plan
-
-    def _apply_v2(
-        self, plan: PhysicalPlan, op: PhysicalOperator, logical_op: ReadFiles
-    ):
-        """Set parallelism for a ``ReadFiles`` op using sample-extrapolated size.
-
-        ``ReadFiles`` defers file listing to physical execution, so we don't
-        know the true file count here. The driver has already cached a
-        sample via ``_read_datasource_v2``; we use it plus
-        ``ParquetInMemorySizeEstimator`` to produce an upper-bound
-        in-memory size, then let ``_autodetect_parallelism`` pick a block
-        count. ``scanner.plan()`` rebalances at execution time, so this is
-        a planning-time approximation.
-        """
-        ctx = DataContext.get_current()
-        mem_size = logical_op.estimate_in_memory_size()
-
-        detected_parallelism, reason, _ = _autodetect_parallelism(
-            logical_op.parallelism,
-            op.target_max_block_size_override or ctx.target_max_block_size,
-            ctx,
-            datasource_or_legacy_reader=None,
-            mem_size=mem_size,
-        )
-
-        if logical_op.parallelism == -1:
-            assert reason != ""
-            logger.debug(
-                f"Using autodetected parallelism={detected_parallelism} "
-                f"for operator {logical_op.name} to satisfy {reason}."
-            )
-        plan.op_map[op] = logical_op.set_detected_parallelism(detected_parallelism)
 
     def _apply(self, plan: PhysicalPlan, op: PhysicalOperator, logical_op: Read):
         estimated_in_mem_bytes = logical_op.infer_metadata().size_bytes

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1304,13 +1304,26 @@ def read_parquet(
         if columns is not None:
             # TODO(datasource-v2): remove `columns=` from `read_parquet` once
             # the projection-pushdown rule dispatches to `ReadFiles`. Callers
-            # should use `ray.data.read_parquet(path).select_columns([...])`
-            # — semantically equivalent on V1, and on V2 the pushdown rule
-            # will fold the projection into the scanner once it lands.
+            # should use `ray.data.read_parquet(path).select_columns([...])`.
+            #
+            # Caveat for the ``include_paths=True`` migration: V1
+            # ``columns=[...]`` implicitly retained the synthetic ``"path"``
+            # column (see ``ParquetDatasource.read_fragments`` /
+            # ``get_current_projection``), but ``select_columns([...])`` is
+            # literal and will drop ``"path"`` unless it's listed explicitly.
+            # Callers passing both must add ``"path"`` to their projection
+            # when migrating; the message below flags that case.
+            hint = (
+                " Note: when combined with `include_paths=True`, V1 implicitly"
+                " retained the `path` column — add `'path'` to your"
+                " `select_columns([...])` list to preserve it."
+                if include_paths
+                else ""
+            )
             raise NotImplementedError(
                 "`columns=` on `read_parquet` is deprecated on the DataSourceV2 "
                 "path. Use `ray.data.read_parquet(path).select_columns([...])` "
-                "instead."
+                "instead." + hint
             )
 
         from ray.data._internal.datasource_v2.parquet_datasource_v2 import (

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -126,9 +126,10 @@ def test_include_paths_with_column_projection(
     table = pa.Table.from_pydict({"animals": ["cat", "dog"], "id": [1, 2]})
     pq.write_table(table, path)
 
-    # Under V1, ``include_paths=True`` implicitly retained ``path`` through
-    # ``.select_columns``. V2 respects ``.select_columns`` literally — the
-    # caller must include ``"path"`` explicitly when they want it.
+    # V2 ``select_columns`` is literal — ``"path"`` is dropped unless listed.
+    # V1 ``read_parquet(columns=[...], include_paths=True)`` retained ``"path"``
+    # automatically; the ``columns=`` deprecation message in ``read_api`` calls
+    # this out so callers know to thread ``"path"`` through their projection.
     ds = ray.data.read_parquet(path, include_paths=True).select_columns(["id", "path"])
 
     schema_names = ds.schema().names

--- a/python/ray/data/tests/test_predicate_pushdown.py
+++ b/python/ray/data/tests/test_predicate_pushdown.py
@@ -22,6 +22,7 @@ from ray.data._internal.logical.operators import (
 )
 from ray.data._internal.logical.optimizers import LogicalOptimizer
 from ray.data._internal.util import rows_same
+from ray.data.datasource.partitioning import Partitioning
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.data.expressions import col
 from ray.data.tests.conftest import *  # noqa
@@ -310,19 +311,23 @@ def test_filter_mixed_expression_not_readfiles(ray_start_regular_shared):
         ),
         (
             # rename("sepal.length" -> a).filter(a).rename(a -> b)
-            lambda ds: ds.rename_columns({"sepal.length": "a"})
-            .filter(expr=col("a") > 2.0)
-            .rename_columns({"a": "b"}),
+            lambda ds: (
+                ds.rename_columns({"sepal.length": "a"})
+                .filter(expr=col("a") > 2.0)
+                .rename_columns({"a": "b"})
+            ),
             {"b": "sepal.length"},
             col("sepal.length") > 2.0,
             "rename_filter_rename",
         ),
         (
             # rename("sepal.length" -> a).filter(a).rename(a -> b).filter(b)
-            lambda ds: ds.rename_columns({"sepal.length": "a"})
-            .filter(expr=col("a") > 2.0)
-            .rename_columns({"a": "b"})
-            .filter(expr=col("b") < 5.0),
+            lambda ds: (
+                ds.rename_columns({"sepal.length": "a"})
+                .filter(expr=col("a") > 2.0)
+                .rename_columns({"a": "b"})
+                .filter(expr=col("b") < 5.0)
+            ),
             {"b": "sepal.length"},
             (col("sepal.length") > 2.0) & (col("sepal.length") < 5.0),
             "rename_filter_rename_filter",
@@ -330,11 +335,13 @@ def test_filter_mixed_expression_not_readfiles(ray_start_regular_shared):
         (
             # rename("sepal.length" -> a).filter(a).rename(a -> b).filter(b).rename("sepal.width" -> a)
             # Here column a is referred multiple times in rename
-            lambda ds: ds.rename_columns({"sepal.length": "a"})
-            .filter(expr=col("a") > 2.0)
-            .rename_columns({"a": "b"})
-            .filter(expr=col("b") < 5.0)
-            .rename_columns({"sepal.width": "a"}),
+            lambda ds: (
+                ds.rename_columns({"sepal.length": "a"})
+                .filter(expr=col("a") > 2.0)
+                .rename_columns({"a": "b"})
+                .filter(expr=col("b") < 5.0)
+                .rename_columns({"sepal.width": "a"})
+            ),
             {"b": "sepal.length", "a": "sepal.width"},
             (col("sepal.length") > 2.0) & (col("sepal.length") < 5.0),
             "rename_filter_rename_filter_rename",
@@ -589,6 +596,68 @@ class TestPassthroughWithSubstitutionBehavior:
         assert not plan_has_operator(
             optimized_plan, Filter
         ), "All filters should be fused, rebound, and pushed into Read"
+
+    def test_rename_with_partition_residual_filter(
+        self, ray_start_regular_shared, tmp_path
+    ):
+        """Residual Filter above a renamed ReadFiles must use renamed columns.
+
+        When a predicate mixes partition and data columns under OR, the
+        unsplittable part is wrapped in a Filter above the new ReadFiles by
+        ``ReadFiles.apply_predicate``. ``ReadFiles`` applies ``column_renames``
+        to its output blocks, so that residual Filter must reference renamed
+        columns at runtime — not the originals the scanner sees.
+        """
+        table = pa.table(
+            {
+                "partition_col": [1, 1, 2, 2, 3, 3],
+                "data1": [10, 20, 30, 40, 50, 60],
+                "data2": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            }
+        )
+        pq.write_to_dataset(
+            table, root_path=str(tmp_path), partition_cols=["partition_col"]
+        )
+
+        ds = (
+            ray.data.read_parquet(
+                str(tmp_path),
+                partitioning=Partitioning("hive", field_types={"partition_col": int}),
+            )
+            .rename_columns({"data1": "D1", "data2": "D2"})
+            .filter(
+                expr=((col("D1") > 25) | (col("partition_col") == 1))
+                & (col("D2") < 5.5)
+            )
+        )
+
+        # Equivalent plan without the rename, to validate row-level correctness.
+        expected = ray.data.read_parquet(
+            str(tmp_path),
+            partitioning=Partitioning("hive", field_types={"partition_col": int}),
+        ).filter(
+            expr=((col("data1") > 25) | (col("partition_col") == 1))
+            & (col("data2") < 5.5)
+        )
+
+        # The dataset must execute without binding errors and produce the
+        # expected rows (with renamed column names).
+        result = ds.to_pandas().rename(columns={"D1": "data1", "D2": "data2"})
+        assert rows_same(result, expected.to_pandas())
+
+        # A residual Filter should remain above the read, and its predicate
+        # must reference the renamed columns (``D1``), not the originals.
+        optimized_plan = LogicalOptimizer().optimize(ds._logical_plan)
+        residual_filters = get_operators_of_type(optimized_plan, Filter)
+        assert len(residual_filters) == 1, (
+            f"Expected one residual Filter above the read, got plan: "
+            f"{optimized_plan.dag.dag_str}"
+        )
+        residual_expr_str = str(residual_filters[0].predicate_expr)
+        assert "D1" in residual_expr_str and "data1" not in residual_expr_str, (
+            f"Residual Filter predicate should reference renamed column 'D1', "
+            f"got: {residual_expr_str}"
+        )
 
 
 class TestProjectionWithFilterEdgeCases:


### PR DESCRIPTION

## Summary

Five separable changes that finish the V2 predicate-pushdown story and shore up a few `include_paths` rough edges that surfaced alongside it.

### 1. `ReadFiles.apply_predicate` now splits predicates against partition columns

Previously `ReadFiles.apply_predicate` bailed out (`return self`) whenever the predicate referenced *any* partition column — so a perfectly pushable `data > 5 AND partition == "US"` was kept entirely above the read. Now it splits via `_split_predicate_by_columns`:

- pure-data conjuncts → `scanner.push_filters` (pyarrow scan-time filter)
- pure-partition conjuncts → `scanner.prune_partitions` (path-parser file pruning)
- unsplittable residuals (mixed-column OR, etc.) → wrapped in a `Filter` above the new `ReadFiles` so we don't silently drop rows

Single-bucket "entire predicate is residual" still returns `self` so the upstream `Filter` stays put.

### 2. Fix: residual Filter rebound to renamed namespace

`PredicatePushdown` rewrites predicates from renamed → original names before pushing, because the scanner only binds on-disk columns. But the residual that came back was *also* in original-name space — and `ReadFiles` applies `column_renames` to its output blocks, so the residual `Filter` was binding against columns that no longer exist at runtime.

Fix: after `apply_predicate` returns, if the result is a `Filter` and a rename map was applied, rebind the residual predicate back to the renamed namespace using the inverse map.

V1 (`Read.apply_predicate`) never wraps in a `Filter` (returns `self` or a new `Read`), so the `isinstance(result_op, Filter)` guard makes this a no-op for V1.

### 3. `include_paths` schema/projection consistency

- Extracted the synthetic path column name into `INCLUDE_PATHS_COLUMN_NAME` and threaded it through `file_reader`, `parquet_datasource_v2`, and `parquet_scanner` so every reference is spelled the same way.
- `ParquetScanner.read_schema` only advertises `"path"` when the projection actually keeps it — previously the schema claimed `"path"` even when `select_columns([...])` had pruned it away, leaving schema and blocks out of sync.

### 4. Migration caveat surfaced in `read_parquet`

V1 `read_parquet(columns=[...], include_paths=True)` implicitly retained `"path"`; V2 `select_columns([...])` is literal and drops it. The `columns=` deprecation message now hints at this when `include_paths=True` so users threading both don't lose `"path"` silently. Companion comment cleanup in `test_parquet.py`.

### 5. Dead-code cleanup in `set_read_parallelism`

Removed the V2 branch (`_apply_v2`) and the corresponding `detected_parallelism` field / accessors on `ReadFiles`. V2 reads autodetect parallelism elsewhere (driver-side via the cached sample); the physical-plan rule was never wired in.

## Test plan

- [x] `python/ray/data/_internal/logical/operators/tests/test_read_files_logical.py` — four new unit tests covering each branch of the new splitter: partition-only, mixed AND (splits cleanly), mixed OR (returns self), mixed AND with unsplittable residual (wraps in Filter).
- [x] `python/ray/data/tests/test_predicate_pushdown.py` — E2E regression for the rename + residual case: hive-partitioned parquet, `rename_columns({data1: D1, data2: D2})`, predicate `((D1 > 25) | (partition_col == 1)) & (D2 < 5.5)`. Asserts the dataset runs without binding errors, produces the expected rows, and the residual Filter in the optimized plan references `D1` (not `data1`).
- [ ] Full `test_predicate_pushdown.py` suite green
- [ ] Full `test_parquet.py` datasource suite green
