### PR TITLE
[llm][sglang] Remove signal handler override from SGLang engine

### DIFF
--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -10,7 +10,6 @@ provide feedback at https://github.com/ray-project/ray/issues/61114.
 
 import copy
 import json
-import signal
 import time
 import uuid
 from typing import (
@@ -57,20 +56,7 @@ class SGLangServer:
                 "`pip install sglang[all]` to install required dependencies."
             ) from e
 
-        # TODO(issue-61108): remove this once sglang#18752 is merged and included
-        # in the minimum supported SGLang version for this example.
-        original_signal_func = signal.signal
-
-        def noop_signal_handler(sig, action):
-            # Returns default handler to satisfy signal.signal() return signature
-            return signal.SIG_DFL
-
-        try:
-            # Override signal.signal with our no-op function
-            signal.signal = noop_signal_handler
-            self.engine = sglang.Engine(**self.engine_kwargs)
-        finally:
-            signal.signal = original_signal_func
+        self.engine = sglang.Engine(**self.engine_kwargs)
 
     @staticmethod
     def _build_sampling_params(request: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Why are these changes needed?

Closes #61894.

[sgl-project/sglang#18752](https://github.com/sgl-project/sglang/pull/18752) is upstreamed, so the workaround that temporarily monkey-patched `signal.signal` around `sglang.Engine` construction is no longer needed.

This change:
- Removes the `try`/`finally` block that swapped in a no-op `signal.signal` during engine init in `python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py`.
- Drops the now-unused `import signal`.

## Related issue number

Closes #61894

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR. _(deletion-only change to a single Python file; whitespace verified manually)_
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/. _(no doc changes needed)_
- [x] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` under the corresponding `.rst` file. _(N/A)_
- [x] I've made sure the tests are passing. _(deletion-only; no behavior tests added)_
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
