### PR TITLE
[Serve] Restart gang when recovery drops uninitialized member

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -4127,6 +4127,7 @@ class DeploymentState:
         """
         slow_replicas = []
         failed_gang_ids: Set[str] = set()
+        unrecoverable_replica_ids_without_gang: Set[str] = set()
         for replica in self._replicas.pop(states=[original_state]):
             start_status, error_msg = replica.check_started()
             if start_status == ReplicaStartupStatus.SUCCEEDED:
@@ -4225,6 +4226,10 @@ class DeploymentState:
                     self._stop_replica(replica, graceful_stop=False)
                     if replica.gang_context is not None:
                         failed_gang_ids.add(replica.gang_context.gang_id)
+                    else:
+                        unrecoverable_replica_ids_without_gang.add(
+                            replica.replica_id.unique_id
+                        )
                     continue
 
                 # For gang replicas, count the failure once per gang and not per replica so the
@@ -4253,6 +4258,27 @@ class DeploymentState:
                     self._stop_replica(replica, graceful_stop=False)
                 else:
                     self._replicas.add(original_state, replica)
+
+        if self._is_gang_deployment and original_state == ReplicaState.RECOVERING:
+            # An unrecoverable actor may not have received its initial gang context.
+            # Use recovered siblings' member lists to find and restart the gang.
+            all_tracked_replica_ids = {
+                replica.replica_id.unique_id for replica in self._replicas.get()
+            }
+            unavailable_replica_ids = unrecoverable_replica_ids_without_gang | {
+                replica.replica_id.unique_id
+                for replica in self._replicas.get(states=[ReplicaState.STOPPING])
+            }
+            for replica in self._replicas.get(
+                states=[original_state, ReplicaState.RUNNING]
+            ):
+                gang_context = replica.gang_context
+                if gang_context is not None and any(
+                    member_id not in all_tracked_replica_ids
+                    or member_id in unavailable_replica_ids
+                    for member_id in gang_context.member_replica_ids
+                ):
+                    failed_gang_ids.add(gang_context.gang_id)
 
         # If any gang member failed during startup, stop all other members of
         # that gang so partial gangs never exist.

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -8377,6 +8377,81 @@ class TestScaleDeploymentGangReplicas:
         )
         assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
 
+    def test_recovery_restarts_gang_when_member_uninitialized(
+        self, mock_deployment_state_manager
+    ):
+        """Recovery drops the whole gang if a member never finished initialization."""
+        create_dsm, _, _, _ = mock_deployment_state_manager
+        dsm: DeploymentStateManager = create_dsm(
+            create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+        )
+        gang_size = 2
+        deployment_id = DeploymentID(name="gang_uninitialized_recovery", app_name="app")
+        info, version = deployment_info(
+            num_replicas=gang_size,
+            version="v1",
+            gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+        )
+        dsm.deploy(deployment_id, info)
+        dsm.save_checkpoint()
+        ds = dsm._deployment_states[deployment_id]
+
+        dsm.update()
+        for replica in ds._replicas.get([ReplicaState.STARTING]):
+            replica._actor.set_ready()
+        dsm.update()
+        running = ds._replicas.get([ReplicaState.RUNNING])
+        assert len(running) == gang_size
+
+        member_ids = {replica.replica_id.unique_id for replica in running}
+        gang_context_by_replica_id = {
+            replica.replica_id.unique_id: replica.gang_context for replica in running
+        }
+        uninitialized_replica_id = running[0].replica_id
+        survivor_replica_id = running[1].replica_id
+        uninitialized_replicas_context.add(uninitialized_replica_id)
+
+        try:
+            new_dsm: DeploymentStateManager = create_dsm(
+                [replica.replica_id.to_full_id_str() for replica in running],
+                create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+            )
+            new_ds = new_dsm._deployment_states[deployment_id]
+            recovering = {
+                replica.replica_id.unique_id: replica
+                for replica in new_ds._replicas.get([ReplicaState.RECOVERING])
+            }
+            survivor = recovering[survivor_replica_id.unique_id]
+            assert recovering[uninitialized_replica_id.unique_id].gang_context is None
+
+            new_dsm.update()
+            assert {
+                replica.replica_id.unique_id
+                for replica in new_ds._replicas.get([ReplicaState.STOPPING])
+            } == {uninitialized_replica_id.unique_id}
+            check_counts(
+                new_ds,
+                total=gang_size,
+                by_state=[
+                    (ReplicaState.STOPPING, 1, version),
+                    (ReplicaState.RECOVERING, 1, version),
+                ],
+            )
+
+            survivor._actor._gang_context = gang_context_by_replica_id[
+                survivor_replica_id.unique_id
+            ]
+            survivor._actor.set_ready()
+            new_dsm.update()
+
+            stopping_ids = {
+                replica.replica_id.unique_id
+                for replica in new_ds._replicas.get([ReplicaState.STOPPING])
+            }
+            assert stopping_ids == member_ids
+        finally:
+            uninitialized_replicas_context.remove(uninitialized_replica_id)
+
     def test_gang_startup_failure_per_gang_counter(self, mock_deployment_state_manager):
         """When a gang of replicas fails to start, the failure counter should increment once per gang and not once per replica."""
         create_dsm, _, _, _ = mock_deployment_state_manager


### PR DESCRIPTION
## Why
A Serve controller crash can leave a newly-created gang replica actor alive but uninitialized, before it receives the initial `initialize_and_get_metadata(rank, gang_context)` call. PR #63139 handles the rank-side symptom by dropping the uninitialized actor, but for gang deployments replacing only that member can leave recovered siblings with stale `member_replica_ids`.

## What
When recovery drops an unrecoverable replica that has no gang context, use recovered/running siblings' `gang_context.member_replica_ids` to detect the incomplete gang and force-stop the whole gang. This avoids leaving survivors that still reference replaced or dead siblings.

## Tests
- `python -m pytest python/ray/serve/tests/unit/test_deployment_state.py::TestScaleDeploymentGangReplicas::test_recovery_restarts_gang_when_member_uninitialized -q`
- `python -m pytest python/ray/serve/tests/unit/test_deployment_state.py::TestScaleDeploymentGangReplicas python/ray/serve/tests/unit/test_deployment_state.py::TestGangHealthCheck python/ray/serve/tests/unit/test_deployment_state.py::TestDeploymentRankManagerIntegrationE2E::test_rank_recovery_skips_when_already_assigned -q`
- `python -m pytest python/ray/serve/tests/test_controller_recovery.py::test_controller_recover_initializing_actor -q`
- `python -m pytest python/ray/serve/tests/test_gang_scheduling.py::TestGangControllerRecovery::test_gang_context_recovery -q`
- `python -m pytest "python/ray/serve/tests/test_gang_scheduling.py::TestGangControllerRecovery::test_gang_replica_crash_during_controller_downtime[True]" "python/ray/serve/tests/test_gang_scheduling.py::TestGangControllerRecovery::test_gang_replica_crash_during_controller_downtime[False]" -q`

Fixes #63153.