### PR TITLE
[RLlib] Fix offline prelearner test

### DIFF
--- a/rllib/offline/tests/test_offline_prelearner.py
+++ b/rllib/offline/tests/test_offline_prelearner.py
@@ -206,10 +206,14 @@ class TestOfflinePreLearner:
     ):
         """Tests that _validate_deprecated_map_args: deprecated kwargs are honored and emit warnings."""
 
-        base_config.offline_data(
+        offline_data_kwargs = dict(
             input_=[data_path],
             dataset_num_iters_per_learner=1,
         )
+        if data_path == SAMPLE_BATCH_DATA_PATH:
+            offline_data_kwargs["input_read_method"] = "read_json"
+            offline_data_kwargs["input_read_sample_batches"] = True
+        base_config.offline_data(**offline_data_kwargs)
 
         algo = base_config.build()
         offline_prelearner = OfflinePreLearner(


### PR DESCRIPTION
## Description

Offline prelearner test has been broken for a while. 
Story:

- When we introduced the test, we'd tell RLlib's offline data API to use ``SAMPLE_BATCH_DATA_PATH`` (a json file).
- But we'd forget to set ``input_read_method = "read_json"`` and ``input_read_sample_batches = True``
- So we'd use the read parquet read method in the offline prelearner under the hood
- Behind the scenes, Ray Data's Datasource v1 API would look for parquets at the path and not find any and return
- The was a silent bug in the original implementation
- We now default  Ray Datasource v2 API which exposes this bug in RLlib's test because it errors out if the dataset is empty