### PR TITLE
[serve][3/3] Expose `choose_replica`/`dispatch` on deployment handles

### DIFF
--- a/python/ray/serve/_private/local_testing_mode.py
+++ b/python/ray/serve/_private/local_testing_mode.py
@@ -4,8 +4,19 @@ import inspect
 import logging
 import queue
 import time
+from contextlib import asynccontextmanager
 from functools import wraps
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Coroutine,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import ray
 from ray import cloudpickle
@@ -16,6 +27,7 @@ from ray.serve._private.constants import (
 )
 from ray.serve._private.replica import UserCallableWrapper
 from ray.serve._private.replica_result import ReplicaResult
+from ray.serve._private.request_router.replica_wrapper import ReplicaSelection
 from ray.serve._private.router import Router
 from ray.serve._private.utils import GENERATOR_COMPOSITION_NOT_SUPPORTED_ERROR
 from ray.serve.deployment import Deployment
@@ -340,6 +352,39 @@ class LocalRouter(Router):
             )
         )
         return noop_future
+
+    @asynccontextmanager
+    async def choose_replica(
+        self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> AsyncIterator[ReplicaSelection]:
+        """Choose replica is not supported in local testing mode.
+
+        This is a stub implementation to satisfy the Router ABC interface.
+        """
+        raise NotImplementedError(
+            "choose_replica is not supported in local testing mode. "
+            "Use assign_request instead."
+        )
+        yield  # Make this a generator for asynccontextmanager
+
+    def dispatch(
+        self,
+        selection: ReplicaSelection,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> concurrent.futures.Future[ReplicaResult]:
+        """Dispatch is not supported in local testing mode.
+
+        This is a stub implementation to satisfy the Router ABC interface.
+        """
+        raise NotImplementedError(
+            "dispatch is not supported in local testing mode. "
+            "Use assign_request instead."
+        )
 
     async def broadcast(
         self,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1780,7 +1780,7 @@ class SingletonThreadRouter(Router):
             A concurrent.futures.Future that resolves to the ReplicaResult.
         """
         # Extract operation name from coroutine for logging
-        operation_name = coro.__name__ if hasattr(coro, "__name__") else "operation"
+        operation_name = coro.__name__
 
         def asyncio_future_callback(
             asyncio_future: asyncio.Future, concurrent_future: concurrent.futures.Future

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1753,7 +1753,9 @@ class SingletonThreadRouter(Router):
             future = asyncio.run_coroutine_threadsafe(
                 exit_context(context_manager, *exc_info), self._asyncio_loop
             )
-            await asyncio.wrap_future(future)
+            # Shielded so a cancel landing during cleanup doesn't propagate
+            # through wrap_future and abort __aexit__ on the router loop.
+            await asyncio.shield(asyncio.wrap_future(future))
 
     def dispatch(
         self,

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1728,19 +1728,30 @@ class SingletonThreadRouter(Router):
             selection = await cm.__aenter__()
             return selection, cm
 
+        async def exit_context(cm, exc_type, exc_val, exc_tb):
+            return await cm.__aexit__(exc_type, exc_val, exc_tb)
+
         future = asyncio.run_coroutine_threadsafe(enter_context(), self._asyncio_loop)
-        selection, context_manager = await asyncio.wrap_future(future)
+        try:
+            selection, context_manager = await asyncio.wrap_future(future)
+        except BaseException:
+            # Cancelled after __aenter__ reserved the slot but before we
+            # observed the result: exit the entered CM to release the slot.
+            if future.done() and not future.cancelled() and future.exception() is None:
+                entered_cm = future.result()[1]
+                exc_info = sys.exc_info()
+                cleanup = asyncio.run_coroutine_threadsafe(
+                    exit_context(entered_cm, *exc_info), self._asyncio_loop
+                )
+                await asyncio.shield(asyncio.wrap_future(cleanup))
+            raise
 
         try:
             yield selection
         finally:
-            # Exit context on router loop
-            async def exit_context(exc_type, exc_val, exc_tb):
-                return await context_manager.__aexit__(exc_type, exc_val, exc_tb)
-
             exc_info = sys.exc_info()
             future = asyncio.run_coroutine_threadsafe(
-                exit_context(*exc_info), self._asyncio_loop
+                exit_context(context_manager, *exc_info), self._asyncio_loop
             )
             await asyncio.wrap_future(future)
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -580,7 +580,7 @@ class Router(ABC):
         *request_args,
         **request_kwargs,
     ) -> AsyncIterator[ReplicaSelection]:
-        pass
+        yield
 
     @abstractmethod
     def dispatch(

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import logging
+import sys
 import threading
 import time
 import weakref
@@ -565,6 +566,26 @@ class Router(ABC):
     @abstractmethod
     def assign_request(
         self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> concurrent.futures.Future[ReplicaResult]:
+        pass
+
+    @abstractmethod
+    @asynccontextmanager
+    async def choose_replica(
+        self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> AsyncIterator[ReplicaSelection]:
+        pass
+
+    @abstractmethod
+    def dispatch(
+        self,
+        selection: ReplicaSelection,
         request_meta: RequestMetadata,
         *request_args,
         **request_kwargs,
@@ -1681,6 +1702,85 @@ class SingletonThreadRouter(Router):
             A concurrent.futures.Future resolving to the ReplicaResult representing
             the assigned request.
         """
+        return self._wrap_asyncio_call_in_future(
+            self._asyncio_router.assign_request(
+                request_meta, *request_args, **request_kwargs
+            )
+        )
+
+    @asynccontextmanager
+    async def choose_replica(
+        self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> AsyncIterator[ReplicaSelection]:
+        """Bridge async context manager to router event loop.
+
+        This ensures choose_replica runs on the singleton router loop,
+        maintaining thread safety for all state modifications.
+        """
+        # Enter context on router loop
+        async def enter_context():
+            cm = self._asyncio_router.choose_replica(
+                request_meta, *request_args, **request_kwargs
+            )
+            selection = await cm.__aenter__()
+            return selection, cm
+
+        future = asyncio.run_coroutine_threadsafe(enter_context(), self._asyncio_loop)
+        selection, context_manager = await asyncio.wrap_future(future)
+
+        try:
+            yield selection
+        finally:
+            # Exit context on router loop
+            async def exit_context(exc_type, exc_val, exc_tb):
+                return await context_manager.__aexit__(exc_type, exc_val, exc_tb)
+
+            exc_info = sys.exc_info()
+            future = asyncio.run_coroutine_threadsafe(
+                exit_context(*exc_info), self._asyncio_loop
+            )
+            await asyncio.wrap_future(future)
+
+    def dispatch(
+        self,
+        selection: ReplicaSelection,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> concurrent.futures.Future[ReplicaResult]:
+        """Dispatch request to a previously selected replica."""
+        try:
+            selection._mark_dispatched()
+        except Exception as exc:
+            future = concurrent.futures.Future()
+            future.set_exception(exc)
+            return future
+
+        return self._wrap_asyncio_call_in_future(
+            self._asyncio_router._dispatch_to_marked_selection(
+                selection, request_meta, *request_args, **request_kwargs
+            )
+        )
+
+    def _wrap_asyncio_call_in_future(
+        self,
+        coro: Coroutine,
+    ) -> concurrent.futures.Future[ReplicaResult]:
+        """Wrap an async call in a concurrent.futures.Future for cross-thread execution.
+
+        This is a helper method to execute AsyncioRouter's async methods on the dedicated asyncio event loop thread.
+
+        Args:
+            coro: The coroutine to execute (e.g., _asyncio_router.assign_request(...))
+
+        Returns:
+            A concurrent.futures.Future that resolves to the ReplicaResult.
+        """
+        # Extract operation name from coroutine for logging
+        operation_name = coro.__name__ if hasattr(coro, "__name__") else "operation"
 
         def asyncio_future_callback(
             asyncio_future: asyncio.Future, concurrent_future: concurrent.futures.Future
@@ -1701,19 +1801,15 @@ class SingletonThreadRouter(Router):
             ):
                 result: ReplicaResult = asyncio_future.result()
                 logger.info(
-                    "Asyncio task completed despite cancellation attempt. "
-                    "Attempting to cancel the request that was assigned to a replica."
+                    f"Asyncio task completed despite cancellation attempt during {operation_name}. "
+                    "Attempting to cancel the request."
                 )
                 result.cancel()
 
         concurrent_future = concurrent.futures.Future()
 
         def create_task_and_setup():
-            task = self._asyncio_loop.create_task(
-                self._asyncio_router.assign_request(
-                    request_meta, *request_args, **request_kwargs
-                )
-            )
+            task = self._asyncio_loop.create_task(coro)
 
             # Set up your cancellation callback
             task.add_done_callback(
@@ -1863,6 +1959,43 @@ class CurrentLoopRouter(Router):
             self._asyncio_router.assign_request(
                 request_meta, *request_args, **request_kwargs
             ),
+        )
+
+    @asynccontextmanager
+    async def choose_replica(
+        self,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> AsyncIterator[ReplicaSelection]:
+        """Delegate to AsyncioRouter's choose_replica."""
+        async with self._asyncio_router.choose_replica(
+            request_meta, *request_args, **request_kwargs
+        ) as selection:
+            yield selection
+
+    def dispatch(
+        self,
+        selection: ReplicaSelection,
+        request_meta: RequestMetadata,
+        *request_args,
+        **request_kwargs,
+    ) -> asyncio.Future[ReplicaResult]:
+        """Dispatch request to a previously selected replica.
+
+        Returns an asyncio.Future wrapping the async dispatch call.
+        """
+        try:
+            selection._mark_dispatched()
+        except Exception as exc:
+            future = self._asyncio_loop.create_future()
+            future.set_exception(exc)
+            return future
+
+        return self._asyncio_loop.create_task(
+            self._asyncio_router._dispatch_to_marked_selection(
+                selection, request_meta, *request_args, **request_kwargs
+            )
         )
 
     async def broadcast(

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -256,12 +256,6 @@ class _DeploymentHandleBase(Generic[T]):
     ) -> AsyncIterator[ReplicaSelection]:
         """Execute the request router to select a replica without dispatching."""
         router, metadata = self._init_router_and_get_metadata()
-        self.request_counter.inc(
-            tags={
-                "route": metadata.route,
-                "application": metadata.app_name,
-            }
-        )
 
         # Call the router's choose_replica and inject the deployment handle
         async with router.choose_replica(metadata, *args, **kwargs) as selection:
@@ -288,6 +282,12 @@ class _DeploymentHandleBase(Generic[T]):
             )
 
         metadata = selection._request_metadata
+        self.request_counter.inc(
+            tags={
+                "route": metadata.route,
+                "application": metadata.app_name,
+            }
+        )
         router = self._init_router()
         return router.dispatch(selection, metadata, *args, **kwargs), metadata
 
@@ -1266,7 +1266,8 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
             ValueError: If selection was created by a different DeploymentHandle.
         """
         future, request_metadata = self._dispatch(selection, args, kwargs)
-        if self.handle_options.stream:
+        # Use the stream flag captured at choose_replica time
+        if request_metadata.is_streaming:
             return DeploymentResponseGenerator(
                 future,
                 request_metadata,

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import logging
 import time
 import warnings
+from contextlib import asynccontextmanager
 from typing import (
     Any,
     AsyncIterator,
@@ -18,6 +19,8 @@ from typing import (
     Union,
     cast,
 )
+
+from typing_extensions import AsyncContextManager
 
 import ray
 from ray import serve
@@ -40,6 +43,7 @@ from ray.serve._private.handle_options import (
     InitHandleOptionsBase,
 )
 from ray.serve._private.replica_result import ReplicaResult
+from ray.serve._private.request_router.replica_wrapper import ReplicaSelection
 from ray.serve._private.router import Router
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import (
@@ -182,6 +186,24 @@ class _DeploymentHandleBase(Generic[T]):
             return False
         return self.init_options._run_router_in_separate_loop
 
+    def _init_router(self) -> Router:
+        if not self.is_initialized:
+            self._init()
+
+        if self._router is None:
+            raise RuntimeError("Router is not initialized")
+
+        return self._router
+
+    def _init_router_and_get_metadata(self) -> Tuple[Router, RequestMetadata]:
+        router = self._init_router()
+
+        metadata = serve._private.default_impl.get_request_metadata(
+            self.init_options, self.handle_options
+        )
+
+        return router, metadata
+
     def _options(
         self, _prefer_local_routing=DEFAULT.VALUE, **kwargs
     ) -> "DeploymentHandle[T]":
@@ -216,12 +238,7 @@ class _DeploymentHandleBase(Generic[T]):
         args: Tuple[Any],
         kwargs: Dict[str, Any],
     ) -> Tuple[concurrent.futures.Future, RequestMetadata]:
-        if not self.is_initialized:
-            self._init()
-
-        metadata = serve._private.default_impl.get_request_metadata(
-            self.init_options, self.handle_options
-        )
+        router, metadata = self._init_router_and_get_metadata()
 
         self.request_counter.inc(
             tags={
@@ -229,10 +246,50 @@ class _DeploymentHandleBase(Generic[T]):
                 "application": metadata.app_name,
             }
         )
-        if self._router is None:
-            raise RuntimeError("Router is not initialized")
+        return router.assign_request(metadata, *args, **kwargs), metadata
 
-        return self._router.assign_request(metadata, *args, **kwargs), metadata
+    @asynccontextmanager
+    async def _choose_replica(
+        self,
+        args: Tuple[Any],
+        kwargs: Dict[str, Any],
+    ) -> AsyncIterator[ReplicaSelection]:
+        """Execute the request router to select a replica without dispatching."""
+        router, metadata = self._init_router_and_get_metadata()
+        self.request_counter.inc(
+            tags={
+                "route": metadata.route,
+                "application": metadata.app_name,
+            }
+        )
+
+        # Call the router's choose_replica and inject the deployment handle
+        async with router.choose_replica(metadata, *args, **kwargs) as selection:
+            # Record the owning deployment for dispatch-time validation.
+            selection._deployment_id = self.deployment_id
+            yield selection
+
+    def _dispatch(
+        self,
+        selection: ReplicaSelection,
+        args: Tuple[Any],
+        kwargs: Dict[str, Any],
+    ) -> Tuple[concurrent.futures.Future, RequestMetadata]:
+        """Dispatch a request to a previously selected replica."""
+        # Validate that the selection belongs to the same deployment
+        if (
+            selection._deployment_id is not None
+            and selection._deployment_id != self.deployment_id
+        ):
+            raise ValueError(
+                f"Cannot dispatch a selection created for a different deployment. "
+                f"This handle is for {self.deployment_id}, but the selection was created "
+                f"for {selection._deployment_id}."
+            )
+
+        metadata = selection._request_metadata
+        router = self._init_router()
+        return router.dispatch(selection, metadata, *args, **kwargs), metadata
 
     def options(
         self,
@@ -1132,6 +1189,73 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
         """
 
         future, request_metadata = self._remote(args, kwargs)
+        if self.handle_options.stream:
+            return DeploymentResponseGenerator(
+                future,
+                request_metadata,
+                _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+            )
+        else:
+            return DeploymentResponse(
+                future,
+                request_metadata,
+                _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+            )
+
+    def choose_replica(
+        self,
+        *args: Any,
+        **kwargs: Any,
+    ) -> AsyncContextManager[ReplicaSelection]:
+        """Execute the request router to select a replica without dispatching.
+
+        This method runs the full routing logic (load balancing, locality awareness,
+        queue length probing, etc.) and returns an async context manager that yields
+        a ReplicaSelection. A request slot is reserved on the selected replica,
+        guaranteeing that dispatch will succeed.
+
+        The context manager ensures proper cleanup:
+        - If dispatch() is called, the slot is consumed normally.
+        - If the context exits without dispatch (e.g., exception, early return), the slot is released.
+
+        Args:
+            *args: Arguments that may influence routing decisions
+            **kwargs: Keyword arguments that may influence routing decisions.
+
+        Returns:
+            AsyncContextManager[ReplicaSelection] - must be used with async with.
+        """
+        return self._choose_replica(args, kwargs)
+
+    def dispatch(
+        self,
+        selection: ReplicaSelection,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]]:
+        """Dispatch a request to a previously selected replica.
+
+        By default, the result is a `DeploymentResponse` that can be awaited to fetch
+        the result of the call. Like `.remote()`, `DeploymentResponse` objects can be
+        passed as arguments for deployment composition.
+
+        If `handle.options(stream=True)` is set and a generator method is called, this
+        returns a `DeploymentResponseGenerator` instead.
+        If the selected replica becomes unavailable before dispatch executes,
+        ``ReplicaUnavailableError`` is propagated from the router dispatch path.
+
+        Args:
+            selection: A ReplicaSelection from choose_replica() context manager.
+            *args: The request arguments to send to the replica.
+            **kwargs: The request keyword arguments to send to the replica.
+
+        Returns:
+            DeploymentResponse or DeploymentResponseGenerator (if streaming).
+
+        Raises:
+            ValueError: If selection was created by a different DeploymentHandle.
+        """
+        future, request_metadata = self._dispatch(selection, args, kwargs)
         if self.handle_options.stream:
             return DeploymentResponseGenerator(
                 future,

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -1218,6 +1218,9 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
         - If dispatch() is called, the slot is consumed normally.
         - If the context exits without dispatch (e.g., exception, early return), the slot is released.
 
+        The method name is determined at ``choose_replica`` time. Any method name on
+        the handle passed to ``dispatch`` is ignored.
+
         Args:
             *args: Arguments that may influence routing decisions
             **kwargs: Keyword arguments that may influence routing decisions.
@@ -1243,6 +1246,13 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
         returns a `DeploymentResponseGenerator` instead.
         If the selected replica becomes unavailable before dispatch executes,
         ``ReplicaUnavailableError`` is propagated from the router dispatch path.
+
+        The returned response must be awaited before the ``choose_replica`` context
+        exits. The router fires ``on_request_completed`` exactly once per dispatched
+        request to decrement its queue-length cache. Exiting the context with an
+        unawaited response fires it twice — once during context cleanup, then again
+        when the deferred dispatch task eventually completes — leaving the cache
+        under-counted.
 
         Args:
             selection: A ReplicaSelection from choose_replica() context manager.

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -270,11 +270,8 @@ class _DeploymentHandleBase(Generic[T]):
         kwargs: Dict[str, Any],
     ) -> Tuple[concurrent.futures.Future, RequestMetadata]:
         """Dispatch a request to a previously selected replica."""
-        # Validate that the selection belongs to the same deployment
-        if (
-            selection._deployment_id is not None
-            and selection._deployment_id != self.deployment_id
-        ):
+        # Validate that the selection was produced for this deployment
+        if selection._deployment_id != self.deployment_id:
             raise ValueError(
                 f"Cannot dispatch a selection created for a different deployment. "
                 f"This handle is for {self.deployment_id}, but the selection was created "

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -6,12 +6,17 @@ import pytest
 import ray
 from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
-from ray.serve._private.common import OBJ_REF_NOT_SUPPORTED_ERROR
+from ray.serve._private.common import (
+    OBJ_REF_NOT_SUPPORTED_ERROR,
+    DeploymentID,
+    RequestMetadata,
+)
 from ray.serve._private.replica_result import (
     ActorReplicaResult,
     ReplicaResult,
     gRPCReplicaResult,
 )
+from ray.serve._private.request_router.replica_wrapper import ReplicaSelection
 from ray.serve.handle import DeploymentHandle
 from ray.serve.tests.conftest import *  # noqa
 from ray.serve.tests.conftest import _shared_serve_instance  # noqa
@@ -121,6 +126,29 @@ def test_compose_apps(serve_instance, inner_by_reference, outer_by_reference):
         ).result()
         == "app1|app2|hi1|hi2|app2|hi3|hi4"
     )
+
+
+def test_dispatch_rejects_selection_from_different_deployment():
+    handle = DeploymentHandle("deployment-a", "app")
+    selection = ReplicaSelection(
+        replica_id="replica-1",
+        node_ip="127.0.0.1",
+        port=None,
+        node_id="node-1",
+        availability_zone=None,
+        _replica=object(),
+        _deployment_id=DeploymentID(name="deployment-b", app_name="app"),
+        _request_metadata=RequestMetadata(
+            request_id="request-id",
+            internal_request_id="internal-request-id",
+            call_method="__call__",
+        ),
+        _method_name="__call__",
+        _slot_token="slot-1",
+    )
+
+    with pytest.raises(ValueError, match="different deployment"):
+        handle.dispatch(selection)
 
 
 @pytest.mark.asyncio

--- a/python/ray/serve/tests/test_handle_1.py
+++ b/python/ray/serve/tests/test_handle_1.py
@@ -2,6 +2,7 @@ import asyncio
 import concurrent.futures
 import sys
 import threading
+from contextlib import AsyncExitStack
 from typing import Any
 
 import pytest
@@ -13,6 +14,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
     SERVE_DEFAULT_APP_NAME,
 )
+from ray.serve.api import get_replica_context
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import DeploymentHandle
 
@@ -337,6 +339,239 @@ def test_response_used_in_multiple_calls(serve_instance):
 
     h = serve.run(Ingress.bind(F.bind()))
     assert h.remote().result(timeout_s=10) == ("((r1))", "((r1))")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_choose_replica_and_dispatch_single(serve_instance):
+    """Test choose_replica + dispatch for simple single selection pattern."""
+
+    @serve.deployment(num_replicas=2)
+    class Backend:
+        def process(self, msg: str):
+            replica_id = get_replica_context().replica_id.unique_id
+            return {"actual_replica_id": replica_id, "response": msg}
+
+    @serve.deployment
+    class SimpleProxy:
+        def __init__(self, backend: DeploymentHandle):
+            self.backend = backend
+
+        async def handle_request(self, request: str):
+            # Context manager ensures slot is released if dispatch fails or is skipped
+            async with self.backend.process.choose_replica(request) as selection:
+                assert selection.replica_id is not None
+                assert selection.node_ip is not None
+
+                # Dispatch to the selected replica
+                response = await self.backend.process.dispatch(selection, request)
+
+                # Return both the selection and the response for verification
+                return {"selected_replica_id": selection.replica_id, **response}
+
+    h = serve.run(SimpleProxy.bind(Backend.bind()))
+    result = await h.handle_request.remote("test_message")
+
+    # Verify the result contains the message
+    assert result["response"] == "test_message"
+
+    # Verify that dispatch sent the request to the replica we selected
+    assert result["actual_replica_id"] == result["selected_replica_id"], (
+        f"dispatch sent request to wrong replica: "
+        f"selected {result['selected_replica_id']}, but got response from {result['actual_replica_id']}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_choose_replica_early_return_releases_slot(serve_instance):
+    """Early return from choose_replica should release the reserved slot."""
+
+    @serve.deployment(num_replicas=1, max_ongoing_requests=1)
+    class Backend:
+        def process(self, msg: str):
+            return msg
+
+    @serve.deployment
+    class Proxy:
+        def __init__(self, backend: DeploymentHandle):
+            self.backend = backend
+
+        async def handle_request(self, request: str):
+            async with self.backend.process.choose_replica(request):
+                pass
+
+            # Ensure the second choose_replica request work
+            async with self.backend.process.choose_replica(request) as selection:
+                response = await asyncio.wait_for(
+                    self.backend.process.dispatch(selection, request), timeout=2
+                )
+                return response
+
+    h = serve.run(Proxy.bind(Backend.bind()))
+    assert await h.handle_request.remote("test_message") == "test_message"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_choose_replica_exception_releases_slot(serve_instance):
+    """Exception in choose_replica context should release the reserved slot."""
+
+    @serve.deployment(num_replicas=1, max_ongoing_requests=1)
+    class Backend:
+        def process(self, msg: str):
+            return msg
+
+    @serve.deployment
+    class Proxy:
+        def __init__(self, backend: DeploymentHandle):
+            self.backend = backend
+
+        async def handle_request(self, request: str):
+            try:
+                async with self.backend.process.choose_replica(request):
+                    raise RuntimeError("test exception")
+            except RuntimeError:
+                pass
+
+            # Ensure the second choose_replica request work
+            async with self.backend.process.choose_replica(request) as selection:
+                response = await asyncio.wait_for(
+                    self.backend.process.dispatch(selection, request), timeout=2
+                )
+                return response
+
+    h = serve.run(Proxy.bind(Backend.bind()))
+    assert await h.handle_request.remote("test_message") == "test_message"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_choose_replica_and_dispatch_streaming(serve_instance):
+    """Test choose_replica + dispatch with handle.options(stream=True)."""
+
+    @serve.deployment(num_replicas=2)
+    class Backend:
+        async def stream(self, msg: str):
+            replica_id = get_replica_context().replica_id.unique_id
+            for i in range(3):
+                yield {"actual_replica_id": replica_id, "chunk": f"{msg}-{i}"}
+
+    @serve.deployment
+    class StreamingProxy:
+        def __init__(self, backend: DeploymentHandle):
+            self.backend_stream = backend.stream.options(stream=True)
+
+        async def handle_request(self, request: str):
+            async with self.backend_stream.choose_replica(request) as selection:
+                gen = self.backend_stream.dispatch(selection, request)
+                chunks = [item async for item in gen]
+                return {"selected_replica_id": selection.replica_id, "chunks": chunks}
+
+    h = serve.run(StreamingProxy.bind(Backend.bind()))
+    result = await h.handle_request.remote("stream_test")
+
+    assert [item["chunk"] for item in result["chunks"]] == [
+        "stream_test-0",
+        "stream_test-1",
+        "stream_test-2",
+    ]
+    assert all(
+        item["actual_replica_id"] == result["selected_replica_id"]
+        for item in result["chunks"]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_choose_replica_and_dispatch_parallel(serve_instance):
+    """Test parallel selection pattern (e.g., PD proxy) using AsyncExitStack."""
+
+    @serve.deployment(num_replicas=2)
+    class PrefillServer:
+        def chat(self, msg: str):
+            replica_id = get_replica_context().replica_id.unique_id
+            return {"actual_replica_id": replica_id, "response": msg}
+
+    @serve.deployment(num_replicas=2)
+    class DecodeServer:
+        def chat(self, msg: str):
+            replica_id = get_replica_context().replica_id.unique_id
+            return {"actual_replica_id": replica_id, "response": msg}
+
+    @serve.deployment
+    class PDProxy:
+        def __init__(
+            self,
+            prefill_server: DeploymentHandle,
+            decode_server: DeploymentHandle,
+        ):
+            self.prefill = prefill_server
+            self.decode = decode_server
+
+        async def handle_request(self, request: str):
+            # Use AsyncExitStack to manage multiple context managers in parallel
+            async with AsyncExitStack() as stack:
+                #  Select and RESERVE replicas from BOTH deployments in parallel
+                p_selection, d_selection = await asyncio.gather(
+                    stack.enter_async_context(self.prefill.chat.choose_replica()),
+                    stack.enter_async_context(self.decode.chat.choose_replica()),
+                )
+
+                p_msg = f"prefill:{request}"
+                d_msg = f"decode:{request}"
+
+                # Dispatch to both selected replicas
+                p_result, d_result = await asyncio.gather(
+                    self.prefill.chat.dispatch(p_selection, p_msg),
+                    self.decode.chat.dispatch(d_selection, d_msg),
+                )
+                return {
+                    "prefill": {
+                        "selected_replica_id": p_selection.replica_id,
+                        **p_result,
+                    },
+                    "decode": {
+                        "selected_replica_id": d_selection.replica_id,
+                        **d_result,
+                    },
+                }
+
+    h = serve.run(PDProxy.bind(PrefillServer.bind(), DecodeServer.bind()))
+    result = await h.handle_request.remote("test_parallel")
+
+    assert result["prefill"]["response"] == "prefill:test_parallel"
+    assert result["decode"]["response"] == "decode:test_parallel"
+
+    # Verify that dispatch sent the request to the replica we selected
+    assert (
+        result["prefill"]["actual_replica_id"]
+        == result["prefill"]["selected_replica_id"]
+    ), (
+        f"dispatch sent request to wrong replica for prefill: "
+        f"selected {result['prefill']['selected_replica_id']}, but got response from {result['prefill']['actual_replica_id']}"
+    )
+    assert (
+        result["decode"]["actual_replica_id"] == result["decode"]["selected_replica_id"]
+    ), (
+        f"dispatch sent request to wrong replica for decode: "
+        f"selected {result['decode']['selected_replica_id']}, but got response from {result['decode']['actual_replica_id']}"
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_handle_1.py
+++ b/python/ray/serve/tests/test_handle_1.py
@@ -574,5 +574,49 @@ async def test_choose_replica_and_dispatch_parallel(serve_instance):
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_choose_replica_cancel_releases_slot_across_loop_boundary(
+    serve_instance,
+):
+    """Cancelling a task holding a selection must release the slot, even when
+    the router lives on a different thread (SingletonThreadRouter)."""
+
+    @serve.deployment(num_replicas=1, max_ongoing_requests=1)
+    class Backend:
+        def process(self, msg: str):
+            return msg
+
+    handle = serve.run(Backend.bind())
+    # Warm up so the cancellation isn't racing initialization.
+    assert await handle.process.remote("warmup") == "warmup"
+
+    ready = asyncio.Event()
+    never_set = asyncio.Event()
+
+    async def hold():
+        async with handle.process.choose_replica("first"):
+            ready.set()
+            await never_set.wait()
+
+    task = asyncio.create_task(hold())
+    await asyncio.wait_for(ready.wait(), timeout=5)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Hangs if the cancelled task leaked the only slot.
+    async with handle.process.choose_replica("second") as selection:
+        result = await asyncio.wait_for(
+            handle.process.dispatch(selection, "second"),
+            timeout=5,
+        )
+    assert result == "second"
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_handle_1.py
+++ b/python/ray/serve/tests/test_handle_1.py
@@ -16,7 +16,7 @@ from ray.serve._private.constants import (
 )
 from ray.serve.api import get_replica_context
 from ray.serve.exceptions import RayServeException
-from ray.serve.handle import DeploymentHandle
+from ray.serve.handle import DeploymentHandle, DeploymentResponseGenerator
 
 
 @pytest.mark.skipif(
@@ -616,6 +616,87 @@ async def test_choose_replica_cancel_releases_slot_across_loop_boundary(
             timeout=5,
         )
     assert result == "second"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_dispatch_wrapper_uses_choose_replica_stream_flag(serve_instance):
+    """Wrapper type follows metadata.is_streaming, not the dispatching handle."""
+
+    @serve.deployment
+    class Backend:
+        async def stream(self, msg: str):
+            yield f"{msg}-0"
+            yield f"{msg}-1"
+
+    @serve.deployment
+    class Proxy:
+        def __init__(self, backend: DeploymentHandle):
+            self.stream_handle = backend.stream.options(stream=True)
+            self.dispatch_handle = backend.stream  # default stream=False
+
+        async def run(self, msg: str) -> bool:
+            async with self.stream_handle.choose_replica(msg) as sel:
+                resp = self.dispatch_handle.dispatch(sel, msg)
+                is_gen = isinstance(resp, DeploymentResponseGenerator)
+                if is_gen:
+                    async for _ in resp:
+                        pass
+                else:
+                    try:
+                        await resp
+                    except Exception:
+                        pass
+            return is_gen
+
+    h = serve.run(Proxy.bind(Backend.bind()))
+    assert await h.run.remote("test") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
+async def test_request_counter_only_increments_on_dispatch(serve_instance):
+    """request_counter ticks per dispatched request, not per choose_replica."""
+
+    @serve.deployment
+    class Backend:
+        def process(self, msg: str):
+            return msg
+
+    @serve.deployment
+    class Caller:
+        def __init__(self, backend: DeploymentHandle):
+            self.handle = backend.process
+
+        async def run(self, dispatch_too: bool) -> int:
+            inc_calls: list = []
+            original_inc = self.handle.request_counter.inc
+
+            def tracking_inc(*args, **kwargs):
+                inc_calls.append(1)
+                return original_inc(*args, **kwargs)
+
+            self.handle.request_counter.inc = tracking_inc
+            try:
+                if dispatch_too:
+                    async with self.handle.choose_replica("msg") as sel:
+                        await self.handle.dispatch(sel, "msg")
+                else:
+                    async with self.handle.choose_replica("msg"):
+                        pass
+                return len(inc_calls)
+            finally:
+                self.handle.request_counter.inc = original_inc
+
+    h = serve.run(Caller.bind(Backend.bind()))
+    assert await h.run.remote(False) == 0
+    assert await h.run.remote(True) == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_handle_1.py
+++ b/python/ray/serve/tests/test_handle_1.py
@@ -661,6 +661,38 @@ async def test_dispatch_wrapper_uses_choose_replica_stream_flag(serve_instance):
     RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
     reason="local_testing_mode doesn't support choose_replica/dispatch",
 )
+async def test_dispatch_rejects_selection_without_deployment_id(serve_instance):
+    """dispatch must reject a selection whose deployment_id is unset."""
+
+    @serve.deployment
+    class Backend:
+        def process(self, msg: str):
+            return msg
+
+    @serve.deployment
+    class Caller:
+        def __init__(self, backend: DeploymentHandle):
+            self.handle = backend.process
+
+        async def run(self) -> str:
+            async with self.handle.choose_replica("msg") as sel:
+                sel._deployment_id = None
+                try:
+                    resp = self.handle.dispatch(sel, "msg")
+                except ValueError:
+                    return "raised"
+                await resp
+                return "no_raise"
+
+    h = serve.run(Caller.bind(Backend.bind()))
+    assert await h.run.remote() == "raised"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    RAY_SERVE_FORCE_LOCAL_TESTING_MODE,
+    reason="local_testing_mode doesn't support choose_replica/dispatch",
+)
 async def test_request_counter_only_increments_on_dispatch(serve_instance):
     """request_counter ticks per dispatched request, not per choose_replica."""
 

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -2539,6 +2539,90 @@ class TestSingletonThreadRouter:
         )
 
     @pytest.mark.asyncio
+    async def test_finally_shields_cleanup_from_cancellation(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+        setup_singleton_thread_router: SingletonThreadRouter,
+        monkeypatch,
+    ):
+        """Cancellation during the bridge's finally must not abort cleanup on
+        the router loop. The cleanup await is shielded so __aexit__ runs to
+        completion even if a cancel arrives while we're awaiting it.
+        """
+        fake_router, _ = setup_router
+        thread_router = setup_singleton_thread_router
+        router_loop = thread_router._get_singleton_asyncio_loop(component="unknown")
+
+        fake_selection = ReplicaSelection(
+            replica_id="fake-replica",
+            node_ip="127.0.0.1",
+            port=None,
+            node_id="fake-node",
+            availability_zone=None,
+            _replica=None,
+            _deployment_id=None,
+            _request_metadata=None,
+            _method_name="",
+            _slot_token="",
+        )
+
+        aexit_started = threading.Event()
+        exit_called = threading.Event()
+
+        async def make_event():
+            return asyncio.Event()
+
+        release_event = await asyncio.wrap_future(
+            asyncio.run_coroutine_threadsafe(make_event(), router_loop)
+        )
+
+        @asynccontextmanager
+        async def fake_choose_replica(*args, **kwargs):
+            try:
+                yield fake_selection
+            finally:
+                # Signal that the bridge's finally is now awaiting cleanup.
+                aexit_started.set()
+                # Block until released. If a cancel propagates through to
+                # this loop the wait raises and exit_called is never set.
+                await release_event.wait()
+                exit_called.set()
+
+        monkeypatch.setattr(fake_router, "choose_replica", fake_choose_replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async def runner():
+            async with thread_router.choose_replica(request_metadata):
+                pass
+
+        task = asyncio.create_task(runner())
+
+        # Wait until the bridge's finally is awaiting cleanup.
+        await asyncio.to_thread(aexit_started.wait)
+
+        # Cancel mid-cleanup. Without shielding, the cancel propagates
+        # through wrap_future to the router-loop task and interrupts
+        # fake's __aexit__ before it can set exit_called.
+        task.cancel()
+        await asyncio.sleep(0)
+
+        # Release the gate. With shielding, fake's __aexit__ will now
+        # complete and set exit_called.
+        router_loop.call_soon_threadsafe(release_event.set)
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert exit_called.wait(timeout=2.0), (
+            "Cleanup was aborted by cancellation propagating to the router "
+            "loop; bridge's finally await must be shielded."
+        )
+
+    @pytest.mark.asyncio
     async def test_cancellation_propagation(
         self,
         setup_router: Tuple[AsyncioRouter, FakeRequestRouter],

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -43,6 +43,7 @@ from ray.serve._private.request_router.common import ReplicaQueueLengthCache
 from ray.serve._private.router import (
     QUEUED_REQUESTS_KEY,
     AsyncioRouter,
+    CurrentLoopRouter,
     RouterMetricsManager,
     SingletonThreadRouter,
 )
@@ -1578,6 +1579,84 @@ class TestChooseReplica:
         [{"enable_queue_len_cache": True}],
         indirect=True,
     )
+    async def test_current_loop_dispatch_marks_selection_before_task_runs(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """Wrapper dispatch should consume the selection before its task runs."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        current_loop_router = CurrentLoopRouter.__new__(CurrentLoopRouter)
+        current_loop_router._asyncio_loop = asyncio.get_running_loop()
+        current_loop_router._asyncio_router = router
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            dispatch_task = current_loop_router.dispatch(selection, request_metadata)
+            assert selection._dispatched
+            assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+        assert len(replica._requests_sent) == 0
+
+        replica_result = await dispatch_task
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+
+        replica_result.fire_done_callbacks()
+        await asyncio.sleep(0)
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 0
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_current_loop_dispatch_failure_releases_cache(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        """If wrapper dispatch fails after consuming a selection, it owns cleanup."""
+        router, fake_request_router = setup_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        current_loop_router = CurrentLoopRouter.__new__(CurrentLoopRouter)
+        current_loop_router._asyncio_loop = asyncio.get_running_loop()
+        current_loop_router._asyncio_router = router
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with router.choose_replica(request_metadata) as selection:
+            fake_request_router._replica_to_return = None
+            dispatch_task = current_loop_router.dispatch(selection, request_metadata)
+            assert selection._dispatched
+
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+
+        with pytest.raises(ReplicaUnavailableError):
+            await dispatch_task
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 0
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_queue_len_cache": True}],
+        indirect=True,
+    )
     async def test_cache_decremented_on_choose_without_dispatch(
         self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
     ):
@@ -2330,6 +2409,52 @@ class TestSingletonThreadRouter:
         future = thread_router.assign_request(request_metadata)
         assert isinstance(future, concurrent.futures.Future)
         assert future.result()._replica_id == r1_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_dispatch_marks_selection_before_scheduled_coroutine_runs(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+        setup_singleton_thread_router: SingletonThreadRouter,
+        monkeypatch,
+    ):
+        _, fake_request_router = setup_router
+        thread_router = setup_singleton_thread_router
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(r1_id)
+        fake_request_router.set_replica_to_return(replica)
+
+        pending_coros = []
+
+        def delay_asyncio_call(coro):
+            pending_coros.append(coro)
+            return concurrent.futures.Future()
+
+        monkeypatch.setattr(
+            thread_router, "_wrap_asyncio_call_in_future", delay_asyncio_call
+        )
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async with thread_router.choose_replica(request_metadata) as selection:
+            dispatch_future = thread_router.dispatch(selection, request_metadata)
+            assert selection._dispatched
+
+        assert fake_request_router.replica_queue_len_cache.get(r1_id) == 1
+        assert len(pending_coros) == 1
+
+        dispatch_future.cancel()
+        pending_coros[0].close()
 
     @pytest.mark.asyncio
     async def test_cancellation_propagation(

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -4,6 +4,7 @@ import random
 import sys
 import threading
 from collections import defaultdict
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from typing import Callable, Dict, List, Optional, Set, Tuple
 from unittest.mock import Mock, patch
@@ -40,6 +41,7 @@ from ray.serve._private.request_router import (
     RunningReplica,
 )
 from ray.serve._private.request_router.common import ReplicaQueueLengthCache
+from ray.serve._private.request_router.replica_wrapper import ReplicaSelection
 from ray.serve._private.router import (
     QUEUED_REQUESTS_KEY,
     AsyncioRouter,
@@ -2455,6 +2457,86 @@ class TestSingletonThreadRouter:
 
         dispatch_future.cancel()
         pending_coros[0].close()
+
+    @pytest.mark.asyncio
+    async def test_choose_replica_cancel_during_entry_releases_slot(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+        setup_singleton_thread_router: SingletonThreadRouter,
+        monkeypatch,
+    ):
+        """Cancellation between __aenter__ completing on the router loop and
+        wrap_future returning on the outer loop must still call __aexit__.
+
+        The race: the inner CM's __aenter__ runs on the router loop and
+        reserves a slot. The bridge's concurrent.futures.Future is set, but
+        the outer task is cancelled before observing the result. If the
+        bridge doesn't protect this gap, ``context_manager`` is unbound
+        when the bridge returns, __aexit__ never runs, and the slot is
+        leaked.
+        """
+        fake_router, _ = setup_router
+        thread_router = setup_singleton_thread_router
+        outer_loop = asyncio.get_running_loop()
+
+        fake_selection = ReplicaSelection(
+            replica_id="fake-replica",
+            node_ip="127.0.0.1",
+            port=None,
+            node_id="fake-node",
+            availability_zone=None,
+            _replica=None,
+            _deployment_id=None,
+            _request_metadata=None,
+            _method_name="",
+            _slot_token="",
+        )
+
+        exit_called = threading.Event()
+        outer_task_holder: List[asyncio.Task] = []
+
+        @asynccontextmanager
+        async def fake_choose_replica(*args, **kwargs):
+            # Wait so the outer task enters `await wrap_future(...)` before
+            # we finish entry; otherwise the router loop races past and the
+            # cancellation window never opens.
+            await asyncio.sleep(0.05)
+
+            def cancel_outer():
+                if outer_task_holder:
+                    outer_task_holder[0].cancel()
+
+            # Queue cancel_outer on the outer loop *before* we return.
+            # Returning fires the bridge's future, which then queues
+            # set_result on the outer loop -- behind cancel_outer (FIFO).
+            # So the outer task is cancelled before it sees the result.
+            outer_loop.call_soon_threadsafe(cancel_outer)
+            try:
+                yield fake_selection
+            finally:
+                exit_called.set()
+
+        monkeypatch.setattr(fake_router, "choose_replica", fake_choose_replica)
+
+        request_metadata = RequestMetadata(
+            request_id="test-request-1",
+            internal_request_id="test-internal-request-1",
+        )
+
+        async def runner():
+            async with thread_router.choose_replica(request_metadata):
+                pass
+
+        task = asyncio.create_task(runner())
+        outer_task_holder.append(task)
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert exit_called.wait(timeout=2.0), (
+            "Slot leaked: __aexit__ was not called after outer task was "
+            "cancelled between __aenter__ completing and wrap_future returning."
+        )
 
     @pytest.mark.asyncio
     async def test_cancellation_propagation(


### PR DESCRIPTION
## Description
Plumb `choose_replica` and `dispatch` through `DeploymentHandle`, not just the underlying `AsyncioRouter` which https://github.com/ray-project/ray/pull/63254 ends at.

### Deployment handle
- `DeploymentHandle.choose_replica()` / `dispatch(selection, ...)` validates that the selection belongs to this deployment.

### SingletonThreadRouter / CurrentLoopRouter
- `SingletonThreadRouter.choose_replica`: bridges the async context manager onto the router thread via `run_coroutine_threadsafe`, so all state mutations happen on the singleton router loop.
- `SingletonThreadRouter.dispatch` and `CurrentLoopRouter.dispatch`: both call `selection._mark_dispatched()` *synchronously* before scheduling the dispatch coroutine, so the `choose_replica` `__aexit__` cleanup can't race with the dispatch task. (The race would otherwise double-decrement the queue-length cache on `CurrentLoopRouter`, where `__aexit__` runs synchronously without yielding.)
- `CurrentLoopRouter.choose_replica`: thin async-with passthrough since it shares an event loop with the caller.

### Test-only router
- `LocalRouter` placeholder in `local_testing_mode`: `choose_replica` / `dispatch` raise `NotImplementedError` because the local-testing path invokes user callables directly and doesn't exercise router selection.

## Benchmark
The overhead of `choose_replica() + dispatch()` over `remote()` is constant. This is consistent with the one extra `run_coroutine_threadsafe` round-trip: `remote` does one thread crossing, `choose_dispatch` does two (one for the `__aenter__` bridge, one for the `_dispatch_to_marked_selection` task). Replica count doesn't change the delta, as the overhead is in the bridge, not routing.

<img width="1311" height="417" alt="Screenshot 2026-05-11 at 7 38 36 PM" src="https://github.com/user-attachments/assets/ea107abc-0b8f-480d-9833-86de3fe18267" />


## Related issues
RFC: https://github.com/ray-project/ray/issues/59792
Original PR: https://github.com/ray-project/ray/pull/60865
Next PR: Metric changes https://github.com/ray-project/ray/pull/62356

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
