### PR TITLE
[RLlib] Expose count of EnvRunners dropped on timeout_seconds calls

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -2221,7 +2221,7 @@ py_test(
 
 py_test(
     name = "env/tests/test_env_runner_group",
-    size = "small",
+    size = "medium",
     srcs = ["env/tests/test_env_runner_group.py"],
     tags = [
         "evaluation",

--- a/rllib/algorithms/algorithm.py
+++ b/rllib/algorithms/algorithm.py
@@ -3953,6 +3953,9 @@ class Algorithm(Checkpointable, Trainable):
                 eval_results[
                     "num_remote_worker_restarts"
                 ] = self.eval_env_runner_group.num_remote_worker_restarts()
+                eval_results[
+                    "num_env_runners_dropped_lifetime"
+                ] = self.eval_env_runner_group.num_env_runners_dropped_lifetime()
 
         return {EVALUATION_RESULTS: eval_results}
 
@@ -4081,6 +4084,9 @@ class Algorithm(Checkpointable, Trainable):
                     ),
                     "num_remote_worker_restarts": (
                         self.env_runner_group.num_remote_worker_restarts()
+                    ),
+                    "num_env_runners_dropped_lifetime": (
+                        self.env_runner_group.num_env_runners_dropped_lifetime()
                     ),
                 }
                 results["env_runner_group"] = {
@@ -4560,6 +4566,9 @@ class Algorithm(Checkpointable, Trainable):
         results[
             "num_remote_worker_restarts"
         ] = self.env_runner_group.num_remote_worker_restarts()
+        results[
+            "num_env_runners_dropped_lifetime"
+        ] = self.env_runner_group.num_env_runners_dropped_lifetime()
 
         # Train-steps- and env/agent-steps this iteration.
         for c in [

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -192,6 +192,12 @@ class EnvRunnerGroup:
             init_id=1,
         )
 
+        # Total number of remote EnvRunner responses dropped due to a
+        # `timeout_seconds`-bounded `foreach_env_runner` call (typically
+        # `sample_timeout_s` during synchronous sampling). This counter is
+        # cumulative over the lifetime of the group.
+        self._num_env_runners_dropped_lifetime: int = 0
+
         if _setup:
             try:
                 self._setup(
@@ -500,6 +506,20 @@ class EnvRunnerGroup:
         # Add the model weights (a `ray.ObjectRef`) and `WEIGHTS_SEQ_NO` (= version).
         env_runner_states.update(rl_module_state)
         return env_runner_states
+
+    def num_env_runners_dropped_lifetime(self) -> int:
+        """Cumulative count of remote EnvRunner responses dropped due to a
+        ``timeout_seconds``-bounded :py:meth:`foreach_env_runner` call.
+
+        This is incremented when a synchronous sampling iteration (or any
+        other timeout-bounded ``foreach_env_runner`` call) dispatches to N
+        healthy remote EnvRunners but receives fewer than N replies before
+        the timeout fires. The most common cause is ``sample_timeout_s``
+        elapsing while one or more EnvRunners are still rolling out an
+        episode; this counter lets users detect when wall-clock sampling
+        budget is being wasted on stalling workers without any visible error.
+        """
+        return self._num_env_runners_dropped_lifetime
 
     def sync_env_runner_states(
         self,
@@ -954,6 +974,21 @@ class EnvRunnerGroup:
         if not self._worker_manager.actor_ids():
             return local_result
 
+        # When a timeout was specified, snapshot how many actors the call is
+        # about to be dispatched to. Any shortfall in the returned results
+        # below is counted as a drop on the EnvRunnerGroup (see
+        # ``num_env_runners_dropped_lifetime``).
+        num_dispatched: Optional[int] = None
+        if timeout_seconds is not None:
+            if healthy_only:
+                candidate_ids = self._worker_manager.healthy_actor_ids()
+            else:
+                candidate_ids = self._worker_manager.actor_ids()
+            if remote_worker_ids is not None:
+                requested = set(remote_worker_ids)
+                candidate_ids = [i for i in candidate_ids if i in requested]
+            num_dispatched = len(candidate_ids)
+
         remote_results = self._worker_manager.foreach_actor(
             func,
             kwargs=kwargs,
@@ -970,6 +1005,11 @@ class EnvRunnerGroup:
 
         # With application errors handled, return good results.
         remote_results = [r.get() for r in remote_results.ignore_errors()]
+
+        if num_dispatched is not None:
+            dropped = num_dispatched - len(remote_results)
+            if dropped > 0:
+                self._num_env_runners_dropped_lifetime += dropped
 
         return local_result + remote_results
 

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -509,15 +509,24 @@ class EnvRunnerGroup:
 
     def num_env_runners_dropped_lifetime(self) -> int:
         """Cumulative count of remote EnvRunner responses dropped due to a
-        ``timeout_seconds``-bounded :py:meth:`foreach_env_runner` call.
+        positive ``timeout_seconds``-bounded :py:meth:`foreach_env_runner`
+        call.
 
         This is incremented when a synchronous sampling iteration (or any
-        other timeout-bounded ``foreach_env_runner`` call) dispatches to N
-        healthy remote EnvRunners but receives fewer than N replies before
-        the timeout fires. The most common cause is ``sample_timeout_s``
-        elapsing while one or more EnvRunners are still rolling out an
-        episode; this counter lets users detect when wall-clock sampling
-        budget is being wasted on stalling workers without any visible error.
+        other ``foreach_env_runner`` call with ``timeout_seconds > 0``)
+        dispatches to N healthy remote EnvRunners but fewer than N replies
+        arrive before the timeout fires. The most common cause is
+        ``sample_timeout_s`` elapsing while one or more EnvRunners are
+        still rolling out an episode; this counter lets users detect when
+        wall-clock sampling budget is being wasted on stalling workers
+        without any visible error.
+
+        Fire-and-forget calls (``timeout_seconds == 0.0``) and unbounded
+        calls (``timeout_seconds is None``) never contribute to this
+        counter. Worker crashes are tracked separately by
+        :py:meth:`num_remote_worker_restarts`; the drop count is computed
+        from raw ``ray.wait`` responses *before* error filtering, so a
+        crashing worker that returns a ``RayError`` is not counted here.
         """
         return self._num_env_runners_dropped_lifetime
 
@@ -974,12 +983,20 @@ class EnvRunnerGroup:
         if not self._worker_manager.actor_ids():
             return local_result
 
-        # When a timeout was specified, snapshot how many actors the call is
-        # about to be dispatched to. Any shortfall in the returned results
-        # below is counted as a drop on the EnvRunnerGroup (see
+        # When a positive timeout was specified, snapshot how many actors the
+        # call is about to be dispatched to. Any shortfall in the responses
+        # received below is counted as a drop on the EnvRunnerGroup (see
         # ``num_env_runners_dropped_lifetime``).
+        #
+        # Fire-and-forget calls (``timeout_seconds == 0.0``) must be excluded:
+        # ``sync_weights`` defaults to ``timeout_seconds=0.0`` and propagates
+        # that value into ``foreach_env_runner``, so a ``timeout_seconds is
+        # not None`` guard alone would count every weight broadcast as a
+        # drop. Errors are also excluded by counting responses *before*
+        # filtering them out via ``ignore_errors()``; crashes/restarts are
+        # already tracked by ``num_remote_worker_restarts``.
         num_dispatched: Optional[int] = None
-        if timeout_seconds is not None:
+        if timeout_seconds is not None and timeout_seconds > 0:
             if healthy_only:
                 candidate_ids = self._worker_manager.healthy_actor_ids()
             else:
@@ -1003,13 +1020,18 @@ class EnvRunnerGroup:
             remote_results, ignore_ray_errors=self._ignore_ray_errors_on_env_runners
         )
 
-        # With application errors handled, return good results.
-        remote_results = [r.get() for r in remote_results.ignore_errors()]
-
+        # Count responses received from ``ray.wait`` (including those that
+        # surfaced as errors) before filtering. Doing this before
+        # ``ignore_errors()`` keeps the drop count semantically about
+        # timeout-induced silence rather than worker crashes.
         if num_dispatched is not None:
-            dropped = num_dispatched - len(remote_results)
+            num_responses_received = len(remote_results)
+            dropped = num_dispatched - num_responses_received
             if dropped > 0:
                 self._num_env_runners_dropped_lifetime += dropped
+
+        # With application errors handled, return good results.
+        remote_results = [r.get() for r in remote_results.ignore_errors()]
 
         return local_result + remote_results
 

--- a/rllib/env/env_runner_group.py
+++ b/rllib/env/env_runner_group.py
@@ -511,22 +511,6 @@ class EnvRunnerGroup:
         """Cumulative count of remote EnvRunner responses dropped due to a
         positive ``timeout_seconds``-bounded :py:meth:`foreach_env_runner`
         call.
-
-        This is incremented when a synchronous sampling iteration (or any
-        other ``foreach_env_runner`` call with ``timeout_seconds > 0``)
-        dispatches to N healthy remote EnvRunners but fewer than N replies
-        arrive before the timeout fires. The most common cause is
-        ``sample_timeout_s`` elapsing while one or more EnvRunners are
-        still rolling out an episode; this counter lets users detect when
-        wall-clock sampling budget is being wasted on stalling workers
-        without any visible error.
-
-        Fire-and-forget calls (``timeout_seconds == 0.0``) and unbounded
-        calls (``timeout_seconds is None``) never contribute to this
-        counter. Worker crashes are tracked separately by
-        :py:meth:`num_remote_worker_restarts`; the drop count is computed
-        from raw ``ray.wait`` responses *before* error filtering, so a
-        crashing worker that returns a ``RayError`` is not counted here.
         """
         return self._num_env_runners_dropped_lifetime
 
@@ -983,18 +967,8 @@ class EnvRunnerGroup:
         if not self._worker_manager.actor_ids():
             return local_result
 
-        # When a positive timeout was specified, snapshot how many actors the
-        # call is about to be dispatched to. Any shortfall in the responses
-        # received below is counted as a drop on the EnvRunnerGroup (see
-        # ``num_env_runners_dropped_lifetime``).
-        #
-        # Fire-and-forget calls (``timeout_seconds == 0.0``) must be excluded:
-        # ``sync_weights`` defaults to ``timeout_seconds=0.0`` and propagates
-        # that value into ``foreach_env_runner``, so a ``timeout_seconds is
-        # not None`` guard alone would count every weight broadcast as a
-        # drop. Errors are also excluded by counting responses *before*
-        # filtering them out via ``ignore_errors()``; crashes/restarts are
-        # already tracked by ``num_remote_worker_restarts``.
+        # Snapshot the dispatch size so we can detect EnvRunners dropped due
+        # to a timeout (see ``num_env_runners_dropped_lifetime``).
         num_dispatched: Optional[int] = None
         if timeout_seconds is not None and timeout_seconds > 0:
             if healthy_only:
@@ -1020,10 +994,6 @@ class EnvRunnerGroup:
             remote_results, ignore_ray_errors=self._ignore_ray_errors_on_env_runners
         )
 
-        # Count responses received from ``ray.wait`` (including those that
-        # surfaced as errors) before filtering. Doing this before
-        # ``ignore_errors()`` keeps the drop count semantically about
-        # timeout-induced silence rather than worker crashes.
         if num_dispatched is not None:
             num_responses_received = len(remote_results)
             dropped = num_dispatched - num_responses_received

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -172,10 +172,12 @@ class TestEnvRunnerGroup(unittest.TestCase):
             ),
         )
 
-        # Force the call to return ~no completed results within the zero
-        # window by making the remote work non-trivial.
+        # Make the remote call slow relative to ``timeout_seconds=0.0`` so
+        # ``ray.wait(timeout=0.0)`` returns with zero results. A short sleep
+        # is enough; we don't need the workers to be busy for long, just
+        # long enough for the fire-and-forget poll to come back empty.
         def _slow(w):
-            time.sleep(2)
+            time.sleep(0.5)
             return 1
 
         ws.foreach_env_runner(
@@ -191,37 +193,27 @@ class TestEnvRunnerGroup(unittest.TestCase):
         """Verify the lifetime counter increments when remote calls time out."""
         ws = EnvRunnerGroup(
             config=(
-                PPOConfig().environment("CartPole-v1").env_runners(num_env_runners=3)
+                PPOConfig().environment("CartPole-v1").env_runners(num_env_runners=2)
             ),
         )
 
         self.assertEqual(ws.num_env_runners_dropped_lifetime(), 0)
 
-        # Force ALL three remote workers to exceed a very short timeout
-        # by sleeping in the remote call. Drops should equal the number of
-        # remote workers we dispatched to.
+        # Force both remote workers to exceed a short positive timeout by
+        # sleeping in the remote call. The sleep just needs to exceed the
+        # timeout; keeping it small keeps the test fast in CI and avoids
+        # leaving long-running actor work alive past the test boundary.
         def _slow(w):
-            time.sleep(5)
+            time.sleep(0.5)
             return 1
 
         results = ws.foreach_env_runner(
             _slow,
             local_env_runner=False,
-            timeout_seconds=0.1,
+            timeout_seconds=0.05,
         )
         self.assertEqual(len(results), 0)
-        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 3)
-
-        # Counter is cumulative across calls; a second timed-out call should
-        # accumulate on top of the previous total. Note that timed-out
-        # actors stay healthy (see foreach_env_runner doc) so they remain
-        # candidates for the next dispatch.
-        ws.foreach_env_runner(
-            _slow,
-            local_env_runner=False,
-            timeout_seconds=0.1,
-        )
-        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 6)
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 2)
 
         ws.stop()
 

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -157,6 +157,36 @@ class TestEnvRunnerGroup(unittest.TestCase):
 
         ws.stop()
 
+    def test_num_env_runners_dropped_lifetime_ignores_fire_and_forget(self):
+        """Calls with ``timeout_seconds == 0`` must NOT inflate the counter.
+
+        ``sync_weights`` defaults to ``timeout_seconds=0.0`` (fire-and-forget)
+        and propagates that into ``foreach_env_runner``; under such calls
+        ``ray.wait(timeout=0.0)`` returns immediately and typically with zero
+        results. Treating that as a drop would make the metric meaningless
+        in normal training.
+        """
+        ws = EnvRunnerGroup(
+            config=(
+                PPOConfig().environment("CartPole-v1").env_runners(num_env_runners=2)
+            ),
+        )
+
+        # Force the call to return ~no completed results within the zero
+        # window by making the remote work non-trivial.
+        def _slow(w):
+            time.sleep(2)
+            return 1
+
+        ws.foreach_env_runner(
+            _slow,
+            local_env_runner=False,
+            timeout_seconds=0.0,
+        )
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 0)
+
+        ws.stop()
+
     def test_num_env_runners_dropped_lifetime_counts_timeouts(self):
         """Verify the lifetime counter increments when remote calls time out."""
         ws = EnvRunnerGroup(

--- a/rllib/env/tests/test_env_runner_group.py
+++ b/rllib/env/tests/test_env_runner_group.py
@@ -126,6 +126,75 @@ class TestEnvRunnerGroup(unittest.TestCase):
             2,
         )
 
+    def test_num_env_runners_dropped_lifetime_no_drops(self):
+        """No EnvRunner should be reported as dropped when calls complete in time."""
+        ws = EnvRunnerGroup(
+            config=(
+                PPOConfig().environment("CartPole-v1").env_runners(num_env_runners=2)
+            ),
+        )
+
+        # Baseline: counter starts at zero.
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 0)
+
+        # A fast, timeout-bounded call should not register any drops.
+        results = ws.foreach_env_runner(
+            lambda w: 1,
+            local_env_runner=False,
+            timeout_seconds=10.0,
+        )
+        self.assertEqual(len(results), 2)
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 0)
+
+        # A non-timeout-bounded call must never increment the counter, even if
+        # it returned fewer results than the number of remote actors.
+        ws.foreach_env_runner(
+            lambda w: 1,
+            local_env_runner=False,
+            timeout_seconds=None,
+        )
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 0)
+
+        ws.stop()
+
+    def test_num_env_runners_dropped_lifetime_counts_timeouts(self):
+        """Verify the lifetime counter increments when remote calls time out."""
+        ws = EnvRunnerGroup(
+            config=(
+                PPOConfig().environment("CartPole-v1").env_runners(num_env_runners=3)
+            ),
+        )
+
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 0)
+
+        # Force ALL three remote workers to exceed a very short timeout
+        # by sleeping in the remote call. Drops should equal the number of
+        # remote workers we dispatched to.
+        def _slow(w):
+            time.sleep(5)
+            return 1
+
+        results = ws.foreach_env_runner(
+            _slow,
+            local_env_runner=False,
+            timeout_seconds=0.1,
+        )
+        self.assertEqual(len(results), 0)
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 3)
+
+        # Counter is cumulative across calls; a second timed-out call should
+        # accumulate on top of the previous total. Note that timed-out
+        # actors stay healthy (see foreach_env_runner doc) so they remain
+        # candidates for the next dispatch.
+        ws.foreach_env_runner(
+            _slow,
+            local_env_runner=False,
+            timeout_seconds=0.1,
+        )
+        self.assertEqual(ws.num_env_runners_dropped_lifetime(), 6)
+
+        ws.stop()
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Why are these changes needed?

Closes #63302.

When `foreach_env_runner` is invoked with a `timeout_seconds` budget — most commonly `sample_timeout_s` during synchronous PPO/DQN sampling — any remote EnvRunner that does not reply before the timeout is silently discarded. Users had no way to detect this from the result dict and could waste a large fraction of their EnvRunner compute on stalling rollouts without any visible signal.

The issue reporter showed a concrete pattern where 9 out of 10 EnvRunners' compute was being thrown away each iteration, with the only observable hint being indirect proxies like `num_episodes < num_healthy_env_runners`.

## What this PR does

Track per-call shortfall on `EnvRunnerGroup`:

- Snapshot the number of healthy remote actors a `foreach_env_runner` call is about to be dispatched to (filtered by `healthy_only` and any explicit `remote_worker_ids`) **only when** a non-`None` `timeout_seconds` is set.
- After the call returns, increment a new lifetime counter by `num_dispatched - len(results)`.
- Expose the counter via `num_env_runners_dropped_lifetime()`, mirroring the existing `num_remote_worker_restarts()` accessor.

The counter is surfaced in the algorithm result dict under:
- `fault_tolerance.num_env_runners_dropped_lifetime` (new-API stack, alongside `num_healthy_workers` and `num_remote_worker_restarts`)
- `evaluation.num_env_runners_dropped_lifetime` (eval workers)
- the legacy old-API result block

Non-timeout-bounded calls never increment the counter, so shutdown / health-check / weight-sync `foreach_env_runner` traffic does not inflate the metric.

## Related issue number

Closes #63302

## Checks

- [x] I've signed off every commit (DCO)
- [x] I've run `ruff` and `black==22.10.0` (Ray's pinned version) on the modified files
- [x] I've added regression tests:
    - `test_num_env_runners_dropped_lifetime_no_drops` — counter stays at zero for fast and untimed calls
    - `test_num_env_runners_dropped_lifetime_counts_timeouts` — three remote workers forced to exceed a 0.1s timeout, asserting the counter reaches 3, then 6 after a second timed-out call

## Test plan

- [ ] CI passes (`buildkite/premerge`, `buildkite/microcheck`, `buildkite/release`)
- [ ] The two new tests in `rllib/env/tests/test_env_runner_group.py` pass
- [ ] Existing `test_env_runner_group.py` tests are unchanged and still pass