### PR TITLE
[Serve] Add observability logs for pack scheduling decisions

### DIFF
--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -460,6 +460,7 @@ class DeploymentScheduler(ABC):
         self._launching_replicas[deployment_id].pop(replica_id, None)
         self._recovering_replicas[deployment_id].discard(replica_id)
         self._running_replicas[deployment_id].pop(replica_id, None)
+        self._logged_pack_placement_failures.discard(replica_id)
 
     def on_replica_running(self, replica_id: ReplicaID, node_id: str) -> None:
         """Called whenever a deployment replica is running with a known node id."""
@@ -1002,14 +1003,7 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
         )
 
         if all_scheduling_requests:
-            order_log_key = tuple(
-                (
-                    r.replica_id.deployment_id,
-                    r.replica_id.unique_id,
-                    _format_resources_for_scheduling_log(r.requested_resources),
-                )
-                for r in all_scheduling_requests
-            )
+            order_log_key = tuple(r.replica_id for r in all_scheduling_requests)
             if order_log_key != self._last_pack_schedule_order_log_key:
                 self._last_pack_schedule_order_log_key = order_log_key
                 if Resources.CUSTOM_PRIORITY:
@@ -1122,16 +1116,14 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
                 break
 
         replica_id = scheduling_request.replica_id
-        resource_summary = _format_resources_for_scheduling_log(
-            scheduling_request.requested_resources
-        )
 
         if target_node is None:
             if replica_id not in self._logged_pack_placement_failures:
                 self._logged_pack_placement_failures.add(replica_id)
                 logger.info(
                     f"Pack scheduling could not place {replica_id} "
-                    f"({resource_summary}): no node with sufficient resources."
+                    f"({_format_resources_for_scheduling_log(scheduling_request.requested_resources)}): "
+                    f"no node with sufficient resources."
                 )
             return None
 
@@ -1144,14 +1136,16 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
         if succeeded:
             self._logged_pack_placement_failures.discard(replica_id)
             logger.info(
-                f"Pack scheduled {replica_id} ({resource_summary}) "
+                f"Pack scheduled {replica_id} "
+                f"({_format_resources_for_scheduling_log(scheduling_request.requested_resources)}) "
                 f"onto node {target_node}."
             )
         elif replica_id not in self._logged_pack_placement_failures:
             self._logged_pack_placement_failures.add(replica_id)
             logger.info(
                 f"Pack scheduling failed to launch {replica_id} "
-                f"({resource_summary}) on node {target_node}."
+                f"({_format_resources_for_scheduling_log(scheduling_request.requested_resources)}) "
+                f"on node {target_node}."
             )
 
         return target_node if succeeded else None

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -1123,9 +1123,9 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
                 logger.info(
                     f"Pack scheduling could not place {replica_id} "
                     f"({_format_resources_for_scheduling_log(scheduling_request.requested_resources)}): "
-                    f"no node with sufficient resources."
+                    f"no node with sufficient resources. "
+                    f"Falling back to default scheduling."
                 )
-            return None
 
         succeeded = self._schedule_replica(
             scheduling_request,
@@ -1133,20 +1133,21 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
             target_node_id=target_node,
         )
 
-        if succeeded:
+        if succeeded and target_node is not None:
             self._logged_pack_placement_failures.discard(replica_id)
             logger.info(
                 f"Pack scheduled {replica_id} "
                 f"({_format_resources_for_scheduling_log(scheduling_request.requested_resources)}) "
                 f"onto node {target_node}."
             )
-        elif replica_id not in self._logged_pack_placement_failures:
-            self._logged_pack_placement_failures.add(replica_id)
-            logger.info(
-                f"Pack scheduling failed to launch {replica_id} "
-                f"({_format_resources_for_scheduling_log(scheduling_request.requested_resources)}) "
-                f"on node {target_node}."
-            )
+        elif not succeeded and target_node is not None:
+            if replica_id not in self._logged_pack_placement_failures:
+                self._logged_pack_placement_failures.add(replica_id)
+                logger.info(
+                    f"Pack scheduling failed to launch {replica_id} "
+                    f"({_format_resources_for_scheduling_log(scheduling_request.requested_resources)}) "
+                    f"on node {target_node}."
+                )
 
         return target_node if succeeded else None
 

--- a/python/ray/serve/_private/deployment_scheduler.py
+++ b/python/ray/serve/_private/deployment_scheduler.py
@@ -134,6 +134,25 @@ class Resources(dict):
         return False
 
 
+def _format_resources_for_scheduling_log(resources: Resources) -> str:
+    """Compact resource summary for pack scheduling logs."""
+    priority_keys = list(Resources.CUSTOM_PRIORITY) + ["GPU", "CPU", "memory"]
+    seen = set()
+    parts = []
+    for key in priority_keys:
+        if key in seen:
+            continue
+        seen.add(key)
+        val = resources.get(key)
+        if val:
+            parts.append(f"{key}={val:g}" if isinstance(val, float) else f"{key}={val}")
+    for key in sorted(set(resources.keys()) - seen):
+        val = resources.get(key)
+        if val:
+            parts.append(f"{key}={val:g}" if isinstance(val, float) else f"{key}={val}")
+    return ", ".join(parts) if parts else "none"
+
+
 class AvailableNodeResources(Resources):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -373,6 +392,10 @@ class DeploymentScheduler(ABC):
         # We know where those replicas are running.
         # {deployment_id: {replica_id: running_node_id}}
         self._running_replicas = defaultdict(dict)
+        # Dedupes pack scheduling order logs across control loops.
+        self._last_pack_schedule_order_log_key: Optional[tuple] = None
+        # Dedupes repeated pack placement failure logs for stuck replicas.
+        self._logged_pack_placement_failures: Set[ReplicaID] = set()
 
         self._cluster_node_info_cache = cluster_node_info_cache
         self._head_node_id = head_node_id
@@ -978,6 +1001,38 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
             reverse=True,
         )
 
+        if all_scheduling_requests:
+            order_log_key = tuple(
+                (
+                    r.replica_id.deployment_id,
+                    r.replica_id.unique_id,
+                    _format_resources_for_scheduling_log(r.requested_resources),
+                )
+                for r in all_scheduling_requests
+            )
+            if order_log_key != self._last_pack_schedule_order_log_key:
+                self._last_pack_schedule_order_log_key = order_log_key
+                if Resources.CUSTOM_PRIORITY:
+                    priority_desc = (
+                        f"{Resources.CUSTOM_PRIORITY} "
+                        f"(then GPU, CPU, memory, other custom)"
+                    )
+                else:
+                    priority_desc = (
+                        "GPU, CPU, memory, other custom "
+                        "(RAY_SERVE_HIGH_PRIORITY_CUSTOM_RESOURCES unset)"
+                    )
+                order_desc = ", ".join(
+                    f"{r.replica_id.deployment_id.name}"
+                    f"[{_format_resources_for_scheduling_log(r.requested_resources)}]"
+                    for r in all_scheduling_requests
+                )
+                logger.info(
+                    f"Pack scheduling {len(all_scheduling_requests)} pending "
+                    f"replica(s). Resource priority: {priority_desc}. "
+                    f"Schedule order (first scheduled first): {order_desc}."
+                )
+
         # Fetch node labels for active nodes.
         active_nodes = self._cluster_node_info_cache.get_active_node_ids()
         all_node_labels = {
@@ -1066,11 +1121,38 @@ class DefaultDeploymentScheduler(DeploymentScheduler):
             if target_node:
                 break
 
+        replica_id = scheduling_request.replica_id
+        resource_summary = _format_resources_for_scheduling_log(
+            scheduling_request.requested_resources
+        )
+
+        if target_node is None:
+            if replica_id not in self._logged_pack_placement_failures:
+                self._logged_pack_placement_failures.add(replica_id)
+                logger.info(
+                    f"Pack scheduling could not place {replica_id} "
+                    f"({resource_summary}): no node with sufficient resources."
+                )
+            return None
+
         succeeded = self._schedule_replica(
             scheduling_request,
             default_scheduling_strategy="DEFAULT",
             target_node_id=target_node,
         )
+
+        if succeeded:
+            self._logged_pack_placement_failures.discard(replica_id)
+            logger.info(
+                f"Pack scheduled {replica_id} ({resource_summary}) "
+                f"onto node {target_node}."
+            )
+        elif replica_id not in self._logged_pack_placement_failures:
+            self._logged_pack_placement_failures.add(replica_id)
+            logger.info(
+                f"Pack scheduling failed to launch {replica_id} "
+                f"({resource_summary}) on node {target_node}."
+            )
 
         return target_node if succeeded else None
 

--- a/python/ray/serve/tests/test_deployment_scheduler.py
+++ b/python/ray/serve/tests/test_deployment_scheduler.py
@@ -412,6 +412,36 @@ class TestPackScheduling:
         app_status = serve.status().applications["default"]
         assert app_status.status == "DEPLOYING"
 
+        # Add a second node: pack logs should show a new schedule-order batch
+        # and one cpu_* replica placed on the new node while memory_hog stays up.
+        cluster.add_node(num_cpus=4)
+        cluster.wait_for_nodes()
+
+        def check_one_cpu_replica_after_scale_out():
+            app_status = serve.status().applications["default"]
+            if app_status.status == "DEPLOY_FAILED":
+                raise AssertionError(f"App failed: {app_status.message}")
+
+            deployments_status = app_status.deployments
+            assert (
+                deployments_status["memory_hog"].replica_states.get("RUNNING", 0) == 1
+            )
+
+            cpu_running = sum(
+                deployments_status[f"cpu_{i}"].replica_states.get("RUNNING", 0)
+                for i in range(9)
+            )
+            assert cpu_running == 1, {
+                f"cpu_{i}": deployments_status[f"cpu_{i}"].replica_states
+                for i in range(9)
+            }
+            return True
+
+        wait_for_condition(check_one_cpu_replica_after_scale_out, timeout=60)
+
+        app_status = serve.status().applications["default"]
+        assert app_status.status == "DEPLOYING"
+
         serve.shutdown()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Surface pack scheduling order, placements, and failures via logger output so users can debug why replicas are queued or stuck. Logs are deduped across control loops to avoid spam. Test extends the pack scheduling scenario to verify behavior after scaling out a new node.

controller logs from test
```
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,833 controller 1354790 -- Pack scheduling 11 pending replica(s). Resource priority: ['memory'] (then GPU, CPU, memory, other custom). Schedule order (first scheduled first): memory_hog[memory=52277763686, CPU=3], cpu_0[CPU=4], cpu_1[CPU=4], cpu_2[CPU=4], cpu_3[CPU=4], cpu_4[CPU=4], cpu_5[CPU=4], cpu_6[CPU=4], cpu_7[CPU=4], cpu_8[CPU=4], Ingress[none].
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,884 controller 1354790 -- Pack scheduled Replica(id='ff52ksrl', deployment='memory_hog', app='default') (memory=52277763686, CPU=3) onto node 81c1a6a495ad625da339923896c0da20e7860c6e4f29668ab61af8bd.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,884 controller 1354790 -- Pack scheduling could not place Replica(id='gnubjmrh', deployment='cpu_0', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,884 controller 1354790 -- Pack scheduling could not place Replica(id='6q8d1vi9', deployment='cpu_1', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,884 controller 1354790 -- Pack scheduling could not place Replica(id='iq4vdjqi', deployment='cpu_2', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,884 controller 1354790 -- Pack scheduling could not place Replica(id='y4u16bi2', deployment='cpu_3', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,884 controller 1354790 -- Pack scheduling could not place Replica(id='usrmxpeg', deployment='cpu_4', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,884 controller 1354790 -- Pack scheduling could not place Replica(id='lerwvex0', deployment='cpu_5', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,885 controller 1354790 -- Pack scheduling could not place Replica(id='6cv6ij7m', deployment='cpu_6', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,885 controller 1354790 -- Pack scheduling could not place Replica(id='fy67hbrh', deployment='cpu_7', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,885 controller 1354790 -- Pack scheduling could not place Replica(id='aduyzv14', deployment='cpu_8', app='default') (CPU=4): no node with sufficient resources.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,894 controller 1354790 -- Pack scheduled Replica(id='caxa0fd1', deployment='Ingress', app='default') (none) onto node 81c1a6a495ad625da339923896c0da20e7860c6e4f29668ab61af8bd.
(ServeController pid=1354790) INFO 2026-05-22 18:19:59,998 controller 1354790 -- Pack scheduling 9 pending replica(s). Resource priority: ['memory'] (then GPU, CPU, memory, other custom). Schedule order (first scheduled first): cpu_0[CPU=4], cpu_1[CPU=4], cpu_2[CPU=4], cpu_3[CPU=4], cpu_4[CPU=4], cpu_5[CPU=4], cpu_6[CPU=4], cpu_7[CPU=4], cpu_8[CPU=4].
(ServeController pid=1354790) INFO 2026-05-22 18:20:01,667 controller 1354790 -- Pack scheduled Replica(id='gnubjmrh', deployment='cpu_0', app='default') (CPU=4) onto node 801807d1da7bfebdfa95bab0a3eb7c6c76a63d18b0c8a69f461542fb.
(ServeController pid=1354790) INFO 2026-05-22 18:20:01,771 controller 1354790 -- Pack scheduling 8 pending replica(s). Resource priority: ['memory'] (then GPU, CPU, memory, other custom). Schedule order (first scheduled first): cpu_1[CPU=4], cpu_2[CPU=4], cpu_3[CPU=4], cpu_4[CPU=4], cpu_5[CPU=4], cpu_6[CPU=4], cpu_7[CPU=4], cpu_8[CPU=4].

```