### PR TITLE
[release] add anyscale-template fan-out workflow on Ray .0 releases

### DIFF
--- a/.github/workflows/anyscale-template-fanout.yml
+++ b/.github/workflows/anyscale-template-fanout.yml
@@ -1,0 +1,88 @@
+# Fires the Cursor "template-updater" fan-out webhook for every template in
+# anyscale/templates/BUILD.yaml whenever a Ray .0 release is published, so the
+# agent can open per-template `[ray-update-<target>]` PRs that bump each
+# template's Ray image pin.
+#
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   CURSOR_TEMPLATE_UPDATER_WEBHOOK     Cursor Cloud webhook URL
+#   CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN  Bearer token for the webhook
+#
+# Patch-zero filter: only releases whose tag parses to MAJOR.MINOR.0 trigger
+# the fan-out (e.g. ray-2.55.0 fires, ray-2.55.1 does not). Patch bumps rarely
+# justify refreshing every template image and the agent cycles get noisy.
+#
+# Prereleases are filtered at the job level so the run shows as skipped in the
+# Actions UI rather than burning a runner. workflow_dispatch always proceeds
+# (useful for smoke runs once secrets are provisioned).
+
+name: Anyscale Template Fan-out
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target_ray:
+        description: "Bare Ray version, e.g. 2.55.0 (manual smoke runs only)."
+        required: false
+        type: string
+
+# Minimum required: this workflow only reads from this repo (vendored scripts)
+# and reads cross-repo public PR metadata via gh pr list. It never writes to
+# the current repo. GITHUB_TOKEN can stay locked down to contents: read.
+permissions:
+  contents: read
+
+jobs:
+  fanout:
+    # workflow_dispatch always runs; release events skip when prerelease=true.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease != true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (vendored fan-out scripts)
+        uses: actions/checkout@v4
+
+      - name: Derive target Ray version & apply patch-zero filter
+        id: derive
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            target="${{ inputs.target_ray }}"
+            if [[ -z "$target" ]]; then
+              echo "::error::workflow_dispatch requires the target_ray input"
+              exit 1
+            fi
+          else
+            tag="${{ github.event.release.tag_name }}"
+            target="${tag#ray-}"
+          fi
+          echo "target=$target"
+
+          if [[ ! "$target" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::warning::target '$target' is not MAJOR.MINOR.PATCH — skipping fan-out"
+            echo "should_fanout=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          patch="${BASH_REMATCH[3]}"
+          if [[ "$patch" != "0" ]]; then
+            echo "::notice::PATCH=$patch in target '$target' — patch-zero filter, skipping fan-out"
+            echo "should_fanout=false" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "target_ray=$target" >>"$GITHUB_OUTPUT"
+          echo "should_fanout=true" >>"$GITHUB_OUTPUT"
+
+      - name: Fan out to template-updater webhook
+        if: steps.derive.outputs.should_fanout == 'true'
+        env:
+          CURSOR_TEMPLATE_UPDATER_WEBHOOK: ${{ secrets.CURSOR_TEMPLATE_UPDATER_WEBHOOK }}
+          CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN: ${{ secrets.CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_RAY: ${{ steps.derive.outputs.target_ray }}
+        run: |
+          chmod +x .github/workflows/scripts/list-templates.sh
+          chmod +x .github/workflows/scripts/fanout-template-updater.sh
+          bash .github/workflows/scripts/fanout-template-updater.sh

--- a/.github/workflows/anyscale-template-fanout.yml
+++ b/.github/workflows/anyscale-template-fanout.yml
@@ -1,19 +1,6 @@
-# Fires the Cursor "template-updater" fan-out webhook for every template in
-# anyscale/templates/BUILD.yaml whenever a Ray .0 release is published, so the
-# agent can open per-template `[ray-update-<target>]` PRs that bump each
-# template's Ray image pin.
-#
-# Required repository secrets (Settings → Secrets and variables → Actions):
-#   CURSOR_TEMPLATE_UPDATER_WEBHOOK     Cursor Cloud webhook URL
-#   CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN  Bearer token for the webhook
-#
-# Patch-zero filter: only releases whose tag parses to MAJOR.MINOR.0 trigger
-# the fan-out (e.g. ray-2.55.0 fires, ray-2.55.1 does not). Patch bumps rarely
-# justify refreshing every template image and the agent cycles get noisy.
-#
-# Prereleases are filtered at the job level so the run shows as skipped in the
-# Actions UI rather than burning a runner. workflow_dispatch always proceeds
-# (useful for smoke runs once secrets are provisioned).
+# POSTs to the Cursor template-updater webhook for each entry in
+# anyscale/templates/BUILD.yaml on Ray .0 releases.
+# Requires repo secrets: CURSOR_TEMPLATE_UPDATER_WEBHOOK, CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN.
 
 name: Anyscale Template Fan-out
 
@@ -27,15 +14,11 @@ on:
         required: false
         type: string
 
-# Minimum required: this workflow only reads from this repo (vendored scripts)
-# and reads cross-repo public PR metadata via gh pr list. It never writes to
-# the current repo. GITHUB_TOKEN can stay locked down to contents: read.
 permissions:
   contents: read
 
 jobs:
   fanout:
-    # workflow_dispatch always runs; release events skip when prerelease=true.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease != true }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/scripts/fanout-template-updater.sh
+++ b/.github/workflows/scripts/fanout-template-updater.sh
@@ -11,26 +11,20 @@ if [[ -z "$WEBHOOK_URL" || -z "$WEBHOOK_AUTH_TOKEN" ]]; then
   exit 1
 fi
 
-# Resolve target Ray version once. The agent's PR titles use a bare "2.x.y"
-# (e.g. "[ray-update-2.55.1] Update foo to Ray 2.55.1"), so strip the "ray-"
-# prefix off the GitHub release tag (which looks like "ray-2.55.1").
+# Strip the "ray-" prefix; agent PR titles use the bare "2.x.y" form.
 TARGET_RAY="${TARGET_RAY:-$(gh release view --repo ray-project/ray --json tagName --jq .tagName | sed 's/^ray-//')}"
 echo "target_ray=$TARGET_RAY" >&2
 
-# Skip-list: open OR merged PRs against anyscale/templates whose title contains
-# the [ray-update-<TARGET_RAY>] marker (the agent's own convention). A merged
-# PR means the bump already shipped — re-triggering would be a no-op. An open
-# PR means a run is already in flight. Closed-not-merged are deliberately NOT
-# in the skip-list (those are abandoned attempts worth re-firing).
-# Merged entries are added first so they win on lookup if both states exist.
+# Skip-list: open + merged [ray-update-$TARGET_RAY] PRs on anyscale/templates.
+# Merged added first so it wins on lookup. Closed-not-merged are intentionally
+# excluded — those are abandoned attempts worth re-firing.
 echo "skip-list (open + merged PRs already bumping to $TARGET_RAY):" >&2
 skip_list=""
 for state in merged open; do
   while IFS=$'\t' read -r title url; do
     [[ -z "$title" ]] && continue
-    # TODO(hardening): dots in ${TARGET_RAY} (e.g. 2.55.1) are interpolated raw
-    # and act as regex wildcards. Real agent PR titles won't false-match; if we
-    # ever take user-supplied versions, escape the dots before splicing.
+    # TODO(hardening): dots in $TARGET_RAY are raw regex here. Safe today (the
+    # workflow sets the value); escape if we ever take user input.
     name="$(printf '%s' "$title" | sed -nE "s/^\[ray-update-${TARGET_RAY}\] Update (.+) to Ray ${TARGET_RAY}.*$/\1/p")"
     if [[ -z "$name" ]]; then
       echo "  WARN unparseable PR title: $title ($url)" >&2
@@ -44,14 +38,11 @@ if [[ -z "$skip_list" ]]; then
   echo "  (none)" >&2
 fi
 
-# Lookup helper: echoes "<state>: <url>" for a template name if present.
-# Merged wins over open because we add merged first and exit on first match.
 skip_entry_for() {
   local n="$1"
   printf '%s' "$skip_list" | awk -v n="$n" -F'\t' '$1 == n { print $2 ": " $3; exit }'
 }
 
-# Per-run dir for captured response bodies. Created lazily on first real call.
 RUNS_DIR="$HERE/runs/$(date -u +%Y%m%dT%H%M%SZ)"
 
 ok=0
@@ -64,7 +55,6 @@ while IFS= read -r entry; do
   name="$(jq -r '.name' <<<"$entry")"
   dir="$(jq -r '.dir' <<<"$entry")"
 
-  # Optional one-template filter (used by smoke test).
   if [[ -n "${SMOKE_TEMPLATE:-}" && "$SMOKE_TEMPLATE" != "$name" ]]; then
     continue
   fi

--- a/.github/workflows/scripts/fanout-template-updater.sh
+++ b/.github/workflows/scripts/fanout-template-updater.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+WEBHOOK_URL="${WEBHOOK_URL:-${CURSOR_TEMPLATE_UPDATER_WEBHOOK:-}}"
+WEBHOOK_AUTH_TOKEN="${WEBHOOK_AUTH_TOKEN:-${CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN:-}}"
+
+if [[ -z "$WEBHOOK_URL" || -z "$WEBHOOK_AUTH_TOKEN" ]]; then
+  echo "set WEBHOOK_URL + WEBHOOK_AUTH_TOKEN (or the CURSOR_TEMPLATE_UPDATER_WEBHOOK / CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN defaults)" >&2
+  exit 1
+fi
+
+# Resolve target Ray version once. The agent's PR titles use a bare "2.x.y"
+# (e.g. "[ray-update-2.55.1] Update foo to Ray 2.55.1"), so strip the "ray-"
+# prefix off the GitHub release tag (which looks like "ray-2.55.1").
+TARGET_RAY="${TARGET_RAY:-$(gh release view --repo ray-project/ray --json tagName --jq .tagName | sed 's/^ray-//')}"
+echo "target_ray=$TARGET_RAY" >&2
+
+# Skip-list: open OR merged PRs against anyscale/templates whose title contains
+# the [ray-update-<TARGET_RAY>] marker (the agent's own convention). A merged
+# PR means the bump already shipped — re-triggering would be a no-op. An open
+# PR means a run is already in flight. Closed-not-merged are deliberately NOT
+# in the skip-list (those are abandoned attempts worth re-firing).
+# Merged entries are added first so they win on lookup if both states exist.
+echo "skip-list (open + merged PRs already bumping to $TARGET_RAY):" >&2
+skip_list=""
+for state in merged open; do
+  while IFS=$'\t' read -r title url; do
+    [[ -z "$title" ]] && continue
+    # TODO(hardening): dots in ${TARGET_RAY} (e.g. 2.55.1) are interpolated raw
+    # and act as regex wildcards. Real agent PR titles won't false-match; if we
+    # ever take user-supplied versions, escape the dots before splicing.
+    name="$(printf '%s' "$title" | sed -nE "s/^\[ray-update-${TARGET_RAY}\] Update (.+) to Ray ${TARGET_RAY}.*$/\1/p")"
+    if [[ -z "$name" ]]; then
+      echo "  WARN unparseable PR title: $title ($url)" >&2
+      continue
+    fi
+    skip_list+="$name"$'\t'"$state"$'\t'"$url"$'\n'
+    echo "  $name  ($state: $url)" >&2
+  done < <(gh pr list --repo anyscale/templates --state "$state" --search "ray-update-${TARGET_RAY} in:title" --limit 100 --json title,url --jq '.[] | [.title, .url] | @tsv')
+done
+if [[ -z "$skip_list" ]]; then
+  echo "  (none)" >&2
+fi
+
+# Lookup helper: echoes "<state>: <url>" for a template name if present.
+# Merged wins over open because we add merged first and exit on first match.
+skip_entry_for() {
+  local n="$1"
+  printf '%s' "$skip_list" | awk -v n="$n" -F'\t' '$1 == n { print $2 ": " $3; exit }'
+}
+
+# Per-run dir for captured response bodies. Created lazily on first real call.
+RUNS_DIR="$HERE/runs/$(date -u +%Y%m%dT%H%M%SZ)"
+
+ok=0
+fail=0
+skipped=0
+dry=0
+failed_names=()
+
+while IFS= read -r entry; do
+  name="$(jq -r '.name' <<<"$entry")"
+  dir="$(jq -r '.dir' <<<"$entry")"
+
+  # Optional one-template filter (used by smoke test).
+  if [[ -n "${SMOKE_TEMPLATE:-}" && "$SMOKE_TEMPLATE" != "$name" ]]; then
+    continue
+  fi
+
+  existing="$(skip_entry_for "$name")"
+  if [[ -n "$existing" ]]; then
+    echo "SKIP $name :: existing PR ($existing)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  payload="$(jq -nc --arg n "$name" --arg d "$dir" --arg t "$TARGET_RAY" '{template: $n, dir: $d, target_ray: $t}')"
+
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "DRY  $name :: $payload"
+    dry=$((dry + 1))
+    continue
+  fi
+
+  mkdir -p "$RUNS_DIR"
+  body_file="$RUNS_DIR/${name}.json"
+
+  code="$(curl -sS -o "$body_file" -w '%{http_code}' \
+    -X POST \
+    -H "Authorization: Bearer $WEBHOOK_AUTH_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$WEBHOOK_URL")" || code="000"
+
+  if [[ "$code" =~ ^2 ]]; then
+    echo "OK   $name [$code] -> $body_file"
+    ok=$((ok + 1))
+  else
+    echo "FAIL $name [$code] $(head -c 200 "$body_file")" >&2
+    fail=$((fail + 1))
+    failed_names+=("$name")
+  fi
+done < <("$HERE/list-templates.sh" | jq -c '.[]')
+
+echo "---"
+echo "$ok ok / $skipped skipped / $fail failed / $dry dry"
+if [[ "${DRY_RUN:-0}" != "1" && -d "$RUNS_DIR" ]]; then
+  echo "responses: $RUNS_DIR"
+fi
+
+if ((fail > 0)); then
+  printf 'failed: %s\n' "${failed_names[@]}" >&2
+  exit 1
+fi

--- a/.github/workflows/scripts/list-templates.sh
+++ b/.github/workflows/scripts/list-templates.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Emit a JSON array of {name, dir} entries for every template in
+# anyscale/templates/BUILD.yaml on main. Designed to run from CI: pulls the
+# file straight from raw.githubusercontent.com so we don't need a local clone
+# (and don't need to provision a checkout of anyscale/templates in the runner).
+#
+# BUILD_URL is overridable for local testing against a fork or branch.
+set -euo pipefail
+
+BUILD_URL="${BUILD_URL:-https://raw.githubusercontent.com/anyscale/templates/main/BUILD.yaml}"
+
+curl -fsSL "$BUILD_URL" | python3 -c '
+import json, sys, yaml
+data = yaml.safe_load(sys.stdin)
+print(json.dumps([{"name": t["name"], "dir": t["dir"]} for t in data], indent=2))
+print(f"{len(data)} templates from BUILD.yaml on main", file=sys.stderr)
+'

--- a/.github/workflows/scripts/list-templates.sh
+++ b/.github/workflows/scripts/list-templates.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/env bash
-# Emit a JSON array of {name, dir} entries for every template in
-# anyscale/templates/BUILD.yaml on main. Designed to run from CI: pulls the
-# file straight from raw.githubusercontent.com so we don't need a local clone
-# (and don't need to provision a checkout of anyscale/templates in the runner).
-#
-# BUILD_URL is overridable for local testing against a fork or branch.
+# Emit JSON array of {name, dir} from anyscale/templates/BUILD.yaml on main.
+# Pulled via raw.githubusercontent.com so CI doesn't need a checkout.
+# BUILD_URL overridable for local testing.
 set -euo pipefail
 
 BUILD_URL="${BUILD_URL:-https://raw.githubusercontent.com/anyscale/templates/main/BUILD.yaml}"


### PR DESCRIPTION
Wires Ray release events to the manual Anyscale-templates Ray-image fan-out. On a non-prerelease, patch-zero release (e.g. `ray-2.56.0`), POSTs to the Cursor `template-updater` webhook once per template in `anyscale/templates/BUILD.yaml`, opening one `[ray-update-<target>]` PR per template.

Requires two repo secrets to be provisioned before this can fire: `CURSOR_TEMPLATE_UPDATER_WEBHOOK` and `CURSOR_TEMPLATE_UPDATER_AUTH_TOKEN`.