### PR TITLE
Improve State API filter key handling

### DIFF
--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -10,6 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
+import click
 import pytest
 import yaml
 from click.testing import CliRunner
@@ -79,12 +80,14 @@ from ray.util.state.common import (
     Humanify,
     ObjectState,
     RuntimeEnvState,
+    StateResource,
     StateSchema,
     state_column,
 )
 from ray.util.state.exception import DataSourceUnavailable, RayStateApiException
 from ray.util.state.state_cli import (
     AvailableFormat,
+    _normalize_filter_keys,
     _parse_filter,
     format_list_api_output,
     ray_get,
@@ -1817,7 +1820,21 @@ def test_hang_driver_has_no_is_running_task(monkeypatch, ray_start_cluster):
     all_job_info = client.get_all_job_info()
     assert list(all_job_info.keys()) == [my_job_id]
     assert not all_job_info[my_job_id].HasField("is_running_tasks")
+    
 
+def test_normalize_filter_keys_accepts_case_insensitive_keys():
+    filters = [("STATE", "=", "RUNNING")]
+
+    normalized_filters = _normalize_filter_keys(StateResource.TASKS, filters)
+
+    assert normalized_filters == [("state", "=", "RUNNING")]
+
+
+def test_normalize_filter_keys_rejects_invalid_keys():
+    filters = [("invalid_key", "=", "RUNNING")]
+
+    with pytest.raises(click.BadParameter, match="Invalid filter key"):
+        _normalize_filter_keys(StateResource.TASKS, filters)
 
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1836,5 +1836,6 @@ def test_normalize_filter_keys_rejects_invalid_keys():
     with pytest.raises(click.BadParameter, match="Invalid filter key"):
         _normalize_filter_keys(StateResource.TASKS, filters)
 
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -1820,7 +1820,7 @@ def test_hang_driver_has_no_is_running_task(monkeypatch, ray_start_cluster):
     all_job_info = client.get_all_job_info()
     assert list(all_job_info.keys()) == [my_job_id]
     assert not all_job_info[my_job_id].HasField("is_running_tasks")
-    
+
 
 def test_normalize_filter_keys_accepts_case_insensitive_keys():
     filters = [("STATE", "=", "RUNNING")]

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -93,6 +93,41 @@ def _parse_filter(filter: str) -> Tuple[str, PredicateType, SupportedFilterType]
     return (key, predicate, value)
 
 
+def _normalize_filter_keys(
+    resource: StateResource,
+    filters: List[Tuple[str, PredicateType, SupportedFilterType]],
+) -> List[Tuple[str, PredicateType, SupportedFilterType]]:
+    """Normalize filter keys to match the resource schema.
+
+    Filter values are already documented as case-insensitive, but filter keys
+    may be entered with different casing by users, e.g. STATE=RUNNING instead
+    of state=RUNNING. Normalize keys when they match a valid schema column
+    case-insensitively. If the key is invalid, raise a clear error instead of
+    returning an empty result that later becomes "No resource in the cluster".
+    """
+    schema = resource_to_schema(resource)
+    valid_columns = schema.list_columns(detail=True)
+    valid_column_by_lowercase = {column.lower(): column for column in valid_columns}
+
+    normalized_filters = []
+    for key, predicate, value in filters:
+        if key in valid_columns:
+            normalized_filters.append((key, predicate, value))
+            continue
+
+        normalized_key = valid_column_by_lowercase.get(key.lower())
+        if normalized_key is not None:
+            normalized_filters.append((normalized_key, predicate, value))
+            continue
+
+        raise click.BadParameter(
+            f"Invalid filter key {key!r} for resource {resource.value!r}. "
+            f"Available filter keys are: {', '.join(valid_columns)}"
+        )
+
+    return normalized_filters
+
+
 def _get_available_formats() -> List[str]:
     """Return the available formats in a list of string"""
     return [format_enum.value for format_enum in AvailableFormat]
@@ -568,6 +603,7 @@ def ray_list(
     client = StateApiClient(address=address)
 
     filter = [_parse_filter(f) for f in filter]
+    filter = _normalize_filter_keys(resource, filter)
 
     options = ListApiOptions(
         limit=limit,

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -106,7 +106,9 @@ def _normalize_filter_keys(
     returning an empty result that later becomes "No resource in the cluster".
     """
     schema = resource_to_schema(resource)
-    valid_columns = schema.list_columns(detail=True) or schema.list_columns(detail=False)
+    valid_columns = schema.list_columns(detail=True) or schema.list_columns(
+        detail=False
+    )
     valid_column_by_lowercase = {column.lower(): column for column in valid_columns}
 
     normalized_filters = []

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -106,7 +106,7 @@ def _normalize_filter_keys(
     returning an empty result that later becomes "No resource in the cluster".
     """
     schema = resource_to_schema(resource)
-    valid_columns = schema.list_columns(detail=True)
+    valid_columns = schema.list_columns(detail=True) or schema.list_columns(detail=False)
     valid_column_by_lowercase = {column.lower(): column for column in valid_columns}
 
     normalized_filters = []


### PR DESCRIPTION
## Why are these changes needed?

This PR improves the handling of State API CLI filter keys.

Previously, using a filter key with different casing, such as:

ray list tasks -f STATE=RUNNING

could lead to confusing behavior and eventually display "No resource in the cluster".

This change normalizes filter keys case-insensitively when they match a valid schema column. If the filter key is invalid, the CLI now raises a clearer error message.

## Related issue number

Fixes #50378

## Checks

- [x] I have run `python -m compileall python/ray/util/state/state_cli.py`
- [x] I have run `python -m pytest python/ray/tests/test_state_api.py -k "normalize_filter_keys" -q`

Test result:

2 passed, 58 deselected in 2.32s