### PR TITLE
[serve] Add ControllerOptions for configurable controller runtime_env

### DIFF
--- a/ci/lint/pydoclint-baseline.txt
+++ b/ci/lint/pydoclint-baseline.txt
@@ -1477,8 +1477,6 @@ python/ray/serve/api.py
     DOC103: Function `start`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: ].
     DOC201: Function `get_replica_context` does not have a return section in docstring
     DOC201: Function `ingress` does not have a return section in docstring
-    DOC101: Function `run_many`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `run_many`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_local_testing_mode: bool].
     DOC101: Function `run`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `run`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [_local_testing_mode: bool].
     DOC101: Function `multiplexed`: Docstring contains fewer arguments than in function signature.

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -94,6 +94,7 @@ See the [model composition guide](serve-model-composition) for how to update cod
    :toctree: doc/
    :template: autosummary/autopydantic.rst
 
+   serve.config.ControllerOptions
    serve.config.gRPCOptions
    serve.config.HTTPOptions
    serve.config.AutoscalingConfig

--- a/python/ray/dashboard/modules/serve/serve_head.py
+++ b/python/ray/dashboard/modules/serve/serve_head.py
@@ -170,6 +170,7 @@ class ServeHead(SubprocessModule):
                 http_options=full_http_options,
                 grpc_options=grpc_options,
                 global_logging_config=config.logging_config,
+                controller_options=config.controller_options,
             )
 
         # Serve ignores HTTP options if it was already running when

--- a/python/ray/serve/__init__.py
+++ b/python/ray/serve/__init__.py
@@ -26,7 +26,7 @@ try:
         status,
     )
     from ray.serve.batching import batch
-    from ray.serve.config import HTTPOptions
+    from ray.serve.config import ControllerOptions, HTTPOptions
     from ray.serve.utils import get_trace_context
 
 except ModuleNotFoundError as e:
@@ -48,6 +48,7 @@ __all__ = [
     "_run_many",
     "batch",
     "start",
+    "ControllerOptions",
     "HTTPOptions",
     "get_replica_context",
     "get_deployment_actor",

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -15,7 +15,7 @@ from ray.serve._private.constants import (
     SERVE_NAMESPACE,
 )
 from ray.serve._private.default_impl import get_controller_impl
-from ray.serve.config import HTTPOptions, gRPCOptions
+from ray.serve.config import ControllerOptions, HTTPOptions, gRPCOptions
 from ray.serve.context import (
     _check_cached_client_alive,
     _get_global_client,
@@ -26,6 +26,22 @@ from ray.serve.exceptions import RayServeException
 from ray.serve.schema import LoggingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+
+def _coerce_controller_options(
+    controller_options: Union[None, Dict, ControllerOptions],
+) -> ControllerOptions:
+    """Normalize an optional dict / model into a validated ControllerOptions."""
+    if controller_options is None:
+        return ControllerOptions()
+    if isinstance(controller_options, ControllerOptions):
+        return controller_options
+    if isinstance(controller_options, dict):
+        return ControllerOptions.model_validate(controller_options)
+    raise TypeError(
+        "controller_options must be a dict, ControllerOptions, or None; got "
+        f"{type(controller_options).__name__}."
+    )
 
 
 def _check_http_options(
@@ -56,6 +72,7 @@ def _start_controller(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    controller_options: Union[None, dict, ControllerOptions] = None,
     **kwargs,
 ) -> ActorHandle:
     """Start Ray Serve controller.
@@ -95,7 +112,8 @@ def _start_controller(
     elif isinstance(global_logging_config, dict):
         global_logging_config = LoggingConfig(**global_logging_config)
 
-    controller_impl = get_controller_impl()
+    controller_options = _coerce_controller_options(controller_options)
+    controller_impl = get_controller_impl(controller_options=controller_options)
     controller = controller_impl.remote(
         http_options=http_options,
         grpc_options=grpc_options,
@@ -120,6 +138,7 @@ async def serve_start_async(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    controller_options: Union[None, dict, ControllerOptions] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance asynchronously.
@@ -134,6 +153,10 @@ async def serve_start_async(
 
     usage_lib.record_library_usage("serve")
 
+    # Validate eagerly in the caller so a bad ``controller_options`` raises
+    # locally rather than from the ``_start_controller`` Ray task.
+    controller_options = _coerce_controller_options(controller_options)
+
     client, _ = _check_cached_client_alive()
     if client is None:
         try:
@@ -143,7 +166,7 @@ async def serve_start_async(
     if client is not None:
         logger.info(
             f'Connecting to existing Serve app in namespace "{SERVE_NAMESPACE}".'
-            " New http options will not be applied."
+            " New http_options/controller_options will not be applied."
         )
         if http_options:
             _check_http_options(client, http_options)
@@ -152,7 +175,13 @@ async def serve_start_async(
     controller = (
         await ray.remote(_start_controller)
         .options(num_cpus=0)
-        .remote(http_options, grpc_options, global_logging_config, **kwargs)
+        .remote(
+            http_options,
+            grpc_options,
+            global_logging_config,
+            controller_options=controller_options,
+            **kwargs,
+        )
     )
 
     client = ServeControllerClient(
@@ -167,6 +196,7 @@ def serve_start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     global_logging_config: Union[None, dict, LoggingConfig] = None,
+    controller_options: Union[None, dict, ControllerOptions] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance.
@@ -207,9 +237,16 @@ def serve_start(
             - grpc_servicer_functions(list): List of import paths for gRPC
                 `add_servicer_to_server` functions to add to Serve's gRPC proxy.
                 Default empty list, meaning not to start the gRPC server.
+        controller_options: Optional ``ControllerOptions`` (or dict) for the
+            Serve controller actor. Currently only ``runtime_env.env_vars``
+            is honored; see ``ray.serve.config.ControllerOptions``. Only
+            applied on first controller creation -- ignored if the controller
+            is already running in this Ray cluster (a log line is emitted).
     """
 
     usage_lib.record_library_usage("serve")
+
+    controller_options = _coerce_controller_options(controller_options)
 
     client, _ = _check_cached_client_alive()
     if client is None:
@@ -220,14 +257,18 @@ def serve_start(
     if client is not None:
         logger.info(
             f'Connecting to existing Serve app in namespace "{SERVE_NAMESPACE}".'
-            " New http options will not be applied."
+            " New http_options/controller_options will not be applied."
         )
         if http_options:
             _check_http_options(client, http_options)
         return client
 
     controller = _start_controller(
-        http_options, grpc_options, global_logging_config, **kwargs
+        http_options,
+        grpc_options,
+        global_logging_config,
+        controller_options=controller_options,
+        **kwargs,
     )
 
     client = ServeControllerClient(

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 
 def _coerce_controller_options(
-    controller_options: Union[None, Dict, ControllerOptions],
+    controller_options: Union[None, dict, ControllerOptions],
 ) -> ControllerOptions:
     """Normalize an optional dict / model into a validated ControllerOptions."""
     if controller_options is None:

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Callable, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Optional, Tuple
 
 import ray
 from ray._common.constants import HEAD_NODE_RESOURCE_NAME
@@ -242,10 +242,17 @@ def get_proxy_handle(endpoint: DeploymentID, info: EndpointInfo):
     )
 
 
-def get_controller_impl():
+def get_controller_impl(controller_options: Optional["ControllerOptions"] = None):
+    """Build the Ray actor class for the Serve controller.
+
+    ``controller_options`` is the validated ``ControllerOptions`` model from
+    ``serve.start`` / ``serve.run`` / the YAML schema. Today only its
+    ``runtime_env`` field is consumed; future fields (num_cpus, resources,
+    max_concurrency overrides) slot in here.
+    """
     from ray.serve._private.controller import ServeController
 
-    controller_impl = ray.remote(
+    actor_options = dict(
         name=SERVE_CONTROLLER_NAME,
         namespace=SERVE_NAMESPACE,
         num_cpus=0,
@@ -255,9 +262,17 @@ def get_controller_impl():
         resources={HEAD_NODE_RESOURCE_NAME: 0.001},
         max_concurrency=CONTROLLER_MAX_CONCURRENCY,
         enable_task_events=RAY_SERVE_ENABLE_TASK_EVENTS,
-    )(ServeController)
+    )
+    if controller_options is not None and controller_options.runtime_env:
+        # The validator on ControllerOptions guarantees this is a dict
+        # containing only the ``env_vars`` key with str->str entries.
+        actor_options["runtime_env"] = controller_options.runtime_env
 
-    return controller_impl
+    return ray.remote(**actor_options)(ServeController)
+
+
+if TYPE_CHECKING:
+    from ray.serve.config import ControllerOptions  # noqa: F401
 
 
 def get_proxy_actor_class():

--- a/python/ray/serve/_private/default_impl.py
+++ b/python/ray/serve/_private/default_impl.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import TYPE_CHECKING, Callable, Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import ray
 from ray._common.constants import HEAD_NODE_RESOURCE_NAME
@@ -42,6 +42,7 @@ from ray.serve._private.utils import (
     inside_ray_client_context,
     resolve_deployment_response,
 )
+from ray.serve.config import ControllerOptions
 from ray.util.placement_group import PlacementGroup
 
 # NOTE: Please read carefully before changing!
@@ -242,7 +243,7 @@ def get_proxy_handle(endpoint: DeploymentID, info: EndpointInfo):
     )
 
 
-def get_controller_impl(controller_options: Optional["ControllerOptions"] = None):
+def get_controller_impl(controller_options: Optional[ControllerOptions] = None):
     """Build the Ray actor class for the Serve controller.
 
     ``controller_options`` is the validated ``ControllerOptions`` model from
@@ -269,10 +270,6 @@ def get_controller_impl(controller_options: Optional["ControllerOptions"] = None
         actor_options["runtime_env"] = controller_options.runtime_env
 
     return ray.remote(**actor_options)(ServeController)
-
-
-if TYPE_CHECKING:
-    from ray.serve.config import ControllerOptions  # noqa: F401
 
 
 def get_proxy_actor_class():

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -41,6 +41,7 @@ from ray.serve._private.utils import (
 )
 from ray.serve.config import (
     AutoscalingConfig,
+    ControllerOptions,
     DeploymentActorConfig,
     GangSchedulingConfig,
     HTTPOptions,
@@ -77,6 +78,7 @@ def start(
     http_options: Union[None, dict, HTTPOptions] = None,
     grpc_options: Union[None, dict, gRPCOptions] = None,
     logging_config: Union[None, dict, LoggingConfig] = None,
+    controller_options: Union[None, dict, ControllerOptions] = None,
     **kwargs,
 ):
     """Start Serve on the cluster.
@@ -102,12 +104,19 @@ def start(
           class See `gRPCOptions` for supported options.
         logging_config: logging config options for the serve component (
             controller & proxy).
+        controller_options: [EXPERIMENTAL] Options for the Serve controller actor.
+          Currently scoped to a strictly-validated ``runtime_env.env_vars``
+          (other ``runtime_env`` keys are rejected). See
+          ``ray.serve.config.ControllerOptions``. Only applied on first
+          controller creation -- ignored if a Serve controller is already
+          running in this Ray cluster.
     """
     http_options = prepare_imperative_http_options(proxy_location, http_options)
     _private_api.serve_start(
         http_options=http_options,
         grpc_options=grpc_options,
         global_logging_config=logging_config,
+        controller_options=controller_options,
         **kwargs,
     )
 
@@ -727,6 +736,7 @@ def _run_many(
     wait_for_ingress_deployment_creation: bool = True,
     wait_for_applications_running: bool = True,
     _local_testing_mode: bool = False,
+    controller_options: Union[None, dict, ControllerOptions] = None,
 ) -> List[DeploymentHandle]:
     """Run many applications and return the handles to their ingress deployments.
 
@@ -787,6 +797,7 @@ def _run_many(
         client = _private_api.serve_start(
             http_options={"location": "EveryNode"},
             global_logging_config=None,
+            controller_options=controller_options,
         )
 
         # Record after Ray has been started.
@@ -814,6 +825,7 @@ def _run(
     logging_config: Optional[Union[Dict, LoggingConfig]] = None,
     _local_testing_mode: bool = False,
     external_scaler_enabled: bool = False,
+    controller_options: Union[None, dict, ControllerOptions] = None,
 ) -> DeploymentHandle:
     """Run an application and return a handle to its ingress deployment.
 
@@ -832,6 +844,7 @@ def _run(
         ],
         wait_for_applications_running=_blocking,
         _local_testing_mode=_local_testing_mode,
+        controller_options=controller_options,
     )[0]
 
 
@@ -842,6 +855,7 @@ def run_many(
     wait_for_ingress_deployment_creation: bool = True,
     wait_for_applications_running: bool = True,
     _local_testing_mode: bool = False,
+    controller_options: Union[None, dict, ControllerOptions] = None,
 ) -> List[DeploymentHandle]:
     """Run many applications and return the handles to their ingress deployments.
 
@@ -858,6 +872,13 @@ def run_many(
             `wait_for_ingress_deployment_creation=True`,
             because the ingress deployments must be created
             before the applications can be running.
+        _local_testing_mode: Internal flag enabling in-process local testing
+            mode. Not part of the public API.
+        controller_options: [EXPERIMENTAL] Options for the Serve controller
+            actor (e.g. ``runtime_env.env_vars`` for HAProxy / controller-side
+            tunables). See ``ray.serve.config.ControllerOptions``. Only applied
+            on first controller creation -- ignored if a Serve controller is
+            already running in this Ray cluster.
 
     Returns:
         List[DeploymentHandle]: A list of handles that can be used
@@ -868,6 +889,7 @@ def run_many(
         wait_for_ingress_deployment_creation=wait_for_ingress_deployment_creation,
         wait_for_applications_running=wait_for_applications_running,
         _local_testing_mode=_local_testing_mode,
+        controller_options=controller_options,
     )
 
     if blocking:
@@ -885,6 +907,7 @@ def run(
     logging_config: Optional[Union[Dict, LoggingConfig]] = None,
     _local_testing_mode: bool = False,
     external_scaler_enabled: bool = False,
+    controller_options: Union[None, dict, ControllerOptions] = None,
 ) -> DeploymentHandle:
     """Run an application and return a handle to its ingress deployment.
 
@@ -910,6 +933,11 @@ def run(
             be applied to all deployments which doesn't have logging config.
         external_scaler_enabled: Whether external autoscaling is enabled for
             this application.
+        controller_options: [EXPERIMENTAL] Options for the Serve controller
+            actor (e.g. ``runtime_env.env_vars`` for HAProxy / controller-side
+            tunables). See ``ray.serve.config.ControllerOptions``. Only applied
+            on first controller creation -- ignored if a Serve controller is
+            already running in this Ray cluster.
 
     Returns:
         DeploymentHandle: A handle that can be used to call the application.
@@ -921,6 +949,7 @@ def run(
         logging_config=logging_config,
         _local_testing_mode=_local_testing_mode,
         external_scaler_enabled=external_scaler_enabled,
+        controller_options=controller_options,
     )
 
     if blocking:

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -972,9 +972,9 @@ class ControllerOptions(BaseModel):
                 "controller actor."
             )
 
-        env_vars = v.get("env_vars")
-        if env_vars is None:
+        if "env_vars" not in v:
             return v
+        env_vars = v["env_vars"]
         if not isinstance(env_vars, dict):
             raise ValueError(
                 "runtime_env.env_vars must be a dict[str, str], got "

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -914,6 +914,83 @@ class gRPCOptions(BaseModel):
         return callables
 
 
+_ALLOWED_CONTROLLER_RUNTIME_ENV_KEYS = frozenset({"env_vars"})
+
+
+@PublicAPI(stability="alpha")
+class ControllerOptions(BaseModel):
+    """Options for the Serve controller actor.
+
+    Symmetric with ``HTTPOptions`` and ``gRPCOptions``: pass to
+    ``serve.start(controller_options=...)`` / ``serve.run`` from Python, or
+    as a top-level ``controller_options:`` block in ``serve run foo.yaml``.
+
+    v0 scope is intentionally narrow: only ``runtime_env`` is exposed, and
+    inside ``runtime_env`` only ``env_vars`` is accepted. Other
+    ``runtime_env`` fields (``pip``, ``working_dir``, ``py_modules``,
+    ``container``, ...) would mutate Serve's own dependencies on a
+    detached, long-lived actor and are intentionally rejected by the
+    validator. Per-replica runtime environments belong on the deployment
+    (``serve.deployment(runtime_env=...)``) instead.
+
+    Like ``HTTPOptions``, these options only take effect when the
+    controller is first created. If a Serve controller is already running
+    in the cluster, ``serve.start`` warns and ignores the new options.
+    """
+
+    runtime_env: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description=(
+            "Runtime environment for the controller actor. Only the "
+            "``env_vars`` key is supported; other keys are rejected."
+        ),
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("runtime_env")
+    @classmethod
+    def _validate_runtime_env(
+        cls, v: Optional[Dict[str, Any]]
+    ) -> Optional[Dict[str, Any]]:
+        # All errors raised as ValueError so pydantic aggregates them into a
+        # single ValidationError. TypeError from a field_validator escapes
+        # unwrapped in pydantic v2.
+        if v is None:
+            return v
+        if not isinstance(v, dict):
+            raise ValueError(f"runtime_env must be a dict, got {type(v).__name__}.")
+
+        disallowed = sorted(set(v) - _ALLOWED_CONTROLLER_RUNTIME_ENV_KEYS)
+        if disallowed:
+            raise ValueError(
+                "ControllerOptions.runtime_env only supports "
+                f"{sorted(_ALLOWED_CONTROLLER_RUNTIME_ENV_KEYS)} in this version; "
+                f"got disallowed keys {disallowed}. Per-replica runtime_env "
+                "belongs on the deployment "
+                "(``serve.deployment(runtime_env=...)``), not on the "
+                "controller actor."
+            )
+
+        env_vars = v.get("env_vars")
+        if env_vars is None:
+            return v
+        if not isinstance(env_vars, dict):
+            raise ValueError(
+                "runtime_env.env_vars must be a dict[str, str], got "
+                f"{type(env_vars).__name__}."
+            )
+        for k, val in env_vars.items():
+            if not isinstance(k, str) or not k:
+                raise ValueError(f"env_vars key must be a non-empty str, got {k!r}.")
+            if not isinstance(val, str):
+                raise ValueError(
+                    f"env_vars[{k!r}] must be str (got {type(val).__name__}); "
+                    "coerce explicitly."
+                )
+        return v
+
+
 @PublicAPI(stability="alpha")
 class GangPlacementStrategy(str, Enum):
     """Placement strategy for replicas within a gang."""

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -40,6 +40,7 @@ from ray.serve._private.utils import DEFAULT, validate_ssl_config
 from ray.serve.config import (
     AutoscalingConfig,
     AutoscalingPolicy,
+    ControllerOptions,
     DeploymentActorConfig,
     GangSchedulingConfig,
     ProxyLocation,
@@ -1012,6 +1013,15 @@ class ServeDeploySchema(BaseModel):
     )
     grpc_options: gRPCOptionsSchema = Field(
         default=gRPCOptionsSchema(), description="Options to start the gRPC Proxy with."
+    )
+    controller_options: Optional[ControllerOptions] = Field(
+        default=None,
+        description=(
+            "[EXPERIMENTAL] Options for the Serve controller actor. Currently "
+            "scoped to ``runtime_env.env_vars`` (other ``runtime_env`` keys are "
+            "rejected by the validator). Only applied on first controller "
+            "creation -- ignored if a Serve controller is already running."
+        ),
     )
     logging_config: Optional[LoggingConfig] = Field(
         default=None,

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -540,7 +540,9 @@ def run(
 
     http_options = {"location": "EveryNode"}
     grpc_options = gRPCOptions()
-    # Merge http_options and grpc_options with the ones on ServeDeploySchema.
+    controller_options = None
+    # Merge http_options, grpc_options, and controller_options with the ones on
+    # ServeDeploySchema.
     if is_config and isinstance(config, ServeDeploySchema):
         http_options["location"] = ProxyLocation._to_deployment_mode(
             config.proxy_location
@@ -548,10 +550,12 @@ def run(
         config_http_options = config.http_options.model_dump()
         http_options = {**config_http_options, **http_options}
         grpc_options = gRPCOptions(**config.grpc_options.model_dump())
+        controller_options = config.controller_options
 
     client = _private_api.serve_start(
         http_options=http_options,
         grpc_options=grpc_options,
+        controller_options=controller_options,
     )
 
     try:

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -27,6 +27,7 @@ from ray.serve._private.default_impl import create_cluster_node_info_cache
 from ray.serve._private.http_util import set_socket_reuse_port
 from ray.serve._private.utils import block_until_http_ready, format_actor_name
 from ray.serve.config import (
+    ControllerOptions,
     DeploymentMode,
     GangSchedulingConfig,
     HTTPOptions,
@@ -718,6 +719,72 @@ def test_serve_start_proxy_location(ray_shutdown, options):
     serve.start(**options)
     client = _get_global_client()
     assert ray.get(client._controller.get_http_config.remote()) == expected_options
+
+
+@pytest.mark.parametrize(
+    "controller_options",
+    [
+        ControllerOptions(
+            runtime_env={
+                "env_vars": {
+                    "RAY_SERVE_TEST_CONTROLLER_ENV": "from-model",
+                    "RAY_SERVE_TEST_CONTROLLER_ENV_2": "second",
+                }
+            }
+        ),
+        # Same options passed as a plain dict -- the API coerces it
+        # through ``ControllerOptions.model_validate``.
+        {
+            "runtime_env": {
+                "env_vars": {
+                    "RAY_SERVE_TEST_CONTROLLER_ENV": "from-model",
+                    "RAY_SERVE_TEST_CONTROLLER_ENV_2": "second",
+                }
+            }
+        },
+    ],
+)
+def test_serve_start_controller_options(ray_shutdown, controller_options):
+    """``ControllerOptions.runtime_env.env_vars`` lands on the controller actor.
+
+    Uses a custom RAY_SERVE_TEST_CONTROLLER_ENV var (not a real Serve knob)
+    so the assertion is decoupled from whatever the Anyscale env hook
+    auto-injects. The merge semantics are the env_hook's contract; this
+    test only asserts that *our* requested env_vars made it through.
+    """
+    serve.start(controller_options=controller_options)
+    client = _get_global_client()
+
+    # Reach into the controller actor to read its own os.environ; the
+    # controller is a singleton named actor on the head node, so a remote
+    # task on the same handle runs in the same process.
+    def _read_env(self, *, keys):
+        import os as _os
+
+        return {k: _os.environ.get(k) for k in keys}
+
+    env_seen = ray.get(
+        client._controller.__ray_call__.remote(
+            _read_env,
+            keys=[
+                "RAY_SERVE_TEST_CONTROLLER_ENV",
+                "RAY_SERVE_TEST_CONTROLLER_ENV_2",
+            ],
+        )
+    )
+    assert env_seen["RAY_SERVE_TEST_CONTROLLER_ENV"] == "from-model"
+    assert env_seen["RAY_SERVE_TEST_CONTROLLER_ENV_2"] == "second"
+
+
+def test_serve_start_controller_options_rejects_disallowed_runtime_env(
+    ray_shutdown,
+):
+    """Bad runtime_env fails at the caller, not from a Ray task."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc:
+        serve.start(controller_options={"runtime_env": {"pip": ["numpy"]}})
+    assert "only supports ['env_vars']" in str(exc.value)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -1410,6 +1410,14 @@ class TestControllerOptions:
             ControllerOptions(runtime_env={"env_vars": ["FOO=bar"]})
         assert "env_vars must be a dict" in str(exc.value)
 
+    def test_rejects_env_vars_explicit_none(self):
+        # Explicit ``env_vars: null`` (e.g., from YAML) is distinct from the
+        # key being absent; reject it so a bad config fails locally instead of
+        # surfacing later from the Ray runtime_env layer.
+        with pytest.raises(ValidationError) as exc:
+            ControllerOptions(runtime_env={"env_vars": None})
+        assert "env_vars must be a dict" in str(exc.value)
+
     @pytest.mark.parametrize(
         "bad_value",
         [1, 3.14, True, None, ["1"], {"nested": "value"}],

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -26,6 +26,7 @@ from ray.serve._private.utils import DEFAULT
 from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.config import (
     AutoscalingConfig,
+    ControllerOptions,
     DeploymentActorConfig,
     DeploymentMode,
     GangPlacementStrategy,
@@ -1342,6 +1343,99 @@ def test_grpc_options():
     assert "is not a callable function!" in str(exception)
 
 
+class TestControllerOptions:
+    """Validator + parsing coverage for ControllerOptions.
+
+    The runtime validator is intentionally strict: v0 only accepts
+    ``runtime_env.env_vars``. Other ``runtime_env`` keys (pip, working_dir, ...)
+    would mutate the long-lived detached controller actor's dependencies and
+    are rejected with a message pointing at deployment-level runtime_env.
+    """
+
+    def test_default_is_empty(self):
+        opts = ControllerOptions()
+        assert opts.runtime_env is None
+
+    def test_accepts_dict_from_model_validate(self):
+        opts = ControllerOptions.model_validate(
+            {"runtime_env": {"env_vars": {"X": "y"}}}
+        )
+        assert opts.runtime_env == {"env_vars": {"X": "y"}}
+
+    def test_accepts_env_vars_with_str_str(self):
+        opts = ControllerOptions(
+            runtime_env={
+                "env_vars": {
+                    "RAY_SERVE_HAPROXY_TCP_NODELAY": "1",
+                    "RAY_SERVE_HAPROXY_NBTHREAD": "16",
+                }
+            }
+        )
+        assert opts.runtime_env["env_vars"]["RAY_SERVE_HAPROXY_TCP_NODELAY"] == "1"
+
+    def test_accepts_empty_env_vars(self):
+        opts = ControllerOptions(runtime_env={"env_vars": {}})
+        assert opts.runtime_env == {"env_vars": {}}
+
+    def test_accepts_explicit_none(self):
+        opts = ControllerOptions(runtime_env=None)
+        assert opts.runtime_env is None
+
+    @pytest.mark.parametrize(
+        "disallowed_key, value",
+        [
+            ("pip", ["numpy"]),
+            ("working_dir", "/tmp"),
+            ("py_modules", []),
+            ("conda", "env.yaml"),
+            ("container", {}),
+            # A future runtime_env key we'd want to land via an explicit
+            # API broadening, not by silently accepting it.
+            ("nsight", "default"),
+        ],
+    )
+    def test_rejects_non_env_vars_runtime_env_keys(self, disallowed_key, value):
+        with pytest.raises(ValidationError) as exc:
+            ControllerOptions(runtime_env={disallowed_key: value})
+        msg = str(exc.value)
+        assert "only supports ['env_vars']" in msg
+        assert disallowed_key in msg
+
+    def test_rejects_runtime_env_not_a_dict(self):
+        with pytest.raises(ValidationError):
+            ControllerOptions(runtime_env="env_vars=FOO")
+
+    def test_rejects_env_vars_not_a_dict(self):
+        with pytest.raises(ValidationError) as exc:
+            ControllerOptions(runtime_env={"env_vars": ["FOO=bar"]})
+        assert "env_vars must be a dict" in str(exc.value)
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [1, 3.14, True, None, ["1"], {"nested": "value"}],
+    )
+    def test_rejects_non_str_env_var_values(self, bad_value):
+        with pytest.raises(ValidationError) as exc:
+            ControllerOptions(runtime_env={"env_vars": {"X": bad_value}})
+        assert "must be str" in str(exc.value)
+
+    @pytest.mark.parametrize("bad_key", ["", 1, None])
+    def test_rejects_bad_env_var_keys(self, bad_key):
+        with pytest.raises(ValidationError):
+            ControllerOptions(runtime_env={"env_vars": {bad_key: "v"}})
+
+    def test_rejects_extra_top_level_fields(self):
+        # extra="forbid" guards against typos and against silently accepting
+        # future fields without a validator update.
+        with pytest.raises(ValidationError):
+            ControllerOptions(runtimeenv={"env_vars": {}})  # missing underscore
+
+    def test_rejects_mixed_allowed_and_disallowed_runtime_env_keys(self):
+        with pytest.raises(ValidationError) as exc:
+            ControllerOptions(runtime_env={"env_vars": {"X": "y"}, "pip": ["numpy"]})
+        assert "pip" in str(exc.value)
+
+
 def test_proxy_location_to_deployment_mode():
     assert (
         ProxyLocation._to_deployment_mode(ProxyLocation.Disabled)
@@ -1452,6 +1546,50 @@ def test_default_autoscaling_policy_import_path():
     policy = import_attr(DEFAULT_AUTOSCALING_POLICY_NAME)
 
     assert policy == default_autoscaling_policy
+
+
+class TestGetControllerImpl:
+    """White-box checks that ``get_controller_impl`` wires ``ControllerOptions``
+    into the controller actor class's default options.
+
+    These cover the path without starting a Ray cluster -- the live
+    end-to-end env-propagation test lives in
+    ``tests/test_standalone.py::test_serve_start_controller_options``.
+    """
+
+    def _default_options(self, controller_options=None):
+        from ray.serve._private.default_impl import get_controller_impl
+
+        return get_controller_impl(
+            controller_options=controller_options
+        )._default_options
+
+    def test_no_runtime_env_key_when_options_is_none(self):
+        opts = self._default_options(controller_options=None)
+        # Hardcoded fields stay; no runtime_env unless explicitly requested.
+        assert opts["name"] == "SERVE_CONTROLLER_ACTOR"
+        assert opts["namespace"] == "serve"
+        assert "runtime_env" not in opts
+
+    def test_no_runtime_env_key_when_runtime_env_is_none(self):
+        opts = self._default_options(ControllerOptions(runtime_env=None))
+        assert "runtime_env" not in opts
+
+    def test_env_vars_passthrough(self):
+        opts = self._default_options(
+            ControllerOptions(
+                runtime_env={
+                    "env_vars": {
+                        "RAY_SERVE_HAPROXY_TCP_NODELAY": "1",
+                        "RAY_SERVE_HAPROXY_NBTHREAD": "16",
+                    }
+                }
+            )
+        )
+        assert opts["runtime_env"]["env_vars"] == {
+            "RAY_SERVE_HAPROXY_TCP_NODELAY": "1",
+            "RAY_SERVE_HAPROXY_NBTHREAD": "16",
+        }
 
 
 class TestProtoToDict:

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -809,6 +809,56 @@ class TestServeApplicationSchema:
 
 
 class TestServeDeploySchema:
+    def test_controller_options_default_is_none(self):
+        cfg = ServeDeploySchema.model_validate({"applications": []})
+        assert cfg.controller_options is None
+
+    def test_controller_options_passthrough(self):
+        cfg = ServeDeploySchema.model_validate(
+            {
+                "applications": [],
+                "controller_options": {
+                    "runtime_env": {
+                        "env_vars": {
+                            "RAY_SERVE_HAPROXY_TCP_NODELAY": "1",
+                            "RAY_SERVE_HAPROXY_NBTHREAD": "16",
+                        }
+                    }
+                },
+            }
+        )
+        assert (
+            cfg.controller_options.runtime_env["env_vars"][
+                "RAY_SERVE_HAPROXY_TCP_NODELAY"
+            ]
+            == "1"
+        )
+
+    def test_controller_options_rejects_disallowed_runtime_env_keys(self):
+        # The ControllerOptions validator runs through the nested schema,
+        # so bad runtime_env keys fail at YAML / JSON parse time -- not at
+        # controller-creation time.
+        with pytest.raises(ValidationError) as e:
+            ServeDeploySchema.model_validate(
+                {
+                    "applications": [],
+                    "controller_options": {"runtime_env": {"pip": ["numpy"]}},
+                }
+            )
+        msg = str(e.value)
+        assert "only supports ['env_vars']" in msg
+        assert "pip" in msg
+
+    def test_controller_options_rejects_non_str_env_value(self):
+        with pytest.raises(ValidationError) as e:
+            ServeDeploySchema.model_validate(
+                {
+                    "applications": [],
+                    "controller_options": {"runtime_env": {"env_vars": {"FOO": 1}}},
+                }
+            )
+        assert "must be str" in str(e.value)
+
     def test_deploy_config_duplicate_apps(self):
         deploy_config_dict = {
             "applications": [


### PR DESCRIPTION
## Summary

- Add new public `ControllerOptions` config object (alpha), symmetric with `HTTPOptions` / `gRPCOptions`, that lets `serve.start()` / `serve.run()` / `serve run foo.yaml` pass a strictly-validated `runtime_env` into the Serve controller actor.
- v0 scope: `runtime_env` only, and within `runtime_env` only the `env_vars` key is accepted. Other keys (`pip`, `working_dir`, `py_modules`, `container`, ...) would mutate Serve's own dependencies on a detached, long-lived controller actor and are rejected with a message pointing operators at deployment-level `runtime_env`.

## Motivation

Today if there are env variables that need to be passed to the HAProxy layer (e.g. `RAY_SERVE_HAPROXY_TCP_NO_DELAY`) we have to set them at cluster level, instead of doing something like `RAY_SERVE_HAPROXY_TCP_NO_DELAY=1 serve run foo.yaml` or setting the env var in runtime envs in the yaml. which would be much more convenient for tuning. 

## API

```python
# Python
serve.start(
    controller_options=ControllerOptions(
        runtime_env={\"env_vars\": {\"RAY_SERVE_HAPROXY_NBTHREAD\": \"16\"}},
    ),
)

serve.run(
    app,
    controller_options={\"runtime_env\": {\"env_vars\": {\"FOO\": \"bar\"}}},  # dict also accepted
)
```

```yaml
# serve run foo.yaml
controller_options:
  runtime_env:
    env_vars:
      RAY_SERVE_HAPROXY_TCP_NODELAY: \"1\"
      RAY_SERVE_HAPROXY_NBTHREAD: \"16\"

http_options:
  host: 0.0.0.0
  port: 8000

applications:
  - ...
```

Validator catches typos and disallowed fields at parse time:

```python
>>> ControllerOptions(runtime_env={\"pip\": [\"numpy\"]})
ValidationError: ControllerOptions.runtime_env only supports ['env_vars'] in this
version; got disallowed keys ['pip']. Per-replica runtime_env belongs on the
deployment (serve.deployment(runtime_env=...)), not on the controller actor.

>>> ControllerOptions(runtime_env={\"env_vars\": {\"X\": 1}})
ValidationError: env_vars['X'] must be str (got int); coerce explicitly.
```

## Test plan

- [x] `python/ray/serve/tests/unit/test_config.py::TestControllerOptions` — 12 methods (parametrized) covering accept/reject paths: default `None`, dict coerce via `model_validate`, valid `env_vars`, empty `env_vars`, every non-`env_vars` `runtime_env` key (`pip`, `working_dir`, `py_modules`, `conda`, `container`, `nsight`), non-dict `runtime_env`, non-dict `env_vars`, non-`str` values across types, empty/non-string env-var keys, extra top-level fields, mixed allowed-and-disallowed keys.
- [x] `python/ray/serve/tests/unit/test_config.py::TestGetControllerImpl` — 3 cases asserting `runtime_env` correctly threaded into the actor class's `_default_options` (or omitted when not requested).
- [x] `python/ray/serve/tests/unit/test_schema.py::TestServeDeploySchema` — 4 cases on the YAML schema: default-None, valid passthrough, rejects disallowed `runtime_env` keys, rejects non-str env values.
- [x] `python/ray/serve/tests/test_standalone.py::test_serve_start_controller_options` — parametrized e2e (model + dict input) that asserts the requested env vars actually land on the live controller actor's `os.environ`.
- [x] `python/ray/serve/tests/test_standalone.py::test_serve_start_controller_options_rejects_disallowed_runtime_env` — verifies bad `runtime_env` raises `ValidationError` at the caller, not from a Ray task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)