### PR TITLE
[RLlib] fix duplicated "that" in collector and env_runner comments

### DIFF
--- a/rllib/evaluation/collectors/simple_list_collector.py
+++ b/rllib/evaluation/collectors/simple_list_collector.py
@@ -199,7 +199,7 @@ class SimpleListCollector(SampleCollector):
                         num_individual_observations, env_steps, episode_id
                     )
                     + "are buffered in the sampler. If this is more than you "
-                    "expected, check that that you set a horizon on your "
+                    "expected, check that you set a horizon on your "
                     "environment correctly and that it terminates at some "
                     "point. Note: In multi-agent environments, "
                     "`rollout_fragment_length` sets the batch size based on "

--- a/rllib/evaluation/env_runner_v2.py
+++ b/rllib/evaluation/env_runner_v2.py
@@ -161,7 +161,7 @@ def _build_multi_agent_batch(
                     batch_builder.agent_steps, batch_builder.env_steps, episode_id
                 )
                 + "are buffered in the sampler. If this is more than you "
-                "expected, check that that you set a horizon on your "
+                "expected, check that you set a horizon on your "
                 "environment correctly and that it terminates at some "
                 "point. Note: In multi-agent environments, "
                 "`rollout_fragment_length` sets the batch size based on "


### PR DESCRIPTION
Two small comment-only typos: `check that that you set a horizon on your` becomes `check that you set a horizon on your` in `rllib/evaluation/collectors/simple_list_collector.py` and `rllib/evaluation/env_runner_v2.py`. No code change.