### PR TITLE
[5/N] [HAProxy stability] - Quarantine recently-released replica ports to close 404 routing race

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -905,6 +905,12 @@ RAY_SERVE_DIRECT_INGRESS_MAX_GRPC_PORT = int(
 RAY_SERVE_DIRECT_INGRESS_PORT_RETRY_COUNT = int(
     os.environ.get("RAY_SERVE_DIRECT_INGRESS_PORT_RETRY_COUNT", "100")
 )
+
+# Hold released replica ports out of the pool this long so proxies can
+# drop their stale slot before a new replica grabs the same port. 0 disables.
+RAY_SERVE_PORT_QUARANTINE_S = get_env_float_non_negative(
+    "RAY_SERVE_PORT_QUARANTINE_S", 10.0
+)
 # The minimum drain period for a HTTP proxy.
 # If RAY_SERVE_FORCE_STOP_UNHEALTHY_REPLICAS is set to 1,
 # then the minimum draining period is 0.

--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -1,5 +1,6 @@
 import heapq
 import logging
+import time
 from typing import Dict, List, Optional, Set, Tuple
 
 from ray.serve._private.common import RequestProtocol
@@ -8,6 +9,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_DIRECT_INGRESS_MAX_HTTP_PORT,
     RAY_SERVE_DIRECT_INGRESS_MIN_GRPC_PORT,
     RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT,
+    RAY_SERVE_PORT_QUARANTINE_S,
     SERVE_LOGGER_NAME,
 )
 
@@ -33,11 +35,30 @@ class PortAllocator:
 
         self._allocated_ports: Dict[str, int] = {}
         self._blocked_ports: Set[int] = set()
+        # port -> monotonic deadline at which it leaves quarantine.
+        self._quarantined_ports: Dict[int, float] = {}
+
+    def _drain_expired_quarantine(self) -> None:
+        """Return quarantined ports past their expiry to the available pool."""
+        if not self._quarantined_ports:
+            return
+        now = time.monotonic()
+        expired = [p for p, exp in self._quarantined_ports.items() if exp <= now]
+        for port in expired:
+            heapq.heappush(self._available_ports, port)
+            del self._quarantined_ports[port]
+            logger.info(
+                f"Released {self._protocol} port {port} from quarantine on "
+                f"node {self._node_id}; returning it to the available pool."
+            )
 
     def update_port_if_missing(self, replica_id: str, port: Optional[int]):
         """Update port value for a replica."""
         if replica_id in self._allocated_ports:
             return
+        # Reclaim trumps quarantine: the port is back in active use.
+        if port is not None:
+            self._quarantined_ports.pop(port, None)
         assert (
             port is not None
         ), f"Port is None for {self._protocol} protocol on replica {replica_id} on node {self._node_id}"
@@ -69,9 +90,14 @@ class PortAllocator:
             )
             return self._allocated_ports[replica_id]
 
+        self._drain_expired_quarantine()
+
+        # Recovered replicas live in _allocated_ports but their ports are
+        # still in _available_ports, so guard against re-handing them out.
+        allocated = set(self._allocated_ports.values())
         while self._available_ports:
             port = heapq.heappop(self._available_ports)
-            if port not in self._blocked_ports:
+            if port not in self._blocked_ports and port not in allocated:
                 self._allocated_ports[replica_id] = port
                 logger.info(
                     f"Allocated {self._protocol} port {port} to replica {replica_id} on node {self._node_id}"
@@ -100,15 +126,30 @@ class PortAllocator:
             f"expected {expected_port}, got {port}"
         )
 
-        heapq.heappush(self._available_ports, port)
         del self._allocated_ports[replica_id]
-        logger.info(
-            f"Released {self._protocol} port {port} for replica {replica_id} on node {self._node_id}"
-        )
 
         if block_port:
+            # Block is a stronger guarantee than quarantine; skip quarantine.
             self._blocked_ports.add(port)
-            logger.info(f"Blocked {self._protocol} port {port} on node {self._node_id}")
+            heapq.heappush(self._available_ports, port)
+            logger.info(
+                f"Released and blocked {self._protocol} port {port} for replica "
+                f"{replica_id} on node {self._node_id}"
+            )
+        elif RAY_SERVE_PORT_QUARANTINE_S > 0:
+            self._quarantined_ports[port] = (
+                time.monotonic() + RAY_SERVE_PORT_QUARANTINE_S
+            )
+            logger.info(
+                f"Quarantined {self._protocol} port {port} for "
+                f"{RAY_SERVE_PORT_QUARANTINE_S}s after releasing for replica "
+                f"{replica_id} on node {self._node_id}"
+            )
+        else:
+            heapq.heappush(self._available_ports, port)
+            logger.info(
+                f"Released {self._protocol} port {port} for replica {replica_id} on node {self._node_id}"
+            )
 
     def prune(self, active_replica_ids: Set[str]):
         for replica_id in list(self._allocated_ports.keys()):

--- a/python/ray/serve/_private/node_port_manager.py
+++ b/python/ray/serve/_private/node_port_manager.py
@@ -94,10 +94,17 @@ class PortAllocator:
 
         # Recovered replicas live in _allocated_ports but their ports are
         # still in _available_ports, so guard against re-handing them out.
+        # A recovered port released into quarantine is also still in the heap
+        # (update_port_if_missing never pops it), so guard against handing out
+        # a still-quarantined port too.
         allocated = set(self._allocated_ports.values())
         while self._available_ports:
             port = heapq.heappop(self._available_ports)
-            if port not in self._blocked_ports and port not in allocated:
+            if (
+                port not in self._blocked_ports
+                and port not in allocated
+                and port not in self._quarantined_ports
+            ):
                 self._allocated_ports[replica_id] = port
                 logger.info(
                     f"Allocated {self._protocol} port {port} to replica {replica_id} on node {self._node_id}"

--- a/python/ray/serve/tests/unit/test_node_port_manager.py
+++ b/python/ray/serve/tests/unit/test_node_port_manager.py
@@ -276,5 +276,31 @@ def test_allocate_skips_recovered_port(port_range_constants):
     assert next_port != recovered
 
 
+def test_allocate_skips_quarantined_recovered_port(monkeypatch, port_range_constants):
+    """A port recovered via update_port_if_missing stays in the heap; once
+    released into quarantine it must not be handed out again until the
+    quarantine expires, even though it's still in _available_ports."""
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        60.0,
+    )
+    manager = NodePortManager.get_node_manager("node-recover-quarantine")
+    alloc = manager._http_allocator
+    # Recover at the smallest port so heappop would otherwise return it first.
+    recovered = port_range_constants["RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT"]
+    alloc.update_port_if_missing("replica-r", recovered)
+
+    # Release it: goes into quarantine but is still in the heap (recovery
+    # never popped it).
+    manager.release_port("replica-r", recovered, RequestProtocol.HTTP)
+    assert recovered in alloc._quarantined_ports
+    assert recovered in alloc._available_ports  # the invariant-violating state
+
+    # allocate() must not hand back the still-quarantined port.
+    next_port = manager.allocate_port("replica-new", RequestProtocol.HTTP)
+    assert next_port != recovered
+    assert recovered in alloc._quarantined_ports  # still held
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_node_port_manager.py
+++ b/python/ray/serve/tests/unit/test_node_port_manager.py
@@ -36,6 +36,11 @@ def setup_port_constants(monkeypatch, port_range_constants):
         "ray.serve._private.node_port_manager.RAY_SERVE_DIRECT_INGRESS_MAX_GRPC_PORT",
         port_range_constants["RAY_SERVE_DIRECT_INGRESS_MAX_GRPC_PORT"],
     )
+    # Disable quarantine so existing tests keep their immediate-reuse semantics.
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        0.0,
+    )
     yield
 
 
@@ -191,6 +196,84 @@ def test_check_replica_port_allocated():
 
     # Clean up
     manager.release_port("replica-1", port, RequestProtocol.HTTP)
+
+
+def test_quarantine_holds_released_port(monkeypatch, port_range_constants):
+    """A released port is held in quarantine and not immediately reusable."""
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        60.0,
+    )
+    manager = NodePortManager.get_node_manager("node-quarantine-1")
+
+    first = manager.allocate_port("replica-q1", RequestProtocol.HTTP)
+    manager.release_port("replica-q1", first, RequestProtocol.HTTP)
+
+    next_port = manager.allocate_port("replica-q2", RequestProtocol.HTTP)
+    assert next_port != first
+    assert first not in manager._http_allocator._available_ports
+    assert first in manager._http_allocator._quarantined_ports
+
+
+def test_quarantine_expiry_returns_port_to_pool(monkeypatch, port_range_constants):
+    """Once a quarantined port's timer expires, it becomes available again."""
+    import time
+
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        0.05,
+    )
+    manager = NodePortManager.get_node_manager("node-quarantine-2")
+
+    first = manager.allocate_port("replica-q1", RequestProtocol.HTTP)
+    manager.release_port("replica-q1", first, RequestProtocol.HTTP)
+    assert first in manager._http_allocator._quarantined_ports
+
+    time.sleep(0.1)
+    # Drain explicitly so we don't rely on the allocate-side drain firing.
+    manager._http_allocator._drain_expired_quarantine()
+    assert first not in manager._http_allocator._quarantined_ports
+    assert first in manager._http_allocator._available_ports
+
+
+def test_quarantine_skipped_for_block_port(monkeypatch, port_range_constants):
+    """block_port=True bypasses quarantine."""
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        60.0,
+    )
+    manager = NodePortManager.get_node_manager("node-quarantine-3")
+    port = manager.allocate_port("replica-q", RequestProtocol.HTTP)
+    manager.release_port("replica-q", port, RequestProtocol.HTTP, block_port=True)
+
+    assert port in manager._http_allocator._blocked_ports
+    assert port not in manager._http_allocator._quarantined_ports
+
+
+def test_quarantine_disabled_when_zero(monkeypatch, port_range_constants):
+    """Quarantine at 0 preserves immediate-reuse behavior."""
+    monkeypatch.setattr(
+        "ray.serve._private.node_port_manager.RAY_SERVE_PORT_QUARANTINE_S",
+        0.0,
+    )
+    manager = NodePortManager.get_node_manager("node-quarantine-4")
+    port = manager.allocate_port("replica-q1", RequestProtocol.HTTP)
+    manager.release_port("replica-q1", port, RequestProtocol.HTTP)
+    next_port = manager.allocate_port("replica-q2", RequestProtocol.HTTP)
+    assert next_port == port
+
+
+def test_allocate_skips_recovered_port(port_range_constants):
+    """update_port_if_missing recovers a port but leaves it in the heap;
+    a subsequent allocate must not hand the same port to another replica."""
+    manager = NodePortManager.get_node_manager("node-recover")
+    # Recover a replica at the smallest port in the range — heappop would
+    # otherwise return it first.
+    recovered = port_range_constants["RAY_SERVE_DIRECT_INGRESS_MIN_HTTP_PORT"]
+    manager._http_allocator.update_port_if_missing("replica-r", recovered)
+
+    next_port = manager.allocate_port("replica-new", RequestProtocol.HTTP)
+    assert next_port != recovered
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Carved out of #63507 to land independently.

When a replica stops and its port is released, the port goes straight back into the available pool today. The next replica to be spawned can grab it. If that happens **before** HAProxy (or any proxy that mirrors deployment state) has propagated the previous replica's slot removal, the proxy still has a slot pointing at `host:port` for the **old** deployment, but a **new** deployment's replica is now serving that port. Requests routed via the stale slot hit the new replica, which doesn't serve that route, and return **404**. We observed this extensively in load tests with autoscaling churn.

The fix closes the race at its source by holding released ports in a quarantine set on `NodePortManager` for a configurable window before they re-enter the available pool.

- `RAY_SERVE_PORT_QUARANTINE_S` (env var, float seconds, default `10`). 10s comfortably covers HAProxy's reconfigure latency (broadcast coalescing + reload) under load.
- Quarantine is drained **lazily** on each `allocate()` call — no background timer.
- `block_port=True` (permanent block) bypasses quarantine because it's a strictly stronger guarantee.

Why 10s and not larger: for deployments with long `graceful_shutdown` windows, the drain itself already provides most of the buffer, and the quarantine only really matters for crash/force-kill recoveries. High-churn environments can bump the env var; small clusters where port-pool pressure matters can lower it or set to `0` to disable entirely.