### PR TITLE
[llm] Fix KeyError in get_attn_backends_for_group for pipeline_parallel_size>1 in ray.data.llm

### DIFF
--- a/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
+++ b/python/ray/llm/_internal/batch/stages/vllm_engine_stage.py
@@ -278,6 +278,13 @@ class vLLMEngineWrapper:
         # create_engine_config will set default values including `max_num_seqs`.
         self._vllm_config = engine_args.create_engine_config()
 
+        # Inject the current PG so vLLM's Ray executor uses it directly rather than
+        # creating a secondary PG that conflicts with capture_child_tasks=True,
+        # which causes wrong PP rank → bundle mapping.
+        pg = ray.util.get_current_placement_group()
+        if pg is not None:
+            self._vllm_config.parallel_config.placement_group = pg
+
         stat_loggers = None
         if log_engine_metrics:
             from vllm.v1.metrics.ray_wrappers import RayPrometheusStatLogger
@@ -289,7 +296,7 @@ class vLLMEngineWrapper:
             )
 
         self.engine = vllm.AsyncLLMEngine.from_engine_args(
-            engine_args, stat_loggers=stat_loggers
+            engine_args, engine_config=self._vllm_config, stat_loggers=stat_loggers
         )
 
         # The performance gets really bad if there are too many requests in the pending queue.


### PR DESCRIPTION
## Summary

- **Bug:** `ray.data.llm` (batch path) never passes its placement group to vLLM's `parallel_config.placement_group`. It relies on `placement_group_capture_child_tasks=True` instead, which lets Ray auto-assign vLLM's PP worker actors to PG bundles — but the assignment order does not match vLLM's expected PP rank mapping.
- **Result:** Workers load the wrong layer partitions; `get_attn_backends_for_group` then fails with `KeyError` on the first attention layer each rank expects (e.g. `'model.layers.0.self_attn.attn'` on PP rank 0, `'model.layers.47.self_attn.attn'` on PP rank 1).
- **Fix:** Inject `ray.util.get_current_placement_group()` into `self._vllm_config.parallel_config.placement_group` after `create_engine_config()` and before `AsyncLLMEngine.from_engine_args()`. This is exactly what the Ray Serve path has done since [PR #50643](https://github.com/ray-project/ray/pull/50643) (Feb 2025) — the batch path was simply missing the equivalent.

## Reproduction

```python
import ray, ray.data
from ray.llm import build_processor, vLLMEngineProcessorConfig

ray.init()
ds = ray.data.from_items([
    {"messages": [{"role": "user", "content": "Hello"}],
     "sampling_params": {"temperature": 0.6, "max_tokens": 64},
     "custom_id": "test-0"},
] * 4)

processor = build_processor(
    vLLMEngineProcessorConfig(
        model_source="Qwen/Qwen3-235B-A22B-Instruct-2507",
        engine_kwargs={
            "tensor_parallel_size": 8,
            "pipeline_parallel_size": 2,   # triggers the bug
            "distributed_executor_backend": "ray",
            "max_model_len": 5120,
            "dtype": "bfloat16",
            "trust_remote_code": True,
        },
        concurrency=1,
        batch_size=32,
        chat_template_stage=False,
        tokenize_stage=False,
        detokenize_stage=False,
    )
)
result = processor(ds).take_all()
# KeyError: 'model.layers.0.self_attn.attn'  (vLLM 0.19.1, Ray 2.55.1, 2×8 A100)
```

## Environment

- vLLM 0.19.1 (V1 engine)
- Ray 2.55.1
- Python 3.11
- 2× node × 8× A100-80GB (16 GPUs total, InfiniBand inter-node)

## Test plan

- [ ] Verify existing batch LLM tests pass: `python -m pytest python/ray/llm/tests/batch/ -x`
- [ ] Manual end-to-end test with TP=8, PP=2 on 2-node A100 cluster with a large MoE model

🤖 Generated with [Claude Code](https://claude.com/claude-code)