### PR TITLE
[doc][DOC-935] bump myst-nb 1.0.0rc0 -> 1.4.0

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -29,7 +29,7 @@ pydantic==2.5.0
 
 # MyST
 myst-parser==2.0.0 # Needed to parse markdown
-myst-nb==1.0.0rc0 # Most recent version of myst-nb; pin when new release is made
+myst-nb==1.4.0
 # Jupyter conversion
 jupytext==1.15.2
 

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -18,6 +18,7 @@ sphinxcontrib-redoc==1.6.0
 sphinx-remove-toctrees==0.0.3
 sphinx_design==0.5.0
 sphinx-autobuild==2024.4.16
+sphinxext-opengraph==0.13.0
 pydata-sphinx-theme==0.14.1
 autodoc_pydantic==2.2.0
 appnope

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -19,7 +19,7 @@ sphinx-remove-toctrees==0.0.3
 sphinx_design==0.5.0
 sphinx-autobuild==2024.4.16
 sphinxext-opengraph==0.13.0
-pydata-sphinx-theme==0.14.1
+pydata-sphinx-theme==0.17.1
 autodoc_pydantic==2.2.0
 appnope
 sphinx-docsearch==0.0.7

--- a/doc/source/_static/css/custom.css
+++ b/doc/source/_static/css/custom.css
@@ -177,6 +177,15 @@ div.navbar-content a {
   align-items: start;
   white-space: pre;
   justify-content: center;
+  /* pydata-sphinx-theme 0.14's `.navbar-nav li a { height: 100% }` was
+     scoped to `ul.navbar-nav li a` in 0.17, which no longer matches our
+     `<nav class="navbar-nav">`. Without height: 100% on <a>, the <a>
+     shrinks to text height (~26px) inside its 64px-tall <p> parent,
+     leaving the link text top-aligned in the navbar and the chevron
+     (which is centered on the .ref-container) visually below the text.
+     Restoring height: 100% lets justify-content: center vertically
+     center the text in the full-height anchor. */
+  height: 100%;
 }
 div.navbar-content {
   height: 100%;
@@ -215,6 +224,20 @@ li.active-link {
 /* Disable underline for hovered links in the nav bar */
 .navbar-nav li a:hover {
   text-decoration: none;
+}
+/* pydata-sphinx-theme 0.17 stopped removing text-decoration on
+   <a class="reference internal"> inside the top navbar (the rule it
+   ships now only matches <a class="nav-link">). Re-add it for our
+   reference-internal anchors. */
+.navbar-toplevel a.reference {
+  text-decoration: none;
+}
+/* pydata-sphinx-theme 0.17 stopped hiding the sidebar-header-items__title
+   element (Ray's navbar-links.html template emits "Site Navigation" as
+   a screen-reader heading). Hide it in the header context — it still
+   renders in the actual sidebar drawer where the heading is useful. */
+.navbar-header-items .sidebar-header-items__title {
+  display: none;
 }
 .navbar-header-items {
   padding-left: 0;
@@ -375,11 +398,14 @@ table.autosummary tr > td:first-child > p > a > code > span {
   width: 30%;
 }
 
+/* pydata-sphinx-theme 0.14 painted the announcement banner background via
+   an absolutely-positioned `::after` pseudo-element. 0.17 replaced that
+   with `background-color: var(--pst-color-secondary-bg)` directly on
+   `.bd-header-announcement`, so the `::after` rule is now a no-op and
+   pydata's default secondary-bg paints the banner lavender. Set the
+   background directly on the element to keep Ray's teal. */
 .bd-header-announcement {
   color: var(--pst-color-light);
-}
-
-.bd-header-announcement::after {
   background-color: var(--ray-blue);
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,6 +78,7 @@ extensions = [
     "sphinx_docsearch",
     "sphinx_collections",
     "sphinx_llms_txt",
+    "sphinxext.opengraph",
 ]
 
 # -- sphinx-llms-txt: agent-friendly summary and full corpus -----------
@@ -294,6 +295,15 @@ html_baseurl = "https://docs.ray.io/en/latest/"
 # default `{lang}{version}{link}` scheme to just `{link}`. Otherwise the
 # extension prepends `en/` again, producing URLs like `en/latesten/<page>`.
 sitemap_url_scheme = "{link}"
+
+# sphinxext-opengraph: emit Open Graph metadata per page. Pin `ogp_site_url`
+# to `html_baseurl` so the `og:url` tag tracks the same canonical URL as
+# Sphinx's `<link rel="canonical">`. If `ogp_site_url` were left unset, the
+# extension would fall back to Read the Docs' `READTHEDOCS_CANONICAL_URL`
+# env var (set by RtD's Addons framework from the project's "Canonical
+# version" admin setting), which can diverge from `html_baseurl`. Per-page
+# `:og:description:` and `:og:image:` can still be set in individual files.
+ogp_site_url = html_baseurl
 
 # This pattern matches:
 # - Python Repl prompts (">>> ") and it's continuation ("... ")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -503,8 +503,8 @@ html_theme_options = {
         "csat",
     ],
     "navigation_depth": 4,
-    "pygment_light_style": "stata-dark",
-    "pygment_dark_style": "stata-dark",
+    "pygments_light_style": "stata-dark",
+    "pygments_dark_style": "stata-dark",
     "switcher": {
         "json_url": "https://docs.ray.io/en/master/_static/versions.json",
         "version_match": os.getenv("READTHEDOCS_VERSION", "master"),

--- a/doc/source/serve/tutorials/asynchronous-inference/content/asynchronous-inference.ipynb
+++ b/doc/source/serve/tutorials/asynchronous-inference/content/asynchronous-inference.ipynb
@@ -589,6 +589,7 @@
    "name": "python3"
   },
   "language_info": {
+    "name": "python",
     "pygments_lexer": "ipython3"
   }
  },

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -1637,6 +1637,7 @@ sphinx==7.3.7 \
     #   sphinx-remove-toctrees
     #   sphinxcontrib-redoc
     #   sphinxemoji
+    #   sphinxext-opengraph
 sphinx-autobuild==2024.4.16 \
     --hash=sha256:1c0ed37a1970eed197f9c5a66d65759e7c4e4cba7b5a5d77940752bf1a59f2c7 \
     --hash=sha256:f2522779d30fcbf0253e09714f274ce8c608cb6ebcd67922b1c54de59faba702
@@ -1710,6 +1711,10 @@ sphinxcontrib-serializinghtml==2.0.0 \
 sphinxemoji==0.3.2 \
     --hash=sha256:0fb07a95bca5960a3b312bc05b65b0c3040456414a076c363f4ecaf546c6e09e \
     --hash=sha256:814da89a9a7603b7e4d85c487c7381656fa83632f20065e5ed782ab1dbbb5083
+    # via -r doc/requirements-doc.txt
+sphinxext-opengraph==0.13.0 \
+    --hash=sha256:103335d08567ad8468faf1425f575e3b698e9621f9323949a6c8b96d9793e80b \
+    --hash=sha256:936c07828edc9ad9a7b07908b29596dc84ed0b3ceaa77acdf51282d232d4d80e
     # via -r doc/requirements-doc.txt
 sqlalchemy==2.0.44 \
     --hash=sha256:0765e318ee9179b3718c4fd7ba35c434f4dd20332fbc6857a5e8df17719c24d7 \

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -710,9 +710,9 @@ ml-dtypes==0.5.4 \
     # via
     #   keras
     #   tensorflow
-myst-nb==1.0.0rc0 \
-    --hash=sha256:1e16ac04cdbc6bdb9e02dc16fc74925b48737c27c9f21a6bc7134116489fdeda \
-    --hash=sha256:3e778877f59c97452879a8bfb370afa77db14a8800f3e7de4dcaeb44f4230997
+myst-nb==1.4.0 \
+    --hash=sha256:0e2c86e7d3b82c3aa51383f82d6268f7714f3b772c23a796ab09538a8e68b4e4 \
+    --hash=sha256:c145598de62446a6fd009773dd071a40d3b76106ace780de1abdfc6961f614c2
     # via -r doc/requirements-doc.txt
 myst-parser==2.0.0 \
     --hash=sha256:7c36344ae39c8e740dad7fdabf5aa6fc4897a813083c6cc9990044eb93656b14 \

--- a/python/deplocks/docs/docbuild_depset_py3.10.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.10.lock
@@ -897,7 +897,6 @@ packaging==25.0 \
     # via
     #   ipykernel
     #   keras
-    #   pydata-sphinx-theme
     #   sphinx
     #   sphinx-collections
     #   tensorboard
@@ -1203,9 +1202,9 @@ pydantic-settings==2.2.1 \
     --hash=sha256:00b9f6a5e95553590434c0fa01ead0b216c3e10bc54ae02e37f359948643c5ed \
     --hash=sha256:0235391d26db4d2190cb9b31051c4b46882d28a51533f97440867f012d4da091
     # via autodoc-pydantic
-pydata-sphinx-theme==0.14.1 \
-    --hash=sha256:c436027bc76ae023df4e70517e3baf90cdda5a88ee46b818b5ef0cc3884aba04 \
-    --hash=sha256:d8d4ac81252c16a002e835d21f0fea6d04cf3608e95045c816e8cc823e79b053
+pydata-sphinx-theme==0.17.1 \
+    --hash=sha256:2cfc1d926c753c77039b7ee53f0ccebcbee5e81f0db61432b01cbb10ad7fd0af \
+    --hash=sha256:320b022d7808bdf5920d9a28e573f27aace9b23e1af6ca103eecc752411df492
     # via -r doc/requirements-doc.txt
 pygments==2.16.1 \
     --hash=sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692 \


### PR DESCRIPTION
## Why

`myst-nb` is pinned at `1.0.0rc0` (a release candidate) in `doc/requirements-doc.txt`. Latest stable is `1.4.0` — four minor releases ahead. The `# Pin when new release is made` comment is stale: 1.0.0 shipped, and the project has moved on.

Notebook parsing/output is downstream of `myst-nb`. Ray ships 127 Jupyter notebooks (`RUN_NOTEBOOKS=off` by default), parsed from stored cell outputs. The bump tests the parsing path against existing outputs without requiring re-execution.

## What

- `doc/requirements-doc.txt`: `myst-nb==1.0.0rc0` → `myst-nb==1.4.0`. Drops the stale "pin when new release is made" comment.
- `python/deplocks/docs/docbuild_depset_py3.10.lock`: update version + hashes for `myst-nb`.

## Lock-file scope

myst-nb 1.4.0 declares more core dependencies than 1.0.0rc0 — `ipython`, `ipykernel`, `nbclient`, `pyyaml`, `typing-extensions`, `importlib-metadata`, and `sphinx>=5`. I verified that **all** of these are already present in `docbuild_depset_py3.10.lock` as transitives from other packages, so the hand-edit per the [#63130](https://github.com/ray-project/ray/pull/63130) pattern works here without regenerating the full lock.

The lock's `# via` comments for those transitives don't yet include `myst-nb` as a source. Those comments are informational (they don't affect resolution), but `raydepsets --check` in CI will flag them if it cares about the discrepancy. If CI complains, the fix is either to update via-comments by hand or regenerate via:

```bash
bazelisk run //ci/raydepsets:raydepsets -- build ci/raydepsets/configs/docs.depsets.yaml
```

## Validation surface

- RtD PR preview build with `fail_on_warning: true`. Build must succeed.
- Spot check a notebook-rendered page (e.g., Tune tutorials, RLlib examples).
- Look for new warnings in build logs.

## Risks

- 1.0 → 1.4 may have changed default output rendering for some MIME types. The `nb_mime_priority_overrides` and `nb_execution_mode = "off"` settings in `conf.py` should still apply but warrant a visual check.
- Migrations between rc and stable can be sensitive on edge cases.
- The cell-id `MissingIDFieldWarning` ([DOC-944](https://anyscale1.atlassian.net/browse/DOC-944)) may escalate to a hard error under stricter validation in 1.4.0. The strict `language_info.name` error is fixed below in the stack ([#63359](https://github.com/ray-project/ray/pull/63359)).

## Stack

This PR is stacked on:

1. [#63343](https://github.com/ray-project/ray/pull/63343) — [DOC-933](https://anyscale1.atlassian.net/browse/DOC-933) (additive extensions)
2. [#63344](https://github.com/ray-project/ray/pull/63344) — [DOC-934](https://anyscale1.atlassian.net/browse/DOC-934) (pydata-sphinx-theme bump)
3. [#63359](https://github.com/ray-project/ray/pull/63359) — [DOC-942](https://anyscale1.atlassian.net/browse/DOC-942) (notebook `language_info.name` fix)

Base is `master` per the team's fork-stack convention; the diff temporarily includes the lower PRs and shrinks as they merge. The CI signal for this PR validates the combined state of the four changes.

## Context

Part of the [DOC-932](https://anyscale1.atlassian.net/browse/DOC-932) campaign: Ray docs dependency upgrades. Strategy context: `anyscale/docs:strategy/ray-docs/sphinx-rtd-viability.md` and `config-deep-dive.md`.

[DOC-935](https://anyscale1.atlassian.net/browse/DOC-935)
