### PR TITLE
[Docs] Document sync-method behavior in async actors (#44454)

### DIFF
--- a/doc/source/ray-core/actors/async_api.rst
+++ b/doc/source/ray-core/actors/async_api.rst
@@ -219,6 +219,15 @@ of the event loop.
 
 In async actors, only one task can be running at any point in time (though tasks can be multiplexed). There will be only one thread in AsyncActor! See :ref:`threaded-actors` if you want a threadpool.
 
+.. warning::
+    Sync methods (regular ``def`` methods) defined on an async actor also run
+    on that actor's single asyncio event loop. Because a sync method does not
+    yield control back to the loop until it returns, a long-running or blocking
+    sync method blocks every other async task on the actor until it completes.
+    If you need to call blocking code from an async actor, run it in a thread
+    using ``asyncio.get_event_loop().run_in_executor(...)`` or
+    ``asyncio.to_thread(...)`` so the event loop stays responsive.
+
 Setting concurrency in Async Actors
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Description

Add a warning admonition to `doc/source/ray-core/actors/async_api.rst` clarifying that sync (non-`async`) methods on an async actor execute on that actor's single asyncio event loop. Because a sync method never yields back to the loop until it returns, a long-running or blocking sync method blocks every other async task on the actor. The note suggests `run_in_executor` or `asyncio.to_thread` for blocking work, so the event loop stays responsive.

## Related issues

Closes ray-project/ray#44454

[DOC-990]

## Additional information

The admonition is placed right after the "Defining an Async Actor" section already mentions that "Ray runs all of the methods inside a single python event loop," which is the natural spot to call out the consequence for sync methods.

Generated with [Claude Code](https://claude.com/claude-code)
