### PR TITLE
[doc][DOC-897] probe: remove obsolete RAY_TRAIN_V2_ENABLED=1 force in conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -907,6 +907,4 @@ assert (
     "ray" not in sys.modules
 ), "If ray is already imported, we will not render documentation correctly!"
 
-os.environ["RAY_TRAIN_V2_ENABLED"] = "1"
-
 os.environ["RAY_DOC_BUILD"] = "1"


### PR DESCRIPTION
## Why

The Anyscale docs team is auditing `doc/source/conf.py` against current Ray state as part of strategy work tracked in [anyscale/docs#2064](https://github.com/anyscale/docs/pull/2064). One finding: the last two lines of conf.py force two env vars unconditionally:

```python
os.environ["RAY_TRAIN_V2_ENABLED"] = "1"
os.environ["RAY_DOC_BUILD"] = "1"
```

`RAY_TRAIN_V2_ENABLED=1` was added when Train v2 was opt-in. Justin Yu's [#57857](https://github.com/ray-project/ray/pull/57857) (Oct 2025) made Train v2 the default. The conf.py force should now be vestigial.

`RAY_DOC_BUILD=1` is intentional and stays — it switches Ray-internal code paths during doc generation.

## What this PR does

Drops the `os.environ["RAY_TRAIN_V2_ENABLED"] = "1"` line from `doc/source/conf.py`.

## How to validate

This is a probe, not a request-for-merge. The validation surfaces are:

1. **RtD PR preview build** — runs against this branch. With `fail_on_warning: true` set in `.readthedocs.yaml`, any new Sphinx warning means the line was still load-bearing.
2. **`doc: check API doc consistency`** — premerge step that runs `make -C doc/ html` internally. Same fail-on-warning gate.
3. **Visual diff of API ref pages** for any class previously rendered through Train v2 codepaths.

If the build is clean and the API ref renders identically, this line can be dropped.

## What happens if I'm wrong

If `RAY_TRAIN_V2_ENABLED=1` is still load-bearing, the doc build will surface the dependency (likely as a missing-reference or autosummary failure). I revert and document the actual reason it's still needed.

## Status

**Draft.** Posting for visibility and validation, not for merge. Looking for confirmation from a Ray maintainer (Justin Yu @justinvyu would be the natural reviewer given Train v2 ownership) that there's no non-obvious reason to keep this. Happy to close if there is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
