### PR TITLE
[RLlib] Support lowercase Torch activation aliases

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -2589,6 +2589,17 @@ py_test(
     deps = [":conftest"],
 )
 
+py_test(
+    name = "test_utils",
+    size = "small",
+    srcs = ["models/tests/test_utils.py"],
+    tags = [
+        "models",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
 # --------------------------------------------------------------------
 # Offline
 # rllib/offline/

--- a/rllib/models/tests/test_utils.py
+++ b/rllib/models/tests/test_utils.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch
+
+from ray.rllib.models.utils import get_activation_fn
+
+
+class _DummyTorchNN:
+    class GELU:
+        pass
+
+    class LeakyReLU:
+        pass
+
+
+class TestModelUtils(unittest.TestCase):
+    def test_get_torch_activation_fn_supports_lowercase_aliases(self):
+        with patch(
+            "ray.rllib.models.utils.try_import_torch",
+            return_value=(None, _DummyTorchNN),
+        ):
+            self.assertIs(
+                get_activation_fn("gelu", framework="torch"), _DummyTorchNN.GELU
+            )
+            self.assertIs(
+                get_activation_fn("leaky_relu", framework="torch"),
+                _DummyTorchNN.LeakyReLU,
+            )
+            self.assertIs(
+                get_activation_fn("leakyrelu", framework="torch"),
+                _DummyTorchNN.LeakyReLU,
+            )
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -12,7 +12,7 @@ def get_activation_fn(
     """Returns a framework specific activation function, given a name string.
 
     Args:
-        name: One of "relu" (default), "tanh", "elu",
+        name: One of "relu" (default), "tanh", "elu", "gelu", "leaky_relu",
             "swish" (or "silu", which is the same), or "linear" (same as None).
         framework: One of "jax", "tf|tf2" or "torch".
 
@@ -41,16 +41,19 @@ def get_activation_fn(
         if fn is not None:
             return fn
 
-        if name_lower in ["swish", "silu"]:
-            return nn.SiLU
-        elif name_lower == "relu":
-            return nn.ReLU
-        elif name_lower == "tanh":
-            return nn.Tanh
-        elif name_lower == "elu":
-            return nn.ELU
-        elif name_lower == "softmax":
-            return nn.Softmax
+        torch_activation_aliases_to_class_names = {
+            "swish": "SiLU",
+            "silu": "SiLU",
+            "relu": "ReLU",
+            "tanh": "Tanh",
+            "elu": "ELU",
+            "gelu": "GELU",
+            "leaky_relu": "LeakyReLU",
+            "leakyrelu": "LeakyReLU",
+            "softmax": "Softmax",
+        }
+        if name_lower in torch_activation_aliases_to_class_names:
+            return getattr(nn, torch_activation_aliases_to_class_names[name_lower])
     elif framework == "jax":
         if name_lower in ["linear", None]:
             return None

--- a/rllib/models/utils.py
+++ b/rllib/models/utils.py
@@ -13,7 +13,8 @@ def get_activation_fn(
 
     Args:
         name: One of "relu" (default), "tanh", "elu", "gelu", "leaky_relu",
-            "swish" (or "silu", which is the same), or "linear" (same as None).
+            "leakyrelu", "softmax", "swish" (or "silu", which is the same),
+            or "linear" (same as None).
         framework: One of "jax", "tf|tf2" or "torch".
 
     Returns:


### PR DESCRIPTION
Fixes #61076

## Summary
- Added lowercase Torch activation aliases for `gelu`, `leaky_relu`, and `leakyrelu` in `get_activation_fn`.
- Added focused unit coverage for alias resolution without requiring a real Torch install.

## Why
RLlib config users can pass lowercase activation names such as `relu` and `silu`, but lowercase GELU and LeakyReLU names were not resolved for Torch even though the canonical class names worked.

## Testing
- Ran: `.venv/bin/python -m pytest -v -s rllib/models/tests/test_utils.py` — passed
- Ran: `.venv/bin/ruff check rllib/models/utils.py rllib/models/tests/test_utils.py` — passed
- Ran: `.venv/bin/black --check rllib/models/utils.py rllib/models/tests/test_utils.py` — passed
- Ran: `.venv/bin/python -m py_compile rllib/models/utils.py rllib/models/tests/test_utils.py` — passed

## Notes
- `.venv/bin/pre-commit run --files rllib/models/utils.py rllib/models/tests/test_utils.py` could not complete because `nodeenv` failed SSL certificate verification while setting up an unrelated Node environment. The relevant Python lint checks passed directly.