### PR TITLE
[serve] Fix `ServeController` memory leak under autoscaling cycles

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -57,7 +57,10 @@ from ray.serve._private.default_impl import (
     create_cluster_node_info_cache,
     get_proxy_actor_class,
 )
-from ray.serve._private.deployment_info import DeploymentInfo
+from ray.serve._private.deployment_info import (
+    _DYNAMIC_ACTOR_CLASS_CACHE,
+    DeploymentInfo,
+)
 from ray.serve._private.deployment_state import (
     DeploymentStateManager,
 )
@@ -427,6 +430,12 @@ class ServeController:
         self.deployment_state_manager._stop_one_running_replica_for_testing(
             deployment_id
         )
+
+    def _get_dynamic_actor_class_cache_ids_for_testing(self) -> Dict[str, int]:
+        """
+        Snapshot of the dynamic-actor-class cache.
+        """
+        return {name: id(cls) for name, cls in _DYNAMIC_ACTOR_CLASS_CACHE.items()}
 
     async def listen_for_change(self, keys_to_snapshot_ids: Dict[str, int]):
         """Proxy long pull client's listen request.

--- a/python/ray/serve/_private/deployment_info.py
+++ b/python/ray/serve/_private/deployment_info.py
@@ -8,6 +8,16 @@ from ray.serve.generated.serve_pb2 import (
     TargetCapacityDirection as TargetCapacityDirectionProto,
 )
 
+# Process-global cache of the dynamically-created Ray actor class produced
+# for each `actor_name`. Without this, every DeploymentInfo recreation
+# (pickle round-trip, `update()`, recovery load) constructs a brand-new Python
+# class via `type(actor_name, (ReplicaActor,), …)`, which is then registered
+# with `ray.remote(...)`. Ray retains the registered class in its actor
+# metadata table for the lifetime of the controller. Under fast autoscaling
+# cycles this is one of the per-cycle accumulators behind issue
+# https://github.com/ray-project/ray/issues/58815.
+_DYNAMIC_ACTOR_CLASS_CACHE: Dict[str, Any] = {}
+
 
 class DeploymentInfo:
     def __init__(
@@ -98,18 +108,23 @@ class DeploymentInfo:
         if self._cached_actor_def is None:
             assert self.actor_name is not None
 
-            # Break circular import :(.
-            from ray.serve._private.replica import ReplicaActor
+            cached = _DYNAMIC_ACTOR_CLASS_CACHE.get(self.actor_name)
+            if cached is None:
+                # Break circular import :(.
+                from ray.serve._private.replica import ReplicaActor
 
-            # Dynamically create a new class with custom name here so Ray picks it up
-            # correctly in actor metadata table and observability stack.
-            self._cached_actor_def = ray.remote(
-                type(
-                    self.actor_name,
-                    (ReplicaActor,),
-                    dict(ReplicaActor.__dict__),
+                # Dynamically create a new class with custom name here so Ray picks it up
+                # correctly in actor metadata table and observability stack.
+                cached = ray.remote(
+                    type(
+                        self.actor_name,
+                        (ReplicaActor,),
+                        dict(ReplicaActor.__dict__),
+                    )
                 )
-            )
+                _DYNAMIC_ACTOR_CLASS_CACHE[self.actor_name] = cached
+
+            self._cached_actor_def = cached
 
         return self._cached_actor_def
 

--- a/python/ray/serve/_private/deployment_info.py
+++ b/python/ray/serve/_private/deployment_info.py
@@ -16,6 +16,9 @@ from ray.serve.generated.serve_pb2 import (
 # metadata table for the lifetime of the controller. Under fast autoscaling
 # cycles this is one of the per-cycle accumulators behind issue
 # https://github.com/ray-project/ray/issues/58815.
+#
+# Grows monotonically, bounded by the set of unique `(app, deployment)` pairs
+# ever deployed in this controller process.
 _DYNAMIC_ACTOR_CLASS_CACHE: Dict[str, Any] = {}
 
 

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -422,6 +422,12 @@ class AggregationFunction(str, Enum):
     MIN = "min"
 
 
+# Process-global cache of deserialized autoscaling policy callables, keyed by
+# the policy's importable path (e.g. "ray.serve.autoscaling_policy:default_autoscaling_policy").
+# See AutoscalingPolicy.get_policy for the rationale.
+_GLOBAL_POLICY_CACHE: Dict[str, Callable] = {}
+
+
 @PublicAPI(stability="stable")
 class AutoscalingPolicy(BaseModel):
     # Cloudpickled policy definition.
@@ -526,11 +532,25 @@ class AutoscalingPolicy(BaseModel):
     def get_policy(self) -> Callable:
         """Deserialize policy from cloudpickled bytes.
 
-        The result is cached to avoid repeated cloudpickle deserialization on
-        every call (e.g. on every autoscaling tick).
+        Cached process-globally by ``policy_function`` path: every
+        ``cloudpickle.loads`` rebuilds a fresh module namespace (because
+        ``serialize_policy`` uses ``register_pickle_by_value``) whose function
+        objects cycle through ``function.__globals__``; resolving once per path
+        avoids that per-call accumulator. See
+        https://github.com/ray-project/ray/issues/58815.
         """
         if self._cached_policy is not None:
             return self._cached_policy
+
+        cache_key = (
+            self.policy_function if isinstance(self.policy_function, str) else None
+        )
+        if cache_key is not None:
+            cached = _GLOBAL_POLICY_CACHE.get(cache_key)
+            if cached is not None:
+                self._cached_policy = cached
+                return cached
+
         try:
             policy = cloudpickle.loads(self._serialized_policy_def)
         except (ModuleNotFoundError, ImportError) as e:
@@ -545,6 +565,8 @@ class AutoscalingPolicy(BaseModel):
                 "advanced-autoscaling.html#gotchas-and-limitations"
             ) from e
         self._cached_policy = policy
+        if cache_key is not None:
+            _GLOBAL_POLICY_CACHE[cache_key] = policy
         return policy
 
 

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -1,3 +1,4 @@
+import hashlib
 import inspect
 import json
 import logging
@@ -423,9 +424,12 @@ class AggregationFunction(str, Enum):
 
 
 # Process-global cache of deserialized autoscaling policy callables, keyed by
-# the policy's importable path (e.g. "ray.serve.autoscaling_policy:default_autoscaling_policy").
-# See AutoscalingPolicy.get_policy for the rationale.
-_GLOBAL_POLICY_CACHE: Dict[str, Callable] = {}
+# a hash of the serialized policy bytes. The bytes-hash key (rather than the
+# importable path) lets the cache invalidate automatically when a user
+# redeploys with updated policy code on the same import path, while still
+# deduplicating across the many ``AutoscalingPolicy`` instances Pydantic
+# rebuilds for the same policy.
+_GLOBAL_POLICY_CACHE: Dict[bytes, Callable] = {}
 
 
 @PublicAPI(stability="stable")
@@ -532,18 +536,22 @@ class AutoscalingPolicy(BaseModel):
     def get_policy(self) -> Callable:
         """Deserialize policy from cloudpickled bytes.
 
-        Cached process-globally by ``policy_function`` path: every
-        ``cloudpickle.loads`` rebuilds a fresh module namespace (because
-        ``serialize_policy`` uses ``register_pickle_by_value``) whose function
-        objects cycle through ``function.__globals__``; resolving once per path
-        avoids that per-call accumulator. See
-        https://github.com/ray-project/ray/issues/58815.
+        Cached process-globally, keyed by a hash of the serialized bytes.
+        Every ``cloudpickle.loads`` rebuilds a fresh module namespace
+        (because ``serialize_policy`` uses ``register_pickle_by_value``)
+        whose function objects cycle through ``function.__globals__``;
+        deduplicating by content lets fresh instances of the same policy
+        reuse one callable while still picking up a redeploy on the same
+        import path that ships new code (different bytes → cache miss).
+        See https://github.com/ray-project/ray/issues/58815.
         """
         if self._cached_policy is not None:
             return self._cached_policy
 
         cache_key = (
-            self.policy_function if isinstance(self.policy_function, str) else None
+            hashlib.sha256(self._serialized_policy_def).digest()
+            if self._serialized_policy_def
+            else None
         )
         if cache_key is not None:
             cached = _GLOBAL_POLICY_CACHE.get(cache_key)

--- a/python/ray/serve/tests/test_deploy.py
+++ b/python/ray/serve/tests/test_deploy.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 import ray
 from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
+from ray.serve._private.common import DeploymentID
 from ray.serve._private.test_utils import check_running, get_application_url
 from ray.serve._private.utils import get_random_string
 from ray.serve.exceptions import RayServeException
@@ -531,6 +532,47 @@ def test_redeploy_scale_up(serve_instance, use_handle):
     serve.run(v2.bind(), name="app")
     responses2 = make_calls({"2": 4})
     assert all(pid not in pids1 for pid in responses2["2"])
+
+
+def test_redeploy_uses_cached_actor_class(serve_instance):
+    # The controller caches the dynamic ReplicaActor subclass by `actor_name`
+    # (i.e. per `(app, deployment)` pair) to avoid the per-cycle class leak.
+    # User code rides on `replica_config.serialized_deployment_def` (a
+    # cloudpickled init arg), not on the cached class, so a rollout with the
+    # same name must still invoke the new code while reusing the cached class.
+    name = "D"
+    app = "rollout"
+    actor_name = DeploymentID(name=name, app_name=app).to_replica_actor_class_name()
+    controller = serve_instance._controller
+
+    @serve.deployment(name=name)
+    class V1:
+        async def __call__(self):
+            return "v1"
+
+    handle = serve.run(V1.bind(), name=app)
+    assert handle.remote().result() == "v1"
+
+    cache_after_v1 = ray.get(
+        controller._get_dynamic_actor_class_cache_ids_for_testing.remote()
+    )
+    assert actor_name in cache_after_v1
+    v1_class_id = cache_after_v1[actor_name]
+
+    @serve.deployment(name=name)
+    class V2:
+        async def __call__(self):
+            return "v2"
+
+    handle = serve.run(V2.bind(), name=app)
+    assert handle.remote().result() == "v2"
+
+    cache_after_v2 = ray.get(
+        controller._get_dynamic_actor_class_cache_ids_for_testing.remote()
+    )
+    # Same actor_name across the rollout -> same cached class object reused
+    # (id(cls) is stable within the controller process).
+    assert cache_after_v2[actor_name] == v1_class_id
 
 
 def test_handle_method_name_validation(serve_instance):

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 import ray
 from ray import cloudpickle, serve
 from ray._common.utils import import_attr
+from ray.serve import config as config_module
 from ray.serve._private.config import (
     DeploymentConfig,
     ReplicaConfig,
@@ -26,6 +27,7 @@ from ray.serve._private.utils import DEFAULT
 from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.config import (
     AutoscalingConfig,
+    AutoscalingPolicy,
     ControllerOptions,
     DeploymentActorConfig,
     DeploymentMode,
@@ -1554,6 +1556,35 @@ def test_default_autoscaling_policy_import_path():
     policy = import_attr(DEFAULT_AUTOSCALING_POLICY_NAME)
 
     assert policy == default_autoscaling_policy
+
+
+def test_autoscaling_policy_caches_deserialized_callable_globally(monkeypatch):
+    """Fresh ``AutoscalingPolicy`` instances share one deserialized callable;
+    ``cloudpickle.loads`` runs once per ``policy_function`` path.
+    See https://github.com/ray-project/ray/issues/58815.
+    """
+    monkeypatch.setattr(config_module, "_GLOBAL_POLICY_CACHE", {})
+
+    p1 = AutoscalingPolicy()
+    p2 = AutoscalingPolicy()
+    assert p1.get_policy() is p2.get_policy()
+    assert (
+        config_module._GLOBAL_POLICY_CACHE[DEFAULT_AUTOSCALING_POLICY_NAME]
+        is p1.get_policy()
+    )
+
+    # Per-instance cache populated from the global cache on the very first
+    # call — ``cloudpickle.loads`` runs at most once per path.
+    loads_calls = []
+    real_loads = config_module.cloudpickle.loads
+
+    def _counting_loads(data):
+        loads_calls.append(data)
+        return real_loads(data)
+
+    monkeypatch.setattr(config_module.cloudpickle, "loads", _counting_loads)
+    assert AutoscalingPolicy().get_policy() is p1.get_policy()
+    assert loads_calls == []
 
 
 class TestGetControllerImpl:

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -1559,22 +1559,11 @@ def test_default_autoscaling_policy_import_path():
 
 
 def test_autoscaling_policy_caches_deserialized_callable_globally(monkeypatch):
-    """Fresh ``AutoscalingPolicy`` instances share one deserialized callable;
-    ``cloudpickle.loads`` runs once per ``policy_function`` path.
-    See https://github.com/ray-project/ray/issues/58815.
+    """Fresh ``AutoscalingPolicy`` instances share one deserialized callable
+    when the policy is the same; a different policy on a different import
+    path bypasses the cache.
     """
     monkeypatch.setattr(config_module, "_GLOBAL_POLICY_CACHE", {})
-
-    p1 = AutoscalingPolicy()
-    p2 = AutoscalingPolicy()
-    assert p1.get_policy() is p2.get_policy()
-    assert (
-        config_module._GLOBAL_POLICY_CACHE[DEFAULT_AUTOSCALING_POLICY_NAME]
-        is p1.get_policy()
-    )
-
-    # Per-instance cache populated from the global cache on the very first
-    # call — ``cloudpickle.loads`` runs at most once per path.
     loads_calls = []
     real_loads = config_module.cloudpickle.loads
 
@@ -1583,8 +1572,22 @@ def test_autoscaling_policy_caches_deserialized_callable_globally(monkeypatch):
         return real_loads(data)
 
     monkeypatch.setattr(config_module.cloudpickle, "loads", _counting_loads)
-    assert AutoscalingPolicy().get_policy() is p1.get_policy()
-    assert loads_calls == []
+
+    # Two instances of the default policy → one deserialization, one cache entry.
+    p1 = AutoscalingPolicy()
+    p2 = AutoscalingPolicy()
+    assert p1.get_policy() is p2.get_policy()
+    assert len(loads_calls) == 1
+    assert len(config_module._GLOBAL_POLICY_CACHE) == 1
+
+    # A different policy doesn't hit the cache and deserializes fresh.
+    p3 = AutoscalingPolicy(
+        policy_function="ray.serve.tests.unit.test_config:fake_policy"
+    )
+    assert p3.get_policy() is not p1.get_policy()
+    assert p3.get_policy()() == fake_policy_return_value
+    assert len(loads_calls) == 2
+    assert len(config_module._GLOBAL_POLICY_CACHE) == 2
 
 
 class TestGetControllerImpl:

--- a/python/ray/serve/tests/unit/test_deployment_info.py
+++ b/python/ray/serve/tests/unit/test_deployment_info.py
@@ -1,8 +1,12 @@
+import sys
+import types
 from typing import Optional
 from unittest.mock import patch
 
 import pytest
 
+from ray import cloudpickle
+from ray.serve._private import deployment_info as deployment_info_module
 from ray.serve._private.common import TargetCapacityDirection
 from ray.serve._private.config import DeploymentConfig, ReplicaConfig
 from ray.serve._private.deployment_info import DeploymentInfo
@@ -83,7 +87,83 @@ def test_deployment_info_serialization(
     compare_deployment_info(reconstructed_info, info)
 
 
-if __name__ == "__main__":
-    import sys
+@pytest.fixture
+def stub_actor_class_build(monkeypatch):
+    """Isolate the dynamic actor cache and stub `ReplicaActor` + `ray.remote`.
 
+    Yields the list of `ray.remote(...)` invocations so tests can assert how
+    many times the dynamic class was actually (re)built.
+    """
+    monkeypatch.setattr(deployment_info_module, "_DYNAMIC_ACTOR_CLASS_CACHE", {})
+
+    class _FakeReplicaActor:
+        pass
+
+    fake_replica_module = types.ModuleType("ray.serve._private.replica")
+    fake_replica_module.ReplicaActor = _FakeReplicaActor
+    monkeypatch.setitem(sys.modules, "ray.serve._private.replica", fake_replica_module)
+
+    remote_calls = []
+
+    def _fake_remote(cls):
+        remote_calls.append(cls)
+        return cls
+
+    monkeypatch.setattr(deployment_info_module.ray, "remote", _fake_remote)
+
+    yield remote_calls
+
+
+def _make_info(actor_name: str) -> DeploymentInfo:
+    return DeploymentInfo(
+        deployment_config=DeploymentConfig(num_replicas=1),
+        replica_config=ReplicaConfig.create(lambda x: x),
+        start_time_ms=0,
+        deployer_job_id="",
+        actor_name=actor_name,
+    )
+
+
+def _via_cloudpickle(info: DeploymentInfo) -> DeploymentInfo:
+    # Matches the controller's recovery path
+    return cloudpickle.loads(cloudpickle.dumps(info))
+
+
+def _via_update(info: DeploymentInfo) -> DeploymentInfo:
+    return info.update(deployment_config=DeploymentConfig(num_replicas=2))
+
+
+def test_actor_def_caches_dynamic_class_per_actor_name(stub_actor_class_build):
+    remote_calls = stub_actor_class_build
+
+    info_a = _make_info("dep_foo")
+    info_b = _make_info("dep_foo")
+    info_c = _make_info("dep_bar")
+
+    assert info_a.actor_def is info_b.actor_def
+    assert info_c.actor_def is not info_a.actor_def
+    assert len(remote_calls) == 2
+
+
+@pytest.mark.parametrize(
+    "make_fresh_info",
+    [_via_cloudpickle, _via_update],
+    ids=["cloudpickle", "update"],
+)
+def test_actor_def_cache_survives_fresh_instance(
+    stub_actor_class_build, make_fresh_info
+):
+    """A DeploymentInfo with no per-instance cache reuses the global cache."""
+    remote_calls = stub_actor_class_build
+
+    info = _make_info("dep_foo")
+    original_cls = info.actor_def
+
+    fresh = make_fresh_info(info)
+    assert fresh._cached_actor_def is None
+    assert fresh.actor_def is original_cls
+    assert len(remote_calls) == 1
+
+
+if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Description
`ServeController` leaks memory continuously while the cluster is undergoing autoscaling cycles. RSS climbs and does not return to baseline even after deployments return to their original configuration.

This PR adds two targeted fixes that, on a reproducer that matches the issue's pattern, cut the leak slope by **~83 %** (from **+151 MB/h** to **+25 MB/h**) over a 20-minute window with ~875 autoscale events. Memory pressure on sibling proxy actors drops in parallel.

## Reproduction
### Reproducer script
https://gist.github.com/jeffreywang-anyscale/197a23d0b49199cadd2d7862ae373571

### Reproducer config
- 4 worker apps + 4 router apps, where each router replica holds a `DeploymentHandle` to each worker app (cross-app fan-out).
- `AutoscalingConfig(min_replicas=0, max_replicas=4, upscale_delay_s=1, downscale_delay_s=2, downscale_to_zero_delay_s=2, metrics_interval_s=1, look_back_period_s=3)`
- Cyclic in-cluster traffic: 10 s burst (~40 RPS) + 10 s lull, repeated.
- 200–300 ms handlers, so scale-downs catch replicas mid-request and strand ghost entries
  in router state.

In a 20-minute run this produces ~36 autoscale events / minute (~875 total).

### Observations (controller RSS via `psutil`)

| Config | Initial RSS | Final RSS | Post-warmup slope |
|---|---|---|---|
| master | 209.7 MB | 275.1 MB | **+151 MB/h** |
| This PR | 203.7 MB | 223.3 MB | **+25 MB/h** |

## Solution

Two independent retention paths were confirmed with `memray attach --aggregate` on a leaking controller.

### Commit 1: cache the dynamic actor class globally

`DeploymentInfo.actor_def` generates a fresh `ray.remote(type(...))` actor class on every uncached access. The instance-level cache is reset by `__setstate__`, `update()`, and recovery loads, so a new class is registered with Ray every autoscale cycle. Ray's actor metadata table retains every registered class for the controller's lifetime.

**Fix**: promote the cache from per-instance to process-global, keyed by `actor_name`. Two
DeploymentInfos with the same `actor_name` can safely share the class.

<img width="4447" height="791" alt="image" src="https://github.com/user-attachments/assets/deaf459c-fbcc-4a47-b536-09e3f29f6eff" />
<img width="4292" height="794" alt="image" src="https://github.com/user-attachments/assets/9eaaf2e7-976a-431d-b56b-32d12a464dba" />


### Commit 2: cache the deserialized autoscaling policy globally

**Symptom**: Even with commit 1 applied, the controller was still leaking. To find out where, this [script](https://gist.github.com/jeffreywang-anyscale/197a23d0b49199cadd2d7862ae373571#file-diag_cycles-py) enables `gc.DEBUG_SAVEALL` inside the control loop: every object that *only* generational GC was reclaiming gets routed into `gc.garbage` so we can inspect it.


Every sweep consistently showed the same two autoscaling-policy helpers in the cycle surface:

```
[loop=800 t=84.8s] gc.collect()=35 took 50.9ms len(garbage)=35
   functions:
      n=   7  ray.serve.autoscaling_policy._get_cold_start_scale_up_replicas
      n=   7  ray.serve.autoscaling_policy._core_replica_queue_length_policy
```

That means: every autoscale tick was creating ~7 fresh copies of these functions, none of which Python's refcount could free.

**Cause**: Tracing the call path:

- Every autoscale tick (and every redeploy / config change) calls `register_deployment`, which builds a fresh `AutoscalingPolicy` and calls `get_policy()`.
- `get_policy()` runs `cloudpickle.loads(self._serialized_policy_def)`. The existing `_cached_policy` attribute is *per instance*, so a fresh `AutoscalingPolicy` always re-runs `loads`.
- `serialize_policy` uses `cloudpickle.register_pickle_by_value(policy_module)` (so user-defined policies survive a controller that lacks the policy module on its `PYTHONPATH`). The side effect: every `cloudpickle.loads` rebuilds a fresh module namespace *and* fresh function objects for the policy and every helper it references.
- Those reconstituted function objects form a reference cycle: each `function.__globals__` points back at the synthetic module dict, which holds the function. Refcount can't break that; only generational GC can.
- Gen-2 GC is far less frequent than autoscale events (~36/min in the reproducer), so cycles accumulate between sweeps.

**Fix**: Cache the deserialized callable in a process-global dict keyed by `policy_function` path. `cloudpickle.loads` then runs once per unique path per process, and every subsequent `AutoscalingPolicy` with that path reuses the same function.

Verified in isolation: 5 fresh `AutoscalingPolicy() + get_policy()` calls produce **0** cycle-trapped objects with the cache, vs **25** (5 cycles × 5 objects each) without.

### Verification

| Config | Post-warmup slope |
|---|---|
| master | +123 MB/h |
| Commit 1 (`actor_def` cache) | +22.6 MB/h (−82 %) |
| Commits 1 + 2 (`actor_def` cache + policy cache) | **+20.0 MB/h (−84 %)** |

## Related issues
Closes https://github.com/ray-project/ray/issues/58815.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
