### PR TITLE
[Data] Make logging configurable by RAY_DATA_LOG_LEVEL env var

### DIFF
--- a/python/ray/data/_internal/logging.py
+++ b/python/ray/data/_internal/logging.py
@@ -311,7 +311,13 @@ def _configure_loggers(config: dict, handlers: dict) -> None:
     """Configure logger instances from config."""
     for logger_name, logger_config in config.get("loggers", {}).items():
         logger = logging.getLogger(logger_name)
-        logger.setLevel(logger_config.get("level", logging.NOTSET))
+        # The environment variable takes precedence over the config.
+        log_level = (
+            os.environ.get("RAY_DATA_LOG_LEVEL")
+            or logger_config.get("level")
+            or logging.NOTSET
+        )
+        logger.setLevel(log_level)
 
         # Clear existing handlers
         for handler in logger.handlers[:]:

--- a/python/ray/data/tests/test_logging.py
+++ b/python/ray/data/tests/test_logging.py
@@ -75,6 +75,18 @@ def test_messages_printed_to_console(
     assert "ham" in capsys.readouterr().err
 
 
+def test_env_var_configures_log_level(
+    monkeypatch,
+    reset_logging,
+):
+    monkeypatch.setenv("RAY_DATA_LOG_LEVEL", "TRACE")
+
+    configure_logging()
+
+    logger = logging.getLogger("ray.data")
+    assert logger.getEffectiveLevel() == logging.getLevelName("TRACE")
+
+
 def test_hidden_messages_not_printed_to_console(
     capsys,
     configure_logging,


### PR DESCRIPTION
## Description

Allow users to configure Ray Data's log level via the `RAY_DATA_LOG_LEVEL` environment variable. The env var takes precedence over the logging config file, making it easy to adjust log verbosity (e.g., to `DEBUG` or `TRACE`) by setting an environment variable in your image without modifying config files.

## Related issues

None.

