### PR TITLE
Fix typos in code comments

### DIFF
--- a/python/ray/autoscaler/_private/vsphere/cluster_operator_client.py
+++ b/python/ray/autoscaler/_private/vsphere/cluster_operator_client.py
@@ -57,7 +57,7 @@ class KubernetesHttpApiClient(object):
         token = SERVICE_ACCOUNT_TOKEN
         # If SERVICE_ACCOUNT_TOKEN not present, use local
         # ~/.kube/config file. Active context will be used.
-        # This is usefull when Ray CLI are used and local autoscaler needs
+        # This is useful when Ray CLI are used and local autoscaler needs
         # communicate with the k8s API server
         # If the token is present then use that for communication.
         if not token:

--- a/python/ray/tests/test_client.py
+++ b/python/ray/tests/test_client.py
@@ -471,7 +471,7 @@ def test_basic_log_stream(call_ray_start_shared):
 
         ray.worker.log_client.log = test_log
         ray.worker.log_client.set_logstream_level(logging.DEBUG)
-        # Allow some time to propogate
+        # Allow some time to propagate
         time.sleep(1)
         x = ray.put("Foo")
         assert ray.get(x) == "Foo"

--- a/python/ray/util/client/logsclient.py
+++ b/python/ray/util/client/logsclient.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 # TODO(barakmich): Running a logger in a logger causes loopback.
 # The client logger need its own root -- possibly this one.
-# For the moment, let's just not propogate beyond this point.
+# For the moment, let's just not propagate beyond this point.
 logger.propagate = False
 
 

--- a/python/ray/util/client/server/server.py
+++ b/python/ray/util/client/server/server.py
@@ -78,7 +78,7 @@ def _use_response_cache(func):
         cached_entry = response_cache.check_cache(thread_id, req_id)
         if cached_entry is not None:
             if isinstance(cached_entry, Exception):
-                # Original call errored, propogate error
+                # Original call errored, propagate error
                 context.set_code(grpc.StatusCode.FAILED_PRECONDITION)
                 context.set_details(str(cached_entry))
                 raise cached_entry

--- a/rllib/utils/metrics/tests/test_metrics_logger.py
+++ b/rllib/utils/metrics/tests/test_metrics_logger.py
@@ -511,7 +511,7 @@ def test_edge_cases(root_logger):
     with pytest.raises(ValueError):
         root_logger.log_value("invalid_window_ema", 0.1, window=2, ema_coeff=0.1)
 
-    # Test value persistance after reduce
+    # Test value persistence after reduce
     root_logger.log_value("clear_test", 0.1)
     root_logger.log_value("clear_test", 0.2)
     results = root_logger.reduce()

--- a/rllib/utils/tests/test_actor_manager.py
+++ b/rllib/utils/tests/test_actor_manager.py
@@ -184,7 +184,7 @@ class TestActorManager(unittest.TestCase):
             ).ignore_errors()
         ]
 
-        # Results from blocking calls show the # of calls happend on
+        # Results from blocking calls show the # of calls happened on
         # each remote actor. 11 calls to each actor in total.
         self.assertEqual(results2, [11, 11, 11, 11])
 


### PR DESCRIPTION
Tiny typo fixes in code comments across a few files:

- `usefull` -> `useful` in [vsphere/cluster_operator_client.py](python/ray/autoscaler/_private/vsphere/cluster_operator_client.py)
- `propogate` -> `propagate` in [test_client.py](python/ray/tests/test_client.py), [logsclient.py](python/ray/util/client/logsclient.py), [server.py](python/ray/util/client/server/server.py)
- `persistance` -> `persistence` in [test_metrics_logger.py](rllib/utils/metrics/tests/test_metrics_logger.py)
- `happend` -> `happened` in [test_actor_manager.py](rllib/utils/tests/test_actor_manager.py)

Comments only, no behavior change.