### PR TITLE
[Serve] Fail loudly when subclassing @serve.ingress with sync __init__

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -450,6 +450,37 @@ def ingress(app: Optional[Union[ASGIApp, Callable]] = None) -> Callable:
                 ServeUsageTag.FASTAPI_USED.record("1")
                 ASGIAppReplicaWrapper.__init__(self, frozen_app_or_func)
 
+            def __init_subclass__(subcls, **subclass_kwargs):
+                # The parent `__init__` is async, so any sync `__init__`
+                # resolved on the subclass (whether defined directly or
+                # inherited from a mixin earlier in the MRO) would, when
+                # calling `super().__init__(...)`, silently discard the
+                # returned coroutine — leaving the replica uninitialized
+                # (e.g. `_serve_asgi_lifespan` never set). Check the resolved
+                # `__init__` on the class (which honors MRO) rather than only
+                # `__dict__`, so cases like
+                # `class Sub(SyncMixin, WrappedIngress)` are also caught.
+                # Fail loudly at class-definition time with a clear migration
+                # message instead of crashing later at runtime.
+                super().__init_subclass__(**subclass_kwargs)
+                if not inspect.iscoroutinefunction(subcls.__init__):
+                    raise TypeError(
+                        f"{subcls.__name__}.__init__ must be `async def` "
+                        "when subclassing a class decorated with "
+                        "@serve.ingress (or returned by "
+                        "`make_fastapi_ingress`). The parent `__init__` is "
+                        "async; a sync `super().__init__(...)` call would "
+                        "silently drop the returned coroutine and leave the "
+                        "replica uninitialized. Change "
+                        "`def __init__(self, ...)` to "
+                        "`async def __init__(self, ...)` and "
+                        "`super().__init__(...)` to "
+                        "`await super().__init__(...)`. If the sync "
+                        "`__init__` comes from a mixin in the MRO, override "
+                        "it on the subclass with an `async def __init__` "
+                        "that awaits both parents."
+                    )
+
             async def __del__(self):
                 await ASGIAppReplicaWrapper.__del__(self)
 

--- a/python/ray/serve/tests/test_api.py
+++ b/python/ray/serve/tests/test_api.py
@@ -117,6 +117,75 @@ def test_ingress_async_init(serve_instance):
     assert resp.json() == "initialized"
 
 
+def test_ingress_sync_init_subclass_raises():
+    """Subclassing a @serve.ingress class with a sync __init__ must fail loudly.
+
+    The parent __init__ is async, so a sync `super().__init__(...)` call from
+    a subclass would silently drop the returned coroutine and leave the
+    replica uninitialized (e.g. `_serve_asgi_lifespan` never set), surfacing
+    later as a cryptic AttributeError at runtime. We reject the bad pattern
+    at class-definition time with a clear migration message instead.
+    """
+    app = FastAPI()
+
+    class BaseIngress:
+        pass
+
+    WrappedIngress = serve.ingress(app)(BaseIngress)
+
+    with pytest.raises(TypeError, match="async def"):
+
+        class ExtendedIngress(WrappedIngress):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+
+def test_ingress_sync_init_via_mixin_subclass_raises():
+    """A sync __init__ inherited from a mixin earlier in the MRO must also raise.
+
+    `class Sub(SyncMixin, WrappedIngress)` doesn't define `__init__` on
+    `Sub` itself, but the resolved `Sub.__init__` is the sync mixin's, which
+    would still silently drop the wrapper's async coroutine. The check must
+    use MRO resolution, not just the subclass `__dict__`.
+    """
+    app = FastAPI()
+
+    class BaseIngress:
+        pass
+
+    WrappedIngress = serve.ingress(app)(BaseIngress)
+
+    class SyncMixin:
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    with pytest.raises(TypeError, match="async def"):
+
+        class ExtendedIngress(SyncMixin, WrappedIngress):
+            pass
+
+
+def test_ingress_async_init_subclass_allowed():
+    """Subclassing a @serve.ingress class with an async __init__ is allowed."""
+    app = FastAPI()
+
+    class BaseIngress:
+        pass
+
+    WrappedIngress = serve.ingress(app)(BaseIngress)
+
+    class ExtendedIngress(WrappedIngress):
+        async def __init__(self, *args, **kwargs):
+            await super().__init__(*args, **kwargs)
+
+    # No __init__ defined on subclass is also allowed (inherits parent's async).
+    class InheritingIngress(WrappedIngress):
+        pass
+
+    assert ExtendedIngress is not None
+    assert InheritingIngress is not None
+
+
 class FakeRequestRouter(RequestRouter):
     async def choose_replicas(
         self,


### PR DESCRIPTION
## Summary

Fixes #63170.

## Description

`ASGIIngressWrapper.__init__` was changed from `def` to `async def` in #61490 to properly await user-defined async constructors. That fix had an unintended side effect on subclasses of the wrapper (including those returned by `make_fastapi_ingress`):

```python
class ExtendedIngress(make_fastapi_ingress(OpenAiIngress)):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)   # returns a coroutine, silently discarded!
```

Because the resolved `__init__` is sync, `super().__init__(...)` returns a coroutine that is never awaited. `ASGIAppReplicaWrapper.__init__` never runs, `_serve_asgi_lifespan` is never set, and the replica later crashes at startup with:

```
AttributeError: 'ExtendedIngress' object has no attribute '_serve_asgi_lifespan'
```

This worked in Ray 2.54 (where the parent `__init__` was sync) and broke in 2.55 — a backward-compat regression in a minor release.

## Fix

This PR adds `__init_subclass__` to `ASGIIngressWrapper` that checks the resolved `subcls.__init__` and raises `TypeError` at class-definition time with a clear migration message, converting a silent runtime failure into an immediate, actionable error.

The check honors MRO, so a sync `__init__` inherited from a mixin earlier in the MRO is also caught:

```python
class SyncMixin:
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

class ExtendedIngress(SyncMixin, WrappedIngress):  # also rejected
    pass
```

## Related Issues

Fixes #63170.

## Test Coverage

- **`test_ingress_sync_init_subclass_raises`** — sync `__init__` defined directly on the subclass raises `TypeError`
- **`test_ingress_sync_init_via_mixin_subclass_raises`** — sync `__init__` inherited via MRO from a mixin also raises (this is why the check uses `subcls.__init__` rather than `subcls.__dict__.get("__init__")`)
- **`test_ingress_async_init_subclass_allowed`** — async `__init__` subclass and no-`__init__` subclass both succeed
- Existing `test_ingress_async_init`, `test_ingress_wrapper_preserves_metadata`, `test_async_del_called_on_deleted_deployment` unaffected

## Scope

The fix is purely in the HTTP ingress path (`python/ray/serve/api.py`) — no GPU or model-serving code is touched.

## User-Side Workaround (works without this PR)

```python
class ExtendedIngress(make_fastapi_ingress(OpenAiIngress)):
    async def __init__(self, *args, **kwargs):
        await super().__init__(*args, **kwargs)
```