### PR TITLE
[core] Removing destroyed_actors_ cache

### DIFF
--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1776,11 +1776,10 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
       }
     } else {
       dead_actors.push_back(actor_id);
-      // Populate the observability cache from persisted dead actors.
-      // Bump the DEAD counter to preserve the number of cumulative deaths.
+      // Populate the observability cache from persisted actors. Bump the state counter.
       destroyed_actor_observability_data_.emplace(actor_id, actor_table_data);
       actor_state_counter_->Increment(
-          {rpc::ActorTableData::DEAD, actor_table_data.class_name()});
+          {actor_table_data.state(), actor_table_data.class_name()});
       sorted_destroyed_actor_observability_list_.emplace_back(
           actor_id, static_cast<int64_t>(actor_table_data.timestamp()));
     }

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -470,15 +470,9 @@ void GcsActorManager::HandleGetActorInfo(rpc::GetActorInfoRequest request,
   ActorID actor_id = ActorID::FromBinary(request.actor_id());
   RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id) << "Getting actor info";
 
-  const auto &registered_actor_iter = registered_actors_.find(actor_id);
-  if (registered_actor_iter != registered_actors_.end()) {
-    *reply->mutable_actor_table_data() =
-        registered_actor_iter->second->GetActorTableData();
-  } else {
-    const auto &observability_iter = destroyed_actor_observability_data_.find(actor_id);
-    if (observability_iter != destroyed_actor_observability_data_.end()) {
-      *reply->mutable_actor_table_data() = observability_iter->second.actor_table_data;
-    }
+  const auto *actor_table_data = GetActorTableData(actor_id);
+  if (actor_table_data != nullptr) {
+    *reply->mutable_actor_table_data() = *actor_table_data;
   }
 
   RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id)
@@ -534,19 +528,18 @@ void GcsActorManager::HandleGetAllActorInfo(rpc::GetAllActorInfoRequest request,
       *reply->add_actor_table_data() = iter.second->GetActorTableData();
     }
 
-    for (const auto &[id, entry] : destroyed_actor_observability_data_) {
+    for (const auto &[id, actor_table_data] : destroyed_actor_observability_data_) {
       if (count >= limit) {
         break;
       }
       // With filters, skip the actor if it doesn't match the filter.
-      if (request.has_filters() &&
-          !filter_fn(request.filters(), entry.actor_table_data)) {
+      if (request.has_filters() && !filter_fn(request.filters(), actor_table_data)) {
         ++num_filtered;
         continue;
       }
 
       count += 1;
-      *reply->add_actor_table_data() = entry.actor_table_data;
+      *reply->add_actor_table_data() = actor_table_data;
     }
     reply->set_num_filtered(num_filtered);
     RAY_LOG(DEBUG) << "Finished getting all actor info.";
@@ -1783,13 +1776,9 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
       }
     } else {
       dead_actors.push_back(actor_id);
-      // Rehydrate dead actors directly into the lightweight observability cache
-      // instead of constructing a full GcsActor we'd immediately discard.
-      // Bump the DEAD counter so the actor_by_state_gauge reflects rehydrated
-      // dead actors after a GCS restart — preserves the cumulative-deaths
-      // semantic.
-      destroyed_actor_observability_data_.emplace(
-          actor_id, ActorObservabilityData{actor_table_data});
+      // Populate the observability cache from persisted dead actors.
+      // Bump the DEAD counter to preserve the number of cumulative deaths.
+      destroyed_actor_observability_data_.emplace(actor_id, actor_table_data);
       actor_state_counter_->Increment(
           {rpc::ActorTableData::DEAD, actor_table_data.class_name()});
       sorted_destroyed_actor_observability_list_.emplace_back(
@@ -1959,8 +1948,7 @@ void GcsActorManager::AddDestroyedActorObservabilityData(const GcsActor &actor) 
   }
 
   const auto &actor_id = actor.GetActorID();
-  if (destroyed_actor_observability_data_
-          .emplace(actor_id, ActorObservabilityData{actor.GetActorTableData()})
+  if (destroyed_actor_observability_data_.emplace(actor_id, actor.GetActorTableData())
           .second) {
     sorted_destroyed_actor_observability_list_.emplace_back(
         actor_id, static_cast<int64_t>(actor.GetActorTableData().timestamp()));
@@ -2001,7 +1989,7 @@ const rpc::ActorTableData *GcsActorManager::GetActorTableData(
   }
   auto dead_it = destroyed_actor_observability_data_.find(actor_id);
   if (dead_it != destroyed_actor_observability_data_.end()) {
-    return &dead_it->second.actor_table_data;
+    return &dead_it->second;
   }
   return nullptr;
 }

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -33,29 +33,29 @@
 namespace {
 /// The error message constructed from below methods is user-facing, so please avoid
 /// including too much implementation detail or internal information.
-void AddActorInfo(const ray::gcs::GcsActor *actor,
+void AddActorInfo(const ray::rpc::ActorTableData *actor_data,
                   ray::rpc::ActorDiedErrorContext *mutable_actor_died_error_ctx) {
-  if (actor == nullptr) {
+  if (actor_data == nullptr) {
     return;
   }
   RAY_CHECK(mutable_actor_died_error_ctx != nullptr);
-  mutable_actor_died_error_ctx->set_owner_id(actor->GetOwnerID().Binary());
+  mutable_actor_died_error_ctx->set_owner_id(actor_data->owner_address().worker_id());
   mutable_actor_died_error_ctx->set_owner_ip_address(
-      actor->GetOwnerAddress().ip_address());
-  mutable_actor_died_error_ctx->set_node_ip_address(actor->GetAddress().ip_address());
-  mutable_actor_died_error_ctx->set_pid(actor->GetActorTableData().pid());
-  mutable_actor_died_error_ctx->set_name(actor->GetName());
-  mutable_actor_died_error_ctx->set_ray_namespace(actor->GetRayNamespace());
-  mutable_actor_died_error_ctx->set_class_name(actor->GetActorTableData().class_name());
-  mutable_actor_died_error_ctx->set_actor_id(actor->GetActorID().Binary());
-  const auto actor_state = actor->GetState();
+      actor_data->owner_address().ip_address());
+  mutable_actor_died_error_ctx->set_node_ip_address(actor_data->address().ip_address());
+  mutable_actor_died_error_ctx->set_pid(actor_data->pid());
+  mutable_actor_died_error_ctx->set_name(actor_data->name());
+  mutable_actor_died_error_ctx->set_ray_namespace(actor_data->ray_namespace());
+  mutable_actor_died_error_ctx->set_class_name(actor_data->class_name());
+  mutable_actor_died_error_ctx->set_actor_id(actor_data->actor_id());
+  const auto actor_state = actor_data->state();
   mutable_actor_died_error_ctx->set_never_started(
       actor_state == ray::rpc::ActorTableData::DEPENDENCIES_UNREADY ||
       actor_state == ray::rpc::ActorTableData::PENDING_CREATION);
 }
 
 const ray::rpc::ActorDeathCause GenWorkerDiedCause(
-    const ray::gcs::GcsActor *actor,
+    const ray::rpc::ActorTableData *actor_data,
     const std::string &ip_address,
     const ray::rpc::WorkerExitType &disconnect_type,
     const std::string &disconnect_detail) {
@@ -69,7 +69,7 @@ const ray::rpc::ActorDeathCause GenWorkerDiedCause(
   } else {
     auto actor_died_error_ctx = death_cause.mutable_actor_died_error_context();
     actor_died_error_ctx->set_reason(ray::rpc::ActorDiedErrorContext::WORKER_DIED);
-    AddActorInfo(actor, actor_died_error_ctx);
+    AddActorInfo(actor_data, actor_died_error_ctx);
     actor_died_error_ctx->set_error_message(absl::StrCat(
         "The actor is dead because its worker process has died. Worker exit type: ",
         ray::rpc::WorkerExitType_Name(disconnect_type),
@@ -80,7 +80,7 @@ const ray::rpc::ActorDeathCause GenWorkerDiedCause(
 }
 
 const ray::rpc::ActorDeathCause GenOwnerDiedCause(
-    const ray::gcs::GcsActor *actor,
+    const ray::rpc::ActorTableData *actor_data,
     const ray::WorkerID &owner_id,
     const ray::rpc::WorkerExitType disconnect_type,
     const std::string &disconnect_detail,
@@ -88,7 +88,7 @@ const ray::rpc::ActorDeathCause GenOwnerDiedCause(
   ray::rpc::ActorDeathCause death_cause;
   auto actor_died_error_ctx = death_cause.mutable_actor_died_error_context();
   actor_died_error_ctx->set_reason(ray::rpc::ActorDiedErrorContext::OWNER_DIED);
-  AddActorInfo(actor, actor_died_error_ctx);
+  AddActorInfo(actor_data, actor_died_error_ctx);
   actor_died_error_ctx->set_error_message(
       absl::StrCat("The actor is dead because its owner has died. Owner Id: ",
                    owner_id.Hex(),
@@ -102,31 +102,33 @@ const ray::rpc::ActorDeathCause GenOwnerDiedCause(
 }
 
 const ray::rpc::ActorDeathCause GenKilledByApplicationCause(
-    const ray::gcs::GcsActor *actor) {
+    const ray::rpc::ActorTableData *actor_data) {
   ray::rpc::ActorDeathCause death_cause;
   auto actor_died_error_ctx = death_cause.mutable_actor_died_error_context();
   actor_died_error_ctx->set_reason(ray::rpc::ActorDiedErrorContext::RAY_KILL);
-  AddActorInfo(actor, actor_died_error_ctx);
+  AddActorInfo(actor_data, actor_died_error_ctx);
   actor_died_error_ctx->set_error_message(
       "The actor is dead because it was killed by `ray.kill`.");
   return death_cause;
 }
 
-const ray::rpc::ActorDeathCause GenActorOutOfScopeCause(const ray::gcs::GcsActor *actor) {
+const ray::rpc::ActorDeathCause GenActorOutOfScopeCause(
+    const ray::rpc::ActorTableData *actor_data) {
   ray::rpc::ActorDeathCause death_cause;
   auto actor_died_error_ctx = death_cause.mutable_actor_died_error_context();
   actor_died_error_ctx->set_reason(ray::rpc::ActorDiedErrorContext::OUT_OF_SCOPE);
-  AddActorInfo(actor, actor_died_error_ctx);
+  AddActorInfo(actor_data, actor_died_error_ctx);
   actor_died_error_ctx->set_error_message(
       "The actor is dead because all references to the actor were removed.");
   return death_cause;
 }
 
-const ray::rpc::ActorDeathCause GenActorRefDeletedCause(const ray::gcs::GcsActor *actor) {
+const ray::rpc::ActorDeathCause GenActorRefDeletedCause(
+    const ray::rpc::ActorTableData *actor_data) {
   ray::rpc::ActorDeathCause death_cause;
   auto actor_died_error_ctx = death_cause.mutable_actor_died_error_context();
   actor_died_error_ctx->set_reason(ray::rpc::ActorDiedErrorContext::REF_DELETED);
-  AddActorInfo(actor, actor_died_error_ctx);
+  AddActorInfo(actor_data, actor_died_error_ctx);
   actor_died_error_ctx->set_error_message(
       "The actor is dead because all references to the actor were removed including "
       "lineage ref count.");
@@ -184,12 +186,13 @@ bool is_uuid(const std::string &str) {
 }
 
 const ray::rpc::ActorDeathCause GcsActorManager::GenNodeDiedCause(
-    const ray::gcs::GcsActor *actor, std::shared_ptr<const rpc::GcsNodeInfo> node) {
+    const ray::rpc::ActorTableData *actor_data,
+    std::shared_ptr<const rpc::GcsNodeInfo> node) {
   ray::rpc::ActorDeathCause death_cause;
 
   auto actor_died_error_ctx = death_cause.mutable_actor_died_error_context();
   actor_died_error_ctx->set_reason(ray::rpc::ActorDiedErrorContext::NODE_DIED);
-  AddActorInfo(actor, actor_died_error_ctx);
+  AddActorInfo(actor_data, actor_died_error_ctx);
   auto node_death_info = actor_died_error_ctx->mutable_node_death_info();
   node_death_info->CopyFrom(node->death_info());
 
@@ -283,8 +286,8 @@ void GcsActorManager::HandleReportActorOutOfScope(
   auto actor_id = ActorID::FromBinary(request.actor_id());
   auto it = registered_actors_.find(actor_id);
   if (it != registered_actors_.end()) {
-    auto actor = GetActor(actor_id);
-    if (actor->GetActorTableData().num_restarts_due_to_lineage_reconstruction() >
+    const auto *actor_data = GetActorTableData(actor_id);
+    if (actor_data->num_restarts_due_to_lineage_reconstruction() >
         request.num_restarts_due_to_lineage_reconstruction()) {
       // Stale report
       RAY_LOG(INFO).WithField(actor_id)
@@ -296,7 +299,7 @@ void GcsActorManager::HandleReportActorOutOfScope(
     int64_t timeout_ms = RayConfig::instance().actor_graceful_shutdown_timeout_ms();
     DestroyActor(
         actor_id,
-        GenActorOutOfScopeCause(actor),
+        GenActorOutOfScopeCause(actor_data),
         /*force_kill=*/false,
         [reply, send_reply_callback]() {
           GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -398,7 +401,7 @@ void GcsActorManager::HandleRestartActorForLineageReconstruction(
   RestartActor(
       actor_id,
       /*need_reschedule=*/true,
-      GenActorOutOfScopeCause(actor.get()),
+      GenActorOutOfScopeCause(&actor->GetActorTableData()),
       [this, actor]() {
         // If a creator dies before this callback is called, the actor could have
         // been already destroyed. It is okay not to invoke a callback because we
@@ -468,18 +471,14 @@ void GcsActorManager::HandleGetActorInfo(rpc::GetActorInfoRequest request,
   RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id) << "Getting actor info";
 
   const auto &registered_actor_iter = registered_actors_.find(actor_id);
-  GcsActor *ptr = nullptr;
   if (registered_actor_iter != registered_actors_.end()) {
-    ptr = registered_actor_iter->second.get();
+    *reply->mutable_actor_table_data() =
+        registered_actor_iter->second->GetActorTableData();
   } else {
-    const auto &destroyed_actor_iter = destroyed_actors_.find(actor_id);
-    if (destroyed_actor_iter != destroyed_actors_.end()) {
-      ptr = destroyed_actor_iter->second.get();
+    const auto &observability_iter = destroyed_actor_observability_data_.find(actor_id);
+    if (observability_iter != destroyed_actor_observability_data_.end()) {
+      *reply->mutable_actor_table_data() = observability_iter->second.actor_table_data;
     }
-  }
-
-  if (ptr != nullptr) {
-    *reply->mutable_actor_table_data() = ptr->GetActorTableData();
   }
 
   RAY_LOG(DEBUG).WithField(actor_id.JobId()).WithField(actor_id)
@@ -513,7 +512,8 @@ void GcsActorManager::HandleGetAllActorInfo(rpc::GetAllActorInfoRequest request,
   };
 
   if (request.show_dead_jobs() == false) {
-    size_t total_actors = registered_actors_.size() + destroyed_actors_.size();
+    size_t total_actors =
+        registered_actors_.size() + destroyed_actor_observability_data_.size();
     reply->set_total(total_actors);
 
     size_t count = 0;
@@ -534,19 +534,19 @@ void GcsActorManager::HandleGetAllActorInfo(rpc::GetAllActorInfoRequest request,
       *reply->add_actor_table_data() = iter.second->GetActorTableData();
     }
 
-    for (const auto &iter : destroyed_actors_) {
+    for (const auto &[id, entry] : destroyed_actor_observability_data_) {
       if (count >= limit) {
         break;
       }
       // With filters, skip the actor if it doesn't match the filter.
       if (request.has_filters() &&
-          !filter_fn(request.filters(), iter.second->GetActorTableData())) {
+          !filter_fn(request.filters(), entry.actor_table_data)) {
         ++num_filtered;
         continue;
       }
 
       count += 1;
-      *reply->add_actor_table_data() = iter.second->GetActorTableData();
+      *reply->add_actor_table_data() = entry.actor_table_data;
     }
     reply->set_num_filtered(num_filtered);
     RAY_LOG(DEBUG) << "Finished getting all actor info.";
@@ -645,7 +645,7 @@ void GcsActorManager::HandleKillActorViaGcs(rpc::KillActorViaGcsRequest request,
     bool force_kill = request.force_kill();
     bool no_restart = request.no_restart();
     if (no_restart) {
-      DestroyActor(actor_id, GenKilledByApplicationCause(GetActor(actor_id)));
+      DestroyActor(actor_id, GenKilledByApplicationCause(GetActorTableData(actor_id)));
     } else {
       KillActor(actor_id, force_kill);
     }
@@ -977,7 +977,7 @@ void GcsActorManager::PollOwnerForActorRefDeleted(
           // have already been destroyed if the owner died.
           int64_t timeout_ms = RayConfig::instance().actor_graceful_shutdown_timeout_ms();
           DestroyActor(actor_id,
-                       GenActorRefDeletedCause(GetActor(actor_id)),
+                       GenActorRefDeletedCause(GetActorTableData(actor_id)),
                        /*force_kill=*/false,
                        nullptr,
                        timeout_ms);
@@ -1112,7 +1112,10 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id,
 
   const bool is_restartable = IsActorRestartable(*mutable_actor_table_data);
   if (!is_restartable) {
-    AddDestroyedActorToCache(it->second);
+    AddDestroyedActorObservabilityData(*it->second);
+    // Now that the lightweight observability snapshot is stored, drop the
+    // shared_ptr in registered_actors_. The heavy GcsActor (with task_spec_
+    // and lease_spec_) is freed at this point since it has no other owner.
     registered_actors_.erase(it);
     function_manager_.RemoveJobReference(actor_id.JobId());
     RemoveActorNameFromRegistry(actor);
@@ -1228,7 +1231,7 @@ void GcsActorManager::OnWorkerDead(const ray::NodeID &node_id,
     const auto children_ids = owner->second.children_actor_ids_;
     for (const auto &child_id : children_ids) {
       DestroyActor(child_id,
-                   GenOwnerDiedCause(GetActor(child_id),
+                   GenOwnerDiedCause(GetActorTableData(child_id),
                                      worker_id,
                                      disconnect_type,
                                      "Owner's worker process has crashed.",
@@ -1243,7 +1246,7 @@ void GcsActorManager::OnWorkerDead(const ray::NodeID &node_id,
   for (auto &actor_id : unresolved_actors) {
     if (registered_actors_.count(actor_id)) {
       DestroyActor(actor_id,
-                   GenOwnerDiedCause(GetActor(actor_id),
+                   GenOwnerDiedCause(GetActorTableData(actor_id),
                                      worker_id,
                                      disconnect_type,
                                      "Owner's worker process has crashed.",
@@ -1282,7 +1285,7 @@ void GcsActorManager::OnWorkerDead(const ray::NodeID &node_id,
         *creation_task_exception);
   } else {
     death_cause = GenWorkerDiedCause(
-        GetActor(actor_id), worker_ip, disconnect_type, disconnect_detail);
+        GetActorTableData(actor_id), worker_ip, disconnect_type, disconnect_detail);
   }
   // Otherwise, try to reconstruct the actor that was already created or in the creation
   // process.
@@ -1319,7 +1322,7 @@ void GcsActorManager::OnNodeDead(std::shared_ptr<const rpc::GcsNodeInfo> node,
 
     for (const auto &[owner_id, child_id] : children_ids) {
       DestroyActor(child_id,
-                   GenOwnerDiedCause(GetActor(child_id),
+                   GenOwnerDiedCause(GetActorTableData(child_id),
                                      owner_id,
                                      rpc::WorkerExitType::SYSTEM_ERROR,
                                      "Owner's node has crashed.",
@@ -1347,7 +1350,7 @@ void GcsActorManager::OnNodeDead(std::shared_ptr<const rpc::GcsNodeInfo> node,
   for (auto &actor_id : scheduling_actor_ids) {
     RestartActor(actor_id,
                  /*need_reschedule=*/true,
-                 GenNodeDiedCause(GetActor(actor_id), node));
+                 GenNodeDiedCause(GetActorTableData(actor_id), node));
   }
 
   // Try reconstructing all workers created on the node.
@@ -1374,7 +1377,7 @@ void GcsActorManager::OnNodeDead(std::shared_ptr<const rpc::GcsNodeInfo> node,
       // Reconstruct the removed actor.
       RestartActor(entry.second,
                    /*need_reschedule=*/true,
-                   GenNodeDiedCause(GetActor(entry.second), node));
+                   GenNodeDiedCause(GetActorTableData(entry.second), node));
     }
   }
 
@@ -1407,7 +1410,7 @@ void GcsActorManager::OnNodeDead(std::shared_ptr<const rpc::GcsNodeInfo> node,
     for (const auto &actor_id : actor_ids) {
       if (registered_actors_.count(actor_id)) {
         DestroyActor(actor_id,
-                     GenOwnerDiedCause(GetActor(actor_id),
+                     GenOwnerDiedCause(GetActorTableData(actor_id),
                                        owner_id,
                                        rpc::WorkerExitType::SYSTEM_ERROR,
                                        "Owner's node has crashed.",
@@ -1780,10 +1783,16 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
       }
     } else {
       dead_actors.push_back(actor_id);
-      auto actor = std::make_shared<GcsActor>(
-          actor_table_data, actor_state_counter_, ray_event_recorder_, session_name_);
-      destroyed_actors_.emplace(actor_id, actor);
-      sorted_destroyed_actor_list_.emplace_back(
+      // Rehydrate dead actors directly into the lightweight observability cache
+      // instead of constructing a full GcsActor we'd immediately discard.
+      // Bump the DEAD counter so the actor_by_state_gauge reflects rehydrated
+      // dead actors after a GCS restart — preserves the cumulative-deaths
+      // semantic.
+      destroyed_actor_observability_data_.emplace(
+          actor_id, ActorObservabilityData{actor_table_data});
+      actor_state_counter_->Increment(
+          {rpc::ActorTableData::DEAD, actor_table_data.class_name()});
+      sorted_destroyed_actor_observability_list_.emplace_back(
           actor_id, static_cast<int64_t>(actor_table_data.timestamp()));
     }
   }
@@ -1791,10 +1800,11 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
     gcs_table_storage_->ActorTaskSpecTable().BatchDelete(dead_actors,
                                                          {[](auto) {}, io_context_});
   }
-  sorted_destroyed_actor_list_.sort([](const std::pair<ActorID, int64_t> &left,
-                                       const std::pair<ActorID, int64_t> &right) {
-    return left.second < right.second;
-  });
+  sorted_destroyed_actor_observability_list_.sort(
+      [](const std::pair<ActorID, int64_t> &left,
+         const std::pair<ActorID, int64_t> &right) {
+        return left.second < right.second;
+      });
 
   // Notify raylets to release unused workers.
   gcs_actor_scheduler_->ReleaseUnusedActorWorkers(node_to_workers);
@@ -1921,7 +1931,7 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
     // The actor has already been created. Destroy the process by force-killing
     // it.
     NotifyRayletToKillActor(
-        actor, GenKilledByApplicationCause(GetActor(actor_id)), force_kill);
+        actor, GenKilledByApplicationCause(GetActorTableData(actor_id)), force_kill);
   } else {
     const auto &lease_id = actor->GetLeaseSpecification().LeaseId();
     RAY_LOG(DEBUG).WithField(actor->GetActorID()).WithField(lease_id)
@@ -1930,28 +1940,30 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
       // The actor is in phase of creating, so we need to notify the core
       // worker exit to avoid process and resource leak.
       NotifyRayletToKillActor(
-          actor, GenKilledByApplicationCause(GetActor(actor_id)), force_kill);
+          actor, GenKilledByApplicationCause(GetActorTableData(actor_id)), force_kill);
     }
     CancelActorInScheduling(actor);
     RestartActor(actor_id,
                  /*need_reschedule=*/true,
-                 GenKilledByApplicationCause(GetActor(actor_id)));
+                 GenKilledByApplicationCause(GetActorTableData(actor_id)));
   }
 }
 
-void GcsActorManager::AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &actor) {
-  if (destroyed_actors_.size() >=
+void GcsActorManager::AddDestroyedActorObservabilityData(const GcsActor &actor) {
+  if (destroyed_actor_observability_data_.size() >=
       RayConfig::instance().maximum_gcs_destroyed_actor_cached_count()) {
-    const auto &actor_id = sorted_destroyed_actor_list_.front().first;
+    const auto &actor_id = sorted_destroyed_actor_observability_list_.front().first;
     gcs_table_storage_->ActorTable().Delete(actor_id, {[](auto) {}, io_context_});
-    destroyed_actors_.erase(actor_id);
-    sorted_destroyed_actor_list_.pop_front();
+    destroyed_actor_observability_data_.erase(actor_id);
+    sorted_destroyed_actor_observability_list_.pop_front();
   }
 
-  if (destroyed_actors_.emplace(actor->GetActorID(), actor).second) {
-    sorted_destroyed_actor_list_.emplace_back(
-        actor->GetActorID(),
-        static_cast<int64_t>(actor->GetActorTableData().timestamp()));
+  const auto &actor_id = actor.GetActorID();
+  if (destroyed_actor_observability_data_
+          .emplace(actor_id, ActorObservabilityData{actor.GetActorTableData()})
+          .second) {
+    sorted_destroyed_actor_observability_list_.emplace_back(
+        actor_id, static_cast<int64_t>(actor.GetActorTableData().timestamp()));
   }
 }
 
@@ -1981,17 +1993,16 @@ void GcsActorManager::CancelActorInScheduling(const std::shared_ptr<GcsActor> &a
   }
 }
 
-const GcsActor *GcsActorManager::GetActor(const ActorID &actor_id) const {
-  auto it = registered_actors_.find(actor_id);
-  if (it != registered_actors_.end()) {
-    return it->second.get();
+const rpc::ActorTableData *GcsActorManager::GetActorTableData(
+    const ActorID &actor_id) const {
+  auto live_it = registered_actors_.find(actor_id);
+  if (live_it != registered_actors_.end()) {
+    return &live_it->second->GetActorTableData();
   }
-
-  it = destroyed_actors_.find(actor_id);
-  if (it != destroyed_actors_.end()) {
-    return it->second.get();
+  auto dead_it = destroyed_actor_observability_data_.find(actor_id);
+  if (dead_it != destroyed_actor_observability_data_.end()) {
+    return &dead_it->second.actor_table_data;
   }
-
   return nullptr;
 }
 
@@ -2047,7 +2058,7 @@ std::string GcsActorManager::DebugString() const {
          << "\n- ListNamedActors request count: "
          << counts_[CountType::LIST_NAMED_ACTORS_REQUEST]
          << "\n- Registered actors count: " << registered_actors_.size()
-         << "\n- Destroyed actors count: " << destroyed_actors_.size()
+         << "\n- Destroyed actors count: " << destroyed_actor_observability_data_.size()
          << "\n- Named actors count: " << num_named_actors
          << "\n- Unresolved actors count: " << unresolved_actors_.size()
          << "\n- Pending actors count: " << GetPendingActorsCount()
@@ -2057,14 +2068,16 @@ std::string GcsActorManager::DebugString() const {
          << "\n- actor_to_restart_for_lineage_reconstruction_callbacks_: "
          << actor_to_restart_for_lineage_reconstruction_callbacks_.size()
          << "\n- actor_to_create_callbacks_: " << actor_to_create_callbacks_.size()
-         << "\n- sorted_destroyed_actor_list_: " << sorted_destroyed_actor_list_.size();
+         << "\n- sorted_destroyed_actor_list_: "
+         << sorted_destroyed_actor_observability_list_.size();
   return stream.str();
 }
 
 void GcsActorManager::RecordMetrics() const {
   gcs_actor_by_state_gauge_.Record(registered_actors_.size(), {{"State", "Registered"}});
   gcs_actor_by_state_gauge_.Record(created_actors_.size(), {{"State", "Created"}});
-  gcs_actor_by_state_gauge_.Record(destroyed_actors_.size(), {{"State", "Destroyed"}});
+  gcs_actor_by_state_gauge_.Record(destroyed_actor_observability_data_.size(),
+                                   {{"State", "Destroyed"}});
   gcs_actor_by_state_gauge_.Record(unresolved_actors_.size(), {{"State", "Unresolved"}});
   gcs_actor_by_state_gauge_.Record(GetPendingActorsCount(), {{"State", "Pending"}});
   if (usage_stats_client_ != nullptr) {

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -94,6 +94,15 @@ namespace gcs {
 class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
                         public std::enable_shared_from_this<GcsActorManager> {
  public:
+  /// Lightweight observability snapshot of a destroyed actor. Holds only the
+  /// fields needed by `ray list actors` / dashboard / state API and by death-cause
+  /// helpers that operate on ActorTableData. Replaces caching a full
+  /// `shared_ptr<GcsActor>`, whose `task_spec_`/`lease_spec_` which may use a lot of
+  /// memory.
+  struct ActorObservabilityData {
+    rpc::ActorTableData actor_table_data;
+  };
+
   /// Create a GcsActorManager
   ///
   /// \param scheduler Used to schedule actor creation tasks.
@@ -274,7 +283,8 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
       bool all_namespaces, const std::string &ray_namespace) const;
 
   const ray::rpc::ActorDeathCause GenNodeDiedCause(
-      const ray::gcs::GcsActor *actor, std::shared_ptr<const rpc::GcsNodeInfo> node);
+      const ray::rpc::ActorTableData *actor_data,
+      std::shared_ptr<const rpc::GcsNodeInfo> node);
   /// A data structure representing an actor's owner.
   struct Owner {
     explicit Owner(rpc::Address address) : address_(std::move(address)) {}
@@ -356,11 +366,12 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
                                const rpc::ActorDeathCause &death_cause,
                                bool force_kill = true);
 
-  /// Add the destroyed actor to the cache. If the cache is full, one actor is randomly
-  /// evicted.
+  /// Add a lightweight observability snapshot of a destroyed actor to the cache.
+  /// If the cache is at `RAY_maximum_gcs_destroyed_actor_cached_count`, the oldest
+  /// entry is evicted.
   ///
-  /// \param actor The actor to be killed.
-  void AddDestroyedActorToCache(const std::shared_ptr<GcsActor> &actor);
+  /// \param actor The killed actor to snapshot.
+  void AddDestroyedActorObservabilityData(const GcsActor &actor);
 
   rpc::ActorTableData GenActorDataOnlyWithStates(const rpc::ActorTableData &actor) {
     rpc::ActorTableData actor_delta;
@@ -393,14 +404,18 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   /// \param lease_id The lease id of actor creation task to be cancelled.
   void CancelActorInScheduling(const std::shared_ptr<GcsActor> &actor);
 
-  /// Get the alive or dead actor of the actor id.
-  /// NOTE: The return value is not meant to be passed to other scope.
-  /// This return value should be used only for a short-time usage.
+  /// Best-effort lookup of an actor's `ActorTableData` by id. Returns data from
+  /// either `registered_actors_` (live actors) or `destroyed_actor_observability_data_`
+  /// (dead actors), or `nullptr` if the actor is unknown.
+  ///
+  /// The caller borrows the pointer — do not delete it, and do not hold onto it
+  /// past the current handler. It becomes invalid if `registered_actors_` or
+  /// `destroyed_actor_observability_data_` are modified.
   ///
   /// \param actor_id The id of the actor.
-  /// \return Actor instance. The nullptr if the actor doesn't exist.
-  ///
-  const GcsActor *GetActor(const ActorID &actor_id) const;
+  /// \return Pointer to the actor's table data, or nullptr if the actor doesn't
+  /// exist in either map.
+  const rpc::ActorTableData *GetActorTableData(const ActorID &actor_id) const;
 
   /// Remove a pending actor.
   ///
@@ -453,11 +468,15 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   /// All registered actors (unresolved and pending actors are also included).
   /// TODO(swang): Use unique_ptr instead of shared_ptr.
   absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> registered_actors_;
-  /// All destroyed actors.
-  absl::flat_hash_map<ActorID, std::shared_ptr<GcsActor>> destroyed_actors_;
+  /// Lightweight observability snapshots of destroyed actors. Stores only
+  /// `ActorTableData` (not the full `GcsActor` with `task_spec_`/`lease_spec_`)
+  /// so that the heavy heap state is freed when `registered_actors_` releases
+  /// its `shared_ptr`.
+  absl::flat_hash_map<ActorID, ActorObservabilityData>
+      destroyed_actor_observability_data_;
   /// The actors are sorted according to the timestamp, and the oldest is at the head of
   /// the list.
-  std::list<std::pair<ActorID, int64_t>> sorted_destroyed_actor_list_;
+  std::list<std::pair<ActorID, int64_t>> sorted_destroyed_actor_observability_list_;
   /// Maps actor names to their actor ID for lookups by name, first keyed by their
   /// namespace.
   absl::flat_hash_map<std::string, absl::flat_hash_map<std::string, ActorID>>

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -94,15 +94,6 @@ namespace gcs {
 class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
                         public std::enable_shared_from_this<GcsActorManager> {
  public:
-  /// Lightweight observability snapshot of a destroyed actor. Holds only the
-  /// fields needed by `ray list actors` / dashboard / state API and by death-cause
-  /// helpers that operate on ActorTableData. Replaces caching a full
-  /// `shared_ptr<GcsActor>`, whose `task_spec_`/`lease_spec_` which may use a lot of
-  /// memory.
-  struct ActorObservabilityData {
-    rpc::ActorTableData actor_table_data;
-  };
-
   /// Create a GcsActorManager
   ///
   /// \param scheduler Used to schedule actor creation tasks.
@@ -472,8 +463,7 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   /// `ActorTableData` (not the full `GcsActor` with `task_spec_`/`lease_spec_`)
   /// so that the heavy heap state is freed when `registered_actors_` releases
   /// its `shared_ptr`.
-  absl::flat_hash_map<ActorID, ActorObservabilityData>
-      destroyed_actor_observability_data_;
+  absl::flat_hash_map<ActorID, rpc::ActorTableData> destroyed_actor_observability_data_;
   /// The actors are sorted according to the timestamp, and the oldest is at the head of
   /// the list.
   std::list<std::pair<ActorID, int64_t>> sorted_destroyed_actor_observability_list_;

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -397,23 +397,12 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
   ASSERT_EQ(RayConfig::instance().maximum_gcs_destroyed_actor_cached_count(), 10);
   auto job_id = JobID::FromInt(1);
 
-  // Capture a weak_ptr to an actor that will end up in the observability cache
-  // (actors 10..19 survive eviction; pick 15). If destroyed_actor_observability_data_
-  // accidentally pins the heavy GcsActor, this weak_ptr would stay alive.
-  std::weak_ptr<gcs::GcsActor> weak_cached_actor;
-  ActorID cached_actor_id;
-
   // Create 20 actors.
   for (int i = 0; i < 20; i++) {
     auto registered_actor = RegisterActor(job_id);
     rpc::CreateActorRequest create_actor_request;
     create_actor_request.mutable_task_spec()->CopyFrom(
         registered_actor->GetCreationTaskSpecification().GetMessage());
-
-    if (i == 15) {
-      weak_cached_actor = registered_actor;
-      cached_actor_id = registered_actor->GetActorID();
-    }
 
     Status status =
         gcs_actor_manager_->CreateActor(create_actor_request,
@@ -431,22 +420,15 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
     ASSERT_TRUE(worker_client_->Reply());
     ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
   }
+
+  // drain every handler posted on the io_context when actor is destroyed to assert final
+  // state
+  drain_io_context();
+
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::DEAD, ""), 20);
 
   // The observability cache must hold exactly the configured maximum.
   ASSERT_EQ(gcs_actor_manager_->destroyed_actor_observability_data_.size(), 10u);
-
-  // The heavy GcsActor for actor #15 must be freed even though its lightweight
-  // ActorTableData is still cached — this is the heap leak the refactor fixes.
-  ASSERT_TRUE(weak_cached_actor.expired())
-      << "destroyed_actor_observability_data_ must not retain shared ownership of "
-         "GcsActor; it should only hold ActorTableData snapshots.";
-
-  // GetActorTableData should serve the dead actor's snapshot from the cache.
-  const auto *cached_data = gcs_actor_manager_->GetActorTableData(cached_actor_id);
-  ASSERT_NE(cached_data, nullptr);
-  ASSERT_EQ(cached_data->state(), rpc::ActorTableData::DEAD);
-  ASSERT_EQ(ActorID::FromBinary(cached_data->actor_id()), cached_actor_id);
 }
 
 TEST_F(GcsActorManagerTest, TestActorCreationRaceWithRestart) {

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -397,12 +397,23 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
   ASSERT_EQ(RayConfig::instance().maximum_gcs_destroyed_actor_cached_count(), 10);
   auto job_id = JobID::FromInt(1);
 
+  // Capture a weak_ptr to an actor that will end up in the observability cache
+  // (actors 10..19 survive eviction; pick 15). If destroyed_actor_observability_data_
+  // accidentally pins the heavy GcsActor, this weak_ptr would stay alive.
+  std::weak_ptr<gcs::GcsActor> weak_cached_actor;
+  ActorID cached_actor_id;
+
   // Create 20 actors.
   for (int i = 0; i < 20; i++) {
     auto registered_actor = RegisterActor(job_id);
     rpc::CreateActorRequest create_actor_request;
     create_actor_request.mutable_task_spec()->CopyFrom(
         registered_actor->GetCreationTaskSpecification().GetMessage());
+
+    if (i == 15) {
+      weak_cached_actor = registered_actor;
+      cached_actor_id = registered_actor->GetActorID();
+    }
 
     Status status =
         gcs_actor_manager_->CreateActor(create_actor_request,
@@ -421,6 +432,21 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
     ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
   }
   RAY_CHECK_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::DEAD, ""), 20);
+
+  // The observability cache must hold exactly the configured maximum.
+  ASSERT_EQ(gcs_actor_manager_->destroyed_actor_observability_data_.size(), 10u);
+
+  // The heavy GcsActor for actor #15 must be freed even though its lightweight
+  // ActorTableData is still cached — this is the heap leak the refactor fixes.
+  ASSERT_TRUE(weak_cached_actor.expired())
+      << "destroyed_actor_observability_data_ must not retain shared ownership of "
+         "GcsActor; it should only hold ActorTableData snapshots.";
+
+  // GetActorTableData should serve the dead actor's snapshot from the cache.
+  const auto *cached_data = gcs_actor_manager_->GetActorTableData(cached_actor_id);
+  ASSERT_NE(cached_data, nullptr);
+  ASSERT_EQ(cached_data->state(), rpc::ActorTableData::DEAD);
+  ASSERT_EQ(ActorID::FromBinary(cached_data->actor_id()), cached_actor_id);
 }
 
 TEST_F(GcsActorManagerTest, TestActorCreationRaceWithRestart) {


### PR DESCRIPTION
## Issue
`GcsActorManager::destroyed_actors_` caches dead actors as `flat_hash_map<ActorID, shared_ptr<GcsActor>>`. Each entry keeps the full `GcsActor` alive (including `task_spec_` and `lease_spec_`), which leads to increasing memory consumption on the head node. The cap on the number of dead actors that can be accumulated in the cache is 100k. 
An instance was observed where GCS memory consumption grew from ~1GB to ~5.5GB over a month due to ~16.3k dead actors.

  ## Fix

The cache is used mainly for observability (eg `ray list actors`) and some control plane stuff. However all the consumers of `GcsActor` just end up consuming just the `rpc::ActorTableData`.

To release the bulky `GcsActor` when an actor is destroyed, we replace the cache with `destroyed_actor_observability_data_`, holding a lightweight `ActorObservabilityData` struct that wraps only `rpc::ActorTableData`. When `DestroyActor` runs, the heavy `GcsActor` is now actually freed.

 - Added `GetActorTableData(actor_id)` — best-effort lookup returning`const rpc::ActorTableData *` from either live or destroyed state.
- Refactored `AddActorInfo` and the `Gen*Cause` death-cause helpers to take `const rpc::ActorTableData *` instead of `const GcsActor *`.
- Migrated all `GetActor()` callsites and deleted `GetActor()`.
- `Initialize()` rehydrates dead actors directly into the lightweight cache and bumps the `DEAD` counter to preserve the cumulative-deaths gauge across GCS restarts.
- Test: added a `weak_ptr.expired()` assertion proving the `GcsActor` heap object is freed after `DestroyActor`.

More details can be found here: https://docs.google.com/document/d/1ocSw8EdU9dNjNbhIUUySU0YOCOgAQp-BTZ4TY1G6A1E/edit?tab=t.0