### PR TITLE
[core] Warn when runtime_env package approaches upload size limit

### DIFF
--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -42,7 +42,10 @@ GCS_STORAGE_MAX_SIZE = int(
 # If the resulting zipped package is at least this large, emit a warning before
 # attempting upload. This catches cases the per-file `FILE_SIZE_WARNING` misses,
 # notably large directories of many small files (e.g. `.git`). See GH #45602.
+# Override at runtime with the `RAY_PACKAGE_SIZE_WARNING_MIB` env var (units of
+# MiB); set the env var to `-1` to disable the warning entirely.
 PACKAGE_SIZE_WARNING = GCS_STORAGE_MAX_SIZE // 2
+PACKAGE_SIZE_WARNING_MIB_ENV_VAR = "RAY_PACKAGE_SIZE_WARNING_MIB"
 RAY_PKG_PREFIX = "_ray_pkg_"
 
 RAY_RUNTIME_ENV_FAIL_UPLOAD_FOR_TESTING_ENV_VAR = (
@@ -677,6 +680,27 @@ def upload_package_to_gcs(pkg_uri: str, pkg_bytes: bytes) -> None:
         raise NotImplementedError(f"Protocol {protocol} is not supported")
 
 
+def _resolve_package_size_warning_threshold() -> Optional[int]:
+    """Return the warning threshold in bytes, or None if disabled by the user.
+
+    Reads `RAY_PACKAGE_SIZE_WARNING_MIB` at call time so users can tune or
+    disable the warning without restarting the driver. A negative value
+    disables the warning. A malformed value falls back to the default rather
+    than silently suppressing the warning (a noisy default is safer than a
+    silent miss for an upload-size limit).
+    """
+    env_val = os.environ.get(PACKAGE_SIZE_WARNING_MIB_ENV_VAR)
+    if env_val is None:
+        return PACKAGE_SIZE_WARNING
+    try:
+        mib = int(env_val)
+    except ValueError:
+        return PACKAGE_SIZE_WARNING
+    if mib < 0:
+        return None
+    return mib * 1024 * 1024
+
+
 def _warn_if_package_size_near_limit(
     package_path: Path,
     logger: Optional[logging.Logger] = default_logger,
@@ -691,15 +715,20 @@ def _warn_if_package_size_near_limit(
     inspection, and `module_path` (the user-supplied source directory or file)
     is included when available so the user can immediately identify which
     runtime_env input is causing the bloat — the temp zip path is short-lived
-    and has an obscure auto-generated name. See GH #45602.
+    and has an obscure auto-generated name. The threshold is tunable via the
+    `RAY_PACKAGE_SIZE_WARNING_MIB` env var (set to `-1` to disable). See
+    GH #45602.
     """
     if logger is None:
         logger = default_logger
+    threshold = _resolve_package_size_warning_threshold()
+    if threshold is None:
+        return
     try:
         package_size = package_path.stat().st_size
     except OSError:
         return
-    if package_size < PACKAGE_SIZE_WARNING:
+    if package_size < threshold:
         return
     source_info = f" for '{module_path}'" if module_path else ""
     logger.warning(
@@ -708,7 +737,10 @@ def _warn_if_package_size_near_limit(
         f"of {_mib_string(GCS_STORAGE_MAX_SIZE)}. If the upload fails, exclude "
         "large directories (commonly '.git', '.venv', or build artifacts) via "
         "the 'excludes' option in runtime_env, or list them in '.gitignore' / "
-        "'.rayignore'. For details see "
+        "'.rayignore'. To raise the warning threshold set "
+        f"`{PACKAGE_SIZE_WARNING_MIB_ENV_VAR}=<size_in_MiB>`, or disable the "
+        f"warning entirely with `{PACKAGE_SIZE_WARNING_MIB_ENV_VAR}=-1`. For "
+        "details see "
         "https://docs.ray.io/en/latest/ray-core/handling-dependencies.html"
         "#api-reference"
     )

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -39,6 +39,10 @@ FILE_SIZE_WARNING = 10 * 1024 * 1024  # 10MiB
 GCS_STORAGE_MAX_SIZE = int(
     os.environ.get("RAY_max_grpc_message_size", GRPC_CPP_MAX_MESSAGE_SIZE)
 )
+# If the resulting zipped package is at least this large, emit a warning before
+# attempting upload. This catches cases the per-file `FILE_SIZE_WARNING` misses,
+# notably large directories of many small files (e.g. `.git`). See GH #45602.
+PACKAGE_SIZE_WARNING = GCS_STORAGE_MAX_SIZE // 2
 RAY_PKG_PREFIX = "_ray_pkg_"
 
 RAY_RUNTIME_ENV_FAIL_UPLOAD_FOR_TESTING_ENV_VAR = (
@@ -673,6 +677,38 @@ def upload_package_to_gcs(pkg_uri: str, pkg_bytes: bytes) -> None:
         raise NotImplementedError(f"Protocol {protocol} is not supported")
 
 
+def _warn_if_package_size_near_limit(
+    package_path: Path,
+    logger: Optional[logging.Logger] = default_logger,
+) -> None:
+    """Warn if the zipped package is approaching the GCS upload size limit.
+
+    The per-file warning in `_zip_files` does not fire for directories that
+    contain many small files (e.g. `.git`), so the user has no signal that
+    they are about to hit `GCS_STORAGE_MAX_SIZE` until the upload itself
+    fails. This warning closes that gap and includes the local package path
+    so the user can inspect its contents. See GH #45602.
+    """
+    if logger is None:
+        logger = default_logger
+    try:
+        package_size = package_path.stat().st_size
+    except OSError:
+        return
+    if package_size < PACKAGE_SIZE_WARNING:
+        return
+    logger.warning(
+        f"The runtime_env package at '{package_path}' is "
+        f"{_mib_string(package_size)}, approaching the maximum upload size "
+        f"of {_mib_string(GCS_STORAGE_MAX_SIZE)}. If the upload fails, exclude "
+        "large directories (commonly '.git', '.venv', or build artifacts) via "
+        "the 'excludes' option in runtime_env, or list them in '.gitignore' / "
+        "'.rayignore'. For details see "
+        "https://docs.ray.io/en/latest/ray-core/handling-dependencies.html"
+        "#api-reference"
+    )
+
+
 def create_package(
     module_path: str,
     target_path: Path,
@@ -697,6 +733,7 @@ def create_package(
             include_parent_dir=include_parent_dir,
             logger=logger,
         )
+        _warn_if_package_size_near_limit(target_path, logger)
 
 
 def upload_package_if_needed(

--- a/python/ray/_private/runtime_env/packaging.py
+++ b/python/ray/_private/runtime_env/packaging.py
@@ -680,14 +680,18 @@ def upload_package_to_gcs(pkg_uri: str, pkg_bytes: bytes) -> None:
 def _warn_if_package_size_near_limit(
     package_path: Path,
     logger: Optional[logging.Logger] = default_logger,
+    module_path: Optional[str] = None,
 ) -> None:
     """Warn if the zipped package is approaching the GCS upload size limit.
 
     The per-file warning in `_zip_files` does not fire for directories that
     contain many small files (e.g. `.git`), so the user has no signal that
     they are about to hit `GCS_STORAGE_MAX_SIZE` until the upload itself
-    fails. This warning closes that gap and includes the local package path
-    so the user can inspect its contents. See GH #45602.
+    fails. This warning closes that gap. The local zip path is included for
+    inspection, and `module_path` (the user-supplied source directory or file)
+    is included when available so the user can immediately identify which
+    runtime_env input is causing the bloat — the temp zip path is short-lived
+    and has an obscure auto-generated name. See GH #45602.
     """
     if logger is None:
         logger = default_logger
@@ -697,8 +701,9 @@ def _warn_if_package_size_near_limit(
         return
     if package_size < PACKAGE_SIZE_WARNING:
         return
+    source_info = f" for '{module_path}'" if module_path else ""
     logger.warning(
-        f"The runtime_env package at '{package_path}' is "
+        f"The runtime_env package{source_info} at '{package_path}' is "
         f"{_mib_string(package_size)}, approaching the maximum upload size "
         f"of {_mib_string(GCS_STORAGE_MAX_SIZE)}. If the upload fails, exclude "
         "large directories (commonly '.git', '.venv', or build artifacts) via "
@@ -733,7 +738,7 @@ def create_package(
             include_parent_dir=include_parent_dir,
             logger=logger,
         )
-        _warn_if_package_size_near_limit(target_path, logger)
+        _warn_if_package_size_near_limit(target_path, logger, module_path=module_path)
 
 
 def upload_package_if_needed(

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -336,9 +336,13 @@ class TestCreatePackageSizeWarning:
         create_package(str(src), target, include_gitignore=False, logger=logger)
 
         assert target.exists()
+        # Warning must surface BOTH the local zip path (for inspection) and
+        # the source module_path (since the zip is short-lived and has an
+        # auto-generated name in production code paths).
         assert any(
             "approaching the maximum upload size" in record.getMessage()
             and str(target) in record.getMessage()
+            and str(src) in record.getMessage()
             for record in records
         ), [r.getMessage() for r in records]
 

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -374,6 +374,77 @@ class TestCreatePackageSizeWarning:
             for record in records
         ), [r.getMessage() for r in records]
 
+    def test_env_var_disables_warning(self, tmp_path, monkeypatch):
+        """`RAY_PACKAGE_SIZE_WARNING_MIB=-1` must silence the warning even
+        when the package is well over the default threshold."""
+        src = self._make_dir_with_many_small_files(tmp_path / "src", count=64)
+        # Default threshold would normally fire (we set it small here just to
+        # make sure the *only* reason it's silent is the env-var disable).
+        monkeypatch.setattr(packaging_module, "PACKAGE_SIZE_WARNING", 1)
+        monkeypatch.setenv(packaging_module.PACKAGE_SIZE_WARNING_MIB_ENV_VAR, "-1")
+        target = tmp_path / "pkg.zip"
+        logger, records = self._make_capturing_logger()
+
+        create_package(str(src), target, include_gitignore=False, logger=logger)
+
+        assert target.exists()
+        assert not any(
+            "approaching the maximum upload size" in record.getMessage()
+            for record in records
+        ), [r.getMessage() for r in records]
+
+    def test_env_var_overrides_threshold_high_disables(self, tmp_path, monkeypatch):
+        """A high env-var threshold must suppress warnings the default would
+        have raised."""
+        src = self._make_dir_with_many_small_files(tmp_path / "src", count=64)
+        monkeypatch.setattr(packaging_module, "PACKAGE_SIZE_WARNING", 1)
+        # 10 GiB threshold; small fixture zip will not approach this.
+        monkeypatch.setenv(packaging_module.PACKAGE_SIZE_WARNING_MIB_ENV_VAR, "10240")
+        target = tmp_path / "pkg.zip"
+        logger, records = self._make_capturing_logger()
+
+        create_package(str(src), target, include_gitignore=False, logger=logger)
+
+        assert not any(
+            "approaching the maximum upload size" in record.getMessage()
+            for record in records
+        ), [r.getMessage() for r in records]
+
+    def test_env_var_overrides_threshold_low_warns(self, tmp_path, monkeypatch):
+        """A low env-var threshold must *raise* warnings the default would
+        have suppressed, and the message must advertise how to disable it."""
+        src = self._make_dir_with_many_small_files(tmp_path / "src", count=64)
+        # Default threshold (half of GCS_STORAGE_MAX_SIZE) is far above the
+        # small fixture zip, so without the env override no warning would fire.
+        monkeypatch.setenv(packaging_module.PACKAGE_SIZE_WARNING_MIB_ENV_VAR, "0")
+        target = tmp_path / "pkg.zip"
+        logger, records = self._make_capturing_logger()
+
+        create_package(str(src), target, include_gitignore=False, logger=logger)
+
+        assert any(
+            "approaching the maximum upload size" in record.getMessage()
+            and packaging_module.PACKAGE_SIZE_WARNING_MIB_ENV_VAR in record.getMessage()
+            for record in records
+        ), [r.getMessage() for r in records]
+
+    def test_env_var_malformed_falls_back_to_default(self, tmp_path, monkeypatch):
+        """A malformed env value must not silently disable the warning."""
+        src = self._make_dir_with_many_small_files(tmp_path / "src", count=64)
+        monkeypatch.setattr(packaging_module, "PACKAGE_SIZE_WARNING", 1)
+        monkeypatch.setenv(
+            packaging_module.PACKAGE_SIZE_WARNING_MIB_ENV_VAR, "not-a-number"
+        )
+        target = tmp_path / "pkg.zip"
+        logger, records = self._make_capturing_logger()
+
+        create_package(str(src), target, include_gitignore=False, logger=logger)
+
+        assert any(
+            "approaching the maximum upload size" in record.getMessage()
+            for record in records
+        ), [r.getMessage() for r in records]
+
 
 class TestStorePackageInGcs:
     class DisconnectedClient:

--- a/python/ray/tests/test_runtime_env_packaging.py
+++ b/python/ray/tests/test_runtime_env_packaging.py
@@ -19,6 +19,7 @@ import ray
 from ray._private.ray_constants import (
     KV_NAMESPACE_PACKAGE,
 )
+from ray._private.runtime_env import packaging as packaging_module
 from ray._private.runtime_env.packaging import (
     GCS_STORAGE_MAX_SIZE,
     MAC_OS_ZIP_HIDDEN_DIR_NAME,
@@ -27,6 +28,7 @@ from ray._private.runtime_env.packaging import (
     _get_excludes,
     _get_ignore_file,
     _store_package_in_gcs,
+    create_package,
     download_and_unpack_package,
     get_excludes_from_ignore_files,
     get_local_dir_from_uri,
@@ -281,6 +283,92 @@ class TestUploadPackageIfNeeded:
             uri, tmp_path, random_dir, include_gitignore=True
         )
         assert uploaded
+
+
+class TestCreatePackageSizeWarning:
+    """Regression coverage for GH #45602.
+
+    The per-file warning in `_zip_files` does not fire for a directory of many
+    small files (e.g. `.git`). `create_package` should emit a single warning
+    whenever the resulting zip is at least `PACKAGE_SIZE_WARNING` so that users
+    have an actionable signal before the upload itself fails.
+    """
+
+    @staticmethod
+    def _make_dir_with_many_small_files(root: Path, count: int) -> Path:
+        sub = root / "lots_of_small_files"
+        sub.mkdir(parents=True)
+        # Use incompressible random bytes so the zip cannot shrink them below
+        # the threshold the test enforces.
+        for i in range(count):
+            (sub / f"f{i}.bin").write_bytes(os.urandom(256))
+        return sub
+
+    @staticmethod
+    def _make_capturing_logger() -> tuple:
+        """Return (logger, records_list). Ray's default logger does not
+        propagate to caplog, so capture WARNING records via a list handler."""
+        import logging as _logging
+
+        records: list = []
+
+        class _ListHandler(_logging.Handler):
+            def emit(self, record):
+                records.append(record)
+
+        logger = _logging.getLogger(
+            "test_runtime_env_packaging.TestCreatePackageSizeWarning"
+        )
+        logger.handlers.clear()
+        logger.setLevel(_logging.WARNING)
+        logger.addHandler(_ListHandler())
+        logger.propagate = False
+        return logger, records
+
+    def test_warns_when_zip_exceeds_threshold(self, tmp_path, monkeypatch):
+        src = self._make_dir_with_many_small_files(tmp_path / "src", count=64)
+        # Force the threshold low enough that this small fixture trips it,
+        # without inflating test runtime.
+        monkeypatch.setattr(packaging_module, "PACKAGE_SIZE_WARNING", 1)
+        target = tmp_path / "pkg.zip"
+        logger, records = self._make_capturing_logger()
+
+        create_package(str(src), target, include_gitignore=False, logger=logger)
+
+        assert target.exists()
+        assert any(
+            "approaching the maximum upload size" in record.getMessage()
+            and str(target) in record.getMessage()
+            for record in records
+        ), [r.getMessage() for r in records]
+
+    def test_does_not_warn_when_zip_below_threshold(self, tmp_path, monkeypatch):
+        src = self._make_dir_with_many_small_files(tmp_path / "src", count=4)
+        # Threshold far above the small fixture's zip size.
+        monkeypatch.setattr(packaging_module, "PACKAGE_SIZE_WARNING", 10 * 1024 * 1024)
+        target = tmp_path / "pkg.zip"
+        logger, records = self._make_capturing_logger()
+
+        create_package(str(src), target, include_gitignore=False, logger=logger)
+
+        assert target.exists()
+        assert not any(
+            "approaching the maximum upload size" in record.getMessage()
+            for record in records
+        ), [r.getMessage() for r in records]
+
+    def test_warn_handles_missing_file(self, tmp_path, monkeypatch):
+        # Even if the package vanishes between zip and stat (e.g. concurrent
+        # cleanup), the helper must not raise.
+        monkeypatch.setattr(packaging_module, "PACKAGE_SIZE_WARNING", 1)
+        logger, records = self._make_capturing_logger()
+        packaging_module._warn_if_package_size_near_limit(
+            tmp_path / "does_not_exist.zip", logger=logger
+        )
+        assert not any(
+            "approaching the maximum upload size" in record.getMessage()
+            for record in records
+        ), [r.getMessage() for r in records]
 
 
 class TestStorePackageInGcs:


### PR DESCRIPTION
## Description

Adds an actionable warning when a `runtime_env` package is approaching `GCS_STORAGE_MAX_SIZE`, so users can react before the upload itself fails with a hard `ValueError`.

Today, `_zip_files` already warns about *individual* files over 10 MiB (`FILE_SIZE_WARNING`). It does **not** warn about a working_dir built from many small files — most commonly a `.git` directory — so a user can silently zip past `GCS_STORAGE_MAX_SIZE` and only find out when the upload fails. The error message they hit (`Package size (… MiB) exceeds the maximum size of …`) does not tell them where the temp zip lives, so they can't inspect what bloated it.

This PR closes that gap:

- Adds a `PACKAGE_SIZE_WARNING = GCS_STORAGE_MAX_SIZE // 2` threshold next to the existing `FILE_SIZE_WARNING`.
- Adds `_warn_if_package_size_near_limit(...)` which calls `package_path.stat().st_size` (single syscall — no directory walk) and emits a warning naming the local zip path and the most common offenders (`.git`, `.venv`, build artifacts).
- Calls it from `create_package` *after* `_zip_files`. That single call site covers **both** entry points: `ray.init(runtime_env=...)` (which goes through `upload_package_if_needed` → `create_package`) and `ray job submit` / dashboard SDK (which goes through `_upload_package` → `create_package`).

The hard limit behavior in `_store_package_in_gcs` is unchanged — this is purely an earlier, friendlier warning.

## Related issues

Closes #45602

This picks up the work from the now-stale #45818, which a maintainer (@edoakes) explicitly offered to shepherd if a contributor resumed it. The previous attempt only modified the dashboard SDK path; this PR puts the check in `create_package` so the warning also fires for the in-process `ray.init(runtime_env=...)` upload path.

## Additional information

### Test plan

New `TestCreatePackageSizeWarning` class in `test_runtime_env_packaging.py`:

- `test_warns_when_zip_exceeds_threshold` — builds a directory of many small incompressible files, lowers `PACKAGE_SIZE_WARNING` to 1 byte via monkeypatch, calls `create_package`, asserts the warning was emitted and includes the local package path.
- `test_does_not_warn_when_zip_below_threshold` — same fixture but threshold set to 10 MiB, asserts no warning.
- `test_warn_handles_missing_file` — calls `_warn_if_package_size_near_limit` on a path that doesn't exist; the helper must not raise (defensive against concurrent cleanup between zip creation and stat).

Each test passes its own `logging.Logger` with a list handler, because the default Ray logger doesn't propagate to `caplog`.

All three tests pass locally:

```
TestCreatePackageSizeWarning::test_warns_when_zip_exceeds_threshold PASSED
TestCreatePackageSizeWarning::test_does_not_warn_when_zip_below_threshold PASSED
TestCreatePackageSizeWarning::test_warn_handles_missing_file PASSED
```

`ruff check` and `ruff format --check` are clean on both modified files (the only remaining `ruff format` diff in the repo is on pre-existing code I didn't touch).