### PR TITLE
fix: broken ray data link readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Install Ray with: ``pip install ray``. For nightly wheels, see the
 `Installation page <https://docs.ray.io/en/latest/ray-overview/installation.html>`__.
 
 .. _`Serve`: https://docs.ray.io/en/latest/serve/index.html
-.. _`Data`: https://docs.ray.io/en/latest/data/dataset.html
+.. _`Data`: https://docs.ray.io/en/latest/data/data.html
 .. _`Workflow`: https://docs.ray.io/en/latest/workflows/
 .. _`Train`: https://docs.ray.io/en/latest/train/train.html
 .. _`Tune`: https://docs.ray.io/en/latest/tune/index.html


### PR DESCRIPTION
## Description
In the repo root readme `README.rst`, I could find the link for ray [data](https://docs.ray.io/en/latest/data/dataset.html) broken.

## Related issues
> Link related issues: Fixes #63411 

## Additional information
N/A
