### PR TITLE
[llm][ci] Re-enable `llm_batch_vllm_multi_node`

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4524,8 +4524,7 @@
       pytest -sv test_batch_sglang.py
 
 - name: llm_batch_vllm_multi_node
-  # TODO(ray-llm): https://github.com/anyscale/ray/issues/572
-  frequency: manual
+  frequency: nightly
   python: "3.12"
   group: llm-batch
   team: llm


### PR DESCRIPTION
## Description
A compiled graph bug manifests in `llm_batch_vllm_multi_node` via the Ray executor backend in vLLM. In vLLM 0.20.0, the ray executor backend is revamped and moved off compiled graph. In Ray LLM release images, the revamped ray executor backend is turned on by default: https://github.com/ray-project/ray/pull/62970/changes#diff-9a06c622586d761628d2e83c393109b8885f94d700a04383a68f3981ac6878f2R70. The bug should no longer repro and therefore we re-enable the jailed test.

## Related issues
Closes https://github.com/ray-project/ray/issues/58062.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
