### PR TITLE
[Core][GPU fraction][4/n] Introduce abstract base class and shadow class for branch-by-abstraction migration strategy

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -1134,3 +1134,11 @@ RAY_CONFIG(uint64_t, gcs_resource_broadcast_max_batch_delay_ms, 0)
 // Whether to enable/disable multiple gRPC connections to improve object transfer
 // throughput.
 RAY_CONFIG(bool, experimental_object_manager_enable_multiple_connections, true)
+
+/// This is a temporary config for fixing GPU fractional scheduling by tracking
+/// per-instance availability. If true, use per-instance resource view (NewNodeResources)
+/// for cluster scheduling instead of the scalar NodeResources. This enables accurate GPU
+/// fragmentation detection in the scheduler so that tasks are not scheduled to nodes
+/// where aggregate GPU capacity is sufficient but no single GPU instance has enough
+/// remaining capacity. Defaults to false.
+RAY_CONFIG(bool, enable_per_instance_resource_scheduling, false)

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -15,7 +15,9 @@
 #include "ray/common/scheduling/cluster_resource_data.h"
 
 #include <algorithm>
+#include <set>
 #include <string>
+#include <utility>
 
 namespace ray {
 
@@ -54,7 +56,7 @@ NodeResources ResourceMapToNodeResources(
     const absl::flat_hash_map<std::string, std::string> &node_labels) {
   NodeResources node_resources;
   node_resources.total = NodeResourceSet(resource_map_total);
-  node_resources.available = NodeResourceSet(resource_map_available);
+  node_resources.SetAvailable(NodeResourceSet(resource_map_available));
   node_resources.labels = node_labels;
   return node_resources;
 }
@@ -164,6 +166,40 @@ std::string NodeResources::DebugString() const {
 }
 
 std::string NodeResources::DictString() const { return DebugString(); }
+
+FixedPoint NodeResources::GetAvailableSum(scheduling::ResourceID resource_id) const {
+  return available.Get(resource_id);
+}
+
+std::set<scheduling::ResourceID> NodeResources::GetAvailableResourceIds() const {
+  return available.ExplicitResourceIds();
+}
+
+void NodeResources::SubtractAvailable(const ResourceSet &resource_set) {
+  available -= resource_set;
+  available.RemoveNegative();
+}
+
+void NodeResources::SetAvailableResource(scheduling::ResourceID resource_id,
+                                         FixedPoint value) {
+  available.Set(resource_id, value);
+}
+
+void NodeResources::SetAvailable(NodeResourceSet resource_set) {
+  available = std::move(resource_set);
+}
+
+absl::flat_hash_map<std::string, double> NodeResources::GetAvailableResourceMap() const {
+  return available.GetResourceMap();
+}
+
+bool NodeResources::HasAvailableResource(scheduling::ResourceID resource_id) const {
+  return available.Has(resource_id);
+}
+
+const NodeResourceSet &NodeResources::GetAvailable() const { return available; }
+
+NodeResourceSet NodeResources::TakeAvailable() { return std::move(available); }
 
 bool NodeResourceInstances::operator==(const NodeResourceInstances &other) const {
   return this->total == other.total && this->available == other.available;

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -61,6 +61,24 @@ NodeResources ResourceMapToNodeResources(
   return node_resources;
 }
 
+/// Convert a map of resources to a NodeResourcesV2 data structure.
+///
+/// \param resource_map_total: Total capacities of resources we want to convert.
+/// \param resource_map_available: Available capacities of resources we want to convert.
+/// \param node_labels: Labels for the node.
+///
+/// \return Conversion result to a NodeResourcesV2 data structure.
+NodeResourcesV2 ResourceMapToNodeResourcesV2(
+    const absl::flat_hash_map<std::string, double> &resource_map_total,
+    const absl::flat_hash_map<std::string, double> &resource_map_available,
+    const absl::flat_hash_map<std::string, std::string> &node_labels) {
+  NodeResourcesV2 node_resources;
+  node_resources.total = NodeResourceSet(resource_map_total);
+  node_resources.SetAvailable(NodeResourceSet(resource_map_available));
+  node_resources.labels = node_labels;
+  return node_resources;
+}
+
 float NodeResources::CalculateCriticalResourceUtilization() const {
   float highest = 0;
   for (const auto &i : {CPU, MEM, OBJECT_STORE_MEM}) {
@@ -137,12 +155,16 @@ bool NodeResources::NodeLabelMatchesConstraint(const LabelConstraint &constraint
   return false;
 }
 
-bool NodeResources::operator==(const NodeResources &other) const {
-  return this->available == other.available && this->total == other.total &&
-         this->labels == other.labels;
+bool NodeResources::operator==(const NodeResourcesBase &other) const {
+  const auto *o = dynamic_cast<const NodeResources *>(&other);
+  if (o == nullptr) {
+    return false;
+  }
+  return this->available == o->available && this->total == o->total &&
+         this->labels == o->labels;
 }
 
-bool NodeResources::operator!=(const NodeResources &other) const {
+bool NodeResources::operator!=(const NodeResourcesBase &other) const {
   return !(*this == other);
 }
 
@@ -200,6 +222,152 @@ bool NodeResources::HasAvailableResource(scheduling::ResourceID resource_id) con
 const NodeResourceSet &NodeResources::GetAvailable() const { return available; }
 
 NodeResourceSet NodeResources::TakeAvailable() { return std::move(available); }
+
+float NodeResourcesV2::CalculateCriticalResourceUtilization() const {
+  float highest = 0;
+  for (const auto &i : {CPU, MEM, OBJECT_STORE_MEM}) {
+    const auto &cur_total = this->total.Get(ResourceID(i));
+    if (cur_total == 0) {
+      continue;
+    }
+    auto cur_available = this->available.Get(ResourceID(i)).Double();
+    float utilization = 1 - (cur_available / cur_total.Double());
+    if (utilization > highest) {
+      highest = utilization;
+    }
+  }
+  return highest;
+}
+
+bool NodeResourcesV2::IsAvailable(const ResourceRequest &resource_request,
+                                  bool ignore_pull_manager_at_capacity) const {
+  if (!ignore_pull_manager_at_capacity && resource_request.RequiresObjectStoreMemory() &&
+      object_pulls_queued) {
+    RAY_LOG(DEBUG) << "At pull manager capacity";
+    return false;
+  }
+
+  const auto &label_selector = resource_request.GetLabelSelector();
+  if (!HasRequiredLabels(label_selector)) {
+    return false;
+  }
+
+  return this->available >= resource_request.GetResourceSet();
+}
+
+bool NodeResourcesV2::IsFeasible(const ResourceRequest &resource_request) const {
+  const auto &label_selector = resource_request.GetLabelSelector();
+  if (!HasRequiredLabels(label_selector)) {
+    return false;
+  }
+  return this->total >= resource_request.GetResourceSet();
+}
+
+bool NodeResourcesV2::HasRequiredLabels(const LabelSelector &label_selector) const {
+  // Check if node labels satisfy all label constraints
+  const auto &constraints = label_selector.GetConstraints();
+  for (const auto &constraint : constraints) {
+    if (!NodeLabelMatchesConstraint(constraint)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool NodeResourcesV2::NodeLabelMatchesConstraint(
+    const LabelConstraint &constraint) const {
+  const auto &key = constraint.GetLabelKey();
+  const auto &match_operator = constraint.GetOperator();
+  const auto &values = constraint.GetLabelValues();
+
+  const auto &node_labels = this->labels;
+  if (match_operator == LabelSelectorOperator::LABEL_IN) {
+    // Check for equals or in() labels
+    if (node_labels.contains(key) && values.contains(node_labels.at(key))) {
+      return true;
+    }
+  } else if (match_operator == LabelSelectorOperator::LABEL_NOT_IN) {
+    // Check for not equals (!) or not in (!in()) labels
+    if (!(node_labels.contains(key) && values.contains(node_labels.at(key)))) {
+      return true;
+    }
+  } else {
+    RAY_CHECK(false)
+        << "Node label constraint operator type must be one of equals, not equals (!), "
+           "in, or not in (!in)";
+  }
+  return false;
+}
+
+bool NodeResourcesV2::operator==(const NodeResourcesBase &other) const {
+  const auto *o = dynamic_cast<const NodeResourcesV2 *>(&other);
+  if (o == nullptr) {
+    return false;
+  }
+  return this->available == o->available && this->total == o->total &&
+         this->labels == o->labels;
+}
+
+bool NodeResourcesV2::operator!=(const NodeResourcesBase &other) const {
+  return !(*this == other);
+}
+
+std::string NodeResourcesV2::DebugString() const {
+  std::stringstream buffer;
+  buffer << "{\"total\":" << total.DebugString();
+  buffer << ", \"available\": " << available.DebugString();
+  buffer << ", \"labels\":{";
+  bool first = true;
+  for (const auto &[key, value] : labels) {
+    if (!first) {
+      buffer << ",";
+    }
+    first = false;
+    buffer << "\"" << key << "\":\"" << value << "\"";
+  }
+  buffer << "}, \"is_draining\": " << is_draining;
+  buffer << ", \"draining_deadline_timestamp_ms\": " << draining_deadline_timestamp_ms
+         << "}";
+  return buffer.str();
+}
+
+std::string NodeResourcesV2::DictString() const { return DebugString(); }
+
+FixedPoint NodeResourcesV2::GetAvailableSum(scheduling::ResourceID resource_id) const {
+  return available.Get(resource_id);
+}
+
+std::set<scheduling::ResourceID> NodeResourcesV2::GetAvailableResourceIds() const {
+  return available.ExplicitResourceIds();
+}
+
+void NodeResourcesV2::SubtractAvailable(const ResourceSet &resource_set) {
+  available -= resource_set;
+  available.RemoveNegative();
+}
+
+void NodeResourcesV2::SetAvailableResource(scheduling::ResourceID resource_id,
+                                           FixedPoint value) {
+  available.Set(resource_id, value);
+}
+
+void NodeResourcesV2::SetAvailable(NodeResourceSet resource_set) {
+  available = std::move(resource_set);
+}
+
+absl::flat_hash_map<std::string, double> NodeResourcesV2::GetAvailableResourceMap()
+    const {
+  return available.GetResourceMap();
+}
+
+bool NodeResourcesV2::HasAvailableResource(scheduling::ResourceID resource_id) const {
+  return available.Has(resource_id);
+}
+
+const NodeResourceSet &NodeResourcesV2::GetAvailable() const { return available; }
+
+NodeResourceSet NodeResourcesV2::TakeAvailable() { return std::move(available); }
 
 bool NodeResourceInstances::operator==(const NodeResourceInstances &other) const {
   return this->total == other.total && this->available == other.available;

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -16,6 +16,7 @@
 
 #include <boost/range/adaptor/map.hpp>
 #include <optional>
+#include <set>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -311,7 +312,6 @@ class NodeResources {
   explicit NodeResources(const NodeResourceSet &resources)
       : total(resources), available(resources) {}
   NodeResourceSet total;
-  NodeResourceSet available;
   /// Only used by light resource report.
   ResourceSet load;
 
@@ -355,6 +355,37 @@ class NodeResources {
   std::string DebugString() const;
   /// Returns compact dict-like string.
   std::string DictString() const;
+
+  /// Get the scalar available amount for a resource.
+  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const;
+
+  /// Get the set of resource IDs that have explicit available entries.
+  std::set<scheduling::ResourceID> GetAvailableResourceIds() const;
+
+  /// Subtract resources from available, clamping each entry to 0.
+  void SubtractAvailable(const ResourceSet &resource_set);
+
+  /// Set a single resource's available to an explicit scalar value.
+  void SetAvailableResource(scheduling::ResourceID resource_id, FixedPoint value);
+
+  /// Replace the entire available field from a NodeResourceSet.
+  void SetAvailable(NodeResourceSet resource_set);
+
+  /// Return available resources as a name->value map.
+  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const;
+
+  /// Returns true if the resource has an explicit available entry.
+  bool HasAvailableResource(scheduling::ResourceID resource_id) const;
+
+  /// Read-only access to the entire available resource set.
+  const NodeResourceSet &GetAvailable() const;
+
+  /// Transfer ownership of the available resource set (leaves available in a moved-from
+  /// state).
+  NodeResourceSet TakeAvailable();
+
+ private:
+  NodeResourceSet available;
 };
 
 /// Total and available capacities of each resource instance.

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -305,12 +305,10 @@ class TaskResourceInstances {
   absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> resources_;
 };
 
-/// Total and available capacities of each resource of a node.
-class NodeResources {
+/// Temporary Abstract base class for node resource.
+/// Provides the common interface shared by NodeResources and NodeResourcesV2.
+class NodeResourcesBase {
  public:
-  NodeResources() {}
-  explicit NodeResources(const NodeResourceSet &resources)
-      : total(resources), available(resources) {}
   NodeResourceSet total;
   /// Only used by light resource report.
   ResourceSet load;
@@ -335,54 +333,187 @@ class NodeResources {
 
   bool object_pulls_queued = false;
 
+  NodeResourcesBase() = default;
+  virtual ~NodeResourcesBase() = default;
+  NodeResourcesBase(const NodeResourcesBase &) = default;
+  NodeResourcesBase &operator=(const NodeResourcesBase &) = default;
+  NodeResourcesBase(NodeResourcesBase &&) = default;
+  NodeResourcesBase &operator=(NodeResourcesBase &&) = default;
+
   /// Amongst CPU, memory, and object store memory, calculate the utilization percentage
   /// of each resource and return the highest.
-  float CalculateCriticalResourceUtilization() const;
+  virtual float CalculateCriticalResourceUtilization() const = 0;
   /// Returns true if the node has the available resources to run the task.
   /// Note: This doesn't account for the binpacking of unit resources.
-  bool IsAvailable(const ResourceRequest &resource_request,
-                   bool ignore_at_capacity = false) const;
+  virtual bool IsAvailable(const ResourceRequest &resource_request,
+                           bool ignore_at_capacity = false) const = 0;
   /// Returns true if the node's total resources are enough to run the task.
   /// Note: This doesn't account for the binpacking of unit resources.
-  bool IsFeasible(const ResourceRequest &resource_request) const;
+  virtual bool IsFeasible(const ResourceRequest &resource_request) const = 0;
   // Returns true if the node's labels satisfy the label selector requirement.
-  bool HasRequiredLabels(const LabelSelector &label_selector) const;
-  bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const;
+  virtual bool HasRequiredLabels(const LabelSelector &label_selector) const = 0;
+  virtual bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const = 0;
   /// Returns if this equals another node resources.
-  bool operator==(const NodeResources &other) const;
-  bool operator!=(const NodeResources &other) const;
+  virtual bool operator==(const NodeResourcesBase &other) const = 0;
+  virtual bool operator!=(const NodeResourcesBase &other) const = 0;
+
   /// Returns human-readable string for these resources.
-  std::string DebugString() const;
+  virtual std::string DebugString() const = 0;
   /// Returns compact dict-like string.
-  std::string DictString() const;
+  virtual std::string DictString() const = 0;
 
   /// Get the scalar available amount for a resource.
-  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const;
+  virtual FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const = 0;
 
   /// Get the set of resource IDs that have explicit available entries.
-  std::set<scheduling::ResourceID> GetAvailableResourceIds() const;
+  virtual std::set<scheduling::ResourceID> GetAvailableResourceIds() const = 0;
 
   /// Subtract resources from available, clamping each entry to 0.
-  void SubtractAvailable(const ResourceSet &resource_set);
+  virtual void SubtractAvailable(const ResourceSet &resource_set) = 0;
 
   /// Set a single resource's available to an explicit scalar value.
-  void SetAvailableResource(scheduling::ResourceID resource_id, FixedPoint value);
+  virtual void SetAvailableResource(scheduling::ResourceID resource_id,
+                                    FixedPoint value) = 0;
 
   /// Replace the entire available field from a NodeResourceSet.
-  void SetAvailable(NodeResourceSet resource_set);
+  virtual void SetAvailable(NodeResourceSet resource_set) = 0;
 
   /// Return available resources as a name->value map.
-  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const;
+  virtual absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const = 0;
 
   /// Returns true if the resource has an explicit available entry.
-  bool HasAvailableResource(scheduling::ResourceID resource_id) const;
+  virtual bool HasAvailableResource(scheduling::ResourceID resource_id) const = 0;
 
   /// Read-only access to the entire available resource set.
-  const NodeResourceSet &GetAvailable() const;
+  virtual const NodeResourceSet &GetAvailable() const = 0;
 
   /// Transfer ownership of the available resource set (leaves available in a moved-from
   /// state).
-  NodeResourceSet TakeAvailable();
+  virtual NodeResourceSet TakeAvailable() = 0;
+};
+
+/// Total and available capacities of each resource of a node.
+class NodeResources : public NodeResourcesBase {
+ public:
+  NodeResources() {}
+  explicit NodeResources(const NodeResourceSet &resources) : available(resources) {
+    total = resources;
+  }
+
+  /// Amongst CPU, memory, and object store memory, calculate the utilization percentage
+  /// of each resource and return the highest.
+  float CalculateCriticalResourceUtilization() const override;
+  /// Returns true if the node has the available resources to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsAvailable(const ResourceRequest &resource_request,
+                   bool ignore_at_capacity = false) const override;
+  /// Returns true if the node's total resources are enough to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsFeasible(const ResourceRequest &resource_request) const override;
+  // Returns true if the node's labels satisfy the label selector requirement.
+  bool HasRequiredLabels(const LabelSelector &label_selector) const override;
+  bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const override;
+  /// Returns if this equals another node resources.
+  bool operator==(const NodeResourcesBase &other) const override;
+  bool operator!=(const NodeResourcesBase &other) const override;
+  /// Returns human-readable string for these resources.
+  std::string DebugString() const override;
+  /// Returns compact dict-like string.
+  std::string DictString() const override;
+
+  /// Get the scalar available amount for a resource.
+  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const override;
+
+  /// Get the set of resource IDs that have explicit available entries.
+  std::set<scheduling::ResourceID> GetAvailableResourceIds() const override;
+
+  /// Subtract resources from available, clamping each entry to 0.
+  void SubtractAvailable(const ResourceSet &resource_set) override;
+
+  /// Set a single resource's available to an explicit scalar value.
+  void SetAvailableResource(scheduling::ResourceID resource_id,
+                            FixedPoint value) override;
+
+  /// Replace the entire available field from a NodeResourceSet.
+  void SetAvailable(NodeResourceSet resource_set) override;
+
+  /// Return available resources as a name->value map.
+  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const override;
+
+  /// Returns true if the resource has an explicit available entry.
+  bool HasAvailableResource(scheduling::ResourceID resource_id) const override;
+
+  /// Read-only access to the entire available resource set.
+  const NodeResourceSet &GetAvailable() const override;
+
+  /// Transfer ownership of the available resource set (leaves available in a moved-from
+  /// state).
+  NodeResourceSet TakeAvailable() override;
+
+ private:
+  NodeResourceSet available;
+};
+
+/// NodeResourcesV2 is currently identical to NodeResources. It will diverge in a
+/// subsequent PR to store available resources as a per-instance vector
+/// (NodeResourceInstanceSet) rather than an aggregated scalar NodeResourceSet, enabling
+/// GPU-fraction scheduling.
+class NodeResourcesV2 : public NodeResourcesBase {
+ public:
+  NodeResourcesV2() {}
+  explicit NodeResourcesV2(const NodeResourceSet &resources) : available(resources) {
+    total = resources;
+  }
+
+  /// Amongst CPU, memory, and object store memory, calculate the utilization percentage
+  /// of each resource and return the highest.
+  float CalculateCriticalResourceUtilization() const override;
+  /// Returns true if the node has the available resources to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsAvailable(const ResourceRequest &resource_request,
+                   bool ignore_at_capacity = false) const override;
+  /// Returns true if the node's total resources are enough to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsFeasible(const ResourceRequest &resource_request) const override;
+  // Returns true if the node's labels satisfy the label selector requirement.
+  bool HasRequiredLabels(const LabelSelector &label_selector) const override;
+  bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const override;
+  /// Returns if this equals another node resources.
+  bool operator==(const NodeResourcesBase &other) const override;
+  bool operator!=(const NodeResourcesBase &other) const override;
+  /// Returns human-readable string for these resources.
+  std::string DebugString() const override;
+  /// Returns compact dict-like string.
+  std::string DictString() const override;
+
+  /// Get the scalar available amount for a resource.
+  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const override;
+
+  /// Get the set of resource IDs that have explicit available entries.
+  std::set<scheduling::ResourceID> GetAvailableResourceIds() const override;
+
+  /// Subtract resources from available, clamping each entry to 0.
+  void SubtractAvailable(const ResourceSet &resource_set) override;
+
+  /// Set a single resource's available to an explicit scalar value.
+  void SetAvailableResource(scheduling::ResourceID resource_id,
+                            FixedPoint value) override;
+
+  /// Replace the entire available field from a NodeResourceSet.
+  void SetAvailable(NodeResourceSet resource_set) override;
+
+  /// Return available resources as a name->value map.
+  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const override;
+
+  /// Returns true if the resource has an explicit available entry.
+  bool HasAvailableResource(scheduling::ResourceID resource_id) const override;
+
+  /// Read-only access to the entire available resource set.
+  const NodeResourceSet &GetAvailable() const override;
+
+  /// Transfer ownership of the available resource set (leaves available in a moved-from
+  /// state).
+  NodeResourceSet TakeAvailable() override;
 
  private:
   NodeResourceSet available;
@@ -438,6 +569,18 @@ struct Node {
 ///
 /// \return Conversion result to a NodeResources data structure.
 NodeResources ResourceMapToNodeResources(
+    const absl::flat_hash_map<std::string, double> &resource_map_total,
+    const absl::flat_hash_map<std::string, double> &resource_map_available,
+    const absl::flat_hash_map<std::string, std::string> &node_labels = {});
+
+/// Convert a map of resources to a NodeResourcesV2 data structure.
+///
+/// \param string_to_int_map: Map between names and ids maintained by the
+/// \param resource_map_total: Total capacities of resources we want to convert.
+/// \param resource_map_available: Available capacities of resources we want to convert.
+///
+/// \request Conversion result to a NodeResourcesV2 data structure.
+NodeResourcesV2 ResourceMapToNodeResourcesV2(
     const absl::flat_hash_map<std::string, double> &resource_map_total,
     const absl::flat_hash_map<std::string, double> &resource_map_available,
     const absl::flat_hash_map<std::string, std::string> &node_labels = {});

--- a/src/ray/gcs/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_resource_manager.cc
@@ -90,9 +90,9 @@ void GcsResourceManager::HandleGetAllAvailableResources(
     rpc::AvailableResources resource;
     resource.set_node_id(node_resources_entry.first.Binary());
     const auto &node_resources = node_resources_entry.second.GetLocalView();
-    for (const auto &resource_id : node_resources.available.ExplicitResourceIds()) {
+    for (const auto &resource_id : node_resources.GetAvailableResourceIds()) {
       const auto &resource_name = resource_id.Binary();
-      const auto &resource_value = node_resources.available.Get(resource_id);
+      const auto resource_value = node_resources.GetAvailableSum(resource_id);
       resource.mutable_resources_available()->insert(
           {resource_name, resource_value.Double()});
     }

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -260,7 +260,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     auto resource_view_before_scheduling = cluster_resource_manager.GetResourceView();
     // Make sure the resources are not used.
     for (const auto &[node_id, node] : resource_view_before_scheduling) {
-      if (node.GetLocalView().total != node.GetLocalView().available) {
+      if (node.GetLocalView().total != node.GetLocalView().GetAvailable()) {
         return false;
       }
     }

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -91,7 +91,7 @@ bool ClusterResourceManager::UpdateNode(
   RAY_CHECK(GetNodeResources(node_id, &local_view));
 
   local_view.total = std::move(node_resources.total);
-  local_view.available = std::move(node_resources.available);
+  local_view.SetAvailable(node_resources.TakeAvailable());
   local_view.labels = std::move(node_labels);
   local_view.object_pulls_queued = resource_view_sync_message.object_pulls_queued();
 
@@ -168,7 +168,7 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
   auto local_view = it->second.GetMutableLocalView();
   FixedPoint resource_total_fp(resource_total);
   auto local_total = local_view->total.Get(resource_id);
-  auto local_available = local_view->available.Get(resource_id);
+  auto local_available = local_view->GetAvailableSum(resource_id);
   auto diff_capacity = resource_total_fp - local_total;
   auto total = local_total + diff_capacity;
   auto available = local_available + diff_capacity;
@@ -179,7 +179,7 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
     available = 0;
   }
   local_view->total.Set(resource_id, total);
-  local_view->available.Set(resource_id, available);
+  local_view->SetAvailableResource(resource_id, available);
 }
 
 bool ClusterResourceManager::DeleteResources(
@@ -192,7 +192,7 @@ bool ClusterResourceManager::DeleteResources(
   auto local_view = it->second.GetMutableLocalView();
   for (const auto &resource_id : resource_ids) {
     local_view->total.Set(resource_id, 0);
-    local_view->available.Set(resource_id, 0);
+    local_view->SetAvailableResource(resource_id, 0);
   }
   return true;
 }
@@ -217,8 +217,7 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
 
   NodeResources *resources = it->second.GetMutableLocalView();
 
-  resources->available -= resource_request.GetResourceSet();
-  resources->available.RemoveNegative();
+  resources->SubtractAvailable(resource_request.GetResourceSet());
 
   // TODO(swang): We should also subtract object store memory if the task has
   // arguments. Right now we do not modify object_pulls_queued in case of
@@ -260,13 +259,13 @@ bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_i
   auto node_resources = it->second.GetMutableLocalView();
   for (auto &resource_id : resource_set.ResourceIds()) {
     if (node_resources->total.Has(resource_id)) {
-      auto available = node_resources->available.Get(resource_id);
+      auto available = node_resources->GetAvailableSum(resource_id);
       auto total = node_resources->total.Get(resource_id);
       auto new_available = available + resource_set.Get(resource_id);
       if (new_available > total) {
         new_available = total;
       }
-      node_resources->available.Set(resource_id, new_available);
+      node_resources->SetAvailableResource(resource_id, new_available);
     }
   }
   return true;

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -44,7 +44,7 @@ LocalResourceManager::LocalResourceManager(
       shutdown_raylet_gracefully_(shutdown_raylet_gracefully),
       resource_change_subscriber_(resource_change_subscriber),
       resource_usage_gauge_(resource_usage_gauge) {
-  RAY_CHECK(node_resources.total == node_resources.available);
+  RAY_CHECK(node_resources.total == node_resources.GetAvailable());
   local_resources_.available = NodeResourceInstanceSet(node_resources.total);
   local_resources_.total = NodeResourceInstanceSet(node_resources.total);
   local_resources_.labels = node_resources.labels;
@@ -310,7 +310,7 @@ void LocalResourceManager::ReleaseWorkerResources(
 
 NodeResources LocalResourceManager::ToNodeResources() const {
   NodeResources node_resources;
-  node_resources.available = local_resources_.available.ToNodeResourceSet();
+  node_resources.SetAvailable(local_resources_.available.ToNodeResourceSet());
   node_resources.total = local_resources_.total.ToNodeResourceSet();
   node_resources.labels = local_resources_.labels;
   node_resources.is_draining = IsLocalNodeDraining();
@@ -367,7 +367,7 @@ void LocalResourceManager::PopulateResourceViewSyncMessage(
   resource_view_sync_message.mutable_resources_total()->insert(total.begin(),
                                                                total.end());
 
-  for (const auto &[resource_name, available] : resources.available.GetResourceMap()) {
+  for (const auto &[resource_name, available] : resources.GetAvailableResourceMap()) {
     // Resource availability can be negative locally but treat it as 0
     // when we broadcast to others since other parts of the
     // system assume resource availability cannot be negative and

--- a/src/ray/raylet/scheduling/policy/scorer.cc
+++ b/src/ray/raylet/scheduling/policy/scorer.cc
@@ -26,7 +26,7 @@ double LeastResourceScorer::Score(const ResourceRequest &required_resources,
   double node_score = 0.;
   for (auto &resource_id : required_resources.ResourceIds()) {
     const auto &request_resource = required_resources.Get(resource_id);
-    const auto &node_available_resource = node_resources.available.Get(resource_id);
+    const auto node_available_resource = node_resources.GetAvailableSum(resource_id);
     node_score += Calculate(request_resource, node_available_resource);
   }
   return node_score;

--- a/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
@@ -32,9 +32,9 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double available_gpu,
                                   double total_gpu) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu)
-      .Set(ResourceID::Memory(), available_memory)
-      .Set(ResourceID::GPU(), available_gpu);
+  resources.SetAvailableResource(ResourceID::CPU(), available_cpu);
+  resources.SetAvailableResource(ResourceID::Memory(), available_memory);
+  resources.SetAvailableResource(ResourceID::GPU(), available_gpu);
   resources.total.Set(ResourceID::CPU(), total_cpu)
       .Set(ResourceID::Memory(), total_memory)
       .Set(ResourceID::GPU(), total_gpu);

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -30,9 +30,9 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double available_gpu,
                                   double total_gpu) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu)
-      .Set(ResourceID::Memory(), available_memory)
-      .Set(ResourceID::GPU(), available_gpu);
+  resources.SetAvailableResource(ResourceID::CPU(), available_cpu);
+  resources.SetAvailableResource(ResourceID::Memory(), available_memory);
+  resources.SetAvailableResource(ResourceID::GPU(), available_gpu);
   resources.total.Set(ResourceID::CPU(), total_cpu)
       .Set(ResourceID::Memory(), total_memory)
       .Set(ResourceID::GPU(), total_gpu);
@@ -242,7 +242,7 @@ TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
   auto task_req2 = ResourceMapToResourceRequest({{"CPU", 1}}, false);
 
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), 2.0);
+  resources.SetAvailableResource(ResourceID::CPU(), 2.0);
   resources.total.Set(ResourceID::CPU(), 2.0);
   ASSERT_FALSE(resources.IsAvailable(task_req1));
   ASSERT_TRUE(resources.IsAvailable(task_req2));
@@ -251,17 +251,17 @@ TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
 TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {
   {
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0);
+    resources.SetAvailableResource(ResourceID::CPU(), 1.0);
     resources.total.Set(ResourceID::CPU(), 2.0);
     ASSERT_EQ(resources.CalculateCriticalResourceUtilization(), 0.5);
   }
   {
     // Basic test of max
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0)
-        .Set(ResourceID::Memory(), 0.25)
-        .Set(ResourceID::GPU(), 1)
-        .Set(ResourceID::ObjectStoreMemory(), 50);
+    resources.SetAvailableResource(ResourceID::CPU(), 1.0);
+    resources.SetAvailableResource(ResourceID::Memory(), 0.25);
+    resources.SetAvailableResource(ResourceID::GPU(), 1);
+    resources.SetAvailableResource(ResourceID::ObjectStoreMemory(), 50);
     resources.total.Set(ResourceID::CPU(), 2.0)
         .Set(ResourceID::Memory(), 1)
         .Set(ResourceID::GPU(), 2)
@@ -272,10 +272,10 @@ TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {
   {
     // Skip GPU
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0)
-        .Set(ResourceID::Memory(), 0.25)
-        .Set(ResourceID::GPU(), 0)
-        .Set(ResourceID::ObjectStoreMemory(), 50);
+    resources.SetAvailableResource(ResourceID::CPU(), 1.0);
+    resources.SetAvailableResource(ResourceID::Memory(), 0.25);
+    resources.SetAvailableResource(ResourceID::GPU(), 0);
+    resources.SetAvailableResource(ResourceID::ObjectStoreMemory(), 50);
     resources.total.Set(ResourceID::CPU(), 2.0)
         .Set(ResourceID::Memory(), 1)
         .Set(ResourceID::GPU(), 2)

--- a/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
@@ -2389,18 +2389,20 @@ TEST_F(ClusterLeaseManagerTest, NegativePlacementGroupCpuResources) {
 
   // ray.get() returns and worker1 acquires the CPU resource again
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_1_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")),
+            -1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_1_aaa")), 1);
 
   auto worker3 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 7678);
   allocated_instances = std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
       {{"CPU_group_aaa", 1.}, {"CPU_group_1_aaa", 1.}}, allocated_instances));
   worker3->SetAllocatedInstances(allocated_instances);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_1_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), -1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")),
+            -1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_1_aaa")), 0);
 }
 
 TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources) {
@@ -2417,8 +2419,8 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   const NodeResources &node_resources =
       scheduler_->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(id_.Binary()));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 4);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 4);
 
   auto worker1 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
   auto worker2 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 5678);
@@ -2448,24 +2450,24 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   worker2->SetAllocatedInstances(allocated_instances);
 
   // Check that the resources are allocated successfully.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are released successfully.
   ASSERT_TRUE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
   ASSERT_TRUE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
 
   // Check that only cpu resources are released.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as blocked.
   worker1->MarkBlocked();
@@ -2474,24 +2476,24 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   ASSERT_FALSE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
   ASSERT_FALSE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
   // Check nothing will be changed.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are returned back to worker successfully.
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
 
   // Check that only cpu resources are returned back to the worker.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as unblocked.
   worker1->MarkUnblocked();
@@ -2499,12 +2501,12 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   ASSERT_FALSE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
   ASSERT_FALSE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
   // Check nothing will be changed.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 }
 
 TEST_F(ClusterLeaseManagerTest, TestSpillWaitingLeases) {

--- a/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
@@ -26,9 +26,10 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double total_custom_resource = 0,
                                   bool object_pulls_queued = false) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu);
+  resources.SetAvailableResource(ResourceID::CPU(), available_cpu);
   resources.total.Set(ResourceID::CPU(), total_cpu);
-  resources.available.Set(scheduling::ResourceID("CUSTOM"), available_custom_resource);
+  resources.SetAvailableResource(scheduling::ResourceID("CUSTOM"),
+                                 available_custom_resource);
   resources.total.Set(scheduling::ResourceID("CUSTOM"), total_custom_resource);
   resources.object_pulls_queued = object_pulls_queued;
   return resources;
@@ -76,7 +77,7 @@ TEST_F(ClusterResourceManagerTest, UpdateNode) {
 
   const auto &node_resources = manager->GetNodeResources(node0);
   ASSERT_EQ(node_resources.total.Get(scheduling::ResourceID("CPU")), 10);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU")), 5);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU")), 5);
   ASSERT_EQ(node_resources.labels.at("zone"), "us-east-1a");
   ASSERT_TRUE(node_resources.object_pulls_queued);
   ASSERT_EQ(node_resources.idle_resource_duration_ms, 42);
@@ -163,26 +164,26 @@ TEST_F(ClusterResourceManagerTest, HasAvailableResourcesTest) {
 
 TEST_F(ClusterResourceManagerTest, SubtractAndAddNodeAvailableResources) {
   const auto &node_resources = manager->GetNodeResources(node0);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 1);
 
   manager->SubtractNodeAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 0);
   // Subtract again and make sure the available == 0.
   manager->SubtractNodeAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 0);
 
   // Add resources back.
   manager->AddNodeAvailableResources(node0, ResourceSet({{"CPU", FixedPoint(1)}}));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 1);
   // Add again and make sure the available == 1 (<= total).
   manager->AddNodeAvailableResources(node0, ResourceSet({{"CPU", FixedPoint(1)}}));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 1);
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
@@ -83,8 +83,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
         cluster_resource_manager.GetNodeResources(scheduling::NodeID(node_id.Binary()));
     auto resource_id = scheduling::ResourceID(resource_name);
 
-    ASSERT_TRUE(node_resources.available.Has(resource_id));
-    ASSERT_EQ(node_resources.available.Get(resource_id).Double(), resource_value);
+    ASSERT_TRUE(node_resources.HasAvailableResource(resource_id));
+    ASSERT_EQ(node_resources.GetAvailableSum(resource_id).Double(), resource_value);
   }
 
   void TestResourceLeaks(SchedulingOptions scheduling_options) {

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
@@ -636,9 +636,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
         resource_scheduler.GetClusterResourceManager().GetNodeResources(node_id, &nr2));
 
     for (auto &resource_id : nr1.total.ExplicitResourceIds()) {
-      auto t = nr1.available.Get(resource_id) - resource_request.Get(resource_id);
+      auto t = nr1.GetAvailableSum(resource_id) - resource_request.Get(resource_id);
       if (t < 0) t = 0;
-      ASSERT_EQ(nr2.available.Get(resource_id), t);
+      ASSERT_EQ(nr2.GetAvailableSum(resource_id), t);
     }
   }
 }
@@ -1296,7 +1296,7 @@ TEST_F(ClusterResourceSchedulerTest,
       NodeResources nr;
       resource_scheduler.GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(0), &nr);
-      ASSERT_TRUE(nr.available.Get(ResourceID::GPU()) == 1.5);
+      ASSERT_TRUE(nr.GetAvailableSum(ResourceID::GPU()) == 1.5);
     }
 
     {
@@ -1318,7 +1318,7 @@ TEST_F(ClusterResourceSchedulerTest,
       NodeResources nr;
       resource_scheduler.GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(0), &nr);
-      ASSERT_TRUE(nr.available.Get(ResourceID::GPU()) == 3.8);
+      ASSERT_TRUE(nr.GetAvailableSum(ResourceID::GPU()) == 3.8);
     }
   }
 }

--- a/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
@@ -36,7 +36,7 @@ class LocalResourceManagerTest : public ::testing::Test {
       absl::flat_hash_map<ResourceID, double> resource_usage_map) {
     NodeResources resources;
     for (auto &[resource_id, total] : resource_usage_map) {
-      resources.available.Set(resource_id, total);
+      resources.SetAvailableResource(resource_id, total);
       resources.total.Set(resource_id, total);
     }
     return resources;

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -783,7 +783,7 @@ TEST_F(NodeManagerTest, TestConsumeSyncMessage) {
   EXPECT_EQ(node_resources.labels.at("label1"), "value1");
   EXPECT_EQ(node_resources.total.Get(scheduling::ResourceID("CPU")).Double(),
             kTestTotalCpuResource);
-  EXPECT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU")).Double(),
+  EXPECT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU")).Double(),
             kTestTotalCpuResource);
 }
 


### PR DESCRIPTION
## Description

### Context
- This PR is a preparatory refactor for the final goal to change `available` type from `NodeResourceSet` (scalar) to `NodeResourceInstanceSet` (per-instance vector) for accurate GPU fragmentation detection(https://github.com/ray-project/ray/pull/62005)
- To safely and gradually migrate this big change, we are leveraging branch by abstraction achieved via runtime polymorphism. We introduces a base case and lets both the old class and the new class inherit from it, and change the codebase to interact with the base class pointer. Then, we can use a config flag to toggle what the base class pointer actually points to (the old class or the new class) to control which logic the codebase uses
- The introduction of the base class and derived classes is split into two stages:
  - **First Stage (this PR):** Introduce the base class and `NodeResourcesV2`, where `NodeResourcesV2` is completely identical to `NodeResources`
  - **Second Stage (next PR):** Change `NodeResourcesV2`'s `available` field and its related methods to the per-instance vector version

### What This PR Does
This PR is the first stage to introduce the base class and `NodeResourcesV2`
- Introduces the base class and `NodeResourcesV2` as an exact duplicate of `NodeResources`
- Adds a config flag to toggle between the original and new scheduling logic

### Details

- **Adds `enable_per_instance_resource_scheduling` config flag** (default `false`) in `ray_config_def.h` to gate the new behavior
- **Introduces `NodeResourcesBase`**, an abstract base class holding all shared fields **except `available`** (since `available` will have a different type in two subclass) and declaring all methods as virtual
- **`NodeResources` now inherits from `NodeResourcesBase`**. All its existing logic is preserved, the only change is that `operator==` and `operator!=` now take a `NodeResourcesBase &` parameter instead of `NodeResources &` . This change was made because we need to include these operators in the base class to enable runtime polymorphism
- **Adds `NodeResourcesV2`**, currently identical to `NodeResources`. It will diverge in the next PR when `available` and its related methods are changed to the per-instance vector version
- Introduces `ResourceMapToNodeResourcesV2` helper function(the `NodeResourcesV2` equivalent of `ResourceMapToNodeResources`), which converts a map of resources into a `NodeResourcesV2` data structure

## Related issues
Related to https://github.com/ray-project/ray/pull/62005

