### PR TITLE
Add routing microbenchmark for choose_replica + dispatch pattern

### DIFF
--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -264,6 +264,25 @@ class Benchmarker:
         end = time.perf_counter()
         return 1000 * (end - start)
 
+    async def do_single_choose_dispatch(self, payload: Any = None) -> float:
+        """Completes a single unary request via choose_replica + dispatch.
+
+        Returns e2e latency in ms. With SingletonThreadRouter this involves
+        two run_coroutine_threadsafe round-trips (one for __aenter__, one
+        for _dispatch_to_marked_selection) vs. one for ``remote``.
+        """
+        start = time.perf_counter()
+
+        if payload is None:
+            async with self._handle.choose_replica() as sel:
+                await self._handle.dispatch(sel)
+        else:
+            async with self._handle.choose_replica(payload) as sel:
+                await self._handle.dispatch(sel, payload)
+
+        end = time.perf_counter()
+        return 1000 * (end - start)
+
     async def _do_single_stream(self) -> float:
         """Consumes a single streaming request. Returns e2e latency in ms."""
         start = time.perf_counter()
@@ -285,10 +304,24 @@ class Benchmarker:
             )
 
     async def run_latency_benchmark(
-        self, *, num_requests: int, payload: Any = None
+        self,
+        *,
+        num_requests: int,
+        payload: Any = None,
+        mode: str = "remote",
     ) -> pd.Series:
-        async def f():
-            await self.do_single_request(payload)
+        if mode == "remote":
+
+            async def f():
+                await self.do_single_request(payload)
+
+        elif mode == "choose_dispatch":
+
+            async def f():
+                await self.do_single_choose_dispatch(payload)
+
+        else:
+            raise ValueError(f"Unknown mode {mode!r}")
 
         return await run_latency_benchmark(f, num_requests=num_requests)
 

--- a/python/ray/serve/_private/benchmarks/handle_noop_latency.py
+++ b/python/ray/serve/_private/benchmarks/handle_noop_latency.py
@@ -1,7 +1,6 @@
 import time
 
 import click
-import pandas as pd
 
 from ray import serve
 from ray.serve._private.benchmarks.common import Benchmarker, Noop
@@ -11,20 +10,26 @@ from ray.serve.handle import DeploymentHandle
 @click.command(help="Benchmark no-op DeploymentHandle latency.")
 @click.option("--num-replicas", type=int, default=1)
 @click.option("--num-requests", type=int, default=100)
-def main(num_replicas: int, num_requests: int):
+@click.option(
+    "--mode",
+    type=click.Choice(["remote", "choose_dispatch"]),
+    default="remote",
+    help="Which call pattern to benchmark.",
+)
+def main(num_replicas: int, num_requests: int, mode: str):
     h: DeploymentHandle = serve.run(
         Benchmarker.bind(Noop.options(num_replicas=num_replicas).bind())
     )
 
-    latencies: pd.Series = h.run_latency_benchmark.remote(
-        num_requests,
+    latencies = h.run_latency_benchmark.remote(
+        num_requests=num_requests, mode=mode
     ).result()
 
     # Let the logs flush to avoid interwoven output.
     time.sleep(1)
 
     print(
-        "Latency (ms) for noop DeploymentHandle requests "
+        f"Latency (ms) for noop DeploymentHandle requests via {mode!r} "
         f"(num_replicas={num_replicas},num_requests={num_requests}):"
     )
     print(latencies.describe(percentiles=[0.5, 0.9, 0.95, 0.99]))

--- a/release/serve_tests/workloads/microbenchmarks.py
+++ b/release/serve_tests/workloads/microbenchmarks.py
@@ -447,14 +447,15 @@ async def _main(
     # Handle
     if run_handle:
         if run_latency:
-            for payload, name in [
-                (None, "handle"),
-                (payload_1mb, "handle_1mb"),
-                (payload_10mb, "handle_10mb"),
+            for payload, name, mode in [
+                (None, "handle", "remote"),
+                (payload_1mb, "handle_1mb", "remote"),
+                (payload_10mb, "handle_10mb", "remote"),
+                (None, "handle_choose_dispatch", "choose_dispatch"),
             ]:
                 h: DeploymentHandle = serve.run(Benchmarker.bind(Noop.bind()))
                 latencies = await h.run_latency_benchmark.remote(
-                    num_requests=NUM_REQUESTS, payload=payload
+                    num_requests=NUM_REQUESTS, payload=payload, mode=mode
                 )
                 perf_metrics.extend(convert_latencies_to_perf_metrics(name, latencies))
                 await serve.shutdown_async()


### PR DESCRIPTION
## Description

Following up on https://github.com/ray-project/ray/pull/63255#issuecomment-4426420093, we'd like to show the delta between `choose_replica + dispatch` and `remote` in our DB dashboards.

**Release test results** -- latencies in ms (https://buildkite.com/ray-project/release/builds/92517/canvas?sid=019e1a3c-642f-4a42-867b-2818577272b6&tab=output)
| Percentile | `remote` | `choose_replica + dispatch` | Delta |
|---|---|---|---|
| p50 | 1.040 | 1.784 | +0.74 |
| p90 | 1.149 | 1.922 | +0.77 |
| p95 | 1.199 | 1.970 | +0.77 |
| p99 | 1.437 | 2.137 | +0.70 |

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
