### PR TITLE
[core] Fixing actor state counter bug

### DIFF
--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1940,9 +1940,18 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
 void GcsActorManager::AddDestroyedActorObservabilityData(const GcsActor &actor) {
   if (destroyed_actor_observability_data_.size() >=
       RayConfig::instance().maximum_gcs_destroyed_actor_cached_count()) {
-    const auto &actor_id = sorted_destroyed_actor_observability_list_.front().first;
-    gcs_table_storage_->ActorTable().Delete(actor_id, {[](auto) {}, io_context_});
-    destroyed_actor_observability_data_.erase(actor_id);
+    const auto &evict_id = sorted_destroyed_actor_observability_list_.front().first;
+
+    // Mirror GcsActor::~GcsActor: decrement the counter for non-DEAD states on eviction.
+    auto evict_it = destroyed_actor_observability_data_.find(evict_id);
+    RAY_CHECK(evict_it != destroyed_actor_observability_data_.end());
+    if (evict_it->second.state() != rpc::ActorTableData::DEAD) {
+      actor_state_counter_->Decrement(
+          {evict_it->second.state(), evict_it->second.class_name()});
+    }
+
+    gcs_table_storage_->ActorTable().Delete(evict_id, {[](auto) {}, io_context_});
+    destroyed_actor_observability_data_.erase(evict_it);
     sorted_destroyed_actor_observability_list_.pop_front();
   }
 

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -552,6 +552,7 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   FRIEND_TEST(GcsActorManagerTest, TestKillActorWhenActorIsCreating);
   FRIEND_TEST(GcsActorManagerTest, TestBasic);
   FRIEND_TEST(GcsActorManagerTest, TestDeadCount);
+  FRIEND_TEST(GcsActorManagerTest, TestNonDeadEntryEvictionDecrementsCounter);
   FRIEND_TEST(GcsActorManagerTest, TestSchedulingFailed);
   FRIEND_TEST(GcsActorManagerTest, TestWorkerFailure);
   FRIEND_TEST(GcsActorManagerTest, TestNodeFailure);

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -431,6 +431,78 @@ TEST_F(GcsActorManagerTest, TestDeadCount) {
   ASSERT_EQ(gcs_actor_manager_->destroyed_actor_observability_data_.size(), 10u);
 }
 
+TEST_F(GcsActorManagerTest, TestNonDeadEntryEvictionDecrementsCounter) {
+  ///
+  /// Verify that when a non-DEAD entry is evicted from the observability cache,
+  /// the counter for that state is decremented. This mirrors
+  /// `GcsActor::~GcsActor`'s carve-out: DEAD counts are intentionally cumulative,
+  /// but non-DEAD counts must be balanced. Only Initialize-rehydrated orphans
+  /// (e.g., ALIVE actor whose owning job died) ever land in the cache with a
+  /// non-DEAD state; the normal `DestroyActor` path always transitions to DEAD
+  /// before insertion, so `TestDeadCount` doesn't exercise this path.
+  ///
+  ASSERT_EQ(RayConfig::instance().maximum_gcs_destroyed_actor_cached_count(), 10);
+
+  // Seed the cache with an orphaned ALIVE entry, simulating what Initialize
+  // would produce for an actor whose owner job died while it was still alive.
+  const std::string orphan_class = "OrphanClass";
+  auto orphan_job_id = JobID::FromInt(99);
+  ActorID orphan_id =
+      ActorID::Of(orphan_job_id, TaskID::FromRandom(orphan_job_id), /*counter=*/0);
+  rpc::ActorTableData orphan_data;
+  orphan_data.set_actor_id(orphan_id.Binary());
+  orphan_data.set_state(rpc::ActorTableData::ALIVE);
+  orphan_data.set_class_name(orphan_class);
+  // timestamp=0 ensures the orphan stays at the head of the sorted list so it's
+  // the first thing evicted when the cache fills.
+  orphan_data.set_timestamp(0);
+
+  gcs_actor_manager_->destroyed_actor_observability_data_.emplace(orphan_id, orphan_data);
+  gcs_actor_manager_->sorted_destroyed_actor_observability_list_.emplace_back(orphan_id,
+                                                                              0);
+  gcs_actor_manager_->actor_state_counter_->Increment(
+      {rpc::ActorTableData::ALIVE, orphan_class});
+
+  ASSERT_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, orphan_class), 1);
+  ASSERT_EQ(gcs_actor_manager_->destroyed_actor_observability_data_.size(), 1u);
+
+  // Now drive 10 actor deaths through the normal flow. Cache cap is 10; starting
+  // size is 1; the 10th destroy finds size>=10 and triggers eviction of the
+  // orphan (oldest by timestamp).
+  auto job_id = JobID::FromInt(1);
+  for (int i = 0; i < 10; i++) {
+    auto registered_actor = RegisterActor(job_id);
+    rpc::CreateActorRequest create_actor_request;
+    create_actor_request.mutable_task_spec()->CopyFrom(
+        registered_actor->GetCreationTaskSpecification().GetMessage());
+
+    Status status =
+        gcs_actor_manager_->CreateActor(create_actor_request,
+                                        [](const std::shared_ptr<gcs::GcsActor> &actor,
+                                           const rpc::PushTaskReply &reply,
+                                           const Status &) {});
+    RAY_CHECK_OK(status);
+    auto actor = mock_actor_scheduler_->actors.back();
+    mock_actor_scheduler_->actors.pop_back();
+    // Check that the actor is in state `ALIVE`.
+    actor->UpdateAddress(RandomAddress());
+    gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+    io_service_.run_one();
+    // Actor is killed.
+    ASSERT_TRUE(worker_client_->Reply());
+    ASSERT_EQ(actor->GetState(), rpc::ActorTableData::DEAD);
+  }
+  drain_io_context();
+
+  // The orphan should have been evicted and its ALIVE count decremented.
+  ASSERT_FALSE(
+      gcs_actor_manager_->destroyed_actor_observability_data_.contains(orphan_id));
+  ASSERT_EQ(gcs_actor_manager_->CountFor(rpc::ActorTableData::ALIVE, orphan_class), 0);
+
+  // Cache is still at the configured cap.
+  ASSERT_EQ(gcs_actor_manager_->destroyed_actor_observability_data_.size(), 10u);
+}
+
 TEST_F(GcsActorManagerTest, TestActorCreationRaceWithRestart) {
   auto job_id = JobID::FromInt(1);
 


### PR DESCRIPTION
This is followup to this PR: https://github.com/ray-project/ray/pull/63551

There was a bug found by cursor bot in https://github.com/ray-project/ray/pull/63551 where, when we evict from the destroyed actor cache, if the state of actor is not DEAD, actor state counter will not be decremented. This is the link to the comment: https://github.com/ray-project/ray/pull/63551#discussion_r3305579538

A non-DEAD actor can be in the destroyed actor cache in the following way: 
1. When initializing GCS after failure, we read persisted data for actors. 
2. For each actor, we either put it in registered actors or destroyed actors based on this check: `OnInitializeActorShouldLoad`. We put an actor in destroyed actor cache if: 

- It is dead and not restartable.
- The job it belongs to is dead or the root detached actor it belongs to is dead. 

So when the job is dead, but the actor isn't marked DEAD yet, it might go to the destroyed cache even when its not DEAD.  

Before https://github.com/ray-project/ray/pull/63551, we used to construct `GcsActor` in Initialize path, which would increment the actor state counter and then eviction from destroyed actor cache would trigger `~GcsActor` which would decrement the actor state counter if the actor state is not DEAD. Now that we don't use GcsActor, we do it manually.

