### PR TITLE
[Train] On train initialization block until `create_or_update_train_run` is complete

### DIFF
--- a/python/ray/train/v2/_internal/state/state_manager.py
+++ b/python/ray/train/v2/_internal/state/state_manager.py
@@ -120,7 +120,8 @@ class TrainStateManager:
             run_settings=run_settings,
         )
         self._runs[run.id] = run
-        self._create_or_update_train_run(run)
+        # Block so ExportTrainRun is recorded before any ExportTrainRunAttempt.
+        self._create_or_update_train_run(run, block=True)
 
     def update_train_run_scheduling(
         self,
@@ -174,7 +175,8 @@ class TrainStateManager:
         run.status = RunStatus.FINISHED
         run.status_detail = None
         run.end_time_ns = current_time_ns()
-        self._create_or_update_train_run(run)
+        # Block on terminal status so the final state isn't lost if the controller exits right after.
+        self._create_or_update_train_run(run, block=True)
 
     def update_train_run_errored(
         self,
@@ -185,7 +187,8 @@ class TrainStateManager:
         run.status = RunStatus.ERRORED
         run.status_detail = status_detail
         run.end_time_ns = current_time_ns()
-        self._create_or_update_train_run(run)
+        # Block on terminal status so the final state isn't lost if the controller exits right after.
+        self._create_or_update_train_run(run, block=True)
 
     def update_train_run_aborted(
         self,
@@ -193,7 +196,8 @@ class TrainStateManager:
     ):
         run = self._runs[run_id]
         update_train_run_aborted(run=run, graceful=True)
-        self._create_or_update_train_run(run)
+        # Block on terminal status so the final state isn't lost if the controller exits right after.
+        self._create_or_update_train_run(run, block=True)
 
     def update_train_run_framework_versions(
         self, run_id: str, framework_versions: Dict[str, str]
@@ -267,7 +271,8 @@ class TrainStateManager:
         run_attempt.status_detail = None
         run_attempt.end_time_ns = current_time_ns()
         mark_workers_dead(run_attempt)
-        self._create_or_update_train_run_attempt(run_attempt)
+        # Block to avoid case where controller is dead but attempt is not terminal.
+        self._create_or_update_train_run_attempt(run_attempt, block=True)
 
     def update_train_run_attempt_errored(
         self,
@@ -280,7 +285,8 @@ class TrainStateManager:
         run_attempt.status_detail = status_detail
         run_attempt.end_time_ns = current_time_ns()
         mark_workers_dead(run_attempt)
-        self._create_or_update_train_run_attempt(run_attempt)
+        # Block to avoid case where controller is dead but attempt is not terminal.
+        self._create_or_update_train_run_attempt(run_attempt, block=True)
 
     def update_train_run_attempt_aborted(
         self,
@@ -289,23 +295,25 @@ class TrainStateManager:
     ):
         run_attempt = self._run_attempts[run_id][attempt_id]
         update_train_run_attempt_aborted(run_attempt=run_attempt, graceful=True)
-        self._create_or_update_train_run_attempt(run_attempt)
+        # Block to avoid case where controller is dead but attempt is not terminal.
+        self._create_or_update_train_run_attempt(run_attempt, block=True)
 
     def get_train_run_framework(self, run_id: str) -> Optional[TrainingFramework]:
         run = self._runs[run_id]
         return run.run_settings.backend_config.framework
 
-    def _create_or_update_train_run(self, run: TrainRun) -> None:
+    def _create_or_update_train_run(
+        self, run: TrainRun, *, block: bool = False
+    ) -> None:
         ref = self._state_actor.create_or_update_train_run.remote(run)
-        # Block on INITIALIZING to ensure ExportTrainRun is recorded before any ExportTrainRunAttempt
-        # Block on terminal status so the final state isn't lost if the controller exits right after.
-        if run.status == RunStatus.INITIALIZING or run.status.is_terminal():
+        if block:
             ray.get(ref)
 
-    def _create_or_update_train_run_attempt(self, run_attempt: TrainRunAttempt) -> None:
-        # Block to avoid case where controller is dead but attempt is not terminal.
+    def _create_or_update_train_run_attempt(
+        self, run_attempt: TrainRunAttempt, *, block: bool = False
+    ) -> None:
         ref = self._state_actor.create_or_update_train_run_attempt.remote(run_attempt)
-        if run_attempt.status.is_terminal():
+        if block:
             ray.get(ref)
 
 

--- a/python/ray/train/v2/_internal/state/state_manager.py
+++ b/python/ray/train/v2/_internal/state/state_manager.py
@@ -120,7 +120,10 @@ class TrainStateManager:
             run_settings=run_settings,
         )
         self._runs[run.id] = run
-        # Block so ExportTrainRun is recorded before any ExportTrainRunAttempt.
+        # Block so the initial run state isn't lost if the controller exits
+        # right after. Without this, the .remote() task could still be in the
+        # caller's outbound queue when the controller dies, leaving the state
+        # actor with no record of the run.
         self._create_or_update_train_run(run, block=True)
 
     def update_train_run_scheduling(

--- a/python/ray/train/v2/_internal/state/state_manager.py
+++ b/python/ray/train/v2/_internal/state/state_manager.py
@@ -65,7 +65,6 @@ class TrainStateManager:
         datasets: Dict[str, ray.data.Dataset],
         dataset_config: DataConfig,
     ) -> None:
-
         run_config_schema = RunConfigSchema(
             name=run_config.name,
             failure_config=FailureConfigSchema(
@@ -298,8 +297,9 @@ class TrainStateManager:
 
     def _create_or_update_train_run(self, run: TrainRun) -> None:
         ref = self._state_actor.create_or_update_train_run.remote(run)
-        # Block to avoid case where controller is dead but run is not terminal.
-        if run.status.is_terminal():
+        # Block on INITIALIZING to ensure ExportTrainRun is recorded before any ExportTrainRunAttempt
+        # Block on terminal status so the final state isn't lost if the controller exits right after.
+        if run.status == RunStatus.INITIALIZING or run.status.is_terminal():
             ray.get(ref)
 
     def _create_or_update_train_run_attempt(self, run_attempt: TrainRunAttempt) -> None:

--- a/python/ray/train/v2/tests/test_state.py
+++ b/python/ray/train/v2/tests/test_state.py
@@ -1,6 +1,7 @@
 import json
+import threading
 import time
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -484,6 +485,153 @@ def test_train_state_actor_abort_dead_controller_live_runs_server_unavailable(
 # =============================================================================
 # TrainStateManager: run and run-attempt lifecycle
 # =============================================================================
+
+
+# max_concurrency=2 lets open_gate run alongside a gated create_or_update call;
+# otherwise the actor's single-threaded queue would deadlock.
+@ray.remote(max_concurrency=2)
+class _GatedStateActor:
+    """Mimics TrainStateActor but blocks create_or_update calls until released.
+
+    Used to verify that TrainStateManager.create_*/update_* calls with block=True
+    do not return until the state actor has finished processing the request.
+    """
+
+    def __init__(self):
+        self._runs = {}
+        self._run_attempts = defaultdict(dict)
+        self._gate_open = False
+
+    def open_gate(self):
+        self._gate_open = True
+
+    def _wait_for_gate(self):
+        while not self._gate_open:
+            time.sleep(0.01)
+
+    def create_or_update_train_run(self, run):
+        self._wait_for_gate()
+        self._runs[run.id] = run
+
+    def create_or_update_train_run_attempt(self, attempt):
+        self._wait_for_gate()
+        self._run_attempts[attempt.run_id][attempt.attempt_id] = attempt
+
+    def get_train_runs(self):
+        return self._runs
+
+    def get_train_run_attempts(self):
+        return self._run_attempts
+
+
+def test_create_train_run_blocks_for_caller_death_safety(
+    ray_start_regular, monkeypatch
+):
+    """create_train_run must not return until the state actor has finished
+    recording the run.
+
+    Without this, the controller could exit between .remote() submission and
+    the task being delivered to the state actor, losing the run entirely.
+    """
+    gated = _GatedStateActor.remote()
+    monkeypatch.setattr(
+        "ray.train.v2._internal.state.state_manager.get_or_create_state_actor",
+        lambda: gated,
+    )
+
+    manager = TrainStateManager()
+    finished = threading.Event()
+
+    def call():
+        manager.create_train_run(
+            id="test_run",
+            name="test",
+            job_id="job_1",
+            controller_actor_id="controller_1",
+            controller_log_file_path="/tmp/ray/session_xxx/logs/train/ray-train-app-controller.log",
+            run_config=RunConfig(
+                name="test",
+                failure_config=FailureConfig(max_failures=1),
+                storage_path="s3://bucket/path",
+            ),
+            train_loop_config=None,
+            scaling_config=ScalingConfig(num_workers=1),
+            backend_config=BackendConfig(),
+            datasets={},
+            dataset_config=DataConfig(),
+        )
+        finished.set()
+
+    thread = threading.Thread(target=call)
+    thread.start()
+
+    # While the gate is closed, the manager must remain blocked.
+    finished.wait(timeout=1.0)
+    assert not finished.is_set(), (
+        "create_train_run returned before the state actor processed the "
+        "request — block=True is not enforcing caller-death safety."
+    )
+
+    # Opening the gate lets the state actor finish; the manager call unblocks.
+    ray.get(gated.open_gate.remote())
+    finished.wait(timeout=10)
+    assert finished.is_set()
+    thread.join()
+
+    runs = ray.get(gated.get_train_runs.remote())
+    assert "test_run" in runs
+
+
+def test_update_train_run_attempt_finished_blocks_for_caller_death_safety(
+    ray_start_regular, monkeypatch
+):
+    """update_train_run_attempt_finished must not return until the state actor
+    has recorded the terminal status.
+
+    Without blocking on terminal-status writes, the controller could exit with
+    the attempt still showing as RUNNING in the state actor.
+    """
+    gated = _GatedStateActor.remote()
+    monkeypatch.setattr(
+        "ray.train.v2._internal.state.state_manager.get_or_create_state_actor",
+        lambda: gated,
+    )
+
+    manager = TrainStateManager()
+    # Skip the create flow (which uses block=False for attempt creation) and
+    # seed the manager's in-memory state so the terminal update has something
+    # to act on.
+    manager._run_attempts["test_run"]["attempt_1"] = create_mock_train_run_attempt(
+        attempt_id="attempt_1",
+        run_id="test_run",
+        status=RunAttemptStatus.RUNNING,
+    )
+
+    finished = threading.Event()
+
+    def call():
+        manager.update_train_run_attempt_finished(
+            run_id="test_run", attempt_id="attempt_1"
+        )
+        finished.set()
+
+    thread = threading.Thread(target=call)
+    thread.start()
+
+    finished.wait(timeout=1.0)
+    assert not finished.is_set(), (
+        "update_train_run_attempt_finished returned before the state actor "
+        "processed the request — block=True is not enforcing caller-death "
+        "safety on terminal status."
+    )
+
+    ray.get(gated.open_gate.remote())
+    finished.wait(timeout=10)
+    assert finished.is_set()
+    thread.join()
+
+    attempts = ray.get(gated.get_train_run_attempts.remote())
+    assert attempts["test_run"]["attempt_1"].status == RunAttemptStatus.FINISHED
 
 
 def test_train_state_manager_run_lifecycle(ray_start_regular):


### PR DESCRIPTION
## Description
In Ray Train, we produce `ExportTrainRun` which is a prerequisite for each `ExportTrainRunAttempt` however its possible that due a race condition then `ExportTrainRun` might not run before the user code fails or the `ExportTrainRunAttempt` is flushed before `ExportTrainRun`.

Therefore, this PR adds a block to ensure that `ExportTrainRun` is flushed before we move onto the next stage. This should avoid problems downstream on Anyscale.