### PR TITLE
[Data] Report pending object store memory in progress status

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -174,7 +174,7 @@ class ResourceManager:
             return 0
 
         # Operator's internal Object Store usage
-        mem_op_internal = op.metrics.obj_store_mem_pending_task_outputs or 0
+        mem_op_internal = self._estimate_pending_object_store_memory_usage(op)
 
         # Operator's outputs' Object Store usage
         op_outputs_bytes = (
@@ -208,6 +208,13 @@ class ResourceManager:
 
         return self._mem_op_outputs[op] + self._mem_op_internal[op]
 
+    def _estimate_pending_object_store_memory_usage(
+        self, op: "PhysicalOperator"
+    ) -> int:
+        if isinstance(op, InputDataBuffer):
+            return 0
+        return op.metrics.obj_store_mem_pending_task_outputs or 0
+
     def update_usages(self):
         """Recalculate resource usages."""
         # TODO(hchen): This method will be called frequently during the execution loop.
@@ -233,10 +240,15 @@ class ResourceManager:
             assert not op_pending_usage.object_store_memory
 
             used_object_store = self._estimate_object_store_memory_usage(op, state)
+            running_object_store = self.get_mem_op_outputs(op)
+            pending_object_store = self.get_mem_op_internal(op)
 
             op_usage = op_usage.copy(object_store_memory=used_object_store)
             op_running_usage = op_running_usage.copy(
-                object_store_memory=used_object_store
+                object_store_memory=running_object_store
+            )
+            op_pending_usage = op_pending_usage.copy(
+                object_store_memory=pending_object_store
             )
 
             if isinstance(op, ReportsExtraResourceUsage):

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -586,17 +586,18 @@ class StreamingExecutor(Executor, threading.Thread):
             f"{limits.object_store_memory_str()} object store"
         )
 
+        pending_resources = []
+        if pending_usage.cpu:
+            pending_resources.append(f"{pending_usage.cpu:.4g} CPU")
+        if pending_usage.gpu:
+            pending_resources.append(f"{pending_usage.gpu:.4g} GPU")
+        if pending_usage.object_store_memory:
+            pending_resources.append(
+                f"{pending_usage.object_store_memory_str()} object store"
+            )
         # Only include pending section when there are pending resources.
-        if pending_usage.cpu or pending_usage.gpu:
-            if pending_usage.cpu and pending_usage.gpu:
-                pending_str = (
-                    f"{pending_usage.cpu:.4g} CPU, {pending_usage.gpu:.4g} GPU"
-                )
-            elif pending_usage.cpu:
-                pending_str = f"{pending_usage.cpu:.4g} CPU"
-            else:
-                pending_str = f"{pending_usage.gpu:.4g} GPU"
-            resources_status += f" (pending: {pending_str})"
+        if pending_resources:
+            resources_status += f" (pending: {', '.join(pending_resources)})"
 
         self._progress_manager.update_total_resource_status(resources_status)
 

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -287,16 +287,19 @@ class TestResourceManager:
 
         global_cpu = 0
         global_mem = 0
+        global_pending_mem = 0
         for op in [o1, o2, o3]:
             if op == o1:
                 # Resource usage of InputDataBuffer doesn't count.
                 expected_mem = 0
+                expected_pending_mem = 0
             else:
                 expected_mem = (
                     mock_pending_task_outputs[op]
                     + mock_internal_outqueue[op]
                     + mock_external_outqueue_sizes[op]
                 )
+                expected_pending_mem = mock_pending_task_outputs[op]
                 for next_op in op.output_dependencies:
                     expected_mem += (
                         +mock_internal_inqueue[next_op]
@@ -318,9 +321,16 @@ class TestResourceManager:
                 )
             global_cpu += mock_cpu[op]
             global_mem += expected_mem
+            global_pending_mem += expected_pending_mem
 
         assert resource_manager.get_global_usage() == ExecutionResources(
             global_cpu, 0, global_mem
+        )
+        assert resource_manager.get_global_running_usage() == ExecutionResources(
+            global_cpu, 0, global_mem - global_pending_mem
+        )
+        assert resource_manager.get_global_pending_usage() == ExecutionResources(
+            0, 0, global_pending_mem
         )
 
     def test_object_store_usage(self, restore_data_context):

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -70,13 +70,19 @@ from ray.data.tests.conftest import *  # noqa
 def mock_resource_manager(
     global_limits=None,
     global_usage=None,
+    global_running_usage=None,
+    global_pending_usage=None,
 ):
     empty_resource = ExecutionResources(0, 0, 0)
     global_limits = global_limits or empty_resource
     global_usage = global_usage or empty_resource
+    global_running_usage = global_running_usage or global_usage
+    global_pending_usage = global_pending_usage or empty_resource
     return MagicMock(
         get_global_limits=MagicMock(return_value=global_limits),
         get_global_usage=MagicMock(return_value=global_usage),
+        get_global_running_usage=MagicMock(return_value=global_running_usage),
+        get_global_pending_usage=MagicMock(return_value=global_pending_usage),
         op_resource_allocator_enabled=MagicMock(return_value=True),
     )
 
@@ -567,6 +573,27 @@ def test_rank_operators(ray_start_regular_shared):
     ranks = ranker.rank_operators([o1, o2, o3, o4], {}, resource_manager)
 
     assert [(1, 1024), (1, 2048), (1, 4096), (0, 8092)] == ranks
+
+
+def test_report_current_usage_includes_pending_object_store_memory():
+    executor = StreamingExecutor(DataContext.get_current(), dataset_id="dataset")
+    executor._resource_manager = mock_resource_manager(
+        global_limits=ExecutionResources.for_limits(
+            cpu=4, gpu=1, object_store_memory=1024 * MiB
+        ),
+        global_running_usage=ExecutionResources(
+            cpu=2, gpu=1, object_store_memory=512 * MiB
+        ),
+        global_pending_usage=ExecutionResources(cpu=1, object_store_memory=256 * MiB),
+    )
+    executor._progress_manager = MagicMock()
+
+    executor._report_current_usage()
+
+    executor._progress_manager.update_total_resource_status.assert_called_once_with(
+        "Active & requested resources: 2/4 CPU, 1/1 GPU, "
+        "512.0MiB/1.0GiB object store (pending: 1 CPU, 256.0MiB object store)"
+    )
 
 
 def test_select_ops_to_run(ray_start_regular_shared):


### PR DESCRIPTION
## Description
Report estimated pending task output object store memory in Ray Data progress status.

This updates ResourceManager to split object store usage into running and pending portions, using obj_store_mem_pending_task_outputs for the pending portion. The streaming executor now includes pending object store memory in the total resource status when present.

## Related issues
Fixes #47125.

## Additional information
Tested with:

```bash
git diff --check origin/master..HEAD
PYTHONPYCACHEPREFIX=/private/tmp/ray-community-pycache python3 -m py_compile python/ray/data/_internal/execution/resource_manager.py python/ray/data/_internal/execution/streaming_executor.py python/ray/data/tests/test_resource_manager.py python/ray/data/tests/test_streaming_executor.py
```