### PR TITLE
[Autoscaler] Fix V1 monitor reporting dead nodes as active

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -42,6 +42,7 @@ from ray.autoscaler._private.prom_metrics import AutoscalerPrometheusMetrics
 from ray.autoscaler._private.util import format_readonly_node_type
 from ray.autoscaler.v2.sdk import get_cluster_resource_state
 from ray.core.generated import gcs_pb2
+from ray.core.generated.autoscaler_pb2 import NodeStatus
 from ray.core.generated.event_pb2 import Event as RayEvent
 from ray.experimental.internal_kv import (
     _initialize_internal_kv,
@@ -261,15 +262,22 @@ class Monitor:
         # from "get_cluster_resource_state"
         # ref: https://github.com/ray-project/ray/pull/48519#issuecomment-2481659346
         cluster_resource_state = get_cluster_resource_state(self.gcs_client)
-        ray_node_states = cluster_resource_state.node_states
+        # Filter out dead nodes to avoid reporting them as active.
+        # The V2 autoscaler handles this in its own _parse_nodes(), but the V1
+        # path passes node_states directly, so we must filter here.
+        alive_node_states = [
+            node
+            for node in cluster_resource_state.node_states
+            if node.status != NodeStatus.DEAD
+        ]
         ray_nodes_idle_duration_ms_by_id = {
-            node.node_id: node.idle_duration_ms for node in ray_node_states
+            node.node_id: node.idle_duration_ms for node in alive_node_states
         }
 
         # Tell the readonly node provider what nodes to report.
         if self.readonly_config:
             new_nodes = []
-            for msg in list(cluster_resource_state.node_states):
+            for msg in alive_node_states:
                 node_id = msg.node_id.hex()
                 new_nodes.append((node_id, msg.node_ip_address))
             self.autoscaler.provider._set_nodes(new_nodes)
@@ -283,7 +291,7 @@ class Monitor:
         )
 
         mirror_node_types = {}
-        for resource_message in cluster_resource_state.node_states:
+        for resource_message in alive_node_states:
             node_id = resource_message.node_id
             # Generate node type config based on GCS reported node list.
             if self.readonly_config:


### PR DESCRIPTION
## Why are these changes needed?

The V1 autoscaler monitor (`enable_autoscaler_v2=false`, the default) incorrectly reports dead nodes as active in both `ray status` and the Dashboard.

`GetNodeStates()` returns all nodes including dead ones, but `update_load_metrics()` passes them unfiltered to:
1. `ReadonlyNodeProvider._set_nodes()` — dead nodes appear as non-terminated
2. `ray_nodes_idle_duration_ms_by_id` — dead nodes get fresh heartbeat timestamps
3. `load_metrics.update()` — dead nodes' resources inflate cluster capacity
4. `mirror_node_types` — phantom node types added to readonly config

The V2 autoscaler is unaffected because `ClusterStatusParser._parse_nodes()` explicitly filters `NodeStatus.DEAD`.

## Fix

Filter dead nodes once at the top of `update_load_metrics()` using `node.status != NodeStatus.DEAD`, then use the filtered list (`alive_node_states`) in all downstream code paths. This is consistent with the V2 autoscaler's approach.

## Related issue number

Fixes #63566

## Checks

- [x] I've signed off every commit (by using `--signoff`). See [CONTRIBUTING.md](https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst)
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
  - [ ] I've added any new APIs to the API Reference. For example, if I added a method in Tune, I've added it in `doc/source/tune/api/` under the corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(