### PR TITLE
[Core] deflake test_autoscaler_e2e

### DIFF
--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -46,7 +46,7 @@ def test_ray_status_activity(local_autoscaling_cluster, shutdown_only, enable_v2
     ray.init(address="auto")
     if enable_v2:
         wait_for_condition(
-            lambda: subprocess.check_output("ray status --verbose", shell=True)
+            lambda: subprocess.run("ray status --verbose", shell=True, capture_output=True).stdout
             .decode()
             .count("Idle: ")
             > 0

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -45,8 +45,8 @@ def test_ray_status_activity(local_autoscaling_cluster, shutdown_only, enable_v2
 
     ray.init(address="auto")
     if enable_v2:
-        assert (
-            subprocess.check_output("ray status --verbose", shell=True)
+        wait_for_condition(
+            lambda: subprocess.check_output("ray status --verbose", shell=True)
             .decode()
             .count("Idle: ")
             > 0

--- a/python/ray/tests/test_autoscaler_e2e.py
+++ b/python/ray/tests/test_autoscaler_e2e.py
@@ -46,8 +46,10 @@ def test_ray_status_activity(local_autoscaling_cluster, shutdown_only, enable_v2
     ray.init(address="auto")
     if enable_v2:
         wait_for_condition(
-            lambda: subprocess.run("ray status --verbose", shell=True, capture_output=True).stdout
-            .decode()
+            lambda: subprocess.run(
+                "ray status --verbose", shell=True, capture_output=True
+            )
+            .stdout.decode()
             .count("Idle: ")
             > 0
         )


### PR DESCRIPTION
the `test_ray_status_activity` test asserts that the head node is idle before proceeding. but this is done immediately after ray.init() which can lead to a race between head node being marked as idle and test asserting. This pr fixes the issue by wrapping the assertion within a `wait_for_condition` call.
