### PR TITLE
[Serve] Gate ingress request router body forwarding behind escape hatch

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -799,8 +799,18 @@ RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S = get_env_int(
 # active. Bodies longer than this are truncated; the Lua forwards what it has
 # with an `X-Body-Truncated: <bytes>/<content-length>` header so the router can
 # do best-effort prefix matching. Memory cost is ~2 * bufsize * maxconn.
+# Only consulted when RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY=1.
 RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_BUFSIZE = get_env_int(
     "RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_BUFSIZE", 262144
+)
+
+# Escape hatch: when true, HAProxy forwards the (possibly truncated) request
+# body to /internal/route and the router reads it. Off by default because the
+# round-robin policy ignores the body; flipping this on costs memory
+# (tune.bufsize) and a body read on every routed request, but is required for
+# body-aware routing policies (prefix cache, etc.).
+RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY = get_env_bool(
+    "RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY", False
 )
 
 RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT = int(

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -56,6 +56,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_HAPROXY_TIMEOUT_CLIENT_S,
     RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S,
     RAY_SERVE_HAPROXY_TIMEOUT_SERVER_S,
+    RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY,
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
@@ -804,6 +805,7 @@ class HAProxyApi(ProxyApi):
 
         content = _load_lua_template().substitute(
             TIMEOUT_S=RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S,
+            FORWARD_BODY=str(RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY).lower(),
             ROUTERS=_format_routers_lua(routers),
             REPLICA_TARGETS=_format_replica_targets_lua(targets),
         )
@@ -871,6 +873,9 @@ class HAProxyApi(ProxyApi):
                     ),
                     "ingress_request_router_bufsize": (
                         RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_BUFSIZE
+                    ),
+                    "ingress_request_router_forward_body": (
+                        RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY
                     ),
                 }
             )

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -99,6 +99,11 @@ frontend http_frontend
     acl has_ingress_request_router_app var(txn.ingress_request_router_app) -m found
     http-request wait-for-body time {{ ingress_request_router_timeout_s }}s if METH_POST has_ingress_request_router_app
     http-request lua.route_via_ingress_request_router if METH_POST has_ingress_request_router_app
+    # Fail loudly when the Lua dispatch did not pick a replica. Must appear
+    # before the use_backend rules below so the request never falls back to
+    # the primary backend (which would be a silent bypass of the configured
+    # router policy).
+    http-request return status 503 content-type text/plain lf-string "Ingress request router failed: %[var(txn.ingress_request_router_failed)]" hdr X-Serve-Reason %[var(txn.ingress_request_router_failed)] if { var(txn.ingress_request_router_failed) -m found }
     {%- endif %}
     # Static routing based on path prefixes in decreasing length then alphabetical order
 {%- for backend in backends %}

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -28,6 +28,8 @@ HAPROXY_CONFIG_TEMPLATE = """global
     nbthread {{ config.nbthread }}
     {%- if has_ingress_request_router %}
     lua-load-per-thread {{ ingress_request_router_lua_path }}
+    {%- endif %}
+    {%- if has_ingress_request_router and ingress_request_router_forward_body %}
     tune.bufsize {{ ingress_request_router_bufsize }}
     {%- endif %}
     {%- if config.enable_hap_optimization %}
@@ -97,7 +99,9 @@ frontend http_frontend
     {%- endif %}
     {%- endfor %}
     acl has_ingress_request_router_app var(txn.ingress_request_router_app) -m found
+    {%- if ingress_request_router_forward_body %}
     http-request wait-for-body time {{ ingress_request_router_timeout_s }}s if METH_POST has_ingress_request_router_app
+    {%- endif %}
     http-request lua.route_via_ingress_request_router if METH_POST has_ingress_request_router_app
     # Fail loudly when the Lua dispatch did not pick a replica. Must appear
     # before the use_backend rules below so the request never falls back to

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -4,8 +4,10 @@
 --
 -- Bodies exceeding tune.bufsize are truncated; we forward what we have with
 -- X-Body-Truncated since prefix-routing only needs the head of the body.
+-- See RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY in constants.py.
 
 local ROUTER_REQUEST_TIMEOUT_S = ${TIMEOUT_S}
+local FORWARD_BODY = ${FORWARD_BODY}
 
 -- Per-app state. The frontend sets txn.ingress_request_router_app to the
 -- backend name whose path prefix matched, and we look up that app's
@@ -97,17 +99,24 @@ core.register_action("route_via_ingress_request_router", {"http-req"}, function(
         return
     end
 
-    local body = txn.sf:req_body()
-    if not body or body == "" then
-        txn:set_var("txn.ingress_request_router_failed", "empty_body")
-        return
-    end
-
-    local truncated = truncated_full_length(txn, body)
-    if truncated then
-        core.log(core.warning,
-            "ingress_request_router: forwarding truncated body to router ("
-                .. #body .. "/" .. truncated .. " bytes)")
+    -- FORWARD_BODY=false: don't read or forward the body; call the router
+    -- with body="" so a Content-Length: 0 POST still goes through routing
+    -- (any policy that needs the body must opt in via FORWARD_BODY=true).
+    -- Empty body in FORWARD_BODY=true mode is treated the same -- a
+    -- legitimate input the router can accept or reject on its own terms;
+    -- we don't synthesize a sentinel for it here.
+    local body = ""
+    local truncated = nil
+    if FORWARD_BODY then
+        body = txn.sf:req_body() or ""
+        if body ~= "" then
+            truncated = truncated_full_length(txn, body)
+            if truncated then
+                core.log(core.warning,
+                    "ingress_request_router: forwarding truncated body to router ("
+                        .. #body .. "/" .. truncated .. " bytes)")
+            end
+        end
     end
 
     local response = call_router(router, body, truncated)

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -99,18 +99,31 @@ core.register_action("route_via_ingress_request_router", {"http-req"}, function(
                 .. #body .. "/" .. truncated .. " bytes)")
     end
 
+    -- Past this point, every error path arms txn.ingress_request_router_failed
+    -- so the frontend can return 5xx instead of letting the request silently
+    -- fall through to the primary backend. The product invariant is: requests
+    -- to a router-bearing app are served via the router or fail; there is no
+    -- quiet alternative path. Failure-mode bucketing belongs in observability
+    -- (response header label, metric label), not in the data plane.
     local response = call_router(router, body, truncated)
-    if not response or not is_http_200(response) then
+    if not response then
+        txn:set_var("txn.ingress_request_router_failed", "router_unreachable")
+        return
+    end
+    if not is_http_200(response) then
+        txn:set_var("txn.ingress_request_router_failed", "router_non_200")
         return
     end
 
     local replica_id = extract_replica_id(http_response_body(response))
     if not replica_id then
+        txn:set_var("txn.ingress_request_router_failed", "unparseable_replica_id")
         return
     end
 
     local server_name = replica_map[replica_id]
     if not server_name then
+        txn:set_var("txn.ingress_request_router_failed", "unknown_replica_id")
         return
     end
 

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -76,6 +76,16 @@ local function truncated_full_length(txn, body)
     end
 end
 
+-- Failure semantics: every path that reaches a router decision but cannot pin
+-- a replica must arm txn.ingress_request_router_failed so the frontend's 503
+-- rule fires instead of letting the request silently fall through to the
+-- primary backend. The product invariant is: requests to a router-bearing app
+-- are served via the router or fail; there is no quiet alternative path.
+-- Two silent returns are correct: (1) the request didn't target a
+-- router-bearing app (no txn var set, no app entry in our maps), and
+-- (2) the controller hasn't pushed router/replica state for this app yet.
+-- Failure-mode bucketing belongs in observability (response header label,
+-- metric label), not in the data plane.
 core.register_action("route_via_ingress_request_router", {"http-req"}, function(txn)
     local app = txn:get_var("txn.ingress_request_router_app")
     if not app then
@@ -89,6 +99,7 @@ core.register_action("route_via_ingress_request_router", {"http-req"}, function(
 
     local body = txn.sf:req_body()
     if not body or body == "" then
+        txn:set_var("txn.ingress_request_router_failed", "empty_body")
         return
     end
 
@@ -99,12 +110,6 @@ core.register_action("route_via_ingress_request_router", {"http-req"}, function(
                 .. #body .. "/" .. truncated .. " bytes)")
     end
 
-    -- Past this point, every error path arms txn.ingress_request_router_failed
-    -- so the frontend can return 5xx instead of letting the request silently
-    -- fall through to the primary backend. The product invariant is: requests
-    -- to a router-bearing app are served via the router or fail; there is no
-    -- quiet alternative path. Failure-mode bucketing belongs in observability
-    -- (response header label, metric label), not in the data plane.
     local response = call_router(router, body, truncated)
     if not response then
         txn:set_var("txn.ingress_request_router_failed", "router_unreachable")

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2535,8 +2535,11 @@ class Replica:
             return
 
         # If the HTTP path does not match the deployment route prefix,
-        # it is invalid and we should not serve it.
-        if not route.startswith(self._route_prefix):
+        # it is invalid and we should not serve it. Ingress request router
+        # peer deployments (e.g. LLMRouter) have no route prefix; treat
+        # that as "/" so any path matches and downstream code dispatches.
+        route_prefix = self._route_prefix or "/"
+        if not route.startswith(route_prefix):
             for msg in convert_object_to_asgi_messages(
                 f"Path '{route}' not found. "
                 "Ping http://.../-/routes for available routes.",

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2536,9 +2536,10 @@ class Replica:
 
         # If the HTTP path does not match the deployment route prefix,
         # it is invalid and we should not serve it. Ingress request router
-        # peer deployments (e.g. LLMRouter) have no route prefix; treat
-        # that as "/" so any path matches and downstream code dispatches.
-        route_prefix = self._route_prefix or "/"
+        # peer deployments (e.g. LLMRouter) have no route prefix; fall
+        # back to "" so any path (including the empty-path ASGI edge case)
+        # matches and downstream user code dispatches.
+        route_prefix = self._route_prefix or ""
         if not route.startswith(route_prefix):
             for msg in convert_object_to_asgi_messages(
                 f"Path '{route}' not found. "

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -589,6 +589,55 @@ def test_ingress_request_router_does_not_leak_into_other_backends(
         assert "set-var(txn.ingress_request_router_app) str(api)" not in cfg
 
 
+def test_router_failure_503_rule_appears_before_use_backend(haproxy_api_cleanup):
+    """The 503-on-router-failure rule must be rendered before any
+    ``use_backend`` directive. If it isn't, a failed Lua dispatch would
+    silently fall through to the primary backend and the router policy
+    the operator opted into would be invisibly bypassed."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        api = _make_api(
+            temp_dir,
+            {
+                "llm": BackendConfig(
+                    name="llm",
+                    path_prefix="/",
+                    app_name="llm",
+                    servers=[
+                        ServerConfig(
+                            name="r1",
+                            host="10.0.0.1",
+                            port=30001,
+                            replica_id="rid_1",
+                        )
+                    ],
+                    ingress_request_router_servers=[
+                        ServerConfig(name="router", host="10.0.0.10", port=9000)
+                    ],
+                ),
+            },
+        )
+        with mock.patch(
+            "ray.serve._private.constants.RAY_SERVE_HAPROXY_CONFIG_FILE_LOC",
+            api.config_file_path,
+        ):
+            api._generate_config_file_internal()
+        with open(api.config_file_path) as f:
+            cfg = f.read()
+
+        sentinel_idx = cfg.find("var(txn.ingress_request_router_failed) -m found")
+        first_use_backend_idx = cfg.find("use_backend")
+        assert sentinel_idx != -1, cfg
+        assert first_use_backend_idx != -1, cfg
+        assert sentinel_idx < first_use_backend_idx, (
+            "503-on-router-failure rule must precede every use_backend so a "
+            "failed dispatch does not silently fall through to the primary "
+            "backend.\n" + cfg
+        )
+        # Spot-check rule shape.
+        assert "status 503" in cfg, cfg
+        assert "X-Serve-Reason" in cfg, cfg
+
+
 def _create_replica_server(port: int, replica_id_header: str):
     """Fake data-plane replica that echoes its identity in a response header."""
     app = FastAPI()
@@ -758,6 +807,149 @@ async def test_ingress_request_router_end_to_end(haproxy_api_cleanup):
                 except Exception:
                     pass
             for thr in (replica_a_thread, replica_b_thread, router_thread):
+                try:
+                    thr.join(timeout=5)
+                except Exception:
+                    pass
+
+
+def _create_broken_router_server(port: int, status_code: int = 500):
+    """Fake /internal/route that always returns ``status_code`` (default 500).
+    Used to verify the fail-loud path: a router non-200 must surface to the
+    client as 5xx with X-Serve-Reason, not silently fall back to a primary
+    backend."""
+    app = FastAPI()
+
+    @app.get("/-/healthz")
+    async def health():
+        return {"status": "OK"}
+
+    @app.post("/internal/route")
+    async def route(res: Response):
+        res.status_code = status_code
+        return {"error": "broken"}
+
+    return _serve_fastapi_app(app, port, _healthz_ready(port))
+
+
+def _backend_stot(stats_csv: str, backend_name: str) -> int:
+    """Pull ``stot`` (cumulative sessions) for the BACKEND aggregate row of
+    ``backend_name`` from HAProxy's CSV stats. Returns -1 if not found."""
+    lines = stats_csv.splitlines()
+    if not lines:
+        return -1
+    header = lines[0].lstrip("# ").split(",")
+    pxname_idx = header.index("pxname")
+    svname_idx = header.index("svname")
+    stot_idx = header.index("stot")
+    for row in lines[1:]:
+        parts = row.split(",")
+        if (
+            len(parts) > stot_idx
+            and parts[pxname_idx] == backend_name
+            and parts[svname_idx] == "BACKEND"
+        ):
+            return int(parts[stot_idx] or 0)
+    return -1
+
+
+@pytest.mark.asyncio
+async def test_router_failure_fails_loud_with_reason(haproxy_api_cleanup):
+    """When ``/internal/route`` returns non-200, HAProxy must return 5xx with
+    ``X-Serve-Reason`` rather than silently falling back to the primary
+    backend. The primary backend's cumulative session count must stay 0."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        haproxy_port = find_free_port()
+        stats_port = find_free_port()
+        replica_port = find_free_port()
+        router_port = find_free_port()
+
+        actor_name = "SERVE_REPLICA::app#dep#aaa"
+
+        replica, replica_thread = _create_replica_server(
+            replica_port, replica_id_header="A"
+        )
+        broken_router, broken_router_thread = _create_broken_router_server(router_port)
+
+        try:
+            config = HAProxyConfig(
+                http_options=HTTPOptions(
+                    host="127.0.0.1",
+                    port=haproxy_port,
+                    keep_alive_timeout_s=58,
+                ),
+                stats_port=stats_port,
+                socket_path=os.path.join(temp_dir, "admin.sock"),
+                has_received_routes=True,
+                has_received_servers=True,
+                health_check_path="/-/healthz",
+                health_check_inter="500ms",
+                health_check_rise=1,
+                health_check_fall=2,
+            )
+
+            backend = BackendConfig(
+                name="llm",
+                path_prefix="/",
+                app_name="llm",
+                health_check_path="/-/healthz",
+                servers=[
+                    ServerConfig(
+                        name="A",
+                        host="127.0.0.1",
+                        port=replica_port,
+                        replica_id=actor_name,
+                    ),
+                ],
+                ingress_request_router_servers=[
+                    ServerConfig(name="router", host="127.0.0.1", port=router_port),
+                ],
+            )
+
+            api = HAProxyApi(
+                cfg=config,
+                backend_configs={"llm": backend},
+                config_file_path=os.path.join(temp_dir, "haproxy.cfg"),
+            )
+            haproxy_api_cleanup(api)
+            await api.start()
+
+            wait_for_condition(lambda: check_haproxy_ready(stats_port), timeout=10)
+            await async_wait_for_condition(
+                lambda: requests.get(
+                    f"http://127.0.0.1:{haproxy_port}/-/healthz", timeout=2
+                ).status_code
+                == 200,
+                timeout=10,
+            )
+
+            # Every POST through the router must surface as a 5xx with the
+            # reason label, never as a silent primary-backend fallback.
+            for _ in range(5):
+                resp = requests.post(
+                    f"http://127.0.0.1:{haproxy_port}/predict",
+                    json={"prompt": "hi"},
+                    timeout=5,
+                )
+                assert resp.status_code == 503, resp.text
+                assert (
+                    resp.headers.get("X-Serve-Reason") == "router_non_200"
+                ), resp.headers
+
+            stats_csv = requests.get(
+                f"http://127.0.0.1:{stats_port}/stats;csv", timeout=5
+            ).text
+            assert _backend_stot(stats_csv, "llm") == 0, stats_csv
+            assert (
+                _backend_stot(stats_csv, "llm-via-ingress-request-router") == 0
+            ), stats_csv
+        finally:
+            for srv in (replica, broken_router):
+                try:
+                    srv.should_exit = True
+                except Exception:
+                    pass
+            for thr in (replica_thread, broken_router_thread):
                 try:
                     thr.join(timeout=5)
                 except Exception:

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -651,6 +651,64 @@ def test_router_failure_503_rule_appears_before_use_backend(haproxy_api_cleanup)
         assert "X-Serve-Reason" in cfg, cfg
 
 
+@pytest.mark.parametrize("forward_body", [True, False])
+def test_ingress_request_router_forward_body_gate_renders(
+    haproxy_api_cleanup, monkeypatch, forward_body
+):
+    """The FORWARD_BODY escape hatch must drive both:
+    - HAProxy ``wait-for-body`` + ``tune.bufsize`` directives (memory cost
+      and the per-request body round-trip), and
+    - the Lua ``FORWARD_BODY`` constant (whether the action reads the body
+      and forwards it to ``/internal/route``).
+
+    Off by default: round-robin ignores the body, so neither cost is paid.
+    """
+    monkeypatch.setattr(
+        "ray.serve._private.haproxy.RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY",
+        forward_body,
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        api = _make_api(
+            temp_dir,
+            {
+                "llm": BackendConfig(
+                    name="llm",
+                    path_prefix="/",
+                    app_name="llm",
+                    servers=[
+                        ServerConfig(
+                            name="r1",
+                            host="10.0.0.1",
+                            port=30001,
+                            replica_id="rid_1",
+                        )
+                    ],
+                    ingress_request_router_servers=[
+                        ServerConfig(name="router", host="10.0.0.10", port=9000)
+                    ],
+                ),
+            },
+        )
+        with mock.patch(
+            "ray.serve._private.constants.RAY_SERVE_HAPROXY_CONFIG_FILE_LOC",
+            api.config_file_path,
+        ):
+            api._generate_config_file_internal()
+        with open(api.config_file_path) as f:
+            cfg = f.read()
+        with open(os.path.join(temp_dir, "ingress_request_router.lua")) as f:
+            lua = f.read()
+
+        if forward_body:
+            assert "tune.bufsize" in cfg, cfg
+            assert "wait-for-body" in cfg, cfg
+            assert "local FORWARD_BODY = true" in lua, lua
+        else:
+            assert "tune.bufsize" not in cfg, cfg
+            assert "wait-for-body" not in cfg, cfg
+            assert "local FORWARD_BODY = false" in lua, lua
+
+
 def _create_replica_server(port: int, replica_id_header: str):
     """Fake data-plane replica that echoes its identity in a response header."""
     app = FastAPI()
@@ -693,10 +751,15 @@ def _create_router_server(port: int, replica_id_to_return: str):
 
 
 @pytest.mark.asyncio
-async def test_ingress_request_router_end_to_end(haproxy_api_cleanup):
+async def test_ingress_request_router_end_to_end(haproxy_api_cleanup, monkeypatch):
     """Run actual HAProxy against a fake router + two replicas; verify a POST
     is pinned to the replica the router selects, while a GET (which doesn't
-    trigger the router-routed path) is not."""
+    trigger the router-routed path) is not. Forces FORWARD_BODY=True so the
+    body-forwarding path stays exercised end-to-end."""
+    monkeypatch.setattr(
+        "ray.serve._private.haproxy.RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY",
+        True,
+    )
     with tempfile.TemporaryDirectory() as temp_dir:
         haproxy_port = find_free_port()
         stats_port = find_free_port()
@@ -936,28 +999,25 @@ async def test_router_failure_fails_loud_with_reason(haproxy_api_cleanup):
                 timeout=10,
             )
 
-            # Every dispatch failure mode must surface as a 5xx with a
-            # reason label, never as a silent primary-backend fallback.
-            # ``router_non_200``: router answered with status != 200 (forced
-            # by the broken-router stub).
-            # ``empty_body``: HAProxy's wait-for-body completed but the
-            # request had no body to forward to the router.
-            failure_cases = [
-                (dict(json={"prompt": "hi"}), "router_non_200"),
-                (dict(data=""), "empty_body"),
-            ]
-            for kwargs, expected_reason in failure_cases:
+            # Every dispatch failure must surface as 5xx with a reason
+            # label, never as a silent primary-backend fallback. Both
+            # empty and non-empty bodies are routed through the broken
+            # router (router gets called with body="" when FORWARD_BODY
+            # is off, which is the default), so both shapes surface as
+            # ``router_non_200``. The empty-body shape is included to
+            # pin that empty bodies still go through routing rather than
+            # silently bypassing the router.
+            for body_kwargs in (dict(json={"prompt": "hi"}), dict(data="")):
                 for _ in range(3):
                     resp = requests.post(
                         f"http://127.0.0.1:{haproxy_port}/predict",
                         timeout=5,
-                        **kwargs,
+                        **body_kwargs,
                     )
-                    assert resp.status_code == 503, (expected_reason, resp.text)
-                    assert resp.headers.get("X-Serve-Reason") == expected_reason, (
-                        expected_reason,
-                        resp.headers,
-                    )
+                    assert resp.status_code == 503, resp.text
+                    assert (
+                        resp.headers.get("X-Serve-Reason") == "router_non_200"
+                    ), resp.headers
 
             stats_csv = requests.get(
                 f"http://127.0.0.1:{stats_port}/stats;csv", timeout=5

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -624,11 +624,24 @@ def test_router_failure_503_rule_appears_before_use_backend(haproxy_api_cleanup)
         with open(api.config_file_path) as f:
             cfg = f.read()
 
-        sentinel_idx = cfg.find("var(txn.ingress_request_router_failed) -m found")
-        first_use_backend_idx = cfg.find("use_backend")
-        assert sentinel_idx != -1, cfg
-        assert first_use_backend_idx != -1, cfg
-        assert sentinel_idx < first_use_backend_idx, (
+        # Parse line-by-line so we don't accidentally match the substring
+        # "use_backend" inside an explanatory comment block rendered above.
+        lines = cfg.splitlines()
+        sentinel_line = next(
+            (
+                i
+                for i, ln in enumerate(lines)
+                if "var(txn.ingress_request_router_failed) -m found" in ln
+            ),
+            None,
+        )
+        first_use_backend_line = next(
+            (i for i, ln in enumerate(lines) if ln.strip().startswith("use_backend ")),
+            None,
+        )
+        assert sentinel_line is not None, cfg
+        assert first_use_backend_line is not None, cfg
+        assert sentinel_line < first_use_backend_line, (
             "503-on-router-failure rule must precede every use_backend so a "
             "failed dispatch does not silently fall through to the primary "
             "backend.\n" + cfg
@@ -923,18 +936,28 @@ async def test_router_failure_fails_loud_with_reason(haproxy_api_cleanup):
                 timeout=10,
             )
 
-            # Every POST through the router must surface as a 5xx with the
+            # Every dispatch failure mode must surface as a 5xx with a
             # reason label, never as a silent primary-backend fallback.
-            for _ in range(5):
-                resp = requests.post(
-                    f"http://127.0.0.1:{haproxy_port}/predict",
-                    json={"prompt": "hi"},
-                    timeout=5,
-                )
-                assert resp.status_code == 503, resp.text
-                assert (
-                    resp.headers.get("X-Serve-Reason") == "router_non_200"
-                ), resp.headers
+            # ``router_non_200``: router answered with status != 200 (forced
+            # by the broken-router stub).
+            # ``empty_body``: HAProxy's wait-for-body completed but the
+            # request had no body to forward to the router.
+            failure_cases = [
+                (dict(json={"prompt": "hi"}), "router_non_200"),
+                (dict(data=""), "empty_body"),
+            ]
+            for kwargs, expected_reason in failure_cases:
+                for _ in range(3):
+                    resp = requests.post(
+                        f"http://127.0.0.1:{haproxy_port}/predict",
+                        timeout=5,
+                        **kwargs,
+                    )
+                    assert resp.status_code == 503, (expected_reason, resp.text)
+                    assert resp.headers.get("X-Serve-Reason") == expected_reason, (
+                        expected_reason,
+                        resp.headers,
+                    )
 
             stats_csv = requests.get(
                 f"http://127.0.0.1:{stats_port}/stats;csv", timeout=5


### PR DESCRIPTION
Stacked on #63215. **Review #63215 first; this PR's diff will collapse to just the FORWARD_BODY changes once that merges.**

Rebases #63183 onto master with #63215 (fail-loud) landed.

## Summary

Round-robin `/internal/route` ignores the request body, so make body forwarding opt-in via `RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY` (off by default).

When off, the data plane saves on every routed request:
- HAProxy `wait-for-body` round-trip and per-connection buffer cost (~`2 * tune.bufsize * maxconn`).
- Lua `txn.sf:req_body()` plus body re-emit on the socket.

Rendered HAProxy config gates `tune.bufsize` and `wait-for-body` on the flag; the Lua template gates the body read on a `FORWARD_BODY` substitution.

Also closes the empty-body invariant gap from #63215. The empty-body Lua return is removed entirely: in either FORWARD_BODY mode, an empty body now flows through to the router with `body=""` rather than silently bypassing it. The router decides whether an empty body is a failure. The transient `empty_body` sentinel from #63215 (a stop-gap until this PR landed) is therefore dropped.

## Test plan

- [x] New parametrized template-render test pins that `tune.bufsize`, `wait-for-body`, and the Lua `FORWARD_BODY` constant render consistently with the env var on/off.
- [x] Existing `test_ingress_request_router_end_to_end` flips the flag on via monkeypatch; body-forwarded path stays covered end-to-end.
- [x] `test_router_failure_fails_loud_with_reason` exercises both empty and non-empty POSTs through the broken router and asserts both surface as 503 `router_non_200` — pins that empty bodies still go through routing rather than silently bypassing it.
- [x] Manually verified end-to-end with real HAProxy + working router: `FORWARD_BODY=false` sends `body=""` to the router for any POST shape; `FORWARD_BODY=true` forwards the request body through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)