### PR TITLE
[Data] Fix JSONL read retry with advanced file cursor

### DIFF
--- a/python/ray/data/_internal/datasource/json_datasource.py
+++ b/python/ray/data/_internal/datasource/json_datasource.py
@@ -206,29 +206,36 @@ class PandasJSONDatasource(FileBasedDatasource):
 
         if not f.seekable():
             return self._DEFAULT_CHUNK_SIZE
-        assert f.tell() == 0, "File pointer must be at the beginning"
+
+        # ``_read_stream`` can be recreated on the same file handle when
+        # ``FileBasedDatasource`` retries a transient read error.
+        f.seek(0)
 
         if self._target_output_size_bytes is None:
             return None
 
-        stream = StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE)
-        with pd.read_json(stream, chunksize=1, lines=True) as reader:
-            try:
-                df = _cast_range_index_to_string(next(reader))
-            except StopIteration:
-                return 1
+        try:
+            stream = StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE)
+            with pd.read_json(stream, chunksize=1, lines=True) as reader:
+                try:
+                    df = _cast_range_index_to_string(next(reader))
+                except StopIteration:
+                    return 1
 
-        block_accessor = PandasBlockAccessor.for_block(df)
-        if block_accessor.num_rows() == 0:
-            chunksize = 1
-        else:
-            bytes_per_row = block_accessor.size_bytes() / block_accessor.num_rows()
-            chunksize = max(round(self._target_output_size_bytes / bytes_per_row), 1)
+            block_accessor = PandasBlockAccessor.for_block(df)
+            if block_accessor.num_rows() == 0:
+                chunksize = 1
+            else:
+                bytes_per_row = block_accessor.size_bytes() / block_accessor.num_rows()
+                chunksize = max(
+                    round(self._target_output_size_bytes / bytes_per_row), 1
+                )
 
-        # Reset file pointer to the beginning.
-        f.seek(0)
-
-        return chunksize
+            return chunksize
+        finally:
+            # Reset file pointer to the beginning for the actual read and for any
+            # subsequent retry that reuses the same file handle.
+            f.seek(0)
 
     def _open_input_source(
         self,

--- a/python/ray/data/_internal/datasource/json_datasource.py
+++ b/python/ray/data/_internal/datasource/json_datasource.py
@@ -187,16 +187,18 @@ class PandasJSONDatasource(FileBasedDatasource):
     def _read_stream(self, f: "pyarrow.NativeFile", path: str):
         chunksize = self._estimate_chunksize(f)
 
-        stream = StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE)
-        if chunksize is None:
-            # When chunksize=None, pandas returns DataFrame directly (no context manager)
-            df = pd.read_json(stream, chunksize=chunksize, lines=True)
-            yield _cast_range_index_to_string(df)
-        else:
-            # When chunksize is a number, pandas returns JsonReader (supports context manager)
-            with pd.read_json(stream, chunksize=chunksize, lines=True) as reader:
-                for df in reader:
-                    yield _cast_range_index_to_string(df)
+        with StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE) as stream:
+            if chunksize is None:
+                # When chunksize=None, pandas returns DataFrame directly
+                # (no context manager).
+                df = pd.read_json(stream, chunksize=chunksize, lines=True)
+                yield _cast_range_index_to_string(df)
+            else:
+                # When chunksize is a number, pandas returns JsonReader
+                # (supports context manager).
+                with pd.read_json(stream, chunksize=chunksize, lines=True) as reader:
+                    for df in reader:
+                        yield _cast_range_index_to_string(df)
 
     def _estimate_chunksize(self, f: "pyarrow.NativeFile") -> Optional[int]:
         """Estimate the chunksize by sampling the first row.
@@ -215,12 +217,12 @@ class PandasJSONDatasource(FileBasedDatasource):
             return None
 
         try:
-            stream = StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE)
-            with pd.read_json(stream, chunksize=1, lines=True) as reader:
-                try:
-                    df = _cast_range_index_to_string(next(reader))
-                except StopIteration:
-                    return 1
+            with StrictBufferedReader(f, buffer_size=self._BUFFER_SIZE) as stream:
+                with pd.read_json(stream, chunksize=1, lines=True) as reader:
+                    try:
+                        df = _cast_range_index_to_string(next(reader))
+                    except StopIteration:
+                        return 1
 
             block_accessor = PandasBlockAccessor.for_block(df)
             if block_accessor.num_rows() == 0:
@@ -288,5 +290,4 @@ class StrictBufferedReader(io.RawIOBase):
     def close(self):
         if not self.closed:
             self._file.detach()
-            self._file.close()
             super().close()

--- a/python/ray/data/tests/datasource/test_json.py
+++ b/python/ray/data/tests/datasource/test_json.py
@@ -434,6 +434,31 @@ class TestPandasJSONDatasource:
         # Verify.
         assert rows_same(block, df)
 
+    def test_read_stream_with_advanced_file_pointer(
+        self, tmp_path, target_max_block_size_infinite_or_default
+    ):
+        # Setup test file.
+        df = pd.DataFrame({"one": [1, 2, 3], "two": ["a", "b", "c"]})
+        path = os.path.join(tmp_path, "test.json")
+        df.to_json(path, orient="records", lines=True)
+
+        # Setup datasource.
+        local_filesystem = fs.LocalFileSystem()
+        source = PandasJSONDatasource(
+            path, target_output_size_bytes=1, filesystem=local_filesystem
+        )
+
+        # Simulate retrying a stream read on a file handle that was already consumed.
+        block_builder = PandasBlockBuilder()
+        with source._open_input_source(local_filesystem, path) as f:
+            f.read(1)
+            for block in source._read_stream(f, path):
+                block_builder.add_block(block)
+        block = block_builder.build()
+
+        # Verify.
+        assert rows_same(block, df)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Summary
- Fix `PandasJSONDatasource` so seekable JSONL files are rewound before chunk-size estimation and again after sampling, including when sampling raises.
- This prevents retries in `FileBasedDatasource` from recreating `_read_stream()` on a file handle whose cursor was already advanced.
- Add a regression test that simulates retrying a JSONL stream read with a partially consumed file handle.

## Problem
The `image_embedding_from_jsonl` release test can hit transient S3/read errors while reading JSONL input. `FileBasedDatasource` retries the stream read with the same open file handle, but `PandasJSONDatasource._estimate_chunksize()` previously asserted that seekable files always started at offset 0. If the first attempt advanced the cursor before failing, the retry raised `AssertionError: File pointer must be at the beginning`, masking the original transient read error and failing the release test.

## Fix
For seekable files, `_estimate_chunksize()` now seeks to the beginning before sampling and uses a `finally` block to rewind the file before the actual read or any later retry. Non-seekable compressed streams keep using the existing default chunk size path.

## Test plan
- `.venv/bin/python -m pytest python/ray/data/tests/datasource/test_json.py::TestPandasJSONDatasource::test_read_stream_with_advanced_file_pointer -q`

Made with [Cursor](https://cursor.com)