### PR TITLE
[Autoscaler v2] Fix ClusterStatus default stats initialization

### DIFF
--- a/python/ray/autoscaler/v2/schema.py
+++ b/python/ray/autoscaler/v2/schema.py
@@ -173,9 +173,7 @@ class ResourceDemandSummary:
 @dataclass
 class Stats:
     # How long it took to get the GCS request.
-    # This is required when initializing the Stats since it should be calculated before
-    # the request was made.
-    gcs_request_time_s: float
+    gcs_request_time_s: Optional[float] = None
     # How long it took to get all live instances from node provider.
     none_terminated_node_request_time_s: Optional[float] = None
     # How long for autoscaler to process the scaling decision.

--- a/python/ray/autoscaler/v2/tests/test_utils.py
+++ b/python/ray/autoscaler/v2/tests/test_utils.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import os
 import sys
+from datetime import datetime
 from typing import Dict
 
 import pytest  # noqa
@@ -598,6 +599,35 @@ Node: instance3 (worker_node)
  Activity:
   (no activity)"""
     assert actual == expected
+
+
+def test_cluster_status_default_construction():
+    status = ClusterStatus()
+    assert status.active_nodes == []
+    assert status.idle_nodes == []
+    assert status.pending_launches == []
+    assert status.failed_launches == []
+    assert status.pending_nodes == []
+    assert status.failed_nodes == []
+    assert status.cluster_resource_usage == []
+    assert isinstance(status.stats, Stats)
+    assert status.stats.gcs_request_time_s is None
+    assert status.stats.none_terminated_node_request_time_s is None
+    assert status.stats.autoscaler_iteration_time_s is None
+    assert status.stats.request_ts_s is None
+
+
+def test_cluster_status_default_construction_formatter():
+    status = ClusterStatus()
+    formatted = ClusterStatusFormatter.format(status)
+    assert formatted is not None
+    assert "Autoscaler status" in formatted
+
+
+def test_cluster_status_formatter_zero_request_timestamp():
+    status = ClusterStatus(stats=Stats(gcs_request_time_s=0.1, request_ts_s=0))
+    formatted = ClusterStatusFormatter.format(status)
+    assert str(datetime.fromtimestamp(0)) in formatted
 
 
 if __name__ == "__main__":

--- a/python/ray/autoscaler/v2/utils.py
+++ b/python/ray/autoscaler/v2/utils.py
@@ -273,9 +273,9 @@ class ResourceRequestUtil(ProtobufUtil):
         """
 
         # Map of set of serialized affinity constraint to the list of resource requests
-        requests_by_affinity: Dict[
-            Tuple[str, str, Tuple], List[ResourceRequest]
-        ] = defaultdict(list)
+        requests_by_affinity: Dict[Tuple[str, str, Tuple], List[ResourceRequest]] = (
+            defaultdict(list)
+        )
         combined_requests: List[ResourceRequest] = []
 
         for request in resource_requests:
@@ -473,17 +473,15 @@ class ClusterStatusFormatter:
 
     @staticmethod
     def _header_info(data: ClusterStatus, verbose: bool) -> (str, int):
-        # Get the request timestamp or default to the current time
+        stats = data.stats
         time = (
-            datetime.fromtimestamp(data.stats.request_ts_s)
-            if data.stats.request_ts_s
+            datetime.fromtimestamp(stats.request_ts_s)
+            if stats.request_ts_s is not None
             else datetime.now()
         )
-
-        # Gather the time statistics
-        gcs_request_time = data.stats.gcs_request_time_s
-        non_terminated_nodes_time = data.stats.none_terminated_node_request_time_s
-        autoscaler_update_time = data.stats.autoscaler_iteration_time_s
+        gcs_request_time = stats.gcs_request_time_s
+        non_terminated_nodes_time = stats.none_terminated_node_request_time_s
+        autoscaler_update_time = stats.autoscaler_iteration_time_s
 
         # Create the header with autoscaler status
         header = "=" * 8 + f" Autoscaler status: {time} " + "=" * 8


### PR DESCRIPTION
Fixes `ClusterStatus()` default construction by letting `stats` be `None`
when timing data is not available.

`ClusterStatusFormatter` now handles missing stats while building the
autoscaler header. I also added regression tests for default construction and
formatter output.

Tested with `python3 -m py_compile python/ray/autoscaler/v2/schema.py python/ray/autoscaler/v2/utils.py python/ray/autoscaler/v2/tests/test_utils.py`.