### PR TITLE
Fix copy message typo in retry invoke

### DIFF
--- a/src/ray/raylet/runtime_env_agent_client.cc
+++ b/src/ray/raylet/runtime_env_agent_client.cc
@@ -344,7 +344,7 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
       } else if (current_time_ms() > deadline_ms) {
         RAY_LOG(ERROR) << "Runtime Env Agent timed out in " << agent_register_timeout_ms_
                        << "ms. Status: " << status << ", address: " << this->address_
-                       << ", port: " << this->port_str_ << ", existing immediately...";
+                       << ", port: " << this->port_str_ << ", exiting immediately...";
         ExitImmediately();
       } else {
         RAY_LOG(INFO) << "Runtime Env Agent network error: " << status


### PR DESCRIPTION
Message should say "exiting immediately..."

Message was wrong to say "existing immediately" per comments and behavior.