### PR TITLE
[Docs] Restructure Tune example pages (#36167)

### DIFF
--- a/doc/source/tune/examples/lightgbm_example.ipynb
+++ b/doc/source/tune/examples/lightgbm_example.ipynb
@@ -140,7 +140,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-02-18 17:33:55,300\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/Users/user/ray_results/train_breast_cancer_2025-02-18_17-33-54' in 0.0035s.\n",
+      "2025-02-18 17:33:55,300\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '~/ray_results/train_breast_cancer_2025-02-18_17-33-54' in 0.0035s.\n",
       "2025-02-18 17:33:55,302\tINFO tune.py:1041 -- Total run time: 1.28 seconds (1.27 seconds for the tuning loop).\n"
      ]
     },

--- a/doc/source/tune/examples/lightgbm_example.ipynb
+++ b/doc/source/tune/examples/lightgbm_example.ipynb
@@ -40,7 +40,11 @@
     "\n",
     "```bash\n",
     "pip install \"ray[tune]\" lightgbm scikit-learn numpy\n",
-    "```"
+    "```\n",
+    "\n",
+    "## Training script\n",
+    "\n",
+    "The script below defines a `train_breast_cancer` training function, configures the search space, and runs the tuner with the {class}`~ray.tune.schedulers.ASHAScheduler`."
    ]
   },
   {
@@ -136,7 +140,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-02-18 17:33:55,300\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/Users/rdecal/ray_results/train_breast_cancer_2025-02-18_17-33-54' in 0.0035s.\n",
+      "2025-02-18 17:33:55,300\tINFO tune.py:1009 -- Wrote the latest version of all result files and experiment state to '/Users/user/ray_results/train_breast_cancer_2025-02-18_17-33-54' in 0.0035s.\n",
       "2025-02-18 17:33:55,302\tINFO tune.py:1041 -- Total run time: 1.28 seconds (1.27 seconds for the tuning loop).\n"
      ]
     },
@@ -220,6 +224,8 @@
    "id": "01d74c39",
    "metadata": {},
    "source": [
+    "## Expected output\n",
+    "\n",
     "This should give an output like:\n",
     "\n",
     "```python\n",

--- a/doc/source/tune/examples/pbt_transformers.ipynb
+++ b/doc/source/tune/examples/pbt_transformers.ipynb
@@ -26,7 +26,14 @@
     ":local: true\n",
     "```\n",
     "\n",
-    "## Example"
+    "This example tunes a Huggingface Transformers model with Ray Tune's Population Based Training (PBT) scheduler, using Huggingface's official `hyperparameter_search` API.\n",
+    "\n",
+    "The example is split into two parts:\n",
+    "\n",
+    "- A **training script** that defines the `tune_transformer` entry point and wires together the model, dataset, scheduler, and reporter.\n",
+    "- A **utility module** (`ray.tune.examples.pbt_transformers.utils`) that provides the data download and metrics helpers imported by the training script.\n",
+    "\n",
+    "## Training script"
    ]
   },
   {
@@ -210,7 +217,9 @@
    "id": "42b27553",
    "metadata": {},
    "source": [
-    "Utility code, imported in script above."
+    "## Utility module\n",
+    "\n",
+    "The training script above imports the following helpers from `ray.tune.examples.pbt_transformers.utils`. They handle GLUE data download and define the `compute_metrics` function passed to the Huggingface `Trainer`."
    ]
   },
   {

--- a/doc/source/tune/examples/pbt_transformers.ipynb
+++ b/doc/source/tune/examples/pbt_transformers.ipynb
@@ -26,7 +26,7 @@
     ":local: true\n",
     "```\n",
     "\n",
-    "This example tunes a Huggingface Transformers model with Ray Tune's Population Based Training (PBT) scheduler, using Huggingface's official `hyperparameter_search` API.\n",
+    "This example tunes a Hugging Face Transformers model with Ray Tune's Population Based Training (PBT) scheduler, using Hugging Face's official `hyperparameter_search` API.\n",
     "\n",
     "The example is split into two parts:\n",
     "\n",
@@ -219,7 +219,7 @@
    "source": [
     "## Utility module\n",
     "\n",
-    "The training script above imports the following helpers from `ray.tune.examples.pbt_transformers.utils`. They handle GLUE data download and define the `compute_metrics` function passed to the Huggingface `Trainer`."
+    "The training script above imports the following helpers from `ray.tune.examples.pbt_transformers.utils`. They handle GLUE data download and define the `compute_metrics` function passed to the Hugging Face `Trainer`."
    ]
   },
   {


### PR DESCRIPTION
## Description

Audits `doc/source/tune/examples/*.ipynb` for the structural issues called out in ray-project/ray#36167 and fixes the two notebooks where they apply:

- **`pbt_transformers.ipynb`** — the page concatenated the training script and its imported utility module with no headings between them, so the local sub-TOC showed only one entry ("Example"). Adds an intro paragraph that names the two parts, splits them under `## Training script` and `## Utility module` headings, and clarifies that the second cell is the `ray.tune.examples.pbt_transformers.utils` module imported by the first.
- **`lightgbm_example.ipynb`** — the local sub-TOC contained only `Installation`. Adds `## Training script` and `## Expected output` headings so the `{contents}` directive renders a useful TOC. Also anonymizes a `/Users/<name>/ray_results` path leaked in a cell output.

The notebooks called out by the original reporter are now restructured to satisfy the three concerns in the issue body: useful sub-TOCs, no leaked personal paths in the output cells touched, and clearer structure for `pbt_transformers` (the two scripts are now distinct sections with a preamble explaining their relationship).

## Related issues

Closes ray-project/ray#36167

[DOC-991]

## Additional information

Audit scope was `doc/source/tune/examples/*.ipynb`. Other notebooks in that directory carry similar `/Users/<name>` / `/home/<name>` leaks in their output cells (`ax_example.ipynb`, `bayesopt_example.ipynb`, `bohb_example.ipynb`, `nevergrad_example.ipynb`, `tune-xgboost.ipynb`, others). They are not restructured here because they don't have the single-entry sub-TOC structure called out in the original report; a follow-up could sweep those output cells.

Reviewers can preview the rendered pages locally with `cd doc && make html` and open `_build/html/tune/examples/pbt_transformers.html` and `lightgbm_example.html`.

## Checks

- [x] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.

Generated with [Claude Code](https://claude.com/claude-code)
