### PR TITLE
[serve] Introduce round robin router

### DIFF
--- a/python/ray/serve/experimental/round_robin_router.py
+++ b/python/ray/serve/experimental/round_robin_router.py
@@ -1,0 +1,50 @@
+"""Round-robin request router.
+
+RoundRobinRouter cycles through the candidate replicas passed in by Serve and
+returns the selected replica as the highest-ranked candidate for each request.
+If that replica is unavailable or at capacity, the existing Serve retry loop
+calls back into the router and advances to the next replica.
+"""
+
+import random
+from typing import List, Optional
+
+from ray.serve._private.request_router.common import (
+    PendingRequest,
+)
+from ray.serve._private.request_router.replica_wrapper import (
+    RunningReplica,
+)
+from ray.serve._private.request_router.request_router import (
+    FIFOMixin,
+    RequestRouter,
+)
+
+
+class RoundRobinRouter(FIFOMixin, RequestRouter):
+    """Routes requests by cycling through candidate replicas.
+
+    Each call to ``choose_replicas`` advances a shared cursor by one position
+    and returns a single highest-ranked candidate. This keeps the normal
+    queue-length, rejection, retry, and backoff machinery in charge after the
+    round-robin pick is made.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._round_robin_counter = random.randrange(2**31)
+
+    def initialize_state(self, **kwargs) -> None:
+        pass
+
+    async def choose_replicas(
+        self,
+        candidate_replicas: List[RunningReplica],
+        pending_request: Optional[PendingRequest] = None,
+    ) -> List[List[RunningReplica]]:
+        if not candidate_replicas:
+            return []
+
+        index = self._round_robin_counter % len(candidate_replicas)
+        self._round_robin_counter += 1
+        return [[candidate_replicas[index]]]

--- a/python/ray/serve/experimental/round_robin_router.py
+++ b/python/ray/serve/experimental/round_robin_router.py
@@ -29,29 +29,28 @@ class _RoundRobinReplicaRanks(Sequence[List[RunningReplica]]):
         self,
         replicas: List[RunningReplica],
         start_index: int,
-        num_ranks: int,
     ):
         self._replicas = replicas
         self._start_index = start_index
-        self._num_ranks = num_ranks
 
     def __len__(self) -> int:
-        return self._num_ranks
+        return len(self._replicas)
 
     def __getitem__(self, index):
         if isinstance(index, slice):
             return list(self)[index]
 
+        num_replicas = len(self._replicas)
         if index < 0:
-            index += self._num_ranks
-        if index < 0 or index >= self._num_ranks:
+            index += num_replicas
+        if index < 0 or index >= num_replicas:
             raise IndexError(index)
 
-        return [self._replicas[(self._start_index + index) % len(self._replicas)]]
+        return [self._replicas[(self._start_index + index) % num_replicas]]
 
     def __iter__(self):
         num_replicas = len(self._replicas)
-        for offset in range(self._num_ranks):
+        for offset in range(num_replicas):
             yield [self._replicas[(self._start_index + offset) % num_replicas]]
 
 
@@ -79,11 +78,13 @@ class RoundRobinRouter(FIFOMixin, RequestRouter):
         if not candidate_replicas:
             return []
 
+        if pending_request is not None:
+            # Enable exponential-backoff sleep between outer retry iterations.
+            # Without this, the base class tight-loops calling choose_replicas
+            # when every replica is at capacity.
+            pending_request.routing_context.should_backoff = True
+
         index = self._round_robin_counter % len(candidate_replicas)
         self._round_robin_counter += 1
 
-        return _RoundRobinReplicaRanks(
-            candidate_replicas,
-            index,
-            len(candidate_replicas),
-        )
+        return _RoundRobinReplicaRanks(candidate_replicas, index)

--- a/python/ray/serve/experimental/round_robin_router.py
+++ b/python/ray/serve/experimental/round_robin_router.py
@@ -1,12 +1,13 @@
 """Round-robin request router.
 
 RoundRobinRouter cycles through the candidate replicas passed in by Serve and
-returns the selected replica as the highest-ranked candidate for each request.
-If that replica is unavailable or at capacity, the existing Serve retry loop
-calls back into the router and advances to the next replica.
+returns strictly ordered singleton ranks. Each request starts at the current
+round-robin cursor; if that replica cannot fulfill the request, Serve tries the
+next replica in order, wrapping around the candidate list.
 """
 
 import random
+from collections.abc import Sequence
 from typing import List, Optional
 
 from ray.serve._private.request_router.common import (
@@ -21,13 +22,46 @@ from ray.serve._private.request_router.request_router import (
 )
 
 
+class _RoundRobinReplicaRanks(Sequence[List[RunningReplica]]):
+    """Lazy ordered singleton ranks for a strict round-robin attempt."""
+
+    def __init__(
+        self,
+        replicas: List[RunningReplica],
+        start_index: int,
+        num_ranks: int,
+    ):
+        self._replicas = replicas
+        self._start_index = start_index
+        self._num_ranks = num_ranks
+
+    def __len__(self) -> int:
+        return self._num_ranks
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return list(self)[index]
+
+        if index < 0:
+            index += self._num_ranks
+        if index < 0 or index >= self._num_ranks:
+            raise IndexError(index)
+
+        return [self._replicas[(self._start_index + index) % len(self._replicas)]]
+
+    def __iter__(self):
+        num_replicas = len(self._replicas)
+        for offset in range(self._num_ranks):
+            yield [self._replicas[(self._start_index + offset) % num_replicas]]
+
+
 class RoundRobinRouter(FIFOMixin, RequestRouter):
     """Routes requests by cycling through candidate replicas.
 
     Each call to ``choose_replicas`` advances a shared cursor by one position
-    and returns a single highest-ranked candidate. This keeps the normal
-    queue-length, rejection, retry, and backoff machinery in charge after the
-    round-robin pick is made.
+    and returns ordered singleton ranks starting from that cursor. This upholds
+    strict round-robin ordering while still allowing Serve's existing selector
+    to continue to the next replica if the current one is full.
     """
 
     def __init__(self, *args, **kwargs):
@@ -41,10 +75,15 @@ class RoundRobinRouter(FIFOMixin, RequestRouter):
         self,
         candidate_replicas: List[RunningReplica],
         pending_request: Optional[PendingRequest] = None,
-    ) -> List[List[RunningReplica]]:
+    ) -> Sequence[List[RunningReplica]]:
         if not candidate_replicas:
             return []
 
         index = self._round_robin_counter % len(candidate_replicas)
         self._round_robin_counter += 1
-        return [[candidate_replicas[index]]]
+
+        return _RoundRobinReplicaRanks(
+            candidate_replicas,
+            index,
+            len(candidate_replicas),
+        )

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -139,6 +139,7 @@ py_test_module_list(
         "test_regression.py",
         "test_replica_placement_group.py",
         "test_request_timeout.py",
+        "test_round_robin_router.py",
         "test_streaming_response.py",
         "test_task_consumer_autoscaling.py",
         "test_task_processor.py",

--- a/python/ray/serve/tests/test_round_robin_router.py
+++ b/python/ray/serve/tests/test_round_robin_router.py
@@ -1,0 +1,209 @@
+import asyncio
+import sys
+
+import grpc
+import httpx
+import pytest
+
+import ray
+from ray import serve
+from ray._common.test_utils import wait_for_condition
+from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_DIRECT_INGRESS,
+)
+from ray.serve._private.test_utils import check_running, get_application_url
+from ray.serve.config import RequestRouterConfig
+from ray.serve.context import _get_internal_replica_context
+from ray.serve.generated import serve_pb2, serve_pb2_grpc
+
+ROUTER_CLASS = "ray.serve.experimental.round_robin_router:RoundRobinRouter"
+
+
+def _round_robin_config() -> RequestRouterConfig:
+    return RequestRouterConfig(
+        request_router_class=ROUTER_CLASS,
+        initial_backoff_s=0.01,
+        backoff_multiplier=1.0,
+        max_backoff_s=0.01,
+    )
+
+
+def _get_request_router(handle):
+    if not handle.is_initialized:
+        handle._init()
+    return handle._router._asyncio_router._request_router
+
+
+@ray.remote(num_cpus=0)
+class ReplicaBlocker:
+    def __init__(self):
+        self.replica_id = None
+        self.released = False
+
+    def record_replica(self, replica_id: str):
+        self.replica_id = replica_id
+
+    def get_replica(self):
+        return self.replica_id
+
+    def release(self):
+        self.released = True
+
+    def is_released(self):
+        return self.released
+
+
+def _assert_round_robin_wraps_and_cycles(call, num_replicas: int) -> None:
+    wait_for_condition(
+        lambda: len({call() for _ in range(num_replicas * 2)}) == num_replicas,
+        timeout=30,
+    )
+
+    replicas = [call() for _ in range(num_replicas * 2)]
+    expected_cycle = replicas[:num_replicas]
+    assert len(set(expected_cycle)) == num_replicas
+    assert replicas[num_replicas] == replicas[0]
+    assert replicas[num_replicas:] == expected_cycle
+
+
+def test_handle_options_and_http_round_robin(serve_instance):
+    num_replicas = 3
+
+    @serve.deployment(
+        request_router_config=_round_robin_config(),
+        num_replicas=num_replicas,
+        max_ongoing_requests=100,
+        ray_actor_options={"num_cpus": 0},
+    )
+    class App:
+        def __init__(self):
+            self.unique_id = _get_internal_replica_context().replica_id.unique_id
+
+        def __call__(self):
+            return self.unique_id
+
+        def via_options(self):
+            return self.unique_id
+
+    handle = serve.run(App.bind())
+    wait_for_condition(check_running, timeout=30)
+
+    def handle_call():
+        response = (
+            handle.options(
+                method_name="via_options",
+                session_id="client-session",
+            )
+            .remote()
+            .result(timeout_s=10)
+        )
+        return response
+
+    _assert_round_robin_wraps_and_cycles(handle_call, num_replicas)
+
+    url = get_application_url()
+
+    def http_call():
+        response = httpx.get(url, timeout=10)
+        assert response.status_code == 200
+        return response.text
+
+    _assert_round_robin_wraps_and_cycles(http_call, num_replicas)
+
+
+def test_handle_round_robin_backs_off_from_full_replica(serve_instance):
+    @serve.deployment(
+        request_router_config=_round_robin_config(),
+        num_replicas=2,
+        max_ongoing_requests=1,
+        ray_actor_options={"num_cpus": 0},
+    )
+    class BlockingApp:
+        def __init__(self):
+            self.unique_id = _get_internal_replica_context().replica_id.unique_id
+
+        async def __call__(self):
+            return self.unique_id
+
+        async def block(self, blocker):
+            await blocker.record_replica.remote(self.unique_id)
+            while not await blocker.is_released.remote():
+                await asyncio.sleep(0.05)
+            return self.unique_id
+
+    handle = serve.run(BlockingApp.bind())
+    wait_for_condition(check_running, timeout=30)
+
+    blocker = ReplicaBlocker.remote()
+    blocked_ref = handle.options(method_name="block").remote(blocker)
+    wait_for_condition(
+        lambda: ray.get(blocker.get_replica.remote()) is not None,
+        timeout=30,
+    )
+    blocked_replica = ray.get(blocker.get_replica.remote())
+
+    request_router = _get_request_router(handle)
+
+    def _set_counter_to_blocked_replica():
+        for index, replica in enumerate(request_router._replicas_list):
+            if replica.replica_id.unique_id == blocked_replica:
+                request_router._round_robin_counter = index
+                return True
+        return False
+
+    wait_for_condition(_set_counter_to_blocked_replica, timeout=30)
+
+    try:
+        fallback_replica = handle.remote().result(timeout_s=10)
+        assert fallback_replica != blocked_replica
+    finally:
+        ray.get(blocker.release.remote())
+        assert blocked_ref.result(timeout_s=10) == blocked_replica
+
+
+def test_grpc_round_robin(serve_instance):
+    if RAY_SERVE_ENABLE_DIRECT_INGRESS:
+        pytest.skip("Routing doesn't happen in direct ingress mode.")
+
+    num_replicas = 3
+    app_name = "grpc-round-robin"
+
+    @serve.deployment(
+        request_router_config=_round_robin_config(),
+        num_replicas=num_replicas,
+        max_ongoing_requests=100,
+        ray_actor_options={"num_cpus": 0},
+    )
+    class GrpcApp:
+        def __init__(self):
+            self.unique_id = _get_internal_replica_context().replica_id.unique_id
+
+        def __call__(self, user_message):
+            return serve_pb2.UserDefinedResponse(
+                greeting=self.unique_id,
+                num_x2=user_message.num * 2,
+            )
+
+    serve.run(GrpcApp.bind(), name=app_name, route_prefix=f"/{app_name}")
+    wait_for_condition(lambda: check_running(app_name), timeout=30)
+
+    channel = grpc.insecure_channel(
+        get_application_url("gRPC", app_name=app_name, use_localhost=True)
+    )
+    stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
+    request = serve_pb2.UserDefinedMessage(name="x", num=1, foo="y")
+    metadata = (("application", app_name),)
+
+    def grpc_call():
+        response, call = stub.__call__.with_call(
+            request=request,
+            metadata=metadata,
+        )
+        assert call.code() == grpc.StatusCode.OK
+        return response.greeting
+
+    _assert_round_robin_wraps_and_cycles(grpc_call, num_replicas)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_round_robin_router.py
+++ b/python/ray/serve/tests/test_round_robin_router.py
@@ -90,12 +90,7 @@ def test_handle_options_and_http_round_robin(serve_instance):
 
     def handle_call():
         response = (
-            handle.options(
-                method_name="via_options",
-                session_id="client-session",
-            )
-            .remote()
-            .result(timeout_s=10)
+            handle.options(method_name="via_options").remote().result(timeout_s=10)
         )
         return response
 

--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -9,8 +9,22 @@ py_library(
 py_test_run_all_subdirectory(
     size = "small",
     include = glob(["test_*.py"]),
-    exclude = ["test_haproxy_binary.py"],
+    exclude = [
+        "test_haproxy_binary.py",
+        "test_round_robin_router.py",
+    ],
     extra_srcs = [],
+    tags = ["team:serve"],
+    deps = [
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+        "//python/ray/serve/tests:common",
+    ],
+)
+
+py_test_module_list(
+    size = "small",
+    files = ["test_round_robin_router.py"],
     tags = ["team:serve"],
     deps = [
         ":conftest",

--- a/python/ray/serve/tests/unit/test_round_robin_router.py
+++ b/python/ray/serve/tests/unit/test_round_robin_router.py
@@ -36,18 +36,22 @@ def router(request) -> RoundRobinRouter:
     if not hasattr(request, "param"):
         request.param = {}
 
+    params = dict(request.param)
+    use_replica_queue_len_cache = params.pop("use_replica_queue_len_cache", False)
+
     TIMER.reset()
     request_router = RoundRobinRouter(
         deployment_id=DEPLOYMENT_ID,
         handle_source=DeploymentHandleSource.REPLICA,
         self_actor_id="fake-actor-id",
         self_actor_handle=None,
+        use_replica_queue_len_cache=use_replica_queue_len_cache,
         get_curr_time_s=TIMER.time,
         initial_backoff_s=0.001,
         backoff_multiplier=1,
         max_backoff_s=0.001,
     )
-    request_router.initialize_state(**request.param)
+    request_router.initialize_state(**params)
 
     yield request_router
 
@@ -63,7 +67,7 @@ def _make_replicas(*replica_ids: str, **kwargs):
 
 
 def _ranked_replica_unique_ids(ranks):
-    return [rank[0].replica_id.unique_id for rank in ranks]
+    return [[replica.replica_id.unique_id for replica in rank] for rank in ranks]
 
 
 def test_initialize_state_ignores_router_kwargs(router):
@@ -83,16 +87,16 @@ async def test_choose_replicas_round_robin_order(router):
 
     assert _ranked_replica_unique_ids(
         await router.choose_replicas(replicas, _make_request())
-    ) == ["r2"]
+    ) == [["r2"], ["r0"], ["r1"]]
     assert _ranked_replica_unique_ids(
         await router.choose_replicas(replicas, _make_request())
-    ) == ["r0"]
+    ) == [["r0"], ["r1"], ["r2"]]
     assert _ranked_replica_unique_ids(
         await router.choose_replicas(replicas, _make_request())
-    ) == ["r1"]
+    ) == [["r1"], ["r2"], ["r0"]]
     assert _ranked_replica_unique_ids(
         await router.choose_replicas(replicas, _make_request())
-    ) == ["r2"]
+    ) == [["r2"], ["r0"], ["r1"]]
 
 
 @pytest.mark.asyncio
@@ -110,13 +114,37 @@ async def test_choose_replicas_ignores_request_metadata(router):
 
     assert _ranked_replica_unique_ids(
         await router.choose_replicas(replicas, _make_request(model_id="model-a"))
-    ) == ["r0"]
+    ) == [["r0"], ["r1"], ["r2"]]
     assert _ranked_replica_unique_ids(
         await router.choose_replicas(replicas, _make_request(model_id="model-a"))
-    ) == ["r1"]
+    ) == [["r1"], ["r2"], ["r0"]]
     assert _ranked_replica_unique_ids(
         await router.choose_replicas(replicas, _make_request(model_id="model-a"))
-    ) == ["r2"]
+    ) == [["r2"], ["r0"], ["r1"]]
+
+
+@pytest.mark.parametrize(
+    "router", [{"use_replica_queue_len_cache": True}], indirect=True
+)
+@pytest.mark.asyncio
+async def test_choose_replicas_includes_cached_full_replica_first(router):
+    replicas = [
+        FakeRunningReplica("r0", max_ongoing_requests=1),
+        FakeRunningReplica("r1", max_ongoing_requests=1),
+        FakeRunningReplica("r2", max_ongoing_requests=1),
+    ]
+    for replica in replicas:
+        replica.set_queue_len_response(0)
+    router.update_replicas(replicas)
+    router.replica_queue_len_cache.update(replicas[0].replica_id, 1)
+    router._round_robin_counter = 0
+    await asyncio.sleep(0)
+
+    # Selection should preserve strict round-robin order even if fulfillment
+    # later rejects the cached-full replica and advances to the next rank.
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request())
+    ) == [["r0"], ["r1"], ["r2"]]
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/unit/test_round_robin_router.py
+++ b/python/ray/serve/tests/unit/test_round_robin_router.py
@@ -173,5 +173,19 @@ async def test_choose_replicas_empty_candidates(router):
     assert router._round_robin_counter == counter
 
 
+@pytest.mark.asyncio
+async def test_choose_replicas_sets_should_backoff(router):
+    # Without should_backoff, the base class tight-loops choose_replicas when
+    # every replica is at capacity (see _choose_replicas_with_backoff).
+    replicas = _make_replicas("r0", "r1")
+    router.update_replicas(replicas)
+    await asyncio.sleep(0)
+
+    request = _make_request()
+    assert request.routing_context.should_backoff is False
+    await router.choose_replicas(replicas, request)
+    assert request.routing_context.should_backoff is True
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_round_robin_router.py
+++ b/python/ray/serve/tests/unit/test_round_robin_router.py
@@ -1,0 +1,149 @@
+import asyncio
+import sys
+
+import pytest
+
+from ray.serve._private.common import (
+    DeploymentHandleSource,
+    RequestMetadata,
+)
+from ray.serve._private.request_router import PendingRequest
+from ray.serve._private.test_utils import (
+    FAKE_REPLICA_DEPLOYMENT_ID as DEPLOYMENT_ID,
+    FakeRunningReplica,
+    MockTimer,
+)
+from ray.serve._private.utils import generate_request_id
+from ray.serve.experimental.round_robin_router import RoundRobinRouter
+
+TIMER = MockTimer()
+
+
+def _make_request(model_id: str = "") -> PendingRequest:
+    return PendingRequest(
+        args=[],
+        kwargs={},
+        metadata=RequestMetadata(
+            request_id=generate_request_id(),
+            internal_request_id=generate_request_id(),
+            multiplexed_model_id=model_id,
+        ),
+    )
+
+
+@pytest.fixture
+def router(request) -> RoundRobinRouter:
+    if not hasattr(request, "param"):
+        request.param = {}
+
+    TIMER.reset()
+    request_router = RoundRobinRouter(
+        deployment_id=DEPLOYMENT_ID,
+        handle_source=DeploymentHandleSource.REPLICA,
+        self_actor_id="fake-actor-id",
+        self_actor_handle=None,
+        get_curr_time_s=TIMER.time,
+        initial_backoff_s=0.001,
+        backoff_multiplier=1,
+        max_backoff_s=0.001,
+    )
+    request_router.initialize_state(**request.param)
+
+    yield request_router
+
+    assert request_router.curr_num_routing_tasks == 0
+    assert request_router.num_pending_requests == 0
+
+
+def _make_replicas(*replica_ids: str, **kwargs):
+    replicas = [FakeRunningReplica(replica_id, **kwargs) for replica_id in replica_ids]
+    for replica in replicas:
+        replica.set_queue_len_response(0)
+    return replicas
+
+
+def _ranked_replica_unique_ids(ranks):
+    return [rank[0].replica_id.unique_id for rank in ranks]
+
+
+def test_initialize_state_ignores_router_kwargs(router):
+    router.initialize_state(unused=True)
+
+
+def test_round_robin_counter_initialized_randomly(router):
+    assert 0 <= router._round_robin_counter < 2**31
+
+
+@pytest.mark.asyncio
+async def test_choose_replicas_round_robin_order(router):
+    replicas = _make_replicas("r2", "r0", "r1")
+    router.update_replicas(replicas)
+    router._round_robin_counter = 0
+    await asyncio.sleep(0)
+
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request())
+    ) == ["r2"]
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request())
+    ) == ["r0"]
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request())
+    ) == ["r1"]
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request())
+    ) == ["r2"]
+
+
+@pytest.mark.asyncio
+async def test_choose_replicas_ignores_request_metadata(router):
+    replicas = [
+        FakeRunningReplica("r0", model_ids={"model-a"}),
+        FakeRunningReplica("r1"),
+        FakeRunningReplica("r2", model_ids={"model-a"}),
+    ]
+    for replica in replicas:
+        replica.set_queue_len_response(0)
+    router.update_replicas(replicas)
+    router._round_robin_counter = 0
+    await asyncio.sleep(0)
+
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request(model_id="model-a"))
+    ) == ["r0"]
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request(model_id="model-a"))
+    ) == ["r1"]
+    assert _ranked_replica_unique_ids(
+        await router.choose_replicas(replicas, _make_request(model_id="model-a"))
+    ) == ["r2"]
+
+
+@pytest.mark.asyncio
+async def test_choose_replica_falls_back_when_current_candidate_full(router):
+    replicas = [
+        FakeRunningReplica("r0", max_ongoing_requests=1),
+        FakeRunningReplica("r1"),
+        FakeRunningReplica("r2"),
+    ]
+    replicas[0].set_queue_len_response(1)
+    replicas[1].set_queue_len_response(0)
+    replicas[2].set_queue_len_response(0)
+    router.update_replicas(replicas)
+    router._round_robin_counter = 0
+    await asyncio.sleep(0)
+
+    chosen = await router._choose_replica_for_request(_make_request())
+    assert chosen.replica_id.unique_id == "r1"
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_choose_replicas_empty_candidates(router):
+    counter = router._round_robin_counter
+    assert await router.choose_replicas([], _make_request()) == []
+    assert router._round_robin_counter == counter
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Description
Round robin ensures fairness and is particularly beneficial in LLM benchmarking where the workloads (ISL/OSL) are homogeneous.

The router returns a lazy ordered `Sequence` of singleton replica ranks:
- Request starts at the current round-robin cursor.
- If that replica cannot fulfill, try `idx + 1`, then `idx + 2`, wrapping around.
- The next request advances the cursor by exactly one.
- Ranks are generated lazily instead of eagerly materializing all candidates.

## Benchmark
No regression from power-of-two-choices router. Will add round robin router to nightly benchmark suite in a follow-up PR.
<img width="1018" height="401" alt="Screenshot 2026-05-09 at 5 32 31 PM" src="https://github.com/user-attachments/assets/125ae399-d05c-4067-9341-c8a062646a8a" />



The original implementation (https://github.com/ray-project/ray/pull/63238/commits/3cc52c78911faae3b6b37e3a9518684a18a941f4) yields 1.5x worse latency because the router only returns one candidate. If the candidate rejects, the fallback needs to experience backoffs.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
