### PR TITLE
[Docs] Replace broken MCP template link in LangChain agent example (#62943)

### DIFF
--- a/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb
+++ b/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb
@@ -153,8 +153,7 @@
         "\n",
         "**Additional resources:**\n",
         "- [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)\n",
-        "- [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)\n",
-        "- [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve)\n"
+        "- [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)\n"
       ]
     },
     {
@@ -631,7 +630,7 @@
         "### Extend your agent\n",
         "\n",
         "**Add more tools**  \n",
-        "Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve).\n",
+        "Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation guidance, see [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).\n",
         "\n",
         "**Swap or upgrade LLMs**  \n",
         "Replace the Qwen model with other tool-calling models such as GPT-4, Claude, or Llama variants. Since the LLM runs as a separate service, you can A/B test different models or perform zero-downtime upgrades. For deployment patterns, see the [Anyscale LLM Serving Template](https://console.anyscale.com/template-preview/deployment-serve-llm).\n",

--- a/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb
+++ b/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb
@@ -153,7 +153,7 @@
         "\n",
         "**Additional resources:**\n",
         "- [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)\n",
-        "- [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)\n"
+        "- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)\n"
       ]
     },
     {

--- a/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
+++ b/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
@@ -123,7 +123,7 @@ mcp = FastMCP("weather", stateless_http=True)
 
 **Additional resources:**
 - [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)
-- [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)
+- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)
 
 
 ### Step 3: Create the agent logic

--- a/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
+++ b/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
@@ -124,7 +124,6 @@ mcp = FastMCP("weather", stateless_http=True)
 **Additional resources:**
 - [MCP quickstart guide](https://docs.anyscale.com/mcp/mcp-quickstart-guide)
 - [Deploy scalable MCP servers](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment)
-- [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve)
 
 
 ### Step 3: Create the agent logic
@@ -513,7 +512,7 @@ You've successfully built, deployed, and tested a multi-tool agent using Ray Ser
 ### Extend your agent
 
 **Add more tools**  
-Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation examples, see the [Anyscale MCP Deployment Template](https://console.anyscale.com/template-preview/mcp-ray-serve).
+Extend the MCP service with additional capabilities such as database queries, API integrations, or custom business logic. The MCP protocol allows your agent to discover new tools dynamically without code changes. For implementation guidance, see [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).
 
 **Swap or upgrade LLMs**  
 Replace the Qwen model with other tool-calling models such as GPT-4, Claude, or Llama variants. Since the LLM runs as a separate service, you can A/B test different models or perform zero-downtime upgrades. For deployment patterns, see the [Anyscale LLM Serving Template](https://console.anyscale.com/template-preview/deployment-serve-llm).

--- a/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
+++ b/doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md
@@ -559,4 +559,3 @@ For comprehensive guidance on production deployments, see the [Anyscale Services
 
 
 
-

--- a/doc/source/ray-overview/examples/multi_agent_a2a/content/README.ipynb
+++ b/doc/source/ray-overview/examples/multi_agent_a2a/content/README.ipynb
@@ -556,7 +556,7 @@
     "\n",
     "Ray Serve only supports stateless HTTP mode in MCP. Set `stateless_http=True` to prevent \"session not found\" errors when running multiple replicas.\n",
     "\n",
-    "For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [MCP Ray Serve template](https://console.anyscale.com/template-preview/mcp-ray-serve).\n",
+    "For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).\n",
     "\n",
     "#### 5.2.1 Weather MCP server\n",
     "\n",
@@ -969,7 +969,7 @@
     "- [Anyscale LLM Serving Documentation](https://docs.anyscale.com/llm/serving) - Detailed guide for deploying and configuring LLM services.\n",
     "- [Deploy LLM Template](https://console.anyscale.com/template-preview/deployment-serve-llm) - Template for deploying LLM services on Anyscale.\n",
     "- [Anyscale MCP Documentation](https://docs.anyscale.com/mcp) - Guide for deploying and configuring MCP servers with Ray Serve.\n",
-    "- [MCP Ray Serve Template](https://console.anyscale.com/template-preview/mcp-ray-serve) - Template for deploying MCP servers on Anyscale."
+    "- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment) - Guide for deploying MCP servers on Anyscale."
    ]
   }
  ],

--- a/doc/source/ray-overview/examples/multi_agent_a2a/content/README.md
+++ b/doc/source/ray-overview/examples/multi_agent_a2a/content/README.md
@@ -374,7 +374,7 @@ For detailed information on deploying and configuring LLM services, see the [Any
 
 Ray Serve only supports stateless HTTP mode in MCP. Set `stateless_http=True` to prevent "session not found" errors when running multiple replicas.
 
-For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [MCP Ray Serve template](https://console.anyscale.com/template-preview/mcp-ray-serve).
+For more information, see the [Anyscale MCP documentation](https://docs.anyscale.com/mcp) and [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment).
 
 #### 5.2.1 Weather MCP server
 
@@ -722,4 +722,4 @@ The system uses Ray Serve's built-in autoscaling to handle variable load. See th
 - [Anyscale LLM Serving Documentation](https://docs.anyscale.com/llm/serving) - Detailed guide for deploying and configuring LLM services.
 - [Deploy LLM Template](https://console.anyscale.com/template-preview/deployment-serve-llm) - Template for deploying LLM services on Anyscale.
 - [Anyscale MCP Documentation](https://docs.anyscale.com/mcp) - Guide for deploying and configuring MCP servers with Ray Serve.
-- [MCP Ray Serve Template](https://console.anyscale.com/template-preview/mcp-ray-serve) - Template for deploying MCP servers on Anyscale.
+- [Deploy scalable MCP servers with Ray Serve](https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment) - Guide for deploying MCP servers on Anyscale.


### PR DESCRIPTION
## Description

The `Anyscale MCP Deployment Template` link in the LangChain agent Ray Serve example points to `https://console.anyscale.com/template-preview/mcp-ray-serve`, which fails to render in the Anyscale Console for users outside the appropriate organization. Replace the link with the public Anyscale docs page "Deploy scalable MCP servers with Ray Serve" (https://docs.anyscale.com/mcp/scalable-remote-mcp-deployment), which is the equivalent public guide. The same target was already listed one bullet up in the Step 2 resources list, so that duplicate bullet is removed.

## Related issues

Closes ray-project/ray#62943

[DOC-951]

## Additional information

Edited files:

- `doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.ipynb`
- `doc/source/ray-overview/examples/langchain_agent_ray_serve/content/README.md`

The `README.md` is generated from `README.ipynb` via `convert_to_md.sh`; both files are edited to keep them in sync without requiring a `jupyter` round-trip.
