### PR TITLE
[Serve] (cont.) add locality routing vars to deploy options and prioritize them over env

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2944,7 +2944,7 @@ def exit_actor():
     observes the actor's death rather than a return value, and methods that have
     not started executing fail with ``RayActorError``.
 
-    Tasks queued for execution will fail with ``RayActorError``. For concurrent actors, tasks currently executing will run to completion before the actor exits.
+    Tasks queued for execution will fail with ``RayActorError``. For concurrent and async actors, tasks currently executing will run to completion before the actor exits.
 
     Any ``atexit`` handlers installed in the actor will be run.
 

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -157,6 +157,12 @@ class DeploymentConfig(BaseModel):
         rolling_update_percentage: The fraction of replicas (of
             ``target_num_replicas``) to update at a time during a rolling
             update. Must be in ``(0.0, 1.0]``. Defaults to 0.2 (20%).
+        prefer_local_node_routing: Feature flag to turn on node locality
+            routing. Applies to both proxy-to-replica and replica-to-replica
+            routing. On by default.
+        prefer_local_az_routing: Feature flag to turn on AZ locality routing.
+            Applies to both proxy-to-replica and replica-to-replica routing.
+            On by default.
     """
 
     num_replicas: Optional[NonNegativeInt] = Field(
@@ -231,6 +237,16 @@ class DeploymentConfig(BaseModel):
     deployment_actors: Optional[List[DeploymentActorConfig]] = Field(
         default=None,
         update_type=DeploymentOptionUpdateType.HeavyWeight,
+    )
+
+    prefer_local_node_routing: bool = Field(
+        default=True,
+        update_type=DeploymentOptionUpdateType.LightWeight,
+    )
+
+    prefer_local_az_routing: bool = Field(
+        default=True,
+        update_type=DeploymentOptionUpdateType.LightWeight,
     )
 
     rolling_update_percentage: float = Field(

--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -29,6 +29,8 @@ from ray.serve._private.constants import (
     DEFAULT_MAX_ONGOING_REQUESTS,
     DEFAULT_ROLLING_UPDATE_PERCENTAGE,
     MAX_REPLICAS_PER_NODE_MAX_VALUE,
+    RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
+    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
 )
 from ray.serve._private.utils import DEFAULT, DeploymentOptionUpdateType
 from ray.serve.config import (
@@ -159,10 +161,14 @@ class DeploymentConfig(BaseModel):
             update. Must be in ``(0.0, 1.0]``. Defaults to 0.2 (20%).
         prefer_local_node_routing: Feature flag to turn on node locality
             routing. Applies to both proxy-to-replica and replica-to-replica
-            routing. On by default.
+            routing. Defaults to the value of
+            ``RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING`` (on by default).
+            Explicit deployment config overrides the env var.
         prefer_local_az_routing: Feature flag to turn on AZ locality routing.
             Applies to both proxy-to-replica and replica-to-replica routing.
-            On by default.
+            Defaults to the value of
+            ``RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING`` (on by default).
+            Explicit deployment config overrides the env var.
     """
 
     num_replicas: Optional[NonNegativeInt] = Field(
@@ -240,12 +246,12 @@ class DeploymentConfig(BaseModel):
     )
 
     prefer_local_node_routing: bool = Field(
-        default=True,
+        default=RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
         update_type=DeploymentOptionUpdateType.LightWeight,
     )
 
     prefer_local_az_routing: bool = Field(
-        default=True,
+        default=RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
         update_type=DeploymentOptionUpdateType.LightWeight,
     )
 

--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -116,6 +116,22 @@ class LocalityMixin:
 
         self._colocated_replica_ids = new_colocated_replica_ids
 
+    def update_locality_routing_params(
+        self,
+        prefer_local_node_routing: bool,
+        prefer_local_az_routing: bool,
+    ) -> None:
+        """Update locality routing parameters at runtime.
+
+        Args:
+            prefer_local_node_routing: Whether to prefer routing to replicas on
+                the same node as the caller.
+            prefer_local_az_routing: Whether to prefer routing to replicas in
+                the same availability zone as the caller.
+        """
+        self._prefer_local_node_routing = prefer_local_node_routing
+        self._prefer_local_az_routing = prefer_local_az_routing
+
     def apply_locality_routing(
         self,
         pending_request: Optional[PendingRequest] = None,
@@ -652,6 +668,24 @@ class RequestRouter(ABC):
         self.initial_backoff_s = initial_backoff_s
         self.backoff_multiplier = backoff_multiplier
         self.max_backoff_s = max_backoff_s
+
+    def update_locality_routing_params(
+        self,
+        prefer_local_node_routing: bool,
+        prefer_local_az_routing: bool,
+    ) -> None:
+        """Update locality routing parameters at runtime.
+
+        Request router implementations that use these parameters should override
+        this method.
+
+        Args:
+            prefer_local_node_routing: Whether to prefer routing to replicas on
+                the same node as the caller.
+            prefer_local_az_routing: Whether to prefer routing to replicas in
+                the same availability zone as the caller.
+        """
+        pass
 
     async def _backoff(self, attempt: int) -> None:
         """Sleep for the appropriate backoff time for a given retry attempt.

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -51,6 +51,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     RAY_SERVE_METRICS_EXPORT_INTERVAL_MS,
     RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
+    RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING,
     SERVE_LOGGER_NAME,
 )
 from ray.serve._private.constants_utils import warn_if_deprecated_env_var_set
@@ -648,6 +649,7 @@ class AsyncioRouter:
         self._node_id = node_id
         self._availability_zone = availability_zone
         self._prefer_local_node_routing = prefer_local_node_routing
+        self._prefer_local_az_routing = RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING
         # By default, deployment is available unless we receive news
         # otherwise through a long poll broadcast from the controller.
         self._deployment_available = True
@@ -787,7 +789,7 @@ class AsyncioRouter:
                 use_replica_queue_len_cache=self._enable_strict_max_ongoing_requests,
                 create_replica_wrapper_func=lambda r: RunningReplica(r),
                 prefer_local_node_routing=self._prefer_local_node_routing,
-                prefer_local_az_routing=RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING,
+                prefer_local_az_routing=self._prefer_local_az_routing,
                 self_availability_zone=self._availability_zone,
                 **backoff_kwargs,
             )
@@ -835,6 +837,29 @@ class AsyncioRouter:
         self._request_router_kwargs = (
             deployment_config.request_router_config.request_router_kwargs
         )
+
+        # Priority is: explicit DeploymentConfig setting > env var > default.
+        if (
+            "prefer_local_node_routing"
+            in deployment_config.user_configured_option_names
+        ):
+            self._prefer_local_node_routing = (
+                deployment_config.prefer_local_node_routing
+            )
+        else:
+            self._prefer_local_node_routing = RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING
+
+        if "prefer_local_az_routing" in deployment_config.user_configured_option_names:
+            self._prefer_local_az_routing = deployment_config.prefer_local_az_routing
+        else:
+            self._prefer_local_az_routing = RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING
+
+        # Propagate to the request router if it has already been initialized.
+        if self._request_router is not None:
+            self._request_router.update_locality_routing_params(
+                prefer_local_node_routing=self._prefer_local_node_routing,
+                prefer_local_az_routing=self._prefer_local_az_routing,
+            )
 
         # Warn if deprecated env vars are set
         warn_if_deprecated_env_var_set("RAY_SERVE_ROUTER_RETRY_INITIAL_BACKOFF_S")

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1,6 +1,8 @@
 import collections
 import inspect
 import logging
+import os
+import warnings
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
@@ -540,6 +542,8 @@ def deployment(
         Optional[List[Union[Dict, DeploymentActorConfig]]]
     ] = DEFAULT.VALUE,
     rolling_update_percentage: Default[float] = DEFAULT.VALUE,
+    prefer_local_node_routing: Default[bool] = DEFAULT.VALUE,
+    prefer_local_az_routing: Default[bool] = DEFAULT.VALUE,
 ) -> Callable[[Callable], Deployment]:
     """Decorator that converts a Python class to a `Deployment`.
 
@@ -620,6 +624,12 @@ def deployment(
         rolling_update_percentage: The fraction of replicas to update at a
             time during a rolling update. Must be in ``(0.0, 1.0]``.
             Defaults to ``0.2`` (20%).
+        prefer_local_node_routing: Feature flag to turn on node locality routing.
+            Applies to both proxy-to-replica and replica-to-replica routing.
+            On by default.
+        prefer_local_az_routing: Feature flag to turn on AZ locality routing.
+            Applies to both proxy-to-replica and replica-to-replica routing.
+            On by default.
 
     Returns:
         `Deployment`
@@ -683,6 +693,32 @@ def deployment(
             "autoscaling_config is provided."
         )
 
+    if version is not DEFAULT.VALUE:
+        logger.warning(
+            "DeprecationWarning: `version` in `@serve.deployment` has been deprecated. "
+            "Explicitly specifying version will raise an error in the future!"
+        )
+
+    # check for deprecated environment variable usage
+    if "RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING" in os.environ:
+        warnings.warn(
+            "The environment variable 'RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING' "
+            "is deprecated and will be removed in a future release. "
+            "Please use 'prefer_local_node_routing' in @serve.deployment instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    # check for deprecated environment variable usage
+    if "RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING" in os.environ:
+        warnings.warn(
+            "The environment variable 'RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING' "
+            "is deprecated and will be removed in a future release. "
+            "Please use 'prefer_local_az_routing' in @serve.deployment instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if isinstance(logging_config, LoggingConfig):
         logging_config = logging_config.model_dump()
 
@@ -702,6 +738,8 @@ def deployment(
         gang_scheduling_config=gang_scheduling_config,
         deployment_actors=deployment_actors,
         rolling_update_percentage=rolling_update_percentage,
+        prefer_local_node_routing=prefer_local_node_routing,
+        prefer_local_az_routing=prefer_local_az_routing,
     )
     deployment_config.user_configured_option_names = set(user_configured_option_names)
 

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -693,12 +693,6 @@ def deployment(
             "autoscaling_config is provided."
         )
 
-    if version is not DEFAULT.VALUE:
-        logger.warning(
-            "DeprecationWarning: `version` in `@serve.deployment` has been deprecated. "
-            "Explicitly specifying version will raise an error in the future!"
-        )
-
     # check for deprecated environment variable usage
     if "RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING" in os.environ:
         warnings.warn(

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -1,8 +1,6 @@
 import collections
 import inspect
 import logging
-import os
-import warnings
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Sequence, Type, Union
 
@@ -626,10 +624,12 @@ def deployment(
             Defaults to ``0.2`` (20%).
         prefer_local_node_routing: Feature flag to turn on node locality routing.
             Applies to both proxy-to-replica and replica-to-replica routing.
-            On by default.
+            Defaults to the value of ``RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING``
+            (on by default). Explicit deployment config overrides the env var.
         prefer_local_az_routing: Feature flag to turn on AZ locality routing.
             Applies to both proxy-to-replica and replica-to-replica routing.
-            On by default.
+            Defaults to the value of ``RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING``
+            (on by default). Explicit deployment config overrides the env var.
 
     Returns:
         `Deployment`
@@ -691,26 +691,6 @@ def deployment(
         raise ValueError(
             "Manually setting num_replicas is not allowed when "
             "autoscaling_config is provided."
-        )
-
-    # check for deprecated environment variable usage
-    if "RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING" in os.environ:
-        warnings.warn(
-            "The environment variable 'RAY_SERVE_PROXY_PREFER_LOCAL_NODE_ROUTING' "
-            "is deprecated and will be removed in a future release. "
-            "Please use 'prefer_local_node_routing' in @serve.deployment instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    # check for deprecated environment variable usage
-    if "RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING" in os.environ:
-        warnings.warn(
-            "The environment variable 'RAY_SERVE_PROXY_PREFER_LOCAL_AZ_ROUTING' "
-            "is deprecated and will be removed in a future release. "
-            "Please use 'prefer_local_az_routing' in @serve.deployment instead.",
-            DeprecationWarning,
-            stacklevel=2,
         )
 
     if isinstance(logging_config, LoggingConfig):

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -251,8 +251,6 @@ class Deployment:
         deployment_actors: Default[
             Optional[List[Union[Dict, DeploymentActorConfig]]]
         ] = DEFAULT.VALUE,
-        prefer_local_node_routing: Default[bool] = DEFAULT.VALUE,
-        prefer_local_az_routing: Default[bool] = DEFAULT.VALUE,
     ) -> "Deployment":
         """Return a copy of this deployment with updated options.
 
@@ -400,12 +398,6 @@ class Deployment:
         if deployment_actors is not DEFAULT.VALUE:
             new_deployment_config.deployment_actors = deployment_actors
 
-        if prefer_local_node_routing is not DEFAULT.VALUE:
-            new_deployment_config.prefer_local_node_routing = prefer_local_node_routing
-
-        if prefer_local_az_routing is not DEFAULT.VALUE:
-            new_deployment_config.prefer_local_az_routing = prefer_local_az_routing
-
         gc = new_deployment_config.gang_scheduling_config
         if (
             gc is not None
@@ -511,8 +503,6 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
         "gang_scheduling_config": d._deployment_config.gang_scheduling_config,
         "deployment_actors": d._deployment_config.deployment_actors,
         "rolling_update_percentage": d._deployment_config.rolling_update_percentage,
-        "prefer_local_node_routing": d._deployment_config.prefer_local_node_routing,
-        "prefer_local_az_routing": d._deployment_config.prefer_local_az_routing,
     }
 
     # Let non-user-configured options be set to defaults. If the schema
@@ -577,8 +567,6 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         gang_scheduling_config=s.gang_scheduling_config,
         deployment_actors=s.deployment_actors,
         rolling_update_percentage=s.rolling_update_percentage,
-        prefer_local_node_routing=s.prefer_local_node_routing,
-        prefer_local_az_routing=s.prefer_local_az_routing,
     )
     deployment_config.user_configured_option_names = (
         s._get_user_configured_option_names()

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -251,6 +251,8 @@ class Deployment:
         deployment_actors: Default[
             Optional[List[Union[Dict, DeploymentActorConfig]]]
         ] = DEFAULT.VALUE,
+        prefer_local_node_routing: Default[bool] = DEFAULT.VALUE,
+        prefer_local_az_routing: Default[bool] = DEFAULT.VALUE,
     ) -> "Deployment":
         """Return a copy of this deployment with updated options.
 
@@ -398,6 +400,12 @@ class Deployment:
         if deployment_actors is not DEFAULT.VALUE:
             new_deployment_config.deployment_actors = deployment_actors
 
+        if prefer_local_node_routing is not DEFAULT.VALUE:
+            new_deployment_config.prefer_local_node_routing = prefer_local_node_routing
+
+        if prefer_local_az_routing is not DEFAULT.VALUE:
+            new_deployment_config.prefer_local_az_routing = prefer_local_az_routing
+
         gc = new_deployment_config.gang_scheduling_config
         if (
             gc is not None
@@ -503,6 +511,8 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
         "gang_scheduling_config": d._deployment_config.gang_scheduling_config,
         "deployment_actors": d._deployment_config.deployment_actors,
         "rolling_update_percentage": d._deployment_config.rolling_update_percentage,
+        "prefer_local_node_routing": d._deployment_config.prefer_local_node_routing,
+        "prefer_local_az_routing": d._deployment_config.prefer_local_az_routing,
     }
 
     # Let non-user-configured options be set to defaults. If the schema
@@ -567,6 +577,8 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         gang_scheduling_config=s.gang_scheduling_config,
         deployment_actors=s.deployment_actors,
         rolling_update_percentage=s.rolling_update_percentage,
+        prefer_local_node_routing=s.prefer_local_node_routing,
+        prefer_local_az_routing=s.prefer_local_az_routing,
     )
     deployment_config.user_configured_option_names = (
         s._get_user_configured_option_names()

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -479,6 +479,22 @@ class DeploymentSchema(BaseModel):
         gt=0.0,
         le=1.0,
     )
+    prefer_local_node_routing: bool = Field(
+        default=DEFAULT.VALUE,
+        description=(
+            "Whether to prefer routing requests to replicas on the same node "
+            "as the caller. Applies to both proxy-to-replica and "
+            "replica-to-replica routing."
+        ),
+    )
+    prefer_local_az_routing: bool = Field(
+        default=DEFAULT.VALUE,
+        description=(
+            "Whether to prefer routing requests to replicas in the same "
+            "availability zone as the caller. Applies to both proxy-to-replica "
+            "and replica-to-replica routing."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -676,6 +692,8 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
         ray_actor_options=info.replica_config.ray_actor_options,
         request_router_config=info.deployment_config.request_router_config,
         rolling_update_percentage=info.deployment_config.rolling_update_percentage,
+        prefer_local_node_routing=info.deployment_config.prefer_local_node_routing,
+        prefer_local_az_routing=info.deployment_config.prefer_local_az_routing,
     )
 
     if info.deployment_config.autoscaling_config is not None:

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -479,22 +479,6 @@ class DeploymentSchema(BaseModel):
         gt=0.0,
         le=1.0,
     )
-    prefer_local_node_routing: bool = Field(
-        default=DEFAULT.VALUE,
-        description=(
-            "Whether to prefer routing requests to replicas on the same node "
-            "as the caller. Applies to both proxy-to-replica and "
-            "replica-to-replica routing."
-        ),
-    )
-    prefer_local_az_routing: bool = Field(
-        default=DEFAULT.VALUE,
-        description=(
-            "Whether to prefer routing requests to replicas in the same "
-            "availability zone as the caller. Applies to both proxy-to-replica "
-            "and replica-to-replica routing."
-        ),
-    )
 
     @model_validator(mode="before")
     @classmethod
@@ -692,8 +676,6 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
         ray_actor_options=info.replica_config.ray_actor_options,
         request_router_config=info.deployment_config.request_router_config,
         rolling_update_percentage=info.deployment_config.rolling_update_percentage,
-        prefer_local_node_routing=info.deployment_config.prefer_local_node_routing,
-        prefer_local_az_routing=info.deployment_config.prefer_local_az_routing,
     )
 
     if info.deployment_config.autoscaling_config is not None:

--- a/python/ray/serve/tests/unit/test_deployment_class.py
+++ b/python/ray/serve/tests/unit/test_deployment_class.py
@@ -91,6 +91,8 @@ class TestDeploymentOptions:
         "graceful_shutdown_timeout_s": 10,
         "health_check_period_s": 10,
         "health_check_timeout_s": 10,
+        "prefer_local_node_routing": False,
+        "prefer_local_az_routing": False,
     }
 
     deployment_option_combos = get_random_dict_combos(deployment_options, 1000)

--- a/python/ray/serve/tests/unit/test_deployment_class.py
+++ b/python/ray/serve/tests/unit/test_deployment_class.py
@@ -91,8 +91,6 @@ class TestDeploymentOptions:
         "graceful_shutdown_timeout_s": 10,
         "health_check_period_s": 10,
         "health_check_timeout_s": 10,
-        "prefer_local_node_routing": False,
-        "prefer_local_az_routing": False,
     }
 
     deployment_option_combos = get_random_dict_combos(deployment_options, 1000)

--- a/python/ray/serve/tests/unit/test_pow_2_request_router.py
+++ b/python/ray/serve/tests/unit/test_pow_2_request_router.py
@@ -2183,5 +2183,27 @@ def test_compute_backoff_s_does_not_overflow():
     assert router._compute_backoff_s(2048) == router.max_backoff_s
 
 
+def test_request_router_update_locality_routing_params():
+    """Test that locality routing params can be updated at runtime."""
+    router = PowerOfTwoChoicesRequestRouter(
+        deployment_id=DeploymentID(name="TEST_DEPLOYMENT"),
+        handle_source=DeploymentHandleSource.REPLICA,
+        self_node_id=ROUTER_NODE_ID,
+        self_actor_id="fake-actor-id",
+        self_actor_handle=None,
+        get_curr_time_s=TIMER.time,
+        prefer_local_node_routing=False,
+        prefer_local_az_routing=False,
+    )
+
+    router.update_locality_routing_params(
+        prefer_local_node_routing=True,
+        prefer_local_az_routing=True,
+    )
+
+    assert router._prefer_local_node_routing is True
+    assert router._prefer_local_az_routing is True
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -3034,6 +3034,50 @@ class TestAsyncioRouterBackoffConfig:
         assert fake_request_router.backoff_multiplier == custom_multiplier
         assert fake_request_router.max_backoff_s == custom_max_backoff
 
+    async def test_update_deployment_config_sets_locality_routing_params(self):
+        """Test that update_deployment_config propagates locality routing params."""
+        from ray.serve._private.request_router import PowerOfTwoChoicesRequestRouter
+
+        request_router = PowerOfTwoChoicesRequestRouter(
+            deployment_id=DeploymentID(name="test-deployment"),
+            handle_source=DeploymentHandleSource.UNKNOWN,
+            self_node_id="test-node-id",
+            self_actor_id="fake-actor-id",
+            self_actor_handle=None,
+            prefer_local_node_routing=False,
+            prefer_local_az_routing=False,
+        )
+        router = AsyncioRouter(
+            controller_handle=Mock(),
+            deployment_id=DeploymentID(name="test-deployment"),
+            handle_id="test-handle-id",
+            self_actor_id="test-node-id",
+            handle_source=DeploymentHandleSource.UNKNOWN,
+            event_loop=get_or_create_event_loop(),
+            enable_strict_max_ongoing_requests=False,
+            request_router=request_router,
+            node_id="test-node-id",
+            availability_zone="test-az",
+            prefer_local_node_routing=False,
+            _request_router_initialized_event=asyncio.Event(),
+        )
+
+        deployment_config = DeploymentConfig.from_default(
+            prefer_local_node_routing=True,
+            prefer_local_az_routing=True,
+        )
+        deployment_config.user_configured_option_names = {
+            "prefer_local_node_routing",
+            "prefer_local_az_routing",
+        }
+
+        router.update_deployment_config(deployment_config)
+
+        assert router._prefer_local_node_routing is True
+        assert router._prefer_local_az_routing is True
+        assert request_router._prefer_local_node_routing is True
+        assert request_router._prefer_local_az_routing is True
+
 
 class TestOnRequestCompleted:
     """Tests for the on_request_completed hook introduced in this branch.

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -1113,8 +1113,6 @@ def global_f():
 def test_deployment_to_schema_to_deployment():
     @serve.deployment(
         num_replicas=3,
-        prefer_local_node_routing=False,
-        prefer_local_az_routing=False,
         ray_actor_options={
             "runtime_env": {
                 "working_dir": TEST_MODULE_PINNED_URI,
@@ -1142,8 +1140,6 @@ def test_deployment_to_schema_to_deployment():
     assert deployment.ray_actor_options["runtime_env"]["py_modules"] == [
         TEST_DEPLOY_GROUP_PINNED_URI,
     ]
-    assert deployment._deployment_config.prefer_local_node_routing is False
-    assert deployment._deployment_config.prefer_local_az_routing is False
 
 
 def test_unset_fields_schema_to_deployment_ray_actor_options():

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -1113,6 +1113,8 @@ def global_f():
 def test_deployment_to_schema_to_deployment():
     @serve.deployment(
         num_replicas=3,
+        prefer_local_node_routing=False,
+        prefer_local_az_routing=False,
         ray_actor_options={
             "runtime_env": {
                 "working_dir": TEST_MODULE_PINNED_URI,
@@ -1140,6 +1142,8 @@ def test_deployment_to_schema_to_deployment():
     assert deployment.ray_actor_options["runtime_env"]["py_modules"] == [
         TEST_DEPLOY_GROUP_PINNED_URI,
     ]
+    assert deployment._deployment_config.prefer_local_node_routing is False
+    assert deployment._deployment_config.prefer_local_az_routing is False
 
 
 def test_unset_fields_schema_to_deployment_ray_actor_options():

--- a/python/ray/tests/test_asyncio.py
+++ b/python/ray/tests/test_asyncio.py
@@ -214,7 +214,10 @@ async def test_asyncio_double_await(ray_start_regular_shared):
 )
 async def test_asyncio_exit_actor(ray_start_regular_shared):
     # https://github.com/ray-project/ray/issues/12649
-    # The test should just hang without the fix.
+    # exit_actor() must terminate the actor and not leak the process.
+    # exit_actor() drains in-flight tasks before exiting (matching
+    # threaded actors). In-flight task draining on graceful exit is covered in
+    # test_worker_graceful_shutdown.py.
 
     @ray.remote
     class Actor:
@@ -224,14 +227,9 @@ async def test_asyncio_exit_actor(ray_start_regular_shared):
         async def ping(self):
             return os.getpid()
 
-        async def loop_forever(self):
-            while True:
-                await asyncio.sleep(5)
-
     a = Actor.options(max_task_retries=0).remote()
     pid = ray.get(a.ping.remote())
-    a.loop_forever.remote()
-    # Make sure exit_actor exits immediately, not once all tasks completed.
+    # exit_actor() exits the actor, so the caller observes the actor's death.
     with pytest.raises(ray.exceptions.RayError):
         ray.get(a.exit.remote())
 
@@ -264,13 +262,13 @@ def test_asyncio_exit_actor_with_concurrency_group(ray_start_regular_shared):
             ray.actor.exit_actor()
 
         @ray.method(concurrency_group="async")
-        async def loop_forever(self):
-            while True:
-                await asyncio.sleep(5)
+        async def echo(self, value):
+            return value
 
     a = Actor.remote()
-    a.loop_forever.remote()
     pid = ray.get(a.getpid.remote())
+    # Exercise the concurrency group, then exit the actor.
+    assert ray.get(a.echo.remote("hi")) == "hi"
     with pytest.raises(ray.exceptions.RayActorError):
         ray.get(a.exit.remote())
     wait_for_pid_to_exit(pid)

--- a/python/ray/tests/test_worker_graceful_shutdown.py
+++ b/python/ray/tests/test_worker_graceful_shutdown.py
@@ -7,21 +7,26 @@ import pytest
 
 import ray
 from ray._common.test_utils import SignalActor, wait_for_condition
+from ray._private.test_utils import wait_for_pid_to_exit
+
+# Concurrency models that allow already-running tasks to keep executing after a
+# graceful exit is requested. Single-threaded actors are excluded: they run
+# tasks one at a time, so there is never a concurrently in-flight task to drain.
+CONCURRENT_ACTOR_TYPES = ["asyncio", "threaded"]
 
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Windows doesn't handle SIGTERM gracefully."
 )
-@pytest.mark.parametrize("actor_type", ["asyncio", "threaded"])
+@pytest.mark.parametrize("actor_type", CONCURRENT_ACTOR_TYPES)
 def test_ray_get_during_graceful_shutdown(ray_start_regular_shared, actor_type: str):
     """Test that ray.get works as expected when draining tasks during shutdown.
 
-    This currently only applies to concurrent actors, because single-threaded actors do
-    not allow tasks to finish exiting after SIGTERM.
+    This only applies to concurrent actors (threaded and asyncio); single-threaded
+    actors do not allow tasks to finish executing after SIGTERM.
     """
     signal_actor = SignalActor.remote()
 
-    assert actor_type in {"asyncio", "threaded"}
     if actor_type == "asyncio":
 
         @ray.remote
@@ -65,26 +70,38 @@ def test_ray_get_during_graceful_shutdown(ray_start_regular_shared, actor_type: 
     sys.platform == "win32",
     reason="Graceful shutdown draining is unreliable on Windows.",
 )
-def test_exit_actor_delivers_inflight_task_results(ray_start_regular_shared):
-    """In-flight tasks (already executing) on a threaded actor finish and
-    deliver their results when exit_actor() is called from another thread,
-    instead of failing with ActorDiedError.
-
-    Asyncio actors are not covered: exit_actor() on an asyncio actor goes
-    through a different (AsyncioActorExit) path that does not deliver in-flight
-    results.
-    """
+@pytest.mark.parametrize("actor_type", CONCURRENT_ACTOR_TYPES)
+def test_exit_actor_delivers_inflight_task_results(
+    ray_start_regular_shared, actor_type: str
+):
+    """In-flight tasks (already executing) on a concurrent actor finish and
+    deliver their results when exit_actor() is called from another task,
+    instead of failing with ActorDiedError. Covers both threaded actors (tasks
+    on a thread pool) and asyncio actors (coroutines on the event loop)."""
     signal_actor = SignalActor.remote()
     num_tasks = 3
 
-    @ray.remote(max_concurrency=num_tasks + 1)
-    class A:
-        def exit(self):
-            ray.actor.exit_actor()
+    if actor_type == "asyncio":
 
-        def wait_then_return(self, value):
-            ray.get(signal_actor.wait.remote())
-            return value
+        @ray.remote
+        class A:
+            async def exit(self):
+                ray.actor.exit_actor()
+
+            async def wait_then_return(self, value):
+                await signal_actor.wait.remote()
+                return value
+
+    else:
+
+        @ray.remote(max_concurrency=num_tasks + 1)
+        class A:
+            def exit(self):
+                ray.actor.exit_actor()
+
+            def wait_then_return(self, value):
+                ray.get(signal_actor.wait.remote())
+                return value
 
     a = A.remote()
     refs = [a.wait_then_return.remote(i) for i in range(num_tasks)]
@@ -107,20 +124,36 @@ def test_exit_actor_delivers_inflight_task_results(ray_start_regular_shared):
     sys.platform == "win32",
     reason="Graceful shutdown draining is unreliable on Windows.",
 )
-def test_exit_actor_delivers_inflight_task_errors(ray_start_regular_shared):
-    """An in-flight task on a threaded actor that raises an application
+@pytest.mark.parametrize("actor_type", CONCURRENT_ACTOR_TYPES)
+def test_exit_actor_delivers_inflight_task_errors(
+    ray_start_regular_shared, actor_type: str
+):
+    """An in-flight task on a concurrent actor that raises an application
     exception while the actor is gracefully exiting delivers that exception,
     not ActorDiedError."""
     signal_actor = SignalActor.remote()
 
-    @ray.remote(max_concurrency=2)
-    class A:
-        def exit(self):
-            ray.actor.exit_actor()
+    if actor_type == "asyncio":
 
-        def wait_then_raise(self):
-            ray.get(signal_actor.wait.remote())
-            raise ValueError("application error")
+        @ray.remote
+        class A:
+            async def exit(self):
+                ray.actor.exit_actor()
+
+            async def wait_then_raise(self):
+                await signal_actor.wait.remote()
+                raise ValueError("application error")
+
+    else:
+
+        @ray.remote(max_concurrency=2)
+        class A:
+            def exit(self):
+                ray.actor.exit_actor()
+
+            def wait_then_raise(self):
+                ray.get(signal_actor.wait.remote())
+                raise ValueError("application error")
 
     a = A.remote()
     ref = a.wait_then_raise.remote()
@@ -138,59 +171,39 @@ def test_exit_actor_delivers_inflight_task_errors(ray_start_regular_shared):
     sys.platform == "win32",
     reason="Graceful shutdown draining is unreliable on Windows.",
 )
-def test_exit_actor_with_swallowed_exception(ray_start_regular_shared):
-    """A task that calls exit_actor() but swallows the resulting SystemExit
-    still exits the actor and its return value is discarded (the caller
-    observes the actor death), while in-flight tasks on other threads still
-    deliver their results."""
-    signal_actor = SignalActor.remote()
-
-    @ray.remote(max_concurrency=2)
-    class A:
-        def exit_and_swallow(self):
-            try:
-                ray.actor.exit_actor()
-            except SystemExit:
-                pass
-            return "should never be delivered"
-
-        def wait_then_return(self, value):
-            ray.get(signal_actor.wait.remote())
-            return value
-
-    a = A.remote()
-    inflight_ref = a.wait_then_return.remote("ok")
-    wait_for_condition(lambda: ray.get(signal_actor.cur_num_waiters.remote()) == 1)
-    exit_ref = a.exit_and_swallow.remote()
-    ray.get(signal_actor.send.remote())
-
-    # The in-flight task still delivers its result during the graceful exit.
-    assert ray.get(inflight_ref, timeout=30) == "ok"
-    # The exit task's return value is discarded even though the exception was
-    # swallowed; its caller observes the actor death.
-    with pytest.raises(ray.exceptions.RayActorError):
-        ray.get(exit_ref, timeout=30)
-
-
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="Graceful shutdown draining is unreliable on Windows.",
-)
-def test_exit_actor_fails_queued_tasks(ray_start_regular_shared):
+@pytest.mark.parametrize("actor_type", CONCURRENT_ACTOR_TYPES)
+def test_exit_actor_fails_queued_tasks(ray_start_regular_shared, actor_type: str):
     """Methods queued (submitted but not yet started executing) when
-    exit_actor() is called fail with ActorDiedError."""
+    exit_actor() is called fail with ActorDiedError, for both threaded and
+    asyncio actors. ``max_concurrency`` bounds how many methods may run at once,
+    so the ``work`` calls cannot start while the blocking methods hold every
+    slot and are failed when the actor exits."""
     signal_actor = SignalActor.remote()
     max_concurrency = 2
 
-    @ray.remote(max_concurrency=max_concurrency)
-    class A:
-        def block_then_exit(self):
-            # Hold the concurrency slot until released, then exit the actor.
-            ray.get(signal_actor.wait.remote())
-            ray.actor.exit_actor()
+    if actor_type == "asyncio":
 
-        def work(self, value):
-            return value
+        @ray.remote(max_concurrency=max_concurrency)
+        class A:
+            async def block_then_exit(self):
+                # Hold the concurrency slot until released, then exit the actor.
+                await signal_actor.wait.remote()
+                ray.actor.exit_actor()
+
+            async def work(self, value):
+                return value
+
+    else:
+
+        @ray.remote(max_concurrency=max_concurrency)
+        class A:
+            def block_then_exit(self):
+                # Hold the concurrency slot until released, then exit the actor.
+                ray.get(signal_actor.wait.remote())
+                ray.actor.exit_actor()
+
+            def work(self, value):
+                return value
 
     a = A.remote()
     # Fill every concurrency slot with a blocking task so later calls can't
@@ -209,6 +222,68 @@ def test_exit_actor_fails_queued_tasks(ray_start_regular_shared):
     for ref in blocking_refs + queued_refs:
         with pytest.raises(ray.exceptions.RayActorError):
             ray.get(ref, timeout=30)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Graceful shutdown draining is unreliable on Windows.",
+)
+def test_exit_actor_drains_inflight_across_concurrency_groups(ray_start_regular_shared):
+    """exit_actor() on an async actor drains in-flight tasks running in *other*
+    concurrency groups before the actor exits.
+
+    Tasks in flight when exit_actor() is called (here in the "io" and "compute"
+    groups, while exit() runs in the default group) run to completion and
+    deliver their results.
+    """
+    signal_actor = SignalActor.remote()
+    num_io_tasks = 2
+
+    @ray.remote(concurrency_groups={"io": num_io_tasks, "compute": 1})
+    class A:
+        async def getpid(self):
+            return os.getpid()
+
+        async def exit(self):
+            ray.actor.exit_actor()
+
+        @ray.method(concurrency_group="io")
+        async def wait_then_return(self, value):
+            await signal_actor.wait.remote()
+            return value
+
+        @ray.method(concurrency_group="compute")
+        async def wait_then_raise(self):
+            await signal_actor.wait.remote()
+            raise ValueError("application error")
+
+    a = A.remote()
+    pid = ray.get(a.getpid.remote())
+
+    # Start in-flight tasks in two different concurrency groups; all block on
+    # the signal so they are still executing when exit_actor() is called.
+    return_refs = [a.wait_then_return.remote(i) for i in range(num_io_tasks)]
+    raise_ref = a.wait_then_raise.remote()
+    num_inflight = num_io_tasks + 1
+    wait_for_condition(
+        lambda: ray.get(signal_actor.cur_num_waiters.remote()) == num_inflight
+    )
+
+    # Request exit from the default concurrency group (which has a free slot)
+    # while the io/compute tasks are in flight, then unblock them.
+    exit_ref = a.exit.remote()
+    ray.get(signal_actor.send.remote())
+
+    # In-flight tasks across both concurrency groups deliver their results and
+    # errors before the actor exits.
+    assert ray.get(return_refs, timeout=30) == list(range(num_io_tasks))
+    with pytest.raises(ValueError, match="application error"):
+        ray.get(raise_ref, timeout=30)
+    # The task that called exit_actor() observes the actor's death.
+    with pytest.raises(ray.exceptions.RayActorError):
+        ray.get(exit_ref, timeout=30)
+    # The actor exits after draining (no process leak).
+    wait_for_pid_to_exit(pid)
 
 
 if __name__ == "__main__":

--- a/src/ray/core_worker/task_execution/fiber.h
+++ b/src/ray/core_worker/task_execution/fiber.h
@@ -17,6 +17,7 @@
 #include <boost/fiber/all.hpp>
 #include <chrono>
 #include <memory>
+#include <thread>
 #include <utility>
 
 #include "ray/util/logging.h"
@@ -29,33 +30,28 @@ namespace core {
 /// from python to switch control among different coroutines.
 /// Taken from boost::fiber examples
 /// https://github.com/boostorg/fiber/blob/7be4f860e733a92d2fa80a848dd110df009a20e1/examples/wait_stuff.cpp#L115-L142
-/// We use FiberEvent to synchronize fibers and StdEvent to synchronize threads.
-template <typename Mutex, typename Cond>
-class Event {
+class FiberEvent {
  public:
   // Block the fiber until the event is notified.
   void Wait() {
-    std::unique_lock<Mutex> lock(mutex_);
+    std::unique_lock<boost::fibers::mutex> lock(mutex_);
     cond_.wait(lock, [this]() { return ready_; });
   }
 
   // Notify the event and unblock all waiters.
   void Notify() {
     {
-      std::unique_lock<Mutex> lock(mutex_);
+      std::unique_lock<boost::fibers::mutex> lock(mutex_);
       ready_ = true;
     }
     cond_.notify_one();
   }
 
  private:
-  Cond cond_;
-  Mutex mutex_;
+  boost::fibers::condition_variable cond_;
+  boost::fibers::mutex mutex_;
   bool ready_ = false;
 };
-
-using FiberEvent = Event<boost::fibers::mutex, boost::fibers::condition_variable>;
-using StdEvent = Event<std::mutex, std::condition_variable>;
 
 /// Used by async actor mode. The FiberRateLimiter is a barrier that
 /// allows at most num fibers running at once. It implements the
@@ -106,17 +102,39 @@ class FiberState {
       // TODO(kevin85421): The language-specific callback function that
       // initializes threads. It's not currently used in the async mode.
       std::function<std::function<void()>()> initialize_thread_callback = nullptr)
-      : allocator_(kStackSize),
-        rate_limiter_(max_concurrency),
-        fiber_stopped_event_(std::make_shared<StdEvent>()) {
-    std::shared_ptr<StdEvent> fiber_stopped_event = fiber_stopped_event_;
-    auto fiber_runner_thread = std::thread([&, fiber_stopped_event]() {
+      : allocator_(kStackSize), rate_limiter_(max_concurrency) {
+    fiber_runner_thread_ = std::thread([this]() {
       while (!channel_.is_closed()) {
         std::function<void()> func;
         auto op_status = channel_.pop(func);
         if (op_status == boost::fibers::channel_op_status::success) {
-          boost::fibers::fiber(
-              boost::fibers::launch::dispatch, std::allocator_arg, allocator_, func)
+          // Increment in-flight count before launching a fiber, this is called on
+          // the main runner thread as this way we avoid a race where a fiber is submitted
+          // but before it starts execution, num_in_flight_fibers_ value is checked and
+          // observed to be 0 and thread shuts down.
+          {
+            std::unique_lock<boost::fibers::mutex> lock(mutex_);
+            num_in_flight_fibers_ += 1;
+          }
+          boost::fibers::fiber(boost::fibers::launch::dispatch,
+                               std::allocator_arg,
+                               allocator_,
+                               [this, func = std::move(func)]() {
+                                 func();
+                                 // Decrement the in-flight counter once the
+                                 // fiber body has finished and notify the
+                                 // graceful drain. `func` (the EnqueueFiber
+                                 // wrapper) does not throw -- an uncaught
+                                 // exception in a fiber would terminate the
+                                 // process -- so this always runs.
+                                 std::unique_lock<boost::fibers::mutex> lock(mutex_);
+                                 num_in_flight_fibers_ -= 1;
+                                 if (num_in_flight_fibers_ == 0) {
+                                   // The runner thread's main fiber (in the
+                                   // graceful drain below) is the only waiter.
+                                   fibers_drained_event_.notify_one();
+                                 }
+                               })
               .detach();
         } else if (op_status == boost::fibers::channel_op_status::closed) {
           // The channel was closed. We will just exit the loop and finish
@@ -127,29 +145,42 @@ class FiberState {
               << "Async actor fiber channel returned unexpected error code, "
               << "shutting down the worker thread. Please submit a github issue "
               << "at https://github.com/ray-project/ray";
-          return;
+          break;
         }
       }
 
-      // Boost fiber thread cannot be terminated and joined
-      // if there are still running detached fibers.
-      // When we exit async actor, we stop running coroutines
-      // which means the corresponding waiting boost fibers
-      // will never be resumed by done callbacks of those coroutines.
-      // As a result, those fibers will never exit and the fiber
-      // runner thread cannot be joined.
-      // The hack here is that we rely on the process exit to clean up
-      // the fiber runner thread. What we guarantee here is that
-      // no fibers can run after this point as we don't yield here.
-      // This makes sure this thread won't accidentally
-      // access being destructed core worker.
-      fiber_stopped_event->Notify();
-      while (true) {
-        std::this_thread::sleep_for(std::chrono::hours(1));
+      // Graceful drain: wait for all in-flight fibers to finish before stopping.
+      // This keeps the fiber scheduler running so that in-flight coroutines can
+      // complete on their (still-running) asyncio event loops, resume their
+      // parked boost fibers, and store their task outputs -- so callers receive
+      // results instead of ActorDiedError during graceful shutdown.
+      //
+      // The wait uses boost fiber primitives so it yields to the scheduler,
+      // letting parked fibers be resumed as their coroutines complete. Like
+      // BoundedExecutor::Join() for threaded actors, this waits indefinitely;
+      // if an in-flight task never completes the worker hangs here until the
+      // raylet force-kills it (matching threaded-actor behavior).
+      {
+        std::unique_lock<boost::fibers::mutex> lock(mutex_);
+        if (num_in_flight_fibers_ > 0) {
+          RAY_LOG(INFO) << "Async actor is draining " << num_in_flight_fibers_
+                        << " in-flight task(s) before exiting. If this message is the "
+                           "last one printed, the worker is probably hanging because an "
+                           "in-flight async task never completes.";
+        }
+        fibers_drained_event_.wait(lock, [this]() { return num_in_flight_fibers_ == 0; });
       }
-    });
 
-    fiber_runner_thread.detach();
+      // All fibers have completed, so no fiber can run after this point and it
+      // is safe for this thread to finish (and be joined).
+    });
+  }
+
+  ~FiberState() {
+    // Make sure the runner thread is stopped and joined before members are
+    // destroyed. No-op if Stop()/Join() were already called.
+    Stop();
+    Join();
   }
 
   void EnqueueFiber(std::function<void()> &&callback) {
@@ -163,7 +194,11 @@ class FiberState {
 
   void Stop() { channel_.close(); }
 
-  void Join() { fiber_stopped_event_->Wait(); }
+  void Join() {
+    if (fiber_runner_thread_.joinable()) {
+      fiber_runner_thread_.join();
+    }
+  }
 
  private:
   static constexpr size_t kStackSize = 1024 * 256;
@@ -176,13 +211,19 @@ class FiberState {
   /// The fiber semaphore used to limit the number of concurrent fibers
   /// running at once.
   FiberRateLimiter rate_limiter_;
-  /// The fiber event used to notify that the event loop in fiber_runner_thread
-  /// have stopped running.
-  /// Since we don't join the fiber threads, it's possible that the
-  /// `fiber_runner_thread_` still accesses the `fiber_stopped_event_` after it's
-  /// deallocated in the main thread. As a result, we use a shared_ptr here to make sure
-  /// it's not deallocated if `fiber_runner_thread_` still has a reference to it.
-  std::shared_ptr<StdEvent> fiber_stopped_event_;
+  /// Bookkeeping for tracking the number of in-flight fibers and waiting for
+  /// them to finish during graceful shutdown. All accesses happen on
+  /// `fiber_runner_thread_` (its main fiber and the task fibers it launches are
+  /// cooperatively scheduled on that one kernel thread), so the mutex is not
+  /// needed for mutual exclusion; it exists only because
+  /// boost::fibers::condition_variable requires one to wait on.
+  boost::fibers::mutex mutex_;
+  boost::fibers::condition_variable fibers_drained_event_;
+  int num_in_flight_fibers_ = 0;
+  /// The thread that runs the fibers. It pops tasks off `channel_` and runs
+  /// each as a fiber, then (after Stop() closes the channel) drains in-flight
+  /// fibers before finishing. Join() joins it, so it never outlives this object.
+  std::thread fiber_runner_thread_;
 };
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/tests/fiber_state_test.cc
+++ b/src/ray/core_worker/task_execution/tests/fiber_state_test.cc
@@ -59,20 +59,30 @@ class TotalCounter {
   }
 };
 
-TEST(FiberStateTest, CanStopInfiniteTasks) {
+TEST(FiberStateTest, DrainsInFlightFibersBeforeStopping) {
+  // Stop()/Join() drains in-flight fibers: it keeps the scheduler running and
+  // waits for them to finish before returning, instead of abandoning them. This
+  // is what lets async actors deliver in-flight task results during graceful
+  // shutdown. (A fiber that never finishes therefore blocks Join() until the
+  // process is force killed, matching threaded actors.)
   FiberState fiber_state(2);
 
+  std::atomic<bool> task_completed{false};
   fiber_state.EnqueueFiber([&]() {
-    while (true) {
-      boost::this_fiber::sleep_for(std::chrono::milliseconds(10));
-      boost::this_fiber::yield();
-    }
+    // Still running when Stop() is called below: Join() must wait for it.
+    boost::this_fiber::sleep_for(std::chrono::milliseconds(200));
+    task_completed.store(true);
   });
 
-  boost::this_fiber::sleep_for(std::chrono::seconds(1));
+  // EnqueueFiber blocks until the runner accepts the fiber, so it is in flight
+  // (started, not yet finished) at this point.
+  EXPECT_FALSE(task_completed.load());
+
   fiber_state.Stop();
   fiber_state.Join();
-  // Can exit normally even if the fiber did not stop.
+
+  // Join() returned only after the in-flight fiber ran to completion.
+  EXPECT_TRUE(task_completed.load());
 }
 
 TEST(FiberStateTest, RespectsConcurrencyLimit) {
@@ -101,6 +111,20 @@ TEST(FiberStateTest, DoubleStopJoin) {
   fiber_state.Join();
   fiber_state.Stop();
   fiber_state.Join();
+}
+
+TEST(FiberStateTest, DestructorStopsAndJoins) {
+  // Destroying a FiberState without calling Stop()/Join() stops the runner
+  // thread, drains in-flight fibers, and joins the thread.
+  std::atomic<bool> task_completed{false};
+  {
+    FiberState fiber_state(2);
+    fiber_state.EnqueueFiber([&]() {
+      boost::this_fiber::sleep_for(std::chrono::milliseconds(100));
+      task_completed.store(true);
+    });
+  }
+  EXPECT_TRUE(task_completed.load());
 }
 
 }  // namespace core

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -249,6 +249,12 @@ message DeploymentConfig {
   // rolling upgrade) is distinguishable from an explicit value. When unset,
   // the Python side falls back to DEFAULT_ROLLING_UPDATE_PERCENTAGE (0.2).
   optional double rolling_update_percentage = 23;
+
+  // Prefer routing requests to replicas on the same node as the caller.
+  optional bool prefer_local_node_routing = 24;
+
+  // Prefer routing requests to replicas in the same availability zone as the caller.
+  optional bool prefer_local_az_routing = 25;
 }
 
 // Deployment language.


### PR DESCRIPTION
## Description
Enables migration from env-var-only control to per-deployment control without breaking current users.

What this changes:
* Adds deployment-level support for:
  * `prefer_local_node_routing`
  * `prefer_local_az_routing`
* Precedence is:
  * Explicit deployment config value > env var fallback > existing default behavior
* Updates router runtime config propagation
* Adds protobuf schema fields for these deployment config options so config serialization/deserialization remains consistent
* Adds `RequestRouter.update_locality_routing_params(...)` so Serve can propagate deployment-level locality routing config to router implementations at runtime. The default implementation is a no-op for custom routers, while locality-aware routers update their local routing preferences through `LocalityMixin`.
* Adds unit tests
* Adds a two-node e2e test (`test_node_local_routing_between_deployments`) that pins `d1 -> d2` replica-to-replica traffic on-node when the flag is on, then confirms spread routing after a lightweight config update turns it off

## Related issues
- Related to https://github.com/ray-project/ray/issues/59929 **(Phase 1)**
- Continues work from: https://github.com/ray-project/ray/pull/61783

This is not duplicating an existing issue or PR: it is additional work on the already-open PR for issue 59929. No other open PR implements per-deployment `prefer_local_node_routing` / `prefer_local_az_routing`.

## Additional information
Testing:
```bash
python3 -m pytest python/ray/serve/tests/test_gang_scheduling.py \
    python/ray/serve/tests/unit/test_pow_2_request_router.py \
    python/ray/serve/tests/unit/test_router.py \
    python/ray/serve/tests/test_deployment_scheduler_downscale.py -q \
    python/ray/serve/tests/unit/test_application_state.py \
    python/ray/serve/tests/unit/test_handle_options.py \
    python/ray/serve/tests/unit/test_schema.py \
    python/ray/serve/tests/test_cluster.py \
    python/ray/serve/tests/test_controller.py::test_get_serve_instance_details_json_serializable \
    python/ray/serve/tests/test_direct_ingress.py::test_get_serve_instance_details_json_serializable
```

E2e test run locally:
```bash
python -m pytest python/ray/serve/tests/test_cluster.py::test_node_local_routing_between_deployments -v
# PASSED in 88.50s

RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY=1 python -m pytest python/ray/serve/tests/test_cluster.py::test_node_local_routing_between_deployments -v
# PASSED in 88.68s
```

Negative control: forcing the downstream flag off made `_assert_node_local_routing` fail with a cross-node hop, then the change was reverted.

## AI Assistance
- Used Cursor + Opus 5 + Grok 4.6
