### PR TITLE
[Data] Reorder block columns by name before positional schema ops

### DIFF
--- a/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
+++ b/python/ray/data/_internal/arrow_ops/transform_pyarrow.py
@@ -335,6 +335,37 @@ def _unify_schemas_pyarrow(
     return pyarrow.unify_schemas(schemas, promote_options=promote_options)
 
 
+def reorder_columns_by_schema(
+    table: "pyarrow.Table", schema: "pyarrow.Schema"
+) -> "pyarrow.Table":
+    """Return `table` with its columns in the order of `schema.names`.
+
+    No-op when the column orders already match. Use before a positional
+    operation like `Table.cast(schema)` or
+    `RecordBatchReader.from_batches(schema, ...)` so blocks that share
+    the same field names in a different order — common when upstream
+    UDFs build dicts whose key order varies across workers — don't trip
+    the positional schema check.
+
+    Raises `ValueError` if `table` has any columns not in `schema.names`
+    (selecting on `schema.names` would silently drop them) and via
+    `Table.select` if `table` is missing any column in `schema.names`.
+    Callers reconciling field-set mismatches (e.g. via `unify_schemas`)
+    must handle that case before calling here.
+    """
+    if table.schema.names == schema.names:
+        return table
+    target_names = set(schema.names)
+    extra = [n for n in table.schema.names if n not in target_names]
+    if extra:
+        raise ValueError(
+            f"Table has columns not in target schema: {extra}. "
+            f"reorder_columns_by_schema only reorders an existing field set; "
+            f"reconcile the column set before calling."
+        )
+    return table.select(schema.names)
+
+
 def unify_schemas(
     schemas: List["pyarrow.Schema"], *, promote_types: bool = False
 ) -> "pyarrow.Schema":

--- a/python/ray/data/_internal/datasource/clickhouse_datasink.py
+++ b/python/ray/data/_internal/datasource/clickhouse_datasink.py
@@ -13,6 +13,9 @@ import pyarrow
 import pyarrow as pa
 import pyarrow.types as pat
 
+from ray.data._internal.arrow_ops.transform_pyarrow import (
+    reorder_columns_by_schema,
+)
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.util import _check_import
 from ray.data.block import Block, BlockAccessor
@@ -409,6 +412,7 @@ class ClickHouseDatasink(Datasink):
                 arrow_table = BlockAccessor.for_block(block).to_arrow()
                 row_count = arrow_table.num_rows
                 if self._schema is not None:
+                    arrow_table = reorder_columns_by_schema(arrow_table, self._schema)
                     arrow_table = arrow_table.cast(self._schema, safe=True)
                 if self._max_insert_block_rows is not None:
                     max_chunk_size = self._max_insert_block_rows

--- a/python/ray/data/_internal/datasource/lance_datasink.py
+++ b/python/ray/data/_internal/datasource/lance_datasink.py
@@ -16,6 +16,9 @@ from typing import (
 import pyarrow as pa
 
 from ray._common.retry import call_with_retry
+from ray.data._internal.arrow_ops.transform_pyarrow import (
+    reorder_columns_by_schema,
+)
 from ray.data._internal.datasource.lance_utils import (
     create_storage_options_provider,
     get_or_create_namespace,
@@ -121,6 +124,9 @@ def _write_fragment(
     def record_batch_converter(block_stream):
         for block in block_stream:
             tbl = BlockAccessor.for_block(block).to_arrow()
+            # `RecordBatchReader.from_batches(schema, ...)` is positional.
+            if schema is not None:
+                tbl = reorder_columns_by_schema(tbl, schema)
             yield from tbl.to_batches()
 
     max_bytes_per_file = (

--- a/python/ray/data/_internal/datasource/parquet_datasink.py
+++ b/python/ray/data/_internal/datasource/parquet_datasink.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional
 
 from ray._common.retry import call_with_retry
+from ray.data._internal.arrow_ops.transform_pyarrow import (
+    reorder_columns_by_schema,
+)
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.planner.plan_write_op import WRITE_UUID_KWARG_NAME
 from ray.data._internal.savemode import SaveMode
@@ -259,9 +262,11 @@ class ParquetDatasink(_FileDatasink):
     ) -> None:
         import pyarrow.dataset as ds
 
-        # Make every incoming batch conform to the final schema *before* writing
+        # Make every incoming batch conform to the final schema *before* writing.
+        # `pa.unify_schemas` above fixed column order from the first block.
         for idx, table in enumerate(tables):
             if output_schema and not table.schema.equals(output_schema):
+                table = reorder_columns_by_schema(table, output_schema)
                 table = table.cast(output_schema)
             tables[idx] = table
 

--- a/python/ray/data/tests/datasource/test_clickhouse.py
+++ b/python/ray/data/tests/datasource/test_clickhouse.py
@@ -784,14 +784,14 @@ class TestClickHouseDatasink:
                 SinkMode.CREATE,
                 pa.schema([("id", pa.int32())]),
                 [("id", pa.int32()), ("extra_col", pa.int32())],
-                r"(ArrowInvalid|Could not convert|field names are not matching.*)",
+                r"(ArrowInvalid|Could not convert|field names are not matching|columns not in target schema.*)",
             ),
             (
                 True,
                 SinkMode.OVERWRITE,
                 pa.schema([("id", pa.timestamp("ns"))]),
                 [("id", pa.int32())],
-                r"(ArrowInvalid|Could not convert|field names are not matching|Unsupported cast.*)",
+                r"(ArrowInvalid|Could not convert|field names are not matching|columns not in target schema|Unsupported cast.*)",
             ),
         ],
     )

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -92,6 +92,38 @@ def test_read_parquet_rejects_pickle_object_columns(
     assert not marker.exists(), "pickle.load executed attacker code"
 
 
+def test_write_parquet_handles_per_block_column_reorder(
+    ray_start_regular_shared, tmp_path
+):
+    # When the Write task receives multiple blocks whose schemas share the same
+    # field names in a different order, `pa.unify_schemas` fixes the column
+    # order from the first block. Previously the per-block `Table.cast` was
+    # positional and rejected the second block; ParquetDatasink now reorders
+    # columns by name before casting.
+    from ray.data._internal.datasource.parquet_datasink import (
+        WRITE_UUID_KWARG_NAME,
+        ParquetDatasink,
+    )
+    from ray.data._internal.execution.interfaces import TaskContext
+
+    t1 = pa.table({"x": [1], "y": [2]})
+    t2 = pa.table({"y": [3], "x": [4]})
+    sink = ParquetDatasink(path=str(tmp_path))
+    ctx = TaskContext(task_idx=0, op_name="Write")
+    ctx.kwargs = {WRITE_UUID_KWARG_NAME: "wuid"}
+
+    sink.write([t1, t2], ctx)
+
+    out = pq.read_table(str(tmp_path))
+    assert sorted(out.column_names) == ["x", "y"]
+    assert out.num_rows == 2
+    # Pair each row's (x, y) regardless of the unified output order.
+    assert sorted(zip(out.column("x").to_pylist(), out.column("y").to_pylist())) == [
+        (1, 2),
+        (4, 3),
+    ]
+
+
 def test_write_parquet_supports_gzip(ray_start_regular_shared, tmp_path):
     ray.data.range(1).write_parquet(tmp_path, compression="gzip")
 


### PR DESCRIPTION
## Why are these changes needed?

Three Ray Data datasinks crash or silently corrupt data when an upstream
operator emits blocks whose schemas share the same field names in a
different order. PyArrow's positional schema-alignment primitives reject
permuted blocks instead of reordering them by name.

### 1. `ParquetDatasink`

`ParquetDatasink.write` computes its target schema with
`pa.unify_schemas`, which takes the first block's column order as
authoritative. It then calls `Table.cast(output_schema)` on every
remaining block whose schema doesn't already equal the target. PyArrow's
`Table.cast` is positional — a block with the same field names in a
different order trips:

```
ValueError: Target schema's field names are not matching the table's
field names: ['y', 'x', ...], ['x', 'y', ...]
```

**Fix:** call `reorder_columns_by_schema(table, output_schema)` before
the cast so the per-block reorder is by name; `cast` then only has type
promotion to do.

### 2. `ClickHouseDatasink`

`arrow_table.cast(self._schema, safe=True)` against the destination
ClickHouse table's schema is also positional, so a block emitted with
the destination columns in a different order fails the same way before
any rows are inserted.

**Fix:** same — call `reorder_columns_by_schema(arrow_table, self._schema)`
before the cast.

### 3. `LanceDatasink`

`RecordBatchReader.from_batches(schema, ...)` is positional too —
depending on the pyarrow/Lance combo it either errors during reads or
silently misinterprets reordered batches as the wrong types, which is
worse than the parquet case because it can corrupt data rather than
fail loudly.

**Fix:** call `reorder_columns_by_schema(tbl, schema)` inside
`_write_fragment`'s `record_batch_converter` before yielding batches.

### How this surfaces in a real job

Two conditions have to coincide. Neither is exotic.

**1. Upstream UDF emits same-fields-different-order blocks.** Any
`map_batches` UDF that builds its yielded dict from a container with
non-deterministic iteration order produces this. The most common
shape: a UDF that needs to emit the *union* of keys observed across
input rows uses a `set` to dedupe them, then iterates the set:

```python
async def __call__(self, batch):
    out_rows = [...]   # rows whose schemas may differ per-row
    all_keys = set()
    for r in out_rows:
        all_keys.update(r)
    yield {k: [r.get(k) for r in out_rows] for k in all_keys}
```

Python set iteration order depends on `PYTHONHASHSEED`, which differs
across processes — and each Ray Data `MapWorker` is a separate Python
process. So two actors processing structurally identical inputs emit
blocks with the same field *names* in different *orders*. This is the
exact pattern that triggered the production failure prompting this PR.

**2. Multiple of those blocks land in one Write task.** By default
`map_batches → write_parquet` is fused into one physical operator and
each fused task writes its own single block, so per-task
`pa.unify_schemas([only_one_schema])` is trivially equal and the cast
is a no-op. Fusion gets broken whenever the pipeline has anything
between the two — an explicit `.materialize()`, an `AllToAll` operator
like `.repartition()`, or sufficient block volume that the Write op's
`min_rows_per_bundled_input` (= `min_rows_per_file` for parquet) kicks
in and groups multiple upstream blocks per Write task. Once two
permuted-order blocks share a Write task, `pa.unify_schemas` fixes the
first block's order as the target and the second block fails the cast.

The traceback from the failing production job matches verbatim:

```
File ".../ray/data/_internal/datasource/parquet_datasink.py",
  line 276, in _write_parquet_files
    table = table.cast(output_schema)
ValueError: Target schema's field names are not matching the table's
  field names: ['y', 'x', ...], ['x', 'y', ...]
```

### Minimal repro

```python
import pyarrow as pa
from ray.data._internal.datasource.parquet_datasink import (
    ParquetDatasink, WRITE_UUID_KWARG_NAME,
)
from ray.data._internal.execution.interfaces import TaskContext

t1 = pa.table({"x": [1], "y": [2]})
t2 = pa.table({"y": [3], "x": [4]})
ctx = TaskContext(task_idx=0, op_name="Write")
ctx.kwargs = {WRITE_UUID_KWARG_NAME: "wuid"}
ParquetDatasink(path="/tmp/out").write([t1, t2], ctx)
# raises: Target schema's field names are not matching ...
```

## What this changes

- New helper `reorder_columns_by_schema(table, schema)` in
  `ray.data._internal.arrow_ops.transform_pyarrow` that projects a
  table's columns to match a target schema's name order (no-op when
  they already match).
- Calls it from `ParquetDatasink`, `ClickHouseDatasink`, and
  `LanceDatasink` before their respective positional schema operation
  (see "Fix:" notes above).
- Adds a `ParquetDatasink.write` regression test that exercises two
  permuted blocks in one Write task.

## Related issue number

n/a — caught while debugging a Ray Data pipeline failure.

## Checks

- [x] I've signed off every commit (by using the `-s` flag), see https://docs.ray.io/en/master/ray-contribute/getting-involved.html#signing-the-cla
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. If not, I've explained why my changes don't require it.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
