### PR TITLE
[data] Fix CheckpointConfig FileNotFoundError on Azure Blob Storage

### DIFF
--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -87,7 +87,7 @@ def _clean_pending_checkpoints_task(
     def _clean() -> int:
         # 1. List all files in checkpoint dir, find pending ones
         ckpt_files = checkpoint_filesystem.get_file_info(
-            FileSelector(checkpoint_path_unwrapped, recursive=False)
+            FileSelector(checkpoint_path_unwrapped, recursive=False, allow_not_found=True)
         )
         pending_suffix = f"{PENDING_CHECKPOINT_SUFFIX}.parquet"
         pending_file_paths = [

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -106,9 +106,7 @@ def _clean_pending_checkpoints_task(
 
         # 3. List all data files (recursively for partitions)
         data_files = data_file_filesystem.get_file_info(
-            FileSelector(
-                data_file_dir_unwrapped, recursive=True, allow_not_found=True
-            )
+            FileSelector(data_file_dir_unwrapped, recursive=True, allow_not_found=True)
         )
 
         # 4. Delete data files matching a pending checkpoint prefix

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -87,7 +87,9 @@ def _clean_pending_checkpoints_task(
     def _clean() -> int:
         # 1. List all files in checkpoint dir, find pending ones
         ckpt_files = checkpoint_filesystem.get_file_info(
-            FileSelector(checkpoint_path_unwrapped, recursive=False, allow_not_found=True)
+            FileSelector(
+                checkpoint_path_unwrapped, recursive=False, allow_not_found=True
+            )
         )
         pending_suffix = f"{PENDING_CHECKPOINT_SUFFIX}.parquet"
         pending_file_paths = [
@@ -104,7 +106,9 @@ def _clean_pending_checkpoints_task(
 
         # 3. List all data files (recursively for partitions)
         data_files = data_file_filesystem.get_file_info(
-            FileSelector(data_file_dir_unwrapped, recursive=True, allow_not_found=True)
+            FileSelector(
+                data_file_dir_unwrapped, recursive=True, allow_not_found=True
+            )
         )
 
         # 4. Delete data files matching a pending checkpoint prefix

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -973,15 +973,15 @@ def test_clean_pending_checkpoint_with_partitioned_data(
     assert fs.get_file_info(pending.pending_path).type == FileType.NotFound
 
 
-def test_clean_pending_checkpoints_task_failure(ray_start_10_cpus_shared, tmp_path):
-    """Test that _clean_pending_checkpoints raises when the cleanup task fails.
+def test_clean_pending_checkpoints_nonexistent_path(ray_start_10_cpus_shared, tmp_path):
+    """Test that _clean_pending_checkpoints handles a non-existent checkpoint dir.
 
-    This verifies that:
-    1. When the underlying Ray task fails, the exception is propagated
-    2. The error is logged properly before re-raising
+    On cloud storage like Azure Blob Storage, listing a non-existent directory
+    raises FileNotFoundError (unlike S3 which returns an empty result). The
+    FileSelector uses allow_not_found=True so that first-run scenarios where
+    the checkpoint directory does not yet exist succeed without error.
     """
     ctx = ray.data.DataContext.get_current()
-    # Use a non-existent path to trigger a failure when trying to list files
     checkpoint_path = os.path.join(tmp_path, "nonexistent", "deeply", "nested", "path")
 
     ctx.checkpoint_config = CheckpointConfig(
@@ -992,10 +992,11 @@ def test_clean_pending_checkpoints_task_failure(ray_start_10_cpus_shared, tmp_pa
 
     checkpoint_manager = IdColumnCheckpointManager(ctx.checkpoint_config)
 
-    # The cleanup task should fail because the checkpoint directory doesn't exist
-    # and get_file_info on a non-existent path will raise an error
-    with pytest.raises(ray.exceptions.RayTaskError):
-        checkpoint_manager._clean_pending_checkpoints("/dummy/data/path")
+    data_dir = os.path.join(tmp_path, "data")
+    os.makedirs(data_dir, exist_ok=True)
+
+    # Should succeed gracefully (no pending checkpoints to clean)
+    checkpoint_manager._clean_pending_checkpoints(data_dir)
 
 
 def test_prepare_checkpoint_transform_writes_pending(tmp_path):


### PR DESCRIPTION
## Why are these changes needed?

`_clean_pending_checkpoints_task` in `checkpoint_filter.py` uses `FileSelector` without `allow_not_found=True` when listing checkpoint files:

```python
ckpt_files = checkpoint_filesystem.get_file_info(
    FileSelector(checkpoint_path_unwrapped, recursive=False)
)
```

On S3, listing a non-existent prefix returns an empty result. On Azure Blob Storage, it raises `FileNotFoundError`. This breaks `CheckpointConfig` on Azure for first-run scenarios where the checkpoint directory does not yet exist.

The data file listing in the same function already correctly uses `allow_not_found=True`:

```python
data_files = data_file_filesystem.get_file_info(
    FileSelector(data_file_dir_unwrapped, recursive=True, allow_not_found=True)
)
```

Similarly, the `load_checkpoint` method in `CheckpointManager` also uses `allow_not_found=True` for its own `FileSelector` call.

This was introduced in #61821 which was only tested on S3.

## Fix

Add `allow_not_found=True` to the `FileSelector` call in `_clean_pending_checkpoints_task`.

## Related issue number

N/A

## Checks

- [x] I've signed the [Contributor License Agreement](https://docs.google.com/forms/d/e/1FAIpQLSfAMq5v7-hRKRvNaRDhx_WP1W0IKTm7lBvpBlOrLAsNP2MKIQ/viewform).
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` (if applicable).
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/

*This PR was authored with Cursor assistance.*

Made with [Cursor](https://cursor.com)