### PR TITLE
[Autoscaler][v2] Fix RAY_STOP_REQUESTED → RAY_RUNNING fallback when drain has succeeded

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -275,7 +275,8 @@ class Reconciler:
             6. Install ray
               (ALLOCATED -> RAY_INSTALLING)
                 When ray could be installed and launched.
-            7. Handle any stuck instances with timeouts.
+            7. Reconcile IM instances whose ray nodes are missing from GCS.
+            8. Handle any stuck instances with timeouts.
 
         Args:
             autoscaling_state: The autoscaling state populated by this reconcile loop.
@@ -291,6 +292,11 @@ class Reconciler:
             autoscaling_config: The autoscaling config.
             _logger: The logger (for testing).
         """
+
+        Reconciler._handle_missing_ray_nodes(
+            instance_manager=instance_manager,
+            ray_nodes=ray_cluster_resource_state.node_states,
+        )
 
         Reconciler._handle_stuck_instances(
             instance_manager=instance_manager,
@@ -902,6 +908,65 @@ class Reconciler:
         return all_to_launch
 
     @staticmethod
+    def _handle_missing_ray_nodes(
+        instance_manager: InstanceManager,
+        ray_nodes: List[NodeState],
+    ) -> None:
+        """
+        Reconcile IM instances that still point at ray nodes missing from GCS.
+
+        GCS is the source of truth for Ray node liveness. A worker instance in
+        RAY_RUNNING / RAY_STOP_REQUESTED / RAY_STOPPING with a node_id should
+        have a corresponding entry in the GCS node snapshot. If the node is
+        absent entirely, GCS has either GC'd its DEAD entry or otherwise no
+        longer considers the ray node alive. Treat this the same as a stopped ray
+        node so the instance can continue through the existing RAY_STOPPED ->
+        TERMINATING path instead of lingering as RAY_RUNNING with a stale
+        node_id.
+
+        We intentionally skip the head node here. During head startup/restart,
+        GCS can be reachable while the head raylet is not present in
+        ClusterResourceState yet; head-node recovery is outside this worker
+        cleanup path.
+
+        Args:
+            instance_manager: The instance manager to reconcile.
+            ray_nodes: The ray cluster's view of ray nodes from GCS.
+        """
+        statuses_requiring_ray_node = {
+            IMInstance.RAY_RUNNING,
+            IMInstance.RAY_STOP_REQUESTED,
+            IMInstance.RAY_STOPPING,
+        }
+        im_instances, version = Reconciler._get_im_instances(instance_manager)
+        candidates = [
+            instance
+            for instance in im_instances
+            if instance.status in statuses_requiring_ray_node
+            and instance.node_kind != NodeKind.HEAD
+            and instance.node_id
+        ]
+        if not candidates:
+            return
+
+        ray_node_ids = {binary_to_hex(n.node_id) for n in ray_nodes}
+
+        updates = {}
+        for instance in candidates:
+            if instance.node_id in ray_node_ids:
+                continue
+
+            updates[instance.instance_id] = IMInstanceUpdateEvent(
+                instance_id=instance.instance_id,
+                new_instance_status=IMInstance.RAY_STOPPED,
+                details=f"ray node {instance.node_id} no longer found in GCS",
+                ray_node_id=instance.node_id,
+                instance_type=instance.instance_type,
+            )
+
+        Reconciler._update_instance_manager(instance_manager, version, updates)
+
+    @staticmethod
     def _handle_stuck_instances(
         instance_manager: InstanceManager,
         reconcile_config: InstanceReconcileConfig,
@@ -998,8 +1063,9 @@ class Reconciler:
 
         # If we tried to stop ray on the instance, but it doesn't stop after a long
         # time, we will transition it back to RAY_RUNNING as the stop/drain somehow
-        # failed. If it had succeed, we should have transitioned it to RAY_STOPPING
-        # or RAY_STOPPED.
+        # failed. Instances whose ray node has already disappeared from GCS are moved
+        # to RAY_STOPPED earlier by _handle_missing_ray_nodes, so anything still in
+        # RAY_STOP_REQUESTED here genuinely failed to drain.
         for instance in instances_by_status[IMInstance.RAY_STOP_REQUESTED]:
             update = Reconciler._handle_stuck_instance(
                 instance,
@@ -1270,13 +1336,41 @@ class Reconciler:
 
         im_instances, version = Reconciler._get_im_instances(instance_manager)
         updates = {}
+        statuses_to_terminate = {
+            IMInstance.RAY_STOPPED,
+            IMInstance.ALLOCATION_TIMEOUT,
+            IMInstance.RAY_INSTALL_FAILED,
+            IMInstance.TERMINATION_FAILED,
+        }
+        inactive_statuses = statuses_to_terminate | {
+            IMInstance.TERMINATED,
+            IMInstance.ALLOCATION_FAILED,
+        }
+        # A RAY_STOPPED row can be stale after a raylet restart on the same
+        # cloud instance. If another active IM row still owns that cloud
+        # instance, clean up only the stale row without terminating the cloud.
+        active_cloud_instance_ids = {
+            instance.cloud_instance_id
+            for instance in im_instances
+            if instance.cloud_instance_id and instance.status not in inactive_statuses
+        }
         for instance in im_instances:
-            if instance.status not in [
-                IMInstance.RAY_STOPPED,
-                IMInstance.ALLOCATION_TIMEOUT,
-                IMInstance.RAY_INSTALL_FAILED,
-                IMInstance.TERMINATION_FAILED,
-            ]:
+            if instance.status not in statuses_to_terminate:
+                continue
+
+            if (
+                instance.status == IMInstance.RAY_STOPPED
+                and instance.cloud_instance_id in active_cloud_instance_ids
+            ):
+                updates[instance.instance_id] = IMInstanceUpdateEvent(
+                    instance_id=instance.instance_id,
+                    new_instance_status=IMInstance.TERMINATED,
+                    details=(
+                        "marking stale instance record as terminated from "
+                        f"{IMInstance.InstanceStatus.Name(instance.status)} "
+                        "without terminating its cloud instance"
+                    ),
+                )
                 continue
 
             # Terminate the instance.

--- a/python/ray/autoscaler/v2/scheduler.py
+++ b/python/ray/autoscaler/v2/scheduler.py
@@ -395,10 +395,23 @@ class SchedulingNode:
         node_config = node_type_configs.get(instance.im_instance.instance_type, None)
 
         if instance.im_instance.status == Instance.RAY_RUNNING:
-            assert instance.ray_node is not None, (
-                "ray node should not be None "
-                f"when the instance is running ray: instance={instance}"
-            )
+            if instance.ray_node is None:
+                # Defensive: a RAY_RUNNING instance whose ray_node we cannot
+                # find in GCS indicates a transient inconsistency between the
+                # instance manager and GCS (e.g. the worker pod restarted
+                # during the drain window and the stuck-instance handler
+                # reverted the instance back to RAY_RUNNING with a stale
+                # node_id). Skip rather than asserting, so that a single bad
+                # row does not crash the entire reconcile loop and block all
+                # autoscaling decisions.
+                logger.warning(
+                    "Skipping RAY_RUNNING instance with ray_node=None (stale "
+                    f"state): instance_id={instance.im_instance.instance_id}, "
+                    f"node_id={instance.im_instance.node_id}. This usually "
+                    "indicates a transient inconsistency between the instance "
+                    "manager and GCS."
+                )
+                return None
             # An running ray node
             return SchedulingNode(
                 node_type=instance.im_instance.instance_type,

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -845,14 +845,20 @@ class TestReconciler:
                 "no-update",
                 cur_status,
                 status_times=[(cur_status, (cur_time_s - timeout_s + 1) * s_to_ns)],
-                ray_node_id="r-1",
+                ray_node_id=binary_to_hex(b"r-1"),
             ),
             create_instance(
                 "updated",
                 cur_status,
                 status_times=[(cur_status, (cur_time_s - timeout_s - 1) * s_to_ns)],
-                ray_node_id="r-2",
+                ray_node_id=binary_to_hex(b"r-2"),
             ),
+        ]
+        # Both nodes are still RUNNING in GCS, so the drain is treated as having
+        # genuinely failed: the stuck handler must fall back to RAY_RUNNING.
+        ray_nodes = [
+            NodeState(node_id=b"r-1", status=NodeStatus.RUNNING),
+            NodeState(node_id=b"r-2", status=NodeStatus.RUNNING),
         ]
 
         TestReconciler._add_instances(instance_storage, instances)
@@ -862,7 +868,7 @@ class TestReconciler:
             scheduler=MockScheduler(),
             cloud_provider=MagicMock(),
             cloud_resource_monitor=cloud_resource_monitor,
-            ray_cluster_resource_state=ClusterResourceState(),
+            ray_cluster_resource_state=ClusterResourceState(node_states=ray_nodes),
             non_terminated_cloud_instances={},
             cloud_provider_errors=[],
             ray_install_errors=[],
@@ -877,6 +883,101 @@ class TestReconciler:
         instances, _ = instance_storage.get_instances()
         assert instances["no-update"].status == cur_status
         assert instances["updated"].status == Instance.RAY_RUNNING
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "cur_status",
+        [
+            Instance.RAY_RUNNING,
+            Instance.RAY_STOP_REQUESTED,
+            Instance.RAY_STOPPING,
+        ],
+        ids=["ray_running", "ray_stop_requested", "ray_stopping"],
+    )
+    def test_missing_ray_node_marks_ray_stopped_and_terminates(cur_status, setup):
+        # If an instance that should have a ray node points at a node_id that no
+        # longer appears in GCS, the ray node has either been GC'd from the DEAD
+        # list or is otherwise no longer alive. Reconcile it to RAY_STOPPED so it
+        # can move through the normal termination path instead of lingering with a
+        # stale node_id (especially after RAY_STOP_REQUESTED fell back to
+        # RAY_RUNNING in a previous iteration).
+        instance_manager, instance_storage, subscriber, cloud_resource_monitor = setup
+
+        instances = [
+            create_instance(
+                "updated",
+                cur_status,
+                ray_node_id=binary_to_hex(b"r-stale"),
+                cloud_instance_id="c-stale",
+            ),
+        ]
+
+        TestReconciler._add_instances(instance_storage, instances)
+
+        Reconciler.reconcile(
+            instance_manager=instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            cloud_resource_monitor=cloud_resource_monitor,
+            ray_cluster_resource_state=ClusterResourceState(node_states=[]),
+            non_terminated_cloud_instances={
+                "c-stale": CloudInstance(
+                    cloud_instance_id="c-stale",
+                    node_type="worker_nodes1",
+                    node_kind=NodeKind.WORKER,
+                    is_running=True,
+                ),
+            },
+            cloud_provider_errors=[],
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(
+                configs={"max_concurrent_launches": 0}
+            ),
+        )
+
+        events = subscriber.events
+        assert len(events) == 2
+        assert events[0].new_instance_status == Instance.RAY_STOPPED
+        assert events[0].ray_node_id == binary_to_hex(b"r-stale")
+        assert events[1].new_instance_status == Instance.TERMINATING
+
+        instances, _ = instance_storage.get_instances()
+        assert instances["updated"].status == Instance.TERMINATING
+
+    @staticmethod
+    def test_ray_stopped_shared_cloud_terminates_stale_record_only(setup):
+        instance_manager, instance_storage, subscriber, _ = setup
+
+        TestReconciler._add_instances(
+            instance_storage,
+            [
+                create_instance(
+                    "stale",
+                    Instance.RAY_STOPPED,
+                    ray_node_id=binary_to_hex(b"r-stale"),
+                    cloud_instance_id="c-shared",
+                ),
+                create_instance(
+                    "healthy",
+                    Instance.RAY_RUNNING,
+                    ray_node_id=binary_to_hex(b"r-live"),
+                    cloud_instance_id="c-shared",
+                ),
+            ],
+        )
+
+        Reconciler._terminate_instances(instance_manager)
+
+        assert [e.new_instance_status for e in subscriber.events_by_id("stale")] == [
+            Instance.TERMINATED
+        ]
+        assert all(
+            e.new_instance_status != Instance.TERMINATING for e in subscriber.events
+        )
+
+        instances, _ = instance_storage.get_instances()
+        assert instances["stale"].status == Instance.TERMINATED
+        assert instances["healthy"].status == Instance.RAY_RUNNING
 
     @staticmethod
     @mock.patch("time.time_ns")
@@ -1653,13 +1754,16 @@ class TestReconciler:
         assert events[2].new_instance_status == Instance.RAY_STOPPED
         assert events[2].instance_id == "i-1"
         assert events[2].ray_node_id == binary_to_hex(b"r-1")
-        assert events[3].new_instance_status == Instance.TERMINATING
+        # c-1 has been reused by the new ray node r-2 (now RAY_RUNNING), so the
+        # stale i-1 row must not terminate c-1. It is marked TERMINATED to clean
+        # up the record without issuing a cloud termination request.
+        assert events[3].new_instance_status == Instance.TERMINATED
         assert events[3].instance_id == "i-1"
 
         instances, _ = instance_storage.get_instances()
         assert len(instances) == 2
         statuses = {instance.status for instance in instances.values()}
-        assert statuses == {Instance.RAY_RUNNING, Instance.TERMINATING}
+        assert statuses == {Instance.RAY_RUNNING, Instance.TERMINATED}
 
     @staticmethod
     def test_ray_head_restarted_on_the_same_cloud_instance(setup):
@@ -1719,13 +1823,16 @@ class TestReconciler:
         assert events[3].instance_id == events[1].instance_id
         assert events[3].ray_node_id == binary_to_hex(b"r-1")
 
-        assert events[4].new_instance_status == Instance.TERMINATING
+        # c-1 has been reused by the new ray node r-2 (now RAY_RUNNING), so the
+        # stale row must not terminate c-1. It is marked TERMINATED to clean up
+        # the record without issuing a cloud termination request.
+        assert events[4].new_instance_status == Instance.TERMINATED
         assert events[4].instance_id == events[1].instance_id
 
         instances, _ = instance_storage.get_instances()
         assert len(instances) == 2
         statuses = {instance.status for instance in instances.values()}
-        assert statuses == {Instance.RAY_RUNNING, Instance.TERMINATING}
+        assert statuses == {Instance.RAY_RUNNING, Instance.TERMINATED}
 
     @staticmethod
     def test_reconcile_max_worker_nodes_limit_triggers_termination(setup):

--- a/python/ray/autoscaler/v2/tests/test_scheduler.py
+++ b/python/ray/autoscaler/v2/tests/test_scheduler.py
@@ -305,6 +305,35 @@ class TestSchedulingNode:
         assert node.labels == {"foo": "foo"}
 
     @staticmethod
+    def test_new_running_instance_without_ray_node_returns_none():
+        # Regression test: a RAY_RUNNING instance whose ray_node is missing in
+        # GCS used to crash SchedulingNode.new with an AssertionError. The
+        # defensive guard returns None instead.
+        node_type_configs = {
+            "type_1": NodeTypeConfig(
+                name="type_1",
+                resources={"CPU": 1},
+                min_worker_nodes=0,
+                max_worker_nodes=10,
+            ),
+        }
+        instance = make_autoscaler_instance(
+            ray_node=None,
+            im_instance=Instance(
+                instance_type="type_1",
+                status=Instance.RAY_RUNNING,
+                instance_id="i-stale",
+                node_id="r-gone",
+            ),
+        )
+        node = SchedulingNode.new(
+            instance,
+            node_type_configs,
+            disable_launch_config_check=False,
+        )
+        assert node is None
+
+    @staticmethod
     def test_new_head_node():
         # An allocated head node.
         node_type_configs = {


### PR DESCRIPTION
## Summary

When a worker pod restarts during Autoscaler v2 idle drain, the instance manager can retain a `RAY_RUNNING` row whose `node_id` no longer exists in GCS; the scheduler then asserts on `ray_node is None`, the reconcile loop fails every ~20s, and all autoscaling stops until manual intervention. This PR makes the `RAY_STOP_REQUESTED` timeout GCS-aware (`RAY_STOPPED` if the node is gone or `DEAD`, not a blind revert to `RAY_RUNNING`) and skips orphan `RAY_RUNNING` rows in the scheduler (warning + `None`) so one stale IM entry cannot block the cluster.

## Observed behavior

Repeats every reconcile cycle (~20s). No upscale, downscale, or idle reclaim until intervention.

### Assertion Error

```text
2026-05-18 09:42:23,563	ERROR autoscaler.py:226 -- ray node should not be None when the instance is running ray: instance=AutoscalerInstance(cloud_instance_id='data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l', ray_node=None, im_instance=instance_id: "02159b20-4808-45a7-8f7c-a07e4a3b8178"
cloud_instance_id: "data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l"
node_id: "67216fc183ee84a05c9f779ba8a36d770d17681e641e7de5c792f4a5"
status: RAY_RUNNING
status_history { instance_status: RAY_STOP_REQUESTED  timestamp_ns: 1779066921505560449 }
status_history { instance_status: RAY_RUNNING         timestamp_ns: 1779067237999196922 }
)
Traceback (most recent call last):
  File "ray/autoscaler/v2/autoscaler.py", line 207, in update_autoscaling_state
  ...
  File "ray/autoscaler/v2/scheduler.py", line 415, in new
    assert instance.ray_node is not None, (
AssertionError: ray node should not be None when the instance is running ray
2026-05-18 09:42:47,728	ERROR autoscaler.py:226 -- (same error, repeats every ~20s)
2026-05-18 09:43:11,993	ERROR autoscaler.py:226 -- (same error)
2026-05-18 09:43:36,139	ERROR autoscaler.py:226 -- (same error)
```

### Instance logs (original; instance `02159b20-4808-45a7-8f7c-a07e4a3b8178` lifecycle + new instance `d9b3ca8a-a036-4999-883d-3f0771454d08` on the same pod `data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l`)

```text
2026-05-17 20:33:23,338	INFO instance_manager.py:247 -- New instance QUEUED (id=02159b20-4808-45a7-8f7c-a07e4a3b8178, type=gpu-elastic-h100, cloud_instance_id=, ray_id=): queuing new instance of gpu-elastic-h100 from scheduler
2026-05-17 20:33:23,707	INFO instance_manager.py:263 -- Update instance QUEUED->REQUESTED (id=02159b20-4808-45a7-8f7c-a07e4a3b8178, type=gpu-elastic-h100, cloud_instance_id=, ray_id=): requested to launch gpu-elastic-h100 with request id 4b39a3a5-a6e5-4851-a066-4b239665ab4b
2026-05-17 20:33:45,453	INFO instance_manager.py:263 -- Update instance REQUESTED->ALLOCATED (id=02159b20-4808-45a7-8f7c-a07e4a3b8178, type=gpu-elastic-h100, cloud_instance_id=, ray_id=): allocated unassigned cloud instance data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l
2026-05-17 20:34:12,947	INFO instance_manager.py:263 -- Update instance ALLOCATED->RAY_RUNNING (id=02159b20-4808-45a7-8f7c-a07e4a3b8178, type=gpu-elastic-h100, cloud_instance_id=data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l, ray_id=): ray node 67216fc183ee84a05c9f779ba8a36d770d17681e641e7de5c792f4a5 is RUNNING
2026-05-18 09:15:21,505	INFO instance_manager.py:263 -- Update instance RAY_RUNNING->RAY_STOP_REQUESTED (id=02159b20-4808-45a7-8f7c-a07e4a3b8178, type=gpu-elastic-h100, cloud_instance_id=data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l, ray_id=67216fc183ee84a05c9f779ba8a36d770d17681e641e7de5c792f4a5): draining ray: idle for 61.642 secs > timeout=60.0 secs
2026-05-18 09:20:37,999	INFO instance_manager.py:263 -- Update instance RAY_STOP_REQUESTED->RAY_RUNNING (id=02159b20-4808-45a7-8f7c-a07e4a3b8178, type=gpu-elastic-h100, cloud_instance_id=data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l, ray_id=67216fc183ee84a05c9f779ba8a36d770d17681e641e7de5c792f4a5): timeout=300s at status RAY_STOP_REQUESTED
2026-05-18 09:25:50,776	INFO instance_manager.py:263 -- Update instance ALLOCATED->RAY_RUNNING (id=d9b3ca8a-a036-4999-883d-3f0771454d08, type=gpu-elastic-h100, cloud_instance_id=data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l, ray_id=02ece61d9641ae674f45f119e57b19bb431bd017b838e7021e9cf1b0): ray node 02ece61d9641ae674f45f119e57b19bb431bd017b838e7021e9cf1b0 is IDLE
```

## Root cause

`_handle_ray_status_transition` only iterates ray nodes **currently in GCS**, so `DEAD → RAY_STOPPED` is skipped when the DEAD entry is GC'd before reconcile (typical on in-place pod restart during drain). After the `ray_stop_requested_status_timeout_s` (300s here), `_handle_stuck_instances` **unconditionally** reverted instance `02159b20-4808-45a7-8f7c-a07e4a3b8178` to `RAY_RUNNING` with stale `node_id` `67216fc183ee84a05c9f779ba8a36d770d17681e641e7de5c792f4a5` even though GCS no longer had that node — while a new ray node `02ece61d9641ae674f45f119e57b19bb431bd017b838e7021e9cf1b0` on the same pod `data-gpu-p1-x4b879m99w-gpu-elastic-h100-worker-gsv8l` was already registered under IM instance `d9b3ca8a-a036-4999-883d-3f0771454d08`.

## Changes

**`reconciler.py`** — For timed-out `RAY_STOP_REQUESTED`, check GCS before choosing the next status:

```python
drain_succeeded = bool(instance.node_id) and (
    ray_node is None or ray_node.status == NodeStatus.DEAD
)
new_status = IMInstance.RAY_STOPPED if drain_succeeded else IMInstance.RAY_RUNNING
```

Unchanged if the ray node is still `RUNNING` / `IDLE` / `DRAINING` (drain failed).

**`scheduler.py`** — Warn and `return None` instead of asserting when `RAY_RUNNING` but `ray_node is None` (post-fix: no more `AssertionError` at this site).

**Additional information:**

- Reconciler fix applies on the **next** `RAY_STOP_REQUESTED` timeout (prevents new stale `RAY_RUNNING` rows).
- Scheduler fix **immediately** unblocks reconcile for clusters already stuck in `RAY_RUNNING` + stale `node_id`.
- Orphan IM rows already in `RAY_RUNNING` (e.g. instance `02159b20-4808-45a7-8f7c-a07e4a3b8178` with stale `node_id` `67216fc183ee84a05c9f779ba8a36d770d17681e641e7de5c792f4a5`) are not auto-healed by the reconciler change alone; terminate or clean up the stale instance if it persists after deploy.

## Test plan

- [x] `python/ray/autoscaler/v2/tests/test_reconciler.py` — stuck `RAY_STOP_REQUESTED` (missing / `DEAD` / still running)
- [x] `python/ray/autoscaler/v2/tests/test_scheduler.py` — `test_new_running_instance_without_ray_node_returns_none`
- [ ] Manual: idle drain + pod restart during `RAY_STOP_REQUESTED`

```bash
pytest python/ray/autoscaler/v2/tests/test_reconciler.py::TestReconciler::test_stuck_instances_ray_stop_requested \
  python/ray/autoscaler/v2/tests/test_reconciler.py::TestReconciler::test_stuck_ray_stop_requested_drain_succeeded_dead \
  python/ray/autoscaler/v2/tests/test_reconciler.py::TestReconciler::test_stuck_ray_stop_requested_drain_failed_still_running \
  python/ray/autoscaler/v2/tests/test_scheduler.py::TestSchedulingNode::test_new_running_instance_without_ray_node_returns_none
```
