### PR TITLE
[ci][rllib] make py3.12 the default; gate py3.10 behind continuous-build

### DIFF
--- a/.buildkite/rllib.rayci.yml
+++ b/.buildkite/rllib.rayci.yml
@@ -1,25 +1,30 @@
 group: rllib tests
 depends_on:
   - forge
-  - ray-core-build(python=3.10)
+  - ray-core-build(*)
   - ray-dashboard-build
 steps:
   # builds
-  - name: rllibbuild
+  - name: rllibbuild-multipy
+    label: "wanda: rllibbuild-py{{array.python}}"
     wanda: ci/docker/rllib.build.wanda.yaml
-    depends_on: oss-ci-base_ml-multipy(python=3.10)
+    tags: cibase
+    array:
+      python:
+        - "3.10"
+        - "3.12"
     env:
-      PYTHON: "3.10"
+      PYTHON: "{{array.python}}"
       BASE_TYPE: "ml"
       BUILD_VARIANT: "build"
       RAYCI_IS_GPU_BUILD: "false"
-    tags: cibase
+    depends_on: oss-ci-base_ml-multipy($)
 
   - name: rllibgpubuild
     wanda: ci/docker/rllib.build.wanda.yaml
-    depends_on: oss-ci-base_gpu-multipy(python=3.10)
+    depends_on: oss-ci-base_gpu-multipy(python=3.12)
     env:
-      PYTHON: "3.10"
+      PYTHON: "3.12"
       BASE_TYPE: "gpu"
       BUILD_VARIANT: "gpubuild"
       RAYCI_IS_GPU_BUILD: "true"
@@ -37,9 +42,9 @@ steps:
         --only-tags env,evaluation,models,offline,policy,utils,algorithms,callbacks,core
         --except-tags gpu,multi_gpu,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
-    depends_on: rllibbuild
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
+    depends_on: rllibbuild-multipy(python=3.12)
 
   - label: ":brain: rllib: examples"
     tags: rllib
@@ -52,18 +57,18 @@ steps:
         --only-tags examples
         --except-tags gpu,multi_gpu,manual,examples_use_all_core
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
       # Tests all examples without gpu or multi_gpu
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --only-tags examples_use_all_core
         --except-tags gpu,multi_gpu,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
         --skip-ray-installation # reuse the same docker image as the previous run
-    depends_on: rllibbuild
+    depends_on: rllibbuild-multipy(python=3.12)
 
   - label: ":brain: rllib: learning tests"
     tags: rllib
@@ -76,18 +81,18 @@ steps:
         --only-tags learning_tests
         --except-tags gpu,multi_gpu,learning_tests_use_all_core,manual
         --test-arg --framework=torch
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
       # learning tests without a gpu but use all cores
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}" --worker-id "$${BUILDKITE_PARALLEL_JOB}"
         --only-tags learning_tests_use_all_core
         --except-tags gpu,multi_gpu,manual
         --test-arg --framework=torch
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
         --skip-ray-installation # reuse the same docker image as the previous run
-    depends_on: rllibbuild
+    depends_on: rllibbuild-multipy(python=3.12)
 
   - label: ":brain: rllib: gpu tests"
     tags:
@@ -104,8 +109,8 @@ steps:
         --except-tags multi_gpu,manual
         --test-env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
         --test-env=RLLIB_NUM_GPUS=1
-        --build-name rllibgpubuild-py3.10
-        --python-version 3.10
+        --build-name rllibgpubuild-py3.12
+        --python-version 3.12
     depends_on: rllibgpubuild
 
   - label: ":brain: rllib: multi-gpu tests"
@@ -123,8 +128,8 @@ steps:
         --gpus 4
         --only-tags multi_gpu
         --except-tags manual
-        --build-name rllibgpubuild-py3.10
-        --python-version 3.10
+        --build-name rllibgpubuild-py3.12
+        --python-version 3.12
     depends_on: rllibgpubuild
 
   - label: ":brain: rllib: doc tests"
@@ -139,23 +144,40 @@ steps:
         --only-tags doctest
         --except-tags gpu,manual
         --parallelism-per-worker 2
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
       # doc examples
       - bazel run //ci/ray_ci:test_in_docker -- //doc/... rllib
         --except-tags gpu,post_wheel_build,timeseries_libs,doctest
         --parallelism-per-worker 2
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
         --skip-ray-installation # reuse the same docker image as the previous run
       # documentation test
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
         --only-tags documentation
         --parallelism-per-worker 2
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
+        --skip-ray-installation # reuse the same docker image as the previous run
+    depends_on: rllibbuild-multipy(python=3.12)
+
+  - label: ":brain: rllib: python 3.10 component testing ({{matrix.worker_id}})"
+    if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
+    tags: rllib_directly
+    instance_type: large
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib
+        --workers 4 --worker-id {{matrix.worker_id}} --parallelism-per-worker 3
+        --only-tags env,evaluation,models,offline,policy,utils,algorithms,callbacks,core
+        --except-tags gpu,multi_gpu,manual
+        --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
         --build-name rllibbuild-py3.10
         --python-version 3.10
-        --skip-ray-installation # reuse the same docker image as the previous run
-    depends_on: rllibbuild
+    depends_on: rllibbuild-multipy(python=3.10)
+    matrix:
+      setup:
+        worker_id: ["0", "1", "2", "3"]
 
   - label: ":brain: rllib: flaky component & examples tests"
     key: rllib_flaky_tests_02
@@ -170,16 +192,16 @@ steps:
         --only-tags env,evaluation,models,offline,policy,utils,algorithms,callbacks,core
         --except-tags learning_tests,examples,documentation,gpu,multi_gpu,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
 
       # flaky examples
       - bazel run //ci/ray_ci:test_in_docker -- //rllib/... rllib  --run-flaky-tests --parallelism-per-worker 3
         --only-tags examples
         --except-tags multi_gpu,gpu,manual,examples_use_all_core
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
         --skip-ray-installation # reuse the same docker image as the previous run
 
       # flaky examples use all core
@@ -187,10 +209,10 @@ steps:
         --only-tags examples_use_all_core
         --except-tags gpu,multi_gpu,manual
         --test-env RAY_USE_MULTIPROCESSING_CPU_COUNT=1
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
         --skip-ray-installation # reuse the same docker image as the previous run
-    depends_on: rllibbuild
+    depends_on: rllibbuild-multipy(python=3.12)
     soft_fail: true
 
   - label: ":brain: rllib: flaky learning tests"
@@ -206,9 +228,9 @@ steps:
         --only-tags learning_tests
         --except-tags gpu,multi_gpu,manual
         --test-arg --framework=torch
-        --build-name rllibbuild-py3.10
-        --python-version 3.10
-    depends_on: rllibbuild
+        --build-name rllibbuild-py3.12
+        --python-version 3.12
+    depends_on: rllibbuild-multipy(python=3.12)
     soft_fail: true
 
   - label: ":brain: rllib: flaky gpu tests"
@@ -225,8 +247,8 @@ steps:
         --except-tags multi_gpu,manual
         --test-env=RAY_USE_MULTIPROCESSING_CPU_COUNT=1
         --test-env=RLLIB_NUM_GPUS=1
-        --build-name rllibgpubuild-py3.10
-        --python-version 3.10
+        --build-name rllibgpubuild-py3.12
+        --python-version 3.12
     depends_on: rllibgpubuild
     soft_fail: true
 
@@ -244,7 +266,7 @@ steps:
         --gpus 4
         --only-tags multi_gpu
         --except-tags manual
-        --build-name rllibgpubuild-py3.10
-        --python-version 3.10
+        --build-name rllibgpubuild-py3.12
+        --python-version 3.12
     depends_on: rllibgpubuild
     soft_fail: true


### PR DESCRIPTION
## Summary

Rebases on top of current master and **inverts** the previous design: instead of py3.10 on premerge with py3.12 added behind a gate, this PR makes **py3.12 the default for all rllib testing** and keeps a py3.10 safety net behind the `continuous-build` label.

Why: rllib is currently the only major Ray library without a CI signal on Python > 3.10, even though Ray supports 3.10–3.13 in `setup.py`. Following the same direction as core/data/serve, the cheapest path forward is to flip the primary version once py3.12 is healthy and keep the older Python as a smaller gated signal.

### Build changes

- `rllibbuild` → `rllibbuild-multipy` using the upstream array pattern (`array: python: [3.10, 3.12]`, `PYTHON`/`BASE_TYPE`/`BUILD_VARIANT` env vars, `depends_on: oss-ci-base_ml-multipy($)`).
- `rllibgpubuild` is kept as a single-Python build at py3.12 — no py3.10 GPU image is built anymore.
- Group-level `ray-core-build(python=3.10)` → `ray-core-build(*)` to match the matrix span (and `core.rayci.yml`).

### Test changes

- Premerge (component, examples, learning, doc, GPU, multi-GPU): **py3.12**.
- Postmerge-only flaky steps (component & examples, learning, gpu, multi-gpu): **py3.12** as well — flaky detection now matches the version we ship.
- One new gated step: `:brain: rllib: python 3.10 component testing ({{matrix.worker_id}})` — runs the component suite on py3.10 when the `continuous-build` label is present or the build is the postmerge / continuous-build pipeline. 4-worker matrix to match the parallelism of the premerge component step.

### Matches existing patterns

- Build matrix `[3.10, 3.12]` matches `corebuild-multipy`, `databuild-multipy`, `servebuild-multipy`. py3.11 is intentionally omitted: no Ray library tests on it today, and no depset locks exist for it.
- The gated step uses the same `if:` clause used everywhere else: `build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"`.

### Risk

This assumes rllib actually passes on py3.12. We have weak signal — `rllib-build-ci_depset_py3.12.lock` exists (deps install), and the broader Ray py3.12 migration landed long ago — but no test suite has been run against rllib on py3.12. If premerge breaks on this PR, the fall-back is to invert the design back to "premerge=py3.10, py3.12 gated" until we triage the failures.

## Test plan

- [ ] Confirm the no-label premerge run builds `rllibbuild-py3.10` and `rllibbuild-py3.12`, but only runs the py3.12 test steps.
- [ ] Apply the `continuous-build` label and confirm the new py3.10 component step spawns.
- [ ] Triage any py3.12-specific failures and fix them in a follow-up stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)