### PR TITLE
[Train] Deflake `test_tensorflow_checkpoint`

### DIFF
--- a/python/ray/train/BUILD.bazel
+++ b/python/ray/train/BUILD.bazel
@@ -803,7 +803,7 @@ py_test(
 
 py_test(
     name = "test_tensorflow_checkpoint",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_tensorflow_checkpoint.py"],
     env = {
         "RAY_TRAIN_V2_ENABLED": "1",


### PR DESCRIPTION
## Description
`test_tensorflow_checkpoint` is flaky however reviewing the logs, the test is taking the expected length of time however seems to be failing to shutdown in time. 
Therefore, to deflaky, this PR just increases the length of time for the test