### PR TITLE
[Data] Gate unsafe deserialization in WebDataset default decoder

### DIFF
--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -4,6 +4,7 @@
 import fnmatch
 import io
 import json
+import os
 import re
 import tarfile
 from functools import partial
@@ -12,6 +13,13 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 from ray.data._internal.util import iterate_with_retry
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
+
+
+def _allow_unsafe_deserialization():
+    return (
+        os.environ.get("RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION", "0") == "1"
+    )
+
 
 if TYPE_CHECKING:
     import pyarrow
@@ -211,13 +219,26 @@ def _default_decoder(sample: Dict[str, Any], format: Optional[Union[bool, str]] 
 
             sample[key] = msgpack.unpackb(value, raw=False)
         elif extension in ["pt", "pth"]:
+            if not _allow_unsafe_deserialization():
+                raise ValueError(
+                    f"Refusing to load .{extension} member {key!r} from "
+                    f"WebDataset with weights_only=False (arbitrary code "
+                    f"execution risk). Provide a custom decoder or set "
+                    f"RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION=1 "
+                    f"for trusted sources."
+                )
             import torch
 
-            # PyTorch 2.6 changed torch.load default weights_only=True, which
-            # breaks loading general Python objects previously serialized for
-            # WebDataset .pt payloads.
             sample[key] = torch.load(io.BytesIO(value), weights_only=False)
         elif extension in ["pickle", "pkl"]:
+            if not _allow_unsafe_deserialization():
+                raise ValueError(
+                    f"Refusing to unpickle WebDataset member {key!r} "
+                    f"(arbitrary code execution risk). Provide a custom "
+                    f"decoder or set "
+                    f"RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION=1 "
+                    f"for trusted sources."
+                )
             import pickle
 
             sample[key] = pickle.loads(value)

--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -14,7 +14,7 @@ from ray.data._internal.util import iterate_with_retry
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
-RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR = (
+ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR = (
     "RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION"
 )
 
@@ -227,7 +227,7 @@ def _default_decoder(
                     f"Refusing to load .{extension} member {key!r} from "
                     f"WebDataset with weights_only=False (arbitrary code "
                     f"execution risk). Provide a custom decoder or set "
-                    f"RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION=1 "
+                    f"{ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR}=1 "
                     f"for trusted sources."
                 )
             import torch
@@ -239,7 +239,7 @@ def _default_decoder(
                     f"Refusing to unpickle WebDataset member {key!r} "
                     f"(arbitrary code execution risk). Provide a custom "
                     f"decoder or set "
-                    f"RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION=1 "
+                    f"{ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR}=1 "
                     f"for trusted sources."
                 )
             import pickle
@@ -350,7 +350,7 @@ class WebDatasetDatasource(FileBasedDatasource):
         self.expand_json = expand_json
 
         self._allow_unsafe_deserialization = env_bool(
-            RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR, False
+            ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR, False
         )
 
     def _read_stream(self, stream: "pyarrow.NativeFile", path: str):

--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -4,12 +4,12 @@
 import fnmatch
 import io
 import json
-import os
 import re
 import tarfile
 from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
+from ray._common.utils import env_bool
 from ray.data._internal.util import iterate_with_retry
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
@@ -342,18 +342,16 @@ class WebDatasetDatasource(FileBasedDatasource):
     ):
         super().__init__(paths, **file_based_datasource_kwargs)
 
-        self._allow_unsafe_deserialization = (
-            os.environ.get(
-                RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR, "0"
-            )
-            == "1"
-        )
         self.decoder = decoder
         self.fileselect = fileselect
         self.filerename = filerename
         self.suffixes = suffixes
         self.verbose_open = verbose_open
         self.expand_json = expand_json
+
+        self._allow_unsafe_deserialization = env_bool(
+            RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR, False
+        )
 
     def _read_stream(self, stream: "pyarrow.NativeFile", path: str):
         """Read and decode samples from a stream.

--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -14,11 +14,9 @@ from ray.data._internal.util import iterate_with_retry
 from ray.data.block import BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 
-
-def _allow_unsafe_deserialization():
-    return (
-        os.environ.get("RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION", "0") == "1"
-    )
+RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR = (
+    "RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION"
+)
 
 
 if TYPE_CHECKING:
@@ -180,7 +178,11 @@ def _group_by_keys(
         yield current_sample
 
 
-def _default_decoder(sample: Dict[str, Any], format: Optional[Union[bool, str]] = True):
+def _default_decoder(
+    sample: Dict[str, Any],
+    format: Optional[Union[bool, str]] = True,
+    allow_unsafe: bool = False,
+):
     """A default decoder for webdataset.
 
     This handles common file extensions: .txt, .cls, .cls2,
@@ -190,6 +192,7 @@ def _default_decoder(sample: Dict[str, Any], format: Optional[Union[bool, str]] 
 
     Args:
         sample: sample, modified in place
+        allow_unsafe: if True, allow pickle/torch deserialization
     """
     sample = dict(sample)
     for key, value in sample.items():
@@ -219,7 +222,7 @@ def _default_decoder(sample: Dict[str, Any], format: Optional[Union[bool, str]] 
 
             sample[key] = msgpack.unpackb(value, raw=False)
         elif extension in ["pt", "pth"]:
-            if not _allow_unsafe_deserialization():
+            if not allow_unsafe:
                 raise ValueError(
                     f"Refusing to load .{extension} member {key!r} from "
                     f"WebDataset with weights_only=False (arbitrary code "
@@ -231,7 +234,7 @@ def _default_decoder(sample: Dict[str, Any], format: Optional[Union[bool, str]] 
 
             sample[key] = torch.load(io.BytesIO(value), weights_only=False)
         elif extension in ["pickle", "pkl"]:
-            if not _allow_unsafe_deserialization():
+            if not allow_unsafe:
                 raise ValueError(
                     f"Refusing to unpickle WebDataset member {key!r} "
                     f"(arbitrary code execution risk). Provide a custom "
@@ -339,6 +342,12 @@ class WebDatasetDatasource(FileBasedDatasource):
     ):
         super().__init__(paths, **file_based_datasource_kwargs)
 
+        self._allow_unsafe_deserialization = (
+            os.environ.get(
+                RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR, "0"
+            )
+            == "1"
+        )
         self.decoder = decoder
         self.fileselect = fileselect
         self.filerename = filerename
@@ -383,9 +392,12 @@ class WebDatasetDatasource(FileBasedDatasource):
         )
 
         samples = _group_by_keys(files, meta=dict(__url__=path), suffixes=self.suffixes)
+        default_decoder = partial(
+            _default_decoder, allow_unsafe=self._allow_unsafe_deserialization
+        )
         for sample in samples:
             if self.decoder is not None:
-                sample = _apply_list(self.decoder, sample, default=_default_decoder)
+                sample = _apply_list(self.decoder, sample, default=default_decoder)
             if self.expand_json:
                 if isinstance(sample["json"], bytes):
                     parsed_json = json.loads(sample["json"].decode("utf-8"))

--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -232,7 +232,7 @@ def test_webdataset_coding(ray_start_2_cpus, tmp_path, allow_unsafe_deserializat
         assert sample["custom"] == "custom-value"
 
 
-def test_webdataset_decoding(ray_start_2_cpus, tmp_path, allow_unsafe_deserialization):
+def test_webdataset_decoding(ray_start_2_cpus, tmp_path):
     import numpy as np
     import torch
 
@@ -318,7 +318,7 @@ def test_custom_decoder_bypasses_unsafe_guard(ray_start_2_cpus, tmp_path):
     def safe_pkl_decoder(sample):
         sample = dict(sample)
         for key, value in sample.items():
-            if key.endswith(".pkl"):
+            if key == "pkl":
                 sample[key] = pickle.loads(value)
         return sample
 

--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -270,7 +270,7 @@ def test_webdataset_decoding(ray_start_2_cpus, tmp_path):
 
 
 @pytest.mark.parametrize("min_rows_per_file", [5, 10, 50])
-def test_write_min_rows_per_file(tmp_path, ray_start_regular_shared, min_rows_per_file):
+def test_write_min_rows_per_file(tmp_path, ray_start_2_cpus, min_rows_per_file):
     ray.data.from_items(
         [{"id": str(i)} for i in range(100)], override_num_blocks=20
     ).write_webdataset(tmp_path, min_rows_per_file=min_rows_per_file)

--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -4,6 +4,7 @@
 import glob
 import io
 import os
+import pickle
 import tarfile
 
 import pytest
@@ -49,7 +50,14 @@ def test_webdataset_read(ray_start_2_cpus, tmp_path):
         assert sample["b"].decode("utf-8") == str(i**2)
 
 
-def test_webdataset_expand_json(ray_start_2_cpus, tmp_path):
+@pytest.fixture
+def allow_unsafe_deserialization(monkeypatch):
+    monkeypatch.setenv("RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION", "1")
+
+
+def test_webdataset_expand_json(
+    ray_start_2_cpus, tmp_path, allow_unsafe_deserialization
+):
     import numpy as np
     import torch
 
@@ -159,7 +167,7 @@ def custom_decoder(sample):
     return sample
 
 
-def test_webdataset_coding(ray_start_2_cpus, tmp_path):
+def test_webdataset_coding(ray_start_2_cpus, tmp_path, allow_unsafe_deserialization):
     import numpy as np
     import PIL.Image
     import torch
@@ -224,7 +232,7 @@ def test_webdataset_coding(ray_start_2_cpus, tmp_path):
         assert sample["custom"] == "custom-value"
 
 
-def test_webdataset_decoding(ray_start_2_cpus, tmp_path):
+def test_webdataset_decoding(ray_start_2_cpus, tmp_path, allow_unsafe_deserialization):
     import numpy as np
     import torch
 
@@ -270,6 +278,55 @@ def test_write_min_rows_per_file(tmp_path, ray_start_regular_shared, min_rows_pe
     for filename in os.listdir(tmp_path):
         dataset = wds.WebDataset(os.path.join(tmp_path, filename))
         assert len(list(dataset)) == min_rows_per_file
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["000000.pkl", "000000.pickle", "000000.pt", "000000.pth"],
+)
+def test_default_decoder_rejects_unsafe_extensions(
+    ray_start_2_cpus, tmp_path, filename
+):
+    path = os.path.join(tmp_path, "unsafe.tar")
+    with TarWriter(path) as tf:
+        tf.write(filename, b"fake-payload")
+
+    ds = ray.data.read_webdataset(paths=[str(tmp_path)])
+    with pytest.raises(Exception, match="Refusing to"):
+        ds.take_all()
+
+
+def test_default_decoder_allows_unsafe_with_env_var(
+    ray_start_2_cpus, tmp_path, allow_unsafe_deserialization
+):
+    path = os.path.join(tmp_path, "trusted.tar")
+    with TarWriter(path) as tf:
+        tf.write("000000.pkl", pickle.dumps({"key": "value"}))
+
+    ds = ray.data.read_webdataset(paths=[str(tmp_path)])
+    rows = ds.take_all()
+
+    assert len(rows) == 1
+    assert rows[0]["pkl"] == {"key": "value"}
+
+
+def test_custom_decoder_bypasses_unsafe_guard(ray_start_2_cpus, tmp_path):
+    path = os.path.join(tmp_path, "custom.tar")
+    with TarWriter(path) as tf:
+        tf.write("000000.pkl", pickle.dumps({"key": "value"}))
+
+    def safe_pkl_decoder(sample):
+        sample = dict(sample)
+        for key, value in sample.items():
+            if key.endswith(".pkl"):
+                sample[key] = pickle.loads(value)
+        return sample
+
+    ds = ray.data.read_webdataset(paths=[str(tmp_path)], decoder=safe_pkl_decoder)
+    rows = ds.take_all()
+
+    assert len(rows) == 1
+    assert rows[0]["pkl"] == {"key": "value"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The default decoder in `read_webdataset` runs `pickle.loads` on `.pkl/.pickle` files and `torch.load(weights_only=False)` on `.pt/.pth` files from attacker-controlled TAR archives, enabling arbitrary code execution with no opt-in. This is the same class of bug as GHSA-mw35-8rx3-xf9r (patched in 2.55.0 for Parquet), but in a different code path that was not addressed.

This PR gates the unsafe `.pkl/.pickle` and `.pt/.pth` branches in `_default_decoder` behind the `RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION=1` environment variable. The error message points users to the existing `decoder` parameter on `ray.data.read_webdataset()` as the safe escape hatch for custom deserialization.

## Related issues

Fixes GHSA-hhrp-gw25-jr43

## Additional information

- Existing tests that rely on `.pt` round-trip encoding/decoding now use a `monkeypatch.setenv` fixture to opt in
- New tests verify: rejection of all four unsafe extensions by default, opt-in via env var, and bypass via custom `decoder` callable