### PR TITLE
[Docs] Add Azure Files to Train persistent-storage shared filesystem list (#54054)

### DIFF
--- a/doc/source/train/user-guides/persistent-storage.rst
+++ b/doc/source/train/user-guides/persistent-storage.rst
@@ -15,7 +15,7 @@ A Ray Train run produces :ref:`checkpoints <train-checkpointing>` that can be sa
 
 **Ray Train expects all workers to be able to write files to the same persistent storage location.**
 Therefore, Ray Train requires some form of external persistent storage such as
-cloud storage (e.g., S3, GCS) or a shared filesystem (e.g., AWS EFS, Google Filestore, Azure Files, HDFS)
+cloud storage (e.g., S3, GCS) or a shared filesystem (e.g., AWS EFS, Google Cloud Filestore, Azure Files, or HDFS)
 for multi-node training.
 
 Here are some capabilities that persistent storage enables:
@@ -78,7 +78,7 @@ Use by specifying the shared storage path as the :class:`RunConfig(storage_path)
         )
     )
 
-Ensure that all nodes in the Ray cluster have access to the shared filesystem, e.g. AWS EFS, Google Cloud Filestore, Azure Files, or HDFS,
+Ensure that all nodes in the Ray cluster have access to the shared filesystem, e.g., AWS EFS, Google Cloud Filestore, Azure Files, or HDFS,
 so that outputs can be saved to there.
 In this example, all files are saved to ``/mnt/cluster_storage/experiment_name`` for further processing.
 

--- a/doc/source/train/user-guides/persistent-storage.rst
+++ b/doc/source/train/user-guides/persistent-storage.rst
@@ -15,7 +15,7 @@ A Ray Train run produces :ref:`checkpoints <train-checkpointing>` that can be sa
 
 **Ray Train expects all workers to be able to write files to the same persistent storage location.**
 Therefore, Ray Train requires some form of external persistent storage such as
-cloud storage (e.g., S3, GCS) or a shared filesystem (e.g., AWS EFS, Google Filestore, HDFS)
+cloud storage (e.g., S3, GCS) or a shared filesystem (e.g., AWS EFS, Google Filestore, Azure Files, HDFS)
 for multi-node training.
 
 Here are some capabilities that persistent storage enables:
@@ -78,7 +78,7 @@ Use by specifying the shared storage path as the :class:`RunConfig(storage_path)
         )
     )
 
-Ensure that all nodes in the Ray cluster have access to the shared filesystem, e.g. AWS EFS, Google Cloud Filestore, or HDFS,
+Ensure that all nodes in the Ray cluster have access to the shared filesystem, e.g. AWS EFS, Google Cloud Filestore, Azure Files, or HDFS,
 so that outputs can be saved to there.
 In this example, all files are saved to ``/mnt/cluster_storage/experiment_name`` for further processing.
 


### PR DESCRIPTION
## Description

The Ray Train persistent storage guide listed AWS EFS, Google Filestore, and HDFS as shared filesystem options but omitted Azure Files, the standard shared filesystem in Azure environments. This PR adds Azure Files alongside the existing entries in both the overview paragraph and the "Shared filesystem (NFS, HDFS)" section of `doc/source/train/user-guides/persistent-storage.rst`.

## Related issues

Closes ray-project/ray#54054

[DOC-989]

## Additional information

Scope is intentionally limited to the two existing list mentions. No new section or example was added, since Azure Files mounts as a standard POSIX filesystem and the existing `storage_path="/mnt/cluster_storage"` example covers it without modification.

Target file: `doc/source/train/user-guides/persistent-storage.rst`

🤖 Generated with [Claude Code](https://claude.com/claude-code)