### PR TITLE
[Core][GPU fraction][6/n] Update all callers to reference the base class type instead of NodeResources

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -1134,3 +1134,11 @@ RAY_CONFIG(uint64_t, gcs_resource_broadcast_max_batch_delay_ms, 0)
 // Whether to enable/disable multiple gRPC connections to improve object transfer
 // throughput.
 RAY_CONFIG(bool, experimental_object_manager_enable_multiple_connections, true)
+
+/// This is a temporary config for fixing GPU fractional scheduling by tracking
+/// per-instance availability. If true, use per-instance resource view (NewNodeResources)
+/// for cluster scheduling instead of the scalar NodeResources. This enables accurate GPU
+/// fragmentation detection in the scheduler so that tasks are not scheduled to nodes
+/// where aggregate GPU capacity is sufficient but no single GPU instance has enough
+/// remaining capacity. Defaults to false.
+RAY_CONFIG(bool, enable_per_instance_resource_scheduling, false)

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -15,9 +15,11 @@
 #include "ray/common/scheduling/cluster_resource_data.h"
 
 #include <algorithm>
+#include <optional>
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace ray {
 
@@ -74,7 +76,8 @@ NodeResourcesV2 ResourceMapToNodeResourcesV2(
     const absl::flat_hash_map<std::string, std::string> &node_labels) {
   NodeResourcesV2 node_resources;
   node_resources.total = NodeResourceSet(resource_map_total);
-  node_resources.SetAvailable(NodeResourceSet(resource_map_available));
+  node_resources.SetAvailable(
+      NodeResourceInstanceSet(NodeResourceSet(resource_map_available)));
   node_resources.labels = node_labels;
   return node_resources;
 }
@@ -230,7 +233,7 @@ float NodeResourcesV2::CalculateCriticalResourceUtilization() const {
     if (cur_total == 0) {
       continue;
     }
-    auto cur_available = this->available.Get(ResourceID(i)).Double();
+    auto cur_available = this->available.Sum(ResourceID(i)).Double();
     float utilization = 1 - (cur_available / cur_total.Double());
     if (utilization > highest) {
       highest = utilization;
@@ -252,7 +255,7 @@ bool NodeResourcesV2::IsAvailable(const ResourceRequest &resource_request,
     return false;
   }
 
-  return this->available >= resource_request.GetResourceSet();
+  return this->available.CanAllocate(resource_request.GetResourceSet());
 }
 
 bool NodeResourcesV2::IsFeasible(const ResourceRequest &resource_request) const {
@@ -335,39 +338,41 @@ std::string NodeResourcesV2::DebugString() const {
 std::string NodeResourcesV2::DictString() const { return DebugString(); }
 
 FixedPoint NodeResourcesV2::GetAvailableSum(scheduling::ResourceID resource_id) const {
-  return available.Get(resource_id);
+  return available.Sum(resource_id);
 }
 
 std::set<scheduling::ResourceID> NodeResourcesV2::GetAvailableResourceIds() const {
   return available.ExplicitResourceIds();
 }
 
-void NodeResourcesV2::SubtractAvailable(const ResourceSet &resource_set) {
-  available -= resource_set;
-  available.RemoveNegative();
-}
-
 void NodeResourcesV2::SetAvailableResource(scheduling::ResourceID resource_id,
-                                           FixedPoint value) {
-  available.Set(resource_id, value);
+                                           std::vector<FixedPoint> instances) {
+  available.Set(resource_id, std::move(instances));
 }
 
-void NodeResourcesV2::SetAvailable(NodeResourceSet resource_set) {
-  available = std::move(resource_set);
-}
-
-absl::flat_hash_map<std::string, double> NodeResourcesV2::GetAvailableResourceMap()
-    const {
-  return available.GetResourceMap();
+void NodeResourcesV2::SetAvailable(NodeResourceInstanceSet instances) {
+  available = std::move(instances);
 }
 
 bool NodeResourcesV2::HasAvailableResource(scheduling::ResourceID resource_id) const {
   return available.Has(resource_id);
 }
 
-const NodeResourceSet &NodeResourcesV2::GetAvailable() const { return available; }
+absl::flat_hash_map<std::string, std::vector<double>>
+NodeResourcesV2::GetAvailableResourceMap(bool non_negative) const {
+  return available.GetResourceMap(non_negative);
+}
 
-NodeResourceSet NodeResourcesV2::TakeAvailable() { return std::move(available); }
+const NodeResourceInstanceSet &NodeResourcesV2::GetAvailable() const { return available; }
+
+NodeResourceInstanceSet NodeResourcesV2::TakeAvailable() { return std::move(available); }
+
+std::vector<FixedPoint> NodeResourcesV2::Subtract(
+    scheduling::ResourceID resource_id,
+    const std::vector<FixedPoint> &instances,
+    bool allow_going_negative) {
+  return available.Subtract(resource_id, instances, allow_going_negative);
+}
 
 bool NodeResourceInstances::operator==(const NodeResourceInstances &other) const {
   return this->total == other.total && this->available == other.available;

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -15,7 +15,9 @@
 #include "ray/common/scheduling/cluster_resource_data.h"
 
 #include <algorithm>
+#include <set>
 #include <string>
+#include <utility>
 
 namespace ray {
 
@@ -54,7 +56,7 @@ NodeResources ResourceMapToNodeResources(
     const absl::flat_hash_map<std::string, std::string> &node_labels) {
   NodeResources node_resources;
   node_resources.total = NodeResourceSet(resource_map_total);
-  node_resources.available = NodeResourceSet(resource_map_available);
+  node_resources.SetAvailable(NodeResourceSet(resource_map_available));
   node_resources.labels = node_labels;
   return node_resources;
 }
@@ -164,6 +166,40 @@ std::string NodeResources::DebugString() const {
 }
 
 std::string NodeResources::DictString() const { return DebugString(); }
+
+FixedPoint NodeResources::GetAvailableSum(scheduling::ResourceID resource_id) const {
+  return available.Get(resource_id);
+}
+
+std::set<scheduling::ResourceID> NodeResources::GetAvailableResourceIds() const {
+  return available.ExplicitResourceIds();
+}
+
+void NodeResources::SubtractAvailable(const ResourceSet &resource_set) {
+  available -= resource_set;
+  available.RemoveNegative();
+}
+
+void NodeResources::SetAvailableResource(scheduling::ResourceID resource_id,
+                                         FixedPoint value) {
+  available.Set(resource_id, value);
+}
+
+void NodeResources::SetAvailable(NodeResourceSet resource_set) {
+  available = std::move(resource_set);
+}
+
+absl::flat_hash_map<std::string, double> NodeResources::GetAvailableResourceMap() const {
+  return available.GetResourceMap();
+}
+
+bool NodeResources::HasAvailableResource(scheduling::ResourceID resource_id) const {
+  return available.Has(resource_id);
+}
+
+const NodeResourceSet &NodeResources::GetAvailable() const { return available; }
+
+NodeResourceSet NodeResources::TakeAvailable() { return std::move(available); }
 
 bool NodeResourceInstances::operator==(const NodeResourceInstances &other) const {
   return this->total == other.total && this->available == other.available;

--- a/src/ray/common/scheduling/cluster_resource_data.cc
+++ b/src/ray/common/scheduling/cluster_resource_data.cc
@@ -61,6 +61,24 @@ NodeResources ResourceMapToNodeResources(
   return node_resources;
 }
 
+/// Convert a map of resources to a NodeResourcesV2 data structure.
+///
+/// \param resource_map_total: Total capacities of resources we want to convert.
+/// \param resource_map_available: Available capacities of resources we want to convert.
+/// \param node_labels: Labels for the node.
+///
+/// \return Conversion result to a NodeResourcesV2 data structure.
+NodeResourcesV2 ResourceMapToNodeResourcesV2(
+    const absl::flat_hash_map<std::string, double> &resource_map_total,
+    const absl::flat_hash_map<std::string, double> &resource_map_available,
+    const absl::flat_hash_map<std::string, std::string> &node_labels) {
+  NodeResourcesV2 node_resources;
+  node_resources.total = NodeResourceSet(resource_map_total);
+  node_resources.SetAvailable(NodeResourceSet(resource_map_available));
+  node_resources.labels = node_labels;
+  return node_resources;
+}
+
 float NodeResources::CalculateCriticalResourceUtilization() const {
   float highest = 0;
   for (const auto &i : {CPU, MEM, OBJECT_STORE_MEM}) {
@@ -137,12 +155,16 @@ bool NodeResources::NodeLabelMatchesConstraint(const LabelConstraint &constraint
   return false;
 }
 
-bool NodeResources::operator==(const NodeResources &other) const {
-  return this->available == other.available && this->total == other.total &&
-         this->labels == other.labels;
+bool NodeResources::operator==(const NodeResourcesBase &other) const {
+  const auto *o = dynamic_cast<const NodeResources *>(&other);
+  if (o == nullptr) {
+    return false;
+  }
+  return this->available == o->available && this->total == o->total &&
+         this->labels == o->labels;
 }
 
-bool NodeResources::operator!=(const NodeResources &other) const {
+bool NodeResources::operator!=(const NodeResourcesBase &other) const {
   return !(*this == other);
 }
 
@@ -200,6 +222,152 @@ bool NodeResources::HasAvailableResource(scheduling::ResourceID resource_id) con
 const NodeResourceSet &NodeResources::GetAvailable() const { return available; }
 
 NodeResourceSet NodeResources::TakeAvailable() { return std::move(available); }
+
+float NodeResourcesV2::CalculateCriticalResourceUtilization() const {
+  float highest = 0;
+  for (const auto &i : {CPU, MEM, OBJECT_STORE_MEM}) {
+    const auto &cur_total = this->total.Get(ResourceID(i));
+    if (cur_total == 0) {
+      continue;
+    }
+    auto cur_available = this->available.Get(ResourceID(i)).Double();
+    float utilization = 1 - (cur_available / cur_total.Double());
+    if (utilization > highest) {
+      highest = utilization;
+    }
+  }
+  return highest;
+}
+
+bool NodeResourcesV2::IsAvailable(const ResourceRequest &resource_request,
+                                  bool ignore_pull_manager_at_capacity) const {
+  if (!ignore_pull_manager_at_capacity && resource_request.RequiresObjectStoreMemory() &&
+      object_pulls_queued) {
+    RAY_LOG(DEBUG) << "At pull manager capacity";
+    return false;
+  }
+
+  const auto &label_selector = resource_request.GetLabelSelector();
+  if (!HasRequiredLabels(label_selector)) {
+    return false;
+  }
+
+  return this->available >= resource_request.GetResourceSet();
+}
+
+bool NodeResourcesV2::IsFeasible(const ResourceRequest &resource_request) const {
+  const auto &label_selector = resource_request.GetLabelSelector();
+  if (!HasRequiredLabels(label_selector)) {
+    return false;
+  }
+  return this->total >= resource_request.GetResourceSet();
+}
+
+bool NodeResourcesV2::HasRequiredLabels(const LabelSelector &label_selector) const {
+  // Check if node labels satisfy all label constraints
+  const auto &constraints = label_selector.GetConstraints();
+  for (const auto &constraint : constraints) {
+    if (!NodeLabelMatchesConstraint(constraint)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool NodeResourcesV2::NodeLabelMatchesConstraint(
+    const LabelConstraint &constraint) const {
+  const auto &key = constraint.GetLabelKey();
+  const auto &match_operator = constraint.GetOperator();
+  const auto &values = constraint.GetLabelValues();
+
+  const auto &node_labels = this->labels;
+  if (match_operator == LabelSelectorOperator::LABEL_IN) {
+    // Check for equals or in() labels
+    if (node_labels.contains(key) && values.contains(node_labels.at(key))) {
+      return true;
+    }
+  } else if (match_operator == LabelSelectorOperator::LABEL_NOT_IN) {
+    // Check for not equals (!) or not in (!in()) labels
+    if (!(node_labels.contains(key) && values.contains(node_labels.at(key)))) {
+      return true;
+    }
+  } else {
+    RAY_CHECK(false)
+        << "Node label constraint operator type must be one of equals, not equals (!), "
+           "in, or not in (!in)";
+  }
+  return false;
+}
+
+bool NodeResourcesV2::operator==(const NodeResourcesBase &other) const {
+  const auto *o = dynamic_cast<const NodeResourcesV2 *>(&other);
+  if (o == nullptr) {
+    return false;
+  }
+  return this->available == o->available && this->total == o->total &&
+         this->labels == o->labels;
+}
+
+bool NodeResourcesV2::operator!=(const NodeResourcesBase &other) const {
+  return !(*this == other);
+}
+
+std::string NodeResourcesV2::DebugString() const {
+  std::stringstream buffer;
+  buffer << "{\"total\":" << total.DebugString();
+  buffer << ", \"available\": " << available.DebugString();
+  buffer << ", \"labels\":{";
+  bool first = true;
+  for (const auto &[key, value] : labels) {
+    if (!first) {
+      buffer << ",";
+    }
+    first = false;
+    buffer << "\"" << key << "\":\"" << value << "\"";
+  }
+  buffer << "}, \"is_draining\": " << is_draining;
+  buffer << ", \"draining_deadline_timestamp_ms\": " << draining_deadline_timestamp_ms
+         << "}";
+  return buffer.str();
+}
+
+std::string NodeResourcesV2::DictString() const { return DebugString(); }
+
+FixedPoint NodeResourcesV2::GetAvailableSum(scheduling::ResourceID resource_id) const {
+  return available.Get(resource_id);
+}
+
+std::set<scheduling::ResourceID> NodeResourcesV2::GetAvailableResourceIds() const {
+  return available.ExplicitResourceIds();
+}
+
+void NodeResourcesV2::SubtractAvailable(const ResourceSet &resource_set) {
+  available -= resource_set;
+  available.RemoveNegative();
+}
+
+void NodeResourcesV2::SetAvailableResource(scheduling::ResourceID resource_id,
+                                           FixedPoint value) {
+  available.Set(resource_id, value);
+}
+
+void NodeResourcesV2::SetAvailable(NodeResourceSet resource_set) {
+  available = std::move(resource_set);
+}
+
+absl::flat_hash_map<std::string, double> NodeResourcesV2::GetAvailableResourceMap()
+    const {
+  return available.GetResourceMap();
+}
+
+bool NodeResourcesV2::HasAvailableResource(scheduling::ResourceID resource_id) const {
+  return available.Has(resource_id);
+}
+
+const NodeResourceSet &NodeResourcesV2::GetAvailable() const { return available; }
+
+NodeResourceSet NodeResourcesV2::TakeAvailable() { return std::move(available); }
 
 bool NodeResourceInstances::operator==(const NodeResourceInstances &other) const {
   return this->total == other.total && this->available == other.available;

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -16,6 +16,7 @@
 
 #include <boost/range/adaptor/map.hpp>
 #include <optional>
+#include <set>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -311,7 +312,6 @@ class NodeResources {
   explicit NodeResources(const NodeResourceSet &resources)
       : total(resources), available(resources) {}
   NodeResourceSet total;
-  NodeResourceSet available;
   /// Only used by light resource report.
   ResourceSet load;
 
@@ -355,6 +355,37 @@ class NodeResources {
   std::string DebugString() const;
   /// Returns compact dict-like string.
   std::string DictString() const;
+
+  /// Get the scalar available amount for a resource.
+  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const;
+
+  /// Get the set of resource IDs that have explicit available entries.
+  std::set<scheduling::ResourceID> GetAvailableResourceIds() const;
+
+  /// Subtract resources from available, clamping each entry to 0.
+  void SubtractAvailable(const ResourceSet &resource_set);
+
+  /// Set a single resource's available to an explicit scalar value.
+  void SetAvailableResource(scheduling::ResourceID resource_id, FixedPoint value);
+
+  /// Replace the entire available field from a NodeResourceSet.
+  void SetAvailable(NodeResourceSet resource_set);
+
+  /// Return available resources as a name->value map.
+  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const;
+
+  /// Returns true if the resource has an explicit available entry.
+  bool HasAvailableResource(scheduling::ResourceID resource_id) const;
+
+  /// Read-only access to the entire available resource set.
+  const NodeResourceSet &GetAvailable() const;
+
+  /// Transfer ownership of the available resource set (leaves available in a moved-from
+  /// state).
+  NodeResourceSet TakeAvailable();
+
+ private:
+  NodeResourceSet available;
 };
 
 /// Total and available capacities of each resource instance.

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -368,28 +368,8 @@ class NodeResourcesBase {
   /// Get the set of resource IDs that have explicit available entries.
   virtual std::set<scheduling::ResourceID> GetAvailableResourceIds() const = 0;
 
-  /// Subtract resources from available, clamping each entry to 0.
-  virtual void SubtractAvailable(const ResourceSet &resource_set) = 0;
-
-  /// Set a single resource's available to an explicit scalar value.
-  virtual void SetAvailableResource(scheduling::ResourceID resource_id,
-                                    FixedPoint value) = 0;
-
-  /// Replace the entire available field from a NodeResourceSet.
-  virtual void SetAvailable(NodeResourceSet resource_set) = 0;
-
-  /// Return available resources as a name->value map.
-  virtual absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const = 0;
-
   /// Returns true if the resource has an explicit available entry.
   virtual bool HasAvailableResource(scheduling::ResourceID resource_id) const = 0;
-
-  /// Read-only access to the entire available resource set.
-  virtual const NodeResourceSet &GetAvailable() const = 0;
-
-  /// Transfer ownership of the available resource set (leaves available in a moved-from
-  /// state).
-  virtual NodeResourceSet TakeAvailable() = 0;
 };
 
 /// Total and available capacities of each resource of a node.
@@ -428,40 +408,39 @@ class NodeResources : public NodeResourcesBase {
   std::set<scheduling::ResourceID> GetAvailableResourceIds() const override;
 
   /// Subtract resources from available, clamping each entry to 0.
-  void SubtractAvailable(const ResourceSet &resource_set) override;
+  void SubtractAvailable(const ResourceSet &resource_set);
 
-  /// Set a single resource's available to an explicit scalar value.
-  void SetAvailableResource(scheduling::ResourceID resource_id,
-                            FixedPoint value) override;
+  /// Set a single resource's available to a scalar value.
+  void SetAvailableResource(scheduling::ResourceID resource_id, FixedPoint value);
 
-  /// Replace the entire available field from a NodeResourceSet.
-  void SetAvailable(NodeResourceSet resource_set) override;
+  /// Replace the entire available field.
+  void SetAvailable(NodeResourceSet resource_set);
 
   /// Return available resources as a name->value map.
-  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const override;
+  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const;
 
   /// Returns true if the resource has an explicit available entry.
   bool HasAvailableResource(scheduling::ResourceID resource_id) const override;
 
-  /// Read-only access to the entire available resource set.
-  const NodeResourceSet &GetAvailable() const override;
+  /// Read-only access to the entire available
+  const NodeResourceSet &GetAvailable() const;
 
   /// Transfer ownership of the available resource set (leaves available in a moved-from
   /// state).
-  NodeResourceSet TakeAvailable() override;
+  NodeResourceSet TakeAvailable();
 
  private:
   NodeResourceSet available;
 };
 
-/// NodeResourcesV2 is currently identical to NodeResources. It will diverge in a
-/// subsequent PR to store available resources as a per-instance vector
-/// (NodeResourceInstanceSet) rather than an aggregated scalar NodeResourceSet, enabling
+/// NodeResourcesV2 stores available resources as a per-instance vector
+/// NodeResourceInstanceSet rather than an aggregated scalar NodeResourceSet, enabling
 /// GPU-fraction scheduling.
 class NodeResourcesV2 : public NodeResourcesBase {
  public:
   NodeResourcesV2() {}
-  explicit NodeResourcesV2(const NodeResourceSet &resources) : available(resources) {
+  explicit NodeResourcesV2(const NodeResourceSet &resources)
+      : available(NodeResourceInstanceSet(resources)) {
     total = resources;
   }
 
@@ -469,11 +448,9 @@ class NodeResourcesV2 : public NodeResourcesBase {
   /// of each resource and return the highest.
   float CalculateCriticalResourceUtilization() const override;
   /// Returns true if the node has the available resources to run the task.
-  /// Note: This doesn't account for the binpacking of unit resources.
   bool IsAvailable(const ResourceRequest &resource_request,
                    bool ignore_at_capacity = false) const override;
   /// Returns true if the node's total resources are enough to run the task.
-  /// Note: This doesn't account for the binpacking of unit resources.
   bool IsFeasible(const ResourceRequest &resource_request) const override;
   // Returns true if the node's labels satisfy the label selector requirement.
   bool HasRequiredLabels(const LabelSelector &label_selector) const override;
@@ -486,37 +463,49 @@ class NodeResourcesV2 : public NodeResourcesBase {
   /// Returns compact dict-like string.
   std::string DictString() const override;
 
-  /// Get the scalar available amount for a resource.
+  /// Get the scalar available amount for a resource (sum across instances).
   FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const override;
 
   /// Get the set of resource IDs that have explicit available entries.
   std::set<scheduling::ResourceID> GetAvailableResourceIds() const override;
 
-  /// Subtract resources from available, clamping each entry to 0.
-  void SubtractAvailable(const ResourceSet &resource_set) override;
-
-  /// Set a single resource's available to an explicit scalar value.
+  /// Set a single resource's available to a per-instance vector.
   void SetAvailableResource(scheduling::ResourceID resource_id,
-                            FixedPoint value) override;
+                            std::vector<FixedPoint> instances);
 
-  /// Replace the entire available field from a NodeResourceSet.
-  void SetAvailable(NodeResourceSet resource_set) override;
-
-  /// Return available resources as a name->value map.
-  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const override;
+  /// Replace the entire available field from a per-instance vector.
+  void SetAvailable(NodeResourceInstanceSet instances);
 
   /// Returns true if the resource has an explicit available entry.
   bool HasAvailableResource(scheduling::ResourceID resource_id) const override;
 
-  /// Read-only access to the entire available resource set.
-  const NodeResourceSet &GetAvailable() const override;
+  /// Return available resources as a name->per-instance-values map.
+  /// \param non_negative If true, clamp all instance values to be >= 0.
+  absl::flat_hash_map<std::string, std::vector<double>> GetAvailableResourceMap(
+      bool non_negative = false) const;
+
+  /// Read-only access to the entire available
+  const NodeResourceInstanceSet &GetAvailable() const;
 
   /// Transfer ownership of the available resource set (leaves available in a moved-from
   /// state).
-  NodeResourceSet TakeAvailable() override;
+  NodeResourceInstanceSet TakeAvailable();
+
+  /// Decrease the capacities of the instances of a given resource from the available
+  ///
+  /// \param resource_id The id of the resource to be subtracted.
+  /// \param instances A list of capacities for resource's instances to be subtracted.
+  /// \param allow_going_negative Allow the values to go negative (disable underflow).
+  ///
+  /// \return Underflow of resource capacities after subtracting instance
+  /// capacities in "instances", i.e.,.
+  /// max(instances - Get(resource_id), 0)
+  std::vector<FixedPoint> Subtract(scheduling::ResourceID resource_id,
+                                   const std::vector<FixedPoint> &instances,
+                                   bool allow_going_negative);
 
  private:
-  NodeResourceSet available;
+  NodeResourceInstanceSet available;
 };
 
 /// Total and available capacities of each resource instance.

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -26,6 +26,7 @@
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/time/time.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/scheduling/fixed_point.h"
 #include "ray/common/scheduling/label_selector.h"
 #include "ray/common/scheduling/resource_instance_set.h"
@@ -535,23 +536,23 @@ struct Node {
       : local_view_(std::move(resources)) {}
 
   Node(const Node &other) : local_view_modified_ts_(other.local_view_modified_ts_) {
-    if (other.local_view_->IsV2()) {
+    if (RayConfig::instance().enable_per_instance_resource_scheduling()) {
       local_view_ = std::make_unique<NodeResourcesV2>(
-          static_cast<const NodeResourcesV2 &>(*other.local_view_));
+          dynamic_cast<const NodeResourcesV2 &>(*other.local_view_));
     } else {
       local_view_ = std::make_unique<NodeResources>(
-          static_cast<const NodeResources &>(*other.local_view_));
+          dynamic_cast<const NodeResources &>(*other.local_view_));
     }
   }
 
   Node &operator=(const Node &other) {
     if (this != &other) {
-      if (other.local_view_->IsV2()) {
+      if (RayConfig::instance().enable_per_instance_resource_scheduling()) {
         local_view_ = std::make_unique<NodeResourcesV2>(
-            static_cast<const NodeResourcesV2 &>(*other.local_view_));
+            dynamic_cast<const NodeResourcesV2 &>(*other.local_view_));
       } else {
         local_view_ = std::make_unique<NodeResources>(
-            static_cast<const NodeResources &>(*other.local_view_));
+            dynamic_cast<const NodeResources &>(*other.local_view_));
       }
       local_view_modified_ts_ = other.local_view_modified_ts_;
     }
@@ -565,21 +566,22 @@ struct Node {
   /// pointer when the type changes. This preserves existing references to
   /// *local_view_ when the type is unchanged.
   void UpdateView(const NodeResourcesBase &resources) {
-    if (local_view_ && resources.IsV2() == local_view_->IsV2()) {
-      if (resources.IsV2()) {
-        static_cast<NodeResourcesV2 &>(*local_view_) =
-            static_cast<const NodeResourcesV2 &>(resources);
+    const bool is_v2 = RayConfig::instance().enable_per_instance_resource_scheduling();
+    if (local_view_) {
+      if (is_v2) {
+        dynamic_cast<NodeResourcesV2 &>(*local_view_) =
+            dynamic_cast<const NodeResourcesV2 &>(resources);
       } else {
-        static_cast<NodeResources &>(*local_view_) =
-            static_cast<const NodeResources &>(resources);
+        dynamic_cast<NodeResources &>(*local_view_) =
+            dynamic_cast<const NodeResources &>(resources);
       }
     } else {
-      if (resources.IsV2()) {
+      if (is_v2) {
         local_view_ = std::make_unique<NodeResourcesV2>(
-            static_cast<const NodeResourcesV2 &>(resources));
+            dynamic_cast<const NodeResourcesV2 &>(resources));
       } else {
         local_view_ = std::make_unique<NodeResources>(
-            static_cast<const NodeResources &>(resources));
+            dynamic_cast<const NodeResources &>(resources));
       }
     }
   }

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -305,12 +305,10 @@ class TaskResourceInstances {
   absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> resources_;
 };
 
-/// Total and available capacities of each resource of a node.
-class NodeResources {
+/// Temporary Abstract base class for node resource.
+/// Provides the common interface shared by NodeResources and NodeResourcesV2.
+class NodeResourcesBase {
  public:
-  NodeResources() {}
-  explicit NodeResources(const NodeResourceSet &resources)
-      : total(resources), available(resources) {}
   NodeResourceSet total;
   /// Only used by light resource report.
   ResourceSet load;
@@ -335,54 +333,187 @@ class NodeResources {
 
   bool object_pulls_queued = false;
 
+  NodeResourcesBase() = default;
+  virtual ~NodeResourcesBase() = default;
+  NodeResourcesBase(const NodeResourcesBase &) = default;
+  NodeResourcesBase &operator=(const NodeResourcesBase &) = default;
+  NodeResourcesBase(NodeResourcesBase &&) = default;
+  NodeResourcesBase &operator=(NodeResourcesBase &&) = default;
+
   /// Amongst CPU, memory, and object store memory, calculate the utilization percentage
   /// of each resource and return the highest.
-  float CalculateCriticalResourceUtilization() const;
+  virtual float CalculateCriticalResourceUtilization() const = 0;
   /// Returns true if the node has the available resources to run the task.
   /// Note: This doesn't account for the binpacking of unit resources.
-  bool IsAvailable(const ResourceRequest &resource_request,
-                   bool ignore_at_capacity = false) const;
+  virtual bool IsAvailable(const ResourceRequest &resource_request,
+                           bool ignore_at_capacity = false) const = 0;
   /// Returns true if the node's total resources are enough to run the task.
   /// Note: This doesn't account for the binpacking of unit resources.
-  bool IsFeasible(const ResourceRequest &resource_request) const;
+  virtual bool IsFeasible(const ResourceRequest &resource_request) const = 0;
   // Returns true if the node's labels satisfy the label selector requirement.
-  bool HasRequiredLabels(const LabelSelector &label_selector) const;
-  bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const;
+  virtual bool HasRequiredLabels(const LabelSelector &label_selector) const = 0;
+  virtual bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const = 0;
   /// Returns if this equals another node resources.
-  bool operator==(const NodeResources &other) const;
-  bool operator!=(const NodeResources &other) const;
+  virtual bool operator==(const NodeResourcesBase &other) const = 0;
+  virtual bool operator!=(const NodeResourcesBase &other) const = 0;
+
   /// Returns human-readable string for these resources.
-  std::string DebugString() const;
+  virtual std::string DebugString() const = 0;
   /// Returns compact dict-like string.
-  std::string DictString() const;
+  virtual std::string DictString() const = 0;
 
   /// Get the scalar available amount for a resource.
-  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const;
+  virtual FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const = 0;
 
   /// Get the set of resource IDs that have explicit available entries.
-  std::set<scheduling::ResourceID> GetAvailableResourceIds() const;
+  virtual std::set<scheduling::ResourceID> GetAvailableResourceIds() const = 0;
 
   /// Subtract resources from available, clamping each entry to 0.
-  void SubtractAvailable(const ResourceSet &resource_set);
+  virtual void SubtractAvailable(const ResourceSet &resource_set) = 0;
 
   /// Set a single resource's available to an explicit scalar value.
-  void SetAvailableResource(scheduling::ResourceID resource_id, FixedPoint value);
+  virtual void SetAvailableResource(scheduling::ResourceID resource_id,
+                                    FixedPoint value) = 0;
 
   /// Replace the entire available field from a NodeResourceSet.
-  void SetAvailable(NodeResourceSet resource_set);
+  virtual void SetAvailable(NodeResourceSet resource_set) = 0;
 
   /// Return available resources as a name->value map.
-  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const;
+  virtual absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const = 0;
 
   /// Returns true if the resource has an explicit available entry.
-  bool HasAvailableResource(scheduling::ResourceID resource_id) const;
+  virtual bool HasAvailableResource(scheduling::ResourceID resource_id) const = 0;
 
   /// Read-only access to the entire available resource set.
-  const NodeResourceSet &GetAvailable() const;
+  virtual const NodeResourceSet &GetAvailable() const = 0;
 
   /// Transfer ownership of the available resource set (leaves available in a moved-from
   /// state).
-  NodeResourceSet TakeAvailable();
+  virtual NodeResourceSet TakeAvailable() = 0;
+};
+
+/// Total and available capacities of each resource of a node.
+class NodeResources : public NodeResourcesBase {
+ public:
+  NodeResources() {}
+  explicit NodeResources(const NodeResourceSet &resources) : available(resources) {
+    total = resources;
+  }
+
+  /// Amongst CPU, memory, and object store memory, calculate the utilization percentage
+  /// of each resource and return the highest.
+  float CalculateCriticalResourceUtilization() const override;
+  /// Returns true if the node has the available resources to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsAvailable(const ResourceRequest &resource_request,
+                   bool ignore_at_capacity = false) const override;
+  /// Returns true if the node's total resources are enough to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsFeasible(const ResourceRequest &resource_request) const override;
+  // Returns true if the node's labels satisfy the label selector requirement.
+  bool HasRequiredLabels(const LabelSelector &label_selector) const override;
+  bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const override;
+  /// Returns if this equals another node resources.
+  bool operator==(const NodeResourcesBase &other) const override;
+  bool operator!=(const NodeResourcesBase &other) const override;
+  /// Returns human-readable string for these resources.
+  std::string DebugString() const override;
+  /// Returns compact dict-like string.
+  std::string DictString() const override;
+
+  /// Get the scalar available amount for a resource.
+  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const override;
+
+  /// Get the set of resource IDs that have explicit available entries.
+  std::set<scheduling::ResourceID> GetAvailableResourceIds() const override;
+
+  /// Subtract resources from available, clamping each entry to 0.
+  void SubtractAvailable(const ResourceSet &resource_set) override;
+
+  /// Set a single resource's available to an explicit scalar value.
+  void SetAvailableResource(scheduling::ResourceID resource_id,
+                            FixedPoint value) override;
+
+  /// Replace the entire available field from a NodeResourceSet.
+  void SetAvailable(NodeResourceSet resource_set) override;
+
+  /// Return available resources as a name->value map.
+  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const override;
+
+  /// Returns true if the resource has an explicit available entry.
+  bool HasAvailableResource(scheduling::ResourceID resource_id) const override;
+
+  /// Read-only access to the entire available resource set.
+  const NodeResourceSet &GetAvailable() const override;
+
+  /// Transfer ownership of the available resource set (leaves available in a moved-from
+  /// state).
+  NodeResourceSet TakeAvailable() override;
+
+ private:
+  NodeResourceSet available;
+};
+
+/// NodeResourcesV2 is currently identical to NodeResources. It will diverge in a
+/// subsequent PR to store available resources as a per-instance vector
+/// (NodeResourceInstanceSet) rather than an aggregated scalar NodeResourceSet, enabling
+/// GPU-fraction scheduling.
+class NodeResourcesV2 : public NodeResourcesBase {
+ public:
+  NodeResourcesV2() {}
+  explicit NodeResourcesV2(const NodeResourceSet &resources) : available(resources) {
+    total = resources;
+  }
+
+  /// Amongst CPU, memory, and object store memory, calculate the utilization percentage
+  /// of each resource and return the highest.
+  float CalculateCriticalResourceUtilization() const override;
+  /// Returns true if the node has the available resources to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsAvailable(const ResourceRequest &resource_request,
+                   bool ignore_at_capacity = false) const override;
+  /// Returns true if the node's total resources are enough to run the task.
+  /// Note: This doesn't account for the binpacking of unit resources.
+  bool IsFeasible(const ResourceRequest &resource_request) const override;
+  // Returns true if the node's labels satisfy the label selector requirement.
+  bool HasRequiredLabels(const LabelSelector &label_selector) const override;
+  bool NodeLabelMatchesConstraint(const LabelConstraint &constraint) const override;
+  /// Returns if this equals another node resources.
+  bool operator==(const NodeResourcesBase &other) const override;
+  bool operator!=(const NodeResourcesBase &other) const override;
+  /// Returns human-readable string for these resources.
+  std::string DebugString() const override;
+  /// Returns compact dict-like string.
+  std::string DictString() const override;
+
+  /// Get the scalar available amount for a resource.
+  FixedPoint GetAvailableSum(scheduling::ResourceID resource_id) const override;
+
+  /// Get the set of resource IDs that have explicit available entries.
+  std::set<scheduling::ResourceID> GetAvailableResourceIds() const override;
+
+  /// Subtract resources from available, clamping each entry to 0.
+  void SubtractAvailable(const ResourceSet &resource_set) override;
+
+  /// Set a single resource's available to an explicit scalar value.
+  void SetAvailableResource(scheduling::ResourceID resource_id,
+                            FixedPoint value) override;
+
+  /// Replace the entire available field from a NodeResourceSet.
+  void SetAvailable(NodeResourceSet resource_set) override;
+
+  /// Return available resources as a name->value map.
+  absl::flat_hash_map<std::string, double> GetAvailableResourceMap() const override;
+
+  /// Returns true if the resource has an explicit available entry.
+  bool HasAvailableResource(scheduling::ResourceID resource_id) const override;
+
+  /// Read-only access to the entire available resource set.
+  const NodeResourceSet &GetAvailable() const override;
+
+  /// Transfer ownership of the available resource set (leaves available in a moved-from
+  /// state).
+  NodeResourceSet TakeAvailable() override;
 
  private:
   NodeResourceSet available;
@@ -438,6 +569,18 @@ struct Node {
 ///
 /// \return Conversion result to a NodeResources data structure.
 NodeResources ResourceMapToNodeResources(
+    const absl::flat_hash_map<std::string, double> &resource_map_total,
+    const absl::flat_hash_map<std::string, double> &resource_map_available,
+    const absl::flat_hash_map<std::string, std::string> &node_labels = {});
+
+/// Convert a map of resources to a NodeResourcesV2 data structure.
+///
+/// \param string_to_int_map: Map between names and ids maintained by the
+/// \param resource_map_total: Total capacities of resources we want to convert.
+/// \param resource_map_available: Available capacities of resources we want to convert.
+///
+/// \request Conversion result to a NodeResourcesV2 data structure.
+NodeResourcesV2 ResourceMapToNodeResourcesV2(
     const absl::flat_hash_map<std::string, double> &resource_map_total,
     const absl::flat_hash_map<std::string, double> &resource_map_available,
     const absl::flat_hash_map<std::string, std::string> &node_labels = {});

--- a/src/ray/common/scheduling/cluster_resource_data.h
+++ b/src/ray/common/scheduling/cluster_resource_data.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <boost/range/adaptor/map.hpp>
+#include <memory>
 #include <optional>
 #include <set>
 #include <sstream>
@@ -527,16 +528,70 @@ class NodeResourceInstances {
 };
 
 struct Node {
-  explicit Node(const NodeResources &resources) : local_view_(resources) {}
+  explicit Node(const NodeResources &resources)
+      : local_view_(std::make_unique<NodeResources>(resources)) {}
 
-  NodeResources *GetMutableLocalView() {
+  explicit Node(std::unique_ptr<NodeResourcesBase> resources)
+      : local_view_(std::move(resources)) {}
+
+  Node(const Node &other) : local_view_modified_ts_(other.local_view_modified_ts_) {
+    if (other.local_view_->IsV2()) {
+      local_view_ = std::make_unique<NodeResourcesV2>(
+          static_cast<const NodeResourcesV2 &>(*other.local_view_));
+    } else {
+      local_view_ = std::make_unique<NodeResources>(
+          static_cast<const NodeResources &>(*other.local_view_));
+    }
+  }
+
+  Node &operator=(const Node &other) {
+    if (this != &other) {
+      if (other.local_view_->IsV2()) {
+        local_view_ = std::make_unique<NodeResourcesV2>(
+            static_cast<const NodeResourcesV2 &>(*other.local_view_));
+      } else {
+        local_view_ = std::make_unique<NodeResources>(
+            static_cast<const NodeResources &>(*other.local_view_));
+      }
+      local_view_modified_ts_ = other.local_view_modified_ts_;
+    }
+    return *this;
+  }
+
+  Node(Node &&) = default;
+  Node &operator=(Node &&) = default;
+
+  /// Update the local view in-place when the type matches, or replace the
+  /// pointer when the type changes. This preserves existing references to
+  /// *local_view_ when the type is unchanged.
+  void UpdateView(const NodeResourcesBase &resources) {
+    if (local_view_ && resources.IsV2() == local_view_->IsV2()) {
+      if (resources.IsV2()) {
+        static_cast<NodeResourcesV2 &>(*local_view_) =
+            static_cast<const NodeResourcesV2 &>(resources);
+      } else {
+        static_cast<NodeResources &>(*local_view_) =
+            static_cast<const NodeResources &>(resources);
+      }
+    } else {
+      if (resources.IsV2()) {
+        local_view_ = std::make_unique<NodeResourcesV2>(
+            static_cast<const NodeResourcesV2 &>(resources));
+      } else {
+        local_view_ = std::make_unique<NodeResources>(
+            static_cast<const NodeResources &>(resources));
+      }
+    }
+  }
+
+  NodeResourcesBase *GetMutableLocalView() {
     local_view_modified_ts_ = absl::Now();
-    return &local_view_;
+    return local_view_.get();
   }
 
   std::optional<absl::Time> GetViewModifiedTs() const { return local_view_modified_ts_; }
 
-  const NodeResources &GetLocalView() const { return local_view_; }
+  const NodeResourcesBase &GetLocalView() const { return *local_view_; }
 
  private:
   /// Our local view of the remote node's resources. This may be dirty
@@ -545,7 +600,7 @@ struct Node {
   /// get overwritten by the last reported view on each heartbeat tick, to
   /// make sure that our local view does not skew too much from the actual
   /// resources when light heartbeats are enabled.
-  NodeResources local_view_;
+  std::unique_ptr<NodeResourcesBase> local_view_;
   /// The timestamp this node got updated.
   std::optional<absl::Time> local_view_modified_ts_;
 };

--- a/src/ray/common/scheduling/resource_instance_set.cc
+++ b/src/ray/common/scheduling/resource_instance_set.cc
@@ -14,7 +14,9 @@
 
 #include "ray/common/scheduling/resource_instance_set.h"
 
+#include <algorithm>
 #include <cmath>
+#include <set>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -134,6 +136,68 @@ FixedPoint NodeResourceInstanceSet::Sum(ResourceID resource_id) const {
 
 bool NodeResourceInstanceSet::operator==(const NodeResourceInstanceSet &other) const {
   return this->resources_ == other.resources_;
+}
+
+bool NodeResourceInstanceSet::CanAllocate(const ResourceSet &resource_demands) const {
+  for (const auto &[resource_id, demand] : resource_demands.Resources()) {
+    const std::vector<FixedPoint> &available = Get(resource_id);
+
+    if (available.empty()) {
+      return false;
+    }
+
+    if (available.size() == 1) {
+      if (available[0] >= demand) {
+        continue;
+      }
+      return false;
+    }
+
+    FixedPoint remaining_demand = demand;
+    int64_t full_instances_used = 0;
+
+    if (remaining_demand >= 1.) {
+      for (size_t i = 0; i < available.size(); i++) {
+        if (available[i] == 1.) {
+          full_instances_used++;
+          remaining_demand -= 1.;
+        }
+        if (remaining_demand < 1.) {
+          break;
+        }
+      }
+    }
+
+    if (remaining_demand >= 1.) {
+      // Not enough full-capacity instances to cover the integer part.
+      return false;
+    }
+
+    if (remaining_demand > 0.) {
+      bool found_fit = false;
+      int64_t full_instances_skipped = 0;
+
+      for (size_t i = 0; i < available.size(); i++) {
+        // Skip the exact number of full instances we previously calculated
+        if (available[i] == 1. && full_instances_skipped < full_instances_used) {
+          full_instances_skipped++;
+          continue;
+        }
+
+        // EARLY EXIT: We only need to know IF it can fit, not WHERE it fits best.
+        if (available[i] >= remaining_demand) {
+          found_fit = true;
+          break;
+        }
+      }
+
+      if (!found_fit) {
+        return false;
+      }
+    }
+  }
+
+  return true;
 }
 
 std::optional<absl::flat_hash_map<ResourceID, std::vector<FixedPoint>>>
@@ -459,12 +523,37 @@ std::string NodeResourceInstanceSet::DebugString() const {
   return buffer.str();
 }
 
+std::set<ResourceID> NodeResourceInstanceSet::ExplicitResourceIds() const {
+  std::set<ResourceID> ids;
+  for (const auto &[id, _] : resources_) {
+    if (!id.IsImplicitResource()) {
+      ids.insert(id);
+    }
+  }
+
+  return ids;
+}
+
 NodeResourceSet NodeResourceInstanceSet::ToNodeResourceSet() const {
   NodeResourceSet node_resource_set;
   for (const auto &[resource_id, instances] : resources_) {
     node_resource_set.Set(resource_id, FixedPoint::Sum(instances));
   }
   return node_resource_set;
+}
+
+absl::flat_hash_map<std::string, std::vector<double>>
+NodeResourceInstanceSet::GetResourceMap(bool non_negative) const {
+  absl::flat_hash_map<std::string, std::vector<double>> result;
+  for (const auto &[id, instances] : resources_) {
+    std::vector<double> values;
+    values.reserve(instances.size());
+    for (const auto &value : instances) {
+      values.push_back(non_negative ? std::max(value.Double(), 0.0) : value.Double());
+    }
+    result[id.Binary()] = std::move(values);
+  }
+  return result;
 }
 
 }  // namespace ray

--- a/src/ray/common/scheduling/resource_instance_set.h
+++ b/src/ray/common/scheduling/resource_instance_set.h
@@ -14,7 +14,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -56,6 +58,11 @@ class NodeResourceInstanceSet {
 
   std::string DebugString() const;
 
+  /// Returns true if the resources specified by `resource_demands` can be allocated
+  /// from this set without modifying any state. This is a read-only feasibility check
+  /// that accounts for per-instance bin-packing constraints (e.g., GPU fractions).
+  bool CanAllocate(const ResourceSet &resource_demands) const;
+
   /// Try to allocate resources specified by `resource_demands`.
   /// This operation is all or nothing meaning that if any single resource
   /// cannot be allocated, the entire allocation fails and std::nullopt is returned.
@@ -85,6 +92,14 @@ class NodeResourceInstanceSet {
 
   /// Convert to node resource set with summed per-instance values.
   NodeResourceSet ToNodeResourceSet() const;
+
+  /// Return all the ids of explicit resources that this set has.
+  std::set<ResourceID> ExplicitResourceIds() const;
+
+  /// Return a map from resource name to the per-instance values.
+  /// \param non_negative If true, clamp all instance values to be >= 0.
+  absl::flat_hash_map<std::string, std::vector<double>> GetResourceMap(
+      bool non_negative = false) const;
 
   /// Only for testing.
   const absl::flat_hash_map<ResourceID, std::vector<FixedPoint>> &Resources() const {

--- a/src/ray/common/scheduling/tests/resource_instance_set_test.cc
+++ b/src/ray/common/scheduling/tests/resource_instance_set_test.cc
@@ -939,6 +939,89 @@ TEST_F(NodeResourceInstanceSetTest, TestTryAllocateMultiplePgResourceAndNoBundle
   }
 }
 
+TEST_F(NodeResourceInstanceSetTest, TestCanAllocate) {
+  // 1. Test non-unit resource (CPU): single-instance, scalar comparison.
+  {
+    NodeResourceInstanceSet r1 = NodeResourceInstanceSet(NodeResourceSet({{"CPU", 2}}));
+
+    // Demand <= available: should succeed.
+    ASSERT_TRUE(r1.CanAllocate(ResourceSet({{"CPU", FixedPoint(1)}})));
+    ASSERT_TRUE(r1.CanAllocate(ResourceSet({{"CPU", FixedPoint(2)}})));
+    ASSERT_TRUE(r1.CanAllocate(ResourceSet({{"CPU", FixedPoint(1.5)}})));
+
+    // Demand > available: should fail.
+    ASSERT_FALSE(r1.CanAllocate(ResourceSet({{"CPU", FixedPoint(3)}})));
+    ASSERT_FALSE(r1.CanAllocate(ResourceSet({{"CPU", FixedPoint(3.5)}})));
+
+    // Resource not present: should fail.
+    ASSERT_FALSE(r1.CanAllocate(ResourceSet({{"memory", FixedPoint(1)}})));
+  }
+
+  // 2. Test unit resource (GPU): multi-instance, integer demand requires full instances.
+  {
+    // 4 GPUs, all fully available.
+    NodeResourceInstanceSet r2 = NodeResourceInstanceSet(NodeResourceSet({{"GPU", 4}}));
+
+    // Demand fits in available full instances.
+    ASSERT_TRUE(r2.CanAllocate(ResourceSet({{"GPU", FixedPoint(2)}})));
+    ASSERT_TRUE(r2.CanAllocate(ResourceSet({{"GPU", FixedPoint(4)}})));
+
+    // Demand exceeds total instances.
+    ASSERT_FALSE(r2.CanAllocate(ResourceSet({{"GPU", FixedPoint(5)}})));
+
+    // Allocate 2 GPUs so only 2 remain, then test demands against reduced availability.
+    NodeResourceInstanceSet r3;
+    r3.Set(ResourceID("GPU"),
+           std::vector<FixedPoint>(
+               {FixedPoint(0), FixedPoint(0), FixedPoint(1), FixedPoint(1)}));
+
+    // Only 2 full instances remain.
+    ASSERT_TRUE(r3.CanAllocate(ResourceSet({{"GPU", FixedPoint(2)}})));
+    ASSERT_FALSE(r3.CanAllocate(ResourceSet({{"GPU", FixedPoint(3)}})));
+  }
+
+  // 3. Test unit resource (GPU): fractional demand must fit on a single instance.
+  {
+    NodeResourceInstanceSet r4;
+    // Instance 0 has 0.4 remaining, instance 1 has 0.6 remaining.
+    r4.Set(ResourceID("GPU"),
+           std::vector<FixedPoint>({FixedPoint(0.4), FixedPoint(0.6)}));
+
+    // Demand fits on at least one instance.
+    ASSERT_TRUE(r4.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.4)}})));
+    ASSERT_TRUE(r4.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.6)}})));
+
+    // Total available (0.4 + 0.6 = 1.0) exceeds demand (0.7), but no single instance
+    // can accommodate it — fractional GPU demand cannot be split across instances.
+    ASSERT_FALSE(r4.CanAllocate(ResourceSet({{"GPU", FixedPoint(0.7)}})));
+  }
+
+  // 4. Test mixed demand: integer part + fractional remainder across instances.
+  {
+    NodeResourceInstanceSet r5;
+    // 1 full instance + 1 partial instance with 0.5 remaining.
+    r5.Set(ResourceID("GPU"), std::vector<FixedPoint>({FixedPoint(1), FixedPoint(0.5)}));
+
+    // Demand of 1.3: uses the 1 full instance, then needs 0.3 from the 0.5 partial.
+    ASSERT_TRUE(r5.CanAllocate(ResourceSet({{"GPU", FixedPoint(1.3)}})));
+
+    // Demand of 1.6: uses the 1 full instance, then needs 0.6 but only 0.5 is available.
+    ASSERT_FALSE(r5.CanAllocate(ResourceSet({{"GPU", FixedPoint(1.6)}})));
+  }
+
+  // 5. Test multiple resources: all must be satisfiable.
+  {
+    NodeResourceInstanceSet r7 =
+        NodeResourceInstanceSet(NodeResourceSet({{"CPU", 4}, {"GPU", 2}}));
+    ASSERT_TRUE(
+        r7.CanAllocate(ResourceSet({{"CPU", FixedPoint(2)}, {"GPU", FixedPoint(1.5)}})));
+    ASSERT_FALSE(
+        r7.CanAllocate(ResourceSet({{"CPU", FixedPoint(2)}, {"GPU", FixedPoint(2.5)}})));
+    ASSERT_FALSE(
+        r7.CanAllocate(ResourceSet({{"CPU", FixedPoint(5)}, {"GPU", FixedPoint(0.5)}})));
+  }
+}
+
 TEST_F(NodeResourceInstanceSetTest, TestFree) {
   NodeResourceInstanceSet r1;
   r1.Set(ResourceID("GPU"), std::vector<FixedPoint>({FixedPoint(1), FixedPoint(0.3)}));

--- a/src/ray/gcs/gcs_resource_manager.cc
+++ b/src/ray/gcs/gcs_resource_manager.cc
@@ -90,9 +90,9 @@ void GcsResourceManager::HandleGetAllAvailableResources(
     rpc::AvailableResources resource;
     resource.set_node_id(node_resources_entry.first.Binary());
     const auto &node_resources = node_resources_entry.second.GetLocalView();
-    for (const auto &resource_id : node_resources.available.ExplicitResourceIds()) {
+    for (const auto &resource_id : node_resources.GetAvailableResourceIds()) {
       const auto &resource_name = resource_id.Binary();
-      const auto &resource_value = node_resources.available.Get(resource_id);
+      const auto resource_value = node_resources.GetAvailableSum(resource_id);
       resource.mutable_resources_available()->insert(
           {resource_name, resource_value.Double()});
     }

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -24,6 +24,7 @@
 
 #include "mock/ray/pubsub/publisher.h"
 #include "ray/asio/instrumented_io_context.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/test_utils.h"
 #include "ray/gcs/gcs_node_manager.h"
 #include "ray/gcs/gcs_placement_group.h"
@@ -261,8 +262,8 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     // Make sure the resources are not used.
     for (const auto &[node_id, node] : resource_view_before_scheduling) {
       const auto &view = node.GetLocalView();
-      if (!view.IsV2()) {
-        const auto &nr = static_cast<const NodeResources &>(view);
+      if (!RayConfig::instance().enable_per_instance_resource_scheduling()) {
+        const auto &nr = dynamic_cast<const NodeResources &>(view);
         if (nr.total != nr.GetAvailable()) {
           return false;
         }

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -260,7 +260,7 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     auto resource_view_before_scheduling = cluster_resource_manager.GetResourceView();
     // Make sure the resources are not used.
     for (const auto &[node_id, node] : resource_view_before_scheduling) {
-      if (node.GetLocalView().total != node.GetLocalView().available) {
+      if (node.GetLocalView().total != node.GetLocalView().GetAvailable()) {
         return false;
       }
     }

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -260,8 +260,12 @@ class GcsPlacementGroupSchedulerTest : public ::testing::Test {
     auto resource_view_before_scheduling = cluster_resource_manager.GetResourceView();
     // Make sure the resources are not used.
     for (const auto &[node_id, node] : resource_view_before_scheduling) {
-      if (node.GetLocalView().total != node.GetLocalView().GetAvailable()) {
-        return false;
+      const auto &view = node.GetLocalView();
+      if (!view.IsV2()) {
+        const auto &nr = static_cast<const NodeResources &>(view);
+        if (nr.total != nr.GetAvailable()) {
+          return false;
+        }
       }
     }
     return true;

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -67,9 +67,9 @@ void ClusterResourceManager::AddOrUpdateNode(scheduling::NodeID node_id,
   if (it == nodes_.end()) {
     // This node is new, so add it to the map.
     std::unique_ptr<NodeResourcesBase> copy;
-    if (!node_resources.IsV2()) {
+    if (!RayConfig::instance().enable_per_instance_resource_scheduling()) {
       copy = std::make_unique<NodeResources>(
-          static_cast<const NodeResources &>(node_resources));
+          dynamic_cast<const NodeResources &>(node_resources));
     }
     nodes_.emplace(node_id, Node(std::move(copy)));
   } else {
@@ -148,14 +148,12 @@ bool ClusterResourceManager::GetNodeResources(scheduling::NodeID node_id,
   auto it = nodes_.find(node_id);
   if (it != nodes_.end()) {
     const auto &node_resources = it->second.GetLocalView();
-    RAY_CHECK(node_resources.IsV2() == ret_resources->IsV2())
-        << "ret_resources type must match the node's resource version";
-    if (node_resources.IsV2()) {
-      *static_cast<NodeResourcesV2 *>(ret_resources) =
-          static_cast<const NodeResourcesV2 &>(node_resources);
+    if (RayConfig::instance().enable_per_instance_resource_scheduling()) {
+      dynamic_cast<NodeResourcesV2 &>(*ret_resources) =
+          dynamic_cast<const NodeResourcesV2 &>(node_resources);
     } else {
-      *static_cast<NodeResources *>(ret_resources) =
-          static_cast<const NodeResources &>(node_resources);
+      dynamic_cast<NodeResources &>(*ret_resources) =
+          dynamic_cast<const NodeResources &>(node_resources);
     }
     return true;
   } else {
@@ -194,9 +192,9 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
     available = 0;
   }
   local_view->total.Set(resource_id, total);
-  if (!local_view->IsV2()) {
-    static_cast<NodeResources *>(local_view)
-        ->SetAvailableResource(resource_id, available);
+  if (!RayConfig::instance().enable_per_instance_resource_scheduling()) {
+    dynamic_cast<NodeResources &>(*local_view)
+        .SetAvailableResource(resource_id, available);
   }
 }
 
@@ -210,8 +208,8 @@ bool ClusterResourceManager::DeleteResources(
   auto local_view = it->second.GetMutableLocalView();
   for (const auto &resource_id : resource_ids) {
     local_view->total.Set(resource_id, 0);
-    if (!local_view->IsV2()) {
-      static_cast<NodeResources *>(local_view)->SetAvailableResource(resource_id, 0);
+    if (!RayConfig::instance().enable_per_instance_resource_scheduling()) {
+      dynamic_cast<NodeResources &>(*local_view).SetAvailableResource(resource_id, 0);
     }
   }
   return true;
@@ -237,9 +235,9 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
 
   NodeResourcesBase *resources = it->second.GetMutableLocalView();
 
-  if (!resources->IsV2()) {
-    static_cast<NodeResources *>(resources)->SubtractAvailable(
-        resource_request.GetResourceSet());
+  if (!RayConfig::instance().enable_per_instance_resource_scheduling()) {
+    dynamic_cast<NodeResources &>(*resources)
+        .SubtractAvailable(resource_request.GetResourceSet());
   }
 
   // TODO(swang): We should also subtract object store memory if the task has
@@ -288,9 +286,9 @@ bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_i
       if (new_available > total) {
         new_available = total;
       }
-      if (!node_resources->IsV2()) {
-        static_cast<NodeResources *>(node_resources)
-            ->SetAvailableResource(resource_id, new_available);
+      if (!RayConfig::instance().enable_per_instance_resource_scheduling()) {
+        dynamic_cast<NodeResources &>(*node_resources)
+            .SetAvailableResource(resource_id, new_available);
       }
     }
   }

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -35,7 +35,7 @@ ClusterResourceManager::ClusterResourceManager(instrumented_io_context &io_servi
         for (auto &[node_id, resource] : received_node_resources_) {
           auto modified_ts = GetNodeResourceModifiedTs(node_id);
           if (modified_ts && *modified_ts + syncer_delay < absl::Now()) {
-            AddOrUpdateNode(node_id, resource);
+            AddOrUpdateNode(node_id, *resource);
           }
         }
       },
@@ -62,14 +62,19 @@ void ClusterResourceManager::AddOrUpdateNode(
 }
 
 void ClusterResourceManager::AddOrUpdateNode(scheduling::NodeID node_id,
-                                             const NodeResources &node_resources) {
+                                             const NodeResourcesBase &node_resources) {
   auto it = nodes_.find(node_id);
   if (it == nodes_.end()) {
     // This node is new, so add it to the map.
-    nodes_.emplace(node_id, node_resources);
+    std::unique_ptr<NodeResourcesBase> copy;
+    if (!node_resources.IsV2()) {
+      copy = std::make_unique<NodeResources>(
+          static_cast<const NodeResources &>(node_resources));
+    }
+    nodes_.emplace(node_id, Node(std::move(copy)));
   } else {
     // This node exists, so update its resources.
-    it->second = Node(node_resources);
+    it->second.UpdateView(node_resources);
   }
 }
 
@@ -108,7 +113,8 @@ bool ClusterResourceManager::UpdateNode(
   }
 
   AddOrUpdateNode(node_id, local_view);
-  received_node_resources_[node_id] = std::move(local_view);
+  received_node_resources_[node_id] =
+      std::make_unique<NodeResources>(std::move(local_view));
   return true;
 }
 
@@ -130,25 +136,34 @@ bool ClusterResourceManager::SetNodeDraining(const scheduling::NodeID &node_id,
   local_view->draining_deadline_timestamp_ms = draining_deadline_timestamp_ms;
   auto rnr_it = received_node_resources_.find(node_id);
   if (rnr_it != received_node_resources_.end()) {
-    rnr_it->second.is_draining = is_draining;
-    rnr_it->second.draining_deadline_timestamp_ms = draining_deadline_timestamp_ms;
+    rnr_it->second->is_draining = is_draining;
+    rnr_it->second->draining_deadline_timestamp_ms = draining_deadline_timestamp_ms;
   }
 
   return true;
 }
 
 bool ClusterResourceManager::GetNodeResources(scheduling::NodeID node_id,
-                                              NodeResources *ret_resources) const {
+                                              NodeResourcesBase *ret_resources) const {
   auto it = nodes_.find(node_id);
   if (it != nodes_.end()) {
-    *ret_resources = it->second.GetLocalView();
+    const auto &node_resources = it->second.GetLocalView();
+    RAY_CHECK(node_resources.IsV2() == ret_resources->IsV2())
+        << "ret_resources type must match the node's resource version";
+    if (node_resources.IsV2()) {
+      *static_cast<NodeResourcesV2 *>(ret_resources) =
+          static_cast<const NodeResourcesV2 &>(node_resources);
+    } else {
+      *static_cast<NodeResources *>(ret_resources) =
+          static_cast<const NodeResources &>(node_resources);
+    }
     return true;
   } else {
     return false;
   }
 }
 
-const NodeResources &ClusterResourceManager::GetNodeResources(
+const NodeResourcesBase &ClusterResourceManager::GetNodeResources(
     scheduling::NodeID node_id) const {
   const auto &node = map_find_or_die(nodes_, node_id);
   return node.GetLocalView();
@@ -179,7 +194,10 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
     available = 0;
   }
   local_view->total.Set(resource_id, total);
-  local_view->SetAvailableResource(resource_id, available);
+  if (!local_view->IsV2()) {
+    static_cast<NodeResources *>(local_view)
+        ->SetAvailableResource(resource_id, available);
+  }
 }
 
 bool ClusterResourceManager::DeleteResources(
@@ -192,7 +210,9 @@ bool ClusterResourceManager::DeleteResources(
   auto local_view = it->second.GetMutableLocalView();
   for (const auto &resource_id : resource_ids) {
     local_view->total.Set(resource_id, 0);
-    local_view->SetAvailableResource(resource_id, 0);
+    if (!local_view->IsV2()) {
+      static_cast<NodeResources *>(local_view)->SetAvailableResource(resource_id, 0);
+    }
   }
   return true;
 }
@@ -215,9 +235,12 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
     return false;
   }
 
-  NodeResources *resources = it->second.GetMutableLocalView();
+  NodeResourcesBase *resources = it->second.GetMutableLocalView();
 
-  resources->SubtractAvailable(resource_request.GetResourceSet());
+  if (!resources->IsV2()) {
+    static_cast<NodeResources *>(resources)->SubtractAvailable(
+        resource_request.GetResourceSet());
+  }
 
   // TODO(swang): We should also subtract object store memory if the task has
   // arguments. Right now we do not modify object_pulls_queued in case of
@@ -265,7 +288,10 @@ bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_i
       if (new_available > total) {
         new_available = total;
       }
-      node_resources->SetAvailableResource(resource_id, new_available);
+      if (!node_resources->IsV2()) {
+        static_cast<NodeResources *>(node_resources)
+            ->SetAvailableResource(resource_id, new_available);
+      }
     }
   }
   return true;

--- a/src/ray/raylet/scheduling/cluster_resource_manager.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.cc
@@ -91,7 +91,7 @@ bool ClusterResourceManager::UpdateNode(
   RAY_CHECK(GetNodeResources(node_id, &local_view));
 
   local_view.total = std::move(node_resources.total);
-  local_view.available = std::move(node_resources.available);
+  local_view.SetAvailable(node_resources.TakeAvailable());
   local_view.labels = std::move(node_labels);
   local_view.object_pulls_queued = resource_view_sync_message.object_pulls_queued();
 
@@ -168,7 +168,7 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
   auto local_view = it->second.GetMutableLocalView();
   FixedPoint resource_total_fp(resource_total);
   auto local_total = local_view->total.Get(resource_id);
-  auto local_available = local_view->available.Get(resource_id);
+  auto local_available = local_view->GetAvailableSum(resource_id);
   auto diff_capacity = resource_total_fp - local_total;
   auto total = local_total + diff_capacity;
   auto available = local_available + diff_capacity;
@@ -179,7 +179,7 @@ void ClusterResourceManager::UpdateResourceCapacity(scheduling::NodeID node_id,
     available = 0;
   }
   local_view->total.Set(resource_id, total);
-  local_view->available.Set(resource_id, available);
+  local_view->SetAvailableResource(resource_id, available);
 }
 
 bool ClusterResourceManager::DeleteResources(
@@ -192,7 +192,7 @@ bool ClusterResourceManager::DeleteResources(
   auto local_view = it->second.GetMutableLocalView();
   for (const auto &resource_id : resource_ids) {
     local_view->total.Set(resource_id, 0);
-    local_view->available.Set(resource_id, 0);
+    local_view->SetAvailableResource(resource_id, 0);
   }
   return true;
 }
@@ -217,8 +217,7 @@ bool ClusterResourceManager::SubtractNodeAvailableResources(
 
   NodeResources *resources = it->second.GetMutableLocalView();
 
-  resources->available -= resource_request.GetResourceSet();
-  resources->available.RemoveNegative();
+  resources->SubtractAvailable(resource_request.GetResourceSet());
 
   // TODO(swang): We should also subtract object store memory if the task has
   // arguments. Right now we do not modify object_pulls_queued in case of
@@ -260,13 +259,13 @@ bool ClusterResourceManager::AddNodeAvailableResources(scheduling::NodeID node_i
   auto node_resources = it->second.GetMutableLocalView();
   for (auto &resource_id : resource_set.ResourceIds()) {
     if (node_resources->total.Has(resource_id)) {
-      auto available = node_resources->available.Get(resource_id);
+      auto available = node_resources->GetAvailableSum(resource_id);
       auto total = node_resources->total.Get(resource_id);
       auto new_available = available + resource_set.Get(resource_id);
       if (new_available > total) {
         new_available = total;
       }
-      node_resources->available.Set(resource_id, new_available);
+      node_resources->SetAvailableResource(resource_id, new_available);
     }
   }
   return true;

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -91,7 +91,7 @@ class ClusterResourceManager {
   std::string GetNodeResourceViewString(scheduling::NodeID node_id) const;
 
   /// Get local resource.
-  const NodeResources &GetNodeResources(scheduling::NodeID node_id) const;
+  const NodeResourcesBase &GetNodeResources(scheduling::NodeID node_id) const;
 
   /// Subtract available resource from a given node.
   /// Return false if such node doesn't exist.
@@ -185,7 +185,8 @@ class ClusterResourceManager {
   ///
   /// \param node_id: Node ID.
   /// \param node_resources: Up to date total and available resources of the node.
-  void AddOrUpdateNode(scheduling::NodeID node_id, const NodeResources &node_resources);
+  void AddOrUpdateNode(scheduling::NodeID node_id,
+                       const NodeResourcesBase &node_resources);
 
   void AddOrUpdateNode(
       scheduling::NodeID node_id,
@@ -194,14 +195,16 @@ class ClusterResourceManager {
 
   /// Return resources associated to the given node_id in ret_resources.
   /// If node_id not found, return false; otherwise return true.
-  bool GetNodeResources(scheduling::NodeID node_id, NodeResources *ret_resources) const;
+  bool GetNodeResources(scheduling::NodeID node_id,
+                        NodeResourcesBase *ret_resources) const;
 
   /// List of nodes in the clusters and their resources organized as a map.
   /// The key of the map is the node ID.
   absl::flat_hash_map<scheduling::NodeID, Node> nodes_;
 
   /// Resource message updated
-  absl::flat_hash_map<scheduling::NodeID, NodeResources> received_node_resources_;
+  absl::flat_hash_map<scheduling::NodeID, std::unique_ptr<NodeResourcesBase>>
+      received_node_resources_;
 
   BundleLocationIndex bundle_location_index_;
 

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.cc
@@ -25,7 +25,7 @@ using namespace ::ray::raylet_scheduling_policy;  // NOLINT
 ClusterResourceScheduler::ClusterResourceScheduler(
     instrumented_io_context &io_service,
     scheduling::NodeID local_node_id,
-    const NodeResources &local_node_resources,
+    const NodeResourcesBase &local_node_resources,
     std::function<bool(scheduling::NodeID)> is_node_available_fn,
     ray::observability::MetricInterface &resource_usage_gauge,
     ClockInterface &clock,
@@ -67,7 +67,7 @@ ClusterResourceScheduler::ClusterResourceScheduler(
 
 void ClusterResourceScheduler::Init(
     instrumented_io_context &io_service,
-    const NodeResources &local_node_resources,
+    const NodeResourcesBase &local_node_resources,
     std::function<int64_t(void)> get_used_object_store_memory,
     std::function<bool(void)> get_pull_manager_at_capacity,
     std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully,
@@ -80,7 +80,7 @@ void ClusterResourceScheduler::Init(
       get_used_object_store_memory,
       get_pull_manager_at_capacity,
       shutdown_raylet_gracefully,
-      [this](const NodeResources &local_resource_update) {
+      [this](const NodeResourcesBase &local_resource_update) {
         cluster_resource_manager_->AddOrUpdateNode(local_node_id_, local_resource_update);
       },
       resource_usage_gauge,

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -54,7 +54,7 @@ class ClusterResourceScheduler {
   /// \param is_local_node_with_raylet: Whether there is a raylet on the local node.
   ClusterResourceScheduler(instrumented_io_context &io_service,
                            scheduling::NodeID local_node_id,
-                           const NodeResources &local_node_resources,
+                           const NodeResourcesBase &local_node_resources,
                            std::function<bool(scheduling::NodeID)> is_node_available_fn,
                            ray::observability::MetricInterface &resource_usage_gauge,
                            ClockInterface &clock,
@@ -143,7 +143,7 @@ class ClusterResourceScheduler {
 
  private:
   void Init(instrumented_io_context &io_service,
-            const NodeResources &local_node_resources,
+            const NodeResourcesBase &local_node_resources,
             std::function<int64_t(void)> get_used_object_store_memory,
             std::function<bool(void)> get_pull_manager_at_capacity,
             std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully,

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -30,11 +30,11 @@ namespace ray {
 
 LocalResourceManager::LocalResourceManager(
     scheduling::NodeID local_node_id,
-    const NodeResources &node_resources,
+    const NodeResourcesBase &node_resources,
     std::function<int64_t(void)> get_used_object_store_memory,
     std::function<bool(void)> get_pull_manager_at_capacity,
     std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully,
-    std::function<void(const NodeResources &)> resource_change_subscriber,
+    std::function<void(const NodeResourcesBase &)> resource_change_subscriber,
     ray::observability::MetricInterface &resource_usage_gauge,
     ClockInterface &clock)
     : local_node_id_(local_node_id),
@@ -44,7 +44,10 @@ LocalResourceManager::LocalResourceManager(
       shutdown_raylet_gracefully_(shutdown_raylet_gracefully),
       resource_change_subscriber_(resource_change_subscriber),
       resource_usage_gauge_(resource_usage_gauge) {
-  RAY_CHECK(node_resources.total == node_resources.GetAvailable());
+  if (!node_resources.IsV2()) {
+    const auto &v1 = static_cast<const NodeResources &>(node_resources);
+    RAY_CHECK(v1.total == v1.GetAvailable());
+  }
   local_resources_.available = NodeResourceInstanceSet(node_resources.total);
   local_resources_.total = NodeResourceInstanceSet(node_resources.total);
   local_resources_.labels = node_resources.labels;

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "ray/common/ray_config.h"
 #include "ray/common/scheduling/placement_group_util.h"
 #include "ray/common/scheduling/resource_set.h"
 #include "ray/util/logging.h"
@@ -44,8 +45,8 @@ LocalResourceManager::LocalResourceManager(
       shutdown_raylet_gracefully_(shutdown_raylet_gracefully),
       resource_change_subscriber_(resource_change_subscriber),
       resource_usage_gauge_(resource_usage_gauge) {
-  if (!node_resources.IsV2()) {
-    const auto &v1 = static_cast<const NodeResources &>(node_resources);
+  if (!RayConfig::instance().enable_per_instance_resource_scheduling()) {
+    const auto &v1 = dynamic_cast<const NodeResources &>(node_resources);
     RAY_CHECK(v1.total == v1.GetAvailable());
   }
   local_resources_.available = NodeResourceInstanceSet(node_resources.total);

--- a/src/ray/raylet/scheduling/local_resource_manager.cc
+++ b/src/ray/raylet/scheduling/local_resource_manager.cc
@@ -44,7 +44,7 @@ LocalResourceManager::LocalResourceManager(
       shutdown_raylet_gracefully_(shutdown_raylet_gracefully),
       resource_change_subscriber_(resource_change_subscriber),
       resource_usage_gauge_(resource_usage_gauge) {
-  RAY_CHECK(node_resources.total == node_resources.available);
+  RAY_CHECK(node_resources.total == node_resources.GetAvailable());
   local_resources_.available = NodeResourceInstanceSet(node_resources.total);
   local_resources_.total = NodeResourceInstanceSet(node_resources.total);
   local_resources_.labels = node_resources.labels;
@@ -310,7 +310,7 @@ void LocalResourceManager::ReleaseWorkerResources(
 
 NodeResources LocalResourceManager::ToNodeResources() const {
   NodeResources node_resources;
-  node_resources.available = local_resources_.available.ToNodeResourceSet();
+  node_resources.SetAvailable(local_resources_.available.ToNodeResourceSet());
   node_resources.total = local_resources_.total.ToNodeResourceSet();
   node_resources.labels = local_resources_.labels;
   node_resources.is_draining = IsLocalNodeDraining();
@@ -367,7 +367,7 @@ void LocalResourceManager::PopulateResourceViewSyncMessage(
   resource_view_sync_message.mutable_resources_total()->insert(total.begin(),
                                                                total.end());
 
-  for (const auto &[resource_name, available] : resources.available.GetResourceMap()) {
+  for (const auto &[resource_name, available] : resources.GetAvailableResourceMap()) {
     // Resource availability can be negative locally but treat it as 0
     // when we broadcast to others since other parts of the
     // system assume resource availability cannot be negative and

--- a/src/ray/raylet/scheduling/local_resource_manager.h
+++ b/src/ray/raylet/scheduling/local_resource_manager.h
@@ -60,11 +60,11 @@ class LocalResourceManager : public syncer::ReporterInterface {
  public:
   LocalResourceManager(
       scheduling::NodeID local_node_id,
-      const NodeResources &node_resources,
+      const NodeResourcesBase &node_resources,
       std::function<int64_t(void)> get_used_object_store_memory,
       std::function<bool(void)> get_pull_manager_at_capacity,
       std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully,
-      std::function<void(const NodeResources &)> resource_change_subscriber,
+      std::function<void(const NodeResourcesBase &)> resource_change_subscriber,
       ray::observability::MetricInterface &resource_usage_gauge,
       ClockInterface &clock);
 
@@ -250,7 +250,7 @@ class LocalResourceManager : public syncer::ReporterInterface {
   std::function<void(const rpc::NodeDeathInfo &)> shutdown_raylet_gracefully_;
 
   /// Subscribes to resource changes.
-  std::function<void(const NodeResources &)> resource_change_subscriber_;
+  std::function<void(const NodeResourcesBase &)> resource_change_subscriber_;
 
   // Version of this resource. It will incr by one whenever the state changed.
   int64_t version_ = 0;

--- a/src/ray/raylet/scheduling/policy/hybrid_scheduling_policy.cc
+++ b/src/ray/raylet/scheduling/policy/hybrid_scheduling_policy.cc
@@ -23,7 +23,7 @@ namespace raylet_scheduling_policy {
 bool HybridSchedulingPolicy::IsNodeFeasible(
     const scheduling::NodeID &node_id,
     const NodeFilter &node_filter,
-    const NodeResources &node_resources,
+    const NodeResourcesBase &node_resources,
     const ResourceRequest &resource_request) const {
   if (!is_node_alive_(node_id)) {
     return false;
@@ -42,7 +42,8 @@ bool HybridSchedulingPolicy::IsNodeFeasible(
 }
 
 namespace {
-float ComputeNodeScoreImpl(const NodeResources &node_resources, float spread_threshold) {
+float ComputeNodeScoreImpl(const NodeResourcesBase &node_resources,
+                           float spread_threshold) {
   float critical_resource_utilization =
       node_resources.CalculateCriticalResourceUtilization();
   if (critical_resource_utilization < spread_threshold) {

--- a/src/ray/raylet/scheduling/policy/hybrid_scheduling_policy.h
+++ b/src/ray/raylet/scheduling/policy/hybrid_scheduling_policy.h
@@ -76,7 +76,7 @@ class HybridSchedulingPolicy : public ISchedulingPolicy {
   /// satisfy the filter and resource requirement.
   bool IsNodeFeasible(const scheduling::NodeID &node_id,
                       const NodeFilter &node_filter,
-                      const NodeResources &node_resources,
+                      const NodeResourcesBase &node_resources,
                       const ResourceRequest &resource_request) const;
 
   /// helper function compute a score between 0-1 indicates

--- a/src/ray/raylet/scheduling/policy/scorer.cc
+++ b/src/ray/raylet/scheduling/policy/scorer.cc
@@ -26,7 +26,7 @@ double LeastResourceScorer::Score(const ResourceRequest &required_resources,
   double node_score = 0.;
   for (auto &resource_id : required_resources.ResourceIds()) {
     const auto &request_resource = required_resources.Get(resource_id);
-    const auto &node_available_resource = node_resources.available.Get(resource_id);
+    const auto node_available_resource = node_resources.GetAvailableSum(resource_id);
     node_score += Calculate(request_resource, node_available_resource);
   }
   return node_score;

--- a/src/ray/raylet/scheduling/policy/scorer.cc
+++ b/src/ray/raylet/scheduling/policy/scorer.cc
@@ -18,7 +18,7 @@ namespace ray {
 namespace raylet_scheduling_policy {
 
 double LeastResourceScorer::Score(const ResourceRequest &required_resources,
-                                  const NodeResources &node_resources) {
+                                  const NodeResourcesBase &node_resources) {
   if (!node_resources.IsAvailable(required_resources)) {
     return -1.;
   }

--- a/src/ray/raylet/scheduling/policy/scorer.h
+++ b/src/ray/raylet/scheduling/policy/scorer.h
@@ -32,7 +32,7 @@ class NodeScorer {
   /// resources.
   /// \return Score of the node.
   virtual double Score(const ResourceRequest &required_resources,
-                       const NodeResources &node_resources) = 0;
+                       const NodeResourcesBase &node_resources) = 0;
 };
 
 /// LeastResourceScorer is a score plugin that favors nodes with fewer allocation
@@ -40,7 +40,7 @@ class NodeScorer {
 class LeastResourceScorer : public NodeScorer {
  public:
   double Score(const ResourceRequest &required_resources,
-               const NodeResources &node_resources) override;
+               const NodeResourcesBase &node_resources) override;
 
  private:
   /// \brief Calculate one of the resource scores.

--- a/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/hybrid_scheduling_policy_test.cc
@@ -32,9 +32,9 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double available_gpu,
                                   double total_gpu) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu)
-      .Set(ResourceID::Memory(), available_memory)
-      .Set(ResourceID::GPU(), available_gpu);
+  resources.SetAvailableResource(ResourceID::CPU(), available_cpu);
+  resources.SetAvailableResource(ResourceID::Memory(), available_memory);
+  resources.SetAvailableResource(ResourceID::GPU(), available_gpu);
   resources.total.Set(ResourceID::CPU(), total_cpu)
       .Set(ResourceID::Memory(), total_memory)
       .Set(ResourceID::GPU(), total_gpu);

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -756,7 +756,7 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
   ASSERT_EQ(result_1.selected_nodes.size(), 15);
 
   for (const scheduling::NodeID &node_id : result_1.selected_nodes) {
-    const NodeResources &node_resources =
+    const NodeResourcesBase &node_resources =
         cluster_resource_manager->GetNodeResources(node_id);
     absl::flat_hash_map<std::string, std::string>::const_iterator it =
         node_resources.labels.find(kDomainLabelKey);
@@ -786,7 +786,7 @@ TEST_F(SchedulingPolicyTest, GpuDomainSchedulingFeasibleTest) {
   ASSERT_EQ(result_2.selected_nodes.size(), 3);
 
   for (const scheduling::NodeID &node_id : result_2.selected_nodes) {
-    const NodeResources &node_resources =
+    const NodeResourcesBase &node_resources =
         cluster_resource_manager->GetNodeResources(node_id);
     absl::flat_hash_map<std::string, std::string>::const_iterator it =
         node_resources.labels.find(kDomainLabelKey);

--- a/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
+++ b/src/ray/raylet/scheduling/policy/tests/scheduling_policy_test.cc
@@ -30,9 +30,9 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double available_gpu,
                                   double total_gpu) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu)
-      .Set(ResourceID::Memory(), available_memory)
-      .Set(ResourceID::GPU(), available_gpu);
+  resources.SetAvailableResource(ResourceID::CPU(), available_cpu);
+  resources.SetAvailableResource(ResourceID::Memory(), available_memory);
+  resources.SetAvailableResource(ResourceID::GPU(), available_gpu);
   resources.total.Set(ResourceID::CPU(), total_cpu)
       .Set(ResourceID::Memory(), total_memory)
       .Set(ResourceID::GPU(), total_gpu);
@@ -242,7 +242,7 @@ TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
   auto task_req2 = ResourceMapToResourceRequest({{"CPU", 1}}, false);
 
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), 2.0);
+  resources.SetAvailableResource(ResourceID::CPU(), 2.0);
   resources.total.Set(ResourceID::CPU(), 2.0);
   ASSERT_FALSE(resources.IsAvailable(task_req1));
   ASSERT_TRUE(resources.IsAvailable(task_req2));
@@ -251,17 +251,17 @@ TEST_F(SchedulingPolicyTest, AvailableDefinitionTest) {
 TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {
   {
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0);
+    resources.SetAvailableResource(ResourceID::CPU(), 1.0);
     resources.total.Set(ResourceID::CPU(), 2.0);
     ASSERT_EQ(resources.CalculateCriticalResourceUtilization(), 0.5);
   }
   {
     // Basic test of max
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0)
-        .Set(ResourceID::Memory(), 0.25)
-        .Set(ResourceID::GPU(), 1)
-        .Set(ResourceID::ObjectStoreMemory(), 50);
+    resources.SetAvailableResource(ResourceID::CPU(), 1.0);
+    resources.SetAvailableResource(ResourceID::Memory(), 0.25);
+    resources.SetAvailableResource(ResourceID::GPU(), 1);
+    resources.SetAvailableResource(ResourceID::ObjectStoreMemory(), 50);
     resources.total.Set(ResourceID::CPU(), 2.0)
         .Set(ResourceID::Memory(), 1)
         .Set(ResourceID::GPU(), 2)
@@ -272,10 +272,10 @@ TEST_F(SchedulingPolicyTest, CriticalResourceUtilizationDefinitionTest) {
   {
     // Skip GPU
     NodeResources resources;
-    resources.available.Set(ResourceID::CPU(), 1.0)
-        .Set(ResourceID::Memory(), 0.25)
-        .Set(ResourceID::GPU(), 0)
-        .Set(ResourceID::ObjectStoreMemory(), 50);
+    resources.SetAvailableResource(ResourceID::CPU(), 1.0);
+    resources.SetAvailableResource(ResourceID::Memory(), 0.25);
+    resources.SetAvailableResource(ResourceID::GPU(), 0);
+    resources.SetAvailableResource(ResourceID::ObjectStoreMemory(), 50);
     resources.total.Set(ResourceID::CPU(), 2.0)
         .Set(ResourceID::Memory(), 1)
         .Set(ResourceID::GPU(), 2)

--- a/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
@@ -2368,7 +2368,7 @@ TEST_F(ClusterLeaseManagerTest, NegativePlacementGroupCpuResources) {
   scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
       scheduling::ResourceID("CPU_group_1_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
 
-  const NodeResources &node_resources =
+  const NodeResourcesBase &node_resources =
       scheduler_->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(id_.Binary()));
 
@@ -2416,7 +2416,7 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   scheduler_->GetLocalResourceManager().AddLocalResourceInstances(
       scheduling::ResourceID("GPU_group_0_aaa"), std::vector<FixedPoint>{FixedPoint(1)});
 
-  const NodeResources &node_resources =
+  const NodeResourcesBase &node_resources =
       scheduler_->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(id_.Binary()));
   ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 8);

--- a/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
@@ -2389,18 +2389,20 @@ TEST_F(ClusterLeaseManagerTest, NegativePlacementGroupCpuResources) {
 
   // ray.get() returns and worker1 acquires the CPU resource again
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_1_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")),
+            -1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_1_aaa")), 1);
 
   auto worker3 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 7678);
   allocated_instances = std::make_shared<TaskResourceInstances>();
   ASSERT_TRUE(scheduler_->GetLocalResourceManager().AllocateLocalTaskResources(
       {{"CPU_group_aaa", 1.}, {"CPU_group_1_aaa", 1.}}, allocated_instances));
   worker3->SetAllocatedInstances(allocated_instances);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), -1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_1_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), -1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")),
+            -1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_1_aaa")), 0);
 }
 
 TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources) {
@@ -2417,8 +2419,8 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   const NodeResources &node_resources =
       scheduler_->GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(id_.Binary()));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 4);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 4);
 
   auto worker1 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234);
   auto worker2 = std::make_shared<MockWorker>(WorkerID::FromRandom(), 5678);
@@ -2448,24 +2450,24 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   worker2->SetAllocatedInstances(allocated_instances);
 
   // Check that the resources are allocated successfully.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are released successfully.
   ASSERT_TRUE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
   ASSERT_TRUE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
 
   // Check that only cpu resources are released.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as blocked.
   worker1->MarkBlocked();
@@ -2474,24 +2476,24 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   ASSERT_FALSE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker1));
   ASSERT_FALSE(local_lease_manager_->ReleaseCpuResourcesFromBlockedWorker(worker2));
   // Check nothing will be changed.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 8);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 1);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 8);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Check that the cpu resources are returned back to worker successfully.
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
   ASSERT_TRUE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
 
   // Check that only cpu resources are returned back to the worker.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 
   // Mark worker as unblocked.
   worker1->MarkUnblocked();
@@ -2499,12 +2501,12 @@ TEST_F(ClusterLeaseManagerTestWithGPUsAtHead, ReleaseAndReturnWorkerCpuResources
   ASSERT_FALSE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker1));
   ASSERT_FALSE(local_lease_manager_->ReturnCpuResourcesToUnblockedWorker(worker2));
   // Check nothing will be changed.
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 7);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::GPU()), 3);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU_group_0_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_aaa")), 0);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("GPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 7);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::GPU()), 3);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU_group_0_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_aaa")), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("GPU_group_0_aaa")), 0);
 }
 
 TEST_F(ClusterLeaseManagerTest, TestSpillWaitingLeases) {

--- a/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_manager_test.cc
@@ -26,9 +26,10 @@ NodeResources CreateNodeResources(double available_cpu,
                                   double total_custom_resource = 0,
                                   bool object_pulls_queued = false) {
   NodeResources resources;
-  resources.available.Set(ResourceID::CPU(), available_cpu);
+  resources.SetAvailableResource(ResourceID::CPU(), available_cpu);
   resources.total.Set(ResourceID::CPU(), total_cpu);
-  resources.available.Set(scheduling::ResourceID("CUSTOM"), available_custom_resource);
+  resources.SetAvailableResource(scheduling::ResourceID("CUSTOM"),
+                                 available_custom_resource);
   resources.total.Set(scheduling::ResourceID("CUSTOM"), total_custom_resource);
   resources.object_pulls_queued = object_pulls_queued;
   return resources;
@@ -76,7 +77,7 @@ TEST_F(ClusterResourceManagerTest, UpdateNode) {
 
   const auto &node_resources = manager->GetNodeResources(node0);
   ASSERT_EQ(node_resources.total.Get(scheduling::ResourceID("CPU")), 10);
-  ASSERT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU")), 5);
+  ASSERT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU")), 5);
   ASSERT_EQ(node_resources.labels.at("zone"), "us-east-1a");
   ASSERT_TRUE(node_resources.object_pulls_queued);
   ASSERT_EQ(node_resources.idle_resource_duration_ms, 42);
@@ -163,26 +164,26 @@ TEST_F(ClusterResourceManagerTest, HasAvailableResourcesTest) {
 
 TEST_F(ClusterResourceManagerTest, SubtractAndAddNodeAvailableResources) {
   const auto &node_resources = manager->GetNodeResources(node0);
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 1);
 
   manager->SubtractNodeAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 0);
   // Subtract again and make sure the available == 0.
   manager->SubtractNodeAvailableResources(
       node0,
       ResourceMapToResourceRequest({{"CPU", 1}},
                                    /*requires_object_store_memory=*/false));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 0);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 0);
 
   // Add resources back.
   manager->AddNodeAvailableResources(node0, ResourceSet({{"CPU", FixedPoint(1)}}));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 1);
   // Add again and make sure the available == 1 (<= total).
   manager->AddNodeAvailableResources(node0, ResourceSet({{"CPU", FixedPoint(1)}}));
-  ASSERT_EQ(node_resources.available.Get(ResourceID::CPU()), 1);
+  ASSERT_EQ(node_resources.GetAvailableSum(ResourceID::CPU()), 1);
 }
 
 }  // namespace ray

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_2_test.cc
@@ -83,8 +83,8 @@ class GcsResourceSchedulerTest : public ::testing::Test {
         cluster_resource_manager.GetNodeResources(scheduling::NodeID(node_id.Binary()));
     auto resource_id = scheduling::ResourceID(resource_name);
 
-    ASSERT_TRUE(node_resources.available.Has(resource_id));
-    ASSERT_EQ(node_resources.available.Get(resource_id).Double(), resource_value);
+    ASSERT_TRUE(node_resources.HasAvailableResource(resource_id));
+    ASSERT_EQ(node_resources.GetAvailableSum(resource_id).Double(), resource_value);
   }
 
   void TestResourceLeaks(SchedulingOptions scheduling_options) {

--- a/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_resource_scheduler_test.cc
@@ -636,9 +636,9 @@ TEST_F(ClusterResourceSchedulerTest, SchedulingUpdateAvailableResourcesTest) {
         resource_scheduler.GetClusterResourceManager().GetNodeResources(node_id, &nr2));
 
     for (auto &resource_id : nr1.total.ExplicitResourceIds()) {
-      auto t = nr1.available.Get(resource_id) - resource_request.Get(resource_id);
+      auto t = nr1.GetAvailableSum(resource_id) - resource_request.Get(resource_id);
       if (t < 0) t = 0;
-      ASSERT_EQ(nr2.available.Get(resource_id), t);
+      ASSERT_EQ(nr2.GetAvailableSum(resource_id), t);
     }
   }
 }
@@ -1296,7 +1296,7 @@ TEST_F(ClusterResourceSchedulerTest,
       NodeResources nr;
       resource_scheduler.GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(0), &nr);
-      ASSERT_TRUE(nr.available.Get(ResourceID::GPU()) == 1.5);
+      ASSERT_TRUE(nr.GetAvailableSum(ResourceID::GPU()) == 1.5);
     }
 
     {
@@ -1318,7 +1318,7 @@ TEST_F(ClusterResourceSchedulerTest,
       NodeResources nr;
       resource_scheduler.GetClusterResourceManager().GetNodeResources(
           scheduling::NodeID(0), &nr);
-      ASSERT_TRUE(nr.available.Get(ResourceID::GPU()) == 3.8);
+      ASSERT_TRUE(nr.GetAvailableSum(ResourceID::GPU()) == 3.8);
     }
   }
 }

--- a/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/local_resource_manager_test.cc
@@ -36,7 +36,7 @@ class LocalResourceManagerTest : public ::testing::Test {
       absl::flat_hash_map<ResourceID, double> resource_usage_map) {
     NodeResources resources;
     for (auto &[resource_id, total] : resource_usage_map) {
-      resources.available.Set(resource_id, total);
+      resources.SetAvailableResource(resource_id, total);
       resources.total.Set(resource_id, total);
     }
     return resources;

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -783,7 +783,7 @@ TEST_F(NodeManagerTest, TestConsumeSyncMessage) {
   EXPECT_EQ(node_resources.labels.at("label1"), "value1");
   EXPECT_EQ(node_resources.total.Get(scheduling::ResourceID("CPU")).Double(),
             kTestTotalCpuResource);
-  EXPECT_EQ(node_resources.available.Get(scheduling::ResourceID("CPU")).Double(),
+  EXPECT_EQ(node_resources.GetAvailableSum(scheduling::ResourceID("CPU")).Double(),
             kTestTotalCpuResource);
 }
 

--- a/src/ray/raylet/tests/placement_group_resource_manager_test.cc
+++ b/src/ray/raylet/tests/placement_group_resource_manager_test.cc
@@ -110,7 +110,7 @@ class NewPlacementGroupResourceManagerTest : public ::testing::Test {
   }
 
   void CheckRemainingResourceCorrect(NodeResources &node_resources) {
-    auto local_node_resource =
+    const auto &local_node_resource =
         cluster_resource_scheduler_->GetClusterResourceManager().GetNodeResources(
             scheduling::NodeID("local"));
     ASSERT_TRUE(local_node_resource == node_resources);


### PR DESCRIPTION
## Description

### Context
- This PR is a preparatory refactor for the final goal to change `available` type from `NodeResourceSet` (scalar) to `NodeResourceInstanceSet` (per-instance vector) for accurate GPU fragmentation detection(https://github.com/ray-project/ray/pull/62005)
- To safely and gradually migrate this big change, we are leveraging branch by abstraction achieved via runtime polymorphism. We introduces a base case and lets both the old class and the new class inherit from it, and change the codebase to interact with the base class pointer. Then, we can use a config flag to toggle what the base class pointer actually points to (the old class or the new class) to control which logic the codebase uses


### What This PR Does
In previous PRs, we introduced the base class with `NodeResources` (V1) and `NodeResourcesV2` (V2) as derived classes. This PR updates all callers to reference the base class type instead of V1, allowing future PRs to pass either V1 or V2 without further interface changes

There are two major changes:
- In ClusterResourceManager, changing `Struct Node` storage type from the V1 to the base class pointer, so that `ClusterResourceManager` can actually store either V1 or V2. Note that all the Add/Update Node logic inside `ClusterResourceManager` remains V1
- Functions that previously only accepted a reference to V1 now accept a reference to the base class, so that callers can pass either the V1 or V2 class

_Note: This PR doesn't include the logic that actually passes V2 into the code, so the actual objects passed and stored are still V1. Therefore, we don't implement the logic to handle V2 yet. This PR just updates the type definitions so the compiler is ready to accept V2 inputs in future changes_

## Related PRs
Related to https://github.com/ray-project/ray/pull/62005

