### PR TITLE
[Data] DataSourceV2: per-task heap memory hints for ReadFiles

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -120,6 +120,20 @@ py_test(
 )
 
 py_test(
+    name = "test_read_parquet_v2_task_memory_integration",
+    size = "small",
+    srcs = ["tests/datasource_v2/test_read_parquet_v2_task_memory_integration.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_strict_mode",
     size = "small",
     srcs = ["tests/test_strict_mode.py"],

--- a/python/ray/data/_internal/datasource_v2/readers/read_files_task_memory.py
+++ b/python/ray/data/_internal/datasource_v2/readers/read_files_task_memory.py
@@ -1,0 +1,102 @@
+"""Heap memory hints for DataSource V2 ``ReadFiles`` Ray tasks.
+
+The formula is
+    ``task_memory_bytes = max(2 * target_max_block_size, max(file_sizes)) + eps``,
+where ``max(file_sizes)`` is the largest on-disk file size in the manifest.
+``eps`` accounts for additional per-task scratch (pyarrow buffers, transforms,
+generator state). ``eps`` defaults to
+:attr:`~ray.data.context.DataContext.read_files_task_memory_eps_bytes` and can
+be overridden per-context or per-call.
+
+For tuning, see
+``python/ray/data/tests/datasource_v2/read_files_task_memory_probe.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Optional
+
+from ray.data._internal.datasource_v2.listing.file_manifest import (
+    FILE_SIZE_COLUMN_NAME,
+    PATH_COLUMN_NAME,
+    FileManifest,
+)
+from ray.data.block import Block, BlockAccessor, BlockMetadata
+from ray.data.context import DataContext
+from ray.util.annotations import DeveloperAPI
+
+
+def _default_eps() -> int:
+    """Resolve ``eps`` from the current ``DataContext`` (also callable inside workers)."""
+    return int(DataContext.get_current().read_files_task_memory_eps_bytes)
+
+
+@DeveloperAPI
+def estimate_read_files_task_memory_bytes(
+    manifest: FileManifest,
+    target_max_block_size: Optional[int],
+    *,
+    eps: Optional[int] = None,
+) -> int:
+    """Upper bound on heap memory for one ``ReadFiles`` task for ``manifest``.
+
+    Returns ``max(2 * target_max_block_size, max(file_sizes)) + eps``:
+
+    - ``2 * target_max_block_size`` covers the input batch buffer plus the
+      output block being assembled in the same task.
+    - ``max(file_sizes)`` is the largest on-disk file size in the manifest,
+      a fast proxy for per-task peak decode footprint. ``0`` for an empty
+      manifest.
+    - ``eps`` covers additional per-task scratch (defaults to
+      ``DataContext.read_files_task_memory_eps_bytes``; override via the
+      context knob or pass explicitly).
+    """
+    if eps is None:
+        eps = _default_eps()
+    max_file = int(manifest.file_sizes.max()) if len(manifest) else 0
+    block_pair = 2 * int(target_max_block_size or 0)
+    return max(block_pair, max_file) + int(eps)
+
+
+@DeveloperAPI
+def enrich_file_manifest_block_metadata_if_applicable(
+    block: Block,
+    meta: BlockMetadata,
+    *,
+    target_max_block_size: Optional[int],
+    eps: Optional[int] = None,
+) -> BlockMetadata:
+    """Attach ``task_memory_bytes`` when ``block`` is a ``FileManifest`` table.
+
+    Pass-through for any non-manifest block (returns ``meta`` unchanged), so
+    this is safe to apply in a generic per-block postprocess hook.
+    """
+    columns = BlockAccessor.for_block(block).column_names()
+    if PATH_COLUMN_NAME not in columns or FILE_SIZE_COLUMN_NAME not in columns:
+        return meta
+
+    manifest = FileManifest(block)
+    task_mem = estimate_read_files_task_memory_bytes(
+        manifest, target_max_block_size, eps=eps
+    )
+    return replace(meta, task_memory_bytes=task_mem)
+
+
+@DeveloperAPI
+def enrich_manifest_block_metadata_for_map_task(
+    block: Block, meta: BlockMetadata, data_context: DataContext
+) -> BlockMetadata:
+    """Adapter for ``MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS``.
+
+    Module-level so it pickles across the Ray task boundary. Reads
+    ``target_max_block_size`` and ``read_files_task_memory_eps_bytes`` from
+    the serialized worker-side ``DataContext`` so driver-side overrides take
+    effect.
+    """
+    return enrich_file_manifest_block_metadata_if_applicable(
+        block,
+        meta,
+        target_max_block_size=data_context.target_max_block_size,
+        eps=data_context.read_files_task_memory_eps_bytes,
+    )

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -135,6 +135,19 @@ def _get_schema_from_bundle(bundle: RefBundle) -> Optional["pa.Schema"]:
     return None
 
 
+# Reserved ``map_task_kwargs`` key for an optional, datasource-agnostic
+# metadata-postprocess hook. When set, the value must be a *module-level*
+# (picklable) callable with signature:
+#
+#     fn(block, meta, data_context) -> BlockMetadata
+#
+# ``_map_task`` applies it once per yielded block after ``get_metadata()``
+# and before the block is yielded. Planners (e.g. DataSource V2's
+# ``plan_list_files_op``) use this to attach hint-producing helpers
+# without the generic execution layer importing from those modules.
+MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS = "_block_metadata_postprocess_fn"
+
+
 class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
     """A streaming operator that maps input bundles 1:1 to output bundles.
 
@@ -483,6 +496,42 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
                     self._remote_args_for_metrics = copy.deepcopy(ray_remote_args)
         return ray_remote_args
 
+    def _estimate_task_memory_bytes(self, input_bundle: RefBundle) -> Optional[int]:
+        """Max ``task_memory_bytes`` hint across the bundle's block metadata.
+
+        Returns ``None`` when no block carries a hint. Uses ``max`` rather
+        than ``sum`` because each per-block hint is already an upper bound
+        on the per-task peak heap for that block; the bundled task's peak
+        is bounded by the largest constituent hint, not the sum (peak ≠
+        cumulative when blocks are processed sequentially within the task).
+        """
+        max_tm: Optional[int] = None
+        for meta in input_bundle.metadata:
+            tm = getattr(meta, "task_memory_bytes", None)
+            if tm is not None:
+                tm_i = int(tm)
+                if max_tm is None or tm_i > max_tm:
+                    max_tm = tm_i
+        return max_tm
+
+    def _merge_task_memory_into_ray_remote_args(
+        self,
+        input_bundle: RefBundle,
+        ray_remote_args: Dict[str, Any],
+    ) -> None:
+        """Raise Ray ``memory`` reservation using per-block hints.
+
+        No-op when no block carries ``task_memory_bytes``. When at least one
+        does, the Ray ``memory`` arg is raised to
+        ``max(user_memory, max_block_hint)`` — user-supplied ``memory=``
+        wins when larger.
+        """
+        task_mem = self._estimate_task_memory_bytes(input_bundle)
+        if task_mem is None:
+            return
+        user_mem = ray_remote_args.get("memory") or 0
+        ray_remote_args["memory"] = max(user_mem, task_mem)
+
     @abstractmethod
     def _try_schedule_task(self, refs: RefBundle, strict: bool):
         """Method to try schedule task handling provided bundle
@@ -734,6 +783,13 @@ def _map_task(
         with MemoryProfiler(data_context.memory_usage_poll_interval_s) as profiler:
             for block in block_iter:
                 block_meta = BlockAccessor.for_block(block).get_metadata()
+                # Optional per-block metadata postprocess hook. The hook is
+                # opt-in: set by planners (e.g. DataSource V2 ListFiles) via
+                # ``map_task_kwargs[MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS]``.
+                # Must be a module-level callable so it pickles into Ray tasks.
+                postprocess = kwargs.get(MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS)
+                if postprocess is not None:
+                    block_meta = postprocess(block, block_meta, data_context)
                 block_schema = BlockAccessor.for_block(block).schema()
 
                 # Finish processing before yielding the block!

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -124,6 +124,10 @@ class TaskPoolMapOperator(MapOperator):
         )
 
         dynamic_ray_remote_args = self._get_dynamic_ray_remote_args(input_bundle=bundle)
+        # Merge any per-block ``task_memory_bytes`` hints into the Ray
+        # ``memory`` reservation. No-op when no block carries a hint, so this
+        # is safe to call unconditionally for every TaskPoolMapOperator.
+        self._merge_task_memory_into_ray_remote_args(bundle, dynamic_ray_remote_args)
         dynamic_ray_remote_args["name"] = self.name
         logical_usage = ExecutionResources.from_resource_dict(dynamic_ray_remote_args)
 

--- a/python/ray/data/_internal/planner/plan_list_files_op.py
+++ b/python/ray/data/_internal/planner/plan_list_files_op.py
@@ -28,11 +28,17 @@ from ray.data._internal.datasource_v2.listing.listing_utils import (
     partition_files,
     shuffle_files,
 )
+from ray.data._internal.datasource_v2.readers.read_files_task_memory import (
+    enrich_manifest_block_metadata_for_map_task,
+)
 from ray.data._internal.execution.interfaces import PhysicalOperator, RefBundle
 from ray.data._internal.execution.operators.input_data_buffer import (
     InputDataBuffer,
 )
-from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_operator import (
+    MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS,
+    MapOperator,
+)
 from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     MapTransformer,
@@ -120,6 +126,16 @@ def plan_list_files_op(
         # Don't fuse into the downstream ``ReadFiles`` — listing and reading
         # have different resource profiles.
         supports_fusion=False,
+        # Attach a generic per-block postprocess hook that stamps each
+        # emitted FileManifest block's metadata with a ``task_memory_bytes``
+        # hint. The downstream ``ReadFiles`` ``TaskPoolMapOperator``'s
+        # always-on merge consumes the hint to raise its Ray ``memory``
+        # reservation.
+        map_task_kwargs={
+            MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS: (
+                enrich_manifest_block_metadata_for_map_task
+            ),
+        },
     )
     map_op.throttling_disabled = lambda: True
     return map_op

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -299,6 +299,12 @@ class BlockMetadata(BlockStats):
     # the empty list if indeterminate.
     # Stored as a tuple for hash-ability.
     input_files: Optional[Tuple[str, ...]] = field(default=None)
+    # Optional per-task heap-memory hint in bytes. Producers may set this
+    # so a downstream consumer (e.g. ``TaskPoolMapOperator``) can raise the
+    # Ray ``memory`` reservation for the task that consumes the block.
+    # Default ``None`` means "no hint" — generic consumers must treat
+    # missing hints as a no-op.
+    task_memory_bytes: Optional[int] = field(default=None)
 
     def __post_init__(self):
         super().__post_init__()
@@ -327,6 +333,7 @@ class BlockMetadataWithSchema(BlockMetadata):
             exec_stats=metadata.exec_stats,
             task_exec_stats=metadata.task_exec_stats,
             input_files=metadata.input_files,
+            task_memory_bytes=metadata.task_memory_bytes,
             schema=schema,
         )
 
@@ -348,12 +355,18 @@ class BlockMetadataWithSchema(BlockMetadata):
 
     @property
     def metadata(self) -> BlockMetadata:
+        """Plain :class:`BlockMetadata` without schema.
+
+        Preserves all :class:`BlockMetadata` fields, including ``task_memory_bytes``,
+        so streaming hand-offs do not drop the hint.
+        """
         return BlockMetadata(
             num_rows=self.num_rows,
             size_bytes=self.size_bytes,
             exec_stats=self.exec_stats,
             input_files=self.input_files,
             task_exec_stats=self.task_exec_stats,
+            task_memory_bytes=self.task_memory_bytes,
         )
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -79,6 +79,13 @@ DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
 DEFAULT_USE_DATASOURCE_V2 = True
 
+# Padding (in bytes) added on top of the per-task heap-memory hint computed
+# by producers such as DataSource V2 ``ReadFiles``. Tuned empirically; see
+# ``python/ray/data/tests/datasource_v2/read_files_task_memory_probe.py``.
+DEFAULT_READ_FILES_TASK_MEMORY_EPS_BYTES = env_integer(
+    "RAY_DATA_READ_FILES_TASK_MEMORY_EPS_BYTES", 64 * 1024 * 1024
+)
+
 DEFAULT_ACTOR_PREFETCHER_ENABLED = False
 
 DEFAULT_USE_PUSH_BASED_SHUFFLE = bool(
@@ -665,6 +672,13 @@ class DataContext:
     streaming_read_buffer_size: int = DEFAULT_STREAMING_READ_BUFFER_SIZE
     enable_pandas_block: bool = DEFAULT_ENABLE_PANDAS_BLOCK
     actor_prefetcher_enabled: bool = DEFAULT_ACTOR_PREFETCHER_ENABLED
+
+    # Padding (in bytes) added on top of the per-task heap-memory hint
+    # computed by producers such as DataSource V2 ``ReadFiles``. Serialized
+    # on the ``DataContext`` ref, so driver-side changes propagate to
+    # worker tasks. Override via the env var
+    # ``RAY_DATA_READ_FILES_TASK_MEMORY_EPS_BYTES``.
+    read_files_task_memory_eps_bytes: int = DEFAULT_READ_FILES_TASK_MEMORY_EPS_BYTES
 
     autoscaling_config: AutoscalingConfig = field(default_factory=AutoscalingConfig)
 

--- a/python/ray/data/tests/datasource_v2/read_files_task_memory_probe.py
+++ b/python/ray/data/tests/datasource_v2/read_files_task_memory_probe.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Probe ReadFiles Ray ``memory`` reservations against the live formula.
+
+Formula:
+    ``max(2 * target_max_block_size, max(file_sizes)) + eps``
+
+``DataContext`` is serialized into Ray tasks, so setting
+``ctx.read_files_task_memory_eps_bytes`` on the driver propagates to workers.
+Use this to sweep ``eps`` values without code edits.
+
+Run from the ``python/`` directory::
+
+    cd python
+    python ray/data/tests/datasource_v2/read_files_task_memory_probe.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+from typing import List
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+import ray
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data.context import DataContext
+
+
+def main() -> None:
+    captured: List[int] = []
+    orig = MapOperator._merge_task_memory_into_ray_remote_args
+
+    def recorder(self, input_bundle, ray_remote_args):
+        orig(self, input_bundle, ray_remote_args)
+        if self.name.startswith("ReadFiles"):
+            m = ray_remote_args.get("memory")
+            if m is not None:
+                captured.append(int(m))
+
+    MapOperator._merge_task_memory_into_ray_remote_args = recorder  # type: ignore[method-assign]
+
+    ctx = DataContext.get_current()
+    ctx.use_datasource_v2 = True
+    target_max = ctx.target_max_block_size or (128 * 1024 * 1024)
+    eps = int(ctx.read_files_task_memory_eps_bytes)
+
+    ray.init(num_cpus=2, ignore_reinit_error=True)
+    try:
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "t.parquet"
+            pq.write_table(pa.table({"c": list(range(100))}), str(p))
+            ray.data.read_parquet(str(p.parent)).materialize()
+            file_size = int(p.stat().st_size)
+    finally:
+        MapOperator._merge_task_memory_into_ray_remote_args = orig  # type: ignore[method-assign]
+        ray.shutdown()
+
+    if not captured:
+        print("No ReadFiles memory observations (unexpected).", file=sys.stderr)
+        sys.exit(1)
+
+    base = max(2 * int(target_max), file_size)
+    expected = base + eps
+    print(
+        "read_files_task_memory_probe:",
+        f"DataContext.read_files_task_memory_eps_bytes={eps}",
+        f"target_max_block_size={target_max}",
+        f"max(file_sizes)={file_size}",
+        f"expected_task_memory={expected}",
+        f"observed_readfiles_ray_memory_each_task={captured}",
+        sep="\n",
+    )
+    if any(m != expected for m in captured):
+        print(
+            "Mismatch: workers may be using a different install than this interpreter.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/ray/data/tests/datasource_v2/test_read_parquet_v2_task_memory_integration.py
+++ b/python/ray/data/tests/datasource_v2/test_read_parquet_v2_task_memory_integration.py
@@ -1,0 +1,285 @@
+"""Integration checks: DataSource V2 ReadFiles merges manifest ``task_memory_bytes``
+into Ray task ``memory``.
+
+These tests exercise the full ListFiles → manifest enrichment → ReadFiles
+scheduling path. ``eps`` is resolved at enrich time from
+``DataContext.read_files_task_memory_eps_bytes``, which is serialized on the
+``DataContext`` ref so driver-side overrides propagate to workers.
+
+Formula:
+    ``max(2 * target_max_block_size, max(file_sizes)) + eps``
+
+For empirical tuning of ``eps``, see ``read_files_task_memory_probe.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+import ray
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data.context import DataContext
+from ray.data.tests.conftest import *  # noqa
+from ray.tests.conftest import *  # noqa
+
+
+def _write_parquet(path: Path, table: pa.Table) -> None:
+    pq.write_table(table, str(path))
+
+
+def _expected_read_files_task_memory_bytes(
+    parquet_paths: List[Path], target_max_block_size: int, eps: int
+) -> int:
+    """Match :func:`estimate_read_files_task_memory_bytes` for a single-task read."""
+    max_file = max(int(p.stat().st_size) for p in parquet_paths)
+    base = max(2 * int(target_max_block_size), max_file)
+    return base + int(eps)
+
+
+@pytest.fixture
+def restore_ctx():
+    ctx = DataContext.get_current()
+    original_v2 = ctx.use_datasource_v2
+    original_tmax = ctx.target_max_block_size
+    original_eps = ctx.read_files_task_memory_eps_bytes
+    try:
+        yield ctx
+    finally:
+        ctx.use_datasource_v2 = original_v2
+        ctx.target_max_block_size = original_tmax
+        ctx.read_files_task_memory_eps_bytes = original_eps
+
+
+def _merge_capture_wrapper(captured: List[int]):
+    """Wrap ``_merge_task_memory_into_ray_remote_args`` to record ReadFiles memory."""
+
+    orig = MapOperator._merge_task_memory_into_ray_remote_args
+
+    def wrapped(self, input_bundle, ray_remote_args):
+        orig(self, input_bundle, ray_remote_args)
+        if self.name.startswith("ReadFiles"):
+            mem = ray_remote_args.get("memory")
+            if mem is not None:
+                captured.append(int(mem))
+
+    return wrapped
+
+
+def test_read_parquet_v2_merged_ray_memory_matches_task_estimate(
+    ray_start_regular_shared,
+    tmp_path: Path,
+    restore_ctx: DataContext,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """End-to-end: Ray ``memory`` on ReadFiles tasks equals
+    ``max(2 * target, max(file_sizes)) + eps``."""
+    captured: List[int] = []
+    monkeypatch.setattr(
+        MapOperator,
+        "_merge_task_memory_into_ray_remote_args",
+        _merge_capture_wrapper(captured),
+    )
+
+    restore_ctx.use_datasource_v2 = True
+    target_max = 3 * 1024 * 1024
+    restore_ctx.target_max_block_size = target_max
+    eps = int(restore_ctx.read_files_task_memory_eps_bytes)
+
+    data_path = tmp_path / "data.parquet"
+    _write_parquet(data_path, pa.table({"x": list(range(10))}))
+
+    ds = ray.data.read_parquet(str(tmp_path))
+    ds.materialize()
+
+    assert captured, "expected at least one ReadFiles task to merge task memory"
+    expected = _expected_read_files_task_memory_bytes([data_path], target_max, eps)
+    assert all(m == expected for m in captured), (captured, expected)
+
+
+def test_read_parquet_v2_larger_target_max_block_size_raises_ray_memory_reservation(
+    ray_start_regular_shared,
+    tmp_path: Path,
+    restore_ctx: DataContext,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Larger ``DataContext.target_max_block_size`` -> higher merged ``memory``."""
+    captured: List[int] = []
+    monkeypatch.setattr(
+        MapOperator,
+        "_merge_task_memory_into_ray_remote_args",
+        _merge_capture_wrapper(captured),
+    )
+
+    restore_ctx.use_datasource_v2 = True
+    eps = int(restore_ctx.read_files_task_memory_eps_bytes)
+
+    d1 = tmp_path / "d1"
+    d2 = tmp_path / "d2"
+    d1.mkdir()
+    d2.mkdir()
+    table = pa.table({"a": [1, 2, 3]})
+    _write_parquet(d1 / "a.parquet", table)
+    _write_parquet(d2 / "b.parquet", table)
+
+    t_small = 2 * 1024 * 1024
+    t_large = 96 * 1024 * 1024
+
+    restore_ctx.target_max_block_size = t_small
+    captured.clear()
+    ray.data.read_parquet(str(d1)).materialize()
+    assert captured
+    mem_small = max(captured)
+
+    restore_ctx.target_max_block_size = t_large
+    captured.clear()
+    ray.data.read_parquet(str(d2)).materialize()
+    assert captured
+    mem_large = max(captured)
+
+    file_b_size = int((d2 / "b.parquet").stat().st_size)
+    assert mem_small == max(2 * t_small, file_b_size) + eps
+    assert mem_large == max(2 * t_large, file_b_size) + eps
+    # 2 * t_large dominates over the parquet file, so the large-target hint
+    # is strictly larger than the small-target hint.
+    assert mem_small < mem_large
+
+
+def test_read_parquet_v2_user_ray_memory_is_respected_when_larger_than_hint(
+    ray_start_regular_shared,
+    tmp_path: Path,
+    restore_ctx: DataContext,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``max(user memory, task estimate)`` — user wins when already larger."""
+    captured: List[int] = []
+    monkeypatch.setattr(
+        MapOperator,
+        "_merge_task_memory_into_ray_remote_args",
+        _merge_capture_wrapper(captured),
+    )
+
+    restore_ctx.use_datasource_v2 = True
+    restore_ctx.target_max_block_size = 2 * 1024 * 1024
+
+    _write_parquet(tmp_path / "p.parquet", pa.table({"z": [1]}))
+
+    user_floor = 500_000_000
+    ds = ray.data.read_parquet(str(tmp_path), ray_remote_args={"memory": user_floor})
+    ds.materialize()
+
+    assert captured
+    assert all(m == user_floor for m in captured), captured
+
+
+def test_read_parquet_v2_eps_override_via_data_context(
+    ray_start_regular_shared,
+    tmp_path: Path,
+    restore_ctx: DataContext,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """``DataContext.read_files_task_memory_eps_bytes`` propagates to workers."""
+    captured: List[int] = []
+    monkeypatch.setattr(
+        MapOperator,
+        "_merge_task_memory_into_ray_remote_args",
+        _merge_capture_wrapper(captured),
+    )
+
+    restore_ctx.use_datasource_v2 = True
+    target_max = 2 * 1024 * 1024
+    restore_ctx.target_max_block_size = target_max
+    custom_eps = 7 * 1024 * 1024  # 7 MiB — distinguishable from the 64 MiB default
+    restore_ctx.read_files_task_memory_eps_bytes = custom_eps
+
+    data_path = tmp_path / "data.parquet"
+    _write_parquet(data_path, pa.table({"x": list(range(10))}))
+
+    ray.data.read_parquet(str(tmp_path)).materialize()
+
+    assert captured
+    expected = _expected_read_files_task_memory_bytes(
+        [data_path], target_max, custom_eps
+    )
+    assert all(m == expected for m in captured), (captured, expected, custom_eps)
+
+
+def test_read_parquet_v1_legacy_path_does_not_set_task_memory_bytes(
+    ray_start_regular_shared,
+    tmp_path: Path,
+    restore_ctx: DataContext,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """V1 legacy read path does not produce ``ReadFiles`` operators that pass
+    through the merge — so the capture wrapper never fires for them.
+
+    Locks in the V2-only gating contract: only ``plan_list_files_op`` attaches
+    the postprocess hook that stamps ``task_memory_bytes``.
+    """
+    captured: List[int] = []
+    monkeypatch.setattr(
+        MapOperator,
+        "_merge_task_memory_into_ray_remote_args",
+        _merge_capture_wrapper(captured),
+    )
+
+    restore_ctx.use_datasource_v2 = False
+    restore_ctx.target_max_block_size = 4 * 1024 * 1024
+
+    _write_parquet(tmp_path / "data.parquet", pa.table({"x": list(range(10))}))
+
+    ds = ray.data.read_parquet(str(tmp_path))
+    ds.materialize()
+
+    # The capture filter only records ``ReadFiles`` (V2 op name). V1 uses
+    # different operator names (e.g. ``ReadParquet``), so nothing should be
+    # captured.
+    assert captured == [], (
+        "V1 legacy path unexpectedly produced ReadFiles task-memory merges: "
+        f"{captured}"
+    )
+
+
+def test_read_parquet_v2_largest_file_drives_hint(
+    ray_start_regular_shared,
+    tmp_path: Path,
+    restore_ctx: DataContext,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Heterogeneous file sizes -> only ``max(file_sizes)`` shapes the hint."""
+    captured: List[int] = []
+    monkeypatch.setattr(
+        MapOperator,
+        "_merge_task_memory_into_ray_remote_args",
+        _merge_capture_wrapper(captured),
+    )
+
+    restore_ctx.use_datasource_v2 = True
+    target_max = 1 * 1024 * 1024  # 1 MiB — chosen so 2*target won't dominate
+    restore_ctx.target_max_block_size = target_max
+    eps = int(restore_ctx.read_files_task_memory_eps_bytes)
+
+    # Write two files of very different sizes in the same directory.
+    small = tmp_path / "small.parquet"
+    big = tmp_path / "big.parquet"
+    _write_parquet(small, pa.table({"x": list(range(10))}))
+    _write_parquet(big, pa.table({"x": list(range(20_000))}))
+
+    ray.data.read_parquet(str(tmp_path)).materialize()
+
+    assert captured
+    expected = _expected_read_files_task_memory_bytes([small, big], target_max, eps)
+    # All ReadFiles tasks should see the same hint (max file in the manifest
+    # drives it), but at minimum the captured value matches the expected
+    # max-file-driven formula.
+    assert max(captured) == expected, (captured, expected)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-xvs"]))

--- a/python/ray/data/tests/test_context.py
+++ b/python/ray/data/tests/test_context.py
@@ -36,6 +36,32 @@ def test_data_context_current_context_manager():
     assert DataContext.get_current() is original
 
 
+def test_read_files_task_memory_eps_bytes_default():
+    """``DataContext.read_files_task_memory_eps_bytes`` defaults to 64 MiB and is mutable."""
+    from ray.data.context import (
+        DEFAULT_READ_FILES_TASK_MEMORY_EPS_BYTES,
+        DataContext,
+    )
+
+    ctx = DataContext.get_current()
+    original = ctx.read_files_task_memory_eps_bytes
+    try:
+        # Default value is the documented 64 MiB (unless overridden by the
+        # ``RAY_DATA_READ_FILES_TASK_MEMORY_EPS_BYTES`` env var).
+        assert DEFAULT_READ_FILES_TASK_MEMORY_EPS_BYTES == 64 * 1024 * 1024
+        # Live context exposes the field.
+        assert (
+            ctx.read_files_task_memory_eps_bytes
+            == DEFAULT_READ_FILES_TASK_MEMORY_EPS_BYTES
+        )
+
+        # Field is mutable for per-job overrides.
+        ctx.read_files_task_memory_eps_bytes = 7 * 1024 * 1024
+        assert ctx.read_files_task_memory_eps_bytes == 7 * 1024 * 1024
+    finally:
+        ctx.read_files_task_memory_eps_bytes = original
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_map_operator.py
+++ b/python/ray/data/tests/test_map_operator.py
@@ -706,6 +706,211 @@ def test_operator_metrics():
         assert metrics.obj_store_mem_freed == metrics.bytes_task_inputs_processed, i
 
 
+# ---------------------------------------------------------------------------
+# MapOperator: task_memory_bytes merge + metadata-postprocess hook
+# ---------------------------------------------------------------------------
+
+
+def _minimal_map_transformer():
+    """Minimal MapTransformer for constructing map operators in unit tests."""
+    from ray.data._internal.execution.operators.map_transformer import (
+        BlockMapTransformFn,
+        MapTransformer,
+    )
+
+    def _noop(blocks, ctx):
+        return blocks
+
+    return MapTransformer([BlockMapTransformFn(_noop, disable_block_shaping=True)])
+
+
+def _make_task_pool_map_op(*, map_task_kwargs=None, ray_remote_args=None):
+    """Construct a minimal ``TaskPoolMapOperator`` for unit tests."""
+    ctx = DataContext.get_current()
+    return TaskPoolMapOperator(
+        map_transformer=_minimal_map_transformer(),
+        input_op=InputDataBuffer(ctx, input_data=[]),
+        data_context=ctx,
+        name="test_map",
+        target_max_block_size_override=None,
+        min_rows_per_bundle=None,
+        ref_bundler=None,
+        max_concurrency=1,
+        supports_fusion=True,
+        map_task_kwargs=map_task_kwargs,
+        ray_remote_args=ray_remote_args,
+    )
+
+
+def _make_bundle(metadatas):
+    """Wrap one or more ``BlockMetadata`` in a ``RefBundle`` with dummy refs."""
+    from ray.data._internal.execution.interfaces import RefBundle
+    from ray.data.block import BlockMetadata  # noqa: F401  (used by caller)
+
+    blocks = []
+    for i, meta in enumerate(metadatas):
+        blocks.append((ray.ObjectRef(bytes([i + 1]) * 28), meta))
+    return RefBundle(blocks=blocks, schema=None, owns_blocks=False)
+
+
+def test_merge_task_memory_with_no_hint_is_noop():
+    """No block carries ``task_memory_bytes`` -> ``memory`` arg unchanged."""
+    from ray.data.block import BlockMetadata
+
+    meta = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    map_op = _make_task_pool_map_op()
+    remote_args = {"memory": 5_000}
+    map_op._merge_task_memory_into_ray_remote_args(_make_bundle([meta]), remote_args)
+    assert remote_args["memory"] == 5_000
+
+
+def test_merge_task_memory_raises_memory_to_hint():
+    """Single block with hint -> ``memory`` raised to the hint value."""
+    from ray.data.block import BlockMetadata
+
+    meta = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        task_memory_bytes=500_000_000,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    map_op = _make_task_pool_map_op()
+    remote_args = {"memory": 1_000}
+    map_op._merge_task_memory_into_ray_remote_args(_make_bundle([meta]), remote_args)
+    assert remote_args["memory"] == 500_000_000
+
+
+def test_merge_task_memory_zero_hint_does_not_clobber_user_memory():
+    """``task_memory_bytes == 0`` -> ``max(user, 0) == user``; do not zero."""
+    from ray.data.block import BlockMetadata
+
+    meta = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        task_memory_bytes=0,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    map_op = _make_task_pool_map_op()
+    remote_args = {"memory": 1_000}
+    map_op._merge_task_memory_into_ray_remote_args(_make_bundle([meta]), remote_args)
+    assert remote_args["memory"] == 1_000
+
+
+def test_merge_task_memory_respects_user_memory_when_larger():
+    """User-supplied ``memory`` wins when it is larger than the hint."""
+    from ray.data.block import BlockMetadata
+
+    gib = 1024 * 1024 * 1024
+    meta = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        task_memory_bytes=gib,  # 1 GiB
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    map_op = _make_task_pool_map_op()
+    remote_args = {"memory": 2 * gib}  # user reserves 2 GiB
+    map_op._merge_task_memory_into_ray_remote_args(_make_bundle([meta]), remote_args)
+    assert remote_args["memory"] == 2 * gib
+
+
+def test_merge_task_memory_uses_max_hint_across_blocks():
+    """Multiple blocks with hints -> ``memory`` raised to the **max** hint.
+
+    Each per-block hint is already an upper bound on the per-task peak heap
+    for that block. The bundled task's peak is bounded by the largest hint,
+    not the sum (per-block work runs sequentially within the task, so peaks
+    don't compose additively).
+    """
+    from ray.data.block import BlockMetadata
+
+    m1 = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        task_memory_bytes=100_000_000,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    m2 = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        task_memory_bytes=200_000_000,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    m3 = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        # Block without a hint should not affect the result.
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    map_op = _make_task_pool_map_op()
+    remote_args = {"memory": 0}
+    map_op._merge_task_memory_into_ray_remote_args(
+        _make_bundle([m1, m2, m3]), remote_args
+    )
+    assert remote_args["memory"] == 200_000_000
+
+
+# Module-level postprocess fn used by
+# ``test_block_metadata_postprocess_fn_is_invoked`` — must be top-level so it
+# could pickle across a Ray task boundary if a hypothetical caller relied on
+# it. The test invokes ``_map_task`` in-process so pickling isn't actually
+# exercised here, but the contract is enforced this way.
+def _stamp_postprocess(block, meta, data_context):
+    """Test postprocess: stamps ``task_memory_bytes=12345`` onto metadata."""
+    from dataclasses import replace
+
+    return replace(meta, task_memory_bytes=12345)
+
+
+def test_block_metadata_postprocess_fn_is_invoked_by_map_task(
+    ray_start_regular_shared,
+):
+    """End-to-end: the postprocess fn attached via map_task_kwargs runs in-task
+    and the stamped ``task_memory_bytes`` propagates to the output metadata.
+    """
+    from ray.data._internal.execution.operators.map_operator import (
+        MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS,
+    )
+
+    input_op = InputDataBuffer(
+        DataContext.get_current(),
+        make_ref_bundles([[i] for i in range(3)]),
+    )
+    op = MapOperator.create(
+        _mul2_map_data_prcessor,
+        input_op=input_op,
+        data_context=DataContext.get_current(),
+        name="TestPostprocess",
+        compute_strategy=TaskPoolStrategy(),
+        map_task_kwargs={
+            MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS: _stamp_postprocess,
+        },
+    )
+    op.start(ExecutionOptions())
+    run_op_tasks_sync(op)
+
+    captured_metadata = []
+    while op.has_next():
+        bundle = op.get_next()
+        captured_metadata.extend(bundle.metadata)
+
+    assert captured_metadata, "expected at least one output bundle"
+    # The postprocess stamped ``task_memory_bytes=12345`` on every output
+    # block's metadata.
+    observed = [m.task_memory_bytes for m in captured_metadata]
+    assert all(v == 12345 for v in observed), observed
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/unit/datasource_v2/test_memory_estimation.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_memory_estimation.py
@@ -1,0 +1,194 @@
+"""Unit tests for DataSource V2 ReadFiles memory-hint plumbing.
+
+Covers the producer side:
+
+- ``estimate_read_files_task_memory_bytes``: formula
+  ``max(2 * target_max_block_size, max(file_sizes)) + eps``, including
+  boundary conditions (``target=None``, ``eps=0``, empty manifest) and
+  ``eps`` resolution from ``DataContext``.
+- ``enrich_file_manifest_block_metadata_if_applicable``: idempotency,
+  pass-through on non-manifest blocks, preservation of other metadata
+  fields.
+- ``enrich_manifest_block_metadata_for_map_task`` adapter: reads
+  ``DataContext.read_files_task_memory_eps_bytes`` at call time.
+"""
+
+import pyarrow as pa
+import pytest
+
+from ray.data._internal.datasource_v2.listing.file_manifest import (
+    FILE_SIZE_COLUMN_NAME,
+    PATH_COLUMN_NAME,
+    FileManifest,
+)
+from ray.data._internal.datasource_v2.readers.read_files_task_memory import (
+    enrich_file_manifest_block_metadata_if_applicable,
+    enrich_manifest_block_metadata_for_map_task,
+    estimate_read_files_task_memory_bytes,
+)
+from ray.data.block import BlockAccessor, BlockMetadata
+from ray.data.context import DataContext
+
+
+@pytest.fixture
+def reset_ctx_eps():
+    """Restore the original eps value on the live ``DataContext`` after a test."""
+    ctx = DataContext.get_current()
+    original = ctx.read_files_task_memory_eps_bytes
+    try:
+        yield ctx
+    finally:
+        ctx.read_files_task_memory_eps_bytes = original
+
+
+class TestReadFilesTaskMemoryEstimate:
+    """Formula: ``max(2 * target_max_block_size, max(file_sizes)) + eps``."""
+
+    def test_max_file_size_dominates_when_larger_than_two_target(self):
+        manifest = FileManifest.construct_manifest(
+            paths=["/a.parquet", "/b.parquet"],
+            sizes=[50_000_000, 5_000_000],
+        )
+        # 2 * 8M = 16M, max(file_sizes) = 50M -> 50M dominates.
+        got = estimate_read_files_task_memory_bytes(
+            manifest, target_max_block_size=8_000_000, eps=64 * 1024 * 1024
+        )
+        assert got == 50_000_000 + 64 * 1024 * 1024
+
+    def test_two_target_dominates_when_larger_than_max_file_size(self):
+        manifest = FileManifest.construct_manifest(
+            paths=["/a.parquet"], sizes=[1_000_000]
+        )
+        # 2 * 8M = 16M, max(file_sizes) = 1M -> 16M dominates.
+        got = estimate_read_files_task_memory_bytes(
+            manifest, target_max_block_size=8_000_000, eps=64 * 1024 * 1024
+        )
+        assert got == 16_000_000 + 64 * 1024 * 1024
+
+    def test_target_none_coerced_to_zero(self):
+        """``target_max_block_size=None`` -> 2*0=0; result is max_file + eps."""
+        manifest = FileManifest.construct_manifest(
+            paths=["/a.parquet"], sizes=[7_000_000]
+        )
+        got = estimate_read_files_task_memory_bytes(
+            manifest, target_max_block_size=None, eps=64 * 1024 * 1024
+        )
+        assert got == 7_000_000 + 64 * 1024 * 1024
+
+    def test_eps_zero_no_padding(self):
+        manifest = FileManifest.construct_manifest(
+            paths=["/a.parquet"], sizes=[3_000_000]
+        )
+        got = estimate_read_files_task_memory_bytes(
+            manifest, target_max_block_size=1_000_000, eps=0
+        )
+        # max(2*1M, 3M) + 0 = 3M.
+        assert got == 3_000_000
+
+    def test_empty_manifest_returns_two_target_plus_eps(self):
+        """Empty manifest -> max(file_sizes) treated as 0."""
+        manifest = FileManifest.construct_manifest(paths=[], sizes=[])
+        got = estimate_read_files_task_memory_bytes(
+            manifest, target_max_block_size=4_000_000, eps=64 * 1024 * 1024
+        )
+        assert got == 8_000_000 + 64 * 1024 * 1024
+
+    def test_eps_default_resolves_from_data_context(self, reset_ctx_eps):
+        """``eps=None`` -> resolved from ``DataContext`` at call time."""
+        reset_ctx_eps.read_files_task_memory_eps_bytes = 7 * 1024 * 1024  # 7 MiB
+        manifest = FileManifest.construct_manifest(
+            paths=["/a.parquet"], sizes=[5_000_000]
+        )
+        got = estimate_read_files_task_memory_bytes(
+            manifest, target_max_block_size=1_000_000
+        )
+        # max(2M, 5M) + 7M = 5M + 7M.
+        assert got == 5_000_000 + 7 * 1024 * 1024
+
+
+class TestEnrichFileManifestBlockMetadata:
+    """``enrich_file_manifest_block_metadata_if_applicable`` semantics."""
+
+    def test_enrich_sets_task_memory_bytes_from_formula(self):
+        """``enrich`` sets ``task_memory_bytes`` to the formula result."""
+        manifest = FileManifest.construct_manifest(paths=["/f1"], sizes=[2_000_000])
+        block = manifest.as_block()
+        base = BlockMetadata(
+            num_rows=42,
+            size_bytes=999,
+            input_files=("/f1",),
+            exec_stats=None,
+            task_exec_stats=None,
+        )
+        enriched = enrich_file_manifest_block_metadata_if_applicable(
+            block, base, target_max_block_size=1_000_000, eps=64 * 1024 * 1024
+        )
+        # Other fields untouched.
+        assert enriched.num_rows == 42
+        assert enriched.size_bytes == 999
+        assert enriched.input_files == ("/f1",)
+        # max(2*1M, 2M) + 64M = 2M + 64M.
+        assert enriched.task_memory_bytes == 2_000_000 + 64 * 1024 * 1024
+
+    def test_enrich_idempotent(self):
+        """Calling enrich twice yields the same hint (no compounding)."""
+        manifest = FileManifest.construct_manifest(paths=["/f"], sizes=[2_000_000])
+        block = manifest.as_block()
+        base = BlockAccessor.for_block(block).get_metadata()
+
+        once = enrich_file_manifest_block_metadata_if_applicable(
+            block, base, target_max_block_size=1_000_000, eps=64 * 1024 * 1024
+        )
+        twice = enrich_file_manifest_block_metadata_if_applicable(
+            block, once, target_max_block_size=1_000_000, eps=64 * 1024 * 1024
+        )
+        assert once.task_memory_bytes == twice.task_memory_bytes
+
+    def test_enrich_non_manifest_block_is_pass_through(self):
+        """Non-manifest block -> ``enrich`` returns the input meta object unchanged."""
+        block = pa.table({"x": [1, 2]})
+        base = BlockAccessor.for_block(block).get_metadata()
+        enriched = enrich_file_manifest_block_metadata_if_applicable(
+            block, base, target_max_block_size=99, eps=0
+        )
+        assert enriched is base
+
+
+class TestEnrichManifestForMapTaskAdapter:
+    """``enrich_manifest_block_metadata_for_map_task`` reads from ``DataContext``."""
+
+    def test_adapter_reads_eps_from_data_context(self, reset_ctx_eps):
+        """The adapter pulls ``eps`` from the live ``DataContext`` field."""
+        reset_ctx_eps.read_files_task_memory_eps_bytes = 11 * 1024 * 1024
+        reset_ctx_eps.target_max_block_size = 1_000_000
+
+        manifest = FileManifest.construct_manifest(paths=["/f"], sizes=[5_000_000])
+        block = manifest.as_block()
+        base = BlockAccessor.for_block(block).get_metadata()
+
+        enriched = enrich_manifest_block_metadata_for_map_task(
+            block, base, reset_ctx_eps
+        )
+        # max(2*1M, 5M) + 11M = 5M + 11M.
+        assert enriched.task_memory_bytes == 5_000_000 + 11 * 1024 * 1024
+
+
+class TestFileManifestColumnInvariants:
+    """Sanity invariants for the ``__file_size`` column the formula depends on."""
+
+    def test_file_sizes_round_trip_through_arrow_table(self):
+        table = pa.table(
+            {
+                PATH_COLUMN_NAME: ["/f1", "/f2", "/f3"],
+                FILE_SIZE_COLUMN_NAME: [10, 20, 30],
+            }
+        )
+        manifest = FileManifest(table)
+        assert int(manifest.file_sizes.max()) == 30
+        assert int(manifest.file_sizes.sum()) == 60
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-xvs", __file__]))

--- a/python/ray/data/tests/unit/test_block.py
+++ b/python/ray/data/tests/unit/test_block.py
@@ -5,7 +5,12 @@ import pyarrow as pa
 import pytest
 
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
-from ray.data.block import BlockAccessor, BlockColumnAccessor
+from ray.data.block import (
+    BlockAccessor,
+    BlockColumnAccessor,
+    BlockMetadata,
+    BlockMetadataWithSchema,
+)
 
 
 def test_find_partitions_single_column_ascending():
@@ -156,6 +161,41 @@ def test_find_partitions_duplicates():
     assert partitions[1].to_pydict() == {"value": []}  # [1,2)
     assert partitions[2].to_pydict() == {"value": [2, 2, 2, 2, 2]}  # [2,3)
     assert partitions[3].to_pydict() == {"value": []}  # >=3
+
+
+def test_block_metadata_task_memory_bytes_defaults_to_none():
+    """``task_memory_bytes`` is optional and defaults to ``None``."""
+    meta = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    assert meta.task_memory_bytes is None
+
+
+def test_block_metadata_task_memory_bytes_round_trips_through_with_schema():
+    """``BlockMetadataWithSchema`` round-trip preserves ``task_memory_bytes``.
+
+    Streaming hand-offs peel the schema off via the ``metadata`` property; if
+    ``task_memory_bytes`` were dropped there, downstream consumers (e.g. the
+    ``TaskPoolMapOperator`` per-task memory merge) would silently lose the hint.
+    """
+    schema = pa.schema([("a", pa.int64())])
+    meta = BlockMetadata(
+        num_rows=500,
+        size_bytes=2000,
+        task_memory_bytes=750_000_000,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+
+    wrapped = BlockMetadataWithSchema.from_metadata(meta, schema=schema)
+    assert wrapped.task_memory_bytes == 750_000_000
+
+    # ``metadata`` property must not drop the field.
+    round_tripped = wrapped.metadata
+    assert round_tripped.task_memory_bytes == 750_000_000
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

This is a **4-PR series** that adds a per-task heap-memory hint to DataSource V2 `ReadFiles` tasks so the Ray scheduler can reserve enough heap to avoid OOMs on wide schemas or large Parquet files. Each PR is a single atomic commit, independently reviewable, and lands on top of the previous one in the chain.

### Why

DataSource V2 `ReadFiles` tasks currently reserve no extra heap memory, so the Ray scheduler runs the same number of concurrent reads regardless of how much each task actually decodes. On wide Parquet schemas or large files this leads to OOM kills mid-read with no clear signal that the read tasks are individually oversized.

After this series, V2 ReadFiles tasks reserve heap based on the manifest they consume, so the scheduler can throttle concurrency on memory-constrained clusters without user intervention. Users' explicit `ray_remote_args={"memory": ...}` always wins when larger. The V1 read path is untouched.

### Formula

```
task_memory_bytes = max(2 * target_max_block_size, max(file_sizes)) + eps
```

- `2 * target_max_block_size` covers the input batch buffer plus the output block being assembled in the same task.
- `max(file_sizes)` is the largest on-disk file size across files in the manifest (drawn from the always-present `__file_size` column — no parquet-footer reads at listing time; no new manifest column).
- `eps` defaults to `DataContext.read_files_task_memory_eps_bytes` (64 MiB, configurable via the `RAY_DATA_READ_FILES_TASK_MEMORY_EPS_BYTES` env var) and is also overridable per-call.

## Related issues

Related to DATA-2225.

## Additional information

### The 4-PR breakdown

Each PR is independently reviewable and the first three are observably inert until PR 4 activates the feature.

| # | PR | Subject | Files | Lines |
|---|---|---|---|---|
| 1 | #XXX | `[Data] BlockMetadata: add task_memory_bytes hint field` | 2 | +54/−1 |
| 2 | #XXX | `[Data] MapOperator: merge per-block task_memory_bytes hints + metadata-postprocess hook` | 3 | +265 |
| 3 | #XXX | `[Data] DataContext: add read_files_task_memory_eps_bytes knob` | 2 | +40 |
| 4 | #XXX | `[Data] DataSourceV2: per-task heap memory hints for ReadFiles` | 7 | +697/−1 |

**Suggested merge order:** PR 1 → PR 2 → PR 3 → PR 4. PR 3 is independent of PRs 1 and 2 and can land in any order before PR 4; PR 4 requires all three predecessors.

### What each PR does

- **PR 1 — `BlockMetadata.task_memory_bytes`**: adds an optional `Optional[int] = None` field to `BlockMetadata` (the producer-set hint) and propagates it through `BlockMetadataWithSchema.from_metadata` and the `.metadata` property so streaming hand-offs don't drop it. No producer or consumer yet — observably inert.

- **PR 2 — `MapOperator` merge + generic postprocess hook**: two datasource-agnostic engine additions.
  - `_merge_task_memory_into_ray_remote_args` raises Ray `memory` to `max(user_memory, max_block_hint)` whenever a bundle carries `task_memory_bytes` hints. `TaskPoolMapOperator._try_schedule_task` calls it unconditionally; no-op when no hint is present.
  - A generic reserved kwarg key `MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS` lets planners attach a module-level callable `fn(block, meta, data_context) -> meta` that `_map_task` applies once per yielded block. No V2 imports in the execution layer.

- **PR 3 — `DataContext.read_files_task_memory_eps_bytes`**: adds the ε knob (default 64 MiB; env var `RAY_DATA_READ_FILES_TASK_MEMORY_EPS_BYTES`). `DataContext` is serialized on its ref so driver-side changes propagate to worker tasks.

- **PR 4 — DataSourceV2 hint producer**: ties it all together. A new module `read_files_task_memory.py` implements the formula and an enrich helper; `plan_list_files_op` attaches the module-level adapter `enrich_manifest_block_metadata_for_map_task` via the generic postprocess kwarg from PR 2. The downstream `ReadFiles` merge from PR 2 picks up the hint at scheduling time. Includes unit + integration tests and a standalone probe for empirical ε tuning.

### Design notes worth flagging in review

1. **`max` (not `sum`) across blocks in a bundle.** Each per-block hint is already an upper bound on per-task peak heap *for that block*; the bundled task's peak is bounded by the largest constituent hint, not the sum, because per-block work runs sequentially within a task. Using `sum` would multiply ε by the bundle size and chronically over-reserve. There's a dedicated test (`test_merge_task_memory_uses_max_hint_across_blocks`) locking this contract.

2. **Architectural decoupling.** The abstract execution layer (`map_operator.py`, `task_pool_map_operator.py`) imports nothing from `datasource_v2` — confirmed by `grep "datasource_v2" python/ray/data/_internal/execution/operators/*.py` returning empty. Future producers (Iceberg V2, Lance V2, etc.) can reuse the generic `MAP_TASK_KWARG_BLOCK_METADATA_POSTPROCESS` hook + `BlockMetadata.task_memory_bytes` field without further engine-layer changes.

3. **No new manifest column.** The formula reads from `__file_size`, which `FileManifest` always carries. The series intentionally does not add a `__max_uncompressed_row_group_size` column nor read parquet footers during listing — `max(file_sizes)` is a faster, lower-overhead proxy that requires no extra I/O.

4. **V2-only opt-in.** The postprocess adapter is only attached by V2's `plan_list_files_op`. V1 read paths never set `task_memory_bytes`, so the always-on merge stays a no-op for them. There's a regression test (`test_read_parquet_v1_legacy_path_does_not_set_task_memory_bytes`) that locks this contract.

### Untouched files (audited)

The following V2 files are **byte-for-byte master** across the entire series — verified via `git diff origin/master..HEAD -- <file>`:

- `python/ray/data/_internal/datasource_v2/listing/file_manifest.py`
- `python/ray/data/_internal/datasource_v2/listing/file_indexer.py`
- `python/ray/data/_internal/datasource_v2/listing/listing_utils.py`
- `python/ray/data/_internal/datasource_v2/readers/in_memory_size_estimator.py`
- `python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py`
- `python/ray/data/_internal/datasource_v2/partitioners/round_robin_partitioner.py`
- `python/ray/data/_internal/planner/plan_read_files_op.py`
- `python/ray/data/_internal/logical/operators/read_operator.py`
- `python/ray/data/read_api.py`

### Test plan

**Unit tests** (run after each PR lands, or all at once on PR 4):

```bash
pytest -v python/ray/data/tests/unit/test_block.py -k task_memory_bytes                # PR 1
pytest -v python/ray/data/tests/test_map_operator.py -k "task_memory or postprocess"   # PR 2
pytest -v python/ray/data/tests/test_context.py -k read_files_task_memory_eps_bytes    # PR 3
pytest -v python/ray/data/tests/unit/datasource_v2/test_memory_estimation.py           # PR 4
```

**Integration tests** (PR 4 only):

```bash
pytest -v python/ray/data/tests/datasource_v2/test_read_parquet_v2_task_memory_integration.py
```

**Decoupling sanity** (after PR 4 lands):

```bash
grep -n "datasource_v2" python/ray/data/_internal/execution/operators/*.py
# Expected: (empty)
```

**Empirical ε tuning** (manual, post-merge):

```bash
cd python
python ray/data/tests/datasource_v2/read_files_task_memory_probe.py
RAY_DATA_READ_FILES_TASK_MEMORY_EPS_BYTES=$((128 * 1024 * 1024)) python ray/data/tests/datasource_v2/read_files_task_memory_probe.py
```

Aggregate coverage across the series: **21 new test cases** (2 in PR 1, 6 in PR 2, 1 in PR 3, 12 in PR 4 unit) + **6 integration cases** in PR 4.