### PR TITLE
[data][llm] Promote `max_tasks_in_flight_per_actor` to a first-class config field and adjust defaults

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -128,11 +128,13 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
             enough for batch size >= 64. Sets the engine actor's Ray Core
             ``max_concurrency``.
         max_tasks_in_flight_per_actor: Max tasks Ray Data submits concurrently to
-            each engine actor. Defaults to ``max_concurrent_batches *
-            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``; the
-            factor can be overridden via the
-            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``
-            env var. An explicit value here takes precedence.
+            each engine actor. Passed through to ``ActorPoolStrategy``; if unset,
+            Ray Data's actor pool resolves it via
+            ``DataContext.max_tasks_in_flight_per_actor`` (if set globally), else
+            ``max_concurrent_batches *
+            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`` (factor
+            env-overridable via
+            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``).
         should_continue_on_error: If True, continue processing when inference fails for a row
             instead of raising an exception. Failed rows will have a non-empty
             ``__inference_error__`` column containing the error message, and other
@@ -243,11 +245,13 @@ class SGLangEngineProcessorConfig(_SGLangEngineProcessorConfig):
             enough for batch size >= 64. Sets the engine actor's Ray Core
             ``max_concurrency``.
         max_tasks_in_flight_per_actor: Max tasks Ray Data submits concurrently to
-            each engine actor. Defaults to ``max_concurrent_batches *
-            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``; the
-            factor can be overridden via the
-            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``
-            env var. An explicit value here takes precedence.
+            each engine actor. Passed through to ``ActorPoolStrategy``; if unset,
+            Ray Data's actor pool resolves it via
+            ``DataContext.max_tasks_in_flight_per_actor`` (if set globally), else
+            ``max_concurrent_batches *
+            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`` (factor
+            env-overridable via
+            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``).
         chat_template_stage: Chat templating stage config (bool | dict | ChatTemplateStageConfig).
             Defaults to True. Use nested config for per-stage control over batch_size,
             concurrency, runtime_env, num_cpus, and memory. Legacy ``apply_chat_template``

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -128,13 +128,13 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
             enough for batch size >= 64. Sets the engine actor's Ray Core
             ``max_concurrency``.
         max_tasks_in_flight_per_actor: Max tasks Ray Data submits concurrently to
-            each engine actor. Passed through to ``ActorPoolStrategy``; if unset,
-            Ray Data's actor pool resolves it via
-            ``DataContext.max_tasks_in_flight_per_actor`` (if set globally), else
-            ``max_concurrent_batches *
-            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`` (factor
-            env-overridable via
-            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``).
+            each engine actor. Passed through to ``ray.data.ActorPoolStrategy``.
+            If unset, Ray Data uses
+            ``ray.data.DataContext.max_tasks_in_flight_per_actor`` if set globally.
+            Otherwise, it defaults to ``2 * max_concurrent_batches``; the factor
+            can be overridden via the
+            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``
+            env var.
         should_continue_on_error: If True, continue processing when inference fails for a row
             instead of raising an exception. Failed rows will have a non-empty
             ``__inference_error__`` column containing the error message, and other
@@ -245,13 +245,13 @@ class SGLangEngineProcessorConfig(_SGLangEngineProcessorConfig):
             enough for batch size >= 64. Sets the engine actor's Ray Core
             ``max_concurrency``.
         max_tasks_in_flight_per_actor: Max tasks Ray Data submits concurrently to
-            each engine actor. Passed through to ``ActorPoolStrategy``; if unset,
-            Ray Data's actor pool resolves it via
-            ``DataContext.max_tasks_in_flight_per_actor`` (if set globally), else
-            ``max_concurrent_batches *
-            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`` (factor
-            env-overridable via
-            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``).
+            each engine actor. Passed through to ``ray.data.ActorPoolStrategy``.
+            If unset, Ray Data uses
+            ``ray.data.DataContext.max_tasks_in_flight_per_actor`` if set globally.
+            Otherwise, it defaults to ``2 * max_concurrent_batches``; the factor
+            can be overridden via the
+            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``
+            env var.
         chat_template_stage: Chat templating stage config (bool | dict | ChatTemplateStageConfig).
             Defaults to True. Use nested config for per-stage control over batch_size,
             concurrency, runtime_env, num_cpus, and memory. Legacy ``apply_chat_template``

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -125,7 +125,14 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
             This is to overlap the batch processing to avoid the tail latency of
             each batch. The default value may not be optimal when the batch size
             or the batch processing latency is too small, but it should be good
-            enough for batch size >= 64.
+            enough for batch size >= 64. Sets the engine actor's Ray Core
+            ``max_concurrency``.
+        max_tasks_in_flight_per_actor: Max tasks Ray Data submits concurrently to
+            each engine actor. Defaults to ``max_concurrent_batches *
+            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``; the
+            factor can be overridden via the
+            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``
+            env var. An explicit value here takes precedence.
         should_continue_on_error: If True, continue processing when inference fails for a row
             instead of raising an exception. Failed rows will have a non-empty
             ``__inference_error__`` column containing the error message, and other
@@ -233,7 +240,14 @@ class SGLangEngineProcessorConfig(_SGLangEngineProcessorConfig):
             This is to overlap the batch processing to avoid the tail latency of
             each batch. The default value may not be optimal when the batch size
             or the batch processing latency is too small, but it should be good
-            enough for batch size >= 64.
+            enough for batch size >= 64. Sets the engine actor's Ray Core
+            ``max_concurrency``.
+        max_tasks_in_flight_per_actor: Max tasks Ray Data submits concurrently to
+            each engine actor. Defaults to ``max_concurrent_batches *
+            DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``; the
+            factor can be overridden via the
+            ``RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR``
+            env var. An explicit value here takes precedence.
         chat_template_stage: Chat templating stage config (bool | dict | ChatTemplateStageConfig).
             Defaults to True. Use nested config for per-stage control over batch_size,
             concurrency, runtime_env, num_cpus, and memory. Legacy ``apply_chat_template``

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -160,12 +160,15 @@ class OfflineProcessorConfig(ProcessorConfig):
     max_tasks_in_flight_per_actor: Optional[int] = Field(
         default=None,
         description="Max tasks Ray Data submits concurrently to each engine "
-        "actor. Passed through to `ActorPoolStrategy`; if unset, Ray Data's "
-        "actor pool resolves it via `DataContext.max_tasks_in_flight_per_actor` "
-        "(if set globally), else `max_concurrent_batches * "
-        "DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR` (factor "
-        "env-overridable via "
-        "`RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`).",
+        "actor. Passed through to `ray.data.ActorPoolStrategy`. If unset, Ray "
+        "Data uses `ray.data.DataContext.max_tasks_in_flight_per_actor` if set "
+        "globally. Otherwise, it defaults to `2 * max_concurrent_batches`; the "
+        "factor can be overridden via the "
+        "`RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR` "
+        "env var. "
+        "Setting this lower than `max_concurrent_batches` can underutilize the "
+        "engine actor because Ray Data submits fewer tasks than the actor can "
+        "process concurrently.",
     )
     should_continue_on_error: bool = Field(
         default=False,
@@ -290,6 +293,22 @@ class OfflineProcessorConfig(ProcessorConfig):
                     "max_tasks_in_flight_per_actor"
                 ]
         return values
+
+    @model_validator(mode="after")
+    def _warn_if_max_tasks_in_flight_underutilizes_actor(self):
+        if (
+            self.max_tasks_in_flight_per_actor is not None
+            and self.max_tasks_in_flight_per_actor < self.max_concurrent_batches
+        ):
+            logger.warning(
+                "Setting `max_tasks_in_flight_per_actor` (%s) lower than "
+                "`max_concurrent_batches` (%s) can underutilize each engine "
+                "actor because Ray Data will submit fewer tasks than the actor "
+                "can process concurrently.",
+                self.max_tasks_in_flight_per_actor,
+                self.max_concurrent_batches,
+            )
+        return self
 
     @model_validator(mode="before")
     def _warn_prepare_image_stage_deprecation(

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -6,6 +6,7 @@ from pydantic import Field, field_validator, model_validator
 
 from ray.data import Dataset
 from ray.data.block import UserDefinedFunction
+from ray.data.context import DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR
 from ray.llm._internal.batch.stages import (
     StatefulStage,
     wrap_postprocess,
@@ -15,11 +16,6 @@ from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 logger = logging.getLogger(__name__)
-
-
-# Higher values here are better for prefetching and locality. It's ok for this to be
-# fairly high since streaming backpressure prevents us from overloading actors.
-DEFAULT_MAX_TASKS_IN_FLIGHT = 16
 
 
 class ProcessorConfig(BaseModelExtended):
@@ -55,9 +51,12 @@ class ProcessorConfig(BaseModelExtended):
 
     experimental: Dict[str, Any] = Field(
         default_factory=dict,
-        description="[Experimental] Experimental configurations."
+        description="[Experimental] Experimental configurations. "
         "Supported keys:\n"
-        "`max_tasks_in_flight_per_actor`: The maximum number of tasks in flight per actor. Default to 16.",
+        "`max_tasks_in_flight_per_actor`: [DEPRECATED] Prefer the top-level "
+        "`max_tasks_in_flight_per_actor` field on `OfflineProcessorConfig`. "
+        "Setting it here is still respected (and overridden by the top-level "
+        "field if both are set), but logs a deprecation warning.",
     )
 
     @field_validator("concurrency")
@@ -156,7 +155,17 @@ class OfflineProcessorConfig(ProcessorConfig):
         "This is to overlap the batch processing to avoid the tail latency of "
         "each batch. The default value may not be optimal when the batch size "
         "or the batch processing latency is too small, but it should be good "
-        "enough for batch size >= 32.",
+        "enough for batch size >= 32. Sets the engine actor's Ray Core "
+        "`max_concurrency`.",
+    )
+    max_tasks_in_flight_per_actor: Optional[int] = Field(
+        default=None,
+        description="Max tasks Ray Data submits concurrently to each engine "
+        "actor. Defaults to `max_concurrent_batches * "
+        "DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`; the "
+        "factor can be overridden via the "
+        "`RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR` "
+        "env var. An explicit value here takes precedence.",
     )
     should_continue_on_error: bool = Field(
         default=False,
@@ -259,6 +268,39 @@ class OfflineProcessorConfig(ProcessorConfig):
                 values[stage_field] = {"enabled": enabled}
 
         return values
+
+    @model_validator(mode="before")
+    def _warn_experimental_max_tasks_in_flight_per_actor_deprecation(
+        cls, values: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Warn if `max_tasks_in_flight_per_actor` is set via the deprecated
+        `experimental` dict instead of the top-level field."""
+        experimental = values.get("experimental") or {}
+        if "max_tasks_in_flight_per_actor" in experimental:
+            logger.warning(
+                "Setting `max_tasks_in_flight_per_actor` via `experimental` is "
+                "deprecated; use the top-level `max_tasks_in_flight_per_actor` "
+                "field on `OfflineProcessorConfig` instead. The value in "
+                "`experimental` is still respected for now (and overridden by "
+                "the top-level field if both are set), but will be removed in "
+                "a future version."
+            )
+        return values
+
+    @model_validator(mode="after")
+    def _resolve_max_tasks_in_flight_per_actor(self):
+        """If the field wasn't set explicitly, fall back to the deprecated `experimental` key, then
+        to `max_concurrent_batches * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`.
+        """
+        if self.max_tasks_in_flight_per_actor is None:
+            resolved = self.experimental.get(
+                "max_tasks_in_flight_per_actor",
+                self.max_concurrent_batches
+                * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
+            )
+            # Bypass `validate_assignment=True` so we don't re-fire the deprecation warning
+            object.__setattr__(self, "max_tasks_in_flight_per_actor", resolved)
+        return self
 
     @model_validator(mode="before")
     def _warn_prepare_image_stage_deprecation(

--- a/python/ray/llm/_internal/batch/processor/base.py
+++ b/python/ray/llm/_internal/batch/processor/base.py
@@ -6,7 +6,6 @@ from pydantic import Field, field_validator, model_validator
 
 from ray.data import Dataset
 from ray.data.block import UserDefinedFunction
-from ray.data.context import DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR
 from ray.llm._internal.batch.stages import (
     StatefulStage,
     wrap_postprocess,
@@ -161,11 +160,12 @@ class OfflineProcessorConfig(ProcessorConfig):
     max_tasks_in_flight_per_actor: Optional[int] = Field(
         default=None,
         description="Max tasks Ray Data submits concurrently to each engine "
-        "actor. Defaults to `max_concurrent_batches * "
-        "DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`; the "
-        "factor can be overridden via the "
-        "`RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR` "
-        "env var. An explicit value here takes precedence.",
+        "actor. Passed through to `ActorPoolStrategy`; if unset, Ray Data's "
+        "actor pool resolves it via `DataContext.max_tasks_in_flight_per_actor` "
+        "(if set globally), else `max_concurrent_batches * "
+        "DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR` (factor "
+        "env-overridable via "
+        "`RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`).",
     )
     should_continue_on_error: bool = Field(
         default=False,
@@ -270,11 +270,11 @@ class OfflineProcessorConfig(ProcessorConfig):
         return values
 
     @model_validator(mode="before")
-    def _warn_experimental_max_tasks_in_flight_per_actor_deprecation(
+    def _migrate_experimental_max_tasks_in_flight_per_actor(
         cls, values: Dict[str, Any]
     ) -> Dict[str, Any]:
-        """Warn if `max_tasks_in_flight_per_actor` is set via the deprecated
-        `experimental` dict instead of the top-level field."""
+        """Migrate deprecated `experimental[max_tasks_in_flight_per_actor]` to
+        the top-level field; top-level wins if both are set."""
         experimental = values.get("experimental") or {}
         if "max_tasks_in_flight_per_actor" in experimental:
             logger.warning(
@@ -285,22 +285,11 @@ class OfflineProcessorConfig(ProcessorConfig):
                 "the top-level field if both are set), but will be removed in "
                 "a future version."
             )
+            if values.get("max_tasks_in_flight_per_actor") is None:
+                values["max_tasks_in_flight_per_actor"] = experimental[
+                    "max_tasks_in_flight_per_actor"
+                ]
         return values
-
-    @model_validator(mode="after")
-    def _resolve_max_tasks_in_flight_per_actor(self):
-        """If the field wasn't set explicitly, fall back to the deprecated `experimental` key, then
-        to `max_concurrent_batches * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR`.
-        """
-        if self.max_tasks_in_flight_per_actor is None:
-            resolved = self.experimental.get(
-                "max_tasks_in_flight_per_actor",
-                self.max_concurrent_batches
-                * DEFAULT_ACTOR_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR,
-            )
-            # Bypass `validate_assignment=True` so we don't re-fire the deprecation warning
-            object.__setattr__(self, "max_tasks_in_flight_per_actor", resolved)
-        return self
 
     @model_validator(mode="before")
     def _warn_prepare_image_stage_deprecation(

--- a/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/sglang_engine_proc.py
@@ -15,7 +15,6 @@ from ray.llm._internal.batch.observability.usage_telemetry.usage import (
     get_or_create_telemetry_agent,
 )
 from ray.llm._internal.batch.processor.base import (
-    DEFAULT_MAX_TASKS_IN_FLIGHT,
     OfflineProcessorConfig,
     Processor,
     ProcessorBuilder,
@@ -184,9 +183,7 @@ def build_sglang_engine_processor(
                 # saturate `max_concurrency`.
                 compute=ray.data.ActorPoolStrategy(
                     **config.get_concurrency(autoscaling_enabled=True),
-                    max_tasks_in_flight_per_actor=config.experimental.get(
-                        "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
-                    ),
+                    max_tasks_in_flight_per_actor=config.max_tasks_in_flight_per_actor,
                 ),
                 # The number of running batches "per actor" in Ray Core level.
                 # This is used to make sure we overlap batches to avoid the tail

--- a/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
+++ b/python/ray/llm/_internal/batch/processor/vllm_engine_proc.py
@@ -15,7 +15,6 @@ from ray.llm._internal.batch.observability.usage_telemetry.usage import (
     get_or_create_telemetry_agent,
 )
 from ray.llm._internal.batch.processor.base import (
-    DEFAULT_MAX_TASKS_IN_FLIGHT,
     OfflineProcessorConfig,
     Processor,
     ProcessorBuilder,
@@ -284,9 +283,7 @@ def build_vllm_engine_processor(
                 # saturate `max_concurrency`.
                 compute=ray.data.ActorPoolStrategy(
                     **config.get_concurrency(autoscaling_enabled=True),
-                    max_tasks_in_flight_per_actor=config.experimental.get(
-                        "max_tasks_in_flight_per_actor", DEFAULT_MAX_TASKS_IN_FLIGHT
-                    ),
+                    max_tasks_in_flight_per_actor=config.max_tasks_in_flight_per_actor,
                 ),
                 # The number of running batches "per actor" in Ray Core level.
                 # This is used to make sure we overlap batches to avoid the tail

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -1,13 +1,16 @@
-import logging
 import sys
 from typing import Any, AsyncIterator, Dict, List, Type
+from unittest.mock import patch
 
 import pydantic
 import pytest
 
 import ray
 from ray.data.llm import build_processor
-from ray.llm._internal.batch.processor import vLLMEngineProcessorConfig
+from ray.llm._internal.batch.processor import (
+    base as processor_base,
+    vLLMEngineProcessorConfig,
+)
 from ray.llm._internal.batch.processor.base import (
     Processor,
     ProcessorBuilder,
@@ -406,38 +409,72 @@ class TestOfflineProcessorConfig:
         assert config.max_tasks_in_flight_per_actor == expected
         assert config.max_concurrent_batches == kwargs.get("max_concurrent_batches", 8)
 
-    def test_experimental_max_tasks_in_flight_per_actor_deprecated(self, caplog):
+    def test_experimental_max_tasks_in_flight_per_actor_deprecated(self):
         """Setting `experimental['max_tasks_in_flight_per_actor']` migrates to
         the top-level field with a deprecation log; the explicit top-level
         field overrides it but the warning still fires."""
-        logger_name = "ray.llm._internal.batch.processor.base"
 
-        def has_deprecation_log():
+        def has_deprecation_log(warning_mock):
             return any(
-                "max_tasks_in_flight_per_actor" in r.message
-                and "deprecated" in r.message
-                for r in caplog.records
+                "max_tasks_in_flight_per_actor" in call.args[0]
+                and "deprecated" in call.args[0]
+                for call in warning_mock.call_args_list
             )
 
         # Migration: experimental → top-level field.
-        with caplog.at_level(logging.WARNING, logger=logger_name):
+        with patch.object(processor_base.logger, "warning") as warning_mock:
             cfg = vLLMEngineProcessorConfig(
                 model_source="unsloth/Llama-3.2-1B-Instruct",
                 experimental={"max_tasks_in_flight_per_actor": 10},
             )
         assert cfg.max_tasks_in_flight_per_actor == 10
-        assert has_deprecation_log()
+        assert has_deprecation_log(warning_mock)
 
         # Explicit top-level beats experimental, but warning still fires.
-        caplog.clear()
-        with caplog.at_level(logging.WARNING, logger=logger_name):
+        with patch.object(processor_base.logger, "warning") as warning_mock:
             cfg = vLLMEngineProcessorConfig(
                 model_source="unsloth/Llama-3.2-1B-Instruct",
                 max_tasks_in_flight_per_actor=20,
                 experimental={"max_tasks_in_flight_per_actor": 10},
             )
         assert cfg.max_tasks_in_flight_per_actor == 20
-        assert has_deprecation_log()
+        assert has_deprecation_log(warning_mock)
+
+    def test_max_tasks_in_flight_under_max_concurrent_batches_warns(self):
+        with patch.object(processor_base.logger, "warning") as warning_mock:
+            cfg = vLLMEngineProcessorConfig(
+                model_source="unsloth/Llama-3.2-1B-Instruct",
+                max_tasks_in_flight_per_actor=1,
+                max_concurrent_batches=8,
+            )
+
+        assert cfg.max_tasks_in_flight_per_actor == 1
+        assert cfg.max_concurrent_batches == 8
+        warning_messages = [call.args[0] for call in warning_mock.call_args_list]
+        assert any(
+            "max_tasks_in_flight_per_actor" in message
+            and "max_concurrent_batches" in message
+            and "underutilize" in message
+            for message in warning_messages
+        )
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"max_tasks_in_flight_per_actor": 8, "max_concurrent_batches": 8},
+            {"max_tasks_in_flight_per_actor": 16, "max_concurrent_batches": 8},
+        ],
+    )
+    def test_max_tasks_in_flight_does_not_warn_when_not_underutilized(self, kwargs):
+        with patch.object(processor_base.logger, "warning") as warning_mock:
+            vLLMEngineProcessorConfig(
+                model_source="unsloth/Llama-3.2-1B-Instruct",
+                **kwargs,
+            )
+
+        warning_messages = [call.args[0] for call in warning_mock.call_args_list]
+        assert not any("underutilize" in message for message in warning_messages)
 
 
 class TestMapKwargs:

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -386,6 +386,63 @@ class TestProcessorConfig:
         assert conf.get_concurrency() == expected
 
 
+class TestOfflineProcessorConfig:
+    @pytest.mark.parametrize(
+        "kwargs, expected",
+        [
+            # Explicit field wins.
+            ({"max_tasks_in_flight_per_actor": 10}, 10),
+            # Fallback: default max_concurrent_batches (8) * default factor (2).
+            ({}, 16),
+            # Fallback tracks max_concurrent_batches.
+            ({"max_concurrent_batches": 4}, 8),
+            # Explicit field beats the formula.
+            ({"max_concurrent_batches": 4, "max_tasks_in_flight_per_actor": 99}, 99),
+        ],
+    )
+    def test_max_tasks_in_flight_per_actor_resolution(self, kwargs, expected):
+        """Resolution happens at config construction; verify the field holds
+        the resolved value and `max_concurrent_batches` is intact."""
+        config = vLLMEngineProcessorConfig(
+            model_source="unsloth/Llama-3.2-1B-Instruct",
+            **kwargs,
+        )
+        assert config.max_tasks_in_flight_per_actor == expected
+        assert config.max_concurrent_batches == kwargs.get("max_concurrent_batches", 8)
+
+    def test_experimental_max_tasks_in_flight_per_actor_deprecated(self, caplog):
+        """Setting via `experimental` is honored with a deprecation log; the
+        top-level field overrides it but the warning still fires."""
+        import logging
+
+        logger_name = "ray.llm._internal.batch.processor.base"
+
+        def has_deprecation_log():
+            return any(
+                "max_tasks_in_flight_per_actor" in r.message
+                and "deprecated" in r.message
+                for r in caplog.records
+            )
+
+        with caplog.at_level(logging.WARNING, logger=logger_name):
+            cfg = vLLMEngineProcessorConfig(
+                model_source="unsloth/Llama-3.2-1B-Instruct",
+                experimental={"max_tasks_in_flight_per_actor": 10},
+            )
+        assert cfg.max_tasks_in_flight_per_actor == 10
+        assert has_deprecation_log()
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger=logger_name):
+            cfg = vLLMEngineProcessorConfig(
+                model_source="unsloth/Llama-3.2-1B-Instruct",
+                max_tasks_in_flight_per_actor=20,
+                experimental={"max_tasks_in_flight_per_actor": 10},
+            )
+        assert cfg.max_tasks_in_flight_per_actor == 20
+        assert has_deprecation_log()
+
+
 class TestMapKwargs:
     """Tests for preprocess_map_kwargs and postprocess_map_kwargs."""
 

--- a/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
+++ b/python/ray/llm/tests/batch/cpu/processor/test_processor_base.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from typing import Any, AsyncIterator, Dict, List, Type
 
@@ -390,19 +391,14 @@ class TestOfflineProcessorConfig:
     @pytest.mark.parametrize(
         "kwargs, expected",
         [
-            # Explicit field wins.
             ({"max_tasks_in_flight_per_actor": 10}, 10),
-            # Fallback: default max_concurrent_batches (8) * default factor (2).
-            ({}, 16),
-            # Fallback tracks max_concurrent_batches.
-            ({"max_concurrent_batches": 4}, 8),
-            # Explicit field beats the formula.
-            ({"max_concurrent_batches": 4, "max_tasks_in_flight_per_actor": 99}, 99),
+            ({}, None),
+            # Field stays None; the formula runs in Ray Data, not here.
+            ({"max_concurrent_batches": 4}, None),
         ],
     )
-    def test_max_tasks_in_flight_per_actor_resolution(self, kwargs, expected):
-        """Resolution happens at config construction; verify the field holds
-        the resolved value and `max_concurrent_batches` is intact."""
+    def test_max_tasks_in_flight_per_actor_passthrough(self, kwargs, expected):
+        """Field passes through to ActorPoolStrategy; None defers resolution."""
         config = vLLMEngineProcessorConfig(
             model_source="unsloth/Llama-3.2-1B-Instruct",
             **kwargs,
@@ -411,10 +407,9 @@ class TestOfflineProcessorConfig:
         assert config.max_concurrent_batches == kwargs.get("max_concurrent_batches", 8)
 
     def test_experimental_max_tasks_in_flight_per_actor_deprecated(self, caplog):
-        """Setting via `experimental` is honored with a deprecation log; the
-        top-level field overrides it but the warning still fires."""
-        import logging
-
+        """Setting `experimental['max_tasks_in_flight_per_actor']` migrates to
+        the top-level field with a deprecation log; the explicit top-level
+        field overrides it but the warning still fires."""
         logger_name = "ray.llm._internal.batch.processor.base"
 
         def has_deprecation_log():
@@ -424,6 +419,7 @@ class TestOfflineProcessorConfig:
                 for r in caplog.records
             )
 
+        # Migration: experimental → top-level field.
         with caplog.at_level(logging.WARNING, logger=logger_name):
             cfg = vLLMEngineProcessorConfig(
                 model_source="unsloth/Llama-3.2-1B-Instruct",
@@ -432,6 +428,7 @@ class TestOfflineProcessorConfig:
         assert cfg.max_tasks_in_flight_per_actor == 10
         assert has_deprecation_log()
 
+        # Explicit top-level beats experimental, but warning still fires.
         caplog.clear()
         with caplog.at_level(logging.WARNING, logger=logger_name):
             cfg = vLLMEngineProcessorConfig(

--- a/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_sglang_engine_proc.py
@@ -1,7 +1,7 @@
 """This test suite does not need sglang to be installed."""
 
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -9,7 +9,6 @@ import ray
 from ray.data.llm import SGLangEngineProcessorConfig
 from ray.llm._internal.batch.constants import SGLangTaskType
 from ray.llm._internal.batch.processor import ProcessorBuilder
-from ray.llm._internal.batch.processor.base import DEFAULT_MAX_TASKS_IN_FLIGHT
 from ray.llm._internal.batch.processor.sglang_engine_proc import (
     build_sglang_engine_processor,
 )
@@ -76,40 +75,6 @@ def test_sglang_engine_processor(gpu_type, model_llama_3_2_216M):
 
 
 class TestSGLangEngineProcessorConfig:
-    @pytest.mark.parametrize(
-        "experimental_config",
-        [
-            {"max_tasks_in_flight_per_actor": 10},
-            {},
-        ],
-    )
-    def test_experimental_max_tasks_in_flight_per_actor_usage(
-        self, experimental_config
-    ):
-        """Tests that max_tasks_in_flight_per_actor is set properly in the ActorPoolStrategy."""
-
-        with patch("ray.data.ActorPoolStrategy") as mock_actor_pool:
-            mock_actor_pool.return_value = MagicMock()
-
-            config = SGLangEngineProcessorConfig(
-                model_source="unsloth/Llama-3.2-1B-Instruct",
-                experimental=experimental_config,
-            )
-            build_sglang_engine_processor(config)
-
-            mock_actor_pool.assert_called()
-            call_kwargs = mock_actor_pool.call_args[1]
-            if experimental_config:
-                assert (
-                    call_kwargs["max_tasks_in_flight_per_actor"]
-                    == experimental_config["max_tasks_in_flight_per_actor"]
-                )
-            else:
-                assert (
-                    call_kwargs["max_tasks_in_flight_per_actor"]
-                    == DEFAULT_MAX_TASKS_IN_FLIGHT
-                )
-
     def test_build_processor_autoconfig_failure_with_trust_remote_code(self):
         config = SGLangEngineProcessorConfig(
             model_source="nonexistent-org/nonexistent-model",

--- a/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_vllm_engine_proc.py
@@ -1,5 +1,4 @@
 import sys
-from unittest.mock import MagicMock, patch
 
 import pydantic
 import pytest
@@ -691,46 +690,6 @@ class TestVLLMEngineProcessorConfig:
 
         processor = build_processor(config)
         assert processor is not None
-
-    @pytest.mark.parametrize(
-        "experimental_config",
-        [
-            {"max_tasks_in_flight_per_actor": 10},
-            {},
-        ],
-    )
-    def test_experimental_max_tasks_in_flight_per_actor_usage(
-        self, experimental_config
-    ):
-        """Tests that max_tasks_in_flight_per_actor is set properly in the ActorPoolStrategy."""
-
-        from ray.llm._internal.batch.processor.base import DEFAULT_MAX_TASKS_IN_FLIGHT
-        from ray.llm._internal.batch.processor.vllm_engine_proc import (
-            build_vllm_engine_processor,
-            vLLMEngineProcessorConfig,
-        )
-
-        with patch("ray.data.ActorPoolStrategy") as mock_actor_pool:
-            mock_actor_pool.return_value = MagicMock()
-
-            config = vLLMEngineProcessorConfig(
-                model_source="unsloth/Llama-3.2-1B-Instruct",
-                experimental=experimental_config,
-            )
-            build_vllm_engine_processor(config)
-
-            mock_actor_pool.assert_called()
-            call_kwargs = mock_actor_pool.call_args[1]
-            if experimental_config:
-                assert (
-                    call_kwargs["max_tasks_in_flight_per_actor"]
-                    == experimental_config["max_tasks_in_flight_per_actor"]
-                )
-            else:
-                assert (
-                    call_kwargs["max_tasks_in_flight_per_actor"]
-                    == DEFAULT_MAX_TASKS_IN_FLIGHT
-                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why
Ray Data LLM hardcoded `DEFAULT_MAX_TASKS_IN_FLIGHT = 16` instead of using Ray Data's actor-pool fallback, which (a) didn't track `max_concurrent_batches` when users tuned it and (b) bypassed both `DataContext.max_tasks_in_flight_per_actor` and the env-var override of the factor.

## What changes?
- New top-level field `OfflineProcessorConfig.max_tasks_in_flight_per_actor: Optional[int] = None`.
- Removed the `DEFAULT_MAX_TASKS_IN_FLIGHT = 16` constant; engine processors pass `config.max_tasks_in_flight_per_actor` straight through to `ActorPoolStrategy` (including `None`).
- Default in-flight cap: hardcoded `16` → `max_concurrent_batches × FACTOR`, resolved by Ray Data's actor pool.
- `DataContext.max_tasks_in_flight_per_actor` and `RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR` are now honored (previously bypassed by the explicit `16`).
- `experimental["max_tasks_in_flight_per_actor"]` is deprecated: migrated to the new field at construction with a `logger.warning`. Top-level field wins if both are set.

## Original API

```python
OfflineProcessorConfig(
    ...,
    experimental={"max_tasks_in_flight_per_actor": 32},  # only knob
)
```

## New API

```python
OfflineProcessorConfig(
    ...,
    max_concurrent_batches=8,           # unchanged
    max_tasks_in_flight_per_actor=32,   # new top-level field, Optional[int]
)
```

## Behavior changes
- Users who set `RAY_DATA_ACTOR_DEFAULT_MAX_TASKS_IN_FLIGHT_TO_MAX_CONCURRENCY_FACTOR` now have their override honored by Ray Data LLM (previously ignored).
- Setting via `experimental` still works but logs a deprecation warning. The top-level field overrides `experimental` if both are set.

| `max_concurrent_batches` | `max_tasks_in_flight_per_actor` | Ray actor `max_concurrency` | Effective in-flight cap |
|---|---|---|---|
| unset (default 8) | unset (None) | 8 | **16** |
| 16 | unset (None) | 16 | **32** |
| unset (default 8) | 50 | 8 | **50** |
| 16 | 50 | 16 | **50** |

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
