### PR TITLE
[Data] Bump tpch q3 q6 q13 to benchmark better 

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -936,7 +936,7 @@
 
   run:
     timeout: 5400
-    script: python tpch/tpch_q3.py --sf 100
+    script: python tpch/tpch_q3.py --sf 1000
 
 - name: "tpch_q4_{{scaling}}"
   python: "3.10"
@@ -978,7 +978,7 @@
 
   run:
     timeout: 5400
-    script: python tpch/tpch_q6.py --sf 100
+    script: python tpch/tpch_q6.py --sf 1000
 
 - name: "tpch_q7_{{scaling}}"
   python: "3.10"
@@ -1085,7 +1085,7 @@
 
   run:
     timeout: 5400
-    script: python tpch/tpch_q13.py --sf 100
+    script: python tpch/tpch_q13.py --sf 1000
 
 - name: "tpch_q14_{{scaling}}"
   python: "3.10"


### PR DESCRIPTION
## Description
TPCH q3, 6, 13 are lightweight tests, should use larger dataset to denoise the result and make it more reliable.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
