### PR TITLE
[doc][DOC-1051][DOC-1053] add intersphinx and urlopen timeouts

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -139,7 +139,7 @@ def _resolve_template_url(name):
     """Fetch the build zip URL for a template from the channel API."""
     api_url = _TEMPLATE_CHANNEL_API.format(name=name)
     logger.info("sphinx-collections: resolving template URL from %s", api_url)
-    with urlopen(api_url) as resp:
+    with urlopen(api_url, timeout=30) as resp:
         data = json.loads(resp.read())
     url = data["url"]
     # Replace the ascommon:/// protocol with the templates.ci.ray.io base URL.
@@ -160,7 +160,7 @@ def _fetch_and_extract_zip(config):
         shutil.rmtree(target)
     target.mkdir(parents=True, exist_ok=True)
     logger.info("sphinx-collections: downloading %s -> %s", url, target)
-    with urlopen(url) as resp:
+    with urlopen(url, timeout=30) as resp:
         zip_bytes = io.BytesIO(resp.read())
     with zipfile.ZipFile(zip_bytes) as zf:
         zf.extractall(target)
@@ -900,6 +900,8 @@ intersphinx_mapping = {
     "torchvision": ("https://pytorch.org/vision/stable/", None),
     "transformers": ("https://huggingface.co/docs/transformers/main/en/", None),
 }
+
+intersphinx_timeout = 15
 
 # Ray must not be imported in conf.py because third party modules initialized by
 # `import ray` will no be mocked out correctly. Perform a check here to ensure


### PR DESCRIPTION
<!-- Thank you for contributing to Ray! 🚀 -->

## Why are these changes needed?

Two small hardening changes in `doc/source/conf.py` that make hung external fetches fail fast and visibly rather than silently consuming the RtD build budget.

* **`intersphinx_timeout = 15`** — Sphinx currently has no timeout configured for the 24 `objects.inv` fetches that happen at the start of every build. A hung fetch silently consumes time until the platform-level build timeout. Adding a 15-second timeout makes the failure mode legible. Reference: [open-telemetry/opentelemetry-python#2496](https://github.com/open-telemetry/opentelemetry-python/discussions/2496), [readthedocs/readthedocs.org#6691](https://github.com/readthedocs/readthedocs.org/issues/6691).
* **`timeout=30` on `urlopen` in `_resolve_template_url` and `_fetch_and_extract_zip`** — These two helpers fetch from `templates.ci.ray.io` (channel JSON and template build zip). Neither call had a timeout. Same silent-hang risk; same legibility benefit.

Neither change has a nominal speedup on the happy path. Both eliminate a real silent-timeout failure mode.

## Related issue number

[DOC-1051] [DOC-1053]

Part of the [DOC-1046] epic to reduce Ray Sphinx/RtD build wall-clock and variance.

## Checks

- [x] I've signed off every commit (by using the `-s` flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` under the corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
