### PR TITLE
[Data] Repro for map_batches deserialization slowness (investigation only)

### DIFF
--- a/release/nightly_tests/dataset/map_batches_deser_repro.py
+++ b/release/nightly_tests/dataset/map_batches_deser_repro.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Repro: Ray Data map_batches argument-deserialization slowdown.
+
+Four scenarios against the same large (~hundreds of MB) pyarrow Table batches:
+
+  A. Pre-put + tiny arg + ray.get inside __call__   -> baseline (fast deser)
+  B. Bare ray.get of the same batch                 -> raw object-store cost
+  C. read_parquet -> map_batches                    -> slow path (the regression)
+  D. read_parquet().materialize() -> map_batches    -> still slow (proves not upstream)
+
+The parquet must contain an integer column named ``id`` (scenario A indexes
+into pre-put tables by ``batch['id'][0]``). The customer-supplied sample was
+~5000 rows x ~617 columns, ~1.45 GB decoded; any parquet with at least one
+``id`` column and rows >> batch_size should reproduce.
+
+Usage:
+  python repro.py --parquet PATH [--batch-size N] [--n-batches N]
+"""
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import pyarrow.parquet as pq
+import ray
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--parquet", required=True, help="Path to a parquet file with an 'id' column."
+    )
+    p.add_argument("--batch-size", type=int, default=512)
+    p.add_argument("--n-batches", type=int, default=20)
+    return p.parse_args()
+
+
+def snapshot(path):
+    """Dump Ray timeline and collect MapWorker thread IDs that exist now.
+
+    Ray master uses cat names like 'task::MapWorker(MapBatches(MinimalActor)).__init__';
+    older Ray used '_MapWorker'. Match both.
+    """
+    ray.timeline(filename=path)
+    with open(path) as f:
+        tl = json.load(f)
+    tids = {
+        e["tid"]
+        for e in tl
+        if isinstance(e, dict)
+        and e.get("name") == "__init__"
+        and "MapWorker" in e.get("cat", "")
+    }
+    return tl, tids
+
+
+def deser_stats_ms(tl, new_tids):
+    """p25/p50/p90/max of task:deserialize_arguments (ms) for the new MapWorker actors."""
+    durs = sorted(
+        e["dur"] / 1000.0
+        for e in tl
+        if isinstance(e, dict)
+        and e.get("tid") in new_tids
+        and e.get("name") == "task:deserialize_arguments"
+        and e.get("dur", 0) > 0
+    )
+    if not durs:
+        return None
+    n = len(durs)
+    return {
+        "n": n,
+        "p25": durs[n // 4],
+        "p50": durs[n // 2],
+        "p90": durs[int(n * 0.9)],
+        "max": durs[-1],
+    }
+
+
+def load_tables(args):
+    if not Path(args.parquet).exists():
+        raise SystemExit(f"Parquet not found: {args.parquet}")
+    full = pq.read_table(args.parquet)
+    n = min(args.n_batches, full.num_rows // args.batch_size)
+    return [full.slice(i * args.batch_size, args.batch_size) for i in range(n)]
+
+
+def scenario_A_preput_tinyarg(tables):
+    table_refs = [ray.put(t) for t in tables]
+
+    class PrePutActor:
+        def __call__(self, batch):
+            idx = int(batch["id"][0]) % len(table_refs)
+            t = ray.get(table_refs[idx])
+            return {"n": np.array([t.num_rows])}
+
+    tl0, tids0 = snapshot("/tmp/tl_A_before.json")
+    t0 = time.perf_counter()
+    ray.data.range(len(tables)).map_batches(
+        PrePutActor,
+        batch_size=1,
+        num_gpus=0,
+        concurrency=2,
+        batch_format="numpy",
+    ).materialize()
+    wall = time.perf_counter() - t0
+    tl1, tids1 = snapshot("/tmp/tl_A_after.json")
+    return wall, deser_stats_ms(tl1, tids1 - tids0)
+
+
+def scenario_B_bare_rayget(tables):
+    ref = ray.put(tables[0])
+    times_ms = []
+    for _ in range(10):
+        t0 = time.perf_counter()
+        ray.get(ref)
+        times_ms.append((time.perf_counter() - t0) * 1000)
+    times_ms.sort()
+    n = len(times_ms)
+    return None, {
+        "n": n,
+        "p25": times_ms[n // 4],
+        "p50": times_ms[n // 2],
+        "p90": times_ms[int(n * 0.9)],
+        "max": times_ms[-1],
+    }
+
+
+class MinimalActor:
+    def __call__(self, batch):
+        return {"n": np.array([batch.num_rows])}
+
+
+def scenario_C_readparquet_mapbatches(args):
+    ds = ray.data.read_parquet(args.parquet).limit(args.n_batches * args.batch_size)
+    tl0, tids0 = snapshot("/tmp/tl_C_before.json")
+    t0 = time.perf_counter()
+    ds.map_batches(
+        MinimalActor,
+        batch_size=args.batch_size,
+        num_gpus=0,
+        concurrency=2,
+        batch_format="pyarrow",
+        zero_copy_batch=True,
+    ).materialize()
+    wall = time.perf_counter() - t0
+    tl1, tids1 = snapshot("/tmp/tl_C_after.json")
+    return wall, deser_stats_ms(tl1, tids1 - tids0)
+
+
+def scenario_D_prematerialized(args):
+    ds_cached = (
+        ray.data.read_parquet(args.parquet)
+        .limit(args.n_batches * args.batch_size)
+        .materialize()
+    )
+    tl0, tids0 = snapshot("/tmp/tl_D_before.json")
+    t0 = time.perf_counter()
+    ds_cached.map_batches(
+        MinimalActor,
+        batch_size=args.batch_size,
+        num_gpus=0,
+        concurrency=1,
+        batch_format="pyarrow",
+        zero_copy_batch=True,
+    ).materialize()
+    wall = time.perf_counter() - t0
+    tl1, tids1 = snapshot("/tmp/tl_D_after.json")
+    return wall, deser_stats_ms(tl1, tids1 - tids0)
+
+
+def main():
+    args = parse_args()
+    ray.init(ignore_reinit_error=True)
+    print(f"Ray version: {ray.__version__}")
+
+    tables = load_tables(args)
+    print(
+        f"Loaded {len(tables)} batches x {args.batch_size} rows "
+        f"({tables[0].nbytes / 1e6:.1f} MB each)\n"
+    )
+
+    results = {}
+    print("[A] pre-put + tiny arg + ray.get inside ...")
+    results["A_preput_tinyarg"] = scenario_A_preput_tinyarg(tables)
+    print("[B] bare ray.get ...")
+    results["B_bare_rayget"] = scenario_B_bare_rayget(tables)
+    print("[C] read_parquet -> map_batches ...")
+    results["C_readparquet"] = scenario_C_readparquet_mapbatches(args)
+    print("[D] materialized -> map_batches ...")
+    results["D_materialized"] = scenario_D_prematerialized(args)
+
+    print("\n=== Results ===")
+    print(
+        f"{'scenario':<22}  {'wall (s)':>9}  "
+        f"{'n':>4}  {'p25':>7}  {'p50':>7}  {'p90':>7}  {'max':>7}"
+    )
+    print("-" * 75)
+    for name, (wall, stats) in results.items():
+        wall_s = f"{wall:.2f}" if wall is not None else "-"
+        if stats is None:
+            print(
+                f"{name:<22}  {wall_s:>9}  {'-':>4}  {'-':>7}  {'-':>7}  {'-':>7}  {'-':>7}"
+            )
+        else:
+            # B is a single bare-ray.get number — fake it into stats shape
+            print(
+                f"{name:<22}  {wall_s:>9}  {stats['n']:>4}  "
+                f"{stats['p25']:>7.1f}  {stats['p50']:>7.1f}  "
+                f"{stats['p90']:>7.1f}  {stats['max']:>7.1f}"
+            )
+
+    slow = results["C_readparquet"][1]
+    fast = results["B_bare_rayget"][1]
+    if slow and fast:
+        print(
+            f"\nmap_batches deser (p50) vs bare ray.get: "
+            f"{slow['p50'] / fast['p50']:.1f}x slower"
+        )
+        print(
+            f"map_batches deser (p90) vs bare ray.get: "
+            f"{slow['p90'] / fast['p50']:.1f}x slower"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
> **Draft / investigation only.** This PR adds a self-contained repro for a user-reported `task:deserialize_arguments` slowness in `ActorPoolMapOperator`. It is **not** intended to merge as-is — the goal is to share the repro + findings with the Ray Data team and decide where to take it next.

## What the user reported

For a `read_parquet().map_batches(actor, batch_format='pyarrow', zero_copy_batch=True)` pipeline, `task:deserialize_arguments` runs at ~360 ms (p50) per batch, even though a bare `ray.get` of the same plasma object takes ~14 ms. The Dataset object itself is not at fault; the gap shows up only when blocks flow through `ActorPoolMapOperator` as task arguments.

## The repro

`release/nightly_tests/dataset/map_batches_deser_repro.py` runs four scenarios end-to-end against the same pyarrow Table batches and reports `task:deserialize_arguments` p25/p50/p90/max from the Ray timeline:

| # | Scenario | Purpose |
|---|---|---|
| **A** | `ray.put` batches, pass tiny `{id: int}` arg, `ray.get(ref)` inside `__call__` | fast baseline — bypass `ActorPoolMapOperator` arg path |
| **B** | Bare `ray.get` of the same batch from plasma | raw plasma deser cost |
| **C** | `read_parquet().map_batches(actor)` | the slow path |
| **D** | `read_parquet().materialize().map_batches(actor)` | rules out upstream block readiness |

The parquet must have an integer `id` column. The user's sample is ~5000 × 617, ~1.45 GB decoded.

```bash
python release/nightly_tests/dataset/map_batches_deser_repro.py \
  --parquet /path/to/user.parquet \
  --batch-size 512 --n-batches 20
```

## Findings on user master

Run on `ray 3.0.0.dev0` (master), user-supplied sanitized parquet (`5098 × 617`, 9 batches × 512 rows, ~146 MB per batch):

| Scenario | user (older Ray) | Master (3.0.0.dev0) | Δ p50 |
|---|---|---|---|
| **A** pre-put + tiny arg | p50 = 0.3 ms | p50 = 0.8 ms, p90 = 307 ms | ≈ same p50, tail appears |
| **B** bare `ray.get` | 14 ms | p50 = 21 ms | similar |
| **C** `read_parquet → map_batches` | p50 = **360 ms** | p50 = **43 ms**, p90 = 310 ms | **~8× faster at p50** |
| **D** materialized → `map_batches` | p50 = **360 ms** | p50 = **42 ms**, p90 = 107 ms | **~8× faster at p50** |

Wall times also improved: scenario C 17.6 s → 8.9 s, scenario D 6.6 s → 2.4 s.

### Takeaways

1. **The reported median regression is mostly already fixed on master.** Whatever change(s) landed since the user's version dropped p50 from ~360 ms to ~43 ms in both C and D. The most useful next step is to find the user's Ray version and `git log --grep` for the fix between then and now so they have a clear "upgrade to vX.Y" answer.

2. **A residual 2× gap remains at p50** vs raw `ray.get` (43 ms vs 21 ms). `task:deserialize_arguments` for an `ActorPoolMapOperator` task is still doing more than just unpickling the block ref — worth investigating what extra work is on the hot path.

3. **A ~300 ms p90 tail persists** in both the pre-put scenario (A) and `map_batches` (C/D). Since it shows up in A — where the per-task argument is a tiny `{id: int}` — it is more likely **actor first-task warmup** (cold-start, import, JIT) than per-batch data deserialization. Worth confirming before optimizing the data path further.

## Why this is here

Filing as draft so the Ray Data team can:
- Reproduce the (now smaller) gap independently
- Decide whether to keep the script as a perf gate (and where), drop it, or fold it into an existing benchmark
- Help triage the residual 2× p50 / 300 ms p90 tail

Happy to relocate / rename / split into a real benchmark per reviewer feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)