### PR TITLE
[RLlib] Deflake test_actor_manager with 30 sec timeout

### DIFF
--- a/ci/ray_ci/rllib.tests.yml
+++ b/ci/ray_ci/rllib.tests.yml
@@ -17,7 +17,6 @@ flaky_tests:
   - //rllib:policy/tests/test_policy
   - //rllib:env/tests/test_local_inference_cartpole
   - //rllib:evaluation/tests/test_envs_that_crash
-  - //rllib:test_actor_manager
   - //rllib:test_apex_ddpg
   - //rllib:test_algorithm_export_checkpoint
   - //rllib:test_dataset_reader

--- a/rllib/utils/tests/test_actor_manager.py
+++ b/rllib/utils/tests/test_actor_manager.py
@@ -428,9 +428,8 @@ class TestActorManager(unittest.TestCase):
         actors = [Actor.remote(i, maybe_crash=False) for i in range(2)]
         manager = FaultTolerantActorManager(actors=actors)
         manager.foreach_actor_async_fetch_ready(lambda w: w.ping(), tag="ping")
-        time.sleep(5)
         results = manager.foreach_actor_async_fetch_ready(
-            lambda w: w.ping(), tag="ping"
+            lambda w: w.ping(), tag="ping", timeout_seconds=30
         )
         self.assertEqual(len(results), 2)
 


### PR DESCRIPTION
## Description

test_actor_manager is consistently red on CI.
Probably because 5 seconds is not enough time for slow CI workers to spin up two Ray actors and run the ping.
This PR attempts to replace the 5 second wait with a 30 second timeout, making the test "as quick as possible".
Note that we are not testing how fast we can set up Ray actors here.