### PR TITLE
[serve] add max_replicas_per_node to /api/serve/applications response

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -686,6 +686,9 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
             deployment_actors.append(cfg_dict)
         schema.deployment_actors = deployment_actors
 
+    if info.replica_config.max_replicas_per_node is not None:
+        schema.max_replicas_per_node = info.replica_config.max_replicas_per_node
+
     return schema
 
 

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -1404,5 +1404,52 @@ def test_serve_instance_details_is_json_serializable():
     assert "_serialized_policy_def" not in autoscaling_config
 
 
+def test_deployment_info_to_schema_includes_max_replicas_per_node():
+    """_deployment_info_to_schema should propagate max_replicas_per_node
+    from ReplicaConfig into the resulting DeploymentSchema."""
+    from ray.serve._private.deployment_info import DeploymentInfo
+    from ray.serve.schema import _deployment_info_to_schema
+
+    rc = ReplicaConfig.create(
+        deployment_def="",
+        init_args=(),
+        init_kwargs={},
+        max_replicas_per_node=3,
+    )
+    dc = DeploymentConfig.from_default(num_replicas=2)
+    info = DeploymentInfo(
+        deployment_config=dc,
+        replica_config=rc,
+        start_time_ms=0,
+        deployer_job_id="fake_job_id",
+    )
+
+    schema = _deployment_info_to_schema("test_deployment", info)
+    assert schema.max_replicas_per_node == 3
+
+
+def test_deployment_info_to_schema_omits_max_replicas_per_node_when_none():
+    """When max_replicas_per_node is None (default), the schema field should
+    remain at its default (DEFAULT.VALUE), i.e. unset."""
+    from ray.serve._private.deployment_info import DeploymentInfo
+    from ray.serve.schema import _deployment_info_to_schema
+
+    rc = ReplicaConfig.create(
+        deployment_def="",
+        init_args=(),
+        init_kwargs={},
+    )
+    dc = DeploymentConfig.from_default(num_replicas=2)
+    info = DeploymentInfo(
+        deployment_config=dc,
+        replica_config=rc,
+        start_time_ms=0,
+        deployer_job_id="fake_job_id",
+    )
+
+    schema = _deployment_info_to_schema("test_deployment", info)
+    assert schema.max_replicas_per_node is DEFAULT.VALUE
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
when constructing the `DeploymentSchema` from the `DeploymentInfo`, we were excluding some fields including `max_replicas_per_node` which may be helpful for debugging. this PR adds that field in.