### PR TITLE
[Data] Allow datasink tasks to bypass object store budget check

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -25,6 +25,7 @@ from ray.data._internal.execution.operators.hash_shuffle import (
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.execution.util import memory_string
+from ray.data._internal.logical.operators.write_operator import Write
 from ray.data.context import DataContext
 from ray.util.debug import log_once
 
@@ -905,13 +906,16 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         if budget is None:
             return True
 
-        # Sink operators (no downstream consumers, e.g. write_parquet) only
-        # consume blocks from the object store — they never produce output into
-        # it.  Blocking a sink on object store budget is counterproductive: it
-        # prevents draining the very data that is filling the object store.
-        # So for sinks we check CPU budget normally but skip the object store
+        # Datasink operators (write_parquet, etc.) only consume blocks from the
+        # object store — they never produce output into it.  Blocking a datasink
+        # on object store budget is counterproductive: it prevents draining the
+        # very data that is filling the object store.
+        # So for datasinks we check CPU budget normally but skip the object store
         # budget check entirely.
-        if not op.output_dependencies:
+        # We check the logical operator rather than `not op.output_dependencies`
+        # to avoid misidentifying terminal map ops (e.g. materialize()) that DO
+        # produce output into the object store.
+        if self._is_datasink_op(op):
             return op.incremental_resource_usage().satisfies_limit(
                 budget, ignore_object_store_memory=True
             )
@@ -1074,3 +1078,15 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
                 self._op_budgets[op] = self._op_budgets[op].copy(
                     object_store_memory=float("inf")
                 )
+
+    @staticmethod
+    def _is_datasink_op(op: PhysicalOperator) -> bool:
+        """Return True if the operator is a datasink (write) operator.
+
+        Checks the logical operator rather than output_dependencies to avoid
+        misidentifying terminal map ops (e.g. materialize()) that still produce
+        output into the object store.
+        """
+        return any(
+            isinstance(logical_op, Write) for logical_op in op._logical_operators
+        )

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -24,8 +24,7 @@ from ray.data._internal.execution.operators.hash_shuffle import (
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
 from ray.data._internal.execution.operators.zip_operator import ZipOperator
-from ray.data._internal.execution.util import memory_string
-from ray.data._internal.logical.operators.write_operator import Write
+from ray.data._internal.execution.util import is_datasink_op, memory_string
 from ray.data.context import DataContext
 from ray.util.debug import log_once
 
@@ -915,7 +914,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         # We check the logical operator rather than `not op.output_dependencies`
         # to avoid misidentifying terminal map ops (e.g. materialize()) that DO
         # produce output into the object store.
-        if self._is_datasink_op(op):
+        if is_datasink_op(op):
             return op.incremental_resource_usage().satisfies_limit(
                 budget, ignore_object_store_memory=True
             )
@@ -1078,15 +1077,3 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
                 self._op_budgets[op] = self._op_budgets[op].copy(
                     object_store_memory=float("inf")
                 )
-
-    @staticmethod
-    def _is_datasink_op(op: PhysicalOperator) -> bool:
-        """Return True if the operator is a datasink (write) operator.
-
-        Checks the logical operator rather than output_dependencies to avoid
-        misidentifying terminal map ops (e.g. materialize()) that still produce
-        output into the object store.
-        """
-        return any(
-            isinstance(logical_op, Write) for logical_op in op._logical_operators
-        )

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -905,6 +905,17 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         if budget is None:
             return True
 
+        # Sink operators (no downstream consumers, e.g. write_parquet) only
+        # consume blocks from the object store — they never produce output into
+        # it.  Blocking a sink on object store budget is counterproductive: it
+        # prevents draining the very data that is filling the object store.
+        # So for sinks we check CPU budget normally but skip the object store
+        # budget check entirely.
+        if not op.output_dependencies:
+            return op.incremental_resource_usage().satisfies_limit(
+                budget, ignore_object_store_memory=True
+            )
+
         return (
             op.incremental_resource_usage().satisfies_limit(budget)
             and

--- a/python/ray/data/_internal/execution/util.py
+++ b/python/ray/data/_internal/execution/util.py
@@ -6,6 +6,9 @@ from ray.data.block import BlockAccessor, CallableClass
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces import RefBundle
+    from ray.data._internal.execution.interfaces.physical_operator import (
+        PhysicalOperator,
+    )
 
 
 def make_ref_bundles(simple_data: List[List[Any]]) -> List["RefBundle"]:
@@ -80,3 +83,15 @@ def make_callable_class_single_threaded(callable_cls: CallableClass) -> Callable
             return future.result()
 
     return _SingleThreadedWrapper
+
+
+def is_datasink_op(op: "PhysicalOperator") -> bool:
+    """Return True if the operator is a datasink (write) operator.
+
+    Checks the logical operator rather than output_dependencies to avoid
+    misidentifying terminal map ops (e.g. materialize()) that still produce
+    output into the object store.
+    """
+    from ray.data._internal.logical.operators.write_operator import Write
+
+    return any(isinstance(logical_op, Write) for logical_op in op._logical_operators)


### PR DESCRIPTION
## Description
Sink operators (e.g. write_parquet) only consume blocks from the object store — they never produce output into it. Previously, when the object store budget was exhausted (e.g. during a reduce phase producing output faster than write can drain), sink tasks were blocked by the same object store budget check as producers. This is counterproductive: blocking the sink prevents it from draining the very data that is filling the object store, creating a deadlock(kinda?).

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
