### PR TITLE
[serve][llm] Replace LLM ingress router replica selection with `choose_replica`

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -35,14 +35,9 @@ def _build_direct_streaming_llm_deployment(llm_config: LLMConfig) -> Application
     The real ASGI app (vLLM FastAPI) is constructed inside
     `LLMServer.__serve_build_asgi_app__` after the engine starts.
 
-    LLMRouter delegates each replica pick to ``DeploymentHandle.choose_replica``,
-    so the LLMServer deployment's ``request_router_class`` is what actually
-    decides the policy. Default to ``RoundRobinRouter`` to preserve the
-    pre-`choose_replica` behavior, but never overwrite a value the user
-    already set on ``llm_config.deployment_config.request_router_config`` —
-    that would silently break ``ConsistentHashRouter`` /
-    ``PrefixCacheAffinityRouter`` deployments configured per the public
-    LLMConfig API.
+    Replica selection is driven by the deployment's ``request_router_config``.
+    Default to ``RoundRobinRouter`` when the user hasn't set one, and otherwise
+    leave their configured value untouched.
     """
     server_cls = llm_config.server_cls or LLMServer
     override_serve_options: Optional[dict] = None

--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -22,7 +22,9 @@ from ray.llm._internal.serve.core.server.builder import (
 )
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.observability.logging import get_logger
+from ray.serve.config import RequestRouterConfig
 from ray.serve.deployment import Application
+from ray.serve.experimental.round_robin_router import RoundRobinRouter
 
 logger = get_logger(__name__)
 
@@ -32,11 +34,28 @@ def _build_direct_streaming_llm_deployment(llm_config: LLMConfig) -> Application
 
     The real ASGI app (vLLM FastAPI) is constructed inside
     `LLMServer.__serve_build_asgi_app__` after the engine starts.
+
+    LLMRouter delegates each replica pick to ``DeploymentHandle.choose_replica``,
+    so the LLMServer deployment's ``request_router_class`` is what actually
+    decides the policy. Default to ``RoundRobinRouter`` to preserve the
+    pre-`choose_replica` behavior, but never overwrite a value the user
+    already set on ``llm_config.deployment_config.request_router_config`` —
+    that would silently break ``ConsistentHashRouter`` /
+    ``PrefixCacheAffinityRouter`` deployments configured per the public
+    LLMConfig API.
     """
     server_cls = llm_config.server_cls or LLMServer
+    override_serve_options: Optional[dict] = None
+    if "request_router_config" not in llm_config.deployment_config:
+        override_serve_options = {
+            "request_router_config": RequestRouterConfig(
+                request_router_class=RoundRobinRouter,
+            ),
+        }
     return build_llm_deployment(
         llm_config,
         deployment_cls=serve.ingress()(server_cls),
+        override_serve_options=override_serve_options,
     )
 
 

--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 from fastapi import FastAPI, HTTPException, Request
 
 from ray import serve
+from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 
 _BODY_TRUNCATED_HEADER = "x-body-truncated"
@@ -18,10 +19,9 @@ class LLMRouter:
     deployment to get a data plane replica, then forwards traffic directly
     to the matching LLMServer replica's backend HTTP port.
 
-    The routing policy is round-robin, configured by the underlying LLMServer
-    deployment via ``request_router_class``. This class just delegates each pick
-    to ``DeploymentHandle.choose_replica`` and translates the resulting selection
-    into a backend HTTP endpoint.
+    Replica selection is delegated to the underlying deployment's configured
+    request router, and this class translates the resulting pick into a backend
+    HTTP endpoint.
 
     /internal/route HTTP contract
     -----------------------------
@@ -62,7 +62,7 @@ class LLMRouter:
             host, port, replica_id = await self._pick_replica(
                 request_body=body, body_truncated=body_truncated
             )
-        except RuntimeError as e:
+        except (RuntimeError, DeploymentUnavailableError) as e:
             raise HTTPException(status_code=503, detail=str(e))
         return {"host": host, "port": port, "replica_id": replica_id}
 

--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -1,24 +1,11 @@
-import asyncio
-import random
-import time
-from typing import FrozenSet, List, Optional, Tuple
+from typing import Optional, Tuple
 
 from fastapi import FastAPI, HTTPException, Request
 
 from ray import serve
-from ray.serve._private.common import ReplicaID
 from ray.serve.handle import DeploymentHandle
 
 _BODY_TRUNCATED_HEADER = "x-body-truncated"
-
-# How long to wait for the underlying RequestRouter to be lazily created.
-# It's created on the first long-poll from the controller; that is normally
-# sub-second, but we allow up to a minute to ride out controller hiccups
-# before failing the constructor and letting Serve retry.
-_REQUEST_ROUTER_INIT_TIMEOUT_S = 60.0
-_REQUEST_ROUTER_INIT_POLL_INTERVAL_S = 0.05
-
-_ReplicaCacheSignature = FrozenSet[ReplicaID]
 
 router_app = FastAPI()
 
@@ -31,23 +18,26 @@ class LLMRouter:
     deployment to get a data plane replica, then forwards traffic directly
     to the matching LLMServer replica's backend HTTP port.
 
+    The routing policy is round-robin, configured by the underlying LLMServer
+    deployment via ``request_router_class``. This class just delegates each pick
+    to ``DeploymentHandle.choose_replica`` and translates the resulting selection
+    into a backend HTTP endpoint.
+
     /internal/route HTTP contract
     -----------------------------
     Request:
         POST /internal/route
         Content-Type: application/json
         Body: the target ChatCompletions / Completions request payload.
-            Today the router uses round-robin and ignores the body, but it
-            is plumbed through so future routing policies (e.g. prefix
-            cache aware) can score replicas against ``messages`` /
-            ``prompt``. HAProxy should continue forwarding the payload
-            (subject to truncation below).
+            The body is plumbed through to ``choose_replica`` so future
+            body-aware policies (e.g. prefix-cache-aware) can score replicas
+            against ``messages`` / ``prompt``.
 
     Truncated bodies:
         HAProxy may forward only a prefix of the request body for routing.
-        When it does, it must set the ``x-body-truncated`` header. The
-        router forwards both the body bytes and this signal to
-        ``_pick_replica`` for future body-aware policies.
+        When it does, it must set the ``x-body-truncated`` header; both the
+        body bytes and this signal are forwarded to ``choose_replica`` for
+        future body-aware policies.
 
     Responses:
         200 ``{"host": str, "port": int, "replica_id": str}``: pick
@@ -61,52 +51,15 @@ class LLMRouter:
     """
 
     async def __init__(self, server: DeploymentHandle):
-        # Randomized so multiple LLMRouter replicas don't lockstep on the
-        # same replica sequence.
-        self._round_robin_counter = random.randrange(2**31)
-        self._cached_dict_id: Optional[int] = None
-        self._cached_replica_signature: Optional[_ReplicaCacheSignature] = None
-        self._cached_endpoints: List[Tuple[str, int, str]] = []
         self._handle: DeploymentHandle = server
-
-        # Initialize the handle and wait for its underlying RequestRouter to
-        # be lazily created. The RequestRouter is built on the first long-poll
-        # from the controller (which delivers the deployment config that
-        # selects the request-router class), so `_get_request_router()`
-        # returns None for a brief window after `_init()`.
-        # `curr_replicas` is populated by the same long-poll client; until it
-        # carries at least one ready endpoint, /internal/route returns 503
-        # (HAProxy retries). That keeps router liveness decoupled from
-        # LLMServer cold start.
         self._handle._init()
-        self._request_router = await self._wait_for_request_router(
-            _REQUEST_ROUTER_INIT_TIMEOUT_S
-        )
-
-    async def _wait_for_request_router(self, timeout_s: float):
-        deadline = time.monotonic() + timeout_s
-        while True:
-            request_router = self._handle._get_request_router()
-            if request_router is not None:
-                return request_router
-            if time.monotonic() >= deadline:
-                raise RuntimeError(
-                    "DeploymentHandle._get_request_router() still returned "
-                    f"None after {timeout_s}s. The Serve controller may be "
-                    "unreachable, or Serve internals may have changed."
-                )
-            await asyncio.sleep(_REQUEST_ROUTER_INIT_POLL_INTERVAL_S)
-
-    async def check_health(self):
-        if self._request_router is None:
-            raise RuntimeError("request router not initialized")
 
     @router_app.post("/internal/route")
     async def route(self, request: Request):
         body = await request.body()
         body_truncated = _BODY_TRUNCATED_HEADER in request.headers
         try:
-            host, port, replica_id = self._pick_replica(
+            host, port, replica_id = await self._pick_replica(
                 request_body=body, body_truncated=body_truncated
             )
         except RuntimeError as e:
@@ -117,46 +70,27 @@ class LLMRouter:
     async def health(self):
         return {"status": "ok"}
 
-    def _ready_endpoints(self) -> List[Tuple[str, int, str]]:
-        """Backend (host, port, full_id) tuples, cached on replica-set change."""
-        curr_replicas = self._request_router.curr_replicas
-        # RequestRouter swaps the dict wholesale on every controller broadcast,
-        # so dict identity is a cheap "did anything change" check; the keyset
-        # check then filters out broadcasts that didn't actually change the
-        # replica set.
-        if id(curr_replicas) == self._cached_dict_id:
-            return self._cached_endpoints
-        signature = frozenset(curr_replicas.keys())
-        if signature != self._cached_replica_signature:
-            self._cached_replica_signature = signature
-            ready = sorted(
-                (r for r in curr_replicas.values() if r.backend_http_endpoint),
-                key=lambda r: r.replica_id.unique_id,
-            )
-            self._cached_endpoints = [
-                (*r.backend_http_endpoint, r.replica_id.to_full_id_str()) for r in ready
-            ]
-        self._cached_dict_id = id(curr_replicas)
-        return self._cached_endpoints
-
-    def _pick_replica(
+    async def _pick_replica(
         self,
         request_body: Optional[bytes] = None,
         body_truncated: bool = False,
     ) -> Tuple[str, int, str]:
-        """Pick a backend HTTP replica.
+        """Pick a backend HTTP replica via the deployment's request router.
 
-        Today this is plain round-robin and ignores the payload. The
         ``request_body`` (possibly a HAProxy-truncated prefix, indicated by
-        ``body_truncated``) is plumbed through so a future prefix cache aware
-        policy can score replicas against the request's prompt / messages
-        without changing the /internal/route contract or the call site.
+        ``body_truncated``) is forwarded to ``choose_replica`` so a future
+        body-aware policy can score replicas against the request's prompt /
+        messages without changing the /internal/route contract or the call
+        site.
         """
-        del request_body, body_truncated
-        candidates = self._ready_endpoints()
-        if not candidates:
-            raise RuntimeError("no backend-http replicas")
-
-        index = self._round_robin_counter % len(candidates)
-        self._round_robin_counter += 1
-        return candidates[index]
+        async with self._handle.choose_replica(
+            request_body=request_body, body_truncated=body_truncated
+        ) as selection:
+            replica = selection._replica
+            endpoint = replica.backend_http_endpoint
+            if endpoint is None:
+                raise RuntimeError(
+                    f"replica {selection.replica_id} has no backend HTTP endpoint"
+                )
+            host, port = endpoint
+            return host, port, replica.replica_id.to_full_id_str()

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
@@ -392,13 +392,8 @@ class TestBuildOpenaiApp:
         assert ingress_request_router._bound_deployment.name == "LLMRouter"
         assert ingress_request_router._bound_deployment.init_kwargs["server"] is app
 
-        # The LLMServer deployment now owns the routing policy: LLMRouter
-        # delegates each pick to handle.choose_replica, which runs
-        # ``RoundRobinRouter`` inside the AsyncioRouter event loop. Swapping
-        # the policy is therefore a config change on the inner deployment.
-        #
-        # `RequestRouterConfig._serialize_request_router_cls` normalises the
-        # class to its import path at config-build time, so compare strings.
+        # `RequestRouterConfig._serialize_request_router_cls` normalizes the
+        # class to its import path at config-build time.
         request_router_config = (
             app._bound_deployment._deployment_config.request_router_config
         )
@@ -410,10 +405,8 @@ class TestBuildOpenaiApp:
         self, llm_config, disable_placement_bundles, monkeypatch
     ):
         """A user-supplied ``request_router_config`` on ``LLMConfig`` must
-        survive direct-streaming wiring. Regression guard for the time when
-        the builder unconditionally forced ``RoundRobinRouter`` and silently
-        broke ``ConsistentHashRouter`` / ``PrefixCacheAffinityRouter``
-        deployments configured via the public LLMConfig API.
+        survive direct-streaming wiring rather than being overwritten with the
+        default.
         """
         monkeypatch.setattr(
             "ray.llm._internal.serve.core.ingress.builder."

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
@@ -22,7 +22,9 @@ from ray.llm._internal.serve.core.ingress.builder import (
 )
 from ray.llm._internal.serve.core.ingress.ingress import OpenAiIngress
 from ray.serve._private.http_util import ASGIAppReplicaWrapper
-from ray.serve.config import AutoscalingConfig
+from ray.serve.config import AutoscalingConfig, RequestRouterConfig
+from ray.serve.experimental.consistent_hash_router import ConsistentHashRouter
+from ray.serve.experimental.round_robin_router import RoundRobinRouter
 
 
 @pytest.fixture
@@ -389,6 +391,46 @@ class TestBuildOpenaiApp:
         assert ingress_request_router is not None
         assert ingress_request_router._bound_deployment.name == "LLMRouter"
         assert ingress_request_router._bound_deployment.init_kwargs["server"] is app
+
+        # The LLMServer deployment now owns the routing policy: LLMRouter
+        # delegates each pick to handle.choose_replica, which runs
+        # ``RoundRobinRouter`` inside the AsyncioRouter event loop. Swapping
+        # the policy is therefore a config change on the inner deployment.
+        #
+        # `RequestRouterConfig._serialize_request_router_cls` normalises the
+        # class to its import path at config-build time, so compare strings.
+        request_router_config = (
+            app._bound_deployment._deployment_config.request_router_config
+        )
+        assert request_router_config.request_router_class == (
+            f"{RoundRobinRouter.__module__}.{RoundRobinRouter.__name__}"
+        )
+
+    def test_direct_streaming_user_request_router_config_wins(
+        self, llm_config, disable_placement_bundles, monkeypatch
+    ):
+        """A user-supplied ``request_router_config`` on ``LLMConfig`` must
+        survive direct-streaming wiring. Regression guard for the time when
+        the builder unconditionally forced ``RoundRobinRouter`` and silently
+        broke ``ConsistentHashRouter`` / ``PrefixCacheAffinityRouter``
+        deployments configured via the public LLMConfig API.
+        """
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+        llm_config.deployment_config["request_router_config"] = RequestRouterConfig(
+            request_router_class=ConsistentHashRouter,
+        )
+
+        app = build_openai_app(LLMServingArgs(llm_configs=[llm_config]))
+        request_router_config = (
+            app._bound_deployment._deployment_config.request_router_config
+        )
+        assert request_router_config.request_router_class == (
+            f"{ConsistentHashRouter.__module__}.{ConsistentHashRouter.__name__}"
+        )
 
     def test_direct_streaming_rejects_multiple_llm_configs(
         self, llm_config, disable_placement_bundles, monkeypatch

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -1,4 +1,5 @@
 import sys
+from contextlib import asynccontextmanager
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
@@ -41,19 +42,42 @@ class _FakeRequest:
 
 
 class _DirectRouterReplica:
-    def __init__(self, unique_id: str, full_id: Optional[str] = None, port: int = 8000):
+    """RunningReplica stand-in for ``LLMRouter._pick_replica`` tests."""
+
+    def __init__(
+        self,
+        unique_id: str,
+        full_id: Optional[str] = None,
+        endpoint: Optional[tuple] = ("127.0.0.1", 8000),
+    ):
         self.replica_id = _DirectRouterReplicaId(unique_id, full_id)
-        self.backend_http_endpoint = ("127.0.0.1", port)
+        self.backend_http_endpoint = endpoint
 
 
-def _new_direct_router(request_router=None):
+def _new_direct_router(handle=None):
     router = LLMRouter.__new__(LLMRouter)
-    router._round_robin_counter = 0
-    router._cached_dict_id = None
-    router._cached_replica_signature = None
-    router._cached_endpoints = []
-    router._request_router = request_router or MagicMock(curr_replicas={})
+    router._handle = handle or MagicMock()
     return router
+
+
+def _selection_for(replica):
+    """Build a ``ReplicaSelection``-shaped mock that ``_pick_replica`` reads."""
+    return MagicMock(replica_id=replica.replica_id.unique_id, _replica=replica)
+
+
+def _choose_replica_returning(*replicas):
+    """Patch ``handle.choose_replica`` to yield the given replicas in order.
+
+    Each call to ``choose_replica`` consumes one replica from the sequence and
+    yields its ``_DirectRouterReplica`` wrapped as a selection.
+    """
+    selections = iter(_selection_for(r) for r in replicas)
+
+    @asynccontextmanager
+    async def fake_choose_replica(*args, **kwargs):
+        yield next(selections)
+
+    return fake_choose_replica
 
 
 @pytest.fixture(name="llm_config")
@@ -102,7 +126,7 @@ class TestDirectStreamingLLMRouter:
     @pytest.mark.asyncio
     async def test_route_forwards_body_and_truncation_signal(self):
         router = _new_direct_router()
-        router._pick_replica = MagicMock(
+        router._pick_replica = AsyncMock(
             return_value=("127.0.0.1", 9001, "DeploymentName#replica")
         )
 
@@ -123,48 +147,64 @@ class TestDirectStreamingLLMRouter:
     @pytest.mark.asyncio
     async def test_route_returns_503_on_pick_failure(self):
         router = _new_direct_router()
-        router._pick_replica = MagicMock(side_effect=RuntimeError("no replicas"))
+        router._pick_replica = AsyncMock(side_effect=RuntimeError("no replicas"))
 
         with pytest.raises(HTTPException) as exc_info:
             await router.route(_FakeRequest(b"{}"))
         assert exc_info.value.status_code == 503
         assert "no replicas" in exc_info.value.detail
 
-    def test_ready_endpoints_sorts_and_caches_by_replica_id(self):
-        replica_a = _DirectRouterReplica("a", port=8001)
-        replica_b = _DirectRouterReplica("b", port=8002)
-        replica_c = _DirectRouterReplica("c", port=8003)
+    @pytest.mark.asyncio
+    async def test_pick_replica_returns_backend_endpoint_from_handle(self):
+        """``_pick_replica`` reads the endpoint off the selection's replica."""
+        replica = _DirectRouterReplica(
+            "r1",
+            full_id="DeploymentName#r1",
+            endpoint=("10.0.0.1", 8123),
+        )
+        handle = MagicMock()
+        handle.choose_replica = _choose_replica_returning(replica)
+        router = _new_direct_router(handle)
 
-        request_router = MagicMock()
-        request_router.curr_replicas = {
-            "c": replica_c,
-            "a": replica_a,
-            "b": replica_b,
-        }
-        router = _new_direct_router(request_router)
+        host, port, replica_id = await router._pick_replica()
 
-        first = router._ready_endpoints()
-        assert first == [
-            ("127.0.0.1", 8001, "a"),
-            ("127.0.0.1", 8002, "b"),
-            ("127.0.0.1", 8003, "c"),
-        ]
+        assert (host, port, replica_id) == ("10.0.0.1", 8123, "DeploymentName#r1")
 
-        # Same dict identity: cached tuple list returned (identity check).
-        assert router._ready_endpoints() is first
+    @pytest.mark.asyncio
+    async def test_pick_replica_forwards_body_to_choose_replica(self):
+        """``request_body`` / ``body_truncated`` reach the underlying router.
 
-        # New dict, same keyset: signature-cache hits, tuples reused.
-        request_router.curr_replicas = dict(request_router.curr_replicas)
-        assert router._ready_endpoints() is first
+        Future body-aware request routers read these off the PendingRequest.
+        """
+        replica = _DirectRouterReplica("r1", full_id="d#r1")
 
-        # Membership change: cache invalidates and re-sorts.
-        request_router.curr_replicas = {"a": replica_a, "b": replica_b}
-        second = router._ready_endpoints()
-        assert second is not first
-        assert second == [
-            ("127.0.0.1", 8001, "a"),
-            ("127.0.0.1", 8002, "b"),
-        ]
+        captured_kwargs = {}
+
+        @asynccontextmanager
+        async def fake_choose_replica(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield _selection_for(replica)
+
+        handle = MagicMock()
+        handle.choose_replica = fake_choose_replica
+        router = _new_direct_router(handle)
+
+        body = b'{"messages": [{"role": "user", "content": "hi"}]}'
+        await router._pick_replica(request_body=body, body_truncated=True)
+
+        assert captured_kwargs == {"request_body": body, "body_truncated": True}
+
+    @pytest.mark.asyncio
+    async def test_pick_replica_raises_when_endpoint_missing(self):
+        """If the picked replica has no backend HTTP endpoint, surface a 503
+        via ``RuntimeError`` (same error contract as before)."""
+        replica = _DirectRouterReplica("r1", endpoint=None)
+        handle = MagicMock()
+        handle.choose_replica = _choose_replica_returning(replica)
+        router = _new_direct_router(handle)
+
+        with pytest.raises(RuntimeError, match="no backend HTTP endpoint"):
+            await router._pick_replica()
 
 
 class TestOpenAiIngress:

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -21,6 +21,8 @@ from ray.llm._internal.serve.core.ingress.ingress import (
 from ray.llm._internal.serve.core.ingress.router import LLMRouter
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
+from ray.serve._private.common import DeploymentID
+from ray.serve.exceptions import DeploymentUnavailableError
 
 
 class _DirectRouterReplicaId:
@@ -153,6 +155,17 @@ class TestDirectStreamingLLMRouter:
             await router.route(_FakeRequest(b"{}"))
         assert exc_info.value.status_code == 503
         assert "no replicas" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_route_returns_503_on_deployment_unavailable(self):
+        err = DeploymentUnavailableError(DeploymentID(name="LLMServer:test"))
+        router = _new_direct_router()
+        router._pick_replica = AsyncMock(side_effect=err)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await router.route(_FakeRequest(b"{}"))
+        assert exc_info.value.status_code == 503
+        assert "LLMServer:test" in exc_info.value.detail
 
     @pytest.mark.asyncio
     async def test_pick_replica_returns_backend_endpoint_from_handle(self):

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -1137,23 +1137,6 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
             response_serialization=response_serialization,
         )
 
-    def _get_request_router(
-        self,
-    ) -> Optional["ray.serve._private.request_router.request_router.RequestRouter"]:
-        """Temporary: expose the request router used by the HTTP router.
-
-        TODO(eicherseiji): Replace this with DeploymentHandle.choose_replica()
-        when ray-project/ray#60865 lands.
-        """
-        if self._router is None:
-            return None
-
-        asyncio_router = getattr(self._router, "_asyncio_router", None)
-        if asyncio_router is not None:
-            return asyncio_router.request_router
-
-        return getattr(self._router, "request_router", None)
-
     def remote(
         self, *args, **kwargs
     ) -> Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]]:


### PR DESCRIPTION
## Description
Removes the custom round-robin pick from `LLMRouter` and delegates replica selection to `DeploymentHandle.choose_replica` on the underlying `LLMServer` deployment. The pick policy is now whatever the user configured via `llm_config.deployment_config.request_router_config`; the builder fills in `RoundRobinRouter` as the default when nothing was set.

## API
- Declarative (YAML) 

```
  applications:
  - import_path: ray.serve.llm:build_openai_app
    name: llm_app
    route_prefix: "/"
    args:
      llm_configs:
        - model_loading_config:
            model_id: qwen3-4b
            model_source: Qwen/Qwen3-4B
          deployment_config:
            autoscaling_config: { min_replicas: 8, max_replicas: 8 }
            request_router_config: 
              request_router_class: ray.serve.llm.request_router.PrefixCacheAffinityRouter
              request_router_kwargs:
                match_rate_threshold: 0.1
```

- Imperative (Python)

```
  llm_config = LLMConfig(
      model_loading_config={"model_id": "qwen3-4b", "model_source": "Qwen/Qwen3-4B"},
      deployment_config={
          "autoscaling_config": {"min_replicas": 8, "max_replicas": 8},
          "request_router_config": RequestRouterConfig(
              request_router_class=PrefixCacheAffinityRouter,
          ),
      },
  )
```

## Benchmark
No regression from master's implementation on L4, but there is regression identified on H100. Need to apply the changes in this [commit](https://github.com/kouroshHakha/ray/commit/1ce66cc34024fe1cc0e3b919138eecc8fd7f22c7) to avoid regression, which @jeffreywang-anyscale will do in a follow-up PR.
<img width="1432" height="460" alt="Screenshot 2026-05-11 at 4 12 50 PM" src="https://github.com/user-attachments/assets/fa521129-a2fe-4c2f-9f05-2dba59520761" />


## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
