### PR TITLE
[Data] Use precise return type for DistributionTracker.as_dict

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/distribution_tracker.py
+++ b/python/ray/data/_internal/execution/interfaces/distribution_tracker.py
@@ -1,5 +1,5 @@
 import math
-from typing import Any, Dict, Optional
+from typing import Dict, Optional, Union
 
 try:
     from datasketches import kll_doubles_sketch
@@ -93,7 +93,7 @@ class DistributionTracker:
     def p99(self) -> Optional[float]:
         return self._quantile(0.99)
 
-    def as_dict(self) -> Dict[str, Any]:
+    def as_dict(self) -> Dict[str, Optional[Union[int, float]]]:
         return {
             "num_samples": self.num_samples,
             "mean": self.mean,


### PR DESCRIPTION
Narrows the return type of `DistributionTracker.as_dict` from `Dict[str, Any]` to `Dict[str, Optional[Union[int, float]]]` so callers get type-checking coverage on the values.

Follow-up to #63488 per [review feedback](https://github.com/ray-project/ray/pull/63488#discussion_r3268050271).