### PR TITLE
[Tune] Fix Tune search for python 3.14

### DIFF
--- a/python/ray/tune/search/basic_variant.py
+++ b/python/ray/tune/search/basic_variant.py
@@ -391,10 +391,12 @@ class BasicVariantGenerator(SearchAlgorithm):
             return False
         state = self.__dict__.copy()
         del state["_trial_generator"]
+        del state["_trial_iter"]
         return state
 
     def set_state(self, state):
         self.__dict__.update(state)
+        self._trial_iter = None
         for iterator in self._iterators:
             self._trial_generator = itertools.chain(self._trial_generator, iterator)
 

--- a/python/ray/tune/search/basic_variant.py
+++ b/python/ray/tune/search/basic_variant.py
@@ -397,6 +397,7 @@ class BasicVariantGenerator(SearchAlgorithm):
     def set_state(self, state):
         self.__dict__.update(state)
         self._trial_iter = None
+        self._trial_generator = []
         for iterator in self._iterators:
             self._trial_generator = itertools.chain(self._trial_generator, iterator)
 

--- a/python/ray/tune/tests/test_tune_restore.py
+++ b/python/ray/tune/tests/test_tune_restore.py
@@ -56,8 +56,6 @@ def _run(local_dir, driver_semaphore, trainer_semaphore):
 
 
 class TuneInterruptionTest(unittest.TestCase):
-    # Todo(krfricke): Investigate and fix on CI
-    @unittest.skip("Spawn seems to have a malfunction on Python 3.8 CI")
     def testExperimentInterrupted(self):
         local_dir = tempfile.mkdtemp()
         # Unix platforms may default to "fork", which is problematic with


### PR DESCRIPTION
## Description
In updating the release tests to check Python 3.14, I found
```python
Traceback (most recent call last):
--
  | File "/tmp/ray/session_2026-05-21_07-44-59_419182_2769/runtime_resources/working_dir_files/s3_ray-release-automation-results_working_dirs_tune_scalability_bookkeeping_overhead_aws_pwtghglleu__anyscale_pkg_5362fa14e94acaf695fd9b81bc1cfc3c/workloads/test_bookkeeping_overhead.py", line 43, in <module>
  | main()
  | ~~~~^^
  | File "/tmp/ray/session_2026-05-21_07-44-59_419182_2769/runtime_resources/working_dir_files/s3_ray-release-automation-results_working_dirs_tune_scalability_bookkeeping_overhead_aws_pwtghglleu__anyscale_pkg_5362fa14e94acaf695fd9b81bc1cfc3c/workloads/test_bookkeeping_overhead.py", line 33, in main
  | timed_tune_run(
  | ~~~~~~~~~~~~~~^
  | name="bookkeeping overhead",
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | ...<3 lines>...
  | max_runtime=max_runtime,
  | ^^^^^^^^^^^^^^^^^^^^^^^^
  | )
  | ^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/utils/release_test_util.py", line 153, in timed_tune_run
  | analysis = tune.run(
  | _train,
  | ...<3 lines>...
  | **run_kwargs,
  | )
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/tune.py", line 986, in run
  | runner.step()
  | ~~~~~~~~~~~^^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/execution/tune_controller.py", line 701, in step
  | raise e
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/execution/tune_controller.py", line 698, in step
  | self.checkpoint()
  | ~~~~~~~~~~~~~~~^^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/execution/tune_controller.py", line 352, in checkpoint
  | self._checkpoint_manager.sync_up_experiment_state(
  | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
  | save_fn=self.save_to_dir, force=force, wait=wait
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | )
  | ^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/execution/experiment_state.py", line 167, in sync_up_experiment_state
  | save_fn()
  | ~~~~~~~^^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/execution/tune_controller.py", line 348, in save_to_dir
  | self._search_alg.save_to_dir(driver_staging_path, session_str=self._session_str)
  | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/search/basic_variant.py", line 406, in save_to_dir
  | _atomic_save(
  | ~~~~~~~~~~~~^
  | state=state_dict,
  | ^^^^^^^^^^^^^^^^^
  | ...<2 lines>...
  | tmp_file_name=f"tmp-{file_name}",
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | )
  | ^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/tune/utils/util.py", line 416, in _atomic_save
  | cloudpickle.dump(state, f)
  | ~~~~~~~~~~~~~~~~^^^^^^^^^^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/cloudpickle/cloudpickle.py", line 1526, in dump
  | Pickler(file, protocol=protocol, buffer_callback=buffer_callback).dump(obj)
  | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^
  | File "/home/ray/anaconda3/lib/python3.14/site-packages/ray/cloudpickle/cloudpickle.py", line 1313, in dump
  | return super().dump(obj)
  | ~~~~~~~~~~~~^^^^^
  | TypeError: cannot pickle 'itertools.chain' object
  | when serializing dict item '_trial_iter'
  | Subprocess return code: 1
```

Reviewing python 3.14 release notes, https://docs.python.org/3/whatsnew/3.14.html#itertools, `pickle` support has been explicitly removed from all itertool functions. 
To resolve this problem, we can just lazily evaluate `_trial_iter` as it is updated in `next_trial` based on `_trial_generator`

## Related
https://github.com/ray-project/ray/pull/63270