### PR TITLE
[Train] Add datasets_to_split_equally parameter to DataConfig

### DIFF
--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -183,17 +183,16 @@ def test_unequal_split_datasets_invalid():
             DataConfig(unequal_split_datasets=invalid_value)
 
 
-@pytest.mark.parametrize("use_unequal", [True, False])
-def test_configure_unequal_split(use_unequal):
+@pytest.mark.parametrize(
+    ("use_unequal", "dataset_name", "expected_equal"),
+    [(False, "train", True), (True, "eval", False)],
+)
+def test_configure_unequal_split(use_unequal, dataset_name, expected_equal):
     """Test that configure passes the correct equal flag to streaming_split."""
     if use_unequal:
-        # unequal_split_datasets=["eval"] means eval gets equal=False
         data_config = DataConfig(unequal_split_datasets=["eval"])
-        expected_equal = True  # train (default) uses equal=True
     else:
-        # No unequal datasets, all use equal=True
         data_config = DataConfig()
-        expected_equal = True
 
     mock_ds = MagicMock()
     mock_ds.streaming_split = MagicMock()
@@ -202,7 +201,7 @@ def test_configure_unequal_split(use_unequal):
     worker_handles = [MagicMock() for _ in range(world_size)]
     worker_node_ids = ["node" + str(i) for i in range(world_size)]
     data_config.configure(
-        datasets={"train": mock_ds},
+        datasets={dataset_name: mock_ds},
         world_size=world_size,
         worker_handles=worker_handles,
         worker_node_ids=worker_node_ids,
@@ -472,20 +471,27 @@ def test_unequal_split_e2e(ray_start_4_cpus):
     # With equal=True (default), 11 rows / 2 workers = 5 each (1 row dropped).
     # With equal=False, workers get 5 and 6 rows (0 rows dropped).
 
+    @ray.remote
+    class RowCounter:
+        def __init__(self):
+            self._counts = []
+
+        def add(self, count):
+            self._counts.append(count)
+
+        def total(self):
+            return sum(self._counts)
+
+    counter = RowCounter.remote()
+
     class VerifyUnequalSplit(DataParallelTrainer):
-        def __init__(self, expect_equal_split: bool, **kwargs):
+        def __init__(self, **kwargs):
             def train_loop_per_worker():
                 shard = train.get_dataset_shard("eval")
                 count = sum(
                     arr.size for batch in shard.iter_batches() for arr in batch.values()
                 )
-                if expect_equal_split:
-                    assert count == NUM_ROWS // NUM_WORKERS
-                else:
-                    assert count in (
-                        NUM_ROWS // NUM_WORKERS,
-                        NUM_ROWS // NUM_WORKERS + 1,
-                    )
+                ray.get(counter.add.remote(count))
 
             kwargs.pop("scaling_config", None)
             super().__init__(
@@ -496,11 +502,14 @@ def test_unequal_split_e2e(ray_start_4_cpus):
 
     # Test with unequal_split_datasets=["eval"] (no rows dropped)
     trainer = VerifyUnequalSplit(
-        expect_equal_split=False,
         datasets={"eval": ds},
         dataset_config=DataConfig(unequal_split_datasets=["eval"]),
     )
     trainer.fit()
+
+    assert (
+        ray.get(counter.total.remote()) == NUM_ROWS
+    ), f"Expected {NUM_ROWS} total rows, got {ray.get(counter.total.remote())}"
 
 
 if __name__ == "__main__":

--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -176,6 +176,82 @@ def test_configure_locality(enable_locality):
     )
 
 
+def test_unequal_split_datasets_invalid():
+    """Test that unequal_split_datasets rejects invalid arguments."""
+    for invalid_value in ["train", ("train",), {}]:
+        with pytest.raises(TypeError, match="`unequal_split_datasets` should be.*"):
+            DataConfig(unequal_split_datasets=invalid_value)
+
+
+@pytest.mark.parametrize("use_unequal", [True, False])
+def test_configure_unequal_split(use_unequal):
+    """Test that configure passes the correct equal flag to streaming_split."""
+    if use_unequal:
+        # unequal_split_datasets=["eval"] means eval gets equal=False
+        data_config = DataConfig(unequal_split_datasets=["eval"])
+        expected_equal = True  # train (default) uses equal=True
+    else:
+        # No unequal datasets, all use equal=True
+        data_config = DataConfig()
+        expected_equal = True
+
+    mock_ds = MagicMock()
+    mock_ds.streaming_split = MagicMock()
+    mock_ds.copy = MagicMock(return_value=mock_ds)
+    world_size = 2
+    worker_handles = [MagicMock() for _ in range(world_size)]
+    worker_node_ids = ["node" + str(i) for i in range(world_size)]
+    data_config.configure(
+        datasets={"train": mock_ds},
+        world_size=world_size,
+        worker_handles=worker_handles,
+        worker_node_ids=worker_node_ids,
+    )
+    mock_ds.streaming_split.assert_called_once()
+    mock_ds.streaming_split.assert_called_with(
+        world_size,
+        equal=expected_equal,
+        locality_hints=worker_node_ids,
+    )
+
+
+def test_configure_per_dataset_unequal_split():
+    """Test that different datasets can have different equal split settings."""
+    # train uses equal=True (default), eval uses equal=False (in unequal_split_datasets)
+    data_config = DataConfig(
+        datasets_to_split=["train", "eval"],
+        unequal_split_datasets=["eval"],
+    )
+
+    mock_train = MagicMock()
+    mock_train.streaming_split = MagicMock()
+    mock_train.copy = MagicMock(return_value=mock_train)
+
+    mock_eval = MagicMock()
+    mock_eval.streaming_split = MagicMock()
+    mock_eval.copy = MagicMock(return_value=mock_eval)
+
+    world_size = 2
+    worker_node_ids = ["node0", "node1"]
+    data_config.configure(
+        datasets={"train": mock_train, "eval": mock_eval},
+        world_size=world_size,
+        worker_handles=None,
+        worker_node_ids=worker_node_ids,
+    )
+
+    mock_train.streaming_split.assert_called_once_with(
+        world_size,
+        equal=True,
+        locality_hints=worker_node_ids,
+    )
+    mock_eval.streaming_split.assert_called_once_with(
+        world_size,
+        equal=False,
+        locality_hints=worker_node_ids,
+    )
+
+
 class CustomConfig(DataConfig):
     def __init__(self):
         pass
@@ -384,6 +460,47 @@ def test_v1_train_with_v2_data_autoscaler_sets_exclude_resources(
     )
     assert exclude_resources.cpu == num_train_cpus
     assert exclude_resources.gpu == num_train_gpus
+
+
+def test_unequal_split_e2e(ray_start_4_cpus):
+    """End-to-end test: unequal split preserves all rows across workers."""
+    NUM_ROWS = 11
+    NUM_WORKERS = 2
+
+    ds = ray.data.range(NUM_ROWS)
+
+    # With equal=True (default), 11 rows / 2 workers = 5 each (1 row dropped).
+    # With equal=False, workers get 5 and 6 rows (0 rows dropped).
+
+    class VerifyUnequalSplit(DataParallelTrainer):
+        def __init__(self, expect_equal_split: bool, **kwargs):
+            def train_loop_per_worker():
+                shard = train.get_dataset_shard("eval")
+                count = sum(
+                    arr.size for batch in shard.iter_batches() for arr in batch.values()
+                )
+                if expect_equal_split:
+                    assert count == NUM_ROWS // NUM_WORKERS
+                else:
+                    assert count in (
+                        NUM_ROWS // NUM_WORKERS,
+                        NUM_ROWS // NUM_WORKERS + 1,
+                    )
+
+            kwargs.pop("scaling_config", None)
+            super().__init__(
+                train_loop_per_worker=train_loop_per_worker,
+                scaling_config=ScalingConfig(num_workers=NUM_WORKERS),
+                **kwargs,
+            )
+
+    # Test with unequal_split_datasets=["eval"] (no rows dropped)
+    trainer = VerifyUnequalSplit(
+        expect_equal_split=False,
+        datasets={"eval": ds},
+        dataset_config=DataConfig(unequal_split_datasets=["eval"]),
+    )
+    trainer.fit()
 
 
 if __name__ == "__main__":

--- a/python/ray/air/tests/test_new_dataset_config.py
+++ b/python/ray/air/tests/test_new_dataset_config.py
@@ -12,7 +12,7 @@ from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionResources,
 )
 from ray.tests.conftest import *  # noqa
-from ray.train import DataConfig, ScalingConfig
+from ray.train import DataConfig, ScalingConfig, SplitConfig
 from ray.train.data_parallel_trainer import DataParallelTrainer
 
 
@@ -116,7 +116,7 @@ def test_split(ray_start_4_cpus):
     test.fit()
 
     # Test invalid arguments
-    for datasets_to_split in ["train", ("train"), {}]:
+    for datasets_to_split in ["train", ("train"), {"train": False}]:
         with pytest.raises(TypeError, match="`datasets_to_split` should be.*"):
             test = TestBasic(
                 2,
@@ -133,6 +133,16 @@ def test_split(ray_start_4_cpus):
         {"train": 10, "test": 10},
         datasets={"train": ds, "test": ds},
         dataset_config=DataConfig(datasets_to_split=[]),
+    )
+    test.fit()
+
+    # Test empty `datasets_to_split` dict
+    test = TestBasic(
+        2,
+        True,
+        {"train": 10, "test": 10},
+        datasets={"train": ds, "test": ds},
+        dataset_config=DataConfig(datasets_to_split={}),
     )
     test.fit()
 
@@ -181,6 +191,12 @@ def test_unequal_split_datasets_invalid():
     for invalid_value in ["train", ("train",), {}]:
         with pytest.raises(TypeError, match="`unequal_split_datasets` should be.*"):
             DataConfig(unequal_split_datasets=invalid_value)
+
+    with pytest.raises(
+        ValueError,
+        match="`unequal_split_datasets` cannot be combined with dict-based",
+    ):
+        DataConfig(datasets_to_split={}, unequal_split_datasets=["eval"])
 
 
 @pytest.mark.parametrize(
@@ -248,6 +264,44 @@ def test_configure_per_dataset_unequal_split():
         world_size,
         equal=False,
         locality_hints=worker_node_ids,
+    )
+
+
+def test_configure_per_dataset_split_config():
+    """Test that dict-based split config applies per-dataset split behavior."""
+    data_config = DataConfig(
+        datasets_to_split={
+            "train": SplitConfig(),
+            "eval": SplitConfig(equal=False, enable_shard_locality=False),
+        }
+    )
+
+    mock_train = MagicMock()
+    mock_train.streaming_split = MagicMock()
+    mock_train.copy = MagicMock(return_value=mock_train)
+
+    mock_eval = MagicMock()
+    mock_eval.streaming_split = MagicMock()
+    mock_eval.copy = MagicMock(return_value=mock_eval)
+
+    world_size = 2
+    worker_node_ids = ["node0", "node1"]
+    data_config.configure(
+        datasets={"train": mock_train, "eval": mock_eval},
+        world_size=world_size,
+        worker_handles=None,
+        worker_node_ids=worker_node_ids,
+    )
+
+    mock_train.streaming_split.assert_called_once_with(
+        world_size,
+        equal=True,
+        locality_hints=worker_node_ids,
+    )
+    mock_eval.streaming_split.assert_called_once_with(
+        world_size,
+        equal=False,
+        locality_hints=None,
     )
 
 

--- a/python/ray/train/__init__.py
+++ b/python/ray/train/__init__.py
@@ -18,7 +18,7 @@ from ray.air.result import Result
 
 # Import this first so it can be used in other modules
 from ray.train._checkpoint import Checkpoint
-from ray.train._internal.data_config import DataConfig
+from ray.train._internal.data_config import DataConfig, SplitConfig
 from ray.train._internal.session import get_checkpoint, get_dataset_shard, report
 from ray.train._internal.syncer import SyncConfig
 from ray.train.backend import BackendConfig
@@ -85,6 +85,7 @@ __all__ = [
     "Result",
     "RunConfig",
     "ScalingConfig",
+    "SplitConfig",
     "SyncConfig",
     "TrainContext",
     "TrainingFailedError",
@@ -103,6 +104,7 @@ FailureConfig.__module__ = "ray.train"
 Result.__module__ = "ray.train"
 RunConfig.__module__ = "ray.train"
 ScalingConfig.__module__ = "ray.train"
+SplitConfig.__module__ = "ray.train"
 SyncConfig.__module__ = "ray.train"
 TrainContext.__module__ = "ray.train"
 TrainingFailedError.__module__ = "ray.train"

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -21,6 +21,7 @@ class DataConfig:
     def __init__(
         self,
         datasets_to_split: Union[Literal["all"], List[str]] = "all",
+        unequal_split_datasets: Optional[List[str]] = None,
         execution_options: Optional[
             Union["ExecutionOptions", Dict[str, "ExecutionOptions"]]
         ] = None,
@@ -32,6 +33,12 @@ class DataConfig:
             datasets_to_split: Specifies which datasets should be split among workers.
                 Can be set to "all" or a list of dataset names. Defaults to "all",
                 i.e. split all datasets.
+            unequal_split_datasets: Specifies which datasets should use unequal
+                splitting (``equal=False``). By default, all datasets use equal
+                splitting (``equal=True``) for backward compatibility. List datasets
+                here that should NOT drop rows during splitting, such as evaluation
+                or batch inference datasets. Only datasets that are also in
+                ``datasets_to_split`` are affected.
             execution_options: The execution options to pass to Ray Data. Can be either:
                 1. A single ExecutionOptions object that is applied to all datasets.
                 2. A dict mapping dataset names to ExecutionOptions. If a dataset name
@@ -50,6 +57,17 @@ class DataConfig:
                 "`datasets_to_split` should be a 'all' or a list of strings of "
                 "dataset names. Received "
                 f"{type(datasets_to_split).__name__} with value {datasets_to_split}."
+            )
+
+        if unequal_split_datasets is None:
+            self._unequal_split_datasets = []
+        elif isinstance(unequal_split_datasets, list):
+            self._unequal_split_datasets = unequal_split_datasets
+        else:
+            raise TypeError(
+                "`unequal_split_datasets` should be a list of strings of "
+                "dataset names or None. Received "
+                f"{type(unequal_split_datasets).__name__} with value {unequal_split_datasets}."
             )
 
         default_execution_options = DataConfig.default_ingest_options()
@@ -120,6 +138,9 @@ class DataConfig:
         else:
             datasets_to_split = set(self._datasets_to_split)
 
+        # Datasets in unequal_split_datasets use equal=False, all others use equal=True
+        unequal_split_set = set(self._unequal_split_datasets)
+
         locality_hints = worker_node_ids if self._enable_shard_locality else None
         for name, ds in datasets.items():
             execution_options = self._get_execution_options(name)
@@ -138,9 +159,10 @@ class DataConfig:
             ds.context.execution_options = execution_options
 
             if name in datasets_to_split:
+                equal = name not in unequal_split_set
                 for i, split in enumerate(
                     ds.streaming_split(
-                        world_size, equal=True, locality_hints=locality_hints
+                        world_size, equal=equal, locality_hints=locality_hints
                     )
                 ):
                     output[i][name] = split

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -1,6 +1,7 @@
 import copy
 import os
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
 
 from ray.actor import ActorHandle
@@ -8,6 +9,23 @@ from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
     from ray.data import DataIterator, Dataset, ExecutionOptions, NodeIdStr
+
+
+@PublicAPI(stability="stable")
+@dataclass(frozen=True)
+class SplitConfig:
+    """Per-dataset split behavior for Train datasets.
+
+    Args:
+        equal: Whether the dataset should be split equally across workers.
+            When true, Ray Data may drop up to ``world_size - 1`` rows from
+            the tail to keep worker shard lengths aligned.
+        enable_shard_locality: Per-dataset override for shard locality.
+            If unset, falls back to ``DataConfig(enable_shard_locality=...)``.
+    """
+
+    equal: bool = True
+    enable_shard_locality: Optional[bool] = None
 
 
 @PublicAPI(stability="stable")
@@ -20,7 +38,9 @@ class DataConfig:
 
     def __init__(
         self,
-        datasets_to_split: Union[Literal["all"], List[str]] = "all",
+        datasets_to_split: Union[
+            Literal["all"], List[str], Dict[str, SplitConfig]
+        ] = "all",
         unequal_split_datasets: Optional[List[str]] = None,
         execution_options: Optional[
             Union["ExecutionOptions", Dict[str, "ExecutionOptions"]]
@@ -31,14 +51,19 @@ class DataConfig:
 
         Args:
             datasets_to_split: Specifies which datasets should be split among workers.
-                Can be set to "all" or a list of dataset names. Defaults to "all",
-                i.e. split all datasets.
+                Can be set to "all", a list of dataset names, or a dict mapping
+                dataset names to ``SplitConfig``. Dict-based configuration enables
+                per-dataset control over equal splitting and shard locality while
+                preserving the existing list-based API. Defaults to "all", i.e.
+                split all datasets with the global defaults.
             unequal_split_datasets: Specifies which datasets should use unequal
                 splitting (``equal=False``). By default, all datasets use equal
                 splitting (``equal=True``) for backward compatibility. List datasets
                 here that should NOT drop rows during splitting, such as evaluation
                 or batch inference datasets. Only datasets that are also in
-                ``datasets_to_split`` are affected.
+                ``datasets_to_split`` are affected. This is a legacy compatibility
+                option; use ``datasets_to_split={name: SplitConfig(equal=False)}``
+                for new code.
             execution_options: The execution options to pass to Ray Data. Can be either:
                 1. A single ExecutionOptions object that is applied to all datasets.
                 2. A dict mapping dataset names to ExecutionOptions. If a dataset name
@@ -50,13 +75,38 @@ class DataConfig:
         """
         from ray.data import ExecutionOptions
 
-        if isinstance(datasets_to_split, list) or datasets_to_split == "all":
+        self._dataset_split_configs: Dict[str, SplitConfig] = {}
+        using_dict_split_config = isinstance(datasets_to_split, dict)
+        if using_dict_split_config:
+            invalid_dataset_names = [
+                name for name in datasets_to_split if not isinstance(name, str)
+            ]
+            invalid_split_configs = [
+                config
+                for config in datasets_to_split.values()
+                if not isinstance(config, SplitConfig)
+            ]
+            if invalid_dataset_names or invalid_split_configs:
+                raise TypeError(
+                    "`datasets_to_split` should be 'all', a list of strings of "
+                    "dataset names, or a dict of dataset names to SplitConfig. "
+                    f"Received value {datasets_to_split}."
+                )
+            self._datasets_to_split = list(datasets_to_split.keys())
+            self._dataset_split_configs = dict(datasets_to_split)
+        elif isinstance(datasets_to_split, list) or datasets_to_split == "all":
             self._datasets_to_split = datasets_to_split
         else:
             raise TypeError(
-                "`datasets_to_split` should be a 'all' or a list of strings of "
-                "dataset names. Received "
+                "`datasets_to_split` should be 'all', a list of strings of "
+                "dataset names, or a dict of dataset names to SplitConfig. Received "
                 f"{type(datasets_to_split).__name__} with value {datasets_to_split}."
+            )
+
+        if unequal_split_datasets and using_dict_split_config:
+            raise ValueError(
+                "`unequal_split_datasets` cannot be combined with dict-based "
+                "`datasets_to_split`. Use SplitConfig(equal=False) instead."
             )
 
         if unequal_split_datasets is None:
@@ -85,6 +135,23 @@ class DataConfig:
 
         self._num_train_cpus = 0.0
         self._num_train_gpus = 0.0
+
+    def _get_dataset_split_config(self, dataset_name: str) -> SplitConfig:
+        """Return the effective split config for a dataset."""
+        split_config = self._dataset_split_configs.get(dataset_name)
+        if split_config is not None:
+            enable_shard_locality = split_config.enable_shard_locality
+            if enable_shard_locality is None:
+                enable_shard_locality = self._enable_shard_locality
+            return SplitConfig(
+                equal=split_config.equal,
+                enable_shard_locality=enable_shard_locality,
+            )
+
+        return SplitConfig(
+            equal=dataset_name not in set(self._unequal_split_datasets),
+            enable_shard_locality=self._enable_shard_locality,
+        )
 
     def set_train_total_resources(self, num_train_cpus: float, num_train_gpus: float):
         """Set the total number of CPUs and GPUs used by training.
@@ -138,10 +205,6 @@ class DataConfig:
         else:
             datasets_to_split = set(self._datasets_to_split)
 
-        # Datasets in unequal_split_datasets use equal=False, all others use equal=True
-        unequal_split_set = set(self._unequal_split_datasets)
-
-        locality_hints = worker_node_ids if self._enable_shard_locality else None
         for name, ds in datasets.items():
             execution_options = self._get_execution_options(name)
 
@@ -159,10 +222,15 @@ class DataConfig:
             ds.context.execution_options = execution_options
 
             if name in datasets_to_split:
-                equal = name not in unequal_split_set
+                split_config = self._get_dataset_split_config(name)
+                locality_hints = (
+                    worker_node_ids if split_config.enable_shard_locality else None
+                )
                 for i, split in enumerate(
                     ds.streaming_split(
-                        world_size, equal=equal, locality_hints=locality_hints
+                        world_size,
+                        equal=split_config.equal,
+                        locality_hints=locality_hints,
                     )
                 ):
                     output[i][name] = split

--- a/python/ray/train/v2/_internal/state/schema.py
+++ b/python/ray/train/v2/_internal/state/schema.py
@@ -317,6 +317,18 @@ class DataExecutionOptions(BaseModel):
 
 
 @DeveloperAPI
+class SplitConfig(BaseModel):
+    """Per-dataset split settings for a Ray Train run."""
+
+    equal: bool = Field(
+        description="Whether the dataset should be split equally across workers."
+    )
+    enable_shard_locality: bool = Field(
+        description="Whether shard locality optimization is enabled for the dataset."
+    )
+
+
+@DeveloperAPI
 class DataConfig(BaseModel):
     """Configuration for dataset splitting and execution options within Ray Train."""
 
@@ -328,6 +340,10 @@ class DataConfig(BaseModel):
         description="Datasets that should use unequal splitting (equal=False). "
         "By default, all datasets use equal splitting (equal=True) for backward compatibility. "
         "List datasets here that should NOT drop rows during splitting.",
+    )
+    dataset_split_configs: Dict[str, SplitConfig] = Field(
+        default_factory=dict,
+        description="Detailed per-dataset split settings for dict-based datasets_to_split.",
     )
     execution_options: Optional[Dict] = Field(
         default=None,

--- a/python/ray/train/v2/_internal/state/schema.py
+++ b/python/ray/train/v2/_internal/state/schema.py
@@ -323,6 +323,12 @@ class DataConfig(BaseModel):
     datasets_to_split: Union[Literal["all"], List[str]] = Field(
         description="Which datasets to split; either 'all' or a list of dataset names."
     )
+    unequal_split_datasets: List[str] = Field(
+        default_factory=list,
+        description="Datasets that should use unequal splitting (equal=False). "
+        "By default, all datasets use equal splitting (equal=True) for backward compatibility. "
+        "List datasets here that should NOT drop rows during splitting.",
+    )
     execution_options: Optional[Dict] = Field(
         default=None,
         deprecated="DEPRECATED: Use data_execution_options instead.",

--- a/python/ray/train/v2/_internal/state/util.py
+++ b/python/ray/train/v2/_internal/state/util.py
@@ -76,6 +76,7 @@ def construct_data_config(data_config: DataConfig) -> DataConfigSchema:
 
     return DataConfigSchema(
         datasets_to_split=data_config._datasets_to_split,
+        unequal_split_datasets=data_config._unequal_split_datasets,
         data_execution_options=DataExecutionOptions(
             default=execution_options_to_model(exec_options.default_factory()),
             per_dataset_execution_options=per_dataset_execution_options,

--- a/python/ray/train/v2/_internal/state/util.py
+++ b/python/ray/train/v2/_internal/state/util.py
@@ -9,6 +9,7 @@ from ray.train.v2._internal.state.schema import (
     ExecutionOptions as ExecutionOptionsSchema,
     RunAttemptStatus,
     RunStatus,
+    SplitConfig as SplitConfigSchema,
     TrainRun,
     TrainRunAttempt,
 )
@@ -74,9 +75,22 @@ def construct_data_config(data_config: DataConfig) -> DataConfigSchema:
             for ds_name, opts in exec_options.items()
         }
 
+    dataset_split_configs = {
+        ds_name: SplitConfigSchema(
+            equal=split_config.equal,
+            enable_shard_locality=(
+                data_config._enable_shard_locality
+                if split_config.enable_shard_locality is None
+                else split_config.enable_shard_locality
+            ),
+        )
+        for ds_name, split_config in data_config._dataset_split_configs.items()
+    }
+
     return DataConfigSchema(
         datasets_to_split=data_config._datasets_to_split,
         unequal_split_datasets=data_config._unequal_split_datasets,
+        dataset_split_configs=dataset_split_configs,
         data_execution_options=DataExecutionOptions(
             default=execution_options_to_model(exec_options.default_factory()),
             per_dataset_execution_options=per_dataset_execution_options,

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -89,7 +89,7 @@ def test_data_config_validation():
     with pytest.raises(TypeError, match="`datasets_to_split` should be.*"):
         ray.train.DataConfig(datasets_to_split="hello")
     with pytest.raises(TypeError, match="`datasets_to_split` should be.*"):
-        ray.train.DataConfig(datasets_to_split={})
+        ray.train.DataConfig(datasets_to_split={"train": False})
 
 
 def test_datasets_callback(ray_start_4_cpus):
@@ -206,6 +206,43 @@ def test_configure_locality(enable_shard_locality):
         world_size,
         equal=True,
         locality_hints=worker_node_ids if enable_shard_locality else None,
+    )
+
+
+def test_configure_per_dataset_split_config():
+    data_config = ray.train.DataConfig(
+        datasets_to_split={
+            "train": ray.train.SplitConfig(),
+            "eval": ray.train.SplitConfig(equal=False, enable_shard_locality=False),
+        }
+    )
+
+    mock_train = MagicMock()
+    mock_train.streaming_split = MagicMock()
+    mock_train.copy = MagicMock(return_value=mock_train)
+
+    mock_eval = MagicMock()
+    mock_eval.streaming_split = MagicMock()
+    mock_eval.copy = MagicMock(return_value=mock_eval)
+
+    world_size = 2
+    worker_node_ids = ["node0", "node1"]
+    data_config.configure(
+        datasets={"train": mock_train, "eval": mock_eval},
+        world_size=world_size,
+        worker_handles=None,
+        worker_node_ids=worker_node_ids,
+    )
+
+    mock_train.streaming_split.assert_called_once_with(
+        world_size,
+        equal=True,
+        locality_hints=worker_node_ids,
+    )
+    mock_eval.streaming_split.assert_called_once_with(
+        world_size,
+        equal=False,
+        locality_hints=None,
     )
 
 

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -209,6 +209,31 @@ def test_configure_locality(enable_shard_locality):
     )
 
 
+def test_unequal_split_no_rows_dropped(ray_start_4_cpus):
+    """Test that unequal_split_datasets preserves all rows (no dropping)."""
+    NUM_ROWS = 11
+    NUM_WORKERS = 2
+
+    ds = ray.data.range(NUM_ROWS)
+
+    def train_fn():
+        ds_shard = ray.train.get_dataset_shard("eval")
+        rows = list(ds_shard.iter_rows())
+        # With equal=False, no rows are dropped. Total across all workers == NUM_ROWS.
+        # This worker may have 5 or 6 rows (11 // 2 = 5, remainder 1).
+        assert len(rows) in (NUM_ROWS // NUM_WORKERS, NUM_ROWS // NUM_WORKERS + 1)
+
+    trainer = DataParallelTrainer(
+        train_loop_per_worker=train_fn,
+        scaling_config=ray.train.ScalingConfig(num_workers=NUM_WORKERS),
+        datasets={"eval": ds},
+        dataset_config=ray.train.DataConfig(
+            unequal_split_datasets=["eval"],
+        ),
+    )
+    trainer.fit()
+
+
 @pytest.mark.parametrize("cache_random_preprocessing", [True, False])
 def test_per_epoch_preprocessing(ray_start_4_cpus, cache_random_preprocessing):
     """Random preprocessing should change per-epoch."""

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -216,12 +216,23 @@ def test_unequal_split_no_rows_dropped(ray_start_4_cpus):
 
     ds = ray.data.range(NUM_ROWS)
 
+    @ray.remote
+    class RowCounter:
+        def __init__(self):
+            self._counts = []
+
+        def add(self, count):
+            self._counts.append(count)
+
+        def total(self):
+            return sum(self._counts)
+
+    counter = RowCounter.remote()
+
     def train_fn():
         ds_shard = ray.train.get_dataset_shard("eval")
         rows = list(ds_shard.iter_rows())
-        # With equal=False, no rows are dropped. Total across all workers == NUM_ROWS.
-        # This worker may have 5 or 6 rows (11 // 2 = 5, remainder 1).
-        assert len(rows) in (NUM_ROWS // NUM_WORKERS, NUM_ROWS // NUM_WORKERS + 1)
+        ray.get(counter.add.remote(len(rows)))
 
     trainer = DataParallelTrainer(
         train_loop_per_worker=train_fn,
@@ -232,6 +243,11 @@ def test_unequal_split_no_rows_dropped(ray_start_4_cpus):
         ),
     )
     trainer.fit()
+
+    total = ray.get(counter.total.remote())
+    assert (
+        total == NUM_ROWS
+    ), f"Expected {NUM_ROWS} total rows across all workers, got {total}"
 
 
 @pytest.mark.parametrize("cache_random_preprocessing", [True, False])

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -941,6 +941,14 @@ def test_construct_data_config_defaults_and_split_variants():
     result = construct_data_config(DataConfig(enable_shard_locality=False))
     assert result.enable_shard_locality is False
 
+    # unequal_split_datasets default (empty list, all datasets use equal=True)
+    default = construct_data_config(DataConfig())
+    assert default.unequal_split_datasets == []
+
+    # unequal_split_datasets specific list
+    result = construct_data_config(DataConfig(unequal_split_datasets=["eval"]))
+    assert result.unequal_split_datasets == ["eval"]
+
 
 def test_construct_data_config_single_execution_options():
     """A single ExecutionOptions lands in data_execution_options.default and

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -12,7 +12,7 @@ from ray.data._internal.execution.interfaces.execution_options import (
     ExecutionResources,
 )
 from ray.runtime_env import RuntimeEnv
-from ray.train import BackendConfig, DataConfig
+from ray.train import BackendConfig, DataConfig, SplitConfig
 from ray.train.v2._internal.callbacks.state_manager import (
     StateManagerCallback,
     TrainingFramework,
@@ -948,6 +948,21 @@ def test_construct_data_config_defaults_and_split_variants():
     # unequal_split_datasets specific list
     result = construct_data_config(DataConfig(unequal_split_datasets=["eval"]))
     assert result.unequal_split_datasets == ["eval"]
+
+    # Dict-based per-dataset split config preserves legacy split list and stores detail.
+    result = construct_data_config(
+        DataConfig(
+            datasets_to_split={
+                "train": SplitConfig(),
+                "eval": SplitConfig(equal=False, enable_shard_locality=False),
+            }
+        )
+    )
+    assert result.datasets_to_split == ["train", "eval"]
+    assert result.dataset_split_configs["train"].equal is True
+    assert result.dataset_split_configs["train"].enable_shard_locality is True
+    assert result.dataset_split_configs["eval"].equal is False
+    assert result.dataset_split_configs["eval"].enable_shard_locality is False
 
 
 def test_construct_data_config_single_execution_options():


### PR DESCRIPTION
## Summary

This updates `ray.train.DataConfig` to support a per-dataset split configuration API while preserving backward compatibility with the existing `datasets_to_split` and `unequal_split_datasets` usage.

Concretely, `datasets_to_split` now accepts:

- `"all"`
- `List[str]`
- `Dict[str, SplitConfig]`

This enables dataset-specific control over:

- whether a dataset should use equal splitting
- whether shard locality should be enabled for that dataset

Example:

```python
from ray.train import DataConfig, SplitConfig

dataset_config = DataConfig(
    datasets_to_split={
        "train": SplitConfig(),
        "eval": SplitConfig(equal=False, enable_shard_locality=False),
    }
)
```

## Motivation

The original change added support for avoiding silent row dropping on selected datasets by configuring unequal splitting for datasets such as eval or batch inference.

Review feedback suggested moving toward a per-dataset configuration object rather than introducing another top-level list. This change implements that direction without breaking existing users:

- existing `datasets_to_split="all"` and `datasets_to_split=[...]` behavior is unchanged
- existing `unequal_split_datasets=[...]` remains supported as a compatibility path
- new code can use `Dict[str, SplitConfig]` for clearer and more extensible configuration

This also creates a path for per-dataset locality control, which was previously only available as a global `enable_shard_locality` setting.

## What Changed

### User-facing API

- Added public `ray.train.SplitConfig`
- Extended `DataConfig.datasets_to_split` to accept `Dict[str, SplitConfig]`
- Preserved `unequal_split_datasets` as a legacy compatibility option
- Rejected ambiguous usage by raising an error when `unequal_split_datasets` is combined with dict-based `datasets_to_split`

### Runtime behavior

When dict-based `datasets_to_split` is used:

- the dataset keys define which datasets are split
- each dataset uses its own `SplitConfig.equal`
- each dataset uses its own `SplitConfig.enable_shard_locality` if provided
- otherwise shard locality falls back to the global `DataConfig(enable_shard_locality=...)`

Legacy behavior still works:

- list-based `datasets_to_split` continues to control which datasets are split
- `unequal_split_datasets` continues to control which split datasets use `equal=False`

### State / schema updates

- Added per-dataset split config serialization in the V2 Python state schema
- Preserved the existing exported split-list shape for the current external export surface

## Tests

Added and updated coverage for:

- dict-based `datasets_to_split`
- per-dataset `equal` behavior
- per-dataset `enable_shard_locality` behavior
- empty dict input for `datasets_to_split`
- V2 state serialization of `dataset_split_configs`

Affected tests:

- `python/ray/air/tests/test_new_dataset_config.py`
- `python/ray/train/v2/tests/test_data_integration.py`
- `python/ray/train/v2/tests/test_state.py`

## Verification

```bash
RAY_TRAIN_V2_ENABLED=0 python -m pytest \
  python/ray/air/tests/test_new_dataset_config.py::test_configure_per_dataset_unequal_split \
  python/ray/air/tests/test_new_dataset_config.py::test_configure_per_dataset_split_config

python -m pytest \
  python/ray/train/v2/tests/test_data_integration.py::test_data_config_validation \
  python/ray/train/v2/tests/test_data_integration.py::test_configure_per_dataset_split_config

python -m pytest \
  python/ray/train/v2/tests/test_state.py::test_construct_data_config_defaults_and_split_variants
```

## Related issues
Closes #63285

