### PR TITLE
[core] Fix `test_task_events.py::test_failed_task_runtime_env_setup`

### DIFF
--- a/python/ray/tests/test_task_events.py
+++ b/python/ray/tests/test_task_events.py
@@ -243,34 +243,24 @@ def test_failed_task_unschedulable(shutdown_only):
 
 
 def test_failed_task_runtime_env_setup(shutdown_only):
-    import conda
-
     @ray.remote
     def f():
         pass
 
     bad_env = RuntimeEnv(
-        conda={
-            "channels": ["defaults"],
-            "dependencies": ["_this_does_not_exist"],
-        }
+        pip=["nonexistent-package"],
     )
     with pytest.raises(
         RuntimeEnvSetupError,
     ):
         ray.get(f.options(runtime_env=bad_env, name="task-runtime-env-failed").remote())
 
-    conda_major_version = int(conda.__version__.split(".")[0])
-    error_message = (
-        "PackagesNotFoundError"
-        if conda_major_version >= 24
-        else "ResolvePackageNotFound"
-    )
     wait_for_condition(
         verify_failed_task,
         name="task-runtime-env-failed",
         error_type="RUNTIME_ENV_SETUP_FAILED",
-        error_message=error_message,
+        # Verify that the pip error content is propagated to task event.
+        error_message="nonexistent-package",
     )
 
 


### PR DESCRIPTION
Started failing due to output change in new conda version.

Updated test to be more generic and use `pip` instead of conda.