### PR TITLE
[Docs] Drop duplicated Attributes table from ScalingConfig API ref (#38840)

### DIFF
--- a/doc/source/train/api/api.rst
+++ b/doc/source/train/api/api.rst
@@ -131,8 +131,14 @@ Ray Train Configuration
     ~train.FailureConfig
     ~train.LoggingConfig
     ~train.RunConfig
-    ~train.ScalingConfig
     ~train.ValidationConfig
+
+.. autosummary::
+    :nosignatures:
+    :template: autosummary/class_without_autosummary.rst
+    :toctree: doc/
+
+    ~train.ScalingConfig
 
 .. _train-loop-api:
 


### PR DESCRIPTION
## Description

The default `autosummary/class.rst` template renders both a Parameters section (from the docstring `Args:`) and a separate Attributes rubric/table on the rendered `ScalingConfig` API ref. The Attributes table duplicates the parameter names without descriptions and additionally lists derived `@property` members, leaving the page with two overlapping sections that conflict with each other.

This change switches `ScalingConfig` to the `autosummary/class_without_autosummary.rst` template in `doc/source/train/api/api.rst`. The class is rendered with `autodoc :members:`, so public properties and methods appear inline with their own docstrings and the duplicated Attributes rubric goes away.

## Related issues

Closes ray-project/ray#38840

[DOC-982]

## Additional information

Target file: `doc/source/train/api/api.rst`. No docstring changes; the fix is scoped to the autosummary directive for `~train.ScalingConfig` so other configuration classes (`CheckpointConfig`, `RunConfig`, etc.) are unaffected.

Generated with [Claude Code](https://claude.com/claude-code)