### PR TITLE
[data] DataSourceV2: supports_distributed_reads / local-scheme handling

### DIFF
--- a/python/ray/data/_internal/datasource_v2/datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/datasource_v2.py
@@ -97,6 +97,12 @@ class DataSourceV2(ABC, Generic[InputSplit]):
         """
         self._name = name
         self._category = category
+        # File-based subclasses set this to ``False`` in their ``__init__``
+        # when the user-supplied paths are in the ``local://`` scheme —
+        # the driver node is the only one that can read those files.
+        # ``_read_datasource_v2`` consults the flag to decide whether to
+        # pin read tasks via a ``label_selector``.
+        self._supports_distributed_reads: bool = True
 
     @property
     def name(self) -> str:
@@ -107,6 +113,18 @@ class DataSourceV2(ABC, Generic[InputSplit]):
     def category(self) -> DatasourceCategory:
         """Category of this datasource."""
         return self._category
+
+    @property
+    def supports_distributed_reads(self) -> bool:
+        """Whether read tasks may run on any cluster node.
+
+        Defaults to ``True``. File-based subclasses (e.g.
+        :class:`ParquetDatasourceV2`) flip this to ``False`` when the
+        user supplies ``local://``-scheme paths so ``_read_datasource_v2``
+        can pin reads to the driver node via a ``ray.io/node-id``
+        label selector. Mirrors V1 ``Datasource.supports_distributed_reads``.
+        """
+        return self._supports_distributed_reads
 
     def _get_file_indexer(self) -> Optional[FileIndexer]:
         """Return FileIndexer component if applicable.

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -31,6 +31,7 @@ from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
     ParquetInMemorySizeEstimator,
 )
 from ray.data._internal.datasource_v2.scanners.parquet_scanner import ParquetScanner
+from ray.data._internal.util import _is_local_scheme
 from ray.data.context import DataContext
 from ray.data.datasource.partitioning import (
     Partitioning,
@@ -72,6 +73,13 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         schema: Optional[pa.Schema] = None,
     ):
         super().__init__(name="ParquetV2", category=DatasourceCategory.FILE_BASED)
+        # Capture the ``local://`` check against the *original* paths;
+        # ``_resolve_paths_and_filesystem`` below strips the scheme, so
+        # introspecting ``self._paths`` after construction can't tell a
+        # plain local path from a ``local://`` one. ``_supports_distributed_reads``
+        # is exposed by the base-class ``supports_distributed_reads``
+        # property and consumed by ``_read_datasource_v2``.
+        self._supports_distributed_reads = not _is_local_scheme(paths)
         resolved_paths, resolved_filesystem = _resolve_paths_and_filesystem(
             paths, filesystem
         )

--- a/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
@@ -1,17 +1,13 @@
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Literal, Optional, Union
+from typing import Literal, Union
 
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.scanners.scanner import Scanner
-from ray.data._internal.util import _is_local_scheme
 from ray.data.datasource.file_based_datasource import (
     FileShuffleConfig,
     _validate_shuffle_arg,
 )
 from ray.util.annotations import DeveloperAPI
-
-if TYPE_CHECKING:
-    from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 
 @DeveloperAPI
@@ -48,34 +44,3 @@ class FileScanner(Scanner[FileManifest]):
         :func:`plan_read_files_op.do_read`.
         """
         return manifest
-
-    @staticmethod
-    def compute_local_scheduling(
-        paths: Union[str, List[str]],
-    ) -> Optional["NodeAffinitySchedulingStrategy"]:
-        """Return a node-affinity scheduling strategy for local-scheme reads.
-
-        When paths point to a local filesystem, pin read tasks to the driver
-        node with hard affinity so they can access those files. Returns
-        ``None`` for remote paths, which any node can read. Raises under Ray
-        Client because cluster nodes can't see the driver's local files.
-        """
-        import ray
-        import ray.util.client
-
-        if not _is_local_scheme(paths):
-            return None
-
-        if ray.util.client.ray.is_connected():
-            raise ValueError(
-                "Because you're using Ray Client, read tasks scheduled on the "
-                "Ray cluster can't access your local files. To fix this issue, "
-                "store files in cloud storage or a distributed filesystem like "
-                "NFS."
-            )
-
-        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
-
-        return NodeAffinitySchedulingStrategy(
-            ray.get_runtime_context().get_node_id(), soft=False
-        )

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -390,6 +390,52 @@ def range_tensor(
     )
 
 
+def _resolve_read_remote_args(
+    datasource: Datasource,
+    ray_remote_args: Optional[Dict[str, Any]],
+    num_cpus: Optional[float],
+    num_gpus: Optional[float],
+    memory: Optional[float],
+    ctx: DataContext,
+) -> Dict[str, Any]:
+    """Common ``ray_remote_args`` setup shared between ``read_datasource`` and
+    ``_read_datasource_v2``.
+
+    Local-scheme reads (``local://...``) must run on the driver so tasks can
+    see the driver's filesystem. We use the ``ray.io/node-id`` label selector
+    rather than ``NodeAffinitySchedulingStrategy(soft=False)`` — matches the
+    Ray-wide migration in PR #54940. ``supports_distributed_reads`` is
+    captured on the datasource against the original (pre-resolution) paths,
+    so the check survives the scheme-stripping done by
+    ``_resolve_paths_and_filesystem``.
+
+    Callers handle datasource-specific guards (Ray Client rejection,
+    ``_validate_head_node_resources_for_local_scheduling``) themselves since
+    they sit in different positions in the V1 and V2 flows.
+    """
+    if ray_remote_args is None:
+        ray_remote_args = {}
+    if not datasource.supports_distributed_reads:
+        label_selector = ray_remote_args.get("label_selector", {})
+        label_selector[
+            ray._raylet.RAY_NODE_ID_KEY
+        ] = ray.get_runtime_context().get_node_id()
+        ray_remote_args["label_selector"] = label_selector
+        ray_remote_args.pop("scheduling_strategy", None)
+    if (
+        "scheduling_strategy" not in ray_remote_args
+        and "label_selector" not in ray_remote_args
+    ):
+        ray_remote_args["scheduling_strategy"] = ctx.scheduling_strategy
+    return merge_resources_to_ray_remote_args(
+        num_cpus,
+        num_gpus,
+        memory,
+        ray_remote_args,
+    )
+
+
+@wrap_auto_init
 def _read_datasource_v2(
     datasource,
     *,
@@ -418,12 +464,8 @@ def _read_datasource_v2(
     """
     import time
 
-    from ray.data._internal.datasource_v2.listing.file_pruners import (
-        FileExtensionPruner,
-        FilePruner,
-        PartitionPruner,
-    )
     from ray.data._internal.datasource_v2.listing.listing_utils import (
+        _build_pruners,
         sample_files,
     )
     from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner import (
@@ -433,24 +475,27 @@ def _read_datasource_v2(
 
     ctx = DataContext.get_current()
 
-    if ray_remote_args is None:
-        ray_remote_args = {}
+    if not datasource.supports_distributed_reads:
+        import ray.util.client
 
-    if "scheduling_strategy" not in ray_remote_args and (
-        "label_selector" not in ray_remote_args
-    ):
-        ray_remote_args["scheduling_strategy"] = ctx.scheduling_strategy
+        if ray.util.client.ray.is_connected():
+            raise ValueError(
+                "Because you're using Ray Client, read tasks scheduled on the "
+                "Ray cluster can't access your local files. To fix this issue, "
+                "store files in cloud storage or a distributed filesystem like "
+                "NFS."
+            )
 
-    ray_remote_args = merge_resources_to_ray_remote_args(
+    ray_remote_args = _resolve_read_remote_args(
+        datasource,
+        ray_remote_args,
         num_cpus,
         num_gpus,
         memory,
-        ray_remote_args,
+        ctx,
     )
 
-    pruners: List[FilePruner] = [FileExtensionPruner(datasource.file_extensions)]
-    if partition_filter is not None:
-        pruners.append(PartitionPruner(partition_filter))
+    pruners = _build_pruners(datasource.file_extensions, partition_filter)
 
     indexer = datasource._get_file_indexer()
 
@@ -610,28 +655,13 @@ def read_datasource(
 
     ctx = DataContext.get_current()
 
-    if ray_remote_args is None:
-        ray_remote_args = {}
-
-    if not datasource.supports_distributed_reads:
-        label_selector = ray_remote_args.get("label_selector", {})
-        label_selector[
-            ray._raylet.RAY_NODE_ID_KEY
-        ] = ray.get_runtime_context().get_node_id()
-        ray_remote_args["label_selector"] = label_selector
-        ray_remote_args.pop("scheduling_strategy", None)
-
-    if (
-        "scheduling_strategy" not in ray_remote_args
-        and "label_selector" not in ray_remote_args
-    ):
-        ray_remote_args["scheduling_strategy"] = ctx.scheduling_strategy
-
-    ray_remote_args = merge_resources_to_ray_remote_args(
+    ray_remote_args = _resolve_read_remote_args(
+        datasource,
+        ray_remote_args,
         num_cpus,
         num_gpus,
         memory,
-        ray_remote_args,
+        ctx,
     )
 
     if not datasource.supports_distributed_reads:
@@ -1175,9 +1205,8 @@ def read_parquet(
             # row filtering down to the file scan.
             ds = ray.data.read_parquet(
                 "s3://anonymous@ray-example-data/iris.parquet",
-                columns=["sepal.length", "variety"],
                 filter=pa.dataset.field("sepal.length") > 5.0,
-            )
+            ).select_columns(["sepal.length", "variety"])
 
             ds.show(2)
 

--- a/python/ray/data/tests/test_limit_operator.py
+++ b/python/ray/data/tests/test_limit_operator.py
@@ -135,11 +135,13 @@ def test_limit_operator_memory_leak_fix(ray_start_regular_shared, tmp_path):
         total_rows == 5
     ), f"Expected exactly 5 rows after limit(5), but got {total_rows}"
 
-    # Find the ReadParquet operator's OpState
+    # Find the parquet read operator's OpState. Covers both the V1
+    # ``ReadParquet`` op name and the V2 ``ReadFilesParquet{V2,}`` name
+    # under the ``DataContext.use_datasource_v2`` path.
     topology = executor._topology
     read_parquet_op_state = None
     for op, op_state in topology.items():
-        if "ReadParquet" in op.name:
+        if "Parquet" in op.name and ("Read" in op.name or "ReadFiles" in op.name):
             read_parquet_op_state = op_state
             break
 


### PR DESCRIPTION

Pin V2 reads to the driver when ``local://`` is used so cluster
nodes don't try to read driver-local files — V1 parity.

- datasource_v2/datasource_v2.py: ``supports_distributed_reads``
  property on the base class plus a ``_supports_distributed_reads``
  attr (default ``True``) so subclasses can flip it. Mirrors V1
  ``Datasource.supports_distributed_reads``.
- datasource_v2/parquet_datasource_v2.py: capture
  ``_is_local_scheme(paths)`` against the *original* user-supplied
  paths in ``__init__`` (before ``_resolve_paths_and_filesystem``
  strips the scheme), and flip ``_supports_distributed_reads``
  accordingly.
- datasource_v2/scanners/file_scanner.py: drop the now-unused
  ``compute_local_scheduling`` helper. Local-read pinning flows
  entirely through the datasource property and
  ``_read_datasource_v2``.
- read_api.py: extract ``_resolve_read_remote_args`` shared by
  ``read_datasource`` (V1) and ``_read_datasource_v2`` (V2) — the
  label_selector` keyed by ``ray._raylet.RAY_NODE_ID_KEY``
  (label-selector API per PR #54940), ``scheduling_strategy`` drop,
  and ``merge_resources_to_ray_remote_args``.
  ``_read_datasource_v2`` raises the V1
  ``ValueError`` under Ray Client because cluster nodes can't see
  driver-local files; V1 keeps its
  ``_validate_head_node_resources_for_local_scheduling`` call.
- tests/test_limit_operator.py: match both ``ReadParquet`` (V1)
  and ``ReadFilesParquetV2`` (V2) op names.

Signed-off-by: Goutam <goutam@anyscale.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
