### PR TITLE
[Data] Remove docs recommending increased object store memory proportion

### DIFF
--- a/doc/source/data/joining-data.rst
+++ b/doc/source/data/joining-data.rst
@@ -54,15 +54,6 @@ Ray Data provides the following levers to allow tuning the performance of joins 
     -   Note that, `num_partitions * partition_size_hint` should ideally be approximating actual dataset size, ie `partition_size_hint` could be estimated as dataset size divided by `num_partitions` (assuming relatively evenly sized partitions)
     -   However, in cases when dataset partitioning is expected to be heavily skewed `partition_size_hint` should approximate largest partition to prevent Out-of-Memory (OOM) errors
 
-.. note:: Be mindful that by default Ray reserves only 30% of the memory for its Object Store. This is recommended to be set at least to ***50%*** for all
-    Ray Data workloads, but especially so for ones utilizing joins.
-
-To configure Object Store to be 50%, add to your image:
-
-.. testcode::
-
-    RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION=0.5
-
 .. _joins_configuring_num_partitions:
 
 Configuring number of partitions

--- a/doc/source/data/performance-tips.rst
+++ b/doc/source/data/performance-tips.rst
@@ -441,9 +441,6 @@ You can configure execution options with the global DataContext. The options are
         object_store_memory=10e9,
     )
 
-.. note::
-    Be mindful that by default Ray reserves only 30% of the memory for its Object Store. This is recommended to be set at least to ***50%*** for all Ray Data workloads.
-
 Reproducibility
 ---------------
 


### PR DESCRIPTION
#62387 removed the unconditional warning instructing Ray Data users to increase `RAY_DEFAULT_OBJECT_STORE_MEMORY_PROPORTION` from 0.3 to 0.5. This PR removes the same recommendation from the documentation for the same reason.

While increasing the object store proportion may help pipelines bottlenecked on object store memory, it is counterproductive for well-balanced streaming pipelines (e.g., offline inference):

- **Reduced concurrency**: More object store memory means less logical memory available for scheduling, which means fewer concurrent tasks.
- **OOM risk**: If the system aggressively buffers data up to the object store limit, it eats into physical memory headroom.

The blanket recommendation misleads users running common streaming workloads.

## Related issue number

Follow-up to #62387.