### PR TITLE
[Core] Update python event interface to use new asio target

### DIFF
--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -177,7 +177,7 @@ ray_cc_library(
         ":metrics",
         ":ray_event_interface",
         ":ray_event_recorder",
-        "//src/ray/common:asio",
+        "//src/ray/asio:instrumented_io_context",
         "//src/ray/common:grpc_util",
         "//src/ray/common:id",
         "//src/ray/common:status",

--- a/src/ray/observability/python_event_interface.h
+++ b/src/ray/observability/python_event_interface.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "absl/time/time.h"
-#include "ray/common/asio/instrumented_io_context.h"
+#include "ray/asio/instrumented_io_context.h"
 #include "ray/observability/ray_event_interface.h"
 #include "ray/observability/ray_event_recorder.h"
 #include "ray/rpc/event_aggregator_client.h"


### PR DESCRIPTION
## Description
Core fails to build binaries in [microcheck](https://buildkite.com/ray-project/microcheck/builds/44977#019dff0a-0312-4363-8a6f-7ac5c74513aa) right now due to a newly merged PR using an out of date asio target. 

Specifically, this PR moved the asio build target: https://github.com/ray-project/ray/pull/63042
This PR introduced a new file that uses the out-of-date target: https://github.com/ray-project/ray/pull/60858

This PR addresses this issue by updating the out-of-date `python_event_interface.h` to use the new target.

## Related issues

## Additional information
