### PR TITLE
[1/N]  [HAProxy stability] - Wait for old HAProxy workers to exit before marking proxy drained

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -1124,6 +1124,14 @@ class HAProxyApi(ProxyApi):
         except Exception as e:
             raise RuntimeError(f"Failed to update and reload HAProxy: {e}")
 
+    def has_alive_old_procs(self) -> bool:
+        """True if any soft-stopping HAProxy workers from prior reloads remain.
+
+        Also prunes already-exited entries to keep ``_old_procs`` bounded.
+        """
+        self._old_procs = [p for p in self._old_procs if p.returncode is None]
+        return len(self._old_procs) > 0
+
     async def disable(self) -> None:
         """Force haproxy health checks to fail."""
         try:
@@ -1407,19 +1415,22 @@ class HAProxyManager(ProxyActorInterface):
             self._draining_start_time = None
 
     async def is_drained(self, _after: Optional[Any] = None) -> bool:
-        """Check whether the haproxy is drained or not.
+        """Drained iff past min drain period AND no old workers still serving
+        AND current worker reports idle.
 
-        An haproxy is drained if it has no ongoing requests
-        AND it has been draining for more than
-        `PROXY_MIN_DRAINING_PERIOD_S` seconds.
+        The admin socket only sees the current (post-reload) worker; old
+        soft-stopping workers can still hold in-flight long-running requests
+        invisible to ``is_system_idle``. Gating on ``has_alive_old_procs``
+        prevents SIGKILL from severing those connections.
         """
         if not self._is_draining():
             return False
-
+        if (time.time() - self._draining_start_time) <= PROXY_MIN_DRAINING_PERIOD_S:
+            return False
+        if self._haproxy.has_alive_old_procs():
+            return False
         haproxy_stats = await self._haproxy.get_haproxy_stats()
-        return haproxy_stats.is_system_idle and (
-            (time.time() - self._draining_start_time) > PROXY_MIN_DRAINING_PERIOD_S
-        )
+        return haproxy_stats.is_system_idle
 
     async def check_health(self) -> bool:
         # If haproxy is already shutdown, return False.

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -774,9 +774,11 @@ class HAProxyApi(ProxyApi):
 
             self._proc = await self._start_and_wait_for_haproxy(*reload_args)
 
-            # Track old process so we can ensure it's cleaned up during shutdown
+            # Track old process for cleanup; prune exited ones so the list
+            # stays bounded even when the proxy reloads but never drains.
             if old_proc is not None:
                 self._old_procs.append(old_proc)
+            self._prune_old_procs()
 
             logger.info(
                 "Successfully performed graceful HAProxy reload with process restart."
@@ -1124,12 +1126,13 @@ class HAProxyApi(ProxyApi):
         except Exception as e:
             raise RuntimeError(f"Failed to update and reload HAProxy: {e}")
 
-    def has_alive_old_procs(self) -> bool:
-        """True if any soft-stopping HAProxy workers from prior reloads remain.
-
-        Also prunes already-exited entries to keep ``_old_procs`` bounded.
-        """
+    def _prune_old_procs(self) -> None:
+        """Drop references to old workers that have already exited."""
         self._old_procs = [p for p in self._old_procs if p.returncode is None]
+
+    def has_alive_old_procs(self) -> bool:
+        """True if any soft-stopping HAProxy workers from prior reloads remain."""
+        self._prune_old_procs()
         return len(self._old_procs) > 0
 
     async def disable(self) -> None:

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -18,12 +18,14 @@ from fastapi import FastAPI, Request, Response
 from ray._common.network_utils import find_free_port
 from ray._common.test_utils import async_wait_for_condition, wait_for_condition
 from ray.serve._private.constants import (
+    PROXY_MIN_DRAINING_PERIOD_S,
     RAY_SERVE_ENABLE_HA_PROXY,
 )
 from ray.serve._private.haproxy import (
     BackendConfig,
     HAProxyApi,
     HAProxyConfig,
+    HAProxyManager,
     ServerConfig,
 )
 from ray.serve.config import HTTPOptions
@@ -2294,6 +2296,56 @@ async def test_start_with_tcp_nodelay(haproxy_api_cleanup):
             ), "Config should contain 'option http-no-delay' when tcp_nodelay=True"
 
         await api.stop()
+
+
+def _bare_haproxy_manager():
+    """An uninitialized HAProxyManager for unit-testing its methods.
+
+    HAProxyManager is an ``@ray.remote`` actor, so the imported name is an
+    ActorClass, not a plain type. Reach the underlying Python class via
+    ``__ray_metadata__.modified_class`` and instantiate it with ``__new__``
+    so ``__init__`` (actor base class + event loop) is skipped.
+    """
+    cls = HAProxyManager.__ray_metadata__.modified_class
+    return cls.__new__(cls)
+
+
+@pytest.mark.asyncio
+async def test_is_drained_waits_for_old_procs():
+    """is_drained() stays False while a soft-stopping old worker from a
+    prior reload is still alive, even past the drain period with an idle
+    current worker; it flips True once the old worker exits."""
+    # Set only the two attributes is_drained() reads.
+    manager = _bare_haproxy_manager()
+    manager._draining_start_time = time.time() - PROXY_MIN_DRAINING_PERIOD_S - 1
+
+    manager._haproxy = mock.Mock()
+    manager._haproxy.get_haproxy_stats = mock.AsyncMock(
+        return_value=mock.Mock(is_system_idle=True)
+    )
+
+    # Old worker still serving -> not drained despite idle current worker.
+    manager._haproxy.has_alive_old_procs = mock.Mock(return_value=True)
+    assert await manager.is_drained() is False
+
+    # Old worker has exited -> drained.
+    manager._haproxy.has_alive_old_procs = mock.Mock(return_value=False)
+    assert await manager.is_drained() is True
+
+
+@pytest.mark.asyncio
+async def test_is_drained_false_before_min_period():
+    """is_drained() is False until PROXY_MIN_DRAINING_PERIOD_S has elapsed,
+    regardless of old-proc / idle state."""
+    manager = _bare_haproxy_manager()
+    manager._draining_start_time = time.time()  # just started draining
+    manager._haproxy = mock.Mock()
+    manager._haproxy.has_alive_old_procs = mock.Mock(return_value=False)
+    manager._haproxy.get_haproxy_stats = mock.AsyncMock(
+        return_value=mock.Mock(is_system_idle=True)
+    )
+
+    assert await manager.is_drained() is False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Fixes a race condition in `HAProxyProxyActor.is_drained()` that caused in-flight TCP connections to be RST'd (and thus 502s from upstream load balancers) whenever a proxy drained while older HAProxy worker processes were still serving long-running requests.

Detailed investigation: https://gist.github.com/harshit-anyscale/04ed26e4a0ea71886220fed1f903fca9

### The bug

`HAProxyProxyActor.is_drained()` previously gated on:
1. drain time exceeded `PROXY_MIN_DRAINING_PERIOD_S` (default 30s)
2. the current worker's admin-socket stats reported `is_system_idle`

This was unsafe. Each HAProxy graceful reload spawns a new worker that owns the listening socket (via `-x` socket transfer), while the OLD worker enters soft-stop and continues to serve its pre-reload in-flight connections in its own process memory. **Those in-flight connections are invisible to the admin socket** (which is bound to the new worker), so `is_system_idle` could return True while old workers still held long-running connections.

Marking the proxy as drained while old workers were alive caused `proxy_state.shutdown()` → `HAProxyApi.stop()` → `proc.kill()` to SIGKILL the old workers and sever their in-flight TCP connections. Clients saw 502 from upstream load balancers (target broke connection); replicas recorded HTTP 499 (uvicorn received an ASGI disconnect mid-request).

This affected any deployment with request durations exceeding `PROXY_MIN_DRAINING_PERIOD_S` — e.g., long-running inference, streaming responses, model cold-starts.

### The fix

Add condition (3) to `is_drained()`: no OLD workers from `_old_procs` are still alive. Each old worker exits cleanly when its in-flight count reaches zero (or `hard-stop-after` reaps it as a final safety valve), at which point `subprocess.Process.returncode` becomes set. The drain check uses this as a precise per-worker signal.

This makes the drain adaptive: it lasts exactly as long as the longest in-flight request actually needs, plus the `PROXY_MIN_DRAINING_PERIOD_S` floor that's still useful for upstream LB target-deregistration propagation. Previously, operators had to guess a `PROXY_MIN_DRAINING_PERIOD_S` value that exceeded the longest request duration across all deployments on the cluster; with this fix, the env var reverts to its name's actual semantic — a minimum floor, not a worst-case ceiling.

A new helper `HAProxyApi.has_alive_old_procs()` also prunes already-exited entries from `_old_procs` so the list stays bounded across long-lived proxy actors that perform many reloads.

The check order in `is_drained` was reorganized so the cheap, in-memory checks (timer, old-proc list) short-circuit before the async admin-socket query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)