### PR TITLE
[ci] Stop billing tags from overriding advanced_instance_config fields

### DIFF
--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -94,27 +94,40 @@ class ClusterManager(abc.ABC):
         cluster_compute = cluster_compute.copy()
 
         if is_new_schema:
-            # Always tag the top-level advanced_instance_config. Per-group
-            # advanced_instance_config is only tagged when the user has
-            # already set one — never auto-created. Anyscale replaces (does
-            # not merge with) the base spec when a per-group spec is present,
-            # so auto-creating a TagSpecifications-only per-group spec would
-            # drop any IamInstanceProfile/NetworkInterfaces/etc. set at the
-            # cluster level. When a per-group spec already exists, the base
-            # is dropped regardless, so the per-group spec must carry the
-            # billing tags itself.
-            aws = cluster_compute.get("advanced_instance_config", {})
-            cluster_compute["advanced_instance_config"] = add_tags_to_aws_config(
-                aws, extra_tags, RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING
-            )
+            # Anyscale picks an effective advanced_instance_config per node
+            # group: when a per-group spec is set, it replaces (does not
+            # merge with) the cluster-level base. So billing tags must land
+            # wherever the effective spec actually comes from. Rules:
+            #   - No advanced_instance_config anywhere -> tag base only
+            #     (auto-create base spec to hold tags).
+            #   - Base only -> tag base only.
+            #   - Per-group only (head and/or workers, no base) -> tag those
+            #     per-group specs only. Do NOT auto-create a base spec; that
+            #     would tag a base that no node group uses and could
+            #     confuse readers.
+            #   - Base AND per-group -> tag everywhere. Both are
+            #     load-bearing: the base covers node groups without an
+            #     override, the per-group covers node groups with one.
             head = cluster_compute.get("head_node")
-            if isinstance(head, dict) and "advanced_instance_config" in head:
+            workers = cluster_compute.get("worker_nodes", []) or []
+            has_head_aic = isinstance(head, dict) and "advanced_instance_config" in head
+            has_worker_aic = any(
+                isinstance(w, dict) and "advanced_instance_config" in w for w in workers
+            )
+            has_base_aic = "advanced_instance_config" in cluster_compute
+            should_tag_base = has_base_aic or not (has_head_aic or has_worker_aic)
+            if should_tag_base:
+                aws = cluster_compute.get("advanced_instance_config", {})
+                cluster_compute["advanced_instance_config"] = add_tags_to_aws_config(
+                    aws, extra_tags, RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING
+                )
+            if has_head_aic:
                 head["advanced_instance_config"] = add_tags_to_aws_config(
                     head["advanced_instance_config"],
                     extra_tags,
                     RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
                 )
-            for worker in cluster_compute.get("worker_nodes", []) or []:
+            for worker in workers:
                 if isinstance(worker, dict) and "advanced_instance_config" in worker:
                     worker["advanced_instance_config"] = add_tags_to_aws_config(
                         worker["advanced_instance_config"],

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -94,28 +94,15 @@ class ClusterManager(abc.ABC):
         cluster_compute = cluster_compute.copy()
 
         if is_new_schema:
-            # Top-level advanced_instance_config
+            # Only annotate the top-level advanced_instance_config. Tagging
+            # head_node/worker_nodes here causes Anyscale to use the per-group
+            # spec (TagSpecifications-only) at instance launch and drop any
+            # IamInstanceProfile/NetworkInterfaces/etc. set at the cluster
+            # level, since per-group spec replaces (not merges with) the base.
             aws = cluster_compute.get("advanced_instance_config", {})
             cluster_compute["advanced_instance_config"] = add_tags_to_aws_config(
                 aws, extra_tags, RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING
             )
-            # head_node.advanced_instance_config
-            if "head_node" in cluster_compute:
-                head = cluster_compute["head_node"]
-                head_aws = head.get("advanced_instance_config", {})
-                head["advanced_instance_config"] = add_tags_to_aws_config(
-                    head_aws,
-                    extra_tags,
-                    RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
-                )
-            # worker_nodes[*].advanced_instance_config
-            for worker in cluster_compute.get("worker_nodes", []):
-                worker_aws = worker.get("advanced_instance_config", {})
-                worker["advanced_instance_config"] = add_tags_to_aws_config(
-                    worker_aws,
-                    extra_tags,
-                    RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
-                )
         else:
             if "aws" in cluster_compute:
                 raise ValueError(

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -94,15 +94,33 @@ class ClusterManager(abc.ABC):
         cluster_compute = cluster_compute.copy()
 
         if is_new_schema:
-            # Only annotate the top-level advanced_instance_config. Tagging
-            # head_node/worker_nodes here causes Anyscale to use the per-group
-            # spec (TagSpecifications-only) at instance launch and drop any
-            # IamInstanceProfile/NetworkInterfaces/etc. set at the cluster
-            # level, since per-group spec replaces (not merges with) the base.
+            # Always tag the top-level advanced_instance_config. Per-group
+            # advanced_instance_config is only tagged when the user has
+            # already set one — never auto-created. Anyscale replaces (does
+            # not merge with) the base spec when a per-group spec is present,
+            # so auto-creating a TagSpecifications-only per-group spec would
+            # drop any IamInstanceProfile/NetworkInterfaces/etc. set at the
+            # cluster level. When a per-group spec already exists, the base
+            # is dropped regardless, so the per-group spec must carry the
+            # billing tags itself.
             aws = cluster_compute.get("advanced_instance_config", {})
             cluster_compute["advanced_instance_config"] = add_tags_to_aws_config(
                 aws, extra_tags, RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING
             )
+            head = cluster_compute.get("head_node")
+            if isinstance(head, dict) and "advanced_instance_config" in head:
+                head["advanced_instance_config"] = add_tags_to_aws_config(
+                    head["advanced_instance_config"],
+                    extra_tags,
+                    RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
+                )
+            for worker in cluster_compute.get("worker_nodes", []) or []:
+                if isinstance(worker, dict) and "advanced_instance_config" in worker:
+                    worker["advanced_instance_config"] = add_tags_to_aws_config(
+                        worker["advanced_instance_config"],
+                        extra_tags,
+                        RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING,
+                    )
         else:
             if "aws" in cluster_compute:
                 raise ValueError(

--- a/release/ray_release/cluster_manager/cluster_manager.py
+++ b/release/ray_release/cluster_manager/cluster_manager.py
@@ -108,9 +108,14 @@ class ClusterManager(abc.ABC):
             #   - Base AND per-group -> tag everywhere. Both are
             #     load-bearing: the base covers node groups without an
             #     override, the per-group covers node groups with one.
-            head = cluster_compute.get("head_node")
-            workers = cluster_compute.get("worker_nodes", []) or []
-            has_head_aic = isinstance(head, dict) and "advanced_instance_config" in head
+            # Normalize missing/null head_node and worker_nodes to empty
+            # containers so the downstream checks don't need to special-case
+            # them. When head is missing/null the resulting `head` is a
+            # fresh `{}` we never mutate (has_head_aic is False); when
+            # head_node is a real dict we mutate that dict in place below.
+            head = cluster_compute.get("head_node") or {}
+            workers = cluster_compute.get("worker_nodes") or []
+            has_head_aic = "advanced_instance_config" in head
             has_worker_aic = any(
                 isinstance(w, dict) and "advanced_instance_config" in w for w in workers
             )

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -341,30 +341,28 @@ class MinimalSessionManagerTest(unittest.TestCase):
         top_level_aic = cluster_manager.cluster_compute["advanced_instance_config"]
         self.assertIn("TagSpecifications", top_level_aic)
 
-        # head_node.advanced_instance_config should have tags
-        head_aic = cluster_manager.cluster_compute["head_node"][
-            "advanced_instance_config"
-        ]
-        self.assertIn("TagSpecifications", head_aic)
+        # head_node and worker_nodes must NOT be annotated. Populating
+        # per-group advanced_instance_config causes Anyscale to use it
+        # (TagSpecifications only) and drop the cluster-level IamInstanceProfile
+        # and other fields, since per-group spec replaces (not merges with) base.
+        self.assertNotIn(
+            "advanced_instance_config",
+            cluster_manager.cluster_compute.get("head_node", {}),
+        )
+        for worker in cluster_manager.cluster_compute.get("worker_nodes", []):
+            self.assertNotIn("advanced_instance_config", worker)
 
-        # worker_nodes[0].advanced_instance_config should have tags
-        worker_aic = cluster_manager.cluster_compute["worker_nodes"][0][
-            "advanced_instance_config"
-        ]
-        self.assertIn("TagSpecifications", worker_aic)
-
-        # Verify tag values for all tracked resource types
-        for aic in [top_level_aic, head_aic, worker_aic]:
-            tag_specs = aic["TagSpecifications"]
-            self.assertEqual(
-                len(tag_specs), len(RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING)
-            )
-            for resource_type in RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING:
-                resource_tags = [
-                    ts for ts in tag_specs if ts["ResourceType"] == resource_type
-                ]
-                self.assertEqual(len(resource_tags), 1)
-                self.assertIn({"Key": "foo", "Value": "bar"}, resource_tags[0]["Tags"])
+        # Verify tag values for all tracked resource types on the top-level spec
+        tag_specs = top_level_aic["TagSpecifications"]
+        self.assertEqual(
+            len(tag_specs), len(RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING)
+        )
+        for resource_type in RELEASE_AWS_RESOURCE_TYPES_TO_TRACK_FOR_BILLING:
+            resource_tags = [
+                ts for ts in tag_specs if ts["ResourceType"] == resource_type
+            ]
+            self.assertEqual(len(resource_tags), 1)
+            self.assertIn({"Key": "foo", "Value": "bar"}, resource_tags[0]["Tags"])
 
         # Test merging with already existing tags
         cluster_compute_with_tags = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -381,6 +381,42 @@ class MinimalSessionManagerTest(unittest.TestCase):
         cluster_manager.set_cluster_compute(
             cluster_compute_with_per_group, extra_tags={"foo": "bar"}
         )
+        # No base advanced_instance_config in the input: do not auto-create
+        # one. Only the per-group specs should carry the billing tags.
+        self.assertNotIn("advanced_instance_config", cluster_manager.cluster_compute)
+        head_aic = cluster_manager.cluster_compute["head_node"][
+            "advanced_instance_config"
+        ]
+        self.assertEqual(head_aic["IamInstanceProfile"], {"Name": "head-profile"})
+        self.assertIn("TagSpecifications", head_aic)
+        worker_aic = cluster_manager.cluster_compute["worker_nodes"][0][
+            "advanced_instance_config"
+        ]
+        self.assertEqual(worker_aic["IamInstanceProfile"], {"Name": "worker-profile"})
+        self.assertIn("TagSpecifications", worker_aic)
+
+        # When the input compute config has BOTH a base
+        # advanced_instance_config and per-group ones, tags must land in
+        # both places. Anyscale uses the base for any node group that
+        # doesn't supply its own override.
+        cluster_compute_with_base_and_per_group = copy.deepcopy(
+            TEST_CLUSTER_COMPUTE_NEW_SCHEMA
+        )
+        cluster_compute_with_base_and_per_group["advanced_instance_config"] = {
+            "IamInstanceProfile": {"Name": "base-profile"},
+        }
+        cluster_compute_with_base_and_per_group["head_node"][
+            "advanced_instance_config"
+        ] = {"IamInstanceProfile": {"Name": "head-profile"}}
+        cluster_compute_with_base_and_per_group["worker_nodes"][0][
+            "advanced_instance_config"
+        ] = {"IamInstanceProfile": {"Name": "worker-profile"}}
+        cluster_manager.set_cluster_compute(
+            cluster_compute_with_base_and_per_group, extra_tags={"foo": "bar"}
+        )
+        base_aic = cluster_manager.cluster_compute["advanced_instance_config"]
+        self.assertEqual(base_aic["IamInstanceProfile"], {"Name": "base-profile"})
+        self.assertIn("TagSpecifications", base_aic)
         head_aic = cluster_manager.cluster_compute["head_node"][
             "advanced_instance_config"
         ]
@@ -416,6 +452,68 @@ class MinimalSessionManagerTest(unittest.TestCase):
         volume_tags = [ts for ts in merged_specs if ts["ResourceType"] == "volume"]
         self.assertEqual(len(volume_tags), 1)
         self.assertIn({"Key": "foo", "Value": "bar"}, volume_tags[0]["Tags"])
+
+    def _make_new_schema_cluster_manager(
+        self, env: str = "aws"
+    ) -> MinimalClusterManager:
+        sdk = MockSDK()
+        sdk.returns["get_project"] = APIDict(result=APIDict(name="release_unit_tests"))
+        return MinimalClusterManager(
+            project_id=UNIT_TEST_PROJECT_ID,
+            sdk=sdk,
+            test=MockTest(
+                {
+                    "name": "unit_test_new_schema",
+                    "env": env,
+                    "cluster": {"byod": {}, "anyscale_sdk_2026": True},
+                }
+            ),
+        )
+
+    def testClusterComputeNewSchemaNonAws(self):
+        # Non-AWS cloud (gce): annotation should be skipped entirely.
+        cluster_manager = self._make_new_schema_cluster_manager(env="gce")
+        cluster_compute = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)
+        cluster_manager.set_cluster_compute(cluster_compute, extra_tags={"foo": "bar"})
+        self.assertNotIn("advanced_instance_config", cluster_manager.cluster_compute)
+
+    def testClusterComputeNewSchemaPerGroupHeadOnly(self):
+        # advanced_instance_config defined only on head_node (no base, no
+        # worker): tag head only, don't auto-create base.
+        cluster_manager = self._make_new_schema_cluster_manager()
+        cluster_compute = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)
+        cluster_compute["head_node"]["advanced_instance_config"] = {
+            "IamInstanceProfile": {"Name": "head-profile"},
+        }
+        cluster_manager.set_cluster_compute(cluster_compute, extra_tags={"foo": "bar"})
+        self.assertNotIn("advanced_instance_config", cluster_manager.cluster_compute)
+        head_aic = cluster_manager.cluster_compute["head_node"][
+            "advanced_instance_config"
+        ]
+        self.assertEqual(head_aic["IamInstanceProfile"], {"Name": "head-profile"})
+        self.assertIn("TagSpecifications", head_aic)
+        for worker in cluster_manager.cluster_compute["worker_nodes"]:
+            self.assertNotIn("advanced_instance_config", worker)
+
+    def testClusterComputeNewSchemaPerGroupWorkerOnly(self):
+        # advanced_instance_config defined only on a worker (no base, no
+        # head): tag that worker only, don't auto-create base.
+        cluster_manager = self._make_new_schema_cluster_manager()
+        cluster_compute = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)
+        cluster_compute["worker_nodes"][0]["advanced_instance_config"] = {
+            "IamInstanceProfile": {"Name": "worker-profile"},
+        }
+        cluster_manager.set_cluster_compute(cluster_compute, extra_tags={"foo": "bar"})
+        self.assertNotIn("advanced_instance_config", cluster_manager.cluster_compute)
+        self.assertNotIn(
+            "advanced_instance_config",
+            cluster_manager.cluster_compute["head_node"],
+        )
+        worker_aic = cluster_manager.cluster_compute["worker_nodes"][0][
+            "advanced_instance_config"
+        ]
+        self.assertEqual(worker_aic["IamInstanceProfile"], {"Name": "worker-profile"})
+        self.assertIn("TagSpecifications", worker_aic)
 
     @patch("time.sleep", lambda *a, **kw: None)
     def testFindCreateClusterEnvExisting(self):

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -341,10 +341,12 @@ class MinimalSessionManagerTest(unittest.TestCase):
         top_level_aic = cluster_manager.cluster_compute["advanced_instance_config"]
         self.assertIn("TagSpecifications", top_level_aic)
 
-        # head_node and worker_nodes must NOT be annotated. Populating
-        # per-group advanced_instance_config causes Anyscale to use it
-        # (TagSpecifications only) and drop the cluster-level IamInstanceProfile
-        # and other fields, since per-group spec replaces (not merges with) base.
+        # head_node and worker_nodes must NOT be auto-annotated when the
+        # input compute config has no per-group advanced_instance_config.
+        # Creating one (with TagSpecifications only) would cause Anyscale to
+        # use the per-group spec and drop the cluster-level
+        # IamInstanceProfile and other fields, since per-group spec replaces
+        # (not merges with) the base.
         self.assertNotIn(
             "advanced_instance_config",
             cluster_manager.cluster_compute.get("head_node", {}),
@@ -363,6 +365,32 @@ class MinimalSessionManagerTest(unittest.TestCase):
             ]
             self.assertEqual(len(resource_tags), 1)
             self.assertIn({"Key": "foo", "Value": "bar"}, resource_tags[0]["Tags"])
+
+        # When the input compute config already has per-group
+        # advanced_instance_config, those per-group specs MUST be annotated
+        # too. Anyscale replaces the base spec with the per-group spec when
+        # one is present, so without annotation the billing tags would be
+        # lost on that node group.
+        cluster_compute_with_per_group = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)
+        cluster_compute_with_per_group["head_node"]["advanced_instance_config"] = {
+            "IamInstanceProfile": {"Name": "head-profile"},
+        }
+        cluster_compute_with_per_group["worker_nodes"][0][
+            "advanced_instance_config"
+        ] = {"IamInstanceProfile": {"Name": "worker-profile"}}
+        cluster_manager.set_cluster_compute(
+            cluster_compute_with_per_group, extra_tags={"foo": "bar"}
+        )
+        head_aic = cluster_manager.cluster_compute["head_node"][
+            "advanced_instance_config"
+        ]
+        self.assertEqual(head_aic["IamInstanceProfile"], {"Name": "head-profile"})
+        self.assertIn("TagSpecifications", head_aic)
+        worker_aic = cluster_manager.cluster_compute["worker_nodes"][0][
+            "advanced_instance_config"
+        ]
+        self.assertEqual(worker_aic["IamInstanceProfile"], {"Name": "worker-profile"})
+        self.assertIn("TagSpecifications", worker_aic)
 
         # Test merging with already existing tags
         cluster_compute_with_tags = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)

--- a/release/ray_release/tests/test_cluster_manager.py
+++ b/release/ray_release/tests/test_cluster_manager.py
@@ -470,6 +470,23 @@ class MinimalSessionManagerTest(unittest.TestCase):
             ),
         )
 
+    def testClusterComputeNewSchemaNoAic(self):
+        # No advanced_instance_config anywhere: auto-create the base spec to
+        # hold the billing tags. Per-group specs stay absent.
+        cluster_manager = self._make_new_schema_cluster_manager()
+        cluster_compute = copy.deepcopy(TEST_CLUSTER_COMPUTE_NEW_SCHEMA)
+        cluster_manager.set_cluster_compute(cluster_compute, extra_tags={"foo": "bar"})
+        self.assertIn(
+            "TagSpecifications",
+            cluster_manager.cluster_compute["advanced_instance_config"],
+        )
+        self.assertNotIn(
+            "advanced_instance_config",
+            cluster_manager.cluster_compute["head_node"],
+        )
+        for worker in cluster_manager.cluster_compute["worker_nodes"]:
+            self.assertNotIn("advanced_instance_config", worker)
+
     def testClusterComputeNewSchemaNonAws(self):
         # Non-AWS cloud (gce): annotation should be skipped entirely.
         cluster_manager = self._make_new_schema_cluster_manager(env="gce")


### PR DESCRIPTION
## Description

Refines `_annotate_cluster_compute` (new-schema branch) so the billing-tag `TagSpecifications` land at exactly the `advanced_instance_config` levels that the cluster will actually use at launch. Previously every new-schema compute config got tags added at three locations unconditionally: top-level, `head_node`, and every `worker_nodes[*]`.

### Final rules

| Input state                                         | Base tagged?         | Per-group tagged?              |
|-----------------------------------------------------|----------------------|--------------------------------|
| No `advanced_instance_config` anywhere              | yes (auto-created)   | —                              |
| `advanced_instance_config` at base only             | yes                  | —                              |
| `advanced_instance_config` only on head and/or workers | no (not auto-created) | yes (only the groups that already have one) |
| `advanced_instance_config` at base AND on head/workers | yes                | yes (only the groups that already have one) |

In code: `should_tag_base = has_base_aic or not (has_head_aic or has_worker_aic)`; per-group specs are tagged iff the user already supplied them.

### Why

Anyscale resolves the effective advanced instance spec per node group using an either-or pick: when a per-group spec is present, it **replaces** (does not merge with) the cluster-level base spec. The previous behavior unconditionally created `TagSpecifications`-only entries on `head_node` and `worker_nodes[*]`, which made those per-group specs non-empty and caused them to win — silently dropping any `IamInstanceProfile`/`NetworkInterfaces`/etc. set only at the cluster level.

This was observed on the `iceberg_benchmark_*` tests after their compute config was migrated to the new schema: workers no longer picked up the `ray-autoscaler-v1` IAM instance profile that was declared at the top level of `iceberg_benchmark_compute.yaml`, so the test couldn't access the AWS resources it needed.

### Test

`release/ray_release/tests/test_cluster_manager.py`:
- `testClusterComputeExtraTagsNewSchema` (updated) covers the no-AIC and base+per-group rows, including verifying that pre-existing `IamInstanceProfile` values on each level are preserved alongside the added `TagSpecifications`.
- `testClusterComputeNewSchemaNoAic`, `testClusterComputeNewSchemaPerGroupHeadOnly`, `testClusterComputeNewSchemaPerGroupWorkerOnly` (new) — one method per row of the table for clear regression coverage.
- `testClusterComputeNewSchemaNonAws` (new) — verifies the non-AWS early return.

## Related issues

Related to #62863 (where this bug was first observed during the dataset compute-config migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)