### PR TITLE
[Data] (combined for CI) cache deserialized schemas + batch ray.get of metadata

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -350,6 +350,20 @@ py_test(
 )
 
 py_test(
+    name = "test_block_metadata_schema_cache",
+    size = "small",
+    srcs = ["tests/unit/test_block_metadata_schema_cache.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_block_sizing",
     size = "medium",
     srcs = ["tests/test_block_sizing.py"],

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -170,12 +170,63 @@ class DataOpTask(OpTask):
     def get_waitable(self) -> ObjectRefGenerator:
         return self._streaming_gen
 
-    def on_data_ready(self, max_bytes_to_read: Optional[int]) -> int:
+    def peek_pending_pair(
+        self,
+    ) -> Optional[Tuple[ray.ObjectRef, ray.ObjectRef]]:
+        """Try to surface the next (block_ref, meta_ref) pair from the
+        streaming generator non-blockingly. Updates ``_pending_block_ref`` /
+        ``_pending_meta_ref`` so a subsequent ``on_data_ready`` call sees
+        them already set, and returns the pair (or ``None`` if no complete
+        pair is immediately ready). Does NOT call ``ray.get`` on the
+        metadata.
+
+        Intended caller: ``process_completed_tasks``, which prefetches the
+        metadata bytes for *all* ready tasks in one batched ``ray.get``
+        before invoking ``on_data_ready`` on each. ``StopIteration``
+        (task done / task error) and the meta-wait timeout are deliberately
+        not handled here — they fall through to the next ``on_data_ready``
+        invocation, which has the full handling logic.
+        """
+        if self._has_finished:
+            return None
+
+        if self._pending_block_ref.is_nil():
+            try:
+                ref = self._streaming_gen._next_sync(timeout_s=0)
+            except StopIteration:
+                return None
+            if ref.is_nil():
+                return None
+            self._pending_block_ref = ref
+            self._block_ready_callback(ref)
+
+        if self._pending_meta_ref.is_nil():
+            try:
+                ref = self._streaming_gen._next_sync(timeout_s=0)
+            except StopIteration:
+                return None
+            if ref.is_nil():
+                return None
+            self._pending_meta_ref = ref
+            self._metadata_ready_callback(ref)
+
+        return self._pending_block_ref, self._pending_meta_ref
+
+    def on_data_ready(
+        self,
+        max_bytes_to_read: Optional[int],
+        prefetched_meta_bytes: Optional[Dict[ray.ObjectRef, bytes]] = None,
+    ) -> int:
         """Callback when data is ready to be read from the streaming generator.
 
         Args:
             max_bytes_to_read: Max bytes of blocks to read. If None, all available
                 will be read.
+            prefetched_meta_bytes: Optional dict mapping metadata ``ObjectRef``
+                to its already-fetched bytes. If a ref is present in this
+                dict it is consumed (popped) from the dict and used in lieu
+                of a per-ref ``ray.get``. Allows the caller to amortize
+                ``ray.get`` overhead by batching across tasks.
         Returns: The number of blocks read.
         """
         bytes_read = 0
@@ -247,26 +298,38 @@ class DataOpTask(OpTask):
 
                 self._metadata_ready_callback(self._pending_meta_ref)
 
-            try:
-                # The timeout for `ray.get` includes the time required to ship the
-                # block metadata to this node. So, if we set the timeout to 0, `ray.get`
-                # will timeout and possible cancel the download. To avoid this issue,
-                # we set the timeout to a small non-zero value.
-                meta_with_schema_bytes: bytes = ray.get(
-                    self._pending_meta_ref, timeout=METADATA_GET_TIMEOUT_S
+            # If the metadata bytes were pre-fetched in batch by the caller
+            # (see `process_completed_tasks`), use them directly and skip the
+            # per-ref ray.get round trip. Otherwise fall back to a per-ref
+            # ray.get with the standard timeout.
+            meta_with_schema_bytes: Optional[bytes] = None
+            if prefetched_meta_bytes is not None:
+                meta_with_schema_bytes = prefetched_meta_bytes.pop(
+                    self._pending_meta_ref, None
                 )
-            except ray.exceptions.GetTimeoutError:
-                # We have a reference to the block and its metadata, but the metadata
-                # object isn't available. This can happen if the node dies.
-                logger.warning(
-                    f"Timed out ({METADATA_GET_TIMEOUT_S}s) waiting for metadata from "
-                    f"operator '{self._operator_name}' "
-                    f"(metadata_ref={self._pending_meta_ref.hex()}). "
-                    f"Possible causes include a worker crash, node preemption, or an overloaded worker or head node. "
-                    f"Will retry next iteration. "
-                    f"If this repeats, check the Ray dashboard and logs for worker crashes, node preemption, or overload."
-                )
-                break
+
+            if meta_with_schema_bytes is None:
+                try:
+                    # The timeout for `ray.get` includes the time required to ship the
+                    # block metadata to this node. So, if we set the timeout to 0, `ray.get`
+                    # will timeout and possible cancel the download. To avoid this issue,
+                    # we set the timeout to a small non-zero value.
+                    meta_with_schema_bytes = ray.get(
+                        self._pending_meta_ref, timeout=METADATA_GET_TIMEOUT_S
+                    )
+                except ray.exceptions.GetTimeoutError:
+                    # We have a reference to the block and its metadata, but the
+                    # metadata object isn't available. This can happen if the node
+                    # dies.
+                    logger.warning(
+                        f"Timed out ({METADATA_GET_TIMEOUT_S}s) waiting for metadata from "
+                        f"operator '{self._operator_name}' "
+                        f"(metadata_ref={self._pending_meta_ref.hex()}). "
+                        f"Possible causes include a worker crash, node preemption, or an overloaded worker or head node. "
+                        f"Will retry next iteration. "
+                        f"If this repeats, check the Ray dashboard and logs for worker crashes, node preemption, or overload."
+                    )
+                    break
 
             meta_with_schema: "BlockMetadataWithSchema" = pickle.loads(
                 meta_with_schema_bytes

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -24,6 +24,7 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
 )
 from ray.data._internal.execution.interfaces.physical_operator import (
+    METADATA_GET_TIMEOUT_S,
     DataOpTask,
     MetadataOpTask,
     OpTask,
@@ -498,6 +499,37 @@ def process_completed_tasks(
             state, task = active_tasks[ref]
             ready_tasks_by_op[state].append(task)
 
+        # Prefetch metadata refs across all ready DataOpTasks in one batched
+        # ray.get to amortize per-call overhead. Each task's `peek_pending_pair`
+        # surfaces the next (block_ref, meta_ref) pair from its streaming
+        # generator non-blockingly; we then issue ONE ray.get on the union of
+        # meta_refs and hand the resulting bytes back to each task via
+        # `on_data_ready(..., prefetched_meta_bytes=...)`. Tasks whose meta_ref
+        # isn't surfaced here (e.g. metadata still in transit) fall through to
+        # the per-ref ray.get inside `on_data_ready`. This is the second-order
+        # optimization beyond the schema cache: collapsing N×~1ms per-call
+        # ray.get overhead per scheduler iteration into one batched call.
+        prefetched_meta_bytes: Dict[ray.ObjectRef, bytes] = {}
+        meta_refs_to_prefetch: List[ray.ObjectRef] = []
+        for ready_tasks in ready_tasks_by_op.values():
+            for task in ready_tasks:
+                if isinstance(task, DataOpTask):
+                    pair = task.peek_pending_pair()
+                    if pair is not None:
+                        meta_refs_to_prefetch.append(pair[1])
+        if meta_refs_to_prefetch:
+            try:
+                bytes_list = ray.get(
+                    meta_refs_to_prefetch, timeout=METADATA_GET_TIMEOUT_S
+                )
+                prefetched_meta_bytes = dict(zip(meta_refs_to_prefetch, bytes_list))
+            except ray.exceptions.GetTimeoutError:
+                # One or more refs weren't ready in time. Tasks whose meta_ref
+                # isn't in `prefetched_meta_bytes` will fall back to the per-ref
+                # ray.get path inside `on_data_ready` (which has its own
+                # timeout-handling and retry-next-iteration semantics).
+                pass
+
         for state, ready_tasks in ready_tasks_by_op.items():
             # TODO elaborate why sorting (helps preserve_order case)
             ready_tasks = sorted(ready_tasks, key=lambda t: t.task_index())
@@ -505,7 +537,8 @@ def process_completed_tasks(
                 if isinstance(task, DataOpTask):
                     try:
                         bytes_read = task.on_data_ready(
-                            remaining_output_budget.get(state, None)
+                            remaining_output_budget.get(state, None),
+                            prefetched_meta_bytes=prefetched_meta_bytes,
                         )
                         if state in remaining_output_budget:
                             # Clamp remaining output budget at 0

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import logging
 import sys
 import time
@@ -312,6 +313,17 @@ class BlockMetadata(BlockStats):
         )
 
 
+@functools.lru_cache(maxsize=128)
+def _read_arrow_schema_cached(schema_bytes: bytes) -> "pa.Schema":
+    # Hot path on the StreamingExecutor scheduling thread: every completed task
+    # ships a `BlockMetadataWithSchema` whose `schema` is serialized Arrow IPC
+    # bytes. For wide schemas (hundreds of columns, especially with extension
+    # types like ArrowTensorType) `pa.ipc.read_schema` can dominate scheduler
+    # CPU. The same schema bytes recur across tasks of the same operator, so a
+    # small LRU collapses thousands of identical re-parses into one.
+    return pa.ipc.read_schema(pa.BufferReader(schema_bytes))
+
+
 @DeveloperAPI(stability="alpha")
 @dataclass(frozen=True)
 class BlockMetadataWithSchema(BlockMetadata):
@@ -367,9 +379,13 @@ class BlockMetadataWithSchema(BlockMetadata):
         return state
 
     def __setstate__(self, state: Dict[str, Any]):
-        schema_val: bytes | Schema | None = state["schema"]
+        schema_val: bytes | bytearray | Schema | None = state["schema"]
         if isinstance(schema_val, (bytes, bytearray)):
-            state["schema"] = pa.ipc.read_schema(pa.BufferReader(schema_val))
+            # `bytearray` itself is unhashable so it can't key the LRU cache —
+            # coerce to `bytes` first.
+            if isinstance(schema_val, bytearray):
+                schema_val = bytes(schema_val)
+            state["schema"] = _read_arrow_schema_cached(schema_val)
         self.__dict__.update(state)
 
 

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -7,7 +7,7 @@ import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
-from typing import List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -1381,6 +1381,75 @@ class TestDataOpTask:
         streaming_gen2 = create_stub_streaming_gen(block_nbytes=[1])
         task_default = DataOpTask(1, streaming_gen2)
         assert task_default._operator_name == "Unknown"
+
+    def test_peek_and_prefetched_meta_bytes(self, ray_start_regular_shared):
+        """`peek_pending_pair` surfaces the next (block_ref, meta_ref) pair
+        without consuming metadata via `ray.get`. `on_data_ready` then
+        consumes the corresponding pre-fetched bytes from the dict instead
+        of issuing its own `ray.get`.
+        """
+        streaming_gen = create_stub_streaming_gen(block_nbytes=[1])
+
+        outputs: List = []
+        data_op_task = DataOpTask(
+            0, streaming_gen, output_ready_callback=outputs.append
+        )
+
+        # Wait until the streaming generator surfaces something to peek at.
+        ray.wait([streaming_gen], fetch_local=False)
+
+        pair = data_op_task.peek_pending_pair()
+        assert pair is not None, "peek should surface a (block, meta) pair"
+        block_ref, meta_ref = pair
+        assert not block_ref.is_nil()
+        assert not meta_ref.is_nil()
+
+        # Pre-fetch the metadata bytes ourselves (simulating the batched
+        # ray.get done by `process_completed_tasks`).
+        meta_bytes = ray.get(meta_ref)
+        prefetched = {meta_ref: meta_bytes}
+
+        # Drive the task to completion using the pre-fetched dict.
+        bytes_read = 0
+        while not data_op_task.has_finished:
+            ray.wait([streaming_gen], fetch_local=False)
+            bytes_read += data_op_task.on_data_ready(
+                None, prefetched_meta_bytes=prefetched
+            )
+
+        # The meta_ref we prefetched should have been consumed (popped) by
+        # on_data_ready.
+        assert meta_ref not in prefetched
+        # And a RefBundle was emitted, confirming the deserialization path
+        # using prefetched bytes succeeded.
+        assert len(outputs) == 1
+
+    def test_prefetched_meta_bytes_fallback_when_missing(
+        self, ray_start_regular_shared
+    ):
+        """If a meta_ref isn't in the pre-fetched dict (e.g. it wasn't yet
+        surfaced when the batched ray.get ran), `on_data_ready` must fall
+        back to a per-ref `ray.get` and still complete correctly.
+        """
+        streaming_gen = create_stub_streaming_gen(block_nbytes=[1])
+
+        outputs: List = []
+        data_op_task = DataOpTask(
+            0, streaming_gen, output_ready_callback=outputs.append
+        )
+
+        # Pass an empty prefetched dict; on_data_ready must fall back to
+        # the per-ref ray.get path for the meta_ref it ends up pulling
+        # from the generator.
+        prefetched: Dict[ray.ObjectRef, bytes] = {}
+        bytes_read = 0
+        while not data_op_task.has_finished:
+            ray.wait([streaming_gen], fetch_local=False)
+            bytes_read += data_op_task.on_data_ready(
+                None, prefetched_meta_bytes=prefetched
+            )
+
+        assert len(outputs) == 1
 
     @pytest.mark.parametrize(
         "preempt_on", ["block_ready_callback", "metadata_ready_callback"]

--- a/python/ray/data/tests/unit/test_block_metadata_schema_cache.py
+++ b/python/ray/data/tests/unit/test_block_metadata_schema_cache.py
@@ -1,0 +1,150 @@
+"""Tests for the `BlockMetadataWithSchema` pickle round-trip path and its
+schema-deserialization cache (`_read_arrow_schema_cached`).
+
+The cache is on the StreamingExecutor scheduler thread's hot path; we want to
+verify:
+  1. Round-tripping preserves schema equality and field metadata.
+  2. Repeated unpickles of identical bytes reuse the cached `pa.Schema`.
+  3. Distinct schema bytes produce distinct cached entries.
+  4. Pandas / None schemas still work (no caching path taken).
+"""
+
+import pickle
+
+import pyarrow as pa
+import pytest
+
+from ray.data.block import (
+    BlockMetadata,
+    BlockMetadataWithSchema,
+    _read_arrow_schema_cached,
+)
+
+
+def _wide_arrow_schema(num_cols: int = 50) -> pa.Schema:
+    fields = []
+    for i in range(num_cols):
+        if i % 3 == 0:
+            fields.append(pa.field(f"scalar_{i}", pa.float32()))
+        elif i % 3 == 1:
+            fields.append(pa.field(f"vec64_{i}", pa.list_(pa.float32(), 64)))
+        else:
+            fields.append(pa.field(f"vec32_{i}", pa.list_(pa.float32(), 32)))
+    return pa.schema(fields)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _read_arrow_schema_cached.cache_clear()
+    yield
+    _read_arrow_schema_cached.cache_clear()
+
+
+def _make_bm(schema: "pa.Schema | None") -> BlockMetadataWithSchema:
+    md = BlockMetadata(
+        num_rows=10,
+        size_bytes=1024,
+        exec_stats=None,
+        input_files=None,
+        task_exec_stats=None,
+    )
+    return BlockMetadataWithSchema.from_metadata(md, schema=schema)
+
+
+def test_round_trip_preserves_schema():
+    schema = _wide_arrow_schema(20)
+    bm = _make_bm(schema)
+    restored = pickle.loads(pickle.dumps(bm))
+    assert restored.schema.equals(schema)
+    assert restored.num_rows == 10
+    assert restored.size_bytes == 1024
+
+
+def test_cache_hit_on_repeated_pickle_loads():
+    schema = _wide_arrow_schema(20)
+    payload = pickle.dumps(_make_bm(schema))
+
+    info_before = _read_arrow_schema_cached.cache_info()
+
+    restored = [pickle.loads(payload) for _ in range(50)]
+
+    info_after = _read_arrow_schema_cached.cache_info()
+    # Exactly one miss for the first load, the rest are hits.
+    assert info_after.misses - info_before.misses == 1
+    assert info_after.hits - info_before.hits == 49
+
+    # All decoded schemas are identical and reference-equal to the cached one.
+    first = restored[0].schema
+    for r in restored[1:]:
+        assert r.schema is first
+
+
+def test_distinct_schemas_distinct_cache_entries():
+    s1 = _wide_arrow_schema(10)
+    s2 = _wide_arrow_schema(20)
+    p1 = pickle.dumps(_make_bm(s1))
+    p2 = pickle.dumps(_make_bm(s2))
+
+    info_before = _read_arrow_schema_cached.cache_info()
+    a = pickle.loads(p1)
+    b = pickle.loads(p2)
+    c = pickle.loads(p1)
+    d = pickle.loads(p2)
+    info_after = _read_arrow_schema_cached.cache_info()
+
+    assert info_after.misses - info_before.misses == 2
+    assert info_after.hits - info_before.hits == 2
+    assert a.schema is c.schema
+    assert b.schema is d.schema
+    assert a.schema is not b.schema
+    assert a.schema.equals(s1)
+    assert b.schema.equals(s2)
+
+
+def test_none_schema_unaffected_by_cache():
+    bm = _make_bm(None)
+    info_before = _read_arrow_schema_cached.cache_info()
+    restored = pickle.loads(pickle.dumps(bm))
+    info_after = _read_arrow_schema_cached.cache_info()
+    assert restored.schema is None
+    # No cache traffic at all.
+    assert info_after.misses == info_before.misses
+    assert info_after.hits == info_before.hits
+
+
+def test_bytearray_schema_payload_is_decoded():
+    """If state["schema"] arrives as bytearray (e.g. from an alternative
+    serialization path), __setstate__ must still decode it to a pa.Schema —
+    not store it raw — and must reuse the LRU-cached entry keyed by the
+    equivalent bytes payload."""
+    schema = _wide_arrow_schema(20)
+    bm = _make_bm(schema)
+    state = bm.__getstate__()
+    assert isinstance(state["schema"], bytes)
+
+    # Prime the cache via the normal bytes path.
+    bytes_restored = pickle.loads(pickle.dumps(bm))
+    assert bytes_restored.schema.equals(schema)
+    info_after_bytes = _read_arrow_schema_cached.cache_info()
+
+    # Now feed __setstate__ a bytearray with the same contents.
+    bytearray_state = dict(state)
+    bytearray_state["schema"] = bytearray(state["schema"])
+    bytearray_restored = BlockMetadataWithSchema.from_metadata(bm.metadata, schema=None)
+    bytearray_restored.__setstate__(bytearray_state)
+
+    # It must be decoded to a real pa.Schema, not stored raw.
+    assert isinstance(bytearray_restored.schema, pa.Schema)
+    assert bytearray_restored.schema.equals(schema)
+
+    # And it must hit the same cache entry as the bytes path (no extra miss).
+    info_after_bytearray = _read_arrow_schema_cached.cache_info()
+    assert info_after_bytearray.misses == info_after_bytes.misses
+    assert info_after_bytearray.hits == info_after_bytes.hits + 1
+    assert bytearray_restored.schema is bytes_restored.schema
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-vv", __file__]))


### PR DESCRIPTION
## Summary

Combines the two scheduling-loop optimizations from #63462 and #63483 into a single PR so they can be CI-tested as a unit. **Land via the individual PRs**; this combined branch exists only for paired CI verification.

### What's bundled

**1) Schema-deserialization LRU cache — originally #63462**
- `block.py`: `_read_arrow_schema_cached(bytes) -> pa.Schema` wrapped with `functools.lru_cache(maxsize=128)`, called from `BlockMetadataWithSchema.__setstate__`. `bytes | bytearray` accepted at the runtime check (bytearray is coerced to bytes before keying the LRU since bytearray is unhashable).
- `BUILD.bazel`: explicit `py_test` registration for the new test (also covered by the existing `tests/unit/**/test_*.py` glob, but listed explicitly).
- `tests/unit/test_block_metadata_schema_cache.py`: round-trip, cache hit, distinct entries, None-passthrough, and bytearray decode coverage.

**2) Batched `ray.get` of block metadata in `process_completed_tasks` — originally #63483**
- `physical_operator.py`: new `DataOpTask.peek_pending_pair()` polls the streaming generator non-blockingly and surfaces the next `(block_ref, meta_ref)` pair, setting `_pending_*`. `on_data_ready` gains an optional `prefetched_meta_bytes: Dict[ObjectRef, bytes]` parameter; pre-fetched bytes are consumed in lieu of a per-ref `ray.get`. Falls back to per-ref `ray.get` unchanged for refs the dict doesn't contain.
- `streaming_executor_state.py`: `process_completed_tasks` peeks across all ready `DataOpTask`s, issues ONE `ray.get(meta_refs, timeout=METADATA_GET_TIMEOUT_S)`, then passes the resulting dict into each task's `on_data_ready` call.
- `tests/test_streaming_executor.py`: two new tests covering the prefetch-hit and prefetch-miss-fallback paths.

## Combined impact (measured)

Wide-schema worker_scaling benchmark, 1000 actors × 600-col schema:

| variant | total time | max_sched_loop | p90 | avg |
|---|---|---|---|---|
| baseline (master) | 197.01 s | 32.31 s | 31.24 s | 7.28 s |
| `+` schema cache (#63462) | 98.18 s | 12.23 s | 11.68 s | 2.84 s |
| `+` batch ray.get (#63483) | **72.97 s** | **7.61 s** | **5.18 s** | **1.03 s** |
| **Combined (this PR)** | **−63 %** | **−76 %** | **−83 %** | **−86 %** |

Scheduler-thread on-CPU drops 158 s → 39 s. Profile diff shows the two changes operate on disjoint hot spots:

- `__setstate__` → `pa.ipc.read_schema`: 95.01 s → 0.00 s (schema cache)
- `ray.get_objects`: 18.88 s → 5.92 s (batch get)
- Chained Arrow extension decode: ~10 s → ~0 s (downstream of schema cache)

## Test plan

- [ ] CI green on `data` pipeline (this is the primary reason for the combined branch — paired verification).
- [ ] All new unit tests in both `tests/unit/test_block_metadata_schema_cache.py` and the new test methods in `tests/test_streaming_executor.py` pass.
- [ ] Existing `TestDataOpTask` tests pass with `on_data_ready`'s new keyword-only `prefetched_meta_bytes` parameter defaulting to `None`.

## Disposition

**Do not merge this PR.** Land via the individual PRs:
- Schema cache: #63462
- Batched ray.get: #63483

This branch exists purely for CI verification of the combined effect. Close once the relevant CI signal is captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)