### PR TITLE
[serve][ci] Split flaky tests into CPU and GPU steps

### DIFF
--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -308,6 +308,7 @@ steps:
     key: serve_flaky_gpu_tests
     tags:
       - serve
+      - python
       - gpu
       - flaky
       - skip-on-premerge

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -301,5 +301,5 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... serve --run-flaky-tests --parallelism-per-worker 3
         --python-version 3.10 --build-name servebuild-py3.10
-        --except-tags post_wheel_build,gpu,ha_integration,serve_tracing,direct_ingress,haproxy
+        --except-tags gpu
     depends_on: servebuild-multipy(python=3.10)

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -301,4 +301,5 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... serve --run-flaky-tests --parallelism-per-worker 3
         --python-version 3.10 --build-name servebuild-py3.10
+        --except-tags gpu
     depends_on: servebuild-multipy(python=3.10)

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -301,5 +301,5 @@ steps:
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //... serve --run-flaky-tests --parallelism-per-worker 3
         --python-version 3.10 --build-name servebuild-py3.10
-        --except-tags gpu
+        --except-tags post_wheel_build,gpu,ha_integration,serve_tracing,direct_ingress,haproxy
     depends_on: servebuild-multipy(python=3.10)

--- a/.buildkite/serve.rayci.yml
+++ b/.buildkite/serve.rayci.yml
@@ -303,3 +303,18 @@ steps:
         --python-version 3.10 --build-name servebuild-py3.10
         --except-tags gpu
     depends_on: servebuild-multipy(python=3.10)
+
+  - label: ":ray-serve: serve: flaky gpu tests"
+    key: serve_flaky_gpu_tests
+    tags:
+      - serve
+      - gpu
+      - flaky
+      - skip-on-premerge
+    instance_type: gpu
+    soft_fail: true
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //... serve --run-flaky-tests
+        --python-version 3.10 --build-name docgpubuild-py3.10
+        --only-tags gpu
+    depends_on: docgpubuild


### PR DESCRIPTION
## Summary

The `serve: flaky tests` step ran on `instance_type: large` (CPU-only, `servebuild-py3.10` image) and didn't filter `gpu`-tagged tests. When a GPU-required doctest like `doc/source/serve/doc_code/stable_diffusion` got auto-flagged FLAKY in the test-state DB, this step picked it up, tried to schedule a `num_gpus: 1` replica on a CPU runner, hung for 5 minutes while the autoscaler retried, and TIMEOUT'd. Bazel then retried 3× (909s wall) — and the test stayed marked flaky, a self-reinforcing loop with ~64% failure rate for `stable_diffusion` over the past 2 weeks.

This PR matches the pattern already used by the **data** team (`.buildkite/data.rayci.yml:348-378`) and the **core** team (`.buildkite/core.rayci.yml:405-438`) — split the flaky-tests step into a CPU and a GPU variant:

1. Add `--except-tags gpu` to the existing CPU `serve: flaky tests` step so it stops pulling GPU-tagged tests onto a CPU runner.
2. Add a new `serve: flaky gpu tests` step that reuses the existing `docgpubuild-py3.10` image on `instance_type: gpu` with `--only-tags gpu`. This is the only mechanism in the serve pipeline that lets a flaky GPU test re-run on real hardware and accumulate the 10 consecutive passes needed for the state machine's `FLAKY → PASSING` transition (`release/ray_release/test_automation/ci_state_machine.py:136-139`).

Without (2), any `gpu`-tagged serve test that ever gets flagged FLAKY stays stuck forever — the regular `serve: doc gpu tests` step subtracts flaky-flagged tests (`ci/ray_ci/tester.py:438`), and after change (1) the CPU flaky step also skips them.

## Evidence

Buildkite job log excerpt from build [#17411](https://buildkite.com/ray-project/postmerge/builds/17411) showing the cascade:
```
Resources required for each replica: {""CPU"": 1, ""GPU"": 1}, total resources available: {""CPU"": 7.0}
(autoscaler +21s) Error: No available node types can fulfill resource request {'CPU': 1.0, 'GPU': 1.0}.
TIMEOUT: //doc:source/serve/doc_code/stable_diffusion in 3 out of 3 in 303.9s
```

On real GPU hardware (verified in an Anyscale workspace), the same test passes end-to-end in 147s (HF download 43s, total well under the 300s `medium` Bazel budget) — so the test itself is healthy; only the CI routing was broken.

## Behavior after this PR

| Step | Hardware | Image | Picks up |
|---|---|---|---|
| `serve: flaky tests` (modified) | `large` CPU | `servebuild-py3.10` | FLAKY-state `team:serve` tests **except** `gpu`-tagged |
| `serve: flaky gpu tests` (new) | `gpu` | `docgpubuild-py3.10` | FLAKY-state `team:serve` tests **only** `gpu`-tagged |

When no GPU tests are flagged, the new step's bazel query returns empty and it's a near-zero-cost no-op. Both steps remain `soft_fail: true` + `skip-on-premerge`, so flaky reruns never gate merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)