### PR TITLE
[Release / Train] Fix image classification release test with local filesystem

### DIFF
--- a/release/train_tests/benchmark/image_classification/jpeg/download_input_data_from_s3.sh
+++ b/release/train_tests/benchmark/image_classification/jpeg/download_input_data_from_s3.sh
@@ -20,6 +20,10 @@ if [ ! -d "$TRAIN_DIR" ]; then
     unzip -q "$ZIP_NAME"
     rm "$ZIP_NAME"
 
+    echo "--- after unzip, contents of $DATA_DIR ---"
+    ls -la "$DATA_DIR"
+    find "$DATA_DIR" -maxdepth 3 -type d | head -50
+
     popd || exit
 else
     echo "Dataset already exists at $TRAIN_DIR. Skipping download and unzip."


### PR DESCRIPTION
## Description
Currently all the image classification release tests that use local filesystem and run `bash image_classification/jpeg/download_input_data_from_s3.sh` are failing that `FileNotFoundError: [Errno 2] No such file or directory: '/mnt/local_storage/imagenet/train'`

Running the tests, they all passed. not sure why they were failing.
https://buildkite.com/ray-project/release/builds/92392#019e16ff-f5fc-47aa-a69f-944502b48d3d

`name:.*local_fs.*`