### PR TITLE
[Data] Track peak object store memory usage in benchmarks

### DIFF
--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -3,6 +3,7 @@ import json
 import logging
 import math
 import os
+import threading
 import time
 from enum import Enum
 from typing import Any, Callable, Dict, List, Union
@@ -14,16 +15,73 @@ from ray.util.state import list_runtime_envs
 logger = logging.getLogger(__name__)
 
 
-def _get_spilled_bytes_total() -> float:
+def _get_object_store_stats(state):
+    """Get aggregate object store stats across the cluster."""
+    memory_info = get_memory_info_reply(state)
+    return memory_info.store_stats
+
+
+def _get_spilled_bytes_total(state) -> float:
     """Get the total number of spilled bytes across the cluster."""
-    memory_info = get_memory_info_reply(
-        get_state_from_address(ray.get_runtime_context().gcs_address)
-    )
-    return memory_info.store_stats.spilled_bytes_total
+    return _get_object_store_stats(state).spilled_bytes_total
 
 
 def _bytes_to_gb(b: float) -> float:
     return round(b / (1024**3), 4)
+
+
+class ObjectStoreMemorySampler:
+    """Samples aggregate object store usage and tracks the peak value.
+
+    Object store usage is an instantaneous gauge, so checking only at the
+    beginning and end of a benchmark can miss short-lived memory spikes.
+    """
+
+    def __init__(self, state, interval_s: float = 1.0):
+        self._state = state
+        self._interval_s = interval_s
+        self._stop_event = threading.Event()
+        self._thread = None
+
+        self.peak_used_bytes = 0
+        self.peak_utilization = 0.0
+
+    def start(self):
+        self._sample_once()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="object-store-memory-sampler",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join()
+        self._sample_once()
+
+    def _run(self):
+        while not self._stop_event.wait(self._interval_s):
+            self._sample_once()
+
+    def _sample_once(self):
+        try:
+            store_stats = _get_object_store_stats(self._state)
+        except Exception:
+            logger.warning("Failed to sample object store memory.", exc_info=True)
+            return
+
+        used_bytes = store_stats.object_store_bytes_used
+        capacity_bytes = store_stats.object_store_bytes_avail
+
+        self.peak_used_bytes = max(self.peak_used_bytes, used_bytes)
+
+        if capacity_bytes > 0:
+            self.peak_utilization = max(
+                self.peak_utilization,
+                used_bytes / capacity_bytes,
+            )
 
 
 def collect_dataset_stats(ds: "ray.data.Dataset") -> Dict[str, Any]:
@@ -101,6 +159,8 @@ class BenchmarkMetric(Enum):
     THROUGHPUT = "tput"
     ACCURACY = "accuracy"
     OBJECT_STORE_SPILLED_TOTAL_GB = "object_store_spilled_total_gb"
+    OBJECT_STORE_MEMORY_USED_PEAK_GB = "object_store_memory_used_peak_gb"
+    OBJECT_STORE_MEMORY_UTILIZATION_PEAK = "object_store_memory_utilization_peak"
 
 
 class Benchmark:
@@ -153,17 +213,33 @@ class Benchmark:
         gc.collect()
 
         print(f"Running case: {name}")
-        start_time = time.perf_counter()
-        start_spilled_bytes = _get_spilled_bytes_total()
-        fn_output = fn(*fn_args, **fn_kwargs)
-        assert fn_output is None or isinstance(fn_output, dict), fn_output
-        duration = time.perf_counter() - start_time
-        spilled_bytes_total = _get_spilled_bytes_total() - start_spilled_bytes
+        state = get_state_from_address(ray.get_runtime_context().gcs_address)
+        memory_sampler = ObjectStoreMemorySampler(state)
+        memory_sampler.start()
 
+        start_time = time.perf_counter()
+        start_spilled_bytes = _get_spilled_bytes_total(state)
+
+        try:
+            fn_output = fn(*fn_args, **fn_kwargs)
+        finally:
+            duration = time.perf_counter() - start_time
+            memory_sampler.stop()
+
+        assert fn_output is None or isinstance(fn_output, dict), fn_output
+
+        spilled_bytes_total = _get_spilled_bytes_total(state) - start_spilled_bytes
         curr_case_metrics = {
             BenchmarkMetric.RUNTIME.value: duration,
             BenchmarkMetric.OBJECT_STORE_SPILLED_TOTAL_GB.value: _bytes_to_gb(
                 spilled_bytes_total
+            ),
+            BenchmarkMetric.OBJECT_STORE_MEMORY_USED_PEAK_GB.value: _bytes_to_gb(
+                memory_sampler.peak_used_bytes
+            ),
+            BenchmarkMetric.OBJECT_STORE_MEMORY_UTILIZATION_PEAK.value: round(
+                memory_sampler.peak_utilization,
+                4,
             ),
         }
         if isinstance(fn_output, dict):

--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -15,15 +15,9 @@ from ray.util.state import list_runtime_envs
 logger = logging.getLogger(__name__)
 
 
-def _get_object_store_stats(state):
-    """Get aggregate object store stats across the cluster."""
-    memory_info = get_memory_info_reply(state)
-    return memory_info.store_stats
-
-
 def _get_spilled_bytes_total(state) -> float:
     """Get the total number of spilled bytes across the cluster."""
-    return _get_object_store_stats(state).spilled_bytes_total
+    return get_memory_info_reply(state).store_stats.spilled_bytes_total
 
 
 def _bytes_to_gb(b: float) -> float:
@@ -43,8 +37,23 @@ class ObjectStoreMemorySampler:
         self._stop_event = threading.Event()
         self._thread = None
 
-        self.peak_used_bytes = 0
-        self.peak_utilization = 0.0
+        self._peak_used_bytes = 0
+        self._peak_utilization = 0.0
+
+    @property
+    def peak_used_bytes(self) -> int:
+        return self._peak_used_bytes
+
+    @property
+    def peak_utilization(self) -> float:
+        return self._peak_utilization
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
 
     def start(self):
         self._sample_once()
@@ -67,7 +76,7 @@ class ObjectStoreMemorySampler:
 
     def _sample_once(self):
         try:
-            store_stats = _get_object_store_stats(self._state)
+            store_stats = get_memory_info_reply(self._state).store_stats
         except Exception:
             logger.warning("Failed to sample object store memory.", exc_info=True)
             return
@@ -75,11 +84,11 @@ class ObjectStoreMemorySampler:
         used_bytes = store_stats.object_store_bytes_used
         capacity_bytes = store_stats.object_store_bytes_avail
 
-        self.peak_used_bytes = max(self.peak_used_bytes, used_bytes)
+        self._peak_used_bytes = max(self._peak_used_bytes, used_bytes)
 
         if capacity_bytes > 0:
-            self.peak_utilization = max(
-                self.peak_utilization,
+            self._peak_utilization = max(
+                self._peak_utilization,
                 used_bytes / capacity_bytes,
             )
 
@@ -97,11 +106,11 @@ def collect_dataset_stats(ds: "ray.data.Dataset") -> Dict[str, Any]:
                 "operator_name": op.operator_name,
                 "earliest_start_time": op.earliest_start_time,
                 "latest_end_time": op.latest_end_time,
-                "scheduling_overhead": [
-                    dataclasses.asdict(bucket) for bucket in op.scheduling_overhead
-                ]
-                if op.scheduling_overhead
-                else [],
+                "scheduling_overhead": (
+                    [dataclasses.asdict(bucket) for bucket in op.scheduling_overhead]
+                    if op.scheduling_overhead
+                    else []
+                ),
             }
             for op in summary.operators_stats
         ],
@@ -214,17 +223,15 @@ class Benchmark:
 
         print(f"Running case: {name}")
         state = get_state_from_address(ray.get_runtime_context().gcs_address)
-        memory_sampler = ObjectStoreMemorySampler(state)
-        memory_sampler.start()
 
-        start_time = time.perf_counter()
-        start_spilled_bytes = _get_spilled_bytes_total(state)
+        with ObjectStoreMemorySampler(state) as memory_sampler:
+            start_time = time.perf_counter()
+            start_spilled_bytes = _get_spilled_bytes_total(state)
 
-        try:
-            fn_output = fn(*fn_args, **fn_kwargs)
-        finally:
-            duration = time.perf_counter() - start_time
-            memory_sampler.stop()
+            try:
+                fn_output = fn(*fn_args, **fn_kwargs)
+            finally:
+                duration = time.perf_counter() - start_time
 
         assert fn_output is None or isinstance(fn_output, dict), fn_output
 


### PR DESCRIPTION

### Why are these changes needed?

Ray Data benchmarks already report runtime and object store spilling, but they do not show how much object store memory was used at peak during a benchmark run.

This metric is useful for backpressure tuning. We want to know not only whether a run spilled or got slower, but also how much object store memory it used.

### What changes were made?

This PR adds a lightweight sampler to the benchmark utility.

While each benchmark case is running, the sampler periodically reads aggregate object store memory stats and keeps the highest value it sees.

This adds two new benchmark metrics:

```
object_store_memory_used_peak_gb
object_store_memory_utilization_peak
````

### Why sample during the benchmark?

Spilled bytes are cumulative, so they can be measured with an end-minus-start delta.

Object store memory usage is different: it can go up during the benchmark and drop back down before the end. Sampling during the run lets us capture that peak.

### Test

Smoke test with a 100 MB object store allocation:
<img width="409" height="155" alt="Screenshot 2026-05-19 at 03 21 18" src="https://github.com/user-attachments/assets/e97ec77b-e8c9-4ca5-b9ca-5a853415f95f" />

---

Closes https://github.com/ray-project/ray/issues/63417