### PR TITLE
[doc][DOC-898] probe: remove MockedClassDocumenter monkey-patch in conf.py

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -15,7 +15,6 @@ from urllib.request import urlopen
 import sphinx
 from docutils import nodes
 from jinja2.filters import FILTERS
-from sphinx.ext import autodoc
 from sphinx.ext.autosummary import generate
 from sphinx.util.inspect import safe_getattr
 
@@ -844,17 +843,6 @@ for mock_target in autodoc_mock_imports:
             "been loaded into sys.modules when the sphinx build starts."
         )
 
-
-class MockedClassDocumenter(autodoc.ClassDocumenter):
-    """Remove note about base class when a class is derived from object."""
-
-    def add_line(self, line: str, source: str, *lineno: int) -> None:
-        if line == "   Bases: :py:class:`object`":
-            return
-        super().add_line(line, source, *lineno)
-
-
-autodoc.ClassDocumenter = MockedClassDocumenter
 
 # Other sphinx docs can be linked to if the appropriate URL to the docs
 # is specified in the `intersphinx_mapping` - for example, types annotations


### PR DESCRIPTION
## Why

The Anyscale docs team is auditing `doc/source/conf.py` against current Ray state as part of strategy work tracked in [anyscale/docs#2064](https://github.com/anyscale/docs/pull/2064). One finding: `conf.py` globally swaps `sphinx.ext.autodoc.ClassDocumenter` with a `MockedClassDocumenter` subclass that suppresses the `Bases: object` line for classes that inherit directly from `object`.

The patch was added in [#39982](https://github.com/ray-project/ray/pull/39982) (Oct 2023). It's a cosmetic workaround. Two reasons it may now be obsolete:

1. **Modern pydata-sphinx-theme** (Ray pins 0.14.1; current is 0.16.x) renders base class lines differently than it did when the patch was authored.
2. **Global monkey patches at conf.py module scope** are a fragility liability — if a future Sphinx ClassDocumenter signature change lands, the patch breaks the build at import. The cosmetic value should be weighed against that ongoing maintenance cost.

## What this PR does

1. Removes the `MockedClassDocumenter` class and its global assignment to `sphinx.ext.autodoc.ClassDocumenter`.
2. Removes the now-unused `from sphinx.ext import autodoc` import.

## How to validate

This is a probe, not a request-for-merge. The validation surfaces are:

1. **RtD PR preview build** — runs against this branch. With `fail_on_warning: true` set in `.readthedocs.yaml`, any new Sphinx warning means the patch was still load-bearing in a non-cosmetic way.
2. **`doc: check API doc consistency`** — premerge step that runs `make -C doc/ html` internally. Same fail-on-warning gate.
3. **Visual diff of any API ref page** for a class that inherits directly from `object`. If `Bases: object` reappears in those pages, the patch was effectively suppressing visible noise — keep it. If the line is rendered the same way (or absent) by the modern theme without the patch, drop it.

## Possible outcomes

- **Build clean, no visible regression** → the patch is dead weight. Drop.
- **Build clean, `Bases: object` reappears on many pages** → the patch is doing what it claims. Keep, and add a comment explaining what would replace it (a CSS rule on the modern theme's rendered output, or a different autodoc filter).
- **Build fails** → the patch was load-bearing in a way nobody documented. Revert and document.

## Status

**Draft.** Posting for visibility and validation, not for merge. Looking for a Ray maintainer to confirm whether the cosmetic suppression is still desired and whether there's a less-fragile mechanism to achieve it. Justin Yu @justinvyu, Aydin Abiar @aslonnie, or Elliot Barnwell @ebarn-anyscale would all be reasonable reviewers given recent activity in this area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
