### PR TITLE
[release] Add release-test-image-uris and release-test-image-override meta-data for pinned-image runs

### DIFF
--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -816,6 +816,21 @@ py_test(
 )
 
 py_test(
+    name = "test_image_pinning",
+    size = "small",
+    srcs = ["ray_release/tests/test_image_pinning.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "release_unit",
+        "team:ci",
+    ],
+    deps = [
+        ":ray_release",
+        bk_require("pytest"),
+    ],
+)
+
+py_test(
     name = "test_log_aggregator",
     size = "small",
     srcs = ["ray_release/tests/test_log_aggregator.py"],

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -35,7 +35,13 @@ def shape_of(uri: str) -> str:
 
 
 def _uses_released_image(test: Test) -> bool:
-    return test.get_anyscale_byod_image().startswith(_RELEASED_PREFIX)
+    # Pass BUILD_ID_PLACEHOLDER so this works even when RAYCI_BUILD_ID is
+    # unset; the released-vs-custom branch in get_anyscale_byod_image only
+    # depends on ray_version + require_custom_byod_image(), not on the
+    # build_id value, so the placeholder is safe.
+    return test.get_anyscale_byod_image(build_id=BUILD_ID_PLACEHOLDER).startswith(
+        _RELEASED_PREFIX
+    )
 
 
 def match_uris_to_tests(

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -99,7 +99,7 @@ def parse_override(raw_json: str) -> Dict[str, str]:
     except json.JSONDecodeError as e:
         raise ReleaseTestConfigError(
             f"Invalid JSON in release-test-image-override: {e}"
-        )
+        ) from e
     if not isinstance(parsed, dict):
         raise ReleaseTestConfigError(
             f"release-test-image-override must be a JSON object; got "

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -1,11 +1,15 @@
-"""Helpers for pinning release-test images via Buildkite meta-data."""
+"""Helpers for pinning release-test images via Buildkite meta-data.
+
+Shape comparison (see `shape_of`) is how user-supplied override URIs are
+matched against the set of tests scheduled in a release-test build.
+"""
 
 import re
 
 from ray_release.test import BUILD_ID_PLACEHOLDER
 
 
-def _shape_of(uri: str) -> str:
+def shape_of(uri: str) -> str:
     """Return `uri` with the `build_id` portion of its tag replaced by `BUILD_ID_PLACEHOLDER`.
 
     The `build_id` is everything before the first `py<digits>` segment in the tag.
@@ -13,7 +17,11 @@ def _shape_of(uri: str) -> str:
     if ":" not in uri:
         raise ValueError(f"image URI missing ':<tag>' suffix: {uri!r}")
     repo, tag = uri.rsplit(":", 1)
+    if not tag:
+        raise ValueError(f"image URI has empty tag: {uri!r}")
     parts = tag.split("-")
+    # Python-version segment is always the first `py<N>` in the tag (build_id
+    # may contain `-` but never a `py<digit>` segment), so first-match wins.
     for i, part in enumerate(parts):
         if re.fullmatch(r"py\d+", part):
             return f"{repo}:{'-'.join([BUILD_ID_PLACEHOLDER] + parts[i:])}"

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -4,6 +4,7 @@ Shape comparison (see `shape_of`) is how user-supplied override URIs are
 matched against the set of tests scheduled in a release-test build.
 """
 
+import json
 import re
 from typing import Dict, List
 
@@ -81,5 +82,53 @@ def match_uris_to_tests(
             f"Cannot resolve image URIs for {len(failures)} test(s):\n"
             + "\n".join(failures)
             + f"\n(provided URIs: {provided})"
+        )
+    return result
+
+
+def parse_override(raw_json: str) -> Dict[str, str]:
+    """Parse the `release-test-image-override` JSON meta-data into `{test_name: image_uri}`.
+
+    Input is `{image_uri: [test_name, ...]}`. Each test name must appear
+    exactly once across all values. Raises `ReleaseTestConfigError` for
+    JSON parse failures, type errors, duplicate test names, or empty
+    payloads.
+    """
+    try:
+        parsed = json.loads(raw_json)
+    except json.JSONDecodeError as e:
+        raise ReleaseTestConfigError(
+            f"Invalid JSON in release-test-image-override: {e}"
+        )
+    if not isinstance(parsed, dict):
+        raise ReleaseTestConfigError(
+            f"release-test-image-override must be a JSON object; got "
+            f"{type(parsed).__name__}"
+        )
+    result: Dict[str, str] = {}
+    duplicates: Dict[str, List[str]] = {}
+    for uri, names in parsed.items():
+        if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+            raise ReleaseTestConfigError(
+                f"release-test-image-override value for URI {uri!r} must be a "
+                f"list of test names; got {names!r}"
+            )
+        for name in names:
+            if name in result:
+                # First duplicate captures original; later ones append.
+                duplicates.setdefault(name, [result[name]]).append(uri)
+            else:
+                result[name] = uri
+    if duplicates:
+        lines = [
+            f"  - Test {name!r} is mapped to multiple URIs: {', '.join(uris)}"
+            for name, uris in duplicates.items()
+        ]
+        raise ReleaseTestConfigError(
+            "release-test-image-override has duplicate test names:\n" + "\n".join(lines)
+        )
+    if not result:
+        raise ReleaseTestConfigError(
+            "release-test-image-override contains no tests to run."
         )
     return result

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -5,8 +5,13 @@ matched against the set of tests scheduled in a release-test build.
 """
 
 import re
+from typing import Dict, List
 
-from ray_release.test import BUILD_ID_PLACEHOLDER
+from ray_release.exception import ReleaseTestConfigError
+from ray_release.test import BUILD_ID_PLACEHOLDER, Test
+from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX
+
+_RELEASED_PREFIX = f"{ANYSCALE_RAY_IMAGE_PREFIX}:"
 
 
 def shape_of(uri: str) -> str:
@@ -26,3 +31,45 @@ def shape_of(uri: str) -> str:
         if re.fullmatch(r"py\d+", part):
             return f"{repo}:{'-'.join([BUILD_ID_PLACEHOLDER] + parts[i:])}"
     return f"{repo}:{BUILD_ID_PLACEHOLDER}"
+
+
+def _uses_released_image(test: Test) -> bool:
+    return test.get_anyscale_byod_image().startswith(_RELEASED_PREFIX)
+
+
+def match_uris_to_tests(
+    tests: List[Test],
+    uri_list: List[str],
+) -> Dict[str, str]:
+    """Match each non-released test to exactly one URI in `uri_list` by shape.
+
+    Released-image tests are excluded from the returned map; they fall back
+    to `get_anyscale_byod_image()` at test-run time.
+    """
+    failures: List[str] = []
+    result: Dict[str, str] = {}
+    for test in tests:
+        if _uses_released_image(test):
+            continue
+        target_shape = test.get_anyscale_byod_image_shape()
+        matches = [uri for uri in uri_list if shape_of(uri) == target_shape]
+        if len(matches) == 1:
+            result[test["name"]] = matches[0]
+        elif len(matches) == 0:
+            failures.append(
+                f"  - {test['name']}: no URI matched expected shape "
+                f"{target_shape!r}"
+            )
+        else:
+            failures.append(
+                f"  - {test['name']}: {len(matches)} URIs matched shape "
+                f"{target_shape!r} (matching: {', '.join(matches)})"
+            )
+    if failures:
+        provided = ", ".join(uri_list) if uri_list else "(none)"
+        raise ReleaseTestConfigError(
+            f"Cannot resolve image URIs for {len(failures)} test(s):\n"
+            + "\n".join(failures)
+            + f"\n(provided URIs: {provided})"
+        )
+    return result

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -95,9 +95,11 @@ def match_uris_to_tests(
 def parse_override(raw_json: str) -> Dict[str, str]:
     """Parse the `release-test-image-override` JSON meta-data into `{test_name: image_uri}`.
 
-    Input is `{image_uri: [test_name, ...]}`. Each test name must appear
-    exactly once across all values. Raises `ReleaseTestConfigError` for
-    JSON parse failures, type errors, duplicate test names, or empty
+    Input is `{image_uri: [test_name, ...]}`. A name repeated within the
+    same URI's list is silently deduped (the user clearly meant one pin).
+    A name appearing under multiple URIs is an error because the intended
+    mapping is ambiguous. Raises `ReleaseTestConfigError` for JSON parse
+    failures, type errors, cross-URI duplicate test names, or empty
     payloads.
     """
     try:
@@ -119,9 +121,11 @@ def parse_override(raw_json: str) -> Dict[str, str]:
                 f"release-test-image-override value for URI {uri!r} must be a "
                 f"list of test names; got {names!r}"
             )
-        for name in names:
+        # Dedupe within this URI's list before recording so a repeat name
+        # under the same URI is treated as a single pin, not a duplicate.
+        for name in dict.fromkeys(names):
             if name in result:
-                # First duplicate captures original; later ones append.
+                # First cross-URI duplicate captures original; later ones append.
                 duplicates.setdefault(name, [result[name]]).append(uri)
             else:
                 result[name] = uri

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -46,14 +46,24 @@ def match_uris_to_tests(
     Released-image tests are excluded from the returned map; they fall back
     to `get_anyscale_byod_image()` at test-run time.
     """
+    uris_by_shape: Dict[str, List[str]] = {}
+    for uri in uri_list:
+        uris_by_shape.setdefault(shape_of(uri), []).append(uri)
+
     failures: List[str] = []
     result: Dict[str, str] = {}
     for test in tests:
         if _uses_released_image(test):
             continue
         target_shape = test.get_anyscale_byod_image_shape()
-        matches = [uri for uri in uri_list if shape_of(uri) == target_shape]
+        matches = uris_by_shape.get(target_shape, [])
         if len(matches) == 1:
+            if test["name"] in result:
+                failures.append(
+                    f"  - {test['name']}: appears more than once in the test "
+                    f"list; image pinning requires unique test names"
+                )
+                continue
             result[test["name"]] = matches[0]
         elif len(matches) == 0:
             failures.append(

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -132,3 +132,28 @@ def parse_override(raw_json: str) -> Dict[str, str]:
             "release-test-image-override contains no tests to run."
         )
     return result
+
+
+def resolve_override_tests(
+    test_collection: List[Test],
+    override_map: Dict[str, str],
+) -> List[Test]:
+    """Look up each test name in `override_map` against `test_collection`.
+
+    Returns the resolved tests in `override_map` iteration order. Raises
+    `ReleaseTestConfigError` listing every unknown name.
+    """
+    by_name = {t.get_name(): t for t in test_collection}
+    found: List[Test] = []
+    missing: List[str] = []
+    for name in override_map:
+        if name in by_name:
+            found.append(by_name[name])
+        else:
+            missing.append(name)
+    if missing:
+        raise ReleaseTestConfigError(
+            "release-test-image-override names not found in test collection:\n"
+            + "\n".join(f"  - {name}" for name in missing)
+        )
+    return found

--- a/release/ray_release/buildkite/image_pinning.py
+++ b/release/ray_release/buildkite/image_pinning.py
@@ -1,0 +1,20 @@
+"""Helpers for pinning release-test images via Buildkite meta-data."""
+
+import re
+
+from ray_release.test import BUILD_ID_PLACEHOLDER
+
+
+def _shape_of(uri: str) -> str:
+    """Return `uri` with the `build_id` portion of its tag replaced by `BUILD_ID_PLACEHOLDER`.
+
+    The `build_id` is everything before the first `py<digits>` segment in the tag.
+    """
+    if ":" not in uri:
+        raise ValueError(f"image URI missing ':<tag>' suffix: {uri!r}")
+    repo, tag = uri.rsplit(":", 1)
+    parts = tag.split("-")
+    for i, part in enumerate(parts):
+        if re.fullmatch(r"py\d+", part):
+            return f"{repo}:{'-'.join([BUILD_ID_PLACEHOLDER] + parts[i:])}"
+    return f"{repo}:{BUILD_ID_PLACEHOLDER}"

--- a/release/ray_release/buildkite/settings.py
+++ b/release/ray_release/buildkite/settings.py
@@ -110,6 +110,9 @@ def get_buildkite_prompt_value(key: str) -> Optional[str]:
     except Exception as e:
         logger.warning(f"Could not fetch metadata for {key}: {e}")
         return None
+    value = value.strip()
+    if not value:
+        return None
     logger.debug(f"Got Buildkite prompt value for {key}: {value}")
     return value
 

--- a/release/ray_release/buildkite/settings.py
+++ b/release/ray_release/buildkite/settings.py
@@ -134,6 +134,8 @@ def get_default_settings() -> Dict:
         "ray_test_branch": None,
         "priority": Priority.DEFAULT,
         "no_concurrency_limit": False,
+        "image_uris": None,
+        "image_override_json": None,
     }
     return settings
 
@@ -176,6 +178,12 @@ def update_settings_from_environment(settings: Dict) -> Dict:
     if "NO_CONCURRENCY_LIMIT" in os.environ:
         settings["no_concurrency_limit"] = bool(int(os.environ["NO_CONCURRENCY_LIMIT"]))
 
+    if "RELEASE_TEST_IMAGE_URIS" in os.environ:
+        settings["image_uris"] = os.environ["RELEASE_TEST_IMAGE_URIS"]
+
+    if "RELEASE_TEST_IMAGE_OVERRIDE" in os.environ:
+        settings["image_override_json"] = os.environ["RELEASE_TEST_IMAGE_OVERRIDE"]
+
     return settings
 
 
@@ -209,5 +217,13 @@ def update_settings_from_buildkite(settings: Dict):
     no_concurrency_limit = get_buildkite_prompt_value("release-no-concurrency-limit")
     if no_concurrency_limit == "yes":
         settings["no_concurrency_limit"] = True
+
+    image_uris = get_buildkite_prompt_value("release-test-image-uris")
+    if image_uris:
+        settings["image_uris"] = image_uris
+
+    image_override_json = get_buildkite_prompt_value("release-test-image-override")
+    if image_override_json:
+        settings["image_override_json"] = image_override_json
 
     return settings

--- a/release/ray_release/buildkite/step.py
+++ b/release/ray_release/buildkite/step.py
@@ -80,6 +80,7 @@ def get_step_for_test_group(
     is_concurrency_limit: bool = True,
     block_step_key: Optional[str] = None,
     gpu_map: Optional[Dict[str, str]] = None,
+    image_overrides: Optional[Dict[str, str]] = None,
 ):
     steps = []
     for group in sorted(grouped_tests):
@@ -100,6 +101,7 @@ def get_step_for_test_group(
                     global_config=global_config,
                     block_step_key=block_step_key,
                     gpu_map=gpu_map,
+                    image_overrides=image_overrides,
                 )
 
                 if not is_concurrency_limit:
@@ -125,9 +127,15 @@ def get_step(
     global_config: Optional[str] = None,
     block_step_key: Optional[str] = None,
     gpu_map: Optional[Dict[str, str]] = None,
+    image_overrides: Optional[Dict[str, str]] = None,
 ):
     env = env or {}
     step = copy.deepcopy(_DEFAULT_STEP_TEMPLATE)
+
+    # Pinned mode is signaled by a dict (possibly empty); `None` means the
+    # caller did not opt into pinned mode and existing dependency logic applies.
+    pinned_mode = image_overrides is not None
+    image_override = image_overrides.get(test["name"]) if pinned_mode else None
 
     cmd = [
         "./release/run_release_test.sh",
@@ -145,6 +153,9 @@ def get_step(
 
     if smoke_test:
         cmd += ["--smoke-test"]
+
+    if image_override:
+        cmd += ["--image", shlex.quote(image_override)]
 
     num_retries = test.get("run", {}).get("num_retries")
     if num_retries:
@@ -199,18 +210,24 @@ def get_step(
 
     step["label"] = full_label
 
-    image = test.get_anyscale_byod_image()
-    base_image = test.get_anyscale_base_byod_image()
-    if test.require_custom_byod_image():
-        step["depends_on"] = generate_custom_build_step_key(image)
+    if pinned_mode:
+        # In pinned mode the block step is always suppressed (so block_step_key
+        # is None) and the pre-built image already exists in the registry, so
+        # the test step has no in-pipeline dependency.
+        step["depends_on"] = None
     else:
-        step["depends_on"] = get_prerequisite_step(image, base_image, gpu_map)
-
-    if block_step_key:
-        if not step["depends_on"]:
-            step["depends_on"] = block_step_key
+        image = test.get_anyscale_byod_image()
+        base_image = test.get_anyscale_base_byod_image()
+        if test.require_custom_byod_image():
+            step["depends_on"] = generate_custom_build_step_key(image)
         else:
-            step["depends_on"] = [step["depends_on"], block_step_key]
+            step["depends_on"] = get_prerequisite_step(image, base_image, gpu_map)
+
+        if block_step_key:
+            if not step["depends_on"]:
+                step["depends_on"] = block_step_key
+            else:
+                step["depends_on"] = [step["depends_on"], block_step_key]
     return step
 
 

--- a/release/ray_release/scripts/custom_image_build_and_test_init.py
+++ b/release/ray_release/scripts/custom_image_build_and_test_init.py
@@ -5,11 +5,17 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import click
+import yaml
 
 from ray_release.buildkite.filter import filter_tests, group_tests
+from ray_release.buildkite.image_pinning import (
+    match_uris_to_tests,
+    parse_override,
+    resolve_override_tests,
+)
 from ray_release.buildkite.settings import (
     get_frequency,
     get_pipeline_settings,
@@ -36,6 +42,10 @@ PIPELINE_ARTIFACT_PATH = "/tmp/pipeline_artifacts"
 # at time of writing). We split below that with headroom so future growth
 # or step multipliers we don't account for don't trip the limit again.
 DEFAULT_MAX_JOBS_PER_UPLOAD = 450
+
+# Rayci-select sentinel emitted in pinned-image modes; intentionally matches
+# no real build step so rayci launches zero custom-BYOD builds.
+PINNED_RAYCI_SELECT_SENTINEL = "release_test_image_pinned"
 
 
 def _group_job_count(group: Dict[str, Any]) -> int:
@@ -197,6 +207,14 @@ def main(
     test_filters = get_test_filters(test_filters) or settings["test_filters"]
     priority = settings["priority"]
 
+    image_uris_raw = settings["image_uris"]
+    image_override_json = settings["image_override_json"]
+    if image_uris_raw and image_override_json:
+        raise ReleaseTestCLIError(
+            "release-test-image-uris and release-test-image-override are "
+            "mutually exclusive; set only one."
+        )
+
     try:
         test_collection = read_and_validate_release_test_collection(
             test_collection_file or RELEASE_TEST_CONFIG_FILES
@@ -210,32 +228,82 @@ def main(
             "in the dialog that asks for the Ray wheels."
         ) from e
 
-    filtered_tests = filter_tests(
-        test_collection,
-        frequency=frequency,
-        test_filters=test_filters,
-        prefer_smoke_tests=prefer_smoke_tests,
-        run_jailed_tests=run_jailed_tests,
-        run_unstable_tests=run_unstable_tests,
-    )
-    logger.info(f"Found {len(filtered_tests)} tests to run.")
-    if len(filtered_tests) == 0:
-        raise ReleaseTestCLIError(
-            "Empty test collection. The selected frequency or filter did "
-            "not return any tests to run. Adjust your filters."
+    image_overrides: Optional[Dict[str, str]] = None
+    if image_override_json:
+        # Override mode: parse JSON, resolve names, bypass filter_tests.
+        image_overrides = parse_override(image_override_json)
+        tests = resolve_override_tests(test_collection, image_overrides)
+        filtered_tests = [(t, False) for t in tests]
+        logger.info(
+            f"[release-test-image-override] running {len(tests)} test(s) with pinned images."
         )
-    tests = [test for test, _ in filtered_tests]
+    elif image_uris_raw:
+        # URIs mode: normal filter, then shape-match against the user-supplied URIs.
+        filtered_tests = filter_tests(
+            test_collection,
+            frequency=frequency,
+            test_filters=test_filters,
+            prefer_smoke_tests=prefer_smoke_tests,
+            run_jailed_tests=run_jailed_tests,
+            run_unstable_tests=run_unstable_tests,
+        )
+        logger.info(f"Found {len(filtered_tests)} tests to run.")
+        if len(filtered_tests) == 0:
+            raise ReleaseTestCLIError(
+                "Empty test collection. The selected frequency or filter did "
+                "not return any tests to run. Adjust your filters."
+            )
+        tests = [test for test, _ in filtered_tests]
+        uri_list = [u for u in image_uris_raw.split() if u]
+        image_overrides = match_uris_to_tests(tests, uri_list)
+        logger.info(
+            f"[release-test-image-uris] matched {len(image_overrides)} test(s) "
+            f"to user-supplied URIs ({len(uri_list)} URIs provided)."
+        )
+    else:
+        # Normal path — unchanged from prior implementation.
+        filtered_tests = filter_tests(
+            test_collection,
+            frequency=frequency,
+            test_filters=test_filters,
+            prefer_smoke_tests=prefer_smoke_tests,
+            run_jailed_tests=run_jailed_tests,
+            run_unstable_tests=run_unstable_tests,
+        )
+        logger.info(f"Found {len(filtered_tests)} tests to run.")
+        if len(filtered_tests) == 0:
+            raise ReleaseTestCLIError(
+                "Empty test collection. The selected frequency or filter did "
+                "not return any tests to run. Adjust your filters."
+            )
+        tests = [test for test, _ in filtered_tests]
+
+    pinned_mode = image_overrides is not None
 
     gpu_map = build_short_gpu_map(os.path.join(_bazel_workspace_dir, "ray-images.json"))
 
-    # Generate custom image build steps
-    create_custom_build_yaml(
-        os.path.join(_bazel_workspace_dir, custom_build_jobs_output_file),
-        tests,
-        gpu_map,
-    )
-
-    rayci_select_keys = collect_rayci_select_keys(tests, gpu_map)
+    if not pinned_mode:
+        # Generate custom image build steps
+        create_custom_build_yaml(
+            os.path.join(_bazel_workspace_dir, custom_build_jobs_output_file),
+            tests,
+            gpu_map,
+        )
+        rayci_select_keys = collect_rayci_select_keys(tests, gpu_map)
+    else:
+        # Emit an empty custom-build yaml so downstream tooling doesn't trip
+        # on a missing file path. Rayci-select uses a sentinel key that
+        # matches no build step (rayci launches zero build steps).
+        with open(
+            os.path.join(_bazel_workspace_dir, custom_build_jobs_output_file), "w"
+        ) as f:
+            yaml.dump(
+                {"group": "Custom images build", "steps": []},
+                f,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+        rayci_select_keys = {PINNED_RAYCI_SELECT_SENTINEL}
 
     # Generate test job steps
     grouped_tests = group_tests(filtered_tests)
@@ -265,11 +333,17 @@ def main(
         env["RAYCI_BUILD_ID"] = build_id
 
     # If the build is manually triggered and there are more than 5 tests
-    # Ask user to confirm before launching the tests.
+    # Ask user to confirm before launching the tests. Pinned modes always
+    # suppress the block step since the user explicitly opted into the run.
     block_step = None
 
     is_automatic = os.environ.get("AUTOMATIC", "") == "1"
-    if not is_automatic and test_filters and selection_block_threshold > 0:
+    if (
+        not is_automatic
+        and test_filters
+        and selection_block_threshold > 0
+        and not pinned_mode
+    ):
         if len(tests) >= selection_block_threshold:
             block_step = generate_block_step(len(tests))
 
@@ -283,6 +357,7 @@ def main(
         is_concurrency_limit=not no_concurrency_limit,
         block_step_key=block_step["key"] if block_step else None,
         gpu_map=gpu_map,
+        image_overrides=image_overrides,
     )
     steps = [{"group": "block", "steps": [block_step]}] + steps if block_step else steps
 
@@ -314,8 +389,9 @@ def main(
         )
 
         # Only emit RAYCI_SELECT when a filter narrows the test set; an unfiltered
-        # run (e.g. full nightly) wants the complete image pipeline.
-        if rayci_select_output_file and test_filters:
+        # run (e.g. full nightly) wants the complete image pipeline. Pinned mode
+        # always emits the sentinel key to suppress all custom-BYOD build steps.
+        if rayci_select_output_file and (test_filters or pinned_mode):
             with open(
                 os.path.join(_bazel_workspace_dir, rayci_select_output_file),
                 "wt",

--- a/release/ray_release/scripts/custom_image_build_and_test_init.py
+++ b/release/ray_release/scripts/custom_image_build_and_test_init.py
@@ -255,6 +255,10 @@ def main(
             )
         tests = [test for test, _ in filtered_tests]
         uri_list = [u for u in image_uris_raw.split() if u]
+        if not uri_list:
+            raise ReleaseTestCLIError(
+                "release-test-image-uris is set but contains no URIs."
+            )
         image_overrides = match_uris_to_tests(tests, uri_list)
         logger.info(
             f"[release-test-image-uris] matched {len(image_overrides)} test(s) "

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -42,6 +42,7 @@ DEFAULT_PYTHON_VERSION = tuple(
 DATAPLANE_ECR_REPO = "anyscale/ray"
 DATAPLANE_ECR_ML_REPO = "anyscale/ray-ml"
 DATAPLANE_ECR_LLM_REPO = "anyscale/ray-llm"
+_BUILD_ID_PLACEHOLDER = "__BUILD_ID__"
 
 MACOS_TEST_PREFIX = "darwin:"
 LINUX_TEST_PREFIX = "linux:"
@@ -639,6 +640,10 @@ class Test(dict):
         )
         tag = f"{ray_version}-{python_version}-{tag_suffix}"
         return f"{ANYSCALE_RAY_IMAGE_PREFIX}:{tag}"
+
+    def get_anyscale_byod_image_shape(self) -> str:
+        """Return BYOD image URI with build_id replaced by a fixed placeholder."""
+        return self.get_anyscale_byod_image(build_id=_BUILD_ID_PLACEHOLDER)
 
     def get_test_results(
         self,

--- a/release/ray_release/test.py
+++ b/release/ray_release/test.py
@@ -42,7 +42,7 @@ DEFAULT_PYTHON_VERSION = tuple(
 DATAPLANE_ECR_REPO = "anyscale/ray"
 DATAPLANE_ECR_ML_REPO = "anyscale/ray-ml"
 DATAPLANE_ECR_LLM_REPO = "anyscale/ray-llm"
-_BUILD_ID_PLACEHOLDER = "__BUILD_ID__"
+BUILD_ID_PLACEHOLDER = "__BUILD_ID__"
 
 MACOS_TEST_PREFIX = "darwin:"
 LINUX_TEST_PREFIX = "linux:"
@@ -642,8 +642,20 @@ class Test(dict):
         return f"{ANYSCALE_RAY_IMAGE_PREFIX}:{tag}"
 
     def get_anyscale_byod_image_shape(self) -> str:
-        """Return BYOD image URI with build_id replaced by a fixed placeholder."""
-        return self.get_anyscale_byod_image(build_id=_BUILD_ID_PLACEHOLDER)
+        """Return the BYOD image URI with `build_id` substituted by
+        `BUILD_ID_PLACEHOLDER`; released-image URIs (which have no `build_id`)
+        are returned unchanged.
+
+        The `RAY_IMAGE_TAG` env-var backdoor in `get_byod_base_image_tag` is
+        bypassed here so shape comparison is always deterministic against a
+        user-supplied URI list.
+        """
+        saved = os.environ.pop("RAY_IMAGE_TAG", None)
+        try:
+            return self.get_anyscale_byod_image(build_id=BUILD_ID_PLACEHOLDER)
+        finally:
+            if saved is not None:
+                os.environ["RAY_IMAGE_TAG"] = saved
 
     def get_test_results(
         self,

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -4,6 +4,8 @@ import tempfile
 import unittest
 from typing import TYPE_CHECKING, Callable, Dict
 
+import pytest
+
 if TYPE_CHECKING:
     from ray_release.github_client import GitHubRepo
 from unittest.mock import patch
@@ -32,7 +34,7 @@ from ray_release.buildkite.step import (
 )
 from ray_release.configs.global_config import init_global_config
 from ray_release.exception import ReleaseTestConfigError
-from ray_release.test import Test
+from ray_release.test import _BUILD_ID_PLACEHOLDER, Test
 from ray_release.wheels import (
     DEFAULT_BRANCH,
 )
@@ -861,6 +863,69 @@ class BuildkiteSettingsTest(unittest.TestCase):
 
             step = get_step(test_client)
             self.assertEqual(step["agents"]["queue"], str(RELEASE_QUEUE_CLIENT))
+
+
+class TestImageShape:
+    @pytest.fixture(autouse=True)
+    def patch_state(self, monkeypatch):
+        monkeypatch.setenv("RAYCI_BUILD_ID", "abc1234")
+        yield
+
+    def _make_test(self, **overrides) -> MockTest:
+        base = {
+            "name": "t",
+            "team": "reef",
+            "group": "g",
+            "frequency": "nightly",
+            "working_dir": "wd",
+            "python": "3.10",
+            "cluster": {"byod": {}, "cluster_compute": "c.yaml"},
+            "run": {"timeout": 60, "script": "echo hi"},
+        }
+        base.update(overrides)
+        return MockTest(base)
+
+    def test_shape_cpu_base_byod(self):
+        t = self._make_test()
+        shape = t.get_anyscale_byod_image_shape()
+        assert shape.endswith(f":{_BUILD_ID_PLACEHOLDER}-py310-cpu")
+        assert _BUILD_ID_PLACEHOLDER in shape
+
+    def test_shape_cuda_base_byod(self):
+        t = self._make_test(
+            cluster={"byod": {"type": "gpu"}, "cluster_compute": "c.yaml"}
+        )
+        shape = t.get_anyscale_byod_image_shape()
+        assert "ray-ml" in shape
+        assert shape.endswith(f":{_BUILD_ID_PLACEHOLDER}-py310-gpu")
+
+    def test_shape_custom_byod_includes_hash(self):
+        t = self._make_test(
+            cluster={
+                "byod": {"type": "gpu", "post_build_script": "x.sh"},
+                "cluster_compute": "c.yaml",
+            }
+        )
+        shape = t.get_anyscale_byod_image_shape()
+        tag = shape.rsplit(":", 1)[1]
+        parts = tag.split("-")
+        assert parts[0] == _BUILD_ID_PLACEHOLDER
+        assert parts[1] == "py310"
+        assert parts[2] == "gpu"
+        assert len(parts[3]) > 0
+
+    def test_shape_released_image(self):
+        t = self._make_test(
+            cluster={
+                "byod": {},
+                "cluster_compute": "c.yaml",
+                "ray_version": "2.55.1",
+            }
+        )
+        shape = t.get_anyscale_byod_image_shape()
+        # Released images don't have a build_id — placeholder MUST NOT appear.
+        assert _BUILD_ID_PLACEHOLDER not in shape
+        assert shape == "anyscale/ray:2.55.1-py310-cpu"
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -21,6 +21,7 @@ from ray_release.buildkite.filter import filter_tests, group_tests
 from ray_release.buildkite.settings import (
     Frequency,
     Priority,
+    get_buildkite_prompt_value,
     get_default_settings,
     get_test_filters,
     split_ray_repo_str,
@@ -435,6 +436,24 @@ class BuildkiteSettingsTest(unittest.TestCase):
         ):
             update_settings_from_buildkite(settings)
         assert settings["image_override_json"] == '{"uri-a": ["t"]}'
+
+    def testGetBuildkitePromptValueStripsAndEmptyToNone(self):
+        # buildkite-agent meta-data get appends a trailing newline; a "blank"
+        # meta-data field returns "\n". Strip whitespace and treat empty
+        # values as None so callers don't mistake "\n" for a real value.
+        cases = [
+            ("  some-value  \n", "some-value"),
+            ("\n", None),
+            ("", None),
+            ("   \t  \n", None),
+        ]
+        for raw, expected in cases:
+            with self.subTest(raw=raw):
+                with patch(
+                    "ray_release.buildkite.settings.subprocess.check_output",
+                    return_value=raw,
+                ):
+                    assert get_buildkite_prompt_value("key") == expected
 
     def _filter_names(self, *args, **kwargs):
         filtered = filter_tests(*args, **kwargs)

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -34,7 +34,7 @@ from ray_release.buildkite.step import (
 )
 from ray_release.configs.global_config import init_global_config
 from ray_release.exception import ReleaseTestConfigError
-from ray_release.test import _BUILD_ID_PLACEHOLDER, Test
+from ray_release.test import BUILD_ID_PLACEHOLDER, Test
 from ray_release.wheels import (
     DEFAULT_BRANCH,
 )
@@ -885,19 +885,54 @@ class TestImageShape:
         base.update(overrides)
         return MockTest(base)
 
-    def test_shape_cpu_base_byod(self):
-        t = self._make_test()
+    @pytest.mark.parametrize(
+        "overrides, expected_suffix, expect_placeholder, expect_ray_ml, full_uri",
+        [
+            # CPU base BYOD: byod={}, expect placeholder + py310-cpu.
+            ({}, "py310-cpu", True, False, None),
+            # GPU base BYOD: maps to ray-ml repo. Custom-BYOD path preserves
+            # raw `gpu` suffix (cu121 remap only applies in released-image path).
+            (
+                {"cluster": {"byod": {"type": "gpu"}, "cluster_compute": "c.yaml"}},
+                "py310-gpu",
+                True,
+                True,
+                None,
+            ),
+            # Released image: ray_version set, no custom byod required.
+            (
+                {
+                    "cluster": {
+                        "byod": {},
+                        "cluster_compute": "c.yaml",
+                        "ray_version": "2.55.1",
+                    }
+                },
+                None,
+                False,
+                False,
+                "anyscale/ray:2.55.1-py310-cpu",
+            ),
+        ],
+    )
+    def test_shape(
+        self,
+        overrides,
+        expected_suffix,
+        expect_placeholder,
+        expect_ray_ml,
+        full_uri,
+    ):
+        t = self._make_test(**overrides)
         shape = t.get_anyscale_byod_image_shape()
-        assert shape.endswith(f":{_BUILD_ID_PLACEHOLDER}-py310-cpu")
-        assert _BUILD_ID_PLACEHOLDER in shape
-
-    def test_shape_cuda_base_byod(self):
-        t = self._make_test(
-            cluster={"byod": {"type": "gpu"}, "cluster_compute": "c.yaml"}
-        )
-        shape = t.get_anyscale_byod_image_shape()
-        assert "ray-ml" in shape
-        assert shape.endswith(f":{_BUILD_ID_PLACEHOLDER}-py310-gpu")
+        if expect_placeholder:
+            assert BUILD_ID_PLACEHOLDER in shape
+            assert shape.endswith(f":{BUILD_ID_PLACEHOLDER}-{expected_suffix}")
+            if expect_ray_ml:
+                assert "ray-ml" in shape
+        else:
+            assert BUILD_ID_PLACEHOLDER not in shape
+            assert shape == full_uri
 
     def test_shape_custom_byod_includes_hash(self):
         t = self._make_test(
@@ -909,23 +944,19 @@ class TestImageShape:
         shape = t.get_anyscale_byod_image_shape()
         tag = shape.rsplit(":", 1)[1]
         parts = tag.split("-")
-        assert parts[0] == _BUILD_ID_PLACEHOLDER
+        assert parts[0] == BUILD_ID_PLACEHOLDER
         assert parts[1] == "py310"
         assert parts[2] == "gpu"
         assert len(parts[3]) > 0
 
-    def test_shape_released_image(self):
-        t = self._make_test(
-            cluster={
-                "byod": {},
-                "cluster_compute": "c.yaml",
-                "ray_version": "2.55.1",
-            }
-        )
+    def test_shape_ignores_ray_image_tag_env_backdoor(self, monkeypatch):
+        monkeypatch.setenv("RAY_IMAGE_TAG", "leaked-real-tag")
+        t = self._make_test()
         shape = t.get_anyscale_byod_image_shape()
-        # Released images don't have a build_id — placeholder MUST NOT appear.
-        assert _BUILD_ID_PLACEHOLDER not in shape
-        assert shape == "anyscale/ray:2.55.1-py310-cpu"
+        # Shape MUST contain the placeholder even when RAY_IMAGE_TAG is set,
+        # otherwise downstream URI matching breaks.
+        assert BUILD_ID_PLACEHOLDER in shape
+        assert "leaked-real-tag" not in shape
 
 
 if __name__ == "__main__":

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -84,6 +84,12 @@ class BuildkiteSettingsTest(unittest.TestCase):
     def setUp(self) -> None:
         self.buildkite = {}
         self.buildkite_mock = MockBuildkiteAgent(self.buildkite)
+        # Snapshot env so per-test mutations don't leak into other tests.
+        self._original_environ = os.environ.copy()
+
+    def tearDown(self) -> None:
+        os.environ.clear()
+        os.environ.update(self._original_environ)
 
     def testSplitRayRepoStr(self):
         url, branch = split_ray_repo_str("https://github.com/ray-project/ray.git")
@@ -204,6 +210,8 @@ class BuildkiteSettingsTest(unittest.TestCase):
                 "ray_test_branch": "sub/branch",
                 "priority": Priority.MANUAL,
                 "no_concurrency_limit": False,
+                "image_uris": None,
+                "image_override_json": None,
             },
         )
 
@@ -219,6 +227,8 @@ class BuildkiteSettingsTest(unittest.TestCase):
                 "ray_test_branch": "sub/branch",
                 "priority": Priority.MANUAL,
                 "no_concurrency_limit": False,
+                "image_uris": None,
+                "image_override_json": None,
             },
         )
 
@@ -366,6 +376,8 @@ class BuildkiteSettingsTest(unittest.TestCase):
                     "ray_test_branch": "sub/branch",
                     "priority": Priority.MANUAL,
                     "no_concurrency_limit": False,
+                    "image_uris": None,
+                    "image_override_json": None,
                 },
             )
 
@@ -382,8 +394,47 @@ class BuildkiteSettingsTest(unittest.TestCase):
                     "ray_test_branch": "sub/branch",
                     "priority": Priority.MANUAL,
                     "no_concurrency_limit": False,
+                    "image_uris": None,
+                    "image_override_json": None,
                 },
             )
+
+    def testImageUrisFromEnv(self):
+        settings = get_default_settings()
+        assert settings["image_uris"] is None
+        assert settings["image_override_json"] is None
+
+        os.environ.clear()
+        os.environ["RELEASE_TEST_IMAGE_URIS"] = "uri-a uri-b"
+        update_settings_from_environment(settings)
+        assert settings["image_uris"] == "uri-a uri-b"
+
+    def testImageOverrideFromEnv(self):
+        settings = get_default_settings()
+        os.environ.clear()
+        os.environ["RELEASE_TEST_IMAGE_OVERRIDE"] = '{"uri-a": ["t"]}'
+        update_settings_from_environment(settings)
+        assert settings["image_override_json"] == '{"uri-a": ["t"]}'
+
+    def testImageUrisFromBuildkiteMetaData(self):
+        settings = get_default_settings()
+        self.buildkite["release-test-image-uris"] = "uri-a uri-b"
+        with patch(
+            "ray_release.buildkite.settings.get_buildkite_prompt_value",
+            self.buildkite_mock,
+        ):
+            update_settings_from_buildkite(settings)
+        assert settings["image_uris"] == "uri-a uri-b"
+
+    def testImageOverrideFromBuildkiteMetaData(self):
+        settings = get_default_settings()
+        self.buildkite["release-test-image-override"] = '{"uri-a": ["t"]}'
+        with patch(
+            "ray_release.buildkite.settings.get_buildkite_prompt_value",
+            self.buildkite_mock,
+        ):
+            update_settings_from_buildkite(settings)
+        assert settings["image_override_json"] == '{"uri-a": ["t"]}'
 
     def _filter_names(self, *args, **kwargs):
         filtered = filter_tests(*args, **kwargs)

--- a/release/ray_release/tests/test_buildkite.py
+++ b/release/ray_release/tests/test_buildkite.py
@@ -959,6 +959,81 @@ class TestImageShape:
         assert "leaked-real-tag" not in shape
 
 
+class TestStepImageOverride:
+    """Verify image_overrides parameter behavior in get_step."""
+
+    @pytest.fixture(autouse=True)
+    def patch_state(self, monkeypatch):
+        monkeypatch.setenv("RAYCI_BUILD_ID", "abc1234")
+        # Skip update_from_s3 to keep tests offline.
+        monkeypatch.setattr("ray_release.test.Test.update_from_s3", lambda self: None)
+        yield
+
+    def _test(self, name: str = "t") -> MockTest:
+        return MockTest(
+            {
+                "name": name,
+                "team": "reef",
+                "group": "g",
+                "frequency": "nightly",
+                "working_dir": "wd",
+                "python": "3.10",
+                "cluster": {"byod": {}, "cluster_compute": "c.yaml"},
+                "run": {"timeout": 60, "script": "echo hi"},
+            }
+        )
+
+    def test_pinned_mode_with_entry_adds_image_flag(self):
+        t = self._test("my_test")
+        step = get_step(
+            t,
+            test_collection_file=["release/release_tests.yaml"],
+            image_overrides={"my_test": "ecr/r:pinned-py310-cpu"},
+        )
+        cmd = step["commands"][0]
+        # shlex.quote only adds quotes when shell metachars are present; the
+        # image URI here has none, so the flag appears unquoted.
+        assert "--image ecr/r:pinned-py310-cpu" in cmd
+        assert step["depends_on"] is None
+
+    def test_pinned_mode_quotes_image_with_shell_metachars(self):
+        t = self._test("my_test")
+        step = get_step(
+            t,
+            test_collection_file=["release/release_tests.yaml"],
+            image_overrides={"my_test": "ecr/r:pinned py310 cpu"},
+        )
+        cmd = step["commands"][0]
+        # shlex.quote MUST escape whitespace so the shell sees one token.
+        assert "--image 'ecr/r:pinned py310 cpu'" in cmd
+
+    def test_pinned_mode_without_entry_omits_image_flag(self):
+        # Simulates a released-image test in URIs mode: pinned mode is
+        # active (image_overrides is a dict) but this test isn't in it.
+        t = self._test("released_test")
+        step = get_step(
+            t,
+            test_collection_file=["release/release_tests.yaml"],
+            image_overrides={},
+        )
+        cmd = step["commands"][0]
+        assert "--image" not in cmd
+        assert step["depends_on"] is None
+
+    def test_not_pinned_mode_uses_existing_depends_on(self):
+        # image_overrides=None means pre-existing dependency logic applies.
+        t = self._test("normal_test")
+        step = get_step(
+            t,
+            test_collection_file=["release/release_tests.yaml"],
+            image_overrides=None,
+            gpu_map={"cu123": "cu12.3.2-cudnn9"},
+        )
+        cmd = step["commands"][0]
+        assert "--image" not in cmd
+        assert step["depends_on"] is not None
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/release/ray_release/tests/test_custom_image_build_and_test_init.py
+++ b/release/ray_release/tests/test_custom_image_build_and_test_init.py
@@ -666,6 +666,44 @@ def test_init_image_override_mode_happy_path(mock_s3, mock_jailed):
 @patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
 @patch("ray_release.test.Test.update_from_s3", return_value=None)
 @patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_init_image_uris_empty_after_split_fails(mock_s3, mock_jailed):
+    """If RELEASE_TEST_IMAGE_URIS contains only whitespace, init must fail
+    with a clear error rather than silently entering pinned mode with an
+    empty URI list."""
+    runner = CliRunner()
+    with patch.dict("os.environ", {"RELEASE_TEST_IMAGE_URIS": "   \n   "}):
+        result = runner.invoke(
+            main,
+            [
+                "--test-collection-file",
+                "release/ray_release/tests/sample_tests.yaml",
+                "--global-config",
+                "oss_config.yaml",
+                "--frequency",
+                "nightly",
+                "--run-jailed-tests",
+                "--run-unstable-tests",
+                "--test-filters",
+                "prefix:hello_world",
+                "--custom-build-jobs-output-file",
+                "tmp_build_empty.yaml",
+                "--test-jobs-output-file",
+                "tmp_jobs_empty.json",
+                "--rayci-select-output-file",
+                "tmp_select_empty.txt",
+            ],
+            catch_exceptions=True,
+        )
+    assert result.exit_code != 0
+    assert "no URIs" in str(result.exception) or "contains no URIs" in str(
+        result.exception
+    )
+
+
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
 def test_init_both_modes_set_fails(mock_s3, mock_jailed):
     """Setting both meta-data fields must fail with a clear error."""
     runner = CliRunner()

--- a/release/ray_release/tests/test_custom_image_build_and_test_init.py
+++ b/release/ray_release/tests/test_custom_image_build_and_test_init.py
@@ -485,5 +485,218 @@ def test_custom_image_build_and_test_init_uploads_chunks(
     assert upload_calls[0].kwargs.get("check") is True
 
 
+# Sentinel rayci-select value that intentionally matches no build step.
+_PINNED_SENTINEL = "release_test_image_pinned"
+
+
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_init_image_uris_mode_happy_path(mock_s3, mock_jailed):
+    """release-test-image-uris mode: filtered tests get --image, no
+    custom-build yaml is emitted, and rayci-select contains only the
+    sentinel key."""
+    from ray_release.bazel import bazel_runfile
+
+    # Initialize global config so Test methods work outside the CliRunner.
+    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+
+    runner = CliRunner()
+    custom_build_jobs_output_file = "custom_build_jobs_pinned.yaml"
+    test_jobs_output_file = "test_jobs_pinned.json"
+    rayci_select_output_file = "rayci_select_pinned.txt"
+
+    # Compute the expected shapes from the actual test collection so the
+    # URIs we supply pass shape-matching.
+    collection = read_and_validate_release_test_collection(
+        [
+            os.path.join(
+                _bazel_workspace_dir, "release/ray_release/tests/sample_tests.yaml"
+            )
+        ]
+    )
+    # Filter to non-released tests (those with byod), then build matching URIs
+    # by replacing the build_id placeholder with a synthetic one.
+    non_released = [
+        t
+        for t in collection
+        if not t.get_anyscale_byod_image().startswith("anyscale/ray:")
+    ]
+    assert len(non_released) >= 2, "expected at least 2 non-released tests in fixture"
+    uris = [
+        t.get_anyscale_byod_image_shape().replace("__BUILD_ID__", "pr-12345.abcdef")
+        for t in non_released
+    ]
+
+    with patch.dict("os.environ", {"RELEASE_TEST_IMAGE_URIS": " ".join(uris)}):
+        result = runner.invoke(
+            main,
+            [
+                "--test-collection-file",
+                "release/ray_release/tests/sample_tests.yaml",
+                "--global-config",
+                "oss_config.yaml",
+                "--frequency",
+                "nightly",
+                "--run-jailed-tests",
+                "--run-unstable-tests",
+                "--test-filters",
+                "prefix:hello_world",
+                "--custom-build-jobs-output-file",
+                custom_build_jobs_output_file,
+                "--test-jobs-output-file",
+                test_jobs_output_file,
+                "--rayci-select-output-file",
+                rayci_select_output_file,
+            ],
+            catch_exceptions=False,
+        )
+
+    # In pinned mode the custom build yaml should be empty (zero steps).
+    build_yaml_path = os.path.join(_bazel_workspace_dir, custom_build_jobs_output_file)
+    if os.path.exists(build_yaml_path):
+        with open(build_yaml_path) as f:
+            data = yaml.safe_load(f) or {}
+        assert data.get("steps", []) == []
+
+    # Each filtered test's command should contain --image with a matching URI.
+    with open(
+        os.path.join(
+            _bazel_workspace_dir, f"{os.path.splitext(test_jobs_output_file)[0]}_0.json"
+        )
+    ) as f:
+        test_jobs = json.load(f)
+    cmds = [s["commands"][0] for group in test_jobs for s in group["steps"]]
+    for uri in uris:
+        assert any(
+            "--image" in c and uri in c for c in cmds
+        ), f"No test command contained --image {uri}: cmds={cmds}"
+
+    # Rayci-select must contain only the sentinel key.
+    with open(os.path.join(_bazel_workspace_dir, rayci_select_output_file)) as f:
+        assert f.read().strip() == _PINNED_SENTINEL
+
+    assert result.exit_code == 0
+
+
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_init_image_uris_mode_unmatched_test_fails(mock_s3, mock_jailed):
+    """If a filtered test has no shape-matching URI, init must fail with
+    a descriptive ReleaseTestConfigError."""
+    runner = CliRunner()
+    with patch.dict(
+        "os.environ",
+        {"RELEASE_TEST_IMAGE_URIS": "ecr/anyscale/ray:xxx-py999-zzz"},
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "--test-collection-file",
+                "release/ray_release/tests/sample_tests.yaml",
+                "--global-config",
+                "oss_config.yaml",
+                "--frequency",
+                "nightly",
+                "--run-jailed-tests",
+                "--run-unstable-tests",
+                "--test-filters",
+                "prefix:hello_world",
+                "--custom-build-jobs-output-file",
+                "tmp_build_unmatched.yaml",
+                "--test-jobs-output-file",
+                "tmp_jobs_unmatched.json",
+                "--rayci-select-output-file",
+                "tmp_select_unmatched.txt",
+            ],
+            catch_exceptions=True,
+        )
+    assert result.exit_code != 0
+    assert "no URI matched" in str(result.exception)
+
+
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_init_image_override_mode_happy_path(mock_s3, mock_jailed):
+    """release-test-image-override mode: only named tests run, no
+    filter is required, --image flag is injected, custom_build yaml
+    is empty, sentinel rayci-select is emitted."""
+    runner = CliRunner()
+    override = json.dumps({"ecr/r:pinned-py310-cpu": ["hello_world.aws"]})
+    with patch.dict("os.environ", {"RELEASE_TEST_IMAGE_OVERRIDE": override}):
+        result = runner.invoke(
+            main,
+            [
+                "--test-collection-file",
+                "release/ray_release/tests/sample_tests.yaml",
+                "--global-config",
+                "oss_config.yaml",
+                "--frequency",
+                "nightly",
+                "--run-jailed-tests",
+                "--run-unstable-tests",
+                "--custom-build-jobs-output-file",
+                "tmp_build_override.yaml",
+                "--test-jobs-output-file",
+                "tmp_jobs_override.json",
+                "--rayci-select-output-file",
+                "tmp_select_override.txt",
+            ],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+
+    with open(os.path.join(_bazel_workspace_dir, "tmp_jobs_override_0.json")) as f:
+        test_jobs = json.load(f)
+    all_steps = [s for group in test_jobs for s in group["steps"]]
+    assert len(all_steps) == 1
+    # shlex.quote does NOT add quotes for this URI (no shell metachars).
+    assert "--image ecr/r:pinned-py310-cpu" in all_steps[0]["commands"][0]
+
+    with open(os.path.join(_bazel_workspace_dir, "tmp_select_override.txt")) as f:
+        assert f.read().strip() == _PINNED_SENTINEL
+
+
+@patch.dict("os.environ", {"BUILDKITE": "1"})
+@patch.dict("os.environ", {"RAYCI_BUILD_ID": "a1b2c3d4"})
+@patch("ray_release.test.Test.update_from_s3", return_value=None)
+@patch("ray_release.test.Test.is_jailed_with_open_issue", return_value=False)
+def test_init_both_modes_set_fails(mock_s3, mock_jailed):
+    """Setting both meta-data fields must fail with a clear error."""
+    runner = CliRunner()
+    with patch.dict(
+        "os.environ",
+        {
+            "RELEASE_TEST_IMAGE_URIS": "ecr/r:x-py310-cpu",
+            "RELEASE_TEST_IMAGE_OVERRIDE": '{"ecr/r:y-py310-cpu": ["t"]}',
+        },
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "--test-collection-file",
+                "release/ray_release/tests/sample_tests.yaml",
+                "--global-config",
+                "oss_config.yaml",
+                "--frequency",
+                "nightly",
+                "--custom-build-jobs-output-file",
+                "tmp_build_both.yaml",
+                "--test-jobs-output-file",
+                "tmp_jobs_both.json",
+                "--rayci-select-output-file",
+                "tmp_select_both.txt",
+            ],
+            catch_exceptions=True,
+        )
+    assert result.exit_code != 0
+    assert "mutually exclusive" in str(result.exception)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -1,6 +1,12 @@
+import json
+
 import pytest
 
-from ray_release.buildkite.image_pinning import match_uris_to_tests, shape_of
+from ray_release.buildkite.image_pinning import (
+    match_uris_to_tests,
+    parse_override,
+    shape_of,
+)
 from ray_release.exception import ReleaseTestConfigError
 from ray_release.test import BUILD_ID_PLACEHOLDER
 from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX
@@ -166,3 +172,63 @@ class TestMatchUrisToTests:
             ],
         )
         assert result == {"cpu_test": "ecr/anyscale/ray:other-py310-cpu"}
+
+
+class TestParseOverride:
+    def test_happy_path_single_uri(self):
+        raw = json.dumps({"ecr/r:bid-py310-cpu": ["test_a", "test_b"]})
+        result = parse_override(raw)
+        assert result == {
+            "test_a": "ecr/r:bid-py310-cpu",
+            "test_b": "ecr/r:bid-py310-cpu",
+        }
+
+    def test_happy_path_multiple_uris(self):
+        raw = json.dumps(
+            {
+                "ecr/r:bid-py310-cpu": ["a"],
+                "ecr/r:bid-py311-cpu": ["b", "c"],
+            }
+        )
+        result = parse_override(raw)
+        assert result == {
+            "a": "ecr/r:bid-py310-cpu",
+            "b": "ecr/r:bid-py311-cpu",
+            "c": "ecr/r:bid-py311-cpu",
+        }
+
+    def test_json_parse_failure(self):
+        with pytest.raises(ReleaseTestConfigError, match="Invalid JSON"):
+            parse_override("not-json")
+
+    def test_top_level_not_dict(self):
+        with pytest.raises(ReleaseTestConfigError, match="must be a JSON object"):
+            parse_override(json.dumps(["a", "b"]))
+
+    def test_value_not_list(self):
+        with pytest.raises(
+            ReleaseTestConfigError, match="must be a list of test names"
+        ):
+            parse_override(json.dumps({"uri-a": "not-a-list"}))
+
+    def test_value_contains_non_string(self):
+        with pytest.raises(
+            ReleaseTestConfigError, match="must be a list of test names"
+        ):
+            parse_override(json.dumps({"uri-a": ["ok", 123]}))
+
+    def test_duplicate_test_name(self):
+        raw = json.dumps({"uri-a": ["dup", "x"], "uri-b": ["y", "dup"]})
+        with pytest.raises(ReleaseTestConfigError) as exc:
+            parse_override(raw)
+        msg = str(exc.value)
+        assert "dup" in msg
+        assert "uri-a" in msg and "uri-b" in msg
+
+    def test_empty_payload(self):
+        with pytest.raises(ReleaseTestConfigError, match="contains no tests to run"):
+            parse_override(json.dumps({}))
+
+    def test_all_values_empty(self):
+        with pytest.raises(ReleaseTestConfigError, match="contains no tests to run"):
+            parse_override(json.dumps({"uri-a": []}))

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -197,25 +197,26 @@ class TestParseOverride:
             "c": "ecr/r:bid-py311-cpu",
         }
 
-    def test_json_parse_failure(self):
-        with pytest.raises(ReleaseTestConfigError, match="Invalid JSON"):
-            parse_override("not-json")
-
-    def test_top_level_not_dict(self):
-        with pytest.raises(ReleaseTestConfigError, match="must be a JSON object"):
-            parse_override(json.dumps(["a", "b"]))
-
-    def test_value_not_list(self):
-        with pytest.raises(
-            ReleaseTestConfigError, match="must be a list of test names"
-        ):
-            parse_override(json.dumps({"uri-a": "not-a-list"}))
-
-    def test_value_contains_non_string(self):
-        with pytest.raises(
-            ReleaseTestConfigError, match="must be a list of test names"
-        ):
-            parse_override(json.dumps({"uri-a": ["ok", 123]}))
+    @pytest.mark.parametrize(
+        "raw, match",
+        [
+            # JSON parse failure
+            ("not-json", "Invalid JSON"),
+            # top-level not dict
+            (json.dumps(["a", "b"]), "must be a JSON object"),
+            # value not list
+            (json.dumps({"uri-a": "not-a-list"}), "must be a list of test names"),
+            # value contains non-string element
+            (json.dumps({"uri-a": ["ok", 123]}), "must be a list of test names"),
+            # empty top-level
+            (json.dumps({}), "contains no tests to run"),
+            # all values empty
+            (json.dumps({"uri-a": []}), "contains no tests to run"),
+        ],
+    )
+    def test_parse_override_rejects_invalid_payload(self, raw, match):
+        with pytest.raises(ReleaseTestConfigError, match=match):
+            parse_override(raw)
 
     def test_duplicate_test_name(self):
         raw = json.dumps({"uri-a": ["dup", "x"], "uri-b": ["y", "dup"]})
@@ -225,10 +226,18 @@ class TestParseOverride:
         assert "dup" in msg
         assert "uri-a" in msg and "uri-b" in msg
 
-    def test_empty_payload(self):
-        with pytest.raises(ReleaseTestConfigError, match="contains no tests to run"):
-            parse_override(json.dumps({}))
-
-    def test_all_values_empty(self):
-        with pytest.raises(ReleaseTestConfigError, match="contains no tests to run"):
-            parse_override(json.dumps({"uri-a": []}))
+    def test_type_error_raises_before_duplicate_detection(self):
+        # Payload has BOTH a duplicate test name (across uri-a and uri-b) AND
+        # a malformed value at uri-c. The type error should surface first
+        # because duplicate detection requires well-typed values.
+        raw = json.dumps(
+            {
+                "uri-a": ["dup", "x"],
+                "uri-b": ["y", "dup"],
+                "uri-c": "not-a-list",
+            }
+        )
+        with pytest.raises(
+            ReleaseTestConfigError, match="must be a list of test names"
+        ):
+            parse_override(raw)

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -62,9 +62,6 @@ class _StubTest:
         self._byod_image = byod_image
         self._shape = shape
 
-    def get_name(self) -> str:
-        return self._name
-
     def __getitem__(self, key):
         if key == "name":
             return self._name
@@ -141,7 +138,19 @@ class TestMatchUrisToTests:
         with pytest.raises(ReleaseTestConfigError) as exc:
             match_uris_to_tests([a, b], [])
         msg = str(exc.value)
+        # Both failures collected into a single raise (NOT first-failure-wins).
+        assert "Cannot resolve image URIs for 2 test(s)" in msg
         assert "a" in msg and "b" in msg
+
+    def test_duplicate_test_names_collected_as_failure(self):
+        shape = "ecr/anyscale/ray:__BUILD_ID__-py310-cpu"
+        a = _StubTest("dup", "ecr/anyscale/ray:bid1-py310-cpu", shape)
+        b = _StubTest("dup", "ecr/anyscale/ray:bid2-py310-cpu", shape)
+        with pytest.raises(ReleaseTestConfigError) as exc:
+            match_uris_to_tests([a, b], ["ecr/anyscale/ray:other-py310-cpu"])
+        msg = str(exc.value)
+        assert "dup" in msg
+        assert "more than once" in msg
 
     def test_unused_uris_are_not_errors(self):
         t = _StubTest(

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -5,6 +5,7 @@ import pytest
 from ray_release.buildkite.image_pinning import (
     match_uris_to_tests,
     parse_override,
+    resolve_override_tests,
     shape_of,
 )
 from ray_release.exception import ReleaseTestConfigError
@@ -241,3 +242,51 @@ class TestParseOverride:
             ReleaseTestConfigError, match="must be a list of test names"
         ):
             parse_override(raw)
+
+
+class _StubCollectionTest:
+    def __init__(self, name: str):
+        self._name = name
+
+    def get_name(self) -> str:
+        return self._name
+
+    def __getitem__(self, key):
+        if key == "name":
+            return self._name
+        raise KeyError(key)
+
+
+class TestResolveOverrideTests:
+    def _collection(self, names):
+        return [_StubCollectionTest(n) for n in names]
+
+    def test_happy_path(self):
+        coll = self._collection(["a", "b", "c"])
+        override = {"a": "uri1", "c": "uri2"}
+        result = resolve_override_tests(coll, override)
+        assert [t.get_name() for t in result] == ["a", "c"]
+
+    def test_unknown_name_raises_listing_all(self):
+        coll = self._collection(["a"])
+        override = {"a": "uri1", "ghost1": "uri2", "ghost2": "uri3"}
+        with pytest.raises(ReleaseTestConfigError) as exc:
+            resolve_override_tests(coll, override)
+        msg = str(exc.value)
+        assert "ghost1" in msg and "ghost2" in msg
+        # The known test 'a' should not appear in the missing-names section.
+        assert "a" not in msg.split("not found in test collection")[1]
+
+    def test_preserves_override_iteration_order(self):
+        # Test grouping in the UI follows user-provided JSON order,
+        # not collection order.
+        coll = self._collection(["a", "b", "c"])
+        override = {"c": "u3", "a": "u1"}
+        result = resolve_override_tests(coll, override)
+        assert [t.get_name() for t in result] == ["c", "a"]
+
+    def test_empty_override_returns_empty(self):
+        # Defensive: parse_override raises on empty, but resolve_override_tests
+        # should still behave sanely if it ever receives an empty map.
+        result = resolve_override_tests(self._collection(["a"]), {})
+        assert result == []

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import pytest
 
@@ -77,7 +78,7 @@ class _StubTest:
             return self._name
         raise KeyError(key)
 
-    def get_anyscale_byod_image(self) -> str:
+    def get_anyscale_byod_image(self, build_id=None) -> str:
         return self._byod_image
 
     def get_anyscale_byod_image_shape(self) -> str:
@@ -342,3 +343,7 @@ def test_uses_released_image_does_not_require_rayci_build_id(monkeypatch):
         }
     )
     assert _uses_released_image(t_released) is True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ray_release.buildkite.image_pinning import _shape_of
+from ray_release.buildkite.image_pinning import shape_of
 from ray_release.test import BUILD_ID_PLACEHOLDER
 
 
@@ -33,15 +33,20 @@ class TestShapeOf:
         ],
     )
     def test_shape_of(self, uri, expected):
-        assert _shape_of(uri) == expected
+        assert shape_of(uri) == expected
 
     def test_shape_of_rejects_uri_without_tag(self):
         with pytest.raises(ValueError, match="missing ':<tag>'"):
-            _shape_of("ecr/anyscale/ray")
+            shape_of("ecr/anyscale/ray")
+
+    def test_shape_of_rejects_uri_with_empty_tag(self):
+        with pytest.raises(ValueError, match="empty tag"):
+            shape_of("ecr/anyscale/ray:")
 
     def test_shape_of_no_py_segment(self):
-        # When no segment matches py<N>, the whole tag collapses to placeholder.
+        # Released-image tests' shapes have no py<N>; placeholder-only matches
+        # what Test.get_anyscale_byod_image_shape() produces in that branch.
         assert (
-            _shape_of("ecr/anyscale/ray:single")
+            shape_of("ecr/anyscale/ray:single")
             == f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}"
         )

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -231,6 +231,24 @@ class TestParseOverride:
         assert "dup" in msg
         assert "uri-a" in msg and "uri-b" in msg
 
+    def test_within_uri_duplicate_is_silently_deduped(self):
+        # A name listed twice under the same URI is unambiguous (one pin),
+        # so we dedupe silently instead of raising. Cross-URI duplicates
+        # are still errors (covered by test_duplicate_test_name).
+        raw = json.dumps({"uri-a": ["dup", "x", "dup"]})
+        result = parse_override(raw)
+        assert result == {"dup": "uri-a", "x": "uri-a"}
+
+    def test_within_uri_duplicate_does_not_mask_cross_uri_duplicate(self):
+        # Repeats inside uri-a's list are deduped, but `dup` also appearing
+        # under uri-b is still a cross-URI duplicate and must raise.
+        raw = json.dumps({"uri-a": ["dup", "dup"], "uri-b": ["dup"]})
+        with pytest.raises(ReleaseTestConfigError) as exc:
+            parse_override(raw)
+        msg = str(exc.value)
+        assert "dup" in msg
+        assert "uri-a" in msg and "uri-b" in msg
+
     def test_type_error_raises_before_duplicate_detection(self):
         # Payload has BOTH a duplicate test name (across uri-a and uri-b) AND
         # a malformed value at uri-c. The type error should surface first

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -1,7 +1,9 @@
 import pytest
 
-from ray_release.buildkite.image_pinning import shape_of
+from ray_release.buildkite.image_pinning import match_uris_to_tests, shape_of
+from ray_release.exception import ReleaseTestConfigError
 from ray_release.test import BUILD_ID_PLACEHOLDER
+from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX
 
 
 class TestShapeOf:
@@ -50,3 +52,108 @@ class TestShapeOf:
             shape_of("ecr/anyscale/ray:single")
             == f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}"
         )
+
+
+class _StubTest:
+    """Minimal Test stand-in: only the methods match_uris_to_tests calls."""
+
+    def __init__(self, name: str, byod_image: str, shape: str):
+        self._name = name
+        self._byod_image = byod_image
+        self._shape = shape
+
+    def get_name(self) -> str:
+        return self._name
+
+    def __getitem__(self, key):
+        if key == "name":
+            return self._name
+        raise KeyError(key)
+
+    def get_anyscale_byod_image(self) -> str:
+        return self._byod_image
+
+    def get_anyscale_byod_image_shape(self) -> str:
+        return self._shape
+
+
+class TestMatchUrisToTests:
+    def test_happy_path_single_match(self):
+        t = _StubTest(
+            name="cpu_test",
+            byod_image="ecr/anyscale/ray:bid1-py310-cpu",
+            shape=f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+        )
+        result = match_uris_to_tests([t], ["ecr/anyscale/ray:other.id-py310-cpu"])
+        assert result == {"cpu_test": "ecr/anyscale/ray:other.id-py310-cpu"}
+
+    def test_skips_released_image_test(self):
+        t = _StubTest(
+            name="released_test",
+            byod_image=f"{ANYSCALE_RAY_IMAGE_PREFIX}:2.55.1-py310-cpu",
+            shape=f"{ANYSCALE_RAY_IMAGE_PREFIX}:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+        )
+        result = match_uris_to_tests([t], [])
+        assert result == {}
+
+    def test_no_match_raises_with_details(self):
+        t = _StubTest(
+            name="cpu_test",
+            byod_image="ecr/anyscale/ray:bid1-py310-cpu",
+            shape=f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+        )
+        with pytest.raises(ReleaseTestConfigError) as exc:
+            match_uris_to_tests([t], ["ecr/anyscale/ray:bid2-py311-cpu"])
+        msg = str(exc.value)
+        assert "cpu_test" in msg
+        assert "no URI matched" in msg
+        assert f"{BUILD_ID_PLACEHOLDER}-py310-cpu" in msg
+
+    def test_ambiguous_match_raises_with_both_uris(self):
+        t = _StubTest(
+            name="cpu_test",
+            byod_image="ecr/anyscale/ray:bid1-py310-cpu",
+            shape=f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+        )
+        with pytest.raises(ReleaseTestConfigError) as exc:
+            match_uris_to_tests(
+                [t],
+                [
+                    "ecr/anyscale/ray:bid2-py310-cpu",
+                    "ecr/anyscale/ray:bid3-py310-cpu",
+                ],
+            )
+        msg = str(exc.value)
+        assert "2 URIs matched" in msg
+        assert "bid2" in msg and "bid3" in msg
+
+    def test_collects_multiple_failures(self):
+        a = _StubTest(
+            "a",
+            "ecr/anyscale/ray:bid1-py310-cpu",
+            f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+        )
+        b = _StubTest(
+            "b",
+            "ecr/anyscale/ray:bid1-py311-cpu",
+            f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py311-cpu",
+        )
+        with pytest.raises(ReleaseTestConfigError) as exc:
+            match_uris_to_tests([a, b], [])
+        msg = str(exc.value)
+        assert "a" in msg and "b" in msg
+
+    def test_unused_uris_are_not_errors(self):
+        t = _StubTest(
+            "cpu_test",
+            "ecr/anyscale/ray:bid1-py310-cpu",
+            f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+        )
+        result = match_uris_to_tests(
+            [t],
+            [
+                "ecr/anyscale/ray:other-py310-cpu",
+                "ecr/anyscale/ray:other-py311-cu121",
+            ],
+        )
+        assert result == {"cpu_test": "ecr/anyscale/ray:other-py310-cpu"}

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -1,0 +1,47 @@
+import pytest
+
+from ray_release.buildkite.image_pinning import _shape_of
+from ray_release.test import BUILD_ID_PLACEHOLDER
+
+
+class TestShapeOf:
+    @pytest.mark.parametrize(
+        "uri, expected",
+        [
+            (
+                "029272617770.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray:pr-63308.e61e71-py310-cpu",
+                f"029272617770.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+            ),
+            (
+                "ecr/anyscale/ray-ml:abc.def-py310-cu121",
+                f"ecr/anyscale/ray-ml:{BUILD_ID_PLACEHOLDER}-py310-cu121",
+            ),
+            (
+                "ecr/anyscale/ray:abc.def-py310-cpu-deadbeef",
+                f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu-deadbeef",
+            ),
+            (
+                "ecr/anyscale/ray:abc.def-py312-cu130-cafebabe-2.55.1",
+                f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}-py312-cu130-cafebabe-2.55.1",
+            ),
+            (
+                # Released image — first dash-segment is the version, which
+                # gets replaced too; that's by design (see module docstring).
+                "anyscale/ray:2.55.1-py310-cpu",
+                f"anyscale/ray:{BUILD_ID_PLACEHOLDER}-py310-cpu",
+            ),
+        ],
+    )
+    def test_shape_of(self, uri, expected):
+        assert _shape_of(uri) == expected
+
+    def test_shape_of_rejects_uri_without_tag(self):
+        with pytest.raises(ValueError, match="missing ':<tag>'"):
+            _shape_of("ecr/anyscale/ray")
+
+    def test_shape_of_no_py_segment(self):
+        # When no segment matches py<N>, the whole tag collapses to placeholder.
+        assert (
+            _shape_of("ecr/anyscale/ray:single")
+            == f"ecr/anyscale/ray:{BUILD_ID_PLACEHOLDER}"
+        )

--- a/release/ray_release/tests/test_image_pinning.py
+++ b/release/ray_release/tests/test_image_pinning.py
@@ -2,14 +2,17 @@ import json
 
 import pytest
 
+from ray_release.bazel import bazel_runfile
 from ray_release.buildkite.image_pinning import (
+    _uses_released_image,
     match_uris_to_tests,
     parse_override,
     resolve_override_tests,
     shape_of,
 )
+from ray_release.configs.global_config import init_global_config
 from ray_release.exception import ReleaseTestConfigError
-from ray_release.test import BUILD_ID_PLACEHOLDER
+from ray_release.test import BUILD_ID_PLACEHOLDER, Test
 from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX
 
 
@@ -290,3 +293,52 @@ class TestResolveOverrideTests:
         # should still behave sanely if it ever receives an empty map.
         result = resolve_override_tests(self._collection(["a"]), {})
         assert result == []
+
+
+def test_uses_released_image_does_not_require_rayci_build_id(monkeypatch):
+    """_uses_released_image must work in any environment, even when
+    RAYCI_BUILD_ID is unset.
+
+    The build_id is irrelevant to the released-vs-custom decision (which is
+    driven by ray_version + require_custom_byod_image()), so passing
+    BUILD_ID_PLACEHOLDER lets this module be called without first setting
+    the env var — which match_uris_to_tests relies on.
+    """
+    init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
+    monkeypatch.delenv("RAYCI_BUILD_ID", raising=False)
+
+    # Custom BYOD test (no ray_version): would previously raise ValueError
+    # because get_anyscale_byod_image(build_id=None) tries to read
+    # RAYCI_BUILD_ID. Must now succeed and return False.
+    t_custom = Test(
+        {
+            "name": "x",
+            "team": "reef",
+            "group": "g",
+            "frequency": "nightly",
+            "working_dir": "wd",
+            "python": "3.10",
+            "cluster": {"byod": {}, "cluster_compute": "c.yaml"},
+            "run": {"timeout": 60, "script": "echo hi"},
+        }
+    )
+    assert _uses_released_image(t_custom) is False
+
+    # A released-image test (ray_version set) is correctly identified.
+    t_released = Test(
+        {
+            "name": "y",
+            "team": "reef",
+            "group": "g",
+            "frequency": "nightly",
+            "working_dir": "wd",
+            "python": "3.10",
+            "cluster": {
+                "byod": {},
+                "cluster_compute": "c.yaml",
+                "ray_version": "2.55.1",
+            },
+            "run": {"timeout": 60, "script": "echo hi"},
+        }
+    )
+    assert _uses_released_image(t_released) is True


### PR DESCRIPTION
## Description

Adds two new Buildkite meta-data fields to the `release` pipeline that let a build skip its wheel/image build steps and run release tests against pre-built image URIs supplied by the user:

- **`release-test-image-uris`** — space-delimited list of image URIs. Tests come from the existing `release-test-filters` / `release-test-attr-regex-filters` selection. Each filtered test is matched to one URI by image shape (repo + tag without the `build_id` portion). Released-image tests (`anyscale/ray:<version>-…`) are excluded from URI shape-matching — they continue to use their released image at test-run time.

- **`release-test-image-override`** — JSON `{image_uri: [test_name, ...], ...}`. Tests come from the JSON values directly (no filter required). Each test name must appear exactly once across all values.

When either field is set, the init step:
- emits a sentinel `RAYCI_SELECT=release_test_image_pinned` that matches no build step in `.buildkite/release/build.rayci.yml`, so rayci launches zero wheel/image builds,
- writes an empty custom-build YAML,
- suppresses the manual-trigger block step (user has already implicitly confirmed scope by supplying images),
- threads the resolved `{test_name → image_uri}` map through `get_step_for_test_group` → `get_step`, which appends `--image <uri>` to each test's `run_release_test.sh` invocation.

Setting both fields fails the init step with a clear error.

## Related issues

None.

## Additional information

**Architecture**

A new module `release/ray_release/buildkite/image_pinning.py` owns all of the new behavior:

- `shape_of(uri)` — normalize a URI by replacing the build_id portion (everything before the first \`py<N>\` segment) with a fixed \`BUILD_ID_PLACEHOLDER\` so user-supplied URIs can be compared to test-side expected shapes without knowing \`RAYCI_BUILD_ID\`.
- \`match_uris_to_tests(tests, uri_list)\` — URIs-mode shape matching with multi-failure aggregation and duplicate-name detection.
- \`parse_override(raw_json)\` — JSON parsing + structural validation + duplicate-name detection.
- \`resolve_override_tests(test_collection, override_map)\` — look up override-mode test names against the test collection, surface every missing name in a single error.

A new \`Test.get_anyscale_byod_image_shape()\` helper returns the test's expected BYOD image URI with the build_id substituted by the placeholder. It bypasses the \`RAY_IMAGE_TAG\` env-var backdoor in \`get_byod_base_image_tag\` so shape comparison is deterministic regardless of environment.

\`step.py\` gains a single new optional parameter \`image_overrides: Optional[Dict[str, str]]\` plumbed from \`get_step_for_test_group\` into \`get_step\`. \`None\` preserves existing behavior; a (possibly empty) dict signals pinned mode. In pinned mode \`depends_on\` is set to \`None\` (the pre-built image already exists; the block step is always suppressed).

\`settings.py\` reads the two new meta-data fields and the matching \`RELEASE_TEST_IMAGE_URIS\` / \`RELEASE_TEST_IMAGE_OVERRIDE\` env vars (for local debugging). \`get_buildkite_prompt_value\` now strips trailing whitespace and returns \`None\` for empty values so a blank-but-present meta-data field doesn't silently force pinned mode.

**Sentinel rayci-select**

The outer pipeline step (in the Buildkite-server-side \`release\` pipeline config) does:

\`\`\`bash
if [[ -f /tmp/rayci_select.txt ]]; then
  export RAYCI_SELECT=\"\$(cat /tmp/rayci_select.txt)\"
fi
\`\`\`

Writing a sentinel value (\`release_test_image_pinned\`) that matches no step key in \`build.rayci.yml\` produces zero wheel/image build launches. Verified by reading the rayci step-filter source.

**Test plan**

- New unit/integration tests cover: shape extraction (custom-BYOD + released + released-image-tag); URI shape-matching (single match, no match, ambiguous, multi-failure, released-image skip, duplicate test name); override parsing (JSON parse failure, type errors, duplicate names, empty payload, validation-order priority); override name resolution (happy path, unknown names, iteration order); step generation (pinned-mode \`--image\` flag, pinned-mode \`depends_on=None\`, non-pinned passthrough, shlex-quote behavior); settings reading (env + meta-data, whitespace stripping); init script (URIs happy path, URIs unmatched failure, override happy path, both-modes mutual-exclusion failure, empty-URIs guard).
- Full \`release_unit\` test target (29 tests) passes.
- Lint: \`pre-commit\` clean across all modified files.
- Test plan checklist for reviewers:
  - [ ] Trigger a manual build with \`release-test-image-uris\` set to two real PR-built image URIs from a prior build; verify zero wheel/image build steps run and the release-test steps run with \`--image <uri>\`.
  - [ ] Trigger a manual build with \`release-test-image-override\` JSON; verify only the named tests run and each gets its mapped URI.
  - [ ] Trigger a manual build with both fields set; verify the init step fails with the mutual-exclusion error.
  - [ ] Trigger a normal manual build (neither field set) and verify the existing behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)