### PR TITLE
[Data] Add lightweight release test for map_batches deserialization perf

### DIFF
--- a/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
@@ -4,13 +4,7 @@ Synthesizes a wide pyarrow Table on the driver (no external data), pushes the
 batches through ``from_arrow().map_batches(actor, batch_format='pyarrow',
 zero_copy_batch=True)`` with an ``ActorPoolMapOperator``, then reads the Ray
 timeline to report p50/p90/max of ``task:deserialize_arguments`` across the
-MapWorker tasks.
-
-Designed to track regressions like the user-reported case where the actor
-task's per-block argument deserialization was ~360 ms p50 for a ~150 MB
-pyarrow Table block (vs ~14 ms for a bare ``ray.get`` of the same plasma
-object). Lands deliberately on the same code path: a wide-schema pyarrow
-Table flowing into an actor-pool ``map_batches`` task as a block argument.
+actor pool tasks.
 
 Reported metrics:
     deser_p50_ms, deser_p90_ms, deser_max_ms, deser_task_count
@@ -18,16 +12,14 @@ Reported metrics:
 """
 
 import argparse
-import json
-import os
-import tempfile
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import numpy as np
 import pyarrow as pa
 
 import ray
 from benchmark import Benchmark
+from ray._private.test_utils import wait_for_condition
 
 
 def parse_args() -> argparse.Namespace:
@@ -44,9 +36,7 @@ def make_batch(rows: int, cols: int, values_per_cell: int, seed: int) -> pa.Tabl
     """Build a wide pyarrow Table with list<float32> columns.
 
     Bytes per row ≈ cols * values_per_cell * 4. With defaults
-    (400 * 128 * 4 = ~205 KB/row, 256 rows ⇒ ~52 MB/batch), each batch is in
-    the same order of magnitude as the user's ~150 MB block while being
-    cheap to synthesize.
+    (400 * 128 * 4 = ~205 KB/row, 256 rows ⇒ ~52 MB/batch).
     """
     rng = np.random.default_rng(seed)
     arrays: Dict[str, pa.Array] = {"id": pa.array(np.arange(rows, dtype=np.int64))}
@@ -65,7 +55,7 @@ def make_batch(rows: int, cols: int, values_per_cell: int, seed: int) -> pa.Tabl
 _UDF_CLASS_NAME = "MinimalActor"
 
 
-def collect_deser_stats(timeline_path: str) -> Dict[str, float]:
+def collect_deser_stats(events: List[Dict[str, Any]]) -> Dict[str, float]:
     """Extract task:deserialize_arguments durations (ms) for our MinimalActor.
 
     Two stable hooks make this robust:
@@ -84,8 +74,6 @@ def collect_deser_stats(timeline_path: str) -> Dict[str, float]:
     timeline) is wrong: StatsActor / AutoscalingCoordinator / ActorLocationTracker
     contribute many cheap deser events that distort p50.
     """
-    with open(timeline_path) as f:
-        events = json.load(f)
     udf_tids = {
         e["tid"]
         for e in events
@@ -105,7 +93,7 @@ def collect_deser_stats(timeline_path: str) -> Dict[str, float]:
     return {
         "n": n,
         "p50": durs_ms[n // 2],
-        "p90": durs_ms[int(n * 0.9)],
+        "p90": durs_ms[int((n - 1) * 0.9)],
         "max": durs_ms[-1],
     }
 
@@ -138,19 +126,22 @@ def run_deser_benchmark(args: argparse.Namespace) -> Dict[str, Any]:
         zero_copy_batch=True,
     ).materialize()
 
-    events = ray.timeline()
-    stats = collect_deser_stats(events)
-    print(f"Deser stats (ms): {stats}")
+    # Task profile events are flushed to GCS on a periodic interval
+    # (``task_events_report_interval_ms``, default 1000 ms), so events from
+    # the last tasks may not be in the timeline immediately after
+    # ``materialize()`` returns. Retry until we have at least one
+    # ``task:deserialize_arguments`` event per expected map_batches task.
+    # If they never arrive, ``wait_for_condition`` raises and the test fails
+    # loudly — that is also our guard against the timeline event name or
+    # actor-class-name embedding changing under us.
+    stats: Dict[str, float] = {}
 
-    # Sanity check: each map_batches task does one task:deserialize_arguments,
-    # so we expect at least `num_batches` events. If we see fewer, the timeline
-    # event name has likely changed and the metric is silently wrong.
-    if stats["n"] < args.num_batches:
-        raise RuntimeError(
-            f"Expected >= {args.num_batches} task:deserialize_arguments events "
-            f"but found {stats['n']}. The timeline event name may have changed; "
-            f"see python/ray/_raylet.pyx for the current literal."
-        )
+    def _events_arrived() -> bool:
+        stats.update(collect_deser_stats(ray.timeline()))
+        return stats["n"] >= args.num_batches
+
+    wait_for_condition(_events_arrived, timeout=20)
+    print(f"Deser stats (ms): {stats}")
 
     return {
         "deser_p50_ms": stats["p50"],

--- a/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
@@ -62,29 +62,41 @@ def make_batch(rows: int, cols: int, values_per_cell: int, seed: int) -> pa.Tabl
     return pa.table(arrays)
 
 
-def collect_deser_stats(timeline_path: str) -> Dict[str, float]:
-    """Extract task:deserialize_arguments durations (ms) for MapWorker actors.
+_UDF_CLASS_NAME = "MinimalActor"
 
-    The cat string in the Ray timeline for an actor task looks like
-    ``task::MapWorker(MapBatches(<udf>)).__init__``. We collect tids from
-    ``__init__`` events whose cat contains 'MapWorker', then aggregate
-    durations of ``task:deserialize_arguments`` events on those tids.
+
+def collect_deser_stats(timeline_path: str) -> Dict[str, float]:
+    """Extract task:deserialize_arguments durations (ms) for our MinimalActor.
+
+    Two stable hooks make this robust:
+
+    1. ``"task:deserialize_arguments"`` is a Cython literal in
+       ``python/ray/_raylet.pyx:1804`` and is covered by
+       ``src/ray/core_worker/tests/task_event_buffer_test.cc``.
+    2. We scope to tids where the *UDF class name* (``MinimalActor``, defined
+       in this file) appears in the event cat. Ray Data's actor wrapper
+       embeds the UDF name in the cat as ``task::MapWorker(MapBatches(MinimalActor))...``
+       (see ``actor_pool_map_operator.py``). Since ``MinimalActor`` is a
+       symbol we own, this scoping survives Ray Data renaming its wrapper
+       class (which has happened before: ``_MapWorker`` -> ``MapWorker(...)``).
+
+    Unscoped matching (every ``task:deserialize_arguments`` event in the
+    timeline) is wrong: StatsActor / AutoscalingCoordinator / ActorLocationTracker
+    contribute many cheap deser events that distort p50.
     """
     with open(timeline_path) as f:
         events = json.load(f)
-    map_tids = {
+    udf_tids = {
         e["tid"]
         for e in events
-        if isinstance(e, dict)
-        and e.get("name") == "__init__"
-        and "MapWorker" in e.get("cat", "")
+        if isinstance(e, dict) and _UDF_CLASS_NAME in e.get("cat", "")
     }
     durs_ms = sorted(
         e["dur"] / 1000.0
         for e in events
         if isinstance(e, dict)
-        and e.get("tid") in map_tids
-        and e.get("name") == "task:deserialize_arguments"
+        and e.get("tid") in udf_tids
+        and e.get("cat") == "task:deserialize_arguments"
         and e.get("dur", 0) > 0
     )
     if not durs_ms:
@@ -130,6 +142,16 @@ def run_deser_benchmark(args: argparse.Namespace) -> Dict[str, Any]:
     ray.timeline(filename=timeline_path)
     stats = collect_deser_stats(timeline_path)
     print(f"Deser stats (ms): {stats}")
+
+    # Sanity check: each map_batches task does one task:deserialize_arguments,
+    # so we expect at least `num_batches` events. If we see fewer, the timeline
+    # event name has likely changed and the metric is silently wrong.
+    if stats["n"] < args.num_batches:
+        raise RuntimeError(
+            f"Expected >= {args.num_batches} task:deserialize_arguments events "
+            f"but found {stats['n']}. The timeline event name may have changed; "
+            f"see python/ray/_raylet.pyx for the current literal."
+        )
 
     return {
         "deser_p50_ms": stats["p50"],

--- a/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
@@ -92,7 +92,7 @@ def collect_deser_stats(events: List[Dict[str, Any]]) -> Dict[str, float]:
     n = len(durs_ms)
     return {
         "n": n,
-        "p50": durs_ms[n // 2],
+        "p50": durs_ms[int((n - 1) * 0.5)],
         "p90": durs_ms[int((n - 1) * 0.9)],
         "max": durs_ms[-1],
     }

--- a/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
@@ -138,9 +138,8 @@ def run_deser_benchmark(args: argparse.Namespace) -> Dict[str, Any]:
         zero_copy_batch=True,
     ).materialize()
 
-    timeline_path = os.path.join(tempfile.gettempdir(), "deser_perf_timeline.json")
-    ray.timeline(filename=timeline_path)
-    stats = collect_deser_stats(timeline_path)
+    events = ray.timeline()
+    stats = collect_deser_stats(events)
     print(f"Deser stats (ms): {stats}")
 
     # Sanity check: each map_batches task does one task:deserialize_arguments,

--- a/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
+++ b/release/nightly_tests/dataset/map_batches_deser_perf_benchmark.py
@@ -1,0 +1,152 @@
+"""Release test: track task:deserialize_arguments cost for actor-pool map_batches.
+
+Synthesizes a wide pyarrow Table on the driver (no external data), pushes the
+batches through ``from_arrow().map_batches(actor, batch_format='pyarrow',
+zero_copy_batch=True)`` with an ``ActorPoolMapOperator``, then reads the Ray
+timeline to report p50/p90/max of ``task:deserialize_arguments`` across the
+MapWorker tasks.
+
+Designed to track regressions like the user-reported case where the actor
+task's per-block argument deserialization was ~360 ms p50 for a ~150 MB
+pyarrow Table block (vs ~14 ms for a bare ``ray.get`` of the same plasma
+object). Lands deliberately on the same code path: a wide-schema pyarrow
+Table flowing into an actor-pool ``map_batches`` task as a block argument.
+
+Reported metrics:
+    deser_p50_ms, deser_p90_ms, deser_max_ms, deser_task_count
+    (plus the auto-recorded RUNTIME from Benchmark.run_fn)
+"""
+
+import argparse
+import json
+import os
+import tempfile
+from typing import Any, Dict
+
+import numpy as np
+import pyarrow as pa
+
+import ray
+from benchmark import Benchmark
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--num-batches", type=int, default=8)
+    parser.add_argument("--rows-per-batch", type=int, default=256)
+    parser.add_argument("--cols", type=int, default=400)
+    parser.add_argument("--values-per-cell", type=int, default=128)
+    parser.add_argument("--concurrency", type=int, default=2)
+    return parser.parse_args()
+
+
+def make_batch(rows: int, cols: int, values_per_cell: int, seed: int) -> pa.Table:
+    """Build a wide pyarrow Table with list<float32> columns.
+
+    Bytes per row ≈ cols * values_per_cell * 4. With defaults
+    (400 * 128 * 4 = ~205 KB/row, 256 rows ⇒ ~52 MB/batch), each batch is in
+    the same order of magnitude as the user's ~150 MB block while being
+    cheap to synthesize.
+    """
+    rng = np.random.default_rng(seed)
+    arrays: Dict[str, pa.Array] = {"id": pa.array(np.arange(rows, dtype=np.int64))}
+    offsets = pa.array(
+        np.arange(0, (rows + 1) * values_per_cell, values_per_cell, dtype=np.int32)
+    )
+    for i in range(cols):
+        flat = pa.array(
+            rng.standard_normal(rows * values_per_cell).astype(np.float32),
+            type=pa.float32(),
+        )
+        arrays[f"f{i:04d}"] = pa.ListArray.from_arrays(offsets, flat)
+    return pa.table(arrays)
+
+
+def collect_deser_stats(timeline_path: str) -> Dict[str, float]:
+    """Extract task:deserialize_arguments durations (ms) for MapWorker actors.
+
+    The cat string in the Ray timeline for an actor task looks like
+    ``task::MapWorker(MapBatches(<udf>)).__init__``. We collect tids from
+    ``__init__`` events whose cat contains 'MapWorker', then aggregate
+    durations of ``task:deserialize_arguments`` events on those tids.
+    """
+    with open(timeline_path) as f:
+        events = json.load(f)
+    map_tids = {
+        e["tid"]
+        for e in events
+        if isinstance(e, dict)
+        and e.get("name") == "__init__"
+        and "MapWorker" in e.get("cat", "")
+    }
+    durs_ms = sorted(
+        e["dur"] / 1000.0
+        for e in events
+        if isinstance(e, dict)
+        and e.get("tid") in map_tids
+        and e.get("name") == "task:deserialize_arguments"
+        and e.get("dur", 0) > 0
+    )
+    if not durs_ms:
+        return {"n": 0, "p50": -1.0, "p90": -1.0, "max": -1.0}
+    n = len(durs_ms)
+    return {
+        "n": n,
+        "p50": durs_ms[n // 2],
+        "p90": durs_ms[int(n * 0.9)],
+        "max": durs_ms[-1],
+    }
+
+
+class MinimalActor:
+    """No-op actor — we only want to measure argument deserialization cost."""
+
+    def __call__(self, batch: pa.Table) -> Dict[str, np.ndarray]:
+        return {"n": np.array([batch.num_rows])}
+
+
+def run_deser_benchmark(args: argparse.Namespace) -> Dict[str, Any]:
+    tables = [
+        make_batch(args.rows_per_batch, args.cols, args.values_per_cell, seed=i)
+        for i in range(args.num_batches)
+    ]
+    batch_mb = tables[0].nbytes / 1e6
+    print(
+        f"Synthesized {len(tables)} batches x {args.rows_per_batch} rows "
+        f"x {args.cols} cols (~{batch_mb:.1f} MB each)"
+    )
+
+    ds = ray.data.from_arrow(tables)
+    ds.map_batches(
+        MinimalActor,
+        batch_size=args.rows_per_batch,
+        num_gpus=0,
+        concurrency=args.concurrency,
+        batch_format="pyarrow",
+        zero_copy_batch=True,
+    ).materialize()
+
+    timeline_path = os.path.join(tempfile.gettempdir(), "deser_perf_timeline.json")
+    ray.timeline(filename=timeline_path)
+    stats = collect_deser_stats(timeline_path)
+    print(f"Deser stats (ms): {stats}")
+
+    return {
+        "deser_p50_ms": stats["p50"],
+        "deser_p90_ms": stats["p90"],
+        "deser_max_ms": stats["max"],
+        "deser_task_count": stats["n"],
+        "batch_size_mb": batch_mb,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    ray.init()
+    benchmark = Benchmark()
+    benchmark.run_fn("from_arrow_map_batches_actor", run_deser_benchmark, args)
+    benchmark.write_result()
+
+
+if __name__ == "__main__":
+    main()

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -598,6 +598,19 @@
       --num-scalar-cols 100
       --num-array-cols 200
 
+- name: map_batches_deser_perf
+  # Tracks task:deserialize_arguments cost for actor-pool map_batches with a
+  # wide pyarrow Table block argument. Guards against regressions like the
+  # ~360 ms p50 deser seen by a customer on an older Ray, which is ~43 ms
+  # p50 on current master.
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+
+  run:
+    timeout: 600
+    script: python map_batches_deser_perf_benchmark.py
+
 
 ########################
 # Sort and shuffle tests


### PR DESCRIPTION
Adds a nightly release test, `map_batches_deser_perf`, that tracks `task:deserialize_arguments` cost for actor-pool `map_batches` with a wide pyarrow Table block argument.

The test synthesizes a wide pyarrow Table on the driver (no external data), runs `from_arrow().map_batches(actor, batch_format='pyarrow', zero_copy_batch=True)`, and emits `deser_p50_ms` / `deser_p90_ms` / `deser_max_ms` / `deser_task_count` as release-dashboard metrics.

Example: https://buildkite.com/ray-project/release/builds/93790#019e47ac-92f3-4ad1-8946-3747d3da5344

```

{
--
  | "from_arrow_map_batches_actor": {
  | "time": 9.049780516000013,
  | "object_store_spilled_total_gb": 0.0,
  | "deser_p50_ms": 11.381508,
  | "deser_p90_ms": 59.344699,
  | "deser_max_ms": 245.44358499999998,
  | "deser_task_count": 12,
  | "batch_size_mb": 52.840448
  | }
  | }
```