### PR TITLE
[ci] Gate release test image annotation on RAYCI_SELECT membership

### DIFF
--- a/ci/ray_ci/automation/push_release_test_image.py
+++ b/ci/ray_ci/automation/push_release_test_image.py
@@ -55,22 +55,22 @@ def _annotate_pushed_image(image_uri: str, image_type: str) -> None:
     if os.environ.get("BUILDKITE") != "true":
         return
     step_key = os.environ.get("BUILDKITE_STEP_KEY")
-    rayci_select = os.environ.get("RAYCI_SELECT")
-    selected_step_keys = (
-        {key.strip() for key in rayci_select.split(",")} if rayci_select else set()
-    )
-    if step_key and selected_step_keys and step_key not in selected_step_keys:
-        return
-    subprocess.run(
-        [
-            "buildkite-agent",
-            "annotate",
-            "--style=info",
-            f"--context=release-test-{image_type}-images",
-            "--append",
-            f"{image_uri}<br/>",
-        ],
-    )
+    selected_step_keys = {
+        key.strip()
+        for key in os.environ.get("RAYCI_SELECT", "").split(",")
+        if key.strip()
+    }
+    if step_key in selected_step_keys:
+        subprocess.run(
+            [
+                "buildkite-agent",
+                "annotate",
+                "--style=info",
+                f"--context=release-test-{image_type}-images",
+                "--append",
+                f"{image_uri}<br/>",
+            ],
+        )
 
 
 def _run_gcloud_docker_login() -> None:

--- a/ci/ray_ci/automation/push_release_test_image.py
+++ b/ci/ray_ci/automation/push_release_test_image.py
@@ -60,17 +60,18 @@ def _annotate_pushed_image(image_uri: str, image_type: str) -> None:
         for key in os.environ.get("RAYCI_SELECT", "").split(",")
         if key.strip()
     }
-    if step_key in selected_step_keys:
-        subprocess.run(
-            [
-                "buildkite-agent",
-                "annotate",
-                "--style=info",
-                f"--context=release-test-{image_type}-images",
-                "--append",
-                f"{image_uri}<br/>",
-            ],
-        )
+    if step_key not in selected_step_keys:
+        return
+    subprocess.run(
+        [
+            "buildkite-agent",
+            "annotate",
+            "--style=info",
+            f"--context=release-test-{image_type}-images",
+            "--append",
+            f"{image_uri}<br/>",
+        ],
+    )
 
 
 def _run_gcloud_docker_login() -> None:

--- a/ci/ray_ci/automation/test_push_release_test_image.py
+++ b/ci/ray_ci/automation/test_push_release_test_image.py
@@ -267,48 +267,111 @@ class TestDestinationTags:
 
 
 class TestAnnotatePushedImage:
-    def test_skips_when_not_buildkite(self, monkeypatch):
-        monkeypatch.delenv("BUILDKITE", raising=False)
-
-        calls = []
+    @pytest.fixture
+    def captured_calls(self, monkeypatch):
+        calls: list = []
         monkeypatch.setattr(
             "ci.ray_ci.automation.push_release_test_image.subprocess.run",
             lambda args: calls.append(args),
         )
+        return calls
+
+    @staticmethod
+    def _apply_env(monkeypatch, env: dict) -> None:
+        for key, value in env.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+
+    @pytest.mark.parametrize(
+        "env",
+        [
+            pytest.param({"BUILDKITE": None}, id="not_buildkite"),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "ray",
+                    "RAYCI_SELECT": "ray-ml,ray-data",
+                },
+                id="step_key_is_substring_of_selected",
+            ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "release-ray",
+                    "RAYCI_SELECT": None,
+                },
+                id="rayci_select_unset",
+            ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "release-ray",
+                    "RAYCI_SELECT": "",
+                },
+                id="rayci_select_empty",
+            ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "release-ray",
+                    "RAYCI_SELECT": "release-ray-ml,release-ray-data",
+                },
+                id="step_key_not_in_selection",
+            ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": None,
+                    "RAYCI_SELECT": "release-ray,release-ray-ml",
+                },
+                id="step_key_unset",
+            ),
+        ],
+    )
+    def test_skips_annotation(self, monkeypatch, captured_calls, env):
+        self._apply_env(monkeypatch, env)
 
         _annotate_pushed_image("example/image:tag", "ray")
 
-        assert calls == []
+        assert captured_calls == []
 
-    def test_runs_when_exact_step_key_selected(self, monkeypatch):
-        monkeypatch.setenv("BUILDKITE", "true")
-        monkeypatch.setenv("BUILDKITE_STEP_KEY", "release-ray")
-        monkeypatch.setenv("RAYCI_SELECT", "release-ray,release-ray-ml")
-
-        calls = []
-        monkeypatch.setattr(
-            "ci.ray_ci.automation.push_release_test_image.subprocess.run",
-            lambda args: calls.append(args),
-        )
+    @pytest.mark.parametrize(
+        "env",
+        [
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "release-ray",
+                    "RAYCI_SELECT": "release-ray,release-ray-ml",
+                },
+                id="exact_step_key_selected",
+            ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "release-ray",
+                    "RAYCI_SELECT": "release-ray",
+                },
+                id="single_item_selection_matches",
+            ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "release-ray",
+                    "RAYCI_SELECT": "  release-ray , release-ray-ml  ",
+                },
+                id="selection_has_whitespace",
+            ),
+        ],
+    )
+    def test_runs_annotation(self, monkeypatch, captured_calls, env):
+        self._apply_env(monkeypatch, env)
 
         _annotate_pushed_image("example/image:tag", "ray")
 
-        assert len(calls) == 1
-
-    def test_skips_when_step_key_is_only_substring_of_selected_key(self, monkeypatch):
-        monkeypatch.setenv("BUILDKITE", "true")
-        monkeypatch.setenv("BUILDKITE_STEP_KEY", "ray")
-        monkeypatch.setenv("RAYCI_SELECT", "ray-ml,ray-data")
-
-        calls = []
-        monkeypatch.setattr(
-            "ci.ray_ci.automation.push_release_test_image.subprocess.run",
-            lambda args: calls.append(args),
-        )
-
-        _annotate_pushed_image("example/image:tag", "ray")
-
-        assert calls == []
+        assert len(captured_calls) == 1
 
 
 if __name__ == "__main__":

--- a/ci/ray_ci/automation/test_push_release_test_image.py
+++ b/ci/ray_ci/automation/test_push_release_test_image.py
@@ -328,6 +328,22 @@ class TestAnnotatePushedImage:
                 },
                 id="step_key_unset",
             ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "",
+                    "RAYCI_SELECT": "release-ray,release-ray-ml",
+                },
+                id="step_key_empty_string",
+            ),
+            pytest.param(
+                {
+                    "BUILDKITE": "true",
+                    "BUILDKITE_STEP_KEY": "release-ray",
+                    "RAYCI_SELECT": "  ,  ",
+                },
+                id="rayci_select_whitespace_only",
+            ),
         ],
     )
     def test_skips_annotation(self, monkeypatch, captured_calls, env):


### PR DESCRIPTION
## Description

Fixes the gating logic in `_annotate_pushed_image` in `ci/ray_ci/automation/push_release_test_image.py` so the Buildkite annotation runs only when `BUILDKITE_STEP_KEY` is listed in `RAYCI_SELECT`. Previously, an unset/empty `RAYCI_SELECT` bypassed the filter and always annotated.

## Related issues

N/A

## Additional information

- Drops blank entries from the parsed `RAYCI_SELECT` set so an empty env value yields an empty selection rather than `{""}`.
- Refactors `TestAnnotatePushedImage` to use a shared `captured_calls` fixture and `pytest.mark.parametrize`, and adds coverage for previously untested cases: `RAYCI_SELECT` unset, `RAYCI_SELECT` empty, step key not in selection, `BUILDKITE_STEP_KEY` unset, single-item selection, and whitespace around keys.

Verified with `bazel test //ci/ray_ci/automation:test_push_release_test_image` — all 9 `TestAnnotatePushedImage` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)