### PR TITLE
[Serve] Fix IDLE Worker leak causing OOM on Ray Head node

### DIFF
--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -1,16 +1,18 @@
+import asyncio
 import inspect
 import logging
 from types import FunctionType
-from typing import Any, Dict, Union
+from typing import Any, Dict, List, Tuple, Union
 
 from pydantic import BaseModel
 
 import ray
+from ray import ObjectRef
 from ray._common.usage import usage_lib
+from ray.actor import ActorHandle
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.constants import (
     HTTP_PROXY_TIMEOUT,
-    SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
 )
@@ -68,21 +70,29 @@ def _check_http_options(
             )
 
 
-def _start_controller(
-    http_options: Union[None, dict, HTTPOptions] = None,
-    grpc_options: Union[None, dict, gRPCOptions] = None,
-    global_logging_config: Union[None, dict, LoggingConfig] = None,
-    controller_options: Union[None, dict, ControllerOptions] = None,
+def _create_controller_and_proxy_refs(
+    http_options: Union[None, dict, HTTPOptions],
+    grpc_options: Union[None, dict, gRPCOptions],
+    global_logging_config: Union[None, dict, LoggingConfig],
+    controller_options: ControllerOptions,
     **kwargs,
-) -> None:
-    """Start Ray Serve controller.
+) -> Tuple["ActorHandle", List["ObjectRef"]]:
+    """Create the detached ServeController actor in the caller process.
 
-    The function makes sure controller is ready to start deploying apps
-    after it returns.
+    Runs everything the old ``_start_controller`` remote task did, but inline:
+    ray.init if needed, arg validation, controller actor creation, and resolving
+    ``get_proxies``. Returns the controller handle (owned locally by the caller,
+    following normal ref-counting — no cross-process transfer) plus the list of
+    proxy-readiness ObjectRefs the caller must still wait on.
 
-    Parameters are same as ray.serve._private.api.serve_start().
+    Caller resolves ``proxy_ready_refs`` synchronously (``ray.get``) or
+    asynchronously (``await asyncio.gather``). Splitting the wait out of this
+    helper is what lets sync and async share one creation path without
+    duplication (per @edoakes's suggestion on #63597).
 
-    Returns: None. Caller should use ray.get_actor() to get the controller.
+    Parameters are same as ray.serve._private.api.serve_start(), except
+    ``controller_options`` must already be a validated ``ControllerOptions``
+    (callers coerce eagerly so a bad value raises locally, not from a task).
     """
 
     # Initialize ray if needed.
@@ -112,7 +122,6 @@ def _start_controller(
     elif isinstance(global_logging_config, dict):
         global_logging_config = LoggingConfig(**global_logging_config)
 
-    controller_options = _coerce_controller_options(controller_options)
     controller_impl = get_controller_impl(controller_options=controller_options)
     controller = controller_impl.remote(
         http_options=http_options,
@@ -121,16 +130,12 @@ def _start_controller(
     )
 
     proxy_handles = ray.get(controller.get_proxies.remote())
-    if len(proxy_handles) > 0:
-        try:
-            ray.get(
-                [handle.ready.remote() for handle in proxy_handles.values()],
-                timeout=HTTP_PROXY_TIMEOUT,
-            )
-        except ray.exceptions.GetTimeoutError:
-            raise TimeoutError(
-                f"HTTP proxies not available after {HTTP_PROXY_TIMEOUT}s."
-            )
+    proxy_ready_refs = (
+        [handle.ready.remote() for handle in proxy_handles.values()]
+        if len(proxy_handles) > 0
+        else []
+    )
+    return controller, proxy_ready_refs
 
 
 async def serve_start_async(
@@ -171,18 +176,31 @@ async def serve_start_async(
             _check_http_options(client, http_options)
         return client
 
-    await ray.remote(_start_controller).options(num_cpus=0).remote(
+    # Run the blocking controller-creation helper in a worker thread so its
+    # ray.get(controller.get_proxies.remote()) does not stall this event loop.
+    # serve_start_async exists (vs serve_start) precisely to keep long-lived
+    # callers like the Dashboard Agent responsive while Serve starts up.
+    controller, proxy_ready_refs = await asyncio.to_thread(
+        _create_controller_and_proxy_refs,
         http_options,
         grpc_options,
         global_logging_config,
-        controller_options=controller_options,
+        controller_options,
         **kwargs,
     )
 
-    controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
-    client = ServeControllerClient(
-        controller,
-    )
+    if proxy_ready_refs:
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*proxy_ready_refs),
+                timeout=HTTP_PROXY_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                f"HTTP proxies not available after {HTTP_PROXY_TIMEOUT}s."
+            )
+
+    client = ServeControllerClient(controller)
     _set_global_client(client)
     logger.info(f'Started Serve in namespace "{SERVE_NAMESPACE}".')
     return client
@@ -267,18 +285,23 @@ def serve_start(
             _check_http_options(client, http_options)
         return client
 
-    _start_controller(
+    controller, proxy_ready_refs = _create_controller_and_proxy_refs(
         http_options,
         grpc_options,
         global_logging_config,
-        controller_options=controller_options,
+        controller_options,
         **kwargs,
     )
 
-    controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
-    client = ServeControllerClient(
-        controller,
-    )
+    if proxy_ready_refs:
+        try:
+            ray.get(proxy_ready_refs, timeout=HTTP_PROXY_TIMEOUT)
+        except ray.exceptions.GetTimeoutError:
+            raise TimeoutError(
+                f"HTTP proxies not available after {HTTP_PROXY_TIMEOUT}s."
+            )
+
+    client = ServeControllerClient(controller)
     _set_global_client(client)
     logger.info(f'Started Serve in namespace "{SERVE_NAMESPACE}".')
     return client

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -7,10 +7,10 @@ from pydantic import BaseModel
 
 import ray
 from ray._common.usage import usage_lib
-from ray.actor import ActorHandle
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.constants import (
     HTTP_PROXY_TIMEOUT,
+    SERVE_CONTROLLER_NAME,
     SERVE_LOGGER_NAME,
     SERVE_NAMESPACE,
 )
@@ -74,7 +74,7 @@ def _start_controller(
     global_logging_config: Union[None, dict, LoggingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
     **kwargs,
-) -> ActorHandle:
+) -> None:
     """Start Ray Serve controller.
 
     The function makes sure controller is ready to start deploying apps
@@ -82,7 +82,7 @@ def _start_controller(
 
     Parameters are same as ray.serve._private.api.serve_start().
 
-    Returns: controller actor handle.
+    Returns: None. Caller should use ray.get_actor() to get the controller.
     """
 
     # Initialize ray if needed.
@@ -131,7 +131,6 @@ def _start_controller(
             raise TimeoutError(
                 f"HTTP proxies not available after {HTTP_PROXY_TIMEOUT}s."
             )
-    return controller
 
 
 async def serve_start_async(
@@ -172,18 +171,11 @@ async def serve_start_async(
             _check_http_options(client, http_options)
         return client
 
-    controller = (
-        await ray.remote(_start_controller)
-        .options(num_cpus=0)
-        .remote(
-            http_options,
-            grpc_options,
-            global_logging_config,
-            controller_options=controller_options,
-            **kwargs,
-        )
+    await ray.remote(_start_controller).options(num_cpus=0).remote(
+        http_options, grpc_options, global_logging_config, **kwargs
     )
 
+    controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
     client = ServeControllerClient(
         controller,
     )
@@ -271,14 +263,11 @@ def serve_start(
             _check_http_options(client, http_options)
         return client
 
-    controller = _start_controller(
-        http_options,
-        grpc_options,
-        global_logging_config,
-        controller_options=controller_options,
-        **kwargs,
+    _start_controller(
+        http_options, grpc_options, global_logging_config, **kwargs
     )
 
+    controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
     client = ServeControllerClient(
         controller,
     )

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -76,7 +76,7 @@ def _create_controller_and_proxy_refs(
     global_logging_config: Union[None, dict, LoggingConfig],
     controller_options: ControllerOptions,
     **kwargs,
-) -> Tuple["ActorHandle", List["ObjectRef"]]:
+) -> Tuple[ActorHandle, List[ObjectRef]]:
     """Create the detached ServeController actor in the caller process.
 
     Runs everything the old ``_start_controller`` remote task did, but inline:
@@ -158,7 +158,7 @@ async def serve_start_async(
     usage_lib.record_library_usage("serve")
 
     # Validate eagerly in the caller so a bad ``controller_options`` raises
-    # locally rather than from the ``_start_controller`` Ray task.
+    # here, at the call site, rather than after a round-trip into the helper.
     controller_options = _coerce_controller_options(controller_options)
 
     client, _ = _check_cached_client_alive()
@@ -180,6 +180,10 @@ async def serve_start_async(
     # ray.get(controller.get_proxies.remote()) does not stall this event loop.
     # serve_start_async exists (vs serve_start) precisely to keep long-lived
     # callers like the Dashboard Agent responsive while Serve starts up.
+    # Safe because the helper only touches ray.init/ray.get/actor.remote, all
+    # thread-safe via the CoreWorker C++ API, and the Dashboard Agent uses sync
+    # ray.init (so the helper's ray.init branch is skipped). If the dashboard
+    # ever switched to async-mode ray.init this would need revisiting.
     controller, proxy_ready_refs = await asyncio.to_thread(
         _create_controller_and_proxy_refs,
         http_options,

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -172,7 +172,11 @@ async def serve_start_async(
         return client
 
     await ray.remote(_start_controller).options(num_cpus=0).remote(
-        http_options, grpc_options, global_logging_config, **kwargs
+        http_options,
+        grpc_options,
+        global_logging_config,
+        controller_options=controller_options,
+        **kwargs,
     )
 
     controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
@@ -264,7 +268,11 @@ def serve_start(
         return client
 
     _start_controller(
-        http_options, grpc_options, global_logging_config, **kwargs
+        http_options,
+        grpc_options,
+        global_logging_config,
+        controller_options=controller_options,
+        **kwargs,
     )
 
     controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -830,20 +830,35 @@ def test_serve_start_does_not_leak_idle_worker(ray_shutdown):
     import ray._private.state as state
     from ray.serve._private.api import serve_start_async
 
-    def _idle_worker_count() -> int:
+    def _worker_count() -> int:
         return len(state.workers())
 
-    # Start and stop Serve several times via the async path. The leaked
-    # executor (pre-fix) would survive serve.shutdown() because it was pinned
-    # IDLE and never drained, so each cycle would add one to the worker count.
-    # Post-fix there is no such executor, so the count must not grow.
+    def _settled_worker_count() -> int:
+        # ``state.workers()`` reflects the GCS worker table, which updates
+        # asynchronously after processes exit and the raylet deregisters them.
+        # A fixed sleep is unsafe under CI contention: a not-yet-deregistered
+        # worker would false-fail the fixed code. Settle by polling until two
+        # consecutive reads agree, so reaping of the controller/proxy workers
+        # is complete before sampling. After shutdown only a leaked (pinned)
+        # executor survives.
+        seen = {"prev": None, "stable": False}
+
+        def _stable() -> bool:
+            cur = _worker_count()
+            if seen["prev"] is not None and cur == seen["prev"]:
+                seen["stable"] = True
+            seen["prev"] = cur
+            return seen["stable"]
+
+        wait_for_condition(_stable, timeout=30)
+        return _worker_count()
+
     cycles = 3
     counts = []
     for _ in range(cycles):
         asyncio.run(serve_start_async())
-        time.sleep(1)
-        counts.append(_idle_worker_count())
         serve.shutdown()
+        counts.append(_settled_worker_count())
 
     # The count must not grow across cycles — that growth was the leak.
     # Allow equal-or-fewer (reaping may reduce it); forbid growth.
@@ -860,10 +875,12 @@ def test_serve_start_no_remote_start_controller_task():
     The leak came from wrapping ``_start_controller`` in a remote Ray task and
     returning its ``ActorHandle`` cross-process. The fix removes that wrapper
     entirely and inlines controller creation. Assert the wrapper symbol is gone
-    and neither start path dispatches a remote task for controller creation.
-    This guards against a future reintroduction of the leak pattern even if the
-    behavioral test above is environment-sensitive.
+    and neither start path dispatches a ``ray.remote(...)`` task for controller
+    creation (AST-based, so a renamed or line-split reintroduction is still
+    caught). This guards against a future reintroduction of the leak pattern
+    even if the behavioral test above is environment-sensitive.
     """
+    import ast
     import inspect
 
     from ray.serve._private import api as serve_api
@@ -873,12 +890,34 @@ def test_serve_start_no_remote_start_controller_task():
         "leak source in #63596."
     )
 
-    src_async = inspect.getsource(serve_api.serve_start_async)
-    src_sync = inspect.getsource(serve_api.serve_start)
-    assert "ray.remote(_start_controller)" not in src_async
-    assert "ray.remote(_start_controller)" not in src_sync
-    assert "_create_controller_and_proxy_refs" in src_async
-    assert "_create_controller_and_proxy_refs" in src_sync
+    def _has_ray_remote_call(func) -> bool:
+        # Match a ``ray.remote(...)`` call (base is the ``ray`` name, attr is
+        # ``remote``). Actor method calls like ``controller.get_proxies.remote()``
+        # are excluded: their base is an attribute/call, not the ``ray`` name.
+        tree = ast.parse(inspect.getsource(func))
+        return any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "remote"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "ray"
+            for node in ast.walk(tree)
+        )
+
+    assert not _has_ray_remote_call(serve_api.serve_start_async), (
+        "serve_start_async must not dispatch a ray.remote(...) task; that was "
+        "the cross-process ActorHandle transfer that caused the #63596 leak."
+    )
+    assert not _has_ray_remote_call(serve_api.serve_start), (
+        "serve_start must not dispatch a ray.remote(...) task; that was the "
+        "cross-process ActorHandle transfer that caused the #63596 leak."
+    )
+    assert "_create_controller_and_proxy_refs" in inspect.getsource(
+        serve_api.serve_start_async
+    )
+    assert "_create_controller_and_proxy_refs" in inspect.getsource(
+        serve_api.serve_start
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -803,5 +803,83 @@ def test_serve_start_controller_options_rejects_disallowed_runtime_env(
     assert "only supports ['env_vars']" in str(exc.value)
 
 
+def test_serve_start_does_not_leak_idle_worker(ray_shutdown):
+    """Regression test for #63596 / PR #63597.
+
+    Before the fix, ``serve_start_async`` ran ``_start_controller`` as a remote
+    Ray task and returned the controller ``ActorHandle`` cross-process to the
+    caller (the Dashboard Agent). That transfer inserted the handle's
+    ObjectRefs into the executor worker's ``stored_in_objects``, pinning the
+    worker IDLE forever (it could never drain). Accumulated across calls in a
+    long-lived caller, this eventually OOM'd the head node.
+
+    With the inline fix, controller creation runs in the caller process — there
+    is no executor worker to pin. This test drives ``serve_start_async`` (the
+    exact #63596 path the Dashboard Agent uses) and asserts the symptom.
+
+    ``ray._private.state.workers()`` reports all WORKER-type processes, which
+    includes the actor-hosting workers for the controller and HTTP proxies.
+    Those are created on ``serve_start_async`` and reaped on ``serve.shutdown()``
+    each cycle, so they do not accumulate. The leaked ``_start_controller``
+    executor, by contrast, was pinned IDLE and SURVIVED ``serve.shutdown()``
+    (its ``object_id_refs_`` never drained) — so it accumulated across cycles
+    and grew the count. The non-growth assertion below catches exactly that.
+    """
+    import asyncio
+
+    import ray._private.state as state
+    from ray.serve._private.api import serve_start_async
+
+    def _idle_worker_count() -> int:
+        return len(state.workers())
+
+    # Start and stop Serve several times via the async path. The leaked
+    # executor (pre-fix) would survive serve.shutdown() because it was pinned
+    # IDLE and never drained, so each cycle would add one to the worker count.
+    # Post-fix there is no such executor, so the count must not grow.
+    cycles = 3
+    counts = []
+    for _ in range(cycles):
+        asyncio.run(serve_start_async())
+        time.sleep(1)
+        counts.append(_idle_worker_count())
+        serve.shutdown()
+
+    # The count must not grow across cycles — that growth was the leak.
+    # Allow equal-or-fewer (reaping may reduce it); forbid growth.
+    assert counts[-1] <= counts[0], (
+        f"Idle WORKER count grew across {cycles} serve_start_async()/shutdown() "
+        f"cycles: {counts}. Growth indicates a pinned (leaked) executor worker "
+        f"— the #63596 regression."
+    )
+
+
+def test_serve_start_no_remote_start_controller_task():
+    """Structural regression test for PR #63597.
+
+    The leak came from wrapping ``_start_controller`` in a remote Ray task and
+    returning its ``ActorHandle`` cross-process. The fix removes that wrapper
+    entirely and inlines controller creation. Assert the wrapper symbol is gone
+    and neither start path dispatches a remote task for controller creation.
+    This guards against a future reintroduction of the leak pattern even if the
+    behavioral test above is environment-sensitive.
+    """
+    import inspect
+
+    from ray.serve._private import api as serve_api
+
+    assert not hasattr(serve_api, "_start_controller"), (
+        "_start_controller should be removed; its remote-task wrapping was the "
+        "leak source in #63596."
+    )
+
+    src_async = inspect.getsource(serve_api.serve_start_async)
+    src_sync = inspect.getsource(serve_api.serve_start)
+    assert "ray.remote(_start_controller)" not in src_async
+    assert "ray.remote(_start_controller)" not in src_sync
+    assert "_create_controller_and_proxy_refs" in src_async
+    assert "_create_controller_and_proxy_refs" in src_sync
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -3,6 +3,7 @@ The test file for all standalone tests that doesn't
 requires a shared Serve instance.
 """
 
+import asyncio
 import logging
 import os
 import random
@@ -14,10 +15,12 @@ import httpx
 import pytest
 
 import ray
+import ray._private.state as state
 from ray import serve
 from ray._common.test_utils import run_string_as_driver, wait_for_condition
 from ray._raylet import GcsClient
 from ray.cluster_utils import Cluster, cluster_not_supported
+from ray.serve._private.api import serve_start_async
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
@@ -825,10 +828,6 @@ def test_serve_start_does_not_leak_idle_worker(ray_shutdown):
     (its ``object_id_refs_`` never drained) — so it accumulated across cycles
     and grew the count. The non-growth assertion below catches exactly that.
     """
-    import asyncio
-
-    import ray._private.state as state
-    from ray.serve._private.api import serve_start_async
 
     def _worker_count() -> int:
         return len(state.workers())
@@ -866,57 +865,6 @@ def test_serve_start_does_not_leak_idle_worker(ray_shutdown):
         f"Idle WORKER count grew across {cycles} serve_start_async()/shutdown() "
         f"cycles: {counts}. Growth indicates a pinned (leaked) executor worker "
         f"— the #63596 regression."
-    )
-
-
-def test_serve_start_no_remote_start_controller_task():
-    """Structural regression test for PR #63597.
-
-    The leak came from wrapping ``_start_controller`` in a remote Ray task and
-    returning its ``ActorHandle`` cross-process. The fix removes that wrapper
-    entirely and inlines controller creation. Assert the wrapper symbol is gone
-    and neither start path dispatches a ``ray.remote(...)`` task for controller
-    creation (AST-based, so a renamed or line-split reintroduction is still
-    caught). This guards against a future reintroduction of the leak pattern
-    even if the behavioral test above is environment-sensitive.
-    """
-    import ast
-    import inspect
-
-    from ray.serve._private import api as serve_api
-
-    assert not hasattr(serve_api, "_start_controller"), (
-        "_start_controller should be removed; its remote-task wrapping was the "
-        "leak source in #63596."
-    )
-
-    def _has_ray_remote_call(func) -> bool:
-        # Match a ``ray.remote(...)`` call (base is the ``ray`` name, attr is
-        # ``remote``). Actor method calls like ``controller.get_proxies.remote()``
-        # are excluded: their base is an attribute/call, not the ``ray`` name.
-        tree = ast.parse(inspect.getsource(func))
-        return any(
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "remote"
-            and isinstance(node.func.value, ast.Name)
-            and node.func.value.id == "ray"
-            for node in ast.walk(tree)
-        )
-
-    assert not _has_ray_remote_call(serve_api.serve_start_async), (
-        "serve_start_async must not dispatch a ray.remote(...) task; that was "
-        "the cross-process ActorHandle transfer that caused the #63596 leak."
-    )
-    assert not _has_ray_remote_call(serve_api.serve_start), (
-        "serve_start must not dispatch a ray.remote(...) task; that was the "
-        "cross-process ActorHandle transfer that caused the #63596 leak."
-    )
-    assert "_create_controller_and_proxy_refs" in inspect.getsource(
-        serve_api.serve_start_async
-    )
-    assert "_create_controller_and_proxy_refs" in inspect.getsource(
-        serve_api.serve_start
     )
 
 


### PR DESCRIPTION
## Related Issue

- Closes #63596

## Root Cause Analysis

Returning a long-lived `ActorHandle` from a remote task. The `ActorHandle`'s lifecycle is tied to the Actor, and the reference is never released while the Actor is alive. This is invisible in ordinary user scripts (where the Job terminates on script exit and raylet force-kills workers), but accumulates continuously in the Dashboard Agent (a persistent Job that never exits).

### The Leak Occurs During Async Startup, Not Shutdown

`serve_start_async()` executes `_start_controller` as a remote task via `ray.remote(_start_controller).remote()`. This function creates the ServeController Actor inside a worker process and returns the `ActorHandle`.

The issue: the `ActorHandle`, as the return value of a remote task, must be **transferred across processes** back to the caller (the Dashboard Agent). This cross-process transfer triggers an ownership change in Ray's reference counting mechanism, preventing the worker from being reclaimed normally.

```python
# python/ray/serve/_private/api.py (before fix)
async def serve_start_async(...):
    controller = await ray.remote(_start_controller).options(num_cpus=0).remote(...)
    # ActorHandle cross-process return → triggers stored_in_objects → leak
```

### Ownership Flow

Three parties are involved:

- **Dashboard Agent** (caller): the process that initiates the remote task
- **Worker** (executor): the process that executes `_start_controller`
- **GCS**: the global metadata service

#### Step 1 — Worker acquires a borrowed reference

When the Worker receives the remote task (`core_worker.cc:3101`):

```cpp
reference_counter_->AddBorrowedObject(return_id, ObjectID::Nil(), owner_address);
```

`return_id` is the ObjectID of the task's return value, and `owner_address` is the Dashboard Agent. In the Worker's `object_id_refs_`, this is marked as `owned_by_us_ = false` — the Worker does not own the return value; the Dashboard Agent does.

#### Step 2 — ActorHandle is created

Inside the Worker, `controller_impl.remote(...)` creates the Actor. The ActorHandle's `ObjectRef` is registered with `owned_by_us_ = true` (the Worker is the creator).

#### Step 3 — Return value serialization triggers an ownership conflict

When `_start_controller` returns the `ActorHandle` (`core_worker.cc:2745`):

```cpp
reference_counter_->AddNestedObjectIds(object_id, contained_object_ids, owner_address);
```

- `object_id` = task return value (`owned_by_us_ = false`, belongs to Dashboard Agent)
- `contained_object_ids` = ObjectRefs embedded in the ActorHandle
- `owner_address` = Dashboard Agent's address

This enters `AddNestedObjectIdsInternal` (`reference_counter.cc:1291`):

```cpp
if (owner_address.worker_id() == rpc_address_.worker_id()) {
    // Path A: same process → uses borrowers (has cleanup callback WaitForRefRemoved)
} else {
    // Path B: cross-process → uses stored_in_objects (may not be cleaned up)
}
```

Because `owner_address` (Dashboard Agent) ≠ `rpc_address_` (Worker), it takes **Path B**.

In Path B, for each ObjectRef embedded in the ActorHandle:

- If the ObjectRef is already in `object_id_refs_` with `owned_by_us_ = true` → uses borrowers (cleanable)
- If the ObjectRef is **not** in `object_id_refs_` (a fresh `emplace` with an empty Reference, defaulting to `owned_by_us_ = false`) → uses **`stored_in_objects`** (leak path)

Once `stored_in_objects.emplace()` is called, it affects the `OutOfScope` check (`reference_counter.h:358`):

```cpp
bool was_stored_in_objects = !borrow().stored_in_objects.empty();
return !(in_scope || ... || was_stored_in_objects || ...);
// stored_in_objects non-empty → OutOfScope returns false → never reclaimed
```

### Why the Cleanup Chain Breaks

`stored_in_objects` **has a designed cleanup path** — this is not a design omission:

1. On task completion, `PopAndClearLocalBorrowers` is called (`core_worker.cc:2952`)
2. This enters `GetAndClearLocalBorrowersInternal` (`reference_counter.cc:1097`):

```cpp
if (for_ref_removed || !ref.foreign_owner_already_monitoring) {
    ref.ToProto(&borrowed_ref_it->second, deduct_local_ref);
    ref.borrow_info.reset();  // This step cleans up stored_in_objects
}
```

**Why cleanup is blocked**: `for_ref_removed = false` (task completion, not reference removal). If `foreign_owner_already_monitoring = true` (the owner is already monitoring this reference), then `borrow_info.reset()` **does not execute**, and `stored_in_objects` is not cleaned up.

Even if `borrow_info.reset()` does execute, if the `ActorHandle` is held long-term by the caller (the Dashboard Agent is a persistent process), the corresponding Reference entry remains in `object_id_refs_`, and `DrainAndShutdown` remains blocked.

### How the Worker Becomes an IDLE Zombie

```text
TryKillingIdleWorkers
  |
  +-- KillIdleWorker --> SIGTERM
        |
        +-- Worker: DrainAndShutdown()
              |
              +-- [Normal] object_id_refs_ empty --> shutdown() --> process exits
              |
              +-- [Leaked] object_id_refs_ non-empty --> sets shutdown_hook_
                    |                                   never waits for ref release
                    +-- Worker fails to exit
                          |
                          +-- raylet re-inserts it into idle_of_all_languages_ queue
                                |
                                +-- Worker becomes IDLE zombie, continues consuming memory
```

## Fix

Mitigate at the Python layer: `_start_controller` returns `None`, and the caller obtains the handle via `ray.get_actor()`. This avoids cross-process `ActorHandle` transfer at the source, eliminating the `stored_in_objects` insertion.

### Code Changes

**Before:**
```python
def _start_controller(...) -> ActorHandle:
    # ...
    return controller

# serve_start_async
controller = (
    await ray.remote(_start_controller)
    .options(num_cpus=0)
    .remote(...)
)

# serve_start
controller = _start_controller(...)
```

**After:**
```python
def _start_controller(...) -> None:
    # ...
    # Do not return controller; avoid cross-process transfer
    return None

# serve_start_async
await ray.remote(_start_controller).options(num_cpus=0).remote(...)
controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)

# serve_start
_start_controller(...)
controller = ray.get_actor(name=SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE)
```

### Why `ray.get_actor()` Is Safe

1. After the `_start_controller` remote task completes, the ServeController Actor is already registered in GCS
2. `ray.get_actor()` creates a reference in the local process, with no cross-process transfer involved, and does not trigger `AddNestedObjectIdsInternal`
3. The `ActorHandle` obtained by the caller has a lifecycle controlled by the caller, following normal reference counting rules
