### PR TITLE
[Data] Log RAY_DATA environment variables at execution start

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -74,15 +74,20 @@ DATA_CONTEXT_LOG_TRUNCATE_LENGTH = 10000
 _num_shutdown = 0
 
 
-# Ray Core env vars that affect Ray Data behavior.
-_RAY_CORE_DATA_ENV_VARS = ("RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION",)
+# Extra environment variables to log that don't start with RAY_DATA.
+_EXTRA_ENV_VARS_TO_LOG = (
+    # We historically recommended users configure this value. If a Ray Data job uses
+    # more object store memory than expected, it's worth checking how this environment
+    # variable has been configured.
+    "RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION",
+)
 
 
 def _log_ray_data_env_vars() -> None:
     env_vars = {
         k: v
         for k, v in os.environ.items()
-        if k.startswith("RAY_DATA") or k in _RAY_CORE_DATA_ENV_VARS
+        if k.startswith("RAY_DATA") or k in _EXTRA_ENV_VARS_TO_LOG
     }
     if env_vars:
         formatted = ", ".join(f"{k}={v}" for k, v in sorted(env_vars.items()))

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -74,18 +74,19 @@ DATA_CONTEXT_LOG_TRUNCATE_LENGTH = 10000
 _num_shutdown = 0
 
 
-_EXTRA_ENV_VARS = ("RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION",)
+# Ray Core env vars that affect Ray Data behavior.
+_RAY_CORE_DATA_ENV_VARS = ("RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION",)
 
 
 def _log_ray_data_env_vars() -> None:
     env_vars = {
         k: v
         for k, v in os.environ.items()
-        if k.startswith("RAY_DATA") or k in _EXTRA_ENV_VARS
+        if k.startswith("RAY_DATA") or k in _RAY_CORE_DATA_ENV_VARS
     }
     if env_vars:
         formatted = ", ".join(f"{k}={v}" for k, v in sorted(env_vars.items()))
-        logger.debug("RAY_DATA environment variables: %s", formatted)
+        logger.debug(f"RAY_DATA environment variables: {formatted}")
     else:
         logger.debug("No RAY_DATA environment variables set.")
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import threading
 import time
 import typing
@@ -71,6 +72,22 @@ DATA_CONTEXT_LOG_TRUNCATE_LENGTH = 10000
 
 # Visible for testing.
 _num_shutdown = 0
+
+
+_EXTRA_ENV_VARS = ("RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION",)
+
+
+def _log_ray_data_env_vars() -> None:
+    env_vars = {
+        k: v
+        for k, v in os.environ.items()
+        if k.startswith("RAY_DATA") or k in _EXTRA_ENV_VARS
+    }
+    if env_vars:
+        formatted = ", ".join(f"{k}={v}" for k, v in sorted(env_vars.items()))
+        logger.debug("RAY_DATA environment variables: %s", formatted)
+    else:
+        logger.debug("No RAY_DATA environment variables set.")
 
 
 class StreamingExecutor(Executor, threading.Thread):
@@ -156,6 +173,9 @@ class StreamingExecutor(Executor, threading.Thread):
 
         self._initial_stats = initial_stats
         self._start_time = time.perf_counter()
+
+        if logger.isEnabledFor(logging.DEBUG):
+            _log_ray_data_env_vars()
 
         if not isinstance(dag, InputDataBuffer):
             if self._data_context.print_on_execution_start:

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -43,7 +43,6 @@ from ray.data._internal.execution.resource_manager import ResourceManager
 from ray.data._internal.execution.streaming_executor import (
     StreamingExecutor,
     _debug_dump_topology,
-    _log_ray_data_env_vars,
 )
 from ray.data._internal.execution.streaming_executor_state import (
     OpBufferQueue,
@@ -1533,15 +1532,28 @@ class TestDataOpTask:
         assert bp_time == pytest.approx(4.0)
 
 
-def test_log_ray_data_env_vars(monkeypatch, caplog, propagate_logs):
+def test_streaming_executor_logs_relevant_env_vars(
+    monkeypatch, caplog, propagate_logs, ray_start_regular_shared
+):
     monkeypatch.setenv("RAY_DATA_TEST_FOO", "bar")
     monkeypatch.setenv("RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION", "0.3")
 
+    ctx = DataContext.get_current()
+    inputs = make_ref_bundles([[x] for x in range(1)])
+    dag = InputDataBuffer(ctx, inputs)
+
+    executor = StreamingExecutor(ctx)
     with caplog.at_level(
         logging.DEBUG,
         logger="ray.data._internal.execution.streaming_executor",
     ):
-        _log_ray_data_env_vars()
+        output = executor.execute(dag)
+        # Drain the iterator to let execution complete.
+        try:
+            while True:
+                output.get_next()
+        except StopIteration:
+            pass
 
     assert "RAY_DATA_TEST_FOO=bar" in caplog.text
     assert "RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION=0.3" in caplog.text

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1547,13 +1547,7 @@ def test_streaming_executor_logs_relevant_env_vars(
         logging.DEBUG,
         logger="ray.data._internal.execution.streaming_executor",
     ):
-        output = executor.execute(dag)
-        # Drain the iterator to let execution complete.
-        try:
-            while True:
-                output.get_next()
-        except StopIteration:
-            pass
+        executor.execute(dag)
 
     assert "RAY_DATA_TEST_FOO=bar" in caplog.text
     assert "RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION=0.3" in caplog.text

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import pickle
 import random
@@ -42,6 +43,7 @@ from ray.data._internal.execution.resource_manager import ResourceManager
 from ray.data._internal.execution.streaming_executor import (
     StreamingExecutor,
     _debug_dump_topology,
+    _log_ray_data_env_vars,
 )
 from ray.data._internal.execution.streaming_executor_state import (
     OpBufferQueue,
@@ -1529,6 +1531,20 @@ class TestDataOpTask:
         # Total backpressure = 2.5s + 1.5s = 4.0s
         bp_time = captured_stats["task_exec_driver_stats"].task_output_backpressure_s
         assert bp_time == pytest.approx(4.0)
+
+
+def test_log_ray_data_env_vars(monkeypatch, caplog, propagate_logs):
+    monkeypatch.setenv("RAY_DATA_TEST_FOO", "bar")
+    monkeypatch.setenv("RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION", "0.3")
+
+    with caplog.at_level(
+        logging.DEBUG,
+        logger="ray.data._internal.execution.streaming_executor",
+    ):
+        _log_ray_data_env_vars()
+
+    assert "RAY_DATA_TEST_FOO=bar" in caplog.text
+    assert "RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION=0.3" in caplog.text
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
When debugging Ray Data issues, knowing which `RAY_DATA_*` environment variables are set is essential since they override default behavior. This adds a debug log of all `RAY_DATA_*` env vars (plus `RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION`) at the start of every `StreamingExecutor.execute()` call.

## Related issues
None.

## Additional information
The utility function `_log_ray_data_env_vars()` is guarded by `logger.isEnabledFor(logging.DEBUG)` so there is zero overhead when debug logging is disabled.