### PR TITLE
[data] Fix parquet sampling hang on permanent OSError (#57278)

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -1765,7 +1765,9 @@ def _fetch_file_infos(
     futures = []
 
     # Retry in case of transient errors during sampling.
-    task_options = {"retry_exceptions": [OSError]}
+    # Cap retries to avoid hanging indefinitely on permanent errors
+    # (e.g., permission denied, invalid credentials).
+    task_options = {"retry_exceptions": [OSError], "max_retries": 3}
     if local_scheduling:
         task_options["label_selector"] = local_scheduling
     else:
@@ -1786,7 +1788,17 @@ def _fetch_file_infos(
         )
 
     sample_bar = ProgressBar("Parquet dataset sampling", len(futures), unit="file")
-    file_infos = sample_bar.fetch_until_complete(futures)
+    try:
+        file_infos = sample_bar.fetch_until_complete(futures)
+    except ray.exceptions.RayTaskError as e:
+        sample_bar.close()
+        logger.warning(
+            "Parquet dataset sampling failed. "
+            "If this is a credentials or permissions issue, "
+            "check your cloud storage access configuration. "
+            f"Underlying error: {e.cause}"
+        )
+        raise
     sample_bar.close()
 
     return file_infos

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -3049,6 +3049,30 @@ def test_read_parquet_nested_fallback_skipped_when_only_flat_columns_selected(
         mock_safe.assert_not_called()
 
 
+def test_parquet_sampling_fails_on_permanent_error(ray_start_regular_shared, tmp_path):
+    """Test that parquet sampling does not hang on permanent OSError (e.g.,
+    permission denied). Instead, it should fail with a clear error after
+    limited retries. Regression test for #57278."""
+    from unittest.mock import patch
+
+    # Write a valid parquet file so that fragment discovery succeeds.
+    table = pa.table({"col": [1, 2, 3]})
+    pq.write_table(table, os.path.join(tmp_path, "data.parquet"))
+
+    # Patch the remote sampling function to always raise PermissionError
+    # (a subclass of OSError), simulating invalid credentials.
+    original_fn = (
+        "ray.data._internal.datasource.parquet_datasource._fetch_parquet_file_info"
+    )
+
+    def _raise_permission_error(*args, **kwargs):
+        raise PermissionError("Access Denied: invalid credentials")
+
+    with patch(original_fn, new=_raise_permission_error):
+        with pytest.raises(Exception, match="Access Denied"):
+            ray.data.read_parquet(str(tmp_path)).materialize()
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?

  Fixes #57278

  When AWS credentials are invalid (or any permanent `OSError` like `PermissionError`), `read_parquet()` hangs indefinitely
  at the Parquet metadata sampling stage. This happens because:

  1. Sampling tasks use `max_retries=-1` (infinite) with `retry_exceptions=[OSError]`
  2. `PermissionError` is a subclass of `OSError`, so it gets retried forever
  3. No log output tells the user what's going wrong

  ## Changes

  - Cap `max_retries` to 3 for sampling tasks (enough for transient failures, won't hang on permanent errors)
  - Catch `RayTaskError` and log a warning with the underlying error before re-raising

  ## Related issue number

  Fixes #57278

  ## Checks

  - [x] I've signed the [CLA](https://docs.ray.io/en/latest/ray-contribute/getting-involved.html)
  - [x] I've added a regression test (`test_parquet_sampling_fails_on_permanent_error`)