### PR TITLE
[serve][ci] Disable whole-step retry for HAProxy tests

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -224,13 +224,14 @@ steps:
       - python
     instance_type: large
     commands:
+      # Exit 42 skips whole-step retry (per @kouroshHakha); per-test retry is enough.
       - bazel run //ci/ray_ci:test_in_docker -- $(cat ci/ray_ci/serve_hap_test_names.txt) serve
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --build-name servebuild-py3.10 --python-version 3.10
         --test-env=RAY_SERVE_ENABLE_HA_PROXY=1
         --test-env=RAY_SERVE_ENABLE_DIRECT_INGRESS=0
         --test-env=RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S=0.01
-        --test-env=SERVE_SOCKET_REUSE_PORT_ENABLED=1
+        --test-env=SERVE_SOCKET_REUSE_PORT_ENABLED=1 || exit 42
     depends_on: servebuild-multipy(python=3.10)
 
   - label: ":ray-serve: serve: HAProxy tests (pip)"
@@ -240,6 +241,7 @@ steps:
       - python
     instance_type: large
     commands:
+      # Exit 42 skips whole-step retry (per @kouroshHakha); per-test retry is enough.
       - bazel run //ci/ray_ci:test_in_docker -- $(cat ci/ray_ci/serve_hap_test_names.txt) serve
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --build-name servebuild-py3.10 --python-version 3.10
@@ -247,7 +249,7 @@ steps:
         --test-env=RAY_SERVE_EXPERIMENTAL_PIP_HAPROXY=1
         --test-env=RAY_SERVE_ENABLE_DIRECT_INGRESS=0
         --test-env=RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S=0.01
-        --test-env=SERVE_SOCKET_REUSE_PORT_ENABLED=1
+        --test-env=SERVE_SOCKET_REUSE_PORT_ENABLED=1 || exit 42
     depends_on: servebuild-multipy(python=3.10)
 
   - label: ":ray-serve: serve: direct ingress tests"


### PR DESCRIPTION
The HAProxy serve test step takes ~45 minutes; with BuildKite's 2 automatic retries on failure, a genuine test failure isn't surfaced for ~2hr 15min. Per-test retry already runs via --flaky_test_attempts=3, so the whole-step retry just delays the signal without adding value.

Force exit 42 on any failure, which is the rayci convention for skipping BuildKite step retry.

Topic: serve-haproxy-no-retry
Signed-off-by: andrew <andrew@anyscale.com>