### PR TITLE
[Data] Extend StreamingRepartition non-strict fusion to Filter/MapRows/FlatMap

### DIFF
--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -31,7 +31,10 @@ from ray.data._internal.logical.operators import (
     AbstractAllToAll,
     AbstractMap,
     AbstractUDFMap,
+    Filter,
+    FlatMap,
     MapBatches,
+    MapRows,
     RandomShuffle,
     Repartition,
     StreamingRepartition,
@@ -90,10 +93,14 @@ class FuseOperators(Rule):
     def _fuse_streaming_repartition_operators_in_dag(
         self, dag: PhysicalOperator
     ) -> PhysicalOperator:
-        """Fuse (MapBatches -> StreamingRepartition) pair.
+        """Fuse (MapBatches/Filter/MapRows/FlatMap -> StreamingRepartition) pair.
 
-        This will ensure the map_batch's function receive the correct number of rows.
-        We also ensure the output rows is `batch_size`.
+        In strict mode, only MapBatches is supported (requires batch_size % target == 0).
+        In non-strict mode, Filter, MapRows, and FlatMap are also supported since
+        they don't have batch_size constraints; min_rows_per_bundle is None for them.
+
+        For MapBatches in strict mode, this ensures the map_batch's function receives
+        the correct number of rows, and output rows equal batch_size.
 
         Why don't we fuse `StreamingRepartition -> MapBatches`?
 
@@ -123,7 +130,10 @@ class FuseOperators(Rule):
         while (
             len(upstream_ops) == 1
             and isinstance(self._op_map[dag], StreamingRepartition)
-            and isinstance(self._op_map[upstream_ops[0]], MapBatches)
+            and isinstance(
+                self._op_map[upstream_ops[0]],
+                (MapBatches, Filter, MapRows, FlatMap),
+            )
             and self._can_fuse(dag, upstream_ops[0])
         ):
             dag = self._get_fused_streaming_repartition_operator(dag, upstream_ops[0])
@@ -276,31 +286,40 @@ class FuseOperators(Rule):
         ):
             return False
 
-        # only allow fusion of MapBatches -> StreamingRepartition
+        # Allow fusion of MapBatches/Filter/MapRows/FlatMap -> StreamingRepartition
         if isinstance(down_logical_op, StreamingRepartition):
             if not (
-                isinstance(up_logical_op, MapBatches)
-                and down_logical_op.target_num_rows_per_block is not None
+                down_logical_op.target_num_rows_per_block is not None
                 and down_logical_op.target_num_rows_per_block > 0
             ):
                 return False
 
-            # Non-strict mode: can always fuse, no matter what batch_size is.
-            # This allows fusion without cross-task buffering by using default bundler.
-            if not down_logical_op.strict:
-                return True
+            # Filter/MapRows/FlatMap: only fuse in non-strict mode
+            if isinstance(up_logical_op, (Filter, MapRows, FlatMap)):
+                return not down_logical_op.strict
 
-            # Strict mode: only fuse when batch_size is a multiple of target_num_rows_per_block.
-            # When batch_size % target == 0, each batch can be perfectly sliced into chunks
-            # without cross-task buffering. See `_fuse_streaming_repartition_operators_in_dag`
-            # docstring for details.
-            # "auto" batch_size is resolved at task runtime, so divisibility is unknown at
-            # plan time — skip fusion and let the operators run separately.
-            return (
-                isinstance(up_logical_op.batch_size, int)
-                and up_logical_op.batch_size % down_logical_op.target_num_rows_per_block
-                == 0
-            )
+            # MapBatches: fuse in both modes
+            if isinstance(up_logical_op, MapBatches):
+                # Non-strict mode: can always fuse, no matter what batch_size is.
+                # This allows fusion without cross-task buffering by using default bundler.
+                if not down_logical_op.strict:
+                    return True
+
+                # Strict mode: only fuse when batch_size is a multiple of
+                # target_num_rows_per_block.
+                # When batch_size % target == 0, each batch can be perfectly sliced
+                # into chunks without cross-task buffering.
+                # "auto" batch_size is resolved at task runtime, so divisibility is
+                # unknown at plan time — skip fusion.
+                return (
+                    isinstance(up_logical_op.batch_size, int)
+                    and up_logical_op.batch_size
+                    % down_logical_op.target_num_rows_per_block
+                    == 0
+                )
+
+            # Other operators cannot fuse with StreamingRepartition.
+            return False
         # Other operators cannot fuse with StreamingRepartition.
         if isinstance(up_logical_op, StreamingRepartition):
             return False
@@ -312,7 +331,8 @@ class FuseOperators(Rule):
         self, down_op: PhysicalOperator, up_op: PhysicalOperator
     ) -> PhysicalOperator:
         assert self._can_fuse(down_op, up_op), (
-            "Current rule supports fusing MapBatches->StreamingRepartition, but received: "
+            "Current rule supports fusing MapBatches/Filter/MapRows/FlatMap"
+            "->StreamingRepartition, but received: "
             f"{type(up_op).__name__} -> {type(down_op).__name__}"
         )
 
@@ -320,10 +340,10 @@ class FuseOperators(Rule):
 
         down_logical_op = self._op_map.pop(down_op)
         up_logical_op = self._op_map.pop(up_op)
-        assert isinstance(up_logical_op, MapBatches)
+        assert isinstance(up_logical_op, (MapBatches, Filter, MapRows, FlatMap))
         assert isinstance(down_logical_op, StreamingRepartition)
 
-        batch_size = up_logical_op.batch_size
+        batch_size = getattr(up_logical_op, "batch_size", None)
 
         # Choose ref_bundler and fusion behavior based on strict mode
         if down_logical_op.strict:
@@ -357,10 +377,11 @@ class FuseOperators(Rule):
 
         assert up_op.data_context is down_op.data_context
 
-        # In non-strict mode, use min_rows_per_bundle to ensure creating batches with batch_size.
-        # In strict mode, ref_bundler handles bundling, so do not set min_rows_per_bundle.
+        # In non-strict mode, use min_rows_per_bundle to ensure creating batches
+        # with batch_size. In strict mode, ref_bundler handles bundling.
         # "auto" batch_size is resolved at task runtime, so we cannot set a fixed
-        # min_rows_per_bundle at plan time — leave it as None and let bundling use its default.
+        # min_rows_per_bundle at plan time.
+        # For non-MapBatches operators, batch_size is None so min_rows is None.
         min_rows = (
             None if (down_logical_op.strict or batch_size == "auto") else batch_size
         )
@@ -385,10 +406,15 @@ class FuseOperators(Rule):
             op.add_map_task_kwargs_fn(map_task_kwargs_fn)
 
         input_op = up_logical_op.input_dependencies[0]
+        # For expression-based Filter, fn is None; use an identity placeholder
+        # since the fused logical op is only for metadata and further fusion checks.
+        fn = up_logical_op.fn
+        if fn is None:
+            fn = lambda x: x  # noqa: E731
         logical_op = AbstractUDFMap(
             name,
             input_op,
-            up_logical_op.fn,
+            fn,
             can_modify_num_rows=up_logical_op.can_modify_num_rows,
             fn_args=up_logical_op.fn_args,
             fn_kwargs=up_logical_op.fn_kwargs,

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -975,6 +975,110 @@ def test_combine_sort_sort(ray_start_regular_shared_2_cpus, capsys):
     assert expected_optimized_plan in captured
 
 
+@pytest.mark.parametrize(
+    "op_type",
+    ["filter", "map_rows", "flat_map"],
+)
+def test_streaming_repartition_non_mapbatches_fusion_non_strict(
+    ray_start_regular_shared_2_cpus,
+    op_type,
+):
+    """Test that Filter/MapRows/FlatMap fuse with StreamingRepartition in non-strict mode."""
+    n = 100
+    target_rows = 20
+
+    ds = ray.data.range(n, override_num_blocks=2)
+
+    if op_type == "filter":
+        ds = ds.filter(lambda x: True)
+        expected_prefix = "Filter(<lambda>)"
+    elif op_type == "map_rows":
+        ds = ds.map(lambda x: x)
+        expected_prefix = "Map(<lambda>)"
+    elif op_type == "flat_map":
+        ds = ds.flat_map(lambda x: [x])
+        expected_prefix = "FlatMap(<lambda>)"
+
+    ds = ds.repartition(target_num_rows_per_block=target_rows, strict=False)
+
+    expected_fused_name = (
+        f"{expected_prefix}->StreamingRepartition"
+        f"[num_rows_per_block={target_rows},strict=False]"
+    )
+
+    assert len(ds.take_all()) == n
+    stats = ds.stats()
+    assert expected_fused_name in stats, (
+        f"Expected '{expected_fused_name}' in stats for {op_type}: {stats}"
+    )
+
+
+@pytest.mark.parametrize(
+    "op_type",
+    ["filter", "map_rows", "flat_map"],
+)
+def test_streaming_repartition_non_mapbatches_no_fusion_strict(
+    ray_start_regular_shared_2_cpus,
+    op_type,
+):
+    """Test that Filter/MapRows/FlatMap do NOT fuse with StreamingRepartition
+    in strict mode."""
+    n = 100
+    target_rows = 20
+
+    ds = ray.data.range(n, override_num_blocks=2)
+
+    if op_type == "filter":
+        ds = ds.filter(lambda x: True)
+        op_name = "Filter(<lambda>)"
+    elif op_type == "map_rows":
+        ds = ds.map(lambda x: x)
+        op_name = "Map(<lambda>)"
+    elif op_type == "flat_map":
+        ds = ds.flat_map(lambda x: [x])
+        op_name = "FlatMap(<lambda>)"
+
+    ds = ds.repartition(target_num_rows_per_block=target_rows, strict=True)
+
+    fused_name = (
+        f"{op_name}->StreamingRepartition"
+        f"[num_rows_per_block={target_rows},strict=True]"
+    )
+
+    assert len(ds.take_all()) == n
+    stats = ds.stats()
+    assert fused_name not in stats, (
+        f"Did not expect '{fused_name}' in stats for {op_type} "
+        f"in strict mode: {stats}"
+    )
+
+
+def test_streaming_repartition_chain_fusion_non_strict(
+    ray_start_regular_shared_2_cpus,
+):
+    """Test chain fusion: Map -> Filter -> StreamingRepartition(non-strict).
+
+    The Map and Filter should first be fused by map fusion, then the result
+    should be fused with StreamingRepartition.
+    """
+    n = 100
+    target_rows = 20
+
+    ds = ray.data.range(n, override_num_blocks=2)
+    ds = ds.map(lambda x: x)
+    ds = ds.filter(lambda x: True)
+    ds = ds.repartition(target_num_rows_per_block=target_rows, strict=False)
+
+    assert len(ds.take_all()) == n
+    stats = ds.stats()
+
+    # Map and Filter should be fused first, then fused with StreamingRepartition
+    assert (
+        f"Map(<lambda>)->Filter(<lambda>)->StreamingRepartition"
+        f"[num_rows_per_block={target_rows},strict=False]"
+    ) in stats, f"Expected chain fusion in stats: {stats}"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -576,6 +576,84 @@ def test_streaming_repartition_empty_dataset(
     assert ds.count() == 0, "Expected empty dataset"
 
 
+def test_streaming_repartition_filter_fusion_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test Filter -> StreamingRepartition(non-strict) fusion with data correctness."""
+    num_rows = 100
+    target = 20
+
+    ds = ray.data.range(num_rows, override_num_blocks=10)
+    # Filter keeps only even numbers
+    ds = ds.filter(lambda x: x["id"] % 2 == 0)
+    ds = ds.repartition(target_num_rows_per_block=target, strict=False)
+
+    result = sorted([row["id"] for row in ds.take_all()])
+    expected = list(range(0, num_rows, 2))
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_streaming_repartition_expression_filter_fusion_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test expression-based Filter (fn=None) -> StreamingRepartition(non-strict)
+    fusion."""
+    num_rows = 100
+    target = 20
+
+    ds = ray.data.range(num_rows, override_num_blocks=10)
+    # Expression-based filter: fn is None, predicate_expr is set
+    ds = ds.filter(expr="id >= 50")
+    ds = ds.repartition(target_num_rows_per_block=target, strict=False)
+
+    result = sorted([row["id"] for row in ds.take_all()])
+    expected = list(range(50, num_rows))
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_streaming_repartition_map_rows_fusion_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test MapRows -> StreamingRepartition(non-strict) fusion with data
+    correctness."""
+    num_rows = 100
+    target = 20
+
+    ds = ray.data.range(num_rows, override_num_blocks=10)
+    # Double each value
+    ds = ds.map(lambda x: {"id": x["id"] * 2})
+    ds = ds.repartition(target_num_rows_per_block=target, strict=False)
+
+    result = sorted([row["id"] for row in ds.take_all()])
+    expected = sorted([i * 2 for i in range(num_rows)])
+    assert result == expected, f"Expected {expected}, got {result}"
+
+
+def test_streaming_repartition_flat_map_fusion_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """Test FlatMap -> StreamingRepartition(non-strict) fusion with data
+    correctness."""
+    num_rows = 50
+    target = 20
+
+    ds = ray.data.range(num_rows, override_num_blocks=5)
+    # Duplicate each row
+    ds = ds.flat_map(lambda x: [{"id": x["id"]}, {"id": x["id"] + 1000}])
+    ds = ds.repartition(target_num_rows_per_block=target, strict=False)
+
+    result = sorted([row["id"] for row in ds.take_all()])
+    expected = sorted(
+        [i for i in range(num_rows)] + [i + 1000 for i in range(num_rows)]
+    )
+    assert result == expected, "Data mismatch after flat_map fusion"
+    assert len(result) == num_rows * 2
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why are these changes needed?

Currently, only `MapBatches -> StreamingRepartition` fusion is supported. In non-strict mode, `Filter`, `MapRows`, and `FlatMap` can also be safely fused with `StreamingRepartition` since non-strict mode:

- Does not require cross-task stitching
- Does not depend on `batch_size`
- Uses default `BlockRefBundler` (no `RebundleQueue`)

This extends the fusion coverage introduced in #59108 and #60295, reducing intermediate materialization overhead for common pipeline patterns like `filter -> repartition -> map_batches`.

## What changes were included?

**`operator_fusion.py`:**
- Extended `_fuse_streaming_repartition_operators_in_dag` while-loop to match `(MapBatches, Filter, MapRows, FlatMap)`
- Refactored `_can_fuse` StreamingRepartition branch: Filter/MapRows/FlatMap only fuse in non-strict mode; MapBatches behavior unchanged
- Updated `_get_fused_streaming_repartition_operator` to handle:
  - `batch_size` via `getattr` (non-MapBatches operators lack this attribute)
  - Expression-based Filter (`fn=None`) with identity lambda placeholder
  - `min_rows_per_bundled_input` is naturally `None` for these operators

**Strict mode is completely unchanged.**

## Related issues

Closes #63624

Extends #60026 (strict=False mode for StreamingRepartition)
Complementary to #62347 (filter pushdown through StreamingRepartition)

## Checks

- [x] I've signed all my commits with `Signed-off-by`
- [x] I've run `scripts/format.sh` to lint the changes
- [x] I've included tests: 3 unit tests + 4 e2e tests
- [x] Testing Strategy
  - [x] Unit tests for fusion/no-fusion behavior (parametrized over Filter/MapRows/FlatMap)
  - [x] Chain fusion test (Map -> Filter -> SR)
  - [x] E2E data correctness tests for all operator types including expression-based Filter
