### PR TITLE
[Serve][LLM] Wait for request router init in LLMRouter constructor

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -1,4 +1,6 @@
+import asyncio
 import random
+import time
 from typing import FrozenSet, List, Optional, Tuple
 
 from fastapi import FastAPI, HTTPException, Request
@@ -8,6 +10,13 @@ from ray.serve._private.common import ReplicaID
 from ray.serve.handle import DeploymentHandle
 
 _BODY_TRUNCATED_HEADER = "x-body-truncated"
+
+# How long to wait for the underlying RequestRouter to be lazily created.
+# It's created on the first long-poll from the controller; that is normally
+# sub-second, but we allow up to a minute to ride out controller hiccups
+# before failing the constructor and letting Serve retry.
+_REQUEST_ROUTER_INIT_TIMEOUT_S = 60.0
+_REQUEST_ROUTER_INIT_POLL_INTERVAL_S = 0.05
 
 _ReplicaCacheSignature = FrozenSet[ReplicaID]
 
@@ -60,21 +69,36 @@ class LLMRouter:
         self._cached_endpoints: List[Tuple[str, int, str]] = []
         self._handle: DeploymentHandle = server
 
-        # Force the handle's local router and request router to construct
-        # synchronously so /internal/route can read them in the hot path.
-        # `curr_replicas` is populated separately by controller broadcast;
-        # /internal/route returns 503 (HAProxy retries) until then, which
-        # decouples router liveness from LLMServer cold start.
+        # Initialize the handle and wait for its underlying RequestRouter to
+        # be lazily created. The RequestRouter is built on the first long-poll
+        # from the controller (which delivers the deployment config that
+        # selects the request-router class), so `_get_request_router()`
+        # returns None for a brief window after `_init()`.
+        # `curr_replicas` is populated by the same long-poll client; until it
+        # carries at least one ready endpoint, /internal/route returns 503
+        # (HAProxy retries). That keeps router liveness decoupled from
+        # LLMServer cold start.
         self._handle._init()
-        self._request_router = self._handle._get_request_router()
-        if self._request_router is None:
-            raise RuntimeError(
-                "DeploymentHandle._get_request_router() returned None after "
-                "_init(); Serve internals may have changed."
-            )
+        self._request_router = await self._wait_for_request_router(
+            _REQUEST_ROUTER_INIT_TIMEOUT_S
+        )
+
+    async def _wait_for_request_router(self, timeout_s: float):
+        deadline = time.monotonic() + timeout_s
+        while True:
+            request_router = self._handle._get_request_router()
+            if request_router is not None:
+                return request_router
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    "DeploymentHandle._get_request_router() still returned "
+                    f"None after {timeout_s}s. The Serve controller may be "
+                    "unreachable, or Serve internals may have changed."
+                )
+            await asyncio.sleep(_REQUEST_ROUTER_INIT_POLL_INTERVAL_S)
 
     async def check_health(self):
-        if self._handle._get_request_router() is None:
+        if self._request_router is None:
             raise RuntimeError("request router not initialized")
 
     @router_app.post("/internal/route")


### PR DESCRIPTION
## Why this is needed
After #63167, LLMRouter replicas started crashing on startup with:

```
File "/.../ray/llm/_internal/serve/core/ingress/router.py", line 71, in __init__
    raise RuntimeError(
RuntimeError: DeploymentHandle._get_request_router() returned None after _init(); Serve internals may have changed.
```

`LLMRouter.__init__` called `handle._init()` then immediately `handle._get_request_router()` — but the underlying `RequestRouter` is **lazy-created** on the first `DEPLOYMENT_CONFIG` long-poll from the controller (see `AsyncioRouter.request_router` property in `serve/_private/router.py`). For a brief window after `_init()` returns, `_get_request_router()` is still `None`, so the constructor was racing the controller and reliably failing replica startup.

The cleanup commits in #63167 dropped the previous `await self._handle.llm_config.remote()` call that masked this race, because `assign_request` awaits `_request_router_initialized` internally — but reading `_get_request_router()` directly bypasses that synchronization point.

## Summary
- `LLMRouter.__init__` now polls `_get_request_router()` until it returns non-`None` (60s timeout, fails the constructor and lets Serve retry on timeout).
- Caches the resolved router on `self._request_router` for the hot path; `check_health` now consults the cached field.
- This matches the existing pattern in `python/ray/llm/_internal/serve/utils/broadcast.py:67-90`, which already documents the same race for callers that bypass `assign_request`.

## Test plan
- [x] `pre-commit run --files python/ray/llm/_internal/serve/core/ingress/router.py`
- [x] Existing unit tests in `test_router.py` instantiate via `LLMRouter.__new__(LLMRouter)` and pre-set `_request_router`, so they're unaffected by the constructor change.
- [ ] CI (`go` label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)