### PR TITLE
[Data] Fail multimodal release tests on worker OOM by default

### DIFF
--- a/release/release_multimodal_inference_benchmarks_tests.yaml
+++ b/release/release_multimodal_inference_benchmarks_tests.yaml
@@ -9,6 +9,8 @@
   cluster:
     byod:
       runtime_env:
+        # Fail the test if a worker OOMs
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
         # Fail the test if a node dies
         - RAYTEST_FAIL_ON_DEAD_NODES=1
 
@@ -112,6 +114,7 @@
     cluster_compute: video_object_detection/compute.yaml
     byod:
       runtime_env:
+        - RAYTEST_FAIL_ON_WORKER_OOM=0  # Expect worker OOM during test
         - RAYTEST_FAIL_ON_DEAD_NODES=0  # Expect node death during test
       post_build_script: byod_install_multimodal_inference_benchmarks_transcription.sh
       python_depset: video_object_detection_py3.10.lock


### PR DESCRIPTION
## Description

The multimodal inference benchmark release tests were missing `RAYTEST_FAIL_ON_WORKER_OOM=1`, so worker OOMs went undetected. This adds it to the DEFAULTS block (matching `release_data_tests.yaml`) and explicitly opts out `video_object_detection`, which already expects node death and worker OOM during test.

## Related issues

None

## Additional information

- `image_classification`, `large_image_embedding`, `document_embedding`, and `audio_transcription` all inherit the default `RAYTEST_FAIL_ON_WORKER_OOM=1`
- `video_object_detection` sets `RAYTEST_FAIL_ON_WORKER_OOM=0` alongside its existing `RAYTEST_FAIL_ON_DEAD_NODES=0`