### PR TITLE
[serve] Fixes Router skips cache invalidation on gRPC request failure

### DIFF
--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -566,8 +566,28 @@ class gRPCReplicaResult(ReplicaResult):
             )
             return await asyncio.wrap_future(fut)
 
+    async def _process_done_callback(self, call: grpc.aio.Call, callback: Callable):
+        callback_arg = call
+        try:
+            if await call.code() == grpc.StatusCode.UNAVAILABLE:
+                callback_arg = ActorUnavailableError(
+                    "Actor is unavailable.",
+                    self._actor_id.binary(),
+                )
+        except Exception:
+            logger.exception("Failed to process gRPC request completion status.")
+
+        callback(callback_arg)
+
     def add_done_callback(self, callback: Callable):
-        self._call.add_done_callback(callback)
+        def wrapped_callback(call: grpc.aio.Call):
+            self._grpc_call_loop.call_soon_threadsafe(
+                lambda: self._grpc_call_loop.create_task(
+                    self._process_done_callback(call, callback)
+                )
+            )
+
+        self._call.add_done_callback(wrapped_callback)
 
     def cancel(self):
         self._call.cancel()

--- a/python/ray/serve/tests/unit/test_grpc_replica_result.py
+++ b/python/ray/serve/tests/unit/test_grpc_replica_result.py
@@ -2,10 +2,12 @@ import asyncio
 import sys
 import threading
 
+import grpc
 import pytest
 
 from ray import ActorID, cloudpickle
 from ray._common.test_utils import wait_for_condition
+from ray.exceptions import ActorUnavailableError
 from ray.serve._private.common import RequestMetadata
 from ray.serve._private.replica_result import gRPCReplicaResult
 from ray.serve.generated import serve_pb2
@@ -28,6 +30,22 @@ class FakegRPCUnaryCall:
 
     def add_done_callback(self, cb):
         pass
+
+
+class FakegRPCDoneCall:
+    def __init__(self, code):
+        self._callbacks = []
+        self._code = code
+
+    async def code(self):
+        return self._code
+
+    def add_done_callback(self, cb):
+        self._callbacks.append(cb)
+
+    def fire_done_callbacks(self):
+        for cb in self._callbacks:
+            cb(self)
 
 
 class FakegRPCStreamCall:
@@ -130,6 +148,28 @@ class TestSameLoop:
         )
         with pytest.raises(RuntimeError, match="oh no!"):
             await replica_result.__anext__()
+
+    async def test_done_callback_unavailable_maps_to_actor_unavailable(self):
+        fake_call = FakegRPCDoneCall(grpc.StatusCode.UNAVAILABLE)
+        replica_result = gRPCReplicaResult(
+            fake_call,
+            metadata=RequestMetadata(
+                request_id="",
+                internal_request_id="",
+                is_streaming=False,
+                _on_separate_loop=False,
+            ),
+            actor_id=ActorID(b"2" * 16),
+            loop=asyncio.get_running_loop(),
+        )
+        callback_args = []
+        replica_result.add_done_callback(callback_args.append)
+
+        fake_call.fire_done_callbacks()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert isinstance(callback_args[-1], ActorUnavailableError)
 
 
 class TestSeparateLoop:

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -1331,6 +1331,40 @@ class TestAssignRequest:
         [
             {
                 "enable_strict_max_ongoing_requests": True,
+                "enable_queue_len_cache": True,
+            },
+        ],
+        indirect=True,
+    )
+    async def test_replica_actor_unavailable_via_completion_callback(
+        self, setup_router: Tuple[AsyncioRouter, FakeRequestRouter]
+    ):
+        router, fake_request_router = setup_router
+        replica_id = ReplicaID(unique_id="r1", deployment_id=DeploymentID(name="test"))
+        fake_request_router.set_replica_to_return(
+            FakeReplica(
+                replica_id,
+                queue_len_info=ReplicaQueueLengthInfo(
+                    accepted=True, num_ongoing_requests=5
+                ),
+            )
+        )
+
+        replica_result = await router.assign_request(dummy_request_metadata())
+        assert fake_request_router.replica_queue_len_cache.get(replica_id) == 5
+
+        replica_result.fire_done_callbacks(
+            ActorUnavailableError(error_message="unavailable", actor_id=None)
+        )
+        await asyncio.sleep(0)
+
+        assert fake_request_router.replica_queue_len_cache.get(replica_id) is None
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [
+            {
+                "enable_strict_max_ongoing_requests": True,
             },
         ],
         indirect=True,


### PR DESCRIPTION
## Description
This PR addresses the issue where (for gRPC transport), after a gRPC failure, the `AsyncioRouter`'s request-completion callback never invalidates the queue-length cache entry for a failed replica

Hence, here's my approach:
- I'm proposing the main change to be in `gRPCReplicaResult.add_done_callback`.
- It should wrap completed gRPC calls in `python/ray/serve/_private/replica_result.py` and if `await call.code()` in the gRPC loop is `grpc.StatusCode.UNAVAILABLE`, it passes `ActorUnavailableError` to the router callback.
- `AsyncioRouter._process_finished_request` should then handle that error by invalidating the replica queue-length cache via `on_replica_actor_unavailable`.
- Tests should cover the gRPC callback mapping and router cache invalidation path in `test_grpc_replica_result.py` and `test_router.py`

## Related issues
Fixes #63261

## Additional information

Tests:
`python3 -m pytest python/ray/serve/tests/unit/test_grpc_replica_result.py python/ray/serve/tests/unit/test_router.py -q`