### PR TITLE
[core] Populating if actor is detached actor or not in TaskEvents proto

### DIFF
--- a/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
+++ b/cpp/src/ray/runtime/task/local_mode_task_submitter.cc
@@ -94,7 +94,8 @@ ObjectID LocalModeTaskSubmitter::Submit(InvocationSpec &invocation,
                              /*retry_exceptions=*/false,
                              /*serialized_retry_exception_allowlist=*/"",
                              invocation.sequence_number,
-                             /*tensor_transport=*/std::nullopt);
+                             /*tensor_transport=*/std::nullopt,
+                             /*is_detached_actor=*/false);
   } else {
     throw RayException("unknown task type");
   }

--- a/src/ray/common/protobuf_utils.cc
+++ b/src/ray/common/protobuf_utils.cc
@@ -197,6 +197,9 @@ void FillTaskInfo(rpc::TaskInfoEntry *task_info, const TaskSpecification &task_s
   } else if (task_spec.IsActorCreationTask()) {
     type = rpc::TaskType::ACTOR_CREATION_TASK;
     task_info->set_actor_id(task_spec.ActorCreationId().Binary());
+    if (task_spec.IsDetachedActor()) {
+      task_info->set_is_detached_actor(true);
+    }
   } else {
     RAY_CHECK(task_spec.IsActorTask());
     type = rpc::TaskType::ACTOR_TASK;

--- a/src/ray/common/protobuf_utils.cc
+++ b/src/ray/common/protobuf_utils.cc
@@ -197,13 +197,13 @@ void FillTaskInfo(rpc::TaskInfoEntry *task_info, const TaskSpecification &task_s
   } else if (task_spec.IsActorCreationTask()) {
     type = rpc::TaskType::ACTOR_CREATION_TASK;
     task_info->set_actor_id(task_spec.ActorCreationId().Binary());
-    if (task_spec.IsDetachedActor()) {
-      task_info->set_is_detached_actor(true);
-    }
   } else {
     RAY_CHECK(task_spec.IsActorTask());
     type = rpc::TaskType::ACTOR_TASK;
     task_info->set_actor_id(task_spec.ActorId().Binary());
+  }
+  if (task_spec.IsDetachedActor()) {
+    task_info->set_is_detached_actor(true);
   }
   task_info->set_type(type);
   task_info->set_name(task_spec.GetName());

--- a/src/ray/common/task/task_spec.cc
+++ b/src/ray/common/task/task_spec.cc
@@ -513,7 +513,13 @@ bool TaskSpecification::IsAsyncioActor() const {
 }
 
 bool TaskSpecification::IsDetachedActor() const {
-  return IsActorCreationTask() && message_->actor_creation_task_spec().is_detached();
+  if (IsActorCreationTask()) {
+    return message_->actor_creation_task_spec().is_detached();
+  }
+  if (IsActorTask()) {
+    return message_->actor_task_spec().is_detached_actor();
+  }
+  return false;
 }
 
 std::string TaskSpecification::DebugString() const {

--- a/src/ray/common/task/task_util.h
+++ b/src/ray/common/task/task_util.h
@@ -305,7 +305,8 @@ class TaskSpecBuilder {
       bool retry_exceptions,
       const std::string &serialized_retry_exception_allowlist,
       uint64_t concurrency_group_sequence_number,
-      const std::optional<std::string> &tensor_transport) {
+      const std::optional<std::string> &tensor_transport,
+      bool is_detached_actor) {
     message_->set_type(TaskType::ACTOR_TASK);
     message_->set_max_retries(max_retries);
     message_->set_retry_exceptions(retry_exceptions);
@@ -316,6 +317,7 @@ class TaskSpecBuilder {
     actor_spec->set_actor_creation_dummy_object_id(
         actor_creation_dummy_object_id.Binary());
     actor_spec->set_concurrency_group_sequence_number(concurrency_group_sequence_number);
+    actor_spec->set_is_detached_actor(is_detached_actor);
     if (tensor_transport.has_value()) {
       message_->set_tensor_transport(*tensor_transport);
     }

--- a/src/ray/core_worker/actor_management/actor_handle.cc
+++ b/src/ray/core_worker/actor_management/actor_handle.cc
@@ -158,7 +158,8 @@ void ActorHandle::SetActorTaskSpec(
                            retry_exceptions,
                            serialized_retry_exception_allowlist,
                            concurrency_group_counters_[concurrency_group_name]++,
-                           tensor_transport);
+                           tensor_transport,
+                           inner_.is_detached());
 }
 
 void ActorHandle::SetResubmittedActorTaskSpec(TaskSpecification &spec) {

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -266,9 +266,9 @@ void TaskStatusEvent::PopulateRpcRayTaskDefinitionEvent(T &definition_event_data
         task_spec_->FunctionDescriptor()->GetMessage());
     definition_event_data.set_task_type(task_spec_->GetMessage().type());
     definition_event_data.set_task_name(task_spec_->GetName());
-    if (task_spec_->IsDetachedActor()) {
-      definition_event_data.set_is_detached_actor(true);
-    }
+  }
+  if (task_spec_->IsDetachedActor()) {
+    definition_event_data.set_is_detached_actor(true);
   }
 }
 

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -266,6 +266,9 @@ void TaskStatusEvent::PopulateRpcRayTaskDefinitionEvent(T &definition_event_data
         task_spec_->FunctionDescriptor()->GetMessage());
     definition_event_data.set_task_type(task_spec_->GetMessage().type());
     definition_event_data.set_task_name(task_spec_->GetName());
+    if (task_spec_->IsDetachedActor()) {
+      definition_event_data.set_is_detached_actor(true);
+    }
   }
 }
 

--- a/src/ray/core_worker/tests/task_manager_test.cc
+++ b/src/ray/core_worker/tests/task_manager_test.cc
@@ -897,8 +897,14 @@ TEST_F(TaskManagerLineageTest, TestActorLineagePinned) {
       0,
       TaskID::Nil(),
       "");
-  builder.SetActorTaskSpec(
-      actor_id, actor_creation_dummy_object_id, num_retries, false, "", 0, std::nullopt);
+  builder.SetActorTaskSpec(actor_id,
+                           actor_creation_dummy_object_id,
+                           num_retries,
+                           false,
+                           "",
+                           0,
+                           std::nullopt,
+                           /*is_detached_actor=*/false);
   TaskSpecification spec = std::move(builder).ConsumeAndBuild();
 
   ASSERT_EQ(reference_counter_->NumObjectIDsInScope(), 0);

--- a/src/ray/gcs/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_ray_event_converter.cc
@@ -103,6 +103,9 @@ rpc::TaskEvents ConvertToTaskEvents(rpc::events::TaskDefinitionEvent &&event) {
   if (event.task_type() == rpc::TaskType::ACTOR_CREATION_TASK) {
     const auto actor_id = TaskID::FromBinary(event.task_id()).ActorId();
     task_info->set_actor_id(actor_id.Binary());
+    if (event.is_detached_actor()) {
+      task_info->set_is_detached_actor(true);
+    }
   }
   if (!event.placement_group_id().empty()) {
     task_info->set_placement_group_id(event.placement_group_id());

--- a/src/ray/gcs/gcs_ray_event_converter.cc
+++ b/src/ray/gcs/gcs_ray_event_converter.cc
@@ -188,6 +188,9 @@ rpc::TaskEvents ConvertToTaskEvents(rpc::events::ActorTaskDefinitionEvent &&even
   if (!event.actor_id().empty()) {
     task_info->set_actor_id(event.actor_id());
   }
+  if (event.is_detached_actor()) {
+    task_info->set_is_detached_actor(true);
+  }
   if (event.has_call_site()) {
     task_info->set_call_site(event.call_site());
   }

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -662,6 +662,9 @@ message TaskInfoEntry {
   map<string, string> label_selector = 28;
 
   optional FallbackStrategy fallback_strategy = 29;
+  // True if this task creates a detached actor. Only meaningful when
+  // type == ACTOR_CREATION_TASK; defaults to false otherwise.
+  bool is_detached_actor = 30;
 }
 
 message TaskAttempt {

--- a/src/ray/protobuf/common.proto
+++ b/src/ray/protobuf/common.proto
@@ -838,6 +838,9 @@ message ActorTaskSpec {
   bytes actor_creation_dummy_object_id = 4;
   // Per-concurrency-group sequence number for ordering tasks within each group.
   uint64 concurrency_group_sequence_number = 5;
+  // True if the target actor was created with lifetime="detached". Set by the
+  // caller from its ActorHandle at task submission time.
+  bool is_detached_actor = 6;
 }
 
 // Represents a task, including task spec.

--- a/src/ray/protobuf/public/events_actor_task_definition_event.proto
+++ b/src/ray/protobuf/public/events_actor_task_definition_event.proto
@@ -47,4 +47,6 @@ message ActorTaskDefinitionEvent {
   // The key-value label constraints of the node to schedule this actor task on.
   map<string, string> label_selector = 15;
   optional FallbackStrategy fallback_strategy = 16;
+  // True if the target actor was created with lifetime="detached".
+  bool is_detached_actor = 17;
 }

--- a/src/ray/protobuf/public/events_task_definition_event.proto
+++ b/src/ray/protobuf/public/events_task_definition_event.proto
@@ -48,4 +48,7 @@ message TaskDefinitionEvent {
   // The key-value label constraints of the node to schedule this task on.
   map<string, string> label_selector = 15;
   optional FallbackStrategy fallback_strategy = 16;
+  // True if this task creates a detached actor. Only meaningful when
+  // task_type == ACTOR_CREATION_TASK; defaults to false otherwise.
+  bool is_detached_actor = 17;
 }


### PR DESCRIPTION
This PR adds the information if a task belongs to a detached actor or in `rpc::TaskEvents` for consumption in GCS. 

This is a prerequisite for this https://github.com/ray-project/ray/pull/63738. For more context on why this change is necessary read description of the linked PR and the related doc: https://docs.google.com/document/d/1Ythr_3aTjcEzZpWCr4Guqq_5NayZpHdfSWd-661XOqU/edit?tab=t.0#heading=h.borfp3jak5v3

Changes in this PR: 

For actor creation task: 
1. Task spec already contains `is_detached`. 
2. Use this information to populate the `rpc::TaskEvents` which is send to GCS when `task_event_buffer` flushes.
3. Use this information to populate `TaskDefinitionEvent` which is sent as a part of RayEvent framework when `task_event_buffer` is flushed. 
4. Currently GCS receives events both - directly via `task_event_buffer` on `CoreWorker` and `task_event_buffer` => aggregator agent => GCS (though aggregator agent => GCS logic is blocked by a config right now).
5. For the aggregator agent path, consume the flag in `TaskDefinitionEvent` to populate `TaskEvents` since all logic in GCS uses `TaskEvents`. 

For actor tasks: 
1. Task spec doesn't currently have 'is_detached' field. So one part is to add that field for actor tasks.
2. Steps 2-5 are same as actor creation task as described above except that here we use `ActorTaskDefinitionEvent` rather than `TaskDefinitionEvent`. 

The reason we have to do it for actor tasks as well and not just actor creation task is because if we don't do so, then, to identify whether an actor task belongs to a detached actor or not, we need to find the actor creation task for that actor and then check the flag. This can become buggy if we don't find the corresponding actor creation task details in GCS cache (maybe because it didn't arrive on GCS before the actor task)
