### PR TITLE
[train] Implement DatasetManager

### DIFF
--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -301,6 +301,23 @@ py_test(
 )
 
 py_test(
+    name = "test_dataset_manager",
+    size = "medium",
+    srcs = ["tests/test_dataset_manager.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
+    tags = [
+        "data_integration",
+        "exclusive",
+        "team:ml",
+        "train_v2",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_env_callbacks",
     size = "small",
     srcs = ["tests/test_env_callbacks.py"],

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -163,8 +163,9 @@ class DatasetsCallback(WorkerGroupCallback):
     def after_worker_group_shutdown(
         self, worker_group_context: WorkerGroupContext
     ) -> None:
-        assert self._dataset_shard_provider
-        self._dataset_shard_provider.shutdown_data_executors()
+        shard_provider = self._dataset_shard_provider
+        if shard_provider:
+            shard_provider.shutdown_data_executors()
 
     def after_worker_group_abort(
         self, worker_group_context: WorkerGroupContext

--- a/python/ray/train/v2/_internal/callbacks/datasets.py
+++ b/python/ray/train/v2/_internal/callbacks/datasets.py
@@ -1,53 +1,89 @@
 import copy
 import logging
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import ray
 import ray.train
-from ray.actor import ActorHandle
-from ray.exceptions import GetTimeoutError
 from ray.train.v2._internal.data_integration.interfaces import (
     DatasetShardMetadata,
     DatasetShardProvider,
+    GenDataset,
 )
-from ray.train.v2._internal.execution.callback import (
-    ControllerCallback,
-    WorkerGroupCallback,
-)
+from ray.train.v2._internal.execution.callback import WorkerGroupCallback
 from ray.train.v2._internal.execution.context import TrainRunContext
 from ray.train.v2._internal.execution.worker_group.worker_group import (
     Worker,
     WorkerGroup,
     WorkerGroupContext,
 )
-from ray.types import ObjectRef
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
 if TYPE_CHECKING:
-    from ray.data import DataIterator, Dataset
+    from ray.data import DataIterator, Dataset, NodeIdStr
     from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
 
 
 class RayDatasetShardProvider:
-    """A shard provider that Train workers use to access a DataIterator for a dataset."""
+    def __init__(
+        self,
+        datasets: Dict[str, GenDataset],
+        data_config: ray.train.DataConfig,
+        data_context: "DataContext",
+        world_size: int,
+        worker_node_ids: List["NodeIdStr"],
+    ):
+        from ray.train.v2._internal.data_integration.dataset_manager import (
+            DatasetManager,
+        )
 
-    def __init__(self, ds_iterators: Dict[str, "DataIterator"]):
-        # Maps dataset_name to a DataIterator.
-        self._dataset_iterators = ds_iterators
+        self._dataset_names = set(datasets)
+        self._dataset_manager = (
+            ray.remote(DatasetManager)
+            .options(
+                num_cpus=0,
+                scheduling_strategy=NodeAffinitySchedulingStrategy(
+                    ray.get_runtime_context().get_node_id(), soft=False
+                ),
+            )
+            .remote(
+                datasets=datasets,
+                data_config=data_config,
+                data_context=data_context,
+                world_size=world_size,
+                worker_node_ids=worker_node_ids,
+            )
+        )
+        self._cached_dataset_shards: Dict[str, "DataIterator"] = {}
 
     def get_dataset_shard(self, dataset_info: DatasetShardMetadata) -> "DataIterator":
-        if dataset_info.dataset_name not in self._dataset_iterators:
+        dataset_name = dataset_info.dataset_name
+        if dataset_name not in self._dataset_names:
             raise KeyError(
-                f"Dataset shard for '{dataset_info.dataset_name}' not found. "
+                f"Dataset shard for '{dataset_name}' not found. "
                 "Please ensure that the dataset is passed through the Trainer `datasets` "
                 "argument."
             )
 
-        return self._dataset_iterators[dataset_info.dataset_name]
+        if dataset_name not in self._cached_dataset_shards:
+            self._cached_dataset_shards[dataset_name] = ray.get(
+                self._dataset_manager.get_dataset_shard.remote(dataset_info)
+            )
+
+        return self._cached_dataset_shards[dataset_name]
+
+    def shutdown_data_executors(self) -> None:
+        """
+        Attempts to eagerly shutdown the data executors for datasets, freeing resources allocated to data execution.
+        """
+        try:
+            self._dataset_manager.shutdown_data_executors.remote()
+        except Exception:
+            logger.debug("Failed to invoke remote cleanup of Dataset Manager.")
 
 
-class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
+class DatasetsCallback(WorkerGroupCallback):
     """A callback for managing Ray Datasets for the worker group."""
 
     def __init__(
@@ -58,8 +94,7 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
         self._datasets = datasets
         self._data_config = copy.deepcopy(train_run_context.dataset_config)
         self._scaling_config = train_run_context.scaling_config
-        self._coordinator_actors: List[ActorHandle] = []
-        self._shutdown_refs: List[ObjectRef] = []
+        self._dataset_shard_provider: Optional[RayDatasetShardProvider] = None
 
         # Capture the current DataContext to propagate it to
         # the Train workers later.
@@ -86,34 +121,6 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
             return {}
         return scaling_config.total_resources
 
-    def _get_coordinator_actors(
-        self, ds_iterators_per_rank: List[Dict[str, "DataIterator"]]
-    ) -> List[ActorHandle]:
-        """
-        Returns a list of each unique SplitCoordinator actor handle given the iterators per rank.
-        These handles will later be used to call shutdown on the actors.
-        """
-        from ray.data._internal.iterator.stream_split_iterator import (
-            StreamSplitDataIterator,
-        )
-
-        # Note: Currently, we only need to check rank 0 for split iterators.
-        # In the future, if datasets can be split across only a subset of ranks,
-        # we may need to process all ranks.
-        rank_0_iterators = ds_iterators_per_rank[0]
-        coord_actors = [
-            iterator._coord_actor
-            for iterator in rank_0_iterators.values()
-            if isinstance(iterator, StreamSplitDataIterator)
-        ]
-        return coord_actors
-
-    def _shutdown_data_executors(self):
-        """Eagerly shutdown the data executors of the split coordinator actors."""
-        self._shutdown_refs = [
-            coord.shutdown_executor.remote() for coord in self._coordinator_actors
-        ]
-
     # --------------------------
     # WorkerGroupCallback
     # --------------------------
@@ -123,29 +130,23 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
     ) -> Dict[str, List[DatasetShardProvider]]:
         world_size = len(workers)
         worker_node_ids = [worker.metadata.node_id for worker in workers]
+        datasets = {k: v() if callable(v) else v for k, v in self._datasets.items()}
 
+        # TODO: Move this to the constructor.
         # Notify the DataConfig about the total resources reserved for training.
         total_train_resources = self.get_train_total_resources(self._scaling_config)
         self._data_config.set_train_total_resources(
             total_train_resources.get("CPU", 0), total_train_resources.get("GPU", 0)
         )
 
-        datasets = {k: v() if callable(v) else v for k, v in self._datasets.items()}
-        ds_iterators_per_rank = self._data_config.configure(
+        self._dataset_shard_provider = RayDatasetShardProvider(
             datasets=datasets,
+            data_config=self._data_config,
+            data_context=self._data_context,
             world_size=world_size,
-            worker_handles=None,
             worker_node_ids=worker_node_ids,
         )
-        assert len(ds_iterators_per_rank) == world_size
-
-        self._coordinator_actors = self._get_coordinator_actors(ds_iterators_per_rank)
-
-        shard_providers_per_rank = [
-            RayDatasetShardProvider(ds_iterators=ds_iterators_per_rank[rank])
-            for rank in range(world_size)
-        ]
-        return {"dataset_shard_provider": shard_providers_per_rank}
+        return {"dataset_shard_provider": [self._dataset_shard_provider] * world_size}
 
     def after_worker_group_start(self, worker_group: WorkerGroup):
         # Propagate DataContext
@@ -162,21 +163,12 @@ class DatasetsCallback(WorkerGroupCallback, ControllerCallback):
     def after_worker_group_shutdown(
         self, worker_group_context: WorkerGroupContext
     ) -> None:
-        self._shutdown_data_executors()
+        assert self._dataset_shard_provider
+        self._dataset_shard_provider.shutdown_data_executors()
 
     def after_worker_group_abort(
         self, worker_group_context: WorkerGroupContext
     ) -> None:
-        self._shutdown_data_executors()
-
-    # --------------------------
-    # ControllerCallback
-    # --------------------------
-
-    async def before_controller_shutdown(self):
-        try:
-            ray.get(self._shutdown_refs, timeout=5)
-        except GetTimeoutError:
-            logger.error("Ray Data executor shutdown task timed out after 5 seconds.")
-        except Exception:
-            logger.exception("Failed to gracefully terminate Ray Data executors.")
+        shard_provider = self._dataset_shard_provider
+        if shard_provider:
+            shard_provider.shutdown_data_executors()

--- a/python/ray/train/v2/_internal/data_integration/dataset_manager.py
+++ b/python/ray/train/v2/_internal/data_integration/dataset_manager.py
@@ -61,8 +61,6 @@ class DatasetManager:
             worker_node_ids=self._worker_node_ids,
         )
         assert len(iterators_per_rank) == self._world_size
-        # TODO: Update DataConfig to return a List[DataIterator] directly
-        # for configuring a single dataset.
         # Convert the List[Dict[str, DataIterator]] to a List[DataIterator],
         # since we only configured one dataset.
         return [iterators_per_rank[i][dataset_name] for i in range(self._world_size)]

--- a/python/ray/train/v2/_internal/data_integration/dataset_manager.py
+++ b/python/ray/train/v2/_internal/data_integration/dataset_manager.py
@@ -111,7 +111,12 @@ class DatasetManager:
                 iterator = iterators[world_rank]
 
                 # Cache the split coordinators for resource cleanup.
-                self._coordinator_actors.append(iterator._coord_actor)
+                from ray.data._internal.iterator.stream_split_iterator import (
+                    StreamSplitDataIterator,
+                )
+
+                if isinstance(iterator, StreamSplitDataIterator):
+                    self._coordinator_actors.append(iterator._coord_actor)
 
                 # Cache the dataset iterators for future use.
                 self._dataset_iterators[dataset_name] = iterators

--- a/python/ray/train/v2/_internal/data_integration/dataset_manager.py
+++ b/python/ray/train/v2/_internal/data_integration/dataset_manager.py
@@ -27,7 +27,7 @@ class DatasetManager:
         world_size: int,
         worker_node_ids: List["NodeIdStr"],
     ):
-        self._datasets = {k: v() if callable(v) else v for k, v in datasets.items()}
+        self._datasets = datasets
         self._data_config = data_config
         self._datasets_to_split = (
             set(self._datasets.keys())

--- a/python/ray/train/v2/_internal/data_integration/dataset_manager.py
+++ b/python/ray/train/v2/_internal/data_integration/dataset_manager.py
@@ -1,0 +1,171 @@
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Dict, List
+
+import ray
+from ray.exceptions import GetTimeoutError
+from ray.train.v2._internal.data_integration.interfaces import (
+    DatasetShardMetadata,
+    GenDataset,
+)
+
+if TYPE_CHECKING:
+    from ray.data import DataContext, DataIterator, Dataset, NodeIdStr
+
+
+logger = logging.getLogger(__name__)
+
+
+class DatasetManager:
+    """Manages the dataset shards for datasets configured in the trainer."""
+
+    def __init__(
+        self,
+        datasets: Dict[str, GenDataset],
+        data_config: ray.train.DataConfig,
+        data_context: "DataContext",
+        world_size: int,
+        worker_node_ids: List["NodeIdStr"],
+    ):
+        self._datasets = {k: v() if callable(v) else v for k, v in datasets.items()}
+        self._data_config = data_config
+        self._datasets_to_split = (
+            set(self._datasets.keys())
+            if data_config._datasets_to_split == "all"
+            else set(data_config._datasets_to_split)
+        )
+        self._world_size = world_size
+        self._worker_node_ids = worker_node_ids
+        self._coordinator_actors: List[ray.actor.ActorHandle] = []
+
+        # Maps dataset name to a list of cached `DataIterator`s corresponding to
+        # Train worker ranks.
+        self._dataset_iterators: Dict[str, List["DataIterator"]] = {}
+
+        # A condition variable to synchronize the calls to the async `get_dataset_shard` method.
+        self._condition = asyncio.Condition()
+
+        from ray.data import DataContext
+
+        DataContext._set_current(data_context)
+
+    def _create_dataset_iterators(
+        self, dataset_info: DatasetShardMetadata, base_dataset: "Dataset"
+    ) -> List["DataIterator"]:
+        dataset_name = dataset_info.dataset_name
+
+        iterators_per_rank = self._data_config.configure(
+            datasets={dataset_name: base_dataset},
+            world_size=self._world_size,
+            worker_handles=None,
+            worker_node_ids=self._worker_node_ids,
+        )
+        assert len(iterators_per_rank) == self._world_size
+        # TODO: Update DataConfig to return a List[DataIterator] directly
+        # for configuring a single dataset.
+        # Convert the List[Dict[str, DataIterator]] to a List[DataIterator],
+        # since we only configured one dataset.
+        return [iterators_per_rank[i][dataset_name] for i in range(self._world_size)]
+
+    def _get_unsharded_dataset_iterator(
+        self, dataset_info: DatasetShardMetadata
+    ) -> "DataIterator":
+        """Returns the dataset iterator for a dataset that is excluded
+        from `DataConfig.datasets_to_split`.
+        Note that this method is NOT a barrier across workers and can be called
+        by any subset of workers and will return immediately.
+        """
+        dataset_name = dataset_info.dataset_name
+        world_rank = dataset_info.world_rank
+
+        if dataset_name not in self._dataset_iterators:
+            self._dataset_iterators[dataset_name] = self._create_dataset_iterators(
+                dataset_info, self._datasets[dataset_name]
+            )
+
+        return self._dataset_iterators[dataset_name][world_rank]
+
+    async def _get_sharded_dataset_iterator(
+        self, dataset_info: DatasetShardMetadata
+    ) -> "DataIterator":
+        """Returns the dataset iterator for a dataset that is included
+        in `DataConfig.datasets_to_split`.
+        Note that this method is a barrier across workers,
+        and all workers must call this method before training.
+        """
+        dataset_name = dataset_info.dataset_name
+        world_rank = dataset_info.world_rank
+
+        async with self._condition:
+            if dataset_name in self._dataset_iterators:
+                # If the dataset iterators have already been created, return the
+                # existing one.
+                iterator = self._dataset_iterators[dataset_name][world_rank]
+            elif world_rank == 0:
+                # In this case, the dataset iterators have not been created yet.
+                # The dataset only needs to be configured once globally for all workers.
+                # Do it only when the rank 0 worker calls this method.
+                iterators = self._create_dataset_iterators(
+                    dataset_info, self._datasets[dataset_name]
+                )
+                iterator = iterators[world_rank]
+
+                # Cache the split coordinators for resource cleanup.
+                self._coordinator_actors.append(iterator._coord_actor)
+
+                # Cache the dataset iterators for future use.
+                self._dataset_iterators[dataset_name] = iterators
+                self._condition.notify_all()
+            else:
+                # Wait for the dataset iterators to be created by the rank 0 worker.
+                await self._condition.wait_for(
+                    lambda: dataset_name in self._dataset_iterators
+                )
+                iterator = self._dataset_iterators[dataset_name][world_rank]
+        return iterator
+
+    async def get_dataset_shard(
+        self,
+        dataset_info: DatasetShardMetadata,
+    ) -> "DataIterator":
+        """Create and return the dataset shard iterator for a Ray Train worker's
+        call to `ray.train.get_dataset_shard`.
+
+        This method is a barrier that should be called by all Ray Train workers at once.
+        If the dataset iterators have already been created, return the existing ones.
+
+        Otherwise, create the dataset iterators and cache them.
+        Here's an example of how this method is used with 4 workers:
+        Rank 2 calls get_dataset_shard, waits on the condition variable.
+        Rank 1 calls get_dataset_shard, waits on the condition variable.
+        Rank 0 calls get_dataset_shard, creates the dataset iterators, caches them,
+        and notifies all workers hanging on the condition variable.
+        Rank 3 calls get_dataset_shard, returns the cached iterator.
+        """
+        dataset_name = dataset_info.dataset_name
+
+        if dataset_name in self._datasets_to_split:
+            return await self._get_sharded_dataset_iterator(dataset_info)
+        else:
+            return self._get_unsharded_dataset_iterator(dataset_info)
+
+    def shutdown_data_executors(self) -> None:
+        """
+        Attempts to shut down the data executors of each sharded dataset,
+        freeing resources allocated to data execution.
+
+        Note: The data executors for unsharded datasets are not managed by
+        SplitCoordinator actors and hence, are not accessible via the DatasetManager
+        so their cleanup is not handled by this method.
+        """
+        try:
+            shutdown_refs = [
+                coord.shutdown_executor.remote() for coord in self._coordinator_actors
+            ]
+            ray.get(shutdown_refs, timeout=5)
+        except GetTimeoutError:
+            logger.error("Ray Data executor shutdown task timed out after 5 seconds.")
+        except Exception:
+            logger.exception(
+                "Failed to gracefully terminate the Ray Data executor for each running dataset."
+            )

--- a/python/ray/train/v2/_internal/data_integration/interfaces.py
+++ b/python/ray/train/v2/_internal/data_integration/interfaces.py
@@ -14,6 +14,7 @@ class DatasetShardMetadata:
     """Metadata about a dataset shard used for lookup and configuration."""
 
     dataset_name: str
+    world_rank: int
 
 
 class DatasetShardProvider(Protocol):

--- a/python/ray/train/v2/_internal/execution/worker_group/worker.py
+++ b/python/ray/train/v2/_internal/execution/worker_group/worker.py
@@ -20,7 +20,6 @@ from ray.train.v2._internal.execution.callback import (
     TrainContextCallback,
     WorkerCallback,
 )
-from ray.train.v2._internal.execution.checkpoint.sync_actor import SynchronizationActor
 from ray.train.v2._internal.execution.context import (
     DistributedContext,
     ExecutionContext,
@@ -240,7 +239,7 @@ class RayTrainWorker:
         self,
         train_run_context: TrainRunContext,
         distributed_context: DistributedContext,
-        synchronization_actor: SynchronizationActor,
+        synchronization_actor: ActorHandle,
         storage_context: StorageContext,
         worker_callbacks: List[Union[WorkerCallback, TrainContextCallback]],
         controller_actor: ActorHandle,

--- a/python/ray/train/v2/api/train_fn_utils.py
+++ b/python/ray/train/v2/api/train_fn_utils.py
@@ -288,6 +288,10 @@ def get_dataset_shard(dataset_name: Optional[str] = None) -> Optional["DataItera
         The ``DataIterator`` shard to use for this worker.
         If no dataset is passed into Trainer, then return None.
     """
-    return get_train_fn_utils().get_dataset_shard(
-        DatasetShardMetadata(dataset_name=dataset_name)
+    train_fn_utils = get_train_fn_utils()
+    return train_fn_utils.get_dataset_shard(
+        DatasetShardMetadata(
+            dataset_name=dataset_name,
+            world_rank=train_fn_utils.get_context().get_world_rank(),
+        )
     )

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -132,10 +132,10 @@ def test_datasets_callback(ray_start_4_cpus):
 
     dataset_manager = dataset_manager_for_each_worker[0]
     processed_train_ds = dataset_manager.get_dataset_shard(
-        DatasetShardMetadata(dataset_name="train")
+        DatasetShardMetadata(dataset_name="train", world_rank=0)
     )
     processed_valid_ds = dataset_manager.get_dataset_shard(
-        DatasetShardMetadata(dataset_name="valid")
+        DatasetShardMetadata(dataset_name="valid", world_rank=0)
     )
 
     assert isinstance(processed_train_ds, StreamSplitDataIterator)
@@ -618,10 +618,20 @@ def test_exclude_train_resources_applies_to_each_dataset(ray_start_4_cpus):
     trainer.fit()
 
 
-def test_datasets_callback_v1_uses_exclude_resources(ray_start_4_cpus, monkeypatch):
-    """Under the V1 cluster autoscaler, exclude_resources should still be set by DataConfig."""
+@pytest.fixture()
+def ray_start_4_cpus_v1_autoscaler(monkeypatch):
+    # `RAY_DATA_CLUSTER_AUTOSCALER` is read inside the `DatasetManager` actor's
+    # worker process, which snapshots `os.environ` at `ray.init` time. Setting
+    # the env var after `ray.init` doesn't reach already-forked workers, so we
+    # set it here before starting Ray.
     monkeypatch.setenv("RAY_DATA_CLUSTER_AUTOSCALER", "V1")
+    ray.init(num_cpus=4)
+    yield
+    ray.shutdown()
 
+
+def test_datasets_callback_v1_uses_exclude_resources(ray_start_4_cpus_v1_autoscaler):
+    """Under the V1 cluster autoscaler, exclude_resources should still be set by DataConfig."""
     NUM_WORKERS = 2
 
     train_ds = ray.data.range(1000)
@@ -658,10 +668,10 @@ def test_datasets_callback_v1_uses_exclude_resources(ray_start_4_cpus, monkeypat
 
     dataset_manager = dataset_manager_for_each_worker[0]
     processed_train_ds = dataset_manager.get_dataset_shard(
-        DatasetShardMetadata(dataset_name="train")
+        DatasetShardMetadata(dataset_name="train", world_rank=0)
     )
     processed_valid_ds = dataset_manager.get_dataset_shard(
-        DatasetShardMetadata(dataset_name="valid")
+        DatasetShardMetadata(dataset_name="valid", world_rank=0)
     )
 
     # Under the V1 cluster autoscaler, exclude_resources should be set with training resources.
@@ -720,10 +730,10 @@ def test_v2_no_negative_exclude_resources(ray_start_4_cpus):
 
     dataset_manager = dataset_manager_for_each_worker[0]
     processed_train_ds = dataset_manager.get_dataset_shard(
-        DatasetShardMetadata(dataset_name="train")
+        DatasetShardMetadata(dataset_name="train", world_rank=0)
     )
     processed_valid_ds = dataset_manager.get_dataset_shard(
-        DatasetShardMetadata(dataset_name="valid")
+        DatasetShardMetadata(dataset_name="valid", world_rank=0)
     )
 
     # Under the V2 cluster autoscaler (default), exclude_resources should be

--- a/python/ray/train/v2/tests/test_data_resource_cleanup.py
+++ b/python/ray/train/v2/tests/test_data_resource_cleanup.py
@@ -1,6 +1,6 @@
 import sys
 import time
-from unittest.mock import MagicMock, create_autospec
+from unittest.mock import create_autospec
 
 import pytest
 
@@ -11,98 +11,51 @@ from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator impor
 from ray.data._internal.iterator.stream_split_iterator import (
     SplitCoordinator,
 )
-from ray.train.v2._internal.callbacks.datasets import DatasetsCallback
-from ray.train.v2._internal.execution.worker_group import (
-    WorkerGroup,
-    WorkerGroupContext,
+from ray.train.v2._internal.callbacks.datasets import (
+    DatasetsCallback,
+    RayDatasetShardProvider,
 )
+from ray.train.v2._internal.execution.worker_group import WorkerGroupContext
 from ray.train.v2.tests.util import DummyObjectRefWrapper, create_dummy_run_context
 
 pytestmark = pytest.mark.usefixtures("mock_runtime_context")
 
 
-def test_datasets_callback_multiple_datasets(ray_start_4_cpus):
-    """Test that the DatasetsCallback properly collects the coordinator actors for multiple datasets"""
-    # Start worker group
-    worker_group_context = WorkerGroupContext(
+def _dummy_worker_group_context() -> WorkerGroupContext:
+    return WorkerGroupContext(
         run_attempt_id="test",
         train_fn_ref=DummyObjectRefWrapper(lambda: None),
         num_workers=4,
         resources_per_worker={"CPU": 1},
     )
-    wg = WorkerGroup.create(
-        train_run_context=create_dummy_run_context(),
-        worker_group_context=worker_group_context,
-    )
-
-    # Create train run context
-    NUM_ROWS = 100
-
-    datasets = {
-        "sharded_1": ray.data.range(NUM_ROWS),
-        "sharded_2": ray.data.range(NUM_ROWS),
-        "unsharded": ray.data.range(NUM_ROWS),
-    }
-    dataset_config = ray.train.DataConfig(datasets_to_split=["sharded_1", "sharded_2"])
-    train_run_context = create_dummy_run_context(dataset_config=dataset_config)
-
-    callback = DatasetsCallback(
-        train_run_context=train_run_context,
-        datasets=datasets,
-    )
-    callback.before_init_train_context(wg.get_workers())
-
-    # Two coordinator actors, one for each sharded dataset
-    coordinator_actors = callback._coordinator_actors
-    assert len(coordinator_actors) == 2
-
-
-def test_after_worker_group_abort():
-    callback = DatasetsCallback(
-        train_run_context=create_dummy_run_context(),
-        datasets={},
-    )
-
-    # Mock SplitCoordinator shutdown_executor method
-    coord_mock = create_autospec(SplitCoordinator)
-    remote_mock = MagicMock()
-    coord_mock.shutdown_executor.remote = remote_mock
-    callback._coordinator_actors = [coord_mock]
-
-    dummy_wg_context = WorkerGroupContext(
-        run_attempt_id="test",
-        train_fn_ref=DummyObjectRefWrapper(lambda: None),
-        num_workers=4,
-        resources_per_worker={"CPU": 1},
-    )
-    callback.after_worker_group_abort(dummy_wg_context)
-
-    # shutdown_executor called on SplitCoordinator
-    remote_mock.assert_called_once()
 
 
 def test_after_worker_group_shutdown():
+    """The callback delegates shutdown to the dataset shard provider."""
     callback = DatasetsCallback(
-        train_run_context=create_dummy_run_context(),
-        datasets={},
+        train_run_context=create_dummy_run_context(), datasets={}
     )
+    shard_provider = create_autospec(RayDatasetShardProvider)
+    callback._dataset_shard_provider = shard_provider
 
-    # Mock SplitCoordinator shutdown_executor method
-    coord_mock = create_autospec(SplitCoordinator)
-    remote_mock = MagicMock()
-    coord_mock.shutdown_executor.remote = remote_mock
-    callback._coordinator_actors = [coord_mock]
-
-    dummy_wg_context = WorkerGroupContext(
-        run_attempt_id="test",
-        train_fn_ref=DummyObjectRefWrapper(lambda: None),
-        num_workers=4,
-        resources_per_worker={"CPU": 1},
+    callback.after_worker_group_shutdown(
+        worker_group_context=_dummy_worker_group_context()
     )
-    callback.after_worker_group_shutdown(dummy_wg_context)
+    shard_provider.shutdown_data_executors.assert_called_once()
 
-    # shutdown_executor called on SplitCoordinator
-    remote_mock.assert_called_once()
+
+def test_after_worker_group_abort():
+    """The callback delegates abort cleanup to the dataset shard provider."""
+    callback = DatasetsCallback(
+        train_run_context=create_dummy_run_context(), datasets={}
+    )
+    shard_provider = create_autospec(RayDatasetShardProvider)
+    callback._dataset_shard_provider = shard_provider
+
+    callback.after_worker_group_abort(
+        worker_group_context=_dummy_worker_group_context()
+    )
+    shard_provider.shutdown_data_executors.assert_called_once()
 
 
 def test_split_coordinator_shutdown_executor(ray_start_4_cpus):

--- a/python/ray/train/v2/tests/test_dataset_manager.py
+++ b/python/ray/train/v2/tests/test_dataset_manager.py
@@ -1,0 +1,233 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+import ray
+import ray.data
+from ray.data import DataContext
+from ray.data._internal.iterator.stream_split_iterator import StreamSplitDataIterator
+from ray.train.v2._internal.data_integration.dataset_manager import (
+    DatasetManager,
+    DatasetShardMetadata,
+)
+
+
+async def get_dataset_shard_for_worker(
+    dataset_manager: DatasetManager,
+    dataset_name: str,
+    worker_rank: int,
+):
+    return await asyncio.create_task(
+        dataset_manager.get_dataset_shard(
+            DatasetShardMetadata(dataset_name=dataset_name, world_rank=worker_rank)
+        )
+    )
+
+
+async def get_dataset_shard_for_all_workers(
+    dataset_manager: DatasetManager,
+    dataset_name: str,
+    num_workers: int,
+):
+    return await asyncio.gather(
+        *[
+            get_dataset_shard_for_worker(dataset_manager, dataset_name, i)
+            for i in range(num_workers)
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_multiple_datasets_serially(ray_start_4_cpus):
+    """Tests DatasetManager.get_dataset_shard for multiple datasets,
+    called serially by each worker. This is the typical case.
+    Workers 0, 1:
+    ray.train.get_dataset_shard("sharded_1")
+    ray.train.get_dataset_shard("sharded_2")
+    ray.train.get_dataset_shard("unsharded")
+    """
+
+    NUM_ROWS = 100
+    NUM_TRAIN_WORKERS = 2
+
+    sharded_ds_1 = ray.data.range(NUM_ROWS)
+    sharded_ds_2 = ray.data.range(NUM_ROWS)
+    unsharded_ds = ray.data.range(NUM_ROWS)
+
+    dataset_manager = DatasetManager(
+        datasets={
+            "sharded_1": sharded_ds_1,
+            "sharded_2": sharded_ds_2,
+            "unsharded": unsharded_ds,
+        },
+        data_config=ray.train.DataConfig(datasets_to_split=["sharded_1", "sharded_2"]),
+        data_context=DataContext.get_current(),
+        world_size=NUM_TRAIN_WORKERS,
+        worker_node_ids=None,
+    )
+
+    shards = await get_dataset_shard_for_all_workers(
+        dataset_manager, "sharded_1", NUM_TRAIN_WORKERS
+    )
+    assert all(isinstance(shard, StreamSplitDataIterator) for shard in shards)
+    assert all(shard._get_dataset_tag().startswith("sharded_1_") for shard in shards)
+
+    shards = await get_dataset_shard_for_all_workers(
+        dataset_manager, "sharded_2", NUM_TRAIN_WORKERS
+    )
+    assert all(isinstance(shard, StreamSplitDataIterator) for shard in shards)
+    assert all(shard._get_dataset_tag().startswith("sharded_2_") for shard in shards)
+
+    shards = await get_dataset_shard_for_all_workers(
+        dataset_manager, "unsharded", NUM_TRAIN_WORKERS
+    )
+    assert not any(isinstance(shard, StreamSplitDataIterator) for shard in shards)
+    assert all(shard._get_dataset_tag().startswith("unsharded_") for shard in shards)
+
+
+@pytest.mark.asyncio
+async def test_get_multiple_datasets_interleaved(ray_start_4_cpus):
+    """Tests DatasetManager.get_dataset_shard for multiple datasets,
+    called in an interleaved order by workers.
+    Worker 0:
+    ray.train.get_dataset_shard("train")
+    ray.train.get_dataset_shard("valid")
+    Worker 1:
+    ray.train.get_dataset_shard("valid")
+    ray.train.get_dataset_shard("train")
+    """
+
+    NUM_ROWS = 100
+    NUM_TRAIN_WORKERS = 2
+
+    train_ds = ray.data.range(NUM_ROWS)
+    valid_ds = ray.data.range(NUM_ROWS)
+
+    dataset_manager = DatasetManager(
+        datasets={"train": train_ds, "valid": valid_ds},
+        data_config=ray.train.DataConfig(datasets_to_split="all"),
+        data_context=DataContext.get_current(),
+        world_size=NUM_TRAIN_WORKERS,
+        worker_node_ids=None,
+    )
+
+    tasks = [
+        get_dataset_shard_for_worker(dataset_manager, "train", 0),
+        get_dataset_shard_for_worker(dataset_manager, "valid", 1),
+        get_dataset_shard_for_worker(dataset_manager, "train", 1),
+        get_dataset_shard_for_worker(dataset_manager, "valid", 0),
+    ]
+    iterators = await asyncio.gather(*tasks)
+    assert all(isinstance(iterator, StreamSplitDataIterator) for iterator in iterators)
+    expected_names = ["train", "valid", "train", "valid"]
+    assert all(
+        it._get_dataset_tag().startswith(f"{name}_")
+        for it, name in zip(iterators, expected_names)
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_multiple_datasets_rank_specific(ray_start_4_cpus):
+    """Tests rank-specific DatasetManager.get_dataset_shard calls.
+    # Epoch 1
+    ray.train.get_dataset_shard("train")
+    # Validation, which only happens on worker 0.
+    if world_rank == 0:
+        ray.train.get_dataset_shard("valid")
+    # Epoch 2
+    ray.train.get_dataset_shard("train")
+    """
+
+    NUM_ROWS = 100
+    NUM_TRAIN_WORKERS = 2
+
+    train_ds = ray.data.range(NUM_ROWS)
+    valid_ds = ray.data.range(NUM_ROWS)
+
+    dataset_manager = DatasetManager(
+        datasets={"train": train_ds, "valid": valid_ds},
+        data_config=ray.train.DataConfig(datasets_to_split=["train"]),
+        data_context=DataContext.get_current(),
+        world_size=NUM_TRAIN_WORKERS,
+        worker_node_ids=None,
+    )
+
+    # ray.train.get_dataset_shard("train")
+    iterators = await get_dataset_shard_for_all_workers(
+        dataset_manager, "train", NUM_TRAIN_WORKERS
+    )
+    assert all(isinstance(iterator, StreamSplitDataIterator) for iterator in iterators)
+    assert all(it._get_dataset_tag().startswith("train_") for it in iterators)
+
+    # if world_rank == 0:
+    #     ray.train.get_dataset_shard("valid")
+    iterator = await get_dataset_shard_for_worker(dataset_manager, "valid", 0)
+    assert not isinstance(iterator, StreamSplitDataIterator)
+    assert iterator._get_dataset_tag().startswith("valid_")
+
+    # ray.train.get_dataset_shard("train")
+    iterators = await get_dataset_shard_for_all_workers(
+        dataset_manager, "train", NUM_TRAIN_WORKERS
+    )
+    assert all(isinstance(iterator, StreamSplitDataIterator) for iterator in iterators)
+    assert all(it._get_dataset_tag().startswith("train_") for it in iterators)
+
+
+@pytest.mark.asyncio
+async def test_dataset_manager_shutdown_multiple_datasets(ray_start_4_cpus):
+    """The DatasetManager collects SplitCoordinator actors for sharded datasets
+    and triggers executor shutdown on them.
+    """
+
+    NUM_ROWS = 100
+    NUM_TRAIN_WORKERS = 2
+
+    sharded_ds_1 = ray.data.range(NUM_ROWS)
+    sharded_ds_2 = ray.data.range(NUM_ROWS)
+    unsharded_ds = ray.data.range(NUM_ROWS)
+
+    dataset_manager = DatasetManager(
+        datasets={
+            "sharded_1": sharded_ds_1,
+            "sharded_2": sharded_ds_2,
+            "unsharded": unsharded_ds,
+        },
+        data_config=ray.train.DataConfig(datasets_to_split=["sharded_1", "sharded_2"]),
+        data_context=DataContext.get_current(),
+        world_size=NUM_TRAIN_WORKERS,
+        worker_node_ids=None,
+    )
+
+    await get_dataset_shard_for_all_workers(
+        dataset_manager, "sharded_1", NUM_TRAIN_WORKERS
+    )
+    assert len(dataset_manager._coordinator_actors) == 1
+    assert isinstance(dataset_manager._coordinator_actors[0], ray.actor.ActorHandle)
+
+    await get_dataset_shard_for_all_workers(
+        dataset_manager, "sharded_2", NUM_TRAIN_WORKERS
+    )
+    assert len(dataset_manager._coordinator_actors) == 2
+    assert isinstance(dataset_manager._coordinator_actors[1], ray.actor.ActorHandle)
+
+    # Unsharded datasets are not tracked for shutdown.
+    await get_dataset_shard_for_all_workers(
+        dataset_manager, "unsharded", NUM_TRAIN_WORKERS
+    )
+    assert len(dataset_manager._coordinator_actors) == 2
+
+    mocks = [MagicMock() for _ in range(2)]
+    remote_mocks = [mock.shutdown_executor.remote for mock in mocks]
+    dataset_manager._coordinator_actors = mocks
+
+    dataset_manager.shutdown_data_executors()
+
+    for remote_mock in remote_mocks:
+        remote_mock.assert_called_once()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-x", __file__]))

--- a/release/train_tests/benchmark/ray_dataloader_factory.py
+++ b/release/train_tests/benchmark/ray_dataloader_factory.py
@@ -139,6 +139,7 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
 
     def get_ray_data_config(self) -> ray.train.DataConfig:
         return ray.train.DataConfig(
+            datasets_to_split=[],
             enable_shard_locality=self.get_dataloader_config().enable_shard_locality,
         )
 

--- a/release/train_tests/benchmark/ray_dataloader_factory.py
+++ b/release/train_tests/benchmark/ray_dataloader_factory.py
@@ -139,7 +139,6 @@ class RayDataLoaderFactory(BaseDataLoaderFactory):
 
     def get_ray_data_config(self) -> ray.train.DataConfig:
         return ray.train.DataConfig(
-            datasets_to_split=[],
             enable_shard_locality=self.get_dataloader_config().enable_shard_locality,
         )
 


### PR DESCRIPTION
# Summary

Here is a timeline that explains the history of the `DatasetManager`
1) Before https://github.com/ray-project/ray/pull/61607, `StreamSplitDataIterator` held a reference to the `Dataset`, which could be large as explained in [this PR description](https://github.com/ray-project/ray/pull/55760#issue-3336047849). 
2) https://github.com/ray-project/ray/pull/55230 changed how we send `StreamSplitDataIterators` to workers. Basically, we went from presharding the dataset before creating the worker group to configuring the dataset on the fly when calling `ray.train.get_dataset_shard`. Unfortunately, this led to a performance regression, so we had to revert it - see the revert PR (https://github.com/ray-project/ray/pull/55760) for a deeper explanation of what happened, but essentially sending over `StreamSplitDataIterator`s was slow because they contained `Dataset` references which could get big. It's not clear why sending big `StreamSplitDataIterators` was slower in the `get_dataset_shard` case than the presharding case.
3) https://github.com/ray-project/ray/pull/61607 removed `Dataset` references from `StreamSplitDataIterators`
4) This PR brings `DatasetManager` back now that `StreamSplitDataIterators` are small. 

# Testing

The revert PR's description (https://github.com/ray-project/ray/pull/55760) included a nice repro script which I modified slightly:

```
import time

import ray
import ray.data
from ray.data import DataContext
from ray.data.datasource.partitioning import Partitioning
from ray.train.v2._internal.data_integration.dataset_manager import DatasetManager
from ray.train.v2._internal.data_integration.interfaces import DatasetShardMetadata


train_dir = "s3://anyscale-imagenet/ILSVRC/Data/CLS-LOC/train"
train_partitioning = Partitioning(
    "dir", base_dir=train_dir, field_names=["class"]
)
train_ds = ray.data.read_images(
    train_dir,
    mode="RGB",
    include_paths=False,
    partitioning=train_partitioning,
)

num_workers = 16

datasets = {"train": train_ds, "val": train_ds}
dataset_manager = ray.remote(DatasetManager).remote(
    datasets=datasets,
    data_config=ray.train.DataConfig(),
    data_context=DataContext.get_current(),
    world_size=num_workers,
    worker_node_ids=None,
)


def get_size_bytes(obj):
    import ray.cloudpickle as ray_pickle
    return len(ray_pickle.dumps(obj))


@ray.remote(num_cpus=1)
def consumer(dm, rank):
    dataset_info = DatasetShardMetadata("train", rank)

    start = time.perf_counter()
    ds_shard = ray.get(dm.get_dataset_shard.remote(dataset_info))
    end = time.perf_counter()

    size_mb = get_size_bytes(ds_shard) / (1024 * 1024)
    print(f"[{rank=}] TIME TO GET THE DATASET SHARD (SIZE={size_mb}MB):", end - start)


start = time.perf_counter()
ray.get([consumer.remote(dataset_manager, rank) for rank in range(num_workers)])
end = time.perf_counter()
print("elapsed:", end - start)
```

Now we are sending ~1kb `DataIterator`s over in ~5s (the 5s is due to waiting for `streaming_split`, not the transfer time), whereas the revert PR (https://github.com/ray-project/ray/pull/55760#issue-3336047849) showed that we were sending ~780mb `DataIterator`s over in up to 174s! In other words, this is no longer an issue, so it's safe to merge `DatasetManager` for real this time.

```
(ray4) tseah@tseah-LV3607J62K ray % RAY_DEDUP_LOGS=0 python driver.py
2026-05-12 16:34:59,444	INFO worker.py:2018 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265 
(DatasetManager pid=69108) Using blocking ray.get inside async actor. This blocks the event loop. Please use `await` on object ref with asyncio.gather if you want to yield execution to the event loop instead.
elapsed: 6.097738708020188
(consumer pid=69103) [rank=3] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.295730707992334
(consumer pid=69106) [rank=0] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.3177806670137215
(consumer pid=69110) [rank=4] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.318447458994342
(consumer pid=69110) [rank=14] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 0.015125167003134266
(consumer pid=69104) [rank=1] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.295733000006294
(consumer pid=69111) [rank=2] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.337776000000304
(consumer pid=69102) [rank=5] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.340320540999528
(consumer pid=69101) [rank=7] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.306097583001247
(consumer pid=69105) [rank=6] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.326983959006611
(consumer pid=69107) [rank=8] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.3252247920027
(consumer pid=69109) [rank=9] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 5.325624417018844
(consumer pid=69109) [rank=15] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 0.014673249999759719
(consumer pid=69773) [rank=10] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 4.506475125002908
(consumer pid=69774) [rank=12] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 4.497576666995883
(consumer pid=69771) [rank=11] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 4.499152167001739
(consumer pid=69772) [rank=13] TIME TO GET THE DATASET SHARD (SIZE=0.0016326904296875MB): 1.9341769159946125
```

# Testing 2

If the dataset(s) are not sharded the DataIteratorImpl will contain the dataset object. I ran the `training_ingest_benchmark-task=image_classification.skip_training.jpeg` release tests on this PR (https://buildkite.com/ray-project/release/builds/93074) and a master branch PR (https://github.com/ray-project/ray/pull/63388, https://buildkite.com/ray-project/release/builds/93075) with dataset sharding temporarily disabled. Note that these jobs are only failing at the "get stats" step after training is finished; we can just focus on the training time. The results show that this PR actually achieves better e2e runtime. Honestly, I'm not really sure why this is the case - maybe pulling from the datasetmanager actor is faster than pushing from the traincontroller actor since the latter is responsible for many other activities as well?

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-a15063e2-7fff-ee26-79ed-792757465db8"><div dir="ltr" style="margin-left:0pt;" align="left">
  | With DatasetManager | Without DatasetManager
-- | -- | --
  | 2m13s | 5m27s
.preserve_order | 4m48s | 36m37s
.local_fs | 32s | 33s
local_fs.preserve_order | 36s | 35s
local_fs_multi_gpus | 48s | 53s
local_fs_multi_gpus.preserve_order | 1m21s | 2m28s

</div></b>

Note