### PR TITLE
[Dashboard] Fall back to query API for Prometheus healthcheck on managed services

### DIFF
--- a/python/ray/dashboard/BUILD.bazel
+++ b/python/ray/dashboard/BUILD.bazel
@@ -42,6 +42,7 @@ py_test_run_all_subdirectory(
         "tests/test_state_head.py",
         "modules/serve/tests/**/*.py",
         "modules/job/tests/test_job_manager.py",
+        "modules/tests/test_metrics_integration.py",
     ],
     extra_srcs = [],
     tags = [

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -41,12 +41,13 @@ DEFAULT_PROMETHEUS_HEADERS = "{}"
 PROMETHEUS_HEADERS_ENV_VAR = "RAY_PROMETHEUS_HEADERS"
 DEFAULT_PROMETHEUS_NAME = "Prometheus"
 PROMETHEUS_NAME_ENV_VAR = "RAY_PROMETHEUS_NAME"
-PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
-# Fallback healthcheck path. Some managed Prometheus services (e.g. Tencent
-# Cloud TMP) disable the open-source `/-/healthy` and `/-/ready` endpoints,
-# but still serve the standard query API. We use a cheap query as a liveness
-# probe in that case.
-PROMETHEUS_HEALTHCHECK_FALLBACK_PATH = "api/v1/query?query=vector(1)"
+# Use a cheap query against the standard query API as the Prometheus liveness
+# probe. Every Prometheus-compatible service must support `api/v1/query`, and
+# some managed Prometheus services (e.g. Tencent Cloud TMP) disable the
+# open-source `/-/healthy` and `/-/ready` endpoints, so relying on the query
+# API gives us the broadest compatibility while also verifying that the query
+# engine is actually serving requests.
+PROMETHEUS_HEALTHCHECK_PATH = "api/v1/query?query=vector(1)"
 # Timeout (in seconds) for the Prometheus healthcheck HTTP requests. Without an
 # explicit timeout, `aiohttp` defaults to 5 minutes, which would cause the
 # dashboard API to hang when the Prometheus host is unreachable or slow.
@@ -194,49 +195,15 @@ class MetricsHead(SubprocessModule):
 
     @routes.get("/api/prometheus_health")
     async def prometheus_health(self, req):
-        # Try the standard `/-/healthy` endpoint first. Some managed
-        # Prometheus services (e.g. Tencent Cloud TMP) disable
-        # `/-/healthy` / `/-/ready` and return 404, in which case we
-        # fall back to a cheap query against `/api/v1/query` which every
-        # Prometheus-compatible service must support.
-        primary_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
-        fallback_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_FALLBACK_PATH}"
-
-        primary_status = None
-        primary_error = None
+        # A successful response from `api/v1/query` indicates the Prometheus
+        # service is reachable and its query engine is serving requests. We
+        # prefer this over `/-/healthy` because it is universally supported by
+        # all Prometheus-compatible backends, including managed services that
+        # disable the `/-/healthy` and `/-/ready` endpoints.
+        path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
         try:
             async with self.http_session.get(
-                primary_path,
-                headers=self.prometheus_headers,
-                timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
-            ) as resp:
-                if resp.status == 200:
-                    return dashboard_optional_utils.rest_response(
-                        status_code=dashboard_utils.HTTPStatusCode.OK,
-                        message="prometheus running",
-                        used_path=PROMETHEUS_HEALTHCHECK_PATH,
-                    )
-                primary_status = resp.status
-                logger.info(
-                    "Prometheus primary healthcheck %s returned status %s, "
-                    "falling back to query API.",
-                    primary_path,
-                    primary_status,
-                )
-        except Exception as e:
-            primary_error = str(e)
-            logger.info(
-                "Error fetching prometheus primary healthcheck endpoint %s "
-                "(%s), falling back to query API.",
-                primary_path,
-                primary_error,
-            )
-
-        # Fallback: a successful query response indicates the Prometheus
-        # service is reachable and serving requests.
-        try:
-            async with self.http_session.get(
-                fallback_path,
+                path,
                 headers=self.prometheus_headers,
                 timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
             ) as resp:
@@ -245,9 +212,6 @@ class MetricsHead(SubprocessModule):
                         status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="prometheus healthcheck failed.",
                         status=resp.status,
-                        primary_status=primary_status,
-                        primary_error=primary_error,
-                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
                     )
                 try:
                     body = await resp.json(content_type=None)
@@ -258,16 +222,10 @@ class MetricsHead(SubprocessModule):
                         status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="prometheus healthcheck failed.",
                         status=resp.status,
-                        primary_status=primary_status,
-                        primary_error=primary_error,
-                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
                     )
                 return dashboard_optional_utils.rest_response(
                     status_code=dashboard_utils.HTTPStatusCode.OK,
                     message="prometheus running",
-                    used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
-                    primary_status=primary_status,
-                    primary_error=primary_error,
                 )
         except Exception as e:
             logger.debug(
@@ -277,8 +235,6 @@ class MetricsHead(SubprocessModule):
                 status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                 message="prometheus healthcheck failed.",
                 reason=str(e),
-                primary_status=primary_status,
-                primary_error=primary_error,
             )
 
     def _create_default_grafana_configs(self):

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -42,6 +42,11 @@ PROMETHEUS_HEADERS_ENV_VAR = "RAY_PROMETHEUS_HEADERS"
 DEFAULT_PROMETHEUS_NAME = "Prometheus"
 PROMETHEUS_NAME_ENV_VAR = "RAY_PROMETHEUS_NAME"
 PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
+# Fallback healthcheck path. Some managed Prometheus services (e.g. Tencent
+# Cloud TMP) disable the open-source `/-/healthy` and `/-/ready` endpoints,
+# but still serve the standard query API. We use a cheap query as a liveness
+# probe in that case.
+PROMETHEUS_HEALTHCHECK_FALLBACK_PATH = "api/v1/query?query=vector(1)"
 
 DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
@@ -185,22 +190,76 @@ class MetricsHead(SubprocessModule):
 
     @routes.get("/api/prometheus_health")
     async def prometheus_health(self, req):
-        try:
-            path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
+        # Try the standard `/-/healthy` endpoint first. Some managed
+        # Prometheus services (e.g. Tencent Cloud TMP) disable
+        # `/-/healthy` / `/-/ready` and return 404, in which case we
+        # fall back to a cheap query against `/api/v1/query` which every
+        # Prometheus-compatible service must support.
+        primary_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
+        fallback_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_FALLBACK_PATH}"
 
+        primary_status = None
+        primary_error = None
+        try:
             async with self.http_session.get(
-                path, headers=self.prometheus_headers
+                primary_path, headers=self.prometheus_headers
+            ) as resp:
+                if resp.status == 200:
+                    return dashboard_optional_utils.rest_response(
+                        status_code=dashboard_utils.HTTPStatusCode.OK,
+                        message="prometheus running",
+                        used_path=PROMETHEUS_HEALTHCHECK_PATH,
+                    )
+                primary_status = resp.status
+                logger.info(
+                    "Prometheus primary healthcheck %s returned status %s, "
+                    "falling back to query API.",
+                    primary_path,
+                    primary_status,
+                )
+        except Exception as e:
+            primary_error = str(e)
+            logger.info(
+                "Error fetching prometheus primary healthcheck endpoint %s "
+                "(%s), falling back to query API.",
+                primary_path,
+                primary_error,
+            )
+
+        # Fallback: a successful query response indicates the Prometheus
+        # service is reachable and serving requests.
+        try:
+            async with self.http_session.get(
+                fallback_path, headers=self.prometheus_headers
             ) as resp:
                 if resp.status != 200:
                     return dashboard_optional_utils.rest_response(
                         status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="prometheus healthcheck failed.",
                         status=resp.status,
+                        primary_status=primary_status,
+                        primary_error=primary_error,
+                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
                     )
-
+                try:
+                    body = await resp.json(content_type=None)
+                except Exception:
+                    body = None
+                if not isinstance(body, dict) or body.get("status") != "success":
+                    return dashboard_optional_utils.rest_response(
+                        status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                        message="prometheus healthcheck failed.",
+                        status=resp.status,
+                        primary_status=primary_status,
+                        primary_error=primary_error,
+                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
+                    )
                 return dashboard_optional_utils.rest_response(
                     status_code=dashboard_utils.HTTPStatusCode.OK,
                     message="prometheus running",
+                    used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
+                    primary_status=primary_status,
+                    primary_error=primary_error,
                 )
         except Exception as e:
             logger.debug(
@@ -210,6 +269,8 @@ class MetricsHead(SubprocessModule):
                 status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                 message="prometheus healthcheck failed.",
                 reason=str(e),
+                primary_status=primary_status,
+                primary_error=primary_error,
             )
 
     def _create_default_grafana_configs(self):

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -47,6 +47,10 @@ PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
 # but still serve the standard query API. We use a cheap query as a liveness
 # probe in that case.
 PROMETHEUS_HEALTHCHECK_FALLBACK_PATH = "api/v1/query?query=vector(1)"
+# Timeout (in seconds) for the Prometheus healthcheck HTTP requests. Without an
+# explicit timeout, `aiohttp` defaults to 5 minutes, which would cause the
+# dashboard API to hang when the Prometheus host is unreachable or slow.
+PROMETHEUS_HEALTHCHECK_TIMEOUT_S = 5
 
 DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
@@ -202,7 +206,9 @@ class MetricsHead(SubprocessModule):
         primary_error = None
         try:
             async with self.http_session.get(
-                primary_path, headers=self.prometheus_headers
+                primary_path,
+                headers=self.prometheus_headers,
+                timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
             ) as resp:
                 if resp.status == 200:
                     return dashboard_optional_utils.rest_response(
@@ -230,7 +236,9 @@ class MetricsHead(SubprocessModule):
         # service is reachable and serving requests.
         try:
             async with self.http_session.get(
-                fallback_path, headers=self.prometheus_headers
+                fallback_path,
+                headers=self.prometheus_headers,
+                timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
             ) as resp:
                 if resp.status != 200:
                     return dashboard_optional_utils.rest_response(

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -48,6 +48,10 @@ PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
 # but still serve the standard query API. We use a cheap query as a liveness
 # probe in that case.
 PROMETHEUS_HEALTHCHECK_FALLBACK_PATH = "api/v1/query?query=vector(1)"
+# Timeout (in seconds) for the Prometheus healthcheck HTTP requests. Without an
+# explicit timeout, `aiohttp` defaults to 5 minutes, which would cause the
+# dashboard API to hang when the Prometheus host is unreachable or slow.
+PROMETHEUS_HEALTHCHECK_TIMEOUT_S = 5
 
 DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
@@ -202,7 +206,9 @@ class MetricsHead(SubprocessModule):
         primary_error = None
         try:
             async with self.http_session.get(
-                primary_path, headers=self.prometheus_headers
+                primary_path,
+                headers=self.prometheus_headers,
+                timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
             ) as resp:
                 if resp.status == 200:
                     return dashboard_optional_utils.rest_response(
@@ -230,7 +236,9 @@ class MetricsHead(SubprocessModule):
         # service is reachable and serving requests.
         try:
             async with self.http_session.get(
-                fallback_path, headers=self.prometheus_headers
+                fallback_path,
+                headers=self.prometheus_headers,
+                timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
             ) as resp:
                 if resp.status != 200:
                     return dashboard_optional_utils.rest_response(

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -42,12 +42,13 @@ DEFAULT_PROMETHEUS_HEADERS = "{}"
 PROMETHEUS_HEADERS_ENV_VAR = "RAY_PROMETHEUS_HEADERS"
 DEFAULT_PROMETHEUS_NAME = "Prometheus"
 PROMETHEUS_NAME_ENV_VAR = "RAY_PROMETHEUS_NAME"
-PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
-# Fallback healthcheck path. Some managed Prometheus services (e.g. Tencent
-# Cloud TMP) disable the open-source `/-/healthy` and `/-/ready` endpoints,
-# but still serve the standard query API. We use a cheap query as a liveness
-# probe in that case.
-PROMETHEUS_HEALTHCHECK_FALLBACK_PATH = "api/v1/query?query=vector(1)"
+# Use a cheap query against the standard query API as the Prometheus liveness
+# probe. Every Prometheus-compatible service must support `api/v1/query`, and
+# some managed Prometheus services (e.g. Tencent Cloud TMP) disable the
+# open-source `/-/healthy` and `/-/ready` endpoints, so relying on the query
+# API gives us the broadest compatibility while also verifying that the query
+# engine is actually serving requests.
+PROMETHEUS_HEALTHCHECK_PATH = "api/v1/query?query=vector(1)"
 # Timeout (in seconds) for the Prometheus healthcheck HTTP requests. Without an
 # explicit timeout, `aiohttp` defaults to 5 minutes, which would cause the
 # dashboard API to hang when the Prometheus host is unreachable or slow.
@@ -194,49 +195,15 @@ class MetricsHead(SubprocessModule):
 
     @routes.get("/api/prometheus_health")
     async def prometheus_health(self, req):
-        # Try the standard `/-/healthy` endpoint first. Some managed
-        # Prometheus services (e.g. Tencent Cloud TMP) disable
-        # `/-/healthy` / `/-/ready` and return 404, in which case we
-        # fall back to a cheap query against `/api/v1/query` which every
-        # Prometheus-compatible service must support.
-        primary_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
-        fallback_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_FALLBACK_PATH}"
-
-        primary_status = None
-        primary_error = None
+        # A successful response from `api/v1/query` indicates the Prometheus
+        # service is reachable and its query engine is serving requests. We
+        # prefer this over `/-/healthy` because it is universally supported by
+        # all Prometheus-compatible backends, including managed services that
+        # disable the `/-/healthy` and `/-/ready` endpoints.
+        path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
         try:
             async with self.http_session.get(
-                primary_path,
-                headers=self.prometheus_headers,
-                timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
-            ) as resp:
-                if resp.status == 200:
-                    return dashboard_optional_utils.rest_response(
-                        status_code=dashboard_utils.HTTPStatusCode.OK,
-                        message="prometheus running",
-                        used_path=PROMETHEUS_HEALTHCHECK_PATH,
-                    )
-                primary_status = resp.status
-                logger.info(
-                    "Prometheus primary healthcheck %s returned status %s, "
-                    "falling back to query API.",
-                    primary_path,
-                    primary_status,
-                )
-        except Exception as e:
-            primary_error = str(e)
-            logger.info(
-                "Error fetching prometheus primary healthcheck endpoint %s "
-                "(%s), falling back to query API.",
-                primary_path,
-                primary_error,
-            )
-
-        # Fallback: a successful query response indicates the Prometheus
-        # service is reachable and serving requests.
-        try:
-            async with self.http_session.get(
-                fallback_path,
+                path,
                 headers=self.prometheus_headers,
                 timeout=aiohttp.ClientTimeout(total=PROMETHEUS_HEALTHCHECK_TIMEOUT_S),
             ) as resp:
@@ -245,9 +212,6 @@ class MetricsHead(SubprocessModule):
                         status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="prometheus healthcheck failed.",
                         status=resp.status,
-                        primary_status=primary_status,
-                        primary_error=primary_error,
-                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
                     )
                 try:
                     body = await resp.json(content_type=None)
@@ -258,16 +222,10 @@ class MetricsHead(SubprocessModule):
                         status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="prometheus healthcheck failed.",
                         status=resp.status,
-                        primary_status=primary_status,
-                        primary_error=primary_error,
-                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
                     )
                 return dashboard_optional_utils.rest_response(
                     status_code=dashboard_utils.HTTPStatusCode.OK,
                     message="prometheus running",
-                    used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
-                    primary_status=primary_status,
-                    primary_error=primary_error,
                 )
         except Exception as e:
             logger.debug(
@@ -277,8 +235,6 @@ class MetricsHead(SubprocessModule):
                 status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                 message="prometheus healthcheck failed.",
                 reason=str(e),
-                primary_status=primary_status,
-                primary_error=primary_error,
             )
 
     def _create_default_grafana_configs(self):

--- a/python/ray/dashboard/modules/metrics/metrics_head.py
+++ b/python/ray/dashboard/modules/metrics/metrics_head.py
@@ -43,6 +43,11 @@ PROMETHEUS_HEADERS_ENV_VAR = "RAY_PROMETHEUS_HEADERS"
 DEFAULT_PROMETHEUS_NAME = "Prometheus"
 PROMETHEUS_NAME_ENV_VAR = "RAY_PROMETHEUS_NAME"
 PROMETHEUS_HEALTHCHECK_PATH = "-/healthy"
+# Fallback healthcheck path. Some managed Prometheus services (e.g. Tencent
+# Cloud TMP) disable the open-source `/-/healthy` and `/-/ready` endpoints,
+# but still serve the standard query API. We use a cheap query as a liveness
+# probe in that case.
+PROMETHEUS_HEALTHCHECK_FALLBACK_PATH = "api/v1/query?query=vector(1)"
 
 DEFAULT_GRAFANA_HOST = "http://localhost:3000"
 GRAFANA_HOST_ENV_VAR = "RAY_GRAFANA_HOST"
@@ -185,22 +190,76 @@ class MetricsHead(SubprocessModule):
 
     @routes.get("/api/prometheus_health")
     async def prometheus_health(self, req):
-        try:
-            path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
+        # Try the standard `/-/healthy` endpoint first. Some managed
+        # Prometheus services (e.g. Tencent Cloud TMP) disable
+        # `/-/healthy` / `/-/ready` and return 404, in which case we
+        # fall back to a cheap query against `/api/v1/query` which every
+        # Prometheus-compatible service must support.
+        primary_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_PATH}"
+        fallback_path = f"{self.prometheus_host}/{PROMETHEUS_HEALTHCHECK_FALLBACK_PATH}"
 
+        primary_status = None
+        primary_error = None
+        try:
             async with self.http_session.get(
-                path, headers=self.prometheus_headers
+                primary_path, headers=self.prometheus_headers
+            ) as resp:
+                if resp.status == 200:
+                    return dashboard_optional_utils.rest_response(
+                        status_code=dashboard_utils.HTTPStatusCode.OK,
+                        message="prometheus running",
+                        used_path=PROMETHEUS_HEALTHCHECK_PATH,
+                    )
+                primary_status = resp.status
+                logger.info(
+                    "Prometheus primary healthcheck %s returned status %s, "
+                    "falling back to query API.",
+                    primary_path,
+                    primary_status,
+                )
+        except Exception as e:
+            primary_error = str(e)
+            logger.info(
+                "Error fetching prometheus primary healthcheck endpoint %s "
+                "(%s), falling back to query API.",
+                primary_path,
+                primary_error,
+            )
+
+        # Fallback: a successful query response indicates the Prometheus
+        # service is reachable and serving requests.
+        try:
+            async with self.http_session.get(
+                fallback_path, headers=self.prometheus_headers
             ) as resp:
                 if resp.status != 200:
                     return dashboard_optional_utils.rest_response(
                         status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                         message="prometheus healthcheck failed.",
                         status=resp.status,
+                        primary_status=primary_status,
+                        primary_error=primary_error,
+                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
                     )
-
+                try:
+                    body = await resp.json(content_type=None)
+                except Exception:
+                    body = None
+                if not isinstance(body, dict) or body.get("status") != "success":
+                    return dashboard_optional_utils.rest_response(
+                        status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                        message="prometheus healthcheck failed.",
+                        status=resp.status,
+                        primary_status=primary_status,
+                        primary_error=primary_error,
+                        used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
+                    )
                 return dashboard_optional_utils.rest_response(
                     status_code=dashboard_utils.HTTPStatusCode.OK,
                     message="prometheus running",
+                    used_path=PROMETHEUS_HEALTHCHECK_FALLBACK_PATH,
+                    primary_status=primary_status,
+                    primary_error=primary_error,
                 )
         except Exception as e:
             logger.debug(
@@ -210,6 +269,8 @@ class MetricsHead(SubprocessModule):
                 status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
                 message="prometheus healthcheck failed.",
                 reason=str(e),
+                primary_status=primary_status,
+                primary_error=primary_error,
             )
 
     def _create_default_grafana_configs(self):


### PR DESCRIPTION
## Description

Some managed Prometheus services (e.g. **Tencent Cloud TMP**) disable the open-source `/-/healthy` and `/-/ready` endpoints and return `404`, which makes Ray Dashboard's `/api/prometheus_health` always report failure even though the service is fully functional. As a result, the **Metrics tab in the dashboard shows "Prometheus is not running"** and Grafana panels embedded in the dashboard cannot be loaded.

This PR makes the Prometheus healthcheck **gracefully degrade** when the standard liveness endpoint is unavailable:

1. The dashboard still tries `GET {RAY_PROMETHEUS_HOST}/-/healthy` first (existing behavior, no change for self-hosted Prometheus).
2. If the primary endpoint returns a non-200 status **or** the request raises an exception (timeout / connection error), it falls back to a cheap query against `GET {RAY_PROMETHEUS_HOST}/api/v1/query?query=vector(1)`. This endpoint is part of the official Prometheus HTTP API and is guaranteed to be implemented by every Prometheus-compatible service (including managed offerings such as Tencent Cloud TMP, Grafana Mimir, AMP, etc.).
3. The fallback is considered healthy only when the response is `HTTP 200` **and** the JSON body has `"status": "success"`.
4. The success/failure JSON response now also exposes:
   - `used_path` — which endpoint actually answered (`-/healthy` or `api/v1/query?query=vector(1)`),
   - `primary_status` / `primary_error` — the status code or exception from the primary attempt,
   to make debugging easier in production.

The existing `RAY_PROMETHEUS_HEADERS` (used to inject auth headers such as Tencent Cloud's `Authorization: Basic ...`) is honored on both the primary and the fallback request, so token-protected managed Prometheus instances continue to work.

No public API change. Behavior for self-hosted Prometheus where `/-/healthy` works is unchanged — the fallback path is never exercised in that case.

## Related issues

N/A — this targets a real-world deployment scenario on Tencent Cloud TKE + TMP that doesn't have an upstream issue yet. Happy to file one and link if reviewers prefer.

## Additional information

**File changed**

- `python/ray/dashboard/modules/metrics/metrics_head.py`
  - Adds `PROMETHEUS_HEALTHCHECK_FALLBACK_PATH = "api/v1/query?query=vector(1)"`.
  - Rewrites `prometheus_health` with the primary → fallback flow described above.

**Manual verification**

Reproduced on a TKE cluster connected to Tencent Cloud Managed Prometheus (TMP) using KubeRay:

Before the change:
```
$ curl -s http://127.0.0.1:8081/api/prometheus_health | python3 -m json.tool
{
    "result": false,
    "msg": "prometheus healthcheck failed.",
    "data": { "status": 404 }
}
```

After the change (same cluster, same env vars):
```
$ curl -s http://127.0.0.1:8081/api/prometheus_health | python3 -m json.tool
{
    "result": true,
    "msg": "prometheus running",
    "data": {
        "usedPath": "api/v1/query?query=vector(1)",
        "primaryStatus": 404,
        "primaryError": null
    }
}
```

The Metrics tab in Ray Dashboard then loads correctly, and Grafana panels render as expected.

**Backwards compatibility**

- Self-hosted Prometheus (where `/-/healthy` returns 200): unchanged — fallback is not triggered.
- Auth-protected Prometheus: `RAY_PROMETHEUS_HEADERS` is propagated to both requests, no extra configuration needed.