### PR TITLE
[Data] Display logical memory in progress bar

### DIFF
--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -370,10 +370,9 @@ class ResourceManager:
         if op not in self._op_running_usages:
             usage_str = "n/a"
         else:
-            usage_str = ""
+            usage_str = f"{self._op_running_usages[op].cpu:.1f} CPU"
             if self._op_running_usages[op].memory:
-                usage_str += f"{self._op_running_usages[op].memory_str()} memory, "
-            usage_str += f"{self._op_running_usages[op].cpu:.1f} CPU"
+                usage_str += f", {self._op_running_usages[op].memory_str()} memory"
             if self._op_running_usages[op].gpu:
                 usage_str += f", {self._op_running_usages[op].gpu:.1f} GPU"
             usage_str += f", {self._op_running_usages[op].object_store_memory_str()} object store"

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -374,6 +374,8 @@ class ResourceManager:
             if self._op_running_usages[op].gpu:
                 usage_str += f", {self._op_running_usages[op].gpu:.1f} GPU"
             usage_str += f", {self._op_running_usages[op].object_store_memory_str()} object store"
+            if self._op_running_usages[op].memory:
+                usage_str += f", {self._op_running_usages[op].memory_str()} memory"
 
         # NOTE: Config can override requested verbosity level
         if LOG_DEBUG_TELEMETRY_FOR_RESOURCE_MANAGER_OVERRIDE is not None:
@@ -389,13 +391,15 @@ class ResourceManager:
                 if allocation:
                     usage_str += f", alloc=(cpu={allocation.cpu:.1f}"
                     usage_str += f",gpu={allocation.gpu:.1f}"
-                    usage_str += f",obj_store={allocation.object_store_memory_str()})"
+                    usage_str += f",obj_store={allocation.object_store_memory_str()}"
+                    usage_str += f",mem={allocation.memory_str()})"
 
                 budget = self._op_resource_allocator.get_budget(op)
                 if budget:
                     usage_str += f", budget=(cpu={budget.cpu:.1f}"
                     usage_str += f",gpu={budget.gpu:.1f}"
                     usage_str += f",obj_store={budget.object_store_memory_str()}"
+                    usage_str += f",mem={budget.memory_str()}"
 
                     # Remaining memory budget for producing new task outputs.
                     if isinstance(

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -370,12 +370,13 @@ class ResourceManager:
         if op not in self._op_running_usages:
             usage_str = "n/a"
         else:
-            usage_str = f"{self._op_running_usages[op].cpu:.1f} CPU"
+            usage_str = ""
+            if self._op_running_usages[op].memory:
+                usage_str += f"{self._op_running_usages[op].memory_str()} memory, "
+            usage_str += f"{self._op_running_usages[op].cpu:.1f} CPU"
             if self._op_running_usages[op].gpu:
                 usage_str += f", {self._op_running_usages[op].gpu:.1f} GPU"
             usage_str += f", {self._op_running_usages[op].object_store_memory_str()} object store"
-            if self._op_running_usages[op].memory:
-                usage_str += f", {self._op_running_usages[op].memory_str()} memory"
 
         # NOTE: Config can override requested verbosity level
         if LOG_DEBUG_TELEMETRY_FOR_RESOURCE_MANAGER_OVERRIDE is not None:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -390,16 +390,16 @@ class ResourceManager:
                 allocation = self._op_resource_allocator.get_allocation(op)
                 if allocation:
                     usage_str += f", alloc=(cpu={allocation.cpu:.1f}"
+                    usage_str += f",mem={allocation.memory_str()}"
                     usage_str += f",gpu={allocation.gpu:.1f}"
-                    usage_str += f",obj_store={allocation.object_store_memory_str()}"
-                    usage_str += f",mem={allocation.memory_str()})"
+                    usage_str += f",obj_store={allocation.object_store_memory_str()})"
 
                 budget = self._op_resource_allocator.get_budget(op)
                 if budget:
                     usage_str += f", budget=(cpu={budget.cpu:.1f}"
+                    usage_str += f",mem={budget.memory_str()}"
                     usage_str += f",gpu={budget.gpu:.1f}"
                     usage_str += f",obj_store={budget.object_store_memory_str()}"
-                    usage_str += f",mem={budget.memory_str()}"
 
                     # Remaining memory budget for producing new task outputs.
                     if isinstance(

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -575,12 +575,14 @@ class StreamingExecutor(Executor, threading.Thread):
         running_usage = self._resource_manager.get_global_running_usage()
         pending_usage = self._resource_manager.get_global_pending_usage()
         limits = self._resource_manager.get_global_limits()
-        resources_status = "Active & requested resources: "
+        resources_status = (
+            f"Active & requested resources: "
+            f"{running_usage.cpu:.4g}/{limits.cpu:.4g} CPU, "
+        )
         if running_usage.memory > 0:
             resources_status += (
                 f"{running_usage.memory_str()}/{limits.memory_str()} memory, "
             )
-        resources_status += f"{running_usage.cpu:.4g}/{limits.cpu:.4g} CPU, "
         if running_usage.gpu > 0:
             resources_status += f"{running_usage.gpu:.4g}/{limits.gpu:.4g} GPU, "
         resources_status += (
@@ -590,10 +592,10 @@ class StreamingExecutor(Executor, threading.Thread):
 
         # Only include pending section when there are pending resources.
         pending_parts = []
-        if pending_usage.memory:
-            pending_parts.append(f"{pending_usage.memory_str()} memory")
         if pending_usage.cpu:
             pending_parts.append(f"{pending_usage.cpu:.4g} CPU")
+        if pending_usage.memory:
+            pending_parts.append(f"{pending_usage.memory_str()} memory")
         if pending_usage.gpu:
             pending_parts.append(f"{pending_usage.gpu:.4g} GPU")
         if pending_parts:

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -575,29 +575,27 @@ class StreamingExecutor(Executor, threading.Thread):
         running_usage = self._resource_manager.get_global_running_usage()
         pending_usage = self._resource_manager.get_global_pending_usage()
         limits = self._resource_manager.get_global_limits()
-        resources_status = (
-            f"Active & requested resources: "
-            f"{running_usage.cpu:.4g}/{limits.cpu:.4g} CPU, "
-        )
+        resources_status = "Active & requested resources: "
+        if running_usage.memory > 0:
+            resources_status += (
+                f"{running_usage.memory_str()}/{limits.memory_str()} memory, "
+            )
+        resources_status += f"{running_usage.cpu:.4g}/{limits.cpu:.4g} CPU, "
         if running_usage.gpu > 0:
             resources_status += f"{running_usage.gpu:.4g}/{limits.gpu:.4g} GPU, "
         resources_status += (
             f"{running_usage.object_store_memory_str()}/"
             f"{limits.object_store_memory_str()} object store"
         )
-        if running_usage.memory > 0:
-            resources_status += (
-                f", {running_usage.memory_str()}/{limits.memory_str()} memory"
-            )
 
         # Only include pending section when there are pending resources.
         pending_parts = []
+        if pending_usage.memory:
+            pending_parts.append(f"{pending_usage.memory_str()} memory")
         if pending_usage.cpu:
             pending_parts.append(f"{pending_usage.cpu:.4g} CPU")
         if pending_usage.gpu:
             pending_parts.append(f"{pending_usage.gpu:.4g} GPU")
-        if pending_usage.memory:
-            pending_parts.append(f"{pending_usage.memory_str()} memory")
         if pending_parts:
             resources_status += f" (pending: {', '.join(pending_parts)})"
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -585,18 +585,21 @@ class StreamingExecutor(Executor, threading.Thread):
             f"{running_usage.object_store_memory_str()}/"
             f"{limits.object_store_memory_str()} object store"
         )
+        if running_usage.memory > 0:
+            resources_status += (
+                f", {running_usage.memory_str()}/{limits.memory_str()} memory"
+            )
 
         # Only include pending section when there are pending resources.
-        if pending_usage.cpu or pending_usage.gpu:
-            if pending_usage.cpu and pending_usage.gpu:
-                pending_str = (
-                    f"{pending_usage.cpu:.4g} CPU, {pending_usage.gpu:.4g} GPU"
-                )
-            elif pending_usage.cpu:
-                pending_str = f"{pending_usage.cpu:.4g} CPU"
-            else:
-                pending_str = f"{pending_usage.gpu:.4g} GPU"
-            resources_status += f" (pending: {pending_str})"
+        pending_parts = []
+        if pending_usage.cpu:
+            pending_parts.append(f"{pending_usage.cpu:.4g} CPU")
+        if pending_usage.gpu:
+            pending_parts.append(f"{pending_usage.gpu:.4g} GPU")
+        if pending_usage.memory:
+            pending_parts.append(f"{pending_usage.memory_str()} memory")
+        if pending_parts:
+            resources_status += f" (pending: {', '.join(pending_parts)})"
 
         self._progress_manager.update_total_resource_status(resources_status)
 


### PR DESCRIPTION
## Description

The Ray Data progress bar shows CPU, GPU, and object store memory usage, but not logical memory — even though `ExecutionResources` already tracks it and operators already report it via `current_logical_usage()`. This makes it hard to monitor memory-constrained workloads. This PR adds logical memory to both the global resource status line and per-operator usage strings, displayed conditionally when usage is non-zero (matching the existing GPU pattern).

## Related issues

None.

## Additional information

The display order is: CPU, memory, GPU, object store. Memory is only shown when usage > 0, consistent with how GPU is handled.

Example global status line:
```
Active & requested resources: 4/8 CPU, 2.0GiB/8.0GiB memory, 1/2 GPU, 1.0GiB/2.0GiB object store
```