### PR TITLE
[data] V1 _split_predicate_by_columns correctness fix

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -196,71 +196,83 @@ class _SplitPredicateResult:
     """Result of splitting a predicate by column type.
 
     Attributes:
-        data_predicate: Expression containing only data column predicates
-            (for PyArrow pushdown), or None if no data predicates exist.
-        partition_predicate: Expression containing only partition column predicates
-            (for partition pruning), or None if no partition predicates exist.
+        data_predicate: Conjuncts referencing only data columns (for PyArrow
+            pushdown), or None if none could be extracted.
+        partition_predicate: Conjuncts referencing only partition columns
+            (for partition pruning), or None if none could be extracted.
+        residual_predicate: Conjuncts that mix partition and data columns
+            and can't be split safely (e.g. an ``OR`` straddling both
+            kinds). The caller must keep these as a ``Filter`` above the
+            read; dropping them would over-include rows.
     """
 
     data_predicate: Optional[Expr]
     partition_predicate: Optional[Expr]
+    residual_predicate: Optional[Expr]
 
 
 def _split_predicate_by_columns(
     predicate: Expr,
     partition_columns: set,
 ) -> _SplitPredicateResult:
-    """Split a predicate into data-only and partition-only parts.
+    """Split a predicate into data, partition, and residual parts.
 
-    This function extracts both data column predicates and partition column
-    predicates from AND chains, enabling both PyArrow pushdown (data part) and
-    partition pruning (partition part).
+    This function walks the top-level ``AND`` chain and classifies each
+    conjunct by the columns it references:
+
+    - References only data columns (or none) → data bucket; pyarrow can
+      evaluate it at scan time.
+    - References only partition columns → partition bucket; the partition
+      parser can evaluate it from file paths.
+    - References both kinds (i.e. a non-``AND`` whose column set spans
+      both) → residual bucket; semantics-preserving splitting is
+      impossible (e.g. ``data > 5 OR partition == "US"``), so the caller
+      must keep these as a ``Filter`` above the read.
 
     Args:
         predicate: The predicate expression to analyze.
         partition_columns: Set of partition column names.
 
     Returns:
-        _SplitPredicateResult containing:
-        - data_predicate: Expression with only data columns (for PyArrow pushdown),
-          or None if no data predicates can be extracted.
-        - partition_predicate: Expression with only partition columns (for pruning),
-          or None if no partition predicates can be extracted.
+        :class:`_SplitPredicateResult` with the three buckets. Combining
+        ``data_predicate``, ``partition_predicate``, and
+        ``residual_predicate`` with ``AND`` reproduces the original
+        predicate exactly.
 
     Examples:
         >>> from ray.data.expressions import col
         >>> # Pure data predicate:
         >>> result = _split_predicate_by_columns(col("data1") > 5, {"partition_col"})
-        >>> result.data_predicate is not None  # Should have data predicate
+        >>> result.data_predicate is not None
         True
-        >>> result.partition_predicate is None  # Should not have partition predicate
+        >>> result.partition_predicate is None and result.residual_predicate is None
         True
 
         >>> # Pure partition predicate:
         >>> result = _split_predicate_by_columns(col("partition_col") == "US", {"partition_col"})
-        >>> result.data_predicate is None  # Should not have data predicate
+        >>> result.partition_predicate is not None
         True
-        >>> result.partition_predicate is not None  # Should have partition predicate
+        >>> result.data_predicate is None and result.residual_predicate is None
         True
 
-        >>> # Mixed AND - can split both parts:
+        >>> # Mixed AND - can split into data and partition parts:
         >>> result = _split_predicate_by_columns(
         ...     (col("data1") > 5) & (col("partition_col") == "US"),
         ...     {"partition_col"}
         ... )
-        >>> result.data_predicate is not None  # Should have data predicate
+        >>> result.data_predicate is not None and result.partition_predicate is not None
         True
-        >>> result.partition_predicate is not None  # Should have partition predicate
+        >>> result.residual_predicate is None
         True
 
-        >>> # Mixed OR - can't split safely:
+        >>> # Mixed OR - kept as residual; caller wraps it in a Filter above:
         >>> result = _split_predicate_by_columns(
         ...     (col("data1") > 5) | (col("partition_col") == "US"),
         ...     {"partition_col"}
         ... )
-        >>> result.data_predicate is None  # Should not have data predicate
+        >>> result.data_predicate is None and result.partition_predicate is None
         True
-        >>> result.partition_predicate is None  # Should not have partition predicate
+        >>> result.residual_predicate is not None
         True
     """
     referenced_cols = set(get_column_references(predicate))
@@ -268,20 +280,26 @@ def _split_predicate_by_columns(
     partition_cols_in_predicate = referenced_cols & partition_columns
 
     if not partition_cols_in_predicate:
-        # Pure data predicate
-        return _SplitPredicateResult(data_predicate=predicate, partition_predicate=None)
+        # Pure data predicate (or no column refs).
+        return _SplitPredicateResult(
+            data_predicate=predicate,
+            partition_predicate=None,
+            residual_predicate=None,
+        )
 
     if not data_cols:
-        # Pure partition predicate
-        return _SplitPredicateResult(data_predicate=None, partition_predicate=predicate)
+        # Pure partition predicate.
+        return _SplitPredicateResult(
+            data_predicate=None,
+            partition_predicate=predicate,
+            residual_predicate=None,
+        )
 
-    # Mixed predicate - try to split if it's an AND chain
+    # Mixed predicate - keep splitting if it's an AND chain.
     if isinstance(predicate, BinaryExpr) and predicate.op == Operation.AND:
-        # Recursively split left and right sides
         left_result = _split_predicate_by_columns(predicate.left, partition_columns)
         right_result = _split_predicate_by_columns(predicate.right, partition_columns)
 
-        # Helper to combine predicates from both sides
         def combine_predicates(
             left: Optional[Expr], right: Optional[Expr]
         ) -> Optional[Expr]:
@@ -289,20 +307,28 @@ def _split_predicate_by_columns(
                 return left & right
             return left or right
 
-        data_predicate = combine_predicates(
-            left_result.data_predicate, right_result.data_predicate
-        )
-        partition_predicate = combine_predicates(
-            left_result.partition_predicate, right_result.partition_predicate
-        )
-
         return _SplitPredicateResult(
-            data_predicate=data_predicate, partition_predicate=partition_predicate
+            data_predicate=combine_predicates(
+                left_result.data_predicate, right_result.data_predicate
+            ),
+            partition_predicate=combine_predicates(
+                left_result.partition_predicate, right_result.partition_predicate
+            ),
+            residual_predicate=combine_predicates(
+                left_result.residual_predicate, right_result.residual_predicate
+            ),
         )
 
-    # For OR, NOT, or other operations with mixed columns,
-    # we can't safely split - must evaluate the full predicate together
-    return _SplitPredicateResult(data_predicate=None, partition_predicate=None)
+    # ``OR``/``NOT``/etc. straddling both column kinds — not safely
+    # splittable. Surface as residual so the caller doesn't silently drop
+    # it (the prior version returned ``(None, None)`` here, which let the
+    # surrounding ``AND`` chain push partial conjuncts and over-include
+    # rows that should have been filtered by this one).
+    return _SplitPredicateResult(
+        data_predicate=None,
+        partition_predicate=None,
+        residual_predicate=predicate,
+    )
 
 
 class ParquetDatasource(Datasource):
@@ -958,6 +984,16 @@ class ParquetDatasource(Datasource):
 
         # Split predicate into data and partition parts
         split_result = _split_predicate_by_columns(predicate_expr, partition_cols)
+
+        # If a mixed-column conjunct can't be safely split (e.g. ``data > 5
+        # OR partition == "US"``), the V1 ``Read.apply_predicate`` wrapper
+        # has no way to keep it as a ``Filter`` above the read — its return
+        # type is ``Read``, not ``LogicalOperator``. Pushing the splittable
+        # parts and silently dropping the residual would over-include rows.
+        # Return ``self`` so ``PredicatePushdown`` keeps the original
+        # ``Filter`` above intact.
+        if split_result.residual_predicate is not None:
+            return self
 
         # Apply partition pruning if we have a partition predicate
         if (

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -223,6 +223,13 @@ class Read(
     def apply_predicate(self, predicate_expr: Expr) -> "Read":
         predicated_datasource = self.datasource.apply_predicate(predicate_expr)
 
+        # A datasource returns its own instance to signal "no pushdown applied"
+        # (e.g. ``ParquetDatasource`` does this when a mixed-column conjunct
+        # leaves a residual). Preserve identity here so ``PredicatePushdown``'s
+        # ``result_op is input_op`` no-op check keeps the ``Filter`` above.
+        if self.datasource is predicated_datasource:
+            return self
+
         return replace(
             self,
             datasource=predicated_datasource,

--- a/python/ray/data/tests/unit/test_parquet_predicate_split.py
+++ b/python/ray/data/tests/unit/test_parquet_predicate_split.py
@@ -2,7 +2,7 @@
 
 This module tests the _split_predicate_by_columns function which optimizes
 predicate pushdown for partitioned Parquet datasets by splitting predicates
-into data-column and partition-column parts.
+into data-column, partition-column, and residual parts.
 """
 
 from dataclasses import dataclass
@@ -25,6 +25,7 @@ class PredicateSplitTestCase:
     expected_data_predicate: Optional[Expr]
     expected_partition_predicate: Optional[Expr]
     description: str
+    expected_residual_predicate: Optional[Expr] = None
 
 
 # fmt: off
@@ -151,6 +152,7 @@ TEST_CASES = [
         partition_cols={"partition_col"},
         expected_data_predicate=None,
         expected_partition_predicate=None,
+        expected_residual_predicate=(col("data1") > 5) | (col("partition_col") == "US"),
         description="OR with data and partition (unsafe to split)",
     ),
     PredicateSplitTestCase(
@@ -158,6 +160,7 @@ TEST_CASES = [
         partition_cols={"partition_col"},
         expected_data_predicate=None,
         expected_partition_predicate=None,
+        expected_residual_predicate=(col("partition_col") == "US") | (col("data1") > 5),
         description="OR with partition and data (unsafe to split)",
     ),
     PredicateSplitTestCase(
@@ -165,6 +168,7 @@ TEST_CASES = [
         partition_cols={"partition_col"},
         expected_data_predicate=None,
         expected_partition_predicate=None,
+        expected_residual_predicate=((col("data1") > 5) & (col("data2") < 10)) | (col("partition_col") == "US"),
         description="OR with complex data predicate and partition",
     ),
     # ====================================================================
@@ -182,6 +186,7 @@ TEST_CASES = [
         partition_cols={"partition_col"},
         expected_data_predicate=None,
         expected_partition_predicate=None,
+        expected_residual_predicate=~((col("data1") > 5) & (col("partition_col") == "US")),
         description="NOT of mixed AND (becomes OR via De Morgan, unsafe)",
     ),
     PredicateSplitTestCase(
@@ -227,7 +232,8 @@ TEST_CASES = [
         partition_cols={"partition_col"},
         expected_data_predicate=col("data2") < 10,
         expected_partition_predicate=None,
-        description="AND with left side having OR with partition (can extract right side data)",
+        expected_residual_predicate=(col("data1") > 5) | (col("partition_col") == "US"),
+        description="AND with left side having OR with partition (residual carries the unsplittable OR)",
     ),
     # ====================================================================
     # Edge cases
@@ -309,9 +315,9 @@ def test_split_predicate_by_columns(test_case: PredicateSplitTestCase):
     - Pure data predicates (should extract data part only)
     - Pure partition predicates (should extract partition part only)
     - Mixed predicates with AND (should split both parts)
-    - Mixed predicates with OR (can't split safely)
+    - Mixed predicates with OR (kept as residual)
     - Mixed predicates with NOT (varies by case)
-    - Complex nested scenarios
+    - Complex nested scenarios with residual carry-over
     - Edge cases
     """
     result = _split_predicate_by_columns(test_case.predicate, test_case.partition_cols)
@@ -326,6 +332,12 @@ def test_split_predicate_by_columns(test_case: PredicateSplitTestCase):
         result.partition_predicate,
         test_case.expected_partition_predicate,
         "partition",
+        test_case.description,
+    )
+    _assert_predicate_matches(
+        result.residual_predicate,
+        test_case.expected_residual_predicate,
+        "residual",
         test_case.description,
     )
 


### PR DESCRIPTION

Independent V1 bug fix surfaced during V2 work. ``_split_predicate_by_columns``
previously returned ``(None, None)`` for unsplittable mixed conjuncts inside
an enclosing AND chain, which let V1 push the splittable parts and silently
over-include rows. Extend ``_SplitPredicateResult`` with
``residual_predicate`` so V1 keeps the surrounding ``Filter`` intact.

- ``_SplitPredicateResult`` gains ``residual_predicate``.
- ``_split_predicate_by_columns`` reworked to walk the top-level AND
  chain and classify each conjunct into data / partition / residual
  buckets. Combining the three with AND reproduces the original
  predicate exactly.
- V1 ``ParquetDatasource.apply_predicate`` returns ``self`` when
  ``residual_predicate`` is non-None so ``PredicatePushdown`` keeps
  the ``Filter`` above the read.
- New unit-test cases for the unsplittable-mixed-conjunct path.

Signed-off-by: Goutam <goutam@anyscale.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/ray-project/ray/pull/63176).
* #63163
* __->__ #63176