### PR TITLE
[CI] Skip premerge tests for doc/*.rst changes

### DIFF
--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -83,7 +83,6 @@ docker/Dockerfile.ray: docker linux_wheels
 
 doc/code.py: doc
 doc/example.ipynb: doc
-doc/tutorial.rst: doc
 .readthedocs.yaml: doc
 .vale.ini: doc
 .vale/styles/config/vocabularies/Core/accept.txt: doc

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -20,6 +20,13 @@
 ! linux_wheels macos_wheels docker doc python_dependencies min_build tools
 ! release_tests spark_on_ray
 
+# NOTE: dstrodtman is leading effort to rework content in RST files, and wanted to shift
+# from blocking premerge for these changes. We can remove this pass block once effort concludes,
+# or earlier should regressions become an issue.
+doc/*.rst
+# pass
+;
+
 python/ray/air/
 @ ml train train_gpu tune data linux_wheels
 ;


### PR DESCRIPTION
Add a pass block to test.rules.txt so changes touching doc/*.rst files no longer trigger premerge tests, and drop the corresponding doc/tutorial.rst test rule entry. This unblocks ongoing RST content rework, and can be removed once that effort concludes or if regressions surface.

Topic: adjust-test-rules
Signed-off-by: andrew <andrew@anyscale.com>