### PR TITLE
[Data] Fail map_batches benchmark on worker OOM

### DIFF
--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -563,7 +563,7 @@
     byod:
       runtime_env:
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
-        - RAYTEST_FAIL_ON_WORKER_OOM=0
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
     cluster_compute: "{{scaling}}_cpu_compute.yaml"
 


### PR DESCRIPTION
## Description

The map_batches release benchmark had `RAYTEST_FAIL_ON_WORKER_OOM=0`. After we landed some changes to minimize memory bloat like https://github.com/ray-project/ray/pull/62302, the test no longer OOMs, so I'm re-enabling the flag.

## Related issues

None