### PR TITLE
[data][llm] Widen build_processor / build_llm_processor config typing

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from ray._common.deprecation import Deprecated
 from ray.data.block import UserDefinedFunction
@@ -577,9 +577,24 @@ class PrepareImageStageConfig(_PrepareImageStageConfig):
     pass
 
 
+# Union of every user-facing processor config. Each specialized public config
+# (e.g. vLLMEngineProcessorConfig) is a subclass of its own internal base and
+# therefore does not statically satisfy ``isinstance(_, ProcessorConfig)`` even
+# though it is a valid argument at runtime. Annotating the build functions with
+# this union lets type-checkers accept the specialized configs without forcing a
+# multiple-inheritance change to the public class hierarchy.
+AnyProcessorConfig = Union[
+    ProcessorConfig,
+    HttpRequestProcessorConfig,
+    vLLMEngineProcessorConfig,
+    SGLangEngineProcessorConfig,
+    ServeDeploymentProcessorConfig,
+]
+
+
 @Deprecated(new="build_processor", error=False)
 def build_llm_processor(
-    config: ProcessorConfig,
+    config: AnyProcessorConfig,
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
     preprocess_map_kwargs: Optional[Dict[str, Any]] = None,
@@ -601,7 +616,7 @@ def build_llm_processor(
 
 @PublicAPI(stability="beta")
 def build_processor(
-    config: ProcessorConfig,
+    config: AnyProcessorConfig,
     preprocess: Optional[UserDefinedFunction] = None,
     postprocess: Optional[UserDefinedFunction] = None,
     preprocess_map_kwargs: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
## Why are these changes needed?

Closes #57981.

The public processor config classes exposed from `ray.data.llm` are each a `pass`-bodied subclass of their respective internal base:

```python
class ProcessorConfig(_ProcessorConfig): pass
class HttpRequestProcessorConfig(_HttpRequestProcessorConfig): pass
class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig): pass
class SGLangEngineProcessorConfig(_SGLangEngineProcessorConfig): pass
class ServeDeploymentProcessorConfig(_ServeDeploymentProcessorConfig): pass
```

Their only common ancestor is the **internal** `_ProcessorConfig`. As a result, static type-checkers (mypy, pyright) flag the documented call form from the issue's repro:

```python
processor = build_llm_processor(
    config=vLLMEngineProcessorConfig(model_source="..."),  # <-- red
    preprocess=...,
    postprocess=...,
)
```

Runtime behavior is correct; only the static type annotation is wrong.

### Fix

Introduce a module-level `Union` alias `AnyProcessorConfig` covering every user-facing processor config, and use it for the `config:` parameter on both `build_llm_processor` and `build_processor`. The Union explicitly documents what the builders accept, and avoids restructuring the class hierarchy (which would introduce diamond inheritance under Pydantic).

```python
AnyProcessorConfig = Union[
    ProcessorConfig,
    HttpRequestProcessorConfig,
    vLLMEngineProcessorConfig,
    SGLangEngineProcessorConfig,
    ServeDeploymentProcessorConfig,
]
```

### Alternatives considered

- **Multiple inheritance on public configs** (`class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig, ProcessorConfig)`): structurally cleaner but risks Pydantic MRO surprises and changes the public class hierarchy. Happy to switch if maintainers prefer.
- **Type the param as the internal `_ProcessorConfig`**: leaks a leading-underscore name into a `@PublicAPI` signature; Sphinx/docs would render the private name.

## Related issue number

Closes #57981

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR. _(annotations-only Python change; verified with `python -m py_compile`)_
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/. _(no doc changes required — runtime behavior unchanged)_
- [x] I've added any new APIs to the API Reference. _(N/A — no new APIs)_
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [x] This PR is not tested :( _(annotations-only change; no runtime behavior to test. Static type-checking can be verified by pasting the issue's repro into a pyright-enabled editor.)_
