### PR TITLE
Warn or assert deprecated http options

### DIFF
--- a/doc/source/serve/doc_code/http_guide/http_guide.py
+++ b/doc/source/serve/doc_code/http_guide/http_guide.py
@@ -91,6 +91,37 @@ resp = requests.get("http://localhost:8000/")
 assert resp.json() == "Hello from the root!"
 # __end_byo_fastapi__
 
+# __begin_fastapi_middleware__
+import requests
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from ray import serve
+
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["https://example.com"],
+    allow_methods=["GET", "POST"],
+)
+
+
+@serve.deployment
+@serve.ingress(app)
+class Ingress:
+    @app.get("/")
+    def root(self):
+        return "ok"
+
+
+serve.run(Ingress.bind())
+resp = requests.get(
+    "http://localhost:8000/",
+    headers={"Origin": "https://example.com"},
+)
+assert resp.json() == "ok"
+assert resp.headers["access-control-allow-origin"] == "https://example.com"
+# __end_fastapi_middleware__
+
 
 # __begin_fastapi_factory_pattern__
 import requests

--- a/doc/source/serve/http-guide.md
+++ b/doc/source/serve/http-guide.md
@@ -90,6 +90,17 @@ You can also pass in an existing FastAPI app to a deployment to serve it as-is:
 This is useful for scaling out an existing FastAPI app with no modifications necessary.
 Existing middlewares, **automatic OpenAPI documentation generation**, and other advanced FastAPI features should work as-is.
 
+### FastAPI Middleware
+
+Configure HTTP middleware on the FastAPI app that you pass to {mod}`@serve.ingress <ray.serve.ingress>`.
+The `HTTPOptions.middlewares` field is deprecated.
+
+```{literalinclude} doc_code/http_guide/http_guide.py
+:start-after: __begin_fastapi_middleware__
+:end-before: __end_fastapi_middleware__
+:language: python
+```
+
 ### WebSockets
 
 Serve supports WebSockets via FastAPI:

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -813,6 +813,9 @@ class HTTPOptions(BaseModel):
     - ssl_ca_certs: Optional path to CA certificate file for client certificate
       verification.
 
+    - middlewares: [DEPRECATED] A list of Starlette middlewares to apply to the
+      HTTP proxy. Passing a non-empty list raises an error. Use Serve's FastAPI
+      integration to configure middlewares on ingress deployments instead.
     - location: [DEPRECATED: use `proxy_location` field instead] The deployment
       location of HTTP servers:
 
@@ -863,13 +866,13 @@ class HTTPOptions(BaseModel):
 
     @field_validator("middlewares")
     @classmethod
-    def warn_for_middlewares(cls, v):
+    def raise_for_middlewares_assignment(cls, v):
         if v:
-            warnings.warn(
-                "Passing `middlewares` to HTTPOptions is deprecated and will be "
-                "removed in a future version. Consider using the FastAPI integration "
-                "to configure middlewares on your deployments: "
-                "https://docs.ray.io/en/latest/serve/http-guide.html#fastapi-http-deployments"  # noqa 501
+            raise ValueError(
+                "`middlewares` in HTTPOptions has been removed. Use Serve's "
+                "FastAPI integration to configure middlewares on ingress "
+                "deployments instead: "
+                "https://docs.ray.io/en/latest/serve/http-guide.html#fastapi-http-deployments"
             )
         return v
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -271,35 +271,17 @@ def test_middleware(ray_shutdown):
     from starlette.middleware.cors import CORSMiddleware
 
     port = _get_random_port()
-    serve.start(
-        http_options=dict(
-            port=port,
-            middlewares=[
-                Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"])
-            ],
+    # `middlewares` in HTTPOptions has been removed; passing it raises an error.
+    # Use Serve's FastAPI integration to configure middlewares instead.
+    with pytest.raises(ValueError, match="`middlewares` in HTTPOptions"):
+        serve.start(
+            http_options=dict(
+                port=port,
+                middlewares=[
+                    Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"])
+                ],
+            )
         )
-    )
-
-    @serve.deployment
-    class Dummy:
-        pass
-
-    serve.run(Dummy.bind())
-    ray.get(block_until_http_ready.remote(f"http://127.0.0.1:{port}/-/routes"))
-
-    # Snatched several test cases from Starlette
-    # https://github.com/encode/starlette/blob/master/tests/
-    # middleware/test_cors.py
-    headers = {
-        "Origin": "https://example.org",
-        "Access-Control-Request-Method": "GET",
-    }
-    root = f"http://localhost:{port}"
-    resp = httpx.options(root, headers=headers)
-    assert resp.headers["access-control-allow-origin"] == "*"
-
-    resp = httpx.get(f"{root}/-/routes", headers=headers)
-    assert resp.headers["access-control-allow-origin"] == "*"
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Failing on Windows")

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -1159,7 +1159,13 @@ def test_config_schemas_forward_compatible():
 
 def test_http_options():
     HTTPOptions()
-    HTTPOptions(host="8.8.8.8", middlewares=[object()])
+
+    # `middlewares` is removed: a non-empty list raises, but an empty list is
+    # a no-op (matches the prior warn-on-non-empty behavior) so internal
+    # normalization via model_copy/defaults does not break.
+    HTTPOptions(middlewares=[])
+    with pytest.raises(ValueError, match="`middlewares` in HTTPOptions"):
+        HTTPOptions(host="8.8.8.8", middlewares=[object()])
 
     # Test configs ignoring unknown keys (required for forward-compatibility)
     HTTPOptions(new_version_config_key="this config is from newer version of Ray")


### PR DESCRIPTION
## Why are these changes needed?

`HTTPOptions.middlewares` lets users attach Starlette middlewares to the
**shared HTTP proxy**. It has emitted a `DeprecationWarning` since
[#38362](https://github.com/ray-project/ray/pull/38362) (Aug 2023, ~2 years),
with the documented replacement being app-level middleware on a FastAPI
ingress deployment. This PR advances that deprecation from "warn" to "error".

Proxy-level middleware makes the shared proxy a per-user customization point;
the FastAPI/`@serve.ingress` path scopes middleware to the deployment that
needs it, scales with replicas, and uses ordinary FastAPI idioms instead of a
Serve-specific knob.

**What changed**
- `HTTPOptions.middlewares` now raises `ValueError` (with migration guidance)
  when set — both `HTTPOptions(middlewares=...)` and
  `serve.start(http_options={"middlewares": ...})`.
- Serve's own internal HTTPOptions handling switched to `model_copy(...)` so it
  no longer trips the validator on assignment / full-dump reconstruction
  (`_private/http_util.py`, `_private/replica.py`).
- Added a "FastAPI Middleware" section to the HTTP guide with a runnable
  migration example.

**Breaking change.** Setting `middlewares` now errors instead of warning. The
field has been deprecated since 2023; there is no proxy-level replacement —
migrate to FastAPI middleware on an ingress deployment:

```python
# Before
from starlette.middleware import Middleware
from starlette.middleware.cors import CORSMiddleware

serve.start(http_options={
    "middlewares": [Middleware(CORSMiddleware, allow_origins=["https://example.com"])]
})

# After
from fastapi import FastAPI
from fastapi.middleware.cors import CORSMiddleware
from ray import serve

app = FastAPI()
app.add_middleware(CORSMiddleware, allow_origins=["https://example.com"])

@serve.deployment
@serve.ingress(app)
class Ingress:
    @app.get("/")
    def root(self):
        return "ok"

serve.run(Ingress.bind())