### PR TITLE
[data] Add `Dataset.mix()` release test microbenchmark

### DIFF
--- a/release/nightly_tests/dataset/dataset_mixing/compute_8_cpu.yaml
+++ b/release/nightly_tests/dataset/dataset_mixing/compute_8_cpu.yaml
@@ -1,0 +1,10 @@
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+head_node:
+    instance_type: m5.2xlarge
+
+worker_nodes:
+    - instance_type: m5.2xlarge
+      min_nodes: 8
+      max_nodes: 8
+      market_type: ON_DEMAND

--- a/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
+++ b/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
@@ -211,7 +211,7 @@ def main(args):
 
     # Assert ratio correctness after writing results.
     MEAN_THRESHOLD = 0.05
-    STDEV_THRESHOLD = 0.1
+    STDEV_THRESHOLD = 0.15
 
     result_metrics = benchmark.result["main"]
     for i in range(args.num_datasets):

--- a/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
+++ b/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
@@ -1,6 +1,4 @@
 import argparse
-import os
-import sys
 import tempfile
 import time
 
@@ -9,7 +7,6 @@ import pyarrow as pa
 import torch
 import torch.distributed as dist
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark import Benchmark, BenchmarkMetric
 
 import ray

--- a/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
+++ b/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
@@ -6,14 +6,18 @@ import time
 
 import numpy as np
 import pyarrow as pa
+import torch
+import torch.distributed as dist
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark import Benchmark, BenchmarkMetric
 
 import ray
 import ray.data
+import ray.train
 from ray.data import MixStoppingCondition
-from ray.train import Checkpoint
+from ray.train import Checkpoint, ScalingConfig
+from ray.train.torch import TorchTrainer
 
 IMAGENET_TRAIN_PATH = (
     "s3://ray-benchmark-data-internal-us-west-2/imagenet/parquet_split/train"
@@ -37,7 +41,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def _create_dataset(ds_index: int, batch_size: int) -> ray.data.Dataset:
+def _create_dataset(ds_index: int) -> ray.data.Dataset:
     ds = ray.data.read_parquet(IMAGENET_TRAIN_PATH, columns=["image", "label"])
 
     def preprocess(row):
@@ -45,7 +49,6 @@ def _create_dataset(ds_index: int, batch_size: int) -> ray.data.Dataset:
         return row
 
     ds = ds.map(preprocess)
-    ds = ds.repartition(4 * batch_size)
     return ds
 
 
@@ -69,25 +72,25 @@ def main(args):
     total_weight = sum(weights)
     normalized_weights = [w / total_weight for w in weights]
 
-    datasets = [_create_dataset(i, args.batch_size) for i in range(args.num_datasets)]
+    local_batch_size = args.batch_size
+    # Hard code some sensible values for the target block size and shuffle buffer size.
+    target_block_size = 4 * local_batch_size
+    shuffle_buffer_size = 64 * local_batch_size
+
+    datasets = [_create_dataset(i) for i in range(args.num_datasets)]
     first, *rest = datasets
     mixed = first.mix(*rest, weights=weights, stopping_condition=stopping)
+    mixed = mixed.repartition(target_num_rows_per_block=target_block_size)
 
     if args.random_mix:
         mixed = mixed.map_batches(
             _random_shuffle_fn,
-            batch_size=64 * args.batch_size,
+            batch_size=shuffle_buffer_size,
             batch_format="pyarrow",
         )
 
     def benchmark_fn():
-        import torch
-        import torch.distributed as dist
-        from ray.train import ScalingConfig
-        from ray.train.torch import TorchTrainer
-
         def train_fn(config):
-            import ray.train
 
             num_ds = config["num_datasets"]
             batch_size = config["batch_size"]

--- a/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
+++ b/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
@@ -75,9 +75,11 @@ def main(args):
     shuffle_buffer_size = 64 * local_batch_size
 
     datasets = [_create_dataset(i) for i in range(args.num_datasets)]
+    datasets = [
+        ds.repartition(target_num_rows_per_block=target_block_size) for ds in datasets
+    ]
     first, *rest = datasets
     mixed = first.mix(*rest, weights=weights, stopping_condition=stopping)
-    mixed = mixed.repartition(target_num_rows_per_block=target_block_size)
 
     if args.random_mix:
         mixed = mixed.map_batches(
@@ -88,7 +90,6 @@ def main(args):
 
     def benchmark_fn():
         def train_fn(config):
-
             num_ds = config["num_datasets"]
             batch_size = config["batch_size"]
             max_rows = config.get("max_rows_per_worker")
@@ -99,7 +100,26 @@ def main(args):
 
             local_rows = 0
             num_batches = 0
-            ratio_history = [[] for _ in range(num_ds)]
+            count_history = [[] for _ in range(num_ds)]
+            batch_size_history = []
+
+            def compute_global_ratio_mean_stdev():
+                # All-reduce batch sizes once (same across all datasets).
+                batch_size_sums = torch.tensor(batch_size_history, dtype=torch.double)
+                dist.all_reduce(batch_size_sums, op=dist.ReduceOp.SUM)
+
+                ratio_means = []
+                ratio_stdevs = []
+                for i in range(num_ds):
+                    count_sums = torch.tensor(count_history[i], dtype=torch.double)
+                    dist.all_reduce(count_sums, op=dist.ReduceOp.SUM)
+
+                    ratios = count_sums.numpy() / batch_size_sums.numpy()
+                    ratio_means.append(np.mean(ratios))
+                    ratio_stdevs.append(np.std(ratios))
+
+                return ratio_means, ratio_stdevs
+
             start = time.perf_counter()
 
             for batch in shard.iter_batches(batch_size=batch_size):
@@ -108,51 +128,27 @@ def main(args):
                 local_rows += batch_size_actual
 
                 indices, counts = np.unique(batch["ds_index"], return_counts=True)
+                batch_size_history.append(batch_size_actual)
                 for i in range(num_ds):
                     mask = indices == i
-                    ratio = (
-                        float(counts[mask][0]) / batch_size_actual
-                        if mask.any()
-                        else 0.0
-                    )
-                    ratio_history[i].append(ratio)
+                    count_history[i].append(counts[mask][0] if mask.any() else 0)
 
-                if is_rank_0 and num_batches % print_every == 0:
-                    elapsed = time.perf_counter() - start
-                    means = [np.mean(ratio_history[i]) for i in range(num_ds)]
-                    stds = [np.std(ratio_history[i]) for i in range(num_ds)]
-                    avg_str = ", ".join(
-                        f"ds{i}: {means[i]:.3f}±{stds[i]:.3f}" for i in range(num_ds)
-                    )
-                    latest_str = ", ".join(
-                        f"ds{i}: {ratio_history[i][-1]:.3f}" for i in range(num_ds)
-                    )
-                    print(
-                        f"[Rank 0] Batch {num_batches}: "
-                        f"{local_rows} rows, "
-                        f"{local_rows / elapsed:.0f} rows/s, "
-                        f"latest={{{latest_str}}}, "
-                        f"avg={{{avg_str}}}"
-                    )
+                if num_batches % print_every == 0:
+                    ratio_means, ratio_stdevs = compute_global_ratio_mean_stdev()
+
+                    if is_rank_0:
+                        avg_str = ", ".join(
+                            f"ds{i}: {ratio_means[i]:.3f}±{ratio_stdevs[i]:.3f}"
+                            for i in range(num_ds)
+                        )
+                        print(f"[Global] Batch {num_batches}: avg={avg_str}")
 
                 if max_rows is not None and local_rows >= max_rows:
                     break
 
             elapsed = time.perf_counter() - start
 
-            # Aggregate across workers with a single all_reduce per tensor.
-            # Ratio stats: sum and sum-of-squares for global mean/std.
-            ratio_sums = torch.zeros(num_ds, dtype=torch.double)
-            ratio_sq_sums = torch.zeros(num_ds, dtype=torch.double)
-            for i in range(num_ds):
-                arr = np.array(ratio_history[i])
-                ratio_sums[i] = arr.sum()
-                ratio_sq_sums[i] = (arr * arr).sum()
-            n_batches_tensor = torch.tensor([num_batches], dtype=torch.long)
-
-            dist.all_reduce(ratio_sums, op=dist.ReduceOp.SUM)
-            dist.all_reduce(ratio_sq_sums, op=dist.ReduceOp.SUM)
-            dist.all_reduce(n_batches_tensor, op=dist.ReduceOp.SUM)
+            ratio_means, ratio_stdevs = compute_global_ratio_mean_stdev()
 
             # Throughput: total rows / max elapsed across workers.
             local_rows_tensor = torch.tensor([local_rows], dtype=torch.long)
@@ -164,7 +160,6 @@ def main(args):
             global_tput = (
                 total_rows / max_elapsed.item() if max_elapsed.item() > 0 else 0
             )
-            total_n = n_batches_tensor.item()
 
             metrics = {
                 "global_rows": total_rows,
@@ -172,10 +167,8 @@ def main(args):
                 "num_batches": num_batches,
             }
             for i in range(num_ds):
-                mean = ratio_sums[i].item() / total_n
-                var = ratio_sq_sums[i].item() / total_n - mean * mean
-                metrics[f"ratio_mean_ds{i}"] = mean
-                metrics[f"ratio_std_ds{i}"] = max(0.0, var) ** 0.5
+                metrics[f"ratio_mean_ds{i}"] = ratio_means[i]
+                metrics[f"ratio_std_ds{i}"] = ratio_stdevs[i]
 
             with tempfile.TemporaryDirectory() as temp_dir:
                 ray.train.report(

--- a/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
+++ b/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
@@ -13,7 +13,7 @@ import ray
 import ray.data
 import ray.train
 from ray.data import MixStoppingCondition
-from ray.train import Checkpoint, ScalingConfig
+from ray.train import Checkpoint, RunConfig, ScalingConfig
 from ray.train.torch import TorchTrainer
 
 IMAGENET_TRAIN_PATH = (
@@ -196,6 +196,7 @@ def main(args):
                 placement_strategy="SPREAD",
             ),
             datasets={"train": mixed},
+            run_config=RunConfig(storage_path="/mnt/cluster_storage"),
         )
 
         result = trainer.fit()

--- a/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
+++ b/release/nightly_tests/dataset/dataset_mixing/mix_benchmark.py
@@ -1,0 +1,248 @@
+import argparse
+import os
+import sys
+import tempfile
+import time
+
+import numpy as np
+import pyarrow as pa
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from benchmark import Benchmark, BenchmarkMetric
+
+import ray
+import ray.data
+from ray.data import MixStoppingCondition
+from ray.train import Checkpoint
+
+IMAGENET_TRAIN_PATH = (
+    "s3://ray-benchmark-data-internal-us-west-2/imagenet/parquet_split/train"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Dataset.mix() benchmark")
+    parser.add_argument("--num-datasets", type=int, default=2)
+    parser.add_argument("--weights", nargs="+", type=float, default=None)
+    parser.add_argument("--num-workers", type=int, default=16)
+    parser.add_argument("--batch-size", type=int, default=256)
+    parser.add_argument("--max-rows-per-worker", type=int, default=None)
+    parser.add_argument(
+        "--stopping-condition",
+        default="stop_on_longest_drop",
+        choices=["stop_on_shortest", "stop_on_longest_drop"],
+    )
+    parser.add_argument("--random-mix", action="store_true")
+    parser.add_argument("--print-every", type=int, default=50)
+    return parser.parse_args()
+
+
+def _create_dataset(ds_index: int, batch_size: int) -> ray.data.Dataset:
+    ds = ray.data.read_parquet(IMAGENET_TRAIN_PATH, columns=["image", "label"])
+
+    def preprocess(row):
+        row["ds_index"] = np.int64(ds_index)
+        return row
+
+    ds = ds.map(preprocess)
+    ds = ds.repartition(4 * batch_size)
+    return ds
+
+
+def _random_shuffle_fn(batch: pa.Table) -> pa.Table:
+    indices = np.random.permutation(len(batch))
+    return batch.take(indices)
+
+
+def main(args):
+    benchmark = Benchmark()
+
+    stopping = MixStoppingCondition(args.stopping_condition)
+    weights = args.weights or [1.0] * args.num_datasets
+
+    if len(weights) != args.num_datasets:
+        raise ValueError(
+            f"Number of weights ({len(weights)}) must match "
+            f"--num-datasets ({args.num_datasets})"
+        )
+
+    total_weight = sum(weights)
+    normalized_weights = [w / total_weight for w in weights]
+
+    datasets = [_create_dataset(i, args.batch_size) for i in range(args.num_datasets)]
+    first, *rest = datasets
+    mixed = first.mix(*rest, weights=weights, stopping_condition=stopping)
+
+    if args.random_mix:
+        mixed = mixed.map_batches(
+            _random_shuffle_fn,
+            batch_size=64 * args.batch_size,
+            batch_format="pyarrow",
+        )
+
+    def benchmark_fn():
+        import torch
+        import torch.distributed as dist
+        from ray.train import ScalingConfig
+        from ray.train.torch import TorchTrainer
+
+        def train_fn(config):
+            import ray.train
+
+            num_ds = config["num_datasets"]
+            batch_size = config["batch_size"]
+            max_rows = config.get("max_rows_per_worker")
+            print_every = config.get("print_every", 50)
+            is_rank_0 = ray.train.get_context().get_world_rank() == 0
+
+            shard = ray.train.get_dataset_shard("train")
+
+            local_rows = 0
+            num_batches = 0
+            ratio_history = [[] for _ in range(num_ds)]
+            start = time.perf_counter()
+
+            for batch in shard.iter_batches(batch_size=batch_size):
+                num_batches += 1
+                batch_size_actual = len(batch["ds_index"])
+                local_rows += batch_size_actual
+
+                indices, counts = np.unique(batch["ds_index"], return_counts=True)
+                for i in range(num_ds):
+                    mask = indices == i
+                    ratio = (
+                        float(counts[mask][0]) / batch_size_actual
+                        if mask.any()
+                        else 0.0
+                    )
+                    ratio_history[i].append(ratio)
+
+                if is_rank_0 and num_batches % print_every == 0:
+                    elapsed = time.perf_counter() - start
+                    means = [np.mean(ratio_history[i]) for i in range(num_ds)]
+                    stds = [np.std(ratio_history[i]) for i in range(num_ds)]
+                    avg_str = ", ".join(
+                        f"ds{i}: {means[i]:.3f}±{stds[i]:.3f}" for i in range(num_ds)
+                    )
+                    latest_str = ", ".join(
+                        f"ds{i}: {ratio_history[i][-1]:.3f}" for i in range(num_ds)
+                    )
+                    print(
+                        f"[Rank 0] Batch {num_batches}: "
+                        f"{local_rows} rows, "
+                        f"{local_rows / elapsed:.0f} rows/s, "
+                        f"latest={{{latest_str}}}, "
+                        f"avg={{{avg_str}}}"
+                    )
+
+                if max_rows is not None and local_rows >= max_rows:
+                    break
+
+            elapsed = time.perf_counter() - start
+
+            # Aggregate across workers with a single all_reduce per tensor.
+            # Ratio stats: sum and sum-of-squares for global mean/std.
+            ratio_sums = torch.zeros(num_ds, dtype=torch.double)
+            ratio_sq_sums = torch.zeros(num_ds, dtype=torch.double)
+            for i in range(num_ds):
+                arr = np.array(ratio_history[i])
+                ratio_sums[i] = arr.sum()
+                ratio_sq_sums[i] = (arr * arr).sum()
+            n_batches_tensor = torch.tensor([num_batches], dtype=torch.long)
+
+            dist.all_reduce(ratio_sums, op=dist.ReduceOp.SUM)
+            dist.all_reduce(ratio_sq_sums, op=dist.ReduceOp.SUM)
+            dist.all_reduce(n_batches_tensor, op=dist.ReduceOp.SUM)
+
+            # Throughput: total rows / max elapsed across workers.
+            local_rows_tensor = torch.tensor([local_rows], dtype=torch.long)
+            max_elapsed = torch.tensor([elapsed], dtype=torch.double)
+            dist.all_reduce(local_rows_tensor, op=dist.ReduceOp.SUM)
+            dist.all_reduce(max_elapsed, op=dist.ReduceOp.MAX)
+
+            total_rows = local_rows_tensor.item()
+            global_tput = (
+                total_rows / max_elapsed.item() if max_elapsed.item() > 0 else 0
+            )
+            total_n = n_batches_tensor.item()
+
+            metrics = {
+                "global_rows": total_rows,
+                "global_tput": global_tput,
+                "num_batches": num_batches,
+            }
+            for i in range(num_ds):
+                mean = ratio_sums[i].item() / total_n
+                var = ratio_sq_sums[i].item() / total_n - mean * mean
+                metrics[f"ratio_mean_ds{i}"] = mean
+                metrics[f"ratio_std_ds{i}"] = max(0.0, var) ** 0.5
+
+            with tempfile.TemporaryDirectory() as temp_dir:
+                ray.train.report(
+                    metrics, checkpoint=Checkpoint.from_directory(temp_dir)
+                )
+
+        trainer = TorchTrainer(
+            train_fn,
+            train_loop_config={
+                "batch_size": args.batch_size,
+                "num_datasets": args.num_datasets,
+                "max_rows_per_worker": args.max_rows_per_worker,
+                "print_every": args.print_every,
+            },
+            scaling_config=ScalingConfig(
+                num_workers=args.num_workers,
+                use_gpu=False,
+                placement_strategy="SPREAD",
+            ),
+            datasets={"train": mixed},
+        )
+
+        result = trainer.fit()
+
+        output = vars(args)
+        output[BenchmarkMetric.THROUGHPUT] = result.metrics["global_tput"]
+        output[BenchmarkMetric.NUM_ROWS] = result.metrics["global_rows"]
+
+        for i in range(args.num_datasets):
+            for prefix in ("ratio_mean_ds", "ratio_std_ds"):
+                key = f"{prefix}{i}"
+                if key in result.metrics:
+                    output[key] = result.metrics[key]
+
+        return output
+
+    benchmark.run_fn("main", benchmark_fn)
+    benchmark.write_result()
+
+    # Assert ratio correctness after writing results.
+    MEAN_THRESHOLD = 0.05
+    STDEV_THRESHOLD = 0.1
+
+    result_metrics = benchmark.result["main"]
+    for i in range(args.num_datasets):
+        mean_key = f"ratio_mean_ds{i}"
+        std_key = f"ratio_std_ds{i}"
+        if mean_key in result_metrics:
+            expected = normalized_weights[i]
+            actual = result_metrics[mean_key]
+            std = result_metrics.get(std_key, 0)
+            diff = abs(actual - expected)
+
+            assert diff < MEAN_THRESHOLD, (
+                f"Ratio for dataset {i}: expected {expected:.4f}, "
+                f"got {actual:.4f} (diff={diff:.4f} exceeds threshold {MEAN_THRESHOLD})"
+            )
+            assert (
+                std < STDEV_THRESHOLD
+            ), f"Ratio std for dataset {i}: {std:.4f} exceeds threshold {STDEV_THRESHOLD}"
+            print(
+                f"Dataset {i}: mean={actual:.4f}±{std:.4f}, "
+                f"target={expected:.4f}, diff={diff:.4f} OK"
+            )
+
+
+if __name__ == "__main__":
+    ray.init()
+    args = parse_args()
+    main(args)

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -344,27 +344,27 @@
       run:
         script: >
           python dataset_mixing/mix_benchmark.py --num-datasets 8 --num-workers 16
-          --max-rows-per-worker 50000
+          --max-rows-per-worker 100000
 
     - __suffix__: 8ds_power_law
       run:
         script: >
           python dataset_mixing/mix_benchmark.py --num-datasets 8
           --weights 128 64 32 16 8 4 2 1 --num-workers 16
-          --max-rows-per-worker 50000
+          --max-rows-per-worker 100000
 
     - __suffix__: 8ds_equal_random_mix
       run:
         script: >
           python dataset_mixing/mix_benchmark.py --num-datasets 8 --num-workers 1
-          --random-mix --max-rows-per-worker 200000
+          --random-mix --max-rows-per-worker 100000
 
     - __suffix__: 8ds_power_law_random_mix
       run:
         script: >
           python dataset_mixing/mix_benchmark.py --num-datasets 8
           --weights 128 64 32 16 8 4 2 1 --num-workers 1
-          --random-mix --max-rows-per-worker 200000
+          --random-mix --max-rows-per-worker 100000
 
 ################
 # Training tests

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -343,28 +343,28 @@
     - __suffix__: 8ds_equal
       run:
         script: >
-          python dataset_mixing/mix_benchmark.py --num-datasets 8 --num-workers 8
+          python dataset_mixing/mix_benchmark.py --num-datasets 8 --num-workers 16
           --max-rows-per-worker 50000
 
     - __suffix__: 8ds_power_law
       run:
         script: >
           python dataset_mixing/mix_benchmark.py --num-datasets 8
-          --weights 128 64 32 16 8 4 2 1 --num-workers 8
+          --weights 128 64 32 16 8 4 2 1 --num-workers 16
           --max-rows-per-worker 50000
 
     - __suffix__: 8ds_equal_random_mix
       run:
         script: >
           python dataset_mixing/mix_benchmark.py --num-datasets 8 --num-workers 1
-          --random-mix --max-rows-per-worker 50000
+          --random-mix --max-rows-per-worker 200000
 
     - __suffix__: 8ds_power_law_random_mix
       run:
         script: >
           python dataset_mixing/mix_benchmark.py --num-datasets 8
           --weights 128 64 32 16 8 4 2 1 --num-workers 1
-          --random-mix --max-rows-per-worker 50000
+          --random-mix --max-rows-per-worker 200000
 
 ################
 # Training tests

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -331,10 +331,9 @@
 
 - name: mix
   python: "3.10"
-  working_dir: nightly_tests/dataset/dataset_mixing
   cluster:
     anyscale_sdk_2026: true
-    cluster_compute: compute_8_cpu.yaml
+    cluster_compute: dataset_mixing/compute_8_cpu.yaml
   run:
     timeout: 600
     wait_for_nodes:
@@ -344,26 +343,26 @@
     - __suffix__: 8ds_equal
       run:
         script: >
-          python mix_benchmark.py --num-datasets 8 --num-workers 8
+          python dataset_mixing/mix_benchmark.py --num-datasets 8 --num-workers 8
           --max-rows-per-worker 50000
 
     - __suffix__: 8ds_power_law
       run:
         script: >
-          python mix_benchmark.py --num-datasets 8
+          python dataset_mixing/mix_benchmark.py --num-datasets 8
           --weights 128 64 32 16 8 4 2 1 --num-workers 8
           --max-rows-per-worker 50000
 
     - __suffix__: 8ds_equal_random_mix
       run:
         script: >
-          python mix_benchmark.py --num-datasets 8 --num-workers 1
+          python dataset_mixing/mix_benchmark.py --num-datasets 8 --num-workers 1
           --random-mix --max-rows-per-worker 50000
 
     - __suffix__: 8ds_power_law_random_mix
       run:
         script: >
-          python mix_benchmark.py --num-datasets 8
+          python dataset_mixing/mix_benchmark.py --num-datasets 8
           --weights 128 64 32 16 8 4 2 1 --num-workers 1
           --random-mix --max-rows-per-worker 50000
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -325,6 +325,48 @@
       run:
         script: python streaming_split_benchmark.py --num-workers 10 --early-stop
 
+############
+# Mix tests
+############
+
+- name: mix
+  python: "3.10"
+  working_dir: nightly_tests/dataset/dataset_mixing
+  cluster:
+    anyscale_sdk_2026: true
+    cluster_compute: compute_8_cpu.yaml
+  run:
+    timeout: 600
+    wait_for_nodes:
+      num_nodes: 8
+
+  variations:
+    - __suffix__: 8ds_equal
+      run:
+        script: >
+          python mix_benchmark.py --num-datasets 8 --num-workers 8
+          --max-rows-per-worker 50000
+
+    - __suffix__: 8ds_power_law
+      run:
+        script: >
+          python mix_benchmark.py --num-datasets 8
+          --weights 128 64 32 16 8 4 2 1 --num-workers 8
+          --max-rows-per-worker 50000
+
+    - __suffix__: 8ds_equal_random_mix
+      run:
+        script: >
+          python mix_benchmark.py --num-datasets 8 --num-workers 1
+          --random-mix --max-rows-per-worker 50000
+
+    - __suffix__: 8ds_power_law_random_mix
+      run:
+        script: >
+          python mix_benchmark.py --num-datasets 8
+          --weights 128 64 32 16 8 4 2 1 --num-workers 1
+          --random-mix --max-rows-per-worker 50000
+
 ################
 # Training tests
 ################


### PR DESCRIPTION
## Description

Adds a release test benchmark for `Dataset.mix()` (introduced in #63168) that measures mixing throughput and ratio accuracy.

## Benchmark details

Benchmark design:
- Creates 8 datasets reading ImageNet parquet, each stamped with a ds_index column
- Mixes with Dataset.mix(), repartitions to 4 * batch_size rows per block
- Consumes via TorchTrainer to mimic the seen weighting ratio when ingesting multiple local batches which are split across workers.
- Tracks per-batch mixing ratios per worker, aggregates mean/std across workers via all_reduce to get the mean and standard deviation across **global batches.**
- Asserts ratio mean is within 0.05 of target and std < 0.1
- Tests with and without a shuffling step after mixing with `--num-workers=1` to showcase the effectiveness of shuffling removing the dependency of mixing quality on the number of workers. [See here for more details.](https://docs.ray.io/en/master/data/mixing-data.html#random-mixing)

Test variations:
  | Variation | Workers | Weights | Random mix |
  |---|---|---|---|
  | `8ds_equal` | 8 | equal | no |
  | `8ds_power_law` | 8 | 128:64:32:16:8:4:2:1 | no |
  | `8ds_equal_random_mix` | 1 | equal | yes |
  | `8ds_power_law_random_mix` | 1 | 128:64:32:16:8:4:2:1 | yes |

All variants use `--max-rows-per-worker=100_000` for bounded runtime on an 8-node m5.2xlarge cluster, and also to avoid hitting dataset exhaustion which leads to the ratios diverging.

## Benchmark results

8ds_equal
```
Dataset 0: mean=0.1253±0.0695, target=0.1250, diff=0.0003 OK
Dataset 1: mean=0.1252±0.0634, target=0.1250, diff=0.0002 OK
Dataset 2: mean=0.1264±0.0584, target=0.1250, diff=0.0014 OK
Dataset 3: mean=0.1240±0.0600, target=0.1250, diff=0.0010 OK
Dataset 4: mean=0.1254±0.0654, target=0.1250, diff=0.0004 OK
Dataset 5: mean=0.1239±0.0653, target=0.1250, diff=0.0011 OK
Dataset 6: mean=0.1247±0.0630, target=0.1250, diff=0.0003 OK
Dataset 7: mean=0.1250±0.0663, target=0.1250, diff=0.0000 OK
```

8ds_power_law
```
Dataset 0: mean=0.5017±0.0941, target=0.5020, diff=0.0002 OK
Dataset 1: mean=0.2518±0.0858, target=0.2510, diff=0.0008 OK
Dataset 2: mean=0.1244±0.0681, target=0.1255, diff=0.0011 OK
Dataset 3: mean=0.0630±0.0464, target=0.0627, diff=0.0003 OK
Dataset 4: mean=0.0310±0.0327, target=0.0314, diff=0.0004 OK
Dataset 5: mean=0.0160±0.0268, target=0.0157, diff=0.0003 OK
Dataset 6: mean=0.0079±0.0196, target=0.0078, diff=0.0000 OK
Dataset 7: mean=0.0042±0.0151, target=0.0039, diff=0.0003 OK
```

8ds_equal_random_mix
```
  main = {'time': 55.192007467999986, 'object_store_spilled_total_gb': 0.0, 'num_datasets': 8, 'weights': None, 'num_workers': 1, 'batch_size': 256, 'max_rows_per_worker': 100000, 'stopping_condition': 'stop_on_longest_drop', 'random_mix': True, 'print_every': 50, 'tput': 2453.388865730177, 'num_rows': 100096, 'ratio_mean_ds0': 0.12647858056265984, 'ratio_std_ds0': 0.08976139552706039, 'ratio_mean_ds1': 0.12640864769820973, 'ratio_std_ds1': 0.03321393841700443, 'ratio_mean_ds2': 0.12865648976982097, 'ratio_std_ds2': 0.11139429644615093, 'ratio_mean_ds3': 0.12791719948849106, 'ratio_std_ds3': 0.06092154319651775, 'ratio_mean_ds4': 0.12861652813299232, 'ratio_std_ds4': 0.04257910528838874, 'ratio_mean_ds5': 0.12067415281329923, 'ratio_std_ds5': 0.03243481089665854, 'ratio_mean_ds6': 0.12062420076726342, 'ratio_std_ds6': 0.031844610741798195, 'ratio_mean_ds7': 0.12062420076726342, 'ratio_std_ds7': 0.032520041872085376}
```

8ds_power_law_random_mix
```
Dataset 0: mean=0.4944±0.0890, target=0.5020, diff=0.0076 OK
Dataset 1: mean=0.2497±0.0918, target=0.2510, diff=0.0013 OK
Dataset 2: mean=0.1244±0.0953, target=0.1255, diff=0.0011 OK
Dataset 3: mean=0.0606±0.0230, target=0.0627, diff=0.0022 OK
Dataset 4: mean=0.0307±0.0327, target=0.0314, diff=0.0007 OK
Dataset 5: mean=0.0197±0.0302, target=0.0157, diff=0.0040 OK
Dataset 6: mean=0.0102±0.0238, target=0.0078, diff=0.0024 OK
Dataset 7: mean=0.0102±0.0239, target=0.0039, diff=0.0063 OK
```