### PR TITLE
[core] Update outdated description for max_direct_call_object_size

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -244,10 +244,10 @@ RAY_CONFIG(int32_t, scheduler_top_k_absolute, 1);
 /// will become eligible for removal in the autoscaler.
 RAY_CONFIG(bool, scheduler_report_pinned_bytes_only, true)
 
-// Maximum size in bytes of a task return value that may be returned inline
-// in the task reply (and stored in the owner's in-memory store). Returns
-// larger than this are stored in plasma instead. Applies to all task types
-// (normal tasks, actor tasks, generators).
+/// Maximum size in bytes of a task return value that may be returned inline
+/// in the task reply (and stored in the owner's in-memory store). Return
+/// values larger than this are stored in plasma instead. Applies to all task
+/// types (normal tasks, actor tasks, generators).
 RAY_CONFIG(int64_t, max_direct_call_object_size, 100 * 1024)
 
 // The max gRPC message size (the gRPC internal default is 4MB). We use a higher

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -244,8 +244,10 @@ RAY_CONFIG(int32_t, scheduler_top_k_absolute, 1);
 /// will become eligible for removal in the autoscaler.
 RAY_CONFIG(bool, scheduler_report_pinned_bytes_only, true)
 
-// The max allowed size in bytes of a return object from direct actor calls.
-// Objects larger than this size will be spilled/promoted to plasma.
+// Maximum size in bytes of a task return value that may be returned inline
+// in the task reply (and stored in the owner's in-memory store). Returns
+// larger than this are stored in plasma instead. Applies to all task types
+// (normal tasks, actor tasks, generators).
 RAY_CONFIG(int64_t, max_direct_call_object_size, 100 * 1024)
 
 // The max gRPC message size (the gRPC internal default is 4MB). We use a higher


### PR DESCRIPTION
The description for max_direct_call_object_size is 7 years old and doesn't make sense as this bound applies to all task returns. I also don't like the use of "spilling to plasma" as spilling also mean something very different in ray. 