### PR TITLE
[RFC][Data] Scaling the StreamingExecutor scheduling thread (data path + control path)

### DIFF
--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -14,7 +14,7 @@ the relevant code path report what changed.**
 | subsystem      | today's anti-pattern                                                                                                                            | this RFC                                                                                                            |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain each ready task's gen up to its budget — looking up `size_bytes` inline via the Ray Core primitive (no RPC) so we stop pulling at the budget — then issue **one** batched `ray.get(meta_refs)` over what was drained |
-| **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers) — O(N_ops) work per call                | Ops push deltas at mutation sites (emit / dispatch / done) into a single live global aggregate on `ResourceManager`; `update_usages` becomes **O(1)** — just dispatches to the budget allocator |
+| **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers) | Ops push deltas at mutation sites (emit / dispatch / done) into a single live global aggregate on `ResourceManager`; per-op re-summation is gone, and the `_update_allocated_budgets` algorithm is preserved but runs on scalar-array workspace + cached invariants — **exact equivalence, ~10× cheaper per call** |
 
 On the wide-schema `worker_scaling` release-test matrix (m5.2xlarge × {36,
 72, 143, 358} nodes for {500, 1000, 2000, 5000} workers), the two parts
@@ -406,20 +406,17 @@ class ResourceManager:
         self._global_running_usage = self._global_running_usage.subtract(task_bundle)
 
     def update_usages(self) -> None:
-        # O(1). No per-op iteration. Aggregates are already current.
+        # O(1). Aggregates are already current; the allocator's
+        # _update_allocated_budgets still runs per dispatch (see 2c)
+        # but now consumes the live aggregate instead of recomputing.
         if self._op_resource_allocator is not None:
             self._update_allocated_budgets()
 ```
 
-`update_usages` itself shrinks from "iterate all N ops + construct
-N×K `ExecutionResources` + call `safe_round` 4× each" to **a single
-function call** — and even that call is a no-op when no allocator is
-configured. The per-call cost drops to ~0 regardless of N_ops or
-dispatch count.
-
-`_update_allocated_budgets` still runs and reads `_global_*` plus
-per-op cached values; it's the only across-op work that remains, and
-it's per-call-bounded rather than per-op-bounded.
+The per-op summation (the ~80 s of "construct N×K `ExecutionResources`
++ call `safe_round` 4× each" in today's profile) is gone. What
+remains is `_update_allocated_budgets` itself, which we make cheap in
+2c.
 
 Safety note: this is sound because the scheduler thread is
 single-threaded — every mutation site (`on_data_ready`,
@@ -427,7 +424,64 @@ single-threaded — every mutation site (`on_data_ready`,
 the scheduler thread or is funnelled through it. No locking required
 on the global aggregate.
 
-#### 2c. Call-site changes
+#### 2c. Make `_update_allocated_budgets` cheap per call (exact equivalence)
+
+Today's `update_budgets` is ~1.5 ms per call × 20 000 calls/iter ≈
+30 s at 5000 workers. Per-call work:
+
+1. Two passes over `eligible_ops` (reserved-portion, then shared-pool
+   distribution with borrow / cap logic).
+2. Many `ExecutionResources` constructor calls — each invokes
+   `safe_round` 4× on cpu / gpu / memory / object_store_memory.
+3. Calls to `subtract`, `add`, `copy`, `scale`, `min`, `max` — each
+   builds a new `ExecutionResources` instance.
+
+We keep the **algorithm exactly as today** (same fair-share
+distribution, same borrow / cap, same final `_op_budgets`) and just
+shrink the constant factor:
+
+- **Inputs that don't change per dispatch get cached.** `_total_shared`,
+  `_op_reserved`, `eligible_ops`, `_get_completed_ops_usage()`,
+  `get_global_limits()`. `eligible_ops` is invalidated when an op
+  finishes; `_op_reserved` is invalidated when `_update_reservation`
+  runs (i.e., when `limits` changes — every 10 s). The hot path reads
+  the cached values directly, skipping the recompute.
+- **Per-op work runs on scalar fields, not `ExecutionResources`
+  instances.** The allocator keeps `cpu / gpu / memory / object_store`
+  as parallel float arrays indexed by op-id. The arithmetic in the two
+  passes becomes plain `float` math — no constructor allocation, no
+  `safe_round` (rounding is deferred until a caller materializes an
+  `ExecutionResources` via `get_budget(op)`).
+- **`_global_running_usage` is read from the live aggregate** (Part
+  2b) rather than re-summed from per-op caches.
+
+Net effect: same `_op_budgets` after every dispatch as today —
+bit-identical given the same inputs — but ~10× cheaper per call.
+
+```python
+class ReservationOpResourceAllocator:
+    # Cached invariants (refreshed when their inputs change).
+    _total_shared_cpu: float
+    _total_shared_obj_store: float
+    ...
+    _op_reserved_cpu: List[float]            # parallel to _eligible_ops
+    _op_reserved_obj_store: List[float]
+    _eligible_ops: List[PhysicalOperator]
+
+    # Per-call workspace (no allocation).
+    _op_budget_cpu: List[float]
+    _op_budget_obj_store: List[float]
+
+    def update_budgets(self, *, limits: ExecutionResources) -> None:
+        # Same two-pass algorithm as today, on scalar arrays. No
+        # ExecutionResources constructors in the hot path.
+        ...
+```
+
+Projected: ~30 s → ~2-3 s at 5000 workers, with exact equivalence to
+today's per-dispatch budget values.
+
+#### 2d. Call-site changes
 
 ```python
 # DataOpTask.on_data_ready, after emitting each RefBundle:
@@ -436,7 +490,7 @@ self._op.on_output_bytes_added(meta.size_bytes)               # new
 
 # OpState.dispatch_next_task, after submitting:
 op.submit_task(task)
-op.on_task_dispatched(task.task_resource_bundle)              # new
+op.on_task_dispatched(task.task_resource_bundle)              # new (per-op + global delta)
 
 # DataOpTask.task_done_callback wrapper:
 op.on_task_completed(task.task_resource_bundle)               # new
@@ -454,14 +508,22 @@ just observed from different sides.
 
 | frame (at 5000_tasks)                    | today  | projected | reasoning |
 | ---                                      | ---:   | ---:      | --- |
-| `update_usages` (inclusive)              | ~110 s |   <5 s    | O(1) per call — just dispatches to `_update_allocated_budgets` when configured |
-| `safe_round` (leaf)                      |  ~46 s |   <5 s    | only at delta application, not on every `update_usages` |
-| `_update_allocated_budgets`              |  ~30 s | ~20-25 s  | still runs, reads the live global aggregate |
+| `update_usages` (inclusive, excluding allocator) |  ~80 s |  <1 s | per-op summation gone; live global aggregate read directly |
+| `_update_allocated_budgets`              |  ~30 s |  ~2-3 s   | same algorithm, scalar-array workspace + cached invariants — no per-call `ExecutionResources` construction |
+| `safe_round` (leaf, both)                |  ~46 s |  <3 s     | only at delta application + on the boundary where budgets are materialized for callers |
 
-Projected scheduler-thread reduction at 5000 workers: **~110 s → ~25 s
-on the `update_usages` family**, ~14 % of the 600 s total at that
-scale. The O(1) shape also means the win scales with N_ops — at
-higher op-count topologies it grows.
+Projected scheduler-thread reduction at 5000 workers: **~140 s → ~5 s
+on the `update_usages` + `_update_allocated_budgets` family**, ~22 %
+of the 600 s total at that scale. The wins compound with N_ops *and*
+with dispatch count per iteration — at higher op-count or higher
+dispatch-density topologies they grow.
+
+**Equivalence guarantee:** `_op_budgets` after every dispatch is
+bit-identical to today's values given the same inputs. The
+optimization is purely a constant-factor reduction (skip redundant
+re-summation, use scalar fields instead of `ExecutionResources`
+constructors); the fair-share algorithm, the borrow / cap logic, and
+the per-dispatch call cadence are all preserved.
 
 ## Combined effect
 
@@ -469,10 +531,10 @@ Each part attacks a different cost; they compose.
 
 | 5000_tasks scheduler thread | today | + Part 1 | + Parts 1 & 2 |
 | --- | ---: | ---: | ---: |
-| `process_completed_tasks`  | 315 s |  ~280 s | ~280 s   |
-| `update_usages`            | 110 s |  ~110 s |  ~30 s   |
-| `dispatch_next_task`       | 120 s |  ~120 s | ~120 s   |
-| **Total**                  | ~600 s| ~580 s | **~500 s** |
+| `process_completed_tasks`            | 315 s |  ~280 s | ~280 s   |
+| `update_usages` + `_update_allocated_budgets` | 140 s | ~140 s |  ~5 s   |
+| `dispatch_next_task`                 | 120 s |  ~120 s | ~120 s   |
+| **Total**                            | ~600 s| ~580 s | **~440 s** |
 
 The data-path win is concentrated in mid-range scale (1000-2000
 workers, where `on_data_ready` per-call `ray.get` overhead

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -347,76 +347,115 @@ Each hook updates two places:
 2. The `ResourceManager`'s global aggregate (so `update_usages`
    doesn't have to re-sum).
 
+**Hook frequency matters.** At 5000 workers a scheduler iteration
+fires ~20 000 `on_task_dispatched`, ~20 000 `on_task_completed`, and
+hundreds-to-thousands of `on_output_bytes_*` calls. If each hook
+builds a new `ExecutionResources` via `add` / `subtract` /
+`copy`, the constructor + `safe_round` overhead adds **~2-5 s of
+hook cost per iteration** — that would eat most of what we saved on
+the allocator. So the cached state is stored as **scalar fields**,
+not `ExecutionResources` instances; each hook is 1-4 float adds.
+`ExecutionResources` is materialized only when an external caller
+reads via a property.
+
 ```python
 class PhysicalOperator:
-    # Per-op cache. Readers (current_logical_usage etc.) become
-    # trivial properties over these fields.
-    _cached_logical_usage:        ExecutionResources
-    _cached_running_usage:        ExecutionResources
-    _cached_pending_usage:        ExecutionResources
-    _cached_obj_store_mem_bytes:  int
+    # Cached state as plain scalars. Each hook is 1-4 float adds; no
+    # ExecutionResources construction, no safe_round per call.
+    _cached_logical_cpu:    float
+    _cached_logical_gpu:    float
+    _cached_logical_memory: float
+    _cached_running_cpu:    float
+    _cached_running_gpu:    float
+    _cached_running_memory: float
+    _cached_pending_cpu:    float
+    _cached_pending_gpu:    float
+    _cached_pending_memory: float
+    _cached_obj_store_mem_bytes: int
 
-    # ResourceManager set at op-bind time so the hooks can push deltas.
-    _resource_manager:            ResourceManager
+    # Bound at op construction so missing the global-update side is a
+    # deref error, not a silent skew.
+    _resource_manager: ResourceManager
 
     def on_output_bytes_added(self, n: int) -> None:
-        """Called by DataOpTask.on_data_ready after each RefBundle emit."""
-        self._cached_obj_store_mem_bytes += n
-        self._resource_manager._apply_obj_store_delta(n)
+        self._cached_obj_store_mem_bytes                 += n
+        self._resource_manager._global_obj_store_mem_bytes += n
 
     def on_output_bytes_consumed(self, n: int) -> None:
-        """Called when a downstream op pops bytes from this op's output
-        queue, or when an external consumer reads via iter_batches /
-        streaming_split."""
-        self._cached_obj_store_mem_bytes -= n
-        self._resource_manager._apply_obj_store_delta(-n)
+        self._cached_obj_store_mem_bytes                 -= n
+        self._resource_manager._global_obj_store_mem_bytes -= n
 
     def on_task_dispatched(self, task_bundle: ExecutionResources) -> None:
-        """Called by dispatch_next_task after submitting a remote task."""
-        self._cached_running_usage = self._cached_running_usage.add(task_bundle)
-        self._cached_pending_usage = self._cached_pending_usage.subtract(task_bundle)
-        self._resource_manager._apply_dispatch_delta(task_bundle)
+        self._cached_running_cpu    += task_bundle.cpu
+        self._cached_running_gpu    += task_bundle.gpu
+        self._cached_running_memory += task_bundle.memory
+        self._cached_pending_cpu    -= task_bundle.cpu
+        self._cached_pending_gpu    -= task_bundle.gpu
+        self._cached_pending_memory -= task_bundle.memory
+        rm = self._resource_manager
+        rm._global_running_cpu    += task_bundle.cpu
+        rm._global_running_gpu    += task_bundle.gpu
+        rm._global_running_memory += task_bundle.memory
+        rm._global_pending_cpu    -= task_bundle.cpu
+        rm._global_pending_gpu    -= task_bundle.gpu
+        rm._global_pending_memory -= task_bundle.memory
 
     def on_task_completed(self, task_bundle: ExecutionResources) -> None:
-        """Called from task_done_callback."""
-        self._cached_running_usage = self._cached_running_usage.subtract(task_bundle)
-        self._resource_manager._apply_complete_delta(task_bundle)
+        self._cached_running_cpu    -= task_bundle.cpu
+        self._cached_running_gpu    -= task_bundle.gpu
+        self._cached_running_memory -= task_bundle.memory
+        rm = self._resource_manager
+        rm._global_running_cpu    -= task_bundle.cpu
+        rm._global_running_gpu    -= task_bundle.gpu
+        rm._global_running_memory -= task_bundle.memory
+
+    # Readers materialize ExecutionResources on demand. Constructor +
+    # safe_round runs at most once per get_*_usage() call, not on
+    # every hook firing.
+    def current_logical_usage(self) -> ExecutionResources:
+        return ExecutionResources(
+            cpu=self._cached_logical_cpu,
+            gpu=self._cached_logical_gpu,
+            memory=self._cached_logical_memory,
+        )
 ```
 
 #### 2b. `ResourceManager` keeps the global aggregate live
 
 ```python
 class ResourceManager:
-    # Live global aggregates, kept current by the delta appliers.
-    # No per-op poll loop, no re-derivation.
-    _global_usage:         ExecutionResources
-    _global_running_usage: ExecutionResources
-    _global_pending_usage: ExecutionResources
+    # Plain scalar fields, mirroring per-op storage. Updated by hooks.
+    _global_running_cpu:           float
+    _global_running_gpu:           float
+    _global_running_memory:        float
+    _global_pending_cpu:           float
+    _global_pending_gpu:           float
+    _global_pending_memory:        float
+    _global_obj_store_mem_bytes:   int
 
-    def _apply_obj_store_delta(self, n: int) -> None:
-        # Single scalar mutation. Constructed ExecutionResources is
-        # materialized on read, not on every delta.
-        self._global_obj_store_mem_bytes += n
-
-    def _apply_dispatch_delta(self, task_bundle: ExecutionResources) -> None:
-        self._global_running_usage = self._global_running_usage.add(task_bundle)
-        self._global_pending_usage = self._global_pending_usage.subtract(task_bundle)
-
-    def _apply_complete_delta(self, task_bundle: ExecutionResources) -> None:
-        self._global_running_usage = self._global_running_usage.subtract(task_bundle)
+    def get_global_running_usage(self) -> ExecutionResources:
+        return ExecutionResources(
+            cpu=self._global_running_cpu,
+            gpu=self._global_running_gpu,
+            memory=self._global_running_memory,
+            object_store_memory=self._global_obj_store_mem_bytes,
+        )
 
     def update_usages(self) -> None:
-        # O(1). Aggregates are already current; the allocator's
+        # Aggregates are already current. The allocator's
         # _update_allocated_budgets still runs per dispatch (see 2c)
-        # but now consumes the live aggregate instead of recomputing.
+        # but now consumes the live scalar aggregate instead of
+        # recomputing it.
         if self._op_resource_allocator is not None:
             self._update_allocated_budgets()
 ```
 
 The per-op summation (the ~80 s of "construct N×K `ExecutionResources`
-+ call `safe_round` 4× each" in today's profile) is gone. What
-remains is `_update_allocated_budgets` itself, which we make cheap in
-2c.
++ call `safe_round` 4× each" in today's profile) is gone. So is the
+matching cost in the hooks themselves — even though they're now
+called ~40 000 times per iteration at 5000 workers, the cumulative
+cost of all hook firings is **~50–100 ms**. What remains is
+`_update_allocated_budgets` itself, which we make cheap in 2c.
 
 Safety note: this is sound because the scheduler thread is
 single-threaded — every mutation site (`on_data_ready`,
@@ -510,13 +549,15 @@ just observed from different sides.
 | ---                                      | ---:   | ---:      | --- |
 | `update_usages` (inclusive, excluding allocator) |  ~80 s |  <1 s | per-op summation gone; live global aggregate read directly |
 | `_update_allocated_budgets`              |  ~30 s |  ~2-3 s   | same algorithm, scalar-array workspace + cached invariants — no per-call `ExecutionResources` construction |
-| `safe_round` (leaf, both)                |  ~46 s |  <3 s     | only at delta application + on the boundary where budgets are materialized for callers |
+| `safe_round` (leaf, both)                |  ~46 s |  <3 s     | only when callers materialize `ExecutionResources` via `get_*_usage()`, not on every hook firing |
+| **new** hook overhead (~40 k calls/iter) |   —    |  ~50-100 ms | scalar-field deltas, no `ExecutionResources` constructor in the hot path |
 
 Projected scheduler-thread reduction at 5000 workers: **~140 s → ~5 s
 on the `update_usages` + `_update_allocated_budgets` family**, ~22 %
-of the 600 s total at that scale. The wins compound with N_ops *and*
-with dispatch count per iteration — at higher op-count or higher
-dispatch-density topologies they grow.
+of the 600 s total at that scale, with the new hook overhead adding
+**<100 ms** on top. The wins compound with N_ops *and* with dispatch
+count per iteration — at higher op-count or higher dispatch-density
+topologies they grow.
 
 **Equivalence guarantee:** `_op_budgets` after every dispatch is
 bit-identical to today's values given the same inputs. The
@@ -524,6 +565,16 @@ optimization is purely a constant-factor reduction (skip redundant
 re-summation, use scalar fields instead of `ExecutionResources`
 constructors); the fair-share algorithm, the borrow / cap logic, and
 the per-dispatch call cadence are all preserved.
+
+**Why the hooks don't undo the win:** every dispatch / completion /
+emit / pop fires a hook (~40 000 calls per iteration at 5000
+workers), so a naive implementation that built a fresh
+`ExecutionResources` per call would add ~2-5 s of hook overhead and
+eat most of the savings. Storing the cached state as scalar floats
+keeps each hook at 1-4 plain adds (<1 µs); the cumulative cost
+across all hook firings is well under 100 ms. `ExecutionResources`
+is materialized only at the boundary where a caller reads via
+`get_*_usage()` — at most a handful of times per iteration.
 
 ## Combined effect
 

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -13,7 +13,7 @@ the relevant code path report what changed.**
 
 | subsystem      | today's anti-pattern                                                                                                                            | this RFC                                                                                                            |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain all gens first, look up block sizes locally (Ray Core primitive), trim by per-op budget, then issue **one** batched `ray.get(meta_refs)` covering only the pairs that fit budget |
+| **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain each ready task's gen up to its budget — looking up `size_bytes` inline via the Ray Core primitive (no RPC) so we stop pulling at the budget — then issue **one** batched `ray.get(meta_refs)` over what was drained |
 | **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers)             | Ops push resource deltas at mutation sites (emit / dispatch / done); `update_usages` shrinks to an aggregator      |
 
 On the wide-schema `worker_scaling` release-test matrix (m5.2xlarge × {36,
@@ -174,33 +174,39 @@ The redundancy:
 ### Design
 
 Restructure `process_completed_tasks` so each scheduler iteration
-issues **one** batched `ray.get(meta_refs, ...)` instead of N
-per-pair calls. Use the Ray Core size primitive to know each block's
-byte size *before* fetching its metadata, so the batched call covers
-**only the pairs whose blocks fit the per-op budget** — no
-speculative over-fetch, no cross-iteration cache state.
+issues **one** batched `ray.get(meta_refs, ...)` instead of N per-pair
+calls. The drain itself is budget-aware: as each `block_ref` is pulled
+from the gen, look up its `size_bytes` via the Ray Core primitive
+inline and stop pulling when the running sum exceeds the task's
+budget. The batched `ray.get` then covers exactly what was drained —
+no speculative over-fetch, no separate trim pass, no cross-iteration
+cache state.
 
 ```
 process_completed_tasks(topology, ...)
    │
    ├── ray.wait(active_task_refs) → ready set
    │
-   ├── # 1. Drain each ready task's gen into its pending-pairs queue.
+   ├── # 1. Drain each ready task's gen up to its per-task budget.
+   │   #    For each pulled block_ref, look up size_bytes inline,
+   │   #    queue (block_ref, size_bytes, meta_ref) on the task,
+   │   #    and collect meta_ref into to_fetch.
+   │   to_fetch = []
    │   for task in ready_tasks:
-   │       while task.peek_pending_pair() is not None: pass
+   │       bytes_read = 0
+   │       while max_bytes_to_read is None or bytes_read < max_bytes_to_read:
+   │           block_ref  = gen._next_sync(timeout=0)
+   │           if block_ref.is_nil(): break              # gen not ready
+   │           size_bytes = ray.experimental.get_object_sizes([block_ref])[0]
+   │           meta_ref   = gen._next_sync(timeout=METADATA_WAIT_TIMEOUT_S)
+   │           task._pending.append((block_ref, size_bytes, meta_ref))
+   │           to_fetch.append(meta_ref)
+   │           bytes_read += size_bytes
    │
-   ├── # 2. Look up each queued block's byte size (local, no RPC).
-   │   sizes = ray.experimental.get_object_sizes(all_pending_block_refs)
-   │
-   ├── # 3. Per op, walk that op's tasks' queued pairs in order,
-   │   #    sum block sizes against remaining_output_budget, and
-   │   #    collect the prefix of meta_refs that fit.
-   │   to_fetch = [...]
-   │
-   ├── # 4. ONE batched ray.get covering only the trimmed prefix.
+   ├── # 2. ONE batched ray.get covering only what was drained.
    │   bytes_by_meta_ref = dict(zip(to_fetch, ray.get(to_fetch, timeout=…)))
    │
-   └── # 5. Each task pops queue pairs in order and emits.
+   └── # 3. Each task pops queue pairs in order and emits.
        for task in ready_tasks:
            task.on_data_ready(budget, bytes_by_meta_ref)
 ```
@@ -209,41 +215,43 @@ process_completed_tasks(topology, ...)
 Every site that reads `bundle.metadata.X` (size_bytes, num_rows,
 exec_stats, task_exec_stats, input_files) keeps working unmodified.
 
-### 1a. `DataOpTask` queue holds `(block_ref, meta_ref)` pairs
+### 1a. `DataOpTask` queues `(block_ref, size_bytes, meta_ref)` triples
 
 Replace the single `_pending_block_ref` / `_pending_meta_ref` scalar
-slots with a `Deque[(block_ref, meta_ref)]` queue, plus a
+slots with a `Deque[(block_ref, size_bytes, meta_ref)]` queue, plus a
 `_partial_block_ref` stash for the half-pulled-pair case (the gen
 yields block then metadata; they can arrive in separate scheduler
-ticks). `peek_pending_pair()` is a drainable method (call in a loop
-until it returns `None`).
+ticks).
 
 ```python
 class DataOpTask:
-    _pending_pairs: Deque[Tuple[ObjectRef[Block], ObjectRef[BlockMetadata]]]
+    _pending: Deque[Tuple[ObjectRef[Block], int, ObjectRef[BlockMetadata]]]
     _partial_block_ref: ObjectRef[Block]
     _gen_exhausted: bool
     _gen_errored_block: Optional[ObjectRef]
 
-    def peek_pending_pair(self) -> Optional[Tuple[ObjectRef, ObjectRef]]:
-        """Pull one (block_ref, meta_ref) pair from the gen into
-        _pending_pairs. Returns None if no full pair is immediately
-        ready. Loop to drain."""
+    def drain_up_to(self, max_bytes_to_read) -> List[ObjectRef[BlockMetadata]]:
+        """Pull (block_ref, meta_ref) pairs from the gen until either
+        the gen has no more ready output or the running sum of
+        size_bytes (from the Ray Core primitive) exceeds
+        max_bytes_to_read. Each pulled triple is appended to _pending.
+        Returns the meta_refs added this iteration so the caller can
+        collect them into a batched ray.get list."""
         ...
 
     def on_data_ready(self, max_bytes_to_read, bytes_by_meta_ref=None):
-        """Pop queued pairs in order, look up bytes in the caller-
-        supplied dict, emit RefBundles. Per-ref ray.get fallback on
-        cache miss."""
+        """Pop queued triples in order, look up the deserialized
+        metadata in bytes_by_meta_ref, emit RefBundles. Per-ref
+        ray.get fallback on cache miss."""
         ...
 ```
 
 Why a queue rather than a scalar: pulling from the generator is
-**destructive** — once we peek, the ref is gone from the stream.
-Pairs that don't get emitted this iteration (because they didn't fit
-the budget, or the batched `ray.get` timed out) must persist on the
-task. Per-iteration state lives in the caller-supplied
-`bytes_by_meta_ref` dict.
+**destructive** — once we pull, the ref is gone from the stream.
+Triples that don't get emitted this iteration (because the batched
+`ray.get` timed out, or because the per-op budget in `on_data_ready`
+emits only a prefix) must persist on the task. Per-iteration state
+lives in the caller-supplied `bytes_by_meta_ref` dict.
 
 ### 1b. Assumed dependency: cheap per-ref `size_bytes` from Ray Core
 
@@ -278,8 +286,8 @@ warning as a cache-miss fallback. The fallback runs when:
 2. `on_data_ready` was called outside `process_completed_tasks` (tests,
    debugging) with no `bytes_by_meta_ref`.
 
-A convenience `fetch_and_drain(max_bytes_to_read)` wraps `peek` +
-`on_data_ready` for direct callers (tests).
+A convenience `fetch_and_emit(max_bytes_to_read)` wraps `drain_up_to`
++ per-ref `ray.get` + `on_data_ready` for direct callers (tests).
 
 ### Expected impact (data path)
 
@@ -306,14 +314,16 @@ Two observations from the py-spy breakdowns:
   time actually *grows* for the tasks variant (164 s → 218 s). The
   dispatch side starts to dominate — Part 2 below.
 
-Cost: `peek_pending_pair` adds 2-3 % of scheduler-thread time across
-all variants. Small price for the batching infrastructure.
+Cost: the budget-aware drain (`_next_sync` + inline size lookup) adds
+2-3 % of scheduler-thread time across all variants. Small price for
+the batching infrastructure.
 
-Compared to a per-pair `ray.get` baseline, the size-aware batched
-design also keeps the per-iteration over-fetch ceiling at ~1 pair past
-budget (the prefix sum can overshoot by one). Without size info we'd
-either over-fetch up to the entire gen backlog (and need to carry
-cached bytes across iterations) or under-utilize the batched call.
+Compared to a per-pair `ray.get` baseline, the size-aware drain also
+keeps the per-iteration over-fetch ceiling at ~1 pair past budget
+(the running sum can overshoot by one when the next pulled block
+crosses the budget). Without size info we'd either over-fetch up to
+the entire gen backlog (and need to carry cached bytes across
+iterations) or under-utilize the batched call.
 
 ## Part 2: Control path — push, don't poll
 
@@ -437,9 +447,9 @@ tasks variant and 1.4× on the actors variant.
 | file | changes |
 | --- | --- |
 | Ray Core API surface for per-ref `size_bytes` (exact shape TBD with Core team) | exposes the cheap, reliable size lookup that the budget-aware trim depends on |
-| `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` switches from scalar `_pending_*_ref` slots to a `Deque[(block_ref, meta_ref)]` queue + partial-block stash; `peek_pending_pair` drainable; `on_data_ready` takes `bytes_by_meta_ref` dict; per-ref `ray.get` fallback for cache miss; `fetch_and_drain` convenience |
-| `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` runs the 5-step flow above (drain peek → size lookup → budget trim → batched `ray.get` → emit) |
-| `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to new `on_data_ready` signature; new tests for peek-drain + size-aware trim + cache-miss fallback |
+| `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` switches from scalar `_pending_*_ref` slots to a `Deque[(block_ref, size_bytes, meta_ref)]` queue + partial-block stash; new `drain_up_to(max_bytes_to_read)` pulls inline with the size lookup; `on_data_ready` takes `bytes_by_meta_ref` dict; per-ref `ray.get` fallback for cache miss |
+| `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` runs the 3-step flow above (budget-aware drain with inline size lookup → batched `ray.get` → emit) |
+| `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to new `on_data_ready` signature; new tests for budget-aware drain + cache-miss fallback |
 
 `RefBundle` layout and the streaming-generator protocol are
 **unchanged**. The 68 production sites that read
@@ -548,7 +558,7 @@ unchanged.
 3. **Queue state on `DataOpTask`.** The per-task pending-pairs deque
    adds state that must be drained correctly on task completion /
    error / cancellation. Mitigation: drain in `task_done_callback`;
-   covered by new tests for peek-drain + cache-miss fallback.
+   covered by new tests for budget-aware drain + cache-miss fallback.
 
 ### Part 2
 1. **Cache drift.** Any future code path that mutates op state without

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -13,13 +13,14 @@ the relevant code path report what changed.**
 
 | subsystem      | today's anti-pattern                                                                                                                            | this RFC                                                                                                            |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; the scheduler thread blocks on metadata fetch + deserialization | Defer the metadata fetch entirely. Scheduler carries `size_bytes` (from Ray Core) and `num_rows` (inline from the streaming gen) as scalars on the `RefBundle`; downstream consumers that need full `BlockMetadata` (stats reporting, lineage) `ray.get` the `meta_ref` lazily, off the scheduler thread |
+| **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain all gens first, look up block sizes locally (Ray Core primitive), trim by per-op budget, then issue **one** batched `ray.get(meta_refs)` covering only the pairs that fit budget |
 | **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers)             | Ops push resource deltas at mutation sites (emit / dispatch / done); `update_usages` shrinks to an aggregator      |
 
 On the wide-schema `worker_scaling` release-test matrix (m5.2xlarge × {36,
 72, 143, 358} nodes for {500, 1000, 2000, 5000} workers), the two parts
-together are projected to cut max scheduling-loop time by ~40-60 % across
-the matrix.
+together are projected to cut max scheduling-loop time by ~40-50 % at the
+1000-2000 worker scale and ~25-30 % at 5000 workers, where the dispatch
+side dominates.
 
 Both parts are independent. Either can land alone. They're presented
 together because they share the same architectural shift (poll → push,
@@ -168,111 +169,88 @@ The redundancy:
   grew (`meta.size_bytes`), but doesn't tell anyone — the next
   `update_usages` re-walks the output queue to find out.
 
-## Part 1: Data path — defer the metadata fetch entirely
+## Part 1: Data path — batch the metadata `ray.get`, size-aware
 
 ### Design
 
-The scheduler thread **never `ray.get`s metadata**. It carries the two
-scalar fields it actually needs from each block (`size_bytes` and
-`num_rows`) as inline values on the `RefBundle`. The full
-`BlockMetadata` (exec stats, input files, task exec stats) lives behind
-a `meta_ref` that downstream consumers — stats reporting, lineage
-tracking — fetch lazily, off the scheduler thread.
+Restructure `process_completed_tasks` so each scheduler iteration
+issues **one** batched `ray.get(meta_refs, ...)` instead of N
+per-pair calls. Use the Ray Core size primitive to know each block's
+byte size *before* fetching its metadata, so the batched call covers
+**only the pairs whose blocks fit the per-op budget** — no
+speculative over-fetch, no cross-iteration cache state.
 
 ```
 process_completed_tasks(topology, ...)
    │
    ├── ray.wait(active_task_refs) → ready set
    │
-   ├── for each ready DataOpTask:
-   │      while task.peek_pending_pair() is not None: pass     ← drain gen
+   ├── # 1. Drain each ready task's gen into its pending-pairs queue.
+   │   for task in ready_tasks:
+   │       while task.peek_pending_pair() is not None: pass
    │
-   ├── # No ray.get on metadata. We already have:
-   │   #   - block_ref           (from the gen)
-   │   #   - num_rows scalar     (inline from the gen — see 1b)
-   │   #   - meta_ref            (from the gen, kept opaque)
-   │   #   - size_bytes scalar   (from Ray Core — see 1c)
+   ├── # 2. Look up each queued block's byte size (local, no RPC).
+   │   sizes = ray.experimental.get_object_sizes(all_pending_block_refs)
    │
-   └── for each ready DataOpTask:
-          task.on_data_ready(budget)                            ← pure assemble + emit
-              │
-              ├── pop queued pair (block_ref, num_rows, meta_ref)
-              ├── size_bytes ← ray.experimental.get_object_sizes([block_ref])[0]
-              ├── build RefBundle entry (block_ref, size_bytes, num_rows, meta_ref)
-              ├── emit RefBundle
-              └── bytes_read += size_bytes
+   ├── # 3. Per op, walk that op's tasks' queued pairs in order,
+   │   #    sum block sizes against remaining_output_budget, and
+   │   #    collect the prefix of meta_refs that fit.
+   │   to_fetch = [...]
+   │
+   ├── # 4. ONE batched ray.get covering only the trimmed prefix.
+   │   bytes_by_meta_ref = dict(zip(to_fetch, ray.get(to_fetch, timeout=…)))
+   │
+   └── # 5. Each task pops queue pairs in order and emits.
+       for task in ready_tasks:
+           task.on_data_ready(budget, bytes_by_meta_ref)
 ```
 
-### 1a. `DataOpTask` queue holds `(block_ref, num_rows, meta_ref)` triples
+`RefBundle` and the streaming generator protocol are **unchanged**.
+Every site that reads `bundle.metadata.X` (size_bytes, num_rows,
+exec_stats, task_exec_stats, input_files) keeps working unmodified.
+
+### 1a. `DataOpTask` queue holds `(block_ref, meta_ref)` pairs
 
 Replace the single `_pending_block_ref` / `_pending_meta_ref` scalar
-slots with a `Deque[(block_ref, num_rows, meta_ref)]` queue, plus a
-`_partial` stash for the half-pulled-pair case (the gen yields the
-three components in order; they can arrive in separate scheduler
+slots with a `Deque[(block_ref, meta_ref)]` queue, plus a
+`_partial_block_ref` stash for the half-pulled-pair case (the gen
+yields block then metadata; they can arrive in separate scheduler
 ticks). `peek_pending_pair()` is a drainable method (call in a loop
 until it returns `None`).
 
 ```python
 class DataOpTask:
-    _pending: Deque[Tuple[ObjectRef[Block], int, ObjectRef[BlockMetadata]]]
-    _partial: ...                                  # half-pulled state
+    _pending_pairs: Deque[Tuple[ObjectRef[Block], ObjectRef[BlockMetadata]]]
+    _partial_block_ref: ObjectRef[Block]
     _gen_exhausted: bool
     _gen_errored_block: Optional[ObjectRef]
 
-    def peek_pending_pair(self) -> Optional[Tuple[ObjectRef, int, ObjectRef]]:
-        """Pull one (block_ref, num_rows, meta_ref) triple from the gen
-        into _pending. Returns None if not immediately ready."""
+    def peek_pending_pair(self) -> Optional[Tuple[ObjectRef, ObjectRef]]:
+        """Pull one (block_ref, meta_ref) pair from the gen into
+        _pending_pairs. Returns None if no full pair is immediately
+        ready. Loop to drain."""
         ...
 
-    def on_data_ready(self, max_bytes_to_read) -> int:
-        """Pop queued triples, look up size_bytes via the Core primitive,
-        build RefBundle entries, emit."""
+    def on_data_ready(self, max_bytes_to_read, bytes_by_meta_ref=None):
+        """Pop queued pairs in order, look up bytes in the caller-
+        supplied dict, emit RefBundles. Per-ref ray.get fallback on
+        cache miss."""
         ...
 ```
 
 Why a queue rather than a scalar: pulling from the generator is
-**destructive** — once we peek, the values are gone from the stream.
-Triples that don't get emitted this iteration (budget exhausted) must
-persist on the task.
+**destructive** — once we peek, the ref is gone from the stream.
+Pairs that don't get emitted this iteration (because they didn't fit
+the budget, or the batched `ray.get` timed out) must persist on the
+task. Per-iteration state lives in the caller-supplied
+`bytes_by_meta_ref` dict.
 
-### 1b. Streaming generator protocol: yield `num_rows` inline
+### 1b. Assumed dependency: cheap per-ref `size_bytes` from Ray Core
 
-Today the producing worker yields two values per block:
-
-```python
-yield block                                            # ObjectRef
-yield pickle.dumps(BlockMetadataWithSchema(...))       # ObjectRef
-```
-
-Proposed:
-
-```python
-yield block                                            # ObjectRef
-yield num_rows                                         # int — small object, inlined
-yield pickle.dumps(BlockMetadataWithSchema(...))       # ObjectRef — fetched lazily
-```
-
-The `num_rows` value is a small Python `int`, which Ray Core already
-inlines into the `ObjectRef` itself (objects under
-`max_direct_call_object_size`, ~100 KB by default — way more than an
-int needs). `ray.get` on an inlined ref is a local memory copy with
-no object store interaction.
-
-The full metadata is still produced and stored — we just don't fetch it
-on the scheduler thread.
-
-This is a Ray-Data-internal protocol change to the streaming generator
-contract; no Ray Core change involved. It does require updating every
-task generator that participates in `DataOpTask` to yield the
-three-tuple instead of the pair. The existing TODO in
-`DataOpTask.__init__` calls this protocol out as something to evolve.
-
-### 1c. Assumed dependency: cheap per-ref `size_bytes` from Ray Core
-
-The design depends on a Ray Core primitive that returns each ref's byte
-size **without** issuing an RPC or fetching the object data, and that is
-**reliably populated** by the time the streaming generator surfaces the
-ref to the driver. Surface used in the rest of this document:
+The design depends on a Ray Core primitive that returns each ref's
+byte size **without** issuing an RPC or fetching the object data, and
+that is **reliably populated** by the time the streaming generator
+surfaces the ref to the driver:
 
 ```python
 sizes = ray.experimental.get_object_sizes(block_refs)   # List[int], one per ref
@@ -284,125 +262,58 @@ to an existing API, an inlined field on `ObjectRef`, or something else
 This RFC assumes the primitive exists and is reliable for streaming-gen
 owned refs; see the open questions section.
 
-### 1d. `RefBundle` layout change
+The size lets us **trim the metadata fetch up front**, so what we
+`ray.get` is exactly what we emit this iteration. No cross-iteration
+cache, no speculative over-fetch.
 
-`RefBundle.blocks` today is `Tuple[Tuple[ObjectRef[Block],
-BlockMetadata], ...]` — each entry carries a fully-dereferenced
-`BlockMetadata` object. The proposed shape:
-
-```python
-@dataclass(frozen=True)
-class BlockEntry:
-    block_ref:  ObjectRef[Block]
-    size_bytes: int                  # from Ray Core
-    num_rows:   int                  # inlined by the streaming gen
-    _meta_ref:  ObjectRef[BlockMetadata]   # opaque; fetched on demand
-
-    @cached_property
-    def metadata(self) -> BlockMetadata:
-        """Lazy: fetched the first time a consumer asks. Only stats /
-        lineage paths exercise this; scheduler-thread code never does."""
-        return ray.get(self._meta_ref)
-```
-
-`RefBundle` then carries `Tuple[BlockEntry, ...]` instead of
-`Tuple[Tuple[ObjectRef, BlockMetadata], ...]`. Schema stays where it is
-— `RefBundle.schema` is already a top-level field (see 1f below for
-how it's populated without a scheduler-thread `ray.get`).
-
-`RefBundle.size_bytes()` and `RefBundle.num_rows()` (today both walk
-each block's metadata) become direct sums of the inline scalars. No
-dereference, no `ray.get`.
-
-### 1e. Lazy metadata access for stats / lineage consumers
-
-The 68 production sites that read `bundle.metadata.*` fall into two
-groups:
-
-- **Scheduler hot path (read scalars):** `size_bytes`, `num_rows`.
-  After this RFC: direct field reads, no `ray.get`.
-- **Stats / lineage consumers (read non-scalar fields):**
-  `exec_stats`, `task_exec_stats`, `input_files`. After this RFC: pay
-  a `ray.get` on `_meta_ref` when accessing — but this fires once per
-  op completion, not per block per scheduler iteration. Off the
-  scheduler thread.
-
-Examples:
-- `map_operator._output_blocks_stats.extend(to_stats(bundle.metadata))`
-  fires when the op finishes producing — one batched
-  `ray.get(meta_refs)` materializes all the metadata at once.
-- `input_data_buffer` reads `input_files` once at op construction; one
-  `ray.get` per op.
-- Per-block scheduler-loop logging (which currently reads
-  `metadata.num_rows` / `metadata.size_bytes` for progress bar
-  updates) — already covered by the scalar fields.
-
-### 1f. Schema delivery
-
-`RefBundle.schema` is today populated by the scheduler when it
-`pickle.loads`-es the `BlockMetadataWithSchema` payload. With the
-metadata fetch deferred, schema needs another delivery path. Options:
-
-1. **Worker yields schema once per task** (in the gen protocol, as a
-   fourth optional inline value before the first block). The scheduler
-   caches it per-task / per-op; subsequent yields don't repeat it.
-   Schema is identical across all blocks of a single map task, so a
-   single inline yield amortizes naturally.
-2. **Fetch on-demand from the first block's `meta_ref`.** Downstream
-   ops that need schema validation pay one `ray.get` at op-bind time;
-   subsequent blocks reuse the cached schema.
-
-Option 1 is cleaner if we're already changing the gen protocol for
-`num_rows`. See open questions.
-
-### Per-call `ray.get` fallback (error path only)
+### Per-call `ray.get` fallback
 
 `on_data_ready` keeps a per-ref `ray.get(meta_ref)` + `GetTimeoutError`
-warning as a fallback for the rare case the Core size primitive
-returns `None` (Open Questions item 1) — falls through to the
-pre-refactor behavior with the standard per-ref warning and
-retry-next-iteration semantics. In the steady-state happy path this
-fallback is dead code; it exists for diagnostic visibility when
-something has gone wrong upstream.
+warning as a cache-miss fallback. The fallback runs when:
+
+1. The batched `ray.get` raised `GetTimeoutError` and no bytes were
+   cached for the iteration — falls through to per-ref so the worker
+   crash / node preemption surfaces with the standard warning and
+   retry-next-iteration semantics.
+2. `on_data_ready` was called outside `process_completed_tasks` (tests,
+   debugging) with no `bytes_by_meta_ref`.
 
 A convenience `fetch_and_drain(max_bytes_to_read)` wraps `peek` +
 `on_data_ready` for direct callers (tests).
 
 ### Expected impact (data path)
 
-Pre-refactor py-spy breakdown for `on_data_ready` (5000_tasks):
+Prototype measurements on the wide-schema `worker_scaling` matrix:
 
-| frame                              | inclusive | what it is |
-| --- | ---: | --- |
-| `on_data_ready` (total)            | 294 s |  |
-|   `ray.get_objects` (leaf)         | 164 s | per-pair `ray.get(meta_ref)` |
-|   `pickle.loads` (metadata)        |  ~25 s| deserialize `BlockMetadataWithSchema` |
-|   `Schema.__setstate__` etc.       |  ~10 s| schema deserialize on cache miss |
-|   `RefBundle` construction + emit  |  ~15 s| `_output_ready_callback` + bookkeeping |
-|   loop overhead                    |  ~80 s| `_next_sync` gen pulls, queue mgmt |
+| variant     | master | this RFC (data path only) | reduction | speedup |
+| ----------- | -----: | --: | --: | --: |
+| 500_actors  |  0.89 s|  0.69 s | 22.9 % | 1.30× |
+| 500_tasks   |  2.40 s|  1.58 s | 34.3 % | 1.52× |
+| 1000_actors |  1.69 s|  1.28 s | 24.6 % | 1.33× |
+| **1000_tasks** |  6.58 s|  3.72 s | **43.4 %** | **1.77×** |
+| 2000_actors |  3.19 s|  2.33 s | 26.9 % | 1.37× |
+| 2000_tasks  | 14.63 s|  8.96 s | 38.8 % | 1.63× |
+| 5000_actors |  9.83 s|  8.75 s | 11.0 % | 1.12× |
+| 5000_tasks  | 33.61 s| 28.69 s | 14.6 % | 1.17× |
 
-After this RFC, the scheduler thread does:
+Two observations from the py-spy breakdowns:
 
-- `ray.experimental.get_object_sizes(block_refs)` — cheap local lookup.
-- Queue pops + `RefBundle` construction.
-- `bytes_read += size_bytes` (scalar).
+- **Wins peak at 1000–2000 workers.** Per-call `ray.get` overhead was
+  the binding constraint there; `on_data_ready` inclusive share drops
+  from 42–49 % to 4–35 % after batching.
+- **Dampens at 5000 workers.** The batched `ray.get(N refs)` fans out
+  to all 358 nodes and blocks on the slowest ref; `get_objects` leaf
+  time actually *grows* for the tasks variant (164 s → 218 s). The
+  dispatch side starts to dominate — Part 2 below.
 
-**No `ray.get`, no `pickle.loads`, no schema deserialize.** Projected
-`on_data_ready`:
+Cost: `peek_pending_pair` adds 2-3 % of scheduler-thread time across
+all variants. Small price for the batching infrastructure.
 
-| variant     | master `on_data_ready` | projected | reduction |
-| ----------- | ---: | ---: | ---: |
-| 1000_tasks  |  40 s |  ~3 s | ~92 % |
-| 2000_tasks  |  87 s |  ~6 s | ~93 % |
-| 5000_tasks  | 294 s | ~20 s | ~93 % |
-
-The savings concentrate at scale (more pairs ingested per iteration =
-more avoided `ray.get`s).
-
-Cost paid elsewhere: stats / lineage paths now do an extra `ray.get`
-per op completion. For a topology of ~3 ops, that's 3 `ray.get` calls
-per dataset, batched. Negligible compared to the per-pair savings —
-and these run off the scheduler thread.
+Compared to a per-pair `ray.get` baseline, the size-aware batched
+design also keeps the per-iteration over-fetch ceiling at ~1 pair past
+budget (the prefix sum can overshoot by one). Without size info we'd
+either over-fetch up to the entire gen backlog (and need to carry
+cached bytes across iterations) or under-utilize the batched call.
 
 ## Part 2: Control path — push, don't poll
 
@@ -502,38 +413,37 @@ Each part attacks a different cost; they compose.
 
 | 5000_tasks scheduler thread | today | + Part 1 | + Parts 1 & 2 |
 | --- | ---: | ---: | ---: |
-| `process_completed_tasks`  | 315 s |  ~40 s  | ~40 s   |
+| `process_completed_tasks`  | 315 s |  ~280 s | ~280 s   |
 | `update_usages`            | 110 s |  ~110 s |  ~30 s   |
 | `dispatch_next_task`       | 120 s |  ~120 s | ~120 s   |
-| `safe_round` (leaf)        |  ~46 s|   ~46 s |   <5 s  |
-| **Total scheduler thread** | ~600 s| ~320 s | **~200 s** |
+| **Total**                  | ~600 s| ~580 s | **~500 s** |
 
-The data-path win is dramatic at every scale once the per-pair
-`ray.get` and pickle-loads are out of the hot path. The control-path
-win compounds at the high end where `update_usages` dominates after
-the data side shrinks. Together: an estimated **3× reduction in total
-scheduler-thread time** at 5000 workers.
+The data-path win is concentrated in mid-range scale (1000-2000
+workers, where `on_data_ready` per-call `ray.get` overhead
+dominates); the control-path win is concentrated at the high end
+(5000+ workers, where `update_usages` dominates). Together they
+cover the whole scaling range.
 
 For `max_scheduling_loop` (the metric users actually feel), prototype
-batched-`ray.get` measurements (without deferred metadata) showed
-1.3-1.77× reduction at 500-2000 workers, dampening to 1.12-1.17× at
-5000. With deferred metadata + push-model resource accounting, the
-projected combined improvement is **1.5-2.5× across the whole
-scaling range**, with the largest absolute savings at 5000 workers.
+data-path measurements show 1.3-1.77× reduction at 500-2000 workers,
+dampening to 1.12-1.17× at 5000. Adding the control-path refactor
+should restore the win at 5000 — projected combined 1.3-1.5× on the
+tasks variant and 1.4× on the actors variant.
 
 ## Scope
 
-### Part 1: data path (~600-800 LoC)
+### Part 1: data path (~500 LoC)
 
 | file | changes |
 | --- | --- |
-| Ray Core API surface for per-ref `size_bytes` (exact shape TBD with Core team) | exposes the cheap, reliable size lookup |
-| Streaming-generator protocol contract (Ray Data internal) | adds inline `num_rows` (and optionally schema) to the yield sequence; updates the workers that produce blocks for `DataOpTask` (map, read, etc.) |
-| `data/_internal/execution/interfaces/ref_bundle.py` | `RefBundle.blocks` becomes `Tuple[BlockEntry, ...]`; `BlockEntry` carries inline `size_bytes` + `num_rows` + opaque `_meta_ref` + lazy `metadata` property |
-| `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` queue becomes `Deque[(block_ref, num_rows, meta_ref)]`; `peek_pending_pair` drainable; `on_data_ready` does scalar-only emit, no `ray.get` in steady state |
-| `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` no longer batches `ray.get` on metadata |
-| Stats / lineage call sites that read `bundle.metadata.exec_stats` etc. | migrate to the lazy `BlockEntry.metadata` accessor; ideally batch their own `ray.get` over many entries at op-completion time |
-| `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to the new `RefBundle` layout and gen protocol; new tests for inline `num_rows` delivery + lazy metadata access |
+| Ray Core API surface for per-ref `size_bytes` (exact shape TBD with Core team) | exposes the cheap, reliable size lookup that the budget-aware trim depends on |
+| `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` switches from scalar `_pending_*_ref` slots to a `Deque[(block_ref, meta_ref)]` queue + partial-block stash; `peek_pending_pair` drainable; `on_data_ready` takes `bytes_by_meta_ref` dict; per-ref `ray.get` fallback for cache miss; `fetch_and_drain` convenience |
+| `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` runs the 5-step flow above (drain peek → size lookup → budget trim → batched `ray.get` → emit) |
+| `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to new `on_data_ready` signature; new tests for peek-drain + size-aware trim + cache-miss fallback |
+
+`RefBundle` layout and the streaming-generator protocol are
+**unchanged**. The 68 production sites that read
+`bundle.metadata.*` keep working as-is.
 
 ### Part 2: control path (~300-600 LoC)
 
@@ -551,44 +461,47 @@ scaling range**, with the largest absolute savings at 5000 workers.
 
 Both parts are independent. Suggested order:
 
-1. **Ray Core size primitive first.** Part 1 depends on it; landing it
-   first unblocks the Data-side work and lets us validate
-   reliability on the streaming-gen use case before relying on it.
-2. **Part 1 (data path).** Streaming-gen protocol change + `RefBundle`
-   layout + `DataOpTask` queue + lazy `BlockEntry.metadata`. Lands as
-   its own PR.
-3. **Part 2 (control path).** Independent of Parts 1 and the Core
+1. **Ray Core size primitive first.** Part 1's budget-aware trim
+   depends on it; landing it first unblocks the Data-side work.
+2. **Part 1 (data path).** Self-contained, measured wins, smaller
+   blast radius (touches the data-fetch path, not the resource
+   manager).
+3. **Part 2 (control path).** Independent of Part 1 and the Core
    primitive. Could land before Part 1 if convenient.
 
 Either Data-side part can ship without the other. If Part 2's
-op-subclass migration runs long, Part 1 carries most of the wide-schema
+op-subclass migration runs long, Part 1 carries most of the mid-range
 wins in production while Part 2 lands incrementally.
 
 ## Alternatives considered
 
 ### Data path
 
-- **Batched `ray.get` of metadata in `process_completed_tasks`** — keep
-  fetching metadata in the scheduler thread but collapse N small
-  `ray.get` calls into one batched call per scheduler iteration. This
-  was the earlier shape of the same proposal and a measured prototype
-  showed 1.3-1.77× max-loop reduction at 500-2000 workers, dampening
-  to 1.12-1.17× at 5000.
-  - *Pros:* no Ray Core dependency (uses existing `ray.get`); no
-    streaming-gen protocol change; existing `RefBundle` layout
-    preserved.
-  - *Cons:* metadata fetch is still on the scheduler thread, just
-    batched. At 5000 workers the batched call itself becomes the
-    bottleneck (one slow ref blocks the whole call; `get_objects` leaf
-    time *grows* — measured 164 s → 218 s for tasks variant). Solves
-    the per-call overhead, doesn't solve the "metadata is on the
-    critical path at all" question. Adds cross-iteration cache state to
-    handle over-fetch.
 - **Per-pair `ray.get` with smaller fixed overhead** — would require
   Ray Core changes to the `ray.get` codepath; large blast radius for
   a marginal improvement.
 - **Hard cap on batch size** (`MAX_REFS_PER_BATCH=256`) — bounds the
-  blast radius but still fetches metadata on the scheduler thread.
+  blast radius of one slow ref, but the trimmed-by-budget design
+  already caps the batch at what fits the per-op output budget.
+
+Note: removing the metadata `ray.get` from the scheduler thread
+*entirely* is not a viable option. The scheduler thread consumes
+fields from `BlockMetadata` beyond `size_bytes` / `num_rows`:
+
+- `streaming_executor_state.py` reads `ref.schema` to validate and
+  unify schemas across bundles emitted into an op's output queue.
+  `RefBundle.schema` is populated today from the same
+  `pickle.loads(BlockMetadataWithSchema)` that produces the
+  metadata.
+- `DataOpTask.on_data_ready` reads `self._last_block_meta.task_exec_stats`
+  on `StopIteration` to pass into `task_done_callback`.
+- `OpRuntimeMetrics` reads `meta.exec_stats.node_id` to attribute
+  per-node metrics when bundles are emitted on the scheduler thread.
+
+These consumers run on the scheduler thread synchronously with the
+emit. They need the materialized `BlockMetadata`, not an opaque ref.
+The size-aware batched `ray.get` design keeps all of them working
+unchanged.
 
 ### Control path
 
@@ -615,28 +528,27 @@ wins in production while Part 2 lands incrementally.
 ## Risks
 
 ### Part 1
-1. **Streaming-gen protocol change is invasive.** Every task generator
-   that participates in `DataOpTask` (map, read, hash-shuffle, ...)
-   has to yield the new three-tuple instead of the pair. Mitigation:
-   make the inline `num_rows` optional initially — `peek_pending_pair`
-   tolerates pairs (the old shape) and falls back to `ray.get` on the
-   meta_ref to obtain `num_rows`. Migrate generators one at a time,
-   measure each.
-2. **Lazy metadata fetch shifts cost to consumers.** Stats / lineage
-   paths now pay a `ray.get` per `meta_ref`. Mitigation: most
-   consumers operate on whole bundles at op-completion time, so they
-   can batch their own `ray.get(meta_refs)`. The total work is no
-   higher than before — it's just off the scheduler thread.
-3. **Dependence on the Ray Core size primitive being reliable.** If
+1. **Dependence on the Ray Core size primitive being reliable.** If
    the assumed cheap `size_bytes` lookup ever returns stale or missing
-   values for streaming-gen owned refs, the scheduler hot path falls
-   through to `ray.get(meta_ref)` to recover `size_bytes`. Mitigation:
-   see "Open questions" — Core team to specify the guaranteed-reliable
-   surface.
-4. **Schema delivery without metadata fetch.** Two options sketched in
-   1f; the gen-protocol option is preferred but adds yet another
-   inline value. Mitigation: prototype both, measure which is
-   cleaner.
+   values for streaming-gen owned refs, the budget-aware trim
+   degrades: we either over-fetch (treat unknown size as 0 and pull
+   everything) or under-fetch (treat unknown as ∞ and emit nothing).
+   Mitigation: see "Open questions" — Core team to specify the
+   guaranteed-reliable surface; the per-ref `ray.get(meta_ref)`
+   fallback in `on_data_ready` recovers `size_bytes` on cache miss.
+2. **One slow ref still blocks the batched call.** The batched
+   `ray.get(meta_refs, timeout=…)` blocks on the slowest ref in the
+   batch; at 5000 workers measurements show the leaf `get_objects`
+   time *growing* (164 s → 218 s for the tasks variant). Mitigation:
+   the budget trim caps the batch at "what fits the per-op output
+   budget", typically much smaller than the gen backlog; pairs that
+   don't make it persist on the task queue and are retried next
+   iteration. `GetTimeoutError` falls through to per-ref `ray.get`
+   with the existing warning + retry-next-iteration semantics.
+3. **Queue state on `DataOpTask`.** The per-task pending-pairs deque
+   adds state that must be drained correctly on task completion /
+   error / cancellation. Mitigation: drain in `task_done_callback`;
+   covered by new tests for peek-drain + cache-miss fallback.
 
 ### Part 2
 1. **Cache drift.** Any future code path that mutates op state without
@@ -662,19 +574,12 @@ wins in production while Part 2 lands incrementally.
   owned refs at the moment the driver receives the ref. The Python
   entry point and the underlying implementation are both Core-team
   decisions; this RFC assumes the result.
-- **Schema delivery without scheduler-thread `ray.get`:** option 1
-  (worker yields schema once per task in the gen protocol) or option
-  2 (lazy fetch from the first block's `meta_ref` at op-bind time)?
-  Pick one before implementation.
-- **Lazy `BlockEntry.metadata` access pattern:** should the stats /
-  lineage consumers batch their `ray.get` over all of an op's blocks
-  at op-completion time, or fetch per-block as needed? Probably
-  batched-at-completion for efficiency; needs an explicit code-style
-  recommendation.
-- **`BlockEntry` shape:** dataclass with named fields, or just a
-  four-tuple `(block_ref, size_bytes, num_rows, meta_ref)`? Dataclass
-  is clearer; tuple is cheaper to construct. Hot path, so possibly
-  tuple.
+- **Batch `ray.get` timeout policy.** Today's per-pair call uses
+  `METADATA_GET_TIMEOUT_S`. For the batched call we need to pick:
+  a single shared timeout for the whole batch (simpler, but one slow
+  ref starves everything else), or partition the batch by op and use
+  a per-op timeout. Probably the former with the per-ref fallback
+  catching pathological cases.
 - Should `_cached_logical_usage` be a single `ExecutionResources` or
   four separate scalar fields (cpu / gpu / memory / obj_store)?
   Constructors are the bottleneck, so probably scalars;

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -1,0 +1,320 @@
+# RFC: Push-model resource accounting in the Ray Data StreamingExecutor scheduler loop
+
+## Status
+
+Draft. Not implementation; a design proposal for review before code.
+
+## Motivation
+
+After the metadata-fetch batching landed (#63483), py-spy on the wide-schema
+`worker_scaling` release tests shows the StreamingExecutor scheduling thread's
+remaining dominant cost is **resource accounting**, not data movement:
+
+| frame (5000_tasks, inclusive of scheduler thread) | seconds | share |
+| --- | ---: | ---: |
+| `_scheduling_loop_step` (total)                   |  ~600 s | 100 % |
+| `update_usages` + `_update_allocated_budgets`     |  ~110 s |  ~18 % |
+| `safe_round` (leaf hot spot inside update_usages) |   ~46 s |  ~8 %  |
+| `process_completed_tasks` (post-PR #63483)        |  ~280 s |  ~47 % |
+| `dispatch_next_task` (`remote()` + bookkeeping)   |  ~120 s |  ~20 % |
+
+`update_usages` is called **three times per scheduler iteration** — once before
+`process_completed_tasks`, once after, and **once per dispatched task** inside
+the dispatch loop. At 5000 workers × ~10 blocks each, that's ~20 k full
+re-computations of every operator's resource bundle per scheduler iteration,
+even though each individual mutation only changes one operator's slot.
+
+This RFC proposes inverting the control flow: ops push their resource deltas
+at the points of mutation; the `ResourceManager` becomes a passive aggregator;
+`update_usages` shrinks to a near-no-op.
+
+## When each scheduler hook is called today
+
+The scheduling thread runs `_scheduling_loop_step` in a tight loop. Each
+iteration:
+
+```
+_scheduling_loop_step()                                  [streaming_executor.py:460]
+   │
+   ├── update_usages()                                   ← [1] PRE-PROCESS recompute
+   │
+   ├── process_completed_tasks()                         [streaming_executor_state.py]
+   │      │
+   │      ├── ray.wait(active_task_refs) → ready set
+   │      │
+   │      ├── for each ready DataOpTask:
+   │      │     while task.peek_pending_pair() is not None: pass
+   │      │
+   │      ├── ray.experimental.get_object_sizes(block_refs)   ← #63483 size-aware trim
+   │      ├── per-op budget trim
+   │      ├── ray.get(trimmed_meta_refs, timeout=...)         ← ONE batched fetch
+   │      │
+   │      └── for each ready DataOpTask:
+   │             task.on_data_ready(budget, bytes_by_meta_ref)   ← [A] EMITS RefBundles
+   │
+   ├── update_usages()                                   ← [2] POST-PROCESS recompute
+   │
+   └── while True:                                       ← dispatch phase
+          op = select_operator_to_run(...)
+          if op is None: break
+          topology[op].dispatch_next_task()              ← [B] SUBMITS a remote task
+          update_usages()                                ← [3] PER-DISPATCH recompute (hot)
+```
+
+### `on_data_ready` (per-task, called by `process_completed_tasks`)
+
+- **Trigger:** `ray.wait` returned the task's streaming generator as ready
+  (i.e., the producing worker yielded one or more new outputs).
+- **Frequency:** once per iteration per task whose generator surfaced new
+  blocks. Each call may emit multiple RefBundles (subject to
+  `max_bytes_to_read` budget).
+- **State mutated:** the op's output queue (`op.output_queue.append(bundle)`)
+  and the per-task `_pending_pairs` deque.
+- **Resource impact:** **emitting a RefBundle increases the op's
+  object-store-memory usage by `meta.size_bytes`**. Today this delta is
+  observable only by polling `_estimate_object_store_memory_usage(op)`
+  inside the next `update_usages` call.
+
+### `dispatch_next_task` (per-op, called from the scheduler's dispatch loop)
+
+- **Trigger:** `select_operator_to_run` chose this op based on current
+  budgets and backpressure. Decision input includes every op's
+  `current_logical_usage()` — i.e., the cached output of `update_usages`.
+- **Frequency:** N times per iteration, where N is the number of ops the
+  scheduler decides to dispatch to before `select_operator_to_run` returns
+  `None`. Typical: tens to hundreds per iteration.
+- **State mutated:** the op's internal task list (a new in-flight task), the
+  op's pending-task counter, the resource bundle reservation.
+- **Resource impact:** **dispatching a task adds the task's resource bundle
+  (CPU/GPU/memory) to the op's `running_logical_usage()`**. Today this
+  delta is observable only via the per-dispatch `update_usages` poll that
+  follows.
+
+### `update_usages` (cross-op, called by the scheduler 3+ times per iteration)
+
+- **Trigger sites:** call [1] before `process_completed_tasks`, [2] after,
+  and [3] after every `dispatch_next_task`.
+- **Frequency:** **2 + dispatch_count per scheduler iteration**. On the
+  5000_tasks workload that's ~20 002 calls per scheduler tick.
+- **What it does:** wipes `_op_usages`, `_op_running_usages`,
+  `_op_pending_usages`, `_global_usage`, `_global_running_usage`,
+  `_global_pending_usage`, then for each op in topology (reversed):
+  - calls `op.current_logical_usage()` (constructs `ExecutionResources`)
+  - calls `op.running_logical_usage()` (constructs another)
+  - calls `op.pending_logical_usage()` (constructs another)
+  - calls `_estimate_object_store_memory_usage(op, state)` (walks the
+    output queue size)
+  - `op_usage.copy(object_store_memory=...)` (constructs another)
+  - 3× `global.add(op_usage)` (constructs another)
+  - sets `op._metrics.obj_store_mem_used`
+  - calls `_update_allocated_budgets()` if there's an allocator
+- **Cost:** every `ExecutionResources` constructor calls `safe_round` 4×
+  (`cpu/gpu/object_store_memory/memory`). At ~5 constructions per op × 3 ops
+  × 20 k dispatch-loop iterations = **~1.2 M `safe_round` calls per
+  scheduler iteration**. This matches the observed ~17 s of leaf
+  `safe_round` time and the ~110 s inclusive cost of `update_usages` at
+  5000 workers.
+
+The author left a TODO acknowledging this:
+
+```python
+def update_usages(self):
+    """Recalculate resource usages."""
+    # TODO(hchen): This method will be called frequently during the execution loop.
+    # And some computations are redundant. We should either remove redundant
+    # computations or remove this method entirely and compute usages on demand.
+```
+
+## The redundancy
+
+Calls [1] and [2] bracket `process_completed_tasks` but nothing between [3] of
+the previous iteration and [1] of the current iteration mutates op state, so
+[1] is *always* a no-op repeat of [3] from the prior iteration.
+
+Calls of type [3] each only need to refresh **one** op's slot — the one
+that just dispatched — but the implementation re-computes every op's slot
+every time.
+
+## Proposal: push deltas at the mutation sites
+
+Invert the control flow. Each event that changes per-op resource usage tells
+the `ResourceManager` directly, by delta. The manager keeps a per-op cache
+that's always current. `update_usages` shrinks to a final aggregation +
+budget-allocator update.
+
+### New op-level hooks (PhysicalOperator API)
+
+```python
+class PhysicalOperator:
+    # Maintained by the manager; ops update via the hooks below.
+    _cached_logical_usage: ExecutionResources
+    _cached_running_usage: ExecutionResources
+    _cached_pending_usage: ExecutionResources
+    _cached_obj_store_mem_bytes: int
+
+    def on_output_bytes_added(self, n: int) -> None:
+        """Called by DataOpTask.on_data_ready after each RefBundle emit."""
+        self._cached_obj_store_mem_bytes += n
+
+    def on_output_bytes_consumed(self, n: int) -> None:
+        """Called when a downstream operator pops bytes from this op's
+        output queue (or when an external consumer reads via
+        iter_batches / streaming_split)."""
+        self._cached_obj_store_mem_bytes -= n
+
+    def on_task_dispatched(self, task_bundle: ExecutionResources) -> None:
+        """Called by dispatch_next_task after submitting a remote task."""
+        self._cached_running_usage = self._cached_running_usage.add(task_bundle)
+        self._cached_pending_usage = self._cached_pending_usage.subtract(task_bundle)
+
+    def on_task_completed(self, task_bundle: ExecutionResources) -> None:
+        """Called from task_done_callback."""
+        self._cached_running_usage = self._cached_running_usage.subtract(task_bundle)
+```
+
+### ResourceManager becomes an aggregator
+
+```python
+def update_usages(self) -> None:
+    # No re-derivation; just sum the cached values that the hooks maintained.
+    self._global_usage = ExecutionResources.sum(
+        op._cached_logical_usage for op in self._topology
+    )
+    self._global_running_usage = ExecutionResources.sum(
+        op._cached_running_usage for op in self._topology
+    )
+    self._global_pending_usage = ExecutionResources.sum(
+        op._cached_pending_usage for op in self._topology
+    )
+    if self._op_resource_allocator is not None:
+        self._update_allocated_budgets()
+```
+
+The hot path becomes O(N_ops) scalar additions, not O(N_ops × constructors ×
+safe_round_calls).
+
+`_update_allocated_budgets` stays — it does the across-op fair-share work
+that no single op can do alone — but it now reads from the cached aggregates
+instead of re-deriving them.
+
+### Call-site changes
+
+```python
+# DataOpTask.on_data_ready, after emitting each RefBundle:
+self._output_ready_callback(RefBundle(...))
+self._op.on_output_bytes_added(meta.size_bytes)   # new
+
+# OpState.dispatch_next_task, after submitting:
+op.submit_task(task)
+op.on_task_dispatched(task.task_resource_bundle)   # new
+
+# DataOpTask.task_done_callback wrapper:
+op.on_task_completed(task.task_resource_bundle)    # new
+
+# downstream operator pulling from its input queue:
+bundle = input_op.output_queue.pop()
+input_op.on_output_bytes_consumed(bundle.size_bytes)   # new
+```
+
+## Expected wins
+
+| frame                                    | today (5000_tasks) | projected (after RFC) | reasoning |
+| ---                                      | ---:               | ---:                  | --- |
+| `update_usages` (inclusive)              | ~110 s             | ~10-20 s              | drops to "sum N scalars per call" + budget allocator |
+| `safe_round` (leaf)                      | ~46 s              | <5 s                  | called only at construction time, not in the hot path |
+| `_update_allocated_budgets`              | ~30 s              | ~20-25 s              | still runs, reads cached values; small constant-factor save |
+
+Estimated total scheduler-thread reduction at 5000 workers: **~110 s → ~30
+s** (~14 % of the 600 s total). Combined with #63483's data-side wins, max
+scheduling loop should drop another ~15-25 % vs. post-#63483.
+
+## Scope
+
+| layer | changes |
+| --- | --- |
+| `ResourceManager` | new aggregator-only `update_usages`; keeps `_update_allocated_budgets`; removes per-op poll loop |
+| `PhysicalOperator` | adds 4 hooks (`on_output_bytes_added/consumed`, `on_task_dispatched/completed`) + 4 cached fields; existing `current_logical_usage`/`running_logical_usage`/`pending_logical_usage` either delete (pure reads of cache) or become trivial reader properties |
+| `DataOpTask.on_data_ready` | calls `op.on_output_bytes_added(meta.size_bytes)` after each emit |
+| `OpState.dispatch_next_task` | calls `op.on_task_dispatched(...)` after submit |
+| `OpTask.task_done_callback` paths | call `op.on_task_completed(...)` |
+| Downstream-consume sites (output queue pops, external consumer reads) | call `op.on_output_bytes_consumed(...)` |
+| Op subclasses with custom resource accounting (`ActorPoolMapOperator`, `LimitOperator`, `OutputSplitter`, ...) | migrate their `current_logical_usage` overrides to push deltas via the hooks |
+| Tests | every `mock` that replaced `current_logical_usage` needs updating to push deltas or set cached fields |
+
+Estimated diff size: **~300-600 LoC** across `_internal/execution/` files.
+The most invasive part is the op-subclass migration — each subclass that
+overrides one of the `*_logical_usage` methods needs to flip from "compute
+on demand" to "push on mutation".
+
+## Alternatives considered
+
+### Alt 1: incremental `update_usages_for_op(op)`
+
+Keep the poll structure but recompute only the op that just changed at sites
+[3]. ~30-50 LoC change; captures ~70 % of the win.
+
+- Pros: tiny diff, no API changes, low review risk.
+- Cons: leaves the architectural mismatch in place. Any future caller that
+  mutates op state still has to remember to call `update_usages_for_op` —
+  same trap, just slightly cheaper. Doesn't address `safe_round` per-op
+  constructor cost.
+
+### Alt 2: inline / fast-path `safe_round`
+
+Skip `safe_round` when the input is already canonicalized (the steady-state
+case). ~10 LoC change in `execution_options.py`.
+
+- Pros: trivially small. Cuts `safe_round` leaf cost by ~80 %.
+- Cons: addresses the symptom (`safe_round` is expensive), not the cause
+  (we construct millions of `ExecutionResources` per iteration that aren't
+  semantically new). Doesn't unblock anything downstream.
+
+### Alt 3: cache `ExecutionResources` by tuple key
+
+Memoize construction: `ExecutionResources(cpu=0.5, gpu=0, ...)` returns the
+same instance for the same args.
+
+- Pros: works without API changes.
+- Cons: dict-lookup overhead approaches per-construction cost; bookkeeping
+  for the cache becomes its own footgun.
+
+**My take:** Alt 1 ("incremental update_usages_for_op") is the right
+**interim** fix that can land while this RFC is reviewed. The push-model
+refactor is the right **long-term** architecture. Both are independent of
+#63483.
+
+## Risks
+
+1. **Cache drift.** Any future code path that mutates op state without
+   calling a hook will silently corrupt the cached usage. Mitigation: keep
+   `current_logical_usage` etc. as the canonical readers (now backed by the
+   cache); add a debug-mode invariant check that compares cached vs.
+   freshly-recomputed values per N iterations.
+2. **Op subclass migration.** Each subclass override needs auditing.
+   Mitigation: do them one at a time; the cached field defaults to a
+   freshly-recomputed value if the subclass hasn't migrated yet (gradual
+   rollout).
+3. **External consumers.** `iter_batches` / `streaming_split` pop bytes from
+   the output queue outside the scheduler thread. Need to either fire the
+   `on_output_bytes_consumed` hook from those code paths or model
+   "externally-consumed bytes" separately. Either way, an explicit decision
+   rather than today's implicit recomputation.
+
+## Open questions
+
+- Should `_cached_logical_usage` be a single `ExecutionResources` or four
+  separate scalar fields (cpu / gpu / memory / obj_store)? Constructors are
+  the bottleneck, so probably scalars; `ExecutionResources` could be
+  materialized on read.
+- `_update_allocated_budgets` reads `get_completed_ops_usage()` — does that
+  also benefit from the cached values, or is it a separate cost?
+- Backwards compatibility: should we maintain the old method signatures
+  (`current_logical_usage()` etc.) as cached-value readers indefinitely,
+  or deprecate them?
+
+## Out of scope
+
+- Changes to `_update_allocated_budgets` budget-allocation algorithm
+  itself. That's a separate optimization.
+- Changes to the data-fetch side (already covered by #63483).
+- Changes to `ray.wait` / `ray.get` core primitives.

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -14,7 +14,7 @@ the relevant code path report what changed.**
 | subsystem      | today's anti-pattern                                                                                                                            | this RFC                                                                                                            |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain each ready task's gen up to its budget — looking up `size_bytes` inline via the Ray Core primitive (no RPC) so we stop pulling at the budget — then issue **one** batched `ray.get(meta_refs)` over what was drained |
-| **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers) | Ops push deltas at mutation sites (emit / dispatch / done) into a single live global aggregate on `ResourceManager`; per-op re-summation is gone, and the `_update_allocated_budgets` algorithm is preserved but runs on scalar-array workspace + cached invariants — **exact equivalence, ~10× cheaper per call** |
+| **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers) | Ops push deltas at mutation sites (emit / dispatch / done) into a single live global aggregate on `ResourceManager`; per-op re-summation is gone, `safe_round` is dropped from the `ExecutionResources` constructor, and `_update_allocated_budgets` is preserved verbatim with cached invariants — **exact equivalence, ~10× cheaper per call, minimal call-site churn** |
 
 On the wide-schema `worker_scaling` release-test matrix (m5.2xlarge × {36,
 72, 143, 358} nodes for {500, 1000, 2000, 5000} workers), the two parts
@@ -349,113 +349,98 @@ Each hook updates two places:
 
 **Hook frequency matters.** At 5000 workers a scheduler iteration
 fires ~20 000 `on_task_dispatched`, ~20 000 `on_task_completed`, and
-hundreds-to-thousands of `on_output_bytes_*` calls. If each hook
-builds a new `ExecutionResources` via `add` / `subtract` /
-`copy`, the constructor + `safe_round` overhead adds **~2-5 s of
-hook cost per iteration** — that would eat most of what we saved on
-the allocator. So the cached state is stored as **scalar fields**,
-not `ExecutionResources` instances; each hook is 1-4 float adds.
-`ExecutionResources` is materialized only when an external caller
-reads via a property.
+hundreds-to-thousands of `on_output_bytes_*` calls. Naively each hook
+builds a new `ExecutionResources` via `add` / `subtract`, and every
+construction calls `safe_round` 4× on cpu / gpu / memory /
+object_store. The `safe_round` leaf is already ~46 s of today's
+profile — left unchanged, the hooks would re-pay it.
+
+**The cheap fix is to drop `safe_round` from the
+`ExecutionResources` constructor.** It's a one-line change that
+attacks the leaf cost directly, without rewriting every call-site to
+work in scalar fields. `ExecutionResources` stays the data model
+everywhere; arithmetic stays on `add` / `subtract`; the hooks are:
 
 ```python
 class PhysicalOperator:
-    # Cached state as plain scalars. Each hook is 1-4 float adds; no
-    # ExecutionResources construction, no safe_round per call.
-    _cached_logical_cpu:    float
-    _cached_logical_gpu:    float
-    _cached_logical_memory: float
-    _cached_running_cpu:    float
-    _cached_running_gpu:    float
-    _cached_running_memory: float
-    _cached_pending_cpu:    float
-    _cached_pending_gpu:    float
-    _cached_pending_memory: float
-    _cached_obj_store_mem_bytes: int
+    _cached_logical_usage:        ExecutionResources
+    _cached_running_usage:        ExecutionResources
+    _cached_pending_usage:        ExecutionResources
+    _cached_obj_store_mem_bytes:  int
 
     # Bound at op construction so missing the global-update side is a
     # deref error, not a silent skew.
     _resource_manager: ResourceManager
 
     def on_output_bytes_added(self, n: int) -> None:
-        self._cached_obj_store_mem_bytes                 += n
+        self._cached_obj_store_mem_bytes                   += n
         self._resource_manager._global_obj_store_mem_bytes += n
 
     def on_output_bytes_consumed(self, n: int) -> None:
-        self._cached_obj_store_mem_bytes                 -= n
+        self._cached_obj_store_mem_bytes                   -= n
         self._resource_manager._global_obj_store_mem_bytes -= n
 
     def on_task_dispatched(self, task_bundle: ExecutionResources) -> None:
-        self._cached_running_cpu    += task_bundle.cpu
-        self._cached_running_gpu    += task_bundle.gpu
-        self._cached_running_memory += task_bundle.memory
-        self._cached_pending_cpu    -= task_bundle.cpu
-        self._cached_pending_gpu    -= task_bundle.gpu
-        self._cached_pending_memory -= task_bundle.memory
+        self._cached_running_usage = self._cached_running_usage.add(task_bundle)
+        self._cached_pending_usage = self._cached_pending_usage.subtract(task_bundle)
         rm = self._resource_manager
-        rm._global_running_cpu    += task_bundle.cpu
-        rm._global_running_gpu    += task_bundle.gpu
-        rm._global_running_memory += task_bundle.memory
-        rm._global_pending_cpu    -= task_bundle.cpu
-        rm._global_pending_gpu    -= task_bundle.gpu
-        rm._global_pending_memory -= task_bundle.memory
+        rm._global_running_usage   = rm._global_running_usage.add(task_bundle)
+        rm._global_pending_usage   = rm._global_pending_usage.subtract(task_bundle)
 
     def on_task_completed(self, task_bundle: ExecutionResources) -> None:
-        self._cached_running_cpu    -= task_bundle.cpu
-        self._cached_running_gpu    -= task_bundle.gpu
-        self._cached_running_memory -= task_bundle.memory
+        self._cached_running_usage = self._cached_running_usage.subtract(task_bundle)
         rm = self._resource_manager
-        rm._global_running_cpu    -= task_bundle.cpu
-        rm._global_running_gpu    -= task_bundle.gpu
-        rm._global_running_memory -= task_bundle.memory
-
-    # Readers materialize ExecutionResources on demand. Constructor +
-    # safe_round runs at most once per get_*_usage() call, not on
-    # every hook firing.
-    def current_logical_usage(self) -> ExecutionResources:
-        return ExecutionResources(
-            cpu=self._cached_logical_cpu,
-            gpu=self._cached_logical_gpu,
-            memory=self._cached_logical_memory,
-        )
+        rm._global_running_usage   = rm._global_running_usage.subtract(task_bundle)
 ```
+
+With `safe_round` gone from `__init__`, each `add` / `subtract` is
+just a constructor with 4 attribute assignments — ~1-2 µs instead
+of ~50-100 µs. Cumulative hook cost across ~40 000 firings: ~50-100
+ms.
+
+**Accuracy.** Today `safe_round` rounds cpu / gpu to 5 decimal
+digits and memory / object_store_memory to integers, with the
+rationale that Ray Core itself allocates fractional resources at
+5-digit precision. Dropping it means:
+
+- *Float drift on CPU / GPU.* Per-op accumulation drift is ~1e-15;
+  even after a full dataset's worth of add/subtract roundtrips it
+  stays well under 1e-9 — three orders of magnitude tighter than
+  Ray Core's 5-digit precision. Resource comparisons (`<= limit`,
+  budget thresholds) are unaffected.
+- *Memory should remain integer.* Memory and object_store_memory are
+  byte counts; today `safe_round(_, 0)` enforces integer storage.
+  Solution: type them as `int` end-to-end, or call `int(...)` at the
+  `__init__` boundary only (cheap — one cast vs. four `round` calls).
+- *Exact-equality usage of `is_zero()` / `__eq__`.* Today's
+  `is_zero` does `cpu == 0.0`. With drift, a should-be-zero value
+  may end up at 1e-15 and stall any loop keyed on it. Fix:
+  `abs(cpu) < EPS` (and same for `__eq__`) — a single-line change to
+  two methods.
 
 #### 2b. `ResourceManager` keeps the global aggregate live
 
 ```python
 class ResourceManager:
-    # Plain scalar fields, mirroring per-op storage. Updated by hooks.
-    _global_running_cpu:           float
-    _global_running_gpu:           float
-    _global_running_memory:        float
-    _global_pending_cpu:           float
-    _global_pending_gpu:           float
-    _global_pending_memory:        float
+    # Live global aggregates, kept current by the delta appliers.
+    # No per-op poll loop, no re-derivation.
+    _global_usage:                 ExecutionResources
+    _global_running_usage:         ExecutionResources
+    _global_pending_usage:         ExecutionResources
     _global_obj_store_mem_bytes:   int
-
-    def get_global_running_usage(self) -> ExecutionResources:
-        return ExecutionResources(
-            cpu=self._global_running_cpu,
-            gpu=self._global_running_gpu,
-            memory=self._global_running_memory,
-            object_store_memory=self._global_obj_store_mem_bytes,
-        )
 
     def update_usages(self) -> None:
         # Aggregates are already current. The allocator's
         # _update_allocated_budgets still runs per dispatch (see 2c)
-        # but now consumes the live scalar aggregate instead of
-        # recomputing it.
+        # but now consumes the live aggregate instead of recomputing.
         if self._op_resource_allocator is not None:
             self._update_allocated_budgets()
 ```
 
-The per-op summation (the ~80 s of "construct N×K `ExecutionResources`
-+ call `safe_round` 4× each" in today's profile) is gone. So is the
-matching cost in the hooks themselves — even though they're now
-called ~40 000 times per iteration at 5000 workers, the cumulative
-cost of all hook firings is **~50–100 ms**. What remains is
-`_update_allocated_budgets` itself, which we make cheap in 2c.
+The per-op summation (the ~80 s of constructor + `safe_round` work
+in today's `update_usages`) is gone. What remains in the hot path
+are the allocator's own per-call constructions, which we address in
+2c — also primarily by leveraging the cheaper constructor.
 
 Safety note: this is sound because the scheduler thread is
 single-threaded — every mutation site (`on_data_ready`,
@@ -476,44 +461,43 @@ Today's `update_budgets` is ~1.5 ms per call × 20 000 calls/iter ≈
    builds a new `ExecutionResources` instance.
 
 We keep the **algorithm exactly as today** (same fair-share
-distribution, same borrow / cap, same final `_op_budgets`) and just
-shrink the constant factor:
+distribution, same borrow / cap, same final `_op_budgets`) and shrink
+the constant factor in two layers:
 
-- **Inputs that don't change per dispatch get cached.** `_total_shared`,
+- **Drop `safe_round` from `ExecutionResources.__init__`** (per 2a).
+  Every constructor call in `update_budgets` — `subtract`, `add`,
+  `copy`, `scale`, `min`, `max` — drops 4 `safe_round` calls and
+  becomes ~10× cheaper without touching the algorithm or the
+  call-sites.
+- **Cache the inputs that don't change per dispatch.** `_total_shared`,
   `_op_reserved`, `eligible_ops`, `_get_completed_ops_usage()`,
   `get_global_limits()`. `eligible_ops` is invalidated when an op
   finishes; `_op_reserved` is invalidated when `_update_reservation`
   runs (i.e., when `limits` changes — every 10 s). The hot path reads
   the cached values directly, skipping the recompute.
-- **Per-op work runs on scalar fields, not `ExecutionResources`
-  instances.** The allocator keeps `cpu / gpu / memory / object_store`
-  as parallel float arrays indexed by op-id. The arithmetic in the two
-  passes becomes plain `float` math — no constructor allocation, no
-  `safe_round` (rounding is deferred until a caller materializes an
-  `ExecutionResources` via `get_budget(op)`).
-- **`_global_running_usage` is read from the live aggregate** (Part
-  2b) rather than re-summed from per-op caches.
+- **Read `_global_running_usage` from the live aggregate** (Part 2b)
+  rather than re-summing per-op caches.
 
 Net effect: same `_op_budgets` after every dispatch as today —
-bit-identical given the same inputs — but ~10× cheaper per call.
+bit-identical given the same inputs — but ~10× cheaper per call,
+**with no `ExecutionResources` → scalar-array refactor**.
 
 ```python
 class ReservationOpResourceAllocator:
     # Cached invariants (refreshed when their inputs change).
-    _total_shared_cpu: float
-    _total_shared_obj_store: float
-    ...
-    _op_reserved_cpu: List[float]            # parallel to _eligible_ops
-    _op_reserved_obj_store: List[float]
+    _total_shared: ExecutionResources
+    _op_reserved:  Dict[PhysicalOperator, ExecutionResources]
     _eligible_ops: List[PhysicalOperator]
-
-    # Per-call workspace (no allocation).
-    _op_budget_cpu: List[float]
-    _op_budget_obj_store: List[float]
+    _completed_ops_usage: ExecutionResources
+    _limits:       ExecutionResources
 
     def update_budgets(self, *, limits: ExecutionResources) -> None:
-        # Same two-pass algorithm as today, on scalar arrays. No
-        # ExecutionResources constructors in the hot path.
+        # Same two-pass algorithm as today; same code structure.
+        # Calls through .add / .subtract / .copy / .scale, but each
+        # constructor inside those is ~10x cheaper now that
+        # safe_round is gone from __init__.
+        if limits != self._limits:
+            self._refresh_cached_invariants(limits)
         ...
 ```
 
@@ -548,9 +532,9 @@ just observed from different sides.
 | frame (at 5000_tasks)                    | today  | projected | reasoning |
 | ---                                      | ---:   | ---:      | --- |
 | `update_usages` (inclusive, excluding allocator) |  ~80 s |  <1 s | per-op summation gone; live global aggregate read directly |
-| `_update_allocated_budgets`              |  ~30 s |  ~2-3 s   | same algorithm, scalar-array workspace + cached invariants — no per-call `ExecutionResources` construction |
-| `safe_round` (leaf, both)                |  ~46 s |  <3 s     | only when callers materialize `ExecutionResources` via `get_*_usage()`, not on every hook firing |
-| **new** hook overhead (~40 k calls/iter) |   —    |  ~50-100 ms | scalar-field deltas, no `ExecutionResources` constructor in the hot path |
+| `_update_allocated_budgets`              |  ~30 s |  ~2-3 s   | same algorithm, cached invariants; constructors ~10× cheaper now that `safe_round` is gone from `__init__` |
+| `safe_round` (leaf, both)                |  ~46 s |  0 s      | removed from the constructor entirely — see 2a |
+| **new** hook overhead (~40 k calls/iter) |   —    |  ~50-100 ms | each hook does 1-2 `.add`/`.subtract` calls; cheap constructor keeps the cumulative cost negligible |
 
 Projected scheduler-thread reduction at 5000 workers: **~140 s → ~5 s
 on the `update_usages` + `_update_allocated_budgets` family**, ~22 %
@@ -560,21 +544,22 @@ count per iteration — at higher op-count or higher dispatch-density
 topologies they grow.
 
 **Equivalence guarantee:** `_op_budgets` after every dispatch is
-bit-identical to today's values given the same inputs. The
-optimization is purely a constant-factor reduction (skip redundant
-re-summation, use scalar fields instead of `ExecutionResources`
-constructors); the fair-share algorithm, the borrow / cap logic, and
-the per-dispatch call cadence are all preserved.
+bit-identical to today's values given the same inputs *modulo the
+single-place `safe_round` removal* — and that removal is bounded:
+cpu/gpu drift stays below 1e-9 (vs. Ray Core's own 5-digit
+precision), memory/object_store stays integer via type discipline,
+and `is_zero` / `__eq__` get an epsilon-tolerant variant. The
+fair-share algorithm, the borrow / cap logic, and the per-dispatch
+call cadence are all preserved verbatim.
 
 **Why the hooks don't undo the win:** every dispatch / completion /
 emit / pop fires a hook (~40 000 calls per iteration at 5000
-workers), so a naive implementation that built a fresh
-`ExecutionResources` per call would add ~2-5 s of hook overhead and
-eat most of the savings. Storing the cached state as scalar floats
-keeps each hook at 1-4 plain adds (<1 µs); the cumulative cost
-across all hook firings is well under 100 ms. `ExecutionResources`
-is materialized only at the boundary where a caller reads via
-`get_*_usage()` — at most a handful of times per iteration.
+workers). With the unchanged `ExecutionResources` arithmetic but the
+cheaper constructor, each hook costs ~1-2 µs and the cumulative
+hook overhead lands under 100 ms — well under what we save on the
+allocator. The alternative of refactoring every call-site to scalar
+fields was rejected as too invasive given how widely
+`ExecutionResources` is used across the codebase.
 
 ## Combined effect
 
@@ -618,13 +603,14 @@ tasks variant and 1.4× on the actors variant.
 
 | file | changes |
 | --- | --- |
-| `data/_internal/execution/resource_manager.py` | `update_usages` becomes aggregator-only; per-op poll loop removed |
-| `data/_internal/execution/interfaces/physical_operator.py` | 4 new hooks (`on_output_bytes_added` / `consumed`, `on_task_dispatched` / `completed`); 4 new cached fields; readers (`current_logical_usage` etc.) become trivial properties over the cache |
+| `data/_internal/execution/interfaces/execution_options.py` | drop `safe_round` from `ExecutionResources.__init__`; cast `memory` / `object_store_memory` to `int` at the boundary; switch `is_zero` and `__eq__` to epsilon-tolerant comparisons |
+| `data/_internal/execution/resource_manager.py` | `update_usages` becomes aggregator-only; per-op poll loop removed. Live global aggregate (`_global_*`) kept current by the hooks. Allocator caches `_total_shared`, `_op_reserved`, `eligible_ops`, `_completed_ops_usage`, `_limits` and refreshes only when their inputs change |
+| `data/_internal/execution/interfaces/physical_operator.py` | 4 new hooks (`on_output_bytes_added` / `consumed`, `on_task_dispatched` / `completed`); 4 new cached `ExecutionResources` fields + scalar obj-store-byte counter; readers (`current_logical_usage` etc.) become trivial properties over the cache; `_resource_manager` bound at op construction |
 | `data/_internal/execution/streaming_executor.py` | dispatch loop calls `op.on_task_dispatched(...)` after `dispatch_next_task` |
 | `data/_internal/execution/interfaces/physical_operator.py` (DataOpTask) | `on_data_ready` calls `self._op.on_output_bytes_added(meta.size_bytes)` after each emit |
 | Op subclasses with custom resource accounting (`MapOperator`, `LimitOperator`, `OutputSplitter`, `ActorPoolMapOperator`, ...) | migrate `current_logical_usage` overrides to push deltas via the hooks |
 | Downstream-consume sites (output queue pops, external consumer reads) | call `op.on_output_bytes_consumed(...)` |
-| Tests | every mock that replaced `current_logical_usage` updates to push deltas or set cached fields |
+| Tests | every mock that replaced `current_logical_usage` updates to push deltas or set cached fields; new tests cover float-drift bounds and epsilon-tolerant `is_zero` / `__eq__` |
 
 ## Rollout
 
@@ -732,11 +718,21 @@ unchanged.
    global from scratch and asserts equality; (c) bind the
    `ResourceManager` reference at op-construction so missing the
    global-update side is a `None` deref, not a silent skew.
-2. **Op subclass migration.** Each subclass override needs auditing.
+2. **Float drift from dropping `safe_round`.** `ExecutionResources`
+   no longer quantizes cpu/gpu to 5 decimals at construction;
+   long-running add/subtract chains can produce values like
+   0.999…998 instead of 1.0. Bounded mitigation: drift stays under
+   ~1e-9 — three orders of magnitude tighter than Ray Core's own
+   5-digit precision — so comparisons against limits and budgets are
+   unaffected. The two places that *do* care are `is_zero` and
+   `__eq__`; both switch to `abs(x) < EPS` (single-line change to
+   each). Memory and object_store_memory stay integer-typed end-to-
+   end (cast at `__init__` boundary) so byte counts can't drift.
+3. **Op subclass migration.** Each subclass override needs auditing.
    Mitigation: do one op at a time; the cached field defaults to a
    freshly-recomputed value if the subclass hasn't migrated yet
    (gradual rollout).
-3. **External consumers.** `iter_batches` / `streaming_split` pop bytes
+4. **External consumers.** `iter_batches` / `streaming_split` pop bytes
    from the output queue outside the scheduler thread. Need to either
    fire the `on_output_bytes_consumed` hook from those paths or model
    "externally-consumed bytes" separately. Either way, an explicit

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -1,34 +1,61 @@
-# RFC: Push-model resource accounting in the Ray Data StreamingExecutor scheduler loop
+# RFC: Scaling the Ray Data StreamingExecutor scheduling thread
 
 ## Status
 
-Draft. Not implementation; a design proposal for review before code.
+Draft. Design proposal for review before code.
+
+## TL;DR
+
+The StreamingExecutor's scheduling thread has two structurally similar
+bottlenecks that both stem from the same anti-pattern: **the scheduler
+asks every operator the same question every iteration, instead of letting
+the relevant code path report what changed.**
+
+| subsystem      | today's anti-pattern                                                                                                                            | this RFC                                                                                                            |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain all gens first, look up block sizes locally, trim by per-op budget, then issue **one** batched `ray.get`     |
+| **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers)             | Ops push resource deltas at mutation sites (emit / dispatch / done); `update_usages` shrinks to an aggregator      |
+
+On the wide-schema `worker_scaling` release-test matrix (m5.2xlarge × {36,
+72, 143, 358} nodes for {500, 1000, 2000, 5000} workers), the two parts
+together are projected to cut max scheduling-loop time by ~40-50 % at the
+1000-2000 worker scale and ~25-30 % at 5000 workers, where the dispatch
+side dominates.
+
+Both parts are independent. Either can land alone. They're presented
+together because they share the same architectural shift (poll → push,
+batch where you can't push) and the same primary metric.
 
 ## Motivation
 
-After the metadata-fetch batching landed (#63483), py-spy on the wide-schema
-`worker_scaling` release tests shows the StreamingExecutor scheduling thread's
-remaining dominant cost is **resource accounting**, not data movement:
+A representative scheduler-thread breakdown today, captured by py-spy on the
+2000_tasks variant of the wide-schema `worker_scaling` release test (600
+columns, 143 m5.2xlarge nodes, `num_cpus=0.5`):
 
-| frame (5000_tasks, inclusive of scheduler thread) | seconds | share |
+| frame (inclusive, of ~198 s scheduler thread) | seconds | share |
 | --- | ---: | ---: |
-| `_scheduling_loop_step` (total)                   |  ~600 s | 100 % |
-| `update_usages` + `_update_allocated_budgets`     |  ~110 s |  ~18 % |
-| `safe_round` (leaf hot spot inside update_usages) |   ~46 s |  ~8 %  |
-| `process_completed_tasks` (post-PR #63483)        |  ~280 s |  ~47 % |
-| `dispatch_next_task` (`remote()` + bookkeeping)   |  ~120 s |  ~20 % |
+| `_scheduling_loop_step` (total)               | 193 s | 97 % |
+| `process_completed_tasks`                     |  96 s | 48 % |
+|   └─ `on_data_ready`                          |  87 s | 44 % |
+|        └─ `ray.get_objects` (leaf)            |  68 s | 35 % |
+| `update_usages` + `_update_allocated_budgets` |  40 s | 20 % |
+|   └─ `safe_round` (leaf, inside update_usages)|  17 s |  9 % |
+| `dispatch_next_task` (`remote()` + bookkeeping)|  41 s | 21 % |
 
-`update_usages` is called **three times per scheduler iteration** — once before
-`process_completed_tasks`, once after, and **once per dispatched task** inside
-the dispatch loop. At 5000 workers × ~10 blocks each, that's ~20 k full
-re-computations of every operator's resource bundle per scheduler iteration,
-even though each individual mutation only changes one operator's slot.
+At 5000 workers (358 nodes) the same shape blows up:
 
-This RFC proposes inverting the control flow: ops push their resource deltas
-at the points of mutation; the `ResourceManager` becomes a passive aggregator;
-`update_usages` shrinks to a near-no-op.
+| frame                                         | seconds | share of ~600 s |
+| --- | ---: | ---: |
+| `process_completed_tasks`                     | 315 s | 52 % |
+|   └─ `on_data_ready`                          | 294 s | 49 % |
+| `update_usages` + `_update_allocated_budgets` | 110 s | 18 % |
+| `dispatch_next_task`                          | 120 s | 20 % |
 
-## When each scheduler hook is called today
+Both `on_data_ready` and `update_usages` are doing redundant work that
+scales with workload size, not with how much state actually changed.
+This RFC removes that redundancy.
+
+## Background: when each scheduler hook runs
 
 The scheduling thread runs `_scheduling_loop_step` in a tight loop. Each
 iteration:
@@ -42,15 +69,8 @@ _scheduling_loop_step()                                  [streaming_executor.py:
    │      │
    │      ├── ray.wait(active_task_refs) → ready set
    │      │
-   │      ├── for each ready DataOpTask:
-   │      │     while task.peek_pending_pair() is not None: pass
-   │      │
-   │      ├── ray.experimental.get_object_sizes(block_refs)   ← #63483 size-aware trim
-   │      ├── per-op budget trim
-   │      ├── ray.get(trimmed_meta_refs, timeout=...)         ← ONE batched fetch
-   │      │
    │      └── for each ready DataOpTask:
-   │             task.on_data_ready(budget, bytes_by_meta_ref)   ← [A] EMITS RefBundles
+   │             task.on_data_ready(budget)              ← [A] PULLS pairs + ray.get + EMITS
    │
    ├── update_usages()                                   ← [2] POST-PROCESS recompute
    │
@@ -58,108 +78,264 @@ _scheduling_loop_step()                                  [streaming_executor.py:
           op = select_operator_to_run(...)
           if op is None: break
           topology[op].dispatch_next_task()              ← [B] SUBMITS a remote task
-          update_usages()                                ← [3] PER-DISPATCH recompute (hot)
+          update_usages()                                ← [3] PER-DISPATCH recompute (HOT)
 ```
 
-### `on_data_ready` (per-task, called by `process_completed_tasks`)
+### `on_data_ready` — site [A]
 
-- **Trigger:** `ray.wait` returned the task's streaming generator as ready
-  (i.e., the producing worker yielded one or more new outputs).
-- **Frequency:** once per iteration per task whose generator surfaced new
-  blocks. Each call may emit multiple RefBundles (subject to
-  `max_bytes_to_read` budget).
-- **State mutated:** the op's output queue (`op.output_queue.append(bundle)`)
-  and the per-task `_pending_pairs` deque.
-- **Resource impact:** **emitting a RefBundle increases the op's
-  object-store-memory usage by `meta.size_bytes`**. Today this delta is
-  observable only by polling `_estimate_object_store_memory_usage(op)`
-  inside the next `update_usages` call.
+```python
+# inside DataOpTask.on_data_ready(max_bytes_to_read)
+while max_bytes_to_read is None or bytes_read < max_bytes_to_read:
+    # 1. Pull block_ref from streaming gen (timeout=0).
+    # 2. Pull meta_ref from streaming gen (small timeout).
+    # 3. ray.get(meta_ref, timeout=METADATA_GET_TIMEOUT_S)         ← ONE RPC per pair
+    # 4. pickle.loads → BlockMetadataWithSchema
+    # 5. Emit RefBundle via _output_ready_callback
+    # 6. bytes_read += meta.size_bytes
+```
 
-### `dispatch_next_task` (per-op, called from the scheduler's dispatch loop)
+- **Trigger:** the task's streaming generator returned ready from `ray.wait`.
+- **Frequency:** once per iteration per task whose gen surfaced new outputs.
+  Each call may emit multiple RefBundles bounded by `max_bytes_to_read`.
+- **State mutated:** the op's output queue; the task's `_pending_block_ref` /
+  `_pending_meta_ref` slots.
+- **Cost driver:** **one `ray.get` per pair**. With ~1-2 ms fixed Python +
+  Cython + raylet RPC overhead per call, an iteration that ingests M pairs
+  across all tasks pays M × ~1.5 ms. At 5000 workers × ~10 blocks each =
+  ~50 k pairs across the run, this is the largest single cost on the
+  thread.
 
-- **Trigger:** `select_operator_to_run` chose this op based on current
-  budgets and backpressure. Decision input includes every op's
-  `current_logical_usage()` — i.e., the cached output of `update_usages`.
-- **Frequency:** N times per iteration, where N is the number of ops the
-  scheduler decides to dispatch to before `select_operator_to_run` returns
-  `None`. Typical: tens to hundreds per iteration.
-- **State mutated:** the op's internal task list (a new in-flight task), the
-  op's pending-task counter, the resource bundle reservation.
-- **Resource impact:** **dispatching a task adds the task's resource bundle
-  (CPU/GPU/memory) to the op's `running_logical_usage()`**. Today this
-  delta is observable only via the per-dispatch `update_usages` poll that
-  follows.
+### `dispatch_next_task` — site [B]
 
-### `update_usages` (cross-op, called by the scheduler 3+ times per iteration)
+- **Trigger:** `select_operator_to_run` chose this op; its budget &
+  backpressure cleared.
+- **Frequency:** N times per iteration where N = ops dispatched before
+  `select_operator_to_run` returns `None`. Typically tens to hundreds.
+- **State mutated:** op's in-flight task list, pending counter, resource
+  bundle reservation.
+- **Resource impact:** **dispatching adds the task's resource bundle to the
+  op's `running_logical_usage()`**. Observable today only via the
+  per-dispatch `update_usages` poll [3] that follows.
 
-- **Trigger sites:** call [1] before `process_completed_tasks`, [2] after,
-  and [3] after every `dispatch_next_task`.
-- **Frequency:** **2 + dispatch_count per scheduler iteration**. On the
-  5000_tasks workload that's ~20 002 calls per scheduler tick.
-- **What it does:** wipes `_op_usages`, `_op_running_usages`,
-  `_op_pending_usages`, `_global_usage`, `_global_running_usage`,
-  `_global_pending_usage`, then for each op in topology (reversed):
-  - calls `op.current_logical_usage()` (constructs `ExecutionResources`)
-  - calls `op.running_logical_usage()` (constructs another)
-  - calls `op.pending_logical_usage()` (constructs another)
-  - calls `_estimate_object_store_memory_usage(op, state)` (walks the
-    output queue size)
-  - `op_usage.copy(object_store_memory=...)` (constructs another)
-  - 3× `global.add(op_usage)` (constructs another)
-  - sets `op._metrics.obj_store_mem_used`
-  - calls `_update_allocated_budgets()` if there's an allocator
-- **Cost:** every `ExecutionResources` constructor calls `safe_round` 4×
-  (`cpu/gpu/object_store_memory/memory`). At ~5 constructions per op × 3 ops
-  × 20 k dispatch-loop iterations = **~1.2 M `safe_round` calls per
-  scheduler iteration**. This matches the observed ~17 s of leaf
-  `safe_round` time and the ~110 s inclusive cost of `update_usages` at
-  5000 workers.
+### `update_usages` — sites [1], [2], [3]
 
-The author left a TODO acknowledging this:
+Frequency: **2 + dispatch_count per scheduler iteration**. On the
+5000_tasks workload that's ~20 002 calls per scheduler tick.
 
 ```python
 def update_usages(self):
-    """Recalculate resource usages."""
-    # TODO(hchen): This method will be called frequently during the execution loop.
-    # And some computations are redundant. We should either remove redundant
-    # computations or remove this method entirely and compute usages on demand.
+    # Wipe per-op + global usage caches…
+    self._global_usage = ExecutionResources(0, 0, 0)
+    self._op_usages.clear()
+    …
+    for op, state in reversed(self._topology.items()):
+        op_usage         = op.current_logical_usage()       # ExecutionResources()
+        op_running_usage = op.running_logical_usage()       # ExecutionResources()
+        op_pending_usage = op.pending_logical_usage()       # ExecutionResources()
+        used_obj_store   = self._estimate_object_store_memory_usage(op, state)
+        op_usage         = op_usage.copy(object_store_memory=used_obj_store)
+        op_running_usage = op_running_usage.copy(...)
+        self._global_usage         = self._global_usage.add(op_usage)
+        self._global_running_usage = self._global_running_usage.add(op_running_usage)
+        self._global_pending_usage = self._global_pending_usage.add(op_pending_usage)
+        op._metrics.obj_store_mem_used = op_usage.object_store_memory
+    if self._op_resource_allocator is not None:
+        self._update_allocated_budgets()
 ```
 
-## The redundancy
+Every `ExecutionResources` constructor calls `safe_round` 4× (`cpu`, `gpu`,
+`object_store_memory`, `memory`). At ~5 constructions per op × 3 ops × 20 k
+dispatch-loop iterations = **~1.2 M `safe_round` calls per scheduler
+iteration**. This matches the observed ~17 s of leaf `safe_round` time and
+the ~40-110 s inclusive cost of `update_usages` depending on scale.
 
-Calls [1] and [2] bracket `process_completed_tasks` but nothing between [3] of
-the previous iteration and [1] of the current iteration mutates op state, so
-[1] is *always* a no-op repeat of [3] from the prior iteration.
+There's a TODO from the original author acknowledging the redundancy:
 
-Calls of type [3] each only need to refresh **one** op's slot — the one
-that just dispatched — but the implementation re-computes every op's slot
-every time.
+```python
+# TODO(hchen): This method will be called frequently during the execution loop.
+# And some computations are redundant. We should either remove redundant
+# computations or remove this method entirely and compute usages on demand.
+```
 
-## Proposal: push deltas at the mutation sites
+The redundancy:
 
-Invert the control flow. Each event that changes per-op resource usage tells
-the `ResourceManager` directly, by delta. The manager keeps a per-op cache
-that's always current. `update_usages` shrinks to a final aggregation +
-budget-allocator update.
+- Call [1] before `process_completed_tasks` and call [3] from the previous
+  iteration's last dispatch sandwich the period when *nothing mutates op
+  state* — call [1] is always a no-op repeat of the prior [3].
+- Each call of type [3] re-derives **every** op's slot when only *one* op's
+  slot — the one just dispatched — actually changed. With ~3 ops in the
+  topology, that's a 3× over-fetch per dispatch.
+- `on_data_ready` already knows by how many bytes the op's output queue
+  grew (`meta.size_bytes`), but doesn't tell anyone — the next
+  `update_usages` re-walks the output queue to find out.
 
-### New op-level hooks (PhysicalOperator API)
+## Part 1: Data path — batch the per-pair `ray.get`
+
+### Design
+
+Restructure `process_completed_tasks` so that each scheduler iteration
+issues **one** batched `ray.get` covering exactly the metadata for the
+pairs that will be emitted, then hands the bytes to each task for emit.
+
+```
+process_completed_tasks(topology, ...)
+   │
+   ├── ray.wait(active_task_refs) → ready set
+   │
+   ├── # 1. Drain each ready task's gen into its pending-pairs queue.
+   │   for task in ready_tasks:
+   │       while task.peek_pending_pair() is not None: pass
+   │
+   ├── # 2. Look up each queued block's size (local, no RPC).
+   │   sizes = ray.experimental.get_object_sizes(all_pending_block_refs)
+   │
+   ├── # 3. Per op, trim each task's queued pairs by remaining budget.
+   │   #    Collect the prefix of meta_refs whose blocks fit.
+   │   to_fetch = [...]
+   │
+   ├── # 4. ONE batched ray.get covering the trimmed union.
+   │   bytes_by_meta_ref = dict(zip(to_fetch, ray.get(to_fetch, timeout=…)))
+   │
+   └── # 5. Each task pops queue pairs in order and emits.
+       for task in ready_tasks:
+           task.on_data_ready(budget, bytes_by_meta_ref)
+```
+
+Two structural changes underneath:
+
+#### 1a. `DataOpTask` switches to a queue-of-pairs
+
+Replace the single `_pending_block_ref` / `_pending_meta_ref` scalar slots
+with a `Deque[(block_ref, meta_ref)]` queue, plus a `_partial_block_ref`
+stash for the half-pulled-pair case. Add `peek_pending_pair()` as a
+drainable method (callable in a loop until it returns `None`).
+
+```python
+class DataOpTask:
+    _pending_pairs:   Deque[(block_ref, meta_ref)]   # pulled from gen, awaiting emission
+    _partial_block_ref: ObjectRef                    # half-pulled state
+    _gen_exhausted:   bool
+    _gen_errored_block: Optional[ObjectRef]
+
+    def peek_pending_pair(self) -> Optional[Tuple[ObjectRef, ObjectRef]]:
+        """Pull one (block_ref, meta_ref) into _pending_pairs; return it.
+        Returns None if no full pair is immediately ready. Loop to drain."""
+        ...
+
+    def on_data_ready(self, max_bytes_to_read, bytes_by_meta_ref=None):
+        """Pop queued pairs in order, look up bytes in the caller-supplied
+        dict, emit RefBundles. Per-ref ray.get fallback on cache miss."""
+        ...
+```
+
+Why a queue rather than a scalar: pulling from the generator is
+**destructive** — once we peek, the ref is gone from the stream. Pairs
+that don't get emitted this iteration (because they didn't fit the budget,
+or the batched `ray.get` timed out) must persist on the task. Per-iteration
+state lives only in the caller-supplied `bytes_by_meta_ref` dict.
+
+#### 1b. New `ray.experimental.get_object_sizes(refs)` helper
+
+```python
+def get_object_sizes(obj_refs: List[ObjectRef]) -> List[Optional[int]]:
+    """Return the byte size of each object as known to Ray Core, or None
+    if the size isn't yet known (the producing task hasn't sealed the
+    object). Local-only; no RPCs."""
+    locations = get_local_object_locations(obj_refs)
+    return [(locations.get(r) or {}).get("object_size") for r in obj_refs]
+```
+
+Thin wrapper over the existing `get_local_object_locations` (which already
+reads `object_size` from the local reference counter — no new RPC, no new
+Ray Core state, just a focused Python entry point onto data Ray Core
+already maintains for OOM / spill / scheduling decisions).
+
+The size lets us **trim the metadata fetch up front**, so what we
+`ray.get` is exactly what we emit this iteration. No cross-iteration
+cache, no speculative over-fetch.
+
+#### 1c. Graceful `None` handling
+
+`get_object_sizes` returns `None` for refs whose owner hasn't yet
+published a size (small race window between the gen yielding a ref and
+the worker's `SealOwnedObject` report reaching the driver). Treat `None`
+as "fetch this pair anyway" — the per-pair `ray.get` happens, the budget
+is still enforced on the emit side via `bytes_read += meta.size_bytes`.
+Same behavior as today for that pair; the precise-trim win is realized
+for the pairs where the size is known.
+
+### Per-call ray.get fallback
+
+`on_data_ready` keeps a per-ref `ray.get(meta_ref)` + `GetTimeoutError`
+warning as a cache-miss fallback. The fallback runs when:
+
+1. The batched `ray.get` raised `GetTimeoutError` and no bytes were
+   cached for the iteration — falls through to per-ref so the worker
+   crash / node preemption surfaces with the standard warning and
+   retry-next-iteration semantics.
+2. `on_data_ready` was called outside `process_completed_tasks` (tests,
+   debugging) with no `bytes_by_meta_ref`.
+
+A convenience `fetch_and_drain(max_bytes_to_read)` wraps `peek` +
+`on_data_ready` for direct callers (tests).
+
+### Expected impact (data path)
+
+Prototype measurements on the wide-schema `worker_scaling` matrix:
+
+| variant     | master | this RFC (data path only) | reduction | speedup |
+| ----------- | -----: | --: | --: | --: |
+| 500_actors  |  0.89 s|  0.69 s | 22.9 % | 1.30× |
+| 500_tasks   |  2.40 s|  1.58 s | 34.3 % | 1.52× |
+| 1000_actors |  1.69 s|  1.28 s | 24.6 % | 1.33× |
+| **1000_tasks** |  6.58 s|  3.72 s | **43.4 %** | **1.77×** |
+| 2000_actors |  3.19 s|  2.33 s | 26.9 % | 1.37× |
+| 2000_tasks  | 14.63 s|  8.96 s | 38.8 % | 1.63× |
+| 5000_actors |  9.83 s|  8.75 s | 11.0 % | 1.12× |
+| 5000_tasks  | 33.61 s| 28.69 s | 14.6 % | 1.17× |
+
+Two observations from the py-spy breakdowns:
+
+- **Wins peak at 1000–2000 workers.** Per-call `ray.get` overhead was
+  the binding constraint there; `on_data_ready` inclusive share drops
+  from 42–49 % to 4–35 % after batching.
+- **Dampens at 5000 workers.** The batched `ray.get(5000 refs)` fans out
+  to all 358 nodes and blocks on the slowest ref; `get_objects` leaf time
+  actually *grows* for the tasks variant (164 s → 218 s). The dispatch
+  side starts to dominate — Part 2 below.
+
+Cost: `peek_pending_pair` adds 2-3 % of scheduler-thread time across all
+variants. Small price for the batching infrastructure.
+
+## Part 2: Control path — push, don't poll
+
+### Design
+
+Invert the control flow on resource accounting. Each event that changes
+per-op resource usage updates the `ResourceManager`'s cache **at the
+mutation site**, by delta. The manager keeps a per-op cache that's always
+current. `update_usages` shrinks to an aggregation pass + budget
+allocator.
+
+#### 2a. New op-level hooks on `PhysicalOperator`
 
 ```python
 class PhysicalOperator:
-    # Maintained by the manager; ops update via the hooks below.
-    _cached_logical_usage: ExecutionResources
-    _cached_running_usage: ExecutionResources
-    _cached_pending_usage: ExecutionResources
-    _cached_obj_store_mem_bytes: int
+    # Maintained by the hooks; readers (current_logical_usage etc.)
+    # become trivial properties over these fields.
+    _cached_logical_usage:        ExecutionResources
+    _cached_running_usage:        ExecutionResources
+    _cached_pending_usage:        ExecutionResources
+    _cached_obj_store_mem_bytes:  int
 
     def on_output_bytes_added(self, n: int) -> None:
         """Called by DataOpTask.on_data_ready after each RefBundle emit."""
         self._cached_obj_store_mem_bytes += n
 
     def on_output_bytes_consumed(self, n: int) -> None:
-        """Called when a downstream operator pops bytes from this op's
-        output queue (or when an external consumer reads via
-        iter_batches / streaming_split)."""
+        """Called when a downstream op pops bytes from this op's output
+        queue, or when an external consumer reads via iter_batches /
+        streaming_split."""
         self._cached_obj_store_mem_bytes -= n
 
     def on_task_dispatched(self, task_bundle: ExecutionResources) -> None:
@@ -172,149 +348,202 @@ class PhysicalOperator:
         self._cached_running_usage = self._cached_running_usage.subtract(task_bundle)
 ```
 
-### ResourceManager becomes an aggregator
+#### 2b. `ResourceManager.update_usages` becomes an aggregator
 
 ```python
 def update_usages(self) -> None:
     # No re-derivation; just sum the cached values that the hooks maintained.
-    self._global_usage = ExecutionResources.sum(
-        op._cached_logical_usage for op in self._topology
-    )
-    self._global_running_usage = ExecutionResources.sum(
-        op._cached_running_usage for op in self._topology
-    )
-    self._global_pending_usage = ExecutionResources.sum(
-        op._cached_pending_usage for op in self._topology
-    )
+    self._global_usage         = sum_resources(op._cached_logical_usage for op in self._topology)
+    self._global_running_usage = sum_resources(op._cached_running_usage for op in self._topology)
+    self._global_pending_usage = sum_resources(op._cached_pending_usage for op in self._topology)
     if self._op_resource_allocator is not None:
         self._update_allocated_budgets()
 ```
 
-The hot path becomes O(N_ops) scalar additions, not O(N_ops × constructors ×
-safe_round_calls).
+Hot path becomes O(N_ops) scalar additions — not O(N_ops × constructors
+× `safe_round` calls). `_update_allocated_budgets` still runs (it does
+the across-op fair-share work), but it now reads from the cached
+aggregates instead of re-deriving them.
 
-`_update_allocated_budgets` stays — it does the across-op fair-share work
-that no single op can do alone — but it now reads from the cached aggregates
-instead of re-deriving them.
-
-### Call-site changes
+#### 2c. Call-site changes
 
 ```python
 # DataOpTask.on_data_ready, after emitting each RefBundle:
 self._output_ready_callback(RefBundle(...))
-self._op.on_output_bytes_added(meta.size_bytes)   # new
+self._op.on_output_bytes_added(meta.size_bytes)               # new
 
 # OpState.dispatch_next_task, after submitting:
 op.submit_task(task)
-op.on_task_dispatched(task.task_resource_bundle)   # new
+op.on_task_dispatched(task.task_resource_bundle)              # new
 
 # DataOpTask.task_done_callback wrapper:
-op.on_task_completed(task.task_resource_bundle)    # new
+op.on_task_completed(task.task_resource_bundle)               # new
 
-# downstream operator pulling from its input queue:
+# downstream op popping from input queue:
 bundle = input_op.output_queue.pop()
-input_op.on_output_bytes_consumed(bundle.size_bytes)   # new
+input_op.on_output_bytes_consumed(bundle.size_bytes)          # new
 ```
 
-## Expected wins
+The two functions `on_data_ready` and `update_usages` stop being
+two functions: emitting a RefBundle *is* updating resource usage,
+just observed from different sides.
 
-| frame                                    | today (5000_tasks) | projected (after RFC) | reasoning |
-| ---                                      | ---:               | ---:                  | --- |
-| `update_usages` (inclusive)              | ~110 s             | ~10-20 s              | drops to "sum N scalars per call" + budget allocator |
-| `safe_round` (leaf)                      | ~46 s              | <5 s                  | called only at construction time, not in the hot path |
-| `_update_allocated_budgets`              | ~30 s              | ~20-25 s              | still runs, reads cached values; small constant-factor save |
+### Expected impact (control path)
 
-Estimated total scheduler-thread reduction at 5000 workers: **~110 s → ~30
-s** (~14 % of the 600 s total). Combined with #63483's data-side wins, max
-scheduling loop should drop another ~15-25 % vs. post-#63483.
+| frame (at 5000_tasks)                    | today  | projected | reasoning |
+| ---                                      | ---:   | ---:      | --- |
+| `update_usages` (inclusive)              | ~110 s | ~10-20 s  | drops to "sum N scalars per call" + budget allocator |
+| `safe_round` (leaf)                      |  ~46 s |   <5 s    | called only at construction, not in hot path |
+| `_update_allocated_budgets`              |  ~30 s | ~20-25 s  | still runs, reads cached values |
+
+Projected scheduler-thread reduction at 5000 workers: **~110 s → ~30 s
+update_usages**, ~14 % of the 600 s total at that scale.
+
+## Combined effect
+
+Each part attacks a different cost; they compose.
+
+| 5000_tasks scheduler thread | today | + Part 1 | + Parts 1 & 2 |
+| --- | ---: | ---: | ---: |
+| `process_completed_tasks`  | 315 s |  ~280 s | ~280 s   |
+| `update_usages`            | 110 s |  ~110 s |  ~30 s   |
+| `dispatch_next_task`       | 120 s |  ~120 s | ~120 s   |
+| **Total**                  | ~600 s| ~580 s | **~500 s** |
+
+The data-path win is concentrated in mid-range scale (1000-2000 workers,
+where `on_data_ready` dominates); the control-path win is concentrated
+at the high end (5000+ workers, where `update_usages` dominates).
+Together they cover the whole scaling range.
+
+For `max_scheduling_loop` (the metric users actually feel), prototype
+data-path measurements show 1.3-1.77× reduction at 500-2000 workers,
+dampening to 1.12-1.17× at 5000. Adding the control-path refactor should
+restore the win at 5000 — projected combined 1.3-1.5× on the tasks
+variant and 1.4× on the actors variant.
 
 ## Scope
 
-| layer | changes |
-| --- | --- |
-| `ResourceManager` | new aggregator-only `update_usages`; keeps `_update_allocated_budgets`; removes per-op poll loop |
-| `PhysicalOperator` | adds 4 hooks (`on_output_bytes_added/consumed`, `on_task_dispatched/completed`) + 4 cached fields; existing `current_logical_usage`/`running_logical_usage`/`pending_logical_usage` either delete (pure reads of cache) or become trivial reader properties |
-| `DataOpTask.on_data_ready` | calls `op.on_output_bytes_added(meta.size_bytes)` after each emit |
-| `OpState.dispatch_next_task` | calls `op.on_task_dispatched(...)` after submit |
-| `OpTask.task_done_callback` paths | call `op.on_task_completed(...)` |
-| Downstream-consume sites (output queue pops, external consumer reads) | call `op.on_output_bytes_consumed(...)` |
-| Op subclasses with custom resource accounting (`ActorPoolMapOperator`, `LimitOperator`, `OutputSplitter`, ...) | migrate their `current_logical_usage` overrides to push deltas via the hooks |
-| Tests | every `mock` that replaced `current_logical_usage` needs updating to push deltas or set cached fields |
+### Part 1: data path (~500 LoC)
 
-Estimated diff size: **~300-600 LoC** across `_internal/execution/` files.
-The most invasive part is the op-subclass migration — each subclass that
-overrides one of the `*_logical_usage` methods needs to flip from "compute
-on demand" to "push on mutation".
+| file | changes |
+| --- | --- |
+| `ray/experimental/locations.py` + `__init__.py` | new `get_object_sizes(refs)` helper |
+| `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` switches from scalar `_pending_*_ref` to queue + partial; new `peek_pending_pair` + drainable semantics; `on_data_ready` takes `bytes_by_meta_ref` dict; per-ref fallback for cache miss; `fetch_and_drain` convenience |
+| `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` runs the 5-step flow above |
+| `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to new `on_data_ready` signature; new tests for peek-drain + size-aware trim + cache-miss fallback |
+
+### Part 2: control path (~300-600 LoC)
+
+| file | changes |
+| --- | --- |
+| `data/_internal/execution/resource_manager.py` | `update_usages` becomes aggregator-only; per-op poll loop removed |
+| `data/_internal/execution/interfaces/physical_operator.py` | 4 new hooks (`on_output_bytes_added` / `consumed`, `on_task_dispatched` / `completed`); 4 new cached fields; readers (`current_logical_usage` etc.) become trivial properties over the cache |
+| `data/_internal/execution/streaming_executor.py` | dispatch loop calls `op.on_task_dispatched(...)` after `dispatch_next_task` |
+| `data/_internal/execution/interfaces/physical_operator.py` (DataOpTask) | `on_data_ready` calls `self._op.on_output_bytes_added(meta.size_bytes)` after each emit |
+| Op subclasses with custom resource accounting (`MapOperator`, `LimitOperator`, `OutputSplitter`, `ActorPoolMapOperator`, ...) | migrate `current_logical_usage` overrides to push deltas via the hooks |
+| Downstream-consume sites (output queue pops, external consumer reads) | call `op.on_output_bytes_consumed(...)` |
+| Tests | every mock that replaced `current_logical_usage` updates to push deltas or set cached fields |
+
+## Rollout
+
+Both parts are independent. Suggested order:
+
+1. **Part 1 first.** Self-contained, measured wins, smaller blast radius
+   (touches the data-fetch path, not the resource manager). Lands as its
+   own PR with the queue-based `DataOpTask` + `get_object_sizes` helper.
+2. **Part 2 follow-up.** Separate review attention (touches every op
+   subclass that overrides `*_logical_usage`); benefits from Part 1's
+   release-test measurements to baseline against.
+
+Either can ship without the other. If Part 2's op-subclass migration runs
+long, Part 1 carries most of the mid-range win in production while Part 2
+lands incrementally.
 
 ## Alternatives considered
 
-### Alt 1: incremental `update_usages_for_op(op)`
+### Data path
 
-Keep the poll structure but recompute only the op that just changed at sites
-[3]. ~30-50 LoC change; captures ~70 % of the win.
+- **Per-pair `ray.get` with smaller fixed overhead** — would require
+  Ray Core changes to the `ray.get` codepath; large blast radius for
+  a marginal improvement.
+- **Streaming generator protocol change** to yield `(block_ref, size,
+  meta_ref)` triples — biggest API surface change; requires every Ray
+  Data task generator to comply.
+- **Hard cap on batch size** (`MAX_REFS_PER_BATCH=256`) — bounds the
+  blast radius but doesn't make the fetch budget-aware.
 
-- Pros: tiny diff, no API changes, low review risk.
-- Cons: leaves the architectural mismatch in place. Any future caller that
-  mutates op state still has to remember to call `update_usages_for_op` —
-  same trap, just slightly cheaper. Doesn't address `safe_round` per-op
-  constructor cost.
+### Control path
 
-### Alt 2: inline / fast-path `safe_round`
-
-Skip `safe_round` when the input is already canonicalized (the steady-state
-case). ~10 LoC change in `execution_options.py`.
-
-- Pros: trivially small. Cuts `safe_round` leaf cost by ~80 %.
-- Cons: addresses the symptom (`safe_round` is expensive), not the cause
-  (we construct millions of `ExecutionResources` per iteration that aren't
-  semantically new). Doesn't unblock anything downstream.
-
-### Alt 3: cache `ExecutionResources` by tuple key
-
-Memoize construction: `ExecutionResources(cpu=0.5, gpu=0, ...)` returns the
-same instance for the same args.
-
-- Pros: works without API changes.
-- Cons: dict-lookup overhead approaches per-construction cost; bookkeeping
-  for the cache becomes its own footgun.
-
-**My take:** Alt 1 ("incremental update_usages_for_op") is the right
-**interim** fix that can land while this RFC is reviewed. The push-model
-refactor is the right **long-term** architecture. Both are independent of
-#63483.
+- **Incremental `update_usages_for_op(op)`** — keep the poll structure
+  but recompute only the op that just changed at site [3]. ~30-50 LoC
+  change; captures ~70 % of the Part-2 win.
+  - *Pros:* tiny diff, no API changes, low review risk. Could land as
+    a stepping-stone before the full push-model refactor.
+  - *Cons:* leaves the architectural mismatch in place. Any future
+    caller that mutates op state still has to remember to call
+    `update_usages_for_op` — same trap, slightly cheaper. Doesn't
+    address per-op `ExecutionResources` constructor cost.
+- **Inline / fast-path `safe_round`** — skip `safe_round` when input is
+  already canonicalized. ~10 LoC. Cuts `safe_round` leaf cost by ~80 %.
+  - *Pros:* trivially small.
+  - *Cons:* addresses symptom not cause; we still construct millions of
+    `ExecutionResources` per iteration that aren't semantically new.
+- **Memoize `ExecutionResources` by tuple key** — return the same
+  instance for the same args.
+  - *Pros:* works without API changes.
+  - *Cons:* dict-lookup overhead approaches per-construction cost;
+    cache bookkeeping becomes its own footgun.
 
 ## Risks
 
+### Part 1
+1. **`get_object_sizes` race window.** A streaming-gen ref can be
+   delivered to the driver before the owner-side `SealOwnedObject`
+   report arrives, returning `None` from `get_object_sizes`.
+   Mitigation: `None` falls through to "fetch this pair anyway",
+   identical behavior to today's per-pair `ray.get`. Pure optimization,
+   no correctness dependency.
+2. **Batched `ray.get` stragglers.** One slow ref blocks the whole
+   batched call. Mitigation: per-ref fallback inside `on_data_ready`
+   handles `GetTimeoutError`. As a future-future tweak, cap the batch
+   size at ~1000 refs.
+
+### Part 2
 1. **Cache drift.** Any future code path that mutates op state without
-   calling a hook will silently corrupt the cached usage. Mitigation: keep
-   `current_logical_usage` etc. as the canonical readers (now backed by the
-   cache); add a debug-mode invariant check that compares cached vs.
-   freshly-recomputed values per N iterations.
+   calling a hook silently corrupts the cached usage. Mitigation: keep
+   `current_logical_usage` etc. as canonical readers backed by the
+   cache; add a debug-mode invariant check that periodically compares
+   cached vs. freshly-recomputed values.
 2. **Op subclass migration.** Each subclass override needs auditing.
-   Mitigation: do them one at a time; the cached field defaults to a
-   freshly-recomputed value if the subclass hasn't migrated yet (gradual
-   rollout).
-3. **External consumers.** `iter_batches` / `streaming_split` pop bytes from
-   the output queue outside the scheduler thread. Need to either fire the
-   `on_output_bytes_consumed` hook from those code paths or model
-   "externally-consumed bytes" separately. Either way, an explicit decision
-   rather than today's implicit recomputation.
+   Mitigation: do one op at a time; the cached field defaults to a
+   freshly-recomputed value if the subclass hasn't migrated yet
+   (gradual rollout).
+3. **External consumers.** `iter_batches` / `streaming_split` pop bytes
+   from the output queue outside the scheduler thread. Need to either
+   fire the `on_output_bytes_consumed` hook from those paths or model
+   "externally-consumed bytes" separately. Either way, an explicit
+   decision rather than today's implicit recomputation.
 
 ## Open questions
 
-- Should `_cached_logical_usage` be a single `ExecutionResources` or four
-  separate scalar fields (cpu / gpu / memory / obj_store)? Constructors are
-  the bottleneck, so probably scalars; `ExecutionResources` could be
-  materialized on read.
-- `_update_allocated_budgets` reads `get_completed_ops_usage()` — does that
-  also benefit from the cached values, or is it a separate cost?
-- Backwards compatibility: should we maintain the old method signatures
-  (`current_logical_usage()` etc.) as cached-value readers indefinitely,
-  or deprecate them?
+- Should `_cached_logical_usage` be a single `ExecutionResources` or
+  four separate scalar fields (cpu / gpu / memory / obj_store)?
+  Constructors are the bottleneck, so probably scalars;
+  `ExecutionResources` materialized on read.
+- Does `_update_allocated_budgets` benefit from the cached values too,
+  or is it a separate cost worth profiling independently?
+- Backwards compatibility: maintain old method signatures
+  (`current_logical_usage()` etc.) indefinitely as cached-value
+  readers, or deprecate them?
+- For Part 1: cap batch size at a constant `MAX_REFS_PER_BATCH` or
+  size-aware "fetch only what fits ~B bytes of cumulative metadata"?
+  Latter avoids straggler effects without per-iteration count caps.
 
 ## Out of scope
 
 - Changes to `_update_allocated_budgets` budget-allocation algorithm
-  itself. That's a separate optimization.
-- Changes to the data-fetch side (already covered by #63483).
-- Changes to `ray.wait` / `ray.get` core primitives.
+  itself.
+- Changes to `ray.wait` / `ray.get` Ray Core primitives.
+- The other 5000-worker scaling pain (`dispatch_next_task`'s
+  `remote()` overhead). Separate follow-up.
+- Op-fairness / preemption logic.

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -234,35 +234,26 @@ that don't get emitted this iteration (because they didn't fit the budget,
 or the batched `ray.get` timed out) must persist on the task. Per-iteration
 state lives only in the caller-supplied `bytes_by_meta_ref` dict.
 
-#### 1b. New `ray.experimental.get_object_sizes(refs)` helper
+#### 1b. Assumed dependency: cheap, reliable per-ref size lookup
+
+The design depends on a Ray Core primitive that returns each ref's byte
+size **without** issuing an RPC or fetching the object data, and that is
+**reliably populated** by the time the streaming generator surfaces the
+ref to the driver. Surface used in the rest of this document:
 
 ```python
-def get_object_sizes(obj_refs: List[ObjectRef]) -> List[Optional[int]]:
-    """Return the byte size of each object as known to Ray Core, or None
-    if the size isn't yet known (the producing task hasn't sealed the
-    object). Local-only; no RPCs."""
-    locations = get_local_object_locations(obj_refs)
-    return [(locations.get(r) or {}).get("object_size") for r in obj_refs]
+sizes = ray.experimental.get_object_sizes(block_refs)   # List[int], one per ref
 ```
 
-Thin wrapper over the existing `get_local_object_locations` (which already
-reads `object_size` from the local reference counter — no new RPC, no new
-Ray Core state, just a focused Python entry point onto data Ray Core
-already maintains for OOM / spill / scheduling decisions).
+How Ray Core exposes this — whether via a focused helper, an extension to
+an existing API, an inlined field on `ObjectRef`, or something else —
+is a question for the Ray Core team and out of scope for this RFC.
+This RFC assumes the primitive exists and is reliable for streaming-gen
+owned refs; see the open questions section.
 
 The size lets us **trim the metadata fetch up front**, so what we
 `ray.get` is exactly what we emit this iteration. No cross-iteration
 cache, no speculative over-fetch.
-
-#### 1c. Graceful `None` handling
-
-`get_object_sizes` returns `None` for refs whose owner hasn't yet
-published a size (small race window between the gen yielding a ref and
-the worker's `SealOwnedObject` report reaching the driver). Treat `None`
-as "fetch this pair anyway" — the per-pair `ray.get` happens, the budget
-is still enforced on the emit side via `bytes_read += meta.size_bytes`.
-Same behavior as today for that pair; the precise-trim win is realized
-for the pairs where the size is known.
 
 ### Per-call ray.get fallback
 
@@ -427,7 +418,7 @@ variant and 1.4× on the actors variant.
 
 | file | changes |
 | --- | --- |
-| `ray/experimental/locations.py` + `__init__.py` | new `get_object_sizes(refs)` helper |
+| Ray Core API surface for per-ref size (exact shape TBD with Core team) | exposes the cheap, reliable size lookup that Part 1 depends on |
 | `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` switches from scalar `_pending_*_ref` to queue + partial; new `peek_pending_pair` + drainable semantics; `on_data_ready` takes `bytes_by_meta_ref` dict; per-ref fallback for cache miss; `fetch_and_drain` convenience |
 | `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` runs the 5-step flow above |
 | `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to new `on_data_ready` signature; new tests for peek-drain + size-aware trim + cache-miss fallback |
@@ -450,7 +441,8 @@ Both parts are independent. Suggested order:
 
 1. **Part 1 first.** Self-contained, measured wins, smaller blast radius
    (touches the data-fetch path, not the resource manager). Lands as its
-   own PR with the queue-based `DataOpTask` + `get_object_sizes` helper.
+   own PR with the queue-based `DataOpTask`; depends on the Core size
+   primitive landing first.
 2. **Part 2 follow-up.** Separate review attention (touches every op
    subclass that overrides `*_logical_usage`); benefits from Part 1's
    release-test measurements to baseline against.
@@ -497,16 +489,15 @@ lands incrementally.
 ## Risks
 
 ### Part 1
-1. **`get_object_sizes` race window.** A streaming-gen ref can be
-   delivered to the driver before the owner-side `SealOwnedObject`
-   report arrives, returning `None` from `get_object_sizes`.
-   Mitigation: `None` falls through to "fetch this pair anyway",
-   identical behavior to today's per-pair `ray.get`. Pure optimization,
-   no correctness dependency.
-2. **Batched `ray.get` stragglers.** One slow ref blocks the whole
+1. **Batched `ray.get` stragglers.** One slow ref blocks the whole
    batched call. Mitigation: per-ref fallback inside `on_data_ready`
    handles `GetTimeoutError`. As a future-future tweak, cap the batch
    size at ~1000 refs.
+2. **Dependence on the Ray Core size primitive being reliable.** If
+   the assumed `get_object_sizes` ever returns stale or missing
+   values for streaming-gen owned refs, the size-aware trim degrades
+   (we'd over- or under-fetch metadata). Mitigation: see "Open
+   questions" — Core team to specify the guaranteed-reliable surface.
 
 ### Part 2
 1. **Cache drift.** Any future code path that mutates op state without
@@ -526,6 +517,13 @@ lands incrementally.
 
 ## Open questions
 
+- **For the Ray Core team:** what is the right Core-side surface for
+  cheap, no-RPC, reliably-populated per-ref byte size? Part 1's
+  size-aware trim depends on this primitive existing and returning
+  real values (not `None`/stale) at the moment the streaming
+  generator surfaces a ref to the driver. The Python entry point and
+  the underlying implementation are both Core-team decisions; this
+  RFC assumes the result.
 - Should `_cached_logical_usage` be a single `ExecutionResources` or
   four separate scalar fields (cpu / gpu / memory / obj_store)?
   Constructors are the bottleneck, so probably scalars;

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -13,14 +13,13 @@ the relevant code path report what changed.**
 
 | subsystem      | today's anti-pattern                                                                                                                            | this RFC                                                                                                            |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain all gens first, look up block sizes locally, trim by per-op budget, then issue **one** batched `ray.get`     |
+| **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; the scheduler thread blocks on metadata fetch + deserialization | Defer the metadata fetch entirely. Scheduler carries `size_bytes` (from Ray Core) and `num_rows` (inline from the streaming gen) as scalars on the `RefBundle`; downstream consumers that need full `BlockMetadata` (stats reporting, lineage) `ray.get` the `meta_ref` lazily, off the scheduler thread |
 | **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers)             | Ops push resource deltas at mutation sites (emit / dispatch / done); `update_usages` shrinks to an aggregator      |
 
 On the wide-schema `worker_scaling` release-test matrix (m5.2xlarge × {36,
 72, 143, 358} nodes for {500, 1000, 2000, 5000} workers), the two parts
-together are projected to cut max scheduling-loop time by ~40-50 % at the
-1000-2000 worker scale and ~25-30 % at 5000 workers, where the dispatch
-side dominates.
+together are projected to cut max scheduling-loop time by ~40-60 % across
+the matrix.
 
 Both parts are independent. Either can land alone. They're presented
 together because they share the same architectural shift (poll → push,
@@ -169,72 +168,106 @@ The redundancy:
   grew (`meta.size_bytes`), but doesn't tell anyone — the next
   `update_usages` re-walks the output queue to find out.
 
-## Part 1: Data path — batch the per-pair `ray.get`
+## Part 1: Data path — defer the metadata fetch entirely
 
 ### Design
 
-Restructure `process_completed_tasks` so that each scheduler iteration
-issues **one** batched `ray.get` covering exactly the metadata for the
-pairs that will be emitted, then hands the bytes to each task for emit.
+The scheduler thread **never `ray.get`s metadata**. It carries the two
+scalar fields it actually needs from each block (`size_bytes` and
+`num_rows`) as inline values on the `RefBundle`. The full
+`BlockMetadata` (exec stats, input files, task exec stats) lives behind
+a `meta_ref` that downstream consumers — stats reporting, lineage
+tracking — fetch lazily, off the scheduler thread.
 
 ```
 process_completed_tasks(topology, ...)
    │
    ├── ray.wait(active_task_refs) → ready set
    │
-   ├── # 1. Drain each ready task's gen into its pending-pairs queue.
-   │   for task in ready_tasks:
-   │       while task.peek_pending_pair() is not None: pass
+   ├── for each ready DataOpTask:
+   │      while task.peek_pending_pair() is not None: pass     ← drain gen
    │
-   ├── # 2. Look up each queued block's size (local, no RPC).
-   │   sizes = ray.experimental.get_object_sizes(all_pending_block_refs)
+   ├── # No ray.get on metadata. We already have:
+   │   #   - block_ref           (from the gen)
+   │   #   - num_rows scalar     (inline from the gen — see 1b)
+   │   #   - meta_ref            (from the gen, kept opaque)
+   │   #   - size_bytes scalar   (from Ray Core — see 1c)
    │
-   ├── # 3. Per op, trim each task's queued pairs by remaining budget.
-   │   #    Collect the prefix of meta_refs whose blocks fit.
-   │   to_fetch = [...]
-   │
-   ├── # 4. ONE batched ray.get covering the trimmed union.
-   │   bytes_by_meta_ref = dict(zip(to_fetch, ray.get(to_fetch, timeout=…)))
-   │
-   └── # 5. Each task pops queue pairs in order and emits.
-       for task in ready_tasks:
-           task.on_data_ready(budget, bytes_by_meta_ref)
+   └── for each ready DataOpTask:
+          task.on_data_ready(budget)                            ← pure assemble + emit
+              │
+              ├── pop queued pair (block_ref, num_rows, meta_ref)
+              ├── size_bytes ← ray.experimental.get_object_sizes([block_ref])[0]
+              ├── build RefBundle entry (block_ref, size_bytes, num_rows, meta_ref)
+              ├── emit RefBundle
+              └── bytes_read += size_bytes
 ```
 
-Two structural changes underneath:
+### 1a. `DataOpTask` queue holds `(block_ref, num_rows, meta_ref)` triples
 
-#### 1a. `DataOpTask` switches to a queue-of-pairs
-
-Replace the single `_pending_block_ref` / `_pending_meta_ref` scalar slots
-with a `Deque[(block_ref, meta_ref)]` queue, plus a `_partial_block_ref`
-stash for the half-pulled-pair case. Add `peek_pending_pair()` as a
-drainable method (callable in a loop until it returns `None`).
+Replace the single `_pending_block_ref` / `_pending_meta_ref` scalar
+slots with a `Deque[(block_ref, num_rows, meta_ref)]` queue, plus a
+`_partial` stash for the half-pulled-pair case (the gen yields the
+three components in order; they can arrive in separate scheduler
+ticks). `peek_pending_pair()` is a drainable method (call in a loop
+until it returns `None`).
 
 ```python
 class DataOpTask:
-    _pending_pairs:   Deque[(block_ref, meta_ref)]   # pulled from gen, awaiting emission
-    _partial_block_ref: ObjectRef                    # half-pulled state
-    _gen_exhausted:   bool
+    _pending: Deque[Tuple[ObjectRef[Block], int, ObjectRef[BlockMetadata]]]
+    _partial: ...                                  # half-pulled state
+    _gen_exhausted: bool
     _gen_errored_block: Optional[ObjectRef]
 
-    def peek_pending_pair(self) -> Optional[Tuple[ObjectRef, ObjectRef]]:
-        """Pull one (block_ref, meta_ref) into _pending_pairs; return it.
-        Returns None if no full pair is immediately ready. Loop to drain."""
+    def peek_pending_pair(self) -> Optional[Tuple[ObjectRef, int, ObjectRef]]:
+        """Pull one (block_ref, num_rows, meta_ref) triple from the gen
+        into _pending. Returns None if not immediately ready."""
         ...
 
-    def on_data_ready(self, max_bytes_to_read, bytes_by_meta_ref=None):
-        """Pop queued pairs in order, look up bytes in the caller-supplied
-        dict, emit RefBundles. Per-ref ray.get fallback on cache miss."""
+    def on_data_ready(self, max_bytes_to_read) -> int:
+        """Pop queued triples, look up size_bytes via the Core primitive,
+        build RefBundle entries, emit."""
         ...
 ```
 
 Why a queue rather than a scalar: pulling from the generator is
-**destructive** — once we peek, the ref is gone from the stream. Pairs
-that don't get emitted this iteration (because they didn't fit the budget,
-or the batched `ray.get` timed out) must persist on the task. Per-iteration
-state lives only in the caller-supplied `bytes_by_meta_ref` dict.
+**destructive** — once we peek, the values are gone from the stream.
+Triples that don't get emitted this iteration (budget exhausted) must
+persist on the task.
 
-#### 1b. Assumed dependency: cheap, reliable per-ref size lookup
+### 1b. Streaming generator protocol: yield `num_rows` inline
+
+Today the producing worker yields two values per block:
+
+```python
+yield block                                            # ObjectRef
+yield pickle.dumps(BlockMetadataWithSchema(...))       # ObjectRef
+```
+
+Proposed:
+
+```python
+yield block                                            # ObjectRef
+yield num_rows                                         # int — small object, inlined
+yield pickle.dumps(BlockMetadataWithSchema(...))       # ObjectRef — fetched lazily
+```
+
+The `num_rows` value is a small Python `int`, which Ray Core already
+inlines into the `ObjectRef` itself (objects under
+`max_direct_call_object_size`, ~100 KB by default — way more than an
+int needs). `ray.get` on an inlined ref is a local memory copy with
+no object store interaction.
+
+The full metadata is still produced and stored — we just don't fetch it
+on the scheduler thread.
+
+This is a Ray-Data-internal protocol change to the streaming generator
+contract; no Ray Core change involved. It does require updating every
+task generator that participates in `DataOpTask` to yield the
+three-tuple instead of the pair. The existing TODO in
+`DataOpTask.__init__` calls this protocol out as something to evolve.
+
+### 1c. Assumed dependency: cheap per-ref `size_bytes` from Ray Core
 
 The design depends on a Ray Core primitive that returns each ref's byte
 size **without** issuing an RPC or fetching the object data, and that is
@@ -245,58 +278,131 @@ ref to the driver. Surface used in the rest of this document:
 sizes = ray.experimental.get_object_sizes(block_refs)   # List[int], one per ref
 ```
 
-How Ray Core exposes this — whether via a focused helper, an extension to
-an existing API, an inlined field on `ObjectRef`, or something else —
-is a question for the Ray Core team and out of scope for this RFC.
+How Ray Core exposes this — whether via a focused helper, an extension
+to an existing API, an inlined field on `ObjectRef`, or something else
+— is a question for the Ray Core team and out of scope for this RFC.
 This RFC assumes the primitive exists and is reliable for streaming-gen
 owned refs; see the open questions section.
 
-The size lets us **trim the metadata fetch up front**, so what we
-`ray.get` is exactly what we emit this iteration. No cross-iteration
-cache, no speculative over-fetch.
+### 1d. `RefBundle` layout change
 
-### Per-call ray.get fallback
+`RefBundle.blocks` today is `Tuple[Tuple[ObjectRef[Block],
+BlockMetadata], ...]` — each entry carries a fully-dereferenced
+`BlockMetadata` object. The proposed shape:
+
+```python
+@dataclass(frozen=True)
+class BlockEntry:
+    block_ref:  ObjectRef[Block]
+    size_bytes: int                  # from Ray Core
+    num_rows:   int                  # inlined by the streaming gen
+    _meta_ref:  ObjectRef[BlockMetadata]   # opaque; fetched on demand
+
+    @cached_property
+    def metadata(self) -> BlockMetadata:
+        """Lazy: fetched the first time a consumer asks. Only stats /
+        lineage paths exercise this; scheduler-thread code never does."""
+        return ray.get(self._meta_ref)
+```
+
+`RefBundle` then carries `Tuple[BlockEntry, ...]` instead of
+`Tuple[Tuple[ObjectRef, BlockMetadata], ...]`. Schema stays where it is
+— `RefBundle.schema` is already a top-level field (see 1f below for
+how it's populated without a scheduler-thread `ray.get`).
+
+`RefBundle.size_bytes()` and `RefBundle.num_rows()` (today both walk
+each block's metadata) become direct sums of the inline scalars. No
+dereference, no `ray.get`.
+
+### 1e. Lazy metadata access for stats / lineage consumers
+
+The 68 production sites that read `bundle.metadata.*` fall into two
+groups:
+
+- **Scheduler hot path (read scalars):** `size_bytes`, `num_rows`.
+  After this RFC: direct field reads, no `ray.get`.
+- **Stats / lineage consumers (read non-scalar fields):**
+  `exec_stats`, `task_exec_stats`, `input_files`. After this RFC: pay
+  a `ray.get` on `_meta_ref` when accessing — but this fires once per
+  op completion, not per block per scheduler iteration. Off the
+  scheduler thread.
+
+Examples:
+- `map_operator._output_blocks_stats.extend(to_stats(bundle.metadata))`
+  fires when the op finishes producing — one batched
+  `ray.get(meta_refs)` materializes all the metadata at once.
+- `input_data_buffer` reads `input_files` once at op construction; one
+  `ray.get` per op.
+- Per-block scheduler-loop logging (which currently reads
+  `metadata.num_rows` / `metadata.size_bytes` for progress bar
+  updates) — already covered by the scalar fields.
+
+### 1f. Schema delivery
+
+`RefBundle.schema` is today populated by the scheduler when it
+`pickle.loads`-es the `BlockMetadataWithSchema` payload. With the
+metadata fetch deferred, schema needs another delivery path. Options:
+
+1. **Worker yields schema once per task** (in the gen protocol, as a
+   fourth optional inline value before the first block). The scheduler
+   caches it per-task / per-op; subsequent yields don't repeat it.
+   Schema is identical across all blocks of a single map task, so a
+   single inline yield amortizes naturally.
+2. **Fetch on-demand from the first block's `meta_ref`.** Downstream
+   ops that need schema validation pay one `ray.get` at op-bind time;
+   subsequent blocks reuse the cached schema.
+
+Option 1 is cleaner if we're already changing the gen protocol for
+`num_rows`. See open questions.
+
+### Per-call `ray.get` fallback (error path only)
 
 `on_data_ready` keeps a per-ref `ray.get(meta_ref)` + `GetTimeoutError`
-warning as a cache-miss fallback. The fallback runs when:
-
-1. The batched `ray.get` raised `GetTimeoutError` and no bytes were
-   cached for the iteration — falls through to per-ref so the worker
-   crash / node preemption surfaces with the standard warning and
-   retry-next-iteration semantics.
-2. `on_data_ready` was called outside `process_completed_tasks` (tests,
-   debugging) with no `bytes_by_meta_ref`.
+warning as a fallback for the rare case the Core size primitive
+returns `None` (Open Questions item 1) — falls through to the
+pre-refactor behavior with the standard per-ref warning and
+retry-next-iteration semantics. In the steady-state happy path this
+fallback is dead code; it exists for diagnostic visibility when
+something has gone wrong upstream.
 
 A convenience `fetch_and_drain(max_bytes_to_read)` wraps `peek` +
 `on_data_ready` for direct callers (tests).
 
 ### Expected impact (data path)
 
-Prototype measurements on the wide-schema `worker_scaling` matrix:
+Pre-refactor py-spy breakdown for `on_data_ready` (5000_tasks):
 
-| variant     | master | this RFC (data path only) | reduction | speedup |
-| ----------- | -----: | --: | --: | --: |
-| 500_actors  |  0.89 s|  0.69 s | 22.9 % | 1.30× |
-| 500_tasks   |  2.40 s|  1.58 s | 34.3 % | 1.52× |
-| 1000_actors |  1.69 s|  1.28 s | 24.6 % | 1.33× |
-| **1000_tasks** |  6.58 s|  3.72 s | **43.4 %** | **1.77×** |
-| 2000_actors |  3.19 s|  2.33 s | 26.9 % | 1.37× |
-| 2000_tasks  | 14.63 s|  8.96 s | 38.8 % | 1.63× |
-| 5000_actors |  9.83 s|  8.75 s | 11.0 % | 1.12× |
-| 5000_tasks  | 33.61 s| 28.69 s | 14.6 % | 1.17× |
+| frame                              | inclusive | what it is |
+| --- | ---: | --- |
+| `on_data_ready` (total)            | 294 s |  |
+|   `ray.get_objects` (leaf)         | 164 s | per-pair `ray.get(meta_ref)` |
+|   `pickle.loads` (metadata)        |  ~25 s| deserialize `BlockMetadataWithSchema` |
+|   `Schema.__setstate__` etc.       |  ~10 s| schema deserialize on cache miss |
+|   `RefBundle` construction + emit  |  ~15 s| `_output_ready_callback` + bookkeeping |
+|   loop overhead                    |  ~80 s| `_next_sync` gen pulls, queue mgmt |
 
-Two observations from the py-spy breakdowns:
+After this RFC, the scheduler thread does:
 
-- **Wins peak at 1000–2000 workers.** Per-call `ray.get` overhead was
-  the binding constraint there; `on_data_ready` inclusive share drops
-  from 42–49 % to 4–35 % after batching.
-- **Dampens at 5000 workers.** The batched `ray.get(5000 refs)` fans out
-  to all 358 nodes and blocks on the slowest ref; `get_objects` leaf time
-  actually *grows* for the tasks variant (164 s → 218 s). The dispatch
-  side starts to dominate — Part 2 below.
+- `ray.experimental.get_object_sizes(block_refs)` — cheap local lookup.
+- Queue pops + `RefBundle` construction.
+- `bytes_read += size_bytes` (scalar).
 
-Cost: `peek_pending_pair` adds 2-3 % of scheduler-thread time across all
-variants. Small price for the batching infrastructure.
+**No `ray.get`, no `pickle.loads`, no schema deserialize.** Projected
+`on_data_ready`:
+
+| variant     | master `on_data_ready` | projected | reduction |
+| ----------- | ---: | ---: | ---: |
+| 1000_tasks  |  40 s |  ~3 s | ~92 % |
+| 2000_tasks  |  87 s |  ~6 s | ~93 % |
+| 5000_tasks  | 294 s | ~20 s | ~93 % |
+
+The savings concentrate at scale (more pairs ingested per iteration =
+more avoided `ray.get`s).
+
+Cost paid elsewhere: stats / lineage paths now do an extra `ray.get`
+per op completion. For a topology of ~3 ops, that's 3 `ray.get` calls
+per dataset, batched. Negligible compared to the per-pair savings —
+and these run off the scheduler thread.
 
 ## Part 2: Control path — push, don't poll
 
@@ -396,32 +502,38 @@ Each part attacks a different cost; they compose.
 
 | 5000_tasks scheduler thread | today | + Part 1 | + Parts 1 & 2 |
 | --- | ---: | ---: | ---: |
-| `process_completed_tasks`  | 315 s |  ~280 s | ~280 s   |
+| `process_completed_tasks`  | 315 s |  ~40 s  | ~40 s   |
 | `update_usages`            | 110 s |  ~110 s |  ~30 s   |
 | `dispatch_next_task`       | 120 s |  ~120 s | ~120 s   |
-| **Total**                  | ~600 s| ~580 s | **~500 s** |
+| `safe_round` (leaf)        |  ~46 s|   ~46 s |   <5 s  |
+| **Total scheduler thread** | ~600 s| ~320 s | **~200 s** |
 
-The data-path win is concentrated in mid-range scale (1000-2000 workers,
-where `on_data_ready` dominates); the control-path win is concentrated
-at the high end (5000+ workers, where `update_usages` dominates).
-Together they cover the whole scaling range.
+The data-path win is dramatic at every scale once the per-pair
+`ray.get` and pickle-loads are out of the hot path. The control-path
+win compounds at the high end where `update_usages` dominates after
+the data side shrinks. Together: an estimated **3× reduction in total
+scheduler-thread time** at 5000 workers.
 
 For `max_scheduling_loop` (the metric users actually feel), prototype
-data-path measurements show 1.3-1.77× reduction at 500-2000 workers,
-dampening to 1.12-1.17× at 5000. Adding the control-path refactor should
-restore the win at 5000 — projected combined 1.3-1.5× on the tasks
-variant and 1.4× on the actors variant.
+batched-`ray.get` measurements (without deferred metadata) showed
+1.3-1.77× reduction at 500-2000 workers, dampening to 1.12-1.17× at
+5000. With deferred metadata + push-model resource accounting, the
+projected combined improvement is **1.5-2.5× across the whole
+scaling range**, with the largest absolute savings at 5000 workers.
 
 ## Scope
 
-### Part 1: data path (~500 LoC)
+### Part 1: data path (~600-800 LoC)
 
 | file | changes |
 | --- | --- |
-| Ray Core API surface for per-ref size (exact shape TBD with Core team) | exposes the cheap, reliable size lookup that Part 1 depends on |
-| `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` switches from scalar `_pending_*_ref` to queue + partial; new `peek_pending_pair` + drainable semantics; `on_data_ready` takes `bytes_by_meta_ref` dict; per-ref fallback for cache miss; `fetch_and_drain` convenience |
-| `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` runs the 5-step flow above |
-| `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to new `on_data_ready` signature; new tests for peek-drain + size-aware trim + cache-miss fallback |
+| Ray Core API surface for per-ref `size_bytes` (exact shape TBD with Core team) | exposes the cheap, reliable size lookup |
+| Streaming-generator protocol contract (Ray Data internal) | adds inline `num_rows` (and optionally schema) to the yield sequence; updates the workers that produce blocks for `DataOpTask` (map, read, etc.) |
+| `data/_internal/execution/interfaces/ref_bundle.py` | `RefBundle.blocks` becomes `Tuple[BlockEntry, ...]`; `BlockEntry` carries inline `size_bytes` + `num_rows` + opaque `_meta_ref` + lazy `metadata` property |
+| `data/_internal/execution/interfaces/physical_operator.py` | `DataOpTask` queue becomes `Deque[(block_ref, num_rows, meta_ref)]`; `peek_pending_pair` drainable; `on_data_ready` does scalar-only emit, no `ray.get` in steady state |
+| `data/_internal/execution/streaming_executor_state.py` | `process_completed_tasks` no longer batches `ray.get` on metadata |
+| Stats / lineage call sites that read `bundle.metadata.exec_stats` etc. | migrate to the lazy `BlockEntry.metadata` accessor; ideally batch their own `ray.get` over many entries at op-completion time |
+| `data/tests/test_streaming_executor.py` + `tests/util.py` | tests updated to the new `RefBundle` layout and gen protocol; new tests for inline `num_rows` delivery + lazy metadata access |
 
 ### Part 2: control path (~300-600 LoC)
 
@@ -439,30 +551,44 @@ variant and 1.4× on the actors variant.
 
 Both parts are independent. Suggested order:
 
-1. **Part 1 first.** Self-contained, measured wins, smaller blast radius
-   (touches the data-fetch path, not the resource manager). Lands as its
-   own PR with the queue-based `DataOpTask`; depends on the Core size
-   primitive landing first.
-2. **Part 2 follow-up.** Separate review attention (touches every op
-   subclass that overrides `*_logical_usage`); benefits from Part 1's
-   release-test measurements to baseline against.
+1. **Ray Core size primitive first.** Part 1 depends on it; landing it
+   first unblocks the Data-side work and lets us validate
+   reliability on the streaming-gen use case before relying on it.
+2. **Part 1 (data path).** Streaming-gen protocol change + `RefBundle`
+   layout + `DataOpTask` queue + lazy `BlockEntry.metadata`. Lands as
+   its own PR.
+3. **Part 2 (control path).** Independent of Parts 1 and the Core
+   primitive. Could land before Part 1 if convenient.
 
-Either can ship without the other. If Part 2's op-subclass migration runs
-long, Part 1 carries most of the mid-range win in production while Part 2
-lands incrementally.
+Either Data-side part can ship without the other. If Part 2's
+op-subclass migration runs long, Part 1 carries most of the wide-schema
+wins in production while Part 2 lands incrementally.
 
 ## Alternatives considered
 
 ### Data path
 
+- **Batched `ray.get` of metadata in `process_completed_tasks`** — keep
+  fetching metadata in the scheduler thread but collapse N small
+  `ray.get` calls into one batched call per scheduler iteration. This
+  was the earlier shape of the same proposal and a measured prototype
+  showed 1.3-1.77× max-loop reduction at 500-2000 workers, dampening
+  to 1.12-1.17× at 5000.
+  - *Pros:* no Ray Core dependency (uses existing `ray.get`); no
+    streaming-gen protocol change; existing `RefBundle` layout
+    preserved.
+  - *Cons:* metadata fetch is still on the scheduler thread, just
+    batched. At 5000 workers the batched call itself becomes the
+    bottleneck (one slow ref blocks the whole call; `get_objects` leaf
+    time *grows* — measured 164 s → 218 s for tasks variant). Solves
+    the per-call overhead, doesn't solve the "metadata is on the
+    critical path at all" question. Adds cross-iteration cache state to
+    handle over-fetch.
 - **Per-pair `ray.get` with smaller fixed overhead** — would require
   Ray Core changes to the `ray.get` codepath; large blast radius for
   a marginal improvement.
-- **Streaming generator protocol change** to yield `(block_ref, size,
-  meta_ref)` triples — biggest API surface change; requires every Ray
-  Data task generator to comply.
 - **Hard cap on batch size** (`MAX_REFS_PER_BATCH=256`) — bounds the
-  blast radius but doesn't make the fetch budget-aware.
+  blast radius but still fetches metadata on the scheduler thread.
 
 ### Control path
 
@@ -489,15 +615,28 @@ lands incrementally.
 ## Risks
 
 ### Part 1
-1. **Batched `ray.get` stragglers.** One slow ref blocks the whole
-   batched call. Mitigation: per-ref fallback inside `on_data_ready`
-   handles `GetTimeoutError`. As a future-future tweak, cap the batch
-   size at ~1000 refs.
-2. **Dependence on the Ray Core size primitive being reliable.** If
-   the assumed `get_object_sizes` ever returns stale or missing
-   values for streaming-gen owned refs, the size-aware trim degrades
-   (we'd over- or under-fetch metadata). Mitigation: see "Open
-   questions" — Core team to specify the guaranteed-reliable surface.
+1. **Streaming-gen protocol change is invasive.** Every task generator
+   that participates in `DataOpTask` (map, read, hash-shuffle, ...)
+   has to yield the new three-tuple instead of the pair. Mitigation:
+   make the inline `num_rows` optional initially — `peek_pending_pair`
+   tolerates pairs (the old shape) and falls back to `ray.get` on the
+   meta_ref to obtain `num_rows`. Migrate generators one at a time,
+   measure each.
+2. **Lazy metadata fetch shifts cost to consumers.** Stats / lineage
+   paths now pay a `ray.get` per `meta_ref`. Mitigation: most
+   consumers operate on whole bundles at op-completion time, so they
+   can batch their own `ray.get(meta_refs)`. The total work is no
+   higher than before — it's just off the scheduler thread.
+3. **Dependence on the Ray Core size primitive being reliable.** If
+   the assumed cheap `size_bytes` lookup ever returns stale or missing
+   values for streaming-gen owned refs, the scheduler hot path falls
+   through to `ray.get(meta_ref)` to recover `size_bytes`. Mitigation:
+   see "Open questions" — Core team to specify the guaranteed-reliable
+   surface.
+4. **Schema delivery without metadata fetch.** Two options sketched in
+   1f; the gen-protocol option is preferred but adds yet another
+   inline value. Mitigation: prototype both, measure which is
+   cleaner.
 
 ### Part 2
 1. **Cache drift.** Any future code path that mutates op state without
@@ -518,12 +657,24 @@ lands incrementally.
 ## Open questions
 
 - **For the Ray Core team:** what is the right Core-side surface for
-  cheap, no-RPC, reliably-populated per-ref byte size? Part 1's
-  size-aware trim depends on this primitive existing and returning
-  real values (not `None`/stale) at the moment the streaming
-  generator surfaces a ref to the driver. The Python entry point and
-  the underlying implementation are both Core-team decisions; this
-  RFC assumes the result.
+  cheap, no-RPC, reliably-populated per-ref `size_bytes`? Part 1
+  assumes such a primitive exists and is reliable for streaming-gen
+  owned refs at the moment the driver receives the ref. The Python
+  entry point and the underlying implementation are both Core-team
+  decisions; this RFC assumes the result.
+- **Schema delivery without scheduler-thread `ray.get`:** option 1
+  (worker yields schema once per task in the gen protocol) or option
+  2 (lazy fetch from the first block's `meta_ref` at op-bind time)?
+  Pick one before implementation.
+- **Lazy `BlockEntry.metadata` access pattern:** should the stats /
+  lineage consumers batch their `ray.get` over all of an op's blocks
+  at op-completion time, or fetch per-block as needed? Probably
+  batched-at-completion for efficiency; needs an explicit code-style
+  recommendation.
+- **`BlockEntry` shape:** dataclass with named fields, or just a
+  four-tuple `(block_ref, size_bytes, num_rows, meta_ref)`? Dataclass
+  is clearer; tuple is cheaper to construct. Hot path, so possibly
+  tuple.
 - Should `_cached_logical_usage` be a single `ExecutionResources` or
   four separate scalar fields (cpu / gpu / memory / obj_store)?
   Constructors are the bottleneck, so probably scalars;
@@ -533,9 +684,6 @@ lands incrementally.
 - Backwards compatibility: maintain old method signatures
   (`current_logical_usage()` etc.) indefinitely as cached-value
   readers, or deprecate them?
-- For Part 1: cap batch size at a constant `MAX_REFS_PER_BATCH` or
-  size-aware "fetch only what fits ~B bytes of cumulative metadata"?
-  Latter avoids straggler effects without per-iteration count caps.
 
 ## Out of scope
 

--- a/doc/design/scheduler-push-model-rfc.md
+++ b/doc/design/scheduler-push-model-rfc.md
@@ -14,7 +14,7 @@ the relevant code path report what changed.**
 | subsystem      | today's anti-pattern                                                                                                                            | this RFC                                                                                                            |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | **Data path**  | `on_data_ready` issues `ray.get(meta_ref)` once *per ready pair* across *every* ready task; N small RPCs per scheduler iteration                | Drain each ready task's gen up to its budget — looking up `size_bytes` inline via the Ray Core primitive (no RPC) so we stop pulling at the budget — then issue **one** batched `ray.get(meta_refs)` over what was drained |
-| **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers)             | Ops push resource deltas at mutation sites (emit / dispatch / done); `update_usages` shrinks to an aggregator      |
+| **Control path** | `update_usages` re-derives every op's resource bundle from scratch *on every dispatch* (~20 k calls per iteration at 5000 workers) — O(N_ops) work per call                | Ops push deltas at mutation sites (emit / dispatch / done) into a single live global aggregate on `ResourceManager`; `update_usages` becomes **O(1)** — just dispatches to the budget allocator |
 
 On the wide-schema `worker_scaling` release-test matrix (m5.2xlarge × {36,
 72, 143, 358} nodes for {500, 1000, 2000, 5000} workers), the two parts
@@ -329,59 +329,103 @@ iterations) or under-utilize the batched call.
 
 ### Design
 
-Invert the control flow on resource accounting. Each event that changes
-per-op resource usage updates the `ResourceManager`'s cache **at the
-mutation site**, by delta. The manager keeps a per-op cache that's always
-current. `update_usages` shrinks to an aggregation pass + budget
-allocator.
+Invert the control flow on resource accounting. Each event that
+changes resource usage applies the **delta** at the mutation site,
+to both the per-op cache and a single **global running aggregate**
+on `ResourceManager`. Because the scheduler thread is single-threaded
+and every mutation site already knows its delta, threading the delta
+to the global is free. `update_usages` then becomes **O(1)** — no
+per-op summation, just (optionally) `_update_allocated_budgets`.
 
 #### 2a. New op-level hooks on `PhysicalOperator`
 
+Each hook updates two places:
+
+1. The op's local cache (so per-op readers like
+   `current_logical_usage()` and the per-op `obj_store_mem_used`
+   metric stay correct).
+2. The `ResourceManager`'s global aggregate (so `update_usages`
+   doesn't have to re-sum).
+
 ```python
 class PhysicalOperator:
-    # Maintained by the hooks; readers (current_logical_usage etc.)
-    # become trivial properties over these fields.
+    # Per-op cache. Readers (current_logical_usage etc.) become
+    # trivial properties over these fields.
     _cached_logical_usage:        ExecutionResources
     _cached_running_usage:        ExecutionResources
     _cached_pending_usage:        ExecutionResources
     _cached_obj_store_mem_bytes:  int
 
+    # ResourceManager set at op-bind time so the hooks can push deltas.
+    _resource_manager:            ResourceManager
+
     def on_output_bytes_added(self, n: int) -> None:
         """Called by DataOpTask.on_data_ready after each RefBundle emit."""
         self._cached_obj_store_mem_bytes += n
+        self._resource_manager._apply_obj_store_delta(n)
 
     def on_output_bytes_consumed(self, n: int) -> None:
         """Called when a downstream op pops bytes from this op's output
         queue, or when an external consumer reads via iter_batches /
         streaming_split."""
         self._cached_obj_store_mem_bytes -= n
+        self._resource_manager._apply_obj_store_delta(-n)
 
     def on_task_dispatched(self, task_bundle: ExecutionResources) -> None:
         """Called by dispatch_next_task after submitting a remote task."""
         self._cached_running_usage = self._cached_running_usage.add(task_bundle)
         self._cached_pending_usage = self._cached_pending_usage.subtract(task_bundle)
+        self._resource_manager._apply_dispatch_delta(task_bundle)
 
     def on_task_completed(self, task_bundle: ExecutionResources) -> None:
         """Called from task_done_callback."""
         self._cached_running_usage = self._cached_running_usage.subtract(task_bundle)
+        self._resource_manager._apply_complete_delta(task_bundle)
 ```
 
-#### 2b. `ResourceManager.update_usages` becomes an aggregator
+#### 2b. `ResourceManager` keeps the global aggregate live
 
 ```python
-def update_usages(self) -> None:
-    # No re-derivation; just sum the cached values that the hooks maintained.
-    self._global_usage         = sum_resources(op._cached_logical_usage for op in self._topology)
-    self._global_running_usage = sum_resources(op._cached_running_usage for op in self._topology)
-    self._global_pending_usage = sum_resources(op._cached_pending_usage for op in self._topology)
-    if self._op_resource_allocator is not None:
-        self._update_allocated_budgets()
+class ResourceManager:
+    # Live global aggregates, kept current by the delta appliers.
+    # No per-op poll loop, no re-derivation.
+    _global_usage:         ExecutionResources
+    _global_running_usage: ExecutionResources
+    _global_pending_usage: ExecutionResources
+
+    def _apply_obj_store_delta(self, n: int) -> None:
+        # Single scalar mutation. Constructed ExecutionResources is
+        # materialized on read, not on every delta.
+        self._global_obj_store_mem_bytes += n
+
+    def _apply_dispatch_delta(self, task_bundle: ExecutionResources) -> None:
+        self._global_running_usage = self._global_running_usage.add(task_bundle)
+        self._global_pending_usage = self._global_pending_usage.subtract(task_bundle)
+
+    def _apply_complete_delta(self, task_bundle: ExecutionResources) -> None:
+        self._global_running_usage = self._global_running_usage.subtract(task_bundle)
+
+    def update_usages(self) -> None:
+        # O(1). No per-op iteration. Aggregates are already current.
+        if self._op_resource_allocator is not None:
+            self._update_allocated_budgets()
 ```
 
-Hot path becomes O(N_ops) scalar additions — not O(N_ops × constructors
-× `safe_round` calls). `_update_allocated_budgets` still runs (it does
-the across-op fair-share work), but it now reads from the cached
-aggregates instead of re-deriving them.
+`update_usages` itself shrinks from "iterate all N ops + construct
+N×K `ExecutionResources` + call `safe_round` 4× each" to **a single
+function call** — and even that call is a no-op when no allocator is
+configured. The per-call cost drops to ~0 regardless of N_ops or
+dispatch count.
+
+`_update_allocated_budgets` still runs and reads `_global_*` plus
+per-op cached values; it's the only across-op work that remains, and
+it's per-call-bounded rather than per-op-bounded.
+
+Safety note: this is sound because the scheduler thread is
+single-threaded — every mutation site (`on_data_ready`,
+`dispatch_next_task`, `task_done_callback`, output-queue pop) runs on
+the scheduler thread or is funnelled through it. No locking required
+on the global aggregate.
 
 #### 2c. Call-site changes
 
@@ -410,12 +454,14 @@ just observed from different sides.
 
 | frame (at 5000_tasks)                    | today  | projected | reasoning |
 | ---                                      | ---:   | ---:      | --- |
-| `update_usages` (inclusive)              | ~110 s | ~10-20 s  | drops to "sum N scalars per call" + budget allocator |
-| `safe_round` (leaf)                      |  ~46 s |   <5 s    | called only at construction, not in hot path |
-| `_update_allocated_budgets`              |  ~30 s | ~20-25 s  | still runs, reads cached values |
+| `update_usages` (inclusive)              | ~110 s |   <5 s    | O(1) per call — just dispatches to `_update_allocated_budgets` when configured |
+| `safe_round` (leaf)                      |  ~46 s |   <5 s    | only at delta application, not on every `update_usages` |
+| `_update_allocated_budgets`              |  ~30 s | ~20-25 s  | still runs, reads the live global aggregate |
 
-Projected scheduler-thread reduction at 5000 workers: **~110 s → ~30 s
-update_usages**, ~14 % of the 600 s total at that scale.
+Projected scheduler-thread reduction at 5000 workers: **~110 s → ~25 s
+on the `update_usages` family**, ~14 % of the 600 s total at that
+scale. The O(1) shape also means the win scales with N_ops — at
+higher op-count topologies it grows.
 
 ## Combined effect
 
@@ -561,11 +607,18 @@ unchanged.
    covered by new tests for budget-aware drain + cache-miss fallback.
 
 ### Part 2
-1. **Cache drift.** Any future code path that mutates op state without
-   calling a hook silently corrupts the cached usage. Mitigation: keep
-   `current_logical_usage` etc. as canonical readers backed by the
-   cache; add a debug-mode invariant check that periodically compares
-   cached vs. freshly-recomputed values.
+1. **Cache + global-aggregate drift.** Any future code path that
+   mutates op state without going through a hook silently corrupts
+   both the per-op cache *and* the global aggregate. The global makes
+   the drift especially nasty because a single missed delta poisons
+   `_update_allocated_budgets` for the rest of the dataset.
+   Mitigation: (a) keep `current_logical_usage` etc. as canonical
+   readers backed by the cache, so anyone reading sees the cached
+   value (no temptation to compute from raw state); (b) add a
+   debug-mode invariant check that periodically recomputes the
+   global from scratch and asserts equality; (c) bind the
+   `ResourceManager` reference at op-construction so missing the
+   global-update side is a `None` deref, not a silent skew.
 2. **Op subclass migration.** Each subclass override needs auditing.
    Mitigation: do one op at a time; the cached field defaults to a
    freshly-recomputed value if the subclass hasn't migrated yet
@@ -574,7 +627,10 @@ unchanged.
    from the output queue outside the scheduler thread. Need to either
    fire the `on_output_bytes_consumed` hook from those paths or model
    "externally-consumed bytes" separately. Either way, an explicit
-   decision rather than today's implicit recomputation.
+   decision rather than today's implicit recomputation. Because the
+   global aggregate is unlocked (single-thread assumption), any
+   off-scheduler-thread mutation must funnel through a thread-safe
+   queue rather than calling the hook directly.
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

Design RFC for two structurally similar bottlenecks on the StreamingExecutor scheduling thread, both stemming from the same anti-pattern: **the scheduler asks every operator the same question every iteration instead of letting the relevant code path report what changed.**

Full proposal in [`doc/design/scheduler-push-model-rfc.md`](./doc/design/scheduler-push-model-rfc.md).

| subsystem        | today's anti-pattern | this RFC |
| ---              | --- | --- |
| **Data path**    | `on_data_ready` issues `ray.get(meta_ref)` once per ready pair across every ready task; N small RPCs per scheduler iteration | Drain each ready task's gen up to its budget — looking up `size_bytes` inline via the Ray Core primitive (no RPC) so we stop pulling at the budget — then issue **one** batched `ray.get(meta_refs)` over what was drained |
| **Control path** | `update_usages` re-derives every op's resource bundle on every dispatch (~20 k calls per iteration at 5000 workers) | Ops push deltas at mutation sites (emit / dispatch / done) into a single live global aggregate on `ResourceManager`; per-op re-summation is gone, and `_update_allocated_budgets` is preserved verbatim but runs on scalar-array workspace + cached invariants — **exact equivalence, ~10× cheaper per call** |

This PR is **review-of-design**, not implementation — no behavior change. Open for discussion before code lands.

Removing the metadata `ray.get` from the scheduler thread *entirely* is not viable: `streaming_executor_state` reads `ref.schema` for schema unification, `DataOpTask.on_data_ready` reads `task_exec_stats` for `task_done_callback`, and `OpRuntimeMetrics` reads `exec_stats.node_id` on every emit. All run synchronously with the emit and need the materialized `BlockMetadata`. So the design keeps the metadata fetch but moves it from N per-pair calls to one batched, size-trimmed call per scheduler iteration. `RefBundle` layout and the streaming-gen protocol are unchanged.

For Part 2, exact equivalence with today's `_op_budgets` is preserved — the fair-share algorithm, borrow/cap logic, and per-dispatch call cadence stay; we just (1) eliminate the per-op re-summation via the live global aggregate, (2) cache the invariants that don't change per dispatch, and (3) run per-op math on scalar floats instead of constructing `ExecutionResources` per op.

## Why now

A representative scheduler-thread breakdown today (2000_tasks, wide-schema `worker_scaling` release test):

| frame (inclusive of ~198 s scheduler thread) | seconds | share |
| --- | ---: | ---: |
| `process_completed_tasks`                     |  96 s | 48 % |
|   └─ `on_data_ready`                          |  87 s | 44 % |
|        └─ `ray.get_objects` (leaf)            |  68 s | 35 % |
| `update_usages` + `_update_allocated_budgets` |  40 s | 20 % |
|   └─ `safe_round` (leaf)                      |  17 s |  9 % |
| `dispatch_next_task`                          |  41 s | 21 % |

At 5000 workers the same shape blows up to ~600 s scheduler thread; `update_usages` becomes ~110 s of that, called ~20 002 times per scheduler tick.

## What the RFC covers

- **When each scheduler hook is called today** (`on_data_ready`, `dispatch_next_task`, `update_usages`) — the per-iteration flow, trigger conditions, frequencies, and what state each mutates.
- **Part 1: Data path — size-aware budget-bounded drain + batched `ray.get`.** As each `block_ref` is pulled from the gen, look up `size_bytes` via the Ray Core primitive inline and stop pulling when the running sum exceeds the task's budget. Issue **one** batched `ray.get(meta_refs)` covering exactly what was drained — no separate trim pass, no cross-iteration cache. Prototype measurements: **1.3–1.77× max-loop reduction at 500–2000 workers, dampening to 1.12–1.17× at 5000** (where the batched-call fan-out itself starts to dominate).
- **Part 2: Control path — push, don't poll, and make the per-dispatch allocator cheap.** Hooks at every mutation site apply the delta to both per-op cache *and* a single live global aggregate on `ResourceManager` (no locking; single-threaded scheduler). The per-op re-summation in `update_usages` goes away. `_update_allocated_budgets` is preserved verbatim (same algorithm, same call cadence, bit-identical `_op_budgets`) but runs on cached invariants + scalar-array workspace, deferring `safe_round` to the materialization boundary. **Projected: ~140 s → ~5 s on the `update_usages` + allocator family at 5000 workers.**
- **Combined effect** — projected ~40–50 % scheduling-loop reduction at 1000–2000 workers, ~25–30 % at 5000 (where dispatch dominates).
- **Scope** (~500 LoC for Part 1, ~300-600 LoC for Part 2), **rollout order** (Core size primitive first → Part 1 → Part 2 independent), **alternatives**, **risks**, **open questions**.

## Not in this PR

- Implementation. Once design is settled, code lands as one or two follow-up PRs (Core size primitive first; Data-side changes second).
- The other 5000-worker pain (`dispatch_next_task`'s `remote()` Cython overhead). Separate follow-up.

cc Ray Data team — looking for design feedback before writing code.