### PR TITLE
[core] Improve WARNING message in inspect_serializability with action…

### DIFF
--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -2,7 +2,6 @@
 import collections
 import io
 import logging
-import pickle
 import re
 import string
 import sys
@@ -778,9 +777,7 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
 def test_inspect_serializability_warning_message_is_actionable():
     """Regression test: WARNING message should include actionable guidance,
     not just say 'this may be an oversight'."""
-    import io
-
-    from ray.util import inspect_serializability
+    from ray.util.check_serialize import inspect_serializability
 
     # A custom __reduce__ that lies to cloudpickle but trips
     # the traversal — produces the WARNING branch.

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -774,6 +774,7 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
     # It should pass.
     ray.get(test.remote())
 
+
 def test_inspect_serializability_warning_message_is_actionable():
     """Regression test: WARNING message should include actionable guidance,
     not just say 'this may be an oversight'."""

--- a/python/ray/tests/test_serialization.py
+++ b/python/ray/tests/test_serialization.py
@@ -2,6 +2,7 @@
 import collections
 import io
 import logging
+import pickle
 import re
 import string
 import sys
@@ -33,7 +34,7 @@ def test_simple_serialization(ray_start_regular):
         b"a",
         "a",
         string.printable,
-        "\u262F",
+        "\u262f",
         "hello world",
         "\xff\xfe\x9c\x001\x000\x00",
         None,
@@ -151,7 +152,7 @@ def test_complex_serialization(ray_start_regular):
         [1 << 100, [1 << 100]],
         "a",
         string.printable,
-        "\u262F",
+        "\u262f",
         "hello world",
         "\xff\xfe\x9c\x001\x000\x00",
         None,
@@ -773,6 +774,32 @@ def test_can_out_of_band_serialize_object_ref_with_env_var(shutdown_only, monkey
 
     # It should pass.
     ray.get(test.remote())
+
+def test_inspect_serializability_warning_message_is_actionable():
+    """Regression test: WARNING message should include actionable guidance,
+    not just say 'this may be an oversight'."""
+    import io
+
+    from ray.util import inspect_serializability
+
+    # A custom __reduce__ that lies to cloudpickle but trips
+    # the traversal — produces the WARNING branch.
+    class Tricky:
+        def __reduce__(self):
+            raise TypeError("cannot pickle 'Tricky' object")
+
+        def method(self):
+            pass
+
+    output = io.StringIO()
+    inspect_serializability(Tricky(), print_file=output)
+    result = output.getvalue()
+
+    # The warning must exist (Tricky trips the warning branch)
+    assert "WARNING" in result
+    # It must now contain actionable guidance, not the old dead-end message
+    assert "inspect_serializability" in result
+    assert "This may be an oversight" not in result
 
 
 def test_inspect_func_serialization_prints_qualname():

--- a/python/ray/util/check_serialize.py
+++ b/python/ray/util/check_serialize.py
@@ -164,7 +164,9 @@ def _inspect_generic_serialization(
             if found:
                 break
     if not found:
-        obj_name = base_obj.__name__ if inspect.isclass(base_obj) else type(base_obj).__name__
+        obj_name = (
+            base_obj.__name__ if inspect.isclass(base_obj) else type(base_obj).__name__
+        )
         printer.print(
             f"WARNING: Did not find non-serializable object in "
             f"{obj_name if inspect.isclass(base_obj) else f'{obj_name} instance'}. "

--- a/python/ray/util/check_serialize.py
+++ b/python/ray/util/check_serialize.py
@@ -164,12 +164,10 @@ def _inspect_generic_serialization(
             if found:
                 break
     if not found:
-        obj_name = (
-            base_obj.__name__ if inspect.isclass(base_obj) else type(base_obj).__name__
-        )
+        obj_name = base_obj.__name__ if inspect.isclass(base_obj) else type(base_obj).__name__
         printer.print(
             f"WARNING: Did not find non-serializable object in "
-            f"{obj_name} instance. "
+            f"{obj_name if inspect.isclass(base_obj) else f'{obj_name} instance'}. "
             "This may be because the object is only non-serializable when "
             "combined with other objects, or because cloudpickle and the "
             "traversal disagree. "

--- a/python/ray/util/check_serialize.py
+++ b/python/ray/util/check_serialize.py
@@ -1,4 +1,5 @@
 """A utility for debugging serialization issues."""
+
 import inspect
 from contextlib import contextmanager
 from typing import Any, Optional, Set, Tuple
@@ -111,9 +112,14 @@ def _inspect_func_serialization(base_obj, depth, parent, failure_set, printer, p
                 if found:
                     break
     if not found:
+        obj_name = getattr(base_obj, "__qualname__", None) or repr(base_obj)
         printer.print(
-            f"WARNING: Did not find non-serializable object in {base_obj}. "
-            "This may be an oversight."
+            f"WARNING: Did not find non-serializable object in {obj_name}. "
+            "This may be because the object is only non-serializable when "
+            "combined with other objects, or because cloudpickle and the "
+            "traversal disagree on which object causes the failure. "
+            "Try calling `ray.util.inspect_serializability` directly on "
+            "the suspected object, or simplify the closure to isolate the cause."
         )
     return found
 
@@ -158,9 +164,15 @@ def _inspect_generic_serialization(
             if found:
                 break
     if not found:
+        obj_name = getattr(base_obj, "__class__", type(base_obj)).__name__
         printer.print(
-            f"WARNING: Did not find non-serializable object in {base_obj}. "
-            "This may be an oversight."
+            f"WARNING: Did not find non-serializable object in "
+            f"{obj_name} instance. "
+            "This may be because the object is only non-serializable when "
+            "combined with other objects, or because cloudpickle and the "
+            "traversal disagree. "
+            "Try calling `ray.util.inspect_serializability` on individual "
+            "attributes to isolate the cause."
         )
     return found
 

--- a/python/ray/util/check_serialize.py
+++ b/python/ray/util/check_serialize.py
@@ -164,7 +164,9 @@ def _inspect_generic_serialization(
             if found:
                 break
     if not found:
-        obj_name = getattr(base_obj, "__class__", type(base_obj)).__name__
+        obj_name = (
+            base_obj.__name__ if inspect.isclass(base_obj) else type(base_obj).__name__
+        )
         printer.print(
             f"WARNING: Did not find non-serializable object in "
             f"{obj_name} instance. "


### PR DESCRIPTION
## Why are these changes needed?

When `inspect_serializability` fails to identify the exact non-serializable
sub-object, it currently emits a generic warning saying the result
"may be an oversight." That message is not actionable.

This PR improves the warning by:
- naming the object more clearly
- explaining why traversal may disagree with `cloudpickle`
- suggesting concrete next steps to isolate the issue

## Example

Before:

> WARNING: Did not find non-serializable object in `<main.Model ...>`. This may be an oversight.

After:

> WARNING: Did not find non-serializable object in `Model` instance.  
> This may be because the object is only non-serializable when combined with other objects, or because `cloudpickle` and the traversal disagree.  
> Try calling `ray.util.inspect_serializability` on individual attributes to isolate the cause.

## Related issues

Partially addresses #31074

## Checks

- [x] Signed off commit with `git commit -s`
- [x] Ran `ruff`, `black`, and `pydoclint`
- [x] Added test coverage
- [x] No doc changes needed