### PR TITLE
[Docs] Note that class variables aren't shared across actor instances (#12977)

### DIFF
--- a/doc/source/ray-core/actors.rst
+++ b/doc/source/ray-core/actors.rst
@@ -91,6 +91,20 @@ that specific worker. The methods can access and mutate the state of that worker
 
 
 
+.. note::
+
+   Each remote actor runs in its own Python process, so Python class
+   variables aren't shared across actor instances. Each actor receives its
+   own copy of the class state at instantiation time, and any subsequent
+   mutations (for example, ``Counter.value += 1`` from inside a method)
+   are local to that actor's process. They aren't visible to the driver
+   or to other actors created from the same class.
+
+   To share state across actors, store it on a dedicated actor (often a
+   :ref:`named actor <actor-lifetimes>`) and call its methods from the
+   other actors, or place immutable data into the object store with
+   :func:`ray.put`.
+
 Use `ray list actors` from :ref:`State API <state-api-overview-ref>` to see actors states:
 
 .. code-block:: bash


### PR DESCRIPTION
## Description

Long-standing clarification request from 2020: users instantiating multiple `@ray.remote` actors observe that a Python class variable doesn't accumulate across instances. The cause is process isolation — each actor runs in its own Python process and gets its own copy of the class state — but `doc/source/ray-core/actors.rst` only mentions that fact obliquely (once on the introductory line). This PR adds a short note next to the actor instantiation section that states the behavior explicitly and points users at named actors or the object store for shared state.

## Related issues

Closes ray-project/ray#12977

[DOC-992]

## Additional information

Target file: `doc/source/ray-core/actors.rst`. The note is placed immediately after the language tab-set that introduces actor instantiation so it's visible regardless of which language tab the reader selects.

Generated with [Claude Code](https://claude.com/claude-code)