### PR TITLE
[Data] Fix _numpy_size mis-estimating size of skewed object-dtype arrays

### DIFF
--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -49,12 +49,12 @@ def _numpy_size(array: np.ndarray) -> int:
             for item in array.flat:
                 total_size += sys.getsizeof(item)
         else:
-            stride = max(1, len(array) // sample_count)
-            sample = array[::stride][:sample_count]
+            indices = np.linspace(0, len(array) - 1, sample_count, dtype=int)
+            sample = array[indices]
             sample_total_size = 0
             for item in sample.flat:
                 sample_total_size += sys.getsizeof(item)
-            total_size += int(sample_total_size / len(sample) * len(array))
+            total_size += int(sample_total_size / sample_count * len(array))
     return total_size
 
 

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -35,7 +35,12 @@ CHECKPOINT_RECOVERY_MAX_BACKOFF_S = int(
 
 
 def _numpy_size(array: np.ndarray) -> int:
-    """Calculate the size of a numpy ndarray."""
+    """Calculate the size of a numpy ndarray.
+
+    For object-dtype arrays larger than the sample threshold, elements are
+    sampled uniformly across the array so that the estimate's accuracy
+    does not depend on the input ordering.
+    """
     total_size = array.nbytes
     if array.dtype == object:
         sample_count = 10**4
@@ -44,10 +49,12 @@ def _numpy_size(array: np.ndarray) -> int:
             for item in array.flat:
                 total_size += sys.getsizeof(item)
         else:
+            stride = max(1, len(array) // sample_count)
+            sample = array[::stride][:sample_count]
             sample_total_size = 0
-            for item in array[:sample_count].flat:
+            for item in sample.flat:
                 sample_total_size += sys.getsizeof(item)
-            total_size += int(sample_total_size / sample_count * len(array))
+            total_size += int(sample_total_size / len(sample) * len(array))
     return total_size
 
 

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -2050,6 +2050,14 @@ def test_numpy_size_object_array_skewed_by_index():
     assert abs(_numpy_size(arr) / actual - 1) < 0.10
 
 
+def test_numpy_size_object_array_skewed_near_threshold():
+    small = ["x"] * 7_500
+    large = ["x" * 1024] * 7_500
+    arr = np.array(small + large, dtype=object)
+    actual = arr.nbytes + sum(sys.getsizeof(x) for x in arr.flat)
+    assert abs(_numpy_size(arr) / actual - 1) < 0.10
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -1,6 +1,7 @@
 import csv
 import os
 import random
+import sys
 from typing import List, Literal, Union
 
 import numpy as np
@@ -35,6 +36,7 @@ from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_filter import (
     IdColumnCheckpointManager,
     NumpyArrayBasedCheckpointFilter,
+    _numpy_size,
 )
 from ray.data.checkpoint.checkpoint_writer import (
     PENDING_CHECKPOINT_SUFFIX,
@@ -2027,6 +2029,25 @@ def test_clean_pending_checkpoints_no_pending(ray_start_10_cpus_shared, fs, base
 
     # Data file should still exist (no pending checkpoints means nothing to clean)
     assert fs.get_file_info(data_file).type != FileType.NotFound
+
+
+def test_numpy_size_non_object_array():
+    arr = np.arange(100_000, dtype=np.int64)
+    assert _numpy_size(arr) == arr.nbytes
+
+
+def test_numpy_size_small_object_array_exact():
+    arr = np.array(["abc", "defg", "hi"], dtype=object)
+    expected = arr.nbytes + sum(sys.getsizeof(x) for x in arr.flat)
+    assert _numpy_size(arr) == expected
+
+
+def test_numpy_size_object_array_skewed_by_index():
+    small = ["x"] * 10_000
+    large = ["x" * 1024] * 990_000
+    arr = np.array(small + large, dtype=object)
+    actual = arr.nbytes + sum(sys.getsizeof(x) for x in arr.flat)
+    assert abs(_numpy_size(arr) / actual - 1) < 0.10
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
For object-dtype `ndarray`s larger than the sample threshold, `_numpy_size` in `python/ray/data/checkpoint/checkpoint_filter.py`sampled only the first 10K elements (`array[:sample_count]`) and
extrapolated to the full array. When element sizes correlate with index (e.g. arrays sorted by length, monotonic streaming order, frame-by-frame growth), this produced grossly wrong size estimates.

This change replaces sequential first-N sampling with uniform stride sampling, so the estimate's accuracy no longer depends on input ordering. The complexity of the function is unchanged.

## Related issues
Fixes #62709

## Additional information

