### PR TITLE
[Data] Right-size worker_scaling release-test clusters & align actor/task concurrency

### DIFF
--- a/release/nightly_tests/dataset/fixed_size_1000_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_1000_cpu_compute.yaml
@@ -8,6 +8,6 @@ head_node:
 
 worker_nodes:
     - instance_type: m5.2xlarge
-      min_nodes: 63
-      max_nodes: 63
+      min_nodes: 160
+      max_nodes: 160
       market_type: ON_DEMAND

--- a/release/nightly_tests/dataset/fixed_size_2000_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_2000_cpu_compute.yaml
@@ -8,6 +8,6 @@ head_node:
 
 worker_nodes:
     - instance_type: m5.2xlarge
-      min_nodes: 125
-      max_nodes: 125
+      min_nodes: 320
+      max_nodes: 320
       market_type: ON_DEMAND

--- a/release/nightly_tests/dataset/fixed_size_5000_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_5000_cpu_compute.yaml
@@ -8,6 +8,6 @@ head_node:
 
 worker_nodes:
     - instance_type: m5.2xlarge
-      min_nodes: 313
-      max_nodes: 313
+      min_nodes: 800
+      max_nodes: 800
       market_type: ON_DEMAND

--- a/release/nightly_tests/dataset/fixed_size_500_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_500_cpu_compute.yaml
@@ -8,6 +8,6 @@ head_node:
 
 worker_nodes:
     - instance_type: m5.2xlarge
-      min_nodes: 32
-      max_nodes: 32
+      min_nodes: 80
+      max_nodes: 80
       market_type: ON_DEMAND

--- a/release/nightly_tests/dataset/worker_scaling_benchmark.py
+++ b/release/nightly_tests/dataset/worker_scaling_benchmark.py
@@ -143,9 +143,16 @@ def main(args: argparse.Namespace):
         num_rows = num_blocks * rows_per_block
         ds = ray.data.range(num_rows, override_num_blocks=num_blocks)
 
-        map_kwargs = {"num_cpus": 0.5}
+        # Scale the actor pool inversely with `num_cpus` so the total CPU
+        # reservation (and therefore concurrent in-flight units of work) is the
+        # same as the task path, where concurrent task count is
+        # `cluster_cpu / num_cpus`. This keeps the actor / task results
+        # comparable across `num_cpus` settings.
+        cpus_per_worker = 0.5
+        map_kwargs = {"num_cpus": cpus_per_worker}
         if args.worker_type == "actors":
-            map_kwargs["compute"] = ray.data.ActorPoolStrategy(size=args.num_workers)
+            actor_pool_size = int(args.num_workers / cpus_per_worker)
+            map_kwargs["compute"] = ray.data.ActorPoolStrategy(size=actor_pool_size)
             udf = RealisticSchemaUDF
             map_kwargs["fn_constructor_kwargs"] = {
                 "seed": args.seed,


### PR DESCRIPTION
## Summary

Hotfix for #63420: the `worker_scaling_*` matrix tests hang for the full 30-minute timeout. Two coupled changes:

1. **Resize the four compute YAMLs.** The original PR sized clusters from the actor pool reservation alone and ignored ReadRange.
2. **Scale the actor-pool size inversely with `num_cpus`.** Without this, the actor / task variants were running at different concurrency levels (task path ran ~2× more concurrent units), making `max_scheduling_loop_duration_s` not directly comparable across variants.

## Root cause for the hang

For `num_workers=500` on the as-merged 32-node `m5.2xlarge` cluster (256 vCPU):

| consumer | reservation |
|---|---|
| 500 actors × `num_cpus=0.5` | **250 vCPU** (held permanently, packed 16-per-node) |
| ReadRange tasks (`num_cpus=1`) | 1 per running task |
| **Cluster total** | **256 vCPU** |

The packing matters more than the raw accounting: every node holds 16 actors × 0.5 = 8 vCPU = **full**, so no node has the 1 contiguous free vCPU a `num_cpus=1` ReadRange task needs. Ray Core can't place any read task; the Data resource manager optimistically reserves 64 "slots" anyway and the operators deadlock. The runtime explicitly logs:

```
WARNING resource_manager.py:891 -- Cluster resources are not enough to run any
task from TaskPoolMapOperator[ReadRange]. The job may hang forever unless the
cluster scales up.
```

ReadRange produces 0 blocks → MapBatches actors stay idle → 30-min timeout. Same issue affects all four matrix variants.

## Alignment fix

Before this PR:

| | actor path | task path |
|---|---|---|
| total in-flight at `num_cpus=0.5` | `num_workers` (fixed by `ActorPoolStrategy(size=num_workers)`) | `cluster_cpu / num_cpus` ≈ 2 × `num_workers` |

So at `num_cpus=0.5` the actor path ran at half the concurrency of the task path. Any comparison of `max_scheduling_loop_duration_s` between variants was mixing two different workload sizes.

After this PR:

```python
cpus_per_worker = 0.5
map_kwargs = {"num_cpus": cpus_per_worker}
if args.worker_type == "actors":
    actor_pool_size = int(args.num_workers / cpus_per_worker)
    map_kwargs["compute"] = ray.data.ActorPoolStrategy(size=actor_pool_size)
```

→ both paths reserve `num_workers` vCPU and run with the same concurrency.

## Cluster sizes

Sized to fit `2 × num_workers` actors at `num_cpus=0.5` (= `num_workers` vCPU), packed 16-per-node, plus ~25 % empty-node headroom so ReadRange always has nodes to run on:

| variant | actors (new) | broken (#63420) | **this PR** | pre-#63420 baseline |
|---|---|---|---|---|
| `fixed_size_500_cpu_compute.yaml` | 1000 | 32 | **80** | 63 |
| `fixed_size_1000_cpu_compute.yaml` | 2000 | 63 | **160** | 125 |
| `fixed_size_2000_cpu_compute.yaml` | 4000 | 125 | **320** | 250 |
| `fixed_size_5000_cpu_compute.yaml` | 10000 | 313 | **800** | 625 |

The new sizes are ~27 % larger than the pre-#63420 baselines — that's the intrinsic cost of giving ReadRange room while actor packing is dense. The headline savings `num_cpus=0.5` was supposed to deliver don't materialize once ReadRange's CPU need is properly accounted for. We keep `num_cpus=0.5` anyway because the symmetric actor/task concurrency makes the benchmark meaningful again.

## Test plan

- [ ] CI green on data pipeline
- [ ] Re-trigger the `worker_scaling_500_actors` and `worker_scaling_1000_actors` weekly release tests and confirm they complete within the 1800 s timeout
- [ ] Confirm `max_scheduling_loop_duration_s` now lands in a comparable range for `actors` and `tasks` variants at the same `num_workers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)