### PR TITLE
[serve][2/3] Add `choose_replica`/`dispatch` to `AsyncioRouter`

### DIFF
--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -348,7 +348,12 @@ class RunningReplica:
             accepted, num_ongoing_requests = await obj_ref
         except asyncio.CancelledError:
             ray.cancel(obj_ref)
-            # TODO (#63254): Add error handling for actor-unavailable cleanup.
+            self._actor_handle.release_slot.remote(slot_token)
+            raise
+        except Exception:
+            # The actor may have reserved the slot before the reply was lost
+            # (e.g. ActorUnavailableError). `release_slot` is idempotent for unknown
+            # tokens, so this is safe even when the reservation never actually happened.
             self._actor_handle.release_slot.remote(slot_token)
             raise
 

--- a/python/ray/serve/_private/request_router/replica_wrapper.py
+++ b/python/ray/serve/_private/request_router/replica_wrapper.py
@@ -408,6 +408,11 @@ class ReplicaSelection:
         default=False, init=False
     )  # Tracks if dispatch was called
 
+    # Set by dispatch once the result's done-callback is wired up. Read by
+    # choose_replica's finally to decide whether to fire on_request_completed
+    # manually (only one of the two paths should fire it).
+    _completion_callback_registered: bool = field(default=False, init=False)
+
     @property
     def address(self) -> str:
         """Returns the replica address in host:port format."""

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -850,6 +850,25 @@ class RequestRouter(ABC):
             self._replica_queue_len_cache.update(replica_id, new_queue_len)
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
+    def on_replica_result_finished(self, replica_id: ReplicaID):
+        """Decrement queue length cache when a request finishes or is cancelled.
+
+        This is used when a reserved slot is released without being dispatched
+        (e.g., in choose_replica context manager cleanup).
+
+        We cannot rely on on_new_queue_len_info() to correct the cache in this
+        path. The queue length cache is incremented optimistically when a slot is
+        reserved, before dispatch happens. If dispatch is never called or fails
+        before the request reaches the replica, no queue_len_info response is
+        produced, so the cache would otherwise remain inflated.
+        """
+        if self._use_replica_queue_len_cache:
+            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
+            if num_ongoing_requests > 0:
+                new_queue_len = num_ongoing_requests - 1
+                self._replica_queue_len_cache.update(replica_id, new_queue_len)
+                self._update_router_queue_len_gauge(replica_id, new_queue_len)
+
     def decrement_queue_len_cache(self, replica_id: ReplicaID):
         """Decrement the queue length cache for a replica.
 

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -24,7 +24,6 @@ from ray.serve._private.common import (
     DeploymentHandleSource,
     DeploymentID,
     ReplicaID,
-    ReplicaQueueLengthInfo,
     RequestMetadata,
     RunningReplicaInfo,
 )
@@ -830,17 +829,11 @@ class RequestRouter(ABC):
             index += 1
         queue.insert(index, pending_request)
 
-    def on_new_queue_len_info(
-        self, replica_id: ReplicaID, queue_len_info: ReplicaQueueLengthInfo
-    ):
+    def on_new_queue_len_info(self, replica_id: ReplicaID, num_ongoing_requests: int):
         """Update queue length cache with new info received from replica."""
         if self._use_replica_queue_len_cache:
-            self._replica_queue_len_cache.update(
-                replica_id, queue_len_info.num_ongoing_requests
-            )
-            self._update_router_queue_len_gauge(
-                replica_id, queue_len_info.num_ongoing_requests
-            )
+            self._replica_queue_len_cache.update(replica_id, num_ongoing_requests)
+            self._update_router_queue_len_gauge(replica_id, num_ongoing_requests)
 
     def on_send_request(self, replica_id: ReplicaID):
         """Increment queue length cache when a request is sent to a replica."""

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -843,21 +843,6 @@ class RequestRouter(ABC):
             self._replica_queue_len_cache.update(replica_id, new_queue_len)
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
-    def on_replica_result_finished(self, replica_id: ReplicaID):
-        """Undo a prior on_send_request() increment.
-
-        Called from assign_request's cleanup when try_send_request raised
-        after the cache was optimistically incremented by on_send_request
-        but before the result's done callback was registered — there's no
-        other path to reverse that increment.
-        """
-        if self._use_replica_queue_len_cache:
-            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
-            if num_ongoing_requests > 0:
-                new_queue_len = num_ongoing_requests - 1
-                self._replica_queue_len_cache.update(replica_id, new_queue_len)
-                self._update_router_queue_len_gauge(replica_id, new_queue_len)
-
     def decrement_queue_len_cache(self, replica_id: ReplicaID):
         """Decrement the queue length cache for a replica.
 

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -844,16 +844,12 @@ class RequestRouter(ABC):
             self._update_router_queue_len_gauge(replica_id, new_queue_len)
 
     def on_replica_result_finished(self, replica_id: ReplicaID):
-        """Decrement queue length cache when a request finishes or is cancelled.
+        """Undo a prior on_send_request() increment.
 
-        This is used when a reserved slot is released without being dispatched
-        (e.g., in choose_replica context manager cleanup).
-
-        We cannot rely on on_new_queue_len_info() to correct the cache in this
-        path. The queue length cache is incremented optimistically when a slot is
-        reserved, before dispatch happens. If dispatch is never called or fails
-        before the request reaches the replica, no queue_len_info response is
-        produced, so the cache would otherwise remain inflated.
+        Called from assign_request's cleanup when try_send_request raised
+        after the cache was optimistically incremented by on_send_request
+        but before the result's done callback was registered — there's no
+        other path to reverse that increment.
         """
         if self._use_replica_queue_len_cache:
             num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -20,6 +20,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Union,
 )
 
@@ -998,11 +999,7 @@ class AsyncioRouter:
             # This ensures that queue metrics reflect actual pending work,
             # not time spent waiting for upstream DeploymentResponse arguments.
             # See: https://github.com/ray-project/ray/issues/60624
-            if not pr.resolved:
-                resolution_start = time.monotonic()
-                await self._resolve_request_arguments(pr)
-                resolution_ms = (time.monotonic() - resolution_start) * 1000
-                self._objref_resolution_latency_ms.observe(resolution_ms)
+            await self._resolve_args_with_metrics(pr)
 
             num_curr_replicas = len(self.request_router.curr_replicas)
             with self._metrics_manager.wrap_queued_request(is_retry, num_curr_replicas):
@@ -1021,35 +1018,12 @@ class AsyncioRouter:
                 # Proactively update the queue length cache.
                 self.request_router.on_send_request(replica.replica_id)
 
-            # Keep track of requests that have been sent out to replicas
-            if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
-                self._metrics_manager.inc_num_running_requests_for_replica(
-                    replica.replica_id
-                )
-            # Always register callback to notify router when request completes
-            # (needed for token release in queue-based routing, metrics tracking, etc.)
-            # NOTE: add_done_callback fires from a C++ worker thread (for actor
-            # ObjectRefs) or a gRPC callback thread. _process_finished_request
-            # and decrement_queue_len_cache both access shared router state
-            # (e.g., _replica_queue_len_cache) that is not thread-safe, so we
-            # schedule them on the router's event loop.
-            callback = partial(
-                self._process_finished_request,
-                replica.replica_id,
-                pr.metadata.internal_request_id,
-                replica.actor_id,
-            )
-            result.add_done_callback(
-                lambda _, cb=callback: self._event_loop.call_soon_threadsafe(cb, _)
-            )
+            self._register_completion_callback(result, replica, pr)
             callback_registered = True
 
             if not with_rejection:
-                result.add_done_callback(
-                    lambda _: self._event_loop.call_soon_threadsafe(
-                        self.request_router.decrement_queue_len_cache,
-                        replica.replica_id,
-                    )
+                self._register_decrement_queue_len_cache_callback(
+                    result, replica.replica_id
                 )
                 return result
 
@@ -1059,11 +1033,8 @@ class AsyncioRouter:
             )
             if queue_info.accepted:
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
-                result.add_done_callback(
-                    lambda _: self._event_loop.call_soon_threadsafe(
-                        self.request_router.decrement_queue_len_cache,
-                        replica.replica_id,
-                    )
+                self._register_decrement_queue_len_cache_callback(
+                    result, replica.replica_id
                 )
                 return result
 
@@ -1265,10 +1236,10 @@ class AsyncioRouter:
              Reservation metrics stay accurate even if the release call
              itself fails.
         """
+        # TODO(jeffreywang): Add tracing support
         if not self._deployment_available:
             raise DeploymentUnavailableError(self.deployment_id)
 
-        # Wait for the router to be initialized before sending the request.
         await self._request_router_initialized.wait()
 
         with self._metrics_manager.wrap_request_assignment(request_meta):
@@ -1277,54 +1248,11 @@ class AsyncioRouter:
                 kwargs=request_kwargs,
                 metadata=request_meta,
             )
-
-            # Resolve request arguments BEFORE incrementing queued requests.
-            # This ensures that queue metrics reflect actual pending work,
-            # not time spent waiting for upstream DeploymentResponse arguments.
-            # See: https://github.com/ray-project/ray/issues/60624
-            if not pr.resolved:
-                await self._resolve_request_arguments(pr)
-
-            is_retry = False
-            while True:
-                num_curr_replicas = len(self.request_router.curr_replicas)
-                with self._metrics_manager.wrap_queued_request(
-                    is_retry=is_retry, num_curr_replicas=num_curr_replicas
-                ):
-                    replica = await self.request_router._choose_replica_for_request(
-                        pr, is_retry=is_retry
-                    )
-
-                    # Reserve capacity on the replica actor. This must happen on
-                    # the replica, not just in the router cache, so dispatch can
-                    # send without the rejection protocol.
-                    try:
-                        slot_token, queue_info = await replica.reserve_slot(
-                            request_meta
-                        )
-                    except ActorDiedError as e:
-                        self._handle_actor_died_error(
-                            replica.replica_id, replica.actor_id, e
-                        )
-                        is_retry = True
-                        continue
-                    except ActorUnavailableError:
-                        self.request_router.on_replica_actor_unavailable(
-                            replica.replica_id
-                        )
-                        logger.warning(
-                            f"{replica.replica_id} is temporarily unavailable."
-                        )
-                        is_retry = True
-                        continue
-
-                    self.request_router.on_new_queue_len_info(
-                        replica.replica_id, queue_info.num_ongoing_requests
-                    )
-                    if queue_info.accepted:
-                        break
-
-                is_retry = True
+            try:
+                await self._resolve_args_with_metrics(pr)
+            except ActorDiedError as e:
+                raise self._make_upstream_crash_error(e)
+            replica, slot_token = await self._pick_and_reserve_replica(pr)
 
             # Increment reserved slots metric (after queue metric is decremented)
             self._metrics_manager.inc_reserved_slots()
@@ -1346,15 +1274,18 @@ class AsyncioRouter:
             yield selection
         finally:
             try:
-                num_ongoing_requests = await selection._release_slot()
-                if num_ongoing_requests is not None:
-                    self.request_router.on_new_queue_len_info(
-                        replica.replica_id, num_ongoing_requests
+                await self._release_slot_and_refresh_cache(selection, replica)
+                # Every reservation must fire on_request_completed exactly once.
+                # When dispatch wires up the result's done-callback it fires there;
+                # otherwise (no dispatch, or dispatch raised before registering)
+                # fire it here.
+                if (
+                    not selection._completion_callback_registered
+                    and self.request_router
+                ):
+                    self.request_router.on_request_completed(
+                        replica.replica_id, request_meta.internal_request_id
                     )
-            except Exception:
-                logger.exception(
-                    "Failed to release reserved slot on choose_replica exit."
-                )
             finally:
                 # Decrement reserved slots metric even if release failed,
                 # otherwise the gauge leaks for the lifetime of the process.
@@ -1394,61 +1325,44 @@ class AsyncioRouter:
         *request_args,
         **request_kwargs,
     ) -> ReplicaResult:
-        """Dispatch a selection that has already been consumed by dispatch()."""
-        # Verify replica is still available
+        """Send a request to the replica chosen by `choose_replica`.
+
+        Mirrors the send half of `_route_and_send_request_once`: build a
+        PendingRequest, resolve args, send with `with_rejection=False`
+        (the reservation guarantees acceptance), and wire up the same
+        completion callbacks. On failure, releases the held slot before
+        re-raising.
+        """
         replica = selection._replica
+        # Inject the slot token so the replica skips re-acquiring its semaphore.
+        # Args are re-resolved here because dispatch may carry augmented args.
         pr = PendingRequest(
             args=list(request_args),
             kwargs=request_kwargs,
             metadata=replace(request_meta, _reserved_slot_token=selection._slot_token),
         )
 
-        # Send the request without rejection since we already reserved a slot
-        # The slot reservation guarantees that the replica will accept this request
         try:
             if replica.replica_id not in self.request_router.curr_replicas:
                 raise ReplicaUnavailableError(
                     f"Replica {selection.replica_id} is no longer available"
                 )
-            if not pr.resolved:
-                await self._resolve_request_arguments(pr)
+            try:
+                await self._resolve_args_with_metrics(pr)
+            except ActorDiedError as e:
+                raise self._make_upstream_crash_error(e)
             result = replica.try_send_request(pr, with_rejection=False)
         except BaseException:
-            # Release the slot but never let a release-time error replace the
-            # original dispatch failure — the caller needs to see the real cause.
-            try:
-                num_ongoing_requests = await selection._release_slot(force=True)
-                if num_ongoing_requests is not None:
-                    self.request_router.on_new_queue_len_info(
-                        replica.replica_id, num_ongoing_requests
-                    )
-            except Exception:
-                logger.exception("Failed to release reserved slot during dispatch.")
+            # Dispatch failed; release the reservation before re-raising.
+            await self._release_slot_and_refresh_cache(selection, replica, force=True)
             raise
 
-        # Keep track of requests that have been sent out to replicas
-        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
-            self._metrics_manager.inc_num_running_requests_for_replica(
-                replica.replica_id
-            )
-
-        # Always register callback to notify router when request completes
-        # (needed for token release in queue-based routing, metrics tracking, etc.)
-        callback = partial(
-            self._process_finished_request,
-            replica.replica_id,
-            pr.metadata.internal_request_id,
-            replica.actor_id,
-        )
-        result.add_done_callback(
-            lambda _, cb=callback: self._event_loop.call_soon_threadsafe(cb, _)
-        )
-        result.add_done_callback(
-            lambda _: self._event_loop.call_soon_threadsafe(
-                self.request_router.decrement_queue_len_cache,
-                replica.replica_id,
-            )
-        )
+        self._register_completion_callback(result, replica, pr)
+        # The done-callback registered above will fire on_request_completed
+        # when the result completes; flag the selection so choose_replica's
+        # finally skips its manual call (exactly one per reservation).
+        selection._completion_callback_registered = True
+        self._register_decrement_queue_len_cache_callback(result, replica.replica_id)
         result.add_done_callback(
             lambda _: self._event_loop.call_soon_threadsafe(
                 lambda: self._event_loop.create_task(
@@ -1467,6 +1381,113 @@ class AsyncioRouter:
             await selection._release_slot(force=True)
         except Exception:
             logger.debug("Failed to release reserved replica slot.", exc_info=True)
+
+    async def _resolve_args_with_metrics(self, pr: PendingRequest) -> None:
+        """Resolve a PendingRequest's arguments, observing resolution latency."""
+        if pr.resolved:
+            return
+        resolution_start = time.monotonic()
+        await self._resolve_request_arguments(pr)
+        resolution_ms = (time.monotonic() - resolution_start) * 1000
+        self._objref_resolution_latency_ms.observe(resolution_ms)
+
+    async def _pick_and_reserve_replica(
+        self, pr: PendingRequest
+    ) -> Tuple[RunningReplica, str]:
+        """Pick a replica and hold capacity on it.
+
+        Loops until a replica accepts the reservation, retrying on
+        capacity rejection, replica actor death, or transient
+        unavailability. Updates the queue-length cache from the replica's
+        reported count.
+        """
+        is_retry = False
+        while True:
+            num_curr_replicas = len(self.request_router.curr_replicas)
+            with self._metrics_manager.wrap_queued_request(
+                is_retry=is_retry, num_curr_replicas=num_curr_replicas
+            ):
+                replica = await self.request_router._choose_replica_for_request(
+                    pr, is_retry=is_retry
+                )
+                try:
+                    slot_token, queue_info = await replica.reserve_slot(pr.metadata)
+                except ActorDiedError as e:
+                    self._handle_actor_died_error(
+                        replica.replica_id, replica.actor_id, e
+                    )
+                    is_retry = True
+                    continue
+                except ActorUnavailableError:
+                    self.request_router.on_replica_actor_unavailable(replica.replica_id)
+                    logger.warning(f"{replica.replica_id} is temporarily unavailable.")
+                    is_retry = True
+                    continue
+
+                self.request_router.on_new_queue_len_info(
+                    replica.replica_id, queue_info.num_ongoing_requests
+                )
+                if queue_info.accepted:
+                    return replica, slot_token
+
+            is_retry = True
+
+    def _register_completion_callback(
+        self, result: ReplicaResult, replica: RunningReplica, pr: PendingRequest
+    ) -> None:
+        """Count this request as in-flight and register the cleanup
+        callback fired when the result completes or is cancelled.
+        """
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
+            self._metrics_manager.inc_num_running_requests_for_replica(
+                replica.replica_id
+            )
+        # Always register callback to notify router when request completes
+        # (needed for token release in queue-based routing, metrics tracking, etc.)
+        # NOTE: add_done_callback fires from a C++ worker thread (for actor
+        # ObjectRefs) or a gRPC callback thread. _process_finished_request
+        # and decrement_queue_len_cache both access shared router state
+        # (e.g., _replica_queue_len_cache) that is not thread-safe, so we
+        # schedule them on the router's event loop.
+        callback = partial(
+            self._process_finished_request,
+            replica.replica_id,
+            pr.metadata.internal_request_id,
+            replica.actor_id,
+        )
+        result.add_done_callback(
+            lambda _, cb=callback: self._event_loop.call_soon_threadsafe(cb, _)
+        )
+
+    def _register_decrement_queue_len_cache_callback(
+        self, result: ReplicaResult, replica_id: ReplicaID
+    ) -> None:
+        """Schedule a queue-length-cache decrement for when this result completes."""
+        result.add_done_callback(
+            lambda _: self._event_loop.call_soon_threadsafe(
+                self.request_router.decrement_queue_len_cache,
+                replica_id,
+            )
+        )
+
+    async def _release_slot_and_refresh_cache(
+        self,
+        selection: ReplicaSelection,
+        replica: RunningReplica,
+        *,
+        force: bool = False,
+    ) -> None:
+        """Release a reserved slot and feed the replica's reported queue
+        length back into the cache. Swallows release failures so callers
+        can put this in a finally without masking other errors."""
+        try:
+            num_ongoing_requests = await selection._release_slot(force=force)
+            if num_ongoing_requests is not None:
+                self.request_router.on_new_queue_len_info(
+                    replica.replica_id, num_ongoing_requests
+                )
+        except Exception:
+            logger.exception("Failed to release reserved replica slot.")
 
     async def broadcast(
         self,
@@ -1541,33 +1562,9 @@ class AsyncioRouter:
             # Proactively update the queue length cache.
             self.request_router.on_send_request(replica.replica_id)
 
-            # Track running requests and register callback for completion
-            # handling, matching the pattern in _route_and_send_request_once.
-            if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
-                self._metrics_manager.inc_num_running_requests_for_replica(
-                    replica.replica_id
-                )
-            # NOTE: add_done_callback fires from a C++ worker thread (for
-            # actor ObjectRefs) or a gRPC callback thread.
-            # _process_finished_request and decrement_queue_len_cache both
-            # access shared router state that is not thread-safe, so we
-            # schedule them on the router's event loop.
-            callback = partial(
-                self._process_finished_request,
-                replica.replica_id,
-                replica_pr.metadata.internal_request_id,
-                replica.actor_id,
-            )
-            result.add_done_callback(
-                lambda _, cb=callback: self._event_loop.call_soon_threadsafe(cb, _)
-            )
-            result.add_done_callback(
-                lambda _, rid=replica.replica_id: (
-                    self._event_loop.call_soon_threadsafe(
-                        self.request_router.decrement_queue_len_cache,
-                        rid,
-                    )
-                )
+            self._register_completion_callback(result, replica, replica_pr)
+            self._register_decrement_queue_len_cache_callback(
+                result, replica.replica_id
             )
 
             results.append(result)

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -8,11 +8,12 @@ from abc import ABC, abstractmethod
 from asyncio import AbstractEventLoop, ensure_future, futures
 from collections import defaultdict
 from collections.abc import MutableMapping
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import replace
 from functools import lru_cache, partial
 from typing import (
     Any,
+    AsyncIterator,
     Callable,
     Coroutine,
     DefaultDict,
@@ -58,7 +59,10 @@ from ray.serve._private.request_router import PendingRequest, RequestRouter
 from ray.serve._private.request_router.pow_2_router import (
     PowerOfTwoChoicesRequestRouter,
 )
-from ray.serve._private.request_router.replica_wrapper import RunningReplica
+from ray.serve._private.request_router.replica_wrapper import (
+    ReplicaSelection,
+    RunningReplica,
+)
 from ray.serve._private.tracing_utils import (
     create_propagated_context,
     is_span_recording,
@@ -81,6 +85,7 @@ from ray.serve.exceptions import (
     BackPressureError,
     DeploymentUnavailableError,
     RayServeException,
+    ReplicaUnavailableError,
 )
 from ray.types import ObjectRef
 from ray.util import metrics
@@ -154,6 +159,25 @@ class RouterMetricsManager:
         # so non-atomic read and write operations need to be guarded by
         # this thread-safe lock.
         self._queries_lock = threading.Lock()
+
+        # Track reserved slots for choose_replica operations
+        self._num_reserved_slots = 0
+        self._reserved_slots_gauge = metrics.Gauge(
+            "serve_reserved_slots_active",
+            description=(
+                "The current number of reserved slots for choose_replica operations."
+            ),
+            tag_keys=("deployment", "application", "handle", "actor_id"),
+        )
+        self._reserved_slots_gauge.set_default_tags(
+            {
+                "deployment": deployment_id.name,
+                "application": deployment_id.app_name,
+                "handle": self._handle_id,
+                "actor_id": self._self_actor_id,
+            }
+        )
+        self._reserved_slots_gauge.set(0)
         # Regularly aggregate and push autoscaling metrics to controller
         self.metrics_pusher = MetricsPusher()
         self.metrics_store = InMemoryMetricsStore()
@@ -355,6 +379,14 @@ class RouterMetricsManager:
         self.num_queued_requests -= 1
         if not self._cached_metrics_enabled:
             self.num_queued_requests_gauge.set(self.num_queued_requests)
+
+    def inc_reserved_slots(self):
+        self._num_reserved_slots += 1
+        self._reserved_slots_gauge.set(self._num_reserved_slots)
+
+    def dec_reserved_slots(self):
+        self._num_reserved_slots -= 1
+        self._reserved_slots_gauge.set(self._num_reserved_slots)
 
     def inc_num_running_requests_for_replica(self, replica_id: ReplicaID):
         with self._queries_lock:
@@ -961,6 +993,7 @@ class AsyncioRouter:
         result: Optional[ReplicaResult] = None
         replica: Optional[RunningReplica] = None
         callback_registered = False
+        queue_len_incremented = False
         try:
             # Resolve request arguments BEFORE incrementing queued requests.
             # This ensures that queue metrics reflect actual pending work,
@@ -988,6 +1021,7 @@ class AsyncioRouter:
                 result = replica.try_send_request(pr, with_rejection=with_rejection)
                 # Proactively update the queue length cache.
                 self.request_router.on_send_request(replica.replica_id)
+                queue_len_incremented = True
 
             # Keep track of requests that have been sent out to replicas
             if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
@@ -1082,6 +1116,11 @@ class AsyncioRouter:
                 self.request_router.on_request_completed(
                     replica.replica_id, pr.metadata.internal_request_id
                 )
+                # Only decrement if on_send_request was called (i.e., try_send_request
+                # succeeded and incremented the cache). If try_send_request raised error,
+                # on_send_request was never called so there is no +1 to undo.
+                if queue_len_incremented:
+                    self.request_router.on_replica_result_finished(replica.replica_id)
 
         return None
 
@@ -1201,6 +1240,216 @@ class AsyncioRouter:
                         )
                     if exc:
                         set_span_exception(exc, escaped=True)
+
+    @asynccontextmanager
+    async def choose_replica(
+        self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> AsyncIterator[ReplicaSelection]:
+        """Execute routing and reserve a slot, with automatic cleanup.
+
+        This method:
+        1. Checks deployment availability
+        2. Checks backpressure (max_queued_requests)
+        3. Increments serve_num_router_requests metric
+        4. Selects a replica and reserves a slot
+        5. Increments serve_reserved_slots_active metric
+        6. Yields the ReplicaSelection
+        7. On exit, releases the slot if not dispatched
+        """
+        if not self._deployment_available:
+            raise DeploymentUnavailableError(self.deployment_id)
+
+        # Wait for the router to be initialized before sending the request.
+        await self._request_router_initialized.wait()
+
+        with self._metrics_manager.wrap_request_assignment(request_meta):
+            pr = PendingRequest(
+                args=list(request_args),
+                kwargs=request_kwargs,
+                metadata=request_meta,
+            )
+
+            # Resolve request arguments BEFORE incrementing queued requests.
+            # This ensures that queue metrics reflect actual pending work,
+            # not time spent waiting for upstream DeploymentResponse arguments.
+            # See: https://github.com/ray-project/ray/issues/60624
+            if not pr.resolved:
+                await self._resolve_request_arguments(pr)
+
+            is_retry = False
+            while True:
+                num_curr_replicas = len(self.request_router.curr_replicas)
+                with self._metrics_manager.wrap_queued_request(
+                    is_retry=is_retry, num_curr_replicas=num_curr_replicas
+                ):
+                    replica = await self.request_router._choose_replica_for_request(
+                        pr, is_retry=is_retry
+                    )
+
+                    # Reserve capacity on the replica actor. This must happen on
+                    # the replica, not just in the router cache, so dispatch can
+                    # send without the rejection protocol.
+                    try:
+                        slot_token, queue_info = await replica.reserve_slot(
+                            request_meta
+                        )
+                    except ActorDiedError as e:
+                        self._handle_actor_died_error(
+                            replica.replica_id, replica.actor_id, e
+                        )
+                        is_retry = True
+                        continue
+                    except ActorUnavailableError:
+                        self.request_router.on_replica_actor_unavailable(
+                            replica.replica_id
+                        )
+                        logger.warning(
+                            f"{replica.replica_id} is temporarily unavailable."
+                        )
+                        is_retry = True
+                        continue
+
+                    self.request_router.on_new_queue_len_info(
+                        replica.replica_id, queue_info
+                    )
+                    if queue_info.accepted:
+                        break
+
+                is_retry = True
+
+            # Increment reserved slots metric (after queue metric is decremented)
+            self._metrics_manager.inc_reserved_slots()
+
+            selection = ReplicaSelection(
+                replica_id=replica.replica_id.unique_id,
+                node_ip=replica._replica_info.node_ip,
+                port=replica._replica_info.port,
+                node_id=replica.node_id,
+                availability_zone=replica.availability_zone,
+                _replica=replica,
+                _deployment_id=None,  # Injected by DeploymentHandle for dispatch-time validation.
+                _request_metadata=request_meta,
+                _method_name=request_meta.call_method,
+                _slot_token=slot_token,
+            )
+
+        try:
+            yield selection
+        finally:
+            queue_info = await selection._release_slot()
+            if queue_info is not None:
+                self.request_router.on_new_queue_len_info(
+                    replica.replica_id, queue_info
+                )
+
+            # Decrement reserved slots metric
+            self._metrics_manager.dec_reserved_slots()
+
+    async def dispatch(
+        self,
+        selection: ReplicaSelection,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> ReplicaResult:
+        """Dispatch to a specific replica, consuming the reserved slot.
+
+        Args:
+            selection: The replica selection from choose_replica().
+            request_meta: Request metadata.
+            *request_args: Request positional arguments.
+            **request_kwargs: Request keyword arguments.
+
+        Returns:
+            ReplicaResult for the dispatched request.
+
+        Raises:
+            RuntimeError: If the selection has already been dispatched.
+            ReplicaUnavailableError: If the replica is no longer available.
+        """
+        selection._mark_dispatched()
+        return await self._dispatch_to_marked_selection(
+            selection, request_meta, *request_args, **request_kwargs
+        )
+
+    async def _dispatch_to_marked_selection(
+        self,
+        selection: ReplicaSelection,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> ReplicaResult:
+        """Dispatch a selection that has already been consumed by dispatch()."""
+        # Verify replica is still available
+        replica = selection._replica
+        pr = PendingRequest(
+            args=list(request_args),
+            kwargs=request_kwargs,
+            metadata=replace(request_meta, _reserved_slot_token=selection._slot_token),
+        )
+
+        # Send the request without rejection since we already reserved a slot
+        # The slot reservation guarantees that the replica will accept this request
+        try:
+            if replica.replica_id not in self.request_router.curr_replicas:
+                raise ReplicaUnavailableError(
+                    f"Replica {selection.replica_id} is no longer available"
+                )
+            if not pr.resolved:
+                await self._resolve_request_arguments(pr)
+            result = replica.try_send_request(pr, with_rejection=False)
+        except BaseException:
+            queue_info = await selection._release_slot(force=True)
+            if queue_info is not None:
+                self.request_router.on_new_queue_len_info(
+                    replica.replica_id, queue_info
+                )
+            raise
+
+        # Keep track of requests that have been sent out to replicas
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
+            self._metrics_manager.inc_num_running_requests_for_replica(
+                replica.replica_id
+            )
+
+        # Always register callback to notify router when request completes
+        # (needed for token release in queue-based routing, metrics tracking, etc.)
+        callback = partial(
+            self._process_finished_request,
+            replica.replica_id,
+            pr.metadata.internal_request_id,
+            replica.actor_id,
+        )
+        result.add_done_callback(
+            lambda _, cb=callback: self._event_loop.call_soon_threadsafe(cb, _)
+        )
+        result.add_done_callback(
+            lambda _: self._event_loop.call_soon_threadsafe(
+                self.request_router.decrement_queue_len_cache,
+                replica.replica_id,
+            )
+        )
+        result.add_done_callback(
+            lambda _: self._event_loop.call_soon_threadsafe(
+                lambda: self._event_loop.create_task(
+                    self._release_slot_if_still_reserved(selection)
+                )
+            )
+        )
+
+        return result
+
+    async def _release_slot_if_still_reserved(
+        self, selection: ReplicaSelection
+    ) -> None:
+        """Best-effort cleanup if a dispatched request was cancelled before starting."""
+        try:
+            await selection._release_slot(force=True)
+        except Exception:
+            logger.debug("Failed to release reserved replica slot.", exc_info=True)
 
     async def broadcast(
         self,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -993,7 +993,6 @@ class AsyncioRouter:
         result: Optional[ReplicaResult] = None
         replica: Optional[RunningReplica] = None
         callback_registered = False
-        queue_len_incremented = False
         try:
             # Resolve request arguments BEFORE incrementing queued requests.
             # This ensures that queue metrics reflect actual pending work,
@@ -1021,7 +1020,6 @@ class AsyncioRouter:
                 result = replica.try_send_request(pr, with_rejection=with_rejection)
                 # Proactively update the queue length cache.
                 self.request_router.on_send_request(replica.replica_id)
-                queue_len_incremented = True
 
             # Keep track of requests that have been sent out to replicas
             if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
@@ -1118,11 +1116,6 @@ class AsyncioRouter:
                 self.request_router.on_request_completed(
                     replica.replica_id, pr.metadata.internal_request_id
                 )
-                # Only decrement if on_send_request was called (i.e., try_send_request
-                # succeeded and incremented the cache). If try_send_request raised error,
-                # on_send_request was never called so there is no +1 to undo.
-                if queue_len_incremented:
-                    self.request_router.on_replica_result_finished(replica.replica_id)
 
         return None
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1250,16 +1250,27 @@ class AsyncioRouter:
         *request_args,
         **request_kwargs,
     ) -> AsyncIterator[ReplicaSelection]:
-        """Execute routing and reserve a slot, with automatic cleanup.
+        """Pick a replica, hold capacity on it, and yield a selection.
 
-        This method:
-        1. Checks deployment availability
-        2. Checks backpressure (max_queued_requests)
-        3. Increments serve_num_router_requests metric
-        4. Selects a replica and reserves a slot
-        5. Increments serve_reserved_slots_active metric
-        6. Yields the ReplicaSelection
-        7. On exit, releases the slot if not dispatched
+        The yielded selection can be dispatched (consuming the held
+        capacity) or allowed to drop, in which case the capacity is
+        released automatically when the context exits.
+
+        Behavior:
+          1. Refuses immediately if the deployment is unavailable.
+          2. Waits for the router to finish initial setup before routing.
+          3. Refuses with backpressure if the queue limit is already
+             reached; otherwise the request counts against router-level
+             request and queue metrics for the duration of routing.
+          4. Resolves the request arguments (which may block on
+             upstream responses).
+          5. Picks a replica and asks it to hold capacity. Retries on
+             actor failure, transient unavailability, or replica-side
+             capacity rejection until a replica accepts.
+          6. Yields the selection while the reservation is held; on exit,
+             releases the capacity if dispatch never consumed it.
+             Reservation metrics stay accurate even if the release call
+             itself fails.
         """
         if not self._deployment_available:
             raise DeploymentUnavailableError(self.deployment_id)

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -26,7 +26,13 @@ from typing import (
 
 import ray
 from ray.actor import ActorHandle
-from ray.exceptions import ActorDiedError, ActorUnavailableError, RayError, RayTaskError
+from ray.exceptions import (
+    ActorDiedError,
+    ActorUnavailableError,
+    RayError,
+    RayTaskError,
+    TaskCancelledError,
+)
 from ray.serve._private.common import (
     RUNNING_REQUESTS_KEY,
     DeploymentHandleSource,
@@ -1254,9 +1260,6 @@ class AsyncioRouter:
                 raise self._make_upstream_crash_error(e)
             replica, slot_token = await self._pick_and_reserve_replica(pr)
 
-            # Increment reserved slots metric (after queue metric is decremented)
-            self._metrics_manager.inc_reserved_slots()
-
             selection = ReplicaSelection(
                 replica_id=replica.replica_id.unique_id,
                 node_ip=replica._replica_info.node_ip,
@@ -1271,6 +1274,7 @@ class AsyncioRouter:
             )
 
         try:
+            self._metrics_manager.inc_reserved_slots()
             yield selection
         finally:
             try:
@@ -1365,20 +1369,32 @@ class AsyncioRouter:
         # finally skips its manual call (exactly one per reservation).
         selection._completion_callback_registered = True
         self._register_decrement_queue_len_cache_callback(result, replica.replica_id)
-        result.add_done_callback(
-            lambda _: self._event_loop.call_soon_threadsafe(
-                lambda: self._event_loop.create_task(
-                    self._release_slot_if_still_reserved(selection)
-                )
+
+        # Only the cancellation path needs a follow-up release_slot RPC: on
+        # success or replica-side failure, `_start_request` already consumed
+        # the slot. Skipping it on the happy path saves one actor RPC per
+        # dispatched request.
+        def _maybe_release_slot(fut, sel=selection):
+            cancelled = isinstance(fut, TaskCancelledError) or (
+                callable(getattr(fut, "cancelled", None)) and fut.cancelled()
             )
-        )
+            if cancelled:
+                self._event_loop.call_soon_threadsafe(
+                    lambda: self._event_loop.create_task(
+                        self._release_slot_if_still_reserved(sel)
+                    )
+                )
+
+        result.add_done_callback(_maybe_release_slot)
 
         return result
 
     async def _release_slot_if_still_reserved(
         self, selection: ReplicaSelection
     ) -> None:
-        """Best-effort cleanup if a dispatched request was cancelled before starting."""
+        """Best-effort release_slot when a dispatched request was cancelled
+        before the replica could consume the reservation. A no-op on the
+        replica side if the slot was already consumed."""
         try:
             await selection._release_slot(force=True)
         except Exception:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1275,12 +1275,14 @@ class AsyncioRouter:
         finally:
             try:
                 await self._release_slot_and_refresh_cache(selection, replica)
-                # Every reservation must fire on_request_completed exactly once.
-                # When dispatch wires up the result's done-callback it fires there;
-                # otherwise (no dispatch, or dispatch raised before registering)
-                # fire it here.
+                # Every dispatched request must fire on_request_completed exactly
+                # once. When dispatch wires up the result's done-callback it fires
+                # there; otherwise (dispatch raised before registering the
+                # callback) fire it here. Skipped entirely when the caller exits
+                # without dispatch, since no request was sent to the replica.
                 if (
-                    not selection._completion_callback_registered
+                    selection._dispatched
+                    and not selection._completion_callback_registered
                     and self.request_router
                 ):
                     self.request_router.on_request_completed(

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1056,7 +1056,9 @@ class AsyncioRouter:
                 return result
 
             queue_info = await result.get_rejection_response()
-            self.request_router.on_new_queue_len_info(replica.replica_id, queue_info)
+            self.request_router.on_new_queue_len_info(
+                replica.replica_id, queue_info.num_ongoing_requests
+            )
             if queue_info.accepted:
                 self.request_router.on_request_routed(pr, replica.replica_id, result)
                 result.add_done_callback(
@@ -1313,7 +1315,7 @@ class AsyncioRouter:
                         continue
 
                     self.request_router.on_new_queue_len_info(
-                        replica.replica_id, queue_info
+                        replica.replica_id, queue_info.num_ongoing_requests
                     )
                     if queue_info.accepted:
                         break
@@ -1339,10 +1341,10 @@ class AsyncioRouter:
         try:
             yield selection
         finally:
-            queue_info = await selection._release_slot()
-            if queue_info is not None:
+            num_ongoing_requests = await selection._release_slot()
+            if num_ongoing_requests is not None:
                 self.request_router.on_new_queue_len_info(
-                    replica.replica_id, queue_info
+                    replica.replica_id, num_ongoing_requests
                 )
 
             # Decrement reserved slots metric
@@ -1402,10 +1404,10 @@ class AsyncioRouter:
                 await self._resolve_request_arguments(pr)
             result = replica.try_send_request(pr, with_rejection=False)
         except BaseException:
-            queue_info = await selection._release_slot(force=True)
-            if queue_info is not None:
+            num_ongoing_requests = await selection._release_slot(force=True)
+            if num_ongoing_requests is not None:
                 self.request_router.on_new_queue_len_info(
-                    replica.replica_id, queue_info
+                    replica.replica_id, num_ongoing_requests
                 )
             raise
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1341,14 +1341,20 @@ class AsyncioRouter:
         try:
             yield selection
         finally:
-            num_ongoing_requests = await selection._release_slot()
-            if num_ongoing_requests is not None:
-                self.request_router.on_new_queue_len_info(
-                    replica.replica_id, num_ongoing_requests
+            try:
+                num_ongoing_requests = await selection._release_slot()
+                if num_ongoing_requests is not None:
+                    self.request_router.on_new_queue_len_info(
+                        replica.replica_id, num_ongoing_requests
+                    )
+            except Exception:
+                logger.exception(
+                    "Failed to release reserved slot on choose_replica exit."
                 )
-
-            # Decrement reserved slots metric
-            self._metrics_manager.dec_reserved_slots()
+            finally:
+                # Decrement reserved slots metric even if release failed,
+                # otherwise the gauge leaks for the lifetime of the process.
+                self._metrics_manager.dec_reserved_slots()
 
     async def dispatch(
         self,
@@ -1404,11 +1410,16 @@ class AsyncioRouter:
                 await self._resolve_request_arguments(pr)
             result = replica.try_send_request(pr, with_rejection=False)
         except BaseException:
-            num_ongoing_requests = await selection._release_slot(force=True)
-            if num_ongoing_requests is not None:
-                self.request_router.on_new_queue_len_info(
-                    replica.replica_id, num_ongoing_requests
-                )
+            # Release the slot but never let a release-time error replace the
+            # original dispatch failure — the caller needs to see the real cause.
+            try:
+                num_ongoing_requests = await selection._release_slot(force=True)
+                if num_ongoing_requests is not None:
+                    self.request_router.on_new_queue_len_info(
+                        replica.replica_id, num_ongoing_requests
+                    )
+            except Exception:
+                logger.exception("Failed to release reserved slot during dispatch.")
             raise
 
         # Keep track of requests that have been sent out to replicas

--- a/python/ray/serve/tests/test_actor_replica_wrapper.py
+++ b/python/ray/serve/tests/test_actor_replica_wrapper.py
@@ -1,15 +1,16 @@
 import asyncio
 import pickle
 import sys
+from types import SimpleNamespace
 from typing import Union
 
 import pytest
 
 import ray
 from ray import ObjectRef, ObjectRefGenerator
-from ray._common.test_utils import SignalActor
+from ray._common.test_utils import SignalActor, async_wait_for_condition
 from ray._common.utils import get_or_create_event_loop
-from ray.exceptions import TaskCancelledError
+from ray.exceptions import ActorDiedError, ActorUnavailableError, TaskCancelledError
 from ray.serve._private.common import (
     DeploymentID,
     ReplicaID,
@@ -21,6 +22,78 @@ from ray.serve._private.constants import SERVE_NAMESPACE
 from ray.serve._private.request_router.common import PendingRequest
 from ray.serve._private.request_router.replica_wrapper import RunningReplica
 from ray.serve._private.test_utils import send_signal_on_cancellation
+from ray.serve._private.utils import Semaphore
+
+
+class _IntMetricsManager:
+    """Minimal metrics manager that tracks only the in-flight count."""
+
+    def __init__(self):
+        self._n = 0
+
+    def get_num_ongoing_requests(self):
+        return self._n
+
+    def inc_num_ongoing_requests(self, _):
+        self._n += 1
+
+    def dec_num_ongoing_requests(self, _):
+        self._n -= 1
+
+
+@ray.remote(num_cpus=0)
+class SlotReservationActor:
+    """Ray actor wrapping the real Replica.reserve_slot / release_slot.
+
+    Used by integration tests that need production slot-reservation logic
+    running under Ray's actor concurrency model — unit tests share one event
+    loop and can't observe sync/async ordering on a real ReplicaActor.
+    """
+
+    def __init__(self, max_ongoing_requests: int):
+        from ray.serve._private.replica import Replica
+
+        replica = Replica.__new__(Replica)
+        replica._deployment_config = SimpleNamespace(
+            max_ongoing_requests=max_ongoing_requests
+        )
+        replica._reserved_slots = set()
+        replica._semaphore = Semaphore(lambda: max_ongoing_requests)
+        replica._metrics_manager = _IntMetricsManager()
+        self._replica = replica
+
+    async def reserve_slot(self, request_metadata, slot_token: str):
+        return await self._replica.reserve_slot(request_metadata, slot_token)
+
+    def release_slot(self, slot_token: str):
+        return self._replica.release_slot(slot_token)
+
+    def get_num_ongoing_requests(self) -> int:
+        return self._replica.get_num_ongoing_requests()
+
+
+@ray.remote(num_cpus=0)
+class BlockingReserveActor:
+    """Actor whose reserve_slot blocks on a SignalActor.
+
+    Records every release_slot token it receives so a test can verify the
+    cancellation cleanup path in RunningReplica.reserve_slot.
+    """
+
+    def __init__(self, signal_actor):
+        self._signal = signal_actor
+        self._released_tokens = []
+
+    async def reserve_slot(self, request_metadata, slot_token: str):
+        await self._signal.wait.remote()
+        return True, 1
+
+    def release_slot(self, slot_token: str):
+        self._released_tokens.append(slot_token)
+        return True, 0
+
+    def get_released_tokens(self):
+        return list(self._released_tokens)
 
 
 @ray.remote(num_cpus=0)
@@ -289,6 +362,93 @@ async def test_send_request_with_rejection_task_cancelled_error(setup_fake_repli
     replica_result = replica.try_send_request(pr, with_rejection=True)
     with pytest.raises(asyncio.CancelledError):
         await replica_result.get_rejection_response()
+
+
+def _spawn_running_replica(actor_cls, replica_id_str: str, *actor_args, **actor_kwargs):
+    """Spawn a named actor and wrap it in a RunningReplica.
+
+    Returns ``(running_replica, actor_handle)``. The actor must be created
+    with the canonical replica-id name so RunningReplica can resolve it
+    through its normal GCS lookup.
+    """
+    replica_id = ReplicaID(
+        replica_id_str, deployment_id=DeploymentID(name="slot_reservation_test")
+    )
+    actor_name = replica_id.to_full_id_str()
+    actor_handle = actor_cls.options(
+        name=actor_name, namespace=SERVE_NAMESPACE, lifetime="detached"
+    ).remote(*actor_args, **actor_kwargs)
+    info = RunningReplicaInfo(
+        replica_id=replica_id,
+        node_id=None,
+        node_ip=None,
+        availability_zone=None,
+        actor_name=actor_name,
+        max_ongoing_requests=10,
+        is_cross_language=False,
+    )
+    return RunningReplica(info), actor_handle
+
+
+def _dummy_request_metadata() -> RequestMetadata:
+    return RequestMetadata(request_id="abc", internal_request_id="def")
+
+
+@pytest.mark.asyncio
+async def test_reserve_slot_cancellation_releases_slot_on_actor(ray_instance):
+    """If the awaiting reserve_slot task is cancelled, the wrapper must fire a
+    follow-up release_slot.remote(token) so the actor doesn't leak the slot.
+    """
+    signal = SignalActor.remote()
+    replica, actor = _spawn_running_replica(
+        BlockingReserveActor, "blocking-replica", signal
+    )
+
+    task = get_or_create_event_loop().create_task(
+        replica.reserve_slot(_dummy_request_metadata())
+    )
+
+    # Let the actor enter reserve_slot and start awaiting the signal.
+    _, pending = await asyncio.wait([task], timeout=0.5)
+    assert len(pending) == 1
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Unblock the actor so it can process the follow-up release_slot.remote().
+    await signal.send.remote()
+
+    # The wrapper's cancellation cleanup fires release_slot.remote(token)
+    # without awaiting it; wait until the actor records the call.
+    async def _release_received():
+        return bool(await actor.get_released_tokens.remote())
+
+    await async_wait_for_condition(_release_received, timeout=5)
+
+    released_tokens = await actor.get_released_tokens.remote()
+    assert len(released_tokens) == 1
+
+
+@pytest.mark.asyncio
+async def test_reserve_slot_propagates_actor_died_error(ray_instance):
+    """If the replica actor is dead, RunningReplica.reserve_slot must raise
+    ActorDiedError so AsyncioRouter.choose_replica can retry against another
+    replica. ActorUnavailableError is also acceptable on the brief window
+    before the actor failure has propagated.
+    """
+    replica, actor = _spawn_running_replica(
+        SlotReservationActor, "doomed-replica", max_ongoing_requests=1
+    )
+
+    # Confirm liveness via a successful reservation first.
+    _, info = await replica.reserve_slot(_dummy_request_metadata())
+    assert info.accepted
+
+    ray.kill(actor)
+
+    with pytest.raises((ActorDiedError, ActorUnavailableError)):
+        await replica.reserve_slot(_dummy_request_metadata())
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -293,15 +293,6 @@ class FakeRequestRouter(RequestRouter):
             num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
             self._replica_queue_len_cache.update(replica_id, num_ongoing_requests + 1)
 
-    def on_replica_result_finished(self, replica_id: ReplicaID):
-        """Decrement queue length cache when a request finishes or is cancelled."""
-        if self._use_queue_len_cache:
-            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
-            if num_ongoing_requests > 0:
-                self._replica_queue_len_cache.update(
-                    replica_id, num_ongoing_requests - 1
-                )
-
     def on_replica_actor_unavailable(self, replica_id: ReplicaID):
         self._replica_queue_len_cache.invalidate_key(replica_id)
 

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -179,13 +179,10 @@ class FakeReplica(RunningReplica):
             num_ongoing_requests=len(self._reserved_slots),
         )
 
-    async def release_slot(self, slot_token: str) -> ReplicaQueueLengthInfo:
+    async def release_slot(self, slot_token: str) -> int:
         """Release a reserved slot."""
         self._reserved_slots.discard(slot_token)
-        return ReplicaQueueLengthInfo(
-            accepted=True,
-            num_ongoing_requests=len(self._reserved_slots),
-        )
+        return len(self._reserved_slots)
 
     def send_request_with_slot(
         self, pr: PendingRequest, slot_token: str
@@ -280,13 +277,9 @@ class FakeRequestRouter(RequestRouter):
     def on_replica_actor_died(self, replica_id: ReplicaID):
         self._dropped_replicas.add(replica_id)
 
-    def on_new_queue_len_info(
-        self, replica_id: ReplicaID, queue_len_info: ReplicaQueueLengthInfo
-    ):
+    def on_new_queue_len_info(self, replica_id: ReplicaID, num_ongoing_requests: int):
         if self._use_queue_len_cache:
-            self._replica_queue_len_cache.update(
-                replica_id, queue_len_info.num_ongoing_requests
-            )
+            self._replica_queue_len_cache.update(replica_id, num_ongoing_requests)
 
     def on_send_request(self, replica_id: ReplicaID):
         if self._use_queue_len_cache:

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -48,7 +48,11 @@ from ray.serve._private.utils import (
     get_random_string,
 )
 from ray.serve.config import AutoscalingConfig, RequestRouterConfig
-from ray.serve.exceptions import BackPressureError, DeploymentUnavailableError
+from ray.serve.exceptions import (
+    BackPressureError,
+    DeploymentUnavailableError,
+    ReplicaUnavailableError,
+)
 
 
 class FakeReplicaResult(ReplicaResult):
@@ -109,17 +113,42 @@ class FakeReplica(RunningReplica):
         queue_len_info: Optional[ReplicaQueueLengthInfo] = None,
         is_cross_language: bool = False,
         error: Optional[Exception] = None,
+        node_id: str = "fake-node-id",
+        availability_zone: Optional[str] = None,
+        node_ip: str = "127.0.0.1",
+        port: Optional[int] = 8000,
         actor_id: Optional[ray.ActorID] = None,
     ):
         self._replica_id = replica_id
         self._is_cross_language = is_cross_language
         self._queue_len_info = queue_len_info
         self._error = error
+        self._reserved_slots: Set[str] = set()
+        self._slot_counter = 0
+        self._requests_sent = []  # Track all requests sent to this replica
+        self._reject_reservation = False
+        self._reservation_queue_len = 1
+
+        # Create a minimal _replica_info object to satisfy router.py requirements
+        self._replica_info = Mock()
+        self._replica_info.node_id = node_id
+        self._replica_info.availability_zone = availability_zone
+        self._replica_info.node_ip = node_ip
+        self._replica_info.port = port
+        self._replica_info.replica_id = replica_id
         self._actor_id = actor_id
 
     @property
     def replica_id(self) -> ReplicaID:
         return self._replica_id
+
+    @property
+    def node_id(self) -> str:
+        return self._replica_info.node_id
+
+    @property
+    def availability_zone(self) -> Optional[str]:
+        return self._replica_info.availability_zone
 
     @property
     def actor_id(self) -> Optional[ray.ActorID]:
@@ -132,6 +161,44 @@ class FakeReplica(RunningReplica):
     def get_queue_len(self, *, deadline_s: float) -> int:
         raise NotImplementedError
 
+    async def reserve_slot(
+        self, request_metadata: RequestMetadata
+    ) -> Tuple[str, ReplicaQueueLengthInfo]:
+        """Reserve a slot and return a token."""
+        if self._reject_reservation:
+            return "", ReplicaQueueLengthInfo(
+                accepted=False,
+                num_ongoing_requests=self._reservation_queue_len,
+            )
+
+        self._slot_counter += 1
+        token = f"slot-token-{self._slot_counter}"
+        self._reserved_slots.add(token)
+        return token, ReplicaQueueLengthInfo(
+            accepted=True,
+            num_ongoing_requests=len(self._reserved_slots),
+        )
+
+    async def release_slot(self, slot_token: str) -> ReplicaQueueLengthInfo:
+        """Release a reserved slot."""
+        self._reserved_slots.discard(slot_token)
+        return ReplicaQueueLengthInfo(
+            accepted=True,
+            num_ongoing_requests=len(self._reserved_slots),
+        )
+
+    def send_request_with_slot(
+        self, pr: PendingRequest, slot_token: str
+    ) -> FakeReplicaResult:
+        """Send request using a reserved slot."""
+        assert slot_token in self._reserved_slots, f"Invalid slot token: {slot_token}"
+
+        # Create result same way as try_send_request
+        if pr.metadata.is_streaming:
+            return FakeReplicaResult(self._replica_id, is_generator_object=True)
+        else:
+            return FakeReplicaResult(self._replica_id, is_generator_object=False)
+
     def try_send_request(
         self, pr: PendingRequest, with_rejection: bool
     ) -> FakeReplicaResult:
@@ -139,6 +206,17 @@ class FakeReplica(RunningReplica):
         # Real replicas can raise here when with_rejection=False (e.g. broadcast path).
         if self._error:
             raise self._error
+
+        # Track the request
+        if pr.metadata._reserved_slot_token:
+            self._reserved_slots.discard(pr.metadata._reserved_slot_token)
+
+        self._requests_sent.append(
+            {
+                "request_id": pr.metadata.request_id,
+                "with_rejection": with_rejection,
+            }
+        )
 
         if with_rejection:
             assert (
@@ -214,6 +292,15 @@ class FakeRequestRouter(RequestRouter):
         if self._use_queue_len_cache:
             num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
             self._replica_queue_len_cache.update(replica_id, num_ongoing_requests + 1)
+
+    def on_replica_result_finished(self, replica_id: ReplicaID):
+        """Decrement queue length cache when a request finishes or is cancelled."""
+        if self._use_queue_len_cache:
+            num_ongoing_requests = self._replica_queue_len_cache.get(replica_id) or 0
+            if num_ongoing_requests > 0:
+                self._replica_queue_len_cache.update(
+                    replica_id, num_ongoing_requests - 1
+                )
 
     def on_replica_actor_unavailable(self, replica_id: ReplicaID):
         self._replica_queue_len_cache.invalidate_key(replica_id)
@@ -1253,6 +1340,441 @@ class TestAssignRequest:
 
         # After the request is routed, on_request_routed_called should be False.
         assert fake_request_router.on_request_routed_called is True
+
+
+@pytest.mark.asyncio
+class TestChooseReplica:
+    """Tests for choose_replica() and dispatch() flow."""
+
+    async def test_choose_replica_raises_deployment_unavailable(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """choose_replica fails when deployment is marked unavailable."""
+        router, _ = setup_router
+        router._deployment_available = False
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        with pytest.raises(DeploymentUnavailableError):
+            async with router.choose_replica(request_metadata):
+                pass
+
+    async def test_choose_replica_raises_backpressure(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """choose_replica raises BackPressureError when queue limit is reached."""
+        router, _ = setup_router
+        router.update_deployment_config(DeploymentConfig(max_queued_requests=1))
+        # Bump num_queued_requests to 1 to simulate a full queue
+        router._metrics_manager.inc_num_queued_requests()
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        with pytest.raises(BackPressureError):
+            async with router.choose_replica(request_metadata):
+                pass
+
+    async def test_basic_choose_and_dispatch(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test basic choose_replica() and dispatch() workflow."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+            call_method="test_method",
+        )
+
+        # Choose replica
+        async with router.choose_replica(request_metadata) as selection:
+            # Verify selection contains correct information
+            assert selection.replica_id == r1_id.unique_id
+            assert selection._replica == replica
+            assert selection._method_name == "test_method"
+            assert selection._slot_token in replica._reserved_slots
+
+            # Dispatch request
+            replica_result = await router.dispatch(selection, request_metadata)
+            assert replica_result._replica_id == r1_id
+            assert not replica_result._is_generator_object
+
+        # After context exit, slot should be released
+        assert selection._slot_token not in replica._reserved_slots
+
+    async def test_choose_without_dispatch_releases_slot(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test that exiting context without dispatch releases the slot."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        slot_token = None
+        async with router.choose_replica(request_metadata) as selection:
+            slot_token = selection._slot_token
+            assert slot_token in replica._reserved_slots
+            # Exit without calling dispatch
+
+        # After context exit, slot should be released
+        assert slot_token not in replica._reserved_slots
+
+    async def test_choose_with_exception_releases_slot(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test that exception in context releases the slot."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        slot_token = None
+        with pytest.raises(RuntimeError):
+            async with router.choose_replica(request_metadata) as selection:
+                slot_token = selection._slot_token
+                assert slot_token in replica._reserved_slots
+                raise RuntimeError("Test exception")
+
+        # After exception, slot should be released
+        assert slot_token not in replica._reserved_slots
+
+    @pytest.mark.parametrize("is_streaming", [False, True])
+    async def test_choose_and_dispatch_streaming(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+        is_streaming: bool,
+    ):
+        """Test choose_replica() and dispatch() with streaming requests."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+            is_streaming=is_streaming,
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            replica_result = await router.dispatch(selection, request_metadata)
+            assert replica_result._replica_id == r1_id
+            if is_streaming:
+                assert replica_result._is_generator_object
+            else:
+                assert not replica_result._is_generator_object
+
+    async def test_slot_reservation_mock_interaction(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test that reserve_slot and send_request_with_slot are called correctly."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        # Track initial state
+        initial_slot_count = replica._slot_counter
+
+        async with router.choose_replica(request_metadata) as selection:
+            # Verify reserve_slot was called
+            assert replica._slot_counter == initial_slot_count + 1
+            assert len(replica._reserved_slots) == 1
+
+            # Dispatch and verify send_request_with_slot works
+            replica_result = await router.dispatch(selection, request_metadata)
+            assert replica_result._replica_id == r1_id
+
+    async def test_multiple_sequential_selections(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test multiple sequential choose_replica() and dispatch() calls."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        for i in range(3):
+            request_metadata = RequestMetadata(
+                request_id=f"test-request-{i}",
+                internal_request_id=f"test-internal-request-{i}",
+            )
+
+            async with router.choose_replica(request_metadata) as selection:
+                replica_result = await router.dispatch(selection, request_metadata)
+                assert replica_result._replica_id == r1_id
+
+        # All slots should have been created and used
+        assert replica._slot_counter == 3
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_cache_updated_on_choose_replica(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test that queue length cache is updated when choosing a replica."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        # Initially cache should be empty
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) is None
+
+        # Choose replica should update cache to 1
+        async with router.choose_replica(request_metadata) as selection:
+            assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+
+            # Dispatch should NOT increment again (already counted in choose)
+            await router.dispatch(selection, request_metadata)
+            assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+
+        # After dispatch, cache remains incremented while the request is in flight.
+        # It is decremented when request completion is observed.
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_cache_decremented_on_choose_without_dispatch(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test that cache is decremented when choose exits without dispatch."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        # Choose replica without dispatch
+        async with router.choose_replica(request_metadata):
+            # Cache should be 1 (reservation)
+            assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+            # Exit without calling dispatch
+
+        # After context exit without dispatch, cache should be decremented to 0
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 0
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_choose_replica_retries_when_reservation_rejected(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """choose_replica should only yield after replica-side capacity is reserved."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        r2_id = ReplicaID(
+            unique_id="test-replica-2", deployment_id=DeploymentID(name="test")
+        )
+        r1 = FakeReplica(r1_id)
+        r2 = FakeReplica(r2_id)
+        r1._reject_reservation = True
+        fake_request_router.set_replica_to_return(r1)
+        fake_request_router.set_replica_to_return_on_retry(r2)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            assert selection._replica == r2
+            assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+            assert fake_request_router.replica_queue_len_cache.get(r2_id) == 1
+
+        assert fake_request_router.replica_queue_len_cache.get(r2_id) == 0
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_concurrent_choose_replica_updates_cache(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test that concurrent choose_replica calls correctly update cache."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        # Start 3 concurrent choose_replica operations
+        async def choose_and_hold(request_id: str):
+            metadata = RequestMetadata(
+                request_id=request_id,
+                internal_request_id=request_id,
+            )
+            async with router.choose_replica(metadata) as selection:
+                # Hold the selection
+                await asyncio.sleep(0.01)
+                return selection
+
+        # Create tasks
+        tasks = [asyncio.create_task(choose_and_hold(f"request-{i}")) for i in range(3)]
+
+        # Wait a bit for all to enter context
+        await asyncio.sleep(0.005)
+
+        # Cache should reflect all 3 reservations
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 3
+
+        # Let them all exit
+        await asyncio.gather(*tasks)
+
+        # After all exit without dispatch, cache should be 0
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 0
+
+    async def test_dispatch_replica_unavailable(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test dispatch() raises error when replica becomes unavailable."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            # Simulate replica becoming unavailable
+            fake_request_router._replica_to_return = None
+
+            # dispatch should raise ReplicaUnavailableError
+            with pytest.raises(ReplicaUnavailableError):
+                await router.dispatch(selection, request_metadata)
+
+    async def test_dispatch_uses_reserved_slot(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Test that dispatch() sends request using reserved slot without rejection."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            # Verify no requests sent yet
+            assert len(replica._requests_sent) == 0
+
+            # Dispatch the request
+            replica_result = await router.dispatch(selection, request_metadata)
+            assert replica_result._replica_id == r1_id
+
+        # Verify request was sent with with_rejection=False
+        assert len(replica._requests_sent) == 1
+        assert replica._requests_sent[0]["request_id"] == "test-request-1"
+        assert replica._requests_sent[0]["with_rejection"] is False
+
+    async def test_multiple_dispatch_calls_fail(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """A ReplicaSelection can only be dispatched once."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            await router.dispatch(selection, request_metadata)
+
+            with pytest.raises(RuntimeError, match="already been dispatched"):
+                await router.dispatch(selection, request_metadata)
+
+        assert len(replica._requests_sent) == 1
 
 
 def running_replica_info(replica_id: ReplicaID) -> RunningReplicaInfo:

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1424,6 +1424,23 @@ class TestChooseReplica:
         # After context exit, slot should be released
         assert slot_token not in replica._reserved_slots
 
+    async def test_choose_without_dispatch_does_not_fire_on_request_completed(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """on_request_completed shouldn't fire if the caller exits without dispatching."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        fake_request_router.set_replica_to_return(FakeReplica(r1_id))
+
+        async with router.choose_replica(dummy_request_metadata()):
+            pass  # Exit without dispatch.
+
+        assert fake_request_router.on_request_routed_called is False
+        assert fake_request_router.completed_requests == []
+
     async def test_choose_with_exception_releases_slot(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
     ):

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -128,6 +128,7 @@ class FakeReplica(RunningReplica):
         self._requests_sent = []  # Track all requests sent to this replica
         self._reject_reservation = False
         self._reservation_queue_len = 1
+        self._release_slot_error: Optional[Exception] = None
 
         # Create a minimal _replica_info object to satisfy router.py requirements
         self._replica_info = Mock()
@@ -181,8 +182,14 @@ class FakeReplica(RunningReplica):
 
     async def release_slot(self, slot_token: str) -> int:
         """Release a reserved slot."""
+        if self._release_slot_error is not None:
+            raise self._release_slot_error
         self._reserved_slots.discard(slot_token)
         return len(self._reserved_slots)
+
+    def set_release_slot_error(self, error: Optional[Exception]) -> None:
+        """Configure release_slot to raise the given error (or clear with None)."""
+        self._release_slot_error = error
 
     def send_request_with_slot(
         self, pr: PendingRequest, slot_token: str
@@ -1688,6 +1695,58 @@ class TestChooseReplica:
 
         # After all exit without dispatch, cache should be 0
         assert fake_request_router.replica_queue_len_cache.get(r1_id) == 0
+
+    async def test_release_failure_does_not_leak_reserved_slots_metric(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """If the release call raises during choose_replica cleanup, the
+        reserved-slots gauge must still decrement — otherwise it leaks for the
+        process lifetime — and the exception must not propagate to the caller.
+        """
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        replica.set_release_slot_error(RuntimeError("simulated release failure"))
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        before = router._metrics_manager._num_reserved_slots
+        async with router.choose_replica(request_metadata):
+            assert router._metrics_manager._num_reserved_slots == before + 1
+        # Exit ran cleanly even though release raised.
+        assert router._metrics_manager._num_reserved_slots == before
+
+    async def test_dispatch_failure_is_not_masked_by_release_failure(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """If both `try_send_request` and the cleanup `release_slot` raise, the
+        caller must see the original dispatch error, not the release error.
+        """
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        dispatch_error = RuntimeError("dispatch boom")
+        replica = FakeReplica(r1_id, error=dispatch_error)
+        replica.set_release_slot_error(RuntimeError("release boom"))
+        fake_request_router.set_replica_to_return(replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            with pytest.raises(RuntimeError, match="dispatch boom"):
+                await router.dispatch(selection, request_metadata)
 
     async def test_dispatch_replica_unavailable(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1687,6 +1687,52 @@ class TestChooseReplica:
         # After all exit without dispatch, cache should be 0
         assert fake_request_router.replica_queue_len_cache.get(r1_id) == 0
 
+    async def test_reserved_slots_gauge_increments_and_decrements(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Gauge goes 0 → 1 → 0 across choose+dispatch and choose-without-dispatch.
+
+        Asserts the underlying `.set()` calls too, so bumping the counter
+        without pushing to the gauge is caught.
+        """
+        router, fake_request_router = setup_router
+
+        gauge_mock = Mock()
+        router._metrics_manager._reserved_slots_gauge = gauge_mock
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        # Choose + dispatch path.
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+        assert router._metrics_manager._num_reserved_slots == 0
+        async with router.choose_replica(request_metadata) as selection:
+            assert router._metrics_manager._num_reserved_slots == 1
+            gauge_mock.set.assert_called_with(1)
+            await router.dispatch(selection, request_metadata)
+
+        assert router._metrics_manager._num_reserved_slots == 0
+        gauge_mock.set.assert_called_with(0)
+
+        # Choose without dispatch: same gauge transition must hold.
+        gauge_mock.reset_mock()
+        request_metadata = RequestMetadata(
+            request_id="test-request-2",
+            internal_request_id="test-internal-request-2",
+        )
+        async with router.choose_replica(request_metadata):
+            assert router._metrics_manager._num_reserved_slots == 1
+            gauge_mock.set.assert_called_with(1)
+
+        assert router._metrics_manager._num_reserved_slots == 0
+        gauge_mock.set.assert_called_with(0)
+
     async def test_release_failure_does_not_leak_reserved_slots_metric(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
     ):

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -13,7 +13,12 @@ import pytest
 import ray
 from ray._common.test_utils import async_wait_for_condition, wait_for_condition
 from ray._common.utils import get_or_create_event_loop
-from ray.exceptions import ActorDiedError, ActorUnavailableError, RayTaskError
+from ray.exceptions import (
+    ActorDiedError,
+    ActorUnavailableError,
+    RayTaskError,
+    TaskCancelledError,
+)
 from ray.serve._private.common import (
     DeploymentHandleSource,
     DeploymentID,
@@ -1749,6 +1754,95 @@ class TestChooseReplica:
             assert router._metrics_manager._num_reserved_slots == before + 1
         # Exit ran cleanly even though release raised.
         assert router._metrics_manager._num_reserved_slots == before
+
+    async def test_inc_reserved_slots_failure_releases_slot(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """If gauge.set() throws during inc, cleanup must still release the
+        slot and rebalance the counter."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        # Raise only on inc's set(1); the cleanup's set(0) must still run.
+        gauge_mock = Mock()
+        gauge_mock.set = Mock(
+            side_effect=lambda v: (_ for _ in ()).throw(RuntimeError("gauge boom"))
+            if v > 0
+            else None
+        )
+        router._metrics_manager._reserved_slots_gauge = gauge_mock
+
+        with pytest.raises(RuntimeError, match="gauge boom"):
+            async with router.choose_replica(dummy_request_metadata()):
+                pass
+
+        assert replica._reserved_slots == set()
+        assert router._metrics_manager._num_reserved_slots == 0
+
+    @pytest.mark.parametrize(
+        "callback_result,expect_release",
+        [
+            pytest.param(None, False, id="actor_success"),
+            pytest.param(TaskCancelledError(), True, id="actor_cancellation"),
+            pytest.param(
+                Mock(cancelled=Mock(return_value=False)),
+                False,
+                id="grpc_success",
+            ),
+            pytest.param(
+                Mock(cancelled=Mock(return_value=True)),
+                True,
+                id="grpc_cancellation",
+            ),
+        ],
+    )
+    async def test_dispatch_release_slot_fires_only_on_cancellation(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+        callback_result,
+        expect_release,
+    ):
+        """Done-callback fires release_slot only when the dispatched
+        request was cancelled. On success the replica already consumed the
+        slot when try_send_request arrived, so a follow-up RPC would be a
+        no-op per dispatched request. Covers both transports."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        release_slot_calls: List[str] = []
+        original_release_slot = replica.release_slot
+
+        async def spy_release_slot(slot_token):
+            release_slot_calls.append(slot_token)
+            return await original_release_slot(slot_token)
+
+        replica.release_slot = spy_release_slot
+
+        request_metadata = dummy_request_metadata()
+        async with router.choose_replica(request_metadata) as selection:
+            slot_token = selection._slot_token
+            result = await router.dispatch(selection, request_metadata)
+
+        # try_send_request consumed the slot synchronously; the done-callback
+        # hasn't fired yet, so no release_slot call should have happened.
+        assert release_slot_calls == []
+
+        result.fire_done_callbacks(result=callback_result)
+        # Drain the call_soon_threadsafe → create_task chain.
+        for _ in range(2):
+            await asyncio.sleep(0)
+
+        assert release_slot_calls == ([slot_token] if expect_release else [])
 
     async def test_dispatch_failure_is_not_masked_by_release_failure(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1371,40 +1371,6 @@ class TestChooseReplica:
             async with router.choose_replica(request_metadata):
                 pass
 
-    async def test_basic_choose_and_dispatch(
-        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
-    ):
-        """Test basic choose_replica() and dispatch() workflow."""
-        router, fake_request_router = setup_router
-
-        r1_id = ReplicaID(
-            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
-        )
-        replica = FakeReplica(r1_id)
-        fake_request_router.set_replica_to_return(replica)
-
-        request_metadata = RequestMetadata(
-            request_id="test-request-1",
-            internal_request_id="test-internal-request-1",
-            call_method="test_method",
-        )
-
-        # Choose replica
-        async with router.choose_replica(request_metadata) as selection:
-            # Verify selection contains correct information
-            assert selection.replica_id == r1_id.unique_id
-            assert selection._replica == replica
-            assert selection._method_name == "test_method"
-            assert selection._slot_token in replica._reserved_slots
-
-            # Dispatch request
-            replica_result = await router.dispatch(selection, request_metadata)
-            assert replica_result._replica_id == r1_id
-            assert not replica_result._is_generator_object
-
-        # After context exit, slot should be released
-        assert selection._slot_token not in replica._reserved_slots
-
     async def test_choose_without_dispatch_releases_slot(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
     ):
@@ -1459,12 +1425,14 @@ class TestChooseReplica:
         assert slot_token not in replica._reserved_slots
 
     @pytest.mark.parametrize("is_streaming", [False, True])
-    async def test_choose_and_dispatch_streaming(
+    async def test_choose_and_dispatch(
         self,
         setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
         is_streaming: bool,
     ):
-        """Test choose_replica() and dispatch() with streaming requests."""
+        """Happy path: selection fields are populated, dispatch sends with
+        with_rejection=False (slot reservation replaces the rejection
+        round-trip), and the slot is released on exit."""
         router, fake_request_router = setup_router
 
         r1_id = ReplicaID(
@@ -1476,45 +1444,23 @@ class TestChooseReplica:
         request_metadata = RequestMetadata(
             request_id="test-request-1",
             internal_request_id="test-internal-request-1",
+            call_method="test_method",
             is_streaming=is_streaming,
         )
 
         async with router.choose_replica(request_metadata) as selection:
+            assert selection.replica_id == r1_id.unique_id
+            assert selection._replica == replica
+            assert selection._method_name == "test_method"
+            assert selection._slot_token in replica._reserved_slots
+
             replica_result = await router.dispatch(selection, request_metadata)
             assert replica_result._replica_id == r1_id
-            if is_streaming:
-                assert replica_result._is_generator_object
-            else:
-                assert not replica_result._is_generator_object
+            assert replica_result._is_generator_object == is_streaming
 
-    async def test_slot_reservation_mock_interaction(
-        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
-    ):
-        """Test that reserve_slot and send_request_with_slot are called correctly."""
-        router, fake_request_router = setup_router
-
-        r1_id = ReplicaID(
-            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
-        )
-        replica = FakeReplica(r1_id)
-        fake_request_router.set_replica_to_return(replica)
-
-        request_metadata = RequestMetadata(
-            request_id="test-request-1",
-            internal_request_id="test-internal-request-1",
-        )
-
-        # Track initial state
-        initial_slot_count = replica._slot_counter
-
-        async with router.choose_replica(request_metadata) as selection:
-            # Verify reserve_slot was called
-            assert replica._slot_counter == initial_slot_count + 1
-            assert len(replica._reserved_slots) == 1
-
-            # Dispatch and verify send_request_with_slot works
-            replica_result = await router.dispatch(selection, request_metadata)
-            assert replica_result._replica_id == r1_id
+        assert selection._slot_token not in replica._reserved_slots
+        assert len(replica._requests_sent) == 1
+        assert replica._requests_sent[0]["with_rejection"] is False
 
     async def test_multiple_sequential_selections(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
@@ -1809,36 +1755,6 @@ class TestChooseReplica:
             # dispatch should raise ReplicaUnavailableError
             with pytest.raises(ReplicaUnavailableError):
                 await router.dispatch(selection, request_metadata)
-
-    async def test_dispatch_uses_reserved_slot(
-        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
-    ):
-        """Test that dispatch() sends request using reserved slot without rejection."""
-        router, fake_request_router = setup_router
-
-        r1_id = ReplicaID(
-            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
-        )
-        replica = FakeReplica(r1_id)
-        fake_request_router.set_replica_to_return(replica)
-
-        request_metadata = RequestMetadata(
-            request_id="test-request-1",
-            internal_request_id="test-internal-request-1",
-        )
-
-        async with router.choose_replica(request_metadata) as selection:
-            # Verify no requests sent yet
-            assert len(replica._requests_sent) == 0
-
-            # Dispatch the request
-            replica_result = await router.dispatch(selection, request_metadata)
-            assert replica_result._replica_id == r1_id
-
-        # Verify request was sent with with_rejection=False
-        assert len(replica._requests_sent) == 1
-        assert replica._requests_sent[0]["request_id"] == "test-request-1"
-        assert replica._requests_sent[0]["with_rejection"] is False
 
     async def test_multiple_dispatch_calls_fail(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -564,6 +564,33 @@ class TestRunningReplicaSlotReservation:
         reserved_token = actor_handle.reserve_slot.remote.call_args[0][1]
         assert released_token == reserved_token
 
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ActorUnavailableError(error_message="unavailable", actor_id=None),
+            ActorDiedError(),
+            RuntimeError("boom"),
+        ],
+    )
+    async def test_exception_releases_reserved_slot(self, exc):
+        # If reserve_slot's reply fails (e.g. ActorUnavailableError),
+        # the actor may have already reserved the slot. Best-effort
+        # release_slot.remote() prevents the leak.
+        pending = asyncio.get_running_loop().create_future()
+        pending.set_exception(exc)
+        actor_handle = Mock()
+        actor_handle.reserve_slot.remote = Mock(return_value=pending)
+        actor_handle.release_slot.remote = Mock()
+        replica = FakeRunningReplicaForSlotReservation(actor_handle)
+
+        with pytest.raises(type(exc)):
+            await replica.reserve_slot(dummy_request_metadata())
+
+        actor_handle.release_slot.remote.assert_called_once()
+        released_token = actor_handle.release_slot.remote.call_args[0][0]
+        reserved_token = actor_handle.reserve_slot.remote.call_args[0][1]
+        assert released_token == reserved_token
+
 
 @pytest.mark.asyncio
 class TestBroadcast:


### PR DESCRIPTION
## Description
This PR implemented `choose_replica` and `dispatch` flow on `AsyncioRouter` by consuming primitives introduced by #63252.

- `AsyncioRouter.choose_replica`
  - `@asynccontextmanager` that picks a replica via the request router, calls `replica.reserve_slot()`, feeds the returned `num_ongoing_requests` into `on_new_queue_len_info`, and yields a `ReplicaSelection`.
  - Retries on `ActorDiedError`, `ActorUnavailableError`, or replica-side `accepted=False`.
  - `__aexit__` calls `release_slot` if the selection wasn't dispatched, which frees the replica's semaphore and refreshes the cache from the actor's reported queue length.
- `AsyncioRouter.dispatch` / `_dispatch_to_marked_selection`
  - Verifies the replica is still in `curr_replicas`, injects `_reserved_slot_token` into the request metadata, sends with `with_rejection=False` (the replica recognizes the token on the way in and skips re-acquiring the semaphore).
  - Releases the slot on dispatch failure or cancellation.
  - `_release_slot_if_still_reserved` is registered as a done callback for every dispatched result.
- Reserved-slots metric on `RouterMetricsManager` (`inc_reserved_slots` / `dec_reserved_slots`).


### What's still missing in this PR (coming in https://github.com/ray-project/ray/pull/63255)

| Gap |
|---|
| `Router` abstract base doesn't declare `choose_replica` / `dispatch`, so `SingletonThreadRouter` and `CurrentLoopRouter` don't implement them. Callers can only use `AsyncioRouter` directly. |
| `DeploymentHandle` has no `choose_replica` / `dispatch` — there's no public API yet. |
| `local_testing_mode` `LocalRouter` has no choose/dispatch placeholder. |

## Tests
- **Refusal paths**: `test_choose_replica_raises_deployment_unavailable`, `test_choose_replica_raises_backpressure`.
- **Happy path** (parametrized streaming + non-streaming): `test_choose_and_dispatch`.
- **Slot release on every exit shape**: `test_choose_without_dispatch_releases_slot`, `test_choose_with_exception_releases_slot`, `test_release_failure_does_not_leak_reserved_slots_metric` (gauge stays accurate even when `release_slot` itself raises), `test_dispatch_failure_is_not_masked_by_release_failure` (original dispatch error survives a release-time failure).
- **Retry semantics**: `test_choose_replica_retries_when_reservation_rejected` (replica returns `accepted=False` → retry on a different replica).
- **Queue-length cache invariants**: `test_cache_updated_on_choose_replica`, `test_cache_decremented_on_choose_without_dispatch`, `test_concurrent_choose_replica_updates_cache`.
- **Reserved-slots gauge**: `test_reserved_slots_gauge_increments_and_decrements` asserts the `0 → 1 → 0` transition on both the dispatch and the no-dispatch path, via both the internal counter and the underlying `Gauge.set()` calls.
- **Dispatch-time failure modes**: `test_dispatch_replica_unavailable` (replica disappears between reserve and dispatch), `test_multiple_dispatch_calls_fail` (double-dispatch raises).
- **Sequential reuse**: `test_multiple_sequential_selections`.

## Related issues
RFC: https://github.com/ray-project/ray/issues/59792
Original PR: https://github.com/ray-project/ray/pull/60865

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
