### PR TITLE
[Data] Fix get_or_create_stats_actor crash in Ray Client mode

### DIFF
--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -862,14 +862,14 @@ def get_or_create_stats_actor() -> ActorHandle[_StatsActor]:
     does not exist in the connected cluster. The _StatsActor is pinned on
     on driver process' node.
     """
-    if ray._private.worker._global_node is None:
+    if not ray.is_initialized():
         raise RuntimeError(
-            "Global node is not initialized. Driver might be not connected to Ray."
+            "Ray is not initialized. Driver might be not connected to Ray."
         )
 
-    current_cluster_id = ray._private.worker._global_node.cluster_id
-
-    logger.debug(f"Stats Actor located on cluster_id={current_cluster_id}")
+    global_node = ray._private.worker._global_node
+    if global_node is not None:
+        logger.debug(f"Stats Actor located on cluster_id={global_node.cluster_id}")
 
     # so it fate-shares with the driver.
     label_selector = {

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -867,6 +867,8 @@ def get_or_create_stats_actor() -> ActorHandle[_StatsActor]:
             "Ray is not initialized. Driver might be not connected to Ray."
         )
 
+    # `_global_node` is None under Ray Client (the driver is not a cluster
+    # worker), so only log the cluster_id when it is available.
     global_node = ray._private.worker._global_node
     if global_node is not None:
         logger.debug(f"Stats Actor located on cluster_id={global_node.cluster_id}")

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -2085,26 +2085,6 @@ def test_stats_actor_datasets_eviction(ray_start_cluster):
         wait_for_condition(check_eviction)
 
 
-def test_get_or_create_stats_actor_in_client_mode(monkeypatch):
-    """``get_or_create_stats_actor`` must not raise ``RuntimeError`` when
-    ``ray._private.worker._global_node`` is ``None`` while Ray itself is
-    initialized, which is the case for drivers connected via Ray Client.
-    """
-    monkeypatch.setattr(ray, "is_initialized", lambda: True)
-    monkeypatch.setattr(ray._private.worker, "_global_node", None)
-
-    fake_ctx = MagicMock()
-    fake_ctx.get_node_id.return_value = "fake_node_id"
-    monkeypatch.setattr(ray, "get_runtime_context", lambda: fake_ctx)
-
-    fake_handle = MagicMock(name="StatsActorHandle")
-    fake_options = MagicMock()
-    fake_options.remote.return_value = fake_handle
-    monkeypatch.setattr(_StatsActor, "options", lambda **kwargs: fake_options)
-
-    assert get_or_create_stats_actor() is fake_handle
-
-
 # Setting internal=10000 (super high number) value so they are only called
 # once (on cold start), and on shutdown.
 @patch.object(StreamingExecutor, "UPDATE_METRICS_INTERVAL_S", new=10000)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -2085,6 +2085,26 @@ def test_stats_actor_datasets_eviction(ray_start_cluster):
         wait_for_condition(check_eviction)
 
 
+def test_get_or_create_stats_actor_in_client_mode(monkeypatch):
+    """``get_or_create_stats_actor`` must not raise ``RuntimeError`` when
+    ``ray._private.worker._global_node`` is ``None`` while Ray itself is
+    initialized, which is the case for drivers connected via Ray Client.
+    """
+    monkeypatch.setattr(ray, "is_initialized", lambda: True)
+    monkeypatch.setattr(ray._private.worker, "_global_node", None)
+
+    fake_ctx = MagicMock()
+    fake_ctx.get_node_id.return_value = "fake_node_id"
+    monkeypatch.setattr(ray, "get_runtime_context", lambda: fake_ctx)
+
+    fake_handle = MagicMock(name="StatsActorHandle")
+    fake_options = MagicMock()
+    fake_options.remote.return_value = fake_handle
+    monkeypatch.setattr(_StatsActor, "options", lambda **kwargs: fake_options)
+
+    assert get_or_create_stats_actor() is fake_handle
+
+
 # Setting internal=10000 (super high number) value so they are only called
 # once (on cold start), and on shutdown.
 @patch.object(StreamingExecutor, "UPDATE_METRICS_INTERVAL_S", new=10000)


### PR DESCRIPTION
## Description

In Ray Client mode, `ray._private.worker._global_node` is `None` because the client driver is not a Ray worker process, even though `ray.is_initialized()` is `True` and the cluster is connected. `get_or_create_stats_actor` used
`_global_node` as a proxy for "connected to Ray" and raised `RuntimeError` whenever Ray Data tried to register or query the stats actor, causing `ds.take_batch()`, `ds.iter_batches()`, etc. to crash on materialized datasets.

Use `ray.is_initialized()` for the connection check and only emit the `cluster_id` debug log when `_global_node` is available, since `cluster_id` is not exposed via `ray.get_runtime_context()`.

## Related issues

Closes #61162

## Additional information