### PR TITLE
[Data] Add scheduling-loop max metric to DatasetStatsSummary

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -413,10 +413,14 @@ class StreamingExecutor(Executor, threading.Thread):
             builder = stats.child_builder(op.name, override_start_time=self._start_time)
             stats = builder.build_multioperator(op.get_stats())
             stats.extra_metrics = op.metrics.as_dict(skip_internal_metrics=True)
+        # Always assign a ``Timer`` so downstream consumers can call
+        # ``.get()`` / ``.avg()`` / ``.max()`` unconditionally. When
+        # ``_initial_stats`` is absent we hand back an empty Timer (count
+        # 0); the Timer's zero-sample semantics yield 0 across all three.
         stats.streaming_exec_schedule_s = (
             self._initial_stats.streaming_exec_schedule_s
             if self._initial_stats
-            else None
+            else Timer()
         )
         return stats
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -191,19 +191,8 @@ class Timer:
     def max(self) -> float:
         return self._max
 
-    def avg(self, default: float = float("inf")) -> float:
-        """Per-sample average; ``default`` is returned when no samples
-        have been recorded.
-
-        The default of ``float("inf")`` preserves the historical
-        empty-Timer signal (well-suited for "undefined" semantics in
-        display contexts that already render ``inf`` legibly). Callers
-        that need a JSON-safe / arithmetic-safe value can override —
-        e.g. ``timer.avg(default=0.0)``.
-        """
-        if not self._total_count:
-            return default
-        return self._total / self._total_count
+    def avg(self) -> float:
+        return self._total / self._total_count if self._total_count else float("inf")
 
 
 class _DatasetStatsBuilder:
@@ -1169,12 +1158,10 @@ class DatasetStats:
         # produce a meaningful percentage. Per-iteration avg/max are
         # exposed separately. ``StreamingExecutor._generate_stats``
         # always assigns a ``Timer`` (never ``None``), so this call site
-        # needs no guard; we pass ``default=0.0`` to ``avg()`` so the
-        # JSON-emitted release-test metric stays a finite number when no
-        # scheduling iterations have been recorded.
+        # needs no guard.
         schedule_timer = self.streaming_exec_schedule_s
         streaming_exec_schedule_s = schedule_timer.get()
-        streaming_exec_schedule_avg_s = schedule_timer.avg(default=0.0)
+        streaming_exec_schedule_avg_s = schedule_timer.avg()
         streaming_exec_schedule_max_s = schedule_timer.max()
         return DatasetStatsSummary(
             operators_stats,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -192,7 +192,17 @@ class Timer:
         return self._max
 
     def avg(self) -> float:
-        return self._total / self._total_count if self._total_count else float("inf")
+        """Per-sample average. Returns 0 when no samples have been recorded.
+
+        Matches the zero-sample semantics of ``get()`` and ``max()``: a
+        Timer with no samples reports 0 across the board. (The previous
+        behavior of returning ``float("inf")`` made consumers — JSON
+        serialization, runtime_metrics() formatting — handle the empty
+        case specially.)
+        """
+        if not self._total_count:
+            return 0.0
+        return self._total / self._total_count
 
 
 class _DatasetStatsBuilder:
@@ -1156,26 +1166,14 @@ class DatasetStats:
         # Keep ``streaming_exec_schedule_s`` as the total wall-clock time so
         # ``runtime_metrics()`` can still divide by total_wall_time and
         # produce a meaningful percentage. Per-iteration avg/max are
-        # exposed separately.
-        #
-        # The ``streaming_exec_schedule_s`` field is annotated as ``Timer``
-        # but in practice can be ``None`` — see
-        # ``StreamingExecutor._generate_stats`` which explicitly assigns
-        # ``None`` when ``_initial_stats`` is falsy. We also explicitly
-        # handle the zero-iteration case (e.g., non-streaming execution);
-        # ``Timer.avg()`` returns ``float("inf")`` when no samples have
-        # been recorded, which would break JSON serialization in
-        # release-test output and produce nonsense in
-        # ``runtime_metrics()``.
+        # exposed separately. ``StreamingExecutor._generate_stats`` now
+        # always assigns a ``Timer`` (never ``None``), and the Timer's
+        # zero-sample semantics return 0 across get/avg/max — so this
+        # call site no longer needs any guard or private-attribute peek.
         schedule_timer = self.streaming_exec_schedule_s
-        if schedule_timer is not None and schedule_timer._total_count > 0:
-            streaming_exec_schedule_s = schedule_timer.get()
-            streaming_exec_schedule_avg_s = schedule_timer.avg()
-            streaming_exec_schedule_max_s = schedule_timer.max()
-        else:
-            streaming_exec_schedule_s = 0
-            streaming_exec_schedule_avg_s = 0
-            streaming_exec_schedule_max_s = 0
+        streaming_exec_schedule_s = schedule_timer.get()
+        streaming_exec_schedule_avg_s = schedule_timer.avg()
+        streaming_exec_schedule_max_s = schedule_timer.max()
         return DatasetStatsSummary(
             operators_stats,
             iter_stats,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -191,17 +191,18 @@ class Timer:
     def max(self) -> float:
         return self._max
 
-    def avg(self) -> float:
-        """Per-sample average. Returns 0 when no samples have been recorded.
+    def avg(self, default: float = float("inf")) -> float:
+        """Per-sample average; ``default`` is returned when no samples
+        have been recorded.
 
-        Matches the zero-sample semantics of ``get()`` and ``max()``: a
-        Timer with no samples reports 0 across the board. (The previous
-        behavior of returning ``float("inf")`` made consumers — JSON
-        serialization, runtime_metrics() formatting — handle the empty
-        case specially.)
+        The default of ``float("inf")`` preserves the historical
+        empty-Timer signal (well-suited for "undefined" semantics in
+        display contexts that already render ``inf`` legibly). Callers
+        that need a JSON-safe / arithmetic-safe value can override —
+        e.g. ``timer.avg(default=0.0)``.
         """
         if not self._total_count:
-            return 0.0
+            return default
         return self._total / self._total_count
 
 
@@ -1166,13 +1167,14 @@ class DatasetStats:
         # Keep ``streaming_exec_schedule_s`` as the total wall-clock time so
         # ``runtime_metrics()`` can still divide by total_wall_time and
         # produce a meaningful percentage. Per-iteration avg/max are
-        # exposed separately. ``StreamingExecutor._generate_stats`` now
-        # always assigns a ``Timer`` (never ``None``), and the Timer's
-        # zero-sample semantics return 0 across get/avg/max — so this
-        # call site no longer needs any guard or private-attribute peek.
+        # exposed separately. ``StreamingExecutor._generate_stats``
+        # always assigns a ``Timer`` (never ``None``), so this call site
+        # needs no guard; we pass ``default=0.0`` to ``avg()`` so the
+        # JSON-emitted release-test metric stays a finite number when no
+        # scheduling iterations have been recorded.
         schedule_timer = self.streaming_exec_schedule_s
         streaming_exec_schedule_s = schedule_timer.get()
-        streaming_exec_schedule_avg_s = schedule_timer.avg()
+        streaming_exec_schedule_avg_s = schedule_timer.avg(default=0.0)
         streaming_exec_schedule_max_s = schedule_timer.max()
         return DatasetStatsSummary(
             operators_stats,

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1153,11 +1153,29 @@ class DatasetStats:
                 # Single operator scenario: input rows = total output from all parent nodes
                 op_stat.total_input_num_rows = parent_total_output
             operators_stats.append(op_stat)
-        streaming_exec_schedule_s = (
-            self.streaming_exec_schedule_s.get()
-            if self.streaming_exec_schedule_s
-            else 0
-        )
+        # Keep ``streaming_exec_schedule_s`` as the total wall-clock time so
+        # ``runtime_metrics()`` can still divide by total_wall_time and
+        # produce a meaningful percentage. Per-iteration avg/max are
+        # exposed separately.
+        #
+        # The ``streaming_exec_schedule_s`` field is annotated as ``Timer``
+        # but in practice can be ``None`` — see
+        # ``StreamingExecutor._generate_stats`` which explicitly assigns
+        # ``None`` when ``_initial_stats`` is falsy. We also explicitly
+        # handle the zero-iteration case (e.g., non-streaming execution);
+        # ``Timer.avg()`` returns ``float("inf")`` when no samples have
+        # been recorded, which would break JSON serialization in
+        # release-test output and produce nonsense in
+        # ``runtime_metrics()``.
+        schedule_timer = self.streaming_exec_schedule_s
+        if schedule_timer is not None and schedule_timer._total_count > 0:
+            streaming_exec_schedule_s = schedule_timer.get()
+            streaming_exec_schedule_avg_s = schedule_timer.avg()
+            streaming_exec_schedule_max_s = schedule_timer.max()
+        else:
+            streaming_exec_schedule_s = 0
+            streaming_exec_schedule_avg_s = 0
+            streaming_exec_schedule_max_s = 0
         return DatasetStatsSummary(
             operators_stats,
             iter_stats,
@@ -1171,6 +1189,8 @@ class DatasetStats:
             self.global_bytes_restored,
             self.dataset_bytes_spilled,
             streaming_exec_schedule_s,
+            streaming_exec_schedule_avg_s,
+            streaming_exec_schedule_max_s,
         )
 
     def runtime_metrics(self) -> str:
@@ -1206,6 +1226,8 @@ class DatasetStatsSummary:
     global_bytes_restored: int
     dataset_bytes_spilled: int
     streaming_exec_schedule_s: float
+    streaming_exec_schedule_avg_s: float
+    streaming_exec_schedule_max_s: float
 
     def to_string(
         self,

--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -32,6 +32,8 @@ def collect_dataset_stats(ds: "ray.data.Dataset") -> Dict[str, Any]:
     we care about for the release tests."""
     summary = ds.get_stats_summary(detail=True)
     return {
+        "avg_scheduling_loop_duration_s": summary.streaming_exec_schedule_avg_s,
+        "max_scheduling_loop_duration_s": summary.streaming_exec_schedule_max_s,
         "operators": [
             {
                 "operator_name": op.operator_name,


### PR DESCRIPTION
## Description

Adds two new fields to `DatasetStatsSummary`:

| Field | Source | Meaning |
|---|---|---|
| `streaming_exec_schedule_s` | `Timer.get()` (**unchanged**) | total wall-clock time across scheduler iterations |
| `streaming_exec_schedule_avg_s` *(new)* | `Timer.avg()` | per-iteration average |
| `streaming_exec_schedule_max_s` *(new)* | `Timer.max()` | per-iteration max |

The existing `streaming_exec_schedule_s` keeps its total-duration meaning so `runtime_metrics()` (which divides it by `total_wall_time` to compute a percentage) continues to produce a correct breakdown. Per-iteration values are exposed under separate field names.

Memory stays **O(1)** per Timer — no sample buffer; `_max` is already tracked.

Tested using https://buildkite.com/ray-project/release/builds/92867#019e28c9-c8ad-4fb3-9776-c89f52f93200
