### PR TITLE
[serve] Optional HAProxy retry knobs for ingress-request-router backend

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -825,29 +825,15 @@ RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S = get_env_int(
     "RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S", 5
 )
 
-# Optional HAProxy retry knobs applied to the `-via-ingress-request-router`
-# backend (i.e. the data path that runs after the Lua dispatch picked a
-# replica). When set, HAProxy can redispatch a slow-first-byte request to
-# a different replica via `option redispatch` instead of head-of-line-
-# blocking on the original pick. All three default to None (unset) so the
-# behavior is unchanged unless an operator opts in.
-#
-# `retry-on` follows HAProxy's syntax (space-separated tokens). Sensible
-# value for LLM serving: "conn-failure empty-response response-timeout".
-# Full list of accepted tokens:
-#   https://docs.haproxy.org/2.8/configuration.html#4-retry-on
+# Opt-in HAProxy retry knobs on the `-via-ingress-request-router` backend.
+# `retry-on` token reference:
+# https://docs.haproxy.org/2.8/configuration.html#4-retry-on
 RAY_SERVE_HAPROXY_INGRESS_RETRY_ON = get_env_str(
     "RAY_SERVE_HAPROXY_INGRESS_RETRY_ON", None
 )
-
-# Number of retry attempts (default 3 in HAProxy when unset). Each retry
-# is sent via `option redispatch` to a different replica.
 RAY_SERVE_HAPROXY_INGRESS_RETRIES = get_env_int_non_negative(
     "RAY_SERVE_HAPROXY_INGRESS_RETRIES", None
 )
-
-# `timeout server` for the via-ingress-request-router backend specifically.
-# Pair with `retry-on response-timeout` to redispatch on slow first byte.
 RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S = get_env_int_non_negative(
     "RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S", None
 )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -836,24 +836,20 @@ RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S = get_env_int(
 # value for LLM serving: "conn-failure empty-response response-timeout".
 # Full list of accepted tokens:
 #   https://docs.haproxy.org/2.8/configuration.html#4-retry-on
-RAY_SERVE_HAPROXY_INGRESS_RETRY_ON = (
-    os.environ.get("RAY_SERVE_HAPROXY_INGRESS_RETRY_ON") or None
+RAY_SERVE_HAPROXY_INGRESS_RETRY_ON = get_env_str(
+    "RAY_SERVE_HAPROXY_INGRESS_RETRY_ON", None
 )
 
 # Number of retry attempts (default 3 in HAProxy when unset). Each retry
 # is sent via `option redispatch` to a different replica.
-RAY_SERVE_HAPROXY_INGRESS_RETRIES = (
-    int(os.environ["RAY_SERVE_HAPROXY_INGRESS_RETRIES"])
-    if os.environ.get("RAY_SERVE_HAPROXY_INGRESS_RETRIES")
-    else None
+RAY_SERVE_HAPROXY_INGRESS_RETRIES = get_env_int_non_negative(
+    "RAY_SERVE_HAPROXY_INGRESS_RETRIES", None
 )
 
 # `timeout server` for the via-ingress-request-router backend specifically.
 # Pair with `retry-on response-timeout` to redispatch on slow first byte.
-RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S = (
-    int(os.environ["RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S"])
-    if os.environ.get("RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S")
-    else None
+RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S = get_env_int_non_negative(
+    "RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S", None
 )
 
 # Per-buffer byte cap for HAProxy when the ingress-request-router Lua action is

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -825,6 +825,37 @@ RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S = get_env_int(
     "RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S", 5
 )
 
+# Optional HAProxy retry knobs applied to the `-via-ingress-request-router`
+# backend (i.e. the data path that runs after the Lua dispatch picked a
+# replica). When set, HAProxy can redispatch a slow-first-byte request to
+# a different replica via `option redispatch` instead of head-of-line-
+# blocking on the original pick. All three default to None (unset) so the
+# behavior is unchanged unless an operator opts in.
+#
+# `retry-on` follows HAProxy's syntax (space-separated tokens). Sensible
+# value for LLM serving: "conn-failure empty-response response-timeout".
+# Full list of accepted tokens:
+#   https://docs.haproxy.org/2.8/configuration.html#4-retry-on
+RAY_SERVE_HAPROXY_INGRESS_RETRY_ON = (
+    os.environ.get("RAY_SERVE_HAPROXY_INGRESS_RETRY_ON") or None
+)
+
+# Number of retry attempts (default 3 in HAProxy when unset). Each retry
+# is sent via `option redispatch` to a different replica.
+RAY_SERVE_HAPROXY_INGRESS_RETRIES = (
+    int(os.environ["RAY_SERVE_HAPROXY_INGRESS_RETRIES"])
+    if os.environ.get("RAY_SERVE_HAPROXY_INGRESS_RETRIES")
+    else None
+)
+
+# `timeout server` for the via-ingress-request-router backend specifically.
+# Pair with `retry-on response-timeout` to redispatch on slow first byte.
+RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S = (
+    int(os.environ["RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S"])
+    if os.environ.get("RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S")
+    else None
+)
+
 # Per-buffer byte cap for HAProxy when the ingress-request-router Lua action is
 # active. Bodies longer than this are truncated; the Lua forwards what it has
 # with an `X-Body-Truncated: <bytes>/<content-length>` header so the router can

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -44,6 +44,9 @@ from ray.serve._private.constants import (
     RAY_SERVE_HAPROXY_HEALTH_CHECK_RISE,
     RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_BUFSIZE,
     RAY_SERVE_HAPROXY_INGRESS_REQUEST_ROUTER_TIMEOUT_S,
+    RAY_SERVE_HAPROXY_INGRESS_RETRIES,
+    RAY_SERVE_HAPROXY_INGRESS_RETRY_ON,
+    RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S,
     RAY_SERVE_HAPROXY_MAXCONN,
     RAY_SERVE_HAPROXY_METRICS_PORT,
     RAY_SERVE_HAPROXY_NBTHREAD,
@@ -540,6 +543,16 @@ class HAProxyConfig:
     syslog_port: int = RAY_SERVE_HAPROXY_SYSLOG_PORT
 
     balance_algorithm: str = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM
+
+    # Optional retry knobs for the `-via-ingress-request-router` backend.
+    # When set, HAProxy will redispatch a request to a different replica
+    # (via `option redispatch`) on the configured retry events, instead of
+    # head-of-line-blocking on the replica picked by the Lua dispatch.
+    # See ray.serve._private.constants for full docs and the HAProxy
+    # retry-on token reference.
+    ingress_retry_on: Optional[str] = RAY_SERVE_HAPROXY_INGRESS_RETRY_ON
+    ingress_retries: Optional[int] = RAY_SERVE_HAPROXY_INGRESS_RETRIES
+    ingress_timeout_server_s: Optional[int] = RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S
 
     is_head: bool = False
 

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -544,12 +544,6 @@ class HAProxyConfig:
 
     balance_algorithm: str = RAY_SERVE_HAPROXY_BALANCE_ALGORITHM
 
-    # Optional retry knobs for the `-via-ingress-request-router` backend.
-    # When set, HAProxy will redispatch a request to a different replica
-    # (via `option redispatch`) on the configured retry events, instead of
-    # head-of-line-blocking on the replica picked by the Lua dispatch.
-    # See ray.serve._private.constants for full docs and the HAProxy
-    # retry-on token reference.
     ingress_retry_on: Optional[str] = RAY_SERVE_HAPROXY_INGRESS_RETRY_ON
     ingress_retries: Optional[int] = RAY_SERVE_HAPROXY_INGRESS_RETRIES
     ingress_timeout_server_s: Optional[int] = RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S

--- a/python/ray/serve/_private/haproxy_templates.py
+++ b/python/ray/serve/_private/haproxy_templates.py
@@ -172,12 +172,23 @@ backend {{ backend.name or 'unknown' }}-via-ingress-request-router
     # HAProxy holding unread server-side FINs under a burst while worker
     # threads are still routing other requests.
     http-reuse always
-    # use-server falls through to LB if the pinned server is DOWN.
+    # use-server falls through to LB if the pinned server is DOWN. Combined
+    # with `retry-on` below (when configured), this lets HAProxy redispatch
+    # a slow-first-byte request to a different replica instead of head-of-
+    # line-blocking on the original pick.
     option redispatch
+    {%- if config.ingress_retry_on %}
+    retry-on {{ config.ingress_retry_on }}
+    {%- endif %}
+    {%- if config.ingress_retries is not none %}
+    retries {{ config.ingress_retries }}
+    {%- endif %}
     {%- if backend.timeout_connect_s is not none %}
     timeout connect {{ backend.timeout_connect_s }}s
     {%- endif %}
-    {%- if backend.timeout_server_s is not none %}
+    {%- if config.ingress_timeout_server_s is not none %}
+    timeout server {{ config.ingress_timeout_server_s }}s
+    {%- elif backend.timeout_server_s is not none %}
     timeout server {{ backend.timeout_server_s }}s
     {%- endif %}
     {%- if backend.timeout_http_keep_alive_s is not none %}

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -696,7 +696,9 @@ def test_ingress_retry_knobs_render_when_set(haproxy_api_cleanup):
                 return f.read()
 
     unset = render({})
-    assert "retry-on" not in unset
+    # Match the actual HAProxy directive at line-start (4-space indent), not
+    # any occurrences of "retry-on" inside template comments.
+    assert "\n    retry-on " not in unset
     assert "\n    retries " not in unset
     assert "ingress-request-router" in unset  # backend still rendered
 

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -658,6 +658,60 @@ def test_router_failure_503_rule_appears_before_use_backend(haproxy_api_cleanup)
         assert "X-Serve-Reason" in cfg, cfg
 
 
+def test_ingress_retry_knobs_render_when_set(haproxy_api_cleanup):
+    """When the three RAY_SERVE_HAPROXY_INGRESS_* env-var-derived fields are
+    set on HAProxyConfig, the corresponding HAProxy directives are emitted
+    into the ``-via-ingress-request-router`` backend. When unset, none of
+    them appear (backward-compat)."""
+    backends = {
+        "llm": BackendConfig(
+            name="llm",
+            path_prefix="/",
+            app_name="llm",
+            servers=[
+                ServerConfig(name="r1", host="10.0.0.1", port=30001, replica_id="rid_1")
+            ],
+            ingress_request_router_servers=[
+                ServerConfig(name="router", host="10.0.0.10", port=9000)
+            ],
+        ),
+    }
+
+    def render(cfg_overrides):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            api = HAProxyApi(
+                cfg=HAProxyConfig(
+                    socket_path=os.path.join(temp_dir, "admin.sock"),
+                    **cfg_overrides,
+                ),
+                config_file_path=os.path.join(temp_dir, "haproxy.cfg"),
+                backend_configs=backends,
+            )
+            with mock.patch(
+                "ray.serve._private.constants.RAY_SERVE_HAPROXY_CONFIG_FILE_LOC",
+                api.config_file_path,
+            ):
+                api._generate_config_file_internal()
+            with open(api.config_file_path) as f:
+                return f.read()
+
+    unset = render({})
+    assert "retry-on" not in unset
+    assert "\n    retries " not in unset
+    assert "ingress-request-router" in unset  # backend still rendered
+
+    set_cfg = render(
+        {
+            "ingress_retry_on": "conn-failure empty-response response-timeout",
+            "ingress_retries": 4,
+            "ingress_timeout_server_s": 5,
+        }
+    )
+    assert "retry-on conn-failure empty-response response-timeout" in set_cfg
+    assert "\n    retries 4\n" in set_cfg
+    assert "\n    timeout server 5s\n" in set_cfg
+
+
 @pytest.mark.parametrize("forward_body", [True, False])
 def test_ingress_request_router_forward_body_gate_renders(
     haproxy_api_cleanup, monkeypatch, forward_body


### PR DESCRIPTION
## Summary

Adds three opt-in env vars that emit `retry-on`, `retries`, and `timeout server` directives on the `-via-ingress-request-router` backend. Combined with the existing `option redispatch`, this lets HAProxy redispatch a slow-first-byte request to a different replica instead of head-of-line-blocking on the replica that the Lua dispatch originally picked.

All three default unset → existing behavior is unchanged.

| Env var | What it does |
|---|---|
| `RAY_SERVE_HAPROXY_INGRESS_RETRY_ON` | HAProxy `retry-on` token list — see [HAProxy docs §4 `retry-on`](https://docs.haproxy.org/2.8/configuration.html#4-retry-on) for all accepted tokens. Sensible value for LLM serving: `"conn-failure empty-response response-timeout"`. |
| `RAY_SERVE_HAPROXY_INGRESS_RETRIES` | Number of retry attempts. Each retry is redispatched to a different replica via `option redispatch`. |
| `RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S` | Per-backend `timeout server`. Pair with `retry-on response-timeout` to redispatch on slow first byte. |

## Why

In multi-replica LLM serving under high concurrency, one replica's engine queue can stochastically diverge under round-robin / random routing, raising its TTFT into the tens of seconds while peers stay at ~300 ms. Without a retry primitive, this slow-replica state appears as the user-visible p99 tail.

Tiny benchmark on the agentic-loop workload (Qwen3-0.6B-FP8, 8× H100, c=256 round_robin, 3 samples each):

| | TTFT mean (ms) | TTFT p99 (ms) |
|---|---:|---:|
| Ray default (no retry) | 1147 | 15827 (median across 3 runs) |
| **Ray + retry on response-timeout 5 s** | **381** | **1252** (median across 3 runs) |
| vllm-router default | 432 | 1636 |

Mean TTFT drops ~3×; p99 drops ~12×; TPOT / RPS / output-tok/s unchanged (within ±2 %). Mean and p99 also both come in under vllm-router's defaults.

## Caveats

- The retry redispatches via HAProxy's load-balancer (not the user-configured `LLMRouter`), so for session-affinity routers (`ConsistentHashRouter`) a retry would break the pin. Recommendation: leave these env vars unset for session-affinity workloads (where the slow-replica feedback loop is also far less likely in the first place).
- Threshold tuning: `RAY_SERVE_HAPROXY_INGRESS_TIMEOUT_SERVER_S` must be safely above the slowest *legitimate* TTFT or it will fire false-positive retries that themselves add load.

## Test plan

- [x] `test_ingress_retry_knobs_render_when_set` — confirms directives appear when set and are absent (backward-compatible) when unset.
- [x] Manually verified end-to-end with 3-sample variance test (numbers above).

🤖 AI-assisted with Claude Code; reviewed and benchmarked end-to-end before opening.