### PR TITLE
[Data] Use iterator in tf resord datasink

### DIFF
--- a/python/ray/data/_internal/datasource/tfrecords_datasink.py
+++ b/python/ray/data/_internal/datasource/tfrecords_datasink.py
@@ -74,7 +74,7 @@ def _convert_arrow_table_to_examples(
     # lockstep with zip uses ChunkedArray.__iter__ (a C-level loop) instead
     # of per-row __getitem__ calls, which avoids Python-side method dispatch
     # on every element.
-    columns = [arrow_table[name] for name in column_names]
+    columns = arrow_table.columns
     schema_feature_types = [schema_dict.get(name) for name in column_names]
 
     for row_values in zip(*columns):

--- a/python/ray/data/_internal/datasource/tfrecords_datasink.py
+++ b/python/ray/data/_internal/datasource/tfrecords_datasink.py
@@ -59,25 +59,30 @@ def _convert_arrow_table_to_examples(
         for schema_feature in tf_schema.feature:
             schema_dict[schema_feature.name] = schema_feature.type
 
-    # Serialize each row[i] of the block to a tf.train.Example and yield it.
-    for i in range(arrow_table.num_rows):
-        # First, convert row[i] to a dictionary.
-        features: Dict[str, "tf.train.Feature"] = {}
-        for name in arrow_table.column_names:
-            if tf_schema is not None and name not in schema_dict:
+    column_names = arrow_table.column_names
+
+    # Validate schema once up-front rather than per row.
+    if tf_schema is not None:
+        for name in column_names:
+            if name not in schema_dict:
                 raise ValueError(
                     f"Found extra unexpected feature {name} "
                     f"not in specified schema: {tf_schema}"
                 )
-            schema_feature_type = schema_dict.get(name)
-            features[name] = _value_to_feature(
-                arrow_table[name][i],
-                schema_feature_type,
-            )
 
-        # Convert the dictionary to an Example proto.
+    # Hoist per-column lookups out of the row loop. Iterating columns in
+    # lockstep with zip uses ChunkedArray.__iter__ (a C-level loop) instead
+    # of per-row __getitem__ calls, which avoids Python-side method dispatch
+    # on every element.
+    columns = [arrow_table[name] for name in column_names]
+    schema_feature_types = [schema_dict.get(name) for name in column_names]
+
+    for row_values in zip(*columns):
+        features: Dict[str, "tf.train.Feature"] = {
+            name: _value_to_feature(value, sft)
+            for name, value, sft in zip(column_names, row_values, schema_feature_types)
+        }
         proto = tf.train.Example(features=tf.train.Features(feature=features))
-
         yield proto
 
 


### PR DESCRIPTION
## Description
Optimize `_convert_arrow_table_to_examples` in `tfrecords_datasink.py` by hoisting per-column lookups and schema validation out of the row loop, and iterating columns in lockstep with `zip(*columns)`.

The old code called `arrow_table[name][i]` per row × column, paying Python-level `__getitem__` dispatch on every element. The new code uses `ChunkedArray.__iter__` (a C-level loop) for row-by-row scalars, and moves the `name in schema_dict` validation to a one-shot up-front check.

Same optimization pattern as #63152.

## Benchmark

End-to-end TFRecord write (convert → SerializeToString → CRC32C → write-to-buffer), 5 runs each, best time reported. macOS, Apple Silicon, pyarrow 16.

| Case | Before | After | Speedup |
|---|---|---|---|
| Mixed scalars (200k × 3) | 4.55s | 3.71s | **1.22x** |
| Wide table (50k × 20) | 5.55s | 4.34s | **1.28x** |
| List-of-int (200k × 2) | 3.39s | 3.00s | **1.13x** |
| Long strings (50k × 2) | 0.82s | 0.73s | **1.12x** |
| With tf_schema (200k × 2) | 4.79s | 4.16s | **1.15x** |

**12–28% faster end-to-end**, with wider tables seeing the largest wins (hoisting `arrow_table[name]` per column matters more when there are more columns).

## Correctness

Output is byte-identical to the previous implementation. Verified by comparing `SerializeToString()` bytes across scalar columns, list-of-int columns, multi-chunk inputs, empty tables, null-containing columns, and `tf_schema` validation. The existing tests in `python/ray/data/tests/datasource/test_tfrecords.py` exercise these cases and should continue to pass unchanged.
