### PR TITLE
[Data] BlockMetadata: add task_memory_bytes hint field

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -300,6 +300,12 @@ class BlockMetadata(BlockStats):
     # the empty list if indeterminate.
     # Stored as a tuple for hash-ability.
     input_files: Optional[Tuple[str, ...]] = field(default=None)
+    # Optional per-task heap-memory hint in bytes. Producers may set this
+    # so a downstream consumer (e.g. ``TaskPoolMapOperator``) can raise the
+    # Ray ``memory`` reservation for the task that consumes the block.
+    # Default ``None`` means "no hint" — generic consumers must treat
+    # missing hints as a no-op.
+    task_memory_bytes: Optional[int] = field(default=None)
 
     def __post_init__(self):
         super().__post_init__()
@@ -339,6 +345,7 @@ class BlockMetadataWithSchema(BlockMetadata):
             exec_stats=metadata.exec_stats,
             task_exec_stats=metadata.task_exec_stats,
             input_files=metadata.input_files,
+            task_memory_bytes=metadata.task_memory_bytes,
             schema=schema,
         )
 
@@ -360,12 +367,18 @@ class BlockMetadataWithSchema(BlockMetadata):
 
     @property
     def metadata(self) -> BlockMetadata:
+        """Plain :class:`BlockMetadata` without schema.
+
+        Preserves all :class:`BlockMetadata` fields, including ``task_memory_bytes``,
+        so streaming hand-offs do not drop the hint.
+        """
         return BlockMetadata(
             num_rows=self.num_rows,
             size_bytes=self.size_bytes,
             exec_stats=self.exec_stats,
             input_files=self.input_files,
             task_exec_stats=self.task_exec_stats,
+            task_memory_bytes=self.task_memory_bytes,
         )
 
     def __getstate__(self) -> Dict[str, Any]:

--- a/python/ray/data/tests/unit/test_block.py
+++ b/python/ray/data/tests/unit/test_block.py
@@ -5,7 +5,12 @@ import pyarrow as pa
 import pytest
 
 from ray.data._internal.planner.exchange.sort_task_spec import SortKey
-from ray.data.block import BlockAccessor, BlockColumnAccessor
+from ray.data.block import (
+    BlockAccessor,
+    BlockColumnAccessor,
+    BlockMetadata,
+    BlockMetadataWithSchema,
+)
 
 
 def test_find_partitions_single_column_ascending():
@@ -156,6 +161,41 @@ def test_find_partitions_duplicates():
     assert partitions[1].to_pydict() == {"value": []}  # [1,2)
     assert partitions[2].to_pydict() == {"value": [2, 2, 2, 2, 2]}  # [2,3)
     assert partitions[3].to_pydict() == {"value": []}  # >=3
+
+
+def test_block_metadata_task_memory_bytes_defaults_to_none():
+    """``task_memory_bytes`` is optional and defaults to ``None``."""
+    meta = BlockMetadata(
+        num_rows=1,
+        size_bytes=100,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+    assert meta.task_memory_bytes is None
+
+
+def test_block_metadata_task_memory_bytes_round_trips_through_with_schema():
+    """``BlockMetadataWithSchema`` round-trip preserves ``task_memory_bytes``.
+
+    Streaming hand-offs peel the schema off via the ``metadata`` property; if
+    ``task_memory_bytes`` were dropped there, downstream consumers (e.g. the
+    ``TaskPoolMapOperator`` per-task memory merge) would silently lose the hint.
+    """
+    schema = pa.schema([("a", pa.int64())])
+    meta = BlockMetadata(
+        num_rows=500,
+        size_bytes=2000,
+        task_memory_bytes=750_000_000,
+        exec_stats=None,
+        task_exec_stats=None,
+    )
+
+    wrapped = BlockMetadataWithSchema.from_metadata(meta, schema=schema)
+    assert wrapped.task_memory_bytes == 750_000_000
+
+    # ``metadata`` property must not drop the field.
+    round_tripped = wrapped.metadata
+    assert round_tripped.task_memory_bytes == 750_000_000
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

First of a 4-PR series that adds a per-task heap-memory hint to DataSource V2 `ReadFiles` tasks so the Ray scheduler can reserve enough heap to avoid OOMs on wide schemas / large Parquet files. This PR is the data-model foundation: it adds an optional `task_memory_bytes` field to `BlockMetadata` and propagates it through `BlockMetadataWithSchema`. **No producer or consumer is wired up here** — this commit is observably inert and lands the field for the rest of the chain to use.

The field is intentionally generic: it is a producer-set hint that lets *any* downstream consumer (initially `TaskPoolMapOperator`, but the contract is open) raise the Ray `memory` reservation on the task that will consume the block. Default `None` means "no hint" — consumers must treat missing hints as a no-op.

## Related issues

Related to DATA-2225. Wait for the rest of the series:

- PR 2/4 — `[Data] MapOperator: merge per-block task_memory_bytes hints + metadata-postprocess hook`
- PR 3/4 — `[Data] DataContext: add read_files_task_memory_eps_bytes knob` 
- PR 4/4 — `[Data] DataSourceV2: per-task heap memory hints for ReadFiles` — the PR that activates the feature

## Additional information

**API surface change** (additive):

- `BlockMetadata.task_memory_bytes: Optional[int] = None` — appended at the end of the dataclass field list, so positional construction is unaffected.
- `BlockMetadataWithSchema.from_metadata` propagates the new field.
- `BlockMetadataWithSchema.metadata` property propagates the new field — important because streaming hand-offs peel the schema off via this property; if the hint were dropped here, downstream consumers would silently lose it.

**Tests** (in `tests/unit/test_block.py`):

- `test_block_metadata_task_memory_bytes_defaults_to_none`
- `test_block_metadata_task_memory_bytes_round_trips_through_with_schema`

**No behavior change.** No production code in this PR sets `task_memory_bytes`, and the field has no readers yet.