### PR TITLE
[core] Increase `test_state_api_summary.py` test size to "medium"

### DIFF
--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -77,6 +77,7 @@ py_test_module_list(
         "test_runtime_env_agent.py",
         "test_runtime_env_agent_auth.py",
         "test_state_api_2.py",
+        "test_state_api_summary.py",
         "test_task_events_3.py",
         "test_tpu.py",
         "test_unavailable_actors.py",
@@ -572,7 +573,6 @@ py_test_module_list(
         "test_runtime_env_get_wheel_names.py",
         "test_runtime_env_py_executable.py",
         "test_state_api_manager.py",
-        "test_state_api_summary.py",
         "test_streaming_generator_regression.py",
         "test_system_metrics.py",
         "test_task_metrics_reconstruction.py",
@@ -743,7 +743,7 @@ py_test_module_list(
     size = "medium",
     files = [
         "test_autoscaler_e2e.py",
-        "test_autoscaler_fake_multinode.py",  # Temporarily owned by core.
+        "test_autoscaler_fake_multinode.py",
         "test_submission_client_auth.py",
     ],
     tags = [


### PR DESCRIPTION
Some timeouts in postmerge: https://buildkite.com/ray-project/postmerge/builds/17650#019e43c6-6ad4-474c-af66-3eb846c25c81/L2950