### PR TITLE
[Data] Move test_read_parquet_v2 out of unit tests

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -944,6 +944,20 @@ py_test(
 )
 
 py_test(
+    name = "test_read_parquet_v2",
+    size = "small",
+    srcs = ["tests/datasource/test_read_parquet_v2.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_projection_fusion",
     size = "small",
     srcs = ["tests/test_projection_fusion.py"],

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -2,9 +2,9 @@
 
 These tests exercise planning-time behavior: schema inference,
 ``ListFiles → ReadFiles`` attachment to the logical plan, and
-unsupported-option gating. Physical execution (take_all) requires a
-live Ray runtime and is covered by the CI parquet regression suite;
-these tests run with no Ray cluster.
+unsupported-option gating. They call ``ray.data.read_parquet`` which
+triggers Ray auto-init, so they live alongside the other datasource
+integration tests rather than under ``tests/unit/``.
 """
 import pyarrow as pa
 import pyarrow.parquet as pq


### PR DESCRIPTION
## Summary
- Move `tests/unit/datasource_v2/test_read_parquet_v2.py` to `tests/datasource/test_read_parquet_v2.py`. These tests call `ray.data.read_parquet`, which auto-inits Ray and trips the unit-test conftest's `disallow_ray_init` fixture.
- Register the moved file as a `py_test` target in `python/ray/data/BUILD.bazel` (the `tests/unit/` directory is picked up by a glob, but `tests/datasource/` registers each file explicitly).
- Update the file's docstring — the prior "these tests run with no Ray cluster" line was inaccurate (Ray auto-inits as soon as `ray.data.read_parquet` is called).

The two other v2 unit test files (`test_file_indexer.py`, `test_list_files_op.py`) do not need Ray and stay where they are.

## Test plan
- [x] `pytest python/ray/data/tests/datasource/test_read_parquet_v2.py` — 8 passed
- [x] `pytest python/ray/data/tests/unit/datasource_v2/` — 39 passed (remaining unit tests still pass under the unit conftest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)