### PR TITLE
[Core] Preserve uv command args with equals options

### DIFF
--- a/python/ray/_private/runtime_env/uv_runtime_env_hook.py
+++ b/python/ray/_private/runtime_env/uv_runtime_env_hook.py
@@ -241,15 +241,23 @@ def _parse_args(
     by keeping them in the command list instead of erroring and
     discarding them.
     """
-    parser.rargs = args
+    original_args = list(args)
+    parser.rargs = list(args)
     parser.largs = []
     options = parser.get_default_values()
     try:
         parser._process_args(parser.largs, parser.rargs, options)
     except optparse.BadOptionError as err:
-        # If we hit an argument that is not recognized, we put it
-        # back into the unconsumed arguments
-        parser.rargs = [err.opt_str] + parser.rargs
+        # Long options using `--option=value` are split by optparse before
+        # unknown options raise. Restore the original command suffix so callers
+        # can count the consumed `uv run` arguments accurately.
+        command_start = len(original_args) - len(parser.rargs)
+        if command_start < len(original_args) and original_args[
+            command_start
+        ].startswith(f"{err.opt_str}="):
+            parser.rargs = original_args[command_start:]
+        else:
+            parser.rargs = original_args[command_start - 1 :]
     return options, parser.rargs
 
 

--- a/python/ray/tests/test_runtime_env_uv_run.py
+++ b/python/ray/tests/test_runtime_env_uv_run.py
@@ -367,6 +367,18 @@ def test_uv_run_parser():
     assert options.module == "my_module.submodule"
     assert command == ["--model", "Qwen/Qwen3-32B"]
 
+    options, command = _parse_args(
+        parser,
+        [
+            "-m",
+            "ray.util.client.server",
+            "--address=172.18.0.2:6379",
+            "--host=127.0.0.1",
+        ],
+    )
+    assert options.module == "ray.util.client.server"
+    assert command == ["--address=172.18.0.2:6379", "--host=127.0.0.1"]
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Not ported to Windows yet.")
 def test_uv_run_runtime_env_hook_e2e(shutdown_only, temp_dir):


### PR DESCRIPTION
Fixes #62650

## Summary
- Preserve unknown `uv run` command arguments written as `--option=value` when the runtime-env hook stops parsing UV flags.
- Add parser regression coverage for Ray Client server arguments such as `--address=172.18.0.2:6379`.
- Keep the change scoped to the UV runtime-env argument boundary used to rebuild `py_executable`.

## Why
`optparse` splits an unknown long option written with `=` before raising `BadOptionError`. The UV runtime-env hook then undercounts the consumed `uv run` arguments and can truncate the wrapped command before its module argument. Restoring the original command suffix preserves the intended command boundary.

## Testing
- Ran: `.venv/bin/python -m pytest -v -s python/ray/tests/test_runtime_env_uv_run.py::test_uv_run_parser` - passed
- Ran: `.venv/bin/python -m pytest -v -s python/ray/tests/test_runtime_env_uv_run.py::test_uv_run_parser python/ray/tests/test_runtime_env_uv_run.py::test_uv_run_runtime_env_hook` - passed
- Ran: `.venv/bin/ruff check python/ray/_private/runtime_env/uv_runtime_env_hook.py python/ray/tests/test_runtime_env_uv_run.py` - passed
- Ran: `.venv/bin/black --check python/ray/_private/runtime_env/uv_runtime_env_hook.py python/ray/tests/test_runtime_env_uv_run.py` - passed
- Ran: `.venv/bin/python -m py_compile python/ray/_private/runtime_env/uv_runtime_env_hook.py python/ray/tests/test_runtime_env_uv_run.py` - passed

## Notes
- `.venv/bin/pre-commit run --files python/ray/_private/runtime_env/uv_runtime_env_hook.py python/ray/tests/test_runtime_env_uv_run.py` could not finish locally because `nodeenv` failed SSL certificate verification while setting up an unrelated Node hook; the targeted Python checks above passed.
