### PR TITLE
[Docs] Document default output column names for read_text and read_binary_files (#36872)

### DIFF
--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -1915,7 +1915,7 @@ def read_text(
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from lines stored in text files.
 
-    The column name default to "text".
+    The column name defaults to "text".
 
     Examples:
         Read a file in remote storage.
@@ -2604,6 +2604,8 @@ def read_binary_files(
     override_num_blocks: Optional[int] = None,
 ) -> Dataset:
     """Create a :class:`~ray.data.Dataset` from binary files of arbitrary contents.
+
+    The column name defaults to "bytes".
 
     Examples:
         Read a file in remote storage.


### PR DESCRIPTION
## Description

`read_binary_files` did not state the default output column name in its docstring, and `read_text` had a typo ("column name default to" instead of "defaults to"). Add the missing line to `read_binary_files` ("bytes") and fix the typo in `read_text` so both APIs match the existing convention used by `read_images`, `read_audio`, `read_videos`, and `read_numpy` in `python/ray/data/read_api.py`.

## Related issues

Closes ray-project/ray#36872

[DOC-983]

## Additional information

Target file: `python/ray/data/read_api.py`. The existing schema lines in `read_images`, `read_audio`, `read_videos`, and `read_numpy` follow the same pattern; this change brings `read_text` and `read_binary_files` in line.

Generated with [Claude Code](https://claude.com/claude-code)