### PR TITLE
[Data] Add reason for backpressure when trigger  

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy/backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/backpressure_policy.py
@@ -51,6 +51,14 @@ class BackpressurePolicy(ABC):
         """
         return True
 
+    def get_block_reason(self, op: "PhysicalOperator") -> Optional[str]:
+        """Return a short human-readable reason explaining why this policy is
+        blocking ``op``, or ``None`` if it isn't.  Used to enrich the
+        backpressure status string in the progress bar — purely a debug
+        signal, not consulted by execution logic.
+        """
+        return None
+
     def max_task_output_bytes_to_read(self, op: "PhysicalOperator") -> Optional[int]:
         """Return the maximum bytes of pending task outputs can be read for
         the given operator. None means no limit.

--- a/python/ray/data/_internal/execution/backpressure_policy/resource_budget_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/resource_budget_backpressure_policy.py
@@ -24,6 +24,12 @@ class ResourceBudgetBackpressurePolicy(BackpressurePolicy):
 
         return True
 
+    def get_block_reason(self, op: "PhysicalOperator") -> Optional[str]:
+        allocator = self._resource_manager._op_resource_allocator
+        if allocator is None or not hasattr(allocator, "diagnose_can_submit"):
+            return None
+        return allocator.diagnose_can_submit(op)
+
     def max_task_output_bytes_to_read(self, op: "PhysicalOperator") -> Optional[int]:
         """Determine maximum bytes to read based on the resource budgets.
 

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -923,7 +923,7 @@ class PhysicalOperator(Operator):
             in_backpressure: Value this operator's in_backpressure should be set to.
             policy_name: Name of the backpressure policy that triggered.
             reason: Optional short string explaining WHY the policy is blocking
-                this op (e.g. ``"plasma_budget 7GB < pending_output 10GB"``).
+                this op (e.g. ``"object_store_budget 7GB < pending_output 10GB"``).
                 Surfaced in the progress bar.
         """
         # only update on change to in_backpressure

--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -409,6 +409,7 @@ class PhysicalOperator(Operator):
         self._shutdown = False
         self._in_task_submission_backpressure = False
         self._task_submission_backpressure_policy: Optional[str] = None
+        self._task_submission_backpressure_reason: Optional[str] = None
         self._in_task_output_backpressure = False
         self._task_output_backpressure_policy: Optional[str] = None
         self._estimated_num_output_bundles = None
@@ -910,7 +911,10 @@ class PhysicalOperator(Operator):
         return ExecutionResources()
 
     def notify_in_task_submission_backpressure(
-        self, in_backpressure: bool, policy_name: Optional[str] = None
+        self,
+        in_backpressure: bool,
+        policy_name: Optional[str] = None,
+        reason: Optional[str] = None,
     ) -> None:
         """Called periodically from the executor to update internal in backpressure
         status for stats collection purposes.
@@ -918,12 +922,16 @@ class PhysicalOperator(Operator):
         Args:
             in_backpressure: Value this operator's in_backpressure should be set to.
             policy_name: Name of the backpressure policy that triggered.
+            reason: Optional short string explaining WHY the policy is blocking
+                this op (e.g. ``"plasma_budget 7GB < pending_output 10GB"``).
+                Surfaced in the progress bar.
         """
         # only update on change to in_backpressure
         if self._in_task_submission_backpressure != in_backpressure:
             self._metrics.on_toggle_task_submission_backpressure(in_backpressure)
             self._in_task_submission_backpressure = in_backpressure
         self._task_submission_backpressure_policy = policy_name
+        self._task_submission_backpressure_reason = reason
 
     def notify_in_task_output_backpressure(
         self, in_backpressure: bool, policy_name: Optional[str] = None

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -789,7 +789,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         Purely for surfacing in the progress bar; not consulted by scheduling.
         Format is short enough to fit in a status line, e.g.
-        ``"incremental_exceeds: mem 4.0GB>2.0GB"`` or
+        ``"incremental_resource_exceeds: mem 4.0GB>2.0GB"`` or
         ``"plasma_budget 1.0GB < pending_output 2.5GB"``.
         """
         budget = self.get_budget(op)
@@ -823,7 +823,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
                 f"{_fmt_bytes(budget.object_store_memory)}"
             )
         if parts:
-            return "incremental_exceeds: " + ", ".join(parts)
+            return "incremental_resource_exceeds: " + ", ".join(parts)
 
         pending = op.metrics.obj_store_mem_max_pending_output_per_task or 0
         if budget.object_store_memory < pending:

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -790,7 +790,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         Purely for surfacing in the progress bar; not consulted by scheduling.
         Format is short enough to fit in a status line, e.g.
         `"incremental_resource_exceeds: mem 4.0GiB>2.0GiB"` or
-        `"plasma_budget 1.0GiB < pending_output 2.5GiB"`.
+        `"object_store_budget 1.0GiB < pending_output 2.5GiB"`.
         """
         budget = self.get_budget(op)
         if budget is None:
@@ -813,7 +813,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             and incremental.object_store_memory > budget.object_store_memory
         ):
             parts.append(
-                f"plasma_incr {memory_string(incremental.object_store_memory)}>"
+                f"object_store_incr {memory_string(incremental.object_store_memory)}>"
                 f"{memory_string(budget.object_store_memory)}"
             )
         if parts:
@@ -822,7 +822,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         pending = op.metrics.obj_store_mem_max_pending_output_per_task or 0
         if budget.object_store_memory < pending:
             return (
-                f"plasma_budget {memory_string(budget.object_store_memory)} < "
+                f"object_store_budget {memory_string(budget.object_store_memory)} < "
                 f"pending_output {memory_string(pending)}"
             )
 

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -783,6 +783,57 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             >= (op.metrics.obj_store_mem_max_pending_output_per_task or 0)
         )
 
+    def diagnose_can_submit(self, op: PhysicalOperator) -> Optional[str]:
+        """Return a short string explaining why ``can_submit_new_task`` would
+        return False for ``op``, or ``None`` if it would return True.
+
+        Purely for surfacing in the progress bar; not consulted by scheduling.
+        Format is short enough to fit in a status line, e.g.
+        ``"incremental_exceeds: mem 4.0GB>2.0GB"`` or
+        ``"plasma_budget 1.0GB < pending_output 2.5GB"``.
+        """
+        budget = self.get_budget(op)
+        if budget is None:
+            return None
+
+        incremental = op.incremental_resource_usage()
+
+        def _fmt_bytes(b: float) -> str:
+            if b >= 1024**3:
+                return f"{b / 1024**3:.1f}GB"
+            if b >= 1024**2:
+                return f"{b / 1024**2:.0f}MB"
+            return f"{int(b)}B"
+
+        parts = []
+        if incremental.cpu and incremental.cpu > budget.cpu:
+            parts.append(f"cpu {incremental.cpu:g}>{budget.cpu:g}")
+        if incremental.gpu and incremental.gpu > budget.gpu:
+            parts.append(f"gpu {incremental.gpu:g}>{budget.gpu:g}")
+        if incremental.memory and incremental.memory > budget.memory:
+            parts.append(
+                f"mem {_fmt_bytes(incremental.memory)}>{_fmt_bytes(budget.memory)}"
+            )
+        if (
+            incremental.object_store_memory
+            and incremental.object_store_memory > budget.object_store_memory
+        ):
+            parts.append(
+                f"plasma_incr {_fmt_bytes(incremental.object_store_memory)}>"
+                f"{_fmt_bytes(budget.object_store_memory)}"
+            )
+        if parts:
+            return "incremental_exceeds: " + ", ".join(parts)
+
+        pending = op.metrics.obj_store_mem_max_pending_output_per_task or 0
+        if budget.object_store_memory < pending:
+            return (
+                f"plasma_budget {_fmt_bytes(budget.object_store_memory)} < "
+                f"pending_output {_fmt_bytes(pending)}"
+            )
+
+        return None
+
     def get_budget(self, op: PhysicalOperator) -> Optional[ExecutionResources]:
         return self._op_budgets.get(op)
 

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -789,21 +789,14 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
         Purely for surfacing in the progress bar; not consulted by scheduling.
         Format is short enough to fit in a status line, e.g.
-        ``"incremental_resource_exceeds: mem 4.0GB>2.0GB"`` or
-        ``"plasma_budget 1.0GB < pending_output 2.5GB"``.
+        `"incremental_resource_exceeds: mem 4.0GiB>2.0GiB"` or
+        `"plasma_budget 1.0GiB < pending_output 2.5GiB"`.
         """
         budget = self.get_budget(op)
         if budget is None:
             return None
 
         incremental = op.incremental_resource_usage()
-
-        def _fmt_bytes(b: float) -> str:
-            if b >= 1024**3:
-                return f"{b / 1024**3:.1f}GB"
-            if b >= 1024**2:
-                return f"{b / 1024**2:.0f}MB"
-            return f"{int(b)}B"
 
         parts = []
         if incremental.cpu and incremental.cpu > budget.cpu:
@@ -812,15 +805,16 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             parts.append(f"gpu {incremental.gpu:g}>{budget.gpu:g}")
         if incremental.memory and incremental.memory > budget.memory:
             parts.append(
-                f"mem {_fmt_bytes(incremental.memory)}>{_fmt_bytes(budget.memory)}"
+                f"mem {memory_string(incremental.memory)}>"
+                f"{memory_string(budget.memory)}"
             )
         if (
             incremental.object_store_memory
             and incremental.object_store_memory > budget.object_store_memory
         ):
             parts.append(
-                f"plasma_incr {_fmt_bytes(incremental.object_store_memory)}>"
-                f"{_fmt_bytes(budget.object_store_memory)}"
+                f"plasma_incr {memory_string(incremental.object_store_memory)}>"
+                f"{memory_string(budget.object_store_memory)}"
             )
         if parts:
             return "incremental_resource_exceeds: " + ", ".join(parts)
@@ -828,8 +822,8 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         pending = op.metrics.obj_store_mem_max_pending_output_per_task or 0
         if budget.object_store_memory < pending:
             return (
-                f"plasma_budget {_fmt_bytes(budget.object_store_memory)} < "
-                f"pending_output {_fmt_bytes(pending)}"
+                f"plasma_budget {memory_string(budget.object_store_memory)} < "
+                f"pending_output {memory_string(pending)}"
             )
 
         return None

--- a/python/ray/data/_internal/execution/streaming_executor_state.py
+++ b/python/ray/data/_internal/execution/streaming_executor_state.py
@@ -787,9 +787,11 @@ def get_eligible_operators(
         # Operator is considered being in task-submission back-pressure if any
         # back-pressure policy is violated. Track the first triggered policy.
         triggered_policy = None
+        triggered_reason: Optional[str] = None
         for p in backpressure_policies:
             if not p.can_add_input(op):
                 triggered_policy = p.name
+                triggered_reason = p.get_block_reason(op)
                 break
         in_backpressure = triggered_policy is not None
 
@@ -817,7 +819,9 @@ def get_eligible_operators(
         )
 
         # Signal whether op in backpressure for stats collections
-        op.notify_in_task_submission_backpressure(in_backpressure, triggered_policy)
+        op.notify_in_task_submission_backpressure(
+            in_backpressure, triggered_policy, triggered_reason
+        )
 
     # To ensure liveness, allow at least 1 operator to schedule tasks regardless of
     # limits in case when topology is entirely idle (no active tasks running)
@@ -1039,7 +1043,9 @@ def format_op_state_summary(
         if op_state.op._in_task_submission_backpressure:
             # The op is backpressured from submitting new tasks.
             policy = op_state.op._task_submission_backpressure_policy or ""
-            backpressure_types.append(f"tasks({policy})")
+            reason = op_state.op._task_submission_backpressure_reason
+            label = f"{policy}: {reason}" if reason else policy
+            backpressure_types.append(f"tasks({label})")
         if op_state.op._in_task_output_backpressure:
             # The op is backpressured from producing new outputs.
             policy = op_state.op._task_output_backpressure_policy or ""

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -470,6 +470,86 @@ def test_emits_deprecation_warning_when_dynamic_backpressure_enabled(
         ConcurrencyCapBackpressurePolicy(ctx, topology, MagicMock())
 
 
+# ---------------------------------------------------------------------------
+# BackpressurePolicy.get_block_reason
+# ---------------------------------------------------------------------------
+
+
+def test_base_policy_get_block_reason_returns_none():
+    """The base class' ``get_block_reason`` returns ``None`` by default —
+    policies that want to expose a reason must explicitly override."""
+    from ray.data._internal.execution.backpressure_policy.backpressure_policy import (
+        BackpressurePolicy,
+    )
+
+    policy = BackpressurePolicy(
+        data_context=DataContext.get_current(),
+        topology={},
+        resource_manager=MagicMock(),
+    )
+    assert policy.get_block_reason(MagicMock()) is None
+
+
+def test_resource_budget_policy_get_block_reason_delegates_to_allocator():
+    """``ResourceBudgetBackpressurePolicy.get_block_reason`` delegates to
+    the allocator's ``diagnose_can_submit``; ``None`` allocator → ``None``."""
+    from ray.data._internal.execution.backpressure_policy.resource_budget_backpressure_policy import (  # noqa: E501
+        ResourceBudgetBackpressurePolicy,
+    )
+
+    ctx = DataContext.get_current()
+    op = MagicMock()
+    rm = MagicMock()
+
+    # Case 1: no allocator → reason is None.
+    rm._op_resource_allocator = None
+    policy = ResourceBudgetBackpressurePolicy(
+        ctx, topology={op: MagicMock()}, resource_manager=rm
+    )
+    assert policy.get_block_reason(op) is None
+
+    # Case 2: allocator returns a reason string.
+    allocator = MagicMock()
+    allocator.diagnose_can_submit.return_value = (
+        "plasma_budget 0B < pending_output 168B"
+    )
+    rm._op_resource_allocator = allocator
+    policy = ResourceBudgetBackpressurePolicy(
+        ctx, topology={op: MagicMock()}, resource_manager=rm
+    )
+    assert policy.get_block_reason(op) == "plasma_budget 0B < pending_output 168B"
+    allocator.diagnose_can_submit.assert_called_once_with(op)
+
+
+def test_notify_in_task_submission_backpressure_stores_reason():
+    """``PhysicalOperator.notify_in_task_submission_backpressure`` stores
+    the reason on the op so the progress bar can read it back."""
+    from ray.data._internal.execution.operators.input_data_buffer import (
+        InputDataBuffer,
+    )
+
+    ctx = DataContext.get_current()
+    op = InputDataBuffer(ctx, input_data=[MagicMock()])
+
+    op.notify_in_task_submission_backpressure(
+        in_backpressure=True,
+        policy_name="ResourceBudget",
+        reason="plasma_budget 0B < pending_output 168B",
+    )
+    assert op._in_task_submission_backpressure is True
+    assert op._task_submission_backpressure_policy == "ResourceBudget"
+    assert (
+        op._task_submission_backpressure_reason
+        == "plasma_budget 0B < pending_output 168B"
+    )
+
+    # Calling without a reason clears it.
+    op.notify_in_task_submission_backpressure(in_backpressure=False, policy_name=None)
+    assert op._in_task_submission_backpressure is False
+    assert op._task_submission_backpressure_policy is None
+    assert op._task_submission_backpressure_reason is None
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_backpressure_policies.py
+++ b/python/ray/data/tests/test_backpressure_policies.py
@@ -511,13 +511,13 @@ def test_resource_budget_policy_get_block_reason_delegates_to_allocator():
     # Case 2: allocator returns a reason string.
     allocator = MagicMock()
     allocator.diagnose_can_submit.return_value = (
-        "plasma_budget 0B < pending_output 168B"
+        "object_store_budget 0B < pending_output 168B"
     )
     rm._op_resource_allocator = allocator
     policy = ResourceBudgetBackpressurePolicy(
         ctx, topology={op: MagicMock()}, resource_manager=rm
     )
-    assert policy.get_block_reason(op) == "plasma_budget 0B < pending_output 168B"
+    assert policy.get_block_reason(op) == "object_store_budget 0B < pending_output 168B"
     allocator.diagnose_can_submit.assert_called_once_with(op)
 
 
@@ -534,13 +534,13 @@ def test_notify_in_task_submission_backpressure_stores_reason():
     op.notify_in_task_submission_backpressure(
         in_backpressure=True,
         policy_name="ResourceBudget",
-        reason="plasma_budget 0B < pending_output 168B",
+        reason="object_store_budget 0B < pending_output 168B",
     )
     assert op._in_task_submission_backpressure is True
     assert op._task_submission_backpressure_policy == "ResourceBudget"
     assert (
         op._task_submission_backpressure_reason
-        == "plasma_budget 0B < pending_output 168B"
+        == "object_store_budget 0B < pending_output 168B"
     )
 
     # Calling without a reason clears it.

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -800,7 +800,7 @@ class TestResourceManager:
         # Reason is non-None and mentions the failing dimension.
         reason = allocator.diagnose_can_submit(o2)
         assert reason is not None
-        assert "incremental_exceeds" in reason
+        assert "incremental_resource_exceeds" in reason
         assert "mem" in reason
 
     def test_diagnose_can_submit_returns_none_when_unblocked(

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -765,6 +765,76 @@ class TestResourceManager:
             not can_submit
         ), "Task should be blocked: requires 2000 bytes but only 1000 bytes memory available"
 
+    def test_diagnose_can_submit_reports_reason(self, restore_data_context):
+        """``diagnose_can_submit`` returns a short reason string when
+        ``can_submit_new_task`` would refuse.  Used to enrich the
+        backpressure status string in the progress bar."""
+        # Same setup as test_memory_limit_blocks_task_submission: 1000 bytes
+        # cluster memory, op asks 2000 bytes per task.
+        cluster_resources = ExecutionResources(cpu=1, gpu=0, memory=1000)
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(
+            o1,
+            ray_remote_args={"num_cpus": 1, "memory": 2000},
+            name="HighMemoryTask",
+        )
+
+        topo = build_streaming_topology(o2, ExecutionOptions())
+        resource_manager = ResourceManager(
+            topology=topo,
+            options=ExecutionOptions(),
+            get_total_resources=lambda: cluster_resources,
+            data_context=DataContext.get_current(),
+        )
+        resource_manager.update_usages()
+
+        allocator = create_resource_allocator(
+            resource_manager, DataContext.get_current()
+        )
+        assert allocator is not None
+        allocator.update_budgets(limits=resource_manager.get_global_limits())
+
+        # Sanity: can_submit returns False (precondition for diagnose to fire).
+        assert not allocator.can_submit_new_task(o2)
+
+        # Reason is non-None and mentions the failing dimension.
+        reason = allocator.diagnose_can_submit(o2)
+        assert reason is not None
+        assert "incremental_exceeds" in reason
+        assert "mem" in reason
+
+    def test_diagnose_can_submit_returns_none_when_unblocked(
+        self, restore_data_context
+    ):
+        """When the op CAN submit a task, ``diagnose_can_submit`` returns
+        ``None`` — callers use this as the "no blocking reason" signal."""
+        # Plenty of cluster resources; op's per-task ask is tiny.
+        cluster_resources = ExecutionResources(cpu=8, gpu=0, memory=1024 * 1024 * 1024)
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(
+            o1,
+            ray_remote_args={"num_cpus": 1, "memory": 1024},
+            name="SmallTask",
+        )
+
+        topo = build_streaming_topology(o2, ExecutionOptions())
+        resource_manager = ResourceManager(
+            topology=topo,
+            options=ExecutionOptions(),
+            get_total_resources=lambda: cluster_resources,
+            data_context=DataContext.get_current(),
+        )
+        resource_manager.update_usages()
+
+        allocator = create_resource_allocator(
+            resource_manager, DataContext.get_current()
+        )
+        assert allocator is not None
+        allocator.update_budgets(limits=resource_manager.get_global_limits())
+
+        assert allocator.can_submit_new_task(o2)
+        assert allocator.diagnose_can_submit(o2) is None
+
 
 class TestOutputBackpressureGuard:
     """Tests for OutputBackpressureGuard.should_unblock."""

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -387,6 +387,9 @@ def test_backpressure_policy_tracking(ray_start_regular_shared):
         def can_add_input(self, op):
             return op is not o2  # Block o2
 
+        def get_block_reason(self, op):
+            return None
+
         def max_task_output_bytes_to_read(self, op):
             return None
 
@@ -398,6 +401,9 @@ def test_backpressure_policy_tracking(ray_start_regular_shared):
         def can_add_input(self, op):
             return True  # Allow all
 
+        def get_block_reason(self, op):
+            return None
+
         def max_task_output_bytes_to_read(self, op):
             return None
 
@@ -408,6 +414,9 @@ def test_backpressure_policy_tracking(ray_start_regular_shared):
 
         def can_add_input(self, op):
             return op is not o2  # Block o2
+
+        def get_block_reason(self, op):
+            return None
 
         def max_task_output_bytes_to_read(self, op):
             return None


### PR DESCRIPTION
## Description

Surface the *reason* a backpressure policy is blocking an op in the streaming progress bar. Today the status only names the policy (e.g. `ResourceBudget`), which forces you to read the code to figure out which check actually failed. This PR extends each policy with an optional `get_block_reason(op) -> Optional[str]` hook, threads it through `notify_in_task_submission_backpressure`, and appends it to the existing status string.

`ResourceBudgetBackpressurePolicy` implements the hook via a new `ReservationOpResourceAllocator.diagnose_can_submit(op)` that mirrors the two checks in `can_submit_new_task` and emits a short, formatted explanation. Other policies inherit a default that returns `None` (no behavior change).

Pure diagnostic — no scheduling logic consults the reason string.

**Before:**
`Write: Tasks: 1 [backpressured:tasks(ResourceBudget)]; Queued blocks: 134 (16.7GiB); ...`
**After:**

`Write: Tasks: 1 [backpressured:tasks(ResourceBudget: plasma_budget 0B < pending_output 168B)];...`

`Write: Tasks: 0 [backpressured:tasks(ResourceBudget: incremental_resource_exceeds: mem 2.0GB>1.0GB)]; ...`
## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
