### PR TITLE
[Release / Train] Fix Train tutorials

### DIFF
--- a/doc/source/train/tutorials/ci/py_scripts/01_02_03_intro_to_ray_train.py
+++ b/doc/source/train/tutorials/ci/py_scripts/01_02_03_intro_to_ray_train.py
@@ -17,15 +17,13 @@ subprocess.check_call(
         "torch==2.8.0",
         "torchvision==0.23.0",
         "matplotlib==3.10.6",
-        "pyarrow==14.0.2",
+        "pyarrow==17.0.0",
     ]
 )
 
 # 01. Imports
 
 # --- Standard library: file IO, paths, timestamps, temp dirs, cleanup ---
-import csv  # Simple CSV logging for metrics in single-GPU section
-import datetime  # Timestamps for run directories / filenames
 import os  # Filesystem utilities (paths, env vars)
 import tempfile  # Ephemeral dirs for checkpoint staging with ray.train.report()
 import shutil  # Cleanup of artifacts (later cells)

--- a/doc/source/train/tutorials/ci/py_scripts/04a_vision_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04a_vision_pattern.py
@@ -12,7 +12,7 @@ subprocess.check_call([
     "torch==2.8.0",
     "torchvision==0.23.0",
     "matplotlib==3.10.6",
-    "pyarrow==14.0.2",
+    "pyarrow==17.0.0",
     "datasets==2.19.2",
 ])
 
@@ -23,15 +23,12 @@ subprocess.check_call([
 # ————————————————————————
 import os
 import io
-import tempfile
 import shutil  # file I/O and temp dirs
-import json                      # reading/writing configs
 import random, uuid              # randomness and unique IDs
 
 # ————————————————————————
 # Core Data & Storage Libraries
 # ————————————————————————
-import pandas as pd              # tabular data handling
 import numpy as np               # numerical ops
 import pyarrow as pa             # in-memory columnar format
 import pyarrow.parquet as pq     # reading/writing Parquet files

--- a/doc/source/train/tutorials/ci/py_scripts/04b_tabular_workload_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04b_tabular_workload_pattern.py
@@ -11,7 +11,7 @@ subprocess.check_call([
     sys.executable, "-m", "pip", "install", "--no-cache-dir",
     "matplotlib==3.10.6",
     "scikit-learn==1.7.2",
-    "pyarrow==14.0.2",    
+    "pyarrow==17.0.0",
     "xgboost-cpu==3.0.5",
     "seaborn==0.13.2",
 ])
@@ -19,10 +19,6 @@ subprocess.check_call([
 # 01. Imports
 import os
 import shutil
-import json
-import uuid
-import tempfile
-import random
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -36,7 +32,10 @@ import pyarrow as pa
 import ray
 import ray.data as rd
 from ray.data import ActorPoolStrategy
-from ray.train import RunConfig, ScalingConfig, CheckpointConfig, FailureConfig, get_dataset_shard, get_checkpoint, get_context
+from ray.train import (
+    RunConfig, ScalingConfig, CheckpointConfig, FailureConfig,
+    get_dataset_shard, get_checkpoint, get_context
+)
 from ray.train.xgboost import XGBoostTrainer, RayTrainReportCallback
 
 # 02. Load the UCI Cover type dataset (~580k rows, 54 features)

--- a/doc/source/train/tutorials/ci/py_scripts/04c_time_series_workload_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04c_time_series_workload_pattern.py
@@ -11,22 +11,14 @@ subprocess.check_call([
     sys.executable, "-m", "pip", "install", "--no-cache-dir",
     "torch==2.8.0",
     "matplotlib==3.10.6",
-    "pyarrow==14.0.2",
+    "pyarrow==17.0.0",
     "datasets==2.19.2",
 ])
 
 # 01. Imports
 import os
-import io
 import math
-import uuid
 import shutil
-import random
-import requests
-import sys
-from pathlib import Path
-from datetime import datetime, timedelta
-from datasets import load_dataset   
 
 import numpy as np
 import pandas as pd
@@ -39,14 +31,12 @@ import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader
 import torch.optim as optim
 
-import ray
 import ray.data as rdata
-import ray.train as train
 from ray.train import (
     ScalingConfig, RunConfig, FailureConfig,
-    CheckpointConfig, Checkpoint, get_checkpoint, get_context
+    CheckpointConfig, Checkpoint
 )
-from ray.train.torch import prepare_model, prepare_data_loader, TorchTrainer
+from ray.train.torch import prepare_model, TorchTrainer
 
 # 02. Load NYC taxi passenger counts (30-min) from GitHub raw – no auth, ~1 MB
 

--- a/doc/source/train/tutorials/ci/py_scripts/04d1_generative_cv_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04d1_generative_cv_pattern.py
@@ -1,7 +1,7 @@
 # 00. Runtime setup
 import os
-import sys
 import subprocess
+import sys
 
 # Non-secret env var (safe to set here)
 os.environ["RAY_TRAIN_V2_ENABLED"] = "1"
@@ -12,7 +12,7 @@ subprocess.check_call([
     "torch==2.8.0",
     "torchvision==0.23.0",
     "matplotlib==3.10.6",
-    "pyarrow==14.0.2",
+    "pyarrow==17.0.0",
     "datasets==2.19.2",
     "lightning==2.5.5",
 ])
@@ -20,21 +20,17 @@ subprocess.check_call([
 # 01. Imports
 
 # Standard libraries
-import os
 import io
-import json
 import shutil
 import tempfile
 import numpy as np
 import matplotlib.pyplot as plt
-import pandas as pd
 from PIL import Image
 
 # Ray
 import ray, ray.data
-from ray.train import ScalingConfig, get_context, RunConfig, FailureConfig, CheckpointConfig, Checkpoint, get_checkpoint
+from ray.train import ScalingConfig, RunConfig, FailureConfig, CheckpointConfig
 from ray.train.torch import TorchTrainer
-from ray.train.lightning import RayLightningEnvironment
 
 # PyTorch / Lightning
 import lightning.pytorch as pl
@@ -43,11 +39,7 @@ from torch import nn
 
 # Dataset
 from datasets import load_dataset
-import pyarrow as pa
-import pyarrow.parquet as pq
-from tqdm import tqdm  
 from torchvision.transforms import Compose, Resize, CenterCrop
-import random
 
 # 02. Load 10% of food101 (~7,500 images)
 hf_ds = load_dataset("ethz/food101", split="train[:10%]")
@@ -237,7 +229,6 @@ def train_loop(config):
         message="barrier.*using the device under current context",
     )
     import os
-    import torch
     import lightning.pytorch as pl
     from ray.train import get_checkpoint, get_context
     from ray.train.lightning import (
@@ -372,7 +363,6 @@ def sample_image(model, steps=50, device="cpu"):
 # 14. Generate and display samples
 
 import glob
-from ray.train import Checkpoint
 
 assert best_ckpt is not None, "Checkpoint is missing. Did training run and complete?"
 

--- a/doc/source/train/tutorials/ci/py_scripts/04d2_policy_learning_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04d2_policy_learning_pattern.py
@@ -1,7 +1,7 @@
 # 00. Runtime setup 
 import os
-import sys
 import subprocess
+import sys
 
 # Non-secret env var 
 os.environ["RAY_TRAIN_V2_ENABLED"] = "1"
@@ -12,7 +12,7 @@ subprocess.check_call([
     "torch==2.8.0",
     "matplotlib==3.10.6",
     "lightning==2.5.5",
-    "pyarrow==14.0.2",
+    "pyarrow==17.0.0",
 ])
 
 # 01. Imports
@@ -21,18 +21,14 @@ subprocess.check_call([
 import os
 import shutil
 import glob
-import json
-import uuid
 import numpy as np
 import matplotlib.pyplot as plt
-import pandas as pd
 import gymnasium as gym
 
 # Ray libraries for distributed data and training
 import ray
 import ray.data
-from ray.train.lightning import RayLightningEnvironment  
-from ray.train import ScalingConfig, RunConfig, FailureConfig, CheckpointConfig, get_context, get_checkpoint, report, Checkpoint
+from ray.train import ScalingConfig, RunConfig, FailureConfig, CheckpointConfig
 from ray.train.torch import TorchTrainer
 
 # PyTorch Lightning and base PyTorch for model definition and training
@@ -148,7 +144,7 @@ class DiffusionPolicy(pl.LightningModule):
 # 05. Ray Train Lightning-native training loop
 
 def train_loop(config):
-    import os, tempfile, torch, warnings
+    import os, tempfile, warnings
     import lightning.pytorch as pl
     from ray.train import get_checkpoint, get_context
     from ray.train.lightning import (

--- a/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
+++ b/doc/source/train/tutorials/ci/py_scripts/04e_rec_sys_workload_pattern.py
@@ -1,7 +1,7 @@
 # 00. Runtime setup
 import os
-import sys
 import subprocess
+import sys
 
 # Non-secret env var 
 os.environ["RAY_TRAIN_V2_ENABLED"] = "1"
@@ -11,21 +11,17 @@ subprocess.check_call([
     sys.executable, "-m", "pip", "install", "--no-cache-dir",
     "torch==2.8.0",
     "matplotlib==3.10.6",
-    "pyarrow==14.0.2",
+    "pyarrow==17.0.0",
 ])
 
 # 01. Imports
 
 # Standard libraries
 import os
-import uuid
-import json
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
-import zipfile
 import shutil
-import tempfile
 
 # PyTorch
 import torch
@@ -33,13 +29,14 @@ from torch import nn
 import torch.nn.functional as F
 
 # Ray
-import ray
 import ray.data
-from ray.train import ScalingConfig, RunConfig, CheckpointConfig, FailureConfig, Checkpoint, get_checkpoint, get_context,  get_dataset_shard, report
+from ray.train import (
+    ScalingConfig, RunConfig, CheckpointConfig, FailureConfig,
+    Checkpoint, get_checkpoint, get_context,  get_dataset_shard, report
+)
 from ray.train.torch import TorchTrainer, prepare_model
 
 # Other
-from tqdm import tqdm
 
 import subprocess
 # 02. Load MovieLens 100K Dataset and store in /mnt/cluster_storage/ as CSV + Parquet

--- a/release/ray_release/byod/byod_ray_train_workloads.sh
+++ b/release/ray_release/byod/byod_ray_train_workloads.sh
@@ -10,7 +10,7 @@ pip3 install --no-cache-dir \
     "torch==2.8.0" \
     "torchvision==0.23.0" \
     "matplotlib==3.10.6" \
-    "pyarrow==14.0.2" \
+    "pyarrow==17.0.0" \
     "datasets==2.19.2" \
     "lightning==2.5.5" \
     "scikit-learn==1.7.2" \


### PR DESCRIPTION
## Description
`doc/source/train/tutorials` were raising an error that `ImportError: Dataset requires pyarrow >= 17.0.0, but 14.0.2 is installed. Reinstall with 'pip install -U "pyarrow"'.`
Therefore, this PR fixes the tutorials by updating all pyarrows to 17.0.0 and at the same time removing unnecessary import statements