### PR TITLE
[Data] Add backpressure release benchmarks

### DIFF
--- a/release/nightly_tests/dataset/backpressure_benchmark.py
+++ b/release/nightly_tests/dataset/backpressure_benchmark.py
@@ -1,0 +1,126 @@
+import argparse
+import functools
+import time
+
+import numpy as np
+import pyarrow as pa
+import ray
+
+from benchmark import Benchmark
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Backpressure benchmark")
+    parser.add_argument(
+        "--case",
+        choices=["fast-producer-slow-consumer", "training-prefetch"],
+        required=True,
+    )
+    parser.add_argument("--num-input-blocks", type=int, default=128)
+    parser.add_argument("--outputs-per-input", type=int, default=8)
+    parser.add_argument("--batch-rows", type=int, default=128)
+    parser.add_argument("--bytes-per-row", type=int, default=1024**2)
+    parser.add_argument("--consumer-sleep-s", type=float, default=1.0)
+    parser.add_argument("--num-trainers", type=int, default=8)
+    parser.add_argument("--prefetch-batches", type=int, default=8)
+    return parser.parse_args()
+
+
+def make_inputs(num_input_blocks: int):
+    return [
+        pa.Table.from_pydict({"id": [input_id]}) for input_id in range(num_input_blocks)
+    ]
+
+
+def produce(batch, *, outputs_per_input: int, batch_rows: int, bytes_per_row: int):
+    for _ in range(outputs_per_input):
+        yield {
+            "data": np.zeros((batch_rows, bytes_per_row), dtype=np.uint8),
+        }
+
+
+def consume_slow(batch, *, sleep_s: float):
+    time.sleep(sleep_s)
+    return {"status": ["ok"]}
+
+
+def run_fast_producer_slow_consumer(args: argparse.Namespace):
+    producer = functools.partial(
+        produce,
+        outputs_per_input=args.outputs_per_input,
+        batch_rows=args.batch_rows,
+        bytes_per_row=args.bytes_per_row,
+    )
+    consumer = functools.partial(consume_slow, sleep_s=args.consumer_sleep_s)
+
+    ds = (
+        ray.data.from_blocks(make_inputs(args.num_input_blocks))
+        .map_batches(producer)
+        .map_batches(consumer, compute=ray.data.TaskPoolStrategy(size=1))
+    )
+    for _ in ds.iter_internal_ref_bundles():
+        pass
+
+    return vars(args)
+
+
+def run_training_prefetch(args: argparse.Namespace):
+    producer = functools.partial(
+        produce,
+        outputs_per_input=args.outputs_per_input,
+        batch_rows=args.batch_rows,
+        bytes_per_row=args.bytes_per_row,
+    )
+
+    iterators = (
+        ray.data.from_blocks(make_inputs(args.num_input_blocks))
+        .map_batches(producer)
+        .streaming_split(args.num_trainers, equal=True)
+    )
+
+    trainers = [
+        Trainer.options(scheduling_strategy="SPREAD").remote(
+            consumer_sleep_s=args.consumer_sleep_s,
+            prefetch_batches=args.prefetch_batches,
+        )
+        for _ in range(args.num_trainers)
+    ]
+    ray.get(
+        [
+            trainers[i].train.remote(iterators[i], batch_size=args.batch_rows)
+            for i in range(args.num_trainers)
+        ]
+    )
+
+    return vars(args)
+
+
+@ray.remote(num_cpus=1)
+class Trainer:
+    def __init__(self, consumer_sleep_s: float, prefetch_batches: int):
+        self._consumer_sleep_s = consumer_sleep_s
+        self._prefetch_batches = prefetch_batches
+
+    def train(self, data_iterator, batch_size: int):
+        for _ in data_iterator.iter_batches(
+            batch_size=batch_size,
+            prefetch_batches=self._prefetch_batches,
+        ):
+            time.sleep(self._consumer_sleep_s)
+
+
+def main(args: argparse.Namespace):
+    benchmark = Benchmark()
+
+    if args.case == "fast-producer-slow-consumer":
+        benchmark.run_fn(args.case, run_fast_producer_slow_consumer, args)
+    elif args.case == "training-prefetch":
+        benchmark.run_fn(args.case, run_training_prefetch, args)
+    else:
+        raise ValueError(f"Unexpected benchmark case: {args.case}")
+
+    benchmark.write_result()
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/release/nightly_tests/dataset/backpressure_benchmark.py
+++ b/release/nightly_tests/dataset/backpressure_benchmark.py
@@ -17,9 +17,9 @@ def parse_args() -> argparse.Namespace:
         required=True,
     )
     parser.add_argument("--num-input-blocks", type=int, default=128)
-    parser.add_argument("--outputs-per-input", type=int, default=8)
-    parser.add_argument("--batch-rows", type=int, default=128)
-    parser.add_argument("--bytes-per-row", type=int, default=1024**2)
+    parser.add_argument("--output-batches-per-input-batch", type=int, default=8)
+    parser.add_argument("--output-batch-rows", type=int, default=128)
+    parser.add_argument("--output-row-bytes", type=int, default=1024**2)
     parser.add_argument("--consumer-sleep-s", type=float, default=1.0)
     parser.add_argument("--num-trainers", type=int, default=8)
     parser.add_argument("--prefetch-batches", type=int, default=8)
@@ -32,10 +32,16 @@ def make_inputs(num_input_blocks: int):
     ]
 
 
-def produce(batch, *, outputs_per_input: int, batch_rows: int, bytes_per_row: int):
-    for _ in range(outputs_per_input):
+def produce(
+    batch,
+    *,
+    output_batches_per_input_batch: int,
+    output_batch_rows: int,
+    output_row_bytes: int,
+):
+    for _ in range(output_batches_per_input_batch):
         yield {
-            "data": np.zeros((batch_rows, bytes_per_row), dtype=np.uint8),
+            "data": np.zeros((output_batch_rows, output_row_bytes), dtype=np.uint8),
         }
 
 
@@ -47,9 +53,9 @@ def consume_slow(batch, *, sleep_s: float):
 def run_fast_producer_slow_consumer(args: argparse.Namespace):
     producer = functools.partial(
         produce,
-        outputs_per_input=args.outputs_per_input,
-        batch_rows=args.batch_rows,
-        bytes_per_row=args.bytes_per_row,
+        output_batches_per_input_batch=args.output_batches_per_input_batch,
+        output_batch_rows=args.output_batch_rows,
+        output_row_bytes=args.output_row_bytes,
     )
     consumer = functools.partial(consume_slow, sleep_s=args.consumer_sleep_s)
 
@@ -67,9 +73,9 @@ def run_fast_producer_slow_consumer(args: argparse.Namespace):
 def run_training_prefetch(args: argparse.Namespace):
     producer = functools.partial(
         produce,
-        outputs_per_input=args.outputs_per_input,
-        batch_rows=args.batch_rows,
-        bytes_per_row=args.bytes_per_row,
+        output_batches_per_input_batch=args.output_batches_per_input_batch,
+        output_batch_rows=args.output_batch_rows,
+        output_row_bytes=args.output_row_bytes,
     )
 
     iterators = (
@@ -87,7 +93,7 @@ def run_training_prefetch(args: argparse.Namespace):
     ]
     ray.get(
         [
-            trainers[i].train.remote(iterators[i], batch_size=args.batch_rows)
+            trainers[i].train.remote(iterators[i], batch_size=args.output_batch_rows)
             for i in range(args.num_trainers)
         ]
     )

--- a/release/nightly_tests/dataset/fixed_size_8_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_8_cpu_compute.yaml
@@ -1,0 +1,13 @@
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node:
+    instance_type: m5.2xlarge
+
+worker_nodes:
+    - instance_type: m5.2xlarge
+      min_nodes: 8
+      max_nodes: 8
+      market_type: ON_DEMAND

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -584,6 +584,43 @@
     script: python worker_scaling_benchmark.py --num-workers {{num_workers}} --worker-type {{worker_type}}
 
 
+######################
+# Backpressure tests
+######################
+
+- name: backpressure_fast_producer_slow_consumer
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=0
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+    cluster_compute: fixed_size_8_cpu_compute.yaml
+
+  run:
+    timeout: 3600
+    script: >
+      python backpressure_benchmark.py --case fast-producer-slow-consumer
+
+- name: backpressure_training_prefetch
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=0
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+    cluster_compute: fixed_size_8_cpu_compute.yaml
+
+  run:
+    timeout: 3600
+    script: >
+      python backpressure_benchmark.py --case training-prefetch
+
+
 ########################
 # Sort and shuffle tests
 ########################

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -592,11 +592,6 @@
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
-    byod:
-      runtime_env:
-        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
-        - RAYTEST_FAIL_ON_WORKER_OOM=0
-        - RAYTEST_FAIL_ON_DEAD_NODES=1
     cluster_compute: fixed_size_8_cpu_compute.yaml
 
   run:
@@ -608,11 +603,6 @@
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
-    byod:
-      runtime_env:
-        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
-        - RAYTEST_FAIL_ON_WORKER_OOM=0
-        - RAYTEST_FAIL_ON_DEAD_NODES=1
     cluster_compute: fixed_size_8_cpu_compute.yaml
 
   run:


### PR DESCRIPTION
## Summary

- Adds two Ray Data release benchmarks for backpressure tuning.
- Adds a new Backpressure tests section in `release_data_tests.yaml`.
- This PR only adds the benchmarks. Once #63418 lands, these benchmarks will also report peak object store memory through the shared `Benchmark` helper.

## Benchmarks

- `fast-producer-slow-consumer`
  - Produces large batches quickly.
  - Sends them to a slow downstream consumer.
  - This is meant to stress downstream backpressure.

- `training-prefetch`
  - Produces large batches quickly.
  - Splits the dataset across trainer actors with `streaming_split`.
  - Each trainer reads slowly with prefetching.
  - This is meant to simulate a training-style data loading pattern.
## Testing

Ran small smoke tests for both benchmark cases.

Fast producer and slow consumer:

```bash
python backpressure_benchmark.py \
  --case fast-producer-slow-consumer \
  --num-input-blocks 2 \
  --outputs-per-input 1 \
  --batch-rows 4 \
  --bytes-per-row 1048576 \
  --consumer-sleep-s 0.1
```

Result:

<img width="399" height="240" alt="Screenshot 2026-05-20 at 07 04 32" src="https://github.com/user-attachments/assets/33c3c316-7b1b-4e08-bc22-098fe470b609" />

Training prefetch:

```bash
python backpressure_benchmark.py \
  --case training-prefetch \
  --num-input-blocks 4 \
  --outputs-per-input 1 \
  --batch-rows 4 \
  --bytes-per-row 1048576 \
  --consumer-sleep-s 0.1 \
  --num-trainers 2 \
  --prefetch-batches 1
```

Result:

<img width="389" height="241" alt="Screenshot 2026-05-20 at 07 05 18" src="https://github.com/user-attachments/assets/fb36d39e-61db-4445-9c18-6d1b6da2c82d" />

---
Closes https://github.com/ray-project/ray/issues/63523