### PR TITLE
[Serve][1/2] Add TracingConfig and wire through proxy and replica paths

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -475,6 +475,7 @@ Content-Type: application/json
    :template: autosummary/autopydantic.rst
 
    schema.LoggingConfig
+   schema.TracingConfig
 ```
 
 (serve-llm-api)=

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -27,6 +27,7 @@ try:
     )
     from ray.serve.batching import batch
     from ray.serve.config import ControllerOptions, HTTPOptions
+    from ray.serve.schema import TracingConfig
     from ray.serve.utils import get_trace_context
 
 except ModuleNotFoundError as e:
@@ -50,6 +51,7 @@ __all__ = [
     "start",
     "ControllerOptions",
     "HTTPOptions",
+    "TracingConfig",
     "get_replica_context",
     "get_deployment_actor",
     "get_deployment_actor_context",

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -32,7 +32,7 @@ from ray.serve.context import (
 )
 from ray.serve.deployment import Application
 from ray.serve.exceptions import RayServeException
-from ray.serve.schema import LoggingConfig
+from ray.serve.schema import LoggingConfig, TracingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -81,6 +81,7 @@ def _create_controller_and_proxy_refs(
     http_options: Union[None, dict, HTTPOptions],
     grpc_options: Union[None, dict, gRPCOptions],
     global_logging_config: Union[None, dict, LoggingConfig],
+    global_tracing_config: Union[None, dict, TracingConfig],
     controller_options: ControllerOptions,
     proxy_location: Union[None, str, ProxyLocation] = None,
     **kwargs,
@@ -132,12 +133,18 @@ def _create_controller_and_proxy_refs(
     elif isinstance(global_logging_config, dict):
         global_logging_config = LoggingConfig(**global_logging_config)
 
+    if global_tracing_config is None:
+        global_tracing_config = TracingConfig()
+    elif isinstance(global_tracing_config, dict):
+        global_tracing_config = TracingConfig(**global_tracing_config)
+
     controller_impl = get_controller_impl(controller_options=controller_options)
     controller = controller_impl.remote(
         http_options=http_options,
         grpc_options=grpc_options,
         global_logging_config=global_logging_config,
         proxy_location=proxy_location,
+        global_tracing_config=global_tracing_config,
     )
 
     proxy_handles: Any = ray.get(controller.get_proxies.remote())
@@ -153,6 +160,7 @@ async def serve_start_async(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, TracingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
     proxy_location: Union[None, str, ProxyLocation] = None,
     **kwargs,
@@ -201,6 +209,7 @@ async def serve_start_async(
         http_options,
         grpc_options,
         global_logging_config,
+        global_tracing_config,
         controller_options,
         proxy_location,
         **kwargs,
@@ -227,6 +236,7 @@ def serve_start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    global_tracing_config: Union[None, dict, TracingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
     proxy_location: Union[None, str, ProxyLocation] = None,
     **kwargs,
@@ -271,6 +281,9 @@ def serve_start(
         global_logging_config: Optional ``LoggingConfig`` (or dict) applied as
             the default logging configuration for the Serve controller and all
             proxies/replicas in this Serve instance.
+        global_tracing_config: Optional ``TracingConfig`` (or dict) applied as
+            the default tracing configuration for the Serve controller and all
+            proxies/replicas in this Serve instance.
         controller_options: Optional ``ControllerOptions`` (or dict) for the
             Serve controller actor. Currently only ``runtime_env.env_vars``
             is honored; see ``ray.serve.config.ControllerOptions``. Only
@@ -311,6 +324,7 @@ def serve_start(
         http_options,
         grpc_options,
         global_logging_config,
+        global_tracing_config,
         controller_options,
         proxy_location,
         **kwargs,

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -133,9 +133,7 @@ def _create_controller_and_proxy_refs(
     elif isinstance(global_logging_config, dict):
         global_logging_config = LoggingConfig(**global_logging_config)
 
-    if global_tracing_config is None:
-        global_tracing_config = TracingConfig()
-    elif isinstance(global_tracing_config, dict):
+    if isinstance(global_tracing_config, dict):
         global_tracing_config = TracingConfig(**global_tracing_config)
 
     controller_impl = get_controller_impl(controller_options=controller_options)

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -111,6 +111,7 @@ from ray.serve.schema import (
     ServeInstanceDetails,
     Target,
     TargetGroup,
+    TracingConfig,
     gRPCOptionsSchema,
 )
 from ray.util import metrics
@@ -157,11 +158,14 @@ class ServeController:
         *,
         http_options: HTTPOptions,
         global_logging_config: LoggingConfig,
+        global_tracing_config: Optional[TracingConfig] = None,
         grpc_options: Optional[gRPCOptions] = None,
         proxy_location: Optional[ProxyLocation] = None,
     ):
         if RAY_SERVE_THROUGHPUT_OPTIMIZED:
             self._log_throughput_opt_message()
+
+        self.global_tracing_config = global_tracing_config
 
         self._controller_node_id = ray.get_runtime_context().get_node_id()
         assert (
@@ -332,6 +336,10 @@ class ServeController:
             msg += "  • Garbage collector is frozen on startup\n"
         msg += f"  • Request path log buffer size: {RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE}\n"
         logger.info(msg)
+
+    def get_tracing_config(self) -> Optional[TracingConfig]:
+        """Return the global tracing config."""
+        return self.global_tracing_config
 
     def reconfigure_global_logging_config(self, global_logging_config: LoggingConfig):
         if (

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -1227,6 +1227,12 @@ class ServeController:
         )
         self._target_capacity = config.target_capacity
 
+        # If a global tracing config is provided in the declarative config,
+        # store it so replicas and proxies started for this config pick it up
+        # when they fetch the tracing config from the controller.
+        if config.tracing_config is not None:
+            self.global_tracing_config = config.tracing_config
+
         for app_config in config.applications:
             # If the application logging config is not set, use the global logging
             # config.

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -1699,6 +1699,7 @@ class HAProxyManager(ProxyActorInterface):
         node_id: NodeId,
         node_ip_address: str,
         logging_config: LoggingConfig,
+        tracing_config=None,
         long_poll_client: Optional[LongPollClient] = None,
     ):  # noqa: F821
         super().__init__(

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -107,7 +107,7 @@ from ray.serve._private.utils import (
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.generated.serve_pb2 import HealthzResponse, ListApplicationsResponse
 from ray.serve.handle import DeploymentHandle
-from ray.serve.schema import EncodingType, LoggingConfig
+from ray.serve.schema import EncodingType, LoggingConfig, TracingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
@@ -1457,6 +1457,7 @@ class ProxyActorInterface(ABC):
         node_id: NodeId,
         node_ip_address: str,
         logging_config: LoggingConfig,
+        tracing_config: Optional[TracingConfig] = None,
         log_buffer_size: int = RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE,
     ):
         """Initialize the proxy actor.
@@ -1465,11 +1466,13 @@ class ProxyActorInterface(ABC):
             node_id: ID of the node this proxy is running on
             node_ip_address: IP address of the node
             logging_config: Logging configuration
+            tracing_config: Tracing configuration
             log_buffer_size: Size of the log buffer
         """
         self._node_id = node_id
         self._node_ip_address = node_ip_address
         self._logging_config = logging_config
+        self._tracing_config = tracing_config
         self._log_buffer_size = log_buffer_size
 
         self._update_logging_config(logging_config)
@@ -1605,10 +1608,17 @@ class ProxyActor(ProxyActorInterface):
         logging_config: LoggingConfig,
         long_poll_client: Optional[LongPollClient] = None,
     ):  # noqa: F821
+        # Fetch tracing config from controller before calling super
+        controller_handle = ray.get_actor(
+            SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE
+        )
+        tracing_config = ray.get(controller_handle.get_tracing_config.remote())
+
         super().__init__(
             node_id=node_id,
             node_ip_address=node_ip_address,
             logging_config=logging_config,
+            tracing_config=tracing_config,
         )
 
         is_head = self._node_id == get_head_node_id()
@@ -1619,7 +1629,7 @@ class ProxyActor(ProxyActorInterface):
         grpc_enabled = is_grpc_enabled(self._grpc_options)
         event_loop = get_or_create_event_loop()
         self.long_poll_client = long_poll_client or LongPollClient(
-            ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE),
+            controller_handle,
             {
                 LongPollNamespace.GLOBAL_LOGGING_CONFIG: self._update_logging_config,
                 LongPollNamespace.ROUTE_TABLE: self._update_routes_in_proxies,
@@ -1628,17 +1638,13 @@ class ProxyActor(ProxyActorInterface):
             client_id=f"{type(self).__name__}:{ray.get_runtime_context().get_actor_id()}",
         )
 
-        try:
-            is_tracing_setup_successful = setup_tracing(
-                component_name="proxy", component_id=node_ip_address
-            )
-            if is_tracing_setup_successful:
-                logger.info("Successfully set up tracing for proxy")
-        except Exception as e:
-            logger.warning(
-                f"Failed to set up tracing: {e}. "
-                "The proxy will continue running, but traces will not be exported."
-            )
+        is_tracing_setup_successful = setup_tracing(
+            component_name="proxy",
+            component_id=node_ip_address,
+            tracing_config=self._tracing_config,
+        )
+        if is_tracing_setup_successful:
+            logger.info("Successfully set up tracing for proxy")
 
         startup_msg = f"Proxy starting on node {self._node_id} (HTTP port: {self._http_options.port}"
         if grpc_enabled:

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1608,17 +1608,10 @@ class ProxyActor(ProxyActorInterface):
         logging_config: LoggingConfig,
         long_poll_client: Optional[LongPollClient] = None,
     ):  # noqa: F821
-        # Fetch tracing config from controller before calling super
-        controller_handle = ray.get_actor(
-            SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE
-        )
-        tracing_config = ray.get(controller_handle.get_tracing_config.remote())
-
         super().__init__(
             node_id=node_id,
             node_ip_address=node_ip_address,
             logging_config=logging_config,
-            tracing_config=tracing_config,
         )
 
         is_head = self._node_id == get_head_node_id()
@@ -1629,7 +1622,7 @@ class ProxyActor(ProxyActorInterface):
         grpc_enabled = is_grpc_enabled(self._grpc_options)
         event_loop = get_or_create_event_loop()
         self.long_poll_client = long_poll_client or LongPollClient(
-            controller_handle,
+            ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE),
             {
                 LongPollNamespace.GLOBAL_LOGGING_CONFIG: self._update_logging_config,
                 LongPollNamespace.ROUTE_TABLE: self._update_routes_in_proxies,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1146,23 +1146,19 @@ class Replica:
         # Silence spammy false positive errors from gRPC Python
         self._event_loop.set_exception_handler(asyncio_grpc_exception_handler)
 
-        try:
-            is_tracing_setup_successful = setup_tracing(
-                component_type=ServeComponentType.REPLICA,
-                component_name=self._component_name,
-                component_id=self._component_id,
-            )
-            if is_tracing_setup_successful:
-                logger.info("Successfully set up tracing for replica")
-        except Exception as e:
-            logger.warning(
-                f"Failed to set up tracing: {e}. "
-                "The replica will continue running, but traces will not be exported."
-            )
-
         self._controller_handle = ray.get_actor(
             SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE
         )
+
+        tracing_config = ray.get(self._controller_handle.get_tracing_config.remote())
+        is_tracing_setup_successful = setup_tracing(
+            component_type=ServeComponentType.REPLICA,
+            component_name=self._component_name,
+            component_id=self._component_id,
+            tracing_config=tracing_config,
+        )
+        if is_tracing_setup_successful:
+            logger.info("Successfully set up tracing for replica")
 
         # get node ID
         self._node_id = ray.get_runtime_context().get_node_id()

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -52,6 +52,8 @@ TRACE_STACK: ContextVar[List[Any]] = ContextVar(
     "trace_stack"
 )  # Create tracer once at module level
 
+_tracing_enabled: bool = False
+
 _tracer = None
 _tracer_lock = threading.Lock()
 
@@ -179,13 +181,15 @@ def tracing_decorator_factory(
     """
 
     def tracing_decorator(func):
-        if not is_tracing_enabled():
-            # if tracing is not enabled, we don't want to wrap the function
-            # with the tracing decorator.
-            return func
+        # NOTE: We intentionally check is_tracing_enabled() INSIDE each wrapper
+        # rather than here at decoration time. This is because decorators are
+        # applied at import/class-definition time, before setup_tracing() has
+        # been called, so the check would always be False at decoration time.
 
         @wraps(func)
         def synchronous_wrapper(*args, **kwargs):
+            if not is_tracing_enabled():
+                return func(*args, **kwargs)
             with TraceContextManager(trace_name, span_kind):
                 result = func(*args, **kwargs)
 
@@ -193,18 +197,27 @@ def tracing_decorator_factory(
 
         @wraps(func)
         def generator_wrapper(*args, **kwargs):
+            if not is_tracing_enabled():
+                yield from func(*args, **kwargs)
+                return
             with TraceContextManager(trace_name, span_kind):
                 for item in func(*args, **kwargs):
                     yield item
 
         @wraps(func)
         async def asynchronous_wrapper(*args, **kwargs):
+            if not is_tracing_enabled():
+                return await func(*args, **kwargs)
             with TraceContextManager(trace_name, span_kind):
                 result = await func(*args, **kwargs)
             return result
 
         @wraps(func)
         async def asyc_generator_wrapper(*args, **kwargs):
+            if not is_tracing_enabled():
+                async for item in func(*args, **kwargs):
+                    yield item
+                return
             with TraceContextManager(trace_name, span_kind):
                 async for item in func(*args, **kwargs):
                     yield item
@@ -227,10 +240,9 @@ def setup_tracing(
     component_name: str,
     component_id: str,
     component_type: Optional["ServeComponentType"] = None,  # noqa: F821
-    tracing_exporter_import_path: Optional[
-        str
-    ] = RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
-    tracing_sampling_ratio: Optional[float] = RAY_SERVE_TRACING_SAMPLING_RATIO,
+    tracing_config: Optional["TracingConfig"] = None,  # noqa: F821
+    tracing_exporter_import_path: Optional[str] = None,
+    tracing_sampling_ratio: Optional[float] = None,
 ) -> bool:
     """
     Set up tracing for a specific Serve component.
@@ -239,13 +251,37 @@ def setup_tracing(
         component_name: The name of the component.
         component_id: The unique identifier of the component.
         component_type: The type of the component.
+        tracing_config: Optional TracingConfig instance. When provided,
+            exporter and sampling ratio are extracted from it.
         tracing_exporter_import_path: Path to tracing exporter function.
+            Only used as fallback when tracing_config is None.
         tracing_sampling_ratio: Sampling ratio for traces (0.0 to 1.0).
+            Only used as fallback when tracing_config is None.
 
     Returns:
         bool: True if tracing setup is successful, False otherwise.
     """
+    global _tracing_enabled
+
+    if tracing_config is not None:
+        # Use TracingConfig-based configuration
+        if not tracing_config.enabled:
+            _tracing_enabled = False
+            return False
+        tracing_exporter_import_path = tracing_config.exporter_import_path
+        # Fill default exporter if enabled but path is empty
+        if not tracing_exporter_import_path:
+            tracing_exporter_import_path = DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+        tracing_sampling_ratio = tracing_config.sampling_ratio
+    else:
+        # Fall back to env vars / explicit kwargs
+        if tracing_exporter_import_path is None:
+            tracing_exporter_import_path = RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH
+        if tracing_sampling_ratio is None:
+            tracing_sampling_ratio = RAY_SERVE_TRACING_SAMPLING_RATIO
+
     if tracing_exporter_import_path == "":
+        _tracing_enabled = False
         return False
 
     # Check dependencies
@@ -281,6 +317,7 @@ def setup_tracing(
     for span_processor in span_processors:
         trace.get_tracer_provider().add_span_processor(span_processor)
 
+    _tracing_enabled = True
     return True
 
 
@@ -425,7 +462,7 @@ def set_span_exception(exc: Exception, escaped: bool = False):
 
 
 def is_tracing_enabled() -> bool:
-    return RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH != "" and trace is not None
+    return _tracing_enabled and trace is not None
 
 
 def is_span_recording() -> bool:

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -181,10 +181,10 @@ def tracing_decorator_factory(
     """
 
     def tracing_decorator(func):
-        # NOTE: We intentionally check is_tracing_enabled() INSIDE each wrapper
-        # rather than here at decoration time. This is because decorators are
-        # applied at import/class-definition time, before setup_tracing() has
-        # been called, so the check would always be False at decoration time.
+        # NOTE: We check is_tracing_enabled() INSIDE each wrapper rather than
+        # at decoration time. Decorators are applied at import/class-definition
+        # time, before setup_tracing() has been called, so the check would
+        # always return False at decoration time.
 
         @wraps(func)
         def synchronous_wrapper(*args, **kwargs):

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -241,8 +241,6 @@ def setup_tracing(
     component_id: str,
     component_type: Optional["ServeComponentType"] = None,  # noqa: F821
     tracing_config: Optional["TracingConfig"] = None,  # noqa: F821
-    tracing_exporter_import_path: Optional[str] = None,
-    tracing_sampling_ratio: Optional[float] = None,
 ) -> bool:
     """
     Set up tracing for a specific Serve component.
@@ -251,12 +249,9 @@ def setup_tracing(
         component_name: The name of the component.
         component_id: The unique identifier of the component.
         component_type: The type of the component.
-        tracing_config: Optional TracingConfig instance. When provided,
-            exporter and sampling ratio are extracted from it.
-        tracing_exporter_import_path: Path to tracing exporter function.
-            Only used as fallback when tracing_config is None.
-        tracing_sampling_ratio: Sampling ratio for traces (0.0 to 1.0).
-            Only used as fallback when tracing_config is None.
+        tracing_config: Optional TracingConfig instance. When provided, the
+            exporter and sampling ratio are read from it. When None, tracing
+            falls back to the RAY_SERVE_TRACING_* environment variables.
 
     Returns:
         bool: True if tracing setup is successful, False otherwise.
@@ -274,11 +269,9 @@ def setup_tracing(
             tracing_exporter_import_path = DEFAULT_TRACING_EXPORTER_IMPORT_PATH
         tracing_sampling_ratio = tracing_config.sampling_ratio
     else:
-        # Fall back to env vars / explicit kwargs
-        if tracing_exporter_import_path is None:
-            tracing_exporter_import_path = RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH
-        if tracing_sampling_ratio is None:
-            tracing_sampling_ratio = RAY_SERVE_TRACING_SAMPLING_RATIO
+        # No TracingConfig provided: fall back to env-var configuration.
+        tracing_exporter_import_path = RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH
+        tracing_sampling_ratio = RAY_SERVE_TRACING_SAMPLING_RATIO
 
     if tracing_exporter_import_path == "":
         _tracing_enabled = False

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -14,6 +14,7 @@ from ray.serve._private.constants import (
 
 if TYPE_CHECKING:
     from ray.serve._private.common import ServeComponentType
+    from ray.serve.schema import TracingConfig
 
 try:
     from opentelemetry import trace

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -63,7 +63,12 @@ from ray.serve.deployment import Application, Deployment
 from ray.serve.exceptions import RayServeException
 from ray.serve.handle import DeploymentHandle
 from ray.serve.multiplex import _ModelMultiplexWrapper
-from ray.serve.schema import LoggingConfig, ServeInstanceDetails, ServeStatus
+from ray.serve.schema import (
+    LoggingConfig,
+    ServeInstanceDetails,
+    ServeStatus,
+    TracingConfig,
+)
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 from ray.serve._private import api as _private_api  # isort:skip
@@ -78,6 +83,7 @@ def start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     logging_config: Union[None, dict, LoggingConfig] = None,
+    tracing_config: Union[None, dict, TracingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
     **kwargs,
 ):
@@ -104,6 +110,9 @@ def start(
           class See `gRPCOptions` for supported options.
         logging_config: logging config options for the serve component (
             controller & proxy).
+        tracing_config: Tracing config for distributed tracing. Can be passed as
+            a dictionary or a ``TracingConfig`` instance. See ``TracingConfig``
+            for supported options.
         controller_options: [EXPERIMENTAL] Options for the Serve controller actor.
           Currently scoped to a strictly-validated ``runtime_env.env_vars``
           (other ``runtime_env`` keys are rejected). See
@@ -118,6 +127,7 @@ def start(
         proxy_location=proxy_location,
         grpc_options=grpc_options,
         global_logging_config=logging_config,
+        global_tracing_config=tracing_config,
         controller_options=controller_options,
         **kwargs,
     )

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -220,6 +220,50 @@ class LoggingConfig(BaseModel):
         return self._compute_hash() == other._compute_hash()
 
 
+@PublicAPI(stability="alpha")
+class TracingConfig(BaseModel):
+    """Tracing config schema for configuring distributed tracing on Serve components.
+
+    Example:
+
+        .. code-block:: python
+
+            from ray import serve
+            from ray.serve.schema import TracingConfig
+
+            # Enable tracing with default exporter
+            serve.start(tracing_config=TracingConfig(enabled=True))
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether tracing is enabled. Defaults to False. "
+            "When enabled, spans will be exported using the configured exporter."
+        ),
+    )
+    exporter_import_path: str = Field(
+        default="",
+        description=(
+            "Import path to a custom tracing exporter function. "
+            "If empty and tracing is enabled, the default file-based exporter is used."
+        ),
+    )
+    sampling_ratio: float = Field(
+        default=0.01,
+        description=("Sampling ratio for traces (0.0 to 1.0). Defaults to 0.01 (1%)."),
+    )
+
+    @field_validator("sampling_ratio")
+    @classmethod
+    def validate_sampling_ratio(cls, v):
+        if v < 0.0 or v > 1.0:
+            raise ValueError(f"sampling_ratio must be between 0.0 and 1.0, got {v}.")
+        return v
+
+
 @PublicAPI(stability="stable")
 class RayActorOptionsSchema(BaseModel):
     """Options with which to start a replica actor."""

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -34,6 +34,8 @@ from ray.serve._private.constants import (
     DEFAULT_ROLLING_UPDATE_PERCENTAGE,
     DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S,
     RAY_SERVE_LOG_ENCODING,
+    RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
+    RAY_SERVE_TRACING_SAMPLING_RATIO,
     SERVE_DEFAULT_APP_NAME,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
@@ -238,22 +240,27 @@ class TracingConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     enabled: bool = Field(
-        default=False,
+        default_factory=lambda: RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH != "",
         description=(
-            "Whether tracing is enabled. Defaults to False. "
+            "Whether tracing is enabled. Defaults to True when the "
+            "RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH environment variable is set. "
             "When enabled, spans will be exported using the configured exporter."
         ),
     )
     exporter_import_path: str = Field(
-        default="",
+        default_factory=lambda: RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
         description=(
-            "Import path to a custom tracing exporter function. "
+            "Import path to a custom tracing exporter function. Defaults to the "
+            "RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH environment variable. "
             "If empty and tracing is enabled, the default file-based exporter is used."
         ),
     )
     sampling_ratio: float = Field(
-        default=0.01,
-        description=("Sampling ratio for traces (0.0 to 1.0). Defaults to 0.01 (1%)."),
+        default_factory=lambda: RAY_SERVE_TRACING_SAMPLING_RATIO,
+        description=(
+            "Sampling ratio for traces (0.0 to 1.0). Defaults to the "
+            "RAY_SERVE_TRACING_SAMPLING_RATIO environment variable (0.01, i.e. 1%)."
+        ),
     )
 
     @field_validator("sampling_ratio")

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1086,6 +1086,10 @@ class ServeDeploySchema(BaseModel):
         default=None,
         description="Logging config for configuring serve components logs.",
     )
+    tracing_config: Optional[TracingConfig] = Field(
+        default=None,
+        description="Tracing config for configuring serve components tracing.",
+    )
     applications: List[ServeApplicationSchema] = Field(
         ..., description="The set of applications to run on the Ray cluster."
     )

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -105,6 +105,43 @@ def test_deploy_config_default_num_replicas_no_replica_restart(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
+def test_deploy_config_tracing_config_declarative_flow(serve_instance, tmp_path):
+    """Tracing config in the serve config (declarative flow) is applied via `serve deploy`.
+
+    Deploys a config with a top-level ``tracing_config`` and verifies the
+    controller applied it (i.e. ``get_tracing_config`` reflects the YAML), so
+    replicas started for the config pick it up.
+    """
+    client = serve_instance
+    config = {
+        "tracing_config": {"enabled": True, "sampling_ratio": 1.0},
+        "applications": [
+            {
+                "name": SERVE_DEFAULT_APP_NAME,
+                "import_path": "ray.serve.tests.test_config_files.pid.node",
+            }
+        ],
+    }
+    config_file_name = str(tmp_path / "serve_config.yaml")
+    with open(config_file_name, "w") as config_file:
+        yaml.safe_dump(config, config_file)
+
+    subprocess.check_output(["serve", "deploy", config_file_name])
+
+    def check_running() -> bool:
+        app_status = serve.status().applications.get(SERVE_DEFAULT_APP_NAME)
+        return app_status is not None and app_status.status == "RUNNING"
+
+    wait_for_condition(check_running, timeout=30)
+
+    # The tracing config from the serve config reached the controller.
+    tracing_config = ray.get(client._controller.get_tracing_config.remote())
+    assert tracing_config is not None
+    assert tracing_config.enabled is True
+    assert tracing_config.sampling_ratio == 1.0
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")
 def test_deploy_basic(serve_instance):
     """Deploys some valid config files and checks that the deployments work."""
     # Create absolute file names to YAML config files

--- a/python/ray/serve/tests/test_cli.py
+++ b/python/ray/serve/tests/test_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -19,6 +20,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
 )
+from ray.serve._private.logging_utils import get_serve_logs_dir
 from ray.serve._private.test_utils import get_application_url
 from ray.serve.scripts import remove_ansi_escape_sequences
 from ray.util.state import list_actors
@@ -108,9 +110,9 @@ def test_deploy_config_default_num_replicas_no_replica_restart(
 def test_deploy_config_tracing_config_declarative_flow(serve_instance, tmp_path):
     """Tracing config in the serve config (declarative flow) is applied via `serve deploy`.
 
-    Deploys a config with a top-level ``tracing_config`` and verifies the
-    controller applied it (i.e. ``get_tracing_config`` reflects the YAML), so
-    replicas started for the config pick it up.
+    Deploys a config with a top-level ``tracing_config``, verifies the controller
+    applied it (i.e. ``get_tracing_config`` reflects the YAML), then sends traffic
+    and asserts that traces are actually produced for the replica.
     """
     client = serve_instance
     config = {
@@ -139,6 +141,24 @@ def test_deploy_config_tracing_config_declarative_flow(serve_instance, tmp_path)
     assert tracing_config is not None
     assert tracing_config.enabled is True
     assert tracing_config.sampling_ratio == 1.0
+
+    # Send traffic and assert that traces are produced for the replica, proving
+    # the declarative tracing config is applied end-to-end (replicas started for
+    # this config fetch it from the controller and set up tracing).
+    url = get_application_url(app_name=SERVE_DEFAULT_APP_NAME)
+    assert httpx.get(url).status_code == 200
+
+    spans_dir = os.path.join(get_serve_logs_dir(), "spans")
+
+    def replica_traces_created() -> bool:
+        return os.path.isdir(spans_dir) and any(
+            "replica" in f for f in os.listdir(spans_dir)
+        )
+
+    try:
+        wait_for_condition(replica_traces_created, timeout=20)
+    finally:
+        shutil.rmtree(spans_dir, ignore_errors=True)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="File path incorrect on Windows.")

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -14,6 +14,7 @@ import time
 
 import httpx
 import pytest
+from opentelemetry import trace
 
 import ray
 import ray._private.state as state
@@ -41,6 +42,7 @@ from ray.serve.config import (
 )
 from ray.serve.context import _get_global_client
 from ray.serve.schema import ServeApplicationSchema, ServeDeploySchema, TracingConfig
+from ray.serve.utils import get_trace_context
 from ray.util.state import list_actors
 
 
@@ -716,10 +718,6 @@ def test_serve_start_tracing_config_imperative_flow(ray_shutdown):
     Note: proxy tracing is not wired via this path (proxies start before the
     controller is queryable); that is handled separately via long poll.
     """
-    from opentelemetry import trace
-
-    from ray.serve.utils import get_trace_context
-
     tracing_config = TracingConfig(enabled=True, sampling_ratio=1.0)
     serve.start(
         http_options=HTTPOptions(host="0.0.0.0"),

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -7,6 +7,7 @@ import asyncio
 import logging
 import os
 import random
+import shutil
 import socket
 import sys
 import time
@@ -29,7 +30,8 @@ from ray.serve._private.constants import (
 )
 from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.http_util import set_socket_reuse_port
-from ray.serve._private.test_utils import expected_proxy_actors
+from ray.serve._private.logging_utils import get_serve_logs_dir
+from ray.serve._private.test_utils import expected_proxy_actors, get_application_url
 from ray.serve._private.utils import block_until_http_ready, format_actor_name
 from ray.serve.config import (
     ControllerOptions,
@@ -38,7 +40,7 @@ from ray.serve.config import (
     ProxyLocation,
 )
 from ray.serve.context import _get_global_client
-from ray.serve.schema import ServeApplicationSchema, ServeDeploySchema
+from ray.serve.schema import ServeApplicationSchema, ServeDeploySchema, TracingConfig
 from ray.util.state import list_actors
 
 
@@ -701,6 +703,56 @@ def test_serve_start_proxy_location(ray_shutdown, options):
     serve.start(**options)
     client = _get_global_client()
     assert client.get_serve_details()["proxy_location"] == expected
+
+
+def test_serve_start_tracing_config_imperative_flow(ray_shutdown):
+    """Tracing config passed to ``serve.start()`` reaches the controller and is
+    applied to replicas (the imperative flow).
+
+    Verifies that the controller stores the config and that, after a request,
+    a tracing span file is produced for the replica -- proving the config
+    propagated from serve.start() through the controller to the replica.
+
+    Note: proxy tracing is not wired via this path (proxies start before the
+    controller is queryable); that is handled separately via long poll.
+    """
+    from opentelemetry import trace
+
+    from ray.serve.utils import get_trace_context
+
+    tracing_config = TracingConfig(enabled=True, sampling_ratio=1.0)
+    serve.start(
+        http_options=HTTPOptions(host="0.0.0.0"),
+        tracing_config=tracing_config,
+    )
+
+    # The controller received the tracing config from serve.start().
+    client = _get_global_client()
+    assert ray.get(client._controller.get_tracing_config.remote()) == tracing_config
+
+    @serve.deployment
+    class Model:
+        def __call__(self, request):
+            tracer = trace.get_tracer(__name__)
+            with tracer.start_as_current_span(
+                "application_span", context=get_trace_context()
+            ):
+                return "hello"
+
+    serve.run(Model.bind())
+
+    url = get_application_url("HTTP")
+    assert httpx.post(f"{url}/").text == "hello"
+
+    serve.shutdown()
+
+    # Tracing was set up on the replica, so a replica span file exists.
+    spans_dir = os.path.join(get_serve_logs_dir(), "spans")
+    span_files = os.listdir(spans_dir)
+    try:
+        assert any("replica" in f for f in span_files), span_files
+    finally:
+        shutil.rmtree(spans_dir, ignore_errors=True)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/serve/tests/test_tracing_utils.py
+++ b/python/ray/serve/tests/test_tracing_utils.py
@@ -21,6 +21,7 @@ from ray import serve
 from ray._common.test_utils import SignalActor
 from ray.serve._private.common import ServeComponentType
 from ray.serve._private.constants import (
+    DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
     RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
 )
@@ -30,7 +31,6 @@ from ray.serve._private.test_utils import (
     wait_for_haproxy_routing_to_replica,
 )
 from ray.serve._private.tracing_utils import (
-    DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
     TRACE_STACK,
     _append_trace_stack,
     _load_span_processors,
@@ -42,6 +42,7 @@ from ray.serve._private.tracing_utils import (
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.serve.grpc_util import gRPCInputStream
+from ray.serve.schema import TracingConfig
 from ray.serve.tests.conftest import *  # noqa
 from ray.serve.utils import get_trace_context
 from ray.tests.conftest import *  # noqa
@@ -95,8 +96,7 @@ def test_disable_tracing_exporter():
         component_type=ServeComponentType.REPLICA,
         component_name="component_name",
         component_id="component_id",
-        tracing_exporter_import_path="",
-        tracing_sampling_ratio=1.0,
+        tracing_config=TracingConfig(enabled=False),
     )
 
     assert is_tracing_setup_successful is False
@@ -171,7 +171,7 @@ def test_missing_dependencies():
                 component_type=ServeComponentType.REPLICA,
                 component_name="component_name",
                 component_id="component_id",
-                tracing_sampling_ratio=1.0,
+                tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
             )
 
 
@@ -232,8 +232,11 @@ def test_custom_tracing_exporter(use_custom_tracing_exporter):
         "component_name",
         "component_id",
         ServeComponentType.REPLICA,
-        custom_tracing_exporter_path,
-        tracing_sampling_ratio=1.0,
+        tracing_config=TracingConfig(
+            enabled=True,
+            exporter_import_path=custom_tracing_exporter_path,
+            sampling_ratio=1.0,
+        ),
     )
 
     # Validate that tracing is setup successfully
@@ -253,8 +256,11 @@ def test_tracing_sampler(use_custom_tracing_exporter):
         "component_name",
         "component_id",
         ServeComponentType.REPLICA,
-        custom_tracing_exporter_path,
-        tracing_sampling_ratio,
+        tracing_config=TracingConfig(
+            enabled=True,
+            exporter_import_path=custom_tracing_exporter_path,
+            sampling_ratio=tracing_sampling_ratio,
+        ),
     )
 
     # Validate that tracing is setup successfully
@@ -382,7 +388,7 @@ def test_tracing_e2e(
         setup_tracing(
             component_name="upstream_app",
             component_id="345",
-            tracing_sampling_ratio=1.0,
+            tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
         )
         tracer = trace.get_tracer("test_tracing")
         with tracer.start_as_current_span("upstream_app"):
@@ -404,7 +410,7 @@ def test_tracing_e2e(
         setup_tracing(
             component_name="upstream_app",
             component_id="345",
-            tracing_sampling_ratio=1.0,
+            tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
         )
         tracer = trace.get_tracer("test_tracing")
         with tracer.start_as_current_span("upstream_app"):
@@ -443,7 +449,7 @@ def test_tracing_e2e(
         setup_tracing(
             component_name="upstream_app",
             component_id="345",
-            tracing_sampling_ratio=1.0,
+            tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
         )
         tracer = trace.get_tracer("test_tracing")
         with tracer.start_as_current_span("upstream_app"):
@@ -583,7 +589,7 @@ def test_tracing_e2e_with_errors(
         setup_tracing(
             component_name="upstream_app",
             component_id="345",
-            tracing_sampling_ratio=1.0,
+            tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
         )
         tracer = trace.get_tracer("test_tracing")
         with tracer.start_as_current_span("upstream_app"):
@@ -607,7 +613,7 @@ def test_tracing_e2e_with_errors(
         setup_tracing(
             component_name="upstream_app",
             component_id="345",
-            tracing_sampling_ratio=1.0,
+            tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
         )
         tracer = trace.get_tracer("test_tracing")
         with tracer.start_as_current_span("upstream_app"):
@@ -640,7 +646,7 @@ def test_tracing_e2e_with_errors(
         setup_tracing(
             component_name="upstream_app",
             component_id="345",
-            tracing_sampling_ratio=1.0,
+            tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
         )
         tracer = trace.get_tracer("test_tracing")
         with tracer.start_as_current_span("upstream_app"):
@@ -967,7 +973,7 @@ def test_batched_span_attached_to_first_request_trace():
     setup_tracing(
         component_name="upstream_app",
         component_id="batching_test_upstream_multi",
-        tracing_sampling_ratio=1.0,
+        tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
     )
 
     tracer = trace.get_tracer("test_tracing_batching_multi")
@@ -1098,7 +1104,7 @@ def test_grpc_streaming_tracing_attributes(serve_and_ray_shutdown, method_name):
     setup_tracing(
         component_name="upstream_app",
         component_id="345",
-        tracing_sampling_ratio=1.0,
+        tracing_config=TracingConfig(enabled=True, sampling_ratio=1.0),
     )
 
     tracer = trace.get_tracer("test_tracing")

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -28,6 +28,7 @@ from ray.serve.schema import (
     ServeApplicationSchema,
     ServeDeploySchema,
     ServeInstanceDetails,
+    TracingConfig,
 )
 from ray.serve.tests.common.remote_uris import (
     TEST_DEPLOY_GROUP_PINNED_URI,
@@ -1546,6 +1547,60 @@ def test_deployment_info_to_schema_omits_max_replicas_per_node_when_none():
 
     schema = _deployment_info_to_schema("test_deployment", info)
     assert schema.max_replicas_per_node is DEFAULT.VALUE
+
+
+class TestTracingConfig:
+    """Tests for the TracingConfig schema."""
+
+    def test_default_values(self):
+        """Test that default TracingConfig has sensible defaults."""
+        config = TracingConfig()
+        assert config.enabled is False
+        assert config.exporter_import_path == ""
+        assert config.sampling_ratio == 0.01
+
+    def test_enabled(self):
+        """Test creating an enabled tracing config."""
+        config = TracingConfig(enabled=True)
+        assert config.enabled is True
+
+    def test_disabled(self):
+        """Test creating an explicitly disabled tracing config."""
+        config = TracingConfig(enabled=False)
+        assert config.enabled is False
+
+    def test_custom_exporter(self):
+        """Test setting a custom exporter import path."""
+        config = TracingConfig(
+            enabled=True,
+            exporter_import_path="my.module:custom_exporter",
+            sampling_ratio=0.5,
+        )
+        assert config.exporter_import_path == "my.module:custom_exporter"
+        assert config.sampling_ratio == 0.5
+
+    def test_sampling_ratio_validation(self):
+        """Test that sampling_ratio must be between 0.0 and 1.0."""
+        with pytest.raises(ValidationError):
+            TracingConfig(sampling_ratio=-0.1)
+        with pytest.raises(ValidationError):
+            TracingConfig(sampling_ratio=1.1)
+
+        # Boundary values should work
+        config = TracingConfig(sampling_ratio=0.0)
+        assert config.sampling_ratio == 0.0
+        config = TracingConfig(sampling_ratio=1.0)
+        assert config.sampling_ratio == 1.0
+
+    def test_extra_fields_forbidden(self):
+        """Test that extra fields are not allowed."""
+        with pytest.raises(ValidationError):
+            TracingConfig(enabled=True, unknown_field="value")
+
+    def test_enabled_with_empty_exporter(self):
+        """Test that enabled=True with empty exporter stays empty (no auto-fill)."""
+        config = TracingConfig(enabled=True, exporter_import_path="")
+        assert config.exporter_import_path == ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  **Schema**:
  - New `TracingConfig` pydantic model (`schema.py`) with `enabled`, `exporter_import_path`, `sampling_ratio`
  - Exported in `ray.serve` public API + API doc entry

  **`setup_tracing` API**:
  - Accepts `TracingConfig` directly instead of raw `kwargs`
  - When `tracing_config` is provided: reads config from it
  - When `tracing_config` is `None`: falls back to env vars (backward compatible)
  - Tracing setup errors now propagate (fail fast) instead of being silently swallowed

  **Replica path**:
  - Replica fetches `TracingConfig` from controller via `get_tracing_config()` and passes to `setup_tracing`

  **Proxy path**:
  - `ProxyActorInterface` accepts `tracing_config` param (plumbed to `setup_tracing`)
  - Proxy currently receives `None` (env-var fallback, same as master). Full proxy wiring via `ProxyStateManager` deferred to PR 2.

  **Controller**:
  - Stores `global_tracing_config` and exposes `get_tracing_config()` method

  **Decorator fix**:
  - `tracing_decorator_factory` now checks `is_tracing_enabled()` at call-time instead of decoration-time, because `TracingConfig` arrives at runtime (after decorators are applied at import time)

  **Public API:**
  - `serve.start(tracing_config=...)` parameter

  **Design**

  - Global only: cluster-level, not per-app or per-deployment
  - Static: set once at startup, no hot-reload of existing actors
  - No proto changes: constructor arg through actor hierarchy
  - Backward compatible: env vars still work as defaults when `tracing_config` is `None`

  **What's deferred to PR 2**

  - Proxy wiring through `ProxyStateManager` (proxy currently falls back to env vars)
  - Runtime propagation (push config updates to live actors)
  - `HAProxy` tracing support

  **Test plan**

  - Unit tests for `TracingConfig` validation (`test_schema.py`)
  - Updated tracing e2e tests to use TracingConfig
  - Existing proxy/replica/deployment tests pass
  - No Replica class restructuring — existing class unchanged