### PR TITLE
[data] DataSourceV2: don't disable pre_buffer in Parquet scanner options

### DIFF
--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -408,23 +408,28 @@ class ParquetFileReader(FileReader):
 
     @override
     def _arrow_scanner_kwargs(self) -> dict:
-        # pre_buffer=True (pyarrow default) holds a whole fragment's worth of
-        # decoded column chunks resident before yielding batches, so
-        # pa.total_allocated_bytes() climbs monotonically across batches and
-        # peaks near full fragment size. Disabling pre_buffer with
-        # use_buffered_stream caps peak near a small multiple of one row group
-        # while keeping throughput equal to the default.
-        # See apache/arrow#39808.
+        # ``pre_buffer`` is left at pyarrow's default (``True``). With
+        # ``pre_buffer=True`` pyarrow plans a single coalesced range
+        # request covering all needed column chunks for a fragment and
+        # issues it in one I/O burst, then decodes from memory. With
+        # ``pre_buffer=False`` pyarrow opens a per-column buffered
+        # stream and fetches lazily — fine on narrow schemas (few large
+        # columns) but catastrophic on wide schemas (thousands of small
+        # columns become thousands of range requests). V1
+        # ``ParquetDatasource`` also relies on the default. The
+        # cross-fragment memory accumulation that originally motivated
+        # disabling ``pre_buffer`` (apache/arrow#39808) is already
+        # addressed by V2's per-fragment scanners.
         #
-        # ``buffer_size`` controls the per-stream read-ahead buffer pyarrow
-        # issues against the filesystem. The default is small (8 KiB), which
-        # produces many tiny range requests on S3. 8 MiB amortizes S3
-        # latency across meaningful bytes per round-trip. Tunable via env
-        # var for workloads that need a different point on the
-        # latency/memory-peak curve.
+        # ``buffer_size`` controls the per-stream read-ahead buffer
+        # pyarrow issues against the filesystem when ``use_buffered_stream``
+        # is on. The default is small (8 KiB), which produces many tiny
+        # range requests on S3. 8 MiB amortizes S3 latency across
+        # meaningful bytes per round-trip. Tunable via env var for
+        # workloads that need a different point on the latency/memory-
+        # peak curve.
         kwargs: dict = {
             "fragment_scan_options": pds.ParquetFragmentScanOptions(
-                pre_buffer=False,
                 use_buffered_stream=True,
                 buffer_size=_PARQUET_FRAGMENT_BUFFER_SIZE,
             ),


### PR DESCRIPTION
## Summary
V2's ``ParquetFileReader._arrow_scanner_kwargs`` was constructing ``pds.ParquetFragmentScanOptions(pre_buffer=False, use_buffered_stream=True, buffer_size=8 MiB)``. With ``pre_buffer=False``, pyarrow opens a per-column buffered stream and issues range requests lazily. On wide-schema Parquet (thousands of small columns) that turns one fragment read into thousands of S3 GETs.

The ``wide_schema_pipeline_primitives`` release test regressed from ~16s on V1 to ~154s after V2 became the default reader (#63326). Other release tests on wide schemas (``wide_schema_pipeline_{tensors,objects,nested_structs}`` and ``write_parquet``, which is read-then-write) are affected by the same mechanism.

## Evidence
``ds.stats()`` from a regressing run on ``s3://ray-benchmark-data-internal-us-west-2/wide_schema/primitives`` (27 files × 22 MB × 5000 columns):

```
Operator 2 ReadFilesParquetV2: 27 tasks executed, 40 blocks produced in 143.19s
  Remote wall time:  61.73ms min, 141.62s max, 88.67s mean
  Remote cpu time:   62.07ms min, 4.76s max,   2.96s mean
  Peak heap memory:  448.82 MiB min, 612.21 MiB max
```

96% of per-task wall time is blocked, CPU is negligible — the classic many-small-I/O signature, not memory pressure or per-task setup cost.

## Why this only affects V2
- **V1** ``ParquetDatasource`` constructs ``pds.ParquetFragmentScanOptions(use_buffered_stream=True, buffer_size=8 MiB)`` without setting ``pre_buffer`` → pyarrow default ``True`` → one coalesced range request per fragment. Fast.
- **Anyscale internal Turbo** ``ParquetReader`` does the same — ``pre_buffer`` left at default. No regression.
- **V2 (this PR fixes)** explicitly set ``pre_buffer=False``. On narrow schemas the difference is invisible (few large columns either way). On wide schemas it's catastrophic.

The cross-fragment memory accumulation that originally motivated disabling ``pre_buffer`` (apache/arrow#39808) is already addressed by V2's per-fragment scanner construction — so disabling ``pre_buffer`` was load-bearing on a problem that no longer needs that fix.

## Change
Drop the ``pre_buffer=False`` argument. Update the comment to record why we rely on the default. No other behavioral change.

## Test plan
- [x] pre-commit clean on the modified file
- [x] ``python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py`` — 11/11 pass
- [x] ``python/ray/data/tests/datasource/test_parquet.py`` — 267 passed / 6 skipped


Release tests: https://buildkite.com/ray-project/release/builds/93384#_

🤖 Generated with [Claude Code](https://claude.com/claude-code)