### PR TITLE
[Data] Deprecate ConcurrencyCapBackpressurePolicy

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import warnings
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict
 
@@ -26,7 +27,6 @@ logger = logging.getLogger(__name__)
 @Deprecated(
     message="ConcurrencyCapBackpressurePolicy is deprecated and will be removed "
     "on or after Ray 2.59.",
-    warning=True,
 )
 class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
     """A backpressure policy that caps the concurrency of each operator.
@@ -100,6 +100,14 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
         self.enable_dynamic_output_queue_size_backpressure = (
             self._data_context.enable_dynamic_output_queue_size_backpressure
         )
+
+        if self.enable_dynamic_output_queue_size_backpressure:
+            warnings.warn(
+                "ConcurrencyCapBackpressurePolicy is deprecated and will be "
+                "removed on or after Ray 2.59.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         dynamic_output_queue_size_backpressure_configs = ""
         if self.enable_dynamic_output_queue_size_backpressure:

--- a/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
@@ -12,6 +12,7 @@ from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.task_pool_map_operator import (
     TaskPoolMapOperator,
 )
+from ray.util.annotations import Deprecated
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces.physical_operator import (
@@ -22,6 +23,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@Deprecated(
+    message="ConcurrencyCapBackpressurePolicy is deprecated and will be removed "
+    "on or after Ray 2.59.",
+    warning=True,
+)
 class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
     """A backpressure policy that caps the concurrency of each operator.
     This policy dynamically limits the number of concurrent tasks per operator

--- a/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/concurrency_cap_backpressure_policy.py
@@ -13,7 +13,7 @@ from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.task_pool_map_operator import (
     TaskPoolMapOperator,
 )
-from ray.util.annotations import Deprecated
+from ray.util.annotations import Deprecated, RayDeprecationWarning
 
 if TYPE_CHECKING:
     from ray.data._internal.execution.interfaces.physical_operator import (
@@ -105,7 +105,7 @@ class ConcurrencyCapBackpressurePolicy(BackpressurePolicy):
             warnings.warn(
                 "ConcurrencyCapBackpressurePolicy is deprecated and will be "
                 "removed on or after Ray 2.59.",
-                DeprecationWarning,
+                RayDeprecationWarning,
                 stacklevel=2,
             )
 

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -460,29 +460,13 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
 def test_emits_deprecation_warning_when_dynamic_backpressure_enabled(
     restore_data_context,
 ):
-    ctx = restore_data_context
+    ctx = DataContext.get_current()
     ctx.enable_dynamic_output_queue_size_backpressure = True
     input_op = InputDataBuffer(ctx, input_data=[MagicMock()])
     topology = {input_op: MagicMock()}
 
     with pytest.warns(DeprecationWarning, match="deprecated"):
         ConcurrencyCapBackpressurePolicy(ctx, topology, MagicMock())
-
-
-def test_no_deprecation_warning_when_dynamic_backpressure_disabled(
-    restore_data_context,
-):
-    ctx = restore_data_context
-    ctx.enable_dynamic_output_queue_size_backpressure = False
-    input_op = InputDataBuffer(ctx, input_data=[MagicMock()])
-    topology = {input_op: MagicMock()}
-
-    import warnings
-
-    with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
-        ConcurrencyCapBackpressurePolicy(ctx, topology, MagicMock())
-    assert not any(issubclass(w.category, DeprecationWarning) for w in record)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -20,6 +20,7 @@ from ray.data._internal.execution.operators.task_pool_map_operator import (
 from ray.data._internal.execution.resource_manager import ResourceManager
 from ray.data.context import DataContext
 from ray.data.tests.conftest import mock_all_to_all_op
+from ray.util.annotations import RayDeprecationWarning
 
 
 class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
@@ -465,7 +466,7 @@ def test_emits_deprecation_warning_when_dynamic_backpressure_enabled(
     input_op = InputDataBuffer(ctx, input_data=[MagicMock()])
     topology = {input_op: MagicMock()}
 
-    with pytest.warns(DeprecationWarning, match="deprecated"):
+    with pytest.warns(RayDeprecationWarning, match="deprecated"):
         ConcurrencyCapBackpressurePolicy(ctx, topology, MagicMock())
 
 

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -457,6 +457,34 @@ class TestConcurrencyCapBackpressurePolicy(unittest.TestCase):
                 ), f"Expected {expected_result} for {description}"
 
 
+def test_emits_deprecation_warning_when_dynamic_backpressure_enabled(
+    restore_data_context,
+):
+    ctx = restore_data_context
+    ctx.enable_dynamic_output_queue_size_backpressure = True
+    input_op = InputDataBuffer(ctx, input_data=[MagicMock()])
+    topology = {input_op: MagicMock()}
+
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        ConcurrencyCapBackpressurePolicy(ctx, topology, MagicMock())
+
+
+def test_no_deprecation_warning_when_dynamic_backpressure_disabled(
+    restore_data_context,
+):
+    ctx = restore_data_context
+    ctx.enable_dynamic_output_queue_size_backpressure = False
+    input_op = InputDataBuffer(ctx, input_data=[MagicMock()])
+    topology = {input_op: MagicMock()}
+
+    import warnings
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        ConcurrencyCapBackpressurePolicy(ctx, topology, MagicMock())
+    assert not any(issubclass(w.category, DeprecationWarning) for w in record)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
We introduced an experimental "dynamic queue size backpressure" six months ago in https://github.com/ray-project/ray/pull/57996. 

This PR adds a warning that we're going to deprecate it in a few releases.

We've decided to deprecate it for a couple reasons:
* It's hard to understand. The policy requires ~400 lines of control logic with multiple tunable constants, trend detection across two different signals (percentage growth and absolute growth), and sliding window history tracking.
* It performed worse than the simpler `DownstreamCapacityBackpressurePolicy` in our experiments.
* Removing the policy allows us to simplify the `ResourceManager` interface. `ResourceManager` is one of Ray Data's most involved modules.