### PR TITLE
[serve] Deflake serve windows tests

### DIFF
--- a/.buildkite/windows.rayci.yml
+++ b/.buildkite/windows.rayci.yml
@@ -106,7 +106,7 @@ steps:
         --test-env=CI="1"
         --test-env=RAY_CI_POST_WHEEL_TESTS="1"
         --test-env=USERPROFILE
-        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
+        --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 1
     depends_on:
       - windowsbuild
       - block-windows-tests


### PR DESCRIPTION
## Description
Attempt to fix serve's windows flaky tests.

Most failures raise the same exception from `python/ray/_private/node.py` ([example](https://buildkite.com/ray-project/postmerge/builds/17496/canvas?jid=019e157b-bea4-4918-8075-86e9396a89e4&tab=output)):
```
The current node timed out during startup...
```

GCS client polls GCS once per second for `raylet_start_wait_time_s` (default 30 s) and raises if the raylet hasn't registered. The retry log line `Failed to get node info ... node registration may not be complete yet before the timeout. Try increase the RAY_raylet_start_wait_time_s config.` shows up consistently across failed tests.

https://github.com/ray-project/ray/blob/c01dcdefbefa123ba8766e1d90c00588f59026bb/src/ray/gcs_rpc_client/global_state_accessor.cc#L421-L436

The current `--parallelism-per-worker 3` command line argument spawns three docker containers concurrently within one Windows VM. Each container runs its own `ray.init()`, launching raylet + GCS + plasma + dashboard + log-monitor + runtime-env-agent.

**Hypothesis**: Windows pays more per `ray.init()` because it has no `fork()` (every helper re-imports via spawn + CreateProcess), DLL load goes through AV scan, and the raylet binary is on a network-mounted bazel runfiles tree. Linux absorbs 3-way contention in <30 s; Windows doesn't.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
