### PR TITLE
[llm][docs] Document multimodal pixel-budget gotchas and vLLM compatibility

### DIFF
--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -63,7 +63,7 @@ video_processor_config = vLLMEngineProcessorConfig(
         "model_config_kwargs": dict(
             # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
             allowed_local_media_path="/tmp",
-            media_io_kwargs={"video": {"num_frames": 60, "fps": 2}},
+            media_io_kwargs={"video": {"num_frames": 20, "fps": 2}},
         ),
     },
     chat_template_stage=True,
@@ -196,7 +196,7 @@ def create_vlm_video_config():
             "model_config_kwargs": dict(
                 # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
                 allowed_local_media_path="/tmp",
-                media_io_kwargs={"video": {"num_frames": 60, "fps": 2}},
+                media_io_kwargs={"video": {"num_frames": 20, "fps": 2}},
             ),
         },
         chat_template_stage=True,

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -40,23 +40,6 @@ from ray.data.llm import (
 
 
 # __vlm_video_config_example_start__
-# vLLM has a two-stage video pipeline. ``media_io_kwargs["video"]`` controls
-# frame sampling in vLLM's video I/O; ``mm_processor_kwargs`` is forwarded to
-# the HF processor and controls per-frame resizing via the visual-token pixel
-# budget. vLLM reads the engine-level budget once at startup to size memory
-# profiling and the KV cache, so it must cover the worst-case input;
-# per-request overrides may only go *smaller* without OOM risk. If the input
-# exceeds the budget, the HF processor silently downscales it.
-#
-# Knob names differ by model family: Qwen3-VL+ uses ``size.longest_edge`` /
-# ``size.shortest_edge``; the older Qwen2-VL ``max_pixels`` / ``min_pixels``
-# names are dropped before reaching the HF processor on Qwen3-VL+. See the
-# vLLM and HF processor docs for the kwargs each model accepts.
-#
-# Worked example (Qwen3-VL, patch_size=16, merge_size=2, temporal_patch_size=2):
-# a 20-frame 1080p window needs ``20 * 1088 * 1920 ~= 41.8M`` pixels; the
-# model's default video budget (25.17M) downscales anything above ~12 frames
-# at 1080p.
 video_processor_config = vLLMEngineProcessorConfig(
     model_source="Qwen/Qwen3-VL-4B-Instruct",
     engine_kwargs=dict(
@@ -64,16 +47,11 @@ video_processor_config = vLLMEngineProcessorConfig(
         pipeline_parallel_size=1,
         trust_remote_code=True,
         limit_mm_per_prompt={"video": 1},
-        # Stage 2: HF processor resizing. vLLM reads this once at startup to
-        # size memory profiling and the KV cache, so it must cover the
-        # worst-case input. Per-row overrides may only go *smaller*.
         mm_processor_kwargs={
             "size": {
                 "shortest_edge": 65536,
                 "longest_edge": 20 * 1088 * 1920,
             },
-            # Stage-1 sampling above already produced the final frames;
-            # skip the HF processor's own re-sampling.
             "do_sample_frames": False,
         },
     ),
@@ -85,10 +63,6 @@ video_processor_config = vLLMEngineProcessorConfig(
         "model_config_kwargs": dict(
             # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
             allowed_local_media_path="/tmp",
-            # Stage 1: vLLM video I/O frame sampling. In Ray Data LLM the
-            # PrepareMultimodalStage decodes media into arrays before the
-            # engine runs, so media_io_kwargs must be set here (not in
-            # engine_kwargs) to take effect.
             media_io_kwargs={"video": {"num_frames": 60, "fps": 2}},
         ),
     },
@@ -138,11 +112,6 @@ def video_preprocess(row: dict) -> dict:
             "max_tokens": 150,
             "detokenize": False,
         },
-        # The visual-token pixel budget is set engine-side in
-        # ``engine_kwargs["mm_processor_kwargs"]``. A per-row
-        # ``mm_processor_kwargs`` can override that budget *smaller* for a
-        # single row, but never larger than the engine ceiling without OOM
-        # risk.
     }
 
 

--- a/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
+++ b/doc/source/data/doc_code/working-with-llms/vlm_video_example.py
@@ -40,6 +40,23 @@ from ray.data.llm import (
 
 
 # __vlm_video_config_example_start__
+# vLLM has a two-stage video pipeline. ``media_io_kwargs["video"]`` controls
+# frame sampling in vLLM's video I/O; ``mm_processor_kwargs`` is forwarded to
+# the HF processor and controls per-frame resizing via the visual-token pixel
+# budget. vLLM reads the engine-level budget once at startup to size memory
+# profiling and the KV cache, so it must cover the worst-case input;
+# per-request overrides may only go *smaller* without OOM risk. If the input
+# exceeds the budget, the HF processor silently downscales it.
+#
+# Knob names differ by model family: Qwen3-VL+ uses ``size.longest_edge`` /
+# ``size.shortest_edge``; the older Qwen2-VL ``max_pixels`` / ``min_pixels``
+# names are dropped before reaching the HF processor on Qwen3-VL+. See the
+# vLLM and HF processor docs for the kwargs each model accepts.
+#
+# Worked example (Qwen3-VL, patch_size=16, merge_size=2, temporal_patch_size=2):
+# a 20-frame 1080p window needs ``20 * 1088 * 1920 ~= 41.8M`` pixels; the
+# model's default video budget (25.17M) downscales anything above ~12 frames
+# at 1080p.
 video_processor_config = vLLMEngineProcessorConfig(
     model_source="Qwen/Qwen3-VL-4B-Instruct",
     engine_kwargs=dict(
@@ -47,6 +64,18 @@ video_processor_config = vLLMEngineProcessorConfig(
         pipeline_parallel_size=1,
         trust_remote_code=True,
         limit_mm_per_prompt={"video": 1},
+        # Stage 2: HF processor resizing. vLLM reads this once at startup to
+        # size memory profiling and the KV cache, so it must cover the
+        # worst-case input. Per-row overrides may only go *smaller*.
+        mm_processor_kwargs={
+            "size": {
+                "shortest_edge": 65536,
+                "longest_edge": 20 * 1088 * 1920,
+            },
+            # Stage-1 sampling above already produced the final frames;
+            # skip the HF processor's own re-sampling.
+            "do_sample_frames": False,
+        },
     ),
     batch_size=1,
     accelerator_type="L4",
@@ -56,6 +85,11 @@ video_processor_config = vLLMEngineProcessorConfig(
         "model_config_kwargs": dict(
             # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
             allowed_local_media_path="/tmp",
+            # Stage 1: vLLM video I/O frame sampling. In Ray Data LLM the
+            # PrepareMultimodalStage decodes media into arrays before the
+            # engine runs, so media_io_kwargs must be set here (not in
+            # engine_kwargs) to take effect.
+            media_io_kwargs={"video": {"num_frames": 60, "fps": 2}},
         ),
     },
     chat_template_stage=True,
@@ -104,12 +138,11 @@ def video_preprocess(row: dict) -> dict:
             "max_tokens": 150,
             "detokenize": False,
         },
-        # Optional: Multimodal processor kwargs for video processing
-        "mm_processor_kwargs": dict(
-            min_pixels=28 * 28,
-            max_pixels=1280 * 28 * 28,
-            fps=1,
-        ),
+        # The visual-token pixel budget is set engine-side in
+        # ``engine_kwargs["mm_processor_kwargs"]``. A per-row
+        # ``mm_processor_kwargs`` can override that budget *smaller* for a
+        # single row, but never larger than the engine ceiling without OOM
+        # risk.
     }
 
 
@@ -178,6 +211,13 @@ def create_vlm_video_config():
             pipeline_parallel_size=1,
             trust_remote_code=True,
             limit_mm_per_prompt={"video": 1},
+            mm_processor_kwargs={
+                "size": {
+                    "shortest_edge": 65536,
+                    "longest_edge": 20 * 1088 * 1920,
+                },
+                "do_sample_frames": False,
+            },
         ),
         batch_size=1,
         accelerator_type="L4",
@@ -187,6 +227,7 @@ def create_vlm_video_config():
             "model_config_kwargs": dict(
                 # See available model config kwargs at https://docs.vllm.ai/en/latest/api/vllm/config/#vllm.config.ModelConfig
                 allowed_local_media_path="/tmp",
+                media_io_kwargs={"video": {"num_frames": 60, "fps": 2}},
             ),
         },
         chat_template_stage=True,

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -614,7 +614,7 @@ Each Ray release is fully tested with a compatible vLLM version.
 
 .. list-table::
    :header-rows: 1
-   :widths: 8 8
+   :widths: auto
 
    * - Ray release
      - vLLM version
@@ -638,10 +638,10 @@ GPU memory and CUDA OOM
 
 If you encounter CUDA out of memory errors, try these strategies:
 
-- **Reduce batch size**: Start with 8-16 and increase gradually
-- **Lower ``max_num_batched_tokens``**: Reduce from 4096 to 2048 or 1024
-- **Decrease ``max_model_len``**: Use shorter context lengths
-- **Set ``gpu_memory_utilization``**: Use 0.75-0.85 instead of default 0.90
+- Reduce batch size: Start with 8-16 and increase gradually
+- Lower ``max_num_batched_tokens``: Reduce from 4096 to 2048 or 1024
+- Decrease ``max_model_len``: Use shorter context lengths
+- Set ``gpu_memory_utilization``: Use 0.75-0.85 instead of default 0.90
 
 .. literalinclude:: doc_code/working-with-llms/basic_llm_example.py
     :language: python
@@ -694,6 +694,6 @@ If you encounter issues not covered in this guide:
 - `Ray GitHub Issues <https://github.com/ray-project/ray/issues>`_ - Report bugs or request features
 - `Ray Slack <https://ray-distributed.slack.com>`_ - Get help from the community
 - `Ray Discourse Forum <https://discuss.ray.io>`_ - Ask questions and share knowledge
-- `Ray LLM Office Hours <https://docs.google.com/document/d/1n3-Jw_4su8yilo9zdi5OciAduoz6H_VmdL8i9sL4f-E/edit?tab=t.e700ayqsx3v3>`_ - Learn about new features, ask questions, and get guidance from the team
+- `Ray LLM Office Hours <https://zoom-lfx.platform.linuxfoundation.org/meetings/ray?view=month>`_ - Learn about new features, ask questions, and get guidance from the team
 
   - `Past Office Hours Recordings <https://youtube.com/playlist?list=PLzTswPQNepXl2IYF8DcV35FdCoVbeL4_6&si=ik81bljIlasYAHKN>`_ - View recordings from previous sessions

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -206,12 +206,83 @@ First, load a video dataset:
     :end-before: __vlm_video_load_dataset_example_end__
     :dedent: 0
 
+.. _multimodal_pixel_budget:
+
+Sizing the visual-token pixel budget
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Video (and image) inputs are processed by vLLM in two stages, each with its
+own knob and its own placement in :class:`vLLMEngineProcessorConfig`:
+
+1. **Frame sampling** — vLLM's video I/O decodes the source and samples
+   frames according to ``media_io_kwargs["video"]`` (e.g. ``num_frames``,
+   ``fps``). In Ray Data LLM, media is decoded by the
+   ``PrepareMultimodalStage`` *before* the engine runs, so this kwarg must
+   be set in ``prepare_multimodal_stage["model_config_kwargs"]`` — not
+   ``engine_kwargs`` — to take effect.
+2. **Per-frame resizing** — the HuggingFace processor then resizes the
+   sampled frames to fit a *visual-token pixel budget*, controlled by
+   ``engine_kwargs["mm_processor_kwargs"]``. The budget caps total pixels
+   (``height * width`` for an image, ``num_frames * height * width`` for a
+   video, after rounding to the model's patch / temporal factors) and
+   determines how many vision tokens each request produces — which in turn
+   dominates KV-cache cost on multi-modal workloads.
+
+.. warning::
+    If an input would exceed the pixel budget, the HF processor **silently
+    downscales it** — there is no log, warning, or metric. The only symptom
+    is degraded model quality. Always size the budget to cover your
+    worst-case input.
+
+**Engine-level vs per-request.** vLLM reads ``mm_processor_kwargs`` from
+``engine_kwargs`` once at startup and uses it to size memory profiling and
+the KV cache. A per-row ``mm_processor_kwargs`` passed in the preprocessor
+output can override the budget *smaller* for a single row, but **cannot
+raise it past the engine ceiling without OOM risk**. If the budget is never
+set in ``engine_kwargs`` at all, every request runs against the model
+default.
+
+**Knob naming differs by model family.** This is a versioning trap when
+migrating model families:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Family
+     - Pixel-budget knob
+     - Floor knob
+   * - Qwen2-VL, Qwen2.5-VL
+     - ``max_pixels``
+     - ``min_pixels``
+   * - Qwen3-VL and later
+     - ``size.longest_edge``
+     - ``size.shortest_edge``
+
+On Qwen3-VL+, set the budget through ``size``; the older
+``max_pixels`` / ``min_pixels`` names are dropped before reaching the HF
+processor, so the engine ends up resizing against the model's default size.
+For the full set of kwargs each model accepts, see the
+`vLLM multimodal docs <https://docs.vllm.ai/en/latest/features/multimodal_inputs.html>`_
+and the model's HF processor reference.
+
+**Worked example (Qwen3-VL).** Qwen3-VL has ``patch_size=16``,
+``merge_size=2`` (so spatial ``factor = 32``) and ``temporal_patch_size=2``.
+A 1080p video rounds to ``1088 x 1920`` per frame. The model-default video
+budget (``longest_edge = 25,165,824``) silently downscales any 1080p input
+beyond ~12 frames. To preserve detail on a 20-frame 1080p window, set
+``longest_edge = 20 * 1088 * 1920 ~= 41.8M``.
+
 Next, configure the VLM processor with the essential settings:
 
 .. literalinclude:: doc_code/working-with-llms/vlm_video_example.py
     :language: python
     :start-after: __vlm_video_config_example_start__
     :end-before: __vlm_video_config_example_end__
+
+Set ``do_sample_frames=False`` when frame sampling has already happened in
+``media_io_kwargs``; otherwise the HF processor will sample again and the two
+stages will fight.
 
 Define preprocessing and postprocessing functions to convert dataset rows into
 the format expected by the VLM and extract model responses. Within the preprocessor,

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -215,14 +215,14 @@ Next, configure the VLM processor with the essential settings:
 
 Ray Data LLM forwards ``mm_processor_kwargs`` to vLLM, which invokes
 the model's HuggingFace processor with it. The accepted keys are
-defined by the HF processor and differ by model family (e.g.
-``max_pixels`` on Qwen2-VL, ``size`` on Qwen3-VL). Refer to the HF
+defined by the HF processor and differ by model family, for example
+``max_pixels`` on Qwen2-VL, ``size`` on Qwen3-VL. Refer to the HF
 processor source for your model, for example `Qwen3VLVideoProcessor
 <https://github.com/huggingface/transformers/blob/10555512868d663ee1ff627e4f5c5c260114235b/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py#L86>`_.
 
 .. note::
 
-   Understanding multimodal arguments used above:
+   Understanding multimodal arguments:
 
    - ``engine_kwargs.limit_mm_per_prompt={"video": 1}``: caps the number of videos per request.
    - ``engine_kwargs.mm_processor_kwargs.size``: per-frame resize budget;

--- a/doc/source/data/working-with-llms.rst
+++ b/doc/source/data/working-with-llms.rst
@@ -206,73 +206,6 @@ First, load a video dataset:
     :end-before: __vlm_video_load_dataset_example_end__
     :dedent: 0
 
-.. _multimodal_pixel_budget:
-
-Sizing the visual-token pixel budget
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Video (and image) inputs are processed by vLLM in two stages, each with its
-own knob and its own placement in :class:`vLLMEngineProcessorConfig`:
-
-1. **Frame sampling** — vLLM's video I/O decodes the source and samples
-   frames according to ``media_io_kwargs["video"]`` (e.g. ``num_frames``,
-   ``fps``). In Ray Data LLM, media is decoded by the
-   ``PrepareMultimodalStage`` *before* the engine runs, so this kwarg must
-   be set in ``prepare_multimodal_stage["model_config_kwargs"]`` — not
-   ``engine_kwargs`` — to take effect.
-2. **Per-frame resizing** — the HuggingFace processor then resizes the
-   sampled frames to fit a *visual-token pixel budget*, controlled by
-   ``engine_kwargs["mm_processor_kwargs"]``. The budget caps total pixels
-   (``height * width`` for an image, ``num_frames * height * width`` for a
-   video, after rounding to the model's patch / temporal factors) and
-   determines how many vision tokens each request produces — which in turn
-   dominates KV-cache cost on multi-modal workloads.
-
-.. warning::
-    If an input would exceed the pixel budget, the HF processor **silently
-    downscales it** — there is no log, warning, or metric. The only symptom
-    is degraded model quality. Always size the budget to cover your
-    worst-case input.
-
-**Engine-level vs per-request.** vLLM reads ``mm_processor_kwargs`` from
-``engine_kwargs`` once at startup and uses it to size memory profiling and
-the KV cache. A per-row ``mm_processor_kwargs`` passed in the preprocessor
-output can override the budget *smaller* for a single row, but **cannot
-raise it past the engine ceiling without OOM risk**. If the budget is never
-set in ``engine_kwargs`` at all, every request runs against the model
-default.
-
-**Knob naming differs by model family.** This is a versioning trap when
-migrating model families:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 35 35
-
-   * - Family
-     - Pixel-budget knob
-     - Floor knob
-   * - Qwen2-VL, Qwen2.5-VL
-     - ``max_pixels``
-     - ``min_pixels``
-   * - Qwen3-VL and later
-     - ``size.longest_edge``
-     - ``size.shortest_edge``
-
-On Qwen3-VL+, set the budget through ``size``; the older
-``max_pixels`` / ``min_pixels`` names are dropped before reaching the HF
-processor, so the engine ends up resizing against the model's default size.
-For the full set of kwargs each model accepts, see the
-`vLLM multimodal docs <https://docs.vllm.ai/en/latest/features/multimodal_inputs.html>`_
-and the model's HF processor reference.
-
-**Worked example (Qwen3-VL).** Qwen3-VL has ``patch_size=16``,
-``merge_size=2`` (so spatial ``factor = 32``) and ``temporal_patch_size=2``.
-A 1080p video rounds to ``1088 x 1920`` per frame. The model-default video
-budget (``longest_edge = 25,165,824``) silently downscales any 1080p input
-beyond ~12 frames. To preserve detail on a 20-frame 1080p window, set
-``longest_edge = 20 * 1088 * 1920 ~= 41.8M``.
-
 Next, configure the VLM processor with the essential settings:
 
 .. literalinclude:: doc_code/working-with-llms/vlm_video_example.py
@@ -280,9 +213,39 @@ Next, configure the VLM processor with the essential settings:
     :start-after: __vlm_video_config_example_start__
     :end-before: __vlm_video_config_example_end__
 
-Set ``do_sample_frames=False`` when frame sampling has already happened in
-``media_io_kwargs``; otherwise the HF processor will sample again and the two
-stages will fight.
+Ray Data LLM forwards ``mm_processor_kwargs`` to vLLM, which invokes
+the model's HuggingFace processor with it. The accepted keys are
+defined by the HF processor and differ by model family (e.g.
+``max_pixels`` on Qwen2-VL, ``size`` on Qwen3-VL). Refer to the HF
+processor source for your model, for example `Qwen3VLVideoProcessor
+<https://github.com/huggingface/transformers/blob/10555512868d663ee1ff627e4f5c5c260114235b/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py#L86>`_.
+
+.. note::
+
+   Understanding multimodal arguments used above:
+
+   - ``engine_kwargs.limit_mm_per_prompt={"video": 1}``: caps the number of videos per request.
+   - ``engine_kwargs.mm_processor_kwargs.size``: per-frame resize budget;
+     inputs are resized to fall within the range
+     ``shortest_edge`` to ``longest_edge`` in total pixels.
+   - ``engine_kwargs.mm_processor_kwargs.do_sample_frames=False``: skip the
+     HF processor's own frame sampling because ``media_io_kwargs`` already
+     produced the final frames. Set this whenever frame sampling has
+     already happened upstream.
+   - ``prepare_multimodal_stage.model_config_kwargs.allowed_local_media_path``:
+     required for ``file://`` or local-path media inputs.
+   - ``prepare_multimodal_stage.model_config_kwargs.media_io_kwargs``:
+     frame sampling at decode time.
+
+
+.. warning::
+   If a multimodal input exceeds ``mm_processor_kwargs.size``, the HF
+   processor's `smart_resize
+   <https://github.com/huggingface/transformers/blob/10555512868d663ee1ff627e4f5c5c260114235b/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py#L35>`_
+   downscales it automatically. Size ``size.longest_edge``
+   to the largest input you expect to process: ``height * width`` for an
+   image, ``num_frames * height * width`` for a video.
+
 
 Define preprocessing and postprocessing functions to convert dataset rows into
 the format expected by the VLM and extract model responses. Within the preprocessor,
@@ -644,6 +607,32 @@ For multi-turn conversations or complex agentic workflows, share a vLLM engine a
 Troubleshooting
 ---------------
 
+vLLM compatibility
+~~~~~~~~~~~~~~~~~~
+
+Each Ray release is fully tested with a compatible vLLM version.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 8 8
+
+   * - Ray release
+     - vLLM version
+   * - 2.56.0
+     - 0.22.0
+   * - 2.55.0
+     - 0.18.0
+   * - 2.54.0
+     - 0.15.0
+   * - 2.53.0
+     - 0.12.0
+   * - 2.52.0
+     - 0.11.0
+   * - 2.51.0
+     - 0.11.0
+   * - 2.50.0
+     - 0.10.2
+
 GPU memory and CUDA OOM
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -693,7 +682,6 @@ vLLM NIXL EP dependency incompatibility
 
    Remove the incompatible package or ensure the installed ``nixl_ep`` package is compatible with the CUDA runtime
    and vLLM build in your environment.
-
 
 **Usage data collection**: Ray collects anonymous usage data to improve Ray Data LLM. To opt out, see :ref:`Ray usage stats <ref-usage-stats>`.
 

--- a/doc/source/serve/llm/troubleshooting.md
+++ b/doc/source/serve/llm/troubleshooting.md
@@ -112,7 +112,7 @@ If you encounter issues not covered in this guide:
 - [Ray GitHub Issues](https://github.com/ray-project/ray/issues) - Report bugs or request features
 - [Ray Slack](https://ray-distributed.slack.com) - Get help from the community
 - [Ray Discourse Forum](https://discuss.ray.io) - Ask questions and share knowledge
-- [Ray LLM Office Hours](https://docs.google.com/document/d/1n3-Jw_4su8yilo9zdi5OciAduoz6H_VmdL8i9sL4f-E/edit?tab=t.e700ayqsx3v3) - Learn about new features, ask questions, and get guidance from the team
+- [Ray LLM Office Hours](https://zoom-lfx.platform.linuxfoundation.org/meetings/ray?view=month) - Learn about new features, ask questions, and get guidance from the team
   - [Past Office Hours Recordings](https://youtube.com/playlist?list=PLzTswPQNepXl2IYF8DcV35FdCoVbeL4_6&si=ik81bljIlasYAHKN) - View recordings from previous sessions
 
 ## See also

--- a/doc/source/serve/llm/troubleshooting.md
+++ b/doc/source/serve/llm/troubleshooting.md
@@ -91,6 +91,20 @@ and vLLM build in your environment.
 
 :::
 
+## vLLM compatibility
+
+Each Ray release is fully tested with a compatible vLLM version.
+
+| Ray release | vLLM version |
+| ----------- | ------------ |
+| 2.56.0      | 0.22.0       |
+| 2.55.0      | 0.18.0       |
+| 2.54.0      | 0.15.0       |
+| 2.53.0      | 0.12.0       |
+| 2.52.0      | 0.11.0       |
+| 2.51.0      | 0.11.0       |
+| 2.50.0      | 0.10.2       |
+
 ## Get help
 
 If you encounter issues not covered in this guide:

--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -112,20 +112,22 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
             On the other hand, small batch sizes are more fault-tolerant and could
             reduce bubbles in the data pipeline. You can tune the batch size to balance
             the throughput and fault-tolerance based on your use case.
-        engine_kwargs: The kwargs to pass to the vLLM engine. Default engine kwargs are
-            pipeline_parallel_size: 1, tensor_parallel_size: 1, max_num_seqs: 128,
-            distributed_executor_backend: "mp".
+        engine_kwargs: The kwargs to pass to the vLLM engine. Defaults to
+            pipeline_parallel_size: 1 and tensor_parallel_size: 1. Ray Data LLM sets
+            ``distributed_executor_backend`` to ``"uni"`` when ``tp*pp == 1`` and
+            ``"ray"`` otherwise. vLLM's ``max_num_seqs`` default is resolved by vLLM
+            and is GPU-dependent (e.g., 256 on A100/A10G, 1024 on H100/MI300x).
         task_type: The task type to use. If not specified, will use 'generate' by default.
         runtime_env: The runtime environment to use for the vLLM engine. See
             :ref:`this doc <handling_dependencies>` for more details.
-        max_pending_requests: The maximum number of pending requests. If not specified,
-            will use the default value from the vLLM engine.
+        max_pending_requests: The maximum number of pending requests. If unset,
+            defaults to ``ceil(1.1 * max_num_seqs * pipeline_parallel_size)`` using
+            vLLM's resolved engine config.
         max_concurrent_batches: The maximum number of concurrent batches in the engine.
-            This is to overlap the batch processing to avoid the tail latency of
-            each batch. The default value may not be optimal when the batch size
-            or the batch processing latency is too small, but it should be good
-            enough for batch size >= 64. Sets the engine actor's Ray Core
-            ``max_concurrency``.
+            Overlapping batch processing reduces per-batch tail latency. Sets the
+            engine actor's Ray Core ``max_concurrency``. The default is tuned for
+            batch sizes >= 32; consider increasing it for smaller batch sizes or
+            short per-batch latencies.
         max_tasks_in_flight_per_actor: Max tasks Ray Data submits concurrently to
             each engine actor. Passed through to ``ray.data.ActorPoolStrategy``.
             If unset, Ray Data uses
@@ -136,13 +138,27 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
             env var.
         should_continue_on_error: If True, continue processing when inference fails for a row
             instead of raising an exception. Failed rows will have a non-empty
-            ``__inference_error__`` column containing the error message, and other
-            output columns will be empty strings. Error rows bypass postprocess. If False
-            (default), any inference error will raise an exception.
+            ``__inference_error__`` column containing the error message; the other
+            output columns are populated with type-appropriate defaults
+            (empty string/list, ``None``, ``0``, or ``-1``). Error rows bypass
+            postprocess. If False (default), any inference error will raise an
+            exception.
+        log_engine_metrics: If True (default), export vLLM engine metrics (prefix
+            cache hit rate, TTFT, TPOT, KV cache utilization, etc.) via Ray's
+            Prometheus endpoint.
+        dynamic_lora_loading_path: Path holding dynamic LoRA adapter checkpoints
+            (one per subfolder). If unset and LoRA is used, the ``model`` in a
+            LoRA request is interpreted as a HF model ID.
+        placement_group_config: Optional placement group config for scheduling
+            vLLM engine workers. Accepts ``bundle_per_worker`` (auto-replicated by
+            ``tp*pp``) or ``bundles`` (full list of resource dicts), plus an
+            optional ``strategy``
+            (``PACK``/``STRICT_PACK``/``SPREAD``/``STRICT_SPREAD``).
         chat_template_stage: Chat templating stage config (bool | dict | ChatTemplateStageConfig).
             Defaults to True. Use nested config for per-stage control over batch_size,
-            concurrency, runtime_env, num_cpus, and memory. Legacy ``apply_chat_template``
-            and ``chat_template`` fields are deprecated but still supported.
+            concurrency, runtime_env, num_cpus, memory, and model_source. Legacy
+            ``apply_chat_template`` and ``chat_template`` fields are deprecated but
+            still supported.
         tokenize_stage: Tokenizer stage config (bool | dict | TokenizerStageConfig).
             Defaults to True. Use nested config for per-stage control over batch_size,
             concurrency, runtime_env, num_cpus, memory, and model_source. Legacy
@@ -151,13 +167,13 @@ class vLLMEngineProcessorConfig(_vLLMEngineProcessorConfig):
             Defaults to True. Use nested config for per-stage control over batch_size,
             concurrency, runtime_env, num_cpus, memory, and model_source. Legacy
             ``detokenize`` field is deprecated but still supported.
-        prepare_image_stage: Prepare image stage config (bool | dict | PrepareImageStageConfig).
-            Defaults to False. Use nested config for per-stage control over batch_size,
-            concurrency, runtime_env, num_cpus, and memory. Both the legacy ``has_image`` field
-            and ``prepare_image_stage`` are deprecated but still supported. Prefer to use multimodal
-            processor to process multimodal data instead.
-        accelerator_type: The accelerator type used by the LLM stage in a processor.
-            Default to None, meaning that only the CPU will be used.
+        prepare_multimodal_stage: Multimodal preprocessing stage config
+            (bool | dict | PrepareMultimodalStageConfig). Defaults to False.
+            Use nested config for per-stage control over batch_size, concurrency,
+            runtime_env, num_cpus, memory, ``model_config_kwargs``,
+            ``chat_template_content_format``, and ``apply_sys_msg_formatting``.
+        accelerator_type: The accelerator type required for the vLLM engine workers
+            (e.g., "H100", "A100").
         concurrency: The number of workers for data parallelism. Default to 1.
             If ``concurrency`` is a tuple ``(m, n)``, Ray creates an autoscaling
             actor pool that scales between ``m`` and ``n`` workers (``1 <= m <= n``).


### PR DESCRIPTION
## Description
- **Refine Qwen3-VL VLM video example and documentation.**
<img width="1293" height="408" alt="Screenshot 2026-05-21 at 8 44 05 PM" src="https://github.com/user-attachments/assets/62bba88f-1b2b-44f6-950c-4386c0fa26fe" />

- **Remove C++ incompatibility guide (only applicable for Ray 2.55).**
- **Add a Ray ↔ vLLM compatibility table.**
<img width="1300" height="460" alt="Screenshot 2026-05-21 at 8 44 35 PM" src="https://github.com/user-attachments/assets/d50c8d81-a44e-49e8-be2b-f3d5d4762b95" />

- **Update office hour link.**



- **Fix a doc rendering bug**

**Before**
<img width="564" height="194" alt="Screenshot 2026-05-21 at 8 57 20 PM" src="https://github.com/user-attachments/assets/292f0b9d-86d6-4552-976f-851efa4ddb8a" />

**After**
<img width="533" height="198" alt="Screenshot 2026-05-21 at 9 00 37 PM" src="https://github.com/user-attachments/assets/74243bf6-cda8-45c7-b504-ee8514a06ec4" />

- **Fix `vLLMEngineProcessorConfig` inaccurate docstring**

## Related issues
N/A

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
