### PR TITLE
[serve][docs] Add in round robin and consistent hashing router documentation

### DIFF
--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -169,7 +169,7 @@ at an arbitrary replica so routers spun up together don't synchronize on the
 same first replica. If the chosen replica is at capacity, the router falls back
 to the next replica in order and wraps around the candidate list. Each
 router instance keeps its own cursor, so with multiple routers (for example,
-one per HTTP proxy) the fan-out is round-robin per router and approximately
+one per Ray Serve proxy) the fan-out is round-robin per router and approximately
 uniform across replicas in aggregate. The router mixes in
 [`FIFOMixin`](../api/doc/ray.serve.request_router.FIFOMixin.rst) so queued
 requests are routed in arrival order.
@@ -227,8 +227,8 @@ mixing them in would break determinism and therefore break affinity.
 
 ### Example
 Configure the router via
-[`RequestRouterConfig`](../api/doc/ray.serve.config.RequestRouterConfig.rst)
-and pass tuning parameters through `request_router_kwargs`:
+[`RequestRouterConfig`](../api/doc/ray.serve.config.RequestRouterConfig.rst),
+pass tuning parameters through `request_router_kwargs`:
 
 ```{literalinclude} ../doc_code/custom_request_router_app.py
 :start-after: __begin_deploy_app_with_consistent_hash_router__

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -227,8 +227,8 @@ mixing them in would break determinism and therefore break affinity.
 
 ### Example
 Configure the router via
-[`RequestRouterConfig`](../api/doc/ray.serve.config.RequestRouterConfig.rst),
-pass tuning parameters through `request_router_kwargs`:
+[`RequestRouterConfig`](../api/doc/ray.serve.config.RequestRouterConfig.rst)
+and pass tuning parameters through `request_router_kwargs`:
 
 ```{literalinclude} ../doc_code/custom_request_router_app.py
 :start-after: __begin_deploy_app_with_consistent_hash_router__

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -20,6 +20,8 @@ cover the following:
 - Utility mixins for request routing
 - Define a complex throughput-aware request router
 - Deploy an app with the throughput-aware request router
+- Experimental: Use the round-robin request router
+- Experimental: Use the consistent-hash request router for session stickiness
 - Experimental: Define a centralized capacity queue request router
 
 
@@ -157,6 +159,90 @@ You can customize the emission of these statistics by overriding `record_routing
 in the definition of the deployment class. The custom request router can then get the
 updated routing stats by looking up the `routing_stats` attribute of the running
 replicas and use it in the routing policy.
+
+
+(round-robin-request-router)=
+## Experimental: Use the round-robin request router
+
+`RoundRobinRouter` cycles through replicas in round-robin fashion, starting
+at an arbitrary replica so routers spun up together don't synchronize on the
+same first replica. If the chosen replica is at capacity, the router falls back
+to the next replica in order and wraps around the candidate list. Each
+router instance keeps its own cursor, so with multiple routers (for example,
+one per HTTP proxy) the fan-out is round-robin per router and approximately
+uniform across replicas in aggregate. The router mixes in
+[`FIFOMixin`](../api/doc/ray.serve.request_router.FIFOMixin.rst) so queued
+requests are routed in arrival order.
+
+### When to use
+Use the round-robin router when you want a predictable, even distribution
+across replicas and don't need queue-length or locality-aware decisions. It
+fits stateless workloads with roughly uniform per-request latency. Unlike
+the default power-of-two-chocies router, the round-robin routeer doesn't react
+to queue depth and can pile up requests behind a slow replica before falling back.
+
+### Example
+Reference the router by import path through
+[`RequestRouterConfig`](../api/doc/ray.serve.config.RequestRouterConfig.rst):
+
+```{literalinclude} ../doc_code/custom_request_router_app.py
+:start-after: __begin_deploy_app_with_round_robin_router__
+:end-before: __end_deploy_app_with_round_robin_router__
+:language: python
+```
+
+
+(consistent-hash-request-router)=
+## Experimental: Use the consistent-hash request router for session stickiness
+
+`ConsistentHashRouter` pins each session to a specific replica using a
+consistent-hash ring with virtual nodes. The routing key is the session ID
+read from the HTTP header named by `RAY_SERVE_SESSION_ID_HEADER_KEY` (default
+`x-session-id`), so the same session ID consistently maps to the same
+replica. Requests without that header fall back to a per-request internal ID
+and spread uniformly across replicas. If the chosen replica rejects (for
+example, due to backpressure from number of ongoing request), the router
+walks up to `num_fallback_replicas` clockwise successors on the ring. If
+those are also at capacity, the router sleeps with exponential backoff and
+retries the same primary and fallbacks until one accepts. When the replica
+set changes, the ring is rebuilt and only keys owned by added or removed
+replicas are reshuffled.
+
+Two parameters are configurable through
+[`request_router_kwargs`](../api/doc/ray.serve.config.RequestRouterConfig.rst):
+
+* `num_virtual_nodes` (default `100`): vnodes per replica on the ring.
+  Higher values spread sessions more evenly across replicas.
+* `num_fallback_replicas` (default `2`): clockwise successors tried after
+  the primary rejects. Set to `0` for strict affinity with no fallback.
+
+### When to use
+Use the consistent-hash router when requests carry session-scoped state
+worth keeping warm on a single replica, for example in-memory caches keyed
+by user or KV-cache reuse for LLM chat sessions. Skip it for stateless
+workloads, since affinity sacrifices queue-aware balancing and a hot session
+can saturate its assigned replica while others are idle. The router does not
+combine with queue-depth, locality, or multiplexed-model signals, since
+mixing them in would break determinism and therefore break affinity.
+
+### Example
+Configure the router via
+[`RequestRouterConfig`](../api/doc/ray.serve.config.RequestRouterConfig.rst)
+and pass tuning parameters through `request_router_kwargs`:
+
+```{literalinclude} ../doc_code/custom_request_router_app.py
+:start-after: __begin_deploy_app_with_consistent_hash_router__
+:end-before: __end_deploy_app_with_consistent_hash_router__
+:language: python
+```
+
+If your clients send the session identifier under a different header (for
+example, `x-correlation-id`), point Ray Serve at it before the cluster
+starts:
+
+```bash
+export RAY_SERVE_SESSION_ID_HEADER_KEY=x-correlation-id
+```
 
 
 (capacity-queue-request-router)=

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -178,7 +178,7 @@ requests are routed in arrival order.
 Use the round-robin router when you want a predictable, even distribution
 across replicas and don't need queue-length or locality-aware decisions. It
 fits stateless workloads with roughly uniform per-request latency. Unlike
-the default power-of-two-chocies router, the round-robin routeer doesn't react
+the default power-of-two-choices router, the round-robin router doesn't react
 to queue depth and can pile up requests behind a slow replica before falling back.
 
 ### Example
@@ -201,7 +201,7 @@ read from the HTTP header named by `RAY_SERVE_SESSION_ID_HEADER_KEY` (default
 `x-session-id`), so the same session ID consistently maps to the same
 replica. Requests without that header fall back to a per-request internal ID
 and spread uniformly across replicas. If the chosen replica rejects (for
-example, due to backpressure from number of ongoing request), the router
+example, due to backpressure from the number of ongoing request), the router
 walks up to `num_fallback_replicas` clockwise successors on the ring. If
 those are also at capacity, the router sleeps with exponential backoff and
 retries the same primary and fallbacks until one accepts. When the replica

--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -176,10 +176,12 @@ requests are routed in arrival order.
 
 ### When to use
 Use the round-robin router when you want a predictable, even distribution
-across replicas and don't need queue-length or locality-aware decisions. It
+across replicas and don't need load-aware or locality-aware decisions. It
 fits stateless workloads with roughly uniform per-request latency. Unlike
-the default power-of-two-choices router, the round-robin router doesn't react
-to queue depth and can pile up requests behind a slow replica before falling back.
+the default power-of-two-choices router, the round-robin router doesn't compare
+replicas by their number of ongoing requests. It only skips a replica once it reaches
+`max_ongoing_requests`. Therefore, requests can pile up behind a slow replica
+before it falls back to the next one.
 
 ### Example
 Reference the router by import path through

--- a/doc/source/serve/doc_code/custom_request_router_app.py
+++ b/doc/source/serve/doc_code/custom_request_router_app.py
@@ -1,11 +1,13 @@
 # flake8: noqa
 
 # __begin_deploy_app_with_uniform_request_router__
+import requests
 from ray import serve
 from ray.serve.request_router import ReplicaID
 import time
 from collections import defaultdict
 from ray.serve.context import _get_internal_replica_context
+from starlette.requests import Request
 from typing import Any, Dict
 from ray.serve.config import RequestRouterConfig
 
@@ -142,11 +144,16 @@ class ConsistentHashRouterApp:
         context = _get_internal_replica_context()
         self.replica_id: ReplicaID = context.replica_id
 
-    async def __call__(self):
-        return self.replica_id
+    async def __call__(self, request: Request) -> str:
+        return str(self.replica_id)
 
 
-handle = serve.run(ConsistentHashRouterApp.bind())
-response = handle.remote().result()
-print(f"Response from ConsistentHashRouterApp: {response}")
+serve.run(ConsistentHashRouterApp.bind())
+
+# Clients pin a session to a replica by sending the same `x-session-id`
+# on every request.
+requests.get(
+    "http://localhost:8000/",
+    headers={"x-session-id": "example-session-id"},
+)
 # __end_deploy_app_with_consistent_hash_router__

--- a/doc/source/serve/doc_code/custom_request_router_app.py
+++ b/doc/source/serve/doc_code/custom_request_router_app.py
@@ -152,8 +152,12 @@ serve.run(ConsistentHashRouterApp.bind())
 
 # Clients pin a session to a replica by sending the same `x-session-id`
 # on every request.
-requests.get(
+response = requests.get(
     "http://localhost:8000/",
     headers={"x-session-id": "example-session-id"},
 )
+print(f"Response from ConsistentHashRouterApp: {response.text}")
+# Example output:
+#   Response from ConsistentHashRouterApp:
+#   Replica(id='...', deployment='ConsistentHashRouterApp', app='default')
 # __end_deploy_app_with_consistent_hash_router__

--- a/doc/source/serve/doc_code/custom_request_router_app.py
+++ b/doc/source/serve/doc_code/custom_request_router_app.py
@@ -96,3 +96,57 @@ print(f"Response from ThroughputAwareRequestRouterApp: {response}")
 #   Response from ThroughputAwareRequestRouterApp:
 #   Replica(id='tkywafya', deployment='ThroughputAwareRequestRouterApp', app='default')
 # __end_deploy_app_with_throughput_aware_request_router__
+
+
+# __begin_deploy_app_with_round_robin_router__
+@serve.deployment(
+    request_router_config=RequestRouterConfig(
+        request_router_class=(
+            "ray.serve.experimental.round_robin_router:RoundRobinRouter"
+        ),
+    ),
+    num_replicas=4,
+    ray_actor_options={"num_cpus": 0},
+)
+class RoundRobinRouterApp:
+    def __init__(self):
+        context = _get_internal_replica_context()
+        self.replica_id: ReplicaID = context.replica_id
+
+    async def __call__(self):
+        return self.replica_id
+
+
+handle = serve.run(RoundRobinRouterApp.bind())
+response = handle.remote().result()
+print(f"Response from RoundRobinRouterApp: {response}")
+# __end_deploy_app_with_round_robin_router__
+
+
+# __begin_deploy_app_with_consistent_hash_router__
+@serve.deployment(
+    request_router_config=RequestRouterConfig(
+        request_router_class=(
+            "ray.serve.experimental.consistent_hash_router:ConsistentHashRouter"
+        ),
+        request_router_kwargs={
+            "num_virtual_nodes": 100,
+            "num_fallback_replicas": 2,
+        },
+    ),
+    num_replicas=4,
+    ray_actor_options={"num_cpus": 0},
+)
+class ConsistentHashRouterApp:
+    def __init__(self):
+        context = _get_internal_replica_context()
+        self.replica_id: ReplicaID = context.replica_id
+
+    async def __call__(self):
+        return self.replica_id
+
+
+handle = serve.run(ConsistentHashRouterApp.bind())
+response = handle.remote().result()
+print(f"Response from ConsistentHashRouterApp: {response}")
+# __end_deploy_app_with_consistent_hash_router__

--- a/doc/source/serve/doc_code/custom_request_router_app.py
+++ b/doc/source/serve/doc_code/custom_request_router_app.py
@@ -1,13 +1,11 @@
 # flake8: noqa
 
 # __begin_deploy_app_with_uniform_request_router__
-import requests
 from ray import serve
 from ray.serve.request_router import ReplicaID
 import time
 from collections import defaultdict
 from ray.serve.context import _get_internal_replica_context
-from starlette.requests import Request
 from typing import Any, Dict
 from ray.serve.config import RequestRouterConfig
 
@@ -126,6 +124,9 @@ print(f"Response from RoundRobinRouterApp: {response}")
 
 
 # __begin_deploy_app_with_consistent_hash_router__
+import requests
+from starlette.requests import Request
+
 @serve.deployment(
     request_router_config=RequestRouterConfig(
         request_router_class=(


### PR DESCRIPTION
## Description
We recently introduced experimental round robin router and consistent hashing router, but we're missing documentation and user guides. This PR adds those.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
