### PR TITLE
[Dashboard] Add locate mode to log viewer with match navigation

### DIFF
--- a/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
+++ b/python/ray/dashboard/client/src/components/LogView/LogVirtualView.tsx
@@ -1,11 +1,14 @@
-import { Box, Typography } from "@mui/material";
+import { alpha, Box, Typography } from "@mui/material";
 import dayjs from "dayjs";
 import prolog from "highlight.js/lib/languages/prolog";
 import { lowlight } from "lowlight";
 import React, {
+  forwardRef,
   MutableRefObject,
   useCallback,
   useEffect,
+  useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -91,6 +94,14 @@ export type LogVirtualViewProps = {
   revert?: boolean;
   startTime?: string;
   endTime?: string;
+  /** Search mode: "locate" shows all lines with navigation, "filter" shows only matching lines */
+  searchMode?: "filter" | "locate";
+  /** Callback when match info changes (total matches, current index) */
+  onMatchInfoChange?: (info: { total: number; currentIndex: number }) => void;
+};
+
+export type LogVirtualViewHandle = {
+  scrollToMatch: (matchIndex: number) => void;
 };
 
 type LogLineDetailDialogProps = {
@@ -194,237 +205,322 @@ const LogLineDetailDialog = ({
   );
 };
 
-const LogVirtualView: React.FC<LogVirtualViewProps> = ({
-  content,
-  width = "100%",
-  height,
-  fontSize = 12,
-  theme = "light",
-  keywords = "",
-  language = "dos",
-  focusLine = 1,
-  style = {},
-  listRef,
-  onScrollBottom,
-  revert = false,
-  startTime,
-  endTime,
-}) => {
-  const [logs, setLogs] = useState<{ i: number; origin: string }[]>([]);
-  const total = logs.length;
-  const timmer = useRef<ReturnType<typeof setTimeout>>();
-  const el = useRef<List>(null);
-  const outter = useRef<HTMLDivElement>(null);
-  if (listRef) {
-    listRef.current = outter.current;
-  }
-  const [selectedLogLine, setSelectedLogLine] =
-    useState<[string | null, string]>();
-  const handleLogLineClick = useCallback(
-    (logLine: string | null, message: string) => {
-      setSelectedLogLine([logLine, message]);
+const LogVirtualView = forwardRef<LogVirtualViewHandle, LogVirtualViewProps>(
+  (
+    {
+      content,
+      width = "100%",
+      height,
+      fontSize = 12,
+      theme = "light",
+      keywords = "",
+      language = "dos",
+      focusLine = 1,
+      style = {},
+      listRef,
+      onScrollBottom,
+      revert = false,
+      startTime,
+      endTime,
+      searchMode = "locate",
+      onMatchInfoChange,
     },
-    [],
-  );
-
-  const itemRenderer = ({ index, style }: { index: number; style: any }) => {
-    const { i, origin } = logs[revert ? logs.length - 1 - index : index];
-
-    let message = origin;
-    let formattedLogLine: string | null = null;
-    try {
-      const parsedOrigin = JSON.parse(origin);
-      // Iff the parsed origin has a message field, use it as the message.
-      if (parsedOrigin.message) {
-        message = parsedOrigin.message;
-        // If levelname exist on the structured logs, put it in front of the message.
-        if (parsedOrigin.levelname) {
-          message = `${parsedOrigin.levelname} ${message}`;
-        }
-        // If asctime exist on the structured logs, use it as the prefix of the message.
-        if (parsedOrigin.asctime) {
-          message = `${parsedOrigin.asctime}\t${message}`;
-        }
-      }
-      formattedLogLine = JSON.stringify(parsedOrigin, null, 2);
-    } catch (e) {
-      // Keep the `origin` as message, if json parsing failed.
-      // If formattedLogLine is null, then the log line is not JSON and we will
-      // not show the raw json dialog pop up.
+    ref,
+  ) => {
+    const [logs, setLogs] = useState<{ i: number; origin: string }[]>([]);
+    const [matchIndices, setMatchIndices] = useState<number[]>([]);
+    const [currentMatchIndex, setCurrentMatchIndex] = useState<number>(-1);
+    const total = logs.length;
+    const timer = useRef<ReturnType<typeof setTimeout>>();
+    const el = useRef<List>(null);
+    const outter = useRef<HTMLDivElement>(null);
+    if (listRef) {
+      listRef.current = outter.current;
     }
+    const [selectedLogLine, setSelectedLogLine] =
+      useState<[string | null, string]>();
+    const handleLogLineClick = useCallback(
+      (logLine: string | null, message: string) => {
+        setSelectedLogLine([logLine, message]);
+      },
+      [],
+    );
+
+    // Create a set of matching line indices for O(1) lookup
+    const matchIndexSet = useMemo(
+      () => new Set(matchIndices),
+      [matchIndices],
+    );
+
+    // Expose scrollToMatch via ref
+    useImperativeHandle(ref, () => ({
+      scrollToMatch: (matchIndex: number) => {
+        if (matchIndex >= 0 && matchIndex < matchIndices.length) {
+          setCurrentMatchIndex(matchIndex);
+          const logIndex = matchIndices[matchIndex];
+          if (el.current) {
+            const listIndex = revert ? logs.length - 1 - logIndex : logIndex;
+            el.current.scrollToItem(listIndex, "center");
+          }
+        }
+      },
+    }));
+
+    // Notify parent when match info changes
+    useEffect(() => {
+      if (onMatchInfoChange) {
+        onMatchInfoChange({
+          total: matchIndices.length,
+          currentIndex: currentMatchIndex,
+        });
+      }
+    }, [matchIndices, currentMatchIndex, onMatchInfoChange]);
+
+    const itemRenderer = ({ index, style }: { index: number; style: any }) => {
+      const logIndex = revert ? logs.length - 1 - index : index;
+      const { i, origin } = logs[logIndex];
+      const isMatch = searchMode === "locate" && keywords && matchIndexSet.has(logIndex);
+      const isCurrentMatch = isMatch && matchIndices[currentMatchIndex] === logIndex;
+
+      let message = origin;
+      let formattedLogLine: string | null = null;
+      try {
+        const parsedOrigin = JSON.parse(origin);
+        // Iff the parsed origin has a message field, use it as the message.
+        if (parsedOrigin.message) {
+          message = parsedOrigin.message;
+          // If levelname exist on the structured logs, put it in front of the message.
+          if (parsedOrigin.levelname) {
+            message = `${parsedOrigin.levelname} ${message}`;
+          }
+          // If asctime exist on the structured logs, use it as the prefix of the message.
+          if (parsedOrigin.asctime) {
+            message = `${parsedOrigin.asctime}\t${message}`;
+          }
+        }
+        formattedLogLine = JSON.stringify(parsedOrigin, null, 2);
+      } catch (e) {
+        // Keep the `origin` as message, if json parsing failed.
+        // If formattedLogLine is null, then the log line is not JSON and we will
+        // not show the raw json dialog pop up.
+      }
+
+      return (
+        <Box
+          key={`${index}list`}
+          style={style}
+          sx={(theme) => ({
+            // Explicitly create a stacking context so that the ::after pseudo-element
+            // with z-index: -1 stays behind the text but in front of the list background.
+            zIndex: 0,
+            overflowX: "visible",
+            whiteSpace: "nowrap",
+            // Highlight the current match with a distinct background
+            ...(isCurrentMatch && {
+              backgroundColor: alpha(theme.palette.warning.main, 0.3),
+            }),
+            // Highlight other matches with a subtle background
+            ...(isMatch && !isCurrentMatch && {
+              backgroundColor: alpha(theme.palette.warning.main, 0.12),
+            }),
+            // Reveal the hidden button on row hover using a CSS-only selector.
+            // This avoids React state changes on every mouse move, keeping
+            // scroll and render performance smooth for large log files.
+            "&:hover .log-line-details-btn": {
+              opacity: 1,
+              pointerEvents: "auto",
+            },
+            // Expand the row hover area to cover blank viewport space when
+            // the log panel is horizontally scrolled.
+            "&::after": {
+              content: '""',
+              position: "absolute",
+              top: 0,
+              right: "calc(-1 * var(--log-view-scroll-left, 0px))",
+              width: "var(--log-view-scroll-left, 0px)",
+              height: "100%",
+              zIndex: -1,
+            },
+            "&::before": {
+              content: `"${i + 1}"`,
+              marginRight: 0.5,
+              width: `${logs.length}`.length * 6 + 4,
+              color: theme.palette.text.disabled,
+              display: "inline-block",
+            },
+          })}
+        >
+          {lowlight
+            .highlight(language, message)
+            .children.map((v) => value2react(v, index.toString(), keywords))}
+          {/* Only render the button for structured (JSON) log lines.
+              Plain text lines have no additional data to show in the dialog. */}
+
+          {formattedLogLine !== null && (
+            <button
+              className="log-line-details-btn"
+              onClick={(e) => {
+                e.stopPropagation();
+                if ((window.getSelection()?.toString().length ?? 0) === 0) {
+                  handleLogLineClick(formattedLogLine, message);
+                }
+              }}
+            >
+              Show details
+            </button>
+          )}
+          <br />
+        </Box>
+      );
+    };
+
+    useEffect(() => {
+      const originContent = content.split("\n");
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+      timer.current = setTimeout(() => {
+        const allLines = originContent.map((e, i) => ({
+          i,
+          origin: e,
+          time: (startTime || endTime) ? (e?.match(timeReg) || [""])[0] : "",
+        }));
+
+        // Apply time filtering
+        const timeFiltered = allLines.filter((e) => {
+          let bool = true;
+          if (
+            e.time &&
+            startTime &&
+            !dayjs(e.time).isAfter(dayjs(startTime))
+          ) {
+            bool = false;
+          }
+          if (e.time && endTime && !dayjs(e.time).isBefore(dayjs(endTime))) {
+            bool = false;
+          }
+          return bool;
+        });
+
+        if (searchMode === "locate" || !keywords) {
+          // Locate mode: show all lines, track which ones match
+          const filtered = timeFiltered.map((e) => ({ i: e.i, origin: e.origin }));
+          setLogs(filtered);
+
+          // Compute match indices
+          if (keywords) {
+            const indices: number[] = [];
+            filtered.forEach((line, idx) => {
+              if (line.origin.includes(keywords)) {
+                indices.push(idx);
+              }
+            });
+            setMatchIndices(indices);
+            // Reset to first match when keywords change
+            setCurrentMatchIndex(indices.length > 0 ? 0 : -1);
+            // Auto-scroll to first match
+            if (indices.length > 0 && el.current) {
+              const firstMatchIndex = indices[0];
+              setTimeout(() => {
+                const listIndex = revert ? filtered.length - 1 - firstMatchIndex : firstMatchIndex;
+                el.current?.scrollToItem(listIndex, "center");
+              }, 0);
+            }
+          } else {
+            setMatchIndices([]);
+            setCurrentMatchIndex(-1);
+          }
+        } else {
+          // Filter mode: show only matching lines (original behavior)
+          const filtered = timeFiltered
+            .filter((e) => e.origin.includes(keywords))
+            .map((e) => ({ i: e.i, origin: e.origin }));
+          setLogs(filtered);
+          setMatchIndices([]);
+          setCurrentMatchIndex(-1);
+        }
+      }, 500);
+    }, [content, keywords, language, startTime, endTime, searchMode]);
+
+    useEffect(() => {
+      if (el.current) {
+        el.current?.scrollTo((focusLine - 1) * (fontSize + 6));
+      }
+    }, [focusLine, fontSize]);
+
+    useEffect(() => {
+      let outterCurrentValue: any = null;
+      if (outter.current) {
+        outter.current.style.setProperty("--log-view-scroll-left", "0px");
+
+        const scrollFunc = (event: any) => {
+          const { target } = event;
+          if (target) {
+            const scrollLeft = `${target.scrollLeft ?? 0}px`;
+            if (
+              target.style.getPropertyValue("--log-view-scroll-left") !==
+              scrollLeft
+            ) {
+              target.style.setProperty("--log-view-scroll-left", scrollLeft);
+            }
+          }
+          if (
+            target &&
+            target.scrollTop + target.clientHeight === target.scrollHeight
+          ) {
+            if (onScrollBottom) {
+              onScrollBottom(event);
+            }
+          }
+          outterCurrentValue = outter.current;
+        };
+        outter.current.addEventListener("scroll", scrollFunc);
+        return () => {
+          if (outterCurrentValue) {
+            outterCurrentValue.removeEventListener("scroll", scrollFunc);
+          }
+        };
+      }
+    }, [onScrollBottom]);
 
     return (
-      <Box
-        key={`${index}list`}
-        style={style}
-        sx={(theme) => ({
-          // Explicitly create a stacking context so that the ::after pseudo-element
-          // with z-index: -1 stays behind the text but in front of the list background.
-          zIndex: 0,
-          overflowX: "visible",
-          whiteSpace: "nowrap",
-          // Reveal the hidden button on row hover using a CSS-only selector.
-          // This avoids React state changes on every mouse move, keeping
-          // scroll and render performance smooth for large log files.
-          "&:hover .log-line-details-btn": {
-            opacity: 1,
-            pointerEvents: "auto",
-          },
-          // Expand the row hover area to cover blank viewport space when
-          // the log panel is horizontally scrolled.
-          "&::after": {
-            content: '""',
-            position: "absolute",
-            top: 0,
-            right: "calc(-1 * var(--log-view-scroll-left, 0px))",
-            width: "var(--log-view-scroll-left, 0px)",
-            height: "100%",
-            zIndex: -1,
-          },
-          "&::before": {
-            content: `"${i + 1}"`,
-            marginRight: 0.5,
-            width: `${logs.length}`.length * 6 + 4,
-            color: theme.palette.text.disabled,
-            display: "inline-block",
-          },
-        })}
-      >
-        {lowlight
-          .highlight(language, message)
-          .children.map((v) => value2react(v, index.toString(), keywords))}
-        {/* Only render the button for structured (JSON) log lines.
-            Plain text lines have no additional data to show in the dialog. */}
-
-        {formattedLogLine !== null && (
-          <button
-            className="log-line-details-btn"
-            onClick={(e) => {
-              e.stopPropagation();
-              if ((window.getSelection()?.toString().length ?? 0) === 0) {
-                handleLogLineClick(formattedLogLine, message);
-              }
-            }}
-          >
-            Show details
-          </button>
+      <div>
+        {logs && logs.length > MAX_LINES_FOR_LOGS && (
+          <Box component="p" sx={{ color: (theme) => theme.palette.error.main }}>
+            [Truncation warning] This log has been truncated and only the latest{" "}
+            {MAX_LINES_FOR_LOGS} lines are displayed. Click "Download" button
+            above to see the full log
+          </Box>
         )}
-        <br />
-      </Box>
-    );
-  };
-
-  useEffect(() => {
-    const originContent = content.split("\n");
-    if (timmer.current) {
-      clearTimeout(timmer.current);
-    }
-    timmer.current = setTimeout(() => {
-      setLogs(
-        originContent
-          .map((e, i) => ({
-            i,
-            origin: e,
-            time: (e?.match(timeReg) || [""])[0],
-          }))
-          .filter((e) => {
-            let bool = e.origin.includes(keywords);
-            if (
-              e.time &&
-              startTime &&
-              !dayjs(e.time).isAfter(dayjs(startTime))
-            ) {
-              bool = false;
-            }
-            if (e.time && endTime && !dayjs(e.time).isBefore(dayjs(endTime))) {
-              bool = false;
-            }
-            return bool;
-          })
-          .map((e) => ({
-            ...e,
-          })),
-      );
-    }, 500);
-  }, [content, keywords, language, startTime, endTime]);
-
-  useEffect(() => {
-    if (el.current) {
-      el.current?.scrollTo((focusLine - 1) * (fontSize + 6));
-    }
-  }, [focusLine, fontSize]);
-
-  useEffect(() => {
-    let outterCurrentValue: any = null;
-    if (outter.current) {
-      outter.current.style.setProperty("--log-view-scroll-left", "0px");
-
-      const scrollFunc = (event: any) => {
-        const { target } = event;
-        if (target) {
-          const scrollLeft = `${target.scrollLeft ?? 0}px`;
-          if (
-            target.style.getPropertyValue("--log-view-scroll-left") !==
-            scrollLeft
-          ) {
-            target.style.setProperty("--log-view-scroll-left", scrollLeft);
-          }
-        }
-        if (
-          target &&
-          target.scrollTop + target.clientHeight === target.scrollHeight
-        ) {
-          if (onScrollBottom) {
-            onScrollBottom(event);
-          }
-        }
-        outterCurrentValue = outter.current;
-      };
-      outter.current.addEventListener("scroll", scrollFunc);
-      return () => {
-        if (outterCurrentValue) {
-          outterCurrentValue.removeEventListener("scroll", scrollFunc);
-        }
-      };
-    }
-  }, [onScrollBottom]);
-
-  return (
-    <div>
-      {logs && logs.length > MAX_LINES_FOR_LOGS && (
-        <Box component="p" sx={{ color: (theme) => theme.palette.error.main }}>
-          [Truncation warning] This log has been truncated and only the latest{" "}
-          {MAX_LINES_FOR_LOGS} lines are displayed. Click "Download" button
-          above to see the full log
-        </Box>
-      )}
-      <List
-        height={height || 600}
-        width={width}
-        ref={el}
-        outerRef={outter}
-        className={`hljs-${theme}`}
-        style={{
-          fontSize,
-          fontFamily: "menlo, monospace",
-          ...style,
-        }}
-        itemSize={fontSize + 6}
-        itemCount={total}
-      >
-        {itemRenderer}
-      </List>
-      {selectedLogLine && (
-        <LogLineDetailDialog
-          formattedLogLine={selectedLogLine[0]}
-          message={selectedLogLine[1]}
-          onClose={() => {
-            setSelectedLogLine(undefined);
+        <List
+          height={height || 600}
+          width={width}
+          ref={el}
+          outerRef={outter}
+          className={`hljs-${theme}`}
+          style={{
+            fontSize,
+            fontFamily: "menlo, monospace",
+            ...style,
           }}
-        />
-      )}
-    </div>
-  );
-};
+          itemSize={fontSize + 6}
+          itemCount={total}
+          overscanCount={50}
+        >
+          {itemRenderer}
+        </List>
+        {selectedLogLine && (
+          <LogLineDetailDialog
+            formattedLogLine={selectedLogLine[0]}
+            message={selectedLogLine[1]}
+            onClose={() => {
+              setSelectedLogLine(undefined);
+            }}
+          />
+        )}
+      </div>
+    );
+  },
+);
 
 export default LogVirtualView;

--- a/python/ray/dashboard/client/src/pages/log/LogViewer.tsx
+++ b/python/ray/dashboard/client/src/pages/log/LogViewer.tsx
@@ -1,15 +1,24 @@
-import { SearchOutlined } from "@mui/icons-material";
+import {
+  KeyboardArrowDown,
+  KeyboardArrowUp,
+  SearchOutlined,
+} from "@mui/icons-material";
 import {
   Box,
   Button,
+  IconButton,
   InputAdornment,
   LinearProgress,
   Switch,
   TextField,
+  Tooltip,
+  Typography,
 } from "@mui/material";
-import React, { memo, useContext, useState } from "react";
+import React, { memo, useCallback, useContext, useRef, useState } from "react";
 import { GlobalContext } from "../../App";
-import LogVirtualView from "../../components/LogView/LogVirtualView";
+import LogVirtualView, {
+  LogVirtualViewHandle,
+} from "../../components/LogView/LogVirtualView";
 
 const useLogViewer = () => {
   const [search, setSearch] =
@@ -18,9 +27,14 @@ const useLogViewer = () => {
       lineNumber?: string;
       fontSize?: number;
       revert?: boolean;
-    }>();
+      searchMode?: "filter" | "locate";
+    }>({ searchMode: "locate" });
   const [startTime, setStart] = useState<string>();
   const [endTime, setEnd] = useState<string>();
+  const [matchInfo, setMatchInfo] = useState<{
+    total: number;
+    currentIndex: number;
+  }>({ total: 0, currentIndex: -1 });
 
   return {
     search,
@@ -29,6 +43,8 @@ const useLogViewer = () => {
     setStart,
     endTime,
     setEnd,
+    matchInfo,
+    setMatchInfo,
   };
 };
 
@@ -52,9 +68,38 @@ export const LogViewer = memo(
     onRefreshClick,
     height = 600,
   }: LogViewerProps) => {
-    const { search, setSearch, startTime, setStart, endTime, setEnd } =
-      useLogViewer();
+    const {
+      search,
+      setSearch,
+      startTime,
+      setStart,
+      endTime,
+      setEnd,
+      matchInfo,
+      setMatchInfo,
+    } = useLogViewer();
     const { themeMode } = useContext(GlobalContext);
+    const logViewRef = useRef<LogVirtualViewHandle>(null);
+
+    const handlePrevMatch = useCallback(() => {
+      if (matchInfo.total > 0 && logViewRef.current) {
+        const newIndex =
+          matchInfo.currentIndex <= 0
+            ? matchInfo.total - 1
+            : matchInfo.currentIndex - 1;
+        logViewRef.current.scrollToMatch(newIndex);
+      }
+    }, [matchInfo]);
+
+    const handleNextMatch = useCallback(() => {
+      if (matchInfo.total > 0 && logViewRef.current) {
+        const newIndex =
+          matchInfo.currentIndex >= matchInfo.total - 1
+            ? 0
+            : matchInfo.currentIndex + 1;
+        logViewRef.current.scrollToMatch(newIndex);
+      }
+    }, [matchInfo]);
 
     return (
       <React.Fragment>
@@ -68,6 +113,16 @@ export const LogViewer = memo(
                   onChange: ({ target: { value } }) => {
                     setSearch({ ...search, keywords: value });
                   },
+                  onKeyDown: (e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      if (e.shiftKey) {
+                        handlePrevMatch();
+                      } else {
+                        handleNextMatch();
+                      }
+                    }
+                  },
                   type: "",
                   endAdornment: (
                     <InputAdornment position="end">
@@ -80,6 +135,45 @@ export const LogViewer = memo(
                   ),
                 }}
               />
+              {/* Search mode navigation controls */}
+              {search?.searchMode === "locate" && search?.keywords && (
+                <Box
+                  sx={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    margin: 1,
+                    gap: 0.5,
+                  }}
+                >
+                  <Typography variant="body2" sx={{ minWidth: 60 }}>
+                    {matchInfo.total > 0
+                      ? `${matchInfo.currentIndex + 1} / ${matchInfo.total}`
+                      : "0 / 0"}
+                  </Typography>
+                  <Tooltip title="Previous match (Shift+Enter)">
+                    <span>
+                      <IconButton
+                        size="small"
+                        onClick={handlePrevMatch}
+                        disabled={matchInfo.total === 0}
+                      >
+                        <KeyboardArrowUp />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                  <Tooltip title="Next match (Enter)">
+                    <span>
+                      <IconButton
+                        size="small"
+                        onClick={handleNextMatch}
+                        disabled={matchInfo.total === 0}
+                      >
+                        <KeyboardArrowDown />
+                      </IconButton>
+                    </span>
+                  </Tooltip>
+                </Box>
+              )}
               <TextField
                 id="datetime-local"
                 label="Start Time"
@@ -106,10 +200,24 @@ export const LogViewer = memo(
                 }}
               />
               <Box sx={{ margin: 1 }}>
+                Filter Mode:{" "}
+                <Tooltip title="Filter mode shows only matching lines. Locate mode shows all lines with navigation.">
+                  <Switch
+                    checked={search?.searchMode === "filter"}
+                    onChange={(_, checked) =>
+                      setSearch({
+                        ...search,
+                        searchMode: checked ? "filter" : "locate",
+                      })
+                    }
+                  />
+                </Tooltip>
                 Reverse:{" "}
                 <Switch
                   checked={search?.revert}
-                  onChange={(e, v) => setSearch({ ...search, revert: v })}
+                  onChange={(_, checked) =>
+                    setSearch({ ...search, revert: checked })
+                  }
                 />
                 {onRefreshClick && (
                   <Button
@@ -143,6 +251,7 @@ export const LogViewer = memo(
               </Box>
             </div>
             <LogVirtualView
+              ref={logViewRef}
               height={height}
               revert={search?.revert}
               keywords={search?.keywords}
@@ -153,6 +262,8 @@ export const LogViewer = memo(
               theme={themeMode}
               startTime={startTime}
               endTime={endTime}
+              searchMode={search?.searchMode}
+              onMatchInfoChange={setMatchInfo}
             />
           </div>
         )}


### PR DESCRIPTION
## Why are these changes needed?

The current log search in Ray Dashboard only supports **filter mode**, which shows only lines matching the keyword. This makes it difficult to understand the context around matching lines — for example, what happened immediately before/after an error.

This PR adds a **"Locate" mode** (as the new default) that:
- Shows **all log lines** with keyword matches highlighted in-place
- Displays a match count indicator (e.g., "3 / 15") 
- Supports **prev/next navigation** between matches via buttons and keyboard shortcuts
- Keeps the existing filter mode available via a toggle switch

### Motivation

When debugging distributed Ray applications, users often search for keywords like `ERROR`, `timeout`, or actor names in logs. With filter-only behavior:

1. **Context is lost** — the error line is shown without the preceding lines that explain the cause
2. **Navigation is manual** — users must clear the search and scroll to see surrounding lines
3. **No match count** — users cannot tell how many matches exist or track their position

This is the standard search behavior in tools like VS Code, Chrome DevTools, and `less`.

### UI Design

```
┌─────────────────────────────────────────────────────────────────┐
│ [🔍 Keyword]  [3 / 15] [▲] [▼]   Filter Mode: [OFF]  Reverse  │
├─────────────────────────────────────────────────────────────────┤
│  line 41: normal log line                                       │
│  line 42: normal log line                                       │
│▶ line 43: log with [KEYWORD] highlighted  ← current match      │
│  line 44: normal log line                                       │
│  line 45: another [KEYWORD] match (subtle highlight)            │
│  line 46: normal log line                                       │
└─────────────────────────────────────────────────────────────────┘
```

**Keyboard shortcuts:**
- `Enter` — Jump to next match
- `Shift+Enter` — Jump to previous match

## Related issue number

N/A (new feature)

## Checks

- [x] I've signed the [CLA](https://docs.google.com/forms/d/e/1FAIpQLSfp3bMNaA_M64ZqoB2BsHOuC0IYbjzY5Y8e25QhbeMjPx-YAg/viewform)
- [x] I've run `scripts/format.sh` to lint the changes in this PR
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/
- [x] I've made sure the tests are passing
- Testing Strategy:
  - [x] TypeScript compilation passes (`npx tsc --noEmit`)
  - [ ] Manual testing with Ray Dashboard (screenshots to be added)