### PR TITLE
[Dashboard] Implement Frontend UI for Platform Events

### DIFF
--- a/python/ray/dashboard/client/src/App.tsx
+++ b/python/ray/dashboard/client/src/App.tsx
@@ -12,6 +12,7 @@ import { AUTHENTICATION_ERROR_EVENT } from "./authentication/constants";
 import TokenAuthenticationDialog from "./authentication/TokenAuthenticationDialog";
 import ActorDetailPage, { ActorDetailLayout } from "./pages/actor/ActorDetail";
 import { ActorLayout } from "./pages/actor/ActorLayout";
+import PlatformEventsPage from "./pages/events/PlatformEventsPage";
 import Loading from "./pages/exception/Loading";
 import JobList, { JobsLayout } from "./pages/job";
 import { JobDetailChartsPage } from "./pages/job/JobDetail";
@@ -62,6 +63,7 @@ import {
 } from "./pages/serve/ServeSystemDetailPage";
 import { TaskPage } from "./pages/task/TaskPage";
 import { getNodeList } from "./service/node";
+import { getPlatformEventsEnabled } from "./service/platform";
 import { darkTheme, lightTheme } from "./theme";
 
 dayjs.extend(duration);
@@ -103,6 +105,10 @@ export type GlobalContextType = {
    */
   prometheusHealth: boolean | undefined;
   /**
+   * Whether platform events are enabled
+   */
+  platformEventsEnabled?: boolean;
+  /**
    * The name of the currently running ray session.
    */
   sessionName: string | undefined;
@@ -137,6 +143,7 @@ export const GlobalContext = React.createContext<GlobalContextType>({
   grafanaClusterFilter: undefined,
   dashboardUids: undefined,
   prometheusHealth: undefined,
+  platformEventsEnabled: false,
   sessionName: undefined,
   dashboardDatasource: undefined,
   serverTimeZone: undefined,
@@ -181,6 +188,7 @@ const App = () => {
     grafanaClusterFilter: undefined,
     dashboardUids: undefined,
     prometheusHealth: undefined,
+    platformEventsEnabled: false,
     sessionName: undefined,
     dashboardDatasource: undefined,
     serverTimeZone: undefined,
@@ -263,6 +271,16 @@ const App = () => {
       }));
     };
     doEffect();
+  }, []);
+
+  // Detect if platform events are enabled
+  useEffect(() => {
+    getPlatformEventsEnabled().then((platformEventsEnabled) => {
+      setContext((existingContext) => ({
+        ...existingContext,
+        platformEventsEnabled,
+      }));
+    });
   }, []);
 
   useEffect(() => {
@@ -403,6 +421,10 @@ const App = () => {
                 <Route element={<MainNavLayout />} path="/">
                   <Route element={<Navigate replace to="overview" />} path="" />
                   <Route element={<OverviewPage />} path="overview" />
+                  <Route
+                    element={<PlatformEventsPage />}
+                    path="platform-events"
+                  />
                   <Route element={<ClusterMainPageLayout />} path="cluster">
                     <Route element={<ClusterLayout />} path="">
                       <Route

--- a/python/ray/dashboard/client/src/components/StatusChip.tsx
+++ b/python/ray/dashboard/client/src/components/StatusChip.tsx
@@ -89,6 +89,12 @@ const getColorMap = (orange: string, grey: string) =>
       [ServeSystemActorStatus.UNHEALTHY]: red,
       [ServeSystemActorStatus.STARTING]: orange,
     },
+    severity: {
+      INFO: cyan,
+      WARNING: orange,
+      ERROR: red,
+      FATAL: red,
+    },
   } as {
     [key: string]: {
       [key: string]: Color | string;

--- a/python/ray/dashboard/client/src/pages/events/PlatformEvents.tsx
+++ b/python/ray/dashboard/client/src/pages/events/PlatformEvents.tsx
@@ -1,0 +1,296 @@
+import { SearchOutlined } from "@mui/icons-material";
+import {
+  Autocomplete,
+  Box,
+  InputAdornment,
+  Pagination,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  TextFieldProps,
+  Typography,
+} from "@mui/material";
+import React, { useEffect, useMemo, useState } from "react";
+import { formatDateFromTimeMs } from "../../common/formatUtils";
+import { sliceToPage } from "../../common/util";
+import { StatusChip } from "../../components/StatusChip";
+import { PlatformEvent } from "../../type/platform";
+import { useFilter } from "../../util/hook";
+
+const SeverityChip = ({ severity }: { severity: string }) => {
+  return <StatusChip type="severity" status={severity} />;
+};
+
+type FilterKey =
+  | "severity"
+  | "platformEvent.source.platform"
+  | "platformEvent.objectKind";
+
+const DEFAULT_PAGE_SIZE = 25;
+
+export const PlatformEvents = ({
+  events,
+  emptyMessage = "No platform events found.",
+  isLoading = false,
+}: {
+  events: PlatformEvent[];
+  emptyMessage?: string;
+  isLoading?: boolean;
+}) => {
+  const [pageNo, setPageNo] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [searchText, setSearchText] = useState("");
+  const { changeFilter: _changeFilter, filterFunc } = useFilter<FilterKey>();
+  const changeFilter = (key: FilterKey, val: string) => {
+    _changeFilter(key, val);
+    setPageNo(1);
+  };
+  const severityOptions = useMemo(
+    () => Array.from(new Set(events.map((e) => e.severity).filter(Boolean))),
+    [events],
+  );
+  const platformOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          events
+            .map((e) => e.platformEvent?.source?.platform)
+            .filter((v): v is string => !!v),
+        ),
+      ),
+    [events],
+  );
+  const objectKindOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          events
+            .map((e) => e.platformEvent?.objectKind)
+            .filter((v): v is string => !!v),
+        ),
+      ),
+    [events],
+  );
+  const filteredEvents: PlatformEvent[] = useMemo(() => {
+    const needle = searchText.trim().toLowerCase();
+    return events.filter((e: PlatformEvent) => {
+      if (!filterFunc(e)) {
+        return false;
+      }
+      if (!needle) {
+        return true;
+      }
+      const msg = (e.platformEvent?.message || e.message || "").toLowerCase();
+      const reason = (e.platformEvent?.reason || "").toLowerCase();
+      return msg.includes(needle) || reason.includes(needle);
+    });
+  }, [events, filterFunc, searchText]);
+
+  const {
+    items: pageEvents,
+    constrainedPage,
+    maxPage,
+  } = sliceToPage(filteredEvents, pageNo, pageSize);
+
+  const effectivePage = Math.max(1, constrainedPage);
+  const pageCount = Math.max(1, maxPage);
+
+  useEffect(() => {
+    if (effectivePage !== pageNo) {
+      setPageNo(effectivePage);
+    }
+  }, [effectivePage, pageNo]);
+
+  if (isLoading) {
+    return (
+      <Box sx={{ padding: 2, textAlign: "center" }}>
+        <Typography color="textSecondary">Loading events...</Typography>
+      </Box>
+    );
+  }
+
+  if (!events || events.length === 0) {
+    return (
+      <Box sx={{ padding: 2, textAlign: "center" }}>
+        <Typography color="textSecondary">{emptyMessage}</Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 1,
+          marginBottom: 1,
+        }}
+      >
+        <Autocomplete
+          sx={{ width: 160 }}
+          size="small"
+          options={severityOptions}
+          onInputChange={(_: any, value: string) =>
+            changeFilter("severity", value.trim())
+          }
+          renderInput={(params: TextFieldProps) => (
+            <TextField {...params} label="Severity" />
+          )}
+        />
+        <Autocomplete
+          sx={{ width: 200 }}
+          size="small"
+          options={platformOptions}
+          onInputChange={(_: any, value: string) =>
+            changeFilter("platformEvent.source.platform", value.trim())
+          }
+          renderInput={(params: TextFieldProps) => (
+            <TextField {...params} label="Platform" />
+          )}
+        />
+        <Autocomplete
+          sx={{ width: 200 }}
+          size="small"
+          options={objectKindOptions}
+          onInputChange={(_: any, value: string) =>
+            changeFilter("platformEvent.objectKind", value.trim())
+          }
+          renderInput={(params: TextFieldProps) => (
+            <TextField {...params} label="Object Kind" />
+          )}
+        />
+        <TextField
+          sx={{ width: 240 }}
+          size="small"
+          label="Search reason / message"
+          value={searchText}
+          onChange={(e) => {
+            setSearchText(e.target.value);
+            setPageNo(1);
+          }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <SearchOutlined
+                  sx={(theme) => ({ color: theme.palette.text.secondary })}
+                />
+              </InputAdornment>
+            ),
+          }}
+        />
+        <TextField
+          sx={{ width: 120 }}
+          size="small"
+          label="Page size"
+          type="number"
+          value={pageSize}
+          onChange={(e) => {
+            const n = Math.min(
+              500,
+              Math.max(1, Number(e.target.value) || DEFAULT_PAGE_SIZE),
+            );
+            setPageSize(n);
+            setPageNo(1);
+          }}
+        />
+      </Box>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginBottom: 1,
+        }}
+      >
+        <Typography variant="body2" color="textSecondary">
+          {filteredEvents.length === events.length
+            ? `${events.length} events`
+            : `${filteredEvents.length} of ${events.length} events`}
+        </Typography>
+        <Pagination
+          count={pageCount}
+          page={effectivePage}
+          onChange={(_: React.ChangeEvent<unknown>, value: number) =>
+            setPageNo(value)
+          }
+          size="small"
+        />
+      </Box>
+
+      {pageEvents.length === 0 ? (
+        <Box sx={{ padding: 2, textAlign: "center" }}>
+          <Typography color="textSecondary">
+            No events match the current filters.
+          </Typography>
+        </Box>
+      ) : (
+        <TableContainer>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableCell>Time</TableCell>
+                <TableCell>Severity</TableCell>
+                <TableCell>Source</TableCell>
+                <TableCell>Object</TableCell>
+                <TableCell>Reason</TableCell>
+                <TableCell>Message</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {pageEvents.map((event: PlatformEvent, index: number) => {
+                const pEvent = event.platformEvent;
+                const sourceStr = pEvent?.source
+                  ? `${pEvent.source.platform}/${pEvent.source.component}`
+                  : "-";
+                const objectStr = pEvent?.objectKind
+                  ? `${pEvent.objectKind}/${pEvent.objectName}`
+                  : "-";
+                const timeMs = new Date(event.timestamp).getTime();
+
+                return (
+                  <TableRow key={event.eventId || index}>
+                    <TableCell>
+                      {isNaN(timeMs)
+                        ? event.timestamp
+                        : formatDateFromTimeMs(timeMs)}
+                    </TableCell>
+                    <TableCell>
+                      <SeverityChip severity={event.severity} />
+                    </TableCell>
+                    <TableCell>{sourceStr}</TableCell>
+                    <TableCell>{objectStr}</TableCell>
+                    <TableCell>{pEvent?.reason || "-"}</TableCell>
+                    <TableCell
+                      sx={{ whiteSpace: "pre-wrap", wordBreak: "break-word" }}
+                    >
+                      {pEvent?.message || event.message || "-"}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+
+      {maxPage > 1 && (
+        <Box sx={{ display: "flex", justifyContent: "flex-end", marginTop: 1 }}>
+          <Pagination
+            count={pageCount}
+            page={effectivePage}
+            onChange={(_: React.ChangeEvent<unknown>, value: number) =>
+              setPageNo(value)
+            }
+            size="small"
+          />
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/python/ray/dashboard/client/src/pages/events/PlatformEventsPage.tsx
+++ b/python/ray/dashboard/client/src/pages/events/PlatformEventsPage.tsx
@@ -1,0 +1,70 @@
+import { Alert, Box } from "@mui/material";
+import React from "react";
+import useSWR from "swr";
+import { API_REFRESH_INTERVAL_MS } from "../../common/constants";
+import TitleCard from "../../components/TitleCard";
+import { getPlatformEvents } from "../../service/platform";
+import { MainNavPageInfo } from "../layout/mainNavContext";
+import { PlatformEvents } from "./PlatformEvents";
+
+const errorMessage = (error: any): string => {
+  const status = error?.response?.status;
+  if (status === 404) {
+    return "Platform events are not enabled on this cluster.";
+  }
+  if (status === 401 || status === 403) {
+    return "You are not authorized to view platform events.";
+  }
+  if (status) {
+    return `Failed to load platform events (HTTP ${status}).`;
+  }
+  return `Failed to load platform events: ${
+    error?.message || "unknown error"
+  }.`;
+};
+
+const PlatformEventsPage = () => {
+  const isRefreshing = true;
+
+  const {
+    data: platformEvents,
+    isLoading,
+    error,
+  } = useSWR(
+    "useClusterPlatformEvents",
+    async () => {
+      const { data } = await getPlatformEvents();
+      return data?.data?.events || [];
+    },
+    { refreshInterval: isRefreshing ? API_REFRESH_INTERVAL_MS : 0 },
+  );
+
+  const status = error?.response?.status;
+  const isCriticalError = status === 404 || status === 401 || status === 403;
+
+  return (
+    <Box sx={{ padding: 2 }}>
+      <MainNavPageInfo
+        pageInfo={{
+          title: "Platform Events",
+          pageTitle: "Platform Events",
+          id: "platform-events",
+          path: "/platform-events",
+        }}
+      />
+      <TitleCard title="Platform Events">
+        {error && (
+          <Alert severity="error" sx={{ marginBottom: 2 }}>
+            {errorMessage(error)}
+          </Alert>
+        )}
+        {isCriticalError ||
+        (error && (!platformEvents || platformEvents.length === 0)) ? null : (
+          <PlatformEvents events={platformEvents || []} isLoading={isLoading} />
+        )}
+      </TitleCard>
+    </Box>
+  );
+};
+
+export default PlatformEventsPage;

--- a/python/ray/dashboard/client/src/pages/layout/MainNavLayout.tsx
+++ b/python/ray/dashboard/client/src/pages/layout/MainNavLayout.tsx
@@ -110,6 +110,11 @@ const NAV_ITEMS = [
     path: "/logs",
     id: "logs",
   },
+  {
+    title: "Platform Events",
+    path: "/platform-events",
+    id: "platform-events",
+  },
 ];
 
 const MainNavBar = () => {
@@ -118,6 +123,7 @@ const MainNavBar = () => {
   const {
     metricsContextLoaded,
     grafanaHost,
+    platformEventsEnabled,
     serverTimeZone,
     currentTimeZone,
     themeMode,
@@ -129,6 +135,9 @@ const MainNavBar = () => {
   let navItems = NAV_ITEMS;
   if (!metricsContextLoaded || grafanaHost === "DISABLED") {
     navItems = navItems.filter(({ id }) => id !== "metrics");
+  }
+  if (!platformEventsEnabled) {
+    navItems = navItems.filter(({ id }) => id !== "platform-events");
   }
 
   return (

--- a/python/ray/dashboard/client/src/service/platform.ts
+++ b/python/ray/dashboard/client/src/service/platform.ts
@@ -1,0 +1,15 @@
+import { PlatformEventsRsp } from "../type/platform";
+import { get, head } from "./requestHandlers";
+
+export const getPlatformEvents = async () => {
+  return await get<PlatformEventsRsp>("api/v0/platform_events");
+};
+
+export const getPlatformEventsEnabled = async (): Promise<boolean> => {
+  try {
+    await head("api/v0/platform_events");
+    return true;
+  } catch (e: any) {
+    return e?.response?.status !== 404;
+  }
+};

--- a/python/ray/dashboard/client/src/service/requestHandlers.ts
+++ b/python/ray/dashboard/client/src/service/requestHandlers.ts
@@ -66,3 +66,10 @@ export const get = <T = any, R = AxiosResponse<T>>(
 ): Promise<R> => {
   return axiosInstance.get<T, R>(formatUrl(url), config);
 };
+
+export const head = <R = AxiosResponse>(
+  url: string,
+  config?: AxiosRequestConfig,
+): Promise<R> => {
+  return axiosInstance.head<unknown, R>(formatUrl(url), config);
+};

--- a/python/ray/dashboard/client/src/type/platform.ts
+++ b/python/ray/dashboard/client/src/type/platform.ts
@@ -1,0 +1,32 @@
+export type PlatformEventSource = {
+  platform: string;
+  component: string;
+  metadata: { [key: string]: string };
+};
+
+export type PlatformEventData = {
+  source?: PlatformEventSource;
+  objectKind: string;
+  objectName: string;
+  message: string;
+  reason: string;
+  customFields?: { [key: string]: string };
+};
+
+export type PlatformEvent = {
+  eventId: string;
+  sourceType: string;
+  eventType: string;
+  timestamp: string;
+  severity: string;
+  message: string;
+  platformEvent: PlatformEventData;
+};
+
+export type PlatformEventsRsp = {
+  result: boolean;
+  msg: string;
+  data: {
+    events: PlatformEvent[];
+  };
+};

--- a/python/ray/dashboard/modules/platform_events/platform_event_head.py
+++ b/python/ray/dashboard/modules/platform_events/platform_event_head.py
@@ -156,11 +156,11 @@ class PlatformEventsHead(dashboard_utils.DashboardHeadModule):
     @dashboard_optional_utils.aiohttp_cache
     async def get_platform_events(self, req):
         """Return recently observed platform events as a JSON array."""
-        # Sort by timestamp ascending (oldest first) to fix out-of-order
-        # issues caused by potential reconnects/re-deliveries.
+        # Sort by timestamp descending (newest first)
         sorted_events = sorted(
             self._events.values(),
             key=lambda e: e.timestamp.seconds + e.timestamp.nanos / 1e9,
+            reverse=True,
         )
         payload = [
             dashboard_utils.message_to_dict(


### PR DESCRIPTION
## Description
This PR adds the frontend components, types, and navigation topology to render cluster-wide platform events in the Ray Dashboard

Tested on a GKE cluster. 
1. See the following for RayJob events
<img width="3340" height="1996" alt="image" src="https://github.com/user-attachments/assets/5b2a0308-456b-46c8-bbf8-2333c4bdd509" />


2. See the following for RayCluster events
<img width="3420" height="1694" alt="image" src="https://github.com/user-attachments/assets/f8b04b1f-fee0-4d3c-85af-943431aa25f2" />
