### PR TITLE
[data] auto-detect AzureFileSystem for Blob HTTPS URLs in download()

### DIFF
--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -236,6 +236,70 @@ def _is_filesystem_compatible_with_scheme(
     return fs_type in expected_types
 
 
+_AZURE_BLOB_HTTPS_SUFFIXES = (".blob.core.windows.net", ".dfs.core.windows.net")
+
+
+def _rewrite_azure_blob_https_url(path: str) -> Tuple[str, Optional[str]]:
+    """Rewrite Azure Blob/DFS HTTPS URLs to ``abfs://<container>/<blob>`` form.
+
+    PyArrow's scheme auto-detection only recognises ``abfs://`` / ``abfss://`` for
+    Azure; an ``https://<account>.blob.core.windows.net/<container>/<blob>`` URL
+    falls through to the fsspec HTTP filesystem and fetches anonymously, which
+    fails for private blobs.
+
+    We deliberately avoid emitting the Hadoop-style
+    ``abfs://<container>@<account>.dfs.core.windows.net/<path>`` form. PyArrow's
+    C++ ``AzureOptions::FromUri`` parses it correctly when the resolver builds a
+    filesystem from the URI alone — but ``_resolve_filesystem_and_path`` *skips*
+    that parser whenever a filesystem is already supplied (the common case for
+    ``download(..., filesystem=AzureFileSystem(...))``). In that branch PyArrow
+    strips the scheme and treats the authority as part of the path, so requests
+    land on ``https://<fs.account>.blob.core.windows.net/<cont>@<acct>.dfs.core.windows.net/<blob>``
+    and 404. The bare ``abfs://<container>/<blob>`` form sidesteps this entirely
+    because there is no authority to misinterpret.
+
+    Returns ``(rewritten_path, account_name)``. ``account_name`` is the host
+    prefix extracted from the original URL so the caller can construct an
+    ``AzureFileSystem(account_name=...)`` when the user did not pass an explicit
+    filesystem. ``account_name`` is ``None`` when the path was not rewritten.
+
+    URLs carrying a query string (e.g. a SAS token) are returned unchanged: the
+    SAS already carries auth, and the fsspec HTTP path will fetch them with the
+    signature intact.
+    """
+    if not path.startswith("https://"):
+        return path, None
+
+    parsed = urlparse(path, allow_fragments=False)
+    if parsed.query:
+        return path, None
+
+    # `parsed.hostname` strips explicit port and userinfo (and lower-cases the
+    # host per RFC 3986), so the suffix check works for URLs that include
+    # `:443` or `user:pass@`.
+    host = parsed.hostname
+    if not host:
+        return path, None
+    suffix = next(
+        (s for s in _AZURE_BLOB_HTTPS_SUFFIXES if host.endswith(s)),
+        None,
+    )
+    if suffix is None or len(host) == len(suffix):
+        return path, None
+
+    account = host[: -len(suffix)]
+    object_path = parsed.path.lstrip("/")
+    if "/" not in object_path:
+        # No <container>/<blob> split available — leave it alone.
+        return path, None
+
+    container, blob_path = object_path.split("/", 1)
+    if not container or not blob_path:
+        return path, None
+
+    return f"abfs://{container}/{blob_path}", account
+
+
 def _resolve_single_path_with_fallback(
     path: str,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
@@ -259,15 +323,38 @@ def _resolve_single_path_with_fallback(
         ImportError: If required dependencies are missing.
     """
     import pyarrow as pa
+    import pyarrow.fs
     from pyarrow.fs import _resolve_filesystem_and_path
 
     path = _resolve_custom_scheme(path)
+
+    # Only rewrite Azure Blob HTTPS URLs when this PyArrow build actually has
+    # AzureFileSystem support. Otherwise the abfs:// form we would produce
+    # cannot be resolved by PyArrow, and we would block the original https://
+    # URL from falling through to the fsspec HTTP filesystem below.
+    azure_fs_cls = getattr(pyarrow.fs, "AzureFileSystem", None)
+    if azure_fs_cls is not None:
+        path, azure_account = _rewrite_azure_blob_https_url(path)
+    else:
+        azure_account = None
 
     # Validate/wrap filesystem if needed
     try:
         filesystem = _validate_and_wrap_filesystem(filesystem)
     except TypeError as e:
         raise ValueError(f"Invalid filesystem provided: {e}") from e
+
+    # If we rewrote an Azure HTTPS URL and the caller did not supply a
+    # filesystem, build one with the account name we extracted. AzureFileSystem
+    # still resolves credentials (account_key, SAS, default credential chain)
+    # from the environment; supplying a filesystem explicitly to download() with
+    # custom credentials remains the override path for non-default auth.
+    # _resolve_paths_and_filesystem caches the filesystem returned by the first
+    # path and reuses it, so the auto-injected AzureFileSystem is shared across
+    # the rest of the column — multi-account columns are not supported on the
+    # PyArrow path; use obstore for that case.
+    if azure_account is not None and filesystem is None:
+        filesystem = azure_fs_cls(account_name=azure_account)
 
     # Parse scheme to validate filesystem compatibility
     parsed = urlparse(path, allow_fragments=False)

--- a/python/ray/data/tests/unit/test_path_util.py
+++ b/python/ray/data/tests/unit/test_path_util.py
@@ -12,6 +12,8 @@ from ray.data.datasource.path_util import (
     _is_filesystem_compatible_with_scheme,
     _is_local_windows_path,
     _resolve_paths_and_filesystem,
+    _resolve_single_path_with_fallback,
+    _rewrite_azure_blob_https_url,
 )
 
 
@@ -50,6 +52,88 @@ def test_resolve_http_paths(filesystem):
     assert isinstance(resolve_filesystem, pyarrow.fs.PyFileSystem)
     assert isinstance(resolve_filesystem.handler, pyarrow.fs.FSSpecHandler)
     assert isinstance(resolve_filesystem.handler.fs, HTTPFileSystem)
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        # Blob endpoint: rewritten to PyArrow-compatible bare-container form.
+        (
+            "https://acct.blob.core.windows.net/cont/dir/file.jpg",
+            ("abfs://cont/dir/file.jpg", "acct"),
+        ),
+        # DFS / Gen2 endpoint: same target form, account still extracted.
+        (
+            "https://acct.dfs.core.windows.net/cont/dir/file.jpg",
+            ("abfs://cont/dir/file.jpg", "acct"),
+        ),
+        # Mixed-case host is still recognised; account is lower-cased.
+        (
+            "https://Acct.Blob.Core.Windows.Net/cont/file.bin",
+            ("abfs://cont/file.bin", "acct"),
+        ),
+        # Explicit :443 port — host suffix match still works via parsed.hostname.
+        (
+            "https://acct.blob.core.windows.net:443/cont/dir/file.jpg",
+            ("abfs://cont/dir/file.jpg", "acct"),
+        ),
+        # Userinfo prefix (`user:pass@host`) — also stripped by parsed.hostname.
+        (
+            "https://user:pass@acct.blob.core.windows.net/cont/file.bin",
+            ("abfs://cont/file.bin", "acct"),
+        ),
+        # SAS token present — leave URL untouched so HTTP path serves it.
+        (
+            "https://acct.blob.core.windows.net/cont/file?sv=2024&sig=abc",
+            ("https://acct.blob.core.windows.net/cont/file?sv=2024&sig=abc", None),
+        ),
+        # Non-Azure HTTPS host — passthrough.
+        ("https://example.com/cont/file", ("https://example.com/cont/file", None)),
+        # Container with no blob path — not enough to rewrite.
+        (
+            "https://acct.blob.core.windows.net/cont",
+            ("https://acct.blob.core.windows.net/cont", None),
+        ),
+        # Bare account URL with no container.
+        (
+            "https://acct.blob.core.windows.net/",
+            ("https://acct.blob.core.windows.net/", None),
+        ),
+        # Already-abfs URI is unchanged.
+        (
+            "abfs://cont/dir/file",
+            ("abfs://cont/dir/file", None),
+        ),
+        # Non-HTTPS scheme is unchanged.
+        ("s3://bucket/key", ("s3://bucket/key", None)),
+    ],
+)
+def test_rewrite_azure_blob_https_url(path, expected):
+    assert _rewrite_azure_blob_https_url(path) == expected
+
+
+def test_resolve_single_path_without_azure_filesystem_keeps_https_passthrough():
+    """When PyArrow has no AzureFileSystem (older builds), an Azure Blob HTTPS
+    URL must NOT be rewritten to abfs:// — otherwise the resolver would have
+    no filesystem to construct, the HTTP fallback below cannot match the new
+    scheme, and resolution fails outright. The URL should pass through to the
+    fsspec HTTP filesystem unchanged.
+    """
+    import pyarrow.fs
+
+    url = "https://acct.blob.core.windows.net/cont/dir/file.bin"
+
+    # The production code reads pyarrow.fs.AzureFileSystem via
+    # ``getattr(pyarrow.fs, "AzureFileSystem", None)`` and treats ``None`` as
+    # "not available", so patching the attribute to None simulates the
+    # missing-Azure-support build without needing to delete it.
+    with mock.patch.object(pyarrow.fs, "AzureFileSystem", None):
+        fs, resolved = _resolve_single_path_with_fallback(url)
+
+    assert resolved == url
+    assert isinstance(fs, pyarrow.fs.PyFileSystem)
+    assert isinstance(fs.handler, pyarrow.fs.FSSpecHandler)
+    assert isinstance(fs.handler.fs, HTTPFileSystem)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Currently ray.data.expressions.download() hangs at 0% scheduling when the URI column holds the natural Azure Blob HTTPS form (https://<account>.blob.core.windows.net/<container>/<blob>): _resolve_paths_and_filesystem auto-detects a filesystem only for abfs:// / abfss:// schemes for Azure, so HTTPS Blob URLs fall through to the fsspec HTTP filesystem and fetch anonymously, which fails for private blobs. 

This PR rewrite Azure Blob HTTPS URLs to the bare abfs://<container>/<blob> form inside _resolve_single_path_with_fallback, and when the caller did not supply a filesystem, auto-construct AzureFileSystem(account_name=...) with the account extracted from the original URL. 

This PR intentionally avoided The Hadoop-style abfs://<container>@<account>.dfs.core.windows.net/<blob> form. PyArrow's AzureOptions::FromUri parses it correctly when the resolver constructs a filesystem from the URI alone, but _resolve_filesystem_and_path skips that parser whenever a filesystem is already supplied (the common case for download(..., filesystem=...)). In that branch the URI authority is passed through as part of the path, sending requests to https://<fs.account>.blob.core.windows.net/<cont>@<acct>...windows.net/<blob>, which 404s. The bare-container form sidesteps this entirely. 

URLs carrying a query string (e.g. SAS tokens) are passed through unchanged so the existing fsspec HTTP path serves them with the SAS intact. The obstore fast path is untouched: it uses _split_uri + obstore.from_url, which already handles Azure HTTPS URLs natively.

## Related issues
Currently I run following script on a pod with workload identity on Azure. This pr is based on following _convert_https_blob_to_abfs() function:

1. Reads a real HTTPS blob URL (like your STORAGE_BASE_URI + path)
2. Converts it with _convert_https_blob_to_abfs
3. Feeds it to ray.data.expressions.download
  

```
import ray
import pyarrow.fs as pafs
from ray.data.expressions import download

ray.init()

def _convert_https_blob_to_abfs(uri):
    prefix = "https://"
    if not uri.startswith(prefix):
        return uri
    rest = uri[len(prefix):]
    if "/" not in rest:
        return uri
    host, path = rest.split("/", 1)
    if not host.endswith(".blob.core.windows.net"):
        return uri
    if "/" not in path:
        return uri
    container, blob_path = path.split("/", 1)
    return f"abfs://{container}/{blob_path}"

https_url = "https://abcdefg.blob.core.windows.net/ab/cd/ef/gh/0.png"

abfs_url = _convert_https_blob_to_abfs(https_url)
print(f"HTTPS: {https_url}")
print(f"ABFS:  {abfs_url}")

ds = ray.data.from_items([{"image_uri": abfs_url}])

fs = pafs.AzureFileSystem(account_name="mldeva100")
ds = ds.with_column("image_bytes", download("image_uri", filesystem=fs))
 
for row in ds.take(1):
    data = row["image_bytes"]
    if hasattr(data, "as_py"):
        data = data.as_py()
    if data:
        print(f"SUCCESS: downloaded {len(data)} bytes")
        print(f"Type: {type(data)}")
        print(f"PNG magic: {data[:8]}")
    else:
        print("FAILED: got empty/None")

```
Run this on any node with workload identity access to data source. Swap the https_url with any real image path from your dataset.
