### PR TITLE
[LLM] Fix misleading ImportError when vLLM is installed but fails to …

### DIFF
--- a/python/ray/llm/_internal/common/utils/import_utils.py
+++ b/python/ray/llm/_internal/common/utils/import_utils.py
@@ -2,7 +2,7 @@
 import importlib
 import logging
 from types import ModuleType
-from typing import Any, Optional, Type
+from typing import Any, NoReturn, Optional, Type
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +28,53 @@ def try_import(name: str, error: bool = False) -> Optional[ModuleType]:
         else:
             logger.warning("Could not import %s", name)
     return None
+
+
+def raise_llm_engine_import_error(
+    vllm_error: ImportError,
+    sglang_error: ImportError,
+) -> NoReturn:
+    """Raise a descriptive ImportError when both vLLM and SGLang fail to import.
+
+    Distinguishes between a package not being installed (ModuleNotFoundError
+    whose .name matches the top-level package) and a broken installation
+    (any other ImportError, e.g. a missing .so or a missing transitive dep).
+
+    Args:
+        vllm_error: The ImportError raised when importing vLLM.
+        sglang_error: The ImportError raised when importing SGLang.
+    """
+    vllm_not_installed = (
+        isinstance(vllm_error, ModuleNotFoundError) and vllm_error.name == "vllm"
+    )
+    sglang_not_installed = (
+        isinstance(sglang_error, ModuleNotFoundError) and sglang_error.name == "sglang"
+    )
+
+    if vllm_not_installed and sglang_not_installed:
+        raise ImportError(
+            "Neither vLLM nor SGLang is installed. At least one is required "
+            "for Ray Serve LLM protocol models. Install with: "
+            "`pip install ray[llm]` or `pip install sglang[all]`"
+        )
+
+    messages = []
+    if not vllm_not_installed:
+        messages.append(
+            "vLLM is installed but failed to import. This may indicate a "
+            "CUDA version mismatch or a missing vLLM dependency. "
+            f"Original error: {vllm_error}"
+        )
+    if not sglang_not_installed:
+        messages.append(
+            "SGLang is installed but failed to import. This may indicate a "
+            "missing SGLang dependency. "
+            f"Original error: {sglang_error}"
+        )
+    # Chain to the error that is actually relevant: vLLM's if it is broken,
+    # otherwise sglang's (i.e. vLLM was simply not installed).
+    cause = vllm_error if not vllm_not_installed else sglang_error
+    raise ImportError("\n".join(messages)) from cause
 
 
 def load_class(path: str) -> Type[Any]:

--- a/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
+++ b/python/ray/llm/_internal/serve/core/configs/openai_api_models.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Uni
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ray.llm._internal.common.utils.import_utils import raise_llm_engine_import_error
+
 try:
     from vllm.entrypoints.openai.chat_completion.protocol import (
         ChatCompletionRequest as _ChatCompletionRequest,
@@ -47,7 +49,7 @@ try:
         TokenizeResponse as _TokenizeResponse,
     )
 
-except ImportError:
+except ImportError as _vllm_import_error:
     try:
         from sglang.srt.entrypoints.openai.protocol import (
             ChatCompletionRequest as _ChatCompletionRequest,
@@ -65,12 +67,8 @@ except ImportError:
             TokenizeRequest as _TokenizeCompletionRequest,
             TokenizeResponse as _TokenizeResponse,
         )
-    except ImportError:
-        raise ImportError(
-            "Neither vLLM nor SGLang is installed. At least one is required "
-            "for Ray Serve LLM protocol models. Install with: "
-            "`pip install ray[llm]` or `pip install sglang[all]`"
-        )
+    except ImportError as _sglang_import_error:
+        raise_llm_engine_import_error(_vllm_import_error, _sglang_import_error)
 
     def _unsupported_model(name: str, feature: str = ""):
         """Create a BaseModel stub that raises NotImplementedError on instantiation."""

--- a/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_openai_api_models_backends.py
@@ -12,11 +12,32 @@ _OAI_MODELS_MOD = "ray.llm._internal.serve.core.configs.openai_api_models"
 
 
 class _VLLMImportBlocker:
-    """Meta-path finder that makes every ``vllm.*`` import raise."""
+    """Meta-path finder that simulates vLLM not being installed.
+
+    Raises ModuleNotFoundError with .name set to mirror what Python raises
+    when a package is genuinely absent, so raise_llm_engine_import_error
+    can distinguish "not installed" from "installed but broken".
+    """
 
     def find_spec(self, fullname, path=None, target=None):
         if fullname == "vllm" or fullname.startswith("vllm."):
-            raise ImportError(f"Mocked: {fullname} is not installed")
+            err = ModuleNotFoundError(f"Mocked: {fullname} is not installed")
+            err.name = fullname
+            raise err
+        return None
+
+
+class _VLLMBrokenInstallBlocker:
+    """Meta-path finder that simulates vLLM installed but broken at runtime
+    (e.g. missing libcudart.so or a missing transitive dependency).
+    """
+
+    def __init__(self, error: ImportError):
+        self._error = error
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "vllm" or fullname.startswith("vllm."):
+            raise self._error
         return None
 
 
@@ -56,10 +77,8 @@ class TestVLLMBackend:
 
         assert "request_id" in TranscriptionRequest.model_fields
 
-    def test_import_error_when_vllm_blocked(self):
-        """SGLang is not installed here either, so blocking vLLM means neither
-        backend is available."""
-        blocker = _VLLMImportBlocker()
+    def _reload_oai_models_with_blocker(self, blocker):
+        """Helper: evict vllm + the target module, install blocker, reimport."""
         saved = {
             k: sys.modules.pop(k)
             for k in list(sys.modules)
@@ -68,12 +87,36 @@ class TestVLLMBackend:
         sys.modules.pop(_OAI_MODELS_MOD, None)
         sys.meta_path.insert(0, blocker)
         try:
-            with pytest.raises(ImportError, match="Neither vLLM nor SGLang"):
-                importlib.import_module(_OAI_MODELS_MOD)
+            importlib.import_module(_OAI_MODELS_MOD)
         finally:
             sys.meta_path.remove(blocker)
             sys.modules.pop(_OAI_MODELS_MOD, None)
             sys.modules.update(saved)
+
+    def test_import_error_when_vllm_blocked(self):
+        """SGLang is not installed here either, so blocking vLLM means neither
+        backend is available."""
+        with pytest.raises(ImportError, match="Neither vLLM nor SGLang"):
+            self._reload_oai_models_with_blocker(_VLLMImportBlocker())
+
+    def test_vllm_installed_but_broken_cuda(self):
+        """Plain ImportError (e.g. missing libcudart.so) → clear message that
+        vLLM is installed but failed to load, not 'not installed'."""
+        cuda_err = ImportError(
+            "libcudart.so.12: cannot open shared object file: No such file or directory"
+        )
+        blocker = _VLLMBrokenInstallBlocker(cuda_err)
+        with pytest.raises(ImportError, match="vLLM is installed but failed to import"):
+            self._reload_oai_models_with_blocker(blocker)
+
+    def test_vllm_installed_but_missing_transitive_dep(self):
+        """ModuleNotFoundError for a *dependency* of vLLM (not vllm itself)
+        must also be reported as 'installed but broken', not 'not installed'."""
+        dep_err = ModuleNotFoundError("No module named 'msgpack'")
+        dep_err.name = "msgpack"
+        blocker = _VLLMBrokenInstallBlocker(dep_err)
+        with pytest.raises(ImportError, match="vLLM is installed but failed to import"):
+            self._reload_oai_models_with_blocker(blocker)
 
 
 class TestSanitizeChatCompletionRequest:


### PR DESCRIPTION
## Why

Fixes #63187

When vLLM is installed but fails to import at runtime due to a system
library issue (e.g., `libcudart.so.12: cannot open shared object file`
caused by a CUDA version mismatch), the broad `except ImportError` in
`openai_api_models.py` silently swallowed the real error and fell through
to the sglang fallback. When sglang was also unavailable, the user saw:


## What

Distinguish between `ModuleNotFoundError` (package not installed) and a
plain `ImportError` (installed but broken at runtime). When vLLM fails
with a plain `ImportError`, re-raise immediately with the original error
message included so users can diagnose the real cause (e.g., CUDA mismatch).

## Repro (no GPU needed)

```python
import sys

class _BrokenVllm:
    def __getattr__(self, name):
        raise ImportError("libcudart.so.12: cannot open shared object file")

sys.modules["vllm"] = _BrokenVllm()
sys.modules.pop("sglang", None)

from ray.llm._internal.serve.core.configs.openai_api_models import *
# Before: "Neither vLLM nor SGLang is installed"  ← misleading
# After:  "vLLM is installed but failed to import ... Original error: libcudart.so.12 ..."

