### PR TITLE
[Data][1/2] Schema inference for non black box UDF logical operators

### DIFF
--- a/doc/source/data/working-with-images.rst
+++ b/doc/source/data/working-with-images.rst
@@ -68,7 +68,7 @@ To view the full list of supported file formats, see the
             Column     Type
             ------     ----
             image_url  string
-            bytes      null
+            bytes      binary
 
     .. tab-item:: NumPy
 

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1000,6 +1000,20 @@ py_test(
 )
 
 py_test(
+    name = "test_infer_schema",
+    size = "small",
+    srcs = ["tests/test_infer_schema.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_task_pool_map_operator",
     size = "small",
     srcs = ["tests/test_task_pool_map_operator.py"],

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -328,7 +328,9 @@ def _split_unsupported_columns(
         col: "pa.ChunkedArray" = table.column(idx)
         col_type: "pa.DataType" = col.type
 
-        if _is_pa_extension_type(col_type) or _is_pa_join_not_supported(col_type):
+        if _is_pa_extension_type(col_type) or JoinOperator._is_pa_join_not_supported(
+            col_type
+        ):
             unsupported.append(idx)
         else:
             supported.append(idx)
@@ -357,45 +359,6 @@ def _append_index_column(table: "pa.Table", col_name: str) -> "pa.Table":
 
     index_col = pa.array(np.arange(table.num_rows))
     return table.append_column(col_name, index_col)
-
-
-def _is_pa_join_not_supported(type: "pa.DataType") -> bool:
-    """
-    The latest pyarrow versions do not support joins where the
-    tables contain the following types below (lists,
-    structs, maps, unions, extension types, etc.)
-
-    Args:
-        type: The input type of column.
-
-    Returns:
-        True if the type cannot be present (non join-key) during joins.
-        False if the type can be present.
-    """
-    import pyarrow as pa
-
-    pyarrow_version = get_pyarrow_version()
-    is_v12 = pyarrow_version >= MIN_PYARROW_VERSION_RUN_END_ENCODED_TYPES
-    is_v16 = pyarrow_version >= MIN_PYARROW_VERSION_VIEW_TYPES
-
-    return (
-        pa.types.is_map(type)
-        or pa.types.is_union(type)
-        or pa.types.is_list(type)
-        or pa.types.is_struct(type)
-        or pa.types.is_null(type)
-        or pa.types.is_large_list(type)
-        or pa.types.is_fixed_size_list(type)
-        or (is_v12 and pa.types.is_run_end_encoded(type))
-        or (
-            is_v16
-            and (
-                pa.types.is_binary_view(type)
-                or pa.types.is_string_view(type)
-                or pa.types.is_list_view(type)
-            )
-        )
-    )
 
 
 class JoinOperator(HashShufflingOperatorBase):
@@ -449,6 +412,45 @@ class JoinOperator(HashShufflingOperatorBase):
             aggregator_ray_remote_args_override=aggregator_ray_remote_args_override,
             shuffle_progress_bar_name="Shuffle",
             finalize_progress_bar_name="Join",
+        )
+
+    @staticmethod
+    def _is_pa_join_not_supported(dtype: "pa.DataType") -> bool:
+        """
+        The latest pyarrow versions do not support joins where the
+        tables contain the following types below (lists,
+        structs, maps, unions, extension types, etc.)
+
+        Args:
+            dtype: The input type of column.
+
+        Returns:
+            True if the type cannot be present (non join-key) during joins.
+            False if the type can be present.
+        """
+        import pyarrow as pa
+
+        pyarrow_version = get_pyarrow_version()
+        is_v12 = pyarrow_version >= MIN_PYARROW_VERSION_RUN_END_ENCODED_TYPES
+        is_v16 = pyarrow_version >= MIN_PYARROW_VERSION_VIEW_TYPES
+
+        return (
+            pa.types.is_map(dtype)
+            or pa.types.is_union(dtype)
+            or pa.types.is_list(dtype)
+            or pa.types.is_struct(dtype)
+            or pa.types.is_null(dtype)
+            or pa.types.is_large_list(dtype)
+            or pa.types.is_fixed_size_list(dtype)
+            or (is_v12 and pa.types.is_run_end_encoded(dtype))
+            or (
+                is_v16
+                and (
+                    pa.types.is_binary_view(dtype)
+                    or pa.types.is_string_view(dtype)
+                    or pa.types.is_list_view(dtype)
+                )
+            )
         )
 
     def _get_operator_num_cpus_override(self) -> float:

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -245,6 +245,7 @@ def _postprocess(
     should_index_l = _index_name("left") in supported.schema.names
     should_index_r = _index_name("right") in supported.schema.names
 
+    # Add back unsupported columns (join type logic is in should_index_* variables)
     if should_index_l:
         supported = _add_back_unsupported_columns(
             joined_table=supported,

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -159,7 +159,7 @@ def join_tables(
             )
 
     # Preprocess: split unsupported columns and add index columns if needed
-    preprocess_result_l, preprocess_result_r = _preprocess_for_join(
+    preprocess_result_l, preprocess_result_r = _preprocess(
         left_table, right_table, left_on, right_on, join_type
     )
 
@@ -176,14 +176,14 @@ def join_tables(
     )
 
     # Add back unsupported columns
-    return _postprocess_join_result(
+    return _postprocess(
         supported,
         preprocess_result_l.unsupported_projection,
         preprocess_result_r.unsupported_projection,
     )
 
 
-def _preprocess_for_join(
+def _preprocess(
     left_table: "pa.Table",
     right_table: "pa.Table",
     left_on: List[str],
@@ -236,7 +236,7 @@ def _preprocess_for_join(
     return left, right
 
 
-def _postprocess_join_result(
+def _postprocess(
     supported: "pa.Table",
     unsupported_l: "pa.Table",
     unsupported_r: "pa.Table",
@@ -272,7 +272,24 @@ def _should_index_side(
     unsupported_table: "pa.Table",
     join_type: JoinType,
 ) -> bool:
-    """Determine whether to create an index column for a given side of the join."""
+    """
+    Determine whether to create an index column for a given side of the join.
+
+    A column is "supported" if it is "joinable", and "unsupported" otherwise.
+    A supported_table is a table with only "supported" columns. Index columns are
+    needed when we have both supported and unsupported columns in a table, and
+    that table's columns will appear in the final result.
+
+    Args:
+        side: "left" or "right" to indicate which side of the join
+        supported_table: Table containing ONLY joinable columns
+        unsupported_table: Table containing ONLY unjoinable columns
+        join_type: The join type, used to decide whether this side appears in
+            the result (semi/anti joins drop one side).
+
+    Returns:
+        True if an index column should be created for this side
+    """
     # Must have both supported and unsupported columns to need indexing.
     # We cannot rely on row_count because it can return a non-zero row count
     # for an empty-schema.
@@ -291,7 +308,20 @@ def _should_index_side(
 def _split_unsupported_columns(
     table: "pa.Table",
 ) -> Tuple["pa.Table", "pa.Table"]:
-    """Split a PyArrow table into supported / unsupported (for joins) columns."""
+    """
+    Split a PyArrow table into two tables based on column joinability.
+
+    Separates columns into supported types and unsupported types that cannot be
+    directly joined on but should be preserved in results.
+
+    Args:
+        table: Input PyArrow table to split
+
+    Returns:
+        Tuple of (supported_table, unsupported_table) where:
+        - supported_table contains columns with primitive/joinable types
+        - unsupported_table contains columns with complex/unjoinable types
+    """
     supported, unsupported = [], []
     for idx in range(len(table.columns)):
         col: "pa.ChunkedArray" = table.column(idx)
@@ -329,8 +359,18 @@ def _append_index_column(table: "pa.Table", col_name: str) -> "pa.Table":
 
 
 def _is_pa_join_not_supported(type: "pa.DataType") -> bool:
-    """The latest pyarrow versions do not support joins on certain types
-    (lists, structs, maps, unions, extension types, etc.)."""
+    """
+    The latest pyarrow versions do not support joins where the
+    tables contain the following types below (lists,
+    structs, maps, unions, extension types, etc.)
+
+    Args:
+        type: The input type of column.
+
+    Returns:
+        True if the type cannot be present (non join-key) during joins.
+        False if the type can be present.
+    """
     import pyarrow as pa
 
     pyarrow_version = get_pyarrow_version()

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -104,268 +104,257 @@ class JoiningAggregation(ShuffleAggregation):
         left_table = _combine(left_partition_shards)
         right_table = _combine(right_partition_shards)
 
-        left_on = list(self._left_key_col_names)
-        right_on = list(self._right_key_col_names)
-
-        # Eagerly validate suffix conflicts so callers get a clear error instead
-        # of the opaque PyArrow schema-merge error ('Field X exists 2 times').
-        # Skip for semi/anti joins: only one side's columns appear in the result,
-        # so overlapping non-key names between left and right are harmless.
-        if self._join_type not in (
-            JoinType.LEFT_SEMI,
-            JoinType.LEFT_ANTI,
-            JoinType.RIGHT_SEMI,
-            JoinType.RIGHT_ANTI,
-        ):
-            left_cols = set(left_table.schema.names)
-            # PyArrow drops right key columns from output (coalescing them into
-            # the left keys), so only right non-key columns can collide with
-            # left columns. Subtracting only right_on (not left_on) correctly
-            # handles asymmetric key names (left_on != right_on).
-            right_output_cols = set(right_table.schema.names) - set(right_on)
-            collisions = left_cols & right_output_cols
-            if (
-                self._left_columns_suffix is None
-                and self._right_columns_suffix is None
-                and collisions
-            ):
-                raise ValueError(
-                    "Left and right columns suffixes cannot be both None "
-                    f"(overlapping columns: {sorted(collisions)})"
-                )
-
-        # Preprocess: split unsupported columns and add index columns if needed
-        preprocess_result_l, preprocess_result_r = self._preprocess(
-            left_table, right_table, left_on, right_on
+        yield join_tables(
+            left_table,
+            right_table,
+            join_type=self._join_type,
+            left_key_col_names=self._left_key_col_names,
+            right_key_col_names=self._right_key_col_names,
+            left_columns_suffix=self._left_columns_suffix,
+            right_columns_suffix=self._right_columns_suffix,
         )
 
-        # Perform the join on supported columns
-        arrow_join_type = _JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP[self._join_type]
 
-        supported = preprocess_result_l.supported_projection.join(
-            preprocess_result_r.supported_projection,
-            join_type=arrow_join_type,
-            keys=left_on,
-            right_keys=right_on,
-            left_suffix=self._left_columns_suffix,
-            right_suffix=self._right_columns_suffix,
-        )
+def join_tables(
+    left_table: "pa.Table",
+    right_table: "pa.Table",
+    *,
+    join_type: JoinType,
+    left_key_col_names: Tuple[str, ...],
+    right_key_col_names: Tuple[str, ...],
+    left_columns_suffix: Optional[str] = None,
+    right_columns_suffix: Optional[str] = None,
+) -> "pa.Table":
+    """Apply preprocess -> ``pa.Table.join`` -> postprocess to two input tables.
 
-        # Add back unsupported columns
-        result = self._postprocess(
-            supported,
-            preprocess_result_l.unsupported_projection,
-            preprocess_result_r.unsupported_projection,
-        )
+    Shared between the physical executor (``JoiningAggregation.finalize``)
+    and plan-time schema inference (``Join.infer_schema``), which calls
+    this with empty tables built from the input schemas. Plan-time and
+    runtime schemas therefore agree by construction.
+    """
+    left_on = list(left_key_col_names)
+    right_on = list(right_key_col_names)
 
-        yield result
-
-    def _preprocess(
-        self,
-        left_table: "pa.Table",
-        right_table: "pa.Table",
-        left_on: List[str],
-        right_on: List[str],
-    ) -> Tuple[_DatasetPreprocessingResult, _DatasetPreprocessingResult]:
-        """Preprocesses tables by splitting unsupported columns and adding indices."""
-        # Get supported columns
-        supported_l, unsupported_l = self._split_unsupported_columns(left_table)
-        supported_r, unsupported_r = self._split_unsupported_columns(right_table)
-
-        # Handle joins on unsupported columns
-        conflicting_columns: Set[str] = set(unsupported_l.column_names) & set(left_on)
-        if conflicting_columns:
+    # Eagerly validate suffix conflicts so callers get a clear error instead
+    # of the opaque PyArrow schema-merge error ('Field X exists 2 times').
+    # Skip for semi/anti joins: only one side's columns appear in the result,
+    # so overlapping non-key names between left and right are harmless.
+    if join_type not in (
+        JoinType.LEFT_SEMI,
+        JoinType.LEFT_ANTI,
+        JoinType.RIGHT_SEMI,
+        JoinType.RIGHT_ANTI,
+    ):
+        left_cols = set(left_table.schema.names)
+        # PyArrow drops right key columns from output (coalescing them into
+        # the left keys), so only right non-key columns can collide with
+        # left columns. Subtracting only right_on (not left_on) correctly
+        # handles asymmetric key names (left_on != right_on).
+        right_output_cols = set(right_table.schema.names) - set(right_on)
+        collisions = left_cols & right_output_cols
+        if left_columns_suffix is None and right_columns_suffix is None and collisions:
             raise ValueError(
-                f"Cannot join on columns with unjoinable types. "
-                f"Left join key columns {conflicting_columns} have unjoinable types "
-                f"(map, union, list, struct, etc.) which cannot be used for join operations."
+                "Left and right columns suffixes cannot be both None "
+                f"(overlapping columns: {sorted(collisions)})"
             )
 
-        conflicting_columns: Set[str] = set(unsupported_r.column_names) & set(right_on)
-        if conflicting_columns:
-            raise ValueError(
-                f"Cannot join on columns with unjoinable types. "
-                f"Right join key columns {conflicting_columns} have unjoinable types "
-                f"(map, union, list, struct, etc.) which cannot be used for join operations."
-            )
+    # Preprocess: split unsupported columns and add index columns if needed
+    preprocess_result_l, preprocess_result_r = _preprocess_for_join(
+        left_table, right_table, left_on, right_on, join_type
+    )
 
-        # Index if we have unsupported columns
-        should_index_l = self._should_index_side("left", supported_l, unsupported_l)
-        should_index_r = self._should_index_side("right", supported_r, unsupported_r)
+    # Perform the join on supported columns
+    arrow_join_type = _JOIN_TYPE_TO_ARROW_JOIN_VERB_MAP[join_type]
 
-        # Add index columns for back-referencing if we have unsupported columns
-        if should_index_l:
-            supported_l = self._append_index_column(
-                table=supported_l, col_name=self._index_name("left")
-            )
-        if should_index_r:
-            supported_r = self._append_index_column(
-                table=supported_r, col_name=self._index_name("right")
-            )
+    supported = preprocess_result_l.supported_projection.join(
+        preprocess_result_r.supported_projection,
+        join_type=arrow_join_type,
+        keys=left_on,
+        right_keys=right_on,
+        left_suffix=left_columns_suffix,
+        right_suffix=right_columns_suffix,
+    )
 
-        left = _DatasetPreprocessingResult(
-            supported_projection=supported_l,
-            unsupported_projection=unsupported_l,
+    # Add back unsupported columns
+    return _postprocess_join_result(
+        supported,
+        preprocess_result_l.unsupported_projection,
+        preprocess_result_r.unsupported_projection,
+    )
+
+
+def _preprocess_for_join(
+    left_table: "pa.Table",
+    right_table: "pa.Table",
+    left_on: List[str],
+    right_on: List[str],
+    join_type: JoinType,
+) -> Tuple[_DatasetPreprocessingResult, _DatasetPreprocessingResult]:
+    """Split inputs into supported/unsupported columns and add indices."""
+    supported_l, unsupported_l = _split_unsupported_columns(left_table)
+    supported_r, unsupported_r = _split_unsupported_columns(right_table)
+
+    # Handle joins on unsupported columns
+    conflicting_columns: Set[str] = set(unsupported_l.column_names) & set(left_on)
+    if conflicting_columns:
+        raise ValueError(
+            f"Cannot join on columns with unjoinable types. "
+            f"Left join key columns {conflicting_columns} have unjoinable types "
+            f"(map, union, list, struct, etc.) which cannot be used for join operations."
         )
-        right = _DatasetPreprocessingResult(
-            supported_projection=supported_r,
-            unsupported_projection=unsupported_r,
+
+    conflicting_columns: Set[str] = set(unsupported_r.column_names) & set(right_on)
+    if conflicting_columns:
+        raise ValueError(
+            f"Cannot join on columns with unjoinable types. "
+            f"Right join key columns {conflicting_columns} have unjoinable types "
+            f"(map, union, list, struct, etc.) which cannot be used for join operations."
         )
-        return left, right
 
-    def _postprocess(
-        self,
-        supported: "pa.Table",
-        unsupported_l: "pa.Table",
-        unsupported_r: "pa.Table",
-    ) -> "pa.Table":
-        # Index if we have unsupported columns
-        should_index_l = self._index_name("left") in supported.schema.names
-        should_index_r = self._index_name("right") in supported.schema.names
+    # Index if we have unsupported columns
+    should_index_l = _should_index_side("left", supported_l, unsupported_l, join_type)
+    should_index_r = _should_index_side("right", supported_r, unsupported_r, join_type)
 
-        # Add back unsupported columns (join type logic is in should_index_* variables)
-        if should_index_l:
-            supported = self._add_back_unsupported_columns(
-                joined_table=supported,
-                unsupported_table=unsupported_l,
-                index_col_name=self._index_name("left"),
-            )
+    # Add index columns for back-referencing if we have unsupported columns
+    if should_index_l:
+        supported_l = _append_index_column(
+            table=supported_l, col_name=_index_name("left")
+        )
+    if should_index_r:
+        supported_r = _append_index_column(
+            table=supported_r, col_name=_index_name("right")
+        )
 
-        if should_index_r:
-            supported = self._add_back_unsupported_columns(
-                joined_table=supported,
-                unsupported_table=unsupported_r,
-                index_col_name=self._index_name("right"),
-            )
+    left = _DatasetPreprocessingResult(
+        supported_projection=supported_l,
+        unsupported_projection=unsupported_l,
+    )
+    right = _DatasetPreprocessingResult(
+        supported_projection=supported_r,
+        unsupported_projection=unsupported_r,
+    )
+    return left, right
 
-        return supported
 
-    def _index_name(self, suffix: str) -> str:
-        return f"__rd_index_level_{suffix}__"
+def _postprocess_join_result(
+    supported: "pa.Table",
+    unsupported_l: "pa.Table",
+    unsupported_r: "pa.Table",
+) -> "pa.Table":
+    """Re-attach unsupported columns to the joined table via the index column."""
+    should_index_l = _index_name("left") in supported.schema.names
+    should_index_r = _index_name("right") in supported.schema.names
 
-    def _should_index_side(
-        self, side: str, supported_table: "pa.Table", unsupported_table: "pa.Table"
-    ) -> bool:
-        """
-        Determine whether to create an index column for a given side of the join.
+    if should_index_l:
+        supported = _add_back_unsupported_columns(
+            joined_table=supported,
+            unsupported_table=unsupported_l,
+            index_col_name=_index_name("left"),
+        )
 
-        A column is "supported" if it is "joinable", and "unsupported" otherwise.
-        A supported_table is a table with only "supported" columns. Index columns are
-        needed when we have both supported and unsupported columns in a table, and
-        that table's columns will appear in the final result.
+    if should_index_r:
+        supported = _add_back_unsupported_columns(
+            joined_table=supported,
+            unsupported_table=unsupported_r,
+            index_col_name=_index_name("right"),
+        )
 
-        Args:
-            side: "left" or "right" to indicate which side of the join
-            supported_table: Table containing ONLY joinable columns
-            unsupported_table: Table containing ONLY unjoinable columns
+    return supported
 
-        Returns:
-            True if an index column should be created for this side
-        """
-        # Must have both supported and unsupported columns to need indexing.
-        # We cannot rely on row_count because it can return a non-zero row count
-        # for an empty-schema.
-        if not supported_table.schema or not unsupported_table.schema:
-            return False
 
-        # For semi/anti joins, only index the side that appears in the result
-        if side == "left":
-            # Left side appears in result for all joins except right_semi/right_anti
-            return self._join_type not in [JoinType.RIGHT_SEMI, JoinType.RIGHT_ANTI]
-        else:  # side == "right"
-            # Right side appears in result for all joins except left_semi/left_anti
-            return self._join_type not in [JoinType.LEFT_SEMI, JoinType.LEFT_ANTI]
+def _index_name(suffix: str) -> str:
+    return f"__rd_index_level_{suffix}__"
 
-    def _split_unsupported_columns(
-        self, table: "pa.Table"
-    ) -> Tuple["pa.Table", "pa.Table"]:
-        """
-        Split a PyArrow table into two tables based on column joinability.
 
-        Separates columns into supported types and unsupported types that cannot be
-        directly joined on but should be preserved in results.
+def _should_index_side(
+    side: str,
+    supported_table: "pa.Table",
+    unsupported_table: "pa.Table",
+    join_type: JoinType,
+) -> bool:
+    """Determine whether to create an index column for a given side of the join."""
+    # Must have both supported and unsupported columns to need indexing.
+    # We cannot rely on row_count because it can return a non-zero row count
+    # for an empty-schema.
+    if not supported_table.schema or not unsupported_table.schema:
+        return False
 
-        Args:
-            table: Input PyArrow table to split
+    # For semi/anti joins, only index the side that appears in the result
+    if side == "left":
+        # Left side appears in result for all joins except right_semi/right_anti
+        return join_type not in [JoinType.RIGHT_SEMI, JoinType.RIGHT_ANTI]
+    else:  # side == "right"
+        # Right side appears in result for all joins except left_semi/left_anti
+        return join_type not in [JoinType.LEFT_SEMI, JoinType.LEFT_ANTI]
 
-        Returns:
-            Tuple of (supported_table, unsupported_table) where:
-            - supported_table contains columns with primitive/joinable types
-            - unsupported_table contains columns with complex/unjoinable types
-        """
-        supported, unsupported = [], []
-        for idx in range(len(table.columns)):
-            col: "pa.ChunkedArray" = table.column(idx)
-            col_type: "pa.DataType" = col.type
 
-            if _is_pa_extension_type(col_type) or self._is_pa_join_not_supported(
-                col_type
-            ):
-                unsupported.append(idx)
-            else:
-                supported.append(idx)
+def _split_unsupported_columns(
+    table: "pa.Table",
+) -> Tuple["pa.Table", "pa.Table"]:
+    """Split a PyArrow table into supported / unsupported (for joins) columns."""
+    supported, unsupported = [], []
+    for idx in range(len(table.columns)):
+        col: "pa.ChunkedArray" = table.column(idx)
+        col_type: "pa.DataType" = col.type
 
-        return table.select(supported), table.select(unsupported)
+        if _is_pa_extension_type(col_type) or _is_pa_join_not_supported(col_type):
+            unsupported.append(idx)
+        else:
+            supported.append(idx)
 
-    def _add_back_unsupported_columns(
-        self,
-        joined_table: "pa.Table",
-        unsupported_table: "pa.Table",
-        index_col_name: str,
-    ) -> "pa.Table":
-        # Extract the index column array and drop the column from the joined table
-        i = joined_table.schema.get_field_index(index_col_name)
-        indices = joined_table.column(i)
-        joined_table = joined_table.remove_column(i)
+    return table.select(supported), table.select(unsupported)
 
-        # Project the unsupported columns using the indices and combine with joined table
-        projected = ArrowBlockAccessor(unsupported_table).take(indices)
-        return ArrowBlockAccessor(joined_table).hstack(projected)
 
-    def _append_index_column(self, table: "pa.Table", col_name: str) -> "pa.Table":
-        import numpy as np
-        import pyarrow as pa
+def _add_back_unsupported_columns(
+    joined_table: "pa.Table",
+    unsupported_table: "pa.Table",
+    index_col_name: str,
+) -> "pa.Table":
+    # Extract the index column array and drop the column from the joined table
+    i = joined_table.schema.get_field_index(index_col_name)
+    indices = joined_table.column(i)
+    joined_table = joined_table.remove_column(i)
 
-        index_col = pa.array(np.arange(table.num_rows))
-        return table.append_column(col_name, index_col)
+    # Project the unsupported columns using the indices and combine with joined table
+    projected = ArrowBlockAccessor(unsupported_table).take(indices)
+    return ArrowBlockAccessor(joined_table).hstack(projected)
 
-    def _is_pa_join_not_supported(self, type: "pa.DataType") -> bool:
-        """
-        The latest pyarrow versions do not support joins where the
-        tables contain the following types below (lists,
-        structs, maps, unions, extension types, etc.)
 
-        Args:
-            type: The input type of column.
+def _append_index_column(table: "pa.Table", col_name: str) -> "pa.Table":
+    import numpy as np
+    import pyarrow as pa
 
-        Returns:
-            True if the type cannot be present (non join-key) during joins.
-            False if the type can be present.
-        """
-        import pyarrow as pa
+    index_col = pa.array(np.arange(table.num_rows))
+    return table.append_column(col_name, index_col)
 
-        pyarrow_version = get_pyarrow_version()
-        is_v12 = pyarrow_version >= MIN_PYARROW_VERSION_RUN_END_ENCODED_TYPES
-        is_v16 = pyarrow_version >= MIN_PYARROW_VERSION_VIEW_TYPES
 
-        return (
-            pa.types.is_map(type)
-            or pa.types.is_union(type)
-            or pa.types.is_list(type)
-            or pa.types.is_struct(type)
-            or pa.types.is_null(type)
-            or pa.types.is_large_list(type)
-            or pa.types.is_fixed_size_list(type)
-            or (is_v12 and pa.types.is_run_end_encoded(type))
-            or (
-                is_v16
-                and (
-                    pa.types.is_binary_view(type)
-                    or pa.types.is_string_view(type)
-                    or pa.types.is_list_view(type)
-                )
+def _is_pa_join_not_supported(type: "pa.DataType") -> bool:
+    """The latest pyarrow versions do not support joins on certain types
+    (lists, structs, maps, unions, extension types, etc.)."""
+    import pyarrow as pa
+
+    pyarrow_version = get_pyarrow_version()
+    is_v12 = pyarrow_version >= MIN_PYARROW_VERSION_RUN_END_ENCODED_TYPES
+    is_v16 = pyarrow_version >= MIN_PYARROW_VERSION_VIEW_TYPES
+
+    return (
+        pa.types.is_map(type)
+        or pa.types.is_union(type)
+        or pa.types.is_list(type)
+        or pa.types.is_struct(type)
+        or pa.types.is_null(type)
+        or pa.types.is_large_list(type)
+        or pa.types.is_fixed_size_list(type)
+        or (is_v12 and pa.types.is_run_end_encoded(type))
+        or (
+            is_v16
+            and (
+                pa.types.is_binary_view(type)
+                or pa.types.is_string_view(type)
+                or pa.types.is_list_view(type)
             )
         )
+    )
 
 
 class JoinOperator(HashShufflingOperatorBase):

--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -276,7 +276,7 @@ def _should_index_side(
     # Must have both supported and unsupported columns to need indexing.
     # We cannot rely on row_count because it can return a non-zero row count
     # for an empty-schema.
-    if not supported_table.schema or not unsupported_table.schema:
+    if len(supported_table.schema) == 0 or len(unsupported_table.schema) == 0:
         return False
 
     # For semi/anti joins, only index the side that appears in the result

--- a/python/ray/data/_internal/logical/interfaces/__init__.py
+++ b/python/ray/data/_internal/logical/interfaces/__init__.py
@@ -1,8 +1,10 @@
 from .logical_operator import (
     LogicalOperator,
+    LogicalOperatorPreservesSchema,
     LogicalOperatorSupportsPredicatePassThrough,
     LogicalOperatorSupportsPredicatePushdown,
     LogicalOperatorSupportsProjectionPushdown,
+    LogicalOperatorUnifiesInputSchemas,
     PredicatePassThroughBehavior,
 )
 from .logical_plan import LogicalPlan
@@ -21,8 +23,10 @@ __all__ = [
     "Plan",
     "Rule",
     "SourceOperator",
+    "LogicalOperatorPreservesSchema",
     "LogicalOperatorSupportsProjectionPushdown",
     "LogicalOperatorSupportsPredicatePushdown",
     "LogicalOperatorSupportsPredicatePassThrough",
+    "LogicalOperatorUnifiesInputSchemas",
     "PredicatePassThroughBehavior",
 ]

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -170,12 +170,17 @@ class LogicalOperatorUnifiesInputSchemas:
     """
 
     def infer_schema(self) -> Optional["Schema"]:
+        import pyarrow as pa
+
         from ray.data._internal.util import unify_schemas_with_validation
 
         input_schemas = [op.infer_schema() for op in self.input_dependencies]
         if not input_schemas or any(s is None for s in input_schemas):
             return None
-        return unify_schemas_with_validation(input_schemas)
+        try:
+            return unify_schemas_with_validation(input_schemas)
+        except (pa.ArrowTypeError, pa.ArrowInvalid):
+            return None
 
 
 class LogicalOperatorSupportsPredicatePushdown(LogicalOperator):

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -149,6 +149,35 @@ class LogicalOperatorSupportsProjectionPushdown(LogicalOperator):
         return self
 
 
+class LogicalOperatorPreservesSchema:
+    """Mixin for operators whose output column layout is identical to their
+    single input's. Provides a default ``infer_schema()`` that delegates to
+    the input. Use for ops like ``Filter``, ``Sort``, ``Limit``, etc., that
+    only re-order or filter rows.
+    """
+
+    def infer_schema(self) -> Optional["Schema"]:
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        return self.input_dependencies[0].infer_schema()
+
+
+class LogicalOperatorUnifiesInputSchemas:
+    """Mixin for n-ary operators whose output schema is the unification of
+    all inputs' schemas (e.g., ``Union``, ``Mix``). Provides a default
+    ``infer_schema()`` that returns the result of
+    ``unify_schemas_with_validation`` over each input's schema, or
+    ``None`` if any input's schema is unresolvable.
+    """
+
+    def infer_schema(self) -> Optional["Schema"]:
+        from ray.data._internal.util import unify_schemas_with_validation
+
+        input_schemas = [op.infer_schema() for op in self.input_dependencies]
+        if not input_schemas or any(s is None for s in input_schemas):
+            return None
+        return unify_schemas_with_validation(input_schemas)
+
+
 class LogicalOperatorSupportsPredicatePushdown(LogicalOperator):
     """Mixin for reading operators supporting predicate pushdown"""
 

--- a/python/ray/data/_internal/logical/interfaces/logical_operator.py
+++ b/python/ray/data/_internal/logical/interfaces/logical_operator.py
@@ -149,11 +149,15 @@ class LogicalOperatorSupportsProjectionPushdown(LogicalOperator):
         return self
 
 
-class LogicalOperatorPreservesSchema:
+class LogicalOperatorPreservesSchema(LogicalOperator):
     """Mixin for operators whose output column layout is identical to their
     single input's. Provides a default ``infer_schema()`` that delegates to
     the input. Use for ops like ``Filter``, ``Sort``, ``Limit``, etc., that
     only re-order or filter rows.
+
+    List this mixin last in the bases of subclasses so the concrete operator
+    base (e.g., ``AbstractMap``, ``AbstractAllToAll``) drives ``__init__`` /
+    ``super()`` chains.
     """
 
     def infer_schema(self) -> Optional["Schema"]:
@@ -161,12 +165,15 @@ class LogicalOperatorPreservesSchema:
         return self.input_dependencies[0].infer_schema()
 
 
-class LogicalOperatorUnifiesInputSchemas:
+class LogicalOperatorUnifiesInputSchemas(LogicalOperator):
     """Mixin for n-ary operators whose output schema is the unification of
     all inputs' schemas (e.g., ``Union``, ``Mix``). Provides a default
     ``infer_schema()`` that returns the result of
     ``unify_schemas_with_validation`` over each input's schema, or
     ``None`` if any input's schema is unresolvable.
+
+    List this mixin last in the bases of subclasses so the concrete operator
+    base (e.g., ``NAry``) drives ``__init__`` / ``super()`` chains.
     """
 
     def infer_schema(self) -> Optional["Schema"]:
@@ -175,7 +182,7 @@ class LogicalOperatorUnifiesInputSchemas:
         from ray.data._internal.util import unify_schemas_with_validation
 
         input_schemas = [op.infer_schema() for op in self.input_dependencies]
-        if not input_schemas or any(s is None for s in input_schemas):
+        if not all(isinstance(s, pa.Schema) for s in input_schemas):
             return None
         try:
             return unify_schemas_with_validation(input_schemas)

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar, dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -15,7 +15,6 @@ from ray.data.aggregate import AggregateFn
 from ray.data.block import BlockMetadata
 
 if TYPE_CHECKING:
-
     from ray.data.block import Schema
 
 __all__ = [
@@ -239,7 +238,7 @@ class Sort(
 class Aggregate(AbstractAllToAll):
     """Logical operator for aggregate."""
 
-    key: Optional[Union[str, List[str]]]
+    key: Optional[str | List[str]]
     aggs: List[AggregateFn]
     num_partitions: Optional[int] = None
     batch_format: Optional[str] = "default"

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -1,5 +1,5 @@
 from dataclasses import InitVar, dataclass, field, replace
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
@@ -239,7 +239,7 @@ class Sort(
 class Aggregate(AbstractAllToAll):
     """Logical operator for aggregate."""
 
-    key: Optional[str]
+    key: Optional[Union[str, List[str]]]
     aggs: List[AggregateFn]
     num_partitions: Optional[int] = None
     batch_format: Optional[str] = "default"
@@ -274,10 +274,12 @@ class Aggregate(AbstractAllToAll):
 
         fields: List[pa.Field] = []
         if self.key is not None:
-            try:
-                fields.append(input_schema.field(self.key))
-            except (KeyError, ValueError):
-                return None
+            keys = self.key if isinstance(self.key, list) else [self.key]
+            for key in keys:
+                try:
+                    fields.append(input_schema.field(key))
+                except (KeyError, TypeError, ValueError):
+                    return None
         for agg in self.aggs:
             f = agg.output_field(input_schema)
             if f is None:

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -72,9 +72,9 @@ class AbstractAllToAll(LogicalOperator):
 
 @dataclass(frozen=True, repr=False, eq=False)
 class RandomizeBlocks(
-    LogicalOperatorPreservesSchema,
     AbstractAllToAll,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorPreservesSchema,
 ):
     """Logical operator for randomize_block_order."""
 
@@ -103,9 +103,9 @@ class RandomizeBlocks(
 
 @dataclass(frozen=True, repr=False, eq=False)
 class RandomShuffle(
-    LogicalOperatorPreservesSchema,
     AbstractAllToAll,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorPreservesSchema,
 ):
     """Logical operator for random_shuffle."""
 
@@ -149,9 +149,9 @@ class RandomShuffle(
 
 @dataclass(frozen=True, repr=False, eq=False)
 class Repartition(
-    LogicalOperatorPreservesSchema,
     AbstractAllToAll,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorPreservesSchema,
 ):
     """Logical operator for repartition."""
 
@@ -199,9 +199,9 @@ class Repartition(
 
 @dataclass(frozen=True, repr=False, eq=False)
 class Sort(
-    LogicalOperatorPreservesSchema,
     AbstractAllToAll,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorPreservesSchema,
 ):
     """Logical operator for sort."""
 

--- a/python/ray/data/_internal/logical/operators/all_to_all_operator.py
+++ b/python/ray/data/_internal/logical/operators/all_to_all_operator.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
+    LogicalOperatorPreservesSchema,
     LogicalOperatorSupportsPredicatePassThrough,
     PredicatePassThroughBehavior,
 )
@@ -70,7 +71,11 @@ class AbstractAllToAll(LogicalOperator):
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
+class RandomizeBlocks(
+    LogicalOperatorPreservesSchema,
+    AbstractAllToAll,
+    LogicalOperatorSupportsPredicatePassThrough,
+):
     """Logical operator for randomize_block_order."""
 
     seed_config: Optional[RandomSeedConfig] = None
@@ -91,20 +96,17 @@ class RandomizeBlocks(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThro
         assert isinstance(self.input_dependencies[0], LogicalOperator)
         return self.input_dependencies[0].infer_metadata()
 
-    def infer_schema(
-        self,
-    ) -> Optional["Schema"]:
-        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        assert isinstance(self.input_dependencies[0], LogicalOperator)
-        return self.input_dependencies[0].infer_schema()
-
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Randomizing block order doesn't affect filtering correctness
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
+class RandomShuffle(
+    LogicalOperatorPreservesSchema,
+    AbstractAllToAll,
+    LogicalOperatorSupportsPredicatePassThrough,
+):
     """Logical operator for random_shuffle."""
 
     name: InitVar[str] = "RandomShuffle"
@@ -140,20 +142,17 @@ class RandomShuffle(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThroug
         assert isinstance(self.input_dependencies[0], LogicalOperator)
         return self.input_dependencies[0].infer_metadata()
 
-    def infer_schema(
-        self,
-    ) -> Optional["Schema"]:
-        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        assert isinstance(self.input_dependencies[0], LogicalOperator)
-        return self.input_dependencies[0].infer_schema()
-
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Random shuffle doesn't affect filtering correctness
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
+class Repartition(
+    LogicalOperatorPreservesSchema,
+    AbstractAllToAll,
+    LogicalOperatorSupportsPredicatePassThrough,
+):
     """Logical operator for repartition."""
 
     num_outputs: InitVar[int]
@@ -193,20 +192,17 @@ class Repartition(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough)
         assert isinstance(self.input_dependencies[0], LogicalOperator)
         return self.input_dependencies[0].infer_metadata()
 
-    def infer_schema(
-        self,
-    ) -> Optional["Schema"]:
-        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        assert isinstance(self.input_dependencies[0], LogicalOperator)
-        return self.input_dependencies[0].infer_schema()
-
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Repartition doesn't affect filtering correctness
         return PredicatePassThroughBehavior.PASSTHROUGH
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
+class Sort(
+    LogicalOperatorPreservesSchema,
+    AbstractAllToAll,
+    LogicalOperatorSupportsPredicatePassThrough,
+):
     """Logical operator for sort."""
 
     sort_key: SortKey
@@ -233,13 +229,6 @@ class Sort(AbstractAllToAll, LogicalOperatorSupportsPredicatePassThrough):
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         assert isinstance(self.input_dependencies[0], LogicalOperator)
         return self.input_dependencies[0].infer_metadata()
-
-    def infer_schema(
-        self,
-    ) -> Optional["Schema"]:
-        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        assert isinstance(self.input_dependencies[0], LogicalOperator)
-        return self.input_dependencies[0].infer_schema()
 
     def predicate_passthrough_behavior(self) -> PredicatePassThroughBehavior:
         # Sort doesn't affect filtering correctness
@@ -271,3 +260,27 @@ class Aggregate(AbstractAllToAll):
             ],
         )
         object.__setattr__(self, "_num_outputs", None)
+
+    def infer_schema(self) -> Optional["Schema"]:
+        # Output = key field(s) from input schema + one field per aggregator.
+        # Returns None if any aggregator can't declare its output field
+        # (callers fall back to limit(1)).
+        import pyarrow as pa
+
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        input_schema = self.input_dependencies[0].infer_schema()
+        if not isinstance(input_schema, pa.Schema):
+            return None
+
+        fields: List[pa.Field] = []
+        if self.key is not None:
+            try:
+                fields.append(input_schema.field(self.key))
+            except (KeyError, ValueError):
+                return None
+        for agg in self.aggs:
+            f = agg.output_field(input_schema)
+            if f is None:
+                return None
+            fields.append(f)
+        return pa.schema(fields)

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from ray.data._internal.logical.interfaces import LogicalOperator
+
+if TYPE_CHECKING:
+    from ray.data.block import Schema
 
 __all__ = [
     "Count",
@@ -28,3 +31,10 @@ class Count(LogicalOperator):
     @property
     def num_outputs(self) -> Optional[int]:
         return self._num_outputs
+
+    def infer_schema(self) -> Optional["Schema"]:
+        # Fixed output: one row per partial count with a single ``__num_rows``
+        # int64 column.
+        import pyarrow as pa
+
+        return pa.schema([pa.field(self.COLUMN_NAME, pa.int64(), nullable=False)])

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -252,6 +252,6 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
                 left_columns_suffix=self.left_columns_suffix,
                 right_columns_suffix=self.right_columns_suffix,
             )
-        except Exception:
+        except (pa.ArrowTypeError, pa.ArrowInvalid, pa.ArrowKeyError, ValueError):
             return None
         return joined.schema

--- a/python/ray/data/_internal/logical/operators/join_operator.py
+++ b/python/ray/data/_internal/logical/operators/join_operator.py
@@ -219,3 +219,39 @@ class Join(NAry, LogicalOperatorSupportsPredicatePassThrough):
         visitor = _ColumnReferenceCollector()
         visitor.visit(expr)
         return set(visitor.get_column_refs())
+
+    def infer_schema(self) -> Optional["Schema"]:
+        """Infer the output schema by running the shared ``join_tables``
+        utility on empty tables built from the input schemas. The same
+        utility runs at execution time, so plan-time and runtime schemas
+        agree by construction.
+        """
+        import pyarrow as pa
+
+        from ray.data._internal.execution.operators.join import join_tables
+
+        left_schema = self.input_dependencies[0].infer_schema()
+        right_schema = self.input_dependencies[1].infer_schema()
+        if not isinstance(left_schema, pa.Schema) or not isinstance(
+            right_schema, pa.Schema
+        ):
+            return None
+
+        join_type_enum = (
+            self.join_type
+            if isinstance(self.join_type, JoinType)
+            else JoinType(self.join_type)
+        )
+        try:
+            joined = join_tables(
+                left_schema.empty_table(),
+                right_schema.empty_table(),
+                join_type=join_type_enum,
+                left_key_col_names=tuple(self.left_key_columns),
+                right_key_col_names=tuple(self.right_key_columns),
+                left_columns_suffix=self.left_columns_suffix,
+                right_columns_suffix=self.right_columns_suffix,
+            )
+        except Exception:
+            return None
+        return joined.schema

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -26,7 +26,6 @@ from ray.data.expressions import Expr, StarExpr, exprlist_to_fields
 from ray.data.preprocessor import Preprocessor
 
 if TYPE_CHECKING:
-    import pyarrow
 
     from ray.data.block import Schema
 
@@ -282,7 +281,7 @@ class MapRows(AbstractUDFMap):
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Filter(LogicalOperatorPreservesSchema, AbstractUDFMap):
+class Filter(AbstractUDFMap, LogicalOperatorPreservesSchema):
     """Logical operator for filter."""
 
     predicate_expr: Optional[Expr] = None
@@ -422,8 +421,7 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
         rename_map = _extract_input_columns_renaming_mapping(self.exprs)
         return rename_map if rename_map else None
 
-    @functools.cached_property
-    def _cached_inferred_schema(self) -> Optional["pyarrow.Schema"]:
+    def infer_schema(self) -> Optional["Schema"]:
         import pyarrow as pa
 
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -436,9 +434,6 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
         if fields is None:
             return None
         return pa.schema(fields)
-
-    def infer_schema(self) -> Optional["Schema"]:
-        return self._cached_inferred_schema
 
 
 @dataclass(frozen=True, repr=False, eq=False)
@@ -473,9 +468,9 @@ class FlatMap(AbstractUDFMap):
 
 @dataclass(frozen=True, repr=False, eq=False)
 class StreamingRepartition(
-    LogicalOperatorPreservesSchema,
     AbstractMap,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorPreservesSchema,
 ):
     """Logical operator for streaming repartition operation.
 

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -2,18 +2,33 @@ import functools
 import inspect
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Literal,
+    Optional,
+    Union,
+)
 
 from ray.data._internal.compute import ComputeStrategy, TaskPoolStrategy
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
+    LogicalOperatorPreservesSchema,
     LogicalOperatorSupportsPredicatePassThrough,
     PredicatePassThroughBehavior,
 )
 from ray.data._internal.logical.operators.one_to_one_operator import AbstractOneToOne
 from ray.data.block import UserDefinedFunction
-from ray.data.expressions import Expr, StarExpr
+from ray.data.expressions import Expr, StarExpr, exprlist_to_fields
 from ray.data.preprocessor import Preprocessor
+
+if TYPE_CHECKING:
+    import pyarrow
+
+    from ray.data.block import Schema
 
 __all__ = [
     "AbstractMap",
@@ -267,7 +282,7 @@ class MapRows(AbstractUDFMap):
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Filter(AbstractUDFMap):
+class Filter(LogicalOperatorPreservesSchema, AbstractUDFMap):
     """Logical operator for filter."""
 
     predicate_expr: Optional[Expr] = None
@@ -407,6 +422,24 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
         rename_map = _extract_input_columns_renaming_mapping(self.exprs)
         return rename_map if rename_map else None
 
+    @functools.cached_property
+    def _cached_inferred_schema(self) -> Optional["pyarrow.Schema"]:
+        import pyarrow as pa
+
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        input_schema = self.input_dependencies[0].infer_schema()
+        # Only Arrow schemas are supported for static expression resolution.
+        # (``PandasBlockSchema`` chains fall back to ``limit(1)`` execution.)
+        if not isinstance(input_schema, pa.Schema):
+            return None
+        fields = exprlist_to_fields(self.exprs, input_schema)
+        if fields is None:
+            return None
+        return pa.schema(fields)
+
+    def infer_schema(self) -> Optional["Schema"]:
+        return self._cached_inferred_schema
+
 
 @dataclass(frozen=True, repr=False, eq=False)
 class FlatMap(AbstractUDFMap):
@@ -439,7 +472,11 @@ class FlatMap(AbstractUDFMap):
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class StreamingRepartition(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
+class StreamingRepartition(
+    LogicalOperatorPreservesSchema,
+    AbstractMap,
+    LogicalOperatorSupportsPredicatePassThrough,
+):
     """Logical operator for streaming repartition operation.
 
     Args:

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -138,7 +138,7 @@ class Zip(NAry):
 
 
 @dataclass(frozen=True, repr=False, eq=False, init=False)
-class Mix(LogicalOperatorUnifiesInputSchemas, NAry):
+class Mix(NAry, LogicalOperatorUnifiesInputSchemas):
     """Logical operator for weighted dataset mixing."""
 
     _name: str = field(init=False, repr=False)
@@ -191,9 +191,9 @@ class Mix(LogicalOperatorUnifiesInputSchemas, NAry):
 
 @dataclass(frozen=True, repr=False, eq=False, init=False)
 class Union(
-    LogicalOperatorUnifiesInputSchemas,
     NAry,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorUnifiesInputSchemas,
 ):
     """Logical operator for union."""
 

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -1,13 +1,17 @@
 import enum
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorUnifiesInputSchemas,
     PredicatePassThroughBehavior,
 )
 from ray.util.annotations import PublicAPI
+
+if TYPE_CHECKING:
+    from ray.data.block import Schema
 
 __all__ = [
     "Mix",
@@ -111,9 +115,30 @@ class Zip(NAry):
             total_num_outputs = max(total_num_outputs, num_outputs)
         return total_num_outputs
 
+    def infer_schema(self) -> Optional["Schema"]:
+        # Reuse the runtime ``BlockAccessor.zip`` so plan-time and
+        # execution-time schemas agree by construction (same column
+        # suffixing rules, etc.).
+        import pyarrow as pa
+
+        from ray.data.block import BlockAccessor
+
+        input_schemas = [op.infer_schema() for op in self.input_dependencies]
+        if not input_schemas or any(s is None for s in input_schemas):
+            return None
+        if not all(isinstance(s, pa.Schema) for s in input_schemas):
+            return None
+        try:
+            combined = input_schemas[0].empty_table()
+            for s in input_schemas[1:]:
+                combined = BlockAccessor.for_block(combined).zip(s.empty_table())
+        except Exception:
+            return None
+        return combined.schema
+
 
 @dataclass(frozen=True, repr=False, eq=False, init=False)
-class Mix(NAry):
+class Mix(LogicalOperatorUnifiesInputSchemas, NAry):
     """Logical operator for weighted dataset mixing."""
 
     _name: str = field(init=False, repr=False)
@@ -165,7 +190,11 @@ class Mix(NAry):
 
 
 @dataclass(frozen=True, repr=False, eq=False, init=False)
-class Union(NAry, LogicalOperatorSupportsPredicatePassThrough):
+class Union(
+    LogicalOperatorUnifiesInputSchemas,
+    NAry,
+    LogicalOperatorSupportsPredicatePassThrough,
+):
     """Logical operator for union."""
 
     _input_dependencies: List[LogicalOperator] = field(init=False, repr=False)

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -124,9 +124,9 @@ class Zip(NAry):
         from ray.data.block import BlockAccessor
 
         input_schemas = [op.infer_schema() for op in self.input_dependencies]
-        if not input_schemas or any(s is None for s in input_schemas):
-            return None
-        if not all(isinstance(s, pa.Schema) for s in input_schemas):
+        if not input_schemas or not all(
+            isinstance(s, pa.Schema) for s in input_schemas
+        ):
             return None
         try:
             combined = input_schemas[0].empty_table()

--- a/python/ray/data/_internal/logical/operators/n_ary_operator.py
+++ b/python/ray/data/_internal/logical/operators/n_ary_operator.py
@@ -132,7 +132,7 @@ class Zip(NAry):
             combined = input_schemas[0].empty_table()
             for s in input_schemas[1:]:
                 combined = BlockAccessor.for_block(combined).zip(s.empty_table())
-        except Exception:
+        except (pa.ArrowTypeError, pa.ArrowInvalid):
             return None
         return combined.schema
 

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -61,9 +61,9 @@ class AbstractOneToOne(LogicalOperator):
 
 @dataclass(frozen=True, repr=False, eq=False)
 class Limit(
-    LogicalOperatorPreservesSchema,
     AbstractOneToOne,
     LogicalOperatorSupportsPredicatePassThrough,
+    LogicalOperatorPreservesSchema,
 ):
     """Logical operator for limit."""
 
@@ -130,16 +130,17 @@ class Download(AbstractOneToOne):
         object.__setattr__(self, "_num_outputs", None)
 
     def infer_schema(self) -> Optional["Schema"]:
-        # Output = input schema + one binary column per requested output name.
-        # If an output column already exists in the input it is overwritten.
+        # Output = input schema with one binary column appended per requested
+        # output name. The runtime (``download_bytes_threaded``) always appends
+        # via ``add_column`` without removing any pre-existing column of the
+        # same name, so name collisions produce duplicate columns here too.
         import pyarrow as pa
 
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
         input_schema = self.input_dependencies[0].infer_schema()
         if not isinstance(input_schema, pa.Schema):
             return None
-        new_names = set(self.output_bytes_column_names)
-        fields = [f for f in input_schema if f.name not in new_names]
+        fields = list(input_schema)
         for name in self.output_bytes_column_names:
             fields.append(pa.field(name, pa.binary(), nullable=True))
         return pa.schema(fields)

--- a/python/ray/data/_internal/logical/operators/one_to_one_operator.py
+++ b/python/ray/data/_internal/logical/operators/one_to_one_operator.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ray.data._internal.logical.interfaces import (
     LogicalOperator,
+    LogicalOperatorPreservesSchema,
     LogicalOperatorSupportsPredicatePassThrough,
     PredicatePassThroughBehavior,
 )
@@ -59,7 +60,11 @@ class AbstractOneToOne(LogicalOperator):
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
+class Limit(
+    LogicalOperatorPreservesSchema,
+    AbstractOneToOne,
+    LogicalOperatorSupportsPredicatePassThrough,
+):
     """Logical operator for limit."""
 
     limit: int
@@ -79,13 +84,6 @@ class Limit(AbstractOneToOne, LogicalOperatorSupportsPredicatePassThrough):
             input_files=self._input_files(),
             exec_stats=None,
         )
-
-    def infer_schema(
-        self,
-    ) -> Optional["Schema"]:
-        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
-        assert isinstance(self.input_dependencies[0], LogicalOperator)
-        return self.input_dependencies[0].infer_schema()
 
     def _num_rows(self):
         assert len(self.input_dependencies) == 1, len(self.input_dependencies)
@@ -130,3 +128,18 @@ class Download(AbstractOneToOne):
                 f"number of output columns ({len(self.output_bytes_column_names)})"
             )
         object.__setattr__(self, "_num_outputs", None)
+
+    def infer_schema(self) -> Optional["Schema"]:
+        # Output = input schema + one binary column per requested output name.
+        # If an output column already exists in the input it is overwritten.
+        import pyarrow as pa
+
+        assert len(self.input_dependencies) == 1, len(self.input_dependencies)
+        input_schema = self.input_dependencies[0].infer_schema()
+        if not isinstance(input_schema, pa.Schema):
+            return None
+        new_names = set(self.output_bytes_column_names)
+        fields = [f for f in input_schema if f.name not in new_names]
+        for name in self.output_bytes_column_names:
+            fields.append(pa.field(name, pa.binary(), nullable=True))
+        return pa.schema(fields)

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -1,7 +1,10 @@
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, List, Optional
 
-from ray.data._internal.logical.interfaces import LogicalOperator
+from ray.data._internal.logical.interfaces import (
+    LogicalOperator,
+    LogicalOperatorPreservesSchema,
+)
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces import NodeIdStr
@@ -12,7 +15,7 @@ __all__ = [
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class StreamingSplit(LogicalOperator):
+class StreamingSplit(LogicalOperatorPreservesSchema, LogicalOperator):
     """Logical operator that represents splitting the input data to `n` splits."""
 
     num_splits: int

--- a/python/ray/data/_internal/logical/operators/streaming_split_operator.py
+++ b/python/ray/data/_internal/logical/operators/streaming_split_operator.py
@@ -15,7 +15,7 @@ __all__ = [
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class StreamingSplit(LogicalOperatorPreservesSchema, LogicalOperator):
+class StreamingSplit(LogicalOperatorPreservesSchema):
     """Logical operator that represents splitting the input data to `n` splits."""
 
     num_splits: int

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -16,7 +16,7 @@ __all__ = [
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Write(LogicalOperatorPreservesSchema, AbstractMap):
+class Write(AbstractMap, LogicalOperatorPreservesSchema):
     """Logical operator for write."""
 
     datasink_or_legacy_datasource: Union[Datasink, Datasource]

--- a/python/ray/data/_internal/logical/operators/write_operator.py
+++ b/python/ray/data/_internal/logical/operators/write_operator.py
@@ -2,7 +2,10 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, Union
 
 from ray.data._internal.compute import ComputeStrategy
-from ray.data._internal.logical.interfaces import LogicalOperator
+from ray.data._internal.logical.interfaces import (
+    LogicalOperator,
+    LogicalOperatorPreservesSchema,
+)
 from ray.data._internal.logical.operators.map_operator import AbstractMap
 from ray.data.datasource.datasink import Datasink
 from ray.data.datasource.datasource import Datasource
@@ -13,7 +16,7 @@ __all__ = [
 
 
 @dataclass(frozen=True, repr=False, eq=False)
-class Write(AbstractMap):
+class Write(LogicalOperatorPreservesSchema, AbstractMap):
     """Logical operator for write."""
 
     datasink_or_legacy_datasource: Union[Datasink, Datasource]

--- a/python/ray/data/_internal/logical/rules/predicate_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/predicate_pushdown.py
@@ -95,13 +95,10 @@ class PredicatePushdown(Rule):
         - Rename chains with name reuse: rename({'a': 'b', 'b': 'c'}).filter(col('b'))
           (where 'b' is valid output created by a->b)
         """
-        from ray.data._internal.logical.rules.projection_pushdown import (
-            _is_renaming_expr,
-        )
         from ray.data._internal.planner.plan_expression.expression_visitors import (
             _ColumnReferenceCollector,
         )
-        from ray.data.expressions import AliasExpr
+        from ray.data.expressions import AliasExpr, is_rename_expr
 
         collector = _ColumnReferenceCollector()
         collector.visit(filter_op.predicate_expr)
@@ -121,11 +118,11 @@ class PredicatePushdown(Rule):
                 new_names.add(expr.name)
 
                 # Check computed column: with_column('d', 4) creates AliasExpr(lit(4), 'd')
-                if expr.name in predicate_columns and not _is_renaming_expr(expr):
+                if expr.name in predicate_columns and not is_rename_expr(expr):
                     return False  # Computed column
 
                 # Track old names being renamed for later check
-                if _is_renaming_expr(expr):
+                if is_rename_expr(expr):
                     original_columns_being_renamed.add(expr.expr.name)
 
         # Check if filter references columns removed by explicit select

--- a/python/ray/data/_internal/logical/rules/projection_pushdown.py
+++ b/python/ray/data/_internal/logical/rules/projection_pushdown.py
@@ -14,9 +14,9 @@ from ray.data._internal.planner.plan_expression.expression_visitors import (
 )
 from ray.data.expressions import (
     AliasExpr,
-    ColumnExpr,
     Expr,
     StarExpr,
+    is_rename_expr,
 )
 
 __all__ = [
@@ -383,24 +383,14 @@ def _extract_input_columns_renaming_mapping(
         [
             _get_renaming_mapping(expr)
             for expr in _filter_out_star(projection_exprs)
-            if _is_renaming_expr(expr)
+            if is_rename_expr(expr)
         ]
     )
 
 
 def _get_renaming_mapping(expr: Expr) -> Tuple[str, str]:
-    assert _is_renaming_expr(expr)
+    assert is_rename_expr(expr)
 
     alias: AliasExpr = expr
 
     return alias.expr.name, alias.name
-
-
-def _is_renaming_expr(expr: Expr) -> bool:
-    is_renaming = isinstance(expr, AliasExpr) and expr._is_rename
-
-    assert not is_renaming or isinstance(
-        expr.expr, ColumnExpr
-    ), f"Renaming expression expected to be of the shape alias(col('source'), 'target') (got {expr})"
-
-    return is_renaming

--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -32,6 +32,7 @@ from ray.data.expressions import (
     UUIDExpr,
     _ExprVisitor,
     col,
+    is_rename_expr,
 )
 
 logger = logging.getLogger(__name__)
@@ -858,12 +859,7 @@ def eval_projection(projection_exprs: List[Expr], block: Block) -> Block:
         for expr in projection_exprs[1:]:
             # e.g. ``col(source)._rename(new_name)`` — bucket by ``source`` for column order.
             # ``rename_exprs_by_source``: input column name -> that rename ``AliasExpr``.
-            if (
-                isinstance(expr, AliasExpr)
-                and expr._is_rename
-                and isinstance(expr.expr, ColumnExpr)
-                and expr.expr.name in input_column_rename_map
-            ):
+            if is_rename_expr(expr) and expr.expr.name in input_column_rename_map:
                 rename_exprs_by_source[expr.expr.name] = expr
             else:
                 extra_exprs.append(expr)

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -348,13 +348,28 @@ def _agg_output_field(
     name: str,
     input_schema: "pa.Schema",
     target_col: Optional[str],
-    kernel: Callable[[Any], Any],
+    pyarrow_kernel: Callable[[pa.Array], pa.Scalar],
 ) -> Optional["pa.Field"]:
     """Compute the output field of a scalar reduction aggregator by running
     its PyArrow compute kernel on an empty array of the target column's type.
 
-    Returns ``None`` if the target column is missing or the kernel rejects
-    the column's type (e.g., ``pc.sum`` on a string column).
+    Args:
+        name: Name of the *output* column the aggregation produces (the
+            aggregator's alias, e.g. ``"sum(a)"`` or a user-supplied
+            ``alias_name``). This becomes the name of the returned field.
+        input_schema: Schema of the aggregator's input (pre-aggregation)
+            blocks, used to look up the target column's type.
+        target_col: Name of the *input* column being aggregated (the ``on=``
+            argument). This is the column the kernel reads, not the group-by
+            key. ``None`` for aggregations that don't read a column (e.g.
+            ``Count()`` over rows), in which case the type can't be inferred.
+        pyarrow_kernel: The PyArrow compute kernel implementing the reduction
+            (e.g. ``pc.sum``), run on an empty array to derive the output type.
+
+    Returns:
+        The output ``pa.Field`` (``name`` with the inferred type), or ``None``
+        if ``target_col`` is ``None``/missing or the pyarrow_kernel rejects the
+        column's type (e.g., ``pc.sum`` on a string column).
     """
     if target_col is None:
         return None
@@ -363,12 +378,13 @@ def _agg_output_field(
     except (KeyError, ValueError):
         return None
     try:
-        result = kernel(pa.array([], type=in_type))
-    except Exception:
+        result = pyarrow_kernel(pa.array([], type=in_type))
+    except (pa.ArrowNotImplementedError, pa.ArrowInvalid, pa.ArrowTypeError):
+        # The kernel has no implementation for this column's type
+        # (e.g. ``pc.sum`` on a string/struct/list column). Fall back to
+        # an unresolved schema rather than masking a real error.
         return None
-    out_type = getattr(result, "type", None)
-    if out_type is None:
-        return None
+    out_type = result.type
     return pa.field(name, out_type, nullable=True)
 
 
@@ -961,14 +977,15 @@ class AbsMax(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonTyp
         return max(current_accumulator, new)
 
     def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
-        # AbsMax preserves the input column type (just takes abs of max/min).
-        if self._target_col_name is None:
-            return None
-        try:
-            field = input_schema.field(self._target_col_name)
-        except (KeyError, ValueError):
-            return None
-        return pa.field(self.name, field.type, nullable=True)
+        # AbsMax = max(abs(x)). Compose abs + max into a single kernel so the
+        # output type (and the type-support check) come from the same pyarrow
+        # kernels, returning None for types abs/max reject (e.g. strings).
+        return _agg_output_field(
+            self.name,
+            input_schema,
+            self._target_col_name,
+            lambda a: pc.max(pc.abs(a)),
+        )
 
 
 @PublicAPI

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -19,6 +19,7 @@ from typing import (
 )
 
 import numpy as np
+import pyarrow as pa
 import pyarrow.compute as pc
 
 from ray.data._internal.util import is_null
@@ -149,6 +150,17 @@ class AggregateFn:
     def _validate(self, schema: Optional["Schema"]) -> None:
         """Raise an error if this cannot be applied to the given schema."""
         pass
+
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        """Return the PyArrow ``Field`` this aggregator produces.
+
+        Returns ``None`` by default; subclasses that know their output
+        type override. Used by ``Aggregate.infer_schema()`` to compute
+        the post-aggregation schema without executing the plan. When
+        any aggregator returns ``None``, the entire ``Aggregate.infer_schema``
+        returns ``None`` (callers fall back to a ``limit(1)`` execution).
+        """
+        return None
 
 
 @PublicAPI(stability="alpha")
@@ -332,6 +344,34 @@ class AggregateFnV2(AggregateFn, abc.ABC, Generic[AccumulatorType, AggOutputType
             SortKey(self._target_col_name).validate_schema(schema)
 
 
+def _agg_output_field(
+    name: str,
+    input_schema: "pa.Schema",
+    target_col: Optional[str],
+    kernel: Callable[[Any], Any],
+) -> Optional["pa.Field"]:
+    """Compute the output field of a scalar reduction aggregator by running
+    its PyArrow compute kernel on an empty array of the target column's type.
+
+    Returns ``None`` if the target column is missing or the kernel rejects
+    the column's type (e.g., ``pc.sum`` on a string column).
+    """
+    if target_col is None:
+        return None
+    try:
+        in_type = input_schema.field(target_col).type
+    except (KeyError, ValueError):
+        return None
+    try:
+        result = kernel(pa.array([], type=in_type))
+    except Exception:
+        return None
+    out_type = getattr(result, "type", None)
+    if out_type is None:
+        return None
+    return pa.field(name, out_type, nullable=True)
+
+
 @PublicAPI
 class Count(AggregateFnV2[int, int]):
     """Defines count aggregation.
@@ -397,6 +437,9 @@ class Count(AggregateFnV2[int, int]):
 
     def combine(self, current_accumulator: int, new: int) -> int:
         return current_accumulator + new
+
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        return pa.field(self.name, pa.int64(), nullable=False)
 
 
 @PublicAPI
@@ -517,6 +560,9 @@ class Sum(AggregateFnV2[Union[int, float], Union[int, float]]):
     ) -> Union[int, float]:
         return current_accumulator + new
 
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        return _agg_output_field(self.name, input_schema, self._target_col_name, pc.sum)
+
 
 @PublicAPI
 class Min(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType]):
@@ -580,6 +626,9 @@ class Min(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
     ) -> SupportsRichComparisonType:
         return min(current_accumulator, new)
 
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        return _agg_output_field(self.name, input_schema, self._target_col_name, pc.min)
+
 
 @PublicAPI
 class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType]):
@@ -642,6 +691,9 @@ class Max(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType])
         new: SupportsRichComparisonType,
     ) -> SupportsRichComparisonType:
         return max(current_accumulator, new)
+
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        return _agg_output_field(self.name, input_schema, self._target_col_name, pc.max)
 
 
 @PublicAPI
@@ -723,6 +775,9 @@ class Mean(AggregateFnV2[List[Union[int, float]], float]):
             return np.nan
 
         return accumulator[0] / accumulator[1]
+
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        return pa.field(self.name, pa.float64(), nullable=True)
 
 
 @PublicAPI
@@ -833,6 +888,9 @@ class Std(AggregateFnV2[List[Union[int, float]], float]):
         # Standard deviation is the square root of variance (M2 / (count - ddof))
         return math.sqrt(M2 / (count - self._ddof))
 
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        return pa.field(self.name, pa.float64(), nullable=True)
+
 
 @PublicAPI
 class AbsMax(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonType]):
@@ -901,6 +959,16 @@ class AbsMax(AggregateFnV2[SupportsRichComparisonType, SupportsRichComparisonTyp
         new: SupportsRichComparisonType,
     ) -> SupportsRichComparisonType:
         return max(current_accumulator, new)
+
+    def output_field(self, input_schema: "pa.Schema") -> Optional["pa.Field"]:
+        # AbsMax preserves the input column type (just takes abs of max/min).
+        if self._target_col_name is None:
+            return None
+        try:
+            field = input_schema.field(self._target_col_name)
+        except (KeyError, ValueError):
+            return None
+        return pa.field(self.name, field.type, nullable=True)
 
 
 @PublicAPI

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -1688,6 +1688,23 @@ class AliasExpr(Expr):
 
 
 @DeveloperAPI(stability="alpha")
+def is_rename_expr(expr: Expr) -> bool:
+    """Return True iff ``expr`` is a column rename of the form
+    ``col(src)._rename(dst)``.
+
+    Renames are ``AliasExpr`` with ``_is_rename=True`` wrapping a
+    ``ColumnExpr``. ``rename_columns`` produces them, and ``Project``
+    star-expansion treats them specially: the renamed field substitutes
+    for its source column in place rather than appending at the end.
+    """
+    return (
+        isinstance(expr, AliasExpr)
+        and expr._is_rename
+        and isinstance(expr.expr, ColumnExpr)
+    )
+
+
+@DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
 class StarExpr(Expr):
     """Expression that represents all columns from the input.
@@ -1802,8 +1819,10 @@ def exprlist_to_fields(
     """Resolve a list of expressions against the input schema into PyArrow fields.
 
     Handles ``StarExpr`` inline: when encountered, splices in the input
-    schema's fields (minus columns listed as a rename source by any
-    ``AliasExpr`` with ``_is_rename=True`` elsewhere in the list).
+    schema's fields, with each rename ``AliasExpr`` (``_is_rename=True``
+    wrapping a ``ColumnExpr``) substituted in place of its source field.
+    This preserves the source column's position in the output, matching
+    runtime ``eval_projection``.
 
     Deduplicates on field name with last-wins semantics, matching the
     runtime ``eval_projection`` (which uses ``fill_column``/upsert when
@@ -1831,41 +1850,57 @@ def exprlist_to_fields(
     if input_schema is None:
         return None
 
-    # Collect rename sources so StarExpr expansion can drop them.
-    rename_sources = set()
-    for expr in exprs:
-        if (
-            isinstance(expr, AliasExpr)
-            and expr._is_rename
-            and isinstance(expr.expr, ColumnExpr)
-        ):
-            rename_sources.add(expr.expr.name)
-
-    # Walk the projection list, tracking each field by name. Later
-    # entries with the same name replace earlier ones in place to
-    # match runtime upsert semantics.
-    name_to_index: Dict[str, int] = {}
-    out_fields: List["pyarrow.Field"] = []
-
-    def _emit(field_: "pyarrow.Field") -> None:
-        idx = name_to_index.get(field_.name)
-        if idx is None:
-            name_to_index[field_.name] = len(out_fields)
-            out_fields.append(field_)
-        else:
-            out_fields[idx] = field_
-
+    # Bucket the projection list: rename AliasExprs substitute for their
+    # source column during StarExpr expansion (preserving on-disk column
+    # order, matching runtime ``eval_projection``); non-rename exprs are
+    # emitted afterwards in original order.
+    has_star = False
+    rename_by_source_name: Dict[str, AliasExpr] = {}
+    non_rename_exprs: List[Expr] = []
     for expr in exprs:
         if isinstance(expr, StarExpr):
-            for field_ in input_schema:
-                if field_.name not in rename_sources:
-                    _emit(field_)
-            continue
+            has_star = True
+        elif is_rename_expr(expr):
+            rename_by_source_name[expr.expr.name] = expr
+        else:
+            non_rename_exprs.append(expr)
+
+    # Output fields, deduped by name with last-wins semantics (matching
+    # runtime ``eval_projection``'s ``fill_column``/upsert behavior).
+    output_field_index: Dict[str, int] = {}
+    output_fields: List["pyarrow.Field"] = []
+
+    def _upsert_field(field_: "pyarrow.Field") -> None:
+        idx = output_field_index.get(field_.name)
+        if idx is None:
+            output_field_index[field_.name] = len(output_fields)
+            output_fields.append(field_)
+        else:
+            output_fields[idx] = field_
+
+    def _resolve_and_upsert(expr: Expr) -> bool:
         resolved = expr.to_field(input_schema)
         if resolved is None:
+            return False
+        _upsert_field(resolved)
+        return True
+
+    if has_star:
+        for input_field in input_schema:
+            rename_expr = rename_by_source_name.pop(input_field.name, None)
+            if rename_expr is None:
+                _upsert_field(input_field)
+            elif not _resolve_and_upsert(rename_expr):
+                return None
+
+    # Any rename whose source isn't in ``input_schema`` falls through
+    # here and will fail resolution -> None, matching the runtime's
+    # "column not found" error.
+    for expr in (*rename_by_source_name.values(), *non_rename_exprs):
+        if not _resolve_and_upsert(expr):
             return None
-        _emit(resolved)
-    return out_fields
+
+    return output_fields
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -1795,6 +1795,7 @@ class UUIDExpr(Expr):
         return False
 
 
+@DeveloperAPI(stability="alpha")
 def exprlist_to_fields(
     exprs: List[Expr], input_schema: "pyarrow.Schema"
 ) -> Optional[List["pyarrow.Field"]]:

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -251,6 +251,35 @@ class _PyArrowExpressionVisitor(_ExprVisitor["pyarrow.compute.Expression"]):
         raise TypeError("UUID expressions cannot be converted to PyArrow expressions")
 
 
+def _eval_kernel_type(
+    op: "Operation", operand_types: List["pyarrow.DataType"]
+) -> Optional["pyarrow.DataType"]:
+    """Run the PyArrow kernel for ``op`` on empty arrays of the given types
+    and return the result type.
+
+    This delegates type promotion to the same kernels that runtime
+    evaluation uses (``_ARROW_EXPR_OPS_MAP``), so plan-time type
+    predictions match runtime by construction. Returns ``None`` if the
+    operation isn't supported or the kernel rejects the combination.
+    """
+    # Deferred import to avoid a circular dependency with the planner module.
+    from ray.data._internal.planner.plan_expression.expression_evaluator import (
+        _ARROW_EXPR_OPS_MAP,
+    )
+
+    op_fn = _ARROW_EXPR_OPS_MAP.get(op)
+    if op_fn is None:
+        return None
+
+    try:
+        empty_arrays = [pyarrow.array([], type=t) for t in operand_types]
+        result = op_fn(*empty_arrays)
+    except Exception:
+        return None
+
+    return getattr(result, "type", None)
+
+
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True)
 class Expr(ABC):
@@ -779,6 +808,55 @@ class Expr(ABC):
     def _unalias(self) -> "Expr":
         return self
 
+    def get_type(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.DataType"]:
+        """Resolve the output PyArrow data type given the input schema.
+
+        The default implementation converts ``self.data_type`` (the
+        construction-time hint) to a PyArrow type. That's the right
+        answer for self-contained expressions (``LiteralExpr``,
+        ``UDFExpr``, ``DownloadExpr``, ``MonotonicallyIncreasingIdExpr``,
+        ``RandomExpr``, ``UUIDExpr``).
+
+        Schema-dependent expressions (``ColumnExpr``, ``BinaryExpr``,
+        ``UnaryExpr``, ``AliasExpr``, ``StarExpr``) override this to
+        resolve against ``input_schema``.
+
+        Returns ``None`` if the type cannot be statically determined
+        (for example, a UDF without a declared ``return_dtype`` or a
+        column not found in ``input_schema``). Callers fall back to
+        runtime inference (``Dataset.schema()`` falling back to a
+        ``limit(1)`` execution).
+        """
+        try:
+            return self.data_type.to_arrow_dtype()
+        except Exception:
+            return None
+
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        """Whether the output of this expression may contain nulls.
+
+        The default is the conservative ``True``; subclasses that produce
+        a non-nullable output (e.g., ``is_null``, ``RandomExpr``) override.
+        """
+        return True
+
+    def to_field(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.Field"]:
+        """Return the output PyArrow ``Field`` given the input schema.
+
+        Defaults to ``pa.field(self.name, self.get_type(input_schema),
+        nullable=self.nullable(input_schema))``. Returns ``None`` when
+        either the type can't be resolved or the expression has no name
+        (the latter is invalid for projection list entries; ``Project``
+        enforces this in ``__post_init__``).
+        """
+        data_type = self.get_type(input_schema)
+        if data_type is None:
+            return None
+        name = self.name
+        if name is None:
+            return None
+        return pyarrow.field(name, data_type, nullable=self.nullable(input_schema))
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -811,6 +889,25 @@ class ColumnExpr(Expr):
 
     def structurally_equals(self, other: Any) -> bool:
         return isinstance(other, ColumnExpr) and self.name == other.name
+
+    def get_type(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.DataType"]:
+        try:
+            return input_schema.field(self._name).type
+        except (KeyError, ValueError):
+            return None
+
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        try:
+            return input_schema.field(self._name).nullable
+        except (KeyError, ValueError):
+            return True
+
+    def to_field(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.Field"]:
+        # Preserve the input field verbatim (including metadata).
+        try:
+            return input_schema.field(self._name)
+        except (KeyError, ValueError):
+            return None
 
 
 @DeveloperAPI(stability="alpha")
@@ -850,6 +947,11 @@ class LiteralExpr(Expr):
             and type(self.value) is type(other.value)
         )
 
+    # ``get_type`` is inherited from ``Expr``: ``data_type`` is inferred
+    # from ``value`` in ``__post_init__``.
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        return self.value is None
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -886,6 +988,22 @@ class BinaryExpr(Expr):
             and self.right.structurally_equals(other.right)
         )
 
+    def get_type(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.DataType"]:
+        # IN/NOT_IN take a list literal on the right and always return bool;
+        # don't try to type-check the list against the kernel.
+        if self.op in (Operation.IN, Operation.NOT_IN):
+            return pyarrow.bool_()
+
+        left_type = self.left.get_type(input_schema)
+        right_type = self.right.get_type(input_schema)
+        if left_type is None or right_type is None:
+            return None
+
+        return _eval_kernel_type(self.op, [left_type, right_type])
+
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        return self.left.nullable(input_schema) or self.right.nullable(input_schema)
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -921,6 +1039,22 @@ class UnaryExpr(Expr):
             and self.op is other.op
             and self.operand.structurally_equals(other.operand)
         )
+
+    def get_type(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.DataType"]:
+        # IS_NULL / IS_NOT_NULL always return bool regardless of operand type.
+        if self.op in (Operation.IS_NULL, Operation.IS_NOT_NULL):
+            return pyarrow.bool_()
+
+        operand_type = self.operand.get_type(input_schema)
+        if operand_type is None:
+            return None
+
+        return _eval_kernel_type(self.op, [operand_type])
+
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        if self.op in (Operation.IS_NULL, Operation.IS_NOT_NULL):
+            return False
+        return self.operand.nullable(input_schema)
 
 
 @dataclass(frozen=True)
@@ -1164,6 +1298,9 @@ class UDFExpr(Expr):
             )
         )
 
+    # ``get_type`` is inherited from ``Expr``: ``data_type`` is the
+    # user-declared ``return_dtype`` from the ``@udf(...)`` decorator.
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1302,7 +1439,7 @@ def udf(return_dtype: DataType) -> Callable[..., UDFExpr]:
     """
 
     def decorator(
-        func_or_class: Union[Callable[..., BatchColumn], Type[T]]
+        func_or_class: Union[Callable[..., BatchColumn], Type[T]],
     ) -> Decorated:
         # Check if this is a callable class (has __call__ method defined)
         if isinstance(func_or_class, type) and issubclass(func_or_class, Callable):
@@ -1355,7 +1492,7 @@ def udf(return_dtype: DataType) -> Callable[..., UDFExpr]:
 
 
 def _create_pyarrow_wrapper(
-    fn: Callable[..., BatchColumn]
+    fn: Callable[..., BatchColumn],
 ) -> Callable[..., BatchColumn]:
     """Wrap a PyArrow compute function to auto-convert inputs to PyArrow format.
 
@@ -1495,6 +1632,8 @@ class DownloadExpr(Expr):
             and self.uri_column_name == other.uri_column_name
         )
 
+    # ``get_type`` is inherited from ``Expr``: ``data_type`` is fixed to binary.
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1527,6 +1666,26 @@ class AliasExpr(Expr):
             and self._is_rename == other._is_rename
         )
 
+    def get_type(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.DataType"]:
+        return self.expr.get_type(input_schema)
+
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        return self.expr.nullable(input_schema)
+
+    def to_field(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.Field"]:
+        inner: Optional["pyarrow.Field"] = self.expr.to_field(input_schema)
+        if inner is None:
+            # Fall back to deriving from get_type if the wrapped expression
+            # doesn't have a name (e.g., AliasExpr wrapping BinaryExpr).
+            data_type = self.expr.get_type(input_schema)
+            if data_type is None:
+                return None
+            return pyarrow.field(
+                self._name, data_type, nullable=self.expr.nullable(input_schema)
+            )
+        # Preserve the wrapped field's type/nullability/metadata, swap the name.
+        return inner.with_name(self._name)
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1551,6 +1710,11 @@ class StarExpr(Expr):
     def structurally_equals(self, other: Any) -> bool:
         return isinstance(other, StarExpr)
 
+    def to_field(self, input_schema: "pyarrow.Schema") -> Optional["pyarrow.Field"]:
+        # ``StarExpr`` represents many columns, not one. ``exprlist_to_fields``
+        # expands it inline rather than calling ``to_field`` on it.
+        return None
+
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1564,6 +1728,10 @@ class MonotonicallyIncreasingIdExpr(Expr):
 
     def structurally_equals(self, other: Any) -> bool:
         # Non-deterministic, never structurally equal to another expression
+        return False
+
+    # ``get_type`` is inherited from ``Expr``: ``data_type`` is fixed to int64.
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
         return False
 
 
@@ -1600,6 +1768,10 @@ class RandomExpr(Expr):
             and self.reseed_after_execution == other.reseed_after_execution
         )
 
+    # ``get_type`` is inherited from ``Expr``: ``data_type`` is fixed to float64.
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        return False
+
 
 @DeveloperAPI
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1617,6 +1789,82 @@ class UUIDExpr(Expr):
 
     def structurally_equals(self, other: Any) -> bool:
         return isinstance(other, UUIDExpr)
+
+    # ``get_type`` is inherited from ``Expr``: ``data_type`` is fixed to string.
+    def nullable(self, input_schema: "pyarrow.Schema") -> bool:
+        return False
+
+
+def exprlist_to_fields(
+    exprs: List[Expr], input_schema: "pyarrow.Schema"
+) -> Optional[List["pyarrow.Field"]]:
+    """Resolve a list of expressions against the input schema into PyArrow fields.
+
+    Handles ``StarExpr`` inline: when encountered, splices in the input
+    schema's fields (minus columns listed as a rename source by any
+    ``AliasExpr`` with ``_is_rename=True`` elsewhere in the list).
+
+    Deduplicates on field name with last-wins semantics, matching the
+    runtime ``eval_projection`` (which uses ``fill_column``/upsert when
+    building the output block). This is what makes
+    ``with_column("a", expr)`` (which builds ``[StarExpr(), expr.alias("a")]``)
+    produce a single ``a`` field equal to the new expression's output type
+    even if ``a`` was already in the input schema.
+
+    Returns ``None`` if any non-star expression cannot be resolved
+    (e.g., a UDFExpr without a declared ``return_dtype`` or a column
+    not present in ``input_schema``). Callers (typically
+    ``Project.infer_schema``) propagate that ``None`` upward so that
+    ``Dataset.schema()`` falls back to a ``limit(1)`` execution.
+
+    Args:
+        exprs: The projection list. May contain ``StarExpr`` plus
+            named expressions; ``Project`` enforces that every
+            non-star expression has a name.
+        input_schema: The input ``pa.Schema`` to resolve against.
+
+    Returns:
+        A list of ``pa.Field`` in projection order, or ``None`` if
+        any expression is unresolvable.
+    """
+    if input_schema is None:
+        return None
+
+    # Collect rename sources so StarExpr expansion can drop them.
+    rename_sources = set()
+    for expr in exprs:
+        if (
+            isinstance(expr, AliasExpr)
+            and expr._is_rename
+            and isinstance(expr.expr, ColumnExpr)
+        ):
+            rename_sources.add(expr.expr.name)
+
+    # Walk the projection list, tracking each field by name. Later
+    # entries with the same name replace earlier ones in place to
+    # match runtime upsert semantics.
+    name_to_index: Dict[str, int] = {}
+    out_fields: List["pyarrow.Field"] = []
+
+    def _emit(field_: "pyarrow.Field") -> None:
+        idx = name_to_index.get(field_.name)
+        if idx is None:
+            name_to_index[field_.name] = len(out_fields)
+            out_fields.append(field_)
+        else:
+            out_fields[idx] = field_
+
+    for expr in exprs:
+        if isinstance(expr, StarExpr):
+            for field_ in input_schema:
+                if field_.name not in rename_sources:
+                    _emit(field_)
+            continue
+        resolved = expr.to_field(input_schema)
+        if resolved is None:
+            return None
+        _emit(resolved)
+    return out_fields
 
 
 @PublicAPI(stability="beta")

--- a/python/ray/data/expressions.py
+++ b/python/ray/data/expressions.py
@@ -268,8 +268,7 @@ def _eval_kernel_type(
     )
 
     op_fn = _ARROW_EXPR_OPS_MAP.get(op)
-    if op_fn is None:
-        return None
+    assert op_fn is not None, f"Operation not supported: {op}"
 
     try:
         empty_arrays = [pyarrow.array([], type=t) for t in operand_types]
@@ -277,7 +276,7 @@ def _eval_kernel_type(
     except Exception:
         return None
 
-    return getattr(result, "type", None)
+    return result.type
 
 
 @DeveloperAPI(stability="alpha")
@@ -1298,9 +1297,6 @@ class UDFExpr(Expr):
             )
         )
 
-    # ``get_type`` is inherited from ``Expr``: ``data_type`` is the
-    # user-declared ``return_dtype`` from the ``@udf(...)`` decorator.
-
 
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True, eq=False, repr=False)
@@ -1847,9 +1843,6 @@ def exprlist_to_fields(
         A list of ``pa.Field`` in projection order, or ``None`` if
         any expression is unresolvable.
     """
-    if input_schema is None:
-        return None
-
     # Bucket the projection list: rename AliasExprs substitute for their
     # source column during StarExpr expansion (preserving on-disk column
     # order, matching runtime ``eval_projection``); non-rename exprs are

--- a/python/ray/data/tests/test_filter.py
+++ b/python/ray/data/tests/test_filter.py
@@ -437,6 +437,7 @@ def test_filter_expression_display_names(ray_start_regular_shared):
     """Test that filter operations display meaningful expression names in plans."""
     import pyarrow.compute as pc
 
+    from ray.data._internal.dataset_repr import build_dataset_summary_repr
     from ray.data.datatype import DataType
     from ray.data.expressions import udf
 
@@ -444,7 +445,8 @@ def test_filter_expression_display_names(ray_start_regular_shared):
     def _str_len(array):
         return pc.greater(pc.binary_length(array), 0)
 
-    plan_str = str(ray.data.from_items(["a", ""]).filter(expr=_str_len(col("item"))))
+    ds = ray.data.from_items(["a", ""]).filter(expr=_str_len(col("item")))
+    plan_str = build_dataset_summary_repr(ds)
     assert plan_str == (
         "Filter(_str_len(col('item')))\n"
         "+- Dataset(num_rows=2, schema={item: string})"

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -66,7 +66,7 @@ def test_groupby_arrow(
     target_max_block_size_infinite_or_default,
 ):
     # Test empty dataset.
-    agg_ds = ray.data.range(10).filter(lambda r: r["id"] > 10).groupby("value").count()
+    agg_ds = ray.data.range(10).filter(lambda r: r["id"] > 10).groupby("id").count()
     assert agg_ds.count() == 0
 
 

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -228,6 +228,24 @@ class TestNAry:
             [pa.field("a", pa.int32()), pa.field("a_1", pa.int32())]
         )
 
+    def test_union_incompatible_column_types_returns_none(
+        self, ray_start_regular_shared_2_cpus, tmp_path
+    ):
+        # Same column name, irreconcilable types: ``infer_schema`` must
+        # return None (and ``Dataset.schema(fetch_if_missing=False)`` along
+        # with it), not surface an ArrowTypeError from unify_schemas.
+        a_path = tmp_path / "a.parquet"
+        b_path = tmp_path / "b.parquet"
+        pq.write_table(pa.table({"x": pa.array([1, 2], type=pa.int32())}), a_path)
+        pq.write_table(
+            pa.table({"x": pa.array([[1.0], [2.0]], type=pa.list_(pa.float64()))}),
+            b_path,
+        )
+        ds = ray.data.read_parquet(str(a_path)).union(
+            ray.data.read_parquet(str(b_path))
+        )
+        assert ds.schema(fetch_if_missing=False) is None
+
 
 class TestJoin:
     def test_inner_join(self, ray_start_regular_shared_2_cpus, tmp_path):

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -126,11 +126,13 @@ class TestProject:
 
     def test_rename_columns(self, ray_start_regular_shared_2_cpus, parquet_path):
         ds = ray.data.read_parquet(str(parquet_path)).rename_columns({"a": "x"})
+        # Renamed columns occupy the source column's position so the static
+        # schema matches the materialized column order.
         assert _static_schema(ds) == pa.schema(
             [
+                pa.field("x", pa.int32()),
                 pa.field("b", pa.float32()),
                 pa.field("k", pa.string()),
-                pa.field("x", pa.int32()),
             ]
         )
 

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -1,0 +1,308 @@
+"""Integration tests for ``LogicalOperator.infer_schema()`` (Phase 1).
+
+Asserts that ``Dataset.schema()`` resolves the output schema **without**
+falling back to a ``limit(1)`` execution for every non-UDF chain. UDF
+chains (``map``, ``map_batches``, ``flat_map``) correctly return ``None``.
+
+The headline guarantee is verified by calling ``ds.schema(fetch_if_missing=False)``
+through the public API: this disables the ``limit(1)`` fallback in
+``_base_schema``, so a non-``None`` return proves the static
+``LogicalOperator.infer_schema()`` path resolved the schema without
+materializing any blocks.
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import ray
+from ray.data.aggregate import Count, Max, Mean, Min, Sum
+from ray.data.expressions import col, lit
+from ray.data.tests.conftest import *  # noqa: F401,F403
+
+
+@pytest.fixture(scope="module")
+def parquet_path(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("infer_schema")
+    table = pa.table(
+        {
+            "a": pa.array([1, 2, 3, 4, 5], type=pa.int32()),
+            "b": pa.array([1.0, 2.0, 3.0, 4.0, 5.0], type=pa.float32()),
+            "k": pa.array(["x", "x", "y", "y", "z"], type=pa.string()),
+        }
+    )
+    pq.write_table(table, tmp / "data.parquet")
+    return tmp
+
+
+def _static_schema(ds: ray.data.Dataset) -> pa.Schema:
+    """Return the dataset's schema via the static path only.
+
+    ``fetch_if_missing=False`` disables ``_base_schema``'s ``limit(1)``
+    fallback, so a non-``None`` return proves the chain's
+    ``infer_schema()`` resolved without materializing any blocks. Returns
+    ``None`` if the static path failed.
+    """
+    schema = ds.schema(fetch_if_missing=False)
+    return None if schema is None else schema.base_schema
+
+
+class TestSourceAndPassthroughs:
+    def test_read_parquet(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = ray.data.read_parquet(str(parquet_path))
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+            ]
+        )
+
+    def test_filter_with_expr_passthrough(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        ds = ray.data.read_parquet(str(parquet_path)).filter(expr=col("a") > 0)
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+            ]
+        )
+
+    def test_filter_with_fn_passthrough(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        # Filter with a callable still preserves the input schema.
+        ds = ray.data.read_parquet(str(parquet_path)).filter(lambda row: row["a"] > 0)
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+            ]
+        )
+
+    def test_limit_passthrough(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = ray.data.read_parquet(str(parquet_path)).limit(2)
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+            ]
+        )
+
+    def test_sort_passthrough(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = ray.data.read_parquet(str(parquet_path)).sort("a")
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+            ]
+        )
+
+
+class TestProject:
+    def test_select_columns(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = ray.data.read_parquet(str(parquet_path)).select_columns(["a", "b"])
+        assert _static_schema(ds) == pa.schema(
+            [pa.field("a", pa.int32()), pa.field("b", pa.float32())]
+        )
+
+    def test_with_column(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = ray.data.read_parquet(str(parquet_path)).with_column(
+            "s", col("a") + col("b")
+        )
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+                pa.field("s", pa.float32()),
+            ]
+        )
+
+    def test_rename_columns(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = ray.data.read_parquet(str(parquet_path)).rename_columns({"a": "x"})
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+                pa.field("x", pa.int32()),
+            ]
+        )
+
+    def test_with_column_chain(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .with_column("s", col("a") + col("b"))
+            .with_column("d", col("s") * lit(2.0))
+        )
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+                pa.field("s", pa.float32()),
+                pa.field("d", pa.float64()),
+            ]
+        )
+
+
+class TestAggregate:
+    def test_groupby_multi_aggs(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .groupby("k")
+            .aggregate(Sum("a"), Mean("b"), Count("a"), Max("a"), Min("a"))
+        )
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("k", pa.string()),
+                pa.field("sum(a)", pa.int64()),
+                pa.field("mean(b)", pa.float64()),
+                pa.field("count(a)", pa.int64(), nullable=False),
+                pa.field("max(a)", pa.int32()),
+                pa.field("min(a)", pa.int32()),
+            ]
+        )
+
+    def test_groupby_then_sort(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .groupby("k")
+            .aggregate(Sum("a"))
+            .sort("k")
+        )
+        assert _static_schema(ds) == pa.schema(
+            [pa.field("k", pa.string()), pa.field("sum(a)", pa.int64())]
+        )
+
+
+class TestNAry:
+    def test_union(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds_a = ray.data.read_parquet(str(parquet_path))
+        ds_b = ray.data.read_parquet(str(parquet_path))
+        ds = ds_a.union(ds_b)
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("a", pa.int32()),
+                pa.field("b", pa.float32()),
+                pa.field("k", pa.string()),
+            ]
+        )
+
+    def test_zip_disjoint_columns(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds_a = ray.data.read_parquet(str(parquet_path)).select_columns(["a"])
+        ds_b = ray.data.read_parquet(str(parquet_path)).select_columns(["b"])
+        ds = ds_a.zip(ds_b)
+        assert _static_schema(ds) == pa.schema(
+            [pa.field("a", pa.int32()), pa.field("b", pa.float32())]
+        )
+
+    def test_zip_overlapping_columns_get_suffixed(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        # When both inputs have a column named "a", the second input's
+        # column is renamed to "a_1" to match runtime ``_zip`` behavior.
+        ds_a = ray.data.read_parquet(str(parquet_path)).select_columns(["a"])
+        ds_b = ray.data.read_parquet(str(parquet_path)).select_columns(["a"])
+        ds = ds_a.zip(ds_b)
+        assert _static_schema(ds) == pa.schema(
+            [pa.field("a", pa.int32()), pa.field("a_1", pa.int32())]
+        )
+
+
+class TestJoin:
+    def test_inner_join(self, ray_start_regular_shared_2_cpus, tmp_path):
+        left = pa.table(
+            {
+                "k": pa.array(["a", "b", "c"]),
+                "lval": pa.array([1, 2, 3], type=pa.int32()),
+            }
+        )
+        right = pa.table(
+            {
+                "k": pa.array(["a", "b", "c"]),
+                "rval": pa.array([10.0, 20.0, 30.0], type=pa.float32()),
+            }
+        )
+        l_path = tmp_path / "left.parquet"
+        r_path = tmp_path / "right.parquet"
+        pq.write_table(left, l_path)
+        pq.write_table(right, r_path)
+        ds = ray.data.read_parquet(str(l_path)).join(
+            ray.data.read_parquet(str(r_path)),
+            on=("k",),
+            join_type="inner",
+            num_partitions=2,
+        )
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("k", pa.string()),
+                pa.field("lval", pa.int32()),
+                pa.field("rval", pa.float32()),
+            ]
+        )
+
+
+class TestUDFFallback:
+    def test_map_batches_returns_none(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        # The headline guarantee inverse: UDF maps return None from
+        # infer_schema, so ds.schema(fetch_if_missing=False) returns None
+        # (it would only return a value via the limit(1) fallback, which
+        # we've disabled).
+        ds = ray.data.read_parquet(str(parquet_path)).map_batches(lambda b: b)
+        assert ds.schema(fetch_if_missing=False) is None
+
+    def test_select_after_map_batches_also_returns_none(
+        self, ray_start_regular_shared_2_cpus, parquet_path
+    ):
+        # The transitive break: anything downstream of a UDF can't infer
+        # schema either.
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .map_batches(lambda b: b)
+            .select_columns(["a"])
+        )
+        assert ds.schema(fetch_if_missing=False) is None
+
+
+class TestEndToEndStaticResolution:
+    """The headline Phase 1 guarantee: a complex non-UDF chain resolves
+    via ``Dataset.schema()`` without triggering the ``limit(1)`` fallback.
+
+    The check is:
+    - ``ds.schema(fetch_if_missing=False)`` returns the expected schema.
+      Because ``fetch_if_missing=False`` disables the ``limit(1)``
+      fallback in ``_base_schema``, a non-``None`` return proves that
+      ``LogicalOperator.infer_schema()`` resolved the schema statically.
+    """
+
+    def test_complex_typed_chain(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .filter(expr=col("a") > 0)
+            .select_columns(["a", "b", "k"])
+            .with_column("s", col("a") + col("b"))
+            .groupby("k")
+            .aggregate(Sum("a"), Mean("b"))
+            .sort("k")
+        )
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("k", pa.string()),
+                pa.field("sum(a)", pa.int64()),
+                pa.field("mean(b)", pa.float64()),
+            ]
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-xvs"]))

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -169,6 +169,20 @@ class TestAggregate:
             ]
         )
 
+    def test_groupby_multi_key(self, ray_start_regular_shared_2_cpus, parquet_path):
+        ds = (
+            ray.data.read_parquet(str(parquet_path))
+            .groupby(["k", "a"])
+            .aggregate(Count("b"))
+        )
+        assert _static_schema(ds) == pa.schema(
+            [
+                pa.field("k", pa.string()),
+                pa.field("a", pa.int32()),
+                pa.field("count(b)", pa.int64(), nullable=False),
+            ]
+        )
+
     def test_groupby_then_sort(self, ray_start_regular_shared_2_cpus, parquet_path):
         ds = (
             ray.data.read_parquet(str(parquet_path))

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -199,8 +199,11 @@ class TestAggregate:
 
 class TestNAry:
     def test_union(self, ray_start_regular_shared_2_cpus, parquet_path):
-        ds_a = ray.data.read_parquet(str(parquet_path))
-        ds_b = ray.data.read_parquet(str(parquet_path))
+        # Disjoint-but-overlapping column sets exercise the schema
+        # unification: ``a`` only in the first input, ``k`` only in the
+        # second, ``b`` shared. The output is the merged superset.
+        ds_a = ray.data.read_parquet(str(parquet_path)).select_columns(["a", "b"])
+        ds_b = ray.data.read_parquet(str(parquet_path)).select_columns(["b", "k"])
         ds = ds_a.union(ds_b)
         assert _static_schema(ds) == pa.schema(
             [

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -530,6 +530,26 @@ def _assert_scalar_values(result_by_id, expected_values):
             assert result_by_id[row_id][column] == expected_value
 
 
+def test_should_not_index_empty_schema_tables():
+    import pyarrow as pa
+
+    from ray.data._internal.execution.operators.join import _should_index_side
+
+    supported_table = pa.table({"id": pa.array([1])})
+    unsupported_table = pa.table({"unsupported": pa.array([[1]])})
+    empty_schema_table = pa.table({})
+
+    assert not _should_index_side(
+        "left", empty_schema_table, unsupported_table, JoinType.LEFT_OUTER
+    )
+    assert not _should_index_side(
+        "left", supported_table, empty_schema_table, JoinType.LEFT_OUTER
+    )
+    assert _should_index_side(
+        "left", supported_table, unsupported_table, JoinType.LEFT_OUTER
+    )
+
+
 @pytest.mark.skipif(
     get_pyarrow_version() < parse_version("10.0.0"),
     reason="""Joins use empty arrays with type coercion. This pyarrow

--- a/python/ray/data/tests/test_union.py
+++ b/python/ray/data/tests/test_union.py
@@ -19,7 +19,15 @@ def test_union_schema(ray_start_10_cpus_shared):
 
 def test_union_repr(ray_start_10_cpus_shared):
     ds = ray.data.range(1).union(ray.data.range(1))
-    assert repr(ds) == "Union\n+- Dataset(num_rows=?, schema=Unknown schema)"
+    assert repr(ds) == (
+        "shape: (?, 1)\n"
+        "╭───────╮\n"
+        "│ id    │\n"
+        "│ ---   │\n"
+        "│ int64 │\n"
+        "╰───────╯\n"
+        "(Dataset isn't materialized)"
+    )
 
 
 def test_union_with_preserve_order(ray_start_10_cpus_shared, restore_data_context):

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -1,0 +1,265 @@
+"""Tests for schema-aware expression resolution.
+
+Covers ``Expr.get_type``, ``Expr.nullable``, ``Expr.to_field``, and the
+``exprlist_to_fields`` helper. These are the building blocks Phase 1
+operators (``Project``, ``Aggregate``, ``Join``, etc.) use to compute
+``infer_schema()`` without executing the plan.
+"""
+
+import pyarrow as pa
+import pytest
+
+from ray.data.datatype import DataType
+from ray.data.expressions import (
+    DownloadExpr,
+    MonotonicallyIncreasingIdExpr,
+    RandomExpr,
+    UDFExpr,
+    UUIDExpr,
+    col,
+    exprlist_to_fields,
+    lit,
+    star,
+    udf,
+)
+
+
+@pytest.fixture
+def schema():
+    return pa.schema(
+        [
+            pa.field("a", pa.int32(), nullable=True),
+            pa.field("b", pa.float32(), nullable=False),
+            pa.field("name", pa.string(), nullable=True),
+            pa.field("flag", pa.bool_(), nullable=True),
+        ]
+    )
+
+
+class TestColumnExpr:
+    def test_to_field_returns_input_field_verbatim(self):
+        expected = pa.field("x", pa.int64(), nullable=False, metadata={b"k": b"v"})
+        in_schema = pa.schema([expected])
+        assert col("x").to_field(in_schema) == expected
+
+    def test_to_field_int_column(self, schema):
+        assert col("a").to_field(schema) == pa.field("a", pa.int32(), nullable=True)
+
+    def test_to_field_non_nullable_column(self, schema):
+        assert col("b").to_field(schema) == pa.field("b", pa.float32(), nullable=False)
+
+    def test_to_field_missing(self, schema):
+        assert col("missing").to_field(schema) is None
+
+
+class TestLiteralExpr:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (5, pa.field("v", pa.int64(), nullable=False)),
+            (5.0, pa.field("v", pa.float64(), nullable=False)),
+            ("hello", pa.field("v", pa.string(), nullable=False)),
+            (True, pa.field("v", pa.bool_(), nullable=False)),
+            (None, pa.field("v", pa.null(), nullable=True)),
+        ],
+    )
+    def test_to_field(self, schema, value, expected):
+        # ``LiteralExpr`` has no name, so ``to_field`` returns ``None``;
+        # we wrap in an alias to get a named field.
+        assert lit(value).alias("v").to_field(schema) == expected
+
+
+class TestBinaryExpr:
+    @pytest.mark.parametrize(
+        "expr_factory,expected",
+        [
+            # int32 + int64 -> int64 (PyArrow promotion); a is nullable.
+            (lambda: col("a") + lit(5), pa.field("out", pa.int64(), nullable=True)),
+            # int32 + float32 -> float; a is nullable, so output is nullable.
+            (lambda: col("a") + col("b"), pa.field("out", pa.float32(), nullable=True)),
+            # float32 * float64 -> double; both operands are non-nullable
+            # (b is non-null, literal is not None) -> output is non-nullable.
+            (
+                lambda: col("b") * lit(2.0),
+                pa.field("out", pa.float64(), nullable=False),
+            ),
+            # comparisons -> bool
+            (lambda: col("a") > lit(0), pa.field("out", pa.bool_(), nullable=True)),
+            (lambda: col("a") == lit(1), pa.field("out", pa.bool_(), nullable=True)),
+            # logical -> bool
+            (
+                lambda: col("flag") & col("flag"),
+                pa.field("out", pa.bool_(), nullable=True),
+            ),
+            (
+                lambda: col("flag") | col("flag"),
+                pa.field("out", pa.bool_(), nullable=True),
+            ),
+            # in/not_in -> bool
+            (
+                lambda: col("a").is_in([1, 2, 3]),
+                pa.field("out", pa.bool_(), nullable=True),
+            ),
+            (
+                lambda: col("a").not_in([1, 2, 3]),
+                pa.field("out", pa.bool_(), nullable=True),
+            ),
+            # string concat
+            (
+                lambda: col("name") + lit("!"),
+                pa.field("out", pa.string(), nullable=True),
+            ),
+        ],
+    )
+    def test_to_field(self, schema, expr_factory, expected):
+        assert expr_factory().alias("out").to_field(schema) == expected
+
+    def test_unresolvable_returns_none(self, schema):
+        assert (col("missing") + lit(1)).alias("x").to_field(schema) is None
+
+
+class TestUnaryExpr:
+    def test_is_null(self, schema):
+        expected = pa.field("isnull", pa.bool_(), nullable=False)
+        assert col("a").is_null().alias("isnull").to_field(schema) == expected
+
+    def test_is_not_null(self, schema):
+        expected = pa.field("isnotnull", pa.bool_(), nullable=False)
+        assert col("a").is_not_null().alias("isnotnull").to_field(schema) == expected
+
+    def test_not_bool(self, schema):
+        expected = pa.field("neg", pa.bool_(), nullable=True)
+        assert (~col("flag")).alias("neg").to_field(schema) == expected
+
+
+class TestAliasExpr:
+    def test_to_field_renames(self, schema):
+        # Wraps a column field; alias swaps the name, preserves type/nullability.
+        assert col("a").alias("renamed").to_field(schema) == pa.field(
+            "renamed", pa.int32(), nullable=True
+        )
+
+    def test_to_field_around_binary(self, schema):
+        assert (col("a") + col("b")).alias("sum").to_field(schema) == pa.field(
+            "sum", pa.float32(), nullable=True
+        )
+
+
+class TestSelfContainedExprs:
+    def test_udf_uses_return_dtype(self, schema):
+        @udf(return_dtype=DataType.float64())
+        def double(x):
+            return x
+
+        assert double(col("a")).alias("d").to_field(schema) == pa.field(
+            "d", pa.float64(), nullable=True
+        )
+
+    def test_download_is_binary(self, schema):
+        assert DownloadExpr("uri").alias("bytes").to_field(schema) == pa.field(
+            "bytes", pa.binary(), nullable=True
+        )
+
+    def test_monotonically_increasing_id(self, schema):
+        assert MonotonicallyIncreasingIdExpr().alias("id").to_field(schema) == pa.field(
+            "id", pa.int64(), nullable=False
+        )
+
+    def test_random(self, schema):
+        assert RandomExpr().alias("r").to_field(schema) == pa.field(
+            "r", pa.float64(), nullable=False
+        )
+
+    def test_uuid(self, schema):
+        assert UUIDExpr().alias("u").to_field(schema) == pa.field(
+            "u", pa.string(), nullable=False
+        )
+
+
+class TestStarExpr:
+    def test_to_field_returns_none(self, schema):
+        # ``StarExpr`` represents many columns; ``exprlist_to_fields``
+        # expands it inline rather than calling ``to_field`` on it.
+        assert star().to_field(schema) is None
+
+
+class TestExprlistToFields:
+    def test_simple_columns(self, schema):
+        expected = pa.schema(
+            [
+                pa.field("a", pa.int32(), nullable=True),
+                pa.field("b", pa.float32(), nullable=False),
+            ]
+        )
+        result = pa.schema(exprlist_to_fields([col("a"), col("b")], schema))
+        assert result == expected
+
+    def test_star_expansion(self, schema):
+        # Star expands to all input fields verbatim.
+        result = pa.schema(exprlist_to_fields([star()], schema))
+        assert result == schema
+
+    def test_star_with_rename(self, schema):
+        result = pa.schema(
+            exprlist_to_fields([star(), col("a")._rename("renamed_a")], schema)
+        )
+        # Renaming "a" -> "renamed_a" drops "a" from star expansion and
+        # appends the renamed field at the end.
+        expected = pa.schema(
+            [
+                pa.field("b", pa.float32(), nullable=False),
+                pa.field("name", pa.string(), nullable=True),
+                pa.field("flag", pa.bool_(), nullable=True),
+                pa.field("renamed_a", pa.int32(), nullable=True),
+            ]
+        )
+        assert result == expected
+
+    def test_star_with_with_column(self, schema):
+        # with_column-style: [star(), expr.alias(name)] preserves all input
+        # columns and appends the new computed column.
+        result = pa.schema(
+            exprlist_to_fields([star(), (col("a") + col("b")).alias("sum")], schema)
+        )
+        expected = pa.schema(
+            list(schema) + [pa.field("sum", pa.float32(), nullable=True)]
+        )
+        assert result == expected
+
+    def test_returns_none_on_unresolvable(self, schema):
+        assert exprlist_to_fields([col("missing")], schema) is None
+
+    def test_with_column_overrides_existing_column(self, schema):
+        # ``with_column("a", new_expr)`` builds ``[star(), new_expr.alias("a")]``.
+        # The override should replace the existing "a" in place (last-wins,
+        # matching runtime ``eval_projection``'s upsert behavior), not
+        # produce a duplicate.
+        result = pa.schema(
+            exprlist_to_fields([star(), (col("a") + lit(10)).alias("a")], schema)
+        )
+        expected = pa.schema(
+            [
+                pa.field("a", pa.int64(), nullable=True),  # new type from a + 10
+                pa.field("b", pa.float32(), nullable=False),
+                pa.field("name", pa.string(), nullable=True),
+                pa.field("flag", pa.bool_(), nullable=True),
+            ]
+        )
+        assert result == expected
+
+    def test_returns_none_on_udf_without_return_dtype(self, schema):
+        # Construct a synthetic UDFExpr with object data_type to simulate
+        # the "untyped UDF" case.
+        e = UDFExpr(
+            fn=lambda x: x,
+            args=[col("a")],
+            kwargs={},
+            data_type=DataType(object),
+        )
+        assert exprlist_to_fields([e.alias("out")], schema) is None
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-xvs"]))

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -147,11 +147,13 @@ class TestAliasExpr:
 
 class TestSelfContainedExprs:
     def test_udf_uses_return_dtype(self, schema):
-        @udf(return_dtype=DataType.float64())
+        @udf(return_dtype=DataType.float64())  # pyrefly: ignore[missing-attribute]
         def double(x):
             return x
 
-        assert double(col("a")).alias("d").to_field(schema) == pa.field(
+        assert double(col("a")).alias("d").to_field(
+            schema
+        ) == pa.field(  # pyrefly: ignore[not-callable]
             "d", pa.float64(), nullable=True
         )
 

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -203,17 +203,22 @@ class TestExprlistToFields:
         result = pa.schema(
             exprlist_to_fields([star(), col("a")._rename("renamed_a")], schema)
         )
-        # Renaming "a" -> "renamed_a" drops "a" from star expansion and
-        # appends the renamed field at the end.
+        # Renaming "a" -> "renamed_a" substitutes the renamed field at
+        # "a"'s position (matching runtime ``eval_projection``).
         expected = pa.schema(
             [
+                pa.field("renamed_a", pa.int32(), nullable=True),
                 pa.field("b", pa.float32(), nullable=False),
                 pa.field("name", pa.string(), nullable=True),
                 pa.field("flag", pa.bool_(), nullable=True),
-                pa.field("renamed_a", pa.int32(), nullable=True),
             ]
         )
         assert result == expected
+
+    def test_star_with_rename_missing_source_returns_none(self, schema):
+        # Renaming an absent column must fail resolution (matching the
+        # runtime, which raises "column not found"), not silently append.
+        assert exprlist_to_fields([star(), col("missing")._rename("x")], schema) is None
 
     def test_star_with_with_column(self, schema):
         # with_column-style: [star(), expr.alias(name)] preserves all input

--- a/python/ray/data/tests/unit/expressions/test_schema_resolution.py
+++ b/python/ray/data/tests/unit/expressions/test_schema_resolution.py
@@ -151,11 +151,9 @@ class TestSelfContainedExprs:
         def double(x):
             return x
 
-        assert double(col("a")).alias("d").to_field(
+        assert double(col("a")).alias("d").to_field(  # pyrefly: ignore[not-callable]
             schema
-        ) == pa.field(  # pyrefly: ignore[not-callable]
-            "d", pa.float64(), nullable=True
-        )
+        ) == pa.field("d", pa.float64(), nullable=True)
 
     def test_download_is_binary(self, schema):
         assert DownloadExpr("uri").alias("bytes").to_field(schema) == pa.field(


### PR DESCRIPTION
## Description

This PR teaches Ray Data's logical plan to infer output schemas for non-UDF operators before execution.

Previously, a typed pipeline could still make `Dataset.schema()` fall back to a `limit(1)` execution whenever an intermediate logical operator could not describe its output schema. With these overrides, `ds.schema(fetch_if_missing=False)` can resolve through typed pipelines made from projections, filters, shuffles/repartitioning, aggregate/count, union/mix, zip, join, download, write, and streaming split/repartition operators without sampling data.

This does not apply to black-box UDF transforms such as `map`, `map_batches`, and similar APIs. Expression UDF schemas still come from their declared `return_dtype`; this PR does not infer result types from UDF implementation code.

## Related issues

N/A

## Additional information

The main pieces are:

* Adds `LogicalOperator.infer_schema()` plus reusable mixins for operators that preserve or unify input schemas.
* Adds expression-level field resolution through `Expr.to_field()`, `get_type()`, and `nullable()`, including projection handling for `*`, aliases, renames, and upserts.
* Adds aggregate output fields for built-in aggregations such as count, sum, min, max, mean, std, and abs max.
* Reuses runtime table logic for zip and join schema inference on empty Arrow tables so inferred schemas match execution behavior.
* Covers the new behavior with 37 expression/unit cases and 18 integration cases that verify `ds.schema(fetch_if_missing=False)` resolves without execution.