### PR TITLE
[Serve][1/N] Add Serve accelerator config schemas

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -97,9 +97,11 @@ See the [model composition guide](serve-model-composition) for how to update cod
    serve.config.ControllerOptions
    serve.config.gRPCOptions
    serve.config.HTTPOptions
+   serve.config.AcceleratorConfig
    serve.config.AutoscalingConfig
    serve.config.AutoscalingPolicy
    serve.config.RequestRouterConfig
+   serve.config.TPUAcceleratorConfig
    serve.config.GangSchedulingConfig
    serve.config.DeploymentActorConfig
 ```

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -21,6 +21,7 @@ from ray._common import ray_option_utils
 from ray._common.serialization import pickle_dumps
 from ray._common.utils import resources_from_ray_options
 from ray.serve._private.constants import (
+    ACCELERATOR_KIND_TPU,
     DEFAULT_CONSTRUCTOR_RETRY_COUNT,
     DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT_S,
     DEFAULT_GRACEFUL_SHUTDOWN_WAIT_LOOP_S,
@@ -42,8 +43,9 @@ from ray.serve.config import (
     HTTPOptions,
     ProxyLocation,
     RequestRouterConfig,
-    _resolve_accelerator_config,
+    TPUAcceleratorConfig,
 )
+from ray.serve.generated import serve_pb2
 from ray.serve.generated.serve_pb2 import (
     AutoscalingConfig as AutoscalingConfigProto,
     DeploymentActorConfig as DeploymentActorConfigProto,
@@ -89,9 +91,12 @@ def _proto_to_dict(proto: Message) -> Dict:
             # `google.protobuf.internal.containers.RepeatedScalarFieldContainer
             # Explicitly convert to list
             if field.type == FieldDescriptor.TYPE_MESSAGE:
-                data[field.name] = [
-                    _proto_to_dict(v) for v in value
-                ]  # Convert each item
+                if field.message_type.GetOptions().map_entry:
+                    data[field.name] = dict(value)
+                else:
+                    data[field.name] = [
+                        _proto_to_dict(v) for v in value
+                    ]  # Convert each item
             else:
                 data[field.name] = list(value)  # Convert to list directly
         # Recursively call if the field is another protobuf.
@@ -328,10 +333,20 @@ class DeploymentConfig(BaseModel):
 
     def to_proto(self):
         data = self.model_dump()
-        if data.get("accelerator_config") is not None:
-            data[
-                "accelerator_config"
-            ] = self.accelerator_config.model_dump_json().encode("utf-8")
+        if self.accelerator_config is not None:
+            if isinstance(self.accelerator_config, TPUAcceleratorConfig):
+                tpu_proto = serve_pb2.TPUAcceleratorConfig(
+                    topology=self.accelerator_config.topology,
+                    accelerator_version=self.accelerator_config.accelerator_version,
+                    num_slices=self.accelerator_config.num_slices,
+                )
+                if self.accelerator_config.chips_per_vm is not None:
+                    tpu_proto.chips_per_vm = self.accelerator_config.chips_per_vm
+                if self.accelerator_config.resources_per_bundle is not None:
+                    tpu_proto.resources_per_bundle.update(
+                        self.accelerator_config.resources_per_bundle
+                    )
+                data["accelerator_config"] = serve_pb2.AcceleratorConfig(tpu=tpu_proto)
         if data.get("user_config") is not None:
             if self.needs_pickle():
                 data["user_config"] = cloudpickle.dumps(data["user_config"])
@@ -439,12 +454,26 @@ class DeploymentConfig(BaseModel):
             data["is_cross_language"] if "is_cross_language" in data else False
         )
         needs_pickle = _needs_pickle(deployment_language, is_cross_language)
-        if "accelerator_config" in data:
-            if data["accelerator_config"] != b"":
-                config_dict = json.loads(proto.accelerator_config.decode("utf-8"))
-                data["accelerator_config"] = _resolve_accelerator_config(config_dict)
+        if proto.HasField("accelerator_config"):
+            ac_proto = proto.accelerator_config
+            field = ac_proto.WhichOneof("config")
+            if field == ACCELERATOR_KIND_TPU:
+                tpu_proto = ac_proto.tpu
+                data["accelerator_config"] = TPUAcceleratorConfig(
+                    topology=tpu_proto.topology,
+                    accelerator_version=tpu_proto.accelerator_version,
+                    num_slices=tpu_proto.num_slices,
+                    chips_per_vm=tpu_proto.chips_per_vm
+                    if tpu_proto.HasField("chips_per_vm")
+                    else None,
+                    resources_per_bundle=dict(tpu_proto.resources_per_bundle)
+                    if tpu_proto.resources_per_bundle
+                    else None,
+                )
             else:
                 data["accelerator_config"] = None
+        else:
+            data["accelerator_config"] = None
         if "user_config" in data:
             if data["user_config"] != b"":
                 if needs_pickle:

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -32,6 +32,7 @@ from ray.serve._private.constants import (
 )
 from ray.serve._private.utils import DEFAULT, DeploymentOptionUpdateType
 from ray.serve.config import (
+    AcceleratorConfig,
     AggregationFunction,
     AutoscalingConfig,
     DeploymentActorConfig,
@@ -190,6 +191,10 @@ class DeploymentConfig(BaseModel):
         update_type=DeploymentOptionUpdateType.NeedsActorReconfigure,
     )
 
+    accelerator_config: Optional[AcceleratorConfig] = Field(
+        default=None, update_type=DeploymentOptionUpdateType.HeavyWeight
+    )
+
     # This flag is used to let replica know they are deployed from
     # a different language.
     is_cross_language: bool = False
@@ -322,6 +327,8 @@ class DeploymentConfig(BaseModel):
 
     def to_proto(self):
         data = self.model_dump()
+        if data.get("accelerator_config") is not None:
+            data["accelerator_config"] = cloudpickle.dumps(self.accelerator_config)
         if data.get("user_config") is not None:
             if self.needs_pickle():
                 data["user_config"] = cloudpickle.dumps(data["user_config"])
@@ -429,6 +436,11 @@ class DeploymentConfig(BaseModel):
             data["is_cross_language"] if "is_cross_language" in data else False
         )
         needs_pickle = _needs_pickle(deployment_language, is_cross_language)
+        if "accelerator_config" in data:
+            if data["accelerator_config"] != b"":
+                data["accelerator_config"] = cloudpickle.loads(proto.accelerator_config)
+            else:
+                data["accelerator_config"] = None
         if "user_config" in data:
             if data["user_config"] != b"":
                 if needs_pickle:

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -42,6 +42,7 @@ from ray.serve.config import (
     HTTPOptions,
     ProxyLocation,
     RequestRouterConfig,
+    _resolve_accelerator_config,
 )
 from ray.serve.generated.serve_pb2 import (
     AutoscalingConfig as AutoscalingConfigProto,
@@ -328,7 +329,9 @@ class DeploymentConfig(BaseModel):
     def to_proto(self):
         data = self.model_dump()
         if data.get("accelerator_config") is not None:
-            data["accelerator_config"] = cloudpickle.dumps(self.accelerator_config)
+            data[
+                "accelerator_config"
+            ] = self.accelerator_config.model_dump_json().encode("utf-8")
         if data.get("user_config") is not None:
             if self.needs_pickle():
                 data["user_config"] = cloudpickle.dumps(data["user_config"])
@@ -438,7 +441,8 @@ class DeploymentConfig(BaseModel):
         needs_pickle = _needs_pickle(deployment_language, is_cross_language)
         if "accelerator_config" in data:
             if data["accelerator_config"] != b"":
-                data["accelerator_config"] = cloudpickle.loads(proto.accelerator_config)
+                config_dict = json.loads(proto.accelerator_config.decode("utf-8"))
+                data["accelerator_config"] = _resolve_accelerator_config(config_dict)
             else:
                 data["accelerator_config"] = None
         if "user_config" in data:

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -347,6 +347,11 @@ class DeploymentConfig(BaseModel):
                         self.accelerator_config.resources_per_bundle
                     )
                 data["accelerator_config"] = serve_pb2.AcceleratorConfig(tpu=tpu_proto)
+            else:
+                raise TypeError(
+                    f"Unsupported accelerator configuration type: {type(self.accelerator_config)}. "
+                    "Currently only TPUAcceleratorConfig is supported."
+                )
         if data.get("user_config") is not None:
             if self.needs_pickle():
                 data["user_config"] = cloudpickle.dumps(data["user_config"])

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -43,6 +43,8 @@ SERVE_PROXY_NAME = "SERVE_PROXY_ACTOR"
 #: Ray namespace used for all Serve actors
 SERVE_NAMESPACE = "serve"
 
+ACCELERATOR_KIND_TPU = "tpu"
+
 DEFAULT_HTTP_HOST = os.environ.get("RAY_SERVE_DEFAULT_HTTP_HOST")
 
 #: HTTP Port

--- a/python/ray/serve/_private/version.py
+++ b/python/ray/serve/_private/version.py
@@ -79,6 +79,7 @@ class DeploymentVersion:
             or self.max_replicas_per_node != new_version.max_replicas_per_node
             or self.gang_scheduling_config_hash
             != new_version.gang_scheduling_config_hash
+            or self.accelerator_config_hash != new_version.accelerator_config_hash
         )
 
     def requires_actor_reconfigure(self, new_version):
@@ -124,6 +125,12 @@ class DeploymentVersion:
             else {}
         )
         self.gang_scheduling_config_hash = crc32(serialized_gang_scheduling_config)
+        serialized_accelerator_config = (
+            self.deployment_config.accelerator_config.model_dump_json().encode("utf-8")
+            if self.deployment_config.accelerator_config is not None
+            else b""
+        )
+        self.accelerator_config_hash = crc32(serialized_accelerator_config)
         # Include app-level route prefix in the version hashes so changing
         # it triggers an in-place reconfigure of running replicas.
         serialized_route_prefix = _serialize(self.route_prefix)
@@ -152,6 +159,7 @@ class DeploymentVersion:
                 ]
             )
             + serialized_gang_scheduling_config
+            + serialized_accelerator_config
         )
 
     def to_proto(self) -> bytes:

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -40,6 +40,7 @@ from ray.serve._private.utils import (
     wait_for_interrupt,
 )
 from ray.serve.config import (
+    AcceleratorConfig,
     AutoscalingConfig,
     ControllerOptions,
     DeploymentActorConfig,
@@ -47,6 +48,7 @@ from ray.serve.config import (
     HTTPOptions,
     ProxyLocation,
     RequestRouterConfig,
+    _resolve_accelerator_config,
     gRPCOptions,
 )
 from ray.serve.context import (
@@ -484,6 +486,7 @@ def deployment(
     user_config: Default[Optional[Any]] = DEFAULT.VALUE,
     max_ongoing_requests: Default[int] = DEFAULT.VALUE,
     max_queued_requests: Default[int] = DEFAULT.VALUE,
+    accelerator_config: Default[Union[Dict, AcceleratorConfig, None]] = DEFAULT.VALUE,
     autoscaling_config: Default[Union[Dict, AutoscalingConfig, None]] = DEFAULT.VALUE,
     graceful_shutdown_wait_loop_s: Default[float] = DEFAULT.VALUE,
     graceful_shutdown_timeout_s: Default[float] = DEFAULT.VALUE,
@@ -554,6 +557,9 @@ def deployment(
             Once this limit is reached, subsequent requests will raise a
             BackPressureError (for handles) or return an HTTP 503 status code (for HTTP
             requests). Defaults to -1 (no limit).
+        accelerator_config: Configuration for hardware accelerators, such as TPUs.
+            Can be passed as an unstructured dictionary or a structured `AcceleratorConfig`
+            subclass (e.g. `TPUAcceleratorConfig`). See `AcceleratorConfig` for options.
         autoscaling_config: Parameters to configure autoscaling behavior. If this
             is set, `num_replicas` should be "auto" or not set.
         graceful_shutdown_wait_loop_s: Duration that replicas wait until there is
@@ -654,11 +660,32 @@ def deployment(
     if isinstance(logging_config, LoggingConfig):
         logging_config = logging_config.model_dump()
 
+    if accelerator_config is not DEFAULT.VALUE and accelerator_config is not None:
+        accelerator_config = _resolve_accelerator_config(accelerator_config)
+
+        if (
+            gang_scheduling_config is not DEFAULT.VALUE
+            and gang_scheduling_config is not None
+        ):
+            # TODO(ryanaoleary@): Revisit this mutual exclusivity restriction once
+            # Data Parallel (DP) attention or more complex multi-slice gang
+            # scheduling is supported for TPUs.
+            #
+            # The only supported accelerator_config currently is for TPU, which utilizes
+            # SlicePlacementGroup internally for atomic scheduling of SPMD workers. This
+            # check can be loosened if additional accelerator configs are added in the
+            # future that don't manage their own gang scheduling.
+            raise ValueError(
+                "Cannot specify both `accelerator_config` and `gang_scheduling_config`. "
+                "Accelerator configurations automatically manage their own gang scheduling."
+            )
+
     deployment_config = DeploymentConfig.from_default(
         num_replicas=num_replicas if num_replicas is not None else 1,
         user_config=user_config,
         max_ongoing_requests=max_ongoing_requests,
         max_queued_requests=max_queued_requests,
+        accelerator_config=accelerator_config,
         autoscaling_config=autoscaling_config,
         graceful_shutdown_wait_loop_s=graceful_shutdown_wait_loop_s,
         graceful_shutdown_timeout_s=graceful_shutdown_timeout_s,

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -663,22 +663,26 @@ def deployment(
     if accelerator_config is not DEFAULT.VALUE and accelerator_config is not None:
         accelerator_config = _resolve_accelerator_config(accelerator_config)
 
-        if (
-            gang_scheduling_config is not DEFAULT.VALUE
-            and gang_scheduling_config is not None
-        ):
-            # TODO(ryanaoleary@): Revisit this mutual exclusivity restriction once
-            # Data Parallel (DP) attention or more complex multi-slice gang
-            # scheduling is supported for TPUs.
-            #
-            # The only supported accelerator_config currently is for TPU, which utilizes
-            # SlicePlacementGroup internally for atomic scheduling of SPMD workers. This
-            # check can be loosened if additional accelerator configs are added in the
-            # future that don't manage their own gang scheduling.
-            raise ValueError(
-                "Cannot specify both `accelerator_config` and `gang_scheduling_config`. "
-                "Accelerator configurations automatically manage their own gang scheduling."
-            )
+    has_accelerator = (
+        accelerator_config is not DEFAULT.VALUE and accelerator_config is not None
+    )
+    has_gang = (
+        gang_scheduling_config is not DEFAULT.VALUE
+        and gang_scheduling_config is not None
+    )
+    if has_accelerator and has_gang:
+        # TODO(ryanaoleary@): Revisit this mutual exclusivity restriction once
+        # Data Parallel (DP) attention or more complex multi-slice gang
+        # scheduling is supported for TPUs.
+        #
+        # The only supported accelerator_config currently is for TPU, which utilizes
+        # SlicePlacementGroup internally for atomic scheduling of SPMD workers. This
+        # check can be loosened if additional accelerator configs are added in the
+        # future that don't manage their own gang scheduling.
+        raise ValueError(
+            "Cannot specify both `accelerator_config` and `gang_scheduling_config`. "
+            "Accelerator configurations automatically manage their own gang scheduling."
+        )
 
     deployment_config = DeploymentConfig.from_default(
         num_replicas=num_replicas if num_replicas is not None else 1,

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -4,7 +4,7 @@ import logging
 import warnings
 from enum import Enum
 from functools import cached_property
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Union
 
 from pydantic import (
     BaseModel,
@@ -27,6 +27,7 @@ from ray.actor import ActorClass
 # Import types needed for AutoscalingContext
 from ray.serve._private.common import DeploymentID, ReplicaID, TimeSeries
 from ray.serve._private.constants import (
+    ACCELERATOR_KIND_TPU,
     DEFAULT_AUTOSCALING_POLICY_NAME,
     DEFAULT_GRPC_PORT,
     DEFAULT_HTTP_HOST,
@@ -709,6 +710,66 @@ class AutoscalingConfig(BaseModel):
         return self.target_ongoing_requests
 
 
+@PublicAPI(stability="alpha")
+class AcceleratorConfig(BaseModel):
+    """Base class for structured accelerator configurations.
+
+    Use a concrete subclass — e.g. :class:`TPUAcceleratorConfig` — when
+    declaring a deployment's accelerator requirements via
+    ``serve.deployment(accelerator_config=...)``.
+    """
+
+    kind: str = Field(
+        ..., description="Discriminator identifying the accelerator config type."
+    )
+
+    model_config = {"frozen": True, "extra": "forbid"}
+
+
+@PublicAPI(stability="alpha")
+class TPUAcceleratorConfig(AcceleratorConfig):
+    """TPU slice specification for a Serve deployment.
+
+    Mirrors the parameters of :func:`ray.util.tpu.slice_placement_group`.
+    Ray Serve uses this config to provision a TPU slice placement group
+    per replica and to manage its lifecycle through the controller.
+
+    When set on a deployment, this config drives placement-group creation
+    entirely. The deployment's ``placement_group_bundles`` and
+    ``placement_group_strategy`` fields are ignored - the bundles are
+    derived from ``topology`` (or optionally ``resources_per_bundle``),
+    and the strategy is chosen internally to honor slice gang scheduling.
+
+    Example:
+        >>> from ray.serve.config import TPUAcceleratorConfig
+        >>> config = TPUAcceleratorConfig(topology="4x4", accelerator_version="v6e")
+    """
+
+    kind: Literal["tpu"] = ACCELERATOR_KIND_TPU
+
+    topology: str = Field(
+        ..., description="TPU pod topology, e.g. '2x2', '4x4', '2x2x2'."
+    )
+    accelerator_version: str = Field(
+        ..., description="TPU accelerator version, e.g. 'v4', 'v5p', 'v6e'."
+    )
+    num_slices: int = Field(default=1, ge=1, description="Number of slices to reserve.")
+    chips_per_vm: Optional[int] = Field(
+        default=None,
+        description=(
+            "Override for chips per host. Defaults to the canonical value "
+            "for the given accelerator_version."
+        ),
+    )
+    resources_per_bundle: Optional[Dict[str, float]] = Field(
+        default=None,
+        description=(
+            "Resources to include in every worker bundle. When unspecified, "
+            "SlicePlacementGroup defaults to one bundle per TPU host with "
+            "the bundle resources set to the number of chips on that host. "
+            "See ray.util.tpu.slice_placement_group for details."
+        ),
+    )
 @PublicAPI(stability="stable")
 class ProxyLocation(str, Enum):
     """Config for where to run proxies to receive ingress traffic to the cluster.
@@ -1165,3 +1226,19 @@ class GangSchedulingConfig(BaseModel):
                 "RESTART_REPLICA policy is not yet implemented. File a GitHub issue if you need this feature."
             )
         return v
+
+
+def _resolve_accelerator_config(
+    value: Union[Dict, AcceleratorConfig, None],
+) -> Optional[AcceleratorConfig]:
+
+    if value is None or isinstance(value, AcceleratorConfig):
+        return value
+    if isinstance(value, dict):
+        kind = value.get("kind")
+        if kind == ACCELERATOR_KIND_TPU:
+            return TPUAcceleratorConfig(**value)
+        raise ValueError(f"Unknown accelerator kind {kind!r}. Supported types: 'tpu'.")
+    raise TypeError(
+        f"accelerator_config must be a dict or AcceleratorConfig, got {type(value)}."
+    )

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -725,6 +725,15 @@ class AcceleratorConfig(BaseModel):
 
     model_config = {"frozen": True, "extra": "forbid"}
 
+    @model_validator(mode="after")
+    def validate_concrete_subclass(self):
+        if type(self) is AcceleratorConfig:
+            raise ValueError(
+                "AcceleratorConfig is an abstract base class. "
+                "Please use a concrete subclass like TPUAcceleratorConfig."
+            )
+        return self
+
 
 @PublicAPI(stability="alpha")
 class TPUAcceleratorConfig(AcceleratorConfig):

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -770,6 +770,8 @@ class TPUAcceleratorConfig(AcceleratorConfig):
             "See ray.util.tpu.slice_placement_group for details."
         ),
     )
+
+
 @PublicAPI(stability="stable")
 class ProxyLocation(str, Enum):
     """Config for where to run proxies to receive ingress traffic to the cluster.

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -422,7 +422,8 @@ class Deployment:
         gc = new_deployment_config.gang_scheduling_config
         if ac is not None and gc is not None:
             raise ValueError(
-                "Cannot specify both `accelerator_config` and `gang_scheduling_config`."
+                "Cannot specify both `accelerator_config` and `gang_scheduling_config`. "
+                "Accelerator configurations automatically manage their own gang scheduling."
             )
 
         if deployment_actors is not DEFAULT.VALUE:

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -13,9 +13,11 @@ from ray.serve._private.constants import SERVE_LOGGER_NAME
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import DEFAULT, Default
 from ray.serve.config import (
+    AcceleratorConfig,
     AutoscalingConfig,
     DeploymentActorConfig,
     GangSchedulingConfig,
+    _resolve_accelerator_config,
 )
 from ray.serve.schema import DeploymentSchema, LoggingConfig, RayActorOptionsSchema
 from ray.util.annotations import PublicAPI
@@ -257,6 +259,9 @@ class Deployment:
         deployment_actors: Default[
             Optional[List[Union[Dict, DeploymentActorConfig]]]
         ] = DEFAULT.VALUE,
+        accelerator_config: Default[
+            Union[Dict, AcceleratorConfig, None]
+        ] = DEFAULT.VALUE,
     ) -> "Deployment":
         """Return a copy of this deployment with updated options.
 
@@ -408,6 +413,18 @@ class Deployment:
         if gang_scheduling_config is not DEFAULT.VALUE:
             new_deployment_config.gang_scheduling_config = gang_scheduling_config
 
+        if accelerator_config is not DEFAULT.VALUE:
+            if accelerator_config is not None:
+                accelerator_config = _resolve_accelerator_config(accelerator_config)
+            new_deployment_config.accelerator_config = accelerator_config
+
+        ac = new_deployment_config.accelerator_config
+        gc = new_deployment_config.gang_scheduling_config
+        if ac is not None and gc is not None:
+            raise ValueError(
+                "Cannot specify both `accelerator_config` and `gang_scheduling_config`."
+            )
+
         if deployment_actors is not DEFAULT.VALUE:
             new_deployment_config.deployment_actors = deployment_actors
 
@@ -513,6 +530,7 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
         "gang_scheduling_config": d._deployment_config.gang_scheduling_config,
         "deployment_actors": d._deployment_config.deployment_actors,
         "rolling_update_percentage": d._deployment_config.rolling_update_percentage,
+        "accelerator_config": d._deployment_config.accelerator_config,
     }
 
     # Let non-user-configured options be set to defaults. If the schema
@@ -577,6 +595,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         gang_scheduling_config=s.gang_scheduling_config,
         deployment_actors=s.deployment_actors,
         rolling_update_percentage=s.rolling_update_percentage,
+        accelerator_config=s.accelerator_config,
     )
     deployment_config.user_configured_option_names = (
         s._get_user_configured_option_names()

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -38,6 +38,7 @@ from ray.serve._private.constants import (
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.utils import DEFAULT, validate_ssl_config
 from ray.serve.config import (
+    AcceleratorConfig,
     AutoscalingConfig,
     AutoscalingPolicy,
     ControllerOptions,
@@ -45,6 +46,7 @@ from ray.serve.config import (
     GangSchedulingConfig,
     ProxyLocation,
     RequestRouterConfig,
+    _resolve_accelerator_config,
 )
 from ray.util.annotations import PublicAPI
 
@@ -478,6 +480,10 @@ class DeploymentSchema(BaseModel):
         gt=0.0,
         le=1.0,
     )
+    accelerator_config: Optional[Union[Dict, AcceleratorConfig]] = Field(
+        default=DEFAULT.VALUE,
+        description="Structured accelerator configuration for the deployment replicas.",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -498,6 +504,20 @@ class DeploymentSchema(BaseModel):
         elif num_replicas not in ["auto", None, DEFAULT.VALUE]:
             raise ValueError(
                 f'`num_replicas` must be an int or "auto", but got: {num_replicas}'
+            )
+
+        return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_accelerator_config(cls, values):
+        accelerator_config = values.get("accelerator_config", None)
+        if accelerator_config in [None, DEFAULT.VALUE]:
+            return values
+
+        if isinstance(accelerator_config, dict):
+            values["accelerator_config"] = _resolve_accelerator_config(
+                accelerator_config
             )
 
         return values
@@ -627,6 +647,21 @@ class DeploymentSchema(BaseModel):
         return self
 
     @model_validator(mode="after")
+    def validate_accelerator_config_and_gang_scheduling_config(self):
+        accelerator_config = self.accelerator_config
+        gang_scheduling_config = self.gang_scheduling_config
+
+        if accelerator_config not in [
+            DEFAULT.VALUE,
+            None,
+        ] and gang_scheduling_config not in [DEFAULT.VALUE, None]:
+            raise ValueError(
+                "Cannot specify both `accelerator_config` and `gang_scheduling_config`."
+            )
+
+        return self
+
+    @model_validator(mode="after")
     def validate_max_queued_requests(self):
         max_queued_requests = self.max_queued_requests
         if max_queued_requests is None or max_queued_requests == DEFAULT.VALUE:
@@ -688,6 +723,9 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
         schema.gang_scheduling_config = (
             info.deployment_config.gang_scheduling_config.model_dump()
         )
+
+    if info.deployment_config.accelerator_config is not None:
+        schema.accelerator_config = info.deployment_config.accelerator_config
 
     if info.deployment_config.deployment_actors is not None:
         deployment_actors = []

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -656,7 +656,8 @@ class DeploymentSchema(BaseModel):
             None,
         ] and gang_scheduling_config not in [DEFAULT.VALUE, None]:
             raise ValueError(
-                "Cannot specify both `accelerator_config` and `gang_scheduling_config`."
+                "Cannot specify both `accelerator_config` and `gang_scheduling_config`. "
+                "Accelerator configurations automatically manage their own gang scheduling."
             )
 
         return self

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -34,6 +34,7 @@ from ray.serve.config import (
     HTTPOptions,
     ProxyLocation,
     RequestRouterConfig,
+    TPUAcceleratorConfig,
     gRPCOptions,
 )
 from ray.serve.generated.serve_pb2 import (
@@ -1658,6 +1659,27 @@ class TestProtoToDict:
 
         # Optional field should not be filled.
         assert "initial_replicas" not in result
+
+
+def test_accelerator_config_proto_roundtrip():
+    """Test roundtrip serialization of AcceleratorConfig through protobuf."""
+    config = DeploymentConfig(
+        num_replicas=2,
+        accelerator_config=TPUAcceleratorConfig(
+            topology="2x2",
+            accelerator_version="v6e",
+        ),
+    )
+    deserialized = DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
+    assert deserialized.accelerator_config is not None
+    assert isinstance(deserialized.accelerator_config, TPUAcceleratorConfig)
+    assert deserialized.accelerator_config.topology == "2x2"
+    assert deserialized.accelerator_config.accelerator_version == "v6e"
+
+    # Test without accelerator_config
+    config = DeploymentConfig(num_replicas=2)
+    deserialized = DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
+    assert deserialized.accelerator_config is None
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -35,6 +35,7 @@ from ray.serve.config import (
     ProxyLocation,
     RequestRouterConfig,
     TPUAcceleratorConfig,
+    _resolve_accelerator_config,
     gRPCOptions,
 )
 from ray.serve.generated.serve_pb2 import (
@@ -1666,20 +1667,31 @@ def test_accelerator_config_proto_roundtrip():
     config = DeploymentConfig(
         num_replicas=2,
         accelerator_config=TPUAcceleratorConfig(
-            topology="2x2",
+            topology="4x4",
             accelerator_version="v6e",
+            num_slices=2,
+            chips_per_vm=8,
+            resources_per_bundle={"TPU": 4},
         ),
     )
     deserialized = DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
     assert deserialized.accelerator_config is not None
     assert isinstance(deserialized.accelerator_config, TPUAcceleratorConfig)
-    assert deserialized.accelerator_config.topology == "2x2"
+    assert deserialized.accelerator_config.topology == "4x4"
     assert deserialized.accelerator_config.accelerator_version == "v6e"
+    assert deserialized.accelerator_config.num_slices == 2
+    assert deserialized.accelerator_config.chips_per_vm == 8
+    assert deserialized.accelerator_config.resources_per_bundle == {"TPU": 4}
 
     # Test without accelerator_config
     config = DeploymentConfig(num_replicas=2)
     deserialized = DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
     assert deserialized.accelerator_config is None
+
+
+def test_unsupported_kind():
+    with pytest.raises(ValueError, match="Unknown accelerator kind"):
+        _resolve_accelerator_config({"kind": "xpu"})
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -1689,7 +1689,7 @@ def test_accelerator_config_proto_roundtrip():
     assert deserialized.accelerator_config is None
 
 
-def test_unsupported_kind():
+def test_unsupported_accelerator_config_kind():
     with pytest.raises(ValueError, match="Unknown accelerator kind"):
         _resolve_accelerator_config({"kind": "xpu"})
 

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -25,6 +25,7 @@ from ray.serve._private.request_router import PowerOfTwoChoicesRequestRouter
 from ray.serve._private.utils import DEFAULT
 from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.config import (
+    AcceleratorConfig,
     AutoscalingConfig,
     ControllerOptions,
     DeploymentActorConfig,
@@ -1692,6 +1693,16 @@ def test_accelerator_config_proto_roundtrip():
 def test_unsupported_accelerator_config_kind():
     with pytest.raises(ValueError, match="Unknown accelerator kind"):
         _resolve_accelerator_config({"kind": "xpu"})
+
+
+def test_unsupported_accelerator_subclass_to_proto():
+    class DummyAcceleratorConfig(AcceleratorConfig):
+        kind: str = "dummy"
+
+    dummy = DummyAcceleratorConfig()
+    config = DeploymentConfig(accelerator_config=dummy)
+    with pytest.raises(TypeError, match="Unsupported accelerator configuration type"):
+        config.to_proto()
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_deployment_version.py
+++ b/python/ray/serve/tests/unit/test_deployment_version.py
@@ -2,6 +2,7 @@ import pytest
 
 from ray.serve._private.config import DeploymentConfig
 from ray.serve._private.deployment_state import DeploymentVersion
+from ray.serve.config import TPUAcceleratorConfig
 
 
 def test_validation():
@@ -404,6 +405,33 @@ def test_requires_long_poll_broadcast():
     v1 = DeploymentVersion("1", DeploymentConfig(health_check_timeout_s=5), {})
     v2 = DeploymentVersion("1", DeploymentConfig(health_check_timeout_s=10), {})
     assert not v1.requires_long_poll_broadcast(v2)
+
+
+def test_accelerator_config_restart():
+    # Changing topology or other accelerator fields should require replica actor restart
+    v1 = DeploymentVersion(
+        "1",
+        DeploymentConfig(
+            accelerator_config=TPUAcceleratorConfig(
+                topology="2x2", accelerator_version="v6e"
+            )
+        ),
+        {},
+    )
+    v2 = DeploymentVersion(
+        "1",
+        DeploymentConfig(
+            accelerator_config=TPUAcceleratorConfig(
+                topology="4x4", accelerator_version="v6e"
+            )
+        ),
+        {},
+    )
+    assert v1.requires_actor_restart(v2)
+
+    # Going from no accelerator to having one should also require restart
+    v3 = DeploymentVersion("1", DeploymentConfig(), {})
+    assert v3.requires_actor_restart(v1)
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -599,6 +599,38 @@ class TestDeploymentSchema:
         schema = DeploymentSchema.model_validate(deployment_schema)
         assert schema.deployment_actors is None
 
+    def test_accelerator_config_schema_validation(self):
+        """Test that DeploymentSchema resolves accelerator_config to concrete models."""
+        deployment_schema = self.get_minimal_deployment_schema()
+        deployment_schema["accelerator_config"] = {
+            "kind": "tpu",
+            "topology": "2x2",
+            "accelerator_version": "v6e",
+        }
+
+        schema = DeploymentSchema.model_validate(deployment_schema)
+        assert isinstance(schema.accelerator_config, TPUAcceleratorConfig)
+        assert schema.accelerator_config.topology == "2x2"
+        assert schema.accelerator_config.accelerator_version == "v6e"
+
+    def test_mutually_exclusive_accelerator_config_and_gang_scheduling_config(self):
+        """Test that setting both accelerator_config and gang_scheduling_config is rejected."""
+        deployment_schema = self.get_minimal_deployment_schema()
+        deployment_schema["accelerator_config"] = {
+            "kind": "tpu",
+            "topology": "2x2",
+            "accelerator_version": "v6e",
+        }
+        deployment_schema["gang_scheduling_config"] = {
+            "gang_size": 2,
+        }
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot specify both `accelerator_config` and `gang_scheduling_config`",
+        ):
+            DeploymentSchema.model_validate(deployment_schema)
+
 
 class TestServeApplicationSchema:
     def get_valid_serve_application_schema(self):

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -18,6 +18,7 @@ from ray.serve.config import (
     GangPlacementStrategy,
     GangRuntimeFailurePolicy,
     GangSchedulingConfig,
+    TPUAcceleratorConfig,
 )
 from ray.serve.deployment import Deployment, deployment_to_schema, schema_to_deployment
 from ray.serve.schema import (
@@ -1217,6 +1218,85 @@ def test_schema_to_deployment_gang_scheduling_config_from_dict():
     assert gc.gang_size == 3
     assert gc.gang_placement_strategy == GangPlacementStrategy.PACK
     assert dep.num_replicas == 6
+
+
+def test_accelerator_config_deployment_schema_roundtrip():
+    # Ensure deployment_to_schema -> schema_to_deployment preserves accelerator_config
+    accelerator_config = TPUAcceleratorConfig(topology="4x4", accelerator_version="v6e")
+    dc = DeploymentConfig.from_default(
+        num_replicas=4,
+        accelerator_config=accelerator_config,
+    )
+    dc.user_configured_option_names = {"num_replicas", "accelerator_config"}
+
+    rc = ReplicaConfig.create(deployment_def="", init_args=(), init_kwargs={})
+    dep = Deployment(
+        name="TpuDep",
+        deployment_config=dc,
+        replica_config=rc,
+        _internal=True,
+    )
+
+    schema = deployment_to_schema(dep)
+    assert isinstance(schema.accelerator_config, TPUAcceleratorConfig)
+    assert schema.accelerator_config.topology == "4x4"
+    assert schema.accelerator_config.accelerator_version == "v6e"
+    assert schema.num_replicas == 4
+
+    dep2 = schema_to_deployment(schema)
+    ac2 = dep2._deployment_config.accelerator_config
+    assert isinstance(ac2, TPUAcceleratorConfig)
+    assert ac2.topology == "4x4"
+    assert ac2.accelerator_version == "v6e"
+    assert dep2.num_replicas == 4
+
+
+def test_schema_to_deployment_accelerator_config_from_dict():
+    # Ensure schema_to_deployment works when accelerator_config comes from a dict
+    schema = DeploymentSchema.model_validate(
+        {
+            "name": "TpuDep",
+            "num_replicas": 2,
+            "accelerator_config": {
+                "kind": "tpu",
+                "topology": "2x2",
+                "accelerator_version": "v6e",
+            },
+        }
+    )
+
+    assert isinstance(schema.accelerator_config, TPUAcceleratorConfig)
+    assert schema.accelerator_config.topology == "2x2"
+
+    dep = schema_to_deployment(schema)
+    ac = dep._deployment_config.accelerator_config
+    assert isinstance(ac, TPUAcceleratorConfig)
+    assert ac.topology == "2x2"
+    assert ac.accelerator_version == "v6e"
+    assert dep.num_replicas == 2
+
+
+def test_mutual_exclusivity_accelerator_and_gang():
+    # Cannot specify both accelerator_config and gang_scheduling_config
+    with pytest.raises(ValueError) as e:
+        DeploymentSchema.model_validate(
+            {
+                "name": "TpuDep",
+                "num_replicas": 2,
+                "accelerator_config": {
+                    "kind": "tpu",
+                    "topology": "2x2",
+                    "accelerator_version": "v6e",
+                },
+                "gang_scheduling_config": {
+                    "gang_size": 2,
+                },
+            }
+        )
+    assert (
+        "Cannot specify both `accelerator_config` and `gang_scheduling_config`"
+        in str(e.value)
+    )
 
 
 def test_deployment_actors_deployment_schema_roundtrip():

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -5,6 +5,7 @@ import sys
 from typing import Dict, List, Optional, Union
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
 import ray
@@ -13,6 +14,7 @@ from ray.serve._private.config import DeploymentConfig, ReplicaConfig
 from ray.serve._private.deploy_utils import get_app_code_version
 from ray.serve._private.utils import DEFAULT
 from ray.serve.config import (
+    AcceleratorConfig,
     AutoscalingConfig,
     DeploymentActorConfig,
     GangPlacementStrategy,
@@ -630,6 +632,37 @@ class TestDeploymentSchema:
             match="Cannot specify both `accelerator_config` and `gang_scheduling_config`",
         ):
             DeploymentSchema.model_validate(deployment_schema)
+
+    def test_abstract_accelerator_config_raises_error(self):
+        """Test that direct instantiation of the abstract AcceleratorConfig base class is rejected."""
+        with pytest.raises(
+            ValidationError, match="AcceleratorConfig is an abstract base class"
+        ):
+            AcceleratorConfig(kind="tpu")
+
+    def test_yaml_loading_and_validation(self):
+        """Test that DeploymentSchema resolves TPU configurations loaded from declarative YAML config strings."""
+        yaml_string = """
+name: my_tpu_deployment
+num_replicas: 2
+accelerator_config:
+  kind: tpu
+  topology: 4x4
+  accelerator_version: v6e
+  num_slices: 2
+  chips_per_vm: 8
+  resources_per_bundle:
+    TPU: 4
+"""
+        config_dict = yaml.safe_load(yaml_string)
+        schema = DeploymentSchema.model_validate(config_dict)
+
+        assert isinstance(schema.accelerator_config, TPUAcceleratorConfig)
+        assert schema.accelerator_config.topology == "4x4"
+        assert schema.accelerator_config.accelerator_version == "v6e"
+        assert schema.accelerator_config.num_slices == 2
+        assert schema.accelerator_config.chips_per_vm == 8
+        assert schema.accelerator_config.resources_per_bundle == {"TPU": 4}
 
 
 class TestServeApplicationSchema:
@@ -1329,6 +1362,40 @@ def test_mutual_exclusivity_accelerator_and_gang():
         "Cannot specify both `accelerator_config` and `gang_scheduling_config`"
         in str(e.value)
     )
+
+
+def test_serve_decorator_and_options_integration():
+    # 1. Verify serve.deployment decorator integration
+    @serve.deployment(
+        num_replicas=2,
+        accelerator_config={
+            "kind": "tpu",
+            "topology": "2x2",
+            "accelerator_version": "v6e",
+        },
+    )
+    class MyDecoratorDeployment:
+        pass
+
+    assert MyDecoratorDeployment.num_replicas == 2
+    config = MyDecoratorDeployment._deployment_config.accelerator_config
+    assert isinstance(config, TPUAcceleratorConfig)
+    assert config.topology == "2x2"
+    assert config.accelerator_version == "v6e"
+
+    # 2. Verify options() updates and preserves accelerator_config
+    updated_dep = MyDecoratorDeployment.options(
+        num_replicas=5,
+        accelerator_config={
+            "kind": "tpu",
+            "topology": "4x4",
+            "accelerator_version": "v6e",
+        },
+    )
+    assert updated_dep.num_replicas == 5
+    config2 = updated_dep._deployment_config.accelerator_config
+    assert isinstance(config2, TPUAcceleratorConfig)
+    assert config2.topology == "4x4"
 
 
 def test_deployment_actors_deployment_schema_roundtrip():

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -1397,6 +1397,23 @@ def test_serve_decorator_and_options_integration():
     assert isinstance(config2, TPUAcceleratorConfig)
     assert config2.topology == "4x4"
 
+    # 3. Verify mutual exclusivity raises ValueError in decorator
+    with pytest.raises(
+        ValueError,
+        match="Cannot specify both `accelerator_config` and `gang_scheduling_config`",
+    ):
+
+        @serve.deployment(
+            accelerator_config={
+                "kind": "tpu",
+                "topology": "2x2",
+                "accelerator_version": "v6e",
+            },
+            gang_scheduling_config={"gang_size": 2},
+        )
+        class ConflictDeployment:
+            pass
+
 
 def test_deployment_actors_deployment_schema_roundtrip():
     """Ensure deployment_to_schema -> schema_to_deployment preserves deployment_actors."""

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -249,6 +249,9 @@ message DeploymentConfig {
   // rolling upgrade) is distinguishable from an explicit value. When unset,
   // the Python side falls back to DEFAULT_ROLLING_UPDATE_PERCENTAGE (0.2).
   optional double rolling_update_percentage = 23;
+
+  // Serialized representation of AcceleratorConfig.
+  bytes accelerator_config = 24;
 }
 
 // Deployment language.

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -188,6 +188,20 @@ message DeploymentActorConfig {
   string actor_class_name = 6;
 }
 
+message TPUAcceleratorConfig {
+  string topology = 1;
+  string accelerator_version = 2;
+  int32 num_slices = 3;
+  optional int32 chips_per_vm = 4;
+  map<string, double> resources_per_bundle = 5;
+}
+
+message AcceleratorConfig {
+  oneof config {
+    TPUAcceleratorConfig tpu = 1;
+  }
+}
+
 // Configuration options for a deployment, to be set by the user.
 message DeploymentConfig {
   // The number of processes to start up that will handle requests to this deployment.
@@ -251,7 +265,7 @@ message DeploymentConfig {
   optional double rolling_update_percentage = 23;
 
   // Serialized representation of AcceleratorConfig.
-  bytes accelerator_config = 24;
+  optional AcceleratorConfig accelerator_config = 24;
 }
 
 // Deployment language.


### PR DESCRIPTION
## Description
PR split from https://github.com/ray-project/ray/pull/63179 based on this comment: https://github.com/ray-project/ray/pull/63179#pullrequestreview-4332971802. This PR contains just the new `AcceleratorConfig` schemas and the plumbing through `@serve.deployment`, `Deployment.options`, `DeploymentSchema` and the serve proto. This PR should be merged first, since the other PR contains these same changes.

## Related issues
https://github.com/ray-project/ray/issues/57137

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
