### PR TITLE
[serve][llm] Configurable session-id header (RAY_SERVE_SESSION_ID_HEADER_KEY)

### DIFF
--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -76,6 +76,7 @@ from ray.llm._internal.serve.utils.lora_serve_utils import (
     get_lora_model_metadata,
 )
 from ray.llm._internal.serve.utils.server_utils import replace_prefix
+from ray.serve._private.constants import SERVE_SESSION_ID
 from ray.serve.handle import DeploymentHandle
 
 # Import asyncio timeout depends on python version
@@ -515,6 +516,18 @@ class OpenAiIngress(DeploymentProtocol):
         """Calls the model deployment and returns the stream."""
         model_id = await self._get_model_id(body.model)
         model_handle = self._get_configured_serve_handle(model_id)
+
+        # Propagate the session id from the client request to the downstream
+        # LLMServer handle. The Serve HTTP proxy attaches session_id to the
+        # *ingress* deployment handle (proxy.py:_setup_request_context), but
+        # that does NOT carry over to a second handle hop (here -> LLMServer).
+        # Re-read the configured session header from the raw request and apply
+        # it via .options(session_id=...) so session-aware request routers
+        # (e.g. ConsistentHashRouter) on the LLMServer deployment see it.
+        if raw_request is not None:
+            session_id = raw_request.headers.get(SERVE_SESSION_ID)
+            if session_id:
+                model_handle = model_handle.options(session_id=session_id)
 
         # TODO(seiji): Remove when we update to Pydantic v2.11+ with the fix
         # for tool calling ValidatorIterator serialization issue.

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -76,7 +76,7 @@ from ray.llm._internal.serve.utils.lora_serve_utils import (
     get_lora_model_metadata,
 )
 from ray.llm._internal.serve.utils.server_utils import replace_prefix
-from ray.serve._private.constants import SERVE_SESSION_ID
+from ray.serve._private.http_util import _matches_session_id_header
 from ray.serve.handle import DeploymentHandle
 
 # Import asyncio timeout depends on python version
@@ -524,8 +524,18 @@ class OpenAiIngress(DeploymentProtocol):
         # Re-read the configured session header from the raw request and apply
         # it via .options(session_id=...) so session-aware request routers
         # (e.g. ConsistentHashRouter) on the LLMServer deployment see it.
+        # Uses the same case-insensitive, separator-tolerant matcher as
+        # proxy.py so a `-`/`_` rewrite by an intermediate proxy doesn't
+        # silently drop session affinity on this second hop.
         if raw_request is not None:
-            session_id = raw_request.headers.get(SERVE_SESSION_ID)
+            session_id = next(
+                (
+                    v
+                    for k, v in raw_request.headers.items()
+                    if _matches_session_id_header(k)
+                ),
+                None,
+            )
             if session_id:
                 model_handle = model_handle.options(session_id=session_id)
 

--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -3,7 +3,7 @@ from typing import Optional, Tuple
 from fastapi import FastAPI, HTTPException, Request
 
 from ray import serve
-from ray.serve._private.constants import SERVE_SESSION_ID
+from ray.serve._private.http_util import _matches_session_id_header
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 
@@ -68,9 +68,14 @@ class LLMRouter:
     async def route(self, request: Request):
         body = await request.body()
         body_truncated = _BODY_TRUNCATED_HEADER in request.headers
-        # Starlette header lookup is case-insensitive; SERVE_SESSION_ID is
-        # the operator-configured header name (e.g. "x-correlation-id").
-        session_id = request.headers.get(SERVE_SESSION_ID) or None
+        # HAProxy forwards the configured session header on the same name,
+        # but use the same case-insensitive, separator-tolerant matcher as
+        # proxy.py / ingress.py so a `-`/`_` rewrite anywhere in the path
+        # doesn't silently drop session affinity.
+        session_id = next(
+            (v for k, v in request.headers.items() if _matches_session_id_header(k)),
+            None,
+        )
         handle = (
             self._handle.options(session_id=session_id) if session_id else self._handle
         )

--- a/python/ray/llm/_internal/serve/core/ingress/router.py
+++ b/python/ray/llm/_internal/serve/core/ingress/router.py
@@ -3,6 +3,7 @@ from typing import Optional, Tuple
 from fastapi import FastAPI, HTTPException, Request
 
 from ray import serve
+from ray.serve._private.constants import SERVE_SESSION_ID
 from ray.serve.exceptions import DeploymentUnavailableError
 from ray.serve.handle import DeploymentHandle
 
@@ -39,6 +40,15 @@ class LLMRouter:
         body bytes and this signal are forwarded to ``choose_replica`` for
         future body-aware policies.
 
+    Session affinity:
+        If the client request carried the session-id header configured by
+        ``RAY_SERVE_SESSION_ID_HEADER_KEY`` (default ``x-session-id``),
+        HAProxy's Lua action forwards it to ``/internal/route`` on the same
+        name. This handler reads it and applies
+        ``handle.options(session_id=...)`` before calling
+        ``choose_replica`` so session-aware policies (e.g.
+        ``ConsistentHashRouter``) pin all turns of a session to one replica.
+
     Responses:
         200 ``{"host": str, "port": int, "replica_id": str}``: pick
             succeeded.
@@ -58,9 +68,17 @@ class LLMRouter:
     async def route(self, request: Request):
         body = await request.body()
         body_truncated = _BODY_TRUNCATED_HEADER in request.headers
+        # Starlette header lookup is case-insensitive; SERVE_SESSION_ID is
+        # the operator-configured header name (e.g. "x-correlation-id").
+        session_id = request.headers.get(SERVE_SESSION_ID) or None
+        handle = (
+            self._handle.options(session_id=session_id) if session_id else self._handle
+        )
         try:
             host, port, replica_id = await self._pick_replica(
-                request_body=body, body_truncated=body_truncated
+                handle=handle,
+                request_body=body,
+                body_truncated=body_truncated,
             )
         except (RuntimeError, DeploymentUnavailableError) as e:
             raise HTTPException(status_code=503, detail=str(e))
@@ -72,10 +90,15 @@ class LLMRouter:
 
     async def _pick_replica(
         self,
+        handle: DeploymentHandle,
         request_body: Optional[bytes] = None,
         body_truncated: bool = False,
     ) -> Tuple[str, int, str]:
         """Pick a backend HTTP replica via the deployment's request router.
+
+        ``handle`` is the LLMServer deployment handle, optionally configured
+        with ``.options(session_id=...)`` by the caller so session-aware
+        routers see the session id on ``RequestMetadata``.
 
         ``request_body`` (possibly a HAProxy-truncated prefix, indicated by
         ``body_truncated``) is forwarded to ``choose_replica`` so a future
@@ -83,7 +106,7 @@ class LLMRouter:
         messages without changing the /internal/route contract or the call
         site.
         """
-        async with self._handle.choose_replica(
+        async with handle.choose_replica(
             request_body=request_body, body_truncated=body_truncated
         ) as selection:
             replica = selection._replica

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_router.py
@@ -143,7 +143,7 @@ class TestDirectStreamingLLMRouter:
             "replica_id": "DeploymentName#replica",
         }
         router._pick_replica.assert_called_once_with(
-            request_body=body, body_truncated=True
+            handle=router._handle, request_body=body, body_truncated=True
         )
 
     @pytest.mark.asyncio
@@ -179,7 +179,7 @@ class TestDirectStreamingLLMRouter:
         handle.choose_replica = _choose_replica_returning(replica)
         router = _new_direct_router(handle)
 
-        host, port, replica_id = await router._pick_replica()
+        host, port, replica_id = await router._pick_replica(handle=handle)
 
         assert (host, port, replica_id) == ("10.0.0.1", 8123, "DeploymentName#r1")
 
@@ -203,7 +203,9 @@ class TestDirectStreamingLLMRouter:
         router = _new_direct_router(handle)
 
         body = b'{"messages": [{"role": "user", "content": "hi"}]}'
-        await router._pick_replica(request_body=body, body_truncated=True)
+        await router._pick_replica(
+            handle=handle, request_body=body, body_truncated=True
+        )
 
         assert captured_kwargs == {"request_body": body, "body_truncated": True}
 
@@ -217,7 +219,7 @@ class TestDirectStreamingLLMRouter:
         router = _new_direct_router(handle)
 
         with pytest.raises(RuntimeError, match="no backend HTTP endpoint"):
-            await router._pick_replica()
+            await router._pick_replica(handle=handle)
 
 
 class TestOpenAiIngress:

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -386,7 +386,12 @@ SERVE_LOG_EXTRA_FIELDS = "ray_serve_extra_fields"
 SERVE_MULTIPLEXED_MODEL_ID = "serve_multiplexed_model_id"
 
 # Serve HTTP request header key for session-stickiness routing.
-SERVE_SESSION_ID = "x_session_id"
+# Stored as the operator wrote it (no ``-``/``_`` mangling); set via
+# ``RAY_SERVE_SESSION_ID_HEADER_KEY`` (default ``x-session-id``). Compare
+# against incoming header names with ``_matches_session_id_header`` from
+# ``http_util`` -- that helper tolerates intermediate proxies that swap
+# ``-`` and ``_`` (nginx, AWS API Gateway, ...).
+SERVE_SESSION_ID = get_env_str("RAY_SERVE_SESSION_ID_HEADER_KEY", "x-session-id")
 
 # HTTP request ID
 SERVE_HTTP_REQUEST_ID_HEADER = "x-request-id"

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -60,6 +60,7 @@ from ray.serve._private.constants import (
     SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
+    SERVE_SESSION_ID,
 )
 from ray.serve._private.haproxy_templates import (
     HAPROXY_CONFIG_TEMPLATE,
@@ -806,6 +807,10 @@ class HAProxyApi(ProxyApi):
         content = _load_lua_template().substitute(
             TIMEOUT_S=RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S,
             FORWARD_BODY=str(RAY_SERVE_INGRESS_REQUEST_ROUTER_FORWARD_BODY).lower(),
+            # HAProxy's req_get_headers() returns lowercase header keys,
+            # so lowercase here for the Lua lookup. Empty string disables
+            # forwarding entirely.
+            SESSION_HEADER=SERVE_SESSION_ID.lower(),
             ROUTERS=_format_routers_lua(routers),
             REPLICA_TARGETS=_format_replica_targets_lua(targets),
         )

--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -813,18 +813,28 @@ def parse_disconnect_disabled_header(headers: Dict[bytes, bytes]) -> bool:
     )
 
 
-def parse_session_id_header(headers: Dict[bytes, bytes]) -> str:
-    """Return the SERVE_SESSION_ID header value, or '' if absent.
+def _matches_session_id_header(header_key: str) -> bool:
+    """True if ``header_key`` refers to the configured session-id header.
 
-    Accepts both the underscored constant form (``x_session_id``) and the
-    canonical hyphenated form (``x-session-id``) because intermediate proxies
-    (HAProxy, nginx, AWS API Gateway) canonicalize underscored header names
-    to the hyphenated form. ASGI lowercases header names per spec, so
-    case-folding is not needed here.
+    Compares case-insensitively and treats ``-`` and ``_`` as equivalent
+    so intermediate proxies that rewrite the separator (nginx, AWS API
+    Gateway, ...) don't silently drop session affinity. The header name
+    itself is whatever ``SERVE_SESSION_ID`` resolves to (set via the env
+    var ``RAY_SERVE_SESSION_ID_HEADER_KEY``).
     """
-    for form in (SERVE_SESSION_ID, SERVE_SESSION_ID.replace("_", "-")):
-        value = headers.get(form.encode("utf-8"))
-        if value is not None:
+    return header_key.lower().replace("-", "_") == SERVE_SESSION_ID.lower().replace(
+        "-", "_"
+    )
+
+
+def parse_session_id_header(headers: Dict[bytes, bytes]) -> str:
+    """Return the configured session-id header value, or '' if absent.
+
+    Header name is whatever ``SERVE_SESSION_ID`` resolves to (set via
+    ``RAY_SERVE_SESSION_ID_HEADER_KEY``).
+    """
+    for key, value in headers.items():
+        if _matches_session_id_header(key.decode("utf-8")):
             return value.decode("utf-8")
     return ""
 

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -136,10 +136,21 @@ core.register_action("route_via_ingress_request_router", {"http-req"}, function(
     -- with array values (header can appear multiple times); take the
     -- first occurrence. Missing header -> nil -> call_router skips the
     -- forwarded header line entirely.
+    --
+    -- Also probe the `-`/`_` variant so an intermediate proxy that rewrites
+    -- the separator doesn't silently drop session affinity, matching the
+    -- Python-side `_matches_session_id_header` behavior in http_util.py.
     local session_id = nil
     if SESSION_HEADER ~= "" then
         local hdrs = txn.http:req_get_headers()
         local entry = hdrs and hdrs[SESSION_HEADER]
+        if hdrs and not entry then
+            local alt = SESSION_HEADER:gsub("-", "_")
+            if alt == SESSION_HEADER then
+                alt = SESSION_HEADER:gsub("_", "-")
+            end
+            entry = hdrs[alt]
+        end
         if entry then
             session_id = entry[0]
         end

--- a/python/ray/serve/_private/ingress_request_router.lua.tmpl
+++ b/python/ray/serve/_private/ingress_request_router.lua.tmpl
@@ -8,6 +8,12 @@
 
 local ROUTER_REQUEST_TIMEOUT_S = ${TIMEOUT_S}
 local FORWARD_BODY = ${FORWARD_BODY}
+-- Name of the client header that carries the session id Serve should
+-- pin on. Filled from SERVE_SESSION_ID (set via the env var
+-- RAY_SERVE_SESSION_ID_HEADER_KEY) in lowercase form. Forwarded on the
+-- same name to /internal/route so session-aware routers (e.g.
+-- ConsistentHashRouter) can use it.
+local SESSION_HEADER = "${SESSION_HEADER}"
 
 -- Per-app state. The frontend sets txn.ingress_request_router_app to the
 -- backend name whose path prefix matched, and we look up that app's
@@ -16,7 +22,7 @@ local FORWARD_BODY = ${FORWARD_BODY}
 local ROUTERS = ${ROUTERS}
 local REPLICA_TARGETS = ${REPLICA_TARGETS}
 
-local function call_router(router, body, truncated_length)
+local function call_router(router, body, truncated_length, session_id)
     local sock = core.tcp()
     sock:settimeout(ROUTER_REQUEST_TIMEOUT_S)
 
@@ -30,6 +36,11 @@ local function call_router(router, body, truncated_length)
             .. #body .. "/" .. truncated_length .. "\r\n"
     end
 
+    local session_header = ""
+    if session_id and session_id ~= "" then
+        session_header = SESSION_HEADER .. ": " .. session_id .. "\r\n"
+    end
+
     -- Connection: close so sock:receive("*a") terminates on EOF.
     local req = "POST /internal/route HTTP/1.0\r\n"
         .. "Host: " .. router.host_header .. "\r\n"
@@ -37,6 +48,7 @@ local function call_router(router, body, truncated_length)
         .. "Content-Type: application/json\r\n"
         .. "Content-Length: " .. #body .. "\r\n"
         .. truncation_header
+        .. session_header
         .. "\r\n"
         .. body
 
@@ -119,7 +131,21 @@ core.register_action("route_via_ingress_request_router", {"http-req"}, function(
         end
     end
 
-    local response = call_router(router, body, truncated)
+    -- Look up the configured session-id header from the client request.
+    -- req_get_headers() returns a table keyed by lowercase header name
+    -- with array values (header can appear multiple times); take the
+    -- first occurrence. Missing header -> nil -> call_router skips the
+    -- forwarded header line entirely.
+    local session_id = nil
+    if SESSION_HEADER ~= "" then
+        local hdrs = txn.http:req_get_headers()
+        local entry = hdrs and hdrs[SESSION_HEADER]
+        if entry then
+            session_id = entry[0]
+        end
+    end
+
+    local response = call_router(router, body, truncated, session_id)
     if not response then
         txn:set_var("txn.ingress_request_router_failed", "router_unreachable")
         return

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -42,7 +42,6 @@ from ray.serve._private.constants import (
     SERVE_LOGGER_NAME,
     SERVE_MULTIPLEXED_MODEL_ID,
     SERVE_NAMESPACE,
-    SERVE_SESSION_ID,
 )
 from ray.serve._private.default_impl import get_proxy_handle
 from ray.serve._private.event_loop_monitoring import EventLoopMonitor
@@ -53,6 +52,7 @@ from ray.serve._private.grpc_util import (
 )
 from ray.serve._private.http_util import (
     MessageQueue,
+    _matches_session_id_header,
     configure_http_middlewares,
     convert_object_to_asgi_messages,
     get_http_response_status,
@@ -1245,7 +1245,7 @@ class HTTPProxy(GenericProxy):
                 multiplexed_model_id = value.decode()
                 handle = handle.options(multiplexed_model_id=multiplexed_model_id)
                 request_context_info["multiplexed_model_id"] = multiplexed_model_id
-            elif normalized_key == SERVE_SESSION_ID:
+            elif _matches_session_id_header(key.decode()):
                 session_id = value.decode()
                 handle = handle.options(session_id=session_id)
                 request_context_info["session_id"] = session_id

--- a/python/ray/serve/experimental/consistent_hash_router.py
+++ b/python/ray/serve/experimental/consistent_hash_router.py
@@ -15,7 +15,7 @@ from typing import FrozenSet, List, Optional
 import mmh3
 
 from ray.serve._private.common import ReplicaID
-from ray.serve._private.constants import SERVE_LOGGER_NAME
+from ray.serve._private.constants import SERVE_LOGGER_NAME, SERVE_SESSION_ID
 from ray.serve._private.request_router.common import PendingRequest
 from ray.serve._private.request_router.replica_wrapper import RunningReplica
 from ray.serve._private.request_router.request_router import RequestRouter
@@ -50,6 +50,57 @@ class ConsistentHashRouter(RequestRouter):
     replica is a pure function of session ID and ring state. Mixing in queue-depth,
     locality, or multiplexed model signals breaks determinism and therefore breaks
     affinity.
+
+    Kwargs (passed via ``RequestRouterConfig.request_router_kwargs``):
+
+    - ``num_virtual_nodes`` (int, default ``100``): vnodes per replica on
+      the hash ring. Higher values spread sessions more evenly across
+      replicas at the cost of a larger ring.
+    - ``num_fallback_replicas`` (int, default ``2``): number of clockwise
+      successor replicas tried after the primary if it rejects (e.g.
+      backpressure). Set to ``0`` for strict affinity (no fallback).
+
+    Session affinity:
+        The routing key is ``RequestMetadata.session_id`` — populated upstream
+        from the HTTP header named by ``SERVE_SESSION_ID`` (set via env var
+        ``RAY_SERVE_SESSION_ID_HEADER_KEY``; default ``x-session-id``).
+        Requests without that header fall back to ``internal_request_id``
+        (a fresh UUID per request) and therefore distribute uniformly across
+        replicas — same code path, no affinity. See
+        ``ray.serve._private.constants.SERVE_SESSION_ID``.
+
+    Usage (Ray Serve LLM):
+
+    .. code-block:: python
+
+        from ray.serve.config import RequestRouterConfig
+        from ray.serve.llm import LLMConfig, ModelLoadingConfig
+
+        LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="Qwen/Qwen3-0.6B-FP8",
+                model_source="Qwen/Qwen3-0.6B-FP8",
+            ),
+            deployment_config=dict(
+                request_router_config=RequestRouterConfig(
+                    request_router_class=(
+                        "ray.serve.experimental.consistent_hash_router."
+                        "ConsistentHashRouter"
+                    ),
+                    request_router_kwargs={
+                        "num_virtual_nodes": 100,
+                        "num_fallback_replicas": 2,
+                    },
+                ),
+            ),
+        )
+
+    The session header itself is set globally on the cluster:
+
+    .. code-block:: bash
+
+        # Clients sending sessions on x-correlation-id (e.g. aiperf):
+        export RAY_SERVE_SESSION_ID_HEADER_KEY=x-correlation-id
     """
 
     def __init__(self, *args, **kwargs):
@@ -85,6 +136,14 @@ class ConsistentHashRouter(RequestRouter):
 
         self._num_virtual_nodes = num_virtual_nodes
         self._num_fallback_replicas = num_fallback_replicas
+
+        logger.info(
+            f"ConsistentHashRouter initialized for {self._deployment_id}: "
+            f"num_virtual_nodes={self._num_virtual_nodes}, "
+            f"num_fallback_replicas={self._num_fallback_replicas}, "
+            f"session_id_header={SERVE_SESSION_ID!r} "
+            "(set via RAY_SERVE_SESSION_ID_HEADER_KEY)."
+        )
 
     def update_replicas(self, replicas: List[RunningReplica]) -> None:
         """

--- a/python/ray/serve/tests/test_http_headers.py
+++ b/python/ray/serve/tests/test_http_headers.py
@@ -204,6 +204,41 @@ class TestSessionIdHeader:
         )
 
 
+class TestMatchesSessionIdHeader:
+    """Unit tests for the case/separator-tolerant comparison used by the
+    proxy + Lua forwarder. Without this helper, an intermediate proxy that
+    rewrites ``_``↔``-`` (nginx, AWS API Gateway, ...) would silently drop
+    session affinity for half of all clients.
+    """
+
+    @pytest.mark.parametrize(
+        "stored,incoming,expected",
+        [
+            # Default hyphenated form.
+            ("x-session-id", "x-session-id", True),
+            ("x-session-id", "X-Session-Id", True),
+            ("x-session-id", "x_session_id", True),
+            ("x-session-id", "x-Other-Id", False),
+            # Operator stored the underscored form (e.g. legacy).
+            ("x_session_id", "x-session-id", True),
+            ("x_session_id", "x_session_id", True),
+            # Custom configured value via env var (e.g. aiperf's correlation id).
+            ("x-correlation-id", "x-correlation-id", True),
+            ("x-correlation-id", "x_correlation_id", True),
+            ("x-correlation-id", "X-Correlation-Id", True),
+            ("x-correlation-id", "x-session-id", False),
+        ],
+    )
+    def test_match(self, monkeypatch, stored, incoming, expected):
+        # SERVE_SESSION_ID is module-level constant; monkey-patch it on the
+        # two modules that import it for the duration of this test.
+        from ray.serve._private import constants, http_util
+
+        monkeypatch.setattr(constants, "SERVE_SESSION_ID", stored)
+        monkeypatch.setattr(http_util, "SERVE_SESSION_ID", stored)
+        assert http_util._matches_session_id_header(incoming) is expected
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Summary

Make the session-stickiness HTTP header operator-configurable via `RAY_SERVE_SESSION_ID_HEADER_KEY` (default `x-session-id`, was hard-coded `x_session_id`).

Today `SERVE_SESSION_ID` is the literal `"x_session_id"` and `ConsistentHashRouter` only honors that exact header. Real clients don't send it:

- aiperf sends its session UUID on `x-correlation-id`.
- vllm-router exposes `--request-id-headers` so users plumb their own name.
- nginx / AWS API Gateway / most reverse proxies canonicalize `_` → `-` on the wire.

With direct streaming, it's worse: HAProxy's Lua action bypasses `proxy.py` entirely, so `session_id` never reaches `LLMRouter` no matter what the client sends.

This is the third leg of the LLM routing-affinity fix:
- #63280: `LLMRouter` uses `choose_replica`.
- #63352: `ControllerOptions` plumbs env vars into the Serve controller actor.
- this PR: `RAY_SERVE_SESSION_ID_HEADER_KEY` makes the session header configurable end-to-end.

## Changes

- `_private/constants.py`: `SERVE_SESSION_ID` resolves from `RAY_SERVE_SESSION_ID_HEADER_KEY` at import. Default flipped to the on-the-wire conventional form `x-session-id`; the matcher below keeps the underscored form working.
- `_private/http_util.py`: `_matches_session_id_header` helper, case-insensitive and `-` ↔ `_` tolerant so a rewriting proxy doesn't silently drop session affinity.
- `_private/proxy.py`: HTTP proxy uses the helper on the ingress hop.
- `_private/ingress_request_router.lua.tmpl` + `_private/haproxy.py`: HAProxy Lua reads the configured client header and forwards it to `/internal/route` on the same name — without this, direct-streaming has no path for `session_id` to reach `LLMRouter`.
- `llm/.../ingress/router.py`: `LLMRouter` reads the header and calls `handle.options(session_id=...).choose_replica(...)`.
- `llm/.../ingress/ingress.py`: `OpenAiIngress` propagates the header on the second handle hop (the Serve HTTP proxy attaches `session_id` to the ingress handle, but that does not carry over to a second `handle.options(...)` hop).
- `experimental/consistent_hash_router.py`: docstring + init-time `logger.info` so operators can verify wiring without scraping internals.

## Usage

```bash
# e.g. aiperf sends session id on x-correlation-id:
export RAY_SERVE_SESSION_ID_HEADER_KEY=x-correlation-id
```

Combined with the existing `RequestRouterConfig` API:

```python
LLMConfig(
    model_loading_config=ModelLoadingConfig(model_id="qwen3-4b"),
    deployment_config=dict(
        request_router_config=RequestRouterConfig(
            request_router_class=(
                "ray.serve.experimental.consistent_hash_router."
                "ConsistentHashRouter"
            ),
        ),
    ),
)
```

## Test plan

- [x] New `TestMatchesSessionIdHeader` (10 parametrized cases): `python/ray/serve/tests/test_http_headers.py`
- [x] Existing `TestSessionIdHeader::test_header_forms` continues to cover underscored / hyphenated / title-cased forms through the proxy.
- [x] pre-commit
- [ ] CI buildkite/premerge + release
