### PR TITLE
[Docs] Replace broken Zoom recording with YouTube link (#47146)

### DIFF
--- a/doc/source/ray-overview/getting-started.md
+++ b/doc/source/ray-overview/getting-started.md
@@ -787,7 +787,7 @@ Ray has a rich ecosystem of resources to help you learn more about distributed c
 
 ### Videos
 
-- [Unifying Large Scale Data Preprocessing and Machine Learning Pipelines with Ray Data \| PyData 2021](https://zoom.us/rec/share/0cjbk_YdCTbiTm7gNhzSeNxxTCCEy1pCDUkkjfBjtvOsKGA8XmDOx82jflHdQCUP.fsjQkj5PWSYplOTz?startTime=1635456658000) [(slides)](https://docs.google.com/presentation/d/19F_wxkpo1JAROPxULmJHYZd3sKryapkbMd0ib3ndMiU/edit?usp=sharing)
+- [Unifying Large Scale Data Preprocessing and Machine Learning Pipelines with Ray Data \| PyData 2021](https://www.youtube.com/watch?v=wl4tvru9_Cg) [(slides)](https://docs.google.com/presentation/d/19F_wxkpo1JAROPxULmJHYZd3sKryapkbMd0ib3ndMiU/edit?usp=sharing)
 - [Programming at any Scale with Ray \| SF Python Meetup Sept 2019](https://www.youtube.com/watch?v=LfpHyIXBhlE)
 - [Ray for Reinforcement Learning \| Data Council 2019](https://www.youtube.com/watch?v=Ayc0ca150HI)
 - [Scaling Interactive Pandas Workflows with Modin](https://www.youtube.com/watch?v=-HjLd_3ahCw)


### PR DESCRIPTION
## Description

The Zoom recording for "Unifying Large Scale Data Preprocessing and Machine Learning Pipelines with Ray Data | PyData 2021" listed under Talks & Videos in `doc/source/ray-overview/getting-started.md` is no longer accessible. This PR points the link at the canonical PyData Global 2021 upload on YouTube so the resource is preserved for readers instead of dropped.

## Related issues

Closes ray-project/ray#47146

[DOC-968]

## Additional information

- Target file: `doc/source/ray-overview/getting-started.md` (line 790)
- Replacement: https://www.youtube.com/watch?v=wl4tvru9_Cg (verified resolves)
- Same talk, same speakers (Alex Wu, Clark Zinzow); slides link is unchanged

Generated with [Claude Code](https://claude.com/claude-code)