### PR TITLE
fix(dashboard): hide GPU/GRAM columns from clusters and actors table when no GPUs present

### DIFF
--- a/python/ray/dashboard/client/src/components/ActorTable.tsx
+++ b/python/ray/dashboard/client/src/components/ActorTable.tsx
@@ -159,6 +159,11 @@ const ActorTable = ({
     maxPage,
   } = sliceToPage(sortedActors, pageNo, pageSize ?? 10);
 
+  // Check if any actor in the list has GPUs to determine GPU/GRAM column visibility
+  const hasGPU = Object.values(actors).some(
+    (actor) => actor.gpus && actor.gpus.length > 0,
+  );
+
   const columns = [
     { label: "" },
     { label: "ID" },
@@ -340,6 +345,11 @@ const ActorTable = ({
       ),
     },
   ];
+
+  // Hide GPU and GRAM columns when no actors have GPUs
+  const visibleColumns = hasGPU
+    ? columns
+    : columns.filter((col) => col.label !== "GPU" && col.label !== "GRAM");
 
   return (
     <React.Fragment>
@@ -565,7 +575,7 @@ const ActorTable = ({
         <Table>
           <TableHead>
             <TableRow>
-              {columns.map(({ label, helpInfo }) => (
+              {visibleColumns.map(({ label, helpInfo }) => (
                 <TableCell align="center" key={label}>
                   <Box
                     display="flex"
@@ -747,12 +757,16 @@ const ActorTable = ({
                       </PercentageBar>
                     )}
                   </TableCell>
-                  <TableCell>
-                    <WorkerGpuRow workerPID={pid} gpus={gpus} />
-                  </TableCell>
-                  <TableCell>
-                    <WorkerGRAM workerPID={pid} gpus={gpus} />
-                  </TableCell>
+                  {hasGPU && (
+                    <>
+                      <TableCell>
+                        <WorkerGpuRow workerPID={pid} gpus={gpus} />
+                      </TableCell>
+                      <TableCell>
+                        <WorkerGRAM workerPID={pid} gpus={gpus} />
+                      </TableCell>
+                    </>
+                  )}
                   <TableCell
                     align="center"
                     style={{

--- a/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
+++ b/python/ray/dashboard/client/src/pages/node/NodeRow.tsx
@@ -39,6 +39,10 @@ type NodeRowProps = Pick<NodeRowsProps, "node"> & {
    * Click handler for when one clicks on the expand/unexpand button in this row.
    */
   onExpandButtonClick: () => void;
+  /**
+   * Whether to show GPU and GRAM columns. If false, GPU/GRAM cells are hidden.
+   */
+  showGPUColumns?: boolean;
 };
 
 /**
@@ -49,6 +53,7 @@ export const NodeRow = ({
   node,
   expanded,
   onExpandButtonClick,
+  showGPUColumns = true,
 }: NodeRowProps) => {
   const {
     hostname = "",
@@ -157,12 +162,16 @@ export const NodeRow = ({
           </PercentageBar>
         )}
       </TableCell>
-      <TableCell>
-        <NodeGPUView node={node} />
-      </TableCell>
-      <TableCell>
-        <NodeGRAM node={node} />
-      </TableCell>
+      {showGPUColumns && (
+        <>
+          <TableCell>
+            <NodeGPUView node={node} />
+          </TableCell>
+          <TableCell>
+            <NodeGRAM node={node} />
+          </TableCell>
+        </>
+      )}
       <TableCell>
         {raylet && objectStoreTotalMemory && (
           <PercentageBar
@@ -220,12 +229,16 @@ type WorkerRowProps = {
    * Detail of the node the worker is inside.
    */
   node: NodeDetail;
+  /**
+   * Whether to show GPU and GRAM columns.
+   */
+  showGPUColumns?: boolean;
 };
 
 /**
  * A single row that represents the data of a Worker
  */
-export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
+export const WorkerRow = ({ node, worker, showGPUColumns = true }: WorkerRowProps) => {
   const {
     mem,
     raylet: { nodeId },
@@ -297,12 +310,16 @@ export const WorkerRow = ({ node, worker }: WorkerRowProps) => {
           </PercentageBar>
         )}
       </TableCell>
-      <TableCell>
-        <WorkerGpuRow workerPID={pid} gpus={node.gpus} />
-      </TableCell>
-      <TableCell>
-        <WorkerGRAM workerPID={pid} gpus={node.gpus} />
-      </TableCell>
+      {showGPUColumns && (
+        <>
+          <TableCell>
+            <WorkerGpuRow workerPID={pid} gpus={node.gpus} />
+          </TableCell>
+          <TableCell>
+            <WorkerGRAM workerPID={pid} gpus={node.gpus} />
+          </TableCell>
+        </>
+      )}
       <TableCell>N/A</TableCell>
       <TableCell>N/A</TableCell>
       <TableCell align="center">N/A</TableCell>
@@ -326,6 +343,10 @@ type NodeRowsProps = {
    * Whether the row should start expanded. By default, this is false.
    */
   startExpanded?: boolean;
+  /**
+   * Whether to show GPU and GRAM columns.
+   */
+  showGPUColumns?: boolean;
 };
 
 /**
@@ -335,6 +356,7 @@ export const NodeRows = ({
   node,
   isRefreshing,
   startExpanded = false,
+  showGPUColumns = true,
 }: NodeRowsProps) => {
   const [isExpanded, setExpanded] = useState(startExpanded);
 
@@ -371,10 +393,11 @@ export const NodeRows = ({
         node={node}
         expanded={isExpanded}
         onExpandButtonClick={handleExpandButtonClick}
+        showGPUColumns={showGPUColumns}
       />
       {isExpanded &&
         workers.map((worker) => (
-          <WorkerRow key={worker.pid} node={node} worker={worker} />
+          <WorkerRow key={worker.pid} node={node} worker={worker} showGPUColumns={showGPUColumns} />
         ))}
     </React.Fragment>
   );

--- a/python/ray/dashboard/client/src/pages/node/index.tsx
+++ b/python/ray/dashboard/client/src/pages/node/index.tsx
@@ -247,6 +247,14 @@ const Nodes = () => {
     maxPage,
   } = sliceToPage(nodeList, page.pageNo, page.pageSize);
 
+  // Check if any node in the list has GPUs to decide whether to show GPU/GRAM columns
+  const hasGPU = nodeList.some((node) => node.gpus && node.gpus.length > 0);
+
+  // Hide GPU and GRAM columns when no nodes have GPUs
+  const visibleColumns = hasGPU
+    ? columns
+    : columns.filter((col) => col.label !== "GPU" && col.label !== "GRAM");
+
   return (
     <Box
       sx={{
@@ -351,7 +359,7 @@ const Nodes = () => {
             <Table>
               <TableHead>
                 <TableRow>
-                  {columns.map(({ label, helpInfo }) => (
+                  {visibleColumns.map(({ label, helpInfo }) => (
                     <TableCell align="center" key={label}>
                       <Box
                         display="flex"
@@ -374,6 +382,7 @@ const Nodes = () => {
                     node={node}
                     isRefreshing={isRefreshing}
                     startExpanded={nodeList.length === 1}
+                    showGPUColumns={hasGPU}
                   />
                 ))}
               </TableBody>


### PR DESCRIPTION
## Summary of Changes

When a Ray cluster has no nodes or actors with GPUs, the GPU and GRAM columns in the dashboard tables display "N/A" for every row, wasting significant screen real estate as reported in #49989.

This PR conditionally hides the GPU and GRAM columns when no GPUs are detected across all entries.

## Root Cause / What Was Fixed

The cluster nodes table (`pages/node/index.tsx`) and actors table (`components/ActorTable.tsx`) always rendered GPU and GRAM columns regardless of whether any nodes or actors have GPUs, resulting in unnecessary columns of "N/A" values.

### Changes:
1. **`pages/node/index.tsx`** — Added `hasGPU` check across `nodeList`, filters `columns` to exclude GPU/GRAM when false, passes `showGPUColumns` prop to child components
2. **`pages/node/NodeRow.tsx`** — Added `showGPUColumns` prop (default `true`) to `NodeRows`, `NodeRow`, and `WorkerRow`; conditionally renders GPU/GRAM cells
3. **`components/ActorTable.tsx`** — Added `hasGPU` check across `actors`, filters `columns` to exclude GPU/GRAM when false, conditionally renders GPU/GRAM cells

## Testing Done

- TypeScript compilation passes with no errors
- All existing component interfaces remain backward-compatible (`showGPUColumns` defaults to `true`)

## Screenshots

N/A — visual change only takes effect when cluster has 0 GPUs; behavior when GPUs are present is unchanged.