### PR TITLE
[serve] Translate gRPC UNAVAILABLE into ActorUnavailableError in done-callback

### DIFF
--- a/python/ray/serve/_private/replica_result.py
+++ b/python/ray/serve/_private/replica_result.py
@@ -567,7 +567,43 @@ class gRPCReplicaResult(ReplicaResult):
             return await asyncio.wrap_future(fut)
 
     def add_done_callback(self, callback: Callable):
-        self._call.add_done_callback(callback)
+        """Register a done-callback that receives a translated result.
+
+        The actor-path ``add_done_callback`` (``ActorReplicaResult``) delivers
+        either the resolved value or a ``RayError`` subclass to its callback.
+        The raw gRPC done-callback instead delivers the ``grpc.aio.Call`` object
+        regardless of outcome, so routers consuming the callback can't tell a
+        transport failure apart from a successful response and skip cache
+        invalidation on replica unavailability. Translate transport-level
+        failures (currently ``UNAVAILABLE``) into the same Ray error type the
+        actor path raises so consumers see a uniform contract.
+        """
+
+        def _translating_callback(call: grpc.aio.Call) -> None:
+            translated: Any = call
+            try:
+                # ``exception()`` is only safe once the call is done and not
+                # cancelled (otherwise it raises ``InvalidStateError`` /
+                # ``CancelledError``). Cancellation is client-initiated and
+                # not a replica failure, so leave it alone.
+                if call.done() and not call.cancelled():
+                    exc = call.exception()
+                    if (
+                        isinstance(exc, grpc.aio.AioRpcError)
+                        and exc.code() == grpc.StatusCode.UNAVAILABLE
+                    ):
+                        translated = ActorUnavailableError(
+                            "Actor is unavailable.",
+                            self._actor_id.binary(),
+                        )
+            except Exception:
+                logger.exception(
+                    "Failed to translate gRPC done-callback result; "
+                    "passing the call object through."
+                )
+            callback(translated)
+
+        self._call.add_done_callback(_translating_callback)
 
     def cancel(self):
         self._call.cancel()

--- a/python/ray/serve/tests/unit/test_grpc_replica_result.py
+++ b/python/ray/serve/tests/unit/test_grpc_replica_result.py
@@ -1,11 +1,14 @@
 import asyncio
 import sys
 import threading
+from typing import Callable, List
 
+import grpc
 import pytest
 
 from ray import ActorID, cloudpickle
 from ray._common.test_utils import wait_for_condition
+from ray.exceptions import ActorUnavailableError
 from ray.serve._private.common import RequestMetadata
 from ray.serve._private.replica_result import gRPCReplicaResult
 from ray.serve.generated import serve_pb2
@@ -130,6 +133,124 @@ class TestSameLoop:
         )
         with pytest.raises(RuntimeError, match="oh no!"):
             await replica_result.__anext__()
+
+
+class _ControllableFakeCall:
+    """Fake grpc.aio.Call that lets the test trigger done-callback firing."""
+
+    def __init__(self, *, exception: BaseException = None):
+        self._loop = asyncio.get_running_loop()
+        self._done = False
+        self._exception = exception
+        self._callbacks: List[Callable] = []
+
+    # gRPCReplicaResult inspects __aiter__ to decide whether to consume as a
+    # stream; returning False here keeps the result on the unary code path.
+    def __getattr__(self, name):
+        if name == "__aiter__":
+            raise AttributeError(name)
+        raise AttributeError(name)
+
+    def add_done_callback(self, cb: Callable) -> None:
+        if self._done:
+            cb(self)
+        else:
+            self._callbacks.append(cb)
+
+    def done(self) -> bool:
+        return self._done
+
+    def exception(self):
+        if not self._done:
+            raise asyncio.InvalidStateError("Call is not done.")
+        return self._exception
+
+    def cancelled(self) -> bool:
+        return False
+
+    def fire_done(self) -> None:
+        self._done = True
+        for cb in list(self._callbacks):
+            cb(self)
+        self._callbacks.clear()
+
+
+def _make_aio_rpc_error(code: grpc.StatusCode) -> grpc.aio.AioRpcError:
+    return grpc.aio.AioRpcError(
+        code=code,
+        initial_metadata=grpc.aio.Metadata(),
+        trailing_metadata=grpc.aio.Metadata(),
+        details="fake",
+    )
+
+
+@pytest.mark.asyncio
+class TestDoneCallbackTranslation:
+    """gRPCReplicaResult.add_done_callback should translate transport-level
+    failures into the same Ray error type the actor path delivers, so router
+    cache-invalidation branches fire uniformly across transports."""
+
+    def _make_result(self, fake_call: _ControllableFakeCall) -> gRPCReplicaResult:
+        return gRPCReplicaResult(
+            fake_call,
+            metadata=RequestMetadata(
+                request_id="",
+                internal_request_id="",
+                is_streaming=False,
+                _on_separate_loop=False,
+            ),
+            actor_id=ActorID(b"2" * 16),
+            loop=asyncio.get_running_loop(),
+        )
+
+    async def test_unavailable_call_translated_to_actor_unavailable_error(self):
+        fake_call = _ControllableFakeCall(
+            exception=_make_aio_rpc_error(grpc.StatusCode.UNAVAILABLE)
+        )
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        # Filter out the in-flight-tracking callback's invocation (it was
+        # registered in gRPCReplicaResult.__init__ and also fires; its return
+        # value is unused). Our test callback is identified by the appended item.
+        assert len(received) == 1
+        assert isinstance(received[0], ActorUnavailableError)
+
+    async def test_successful_call_passes_through(self):
+        fake_call = _ControllableFakeCall(exception=None)
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        # A done-but-not-failed call should not be replaced with a Ray error;
+        # the call object itself is delivered (consumers that don't care can
+        # ignore it).
+        assert len(received) == 1
+        assert received[0] is fake_call
+
+    async def test_non_unavailable_failure_passes_through(self):
+        # CANCELLED is a client-initiated abort, not a replica problem. The
+        # translator should leave it alone and let upstream callers decide
+        # what to do.
+        fake_call = _ControllableFakeCall(
+            exception=_make_aio_rpc_error(grpc.StatusCode.CANCELLED)
+        )
+        result = self._make_result(fake_call)
+
+        received: List = []
+        result.add_done_callback(lambda r: received.append(r))
+
+        fake_call.fire_done()
+
+        assert len(received) == 1
+        assert received[0] is fake_call
 
 
 class TestSeparateLoop:


### PR DESCRIPTION
## Why are these changes needed?

Closes #63261.

When a `DeploymentHandle` uses `_by_reference=False` (gRPC transport), `gRPCReplicaResult.add_done_callback` previously registered the user's callback directly on the underlying `grpc.aio.Call`:

```python
def add_done_callback(self, callback: Callable):
    self._call.add_done_callback(callback)
```

`grpc.aio.Call` invokes its done-callbacks with the call object itself, not the deserialized result. The router's `AsyncioRouter._process_finished_request` dispatches on the Ray error type of its `result` argument:

```python
actor_died_error = self._get_actor_died_error(result)
if actor_died_error is not None: ...
elif isinstance(result, ActorUnavailableError):
    self.request_router.on_replica_actor_unavailable(replica_id)
```

So on the gRPC path neither error branch fired, the queue-length cache was never invalidated for a failed replica, and power-of-two-choices kept routing to that replica until either the next request's rejection path or a controller long-poll pushed a refresh.

### Fix

Wrap the user callback in a translating shim. When the underlying call is done and not cancelled, inspect `call.exception()`: an `AioRpcError` with `StatusCode.UNAVAILABLE` is translated into an `ActorUnavailableError` — matching what `ActorReplicaResult.add_done_callback` delivers for the actor transport, and matching the existing pattern already used elsewhere in `replica_result.py` (e.g. `replica_result.py:374-379`, `replica_result.py:506-510`).

```python
if call.done() and not call.cancelled():
    exc = call.exception()
    if isinstance(exc, grpc.aio.AioRpcError) and exc.code() == grpc.StatusCode.UNAVAILABLE:
        translated = ActorUnavailableError(
            "Actor is unavailable.",
            self._actor_id.binary(),
        )
```

Cancellations and other status codes pass the call through unchanged so existing callers are unaffected. Failures during translation are logged and the call is passed through (no callback chain breakage).

### Scope intentionally limited to UNAVAILABLE

Only `UNAVAILABLE` is translated, matching the existing precedent at lines 374-379 and 506-510. `INTERNAL` / `UNKNOWN` could in theory indicate replica issues too, but they can also reflect application-level errors that aren't the router's concern. Happy to widen the translation if maintainers prefer.

## Related issue number

Closes #63261

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR. _(verified manually; new code stays within the file's existing line-width budget)_
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/. _(no doc changes needed — bugfix in internal behavior)_
- [x] I've added any new APIs to the API Reference. _(N/A — no new public APIs)_
- [x] I've made sure the tests are passing. _(new unit tests added in `python/ray/serve/tests/unit/test_grpc_replica_result.py`; not run locally because the local environment has no Ray install. Verified `python -m py_compile` on the changed files; relies on CI to confirm the existing suite still passes.)_
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
