### PR TITLE
[Data] Add wide-schema variant to the worker_scaling release test series

### DIFF
--- a/release/nightly_tests/dataset/worker_scaling_benchmark.py
+++ b/release/nightly_tests/dataset/worker_scaling_benchmark.py
@@ -2,10 +2,26 @@
 
 Measures how long it takes to spin up actors, process data, and tear down
 across a range(N) -> map_batches(1000 actors) -> consume pipeline.
+
+Optionally produces a wide, mixed-type output schema modeled after
+production reference data. When ``--num-scalar-cols``,
+``--num-array64-cols``, and/or ``--num-array32-cols`` are non-zero, the
+default no-op UDF is replaced by a ``RealisticSchemaUDF`` that expands
+each input batch into the specified number of:
+
+  - scalar float32 columns
+  - float32[64] array columns (sequence / embedding-shaped)
+  - float32[32] array columns (target-level shape)
+
+This shape is useful for stress-testing the per-block schema
+propagation path (``ray.get(meta_ref)`` + schema deserialization in
+``on_data_ready``), which dominates large-schema production workloads.
 """
 
 import argparse
+from typing import Dict, List
 
+import numpy as np
 import ray
 from benchmark import (
     Benchmark,
@@ -18,6 +34,26 @@ BLOCKS_PER_WORKER: int = 10
 TARGET_BLOCK_SIZE_BYTES: int = 128 * 1024 * 1024  # 128 MiB
 BYTES_PER_ROW: int = 8  # ray.data.range produces one int64 per row
 ROWS_PER_BLOCK: int = TARGET_BLOCK_SIZE_BYTES // BYTES_PER_ROW
+
+# When the wide-schema path is active, cap the output block size at
+# ~16 MiB by adjusting rows-per-block proportionally to the per-row
+# byte budget. Without this, wide schemas at the original 128 MiB
+# sizing exceed worker memory.
+WIDE_SCHEMA_TARGET_BLOCK_SIZE_BYTES: int = 16 * 1024 * 1024  # 16 MiB
+ARRAY_64_LEN: int = 64
+ARRAY_32_LEN: int = 32
+
+
+def _bytes_per_row(num_scalar: int, num_array_64: int, num_array_32: int) -> int:
+    floats = num_scalar + num_array_64 * ARRAY_64_LEN + num_array_32 * ARRAY_32_LEN
+    return 4 * floats  # float32
+
+
+def _rows_per_block_for_wide_schema(
+    num_scalar: int, num_array_64: int, num_array_32: int
+) -> int:
+    bpr = _bytes_per_row(num_scalar, num_array_64, num_array_32)
+    return max(WIDE_SCHEMA_TARGET_BLOCK_SIZE_BYTES // bpr, 1) if bpr else ROWS_PER_BLOCK
 
 
 def parse_args() -> argparse.Namespace:
@@ -35,6 +71,37 @@ def parse_args() -> argparse.Namespace:
         default="actors",
         help="Whether to use actors or regular tasks for map_batches.",
     )
+    parser.add_argument(
+        "--num-scalar-cols",
+        type=int,
+        default=0,
+        help=(
+            "Number of scalar float32 columns to emit per row. "
+            "Default 0 (use the no-op UDF and preserve historical behavior)."
+        ),
+    )
+    parser.add_argument(
+        "--num-array64-cols",
+        type=int,
+        default=0,
+        help=(
+            f"Number of float32[{ARRAY_64_LEN}] array columns per row. " "Default 0."
+        ),
+    )
+    parser.add_argument(
+        "--num-array32-cols",
+        type=int,
+        default=0,
+        help=(
+            f"Number of float32[{ARRAY_32_LEN}] array columns per row. " "Default 0."
+        ),
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Seed used to pre-roll template values once per UDF instance.",
+    )
     return parser.parse_args()
 
 
@@ -47,31 +114,151 @@ def no_op_udf(batch):
     return batch
 
 
+class RealisticSchemaUDF:
+    """Expands each input batch into a mixed-type wide-schema table.
+
+    For producer-side efficiency, one example value per column is
+    pre-rolled in ``__init__`` and tiled across rows. The output schema
+    is genuinely mixed-type (scalar float32 + ``list<float32>`` of two
+    different lengths), so the per-block ``BlockMetadataWithSchema``
+    reflects realistic deserialization cost without paying the data
+    generation cost on every call.
+    """
+
+    def __init__(
+        self,
+        seed: int = 42,
+        num_scalar_cols: int = 0,
+        num_array_64_cols: int = 0,
+        num_array_32_cols: int = 0,
+    ):
+        self._scalar_cols: List[str] = [
+            f"scalar_col_{i}" for i in range(num_scalar_cols)
+        ]
+        self._array_64_cols: List[str] = [
+            f"seq64_col_{i}" for i in range(num_array_64_cols)
+        ]
+        self._array_32_cols: List[str] = [
+            f"target32_col_{i}" for i in range(num_array_32_cols)
+        ]
+
+        rng = np.random.default_rng(seed)
+        self._scalar_template: np.ndarray = rng.uniform(
+            0.0, 1.0, size=num_scalar_cols
+        ).astype(np.float32)
+        self._arr64_templates: np.ndarray = rng.uniform(
+            0.0, 1.0, size=(num_array_64_cols, ARRAY_64_LEN)
+        ).astype(np.float32)
+        self._arr32_templates: np.ndarray = rng.uniform(
+            0.0, 100.0, size=(num_array_32_cols, ARRAY_32_LEN)
+        ).astype(np.float32)
+
+    def __call__(self, batch) -> Dict[str, object]:
+        n_rows = len(batch["id"])
+        out: Dict[str, object] = {}
+
+        for i, col in enumerate(self._scalar_cols):
+            out[col] = np.full(n_rows, self._scalar_template[i], dtype=np.float32)
+
+        # Array columns: each row gets a reference to the same template
+        # array. The producer-side memory footprint is one buffer per
+        # column type, but PyArrow serializes each row's array
+        # independently so the per-block payload reflects realistic
+        # ``list<float32>`` storage.
+        for i, col in enumerate(self._array_64_cols):
+            out[col] = [self._arr64_templates[i]] * n_rows
+
+        for i, col in enumerate(self._array_32_cols):
+            out[col] = [self._arr32_templates[i]] * n_rows
+
+        return out
+
+
+def make_realistic_schema_udf(
+    seed: int = 42,
+    num_scalar_cols: int = 0,
+    num_array_64_cols: int = 0,
+    num_array_32_cols: int = 0,
+):
+    """Functional variant of ``RealisticSchemaUDF`` for the task-based path."""
+    udf = RealisticSchemaUDF(
+        seed=seed,
+        num_scalar_cols=num_scalar_cols,
+        num_array_64_cols=num_array_64_cols,
+        num_array_32_cols=num_array_32_cols,
+    )
+    return udf.__call__
+
+
+def _wide_schema_enabled(args: argparse.Namespace) -> bool:
+    return (args.num_scalar_cols + args.num_array64_cols + args.num_array32_cols) > 0
+
+
 def main(args: argparse.Namespace):
     benchmark = Benchmark()
+    wide = _wide_schema_enabled(args)
 
     def benchmark_fn():
         num_blocks = BLOCKS_PER_WORKER * args.num_workers
-        num_rows = num_blocks * ROWS_PER_BLOCK
+        if wide:
+            rows_per_block = _rows_per_block_for_wide_schema(
+                args.num_scalar_cols,
+                args.num_array64_cols,
+                args.num_array32_cols,
+            )
+        else:
+            rows_per_block = ROWS_PER_BLOCK
+        num_rows = num_blocks * rows_per_block
         ds = ray.data.range(num_rows, override_num_blocks=num_blocks)
 
         if args.worker_type == "actors":
-            ds = ds.map_batches(
-                NoOpUDF,
-                num_cpus=1,
-                compute=ray.data.ActorPoolStrategy(size=args.num_workers),
-            )
+            if wide:
+                ds = ds.map_batches(
+                    RealisticSchemaUDF,
+                    fn_constructor_kwargs={
+                        "seed": args.seed,
+                        "num_scalar_cols": args.num_scalar_cols,
+                        "num_array_64_cols": args.num_array64_cols,
+                        "num_array_32_cols": args.num_array32_cols,
+                    },
+                    num_cpus=1,
+                    compute=ray.data.ActorPoolStrategy(size=args.num_workers),
+                )
+            else:
+                ds = ds.map_batches(
+                    NoOpUDF,
+                    num_cpus=1,
+                    compute=ray.data.ActorPoolStrategy(size=args.num_workers),
+                )
         else:
-            ds = ds.map_batches(
-                no_op_udf,
-                num_cpus=1,
-            )
+            if wide:
+                ds = ds.map_batches(
+                    make_realistic_schema_udf(
+                        args.seed,
+                        args.num_scalar_cols,
+                        args.num_array64_cols,
+                        args.num_array32_cols,
+                    ),
+                    num_cpus=1,
+                )
+            else:
+                ds = ds.map_batches(no_op_udf, num_cpus=1)
 
         ds = ds.materialize()
         metrics = collect_dataset_stats(ds)
         metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
         metrics["num_blocks"] = num_blocks
         metrics["num_rows"] = num_rows
+        if wide:
+            metrics["num_scalar_cols"] = args.num_scalar_cols
+            metrics["num_array64_cols"] = args.num_array64_cols
+            metrics["num_array32_cols"] = args.num_array32_cols
+            metrics["rows_per_block"] = rows_per_block
+            metrics["bytes_per_row"] = _bytes_per_row(
+                args.num_scalar_cols,
+                args.num_array64_cols,
+                args.num_array32_cols,
+            )
         return metrics
 
     benchmark.run_fn("worker_scaling", benchmark_fn)

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -542,6 +542,34 @@
     timeout: 1200
     script: python worker_scaling_benchmark.py --num-workers {{num_workers}} --worker-type {{worker_type}}
 
+# Wide-schema variant of the worker_scaling test. Each map output block
+# carries a 276-column mixed-type schema modeled after production
+# reference data (20 scalar float32 + 27 float32[64] + 229 float32[32]).
+# Stresses the per-block ``BlockMetadataWithSchema`` propagation path on
+# the driver — ``ray.get(meta_ref)`` + schema deserialization in
+# ``on_data_ready`` — which dominates large-schema production workloads.
+- name: worker_scaling_wide_schema_{{num_workers}}_{{worker_type}}
+  python: "3.10"
+  frequency: weekly
+  cluster:
+    anyscale_sdk_2026: true
+    cluster_compute: fixed_size_1000_cpu_compute.yaml
+
+  matrix:
+    setup:
+      num_workers: [1000]
+      worker_type: [actors, tasks]
+
+  run:
+    timeout: 1800
+    script: >
+      python worker_scaling_benchmark.py
+      --num-workers {{num_workers}}
+      --worker-type {{worker_type}}
+      --num-scalar-cols 20
+      --num-array64-cols 27
+      --num-array32-cols 229
+
 
 ########################
 # Sort and shuffle tests


### PR DESCRIPTION
## Description

Adds an optional realistic wide-schema mode to `worker_scaling_benchmark.py` and a new release-test entry that exercises it. The existing `worker_scaling_*` tests are unchanged — defaults preserve their historical no-op behavior.

## What it does

### `worker_scaling_benchmark.py`

Three new CLI flags (all defaulting to `0`):

| Flag | Effect |
|---|---|
| `--num-scalar-cols N` | Emit N scalar `float32` columns per row |
| `--num-array64-cols N` | Emit N `float32[64]` array columns per row |
| `--num-array32-cols N` | Emit N `float32[32]` array columns per row |

When the sum of the three is non-zero, the no-op UDF is replaced by a `RealisticSchemaUDF` that expands each input batch into the specified count of each column type. Template values are pre-rolled once per UDF instance and tiled across rows so producer-side cost stays low — the test target is the per-block schema propagation path on the driver (`ray.get(meta_ref)` + schema deserialization in `on_data_ready`), not the producer.

Output block size is bounded to ~16 MiB via row-count adjustment so worker memory stays constant regardless of how wide the schema is.

### New release test

Adds `worker_scaling_wide_schema_{num_workers}_{worker_type}` to `release_data_tests.yaml` with the production-shape default — **20 scalar + 27 array64 + 229 array32 = 276 cols** — running over the same `[1000] × [actors, tasks]` matrix as the existing `worker_scaling_*` series. Timeout bumped to 1800s (from 1200s) to accommodate the larger per-block payload.

## Why

The original `worker_scaling` test measures actor-pool dispatch overhead with trivial schemas. Production workloads with wide, mixed-type schemas pay an additional per-block cost that this test didn't exercise:

- Each block's serialized `BlockMetadataWithSchema` goes through `ray.get(meta_ref)` on the driver.
- The PyArrow schema is deserialized via `pa.ipc.read_schema`, which scales with field count and per-field type complexity (extension types in particular).

In profiling against a production-shape schema, this path accounted for **~60% of executor-thread wall time** — exclusively `pa.ipc.read_schema` + `__arrow_ext_deserialize__` for the 256 `list<float32>` columns. The new release test guards against regressions in that path.

## Files

| File | Change |
|---|---|
| `release/nightly_tests/dataset/worker_scaling_benchmark.py` | Add 3 CLI flags + `RealisticSchemaUDF`; backward-compatible defaults |
| `release/release_data_tests.yaml` | Add `worker_scaling_wide_schema_*` test entry |

## Test plan

- [x] `--help` lists all three new flags.
- [x] Default invocation (no new flags) is byte-identical to today — still uses `NoOpUDF` / `no_op_udf`.
- [x] `python worker_scaling_benchmark.py --num-workers 1 --num-scalar-cols 20 --num-array64-cols 27 --num-array32-cols 229 --help` parses cleanly.
- [x] `release_data_tests.yaml` parses; both `worker_scaling_*` and `worker_scaling_wide_schema_*` entries exist with the expected matrix.
- [ ] Confirm the new wide-schema release test runs to completion within 1800s on the existing `fixed_size_1000_cpu_compute` config.

## Related

- Profile/analysis discussion: production-shape schemas exhibit a `pa.ipc.read_schema` bottleneck inside `BlockMetadataWithSchema.__setstate__` that isn't exercised by the trivial-schema worker_scaling test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)