### PR TITLE
[Data] Add profiling stack to OSS release benchmarks

### DIFF
--- a/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
+++ b/release/nightly_tests/dataset/image_embedding_from_jsonl/main.py
@@ -1,10 +1,18 @@
+# ABOUTME: Ray Data image embedding benchmark (JSONL input) with GPU and CPU profiling.
+# ABOUTME: Reads base64-encoded images from JSONL, runs HuggingFace ViT inference on GPU actors, writes to parquet.
+
+from __future__ import annotations
+
 import argparse
+import os
+import time
 import uuid
 from io import BytesIO
-from typing import Dict, List, Any
+from typing import Any, Dict, List
 
 import numpy as np
 import ray
+import ray.data
 import torch
 from transformers import ViTImageProcessor, ViTForImageClassification
 from PIL import Image
@@ -18,6 +26,9 @@ from benchmark import (
     benchmark_py_modules,
     collect_dataset_stats,
 )
+from profiling.coordinator import Profiling
+from profiling import nvtx as profiling_nvtx
+from profiling.metrics import extract_pipeline_metrics
 
 
 INPUT_PREFIX = "s3://ray-benchmark-data-internal-us-west-2/10TiB-jsonl-images"
@@ -36,6 +47,9 @@ PROCESSOR = ViTImageProcessor(
     rescale_factor=0.00392156862745098,
     size={"height": 224, "width": 224},
 )
+
+JOB_ID = os.environ.get("ANYSCALE_JOB_ID", f"local-{uuid.uuid4().hex[:8]}")
+SHARED_OUTDIR = f"/mnt/shared_storage/image_embedding_jsonl/{JOB_ID}"
 
 
 def parse_args():
@@ -58,47 +72,9 @@ def parse_args():
     return parser.parse_args()
 
 
-def main(args: argparse.Namespace):
-    benchmark = Benchmark()
-
-    if args.chaos:
-        start_chaos()
-
-    def benchmark_fn():
-        ds = (
-            ray.data.read_json(INPUT_PREFIX, lines=True)
-            .flat_map(decode)
-            .map(preprocess)
-            .map_batches(
-                Infer,
-                batch_size=BATCH_SIZE,
-                num_gpus=1,
-                concurrency=tuple(args.inference_concurrency),
-            )
-        )
-        ds.write_parquet(OUTPUT_PREFIX)
-        metrics = collect_dataset_stats(ds)
-        metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
-        return metrics
-
-    benchmark.run_fn("main", benchmark_fn)
-    benchmark.write_result()
-
-
-def start_chaos():
-    assert ray.is_initialized()
-
-    head_node_id = ray.get_runtime_context().get_node_id()
-    scheduling_strategy = NodeAffinitySchedulingStrategy(
-        node_id=head_node_id, soft=False
-    )
-    resource_killer = EC2InstanceTerminatorWithGracePeriod.options(
-        scheduling_strategy=scheduling_strategy
-    ).remote(head_node_id, max_to_kill=None)
-
-    ray.get(resource_killer.ready.remote())
-
-    resource_killer.run.remote()
+# ---------------------------------------------------------------------------
+# Pipeline UDFs
+# ---------------------------------------------------------------------------
 
 
 def decode(row: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -129,21 +105,181 @@ class Infer:
             "google/vit-base-patch16-224"
         ).to(self._device)
 
+        self._call_count = 0
+        self._profiling_active = False
+        self._profiler_done = False
+        self._profiler_mode = os.environ.get("PROFILER_MODE", "none")
+        self._skip_batches = int(os.environ.get("PROFILE_SKIP_BATCHES", "0"))
+        self._active_batches = int(os.environ.get("PROFILE_ACTIVE_BATCHES", "10000"))
+        self._node_ip = ray.util.get_node_ip_address()
+
+        # The capture range opens at the first cuda_profiler_fence call
+        # (batch == skip_batches + 1) and normally never closes via the
+        # in-loop fence (active_batches is set high). Atexit closes it on
+        # interpreter shutdown; with capture-range-end:stop in
+        # nsys_runtime_env() that finalizes the .nsys-rep synchronously
+        # before Ray tears the actor down.
+        if self._profiler_mode == "nsys":
+            import atexit
+
+            def _stop_nsys():
+                if self._profiling_active:
+                    torch.cuda.cudart().cudaProfilerStop()
+                    self._profiling_active = False
+
+            atexit.register(_stop_nsys)
+
     def __call__(self, batch: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
-        with torch.inference_mode():
+        self._call_count += 1
+
+        # --- nsys capture range control via CUDA profiler API ---
+        if self._profiler_mode == "nsys" and not self._profiler_done:
+            result = profiling_nvtx.cuda_profiler_fence(
+                self._call_count,
+                self._skip_batches,
+                self._active_batches,
+                self._node_ip,
+            )
+            if result[0] is not None:
+                self._profiling_active = result[0]
+            if result[1] is not None:
+                self._profiler_done = result[1]
+
+        # --- GPU work (with NVTX annotations when nsys is active) ---
+        if self._profiler_mode == "nsys":
+            with profiling_nvtx.profiling_range(f"MapBatches_call_{self._call_count}"):
+                with profiling_nvtx.profiling_range("h2d_transfer"):
+                    next_tensor = torch.from_numpy(batch["image"]).to(
+                        dtype=torch.float32,
+                        device=self._device,
+                        non_blocking=True,
+                    )
+
+                with profiling_nvtx.profiling_range("inference"):
+                    with torch.inference_mode():
+                        output = self._model(next_tensor).logits
+
+                with profiling_nvtx.profiling_range("d2h_postprocess"):
+                    result = {
+                        "original_url": batch["original_url"],
+                        "original_width": batch["original_width"],
+                        "original_height": batch["original_height"],
+                        "output": output.cpu().numpy(),
+                    }
+        else:
             next_tensor = torch.from_numpy(batch["image"]).to(
                 dtype=torch.float32, device=self._device, non_blocking=True
             )
-            output = self._model(next_tensor).logits
-            return {
+            with torch.inference_mode():
+                output = self._model(next_tensor).logits
+            result = {
                 "original_url": batch["original_url"],
                 "original_width": batch["original_width"],
                 "original_height": batch["original_height"],
                 "output": output.cpu().numpy(),
             }
 
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(args: argparse.Namespace, profiling: Profiling):
+    benchmark = Benchmark()
+
+    if args.chaos:
+        start_chaos()
+
+    infer_kwargs = {
+        "batch_size": BATCH_SIZE,
+        "num_gpus": 1,
+        "concurrency": tuple(args.inference_concurrency),
+    }
+
+    nsys_env = profiling.nsys_runtime_env()
+    if nsys_env:
+        infer_kwargs["runtime_env"] = nsys_env
+
+    num_gpus = max(args.inference_concurrency)
+
+    def benchmark_fn():
+        ds = (
+            ray.data.read_json(INPUT_PREFIX, lines=True)
+            .flat_map(decode)
+            .map(preprocess)
+            .map_batches(
+                Infer,
+                **infer_kwargs,
+            )
+        )
+        ds.write_parquet(OUTPUT_PREFIX)
+        metrics = collect_dataset_stats(ds)
+        metrics["runtime_env_setup"] = RuntimeEnvSetupTracker.collect()
+        # Hold ds in scope so Ray Data keeps the actor pool alive while nsys
+        # finalizes its .nsys-rep files via stop-on-exit / atexit. Without
+        # this, ds drops out of scope on return and Ray tears the actors
+        # down before nsys gets to flush.
+        if profiling.profiler_mode == "nsys":
+            print("Holding ds in scope for 30s to let nsys finalize...", flush=True)
+            time.sleep(30)
+        if profiling.is_enabled():
+            metrics.update(
+                extract_pipeline_metrics(ds, num_gpus=num_gpus, outdir=SHARED_OUTDIR)
+            )
+        return metrics
+
+    benchmark.run_fn("main", benchmark_fn)
+    benchmark.write_result()
+
+    # Copy result.json to shared storage for telemetry upload.
+    import shutil
+
+    result_path = os.environ.get("TEST_OUTPUT_JSON", "./result.json")
+    if os.path.exists(result_path):
+        shutil.copy2(result_path, SHARED_OUTDIR)
+
+
+def start_chaos():
+    assert ray.is_initialized()
+
+    head_node_id = ray.get_runtime_context().get_node_id()
+    scheduling_strategy = NodeAffinitySchedulingStrategy(
+        node_id=head_node_id, soft=False
+    )
+    resource_killer = EC2InstanceTerminatorWithGracePeriod.options(
+        scheduling_strategy=scheduling_strategy
+    ).remote(head_node_id, max_to_kill=None)
+
+    ray.get(resource_killer.ready.remote())
+
+    resource_killer.run.remote()
+
 
 if __name__ == "__main__":
     ray.init(runtime_env={"py_modules": benchmark_py_modules()})
     args = parse_args()
-    main(args)
+
+    # S3 sometimes returns transient ACCESS_DENIED on HeadObject under heavy
+    # concurrent load (credential refresh or throttling). Retry these instead
+    # of aborting the entire job.
+    ctx = ray.data.DataContext.get_current()
+    ctx.retried_io_errors = list(ctx.retried_io_errors) + [
+        "AWS Error ACCESS_DENIED",
+    ]
+
+    num_gpu_nodes = max(args.inference_concurrency)
+    profiling = Profiling(outdir=SHARED_OUTDIR, num_gpu_nodes=num_gpu_nodes)
+
+    profiling.start(
+        extra_config={
+            "RAY_COMMIT": ray.__commit__,
+            "INFERENCE_CONCURRENCY": args.inference_concurrency,
+        }
+    )
+    try:
+        main(args, profiling)
+    finally:
+        profiling.stop(s3_prefix=f"image-embedding-jsonl/{JOB_ID}")

--- a/release/nightly_tests/dataset/profiling/README.md
+++ b/release/nightly_tests/dataset/profiling/README.md
@@ -1,0 +1,136 @@
+# Shared Profiling Module
+
+Shared profiling and monitoring infrastructure for Ray Data benchmarks.
+Used by benchmarks under `release/nightly_tests/dataset/` (e.g.
+`image_embedding_from_jsonl`).
+
+## How to instrument a benchmark
+
+### Step 1: Build an image with profiling tools
+
+`build_incremental_ray.sh` must be invoked from a Ray or Rayturbo source
+root (it shells out to `bazel`, looks for a `python/ray` subdirectory,
+and pushes the resulting image to ECR).
+
+```bash
+cd ~/work/anyscale/rayturbo2   # or wherever your source tree is
+release/nightly_tests/dataset/profiling/build/build_incremental_ray.sh \
+    --tag <your-tag> --extra
+```
+
+`--extra` adds nsys, perf, gdb, and the cloud SDKs to the base image.
+See `profiling/build/README.md` for `--ml`, `--python-only`, and other
+build modes.
+
+### Step 2: Add profiling to your benchmark's `main.py`
+
+```python
+from profiling.coordinator import Profiling
+from profiling import nvtx as profiling_nvtx
+
+# Create a Profiling instance with your output directory and GPU node count.
+# All configuration is read from environment variables (see table below).
+profiling = Profiling(
+    outdir="/mnt/shared_storage/my_benchmark/<job_id>",
+    num_gpu_nodes=40,
+)
+
+# Start all enabled profilers and monitors.
+profiling.start()
+
+# Get nsys runtime_env for GPU workers (returns {} if PROFILER_MODE != "nsys").
+infer_kwargs["runtime_env"] = profiling.nsys_runtime_env()
+
+# Add NVTX annotations to your GPU actor's __call__ method:
+class MyActor:
+    def __call__(self, batch):
+        with profiling_nvtx.profiling_range("my_operation"):
+            ...
+
+# After the benchmark completes, stop profilers and upload telemetry.
+profiling.stop(s3_prefix="my-benchmark/<job_id>")
+```
+
+That's it. The `Profiling` class handles starting/stopping py-spy, perf,
+nvidia-smi, and network monitors based on which env vars are set.
+
+### Step 3: Configure env vars in `job.yaml`
+
+```yaml
+image_uri: 830883877497.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray:<your-tag>
+
+working_dir: .
+
+env_vars:
+    PROFILER_MODE: "nsys"          # "nsys", "torch", or "none"
+    PYSPY_ENABLED: "1"             # Enable py-spy CPU profiling
+    PERF_PROFILING_ENABLED: "1"    # Enable perf record on raylet/gcs
+```
+
+### Step 4: Submit the job from the `dataset/` directory
+
+```bash
+cd release/nightly_tests/dataset
+anyscale jobs submit -f my_benchmark/job.yaml
+```
+
+Submitting from `dataset/` ensures `benchmark.py` and `profiling/` are
+in scope as the working directory.
+
+### Step 5: Download results and analyze
+
+```bash
+./profiling/analysis/download_job_output.sh prodjob_abc123 my-benchmark/prodjob_abc123
+cd prodjob_abc123
+../profiling/analysis/analyze_pyspy_profile.py pyspy_driver.speedscope.json --list-threads
+# Worker-node UDF profiles (one per sampled ray:: worker):
+../profiling/analysis/analyze_pyspy_profile.py pyspy_worker_<nodeip>_Infer.speedscope.json --list-threads
+../profiling/analysis/analyze_perf_profiles.sh
+```
+
+See [`analysis/README.md`](analysis/README.md) for more analysis examples.
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PROFILER_MODE` | `"none"` | GPU profiler: `"nsys"`, `"torch"`, or `"none"` |
+| `PROFILE_SKIP_BATCHES` | `0` | Batches to skip before nsys capture starts |
+| `PROFILE_ACTIVE_BATCHES` | `10000` | Upper bound on captured batches per actor; left high so atexit closes the capture range |
+| `PYSPY_ENABLED`          | `"0"` | Set to `"1"` to enable py-spy CPU profiling |
+| `PYSPY_NUM_CPU_WORKERS`  | `5`   | Number of CPU worker nodes to py-spy (0 to disable worker py-spy) |
+| `PYSPY_NUM_GPU_WORKERS`  | `5`   | Number of GPU worker nodes to py-spy (0 to disable worker py-spy) |
+| `PERF_PROFILING_ENABLED` | `"0"` | Set to `"1"` to enable perf record on raylet/gcs |
+| `PERF_NUM_CPU_WORKERS`   | `5`   | Number of CPU worker nodes to perf profile |
+| `PERF_NUM_GPU_WORKERS`   | `5`   | Number of GPU worker nodes to perf profile |
+| `GPU_MONITOR_ENABLED` | `"0"` | Set to `"1"` to enable nvidia-smi monitoring |
+| `NET_MONITOR_ENABLED` | `"0"` | Set to `"1"` to enable network I/O monitoring |
+| `OBJECT_STORE_MONITOR_ENABLED` | `"0"` | Set to `"1"` to enable per-(node, operator) object-store sampling |
+| `OBJECT_STORE_MONITOR_INTERVAL_S` | `5` | Seconds between samples after the fast window |
+| `OBJECT_STORE_MONITOR_FAST_WINDOW_S` | `60` | Seconds at the start of the run to sample at the fast interval (set `0` to disable) |
+| `OBJECT_STORE_MONITOR_FAST_INTERVAL_S` | `1` | Tick interval during the fast window |
+| `RAY_MAX_LIMIT_FROM_API_SERVER` | `10000` | Object-store sampling caps `list_objects()` at 10k by default; set to e.g. `200000` on the head node to fully sample large runs |
+| `PROFILING_S3_BUCKET` | `anyscale-staging-data-cld-kvedzwag2qa8i5bjxuevf5i7` | S3 bucket for telemetry upload |
+
+## Modules
+
+| Module | What it does |
+|--------|-------------|
+| `coordinator.py` | Orchestrates all profilers — the main entry point for benchmarks |
+| `pyspy.py` | Attaches py-spy to the driver process and to Ray UDF workers on sampled worker nodes |
+| `perf.py` | Runs `perf record` on GCS/raylet C++ processes (head + worker nodes) |
+| `gpu_monitor.py` | Launches `nvidia-smi dmon` on GPU nodes as they join the cluster |
+| `net_monitor.py` | Samples `psutil.net_io_counters` on every node, writes CSV |
+| `nsys.py` | Builds `runtime_env` config to wrap Ray workers with `nsys profile` |
+| `nvtx.py` | NVTX range annotations and CUDA profiler start/stop for nsys capture control |
+| `object_store.py` | Samples Ray's state API for per-(node, operator) primary-byte time series; writes `object_store_state.csv`, `actor_placement.csv`, and `plasma_stats.csv` |
+| `telemetry.py` | Uploads profiling artifacts from shared storage to S3 |
+
+## Subdirectories
+
+- [`analysis/`](analysis/README.md) -- post-run analysis scripts for profile data
+- [`build/`](build/README.md) -- image build tooling
+
+## Example
+
+See `image_embedding_from_jsonl/main.py` for a complete working example.

--- a/release/nightly_tests/dataset/profiling/__init__.py
+++ b/release/nightly_tests/dataset/profiling/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Shared profiling and instrumentation for Ray Data benchmarks.
+# ABOUTME: Provides GPU/network monitoring, CPU profiling (py-spy, perf), GPU profiling (nsys/nvtx), and S3 telemetry upload.

--- a/release/nightly_tests/dataset/profiling/analysis/README.md
+++ b/release/nightly_tests/dataset/profiling/analysis/README.md
@@ -1,0 +1,80 @@
+# Profile Analysis Scripts
+
+CLI tools for analyzing profiling output after a benchmark run. These
+operate on standard formats (speedscope JSON, collapsed stacks) and
+don't depend on the profiling module -- they can be used standalone.
+
+## Scripts
+
+### `analyze_pyspy_profile.py`
+
+Analyzes speedscope JSON profiles (from py-spy or converted perf data).
+Supports leaf (self-time) analysis, inclusive time, caller/callee stacks,
+call graphs, category grouping, and full stack dumps.
+
+```bash
+# Top 30 leaf functions for the StreamingExecutor thread:
+./analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --top 30
+
+# List all threads and their CPU time:
+./analyze_pyspy_profile.py pyspy_driver.speedscope.json --list-threads
+
+# Caller stacks for a specific function:
+./analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --callers readinto
+
+# Call graph (callers + self-time + callees):
+./analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --call-graph detect
+```
+
+### `collapsed_to_speedscope.py`
+
+Converts collapsed stack format (output of `perf.generate_collapsed_stacks()`)
+to speedscope JSON, so it can be loaded in [speedscope.app](https://www.speedscope.app)
+or analyzed with `analyze_pyspy_profile.py`.
+
+```bash
+./collapsed_to_speedscope.py perf_gcs_collapsed.txt -o gcs.speedscope.json
+```
+
+### `download_job_output.sh`
+
+Downloads Anyscale job logs and S3 telemetry for a completed job into a
+local directory named after the job ID.
+
+```bash
+./download_job_output.sh prodjob_abc123 image-embedding-jsonl/prodjob_abc123
+# Creates prodjob_abc123/ with logs and telemetry files
+```
+
+Respects `PROFILING_S3_BUCKET` env var (same default as `telemetry.py`).
+
+### `analyze_perf_profiles.sh`
+
+Batch-converts all `perf_*_collapsed.txt` files in the current directory to
+speedscope JSON and generates a thread summary. Run from a directory
+containing perf collapsed stack files (downloaded from S3 telemetry).
+
+```bash
+cd /path/to/downloaded/telemetry
+analyze_perf_profiles.sh
+# Produces: *.speedscope.json files + perf_thread_summary.txt
+```
+
+## Typical workflow
+
+1. Run a benchmark with `PERF_PROFILING_ENABLED=1` and/or `PYSPY_ENABLED=1`
+2. Download job output:
+   ```bash
+   ./download_job_output.sh prodjob_abc123 image-embedding-jsonl/prodjob_abc123
+   cd prodjob_abc123
+   ```
+3. Analyze py-spy output:
+   ```bash
+   ./analyze_pyspy_profile.py pyspy_driver.speedscope.json --list-threads
+   ./analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --top 30
+   ```
+4. Convert and analyze perf output:
+   ```bash
+   ./analyze_perf_profiles.sh
+   ./analyze_pyspy_profile.py perf_gcs.speedscope.json --list-threads
+   ```

--- a/release/nightly_tests/dataset/profiling/analysis/analyze_perf_profiles.sh
+++ b/release/nightly_tests/dataset/profiling/analysis/analyze_perf_profiles.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# ABOUTME: Converts all perf collapsed stack files to speedscope JSON and generates a thread summary.
+# ABOUTME: Run from a directory containing perf_*_collapsed.txt files.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+outfile="perf_thread_summary.txt"
+: > "$outfile"
+
+for collapsed in perf_*_collapsed.txt; do
+    [ -f "$collapsed" ] || continue
+    base="${collapsed%_collapsed.txt}"
+    speedscope="${base}.speedscope.json"
+
+    echo "Converting $collapsed..."
+    "$SCRIPT_DIR/collapsed_to_speedscope.py" "$collapsed" -o "$speedscope"
+    echo
+
+    {
+        echo "=== $base ==="
+        "$SCRIPT_DIR/analyze_pyspy_profile.py" "$speedscope" --list-threads
+        echo
+    } >> "$outfile"
+done
+
+echo "Thread summary written to $outfile"

--- a/release/nightly_tests/dataset/profiling/analysis/analyze_pyspy_profile.py
+++ b/release/nightly_tests/dataset/profiling/analysis/analyze_pyspy_profile.py
@@ -1,0 +1,761 @@
+#!/usr/bin/env python3
+# ABOUTME: Analyzes py-spy speedscope JSON profiles to extract leaf (self-time) and inclusive-time statistics.
+# ABOUTME: Supports filtering by thread name and grouping leaf functions into configurable categories.
+
+"""
+Usage:
+    python analyze_pyspy_profile.py <speedscope.json> [--thread <substring>] [--top N] [--categories FILE]
+
+Examples:
+    # Top 30 leaf functions for the StreamingExecutor thread:
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --top 30
+
+    # All threads, top 20 (default):
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json
+
+    # Inclusive time for specific functions:
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --inclusive invoke_detectors,detect,get_task
+
+    # With custom category groupings (JSON file mapping category -> [function names]):
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --categories categories.json
+
+    # Top 10 caller stacks for readinto:
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --callers readinto --top 10
+
+    # Caller stacks with max 8 frames of context:
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --callers readinto --depth 8
+
+    # Call graph (callers + callees) for detect:
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --call-graph detect
+
+    # Call graph with deeper context:
+    python analyze_pyspy_profile.py pyspy_driver.speedscope.json --thread StreamingExecutor --call-graph detect --depth 8 --top 10
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+
+def load_profile(path: str) -> dict:
+    with open(path, encoding="utf-8", errors="replace") as f:
+        return json.load(f)
+
+
+def find_matching_profiles(
+    data: dict, thread_filter: Optional[str]
+) -> List[Tuple[str, dict]]:
+    """Return (name, profile) pairs matching the thread filter substring."""
+    results = []
+    for profile in data["profiles"]:
+        name = profile.get("name", "")
+        if thread_filter is None or thread_filter.lower() in name.lower():
+            results.append((name, profile))
+    return results
+
+
+def analyze_self_time(
+    frames: List[dict], samples: List[List[int]], weights: List[float]
+) -> Dict[int, float]:
+    """Count weighted self-time for each frame index (leaf of each sample stack)."""
+    self_time = defaultdict(float)
+    for stack, weight in zip(samples, weights):
+        if stack:
+            leaf = stack[-1]
+            self_time[leaf] += weight
+    return dict(self_time)
+
+
+def analyze_inclusive_time(
+    frames: List[dict],
+    samples: List[List[int]],
+    weights: List[float],
+    target_names: Set[str],
+) -> Dict[str, Tuple[float, int]]:
+    """Count weighted inclusive time for functions matching target_names.
+
+    Returns {name: (total_weight, sample_count)}.
+    """
+    # Build reverse lookup: frame_index -> name (only for targets)
+    target_indices = {}
+    for idx, frame in enumerate(frames):
+        if frame["name"] in target_names:
+            target_indices[idx] = frame["name"]
+
+    inclusive = defaultdict(lambda: [0.0, 0])
+    for stack, weight in zip(samples, weights):
+        # A function gets inclusive credit once per sample, even if it
+        # appears multiple times in the stack (recursion).
+        seen = set()
+        for frame_idx in stack:
+            if frame_idx in target_indices:
+                name = target_indices[frame_idx]
+                if name not in seen:
+                    seen.add(name)
+                    inclusive[name][0] += weight
+                    inclusive[name][1] += 1
+
+    return {name: (vals[0], vals[1]) for name, vals in inclusive.items()}
+
+
+def categorize_functions(
+    self_time_by_idx: Dict[int, float],
+    frames: List[dict],
+    categories: Dict[str, List[str]],
+) -> Dict[str, Tuple[float, List[str]]]:
+    """Group leaf functions into categories.
+
+    categories: {category_name: [function_name, ...]}
+    Returns: {category_name: (total_weight, [matched_function_names])}
+    """
+    # Build function_name -> category lookup
+    func_to_cat = {}
+    for cat, funcs in categories.items():
+        for fn in funcs:
+            func_to_cat[fn] = cat
+
+    cat_totals = defaultdict(lambda: [0.0, []])
+    uncategorized_total = 0.0
+
+    for frame_idx, weight in self_time_by_idx.items():
+        fname = frames[frame_idx]["name"]
+        cat = func_to_cat.get(fname)
+        if cat:
+            cat_totals[cat][0] += weight
+            if fname not in cat_totals[cat][1]:
+                cat_totals[cat][1].append(fname)
+        else:
+            uncategorized_total += weight
+
+    result = {cat: (vals[0], vals[1]) for cat, vals in cat_totals.items()}
+    if uncategorized_total > 0:
+        result["Other"] = (uncategorized_total, [])
+    return result
+
+
+def analyze_caller_stacks(
+    frames: List[dict],
+    samples: List[List[int]],
+    weights: List[float],
+    target_name: str,
+    max_depth: Optional[int] = None,
+    thread_names: Optional[List[str]] = None,
+) -> List[Tuple[Tuple[str, ...], float, int, str]]:
+    """Find unique caller stacks for a target function.
+
+    For each sample where target_name appears, extracts the stack from
+    the root down to (and including) the target function. Groups identical
+    stacks by (chain, thread_name) and sums their weights.
+
+    Returns [(stack_tuple, total_weight, sample_count, thread_name), ...]
+    sorted by descending weight.
+    """
+    # Build frame_index -> bool for target function
+    target_indices = set()
+    for idx, frame in enumerate(frames):
+        if frame["name"] == target_name:
+            target_indices.add(idx)
+
+    # Key includes thread name so identical stacks from different threads
+    # are kept separate.
+    stack_weights = defaultdict(lambda: [0.0, 0])
+    for i, (stack, weight) in enumerate(zip(samples, weights)):
+        # Find the deepest (last) occurrence of the target in this stack.
+        # Using the deepest handles recursion — we get the full caller chain.
+        target_pos = None
+        for pos in range(len(stack) - 1, -1, -1):
+            if stack[pos] in target_indices:
+                target_pos = pos
+                break
+        if target_pos is None:
+            continue
+
+        # Extract caller chain: root -> ... -> target
+        caller_chain = stack[: target_pos + 1]
+        # Apply depth limit (keep the N frames closest to the target)
+        if max_depth is not None and len(caller_chain) > max_depth:
+            caller_chain = caller_chain[-(max_depth):]
+
+        # Convert to tuple of function names for grouping
+        chain_key = tuple(frames[idx]["name"] for idx in caller_chain)
+        tname = thread_names[i] if thread_names else ""
+        group_key = (chain_key, tname)
+        stack_weights[group_key][0] += weight
+        stack_weights[group_key][1] += 1
+
+    result = [
+        (chain, vals[0], vals[1], tname)
+        for (chain, tname), vals in stack_weights.items()
+    ]
+    result.sort(key=lambda x: -x[1])
+    return result
+
+
+def analyze_callee_stacks(
+    frames: List[dict],
+    samples: List[List[int]],
+    weights: List[float],
+    target_name: str,
+    max_depth: Optional[int] = None,
+) -> List[Tuple[Tuple[str, ...], float, int]]:
+    """Find unique callee stacks for a target function.
+
+    For each sample where target_name appears, extracts the stack from
+    the target function down to the leaf (what it calls). Uses the
+    shallowest (first) occurrence to maximize callee chain length.
+    Groups identical stacks and sums their weights.
+
+    Returns [(stack_tuple, total_weight, sample_count), ...] sorted by
+    descending weight.
+    """
+    target_indices = set()
+    for idx, frame in enumerate(frames):
+        if frame["name"] == target_name:
+            target_indices.add(idx)
+
+    stack_weights = defaultdict(lambda: [0.0, 0])
+    for stack, weight in zip(samples, weights):
+        # Find the shallowest (first) occurrence of the target.
+        target_pos = None
+        for pos in range(len(stack)):
+            if stack[pos] in target_indices:
+                target_pos = pos
+                break
+        if target_pos is None:
+            continue
+
+        # Extract callee chain: target -> ... -> leaf
+        callee_chain = stack[target_pos:]
+        # Apply depth limit (keep the N frames closest to the target)
+        if max_depth is not None and len(callee_chain) > max_depth:
+            callee_chain = callee_chain[:max_depth]
+
+        chain_key = tuple(frames[idx]["name"] for idx in callee_chain)
+        stack_weights[chain_key][0] += weight
+        stack_weights[chain_key][1] += 1
+
+    result = [(chain, vals[0], vals[1]) for chain, vals in stack_weights.items()]
+    result.sort(key=lambda x: -x[1])
+    return result
+
+
+DEFAULT_CATEGORIES = {
+    "Actor state": [
+        "__hash__",
+        "_actor_id",
+        "_get_local_state",
+        "refresh_actor_state",
+        "_update_running_actor_state",
+        "running_actors",
+        "get_actor_id",
+        "max_tasks_in_flight_per_actor",
+    ],
+    "HTTP/detect": [
+        "readinto",
+        "_make_http_get_request",
+        "ray_address_to_api_server_url",
+        "internal_kv_get_with_retry",
+        "_initialize_internal_kv",
+        "check_connected",
+    ],
+    "List/set comprehensions": [
+        "<listcomp>",
+        "<setcomp>",
+        "<dictcomp>",
+    ],
+    "HeapDict": [
+        "_decrease_key",
+        "_swap",
+        "__setitem__",
+        "_build_actor_busyness_heap",
+    ],
+    "Scheduling misc": [
+        "wait",
+        "safe_round",
+        "select_operator_to_run",
+    ],
+}
+
+
+def format_table(
+    headers: List[str], rows: List[List[str]], align: Optional[List[str]] = None
+) -> str:
+    """Format a markdown table with column alignment.
+
+    align: list of 'l' or 'r' per column. Defaults to left.
+    """
+    if align is None:
+        align = ["l"] * len(headers)
+
+    col_widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            col_widths[i] = max(col_widths[i], len(cell))
+
+    def pad(s, w, a):
+        return s.rjust(w) if a == "r" else s.ljust(w)
+
+    sep_parts = []
+    for i, w in enumerate(col_widths):
+        if align[i] == "r":
+            sep_parts.append("-" * (w - 1) + ":")
+        else:
+            sep_parts.append("-" * w)
+
+    header_line = (
+        "| "
+        + " | ".join(pad(h, col_widths[i], align[i]) for i, h in enumerate(headers))
+        + " |"
+    )
+    sep_line = "| " + " | ".join(sep_parts) + " |"
+    data_lines = []
+    for row in rows:
+        data_lines.append(
+            "| "
+            + " | ".join(
+                pad(cell, col_widths[i], align[i]) for i, cell in enumerate(row)
+            )
+            + " |"
+        )
+
+    return "\n".join([header_line, sep_line] + data_lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze py-spy speedscope JSON profiles"
+    )
+    parser.add_argument("profile", help="Path to speedscope JSON file")
+    parser.add_argument(
+        "--thread", "-t", help="Filter profiles by thread name substring"
+    )
+    parser.add_argument(
+        "--top", "-n", type=int, default=20, help="Number of top leaf functions to show"
+    )
+    parser.add_argument(
+        "--inclusive",
+        "-i",
+        help="Comma-separated function names to compute inclusive time for",
+    )
+    parser.add_argument(
+        "--categories",
+        "-c",
+        help="JSON file with category groupings: {category: [func_names]}",
+    )
+    parser.add_argument(
+        "--no-categories",
+        action="store_true",
+        help="Skip category breakdown (show only leaf functions)",
+    )
+    parser.add_argument(
+        "--callers",
+        help="Show top caller stacks for this function name",
+    )
+    parser.add_argument(
+        "--depth",
+        type=int,
+        default=5,
+        help="Max stack depth to show for --callers (default: 5, 0=unlimited)",
+    )
+    parser.add_argument(
+        "--call-graph",
+        help="Show callers, self-time, and callees for this function name",
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Print all unique stack traces sorted by weight",
+    )
+    parser.add_argument(
+        "--list-threads",
+        action="store_true",
+        help="List all threads/profiles and exit",
+    )
+
+    args = parser.parse_args()
+
+    data = load_profile(args.profile)
+    frames = data["shared"]["frames"]
+
+    if args.list_threads:
+        print(f"\nThreads in {args.profile}:\n")
+        entries = []
+        for i, p in enumerate(data["profiles"]):
+            name = p.get("name", "(unnamed)")
+            n_samples = len(p.get("samples", []))
+            total_weight = sum(p.get("weights", []))
+            entries.append((i, n_samples, total_weight, name))
+        grand_total = sum(w for _, _, w, _ in entries)
+        entries.sort(key=lambda e: -e[2])
+        rows = []
+        for i, n_samples, total_weight, name in entries:
+            pct = 100 * total_weight / grand_total if grand_total else 0
+            rows.append([str(n_samples), f"{total_weight:.2f}s", f"{pct:.1f}%", name])
+        print(
+            format_table(
+                ["Samples", "CPU time", "% total", "Thread name"],
+                rows,
+                ["r", "r", "r", "l"],
+            )
+        )
+        return
+
+    # Find matching profiles
+    matches = find_matching_profiles(data, args.thread)
+    if not matches:
+        print(f"No profiles matching thread filter '{args.thread}'", file=sys.stderr)
+        print("Use --list-threads to see available threads", file=sys.stderr)
+        sys.exit(1)
+
+    # Merge samples from all matching profiles
+    all_samples = []
+    all_weights = []
+    all_thread_names = []
+    profile_names = []
+    for name, profile in matches:
+        profile_names.append(name)
+        n_samples = len(profile["samples"])
+        all_samples.extend(profile["samples"])
+        all_weights.extend(profile["weights"])
+        all_thread_names.extend([name] * n_samples)
+
+    total_weight = sum(all_weights)
+    total_samples = len(all_samples)
+
+    print(f"\nProfile: {args.profile}")
+    print(f"Thread filter: {args.thread or '(all threads)'}")
+    print(f"Matching profiles: {len(matches)}")
+    for name in profile_names:
+        print(f"  - {name}")
+    print(f"Total samples: {total_samples:,}")
+    print(f"Total CPU time: {total_weight:.2f}s")
+
+    # If --callers is the only analysis requested, skip leaf/category output
+    callers_only = (args.callers or args.full or args.call_graph) and not args.inclusive
+
+    # --- Self-time (leaf function) analysis ---
+    self_time = analyze_self_time(frames, all_samples, all_weights)
+
+    # Sort by descending self-time
+    sorted_self = sorted(self_time.items(), key=lambda x: -x[1])
+
+    if not callers_only:
+        print(f"\n{'=' * 72}")
+        print(f"Top {args.top} Leaf Functions (self-time)")
+        print(f"{'=' * 72}\n")
+
+        rows = []
+        for frame_idx, weight in sorted_self[: args.top]:
+            frame = frames[frame_idx]
+            pct = 100 * weight / total_weight if total_weight else 0
+            # Count samples where this frame is the leaf
+            sample_count = sum(1 for s in all_samples if s and s[-1] == frame_idx)
+            loc = f"{Path(frame.get('file', '')).name}:{frame.get('line', '?')}"
+            rows.append(
+                [
+                    f"{sample_count:,}",
+                    f"{pct:.1f}%",
+                    f"{weight:.2f}s",
+                    frame["name"],
+                    loc,
+                ]
+            )
+
+        print(
+            format_table(
+                ["Samples", "Self %", "Self time", "Function", "Location"],
+                rows,
+                ["r", "r", "r", "l", "l"],
+            )
+        )
+
+        # --- Category breakdown ---
+        if not args.no_categories:
+            if args.categories:
+                with open(args.categories) as f:
+                    categories = json.load(f)
+            else:
+                categories = DEFAULT_CATEGORIES
+
+            print(f"\n{'=' * 72}")
+            print("Self-Time by Category")
+            print(f"{'=' * 72}\n")
+
+            cat_results = categorize_functions(self_time, frames, categories)
+            sorted_cats = sorted(cat_results.items(), key=lambda x: -x[1][0])
+
+            rows = []
+            for cat, (weight, func_names) in sorted_cats:
+                pct = 100 * weight / total_weight if total_weight else 0
+                funcs_str = ", ".join(func_names[:6])
+                if len(func_names) > 6:
+                    funcs_str += ", ..."
+                rows.append([f"{pct:.1f}%", f"{weight:.2f}s", cat, funcs_str])
+
+            print(
+                format_table(
+                    ["Self %", "Self time", "Category", "Functions"],
+                    rows,
+                    ["r", "r", "l", "l"],
+                )
+            )
+
+    # --- Caller stack analysis ---
+    if args.callers:
+        depth = args.depth if args.depth != 0 else None
+        callers_top = args.top if args.top != 20 else 5
+        caller_stacks = analyze_caller_stacks(
+            frames,
+            all_samples,
+            all_weights,
+            args.callers,
+            depth,
+            thread_names=all_thread_names,
+        )
+
+        if not caller_stacks:
+            print(
+                f"\nFunction '{args.callers}' not found in any sample stack.",
+                file=sys.stderr,
+            )
+        else:
+            # Total weight across all stacks containing the target
+            callers_total_weight = sum(w for _, w, _, _ in caller_stacks)
+            callers_total_samples = sum(c for _, _, c, _ in caller_stacks)
+
+            print(f"\n{'=' * 72}")
+            depth_str = f", depth={args.depth}" if depth else ""
+            print(f"Top {callers_top} Caller Stacks for '{args.callers}'{depth_str}")
+            print(f"{'=' * 72}")
+            print(
+                f"\n{callers_total_samples:,} samples ({callers_total_weight:.2f}s) "
+                f"contain '{args.callers}' "
+                f"({100 * callers_total_weight / total_weight:.1f}% of thread CPU)\n"
+            )
+
+            for rank, (chain, weight, count, tname) in enumerate(
+                caller_stacks[:callers_top], 1
+            ):
+                pct_of_thread = 100 * weight / total_weight if total_weight else 0
+                pct_of_func = (
+                    100 * weight / callers_total_weight if callers_total_weight else 0
+                )
+                # Extract short thread name from "Process NNNN Thread 0xHEX "name""
+                short_tname = tname.rsplit('"', 2)[-2] if '"' in tname else tname
+                print(
+                    f"--- Stack #{rank}: {count:,} samples, "
+                    f"{weight:.2f}s ({pct_of_thread:.1f}% of thread, "
+                    f"{pct_of_func:.1f}% of '{args.callers}') "
+                    f"[{short_tname}] ---"
+                )
+                # Print stack with indentation showing call depth
+                for depth_idx, fname in enumerate(chain):
+                    if depth_idx == len(chain) - 1:
+                        print(f"    {'  ' * depth_idx}** {fname} **")
+                    else:
+                        print(f"    {'  ' * depth_idx}{fname}")
+                print()
+
+    # --- Call graph analysis ---
+    if args.call_graph:
+        target = args.call_graph
+        depth = args.depth if args.depth != 0 else None
+        cg_top = args.top if args.top != 20 else 5
+
+        # Find all frame indices matching the target
+        target_indices = set()
+        for idx, frame in enumerate(frames):
+            if frame["name"] == target:
+                target_indices.add(idx)
+
+        if not target_indices:
+            print(f"\nFunction '{target}' not found in any frame.", file=sys.stderr)
+        else:
+            # Compute self-time: samples where target is the leaf
+            func_self_weight = 0.0
+            func_self_count = 0
+            for stack, weight in zip(all_samples, all_weights):
+                if stack and stack[-1] in target_indices:
+                    func_self_weight += weight
+                    func_self_count += 1
+
+            # Compute inclusive time: samples where target appears anywhere
+            func_inclusive_weight = 0.0
+            func_inclusive_count = 0
+            for stack, weight in zip(all_samples, all_weights):
+                for frame_idx in stack:
+                    if frame_idx in target_indices:
+                        func_inclusive_weight += weight
+                        func_inclusive_count += 1
+                        break
+
+            # Get caller and callee stacks
+            # For callers: use shallowest (first) occurrence to be consistent
+            # with callee analysis (split at the same point)
+            caller_weights = defaultdict(lambda: [0.0, 0])
+            callee_weights = defaultdict(lambda: [0.0, 0])
+            for stack, weight in zip(all_samples, all_weights):
+                # Find shallowest occurrence
+                target_pos = None
+                for pos in range(len(stack)):
+                    if stack[pos] in target_indices:
+                        target_pos = pos
+                        break
+                if target_pos is None:
+                    continue
+
+                # Callers: root -> ... -> target
+                caller_chain = stack[: target_pos + 1]
+                if depth is not None and len(caller_chain) > depth:
+                    caller_chain = caller_chain[-depth:]
+                caller_key = tuple(frames[idx]["name"] for idx in caller_chain)
+                caller_weights[caller_key][0] += weight
+                caller_weights[caller_key][1] += 1
+
+                # Callees: target -> ... -> leaf
+                callee_chain = stack[target_pos:]
+                if depth is not None and len(callee_chain) > depth:
+                    callee_chain = callee_chain[:depth]
+                callee_key = tuple(frames[idx]["name"] for idx in callee_chain)
+                callee_weights[callee_key][0] += weight
+                callee_weights[callee_key][1] += 1
+
+            sorted_callers = sorted(caller_weights.items(), key=lambda x: -x[1][0])
+            sorted_callees = sorted(callee_weights.items(), key=lambda x: -x[1][0])
+
+            # --- Print header ---
+            print(f"\n{'=' * 72}")
+            depth_str = f", depth={args.depth}" if depth else ""
+            print(f"Call Graph for '{target}'{depth_str}")
+            print(f"{'=' * 72}")
+
+            self_pct = 100 * func_self_weight / total_weight if total_weight else 0
+            inc_pct = 100 * func_inclusive_weight / total_weight if total_weight else 0
+            print(
+                f"\nInclusive: {func_inclusive_count:,} samples, "
+                f"{func_inclusive_weight:.2f}s ({inc_pct:.1f}% of thread)"
+            )
+            print(
+                f"Self-time: {func_self_count:,} samples, "
+                f"{func_self_weight:.2f}s ({self_pct:.1f}% of thread)"
+            )
+
+            # --- Callers ---
+            print(
+                f"\n--- Callers ({len(sorted_callers):,} unique chains, "
+                f"showing top {min(cg_top, len(sorted_callers))}) ---\n"
+            )
+
+            for rank, (chain, (weight, count)) in enumerate(sorted_callers[:cg_top], 1):
+                pct = (
+                    100 * weight / func_inclusive_weight if func_inclusive_weight else 0
+                )
+                print(f"  #{rank}: {count:,} samples, {weight:.2f}s ({pct:.1f}%)")
+                for d, fname in enumerate(chain):
+                    if fname == target:
+                        print(f"      {'  ' * d}** {fname} **")
+                    else:
+                        print(f"      {'  ' * d}{fname}")
+                print()
+
+            # --- Callees ---
+            # Separate self-time entries (chain length 1 = target is the leaf)
+            callee_stacks = [(c, w, n) for c, (w, n) in sorted_callees if len(c) > 1]
+            self_entries = [(c, w, n) for c, (w, n) in sorted_callees if len(c) == 1]
+
+            print(
+                f"--- Callees ({len(callee_stacks):,} unique chains, "
+                f"showing top {min(cg_top, len(callee_stacks))}) ---\n"
+            )
+
+            if self_entries:
+                sw = sum(w for _, w, _ in self_entries)
+                sc = sum(n for _, _, n in self_entries)
+                pct = 100 * sw / func_inclusive_weight if func_inclusive_weight else 0
+                print(
+                    f"  (self): {sc:,} samples, {sw:.2f}s ({pct:.1f}%) "
+                    f"-- '{target}' is the leaf\n"
+                )
+
+            for rank, (chain, weight, count) in enumerate(callee_stacks[:cg_top], 1):
+                pct = (
+                    100 * weight / func_inclusive_weight if func_inclusive_weight else 0
+                )
+                print(f"  #{rank}: {count:,} samples, {weight:.2f}s ({pct:.1f}%)")
+                for d, fname in enumerate(chain):
+                    if d == 0:
+                        print(f"      ** {fname} **")
+                    elif d == len(chain) - 1:
+                        print(f"      {'  ' * d}-> {fname}")
+                    else:
+                        print(f"      {'  ' * d}{fname}")
+                print()
+
+    # --- Full stack trace dump ---
+    if args.full:
+        # Group all samples by their complete stack trace
+        stack_groups = defaultdict(lambda: [0.0, 0])
+        for stack, weight in zip(all_samples, all_weights):
+            key = tuple(frames[idx]["name"] for idx in stack)
+            stack_groups[key][0] += weight
+            stack_groups[key][1] += 1
+
+        sorted_stacks = sorted(stack_groups.items(), key=lambda x: -x[1][0])
+        full_top = args.top if args.top != 20 else len(sorted_stacks)
+
+        print(f"\n{'=' * 72}")
+        print(
+            f"All Unique Stack Traces by Weight ({len(sorted_stacks):,} unique stacks)"
+        )
+        print(f"{'=' * 72}\n")
+
+        for rank, (chain, (weight, count)) in enumerate(sorted_stacks[:full_top], 1):
+            pct = 100 * weight / total_weight if total_weight else 0
+            print(
+                f"--- Stack #{rank}: {count:,} samples, {weight:.2f}s ({pct:.1f}%) ---"
+            )
+            for depth_idx, fname in enumerate(chain):
+                if depth_idx == len(chain) - 1:
+                    print(f"    {'  ' * depth_idx}** {fname} **")
+                else:
+                    print(f"    {'  ' * depth_idx}{fname}")
+            print()
+
+    # --- Inclusive time analysis ---
+    if args.inclusive:
+        target_names = set(args.inclusive.split(","))
+
+        print(f"\n{'=' * 72}")
+        print("Inclusive Time (function appears anywhere in stack)")
+        print(f"{'=' * 72}\n")
+
+        inclusive = analyze_inclusive_time(
+            frames, all_samples, all_weights, target_names
+        )
+        sorted_inc = sorted(inclusive.items(), key=lambda x: -x[1][0])
+
+        rows = []
+        for name, (weight, count) in sorted_inc:
+            pct = 100 * weight / total_weight if total_weight else 0
+            rows.append([f"{count:,}", f"{pct:.1f}%", f"{weight:.2f}s", name])
+
+        # Show any requested names that weren't found
+        missing = target_names - set(inclusive.keys())
+        if missing:
+            for name in sorted(missing):
+                rows.append(["0", "0.0%", "0.00s", f"{name} (not found)"])
+
+        print(
+            format_table(
+                ["Samples", "Inclusive %", "Inclusive time", "Function"],
+                rows,
+                ["r", "r", "r", "l"],
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/release/nightly_tests/dataset/profiling/analysis/collapsed_to_speedscope.py
+++ b/release/nightly_tests/dataset/profiling/analysis/collapsed_to_speedscope.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# ABOUTME: Converts collapsed stack format (from stackcollapse-perf.pl) to speedscope JSON.
+# ABOUTME: Output can be loaded in speedscope UI or analyzed with analyze-pyspy-profile.
+
+"""
+Usage:
+    collapsed-to-speedscope input.collapsed.txt [-o output.speedscope.json] [--name PROFILE_NAME]
+
+The collapsed stack format is: semicolon;delimited;stack weight
+Each unique first frame is treated as a separate thread/profile.
+
+Examples:
+    collapsed-to-speedscope perf_gcs_collapsed.txt
+    collapsed-to-speedscope perf_gcs_collapsed.txt -o gcs.speedscope.json
+    collapsed-to-speedscope perf_gcs_collapsed.txt --name "GCS Server"
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+_OFFSET_RE = re.compile(r"\+0x[0-9a-f]+$")
+
+
+def _clean_frame(name):
+    """Strip hex offsets (+0x...) from a frame name."""
+    return _OFFSET_RE.sub("", name)
+
+
+def parse_collapsed(path):
+    """Parse collapsed stack file into list of (stack_frames, weight) tuples."""
+    samples = []
+    with open(path) as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.rstrip()
+            if not line:
+                continue
+            # Last space-separated token is the weight
+            last_space = line.rfind(" ")
+            if last_space == -1:
+                print(f"WARNING: skipping malformed line {lineno}", file=sys.stderr)
+                continue
+            stack_str = line[:last_space]
+            try:
+                weight = int(line[last_space + 1 :])
+            except ValueError:
+                try:
+                    weight = float(line[last_space + 1 :])
+                except ValueError:
+                    print(
+                        f"WARNING: skipping line {lineno} (bad weight)", file=sys.stderr
+                    )
+                    continue
+            frames = [_clean_frame(f) for f in stack_str.split(";")]
+            samples.append((frames, weight))
+    return samples
+
+
+def build_speedscope(samples, profile_name, freq=99):
+    """Convert parsed samples to speedscope JSON format.
+
+    Groups samples by their first frame (thread name in perf output)
+    into separate profiles.
+    """
+    # Group by thread (first frame in stack)
+    by_thread = defaultdict(list)
+    for frames, weight in samples:
+        thread = frames[0] if frames else "(unknown)"
+        by_thread[thread].append((frames, weight))
+
+    # Build shared frame table
+    frame_index = {}
+    frame_list = []
+
+    def get_frame_idx(name):
+        if name not in frame_index:
+            frame_index[name] = len(frame_list)
+            frame_list.append({"name": name})
+        return frame_index[name]
+
+    # Detect if weights are nanosecond periods (from stackcollapse-perf.pl)
+    # vs simple counts. Perf periods are typically >= 1,000,000 (1ms+).
+    all_weights = [w for _, w in samples]
+    median_weight = sorted(all_weights)[len(all_weights) // 2] if all_weights else 1
+    # If median weight > 100,000, assume nanoseconds and convert to seconds.
+    if median_weight > 100_000:
+        weight_scale = 1e-9
+        print(
+            f"  Detected nanosecond weights (median={median_weight}), converting to seconds"
+        )
+    else:
+        # Simple counts: each sample represents 1/freq seconds.
+        weight_scale = 1.0 / freq
+        print(
+            f"  Detected count weights (median={median_weight}), using {freq} Hz -> {weight_scale:.4f}s per sample"
+        )
+
+    # Build profiles (one per thread)
+    profiles = []
+    for thread_name, thread_samples in sorted(by_thread.items()):
+        profile_samples = []
+        profile_weights = []
+        for frames, weight in thread_samples:
+            indices = [get_frame_idx(f) for f in frames]
+            profile_samples.append(indices)
+            profile_weights.append(weight * weight_scale)
+
+        name = thread_name
+        profiles.append(
+            {
+                "type": "sampled",
+                "name": name,
+                "unit": "seconds",
+                "startValue": 0,
+                "endValue": sum(profile_weights),
+                "samples": profile_samples,
+                "weights": profile_weights,
+            }
+        )
+
+    return {
+        "$schema": "https://www.speedscope.app/file-format-schema.json",
+        "shared": {"frames": frame_list},
+        "profiles": profiles,
+        "name": profile_name or os.path.basename(sys.argv[0]),
+        "exporter": "collapsed-to-speedscope",
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert collapsed stack format to speedscope JSON"
+    )
+    parser.add_argument(
+        "input", help="Collapsed stack file (semicolon;delimited;stack weight)"
+    )
+    parser.add_argument(
+        "-o", "--output", help="Output path (default: input with .speedscope.json)"
+    )
+    parser.add_argument("--name", help="Profile name (default: input filename)")
+    parser.add_argument(
+        "--freq",
+        type=int,
+        default=99,
+        help="Sample frequency in Hz for count-based weights (default: 99)",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"Error: {args.input} not found", file=sys.stderr)
+        sys.exit(1)
+
+    output = args.output
+    if not output:
+        base = args.input
+        for ext in (".collapsed.txt", "_collapsed.txt", ".txt"):
+            if base.endswith(ext):
+                base = base[: -len(ext)]
+                break
+        output = base + ".speedscope.json"
+
+    name = args.name or os.path.splitext(os.path.basename(args.input))[0]
+
+    print(f"Reading {args.input}...")
+    samples = parse_collapsed(args.input)
+    print(f"  {len(samples):,} unique stacks")
+
+    speedscope = build_speedscope(samples, name, args.freq)
+    print(f"  {len(speedscope['shared']['frames']):,} unique frames")
+    print(f"  {len(speedscope['profiles'])} profiles (threads)")
+    for p in speedscope["profiles"]:
+        print(f"    - {p['name']}: {len(p['samples']):,} samples")
+
+    with open(output, "w") as f:
+        json.dump(speedscope, f)
+    size = os.path.getsize(output)
+    print(f"Wrote {output} ({size:,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/release/nightly_tests/dataset/profiling/analysis/download_job_output.sh
+++ b/release/nightly_tests/dataset/profiling/analysis/download_job_output.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# ABOUTME: Downloads Anyscale job logs and S3 telemetry to a local directory.
+# ABOUTME: Takes a job ID and S3 prefix as arguments, creates a directory named after the job ID.
+
+set -euo pipefail
+
+JOB_ID="${1:?Usage: download_job_output <job_id> <s3_prefix>}"
+S3_PREFIX="${2:?Usage: download_job_output <job_id> <s3_prefix>}"
+S3_BUCKET="${PROFILING_S3_BUCKET:-anyscale-staging-data-cld-kvedzwag2qa8i5bjxuevf5i7}"
+
+echo "=== Downloading job logs ==="
+anyscale logs job --id "$JOB_ID" --download --download-dir .
+
+cd "$JOB_ID"
+
+echo ""
+echo "=== Downloading telemetry from S3 ==="
+aws s3 cp "s3://${S3_BUCKET}/${S3_PREFIX}/" . --recursive
+
+echo ""
+echo "=== Done ==="
+echo "Output in: $(pwd)"
+ls -1

--- a/release/nightly_tests/dataset/profiling/build/README.md
+++ b/release/nightly_tests/dataset/profiling/build/README.md
@@ -1,0 +1,44 @@
+# Build Tools
+
+Docker image build tooling for Ray Data benchmarks.
+
+## `build_incremental_ray.sh`
+
+Builds Ray docker images with incremental caching for fast iteration.
+Supports full builds, base-extra (profiling tools), ray-ml (ML frameworks),
+and python-only overlay builds.
+
+### Quick reference
+
+```bash
+# Full build (first time or after C++ changes)
+./build_incremental_ray.sh --tag v1
+
+# Full build + profiling tools (nsys, perf, gdb, cloud SDKs)
+./build_incremental_ray.sh --tag v1-extra --extra
+
+# Full build + profiling tools + ML frameworks
+./build_incremental_ray.sh --tag v1-extra-ml --extra --ml
+
+# Python-only overlay (after changing only python/ray/*.py files)
+./build_incremental_ray.sh --tag v2 --python-only --base-image <previous-ecr-uri>
+```
+
+### How it works
+
+1. Builds a manylinux wheel with a persistent Bazel disk cache
+2. Builds `base-deps` (Python dependencies), cached in ECR by lock file hash
+3. Builds the `ray` image on top of base-deps
+4. (with `--extra`) Builds `base-extra` on top of ray, cached in ECR by
+   Dockerfile + lock file hash
+5. (with `--ml`) Builds `ray-ml` on top, cached in ECR by requirements hash
+6. Pushes the final image to ECR
+
+Must be run from a ray or rayturbo source directory. Run `./build_incremental_ray.sh --help`
+for all options.
+
+### Prerequisites
+
+- AWS credentials configured (`aws sts get-caller-identity` must succeed)
+- Docker installed and running
+- ECR access to `830883877497.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray`

--- a/release/nightly_tests/dataset/profiling/build/build_incremental_ray.sh
+++ b/release/nightly_tests/dataset/profiling/build/build_incremental_ray.sh
@@ -1,0 +1,503 @@
+#!/bin/bash
+# ABOUTME: Builds Ray docker images with incremental caching for fast iteration.
+# ABOUTME: Supports full, ray-ml, and python-only overlay builds.
+
+set -euo pipefail
+
+ECR_REGISTRY="${ECR_REGISTRY:-830883877497.dkr.ecr.us-west-2.amazonaws.com}"
+ECR_REPO="${ECR_REPO:-anyscale/ray}"
+BAZEL_CACHE_DIR="${BAZEL_CACHE_DIR:-${HOME}/.cache/ray-bazel}"
+PYTHON_VERSION="3.10"
+IMAGE_TAG=""
+PYTHON_ONLY=""
+BUILD_EXTRA=""
+BUILD_ML=""
+BASE_IMAGE_URI=""
+CLEAN_CACHE=""
+
+usage() {
+    cat <<EOF
+Usage: build_incremental_ray.sh --tag <tag> [options]
+
+Builds a Ray docker image and pushes it to ECR with incremental caching.
+Must be run from a ray or rayturbo source directory.
+
+Modes:
+  Full build (default):
+    Builds wheel (with persistent Bazel cache), builds docker image
+    (reusing cached base-deps when possible), pushes to ECR.
+
+  Extra build (--extra):
+    Full build + base-extra layer (profiling tools, gdb, cloud SDKs, etc.)
+    on top. Uses docker/base-extra/Dockerfile from the repo. The base-extra
+    layer is cached in ECR by hash of its Dockerfile and lock file.
+
+  ML build (--ml):
+    Full build + ray-ml layer (TensorFlow, PyTorch, etc.) on top.
+    Uses docker/ray-ml/Dockerfile from the repo. The ray-ml layer is
+    cached in ECR by hash of its requirements and install script.
+
+  Python-only build (--python-only):
+    Overlays changed Python source files onto an existing ray image.
+    Skips wheel build and base-deps entirely. Takes ~1 minute.
+
+Required:
+  --tag <tag>                Docker image tag (e.g. my_feature_v1)
+
+Build mode options:
+  --extra                    Build base-extra image (profiling tools, cloud SDKs)
+  --ml                       Build ray-ml image (includes ML frameworks)
+  --python-only              Enable python-only overlay mode
+  --base-image <ecr-uri>     Base image to overlay onto (required with --python-only)
+
+Optional:
+  --registry <url>           ECR registry (default: $ECR_REGISTRY)
+  --repo <path>              ECR repository path (default: $ECR_REPO)
+  --python-version <ver>     Python version (default: $PYTHON_VERSION)
+  --clean-cache              Delete Bazel disk cache before building
+  -h, --help                 Show this help message
+
+Environment variables:
+  ECR_REGISTRY               Override the default ECR registry URL
+  ECR_REPO                   Override the default ECR repository path
+  BAZEL_CACHE_DIR            Bazel disk cache location (default: ~/.cache/ray-bazel)
+
+Examples:
+  # Full build (first time)
+  build_incremental_ray.sh --tag v1
+
+  # Full rebuild after C++ changes (Bazel cache speeds this up)
+  build_incremental_ray.sh --tag v2
+
+  # Full build with profiling tools (nsys, perf, gdb, etc.)
+  build_incremental_ray.sh --tag v2-extra --extra
+
+  # Full build with profiling tools + ML frameworks
+  build_incremental_ray.sh --tag v2-extra-ml --extra --ml
+
+  # Full build with ML frameworks (PyTorch, TensorFlow, etc.)
+  build_incremental_ray.sh --tag v2-ml --ml
+
+  # Python-only overlay (after changing python/ray/data/*.py)
+  build_incremental_ray.sh --tag v3 --python-only --base-image \\
+      830883877497.dkr.ecr.us-west-2.amazonaws.com/anyscale/ray:v2-ml
+EOF
+    exit "${1:-0}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag)
+            shift
+            IMAGE_TAG="$1"
+            ;;
+        --python-only)
+            PYTHON_ONLY=1
+            ;;
+        --extra)
+            BUILD_EXTRA=1
+            ;;
+        --ml)
+            BUILD_ML=1
+            ;;
+        --base-image)
+            shift
+            BASE_IMAGE_URI="$1"
+            ;;
+        --registry)
+            shift
+            ECR_REGISTRY="$1"
+            ;;
+        --repo)
+            shift
+            ECR_REPO="$1"
+            ;;
+        --python-version)
+            shift
+            PYTHON_VERSION="$1"
+            ;;
+        --clean-cache)
+            CLEAN_CACHE=1
+            ;;
+        -h|--help)
+            usage 0
+            ;;
+        *)
+            echo "Error: Unknown option '$1'" >&2
+            usage 1
+            ;;
+    esac
+    shift
+done
+
+if [[ -z "$IMAGE_TAG" ]]; then
+    echo "Error: --tag is required" >&2
+    usage 1
+fi
+
+if [[ -n "$PYTHON_ONLY" && -z "$BASE_IMAGE_URI" ]]; then
+    echo "Error: --base-image is required when using --python-only" >&2
+    exit 1
+fi
+
+# Validate we're in a ray source directory
+if [[ ! -d "python/ray" ]]; then
+    echo "Error: Must be run from a ray or rayturbo source directory." >&2
+    exit 1
+fi
+
+# Extract AWS region from registry URL
+ECR_REGION=$(echo "$ECR_REGISTRY" | grep -oP 'ecr\.\K[^.]+')
+if [[ -z "$ECR_REGION" ]]; then
+    echo "Error: Could not extract AWS region from registry URL: $ECR_REGISTRY" >&2
+    exit 1
+fi
+
+# Validate AWS credentials before doing any work
+echo "=== Checking AWS credentials for $ECR_REGISTRY ==="
+if ! aws sts get-caller-identity --region "$ECR_REGION" >/dev/null 2>&1; then
+    echo "Error: AWS credentials are not configured or have expired." >&2
+    echo "  Run 'aws configure' or refresh your SSO session." >&2
+    exit 1
+fi
+
+if ! aws ecr get-login-password --region "$ECR_REGION" \
+    | docker login --username AWS --password-stdin "$ECR_REGISTRY" >/dev/null 2>&1; then
+    echo "Error: Failed to authenticate with ECR registry $ECR_REGISTRY" >&2
+    exit 1
+fi
+echo "AWS credentials verified."
+
+ECR_FULL_TAG="${ECR_REGISTRY}/${ECR_REPO}:${IMAGE_TAG}"
+
+# ---------------------------------------------------------------------------
+# Python-only overlay mode
+# ---------------------------------------------------------------------------
+if [[ -n "$PYTHON_ONLY" ]]; then
+    echo "=== Python-only overlay mode ==="
+
+    # Safety check: ensure no C++/Cython files have uncommitted changes
+    # relative to HEAD. If the user changed C++ files, they need a full build.
+    CPP_CHANGES=$(git diff --name-only HEAD -- \
+        'src/' \
+        'python/ray/_raylet.pyx' \
+        'python/ray/_raylet.pxd' \
+        'python/ray/includes/' \
+        'BUILD.bazel' \
+        'WORKSPACE' \
+    ) || true
+
+    if [[ -n "$CPP_CHANGES" ]]; then
+        echo "Error: C++/Cython/build files have uncommitted changes:" >&2
+        echo "$CPP_CHANGES" >&2
+        echo "" >&2
+        echo "These require a full build. Run without --python-only." >&2
+        exit 1
+    fi
+
+    # Build a thin overlay image
+    OVERLAY_DIR=$(mktemp -d)
+    trap 'rm -rf "$OVERLAY_DIR"' EXIT
+
+    # Copy only the Python source tree (excludes C extensions, compiled files)
+    # rsync is faster than cp for large trees and lets us exclude patterns
+    rsync -a \
+        --include='*.py' \
+        --include='*/' \
+        --exclude='*' \
+        python/ray/ "$OVERLAY_DIR/ray/"
+
+    SITE_PACKAGES="/home/ray/anaconda3/lib/python${PYTHON_VERSION}/site-packages"
+
+    cat > "$OVERLAY_DIR/Dockerfile" <<DOCKERFILE
+FROM ${BASE_IMAGE_URI}
+COPY ray/ ${SITE_PACKAGES}/ray/
+DOCKERFILE
+
+    echo "=== Building overlay image ==="
+    docker build -t "ray-build:${IMAGE_TAG}" "$OVERLAY_DIR"
+
+    echo "=== Pushing to ECR ==="
+    docker tag "ray-build:${IMAGE_TAG}" "$ECR_FULL_TAG"
+    docker push "$ECR_FULL_TAG"
+
+    echo ""
+    echo "=== Done (python-only) ==="
+    echo "Image pushed to: $ECR_FULL_TAG"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Full build mode
+# ---------------------------------------------------------------------------
+
+if [[ ! -f "python/build-wheel-manylinux2014.sh" ]]; then
+    echo "Error: Cannot find python/build-wheel-manylinux2014.sh" >&2
+    exit 1
+fi
+
+# --- Improvement 1: Persistent Bazel cache ---
+
+if [[ -n "$CLEAN_CACHE" ]]; then
+    echo "=== Cleaning Bazel cache at $BAZEL_CACHE_DIR ==="
+    rm -rf "$BAZEL_CACHE_DIR"
+fi
+
+mkdir -p "$BAZEL_CACHE_DIR"
+echo "=== Bazel disk cache: $BAZEL_CACHE_DIR ($(du -sh "$BAZEL_CACHE_DIR" 2>/dev/null | cut -f1)) ==="
+
+# Remove stale wheels from previous builds to avoid picking the wrong version.
+rm -f .whl/ray-*.whl .whl/ray_cpp-*.whl
+
+# Build the manylinux wheel with persistent Bazel cache
+echo "=== Building Ray wheel ==="
+git_parent_args=()
+if [[ -f .git ]] && grep ^gitdir .git >/dev/null 2>&1; then
+	parent=$(grep ^gitdir .git | awk '{print $2}' | sed 's;/worktrees.*$;;')
+	git_parent_args=(-v "${parent}:${parent}")
+fi
+
+docker run -ti --rm \
+    -v "$BAZEL_CACHE_DIR:/bazel-cache" \
+    -e BAZEL_ARGS="--disk_cache=/bazel-cache" \
+    -e HOST_UID="$(id -u)" \
+    -e HOST_GID="$(id -g)" \
+    -e BUILDKITE_COMMIT="$(git rev-parse HEAD)" \
+    -e BUILD_ONE_PYTHON_ONLY=py310 \
+    "${git_parent_args[@]}" \
+    -w /ray -v "$(pwd)":/ray \
+    -e HOME=/tmp \
+    quay.io/pypa/manylinux2014_x86_64:2026.01.02-1 \
+    /ray/python/build-wheel-manylinux2014.sh
+
+# --- Improvement 2: Cache base-deps by lock file hash ---
+
+LOCK_FILE="python/deplocks/base_deps/ray_base_deps_py${PYTHON_VERSION}.lock"
+if [[ ! -f "$LOCK_FILE" ]]; then
+    echo "Error: Lock file not found: $LOCK_FILE" >&2
+    exit 1
+fi
+
+# Hash all files that are COPYed into the base-deps image: the lock file,
+# the constraints file (baked in as requirements_compiled.txt), and the Dockerfile.
+CONSTRAINTS_FILE="python/requirements_compiled_py${PYTHON_VERSION}.txt"
+if [[ ! -f "$CONSTRAINTS_FILE" ]]; then
+    echo "Error: Constraints file not found: $CONSTRAINTS_FILE" >&2
+    exit 1
+fi
+BASE_DEPS_HASH=$(cat "$LOCK_FILE" "$CONSTRAINTS_FILE" docker/base-deps/Dockerfile | sha256sum | cut -c1-12)
+BASE_DEPS_ECR_TAG="base-deps-${BASE_DEPS_HASH}"
+BASE_DEPS_ECR_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${BASE_DEPS_ECR_TAG}"
+
+if aws ecr describe-images \
+    --repository-name "$ECR_REPO" \
+    --image-ids imageTag="$BASE_DEPS_ECR_TAG" \
+    --region "$ECR_REGION" >/dev/null 2>&1; then
+
+    echo "=== base-deps cached as $BASE_DEPS_ECR_TAG, pulling ==="
+    docker pull "$BASE_DEPS_ECR_IMAGE"
+    docker tag "$BASE_DEPS_ECR_IMAGE" "rayproject/base-deps:dev"
+else
+    echo "=== base-deps cache miss ($BASE_DEPS_ECR_TAG), building ==="
+
+    # Build base-deps (replicated from build-docker.sh to avoid needing to
+    # modify that script with a --base-deps-only flag)
+    RAY_DEPS_BUILD_DIR="$(mktemp -d)"
+    trap 'rm -rf "$RAY_DEPS_BUILD_DIR"' EXIT
+
+    cp docker/base-deps/Dockerfile "${RAY_DEPS_BUILD_DIR}/"
+    mkdir -p "${RAY_DEPS_BUILD_DIR}/python"
+    cp "python/requirements_compiled.txt" "${RAY_DEPS_BUILD_DIR}/python/"
+    cp "python/requirements_compiled_py${PYTHON_VERSION}.txt" "${RAY_DEPS_BUILD_DIR}/python/"
+    cp "$LOCK_FILE" "${RAY_DEPS_BUILD_DIR}/"
+
+    PYTHON_DEPSET_FILE_NAME="ray_base_deps_py${PYTHON_VERSION}.lock"
+
+    export DOCKER_BUILDKIT=1
+    docker build \
+        --build-arg BASE_IMAGE="ubuntu:22.04" \
+        --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+        --build-arg PYTHON_DEPSET="${PYTHON_DEPSET_FILE_NAME}" \
+        -t "rayproject/base-deps:dev" "${RAY_DEPS_BUILD_DIR}"
+
+    rm -rf "$RAY_DEPS_BUILD_DIR"
+    trap - EXIT
+
+    # Push base-deps to ECR for future reuse
+    echo "=== Pushing base-deps cache as $BASE_DEPS_ECR_TAG ==="
+    docker tag "rayproject/base-deps:dev" "$BASE_DEPS_ECR_IMAGE"
+    docker push "$BASE_DEPS_ECR_IMAGE"
+fi
+
+# --- Build the ray image on top of cached base-deps ---
+
+echo "=== Building ray image ==="
+
+RAY_BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$RAY_BUILD_DIR"' EXIT
+
+mkdir -p "$RAY_BUILD_DIR/.whl"
+cp .whl/* "$RAY_BUILD_DIR/.whl"
+cp docker/ray/Dockerfile "$RAY_BUILD_DIR"
+
+WHEEL="$(basename .whl/ray-*.whl)"
+WHEEL_HASH=$(sha256sum ".whl/${WHEEL}" | cut -c1-12)
+
+LOCAL_TAG="ray-build:${IMAGE_TAG}"
+
+export DOCKER_BUILDKIT=1
+docker build \
+    --build-arg FULL_BASE_IMAGE="rayproject/base-deps:dev" \
+    --build-arg WHEEL_PATH=".whl/${WHEEL}" \
+    -t "$LOCAL_TAG" "$RAY_BUILD_DIR"
+
+rm -rf "$RAY_BUILD_DIR"
+trap - EXIT
+
+# ---------------------------------------------------------------------------
+# base-extra layer (optional, on top of ray)
+# ---------------------------------------------------------------------------
+if [[ -n "$BUILD_EXTRA" ]]; then
+    echo "=== Building base-extra layer ==="
+
+    EXTRA_LOCK="python/deplocks/base_extra/ray_base_extra_py${PYTHON_VERSION}.lock"
+    if [[ ! -f "$EXTRA_LOCK" ]]; then
+        echo "Error: Lock file not found: $EXTRA_LOCK" >&2
+        exit 1
+    fi
+
+    EXTRA_HASH=$(cat \
+        docker/base-extra/Dockerfile \
+        "$EXTRA_LOCK" \
+        | sha256sum | cut -c1-12)
+    BASE_EXTRA_ECR_TAG="base-extra-${BASE_DEPS_HASH}-${WHEEL_HASH}-${EXTRA_HASH}"
+    BASE_EXTRA_ECR_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${BASE_EXTRA_ECR_TAG}"
+
+    if aws ecr describe-images \
+        --repository-name "$ECR_REPO" \
+        --image-ids imageTag="$BASE_EXTRA_ECR_TAG" \
+        --region "$ECR_REGION" >/dev/null 2>&1; then
+
+        echo "=== base-extra cached as $BASE_EXTRA_ECR_TAG, pulling ==="
+        docker pull "$BASE_EXTRA_ECR_IMAGE"
+        docker tag "$BASE_EXTRA_ECR_IMAGE" "base-extra-build:${IMAGE_TAG}"
+    else
+        echo "=== base-extra cache miss ($BASE_EXTRA_ECR_TAG), building ==="
+
+        BASE_EXTRA_BUILD_DIR="$(mktemp -d)"
+        trap 'rm -rf "$BASE_EXTRA_BUILD_DIR"' EXIT
+
+        cp docker/base-extra/Dockerfile "$BASE_EXTRA_BUILD_DIR/"
+        mkdir -p "$BASE_EXTRA_BUILD_DIR/python/deplocks/base_extra"
+        cp "$EXTRA_LOCK" "$BASE_EXTRA_BUILD_DIR/python/deplocks/base_extra/"
+
+        export DOCKER_BUILDKIT=1
+        docker build \
+            --build-arg BASE_IMAGE="$LOCAL_TAG" \
+            --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+            -t "base-extra-build:${IMAGE_TAG}" "$BASE_EXTRA_BUILD_DIR"
+
+        rm -rf "$BASE_EXTRA_BUILD_DIR"
+        trap - EXIT
+
+        echo "=== Pushing base-extra cache as $BASE_EXTRA_ECR_TAG ==="
+        docker tag "base-extra-build:${IMAGE_TAG}" "$BASE_EXTRA_ECR_IMAGE"
+        docker push "$BASE_EXTRA_ECR_IMAGE"
+    fi
+
+    LOCAL_TAG="base-extra-build:${IMAGE_TAG}"
+fi
+
+# ---------------------------------------------------------------------------
+# Ray-ML layer (optional, on top of ray)
+# ---------------------------------------------------------------------------
+if [[ -n "$BUILD_ML" ]]; then
+    echo "=== Building ray-ml layer ==="
+
+    # Cache the ray-ml layer by hashing its inputs: requirements, install
+    # script, and the base ray image (represented by base-deps hash + wheel).
+    # This way a rebuild is only triggered when ML deps or the ray image change.
+    ML_HASH_INPUTS=$(cat \
+        python/requirements.txt \
+        python/requirements_compiled.txt \
+        python/requirements/ml/*requirements.txt \
+        python/requirements/docker/*requirements.txt \
+        docker/ray-ml/install-ml-docker-requirements.sh \
+        docker/ray-ml/Dockerfile \
+        | sha256sum | cut -c1-12)
+    RAY_ML_ECR_TAG="ray-ml-${BASE_DEPS_HASH}-${WHEEL_HASH}-${ML_HASH_INPUTS}"
+    RAY_ML_ECR_IMAGE="${ECR_REGISTRY}/${ECR_REPO}:${RAY_ML_ECR_TAG}"
+
+    if aws ecr describe-images \
+        --repository-name "$ECR_REPO" \
+        --image-ids imageTag="$RAY_ML_ECR_TAG" \
+        --region "$ECR_REGION" >/dev/null 2>&1; then
+
+        echo "=== ray-ml cached as $RAY_ML_ECR_TAG, pulling ==="
+        docker pull "$RAY_ML_ECR_IMAGE"
+        docker tag "$RAY_ML_ECR_IMAGE" "ray-ml-build:${IMAGE_TAG}"
+    else
+        echo "=== ray-ml cache miss ($RAY_ML_ECR_TAG), building ==="
+
+        RAY_ML_BUILD_DIR="$(mktemp -d)"
+        trap 'rm -rf "$RAY_ML_BUILD_DIR"' EXIT
+
+        # The Dockerfile expects paths relative to repo root:
+        #   python/*requirements.txt
+        #   python/requirements/ml/*requirements.txt
+        #   python/requirements/docker/*requirements.txt
+        #   docker/ray-ml/install-ml-docker-requirements.sh
+        mkdir -p "$RAY_ML_BUILD_DIR/python/requirements/ml"
+        mkdir -p "$RAY_ML_BUILD_DIR/python/requirements/docker"
+        mkdir -p "$RAY_ML_BUILD_DIR/docker/ray-ml"
+
+        cp python/*requirements*.txt "$RAY_ML_BUILD_DIR/python/"
+        cp python/requirements/ml/*requirements.txt "$RAY_ML_BUILD_DIR/python/requirements/ml/"
+        cp python/requirements/docker/*requirements.txt "$RAY_ML_BUILD_DIR/python/requirements/docker/"
+        cp docker/ray-ml/install-ml-docker-requirements.sh "$RAY_ML_BUILD_DIR/docker/ray-ml/"
+        cp docker/ray-ml/Dockerfile "$RAY_ML_BUILD_DIR/"
+
+        export DOCKER_BUILDKIT=1
+        docker build \
+            --build-arg FULL_BASE_IMAGE="$LOCAL_TAG" \
+            -t "ray-ml-build:${IMAGE_TAG}" "$RAY_ML_BUILD_DIR"
+
+        rm -rf "$RAY_ML_BUILD_DIR"
+        trap - EXIT
+
+        echo "=== Pushing ray-ml cache as $RAY_ML_ECR_TAG ==="
+        docker tag "ray-ml-build:${IMAGE_TAG}" "$RAY_ML_ECR_IMAGE"
+        docker push "$RAY_ML_ECR_IMAGE"
+    fi
+
+    LOCAL_TAG="ray-ml-build:${IMAGE_TAG}"
+fi
+
+# --- Tag and push ---
+
+echo "=== Pushing to ECR ==="
+docker tag "$LOCAL_TAG" "$ECR_FULL_TAG"
+docker push "$ECR_FULL_TAG"
+
+echo ""
+DONE_LABEL="full build"
+if [[ -n "$BUILD_EXTRA" ]]; then
+    DONE_LABEL="$DONE_LABEL + base-extra"
+fi
+if [[ -n "$BUILD_ML" ]]; then
+    DONE_LABEL="$DONE_LABEL + ray-ml"
+fi
+echo "=== Done ($DONE_LABEL) ==="
+echo "Image pushed to: $ECR_FULL_TAG"
+echo ""
+echo "Bazel cache: $BAZEL_CACHE_DIR ($(du -sh "$BAZEL_CACHE_DIR" 2>/dev/null | cut -f1))"
+echo "base-deps cache tag: $BASE_DEPS_ECR_TAG"
+if [[ -n "$BUILD_EXTRA" ]]; then
+    echo "base-extra cache tag: $BASE_EXTRA_ECR_TAG"
+fi
+if [[ -n "$BUILD_ML" ]]; then
+    echo "ray-ml cache tag: $RAY_ML_ECR_TAG"
+fi
+echo ""
+echo "For subsequent Python-only changes, use:"
+echo "  $(basename "$0") --tag <new_tag> --python-only --base-image $ECR_FULL_TAG"

--- a/release/nightly_tests/dataset/profiling/coordinator.py
+++ b/release/nightly_tests/dataset/profiling/coordinator.py
@@ -1,0 +1,194 @@
+# ABOUTME: Orchestrates all profiling and monitoring based on environment variables.
+# ABOUTME: Provides start/stop methods so benchmarks don't need per-profiler boilerplate.
+
+import os
+
+from . import gpu_monitor, net_monitor, nsys, object_store, perf, pyspy, telemetry
+
+
+class Profiling:
+    """Coordinates all profiling and monitoring for a benchmark run.
+
+    Reads configuration from environment variables:
+        PROFILER_MODE:          "nsys", "torch", or "none" (default: "none")
+        PROFILE_SKIP_BATCHES:   Batches to skip before nsys capture (default: 0)
+        PROFILE_ACTIVE_BATCHES: Upper bound on captured batches per actor
+                                (default: 10000). The in-loop fence calls
+                                cudaProfilerStop after this many batches; in
+                                normal use the value is left high so the fence
+                                never fires and Infer's atexit hook closes the
+                                capture range at process exit. Combined with
+                                capture-range-end:stop in nsys.runtime_env(),
+                                that finalizes the .nsys-rep synchronously
+                                before Ray tears the actor down. Set this lower
+                                if you want to bound the capture window (e.g.
+                                profile only a warm steady-state window).
+        PYSPY_ENABLED:          "1" to enable py-spy (default: "0")
+        PYSPY_NUM_CPU_WORKERS:  CPU worker nodes to py-spy (default: 5)
+        PYSPY_NUM_GPU_WORKERS:  GPU worker nodes to py-spy (default: 5)
+        PERF_PROFILING_ENABLED: "1" to enable perf record (default: "0")
+        PERF_NUM_CPU_WORKERS:   CPU worker nodes to profile (default: 5)
+        PERF_NUM_GPU_WORKERS:   GPU worker nodes to profile (default: 5)
+        GPU_MONITOR_ENABLED:    "1" to enable nvidia-smi monitoring (default: "0")
+        NET_MONITOR_ENABLED:    "1" to enable network I/O monitoring (default: "0")
+        OBJECT_STORE_MONITOR_ENABLED: "1" to enable object-store sampling (default: "0")
+        OBJECT_STORE_MONITOR_INTERVAL_S: seconds between samples (default: 5)
+        OBJECT_STORE_MONITOR_FAST_WINDOW_S: seconds at the start of the run to
+            sample at OBJECT_STORE_MONITOR_FAST_INTERVAL_S instead of
+            OBJECT_STORE_MONITOR_INTERVAL_S (default: 60). Set to 0 to disable.
+        OBJECT_STORE_MONITOR_FAST_INTERVAL_S: tick interval during fast window (default: 1)
+        RAY_MAX_LIMIT_FROM_API_SERVER: object-store sampling defaults to a 10k
+            object cap per call. Set this env var to e.g. "200000" on the head
+            node to fully sample large runs (otherwise samples are truncated).
+        PROFILING_S3_BUCKET:    S3 bucket for telemetry upload
+
+    Usage:
+        profiling = Profiling(outdir="/mnt/shared_storage/my_benchmark/job123",
+                              num_gpu_nodes=40)
+        profiling.start()
+
+        infer_kwargs["runtime_env"] = profiling.nsys_runtime_env()
+        # ... run benchmark ...
+
+        profiling.stop(s3_prefix="my-benchmark/job123")
+    """
+
+    _instance_active = False
+
+    def __init__(self, outdir, num_gpu_nodes=0):
+        self.outdir = outdir
+        self.num_gpu_nodes = num_gpu_nodes
+
+        self.profiler_mode = os.environ.get("PROFILER_MODE", "none")
+        self.pyspy_enabled = os.environ.get("PYSPY_ENABLED", "0") == "1"
+        self.pyspy_num_cpu_workers = int(os.environ.get("PYSPY_NUM_CPU_WORKERS", "5"))
+        self.pyspy_num_gpu_workers = int(os.environ.get("PYSPY_NUM_GPU_WORKERS", "5"))
+        self.perf_enabled = os.environ.get("PERF_PROFILING_ENABLED", "0") == "1"
+        self.perf_num_cpu_workers = int(os.environ.get("PERF_NUM_CPU_WORKERS", "5"))
+        self.perf_num_gpu_workers = int(os.environ.get("PERF_NUM_GPU_WORKERS", "5"))
+        self.gpu_monitor_enabled = os.environ.get("GPU_MONITOR_ENABLED", "0") == "1"
+        self.net_monitor_enabled = os.environ.get("NET_MONITOR_ENABLED", "0") == "1"
+        self.object_store_monitor_enabled = (
+            os.environ.get("OBJECT_STORE_MONITOR_ENABLED", "0") == "1"
+        )
+        self.object_store_monitor_interval_s = int(
+            os.environ.get("OBJECT_STORE_MONITOR_INTERVAL_S", "5")
+        )
+        self.object_store_monitor_fast_window_s = int(
+            os.environ.get("OBJECT_STORE_MONITOR_FAST_WINDOW_S", "60")
+        )
+        self.object_store_monitor_fast_interval_s = int(
+            os.environ.get("OBJECT_STORE_MONITOR_FAST_INTERVAL_S", "1")
+        )
+
+        self._worker_perf_actors = []
+        self._head_perf_handles = []
+        self._worker_pyspy_actors = []
+
+    def is_enabled(self):
+        """Return True if any profiling or monitoring is enabled."""
+        return (
+            self.profiler_mode != "none"
+            or self.pyspy_enabled
+            or self.perf_enabled
+            or self.gpu_monitor_enabled
+            or self.net_monitor_enabled
+            or self.object_store_monitor_enabled
+        )
+
+    def start(self, extra_config=None):
+        """Start all enabled profilers and monitors.
+
+        Args:
+            extra_config: Optional dict of extra config key/value pairs to print.
+        """
+        Profiling._instance_active = True
+        print("Configuration:")
+        if extra_config:
+            for key, value in extra_config.items():
+                print(f"  {key}: {value}")
+        print(f"  PROFILER_MODE:          {self.profiler_mode}")
+        print(f"  PYSPY_ENABLED:          {self.pyspy_enabled}")
+        if self.pyspy_enabled:
+            print(
+                f"    workers (cpu/gpu):    "
+                f"{self.pyspy_num_cpu_workers}/{self.pyspy_num_gpu_workers}"
+            )
+        print(f"  PERF_PROFILING_ENABLED: {self.perf_enabled}")
+        print(f"  GPU_MONITOR_ENABLED:    {self.gpu_monitor_enabled}")
+        print(f"  NET_MONITOR_ENABLED:    {self.net_monitor_enabled}")
+        print(
+            f"  OBJECT_STORE_MONITOR:   {self.object_store_monitor_enabled} "
+            f"(interval={self.object_store_monitor_interval_s}s, "
+            f"fast_window={self.object_store_monitor_fast_window_s}s @ "
+            f"{self.object_store_monitor_fast_interval_s}s)"
+        )
+        print(f"  SHARED_OUTDIR:          {self.outdir}")
+        print()
+
+        os.makedirs(self.outdir, exist_ok=True)
+
+        if self.gpu_monitor_enabled and self.num_gpu_nodes > 0:
+            gpu_monitor.start(self.outdir, self.num_gpu_nodes)
+        if self.net_monitor_enabled:
+            net_monitor.start(self.outdir)
+        if self.object_store_monitor_enabled:
+            object_store.start(
+                self.outdir,
+                interval_s=self.object_store_monitor_interval_s,
+                fast_window_s=self.object_store_monitor_fast_window_s,
+                fast_interval_s=self.object_store_monitor_fast_interval_s,
+            )
+
+        if self.pyspy_enabled:
+            pyspy.start(self.outdir)
+            if self.pyspy_num_cpu_workers > 0 or self.pyspy_num_gpu_workers > 0:
+                self._worker_pyspy_actors = pyspy.start_worker_nodes(
+                    self.outdir,
+                    num_cpu_workers=self.pyspy_num_cpu_workers,
+                    num_gpu_workers=self.pyspy_num_gpu_workers,
+                )
+
+        if self.perf_enabled:
+            self._head_perf_handles = perf.start_head_node(self.outdir)
+            self._worker_perf_actors = perf.start_worker_nodes(
+                self.outdir,
+                num_cpu_workers=self.perf_num_cpu_workers,
+                num_gpu_workers=self.perf_num_gpu_workers,
+            )
+
+    def nsys_runtime_env(self):
+        """Return nsys runtime_env dict if profiler_mode is "nsys", else empty dict."""
+        if self.profiler_mode == "nsys":
+            return nsys.runtime_env(self.outdir)
+        return {}
+
+    def stop(self, s3_prefix=None, s3_bucket=None):
+        """Stop all profilers and upload telemetry to S3.
+
+        Args:
+            s3_prefix: S3 key prefix for telemetry upload. If None, skips upload.
+            s3_bucket: S3 bucket name. Defaults to PROFILING_S3_BUCKET env var.
+        """
+        if self.pyspy_enabled:
+            # Worker py-spy first: each actor's stop() blocks until its
+            # start() has finished attaching (Ray actor methods are serial),
+            # then SIGINTs py-spy on the worker to flush output to shared
+            # storage before we move on.
+            pyspy.stop_workers(self._worker_pyspy_actors)
+            pyspy.stop()
+
+        if self.perf_enabled:
+            # Each stop_* converts its own .data to collapsed stacks on the
+            # node that produced it — worker .data symbolizes on the worker
+            # (where /tmp/ray/session_* runtime libs still exist), head .data
+            # on the head. A central pass on the head would symbolize worker
+            # data against the head's filesystem and lose most user-space
+            # symbols.
+            perf.stop_workers(self._worker_perf_actors)
+            perf.stop_head(self._head_perf_handles)
+
+        if s3_prefix is not None:
+            telemetry.upload(self.outdir, s3_prefix, s3_bucket=s3_bucket)
+
+        Profiling._instance_active = False

--- a/release/nightly_tests/dataset/profiling/gpu_monitor.py
+++ b/release/nightly_tests/dataset/profiling/gpu_monitor.py
@@ -1,0 +1,107 @@
+# ABOUTME: Launches nvidia-smi monitoring on GPU worker nodes as they join the cluster.
+# ABOUTME: Polls for new GPU nodes and starts nvidia-smi dmon on each via long-lived Ray actors.
+
+import os
+import threading
+import time
+
+import ray
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+# Module-level list of NvidiaSmiActor handles. Holding them at module scope
+# keeps the actors alive for the lifetime of the driver process (Ray drops
+# actors whose last handle is GC'd). Local-in-function holding broke when
+# the launcher thread exited and the local frame was reclaimed.
+_actor_handles = []
+
+
+@ray.remote(num_cpus=0, num_gpus=0)
+class _NvidiaSmiActor:
+    """Long-lived actor that owns an nvidia-smi dmon subprocess on its node.
+
+    Holding nvidia-smi inside an actor (rather than launching it from a Ray
+    task) keeps the parent process alive for the lifetime of the actor handle.
+    Tasks return immediately and the worker is reaped after ~3 min idle,
+    taking nvidia-smi with it; the actor never goes idle, so the subprocess
+    survives the whole run.
+    """
+
+    def __init__(self, outdir):
+        import subprocess
+
+        os.makedirs(outdir, exist_ok=True)
+        node_ip = os.environ.get("ANYSCALE_NODE_IP", "unknown").replace(".", "_")
+        outfile = f"{outdir}/gpu_usage_{node_ip}.txt"
+        self._proc = subprocess.Popen(
+            ["stdbuf", "-oL", "nvidia-smi", "dmon", "-s", "u", "-o", "T"],
+            stdout=open(outfile, "w"),
+            stderr=subprocess.STDOUT,
+        )
+
+    def get_pid(self):
+        return self._proc.pid
+
+
+def _gpu_monitor_loop(outdir, num_gpu_nodes):
+    """Poll for GPU nodes and launch nvidia-smi on each as it joins.
+
+    Monitors continuously until num_gpu_nodes are found or no new nodes
+    appear for 60 seconds, whichever comes first. This avoids blocking
+    forever when the cluster has fewer GPU nodes than expected.
+    """
+    monitored_node_ids = set()
+    stale_polls = 0
+    max_stale_polls = 30  # 30 * 2s = 60s with no new nodes
+
+    while len(monitored_node_ids) < num_gpu_nodes:
+        gpu_nodes = [
+            n for n in ray.nodes() if n["Alive"] and n["Resources"].get("GPU", 0) > 0
+        ]
+        new_nodes = [n for n in gpu_nodes if n["NodeID"] not in monitored_node_ids]
+        if not new_nodes:
+            stale_polls += 1
+            if monitored_node_ids and stale_polls >= max_stale_polls:
+                print(
+                    f"nvidia-smi: no new GPU nodes for {max_stale_polls * 2}s, "
+                    f"proceeding with {len(monitored_node_ids)}/{num_gpu_nodes}"
+                )
+                break
+        else:
+            stale_polls = 0
+        for node in new_nodes:
+            try:
+                handle = _NvidiaSmiActor.options(
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id=node["NodeID"], soft=False
+                    )
+                ).remote(outdir)
+                child_pid = ray.get(handle.get_pid.remote())
+                _actor_handles.append(handle)
+                monitored_node_ids.add(node["NodeID"])
+                print(
+                    f"Started nvidia-smi on GPU node {node['NodeManagerAddress']} "
+                    f"(pid={child_pid}, {len(monitored_node_ids)}/{num_gpu_nodes})"
+                )
+            except Exception as e:
+                monitored_node_ids.add(node["NodeID"])
+                print(
+                    f"Failed to start nvidia-smi on {node['NodeManagerAddress']}: {e}"
+                )
+        time.sleep(2)
+    if len(monitored_node_ids) >= num_gpu_nodes:
+        print(f"nvidia-smi monitoring active on all {num_gpu_nodes} GPU nodes")
+
+
+def start(outdir, num_gpu_nodes):
+    """Start nvidia-smi monitoring on GPU nodes in a background thread.
+
+    Args:
+        outdir: Shared storage directory for output files.
+        num_gpu_nodes: Expected number of GPU nodes to monitor.
+    """
+    thread = threading.Thread(
+        target=_gpu_monitor_loop, args=(outdir, num_gpu_nodes), daemon=True
+    )
+    thread.start()
+    return thread

--- a/release/nightly_tests/dataset/profiling/metrics.py
+++ b/release/nightly_tests/dataset/profiling/metrics.py
@@ -1,0 +1,490 @@
+# ABOUTME: Extracts benchmark metrics from Ray Data stats and GPU monitoring output.
+# ABOUTME: Returns a dict suitable for benchmark.py's extra metrics (written to result.json).
+
+import glob as globmod
+import os
+
+
+def extract_pipeline_metrics(ds, num_gpus=0, outdir=None):
+    """Extract key metrics from a completed dataset and optional GPU output.
+
+    Call after ds.write_parquet() — stats are preserved through the write.
+
+    Args:
+        ds: Ray Dataset that has been executed (e.g. via write_parquet).
+        num_gpus: Number of GPUs in the cluster (for per-GPU throughput).
+        outdir: Shared storage directory containing gpu_usage_*.txt files.
+
+    Returns:
+        Dict of metric name -> value, suitable for benchmark.py extra metrics.
+    """
+    summary = ds.get_stats_summary()
+    metrics = {}
+
+    # --- Tier 1: from DatasetStatsSummary ---
+
+    wall_time = summary.get_total_wall_time()
+
+    # Row count: use the Write operator's input rows (= actual data rows
+    # processed). The Write operator's output_num_rows counts parquet file
+    # blocks, not data rows.
+    num_rows = _get_total_rows(summary)
+    if num_rows and num_rows > 0:
+        metrics["num_rows"] = num_rows
+        if wall_time:
+            rows_per_sec = num_rows / wall_time
+            metrics["rows_per_sec"] = round(rows_per_sec, 1)
+            if num_gpus > 0:
+                metrics["rows_per_gpu_per_sec"] = round(rows_per_sec / num_gpus, 1)
+
+    # streaming_exec_schedule_s measures total time in the scheduler loop,
+    # which overlaps with execution. This is NOT the same as "Infer Scheduling
+    # OH" from run summaries (which is derived from py-spy profiling).
+    sched_s = summary.streaming_exec_schedule_s
+    if sched_s:
+        metrics["scheduler_loop_s"] = round(sched_s, 2)
+
+    # Phase timings: each operator's end time relative to pipeline start
+    _add_phase_timings(summary, metrics)
+
+    # --- Tier 2: locality from per-operator extra_metrics ---
+    _add_locality_metrics(summary, metrics)
+    _add_select_actors_metrics(summary, metrics)
+
+    # --- Tier 3: GPU metrics from nvidia-smi output ---
+    if outdir:
+        gpu_metrics = parse_gpu_utilization(outdir)
+        metrics.update(gpu_metrics)
+        object_store_metrics = parse_object_store_state(outdir)
+        metrics.update(object_store_metrics)
+        plasma_metrics = parse_plasma_stats(outdir)
+        metrics.update(plasma_metrics)
+
+    return metrics
+
+
+def _add_phase_timings(summary, metrics):
+    """Add per-operator phase end times relative to pipeline start."""
+    # Collect all operator summaries by walking the parent chain
+    all_summaries = _collect_all_summaries(summary)
+
+    # Find the earliest start time across all operators
+    start_times = []
+    for s in all_summaries:
+        for op in s.operators_stats:
+            if op.earliest_start_time is not None:
+                start_times.append(op.earliest_start_time)
+    if not start_times:
+        return
+    pipeline_start = min(start_times)
+
+    # Record each operator's end time relative to pipeline start
+    for s in all_summaries:
+        for op in s.operators_stats:
+            if op.latest_end_time is not None and not op.is_sub_operator:
+                name = _normalize_op_name(op.operator_name)
+                metrics[f"phase_{name}_s"] = round(
+                    op.latest_end_time - pipeline_start, 1
+                )
+
+
+def _add_locality_metrics(summary, metrics):
+    """Extract locality counters from the Infer operator's extra_metrics."""
+    all_summaries = _collect_all_summaries(summary)
+    for s in all_summaries:
+        em = s.extra_metrics
+        if not em:
+            continue
+        hit = em.get("num_tasks_task_locality_hit", 0)
+        miss = em.get("num_tasks_task_locality_miss", 0)
+        total = hit + miss
+        if total > 0:
+            # Use the base_name to identify which operator this belongs to
+            name = _normalize_op_name(s.base_name) if s.base_name else "unknown"
+            metrics[f"{name}_locality_pct"] = round(100 * hit / total, 1)
+            metrics[f"{name}_locality_hit"] = hit
+            metrics[f"{name}_locality_miss"] = miss
+
+
+# Counter keys exported by ActorPoolMapOperator._extra_metrics from the underlying
+# _ActorPool.get_select_actors_metrics(). See doc/actor-only-ray-data/
+# actor-pool-map-operator-design.md §5.5 for what each path means.
+_SELECT_ACTORS_KEYS = (
+    "select_actors_calls",
+    "select_actors_capacity_probes",
+    "select_actors_returned_none_empty",
+    "select_actors_returned_none_saturated",
+    "select_actors_probe_returned_none_empty",
+    "select_actors_probe_returned_none_saturated",
+    "select_actors_probe_returned_actor",
+    "select_actors_locality_hit_path",
+    "select_actors_global_fallback_no_locality_enabled",
+    "select_actors_global_fallback_no_prefs",
+    "select_actors_global_fallback_no_actor_on_pref_node",
+    "find_actor_with_locality_nodes_probed_total",
+    "find_actor_with_locality_short_circuited",
+    "find_actor_with_locality_node_heap_absent",
+    "find_actor_with_locality_node_heap_saturated",
+)
+
+
+def _add_select_actors_metrics(summary, metrics):
+    """Extract per-operator select_actors path counters from extra_metrics.
+
+    Only fires for actor-pool operators (the keys are absent on task-pool ops).
+    Result keys are prefixed with the normalized operator name, e.g.
+    ``flat_map_decode__map_preprocess_select_actors_calls``.
+    """
+    for s in _collect_all_summaries(summary):
+        em = s.extra_metrics or {}
+        if not any(k in em for k in _SELECT_ACTORS_KEYS):
+            continue
+        name = _normalize_op_name(s.base_name) if s.base_name else "unknown"
+        for k in _SELECT_ACTORS_KEYS:
+            if k in em:
+                metrics[f"{name}_{k}"] = em[k]
+
+
+def _get_total_rows(summary):
+    """Get total data rows processed by the pipeline.
+
+    Uses the Write operator's total_input_num_rows (which is the actual data
+    row count), falling back to the last non-Write operator's output_num_rows.
+    """
+    # Check current summary's operators for Write input or last op output
+    if summary.operators_stats:
+        last_op = summary.operators_stats[-1]
+        # Write operator's input = actual data rows
+        if last_op.total_input_num_rows and last_op.total_input_num_rows > 0:
+            return last_op.total_input_num_rows
+        # Fallback: last operator's output (may be blocks, not rows)
+        if last_op.output_num_rows and last_op.output_num_rows.sum > 0:
+            return last_op.output_num_rows.sum
+    # Walk parents to find a row count
+    for parent in summary.parents or []:
+        rows = _get_total_rows(parent)
+        if rows and rows > 0:
+            return rows
+    return None
+
+
+def _collect_all_summaries(summary):
+    """Walk the parent chain to collect all DatasetStatsSummary nodes."""
+    result = []
+    queue = [summary]
+    while queue:
+        s = queue.pop(0)
+        result.append(s)
+        if s.parents:
+            queue.extend(s.parents)
+    return result
+
+
+def _normalize_op_name(name):
+    """Normalize operator name for use as a JSON key.
+
+    "MapBatches(Infer)" -> "map_batches_infer"
+    "ReadFiles" -> "read_files"
+    "FlatMap(decode)" -> "flat_map_decode"
+    "FlatMap(decode)->Map(preprocess)" -> "flat_map_decode__map_preprocess"
+    "Limit=717000" -> "limit_717000"
+    """
+    # Replace fused operator separator and parentheses
+    name = name.replace("->", "__").replace("(", "_").replace(")", "")
+    name = name.replace("=", "_").strip("_")
+    # CamelCase to snake_case
+    result = []
+    for i, c in enumerate(name):
+        if c.isupper() and i > 0 and name[i - 1] not in ("_",):
+            result.append("_")
+        result.append(c.lower())
+    return "".join(result)
+
+
+def parse_object_store_state(outdir):
+    """Aggregate the object_store_state.csv + actor_placement.csv into result.json keys.
+
+    Distinguishes per-operator primary-object peak bytes on GPU vs. CPU nodes.
+    "GPU" is detected by cross-referencing IP against nodes that emitted
+    nvidia-smi traces (i.e., where a gpu_usage_<ip>.txt file exists).
+
+    Output keys (each prefixed by normalized operator name):
+        {op}_primary_bytes_gpu_peak_gb
+        {op}_primary_bytes_cpu_peak_gb
+        {op}_primary_pinned_gpu_peak_gb     # currently in active use
+        {op}_primary_local_ref_gpu_peak_gb  # held by Python ref
+        {op}_n_actors_gpu_max
+        {op}_n_actors_cpu_max
+    """
+    import csv as _csv
+
+    obj_path = os.path.join(outdir, "object_store_state.csv")
+    actor_path = os.path.join(outdir, "actor_placement.csv")
+    if not os.path.exists(obj_path):
+        return {}
+
+    # Identify GPU vs CPU IPs by gpu_usage_<ip>.txt presence.
+    gpu_ips = set()
+    for f in globmod.glob(os.path.join(outdir, "gpu_usage_*.txt")):
+        ip = (
+            os.path.basename(f)
+            .replace("gpu_usage_", "")
+            .replace(".txt", "")
+            .replace("_", ".")
+        )
+        gpu_ips.add(ip)
+
+    # Aggregate object-store time series.
+    # For each tick × operator × role, sum bytes across nodes in that role.
+    # Then take the peak of per-tick sums per operator × role.
+    from collections import defaultdict
+
+    # ts -> op -> role -> {bytes_total, bytes_pinned, bytes_local_ref}
+    series = defaultdict(
+        lambda: defaultdict(
+            lambda: defaultdict(
+                lambda: {"bytes_total": 0, "bytes_pinned": 0, "bytes_local_ref": 0}
+            )
+        )
+    )
+    with open(obj_path) as f:
+        for row in _csv.DictReader(f):
+            try:
+                ts = float(row["timestamp"])
+                ip = row["owner_ip"]
+                op = row["operator"]
+                role = "gpu" if ip in gpu_ips else "cpu"
+                bucket = series[ts][op][role]
+                bucket["bytes_total"] += int(row["bytes_total"] or 0)
+                bucket["bytes_pinned"] += int(row["bytes_pinned"] or 0)
+                bucket["bytes_local_ref"] += int(row["bytes_local_ref"] or 0)
+            except (KeyError, ValueError):
+                continue
+
+    # Reduce to peaks per operator × role.
+    peaks = defaultdict(
+        lambda: defaultdict(
+            lambda: {"bytes_total": 0, "bytes_pinned": 0, "bytes_local_ref": 0}
+        )
+    )
+    for ts, by_op in series.items():
+        for op, by_role in by_op.items():
+            for role, bucket in by_role.items():
+                p = peaks[op][role]
+                for k in p:
+                    p[k] = max(p[k], bucket[k])
+
+    out = {}
+    for op, by_role in peaks.items():
+        # Keep "_other" — it captures bytes that couldn't be attributed to a
+        # specific operator (e.g., framework objects, streaming-executor output
+        # buffers, ReadFiles outputs the actor-pid join missed). On GPU nodes
+        # this is often the dominant Plasma filler; dropping it loses the most
+        # diagnostic signal.
+        op_norm = _normalize_op_name(op) if op != "_other" else "other"
+        for role in ("gpu", "cpu"):
+            b = by_role.get(role)
+            if not b:
+                continue
+            out[f"{op_norm}_primary_bytes_{role}_peak_gb"] = round(
+                b["bytes_total"] / 1e9, 2
+            )
+            if role == "gpu":
+                out[f"{op_norm}_primary_pinned_{role}_peak_gb"] = round(
+                    b["bytes_pinned"] / 1e9, 2
+                )
+                out[f"{op_norm}_primary_local_ref_{role}_peak_gb"] = round(
+                    b["bytes_local_ref"] / 1e9, 2
+                )
+
+    # Actor placement peaks per operator × role.
+    if os.path.exists(actor_path):
+        actor_peaks = defaultdict(lambda: defaultdict(int))
+        ts_role_actors = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+        with open(actor_path) as f:
+            for row in _csv.DictReader(f):
+                try:
+                    ts = float(row["timestamp"])
+                    ip = row["node_ip"]
+                    op = row["operator"]
+                    role = "gpu" if ip in gpu_ips else "cpu"
+                    n = int(row["n_actors"] or 0)
+                    ts_role_actors[ts][(op, role)]["n"] += n
+                except (KeyError, ValueError):
+                    continue
+        for ts, m in ts_role_actors.items():
+            for (op, role), v in m.items():
+                actor_peaks[op][role] = max(actor_peaks[op][role], v["n"])
+        for op, by_role in actor_peaks.items():
+            op_norm = _normalize_op_name(op)
+            for role in ("gpu", "cpu"):
+                if role in by_role:
+                    out[f"{op_norm}_n_actors_{role}_max"] = by_role[role]
+
+    return out
+
+
+def parse_plasma_stats(outdir):
+    """Aggregate plasma_stats.csv into per-role peak metrics.
+
+    plasma_stats.csv carries per-(tick, node) Plasma totals from each
+    raylet's GetNodeStats RPC: bytes_used, bytes_avail, bytes_primary,
+    cumulative spilled/restored. The diagnostic value is bytes_used vs
+    bytes_primary — their difference is "secondary copies + framework
+    overhead", which list_objects() can't see.
+
+    Output keys (per role = gpu/cpu, max across the run):
+        plasma_used_<role>_peak_gb
+        plasma_primary_<role>_peak_gb
+        plasma_secondary_or_other_<role>_peak_gb  (= used - primary)
+        plasma_avail_<role>_peak_gb
+        plasma_used_pct_<role>_peak               (= used / avail × 100)
+        plasma_spilled_<role>_total_gb            (final cumulative)
+        plasma_restored_<role>_total_gb           (final cumulative)
+        plasma_spilled_total_gb                   (cluster-wide final)
+    """
+    import csv as _csv
+
+    plasma_path = os.path.join(outdir, "plasma_stats.csv")
+    if not os.path.exists(plasma_path):
+        return {}
+
+    gpu_ips = set()
+    for f in globmod.glob(os.path.join(outdir, "gpu_usage_*.txt")):
+        ip = (
+            os.path.basename(f)
+            .replace("gpu_usage_", "")
+            .replace(".txt", "")
+            .replace("_", ".")
+        )
+        gpu_ips.add(ip)
+
+    # Aggregate per-tick × per-role sums; track peaks and final cumulative.
+    from collections import defaultdict
+
+    ts_role_used = defaultdict(lambda: defaultdict(int))
+    ts_role_primary = defaultdict(lambda: defaultdict(int))
+    ts_role_avail = defaultdict(lambda: defaultdict(int))
+    final_role_spilled = defaultdict(int)  # cumulative final per role
+    final_role_restored = defaultdict(int)
+    final_node_spilled = {}  # ip -> final cumulative
+    final_node_restored = {}
+
+    with open(plasma_path) as f:
+        for row in _csv.DictReader(f):
+            try:
+                ts = float(row["timestamp"])
+                ip = row["node_ip"]
+                role = "gpu" if ip in gpu_ips else "cpu"
+                used = int(row["bytes_used"] or 0)
+                primary = int(row["bytes_primary"] or 0)
+                avail = int(row["bytes_avail"] or 0)
+                spilled = int(row["spilled_bytes_total"] or 0)
+                restored = int(row["restored_bytes_total"] or 0)
+            except (KeyError, ValueError):
+                continue
+            ts_role_used[ts][role] += used
+            ts_role_primary[ts][role] += primary
+            ts_role_avail[ts][role] += avail
+            final_node_spilled[ip] = spilled
+            final_node_restored[ip] = restored
+
+    for ip, b in final_node_spilled.items():
+        role = "gpu" if ip in gpu_ips else "cpu"
+        final_role_spilled[role] += b
+    for ip, b in final_node_restored.items():
+        role = "gpu" if ip in gpu_ips else "cpu"
+        final_role_restored[role] += b
+
+    out = {}
+    for role in ("gpu", "cpu"):
+        peak_used = max((ts_role_used[ts][role] for ts in ts_role_used), default=0)
+        peak_primary = max(
+            (ts_role_primary[ts][role] for ts in ts_role_primary), default=0
+        )
+        peak_avail = max((ts_role_avail[ts][role] for ts in ts_role_avail), default=0)
+        # Per-tick "secondary+other" peak — take the max over ticks of
+        # (used_role - primary_role), since the difference may peak at a
+        # different tick than either component on its own.
+        peak_sec_or_other = max(
+            (ts_role_used[ts][role] - ts_role_primary[ts][role] for ts in ts_role_used),
+            default=0,
+        )
+        out[f"plasma_used_{role}_peak_gb"] = round(peak_used / 1e9, 2)
+        out[f"plasma_primary_{role}_peak_gb"] = round(peak_primary / 1e9, 2)
+        out[f"plasma_secondary_or_other_{role}_peak_gb"] = round(
+            peak_sec_or_other / 1e9, 2
+        )
+        out[f"plasma_avail_{role}_peak_gb"] = round(peak_avail / 1e9, 2)
+        if peak_avail > 0:
+            out[f"plasma_used_pct_{role}_peak"] = round(100 * peak_used / peak_avail, 1)
+        out[f"plasma_spilled_{role}_total_gb"] = round(
+            final_role_spilled[role] / 1e9, 2
+        )
+        out[f"plasma_restored_{role}_total_gb"] = round(
+            final_role_restored[role] / 1e9, 2
+        )
+    out["plasma_spilled_total_gb"] = round(sum(final_node_spilled.values()) / 1e9, 2)
+    out["plasma_restored_total_gb"] = round(sum(final_node_restored.values()) / 1e9, 2)
+    return out
+
+
+def parse_gpu_utilization(outdir):
+    """Parse nvidia-smi dmon output files for GPU utilization metrics.
+
+    Args:
+        outdir: Directory containing gpu_usage_*.txt files.
+
+    Returns:
+        Dict with gpu_sm_mean_pct and gpu_duty_cycle_pct, or empty dict
+        if no GPU data is available.
+    """
+    files = globmod.glob(os.path.join(outdir, "gpu_usage_*.txt"))
+    if not files:
+        return {}
+
+    all_sm_values = []
+    for filepath in files:
+        sm_values = _parse_gpu_file(filepath)
+        all_sm_values.extend(sm_values)
+
+    if not all_sm_values:
+        return {}
+
+    total_samples = len(all_sm_values)
+    active_samples = sum(1 for v in all_sm_values if v > 0)
+    mean_sm = sum(all_sm_values) / total_samples
+
+    return {
+        "gpu_sm_mean_pct": round(mean_sm, 1),
+        "gpu_duty_cycle_pct": round(100 * active_samples / total_samples, 1),
+    }
+
+
+def _parse_gpu_file(filepath):
+    """Parse a single gpu_usage_*.txt file and return list of SM% values.
+
+    Strips trailing zero-SM samples from the end of the file, since
+    nvidia-smi keeps running after the benchmark finishes and those
+    idle samples would skew utilization metrics downward.
+    """
+    sm_values = []
+    try:
+        with open(filepath) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                parts = line.split()
+                # Format: HH:MM:SS  gpu_idx  sm%  mem%  enc%  dec%  jpg%  ofa%
+                if len(parts) >= 3:
+                    try:
+                        sm_values.append(int(parts[2]))
+                    except ValueError:
+                        continue
+    except (OSError, IOError) as e:
+        print(f"WARNING: Failed to read GPU usage file {filepath}: {e}")
+    # Strip trailing idle samples (nvidia-smi continues after benchmark ends).
+    while sm_values and sm_values[-1] == 0:
+        sm_values.pop()
+    return sm_values

--- a/release/nightly_tests/dataset/profiling/net_monitor.py
+++ b/release/nightly_tests/dataset/profiling/net_monitor.py
@@ -1,0 +1,72 @@
+# ABOUTME: Samples psutil network I/O counters on every worker node.
+# ABOUTME: Writes per-node CSV files to shared storage for post-run analysis.
+
+import os
+import threading
+import time
+
+import ray
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+@ray.remote(num_cpus=0, num_gpus=0)
+def _start_net_monitor(outdir):
+    """Sample psutil.net_io_counters every second, write to shared storage."""
+    import csv
+    import psutil
+
+    node_ip = ray.util.get_node_ip_address()
+    os.makedirs(outdir, exist_ok=True)
+    path = f"{outdir}/net_counters_{node_ip.replace('.', '_')}.csv"
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["timestamp", "bytes_sent", "bytes_recv", "packets_sent", "packets_recv"]
+        )
+        while True:
+            c = psutil.net_io_counters()
+            writer.writerow(
+                [
+                    time.time(),
+                    c.bytes_sent,
+                    c.bytes_recv,
+                    c.packets_sent,
+                    c.packets_recv,
+                ]
+            )
+            f.flush()
+            time.sleep(1)
+
+
+def _net_monitor_loop(outdir):
+    """Launch net_io_counters sampling on every worker node as it joins."""
+    monitored_node_ids = set()
+    while True:
+        for node in ray.nodes():
+            if not node["Alive"] or node["NodeID"] in monitored_node_ids:
+                continue
+            try:
+                _start_net_monitor.options(
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id=node["NodeID"], soft=False
+                    )
+                ).remote(outdir)
+                monitored_node_ids.add(node["NodeID"])
+                print(
+                    f"Net monitor on {node['NodeManagerAddress']} "
+                    f"({len(monitored_node_ids)} nodes)"
+                )
+            except Exception as e:
+                print(f"Net monitor failed on {node['NodeManagerAddress']}: {e}")
+        time.sleep(2)
+
+
+def start(outdir):
+    """Start network monitoring on all nodes in a background thread.
+
+    Args:
+        outdir: Shared storage directory for output files.
+    """
+    thread = threading.Thread(target=_net_monitor_loop, args=(outdir,), daemon=True)
+    thread.start()
+    return thread

--- a/release/nightly_tests/dataset/profiling/nsys.py
+++ b/release/nightly_tests/dataset/profiling/nsys.py
@@ -1,0 +1,29 @@
+# ABOUTME: Builds nsys (NVIDIA Nsight Systems) runtime_env configuration for Ray workers.
+# ABOUTME: Configures nsys to wrap worker processes and use cudaProfilerApi for capture range control.
+
+
+def runtime_env(outdir):
+    """Build a runtime_env dict that wraps Ray workers with nsys profile.
+
+    Args:
+        outdir: Shared storage directory for .nsys-rep output files.
+
+    Returns:
+        Dict suitable for passing as runtime_env to map_batches() etc.
+    """
+    # capture-range-end=stop: when cudaProfilerStop() is called, nsys finalizes
+    # the .nsys-rep file synchronously and detaches. Without this, nsys only
+    # finalizes at process exit; if Ray Data hard-kills the Infer actor at end
+    # of pipeline (which it sometimes does), the file is left empty/missing.
+    # cuda_profiler_fence() in profiling/nvtx.py is what triggers cudaProfilerStop
+    # after active_batches batches, so active_batches must be set lower than the
+    # number of batches each actor actually processes.
+    return {
+        "nsight": {
+            "t": "cuda,cudnn,cublas,nvtx",
+            "capture-range": "cudaProfilerApi",
+            "capture-range-end": "stop",
+            "stop-on-exit": "true",
+            "o": f"{outdir}/nsys_%h_%p",
+        }
+    }

--- a/release/nightly_tests/dataset/profiling/nvtx.py
+++ b/release/nightly_tests/dataset/profiling/nvtx.py
@@ -1,0 +1,62 @@
+# ABOUTME: NVTX annotation helpers and CUDA profiler capture range control for nsys.
+# ABOUTME: Provides context managers for NVTX ranges and batch-count-based profiler start/stop.
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def profiling_range(name):
+    """Context manager that pushes/pops an NVTX range.
+
+    Falls back to a no-op if torch.cuda.nvtx is not available.
+    """
+    try:
+        import torch.cuda.nvtx as nvtx
+
+        nvtx.range_push(name)
+    except (ImportError, AttributeError):
+        yield
+        return
+    try:
+        yield
+    finally:
+        nvtx.range_pop()
+
+
+def cuda_profiler_fence(call_count, skip_batches, active_batches, node_ip=""):
+    """Start/stop the CUDA profiler based on batch call count.
+
+    Used with nsys cudaProfilerApi capture range mode. Starts profiling
+    after skip_batches and stops after active_batches more.
+
+    In practice the stop branch rarely fires: PROFILE_ACTIVE_BATCHES is
+    typically left at its large default so the capture spans the entire
+    actor lifetime, and the matching cudaProfilerStop is invoked from
+    Infer's atexit hook instead. Paired with capture-range-end:stop in
+    nsys_runtime_env(), that finalizes the .nsys-rep synchronously
+    before Ray tears the actor down.
+
+    Args:
+        call_count: Current batch call count (1-indexed).
+        skip_batches: Number of batches to skip before starting capture.
+        active_batches: Number of batches to capture.
+        node_ip: Node IP for log messages (optional).
+
+    Returns:
+        (profiling_active, profiler_done) tuple of booleans.
+    """
+    import torch
+
+    if call_count == skip_batches + 1:
+        torch.cuda.cudart().cudaProfilerStart()
+        print(f"[{node_ip}] nsys capture started at batch {call_count}", flush=True)
+        return True, False
+    elif call_count == skip_batches + active_batches + 1:
+        torch.cuda.cudart().cudaProfilerStop()
+        print(
+            f"[{node_ip}] nsys capture stopped at batch {call_count} "
+            f"({active_batches} batches captured)",
+            flush=True,
+        )
+        return False, True
+    return None, None

--- a/release/nightly_tests/dataset/profiling/object_store.py
+++ b/release/nightly_tests/dataset/profiling/object_store.py
@@ -1,0 +1,304 @@
+# ABOUTME: Periodically samples Ray object-store state via ray.util.state.
+# ABOUTME: Emits per-(node, operator) primary-bytes time series for spill diagnosis.
+
+import csv
+import os
+import re
+import threading
+import time
+import traceback
+
+
+_MAPWORKER_RE = re.compile(r"^MapWorker\((.+)\)$")
+
+
+def start(outdir, interval_s=5, fast_window_s=60, fast_interval_s=1):
+    """Start object-store sampling in a background thread.
+
+    Outputs ``object_store_state.csv`` with one row per (tick, owner_node, operator)
+    showing primary-object counts and bytes plus a reference-type breakdown.
+
+    Args:
+        outdir: Shared storage directory for output files.
+        interval_s: Steady-state seconds between samples. Default 5s — fast enough
+            to catch short-lived primaries between produce and GC. ``list_objects()``
+            is ~100ms per call on this benchmark; 5s adds ~2% daemon overhead.
+        fast_window_s: Seconds at the start of the run during which the daemon
+            ticks every ``fast_interval_s`` instead of ``interval_s``. Resolves
+            placement-ramp events (e.g. GPU-node CPU saturation by ReadFiles) to
+            sub-5s precision. Set to 0 to disable.
+        fast_interval_s: Tick interval during the fast window. Default 1s.
+    """
+    thread = threading.Thread(
+        target=_loop,
+        args=(outdir, interval_s, fast_window_s, fast_interval_s),
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _loop(outdir, interval_s, fast_window_s=0, fast_interval_s=1):
+    os.makedirs(outdir, exist_ok=True)
+    csv_path = os.path.join(outdir, "object_store_state.csv")
+    actors_path = os.path.join(outdir, "actor_placement.csv")
+    plasma_path = os.path.join(outdir, "plasma_stats.csv")
+
+    obj_fields = [
+        "timestamp",
+        "owner_ip",
+        "operator",
+        "n_objects",
+        "bytes_total",
+        "bytes_pinned",
+        "bytes_local_ref",
+        "bytes_used_by_pending_task",
+        "bytes_other",
+    ]
+    actor_fields = [
+        "timestamp",
+        "node_ip",
+        "operator",
+        "n_actors",
+    ]
+    # Per-node Plasma stats from raylet GetNodeStats RPC. Distinguishes
+    # primary bytes (objects whose authoritative owner is this node) from
+    # total used bytes (= primary + secondary copies + framework overhead).
+    # Also exposes spill/restore totals per node for time-correlated analysis.
+    plasma_fields = [
+        "timestamp",
+        "node_ip",
+        "bytes_used",
+        "bytes_avail",
+        "bytes_primary",
+        "bytes_fallback",
+        "n_local_objects",
+        "spilled_bytes_total",
+        "spilled_objects_total",
+        "restored_bytes_total",
+        "restored_objects_total",
+    ]
+
+    obj_f = open(csv_path, "w", newline="")
+    obj_writer = csv.DictWriter(obj_f, fieldnames=obj_fields)
+    obj_writer.writeheader()
+    obj_f.flush()
+
+    actor_f = open(actors_path, "w", newline="")
+    actor_writer = csv.DictWriter(actor_f, fieldnames=actor_fields)
+    actor_writer.writeheader()
+    actor_f.flush()
+
+    plasma_f = open(plasma_path, "w", newline="")
+    plasma_writer = csv.DictWriter(plasma_f, fieldnames=plasma_fields)
+    plasma_writer.writeheader()
+    plasma_f.flush()
+
+    if fast_window_s > 0:
+        print(
+            f"object_store_monitor: writing {csv_path}, {actors_path}, {plasma_path} "
+            f"every {fast_interval_s}s for {fast_window_s}s starting from first actor, "
+            f"then every {interval_s}s"
+        )
+    else:
+        print(
+            f"object_store_monitor: writing {csv_path}, {actors_path}, {plasma_path} "
+            f"every {interval_s}s"
+        )
+
+    # Anchor the fast window to "first time we observe any actors" so the 1s
+    # sampling lands on the actual ramp-up regardless of how long the job
+    # idle-waits before spawning actors. None until first non-zero count.
+    fast_window_started_at = None
+    while True:
+        try:
+            now = time.time()
+            actor_to_op, actor_placement = _snapshot_actors()
+            for row in actor_placement:
+                row["timestamp"] = now
+                actor_writer.writerow(row)
+            actor_f.flush()
+
+            plasma_rows = _snapshot_plasma_per_node()
+            for row in plasma_rows:
+                row["timestamp"] = now
+                plasma_writer.writerow(row)
+            plasma_f.flush()
+
+            obj_rows = _snapshot_objects(actor_to_op)
+            for row in obj_rows:
+                row["timestamp"] = now
+                obj_writer.writerow(row)
+            obj_f.flush()
+
+            n_actors = sum(r["n_actors"] for r in actor_placement)
+            if fast_window_started_at is None and n_actors > 0:
+                fast_window_started_at = time.time()
+                print(
+                    f"object_store_monitor: first actor detected; fast window "
+                    f"({fast_interval_s}s tick) active for next {fast_window_s}s"
+                )
+
+            plasma_used_total_gb = sum(r["bytes_used"] for r in plasma_rows) / 1e9
+            spill_total_gb = sum(r["spilled_bytes_total"] for r in plasma_rows) / 1e9
+            print(
+                f"object_store_monitor: tick={now:.0f} "
+                f"actors={n_actors} "
+                f"objects={sum(r['n_objects'] for r in obj_rows)} "
+                f"plasma_used={plasma_used_total_gb:.1f}GB "
+                f"spilled={spill_total_gb:.1f}GB"
+            )
+        except Exception as e:
+            print(f"object_store_monitor: WARN {e}")
+            traceback.print_exc()
+
+        in_fast_window = (
+            fast_window_started_at is not None
+            and (time.time() - fast_window_started_at) < fast_window_s
+        )
+        time.sleep(fast_interval_s if in_fast_window else interval_s)
+
+
+def _snapshot_actors():
+    """Return ((ip, pid) → operator_name) map and per-(node_ip, op) actor counts.
+
+    ActorState carries node_id (a hex string) but not the IP. We join against
+    list_nodes() to recover the IP — which is what list_objects() reports for
+    object owners and what we cross-reference against in the metrics extractor.
+    """
+    from collections import defaultdict
+    from ray.util.state import list_actors, list_nodes
+
+    # raise_on_missing_output=False: allow partial results when the state
+    # API truncates due to data size. Without this the daemon dies on the
+    # first heavy snapshot.
+    nodes = list_nodes(limit=10000, raise_on_missing_output=False)
+    node_id_to_ip = {n["node_id"]: n.get("node_ip", "unknown") for n in nodes}
+
+    actors = list_actors(
+        filters=[("state", "=", "ALIVE")],
+        limit=10000,
+        raise_on_missing_output=False,
+    )
+    actor_to_op = {}
+    counts = defaultdict(int)
+
+    for a in actors:
+        cls = a.get("class_name", "") or ""
+        m = _MAPWORKER_RE.match(cls)
+        if not m:
+            continue
+        operator = m.group(1)
+        node_ip = node_id_to_ip.get(a.get("node_id"), "unknown")
+        if a.get("pid") not in (None, 0) and node_ip != "unknown":
+            actor_to_op[(node_ip, int(a["pid"]))] = operator
+        counts[(node_ip, operator)] += 1
+
+    placement = [
+        {"node_ip": ip, "operator": op, "n_actors": n} for (ip, op), n in counts.items()
+    ]
+    return actor_to_op, placement
+
+
+def _snapshot_objects(actor_to_op):
+    """Aggregate live objects by (owner_ip, operator)."""
+    from collections import defaultdict
+    from ray.util.state import list_objects
+
+    # API server caps the limit at 10000 unless RAY_MAX_LIMIT_FROM_API_SERVER
+    # is set. For runs with > 10k objects, set that env var on the head node:
+    #   RAY_MAX_LIMIT_FROM_API_SERVER=200000
+    # to avoid truncated samples.
+    #
+    # raise_on_missing_output=False: the state API also truncates when the
+    # response size (not just count) exceeds an internal RPC limit; with the
+    # default the daemon dies the moment objects get heavy. Partial data is
+    # preferable to no data here.
+    objs = list_objects(limit=10_000, raise_on_missing_output=False)
+
+    agg = defaultdict(
+        lambda: {
+            "n_objects": 0,
+            "bytes_total": 0,
+            "bytes_pinned": 0,
+            "bytes_local_ref": 0,
+            "bytes_used_by_pending_task": 0,
+            "bytes_other": 0,
+        }
+    )
+
+    for obj in objs:
+        # obj.type is WORKER / DRIVER / SPILL_WORKER / RESTORE_WORKER. We focus on
+        # WORKER since that's the productive workload.
+        if obj.get("type") != "WORKER":
+            continue
+        owner_ip = obj.get("ip") or "unknown"
+        pid = obj.get("pid")
+        operator = (
+            actor_to_op.get((owner_ip, int(pid))) if pid is not None else None
+        ) or "_other"
+        size = int(obj.get("object_size", 0) or 0)
+        ref = obj.get("reference_type") or ""
+
+        bucket = agg[(owner_ip, operator)]
+        bucket["n_objects"] += 1
+        bucket["bytes_total"] += size
+        if ref == "PINNED_IN_MEMORY":
+            bucket["bytes_pinned"] += size
+        elif ref == "LOCAL_REFERENCE":
+            bucket["bytes_local_ref"] += size
+        elif ref == "USED_BY_PENDING_TASK":
+            bucket["bytes_used_by_pending_task"] += size
+        else:
+            bucket["bytes_other"] += size
+
+    rows = []
+    for (ip, op), b in agg.items():
+        rows.append({"owner_ip": ip, "operator": op, **b})
+    return rows
+
+
+def _snapshot_plasma_per_node():
+    """Per-node Plasma stats from each raylet's GetNodeStats RPC.
+
+    Returns a list of dicts, one per alive node, with the fields documented
+    in plasma_fields. The bytes_used vs bytes_primary split is the key
+    diagnostic — bytes_used - bytes_primary = bytes occupied by secondary
+    copies + framework overhead, which list_objects() can't see.
+    """
+    import ray
+    from ray._private.internal_api import node_stats
+
+    rows = []
+    for node in ray.nodes():
+        if not node.get("Alive"):
+            continue
+        ip = node.get("NodeManagerAddress")
+        port = node.get("NodeManagerPort")
+        if not ip or not port:
+            continue
+        try:
+            reply = node_stats(
+                node_manager_address=ip,
+                node_manager_port=port,
+                include_memory_info=False,
+            )
+        except Exception:
+            # Best-effort — skip nodes whose raylet RPC times out.
+            continue
+        s = reply.store_stats
+        rows.append(
+            {
+                "node_ip": ip,
+                "bytes_used": int(s.object_store_bytes_used),
+                "bytes_avail": int(s.object_store_bytes_avail),
+                "bytes_primary": int(s.object_store_bytes_primary_copy),
+                "bytes_fallback": int(getattr(s, "object_store_bytes_fallback", 0)),
+                "n_local_objects": int(s.num_local_objects),
+                "spilled_bytes_total": int(s.spilled_bytes_total),
+                "spilled_objects_total": int(s.spilled_objects_total),
+                "restored_bytes_total": int(s.restored_bytes_total),
+                "restored_objects_total": int(s.restored_objects_total),
+            }
+        )
+    return rows

--- a/release/nightly_tests/dataset/profiling/perf.py
+++ b/release/nightly_tests/dataset/profiling/perf.py
@@ -1,0 +1,473 @@
+# ABOUTME: Attaches perf record CPU profiling to GCS and raylet C++ processes.
+# ABOUTME: Provides head-node profiling, worker-node actor-based profiling, and collapsed stack generation.
+
+import os
+import re
+import shutil
+import signal
+import subprocess
+import time
+
+import ray
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+def _ensure_perf_available():
+    """Check that perf is installed. Returns True if available."""
+    if shutil.which("perf"):
+        return True
+    print("WARNING: perf not found on PATH. Skipping CPU profiling.")
+    return False
+
+
+def _ensure_perf_permissions():
+    """Lower perf_event_paranoid so non-root users can record."""
+    try:
+        subprocess.run(
+            ["sudo", "sysctl", "-w", "kernel.perf_event_paranoid=-1"],
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["sudo", "sysctl", "-w", "kernel.kptr_restrict=0"],
+            check=True,
+            capture_output=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"WARNING: Failed to set perf permissions: {e}")
+
+
+def find_pid(process_name, use_full=False, retries=15, interval=2):
+    """Find a process PID by name with retries for startup races.
+
+    Args:
+        process_name: Process name to match.
+        use_full: If True, match against full command line (pgrep -f).
+                  If False, match exact process name (pgrep -x).
+        retries: Number of retry attempts.
+        interval: Seconds between retries.
+
+    Returns:
+        PID as int, or None if not found after all retries.
+    """
+    flag = "-f" if use_full else "-x"
+    for attempt in range(retries):
+        try:
+            result = subprocess.run(
+                ["pgrep", flag, process_name],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode == 0:
+                pid = int(result.stdout.strip().split("\n")[0])
+                return pid
+        except (ValueError, IndexError):
+            pass
+        if attempt < retries - 1:
+            time.sleep(interval)
+    print(f"WARNING: Process '{process_name}' not found after {retries * interval}s")
+    return None
+
+
+def start_profiling(pid, label, outdir):
+    """Start perf record on a process.
+
+    Args:
+        pid: Target process ID.
+        label: Label for output files (e.g. "gcs", "raylet").
+        outdir: Directory for output files.
+
+    Returns:
+        (subprocess.Popen, IO, data_path) tuple, or (None, None, None) if perf
+        fails to start.
+    """
+    node_ip = ray.util.get_node_ip_address().replace(".", "_")
+
+    os.makedirs(outdir, exist_ok=True)
+    data_path = f"{outdir}/perf_{label}_{node_ip}.data"
+    log_path = f"{outdir}/perf_{label}_{node_ip}.log"
+
+    cmd = [
+        "perf",
+        "record",
+        "-g",
+        "--call-graph",
+        "fp",
+        "-F",
+        "99",
+        "-p",
+        str(pid),
+        "-o",
+        data_path,
+    ]
+
+    log_file = open(log_path, "w")
+    log_file.write(f"cmd: {' '.join(cmd)}\n")
+    log_file.write(f"target pid: {pid}\n")
+    log_file.flush()
+
+    try:
+        proc = subprocess.Popen(cmd, stdout=log_file, stderr=log_file)
+    except OSError as e:
+        log_file.write(f"Failed to start perf: {e}\n")
+        log_file.close()
+        print(f"WARNING: Failed to start perf for {label} (pid {pid}): {e}")
+        return None, None, None
+
+    # Give perf a moment to fail on startup.
+    time.sleep(1)
+    if proc.poll() is not None:
+        log_file.write(f"perf exited early with code {proc.returncode}\n")
+        log_file.close()
+        print(f"WARNING: perf failed to start for {label} (code {proc.returncode})")
+        return None, None, None
+
+    log_file.write(f"perf pid: {proc.pid}\n")
+    log_file.flush()
+    print(f"perf profiling started for {label} (target pid {pid}) -> {data_path}")
+    return proc, log_file, data_path
+
+
+def stop_profiler(proc, log_file, timeout=15):
+    """Stop a perf process gracefully.
+
+    Args:
+        proc: subprocess.Popen handle from start_profiling.
+        log_file: Log file handle from start_profiling.
+        timeout: Seconds to wait for perf to flush output.
+    """
+    if proc is None:
+        return
+
+    print(f"Stopping perf (pid {proc.pid})...")
+    try:
+        # Use SIGTERM rather than SIGINT. perf record handles both for clean
+        # shutdown, but SIGINT can be ignored when perf lacks a controlling
+        # terminal (common inside Ray actor worker processes).
+        os.kill(proc.pid, signal.SIGTERM)
+        proc.wait(timeout=timeout)
+        msg = f"perf exited with code {proc.returncode}"
+        print(msg)
+        if log_file:
+            log_file.write(msg + "\n")
+    except subprocess.TimeoutExpired:
+        msg = f"perf did not exit in {timeout}s, killing"
+        print(msg)
+        proc.kill()
+        if log_file:
+            log_file.write(msg + "\n")
+    except ProcessLookupError:
+        msg = "perf already exited"
+        print(msg)
+        if log_file:
+            log_file.write(msg + "\n")
+    finally:
+        if log_file:
+            log_file.flush()
+            log_file.close()
+
+
+def _clean_func_name(name):
+    """Strip hex offsets and clean up a function name from perf script output.
+
+    Removes trailing +0x... offsets and replaces semicolons (which conflict
+    with the collapsed stack delimiter) with colons.
+    """
+    # Strip trailing +0xHEX offset
+    name = re.sub(r"\+0x[0-9a-f]+$", "", name)
+    # Replace semicolons in C++ names (template args, etc.)
+    name = name.replace(";", ":")
+    return name
+
+
+def generate_collapsed_stacks(outdir, data_path=None):
+    """Convert perf.data files to collapsed stack format.
+
+    Produces *_collapsed.txt next to each *.data. Must be run on a machine
+    whose kernel and runtime libraries match the one that recorded the data —
+    for Ray worker profiles this means the worker node itself, before its
+    /tmp/ray/session_* directory is torn down.
+
+    Args:
+        outdir: Directory to scan (ignored if data_path is given).
+        data_path: If set, convert only this single .data file. Otherwise
+                   convert every perf_*.data under outdir that does not
+                   already have a matching _collapsed.txt.
+
+    perf script output format:
+        command  pid/tid  [cpu] timestamp: event:
+            hex_addr func_name+0xoff (dso)
+            hex_addr func_name+0xoff (dso)
+            ...
+        <blank line>
+    """
+    import glob as globmod
+
+    if data_path is not None:
+        data_files = [data_path]
+    else:
+        data_files = globmod.glob(os.path.join(outdir, "perf_*.data"))
+    if not data_files:
+        print("No perf data files found to convert.")
+        return
+
+    # Regex for the header line: "command pid/tid [cpu] timestamp: event:"
+    header_re = re.compile(r"^\s*(\S+)\s+\d+")
+
+    for data_path in data_files:
+        name = os.path.basename(data_path).replace(".data", "")
+        collapsed_path = os.path.join(
+            os.path.dirname(data_path) or outdir, f"{name}_collapsed.txt"
+        )
+        if os.path.exists(collapsed_path):
+            print(f"Skipping {data_path}: {collapsed_path} already exists")
+            continue
+        print(f"Converting {data_path} -> {collapsed_path}")
+        try:
+            perf_script = subprocess.Popen(
+                ["perf", "script", "-i", data_path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+            )
+            with open(collapsed_path, "w") as out:
+                comm = ""
+                stack = []
+                for line in perf_script.stdout:
+                    line = line.decode("utf-8", errors="replace").rstrip()
+                    if line == "":
+                        if stack:
+                            prefix = comm + ";" if comm else ""
+                            out.write(prefix + ";".join(reversed(stack)) + " 1\n")
+                            stack = []
+                            comm = ""
+                    elif line and line[0] in (" ", "\t"):
+                        # Stack frame: leading whitespace + hex_addr + func_name+0xoff (dso)
+                        parts = line.strip().split(" ", 1)
+                        if len(parts) >= 2:
+                            addr, rest = parts
+                            # Split trailing "(dso)" off the end if present.
+                            # Stripped libs (libcudart, libcublas, libtorch
+                            # extensions, etc.) yield "[unknown] (dso)" — keep
+                            # the DSO basename so per-library time is visible.
+                            dso = ""
+                            if rest.endswith(")"):
+                                paren = rest.rfind(" (")
+                                if paren != -1:
+                                    dso = rest[paren + 2 : -1].strip()
+                                    rest = rest[:paren]
+                            func = _clean_func_name(rest)
+                            if func == "[unknown]":
+                                if dso and dso not in ("unknown", "[unknown]"):
+                                    dso_base = os.path.basename(dso).replace(";", ":")
+                                    # "@0x..." rather than "+0x..." so the
+                                    # address survives collapsed_to_speedscope
+                                    # (which strips trailing +0xHEX offsets).
+                                    # analyze_pyspy_profile groups by DSO by
+                                    # default and shows the @addr with
+                                    # --detail-unknowns.
+                                    func = f"unk_{dso_base}@0x{addr}"
+                                else:
+                                    func = f"unk_0x{addr}"
+                            stack.append(func)
+                    else:
+                        # Header line: extract command name (thread)
+                        m = header_re.match(line)
+                        if m:
+                            comm = m.group(1)
+                if stack:
+                    prefix = comm + ";" if comm else ""
+                    out.write(prefix + ";".join(reversed(stack)) + " 1\n")
+            perf_script.wait()
+            size = os.path.getsize(collapsed_path)
+            print(f"  -> {collapsed_path} ({size} bytes)")
+        except Exception as e:
+            print(f"  WARNING: Failed to convert {data_path}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Head-node profiling: GCS + local raylet
+# ---------------------------------------------------------------------------
+
+
+def start_head_node(outdir):
+    """Start perf profiling on GCS and raylet processes on the head node.
+
+    Returns:
+        List of (proc, log_file, data_path) tuples for each started profiler.
+    """
+    handles = []
+    if not _ensure_perf_available():
+        return handles
+    _ensure_perf_permissions()
+
+    gcs_pid = find_pid("gcs_server", use_full=True)
+    if gcs_pid:
+        handles.append(start_profiling(gcs_pid, "gcs", outdir))
+
+    raylet_pid = find_pid("raylet")
+    if raylet_pid:
+        handles.append(start_profiling(raylet_pid, "raylet", outdir))
+
+    return handles
+
+
+def stop_head(handles):
+    """Stop head-node perf profilers and convert their data to collapsed stacks.
+
+    Symbolization happens here (on the head) because the head's filesystem
+    is what produced the .data files.
+
+    Args:
+        handles: List of (proc, log_file, data_path) tuples from start_head_node.
+    """
+    for proc, log_file, data_path in handles:
+        stop_profiler(proc, log_file)
+        if data_path and os.path.exists(data_path):
+            try:
+                generate_collapsed_stacks(
+                    os.path.dirname(data_path), data_path=data_path
+                )
+            except Exception as e:
+                print(f"WARNING: head collapse failed for {data_path}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Worker-node profiling via Ray actors
+# ---------------------------------------------------------------------------
+
+
+@ray.remote(num_cpus=0, num_gpus=0)
+class _RayletPerfProfiler:
+    """Actor that profiles the local raylet with perf record.
+
+    Using an actor (not a task) so the head node can call stop() explicitly
+    before the job exits, giving perf a clean SIGTERM to finalize the data file.
+    """
+
+    def __init__(self, outdir):
+        self._outdir = outdir
+        self._proc = None
+        self._log_file = None
+        self._data_path = None
+
+    def start(self):
+        if not _ensure_perf_available():
+            return False
+        _ensure_perf_permissions()
+        pid = find_pid("raylet")
+        if pid is None:
+            return False
+        self._proc, self._log_file, self._data_path = start_profiling(
+            pid, "raylet", self._outdir
+        )
+        return self._proc is not None
+
+    def stop(self):
+        if self._proc is not None:
+            print(
+                f"Actor stop() called, perf pid={self._proc.pid}, "
+                f"poll={self._proc.poll()}"
+            )
+        stop_profiler(self._proc, self._log_file, timeout=30)
+        # Convert to collapsed stacks on this worker node, while the local
+        # /tmp/ray/session_* runtime_env libs (libtorch, libcuda, etc.) are
+        # still on disk. If we defer this to the head, those DSOs are gone
+        # and ~every user-space frame resolves to [unknown].
+        if self._data_path and os.path.exists(self._data_path):
+            try:
+                generate_collapsed_stacks(self._outdir, data_path=self._data_path)
+            except Exception as e:
+                print(f"WARNING: worker collapse failed for {self._data_path}: {e}")
+        self._proc = None
+        self._log_file = None
+        self._data_path = None
+
+
+def start_worker_nodes(outdir, num_cpu_workers=5, num_gpu_workers=5):
+    """Launch perf profiling actors on a sample of worker nodes.
+
+    Args:
+        outdir: Shared storage directory for profile output.
+        num_cpu_workers: Number of CPU-only worker nodes to profile.
+        num_gpu_workers: Number of GPU worker nodes to profile.
+
+    Returns:
+        List of actor handles (for passing to stop_workers later).
+    """
+
+    head_node_id = ray.get_runtime_context().get_node_id()
+    monitored_node_ids = set()
+    actors = []
+    cpu_count = 0
+    gpu_count = 0
+    target_count = num_cpu_workers + num_gpu_workers
+
+    stale_polls = 0
+    max_stale_polls = 30  # 30 * 2s = 60s with no new nodes
+
+    while (cpu_count + gpu_count) < target_count:
+        found_new = False
+        for node in ray.nodes():
+            if not node["Alive"] or node["NodeID"] in monitored_node_ids:
+                continue
+            if node["NodeID"] == head_node_id:
+                continue
+            has_gpu = node["Resources"].get("GPU", 0) > 0
+            if has_gpu and gpu_count >= num_gpu_workers:
+                continue
+            if not has_gpu and cpu_count >= num_cpu_workers:
+                continue
+            try:
+                actor = _RayletPerfProfiler.options(
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id=node["NodeID"], soft=False
+                    ),
+                ).remote(outdir)
+                started = ray.get(actor.start.remote())
+                found_new = True
+                if started:
+                    actors.append(actor)
+                    monitored_node_ids.add(node["NodeID"])
+                    if has_gpu:
+                        gpu_count += 1
+                    else:
+                        cpu_count += 1
+                    print(
+                        f"Perf profiling raylet on {node['NodeManagerAddress']} "
+                        f"(cpu={cpu_count}/{num_cpu_workers}, "
+                        f"gpu={gpu_count}/{num_gpu_workers})"
+                    )
+                else:
+                    monitored_node_ids.add(node["NodeID"])
+                    print(f"Perf failed to start on {node['NodeManagerAddress']}")
+            except Exception as e:
+                # Mark the node as monitored so we don't retry it forever.
+                monitored_node_ids.add(node["NodeID"])
+                print(f"Failed perf on {node['NodeManagerAddress']}: {e}")
+        if not found_new:
+            stale_polls += 1
+            if stale_polls >= max_stale_polls:
+                print(
+                    f"Perf: no new worker nodes for {max_stale_polls * 2}s, "
+                    f"proceeding with {cpu_count} CPU + {gpu_count} GPU "
+                    f"({len(actors)} actors attached)"
+                )
+                break
+        else:
+            stale_polls = 0
+        time.sleep(2)
+    if (cpu_count + gpu_count) >= target_count:
+        print(f"Perf profiling active on {cpu_count} CPU + {gpu_count} GPU workers")
+    return actors
+
+
+def stop_workers(actors):
+    """Stop worker-node perf profilers.
+
+    Args:
+        actors: List of actor handles from start_worker_nodes.
+    """
+    if not actors:
+        return
+    print(f"Stopping {len(actors)} worker perf profilers...")
+    ray.get([a.stop.remote() for a in actors])

--- a/release/nightly_tests/dataset/profiling/pyspy.py
+++ b/release/nightly_tests/dataset/profiling/pyspy.py
@@ -1,0 +1,477 @@
+# ABOUTME: Attaches py-spy CPU profiling to the driver and to Ray UDF worker processes.
+# ABOUTME: Driver profiling runs on head; worker profiling runs via Ray actors on sampled nodes.
+
+import os
+import re
+import signal
+import subprocess
+import time
+
+import ray
+from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+
+# --- Configuration (override via environment) ---
+PYSPY_FORMAT = os.environ.get("PYSPY_FORMAT", "speedscope")
+PYSPY_RATE = int(os.environ.get("PYSPY_RATE", "100"))
+
+_FORMAT_EXTENSIONS = {
+    "speedscope": ".speedscope.json",
+    "flamegraph": ".svg",
+    "raw": ".raw",
+}
+
+# Module-level handle so stop() can reach it.
+_pyspy_proc = None
+_log_file = None
+
+
+def _ensure_pyspy_permissions():
+    """Sets ptrace_scope to 0 or applies setuid to py-spy binary."""
+    import shutil
+
+    try:
+        subprocess.run(
+            ["sudo", "sysctl", "-w", "kernel.yama.ptrace_scope=0"],
+            check=True,
+            capture_output=True,
+        )
+        return
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    pyspy_path = shutil.which("py-spy")
+    if pyspy_path:
+        try:
+            subprocess.run(
+                ["sudo", "chmod", "u+s", pyspy_path],
+                check=True,
+                capture_output=True,
+            )
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+
+
+def start(outdir):
+    """Launches py-spy on the current (driver) process with --subprocesses.
+
+    Args:
+        outdir: Shared storage directory for profile output.
+    """
+    global _pyspy_proc, _log_file
+
+    _ensure_pyspy_permissions()
+
+    pid = os.getpid()
+    os.makedirs(outdir, exist_ok=True)
+
+    ext = _FORMAT_EXTENSIONS.get(PYSPY_FORMAT, ".raw")
+    output_path = f"{outdir}/pyspy_driver{ext}"
+    log_path = f"{outdir}/pyspy_driver.log"
+
+    cmd = [
+        "py-spy",
+        "record",
+        "-p",
+        str(pid),
+        "-o",
+        output_path,
+        "-f",
+        PYSPY_FORMAT,
+        "-r",
+        str(PYSPY_RATE),
+        "--nonblocking",
+        "--subprocesses",
+    ]
+
+    _log_file = open(log_path, "w")
+    _log_file.write(f"cmd: {' '.join(cmd)}\n")
+    _log_file.write(f"driver pid: {pid}\n")
+    _log_file.write(f"output_path: {output_path}\n")
+    _log_file.flush()
+
+    _pyspy_proc = subprocess.Popen(cmd, stdout=_log_file, stderr=_log_file)
+    _log_file.write(f"py-spy pid: {_pyspy_proc.pid}\n")
+    _log_file.flush()
+
+    print(f"py-spy profiling started on driver (pid {pid}) -> {output_path}")
+
+
+def stop(timeout=15):
+    """Sends SIGINT to py-spy and waits for it to write output.
+
+    Args:
+        timeout: Seconds to wait for py-spy to flush output.
+    """
+    global _pyspy_proc, _log_file
+
+    if _pyspy_proc is None:
+        print("No py-spy process to stop.")
+        return
+
+    print("Stopping py-spy...")
+    try:
+        _pyspy_proc.send_signal(signal.SIGINT)
+        _pyspy_proc.wait(timeout=timeout)
+        print(f"py-spy exited with code {_pyspy_proc.returncode}")
+        if _log_file:
+            _log_file.write(f"py-spy exited with code {_pyspy_proc.returncode}\n")
+    except subprocess.TimeoutExpired:
+        print(f"py-spy did not exit in {timeout}s, killing")
+        _pyspy_proc.kill()
+        if _log_file:
+            _log_file.write(f"py-spy killed after {timeout}s timeout\n")
+    except ProcessLookupError:
+        print("py-spy already exited")
+        if _log_file:
+            _log_file.write("py-spy already exited\n")
+    finally:
+        if _log_file:
+            _log_file.flush()
+            _log_file.close()
+            _log_file = None
+        _pyspy_proc = None
+
+
+# ---------------------------------------------------------------------------
+# Worker-node UDF profiling via Ray actors
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_proc_name(name):
+    """Strip ray:: prefix and replace filename-unsafe chars."""
+    if name.startswith("ray::"):
+        name = name[len("ray::") :]
+    return re.sub(r"[^A-Za-z0-9_.-]", "_", name) or "unknown"
+
+
+# Linux comm is capped at 15 chars; these are prefixes of the sanitized
+# (ray::-stripped) name that identify non-UDF processes we must skip.
+_INFRA_NAME_PREFIXES = (
+    "DashboardA",  # ray::DashboardAgent
+    "RuntimeEnv",  # ray::RuntimeEnvAgent
+    "APILogAge",  # ray::APILogAgent
+    "AgentBase",  # ray::AgentBase* (older Ray)
+    "_start_net",  # our own net_monitor task (_start_net_io_monitor)
+    "_UDFPySpy",  # our own py-spy actor (_UDFPySpyProfiler)
+    "_RayletPe",  # our own perf actor (_RayletPerfProfiler)
+)
+
+
+def _is_infra_worker(name):
+    return any(name.startswith(p) for p in _INFRA_NAME_PREFIXES)
+
+
+def _find_ray_workers(max_targets, retries=150, interval=2):
+    """Find ray:: UDF worker PIDs on the current node.
+
+    Polls up to retries*interval seconds. Returns on the first attempt that
+    finds at least one non-infrastructure ray:: worker — infra processes
+    (DashboardAgent, RuntimeEnvAgent, our own profiler actors, etc.) exist
+    from node boot and would otherwise be picked before the UDF workers
+    spawn.
+
+    Returns:
+        List of (pid, sanitized_name) tuples, up to max_targets.
+    """
+    own_pid = os.getpid()
+    for attempt in range(retries):
+        try:
+            result = subprocess.run(
+                ["pgrep", "-f", "ray::"],
+                capture_output=True,
+                text=True,
+            )
+            pids = []
+            if result.returncode == 0:
+                pids = [int(p) for p in result.stdout.strip().split("\n") if p]
+                pids = [p for p in pids if p != own_pid]
+            candidates = []
+            for pid in pids:
+                try:
+                    raw = subprocess.check_output(
+                        ["ps", "-p", str(pid), "-o", "comm="],
+                        text=True,
+                    ).strip()
+                except subprocess.CalledProcessError:
+                    continue
+                name = _sanitize_proc_name(raw)
+                if _is_infra_worker(name):
+                    continue
+                candidates.append((pid, name))
+            if candidates:
+                return candidates[:max_targets]
+        except (ValueError, IndexError):
+            pass
+        if attempt < retries - 1:
+            time.sleep(interval)
+    print(
+        f"WARNING: no UDF ray:: workers found after {retries * interval}s "
+        f"(infra-only PIDs skipped)"
+    )
+    return []
+
+
+def _attach_worker_pyspy(pid, name, outdir, name_counts):
+    """Attach py-spy to one Ray worker PID.
+
+    Output filename: pyspy_worker_<nodeip>_<name>.speedscope.json. If the same
+    sanitized name has already been used on this node, append _pid<pid> to
+    disambiguate.
+
+    Returns:
+        (proc, log_file, output_path) tuple, or None on failure.
+    """
+    node_ip = ray.util.get_node_ip_address().replace(".", "_")
+    ext = _FORMAT_EXTENSIONS.get(PYSPY_FORMAT, ".raw")
+
+    if name_counts.get(name, 0) > 0:
+        label = f"{name}_pid{pid}"
+    else:
+        label = name
+    name_counts[name] = name_counts.get(name, 0) + 1
+
+    output_path = f"{outdir}/pyspy_worker_{node_ip}_{label}{ext}"
+    log_path = f"{outdir}/pyspy_worker_{node_ip}_{label}.log"
+
+    # No --subprocesses here: UDF worker processes don't spawn Python
+    # children, and including the flag complicates py-spy's SIGINT shutdown.
+    cmd = [
+        "py-spy",
+        "record",
+        "-p",
+        str(pid),
+        "-o",
+        output_path,
+        "-f",
+        PYSPY_FORMAT,
+        "-r",
+        str(PYSPY_RATE),
+        "--nonblocking",
+    ]
+
+    log_file = open(log_path, "w")
+    log_file.write(f"cmd: {' '.join(cmd)}\n")
+    log_file.write(f"target pid: {pid}\n")
+    log_file.write(f"target name: {name}\n")
+    log_file.flush()
+
+    def _reset_signals():
+        # Ray actor workers run with SIGINT blocked in the process signal
+        # mask (so the actor survives shutdown signals that target the
+        # raylet's group). A blocked signal mask survives both fork AND
+        # exec, so py-spy installs a SIGINT handler that never fires — the
+        # signal is stuck in the pending set. Unblock it here, then reset
+        # the dispositions so py-spy gets a clean slate.
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, [signal.SIGINT, signal.SIGTERM])
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=log_file,
+            stderr=log_file,
+            preexec_fn=_reset_signals,
+            start_new_session=True,
+        )
+    except OSError as e:
+        log_file.write(f"Failed to start py-spy: {e}\n")
+        log_file.close()
+        print(f"WARNING: failed to start py-spy for pid {pid}: {e}")
+        return None
+
+    # Give py-spy a moment to fail on startup (missing permissions etc).
+    time.sleep(1)
+    if proc.poll() is not None:
+        log_file.write(f"py-spy exited early with code {proc.returncode}\n")
+        log_file.close()
+        print(
+            f"WARNING: py-spy failed to start for pid {pid} "
+            f"(code {proc.returncode})"
+        )
+        return None
+
+    log_file.write(f"py-spy pid: {proc.pid}\n")
+    log_file.flush()
+    print(f"py-spy started on {node_ip} for pid {pid} ({name}) -> {output_path}")
+    return (proc, log_file, output_path)
+
+
+def _stop_worker_pyspy(proc, log_file, timeout=60):
+    """SIGINT a single py-spy process and wait for it to flush output.
+
+    py-spy's ctrlc handler handles SIGINT only (SIGTERM hits the default
+    disposition and kills py-spy without flushing). See _reset_signals in
+    _attach_worker_pyspy for why SIGINT works here despite being inherited
+    as SIG_IGN from the Ray actor worker.
+    """
+    if proc is None:
+        return
+    try:
+        proc.send_signal(signal.SIGINT)
+        proc.wait(timeout=timeout)
+        msg = f"py-spy exited with code {proc.returncode}"
+        print(msg)
+        if log_file:
+            log_file.write(msg + "\n")
+    except subprocess.TimeoutExpired:
+        msg = f"py-spy did not exit in {timeout}s, killing"
+        print(msg)
+        proc.kill()
+        if log_file:
+            log_file.write(msg + "\n")
+    except ProcessLookupError:
+        msg = "py-spy already exited"
+        print(msg)
+        if log_file:
+            log_file.write(msg + "\n")
+    finally:
+        if log_file:
+            log_file.flush()
+            log_file.close()
+
+
+@ray.remote(num_cpus=0, num_gpus=0)
+class _UDFPySpyProfiler:
+    """Profiles Ray UDF Python workers on its node.
+
+    Actor is pinned to one node via NodeAffinitySchedulingStrategy. On
+    start() it polls for ray:: worker processes (which are spawned lazily
+    by the raylet once the pipeline begins) and attaches py-spy to each,
+    up to max_targets. Ray actors execute methods serially by default, so
+    stop() blocks until start() completes.
+    """
+
+    def __init__(self, outdir, max_targets=3):
+        self._outdir = outdir
+        self._max_targets = max_targets
+        self._profilers = []
+
+    def ping(self):
+        """Cheap method used by the driver to confirm scheduling.
+
+        Returns once the actor is scheduled and constructed, so the driver
+        can safely fire-and-forget start.remote() after this.
+        """
+        return ray.util.get_node_ip_address()
+
+    def start(self):
+        _ensure_pyspy_permissions()
+        workers = _find_ray_workers(self._max_targets)
+        name_counts = {}
+        for pid, name in workers:
+            handle = _attach_worker_pyspy(pid, name, self._outdir, name_counts)
+            if handle:
+                self._profilers.append(handle)
+        return len(self._profilers)
+
+    def stop(self):
+        for proc, log_file, _ in self._profilers:
+            _stop_worker_pyspy(proc, log_file)
+        self._profilers = []
+
+
+def start_worker_nodes(
+    outdir, num_cpu_workers=5, num_gpu_workers=5, max_targets_per_node=3
+):
+    """Launch py-spy profiling actors on a sample of worker nodes.
+
+    Args:
+        outdir: Shared storage directory for profile output.
+        num_cpu_workers: Number of CPU-only worker nodes to profile.
+        num_gpu_workers: Number of GPU worker nodes to profile.
+        max_targets_per_node: Max ray:: workers to attach py-spy to per node.
+
+    Returns:
+        List of actor handles for stop_workers.
+    """
+    head_node_id = ray.get_runtime_context().get_node_id()
+    monitored_node_ids = set()
+    actors = []
+    cpu_count = 0
+    gpu_count = 0
+    target_count = num_cpu_workers + num_gpu_workers
+
+    stale_polls = 0
+    max_stale_polls = 30  # 30 * 2s = 60s with no new nodes
+
+    while (cpu_count + gpu_count) < target_count:
+        found_new = False
+        for node in ray.nodes():
+            if not node["Alive"] or node["NodeID"] in monitored_node_ids:
+                continue
+            if node["NodeID"] == head_node_id:
+                continue
+            has_gpu = node["Resources"].get("GPU", 0) > 0
+            if has_gpu and gpu_count >= num_gpu_workers:
+                continue
+            if not has_gpu and cpu_count >= num_cpu_workers:
+                continue
+            try:
+                actor = _UDFPySpyProfiler.options(
+                    scheduling_strategy=NodeAffinitySchedulingStrategy(
+                        node_id=node["NodeID"], soft=False
+                    )
+                ).remote(outdir, max_targets=max_targets_per_node)
+                # Confirm scheduling with a cheap ping so stop() isn't left
+                # holding a dead handle later. GPU node actor startup can
+                # take > 30s on a freshly-provisioned cluster.
+                ray.get(actor.ping.remote(), timeout=90)
+                # Fire-and-forget start: the actor polls for ray:: workers to
+                # appear once the pipeline begins. ray.get()ing start here
+                # would block the driver before the pipeline has had a chance
+                # to spawn any workers.
+                actor.start.remote()
+                actors.append(actor)
+                monitored_node_ids.add(node["NodeID"])
+                if has_gpu:
+                    gpu_count += 1
+                else:
+                    cpu_count += 1
+                found_new = True
+                print(
+                    f"py-spy worker actor scheduled on {node['NodeManagerAddress']} "
+                    f"(cpu={cpu_count}/{num_cpu_workers}, "
+                    f"gpu={gpu_count}/{num_gpu_workers})"
+                )
+            except Exception as e:
+                monitored_node_ids.add(node["NodeID"])
+                print(
+                    f"Failed to schedule py-spy actor on "
+                    f"{node['NodeManagerAddress']}: {e}"
+                )
+        if not found_new:
+            stale_polls += 1
+            if stale_polls >= max_stale_polls:
+                print(
+                    f"py-spy: no new worker nodes for {max_stale_polls * 2}s, "
+                    f"proceeding with {cpu_count} CPU + {gpu_count} GPU "
+                    f"({len(actors)} actors attached)"
+                )
+                break
+        else:
+            stale_polls = 0
+        time.sleep(2)
+    if (cpu_count + gpu_count) >= target_count:
+        print(
+            f"py-spy worker actors scheduled on {cpu_count} CPU + "
+            f"{gpu_count} GPU worker nodes"
+        )
+    return actors
+
+
+def stop_workers(actors):
+    """Stop worker-node py-spy profilers.
+
+    Each actor's stop() runs after its start() has completed (Ray actors are
+    serial by default), so this finalizes any py-spy subprocesses that were
+    attached during the run.
+
+    Args:
+        actors: List of actor handles from start_worker_nodes.
+    """
+    if not actors:
+        return
+    print(f"Stopping {len(actors)} worker py-spy profilers...")
+    ray.get([a.stop.remote() for a in actors])

--- a/release/nightly_tests/dataset/profiling/telemetry.py
+++ b/release/nightly_tests/dataset/profiling/telemetry.py
@@ -1,0 +1,53 @@
+# ABOUTME: Uploads profiling and monitoring artifacts from shared storage to S3.
+# ABOUTME: Matches files by glob patterns and uploads them under a job-specific S3 prefix.
+
+import glob as globmod
+import os
+
+
+DEFAULT_S3_BUCKET = os.environ.get(
+    "PROFILING_S3_BUCKET",
+    "anyscale-staging-data-cld-kvedzwag2qa8i5bjxuevf5i7",
+)
+
+DEFAULT_UPLOAD_PATTERNS = [
+    "gpu_usage*",
+    "net_counters*",
+    "nsys_*",
+    "torch_profile_*",
+    "driver_gc*",
+    "pyspy_*",
+    "perf_*",
+    "result*.json",
+    "object_store_state*",
+    "actor_placement*",
+    "plasma_stats*",
+]
+
+
+def upload(outdir, s3_prefix, s3_bucket=None, patterns=None):
+    """Upload telemetry files from outdir to S3.
+
+    Args:
+        outdir: Local directory containing profiling/monitoring output.
+        s3_prefix: S3 key prefix (e.g. "image-embedding-jsonl/<job_id>").
+        s3_bucket: S3 bucket name. Defaults to PROFILING_S3_BUCKET env var.
+        patterns: List of glob patterns to match. Defaults to DEFAULT_UPLOAD_PATTERNS.
+    """
+    import boto3
+
+    if s3_bucket is None:
+        s3_bucket = DEFAULT_S3_BUCKET
+    if patterns is None:
+        patterns = DEFAULT_UPLOAD_PATTERNS
+
+    s3 = boto3.client("s3")
+    total_uploaded = 0
+    for pattern in patterns:
+        files = globmod.glob(os.path.join(outdir, pattern))
+        for filepath in files:
+            key = f"{s3_prefix}/{os.path.basename(filepath)}"
+            print(f"Uploading {filepath} -> s3://{s3_bucket}/{key}")
+            s3.upload_file(filepath, s3_bucket, key)
+            total_uploaded += 1
+    print(f"Uploaded {total_uploaded} telemetry files to s3://{s3_bucket}/{s3_prefix}/")

--- a/release/nightly_tests/dataset/worker_scaling_benchmark.py
+++ b/release/nightly_tests/dataset/worker_scaling_benchmark.py
@@ -10,10 +10,16 @@ map output block carrying a wide mixed-type schema:
 Stresses the per-block schema propagation path (``ray.get(meta_ref)`` +
 schema deserialization in ``on_data_ready``), which dominates large-schema
 production workloads.
+
+Profiling is gated by env vars consumed by ``profiling.coordinator.Profiling``
+(``PYSPY_ENABLED=1``, ``PERF_PROFILING_ENABLED=1`` etc.). When none are set,
+the coordinator is a no-op aside from printing its configuration.
 """
 
 import argparse
+import os
 import pickle
+import uuid
 from typing import Dict, List
 
 import numpy as np
@@ -24,6 +30,10 @@ from benchmark import (
     benchmark_py_modules,
     collect_dataset_stats,
 )
+from profiling.coordinator import Profiling
+
+JOB_ID = os.environ.get("ANYSCALE_JOB_ID", f"local-{uuid.uuid4().hex[:8]}")
+SHARED_OUTDIR = f"/mnt/shared_storage/worker_scaling/{JOB_ID}"
 
 BLOCKS_PER_WORKER: int = 10
 # Cap output block size to avoid OOM under wide schemas.
@@ -183,4 +193,18 @@ def main(args: argparse.Namespace):
 if __name__ == "__main__":
     ray.init(runtime_env={"py_modules": benchmark_py_modules()})
     args = parse_args()
-    main(args)
+
+    profiling = Profiling(outdir=SHARED_OUTDIR, num_gpu_nodes=0)
+    profiling.start(
+        extra_config={
+            "RAY_COMMIT": ray.__commit__,
+            "NUM_WORKERS": args.num_workers,
+            "WORKER_TYPE": args.worker_type,
+            "NUM_SCALAR_COLS": args.num_scalar_cols,
+            "NUM_ARRAY_COLS": args.num_array_cols,
+        }
+    )
+    try:
+        main(args)
+    finally:
+        profiling.stop(s3_prefix=f"worker-scaling/{JOB_ID}")

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -591,7 +591,10 @@
 
   run:
     timeout: 1800
+    # PYSPY_ENABLED=1 → driver-side py-spy speedscope is recorded by the
+    # profiling coordinator and uploaded to PROFILING_S3_BUCKET.
     script: >
+      PYSPY_ENABLED=1
       python worker_scaling_benchmark.py
       --num-workers {{num_workers}}
       --worker-type {{worker_type}}


### PR DESCRIPTION
## Summary

Add `release/nightly_tests/dataset/profiling/` so release benchmarks can capture driver py-spy, perf, nsys/NVTX, GPU/network/object-store telemetry and upload the artifacts to S3.

- All capture modes stay off unless their env vars are set (`PYSPY_ENABLED=1`, `PERF_PROFILING_ENABLED=1`, `PROFILER_MODE=nsys`, etc.).
- Wires the coordinator into `worker_scaling_benchmark.py` and enables `PYSPY_ENABLED=1` for the `worker_scaling_*` matrix so the StreamingExecutor scheduler-thread profile is reproducible from any release run.
- Replaces the throwaway `pyspy_profiler.py` that had been bundled into #63513.

Touches the same `worker_scaling` block in `release_data_tests.yaml` as #63513.