### PR TITLE
[serve][1/3] Add replica-side slot reservation primitive

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -171,6 +171,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.exceptions.RequestCancelledError
    serve.exceptions.gRPCStatusError
    serve.exceptions.DeploymentUnavailableError
+   serve.exceptions.ReplicaUnavailableError
 ```
 
 

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -820,6 +820,9 @@ class RequestMetadata:
     request_serialization: str = "cloudpickle"
     response_serialization: str = "cloudpickle"
 
+    # Token for a replica-side slot reserved by choose_replica().
+    _reserved_slot_token: Optional[str] = None
+
     @property
     def is_http_request(self) -> bool:
         return self._request_protocol == RequestProtocol.HTTP

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1182,13 +1182,36 @@ class Replica:
         self._direct_ingress_grpc_server_task: Optional[asyncio.Task] = None
 
         self._num_queued_requests = 0
+        self._reserved_slots: Set[str] = set()
 
     @property
     def max_ongoing_requests(self) -> int:
         return self._deployment_config.max_ongoing_requests
 
     def get_num_ongoing_requests(self) -> int:
-        return self._metrics_manager.get_num_ongoing_requests()
+        return self._metrics_manager.get_num_ongoing_requests() + len(
+            self._reserved_slots
+        )
+
+    async def reserve_slot(
+        self, request_metadata: RequestMetadata, slot_token: str
+    ) -> Tuple[bool, int]:
+        """Reserve replica capacity for a future dispatch call."""
+        if not self._can_accept_request(request_metadata):
+            return False, self.get_num_ongoing_requests()
+
+        await self._semaphore.acquire()
+        self._reserved_slots.add(slot_token)
+        return True, self.get_num_ongoing_requests()
+
+    def release_slot(self, slot_token: str) -> Tuple[bool, int]:
+        """Release replica capacity reserved by choose_replica()."""
+        if slot_token not in self._reserved_slots:
+            return False, self.get_num_ongoing_requests()
+
+        self._reserved_slots.remove(slot_token)
+        self._semaphore.release()
+        return True, self.get_num_ongoing_requests()
 
     def get_metadata(self) -> ReplicaMetadata:
         current_rank = ray.serve.context._get_internal_replica_context().rank
@@ -1865,12 +1888,25 @@ class Replica:
 
     @asynccontextmanager
     async def _start_request(self, request_metadata: RequestMetadata):
-        async with self._semaphore:
+        reserved_slot_token = request_metadata._reserved_slot_token
+        if reserved_slot_token:
+            if reserved_slot_token not in self._reserved_slots:
+                raise RuntimeError(
+                    "Request tried to consume an unknown reserved slot "
+                    f"{reserved_slot_token}."
+                )
+            self._reserved_slots.remove(reserved_slot_token)
+        else:
+            await self._semaphore.acquire()
+
+        try:
             try:
                 self._metrics_manager.inc_num_ongoing_requests(request_metadata)
                 yield
             finally:
                 self._metrics_manager.dec_num_ongoing_requests(request_metadata)
+        finally:
+            self._semaphore.release()
 
     async def _drain_ongoing_requests(self):
         """Wait for any ongoing requests to finish.
@@ -2758,6 +2794,16 @@ class ReplicaActor:
         not be blocked by user code.
         """
         return self._replica_impl.get_num_ongoing_requests()
+
+    async def reserve_slot(
+        self, request_metadata: RequestMetadata, slot_token: str
+    ) -> Tuple[bool, int]:
+        """Reserve capacity for a future choose_replica/dispatch request."""
+        return await self._replica_impl.reserve_slot(request_metadata, slot_token)
+
+    def release_slot(self, slot_token: str) -> Tuple[bool, int]:
+        """Release capacity reserved by choose_replica()."""
+        return self._replica_impl.release_slot(slot_token)
 
     async def is_allocated(self) -> str:
         """poke the replica to check whether it's alive.

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1197,6 +1197,11 @@ class Replica:
         self, request_metadata: RequestMetadata, slot_token: str
     ) -> Tuple[bool, int]:
         """Reserve replica capacity for a future dispatch call."""
+        if request_metadata.is_direct_ingress:
+            raise RuntimeError(
+                "Slot reservation is not supported for direct-ingress requests."
+            )
+
         if not self._can_accept_request(request_metadata):
             return False, self.get_num_ongoing_requests()
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1919,7 +1919,7 @@ class Replica:
         while True:
             await asyncio.sleep(wait_loop_period_s)
 
-            num_ongoing_requests = self._metrics_manager.get_num_ongoing_requests()
+            num_ongoing_requests = self.get_num_ongoing_requests()
             if num_ongoing_requests > 0:
                 logger.info(
                     f"Waiting for an additional {wait_loop_period_s}s to shut down "

--- a/python/ray/serve/_private/request_router/__init__.py
+++ b/python/ray/serve/_private/request_router/__init__.py
@@ -3,6 +3,7 @@ from ray.serve._private.request_router.pow_2_router import (  # noqa: F401
     PowerOfTwoChoicesRequestRouter,
 )
 from ray.serve._private.request_router.replica_wrapper import (  # noqa: F401
+    ReplicaSelection,
     RunningReplica,
 )
 from ray.serve._private.request_router.request_router import (  # noqa: F401

--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 import pickle
+import uuid
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Set, Tuple
 
 import grpc
@@ -9,7 +11,10 @@ import grpc
 import ray
 from ray.actor import ActorHandle
 from ray.serve._private.common import (
+    DeploymentID,
     ReplicaID,
+    ReplicaQueueLengthInfo,
+    RequestMetadata,
     RunningReplicaInfo,
 )
 from ray.serve._private.constants import (
@@ -324,3 +329,120 @@ class RunningReplica:
             return wrapper.send_request_java(pr)
 
         return wrapper.send_request_python(pr, with_rejection=with_rejection)
+
+    async def reserve_slot(
+        self, request_metadata: RequestMetadata
+    ) -> Tuple[str, ReplicaQueueLengthInfo]:
+        """Reserve a slot on this replica for an upcoming request.
+
+        Returns a unique token that can be used to release the slot later.
+        This is used in the choose_replica/dispatch pattern to track
+        reservations that haven't been dispatched yet.
+        """
+        if self._replica_info.is_cross_language:
+            raise RuntimeError("Slot reservation not supported for Java.")
+
+        slot_token = str(uuid.uuid4())
+        obj_ref = self._actor_handle.reserve_slot.remote(request_metadata, slot_token)
+        try:
+            accepted, num_ongoing_requests = await obj_ref
+        except asyncio.CancelledError:
+            ray.cancel(obj_ref)
+            self._actor_handle.release_slot.remote(slot_token)
+            raise
+
+        return slot_token, ReplicaQueueLengthInfo(
+            accepted=accepted,
+            num_ongoing_requests=num_ongoing_requests,
+        )
+
+    async def release_slot(self, slot_token: str) -> ReplicaQueueLengthInfo:
+        """Release a previously reserved slot.
+
+        This should be called if a request is not dispatched after
+        reserving a slot (e.g., due to an error or cancellation).
+        """
+        if self._replica_info.is_cross_language:
+            raise RuntimeError("Slot reservation not supported for Java.")
+
+        _, num_ongoing_requests = await self._actor_handle.release_slot.remote(
+            slot_token
+        )
+        return ReplicaQueueLengthInfo(
+            accepted=True,
+            num_ongoing_requests=num_ongoing_requests,
+        )
+
+
+@dataclass
+class ReplicaSelection:
+    """Represents a selected replica, holding information for dispatch or coordination.
+
+    This class is returned by the choose_replica() context manager.
+    The slot reservation lifecycle is managed by the context manager.
+    """
+
+    # Public, user-accessible fields
+    replica_id: str
+    """Unique identifier for the selected replica."""
+
+    node_ip: str
+    """IP address of the node running this replica."""
+
+    port: Optional[int]
+    """Port number for direct communication (if configured)."""
+
+    node_id: str
+    """Ray node ID where the replica is running."""
+
+    availability_zone: Optional[str]
+    """Cloud availability zone of the replica's node."""
+
+    # Internal fields (not part of public API)
+    _replica: RunningReplica
+    _deployment_id: Optional[DeploymentID]
+    _request_metadata: RequestMetadata
+    _method_name: str
+    _slot_token: str  # Token for reserved slot
+    _dispatched: bool = field(
+        default=False, init=False
+    )  # Tracks if dispatch was called
+
+    @property
+    def address(self) -> str:
+        """Returns the replica address in host:port format."""
+        if self.port:
+            return f"{self.node_ip}:{self.port}"
+        return self.node_ip
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize public fields to a dictionary."""
+        return {
+            "replica_id": self.replica_id,
+            "node_ip": self.node_ip,
+            "port": self.port,
+            "node_id": self.node_id,
+            "availability_zone": self.availability_zone,
+        }
+
+    def _mark_dispatched(self) -> None:
+        """Internal: Mark this selection as dispatched (slot consumed).
+
+        Raises:
+            RuntimeError: If the selection has already been dispatched.
+        """
+        if self._dispatched:
+            raise RuntimeError(
+                f"ReplicaSelection for {self.replica_id} has already been dispatched. "
+                "Each selection can only be dispatched once."
+            )
+        self._dispatched = True
+
+    async def _release_slot(
+        self, *, force: bool = False
+    ) -> Optional[ReplicaQueueLengthInfo]:
+        """Internal: Release the reserved slot."""
+        if self._dispatched and not force:
+            return None
+
+        return await self._replica.release_slot(self._slot_token)

--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -356,11 +356,13 @@ class RunningReplica:
             num_ongoing_requests=num_ongoing_requests,
         )
 
-    async def release_slot(self, slot_token: str) -> ReplicaQueueLengthInfo:
+    async def release_slot(self, slot_token: str) -> int:
         """Release a previously reserved slot.
 
         This should be called if a request is not dispatched after
         reserving a slot (e.g., due to an error or cancellation).
+
+        Returns the replica's reported num_ongoing_requests after the release.
         """
         if self._replica_info.is_cross_language:
             raise RuntimeError("Slot reservation not supported for Java.")
@@ -368,10 +370,7 @@ class RunningReplica:
         _, num_ongoing_requests = await self._actor_handle.release_slot.remote(
             slot_token
         )
-        return ReplicaQueueLengthInfo(
-            accepted=True,
-            num_ongoing_requests=num_ongoing_requests,
-        )
+        return num_ongoing_requests
 
 
 @dataclass
@@ -438,10 +437,12 @@ class ReplicaSelection:
             )
         self._dispatched = True
 
-    async def _release_slot(
-        self, *, force: bool = False
-    ) -> Optional[ReplicaQueueLengthInfo]:
-        """Internal: Release the reserved slot."""
+    async def _release_slot(self, *, force: bool = False) -> Optional[int]:
+        """Internal: Release the reserved slot.
+
+        Returns the replica's reported num_ongoing_requests after the release,
+        or None if dispatch already consumed the slot (and ``force`` is False).
+        """
         if self._dispatched and not force:
             return None
 

--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -348,6 +348,7 @@ class RunningReplica:
             accepted, num_ongoing_requests = await obj_ref
         except asyncio.CancelledError:
             ray.cancel(obj_ref)
+            # TODO (#63254): Add error handling for actor-unavailable cleanup.
             self._actor_handle.release_slot.remote(slot_token)
             raise
 

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -101,3 +101,10 @@ class DeploymentUnavailableError(RayServeException):
     @property
     def message(self) -> str:
         return f"{self._deployment_id} is unavailable because it failed to deploy."
+
+
+@PublicAPI(stability="alpha")
+class ReplicaUnavailableError(RayServeException):
+    """Raised when the selected replica is no longer available."""
+
+    pass

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -107,4 +107,9 @@ class DeploymentUnavailableError(RayServeException):
 class ReplicaUnavailableError(RayServeException):
     """Raised when the selected replica is no longer available."""
 
-    pass
+    def __init__(self, replica_id: str):
+        self._replica_id = replica_id
+
+    @property
+    def message(self) -> str:
+        return f"Replica {self._replica_id} is no longer available."

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -325,14 +325,28 @@ class FakeReplicaMetricsManager:
         self.num_ongoing_requests -= 1
 
 
+class FakeServeReplicaForSlotReservation(ServeReplica):
+    def __init__(
+        self,
+        *,
+        max_ongoing_requests: int = 1,
+        graceful_shutdown_wait_loop_s: float = 0.01,
+    ):
+        self._deployment_config = Mock(
+            max_ongoing_requests=max_ongoing_requests,
+            graceful_shutdown_wait_loop_s=graceful_shutdown_wait_loop_s,
+        )
+        self._metrics_manager = FakeReplicaMetricsManager()
+        self._reserved_slots = set()
+        self._semaphore = Semaphore(lambda: self.max_ongoing_requests)
+
+
 @pytest.mark.asyncio
 class TestReplicaSlotReservation:
     async def test_reserved_slot_counts_against_replica_capacity(self):
-        replica = ServeReplica.__new__(ServeReplica)
-        replica._deployment_config = Mock(max_ongoing_requests=1)
-        replica._metrics_manager = FakeReplicaMetricsManager()
-        replica._reserved_slots = set()
-        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+        # A reserved slot consumes capacity, so another reservation should be
+        # rejected once the replica reaches max_ongoing_requests.
+        replica = FakeServeReplicaForSlotReservation()
 
         request_metadata = dummy_request_metadata()
 
@@ -359,11 +373,7 @@ class TestReplicaSlotReservation:
     async def test_release_slot_returns_status_and_recovers_capacity(self):
         # Releasing a known token reports True and frees a slot; releasing an
         # unknown or already-released token reports False and is a no-op.
-        replica = ServeReplica.__new__(ServeReplica)
-        replica._deployment_config = Mock(max_ongoing_requests=1)
-        replica._metrics_manager = FakeReplicaMetricsManager()
-        replica._reserved_slots = set()
-        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+        replica = FakeServeReplicaForSlotReservation()
 
         request_metadata = dummy_request_metadata()
         accepted, _ = await replica.reserve_slot(request_metadata, "tok-a")
@@ -393,11 +403,7 @@ class TestReplicaSlotReservation:
         # A request that arrives with a slot token nobody reserved (or that
         # was already released) must be rejected loudly and must not
         # consume capacity.
-        replica = ServeReplica.__new__(ServeReplica)
-        replica._deployment_config = Mock(max_ongoing_requests=1)
-        replica._metrics_manager = FakeReplicaMetricsManager()
-        replica._reserved_slots = set()
-        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+        replica = FakeServeReplicaForSlotReservation()
 
         bogus = replace(dummy_request_metadata(), _reserved_slot_token="never-reserved")
         with pytest.raises(RuntimeError, match="unknown reserved slot"):
@@ -416,14 +422,7 @@ class TestReplicaSlotReservation:
         # graceful shutdown must wait for it just like an in-flight request.
         # Otherwise the replica can finish draining between reserve_slot and
         # the dispatch, leaving the router to send the request to a dead replica.
-        replica = ServeReplica.__new__(ServeReplica)
-        replica._deployment_config = Mock(
-            max_ongoing_requests=1,
-            graceful_shutdown_wait_loop_s=0.01,
-        )
-        replica._metrics_manager = FakeReplicaMetricsManager()
-        replica._reserved_slots = set()
-        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+        replica = FakeServeReplicaForSlotReservation(graceful_shutdown_wait_loop_s=0.01)
 
         request_metadata = dummy_request_metadata()
         accepted, _ = await replica.reserve_slot(request_metadata, "slot-token-1")

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -441,6 +441,51 @@ class TestReplicaSlotReservation:
             if not drain_task.done():
                 drain_task.cancel()
 
+    async def test_direct_ingress_request_is_rejected(self):
+        replica = FakeServeReplicaForSlotReservation()
+
+        request_metadata = replace(dummy_request_metadata(), is_direct_ingress=True)
+
+        with pytest.raises(RuntimeError, match="direct-ingress"):
+            await replica.reserve_slot(request_metadata, "slot-token-1")
+
+        assert replica.get_num_ongoing_requests() == 0
+
+
+class FakeRunningReplicaForSlotReservation(RunningReplica):
+    def __init__(self, actor_handle: Mock):
+        self._replica_info = Mock(is_cross_language=False)
+        self._actor_handle = actor_handle
+
+
+@pytest.mark.asyncio
+class TestRunningReplicaSlotReservation:
+    async def test_cancellation_releases_reserved_slot(self):
+        # Cancellation can arrive after the actor has already reserved the slot,
+        # so ray.cancel(obj_ref) is a no-op and release_slot.remote() is the
+        # only one that frees the leaked slot.
+        pending = asyncio.get_running_loop().create_future()
+        actor_handle = Mock()
+        actor_handle.reserve_slot.remote = Mock(return_value=pending)
+        actor_handle.release_slot.remote = Mock()
+        replica = FakeRunningReplicaForSlotReservation(actor_handle)
+
+        with patch("ray.cancel") as mock_ray_cancel:
+            task = asyncio.create_task(replica.reserve_slot(dummy_request_metadata()))
+            # Yield so the task reaches `await obj_ref` before we cancel.
+            await asyncio.sleep(0)
+            task.cancel()
+
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        mock_ray_cancel.assert_called_once_with(pending)
+
+        actor_handle.release_slot.remote.assert_called_once()
+        released_token = actor_handle.release_slot.remote.call_args[0][0]
+        reserved_token = actor_handle.reserve_slot.remote.call_args[0][1]
+        assert released_token == reserved_token
+
 
 @pytest.mark.asyncio
 class TestBroadcast:

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -4,6 +4,7 @@ import random
 import sys
 import threading
 from collections import defaultdict
+from dataclasses import replace
 from typing import Callable, Dict, List, Optional, Set, Tuple
 from unittest.mock import Mock, patch
 
@@ -26,6 +27,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
 )
+from ray.serve._private.replica import Replica as ServeReplica
 from ray.serve._private.replica_result import ReplicaResult
 from ray.serve._private.request_router import (
     PendingRequest,
@@ -40,7 +42,11 @@ from ray.serve._private.router import (
     SingletonThreadRouter,
 )
 from ray.serve._private.test_utils import FakeCounter, FakeGauge, MockTimer
-from ray.serve._private.utils import decompress_metric_report, get_random_string
+from ray.serve._private.utils import (
+    Semaphore,
+    decompress_metric_report,
+    get_random_string,
+)
 from ray.serve.config import AutoscalingConfig, RequestRouterConfig
 from ray.serve.exceptions import BackPressureError, DeploymentUnavailableError
 
@@ -303,6 +309,52 @@ def dummy_request_metadata(is_streaming: bool = False) -> RequestMetadata:
         internal_request_id="test-internal-request-1",
         is_streaming=is_streaming,
     )
+
+
+class FakeReplicaMetricsManager:
+    def __init__(self):
+        self.num_ongoing_requests = 0
+
+    def get_num_ongoing_requests(self) -> int:
+        return self.num_ongoing_requests
+
+    def inc_num_ongoing_requests(self, request_metadata: RequestMetadata):
+        self.num_ongoing_requests += 1
+
+    def dec_num_ongoing_requests(self, request_metadata: RequestMetadata):
+        self.num_ongoing_requests -= 1
+
+
+@pytest.mark.asyncio
+class TestReplicaSlotReservation:
+    async def test_reserved_slot_counts_against_replica_capacity(self):
+        replica = ServeReplica.__new__(ServeReplica)
+        replica._deployment_config = Mock(max_ongoing_requests=1)
+        replica._metrics_manager = FakeReplicaMetricsManager()
+        replica._reserved_slots = set()
+        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+
+        request_metadata = dummy_request_metadata()
+
+        slot_token = "slot-token-1"
+        accepted, queue_len = await replica.reserve_slot(request_metadata, slot_token)
+        assert accepted
+        assert slot_token in replica._reserved_slots
+        assert queue_len == 1
+        assert replica.get_num_ongoing_requests() == 1
+
+        accepted, queue_len = await replica.reserve_slot(
+            request_metadata, "slot-token-2"
+        )
+        assert not accepted
+        assert queue_len == 1
+
+        dispatch_metadata = replace(request_metadata, _reserved_slot_token=slot_token)
+        async with replica._start_request(dispatch_metadata):
+            assert slot_token not in replica._reserved_slots
+            assert replica.get_num_ongoing_requests() == 1
+
+        assert replica.get_num_ongoing_requests() == 0
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -356,6 +356,37 @@ class TestReplicaSlotReservation:
 
         assert replica.get_num_ongoing_requests() == 0
 
+    async def test_drain_waits_for_reserved_slots(self):
+        # A reserved-but-not-yet-dispatched slot is holding capacity, so a
+        # graceful shutdown must wait for it just like an in-flight request.
+        # Otherwise the replica can finish draining between reserve_slot and
+        # the dispatch, leaving the router to send the request to a dead replica.
+        replica = ServeReplica.__new__(ServeReplica)
+        replica._deployment_config = Mock(
+            max_ongoing_requests=1,
+            graceful_shutdown_wait_loop_s=0.01,
+        )
+        replica._metrics_manager = FakeReplicaMetricsManager()
+        replica._reserved_slots = set()
+        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+
+        request_metadata = dummy_request_metadata()
+        accepted, _ = await replica.reserve_slot(request_metadata, "slot-token-1")
+        assert accepted
+
+        drain_task = asyncio.create_task(replica._drain_ongoing_requests())
+        try:
+            await asyncio.sleep(0.1)
+            assert not drain_task.done(), (
+                "drain should still be running while a slot is reserved"
+            )
+
+            replica.release_slot("slot-token-1")
+            await asyncio.wait_for(drain_task, timeout=1.0)
+        finally:
+            if not drain_task.done():
+                drain_task.cancel()
+
 
 @pytest.mark.asyncio
 class TestBroadcast:

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -356,6 +356,61 @@ class TestReplicaSlotReservation:
 
         assert replica.get_num_ongoing_requests() == 0
 
+    async def test_release_slot_returns_status_and_recovers_capacity(self):
+        # Releasing a known token reports True and frees a slot; releasing an
+        # unknown or already-released token reports False and is a no-op.
+        replica = ServeReplica.__new__(ServeReplica)
+        replica._deployment_config = Mock(max_ongoing_requests=1)
+        replica._metrics_manager = FakeReplicaMetricsManager()
+        replica._reserved_slots = set()
+        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+
+        request_metadata = dummy_request_metadata()
+        accepted, _ = await replica.reserve_slot(request_metadata, "tok-a")
+        assert accepted
+        assert replica.get_num_ongoing_requests() == 1
+
+        accepted, count = replica.release_slot("tok-a")
+        assert accepted
+        assert count == 0
+        assert replica.get_num_ongoing_requests() == 0
+
+        # Releasing the same token a second time is a no-op.
+        accepted, count = replica.release_slot("tok-a")
+        assert not accepted
+        assert count == 0
+
+        # Releasing a token that was never reserved is also a no-op.
+        accepted, count = replica.release_slot("never-reserved")
+        assert not accepted
+        assert count == 0
+
+        # Capacity is fully recovered: a fresh reservation succeeds.
+        accepted, _ = await replica.reserve_slot(request_metadata, "tok-b")
+        assert accepted
+
+    async def test_dispatch_with_unknown_slot_token_is_rejected(self):
+        # A request that arrives with a slot token nobody reserved (or that
+        # was already released) must be rejected loudly and must not
+        # consume capacity.
+        replica = ServeReplica.__new__(ServeReplica)
+        replica._deployment_config = Mock(max_ongoing_requests=1)
+        replica._metrics_manager = FakeReplicaMetricsManager()
+        replica._reserved_slots = set()
+        replica._semaphore = Semaphore(lambda: replica.max_ongoing_requests)
+
+        bogus = replace(dummy_request_metadata(), _reserved_slot_token="never-reserved")
+        with pytest.raises(RuntimeError, match="unknown reserved slot"):
+            async with replica._start_request(bogus):
+                pass
+
+        assert replica.get_num_ongoing_requests() == 0
+
+        # The replica is still healthy: a normal request can still run.
+        async with replica._start_request(dummy_request_metadata()):
+            assert replica.get_num_ongoing_requests() == 1
+        assert replica.get_num_ongoing_requests() == 0
+
     async def test_drain_waits_for_reserved_slots(self):
         # A reserved-but-not-yet-dispatched slot is holding capacity, so a
         # graceful shutdown must wait for it just like an in-flight request.
@@ -377,9 +432,9 @@ class TestReplicaSlotReservation:
         drain_task = asyncio.create_task(replica._drain_ongoing_requests())
         try:
             await asyncio.sleep(0.1)
-            assert not drain_task.done(), (
-                "drain should still be running while a slot is reserved"
-            )
+            assert (
+                not drain_task.done()
+            ), "drain should still be running while a slot is reserved"
 
             replica.release_slot("slot-token-1")
             await asyncio.wait_for(drain_task, timeout=1.0)


### PR DESCRIPTION
## Description
The `choose_replica` / `dispatch` flow needs the router to hold a slot on the replica before dispatching, so that when dispatch finally sends the request it can use `with_rejection=False` (slot already reserved on the actor). This PR adds the underlying primitive: an actor-side `reserve_slot` / `release_slot` pair backed by the existing semaphore, plus the wire format and `ReplicaSelection` wrapper. There are **no callers** yet — the router integration is the next PR.

### Lifecycle
This PR adds the primitives a future caller (implemented in https://github.com/ray-project/ray/pull/63254 and https://github.com/ray-project/ray/pull/63255) will use as a four-step lifecycle:

1. **Reserve**: Grab a permit on the replica's `max_ongoing_requests` semaphore *before* the request is built; get back a token and ground-truth `(accepted, num_ongoing_requests)`.
2. **Hand off**: Wrap the token in a `ReplicaSelection` (address + node + AZ) the caller can pass around.
3. **Consume on dispatch**: The token rides on `RequestMetadata`; the replica skips re-acquiring the semaphore on the way in.
4. **Release on abort**: Early return / exception / cancellation returns the token and frees the permit.

## Primitives
- `Replica.reserve_slot` / `release_slot` (exposed through `ReplicaActor`): the actor-side primitive, leveraging the existing `_start_request` semaphore so reservations count against the same capacity bound and show up in `get_num_ongoing_requests()`.
  - Cross-language (Java) replicas raise `RuntimeError("Slot reservation not supported for Java.")` since there's no actor-side semaphore on the Java replica.
- `RunningReplica.reserve_slot` / `release_slot`: async wrappers over the actor RPC that return `ReplicaQueueLengthInfo` for cache updates.
- `ReplicaSelection`: wraps the token plus replica metadata; enforces single dispatch via `_mark_dispatched`.
- `ReplicaUnavailableError`: raised when a selection is invalidated before dispatch.

## FAQ
<details>
  <summary>1. What's still missing in this PR?</summary>

| Gap | Fixed in |
|---|---|
| Nothing calls `reserve_slot` yet — the primitive exists but is unwired. | https://github.com/ray-project/ray/pull/63254 |
| `RunningReplica.reserve_slot` doesn't yet retry on `ActorDiedError` / `ActorUnavailableError`. | https://github.com/ray-project/ray/pull/63254's caller in `AsyncioRouter.choose_replica` |
| `Router` abstract base, `SingletonThreadRouter`, `CurrentLoopRouter`, and `DeploymentHandle` have no `choose_replica` / `dispatch` methods yet. | https://github.com/ray-project/ray/pull/63255 |
</details>

<details>
  <summary>2. Why do we need both token and replica-side semaphore?</summary>

Reservation creates a gap: `reserve_slot` and `dispatch` are two separate router → actor RPCs, and the design needs to handle both capacity and identity across that gap.

The semaphore is the **capacity gate**. It's anonymous, shared with every other entry path (handle_request, handle_request_with_rejection), so all paths agree on what "at capacity" means.

The token is the **reservation's identity**. The semaphore alone can't tell you:
- Whether an incoming dispatch should acquire a fresh slot or consume one already held — _start_request branches on the token's presence.
- Whether a request that asked to skip semaphore acquisition is legitimately consuming a reservation, vs. forging past the capacity gate.


</details>


## Related issues
RFC: https://github.com/ray-project/ray/issues/59792
Original PR: https://github.com/ray-project/ray/pull/60865
Next PR: https://github.com/ray-project/ray/pull/63254

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
