### PR TITLE
[Data]Make Internal caller to iter_rows(public_row_format=True)

### DIFF
--- a/python/ray/data/_internal/datasource/kafka_datasink.py
+++ b/python/ray/data/_internal/datasource/kafka_datasink.py
@@ -249,7 +249,7 @@ class KafkaDatasink(Datasink):
             for block in blocks:
                 block_accessor = BlockAccessor.for_block(block)
 
-                for row in block_accessor.iter_rows(public_row_format=False):
+                for row in block_accessor.iter_rows(public_row_format=True):
                     row_dict = self._row_to_dict(row)
                     key = self._extract_key(row_dict)
                     value = self._serialize_value(row_dict)

--- a/python/ray/data/_internal/datasource/sql_datasink.py
+++ b/python/ray/data/_internal/datasource/sql_datasink.py
@@ -24,7 +24,7 @@ class SQLDatasink(Datasink[None]):
                 block_accessor = BlockAccessor.for_block(block)
 
                 values = []
-                for row in block_accessor.iter_rows(public_row_format=False):
+                for row in block_accessor.iter_rows(public_row_format=True):
                     values.append(tuple(row.values()))
                     assert len(values) <= self._MAX_ROWS_PER_WRITE, len(values)
                     if len(values) == self._MAX_ROWS_PER_WRITE:

--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -297,7 +297,7 @@ def _make_iterable(block: BlockAccessor):
     Returns:
         Iterable[Dict[str,Any]]: Iterable of samples
     """
-    return block.iter_rows(public_row_format=False)
+    return block.iter_rows(public_row_format=True)
 
 
 class WebDatasetDatasource(FileBasedDatasource):

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -395,9 +395,13 @@ class TableBlockAccessor(BlockAccessor):
         stats = BlockExecStats.builder()
         keys = sort_key.get_columns()
 
+        # `iter_rows(public_row_format=True)` yields plain `Dict[str, Any]`
+        # rows; the previous `tuple(r[keys])` relied on
+        # `ArrowRow.__getitem__` accepting a list of column names, which
+        # plain dicts don't support. Iterate keys individually instead.
         def _key_fn(r):
             if keys:
-                return tuple(r[keys])
+                return tuple(r[k] for k in keys)
             else:
                 return (0,)
 
@@ -411,7 +415,7 @@ class TableBlockAccessor(BlockAccessor):
 
         iter = heapq.merge(
             *[
-                BlockAccessor.for_block(block).iter_rows(public_row_format=False)
+                BlockAccessor.for_block(block).iter_rows(public_row_format=True)
                 for block in blocks
             ],
             key=safe_key_fn,

--- a/python/ray/data/_internal/table_block.py
+++ b/python/ray/data/_internal/table_block.py
@@ -395,10 +395,6 @@ class TableBlockAccessor(BlockAccessor):
         stats = BlockExecStats.builder()
         keys = sort_key.get_columns()
 
-        # `iter_rows(public_row_format=True)` yields plain `Dict[str, Any]`
-        # rows; the previous `tuple(r[keys])` relied on
-        # `ArrowRow.__getitem__` accepting a list of column names, which
-        # plain dicts don't support. Iterate keys individually instead.
         def _key_fn(r):
             if keys:
                 return tuple(r[k] for k in keys)

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -130,7 +130,7 @@ class AggregateFn:
 
             def accumulate_block(a: AccumulatorType, block: Block) -> AccumulatorType:
                 block_acc = BlockAccessor.for_block(block)
-                for r in block_acc.iter_rows(public_row_format=False):
+                for r in block_acc.iter_rows(public_row_format=True):
                     a = accumulate_row(a, r)
                 return a
 
@@ -980,7 +980,7 @@ class Quantile(AggregateFnV2[List[Any], List[Any]]):
         block_acc = BlockAccessor.for_block(block)
         ls = []
 
-        for row in block_acc.iter_rows(public_row_format=False):
+        for row in block_acc.iter_rows(public_row_format=True):
             ls.append(row.get(self._target_col_name))
 
         return ls

--- a/python/ray/data/datasource/file_datasink.py
+++ b/python/ray/data/datasource/file_datasink.py
@@ -220,7 +220,7 @@ class RowBasedFileDatasink(_FileDatasink):
             ctx.task_idx,
         )
         base, ext = _split_base_and_ext(task_filename)
-        for row_index, row in enumerate(block.iter_rows(public_row_format=False)):
+        for row_index, row in enumerate(block.iter_rows(public_row_format=True)):
             filename = f"{base}_{block_index:06}_{row_index:06}{ext}"
             write_path = posixpath.join(self.path, filename)
             logger.debug(f"Writing {write_path} file.")


### PR DESCRIPTION
## Description

`BlockAccessor.iter_rows` has two branches:

- `public_row_format=True` — yields plain `Dict[str, Any]` rows via bulk `batch.to_pylist()` per chunk. C-level conversion, fast.
- `public_row_format=False` — yields an `ArrowRow` view backed by per-row `slice(i, i+1)`, with per-column `select` + `as_py` materialization on access. Lazy, but every row read crosses the Python ↔ C++ boundary multiple times.

This PR migrates the **7 internal callers** of `iter_rows(public_row_format=False)` to `public_row_format=True`. No changes to `iter_rows` itself — the False branch is left in place for any external callers that still want it.

<ins>This speeds up code that goes through BlockAccessor.iter_rows() and reads columns from each row. That's row-based user UDFs in aggregates, and row-based file/messaging sinks. Vectorized built-ins (Sum, Mean, etc.) are unchanged.</ins>

## Why the False path is slower (even for its target use case)

The False path was originally introduced for the `ListFiles` use case (wide metadata blocks with sparse column access. The intent was sound for a C++ codebase: lazy per-column materialization avoids converting columns nobody reads.

Empirically it loses across the board because Python ↔ C++ boundary cost dominates the bytes-moved cost it tries to save. Even reading 1 column out of 20 wide-table columns is **2.5x slower** via the lazy path than via bulk `to_pylist()`. Reading every column is **11x slower**.

Per-call comparison on Arrow blocks (200k rows):

| Access pattern | `False` (lazy) | `True` (bulk) | Speedup |
|---|---|---|---|
| Read 1 col (3 cols total) | 0.98s | 0.21s | **4.7x** |
| Read all 3 cols | 2.41s | 0.22s | **11.0x** |

## End-to-end speedup

Custom V1 `AggregateFn` summing 5M rows via `ds.aggregate(...)` — exercises `aggregate.py:131-134` which is one of the migrated call sites:


| | Wall time |
|---|---|
| Before this PR (False path) | 22.34s |
| After this PR  (True path)  | 2.55s |
| **Speedup** | **8.7x** |

Tested with

```py
import ray, ray.data
import pyarrow as pa
from ray.data.aggregate import AggregateFn

# 5M-row, 1-block Arrow dataset (materialized so we measure aggregate, not I/O)
N = 5_000_000
t = pa.table({
    "id": pa.array(list(range(N))),
    "value": pa.array([float(i) * 0.1 for i in range(N)]),
})
ds_big = ray.data.from_arrow(t).repartition(1).materialize()

# V1 AggregateFn that uses accumulate_row — this is the API form that
# routes through aggregate.py:131-134's auto-built accumulate_block factory.
sum_value = AggregateFn(
    init=lambda key: 0.0,
    accumulate_row=lambda acc, row: acc + (row["value"] or 0),
    merge=lambda a, b: a + b,
    name="sum_value",
)

# The measured operation
ds_big.aggregate(sum_value)
```



## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
