### PR TITLE
[Data] Clean logical rule reconstruction

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -444,6 +444,23 @@ class PhysicalOperator(Operator):
     def input_dependencies(self) -> List["PhysicalOperator"]:
         return self._input_dependencies
 
+    def _replace_input_dependencies(
+        self, input_dependencies: List["PhysicalOperator"]
+    ) -> None:
+        for input_op in self._input_dependencies:
+            assert isinstance(input_op, PhysicalOperator), input_op
+            input_op._output_dependencies = [
+                dep for dep in input_op._output_dependencies if dep is not self
+            ]
+        self._input_dependencies = input_dependencies
+        self._wire_output_deps(input_dependencies)
+
+    def _clear_output_dependencies(self) -> None:
+        self._output_dependencies = []
+
+    def _add_output_dependency(self, output_op: "PhysicalOperator") -> None:
+        self._output_dependencies.append(output_op)
+
     @property
     def dag_str(self) -> str:
         """String representation of the whole physical DAG."""

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -483,6 +483,14 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                     self._remote_args_for_metrics = copy.deepcopy(ray_remote_args)
         return ray_remote_args
 
+    def _get_ray_remote_args_fn(self) -> Optional[Callable[[], Dict[str, Any]]]:
+        return self._ray_remote_args_fn
+
+    def _set_ray_remote_args_fn(
+        self, ray_remote_args_fn: Optional[Callable[[], Dict[str, Any]]]
+    ) -> None:
+        self._ray_remote_args_fn = ray_remote_args_fn
+
     @abstractmethod
     def _try_schedule_task(self, refs: RefBundle, strict: bool):
         """Method to try schedule task handling provided bundle

--- a/python/ray/data/_internal/logical/rules/combine_shuffles.py
+++ b/python/ray/data/_internal/logical/rules/combine_shuffles.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
     LogicalPlan,
@@ -46,43 +48,34 @@ class CombineShuffles(Rule):
 
         if isinstance(input_op, Repartition) and isinstance(op, Repartition):
             shuffle = input_op.shuffle or op.shuffle
-            return Repartition(
-                num_outputs=op.num_outputs,
+            return replace(
+                op,
                 input_dependencies=[input_op.input_dependencies[0]],
                 shuffle=shuffle,
-                keys=op.keys,
-                sort=op.sort,
             )
         elif isinstance(input_op, StreamingRepartition) and isinstance(
             op, StreamingRepartition
         ):
             strict = input_op.strict or op.strict
-            return StreamingRepartition(
-                target_num_rows_per_block=op.target_num_rows_per_block,
+            return replace(
+                op,
                 input_dependencies=[input_op.input_dependencies[0]],
                 strict=strict,
             )
         elif isinstance(input_op, Repartition) and isinstance(op, Aggregate):
-            return Aggregate(
-                key=op.key,
-                aggs=op.aggs,
+            return replace(
+                op,
                 input_dependencies=[input_op.input_dependencies[0]],
-                num_partitions=op.num_partitions,
-                batch_format=op.batch_format,
             )
         elif isinstance(input_op, StreamingRepartition) and isinstance(op, Repartition):
-            return Repartition(
-                num_outputs=op.num_outputs,
+            return replace(
+                op,
                 input_dependencies=[input_op.input_dependencies[0]],
-                shuffle=op.shuffle,
-                keys=op.keys,
-                sort=op.sort,
             )
         elif isinstance(input_op, Sort) and isinstance(op, Sort):
-            return Sort(
-                sort_key=op.sort_key,
+            return replace(
+                op,
                 input_dependencies=[input_op.input_dependencies[0]],
-                batch_format=op.batch_format,
             )
 
         return op

--- a/python/ray/data/_internal/logical/rules/configure_map_task_memory.py
+++ b/python/ray/data/_internal/logical/rules/configure_map_task_memory.py
@@ -20,7 +20,8 @@ class ConfigureMapTaskMemoryRule(Rule, abc.ABC):
                 continue
 
             def ray_remote_args_fn(
-                op: MapOperator = op, original_ray_remote_args_fn=op._ray_remote_args_fn
+                op: MapOperator = op,
+                original_ray_remote_args_fn=op._get_ray_remote_args_fn(),
             ) -> Dict[str, Any]:
                 assert isinstance(op, MapOperator), op
 
@@ -54,7 +55,7 @@ class ConfigureMapTaskMemoryRule(Rule, abc.ABC):
 
                 return dynamic_ray_remote_args
 
-            op._ray_remote_args_fn = ray_remote_args_fn
+            op._set_ray_remote_args_fn(ray_remote_args_fn)
 
         return plan
 

--- a/python/ray/data/_internal/logical/rules/inherit_batch_format.py
+++ b/python/ray/data/_internal/logical/rules/inherit_batch_format.py
@@ -36,14 +36,10 @@ class InheritBatchFormatRule(Rule):
                 if isinstance(upstream_op, MapBatches) and upstream_op.batch_format:
                     if not hasattr(node, "batch_format"):
                         return node
-                    if isinstance(node, AbstractAllToAll) and hasattr(
-                        node, "__dataclass_fields__"
-                    ):
-                        return replace(
-                            node,
-                            input_dependencies=[node.input_dependencies[0]],
-                            batch_format=upstream_op.batch_format,
-                        )
+                    return replace(
+                        node,
+                        batch_format=upstream_op.batch_format,
+                    )
                 upstream_op = upstream_op.input_dependencies[0]
 
             return node

--- a/python/ray/data/_internal/logical/rules/limit_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/limit_pushdown.py
@@ -1,13 +1,11 @@
-import copy
 import logging
-from dataclasses import is_dataclass, replace
+from dataclasses import replace
 from typing import List
 
 from ray.data._internal.logical.interfaces import LogicalOperator, LogicalPlan, Rule
 from ray.data._internal.logical.operators import (
     AbstractMap,
     AbstractOneToOne,
-    Download,
     Limit,
     Read,
     ReadFiles,
@@ -194,51 +192,32 @@ class LimitPushdownRule(Rule):
     ) -> LogicalOperator:
         """Apply per-block limit to operators that support it."""
         if isinstance(op, AbstractMap):
-            if is_dataclass(op):
-                if isinstance(op, Read):
-                    return replace(
-                        op,
-                        per_block_limit=limit,
-                        num_outputs=op.num_outputs,
-                    )
-                if isinstance(op, ReadFiles):
-                    from ray.data._internal.datasource_v2.logical_optimizers import (
-                        SupportsLimitPushdown,
-                    )
-
-                    if isinstance(op.scanner, SupportsLimitPushdown):
-                        return replace(
-                            op,
-                            scanner=op.scanner.push_limit(limit),
-                        )
-                    return op
-                assert len(op.input_dependencies) == 1, len(op.input_dependencies)
+            if isinstance(op, Read):
                 return replace(
                     op,
-                    input_dependencies=[op.input_dependencies[0]],
                     per_block_limit=limit,
                 )
-            new_op = copy.copy(op)
-            new_op.set_per_block_limit(limit)
-            return new_op
+            if isinstance(op, ReadFiles):
+                from ray.data._internal.datasource_v2.logical_optimizers import (
+                    SupportsLimitPushdown,
+                )
+
+                if isinstance(op.scanner, SupportsLimitPushdown):
+                    return replace(
+                        op,
+                        scanner=op.scanner.push_limit(limit),
+                    )
+                return op
+            assert len(op.input_dependencies) == 1, len(op.input_dependencies)
+            return replace(
+                op,
+                per_block_limit=limit,
+            )
         return op
 
     def _recreate_operator_with_new_input(
         self, original_op: LogicalOperator, new_input: LogicalOperator
     ) -> LogicalOperator:
         """Create a new operator of the same type as original_op but with new_input as its input."""
-
-        if isinstance(original_op, Limit):
-            return Limit(original_op.limit, input_dependencies=[new_input])
-        if isinstance(original_op, Download):
-            return Download(
-                uri_column_names=original_op.uri_column_names,
-                output_bytes_column_names=original_op.output_bytes_column_names,
-                input_dependencies=[new_input],
-                ray_remote_args=original_op.ray_remote_args,
-                filesystem=original_op.filesystem,
-            )
-        if isinstance(original_op, AbstractMap) and is_dataclass(original_op):
-            return replace(original_op, input_dependencies=[new_input])
 
         return original_op._with_new_input_dependencies([new_input])

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -68,9 +68,7 @@ class FuseOperators(Rule):
         # we fuse together MapOperator -> AllToAllOperator pairs.
         fused_dag = self._fuse_all_to_all_operators_in_dag(fused_dag)
 
-        # Update output dependencies after fusion.
-        # TODO(hchen): Instead of updating the depdencies manually,
-        # we need a better abstraction for manipulating the DAG.
+        # Rebuild output dependencies after fusion.
         self._remove_output_deps(fused_dag)
         self._update_output_deps(fused_dag)
 
@@ -79,12 +77,12 @@ class FuseOperators(Rule):
 
     def _remove_output_deps(self, op: PhysicalOperator) -> None:
         for input in op.input_dependencies:
-            input._output_dependencies = []
+            input._clear_output_dependencies()
             self._remove_output_deps(input)
 
     def _update_output_deps(self, op: PhysicalOperator) -> None:
         for input in op.input_dependencies:
-            input._output_dependencies.append(op)
+            input._add_output_dependency(op)
             self._update_output_deps(input)
 
     def _fuse_streaming_repartition_operators_in_dag(
@@ -129,10 +127,12 @@ class FuseOperators(Rule):
             dag = self._get_fused_streaming_repartition_operator(dag, upstream_ops[0])
             upstream_ops = dag.input_dependencies
 
-        dag._input_dependencies = [
-            self._fuse_streaming_repartition_operators_in_dag(upstream_op)
-            for upstream_op in upstream_ops
-        ]
+        dag._replace_input_dependencies(
+            [
+                self._fuse_streaming_repartition_operators_in_dag(upstream_op)
+                for upstream_op in upstream_ops
+            ]
+        )
         return dag
 
     def _fuse_map_operators_in_dag(self, dag: PhysicalOperator) -> MapOperator:
@@ -153,9 +153,12 @@ class FuseOperators(Rule):
 
         # Done fusing back-to-back map operators together here,
         # move up the DAG to find the next map operators to fuse.
-        dag._input_dependencies = [
-            self._fuse_map_operators_in_dag(upstream_op) for upstream_op in upstream_ops
-        ]
+        dag._replace_input_dependencies(
+            [
+                self._fuse_map_operators_in_dag(upstream_op)
+                for upstream_op in upstream_ops
+            ]
+        )
         return dag
 
     def _fuse_all_to_all_operators_in_dag(
@@ -183,10 +186,12 @@ class FuseOperators(Rule):
 
         # Done fusing MapOperator -> AllToAllOperator together here,
         # move up the DAG to find the next pair of operators to fuse.
-        dag._input_dependencies = [
-            self._fuse_all_to_all_operators_in_dag(upstream_op)
-            for upstream_op in upstream_ops
-        ]
+        dag._replace_input_dependencies(
+            [
+                self._fuse_all_to_all_operators_in_dag(upstream_op)
+                for upstream_op in upstream_ops
+            ]
+        )
         return dag
 
     def _can_fuse(self, down_op: PhysicalOperator, up_op: PhysicalOperator) -> bool:

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -1,5 +1,3 @@
-import copy
-from dataclasses import is_dataclass, replace
 from typing import List
 
 from ray.data._internal.logical.interfaces import (
@@ -11,15 +9,8 @@ from ray.data._internal.logical.interfaces import (
     Rule,
 )
 from ray.data._internal.logical.operators import (
-    AbstractAllToAll,
-    AbstractMap,
     Filter,
-    Join,
-    Limit,
     Project,
-    RandomShuffle,
-    Repartition,
-    Union,
 )
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     _ColumnSubstitutionVisitor,
@@ -321,45 +312,13 @@ class PredicatePushdown(Rule):
     def _clone_op_with_new_inputs(
         cls, op: LogicalOperator, new_inputs: List[LogicalOperator]
     ) -> LogicalOperator:
-        """Clone an operator with new inputs.
+        """Recreate an operator with new inputs.
 
         Args:
             op: The operator to clone
             new_inputs: List of new input operators (can be single element list)
 
         Returns:
-            A shallow copy of the operator with updated input dependencies
+            A logically equivalent operator with updated input dependencies.
         """
-        if isinstance(op, Limit):
-            assert len(new_inputs) == 1, len(new_inputs)
-            return Limit(op.limit, input_dependencies=[new_inputs[0]])
-        if isinstance(op, AbstractMap) and is_dataclass(op):
-            assert len(new_inputs) == 1, len(new_inputs)
-            return replace(op, input_dependencies=[new_inputs[0]])
-        if isinstance(op, AbstractAllToAll) and is_dataclass(op):
-            assert len(new_inputs) == 1, len(new_inputs)
-            kwargs = {"input_dependencies": [new_inputs[0]]}
-            if isinstance(op, Repartition):
-                kwargs["num_outputs"] = op.num_outputs
-            if isinstance(op, RandomShuffle):
-                kwargs["name"] = op.name
-            return replace(op, **kwargs)
-        if isinstance(op, Join) and is_dataclass(op):
-            assert len(new_inputs) == 2, len(new_inputs)
-            return Join(
-                new_inputs[0],
-                new_inputs[1],
-                op.join_type,
-                op.left_key_columns,
-                op.right_key_columns,
-                num_partitions=op.num_outputs,
-                left_columns_suffix=op.left_columns_suffix,
-                right_columns_suffix=op.right_columns_suffix,
-                partition_size_hint=op.partition_size_hint,
-                aggregator_ray_remote_args=op.aggregator_ray_remote_args,
-            )
-        if isinstance(op, Union) and is_dataclass(op):
-            return Union(*new_inputs)
-        new_op = copy.copy(op)
-        new_op.input_dependencies = new_inputs
-        return new_op
+        return op._with_new_input_dependencies(new_inputs)


### PR DESCRIPTION
## Description

#### Why this is needed:

This is the next small cleanup in the `#60312` logical plan migration stack.

Now that logical operators use a canonical dataclass-backed dependency model, logical rules no longer need to branch on mixed dataclass/non-dataclass reconstruction paths or mutate operator dependency storage directly.

#### What this PR changes:

Removes rule-level `is_dataclass()` / `__dataclass_fields__` checks from logical rule reconstruction paths.

Replaces `copy.copy()` + dependency mutation fallbacks in logical rules with frozen-safe reconstruction through `replace()` or the operator-owned `_with_new_input_dependencies()` helper.

Updates rule-level manual operator reconstruction in predicate pushdown, limit pushdown, inherit-batch-format, and combine-shuffles to rely on the operator field model instead of spelling out constructor arguments in the rule layer.

Moves the remaining direct physical-operator mutation in operator fusion and map-task-memory configuration behind operator-owned helper methods, so rule code no longer rewires physical dependencies or map remote-args callbacks by assigning private fields directly.

This PR does not change logical operator equality/comparability semantics or introduce a broader physical-operator spec cleanup. Those remain separate follow-ups in the current split plan.

## Related issues

Part of #60312.

## Additional information

This PR corresponds to the logical-rule special-casing cleanup step in the current split plan.

### Tests

- `pre-commit run --files ...`
- Relevant Ray Data optimizer, predicate/limit pushdown, operator fusion, and logical plan tests.
- A few related repartition/map/executor resource tests around fusion and dynamic remote args.

### Stack Plan

Done:
- Convert remaining concrete logical operators to frozen dataclasses.
- Make logical abstract classes frozen dataclasses.
- Derive logical operator names from the base class.
- Replace single-input `input_op` InitVars with `input_dependencies`.
- Remove the one-to-one `input_dependency` convenience property.
- Clean up logical operator args export.
- Make `Operator` a thin shared base.
- Consolidate redundant logical operator repr/string logic.
- Make logical operator fields canonical.

This PR:
- Clean up special-casing in logical rules.

Next:
- Finish equality/comparability end-state.
