### PR TITLE
[doc][DOC-941] unpin tf-keras: 2.20.0 was yanked

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -41,6 +41,6 @@ click==8.1.7
 boto3==1.34.69
 requests==2.32.5
 tensorflow==2.20.0
-tf-keras==2.20.0
+tf-keras==2.20.1
 xmltodict==0.13.0
 pyarrow==19.0.1

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -1818,9 +1818,9 @@ termcolor==3.3.0 \
     --hash=sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5 \
     --hash=sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5
     # via tensorflow
-tf-keras==2.20.0 \
-    --hash=sha256:080d1cda2c71be55b3cff03970b0e5fa50754946c5491db0cc8d4fef4d9ebc6c \
-    --hash=sha256:73c547664679ed82da5b89466b9ea70da84dfe5a3a623ab59cd93ee5647165ee
+tf-keras==2.20.1 \
+    --hash=sha256:3f0e0a34d9a4c8758f24fdc1053e6e335f16ab5534c7d34f1899b8924779760c \
+    --hash=sha256:884be5938fb0b2b53b1583c1ae2b660ef87215377c29b5b6a77fd221b472aeaf
     # via -r doc/requirements-doc.txt
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \


### PR DESCRIPTION
## Why

`tf-keras==2.20.0` is pinned in `doc/requirements-doc.txt` and was yanked from PyPI. The RtD build log on [#63344](https://github.com/ray-project/ray/pull/63344) surfaced the warning:

```
WARNING: The candidate selected for download or install is a yanked version: 'tf-keras' candidate (version 2.20.0 at https://files.pythonhosted.org/packages/50/9b/.../tf_keras-2.20.0-py3-none-any.whl)
Reason for being yanked: <none given>
```

The warning doesn't fail the build today (`fail_on_warning: true` doesn't catch yank warnings), but a yanked version may be removed from the index in the future and break the lock.

## What

Patch bump to the next non-yanked release:

- `doc/requirements-doc.txt`: `tf-keras==2.20.0` → `tf-keras==2.20.1`.
- `python/deplocks/docs/docbuild_depset_py3.10.lock`: update the `tf-keras` entry with the 2.20.1 wheel and sdist hashes.

2.20.1 has identical `requires_dist` to 2.20.0 (`tensorflow<2.21,>=2.20`), so the existing `tensorflow==2.20.0` pin still satisfies the constraint and no transitive deps churn. Manual lock edit per the [#63130](https://github.com/ray-project/ray/pull/63130) pattern is appropriate here.

The ML / `dl-cpu-requirements.txt` / `dl-gpu-requirements.txt` pins and the `doctest_depset` lockfile also reference 2.20.0; those are out of scope for this `doc`-tagged PR and can follow up separately.

## Verification

RtD PR preview build with `fail_on_warning: true`. Confirm the yanked-version warning disappears and no new warnings appear.

## Context

Part of the [DOC-932](https://anyscale1.atlassian.net/browse/DOC-932) campaign: Ray docs dependency upgrades. Independent of the other open probes ([#63343](https://github.com/ray-project/ray/pull/63343), [#63344](https://github.com/ray-project/ray/pull/63344), [#63354](https://github.com/ray-project/ray/pull/63354)) — targets `master` directly.

[DOC-941](https://anyscale1.atlassian.net/browse/DOC-941)
