### PR TITLE
[core] Avoid FabricManager stall on NVLink systems in GpuProfilingManager

### DIFF
--- a/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
@@ -88,9 +88,9 @@ class GpuProfilingManager:
     @property
     def enabled(self) -> bool:
         return (
-            self.node_has_gpus()
-            and self._dynolog_bin is not None
+            self._dynolog_bin is not None
             and self._dyno_bin is not None
+            and self.node_has_gpus()
         )
 
     @property
@@ -104,7 +104,10 @@ class GpuProfilingManager:
     @functools.cache
     def node_has_gpus(cls) -> bool:
         try:
-            subprocess.check_output(["nvidia-smi"], stderr=subprocess.DEVNULL)
+            subprocess.check_output(
+                ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+                stderr=subprocess.DEVNULL,
+            )
             return True
         except Exception:
             return False

--- a/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
@@ -74,13 +74,13 @@ class GpuProfilingManager:
 
         self._dynolog_daemon_process: Optional[subprocess.Popen] = None
 
-        if not self.node_has_gpus():
-            logger.warning(
-                "[GpuProfilingManager] No GPUs found on this node, GPU profiling will not be setup."
-            )
         if not self._dynolog_bin or not self._dyno_bin:
             logger.warning(
                 "[GpuProfilingManager] `dynolog` is not installed, GPU profiling will not be available."
+            )
+        elif not self.node_has_gpus():
+            logger.warning(
+                "[GpuProfilingManager] No GPUs found on this node, GPU profiling will not be setup."
             )
 
         self._profile_dir_path.mkdir(parents=True, exist_ok=True)
@@ -107,6 +107,7 @@ class GpuProfilingManager:
             subprocess.check_output(
                 ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
                 stderr=subprocess.DEVNULL,
+                timeout=2,
             )
             return True
         except Exception:

--- a/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
+++ b/python/ray/dashboard/modules/reporter/gpu_profile_manager.py
@@ -107,7 +107,7 @@ class GpuProfilingManager:
             subprocess.check_output(
                 ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
                 stderr=subprocess.DEVNULL,
-                timeout=2,
+                timeout=10,
             )
             return True
         except Exception:

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
@@ -50,6 +50,45 @@ def mock_asyncio_create_subprocess_exec(monkeypatch):
     yield (mock_create_subprocess_exec, mock_async_proc)
 
 
+def test_node_has_gpus_uses_query_gpu_flag(tmp_path, monkeypatch):
+    """node_has_gpus() must use --query-gpu to avoid FabricManager stalls."""
+    captured = {}
+
+    def fake_check_output(cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+        return b""
+
+    monkeypatch.setattr("subprocess.check_output", fake_check_output)
+    # Clear the cache so the monkeypatched check_output is actually called.
+    GpuProfilingManager.node_has_gpus.cache_clear()
+    result = GpuProfilingManager.node_has_gpus()
+    GpuProfilingManager.node_has_gpus.cache_clear()
+
+    assert result is True
+    assert captured["cmd"] == [
+        "nvidia-smi",
+        "--query-gpu=name",
+        "--format=csv,noheader",
+    ]
+
+
+def test_enabled_does_not_call_node_has_gpus_when_dynolog_missing(
+    tmp_path, monkeypatch
+):
+    """enabled must short-circuit on missing dynolog bins before node_has_gpus()."""
+    node_has_gpus_called = []
+
+    def spy_node_has_gpus(self_or_cls):
+        node_has_gpus_called.append(True)
+        return True
+
+    monkeypatch.setattr(GpuProfilingManager, "node_has_gpus", spy_node_has_gpus)
+    # No dynolog binaries on PATH → shutil.which returns None for both.
+    gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
+    assert not gpu_profiler.enabled
+    assert not node_has_gpus_called, "node_has_gpus() must not be called when dynolog binaries are absent"
+
+
 def test_enabled(tmp_path, mock_node_has_gpus, mock_dynolog_binaries):
     gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     assert gpu_profiler.enabled

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_profiler_manager.py
@@ -86,7 +86,9 @@ def test_enabled_does_not_call_node_has_gpus_when_dynolog_missing(
     # No dynolog binaries on PATH → shutil.which returns None for both.
     gpu_profiler = GpuProfilingManager(tmp_path, ip_address=LOCALHOST)
     assert not gpu_profiler.enabled
-    assert not node_has_gpus_called, "node_has_gpus() must not be called when dynolog binaries are absent"
+    assert (
+        not node_has_gpus_called
+    ), "node_has_gpus() must not be called when dynolog binaries are absent"
 
 
 def test_enabled(tmp_path, mock_node_has_gpus, mock_dynolog_binaries):


### PR DESCRIPTION
Fixes #63243

On NVLink/NVSwitch nodes (e.g. A100 SXM4), bare `nvidia-smi` triggers a blocking RPC to the FabricManager daemon. If another process (e.g. `dynolog`) holds the NVML lock, this stalls 15–20 s—long enough to exceed the raylet's dashboard agent startup timeout and prevent `ray.init()` from succeeding.

## Changes

- **`node_has_gpus()`**: replace bare `nvidia-smi` with `nvidia-smi --query-gpu=name --format=csv,noheader`, which queries NVML directly (~0.1 s) without touching the FabricManager.

```python
# Before
subprocess.check_output(["nvidia-smi"], stderr=subprocess.DEVNULL)

# After
subprocess.check_output(
    ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
    stderr=subprocess.DEVNULL,
)
```

- **`enabled` property**: move binary-presence checks before `node_has_gpus()` so the GPU detection call is skipped entirely on nodes without `dynolog` installed.

```python
# Before: node_has_gpus() always called first
return self.node_has_gpus() and self._dynolog_bin is not None and self._dyno_bin is not None

# After: short-circuits before the GPU check when dynolog is absent
return self._dynolog_bin is not None and self._dyno_bin is not None and self.node_has_gpus()
```

- **Tests**: added `test_node_has_gpus_uses_query_gpu_flag` (asserts exact nvidia-smi flags) and `test_enabled_does_not_call_node_has_gpus_when_dynolog_missing` (asserts short-circuit behavior).