### PR TITLE
[doc][DOC-933] add sphinxext-opengraph

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -18,6 +18,7 @@ sphinxcontrib-redoc==1.6.0
 sphinx-remove-toctrees==0.0.3
 sphinx_design==0.5.0
 sphinx-autobuild==2024.4.16
+sphinxext-opengraph==0.13.0
 pydata-sphinx-theme==0.14.1
 autodoc_pydantic==2.2.0
 appnope

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,6 +78,7 @@ extensions = [
     "sphinx_docsearch",
     "sphinx_collections",
     "sphinx_llms_txt",
+    "sphinxext.opengraph",
 ]
 
 # -- sphinx-llms-txt: agent-friendly summary and full corpus -----------
@@ -294,6 +295,15 @@ html_baseurl = "https://docs.ray.io/en/latest/"
 # default `{lang}{version}{link}` scheme to just `{link}`. Otherwise the
 # extension prepends `en/` again, producing URLs like `en/latesten/<page>`.
 sitemap_url_scheme = "{link}"
+
+# sphinxext-opengraph: emit Open Graph metadata per page. Pin `ogp_site_url`
+# to `html_baseurl` so the `og:url` tag tracks the same canonical URL as
+# Sphinx's `<link rel="canonical">`. If `ogp_site_url` were left unset, the
+# extension would fall back to Read the Docs' `READTHEDOCS_CANONICAL_URL`
+# env var (set by RtD's Addons framework from the project's "Canonical
+# version" admin setting), which can diverge from `html_baseurl`. Per-page
+# `:og:description:` and `:og:image:` can still be set in individual files.
+ogp_site_url = html_baseurl
 
 # This pattern matches:
 # - Python Repl prompts (">>> ") and it's continuation ("... ")

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -1637,6 +1637,7 @@ sphinx==7.3.7 \
     #   sphinx-remove-toctrees
     #   sphinxcontrib-redoc
     #   sphinxemoji
+    #   sphinxext-opengraph
 sphinx-autobuild==2024.4.16 \
     --hash=sha256:1c0ed37a1970eed197f9c5a66d65759e7c4e4cba7b5a5d77940752bf1a59f2c7 \
     --hash=sha256:f2522779d30fcbf0253e09714f274ce8c608cb6ebcd67922b1c54de59faba702
@@ -1710,6 +1711,10 @@ sphinxcontrib-serializinghtml==2.0.0 \
 sphinxemoji==0.3.2 \
     --hash=sha256:0fb07a95bca5960a3b312bc05b65b0c3040456414a076c363f4ecaf546c6e09e \
     --hash=sha256:814da89a9a7603b7e4d85c487c7381656fa83632f20065e5ed782ab1dbbb5083
+    # via -r doc/requirements-doc.txt
+sphinxext-opengraph==0.13.0 \
+    --hash=sha256:103335d08567ad8468faf1425f575e3b698e9621f9323949a6c8b96d9793e80b \
+    --hash=sha256:936c07828edc9ad9a7b07908b29596dc84ed0b3ceaa77acdf51282d232d4d80e
     # via -r doc/requirements-doc.txt
 sqlalchemy==2.0.44 \
     --hash=sha256:0765e318ee9179b3718c4fd7ba35c434f4dd20332fbc6857a5e8df17719c24d7 \


### PR DESCRIPTION
## Why

Add `sphinxext-opengraph` — per-page Open Graph metadata. `ogp_site_url` is pinned to `html_baseurl` so the `og:url` tag stays aligned with Sphinx's `<link rel="canonical">`. Improves rich-link previews when docs pages get shared and tightens SEO signal. Low-effort additive change called out as a Bucket 1 quick win in the Anyscale docs team's agent-friendliness assessment.

## What

- `doc/requirements-doc.txt`: add `sphinxext-opengraph==0.13.0`.
- `doc/source/conf.py`: append `"sphinxext.opengraph"` to `extensions`; set `ogp_site_url = html_baseurl`.
- `python/deplocks/docs/docbuild_depset_py3.10.lock`: package entry plus via-comment addition on `sphinx` (the only runtime dep, already pinned, so no further transitives). Matches the manual-lock-edit pattern used in [#63130](https://github.com/ray-project/ray/pull/63130).

## Verification

After this lands and `latest` rebuilds:

- A representative doc page's `<head>` includes `<meta property="og:*">` tags reflecting page title, description, and the site URL.
- No new warnings in the RtD build log (`fail_on_warning: true`).

## Extension diligence

[`sphinxext-opengraph`](https://github.com/sphinx-doc/sphinxext-opengraph) — official `sphinx-doc` org project, BSD-2-Clause. Latest release 0.13.0 (March 2026). Pure-Python, depends only on Sphinx (already pinned to 7.3.7), no system-level requirements.

## What changed in the force-push

This PR originally also bundled [`sphinx-notfound-page`](https://github.com/readthedocs/sphinx-notfound-page) to give the Ray docs a 404 page with absolute URLs. Dropped on 2026-05-15 because the RtD PR preview build surfaced a sitewide regression: 732 of 756 `<a class="reference internal">` sidebar hrefs were emitted with a `.//en/<ver>/...` prefix that doubles when the browser resolves them against the build's `/en/<ver>/` deploy path. Production docs.ray.io (which doesn't have the extension) was unaffected (0/747 hrefs).

The cause is sphinx-notfound-page's `html-page-context` hook: it overrides `pathto`/`toctree` for **every** page in the build, prepending a URL prefix derived from `READTHEDOCS_CANONICAL_URL`. The extension docs imply this is "for the 404 page only," but the override fires on every page-context event. On a PR preview where the canonical URL differs from `html_baseurl`, this produces the doubled-prefix anti-pattern across the entire sidebar.

The 404-page-with-absolute-URLs goal is tracked separately so it can be re-attempted with a config or extension that doesn't break sitewide navigation. Options to revisit: `notfound_urls_prefix = None`, a custom 404 template that bypasses the global `pathto` override, or `html_extra_path` with a static 404.

## Context

Part of the [DOC-932](https://anyscale1.atlassian.net/browse/DOC-932) campaign: Ray docs dependency upgrades. Pattern mirrors the merged [DOC-898](https://anyscale1.atlassian.net/browse/DOC-898) probe ([#63197](https://github.com/ray-project/ray/pull/63197)) and the obsolete-env-var removal in [#63196](https://github.com/ray-project/ray/pull/63196). Strategy context: `anyscale/docs:strategy/ray-docs/sphinx-rtd-viability.md` "Low effort" section.

This is the bottom of a stacked series:

1. **#63343 — sphinxext-opengraph (this PR)**
2. [#63344](https://github.com/ray-project/ray/pull/63344) — pydata-sphinx-theme bump
3. [#63359](https://github.com/ray-project/ray/pull/63359) — notebook `language_info.name` fix
4. [#63360](https://github.com/ray-project/ray/pull/63360) — myst-nb 1.4.0 bump

[DOC-933](https://anyscale1.atlassian.net/browse/DOC-933)
