### PR TITLE
[Data] Jail unstructured_data_ingestion release test

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5164,7 +5164,7 @@
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
   run:
-    timeout: 5000
+    timeout: 3600
     script: bash ci/tests.sh  # relative to working_dir
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5164,7 +5164,7 @@
     cluster_compute: ci/aws.yaml  # relative to working_dir
 
   run:
-    timeout: 3600
+    timeout: 5000
     script: bash ci/tests.sh  # relative to working_dir
 
   variations:

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -5151,7 +5151,7 @@
         cluster_compute: ci/gce.yaml  # relative to working_dir
 
 - name: unstructured_data_ingestion  # do not use dashes (regex sensitive)
-  frequency: weekly
+  frequency: manual # was weekly
   python: "3.11"
   group: ray-examples
   team: data


### PR DESCRIPTION
## Description
Move the `unstructured_data_ingestion` release test from `weekly` to `manual` while the poor throughput / CPU utilization issue is investigated.

The previous timeout bump could mask the underlying runtime behavior, so this change removes the test from scheduled release runs instead of extending its runtime budget.


Jailing test because the current CPU utilization is too low and the test needs to be rewritten. 

## Test plan
- Verified `release/release_tests.yaml` parses and `unstructured_data_ingestion` resolves to `frequency: manual`.
- Commit hooks passed for the staged change.