### PR TITLE
[serve] Recover gang context for orphaned replicas to restart the whole gang

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -723,6 +723,10 @@ class ActorReplicaWrapper:
         # asynchronously verify the actor finished its initial setup before
         # we trigger `initialize_and_get_metadata`.
         self._was_initialized_obj_ref: Optional[ObjectRef] = None
+        # Populated in self.recover() to recover the gang context of an
+        # orphaned actor that never finished `initialize_and_get_metadata`,
+        # so the whole gang can be restarted instead of just the orphan.
+        self._initial_gang_context_obj_ref: Optional[ObjectRef] = None
         # Set to True when `check_ready()` determines the actor cannot be
         # recovered (e.g., the previous controller crashed before the actor
         # finished its initial setup). The reconciler treats this case as a
@@ -1080,6 +1084,11 @@ class ActorReplicaWrapper:
                 deployment_info.ingress,
                 deployment_info.route_prefix,
                 deployment_info.ingress_request_router,
+                # Pass gang_context at construction so the actor can report
+                # its gang identity to the controller during recovery, even
+                # if the previous controller crashed before sending the
+                # first initialize_and_get_metadata.
+                self._gang_context,
             )
         # TODO(simon): unify the constructor arguments across language
         elif (
@@ -1284,6 +1293,15 @@ class ActorReplicaWrapper:
             # don't accidentally drive the bad actor through initialization
             # only to kill it afterwards.
             self._was_initialized_obj_ref = self._actor_handle.was_initialized.remote()
+            # Fire the gang-context probe in parallel. Even an orphaned
+            # actor (one that never ran `initialize_and_get_metadata`)
+            # exposes its gang context here because we pass it at
+            # construction. Recovering this lets us escalate to a whole-
+            # gang restart when the orphan is dropped, instead of leaving
+            # surviving siblings with stale `member_replica_ids`.
+            self._initial_gang_context_obj_ref = (
+                self._actor_handle.get_initial_gang_context.remote()
+            )
 
         return True
 
@@ -1300,6 +1318,30 @@ class ActorReplicaWrapper:
                 f"Failed to kill unrecoverable replica actor "
                 f"{self._replica_id} during controller recovery."
             )
+
+    def _recover_initial_gang_context(self) -> None:
+        """Populate ``self._gang_context`` from the actor's construction-time
+        gang context, so an orphaned gang member exposes its gang identity
+        even if it never finished `initialize_and_get_metadata`.
+
+        Best-effort: if the actor died between the probe being fired in
+        ``recover()`` and being observed here, leave ``self._gang_context``
+        unchanged.
+        """
+        if self._initial_gang_context_obj_ref is None:
+            return
+        gang_ctx_ref = self._initial_gang_context_obj_ref
+        self._initial_gang_context_obj_ref = None
+        try:
+            initial_gang_context = ray.get(gang_ctx_ref)
+        except Exception as e:
+            logger.debug(
+                f"Could not recover initial gang context for "
+                f"{self._replica_id} during controller recovery ({e!r})."
+            )
+            return
+        if initial_gang_context is not None:
+            self._gang_context = initial_gang_context
 
     def check_ready(self) -> Tuple[ReplicaStartupStatus, Optional[str]]:
         """
@@ -1364,6 +1406,11 @@ class ActorReplicaWrapper:
 
             probe_ref = self._was_initialized_obj_ref
             self._was_initialized_obj_ref = None
+            # Recover the construction-time gang context before either
+            # branch below: orphan drops need gang_id for
+            # `failed_gang_ids`, and survivors need it populated for the
+            # same-pass cleanup loop. Best-effort; failures are swallowed.
+            self._recover_initial_gang_context()
             try:
                 was_initialized = ray.get(probe_ref)
             except Exception as e:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1057,6 +1057,7 @@ class Replica:
         ingress: bool,
         route_prefix: str,
         is_ingress_request_router: bool = False,
+        gang_context: Optional[GangContext] = None,
     ):
         self._version = version
         self._replica_id = replica_id
@@ -1105,7 +1106,7 @@ class Replica:
         # subclass implementations.
         self._shutting_down = False
         # Gang context for this replica.
-        self._gang_context: Optional[GangContext] = None
+        self._gang_context: Optional[GangContext] = gang_context
 
         # Will be populated with the wrapped ASGI app if the user callable is an
         # `ASGIAppReplicaWrapper` (i.e., they are using the FastAPI integration).
@@ -2722,6 +2723,7 @@ class ReplicaActor:
         ingress: bool,
         route_prefix: str,
         is_ingress_request_router: bool = False,
+        gang_context: Optional[GangContext] = None,
     ):
         deployment_config = DeploymentConfig.from_proto_bytes(
             deployment_config_proto_bytes
@@ -2739,6 +2741,7 @@ class ReplicaActor:
             ingress=ingress,
             route_prefix=route_prefix,
             is_ingress_request_router=is_ingress_request_router,
+            gang_context=gang_context,
         )
 
     def push_proxy_handle(self, handle: ActorHandle):
@@ -2790,6 +2793,19 @@ class ReplicaActor:
         kill the actor when it returns False.
         """
         return self._replica_impl._user_callable_initialized
+
+    async def get_initial_gang_context(self) -> Optional[GangContext]:
+        """Return the gang context this replica was constructed with.
+
+        Set on the actor side at ``__init__`` time, so the controller can
+        recover an orphaned gang member's gang identity even if the actor
+        never finished its initial ``initialize_and_get_metadata`` call.
+        Without this, an orphan dropped during controller-recovery would
+        leave its surviving siblings with stale ``member_replica_ids``
+        references and split the gang. Returns ``None`` for non-gang
+        deployments.
+        """
+        return self._replica_impl._gang_context
 
     def list_outbound_deployments(self) -> Optional[List[DeploymentID]]:
         return self._replica_impl.list_outbound_deployments()

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -70,6 +70,11 @@ dead_replicas_context = set()
 # controller crashed before the actor finished its initial setup.
 uninitialized_replicas_context = set()
 replica_rank_context: Dict[str, ReplicaRank] = {}
+# Replicas registered in this dict expose their gang context to the
+# controller during recovery via the `get_initial_gang_context` probe,
+# so an orphaned (uninitialized) gang member still exposes its gang
+# identity even if it never finished `initialize_and_get_metadata`.
+replica_gang_context: Dict[ReplicaID, GangContext] = {}
 
 
 class MockTimer(TimerBase):
@@ -540,6 +545,12 @@ class MockReplicaActorWrapper:
         self._assign_rank_callback = assign_rank_callback
         self._rank = assign_rank_callback(self._replica_id.unique_id, node_id=-1)
         replica_rank_context[self._replica_id.unique_id] = self._rank
+        # Persist the gang context so a simulated controller restart
+        # (a fresh wrapper for the same replica_id) can read it back in
+        # `recover()` and expose the gang identity of an orphan that
+        # never finished `initialize_and_get_metadata`.
+        if gang_context is not None:
+            replica_gang_context[self._replica_id] = gang_context
 
         def _on_scheduled_stub(*args, **kwargs):
             pass
@@ -586,6 +597,12 @@ class MockReplicaActorWrapper:
         # observed asynchronously in `check_ready()`. Tests register
         # uninitialized replicas via `uninitialized_replicas_context`.
         self._unrecoverable = self.replica_id in uninitialized_replicas_context
+        # Even an orphan (uninitialized) gang member must expose its
+        # gang identity during recovery so the reconciler can escalate to
+        # a whole-gang restart when the orphan is dropped.
+        recovered_gang_ctx = replica_gang_context.get(self._replica_id)
+        if recovered_gang_ctx is not None:
+            self._gang_context = recovered_gang_ctx
         return True
 
     def check_ready(self) -> ReplicaStartupStatus:

--- a/python/ray/serve/tests/test_controller_recovery.py
+++ b/python/ray/serve/tests/test_controller_recovery.py
@@ -25,6 +25,7 @@ from ray.serve._private.test_utils import (
     get_application_url,
     request_with_retries,
 )
+from ray.serve.config import GangSchedulingConfig
 from ray.serve.schema import LoggingConfig, ServeDeploySchema
 from ray.util.state import list_actors
 
@@ -286,6 +287,129 @@ def test_controller_recover_initializing_actor(serve_instance):
         return not matching or all(a["state"] == "DEAD" for a in matching)
 
     wait_for_condition(original_actor_dead)
+
+
+def test_controller_recover_split_gang_init(serve_instance):
+    """Controller crash mid-startup of a gang where rank=0 finished its
+    initial ``initialize_and_get_metadata(rank=..., gang_context=...)``
+    call but rank=1 did not. The new controller must force-stop the
+    survivor (rank=0) in the same reconcile pass that drops the orphan
+    (rank=1).
+    """
+
+    rank0_init_done = SignalActor.remote()
+    rank1_unblock = SignalActor.remote()
+    client = serve_instance
+
+    @serve.deployment(
+        num_replicas=2,
+        gang_scheduling_config=GangSchedulingConfig(gang_size=2),
+    )
+    class V1:
+        async def __init__(self):
+            ctx = serve.context._get_internal_replica_context()
+            rank = ctx.rank.rank if ctx.rank is not None else None
+            if rank == 0:
+                # rank=0 completes its `initialize_and_get_metadata` so
+                # the controller transitions it to RUNNING and records
+                # its `_gang_context`.
+                ray.get(rank0_init_done.send.remote())
+            else:
+                # rank=1 blocks indefinitely; its first
+                # `initialize_and_get_metadata` never returns. The same
+                # signal also blocks any replacement gang's rank=1.
+                await rank1_unblock.wait.remote()
+
+        def __call__(self, request):
+            return os.getpid()
+
+    serve._run(V1.bind(), _blocking=False, name="app")
+
+    # Wait for rank=0 to finish its constructor.
+    ray.get(rank0_init_done.wait.remote())
+
+    deployment_id = DeploymentID(name="V1", app_name="app")
+    controller = client._controller
+
+    def get_replica_states():
+        return ray.get(
+            controller._dump_replica_states_for_testing.remote(deployment_id)
+        )
+
+    # Wait for rank=0 to reach RUNNING in the controller (i.e., its
+    # `initialize_and_get_metadata` returned and was recorded).
+    def rank0_running():
+        states = get_replica_states()
+        return len(states.get([ReplicaState.RUNNING])) >= 1
+
+    wait_for_condition(rank0_running)
+
+    original_running = get_replica_states().get([ReplicaState.RUNNING])
+    assert len(original_running) == 1
+    original_rank0_id = original_running[0].replica_id
+
+    # Kill the controller so the next reconcile happens on the new one.
+    def get_controller_pid():
+        for actor in list_actors(filters=[("state", "=", "ALIVE")]):
+            if actor["name"] == SERVE_CONTROLLER_NAME:
+                return actor["pid"]
+        return None
+
+    controller1_pid = get_controller_pid()
+    ray.kill(client._controller, no_restart=False)
+
+    def controller_replaced():
+        pid = get_controller_pid()
+        return pid is not None and pid != controller1_pid
+
+    wait_for_condition(controller_replaced)
+    new_controller = ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
+
+    def get_replica_states_new():
+        return ray.get(
+            new_controller._dump_replica_states_for_testing.remote(deployment_id)
+        )
+
+    # The original rank=0 must never re-enter RUNNING after the crash --
+    # its gang_context is recovered via the construction-time probe, the
+    # orphan drop populates `failed_gang_ids`, and the failed_gang_ids
+    # loop force-stops rank=0 in the same reconcile pass. We exit once
+    # we've observed STOPPING for the original rank=0 and a new replica
+    # appearing, which means the whole-gang restart has been triggered.
+    seen_original_rank0_running = False
+    seen_states: set = set()
+    original_replica_ids = {r.replica_id for r in original_running}
+
+    def recovery_progressed():
+        nonlocal seen_original_rank0_running
+        try:
+            states = get_replica_states_new()
+        except Exception:
+            return False
+        for r in states.get([ReplicaState.RUNNING]):
+            seen_states.add(("RUNNING", r.replica_id))
+            if r.replica_id == original_rank0_id:
+                seen_original_rank0_running = True
+                return True
+        for r in states.get([ReplicaState.STOPPING]):
+            seen_states.add(("STOPPING", r.replica_id))
+        observed_original_stopping = ("STOPPING", original_rank0_id) in seen_states
+        new_replica_seen = any(
+            rid not in original_replica_ids for _, rid in seen_states
+        )
+        return observed_original_stopping and new_replica_seen
+
+    try:
+        wait_for_condition(recovery_progressed, timeout=5)
+    finally:
+        # Always unblock rank=1 so the replacement gang can finish startup
+        # and the test's serve_instance fixture can clean up cleanly,
+        # regardless of which assertion below fails first.
+        ray.get(rank1_unblock.send.remote())
+
+    assert not seen_original_rank0_running
+
+    client._wait_for_application_running("app")
 
 
 def test_replica_deletion_after_controller_recover(serve_instance):

--- a/python/ray/serve/tests/unit/conftest.py
+++ b/python/ray/serve/tests/unit/conftest.py
@@ -14,6 +14,7 @@ from ray.serve._private.test_utils import (
     MockReplicaActorWrapper,
     MockTimer,
     dead_replicas_context,
+    replica_gang_context,
     replica_rank_context,
     uninitialized_replicas_context,
 )
@@ -90,5 +91,6 @@ def mock_deployment_state_manager(
         )
 
         dead_replicas_context.clear()
+        replica_gang_context.clear()
         replica_rank_context.clear()
         uninitialized_replicas_context.clear()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -1,6 +1,6 @@
 import sys
 from copy import deepcopy
-from typing import Any, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -3960,6 +3960,134 @@ def test_actor_uninitialized_before_recover(mock_deployment_state_manager):
     check_counts(new_ds, total=1, by_state=[(ReplicaState.STARTING, 1, v1)])
 
     uninitialized_replicas_context.remove(replica_id)
+
+
+def test_gang_orphan_recovery_restarts_whole_gang(mock_deployment_state_manager):
+    """Controller crash mid-startup of a gang member must restart the whole gang.
+
+    When the previous controller crashed between actor creation and the
+    first `initialize_and_get_metadata` call for one member of a gang,
+    the orphan and all its surviving siblings must be force-stopped
+    together in the same reconcile pass.
+    """
+
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    gang_size = 2
+    num_gangs = 2
+    target_replicas = gang_size * num_gangs
+    deployment_id = DeploymentID(name="gang_orphan_recovery", app_name="app")
+
+    dsm: DeploymentStateManager = create_dsm(
+        create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+    )
+    info, version = deployment_info(
+        num_replicas=target_replicas,
+        version="v1",
+        gang_scheduling_config=GangSchedulingConfig(gang_size=gang_size),
+    )
+    dsm.deploy(deployment_id, info)
+    ds = dsm._deployment_states[deployment_id]
+
+    gang_ids = [f"gang_{i}" for i in range(num_gangs)]
+    dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(
+        return_value={
+            deployment_id: GangReservationResult(
+                success=True,
+                gang_pgs=[Mock(name=f"pg-{i}") for i in range(num_gangs)],
+                gang_ids=gang_ids,
+                gang_pg_names=[f"SERVE_GANG::pg-{i}" for i in range(num_gangs)],
+            )
+        }
+    )
+    dsm.update()
+    starting = ds._replicas.get([ReplicaState.STARTING])
+    assert len(starting) == target_replicas
+    for replica in starting:
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(
+        ds,
+        total=target_replicas,
+        by_state=[(ReplicaState.RUNNING, target_replicas, version)],
+    )
+    assert ds.curr_status_info.status == DeploymentStatus.HEALTHY
+
+    # Group running replicas by gang and pick one orphan.
+    running_replicas = ds._replicas.get([ReplicaState.RUNNING])
+    gang_to_replicas: Dict[str, List[DeploymentReplica]] = {}
+    for replica in running_replicas:
+        gang_to_replicas.setdefault(replica.gang_context.gang_id, []).append(replica)
+    failed_gang_id, failed_gang_members = next(iter(gang_to_replicas.items()))
+    surviving_gang_id = next(g for g in gang_ids if g != failed_gang_id)
+    orphan = failed_gang_members[0]
+    sibling = failed_gang_members[1]
+    orphan_id = orphan.replica_id
+    sibling_id = sibling.replica_id
+
+    dsm.save_checkpoint()
+
+    # Simulate controller crash: previous controller crashed between
+    # actor creation and the first `initialize_and_get_metadata(gang_context=...)`
+    # for the orphan. The actor is alive but uninitialized. The sibling's
+    # initialize_and_get_metadata had already completed, so its gang_context
+    # still references the orphan's id.
+    uninitialized_replicas_context.add(orphan_id)
+
+    new_dsm: DeploymentStateManager = create_dsm(
+        [r.replica_id.to_full_id_str() for r in running_replicas],
+        create_placement_group_fn_override=lambda *args, **kwargs: Mock(),
+    )
+    new_ds = new_dsm._deployment_states[deployment_id]
+
+    # All replicas enter RECOVERING. The probes are fired and observed
+    # in the next reconcile pass.
+    check_counts(
+        new_ds,
+        total=target_replicas,
+        by_state=[(ReplicaState.RECOVERING, target_replicas, version)],
+    )
+    failures_before = new_ds._replica_constructor_retry_counter
+
+    # No gang reservation should be needed in this cycle: the failed
+    # gang is force-stopped and replicas of the surviving gang stay put.
+    new_dsm._deployment_scheduler.schedule_gang_placement_groups = Mock(return_value={})
+
+    new_dsm.update()
+
+    # Both members of the failed gang must be force-stopped together.
+    # The orphan's gang_id is recovered from the actor's construction-
+    # time `get_initial_gang_context` probe, which lets failed_gang_ids
+    # match the sibling and force-stop it in the same reconcile pass.
+    stopping = new_ds._replicas.get(states=[ReplicaState.STOPPING])
+    stopping_ids = {r.replica_id for r in stopping}
+    assert (
+        orphan_id in stopping_ids
+    ), "orphan should be force-stopped after was_initialized=False"
+    assert (
+        sibling_id in stopping_ids
+    ), "sibling must be force-stopped so the gang restarts atomically"
+    assert all(
+        r.gang_context is not None and r.gang_context.gang_id == failed_gang_id
+        for r in stopping
+    )
+
+    # The replicas of the OTHER gang must not be affected.
+    surviving_replicas = [
+        r
+        for r in new_ds._replicas.get()
+        if r.gang_context is not None and r.gang_context.gang_id == surviving_gang_id
+    ]
+    assert len(surviving_replicas) == gang_size
+    assert all(
+        r.actor_details.state in (ReplicaState.RECOVERING, ReplicaState.RUNNING)
+        for r in surviving_replicas
+    )
+
+    # The drop must not bump the deploy-failure counter -- the
+    # underlying cause is a previous controller crash, not user code.
+    assert new_ds._replica_constructor_retry_counter == failures_before
+
+    uninitialized_replicas_context.discard(orphan_id)
 
 
 def test_actor_died_before_recover(mock_deployment_state_manager):


### PR DESCRIPTION
## Description
When a Serve controller crashes between actor creation and the first `initialize_and_get_metadata` call for a gang member, the orphaned actor lives with `_rank = None` and `_gang_context = None`. #63139 drops the orphan on recovery, but for gang deployments dropping only the orphan leaves surviving siblings with stale `member_replica_ids` references to the dead orphan, splitting the gang.

## Approach
Pass `gang_context` to the replica constructor so the actor carries its gang identity from `__init__`, and add a `get_initial_gang_context` RPC that the controller probes during recovery alongside `was_initialized`.

The recovered gang_id flows into `failed_gang_ids`, so the existing sibling-cleanup loop force-stops the whole gang in the same reconcile pass leading to atomic restart and no partial gangs.

## Related issues
Closes https://github.com/ray-project/ray/issues/63153.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
