### PR TITLE
[release] Temporarily disable Azure image push for release-test images

### DIFF
--- a/ci/ray_ci/anyscale_docker_container.py
+++ b/ci/ray_ci/anyscale_docker_container.py
@@ -2,8 +2,10 @@ import os
 import subprocess
 
 from ci.ray_ci.container import (
-    _AZURE_REGISTRY_NAME,
-    _DOCKER_AZURE_REGISTRY,
+    # _AZURE_REGISTRY_NAME and _DOCKER_AZURE_REGISTRY imports temporarily
+    # commented out: Azure image push is disabled due to CI issues.
+    # _AZURE_REGISTRY_NAME,
+    # _DOCKER_AZURE_REGISTRY,
     _DOCKER_ECR_REPO,
     _DOCKER_GCP_REGISTRY,
 )
@@ -23,7 +25,8 @@ class AnyscaleDockerContainer(DockerContainer):
         """
         aws_registry = _DOCKER_ECR_REPO.split("/")[0]
         gcp_registry = _DOCKER_GCP_REGISTRY
-        azure_registry = _DOCKER_AZURE_REGISTRY
+        # Azure image push temporarily disabled due to CI issues.
+        # azure_registry = _DOCKER_AZURE_REGISTRY
         tag = self._get_canonical_tag()
         ray_image = f"rayproject/{self.image_type}:{tag}"
         anyscale_image = f"{aws_registry}/anyscale/{self.image_type}:{tag}"
@@ -35,10 +38,14 @@ class AnyscaleDockerContainer(DockerContainer):
             + f"{ray_image} {anyscale_image} {aws_registry}",
             # gcloud login
             f"./release/gcloud_docker_login.sh {gce_credentials}",
-            # azure login
-            "./release/azure_docker_login.sh",
-            # azure cr login
-            f"az acr login --name {_AZURE_REGISTRY_NAME}",
+            # Azure ACR login skipped: Azure image push temporarily disabled
+            # due to CI issues.
+            "echo 'Skipping Azure ACR login: Azure image push temporarily "
+            "disabled due to CI issues.'",
+            # azure login (disabled)
+            # "./release/azure_docker_login.sh",
+            # azure cr login (disabled)
+            # f"az acr login --name {_AZURE_REGISTRY_NAME}",
             "export PATH=$(pwd)/google-cloud-sdk/bin:$PATH",
         ]
         # TODO(can): remove the alias when release test infra uses only the canonical
@@ -47,16 +54,18 @@ class AnyscaleDockerContainer(DockerContainer):
             for alias in self._get_image_tags():
                 aws_alias_image = f"{aws_registry}/anyscale/{self.image_type}:{alias}"
                 gcp_alias_image = f"{gcp_registry}/anyscale/{self.image_type}:{alias}"
-                azure_alias_image = (
-                    f"{azure_registry}/anyscale/{self.image_type}:{alias}"
-                )
+                # Azure alias image computation and push disabled — see above.
+                # azure_alias_image = (
+                #     f"{azure_registry}/anyscale/{self.image_type}:{alias}"
+                # )
                 cmds += [
                     f"docker tag {anyscale_image} {aws_alias_image}",
                     f"docker push {aws_alias_image}",
                     f"docker tag {anyscale_image} {gcp_alias_image}",
                     f"docker push {gcp_alias_image}",
-                    f"docker tag {anyscale_image} {azure_alias_image}",
-                    f"docker push {azure_alias_image}",
+                    # Azure tag/push temporarily disabled due to CI issues.
+                    # f"docker tag {anyscale_image} {azure_alias_image}",
+                    # f"docker push {azure_alias_image}",
                 ]
 
             if os.environ.get("BUILDKITE"):

--- a/ci/ray_ci/automation/push_release_test_image.py
+++ b/ci/ray_ci/automation/push_release_test_image.py
@@ -1,9 +1,10 @@
 """
-Push Wanda-cached release test images to ECR, GCP, and Azure registries used for
+Push Wanda-cached release test images to ECR and GCP registries used for
 release tests:
 - AWS ECR: anyscale/{image_type}:{tag}
 - GCP Artifact Registry: anyscale/{image_type}:{tag}
-- Azure Container Registry: anyscale/{image_type}:{tag}
+- Azure Container Registry: anyscale/{image_type}:{tag} (temporarily disabled
+  due to CI issues — see the Azure-disabled blocks below)
 
 Example:
     bazel run //ci/ray_ci/automation:push_release_test_image -- \\
@@ -274,9 +275,10 @@ def main(
     pull_request: str,
 ) -> None:
     """
-    Push a Wanda-cached release test image to ECR, GCP, and Azure registries.
+    Push a Wanda-cached release test image to ECR and GCP registries.
 
-    Handles authentication for all three registries internally.
+    Handles authentication for both registries internally. Azure ACR push is
+    temporarily disabled due to CI issues.
     """
     ci_init()
 
@@ -313,8 +315,13 @@ def main(
     registries = [
         (ecr_registry, "ECR"),
         (global_config["byod_gcp_cr"], "GCP"),
-        (global_config["byod_azure_cr"], "Azure"),
+        # Azure image push temporarily disabled due to CI issues.
+        # (global_config["byod_azure_cr"], "Azure"),
     ]
+    logger.info(
+        "Azure image push is temporarily disabled due to CI issues; "
+        "skipping Azure Container Registry destination."
+    )
 
     if dry_run:
         for tag in tags:
@@ -326,7 +333,13 @@ def main(
     # Authenticate with all registries
     ecr_docker_login(ecr_registry)
     _run_gcloud_docker_login()
-    _run_azure_docker_login()
+    # Azure image push temporarily disabled due to CI issues; skipping
+    # Azure ACR authentication prerequisite.
+    logger.info(
+        "Skipping Azure ACR authentication: Azure image push is temporarily "
+        "disabled due to CI issues."
+    )
+    # _run_azure_docker_login()
 
     # Verify source image exists
     logger.info("Verifying source image in Wanda cache...")

--- a/ci/ray_ci/test_anyscale_docker_container.py
+++ b/ci/ray_ci/test_anyscale_docker_container.py
@@ -7,7 +7,9 @@ import pytest
 
 from ci.ray_ci.anyscale_docker_container import AnyscaleDockerContainer
 from ci.ray_ci.container import (
-    _DOCKER_AZURE_REGISTRY,
+    # _DOCKER_AZURE_REGISTRY import temporarily commented out: Azure image
+    # push is disabled due to CI issues.
+    # _DOCKER_AZURE_REGISTRY,
     _DOCKER_ECR_REPO,
     _DOCKER_GCP_REGISTRY,
 )
@@ -38,7 +40,9 @@ class TestAnyscaleDockerContainer(RayCITestBase):
             aws_ecr = _DOCKER_ECR_REPO.split("/")[0]
             aws_prj = f"{aws_ecr}/anyscale/ray-ml"
             gcp_prj = f"{_DOCKER_GCP_REGISTRY}/anyscale/ray-ml"
-            azure_prj = f"{_DOCKER_AZURE_REGISTRY}/anyscale/ray-ml"
+            # Azure project URI temporarily removed from expectations:
+            # Azure image push is disabled due to CI issues.
+            # azure_prj = f"{_DOCKER_AZURE_REGISTRY}/anyscale/ray-ml"
             gce_credentials = get_global_config()["aws2gce_credentials"]
 
             tags_want = [
@@ -57,8 +61,10 @@ class TestAnyscaleDockerContainer(RayCITestBase):
                     f"docker push {aws_prj}:{tag}",
                     f"docker tag {aws_prj}:123456-{pv}-cu121 {gcp_prj}:{tag}",
                     f"docker push {gcp_prj}:{tag}",
-                    f"docker tag {aws_prj}:123456-{pv}-cu121 {azure_prj}:{tag}",
-                    f"docker push {azure_prj}:{tag}",
+                    # Azure tag/push expectations temporarily removed: Azure
+                    # image push is disabled due to CI issues.
+                    # f"docker tag {aws_prj}:123456-{pv}-cu121 {azure_prj}:{tag}",
+                    # f"docker push {azure_prj}:{tag}",
                 ]
 
             assert (
@@ -68,8 +74,12 @@ class TestAnyscaleDockerContainer(RayCITestBase):
                     f"rayproject/ray-ml:123456-{pv}-cu121 "
                     f"{aws_prj}:123456-{pv}-cu121 {aws_ecr}",
                     f"./release/gcloud_docker_login.sh {gce_credentials}",
-                    "./release/azure_docker_login.sh",
-                    "az acr login --name rayreleasetest",
+                    # Azure login command replaced by an echo notice while
+                    # Azure image push is disabled due to CI issues.
+                    "echo 'Skipping Azure ACR login: Azure image push "
+                    "temporarily disabled due to CI issues.'",
+                    # "./release/azure_docker_login.sh",
+                    # "az acr login --name rayreleasetest",
                     "export PATH=$(pwd)/google-cloud-sdk/bin:$PATH",
                 ]
                 + push_cmds_want

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -10,7 +10,11 @@ from ray_release.logger import logger
 from ray_release.test import (
     Test,
 )
-from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX, AZURE_REGISTRY_NAME
+
+# AZURE_REGISTRY_NAME import temporarily removed below: Azure image push is
+# disabled due to CI issues. Re-add `AZURE_REGISTRY_NAME` to the import below
+# when re-enabling the Azure tag/push block in build_anyscale_custom_byod_image.
+from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX
 
 bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 
@@ -65,9 +69,16 @@ def build_anyscale_custom_byod_image(
                 f"{image}<br/>",
             ],
         )
-    tag_without_registry = image.split("/")[-1]
-    azure_tag = f"{AZURE_REGISTRY_NAME}.azurecr.io/{tag_without_registry}"
-    _tag_and_push(source=image, target=azure_tag)
+    # Azure tag-and-push for custom BYOD images temporarily disabled due to
+    # CI issues.
+    logger.info(
+        "Skipping Azure ACR tag/push for custom BYOD image %s: Azure image "
+        "push is temporarily disabled due to CI issues.",
+        image,
+    )
+    # tag_without_registry = image.split("/")[-1]
+    # azure_tag = f"{AZURE_REGISTRY_NAME}.azurecr.io/{tag_without_registry}"
+    # _tag_and_push(source=image, target=azure_tag)
 
 
 def build_anyscale_base_byod_images(tests: List[Test]) -> List[str]:

--- a/release/ray_release/custom_byod_build_init_helper.py
+++ b/release/ray_release/custom_byod_build_init_helper.py
@@ -9,7 +9,11 @@ import yaml
 from ray_release.configs.global_config import get_global_config
 from ray_release.logger import logger
 from ray_release.test import Test
-from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX, AZURE_REGISTRY_NAME
+
+# AZURE_REGISTRY_NAME import temporarily removed below: Azure image push is
+# disabled due to CI issues. Re-add `AZURE_REGISTRY_NAME` to the import below
+# when re-enabling the Azure ACR login step in create_custom_build_yaml.
+from ray_release.util import ANYSCALE_RAY_IMAGE_PREFIX
 
 
 def generate_custom_build_step_key(image: str) -> str:
@@ -117,8 +121,12 @@ def create_custom_build_yaml(
                 f"export RAY_WANT_COMMIT_IN_IMAGE={ray_want_commit}",
                 f"bash release/gcloud_docker_login.sh {aws2gce_credentials}",
                 "export PATH=$(pwd)/google-cloud-sdk/bin:$$PATH",
-                "bash release/azure_docker_login.sh",
-                f"az acr login --name {AZURE_REGISTRY_NAME}",
+                # Azure ACR login skipped: Azure image push is temporarily
+                # disabled due to CI issues.
+                "echo 'Skipping Azure ACR login: Azure image push is "
+                "temporarily disabled due to CI issues.'",
+                # "bash release/azure_docker_login.sh",
+                # f"az acr login --name {AZURE_REGISTRY_NAME}",
                 f"aws ecr get-login-password --region {byod_ecr_region} | docker login --username AWS --password-stdin {byod_ecr}",
                 build_cmd,
             ],

--- a/release/ray_release/tests/test_custom_byod_build_init_helper.py
+++ b/release/ray_release/tests/test_custom_byod_build_init_helper.py
@@ -18,7 +18,10 @@ from ray_release.custom_byod_build_init_helper import (
     get_prerequisite_step,
 )
 from ray_release.test import Test
-from ray_release.util import AZURE_REGISTRY_NAME
+
+# AZURE_REGISTRY_NAME import temporarily commented out: the Azure ACR login
+# step it was used to verify is disabled due to CI issues.
+# from ray_release.util import AZURE_REGISTRY_NAME
 
 init_global_config(bazel_runfile("release/ray_release/configs/oss_config.yaml"))
 _GPU_MAP = build_short_gpu_map(bazel_runfile("ray-images.json"))
@@ -162,29 +165,34 @@ def test_create_custom_build_yaml(mock_get_images_from_tests):
                 content["steps"][0]["commands"][1]
                 == f"bash release/gcloud_docker_login.sh {config['aws2gce_credentials']}"
             )
-            assert content["steps"][0]["commands"][4].startswith(
-                "az acr login"
-            ) and content["steps"][0]["commands"][4].endswith(AZURE_REGISTRY_NAME)
+            # Azure ACR login step is replaced by a placeholder echo while
+            # Azure image push is disabled due to CI issues. Verify the
+            # placeholder is present at the expected index instead of an
+            # `az acr login --name <AZURE_REGISTRY_NAME>` command.
+            assert "Skipping Azure ACR login" in content["steps"][0]["commands"][3]
             assert (
                 f"--region {config['byod_ecr_region']}"
-                in content["steps"][0]["commands"][5]
+                in content["steps"][0]["commands"][4]
             )
-            assert f"{config['byod_ecr']}" in content["steps"][0]["commands"][5]
+            assert f"{config['byod_ecr']}" in content["steps"][0]["commands"][4]
             assert (
                 f"--image-name {custom_byod_images[0][0]}"
-                in content["steps"][0]["commands"][6]
+                in content["steps"][0]["commands"][5]
             )
             assert (
                 f"--image-name {custom_byod_images[2][0]}"
-                in content["steps"][1]["commands"][6]
+                in content["steps"][1]["commands"][5]
             )
             assert (
                 f"--image-name {custom_byod_images[3][0]}"
-                in content["steps"][2]["commands"][6]
+                in content["steps"][2]["commands"][5]
             )
             assert content["steps"][3]["depends_on"] == "forge"
-            # Verify env-only image step has --env flags
-            env_only_cmd = content["steps"][4]["commands"][6]
+            # Verify env-only image step has --env flags. Command index
+            # decremented from 6 to 5 because the Azure ACR login command was
+            # collapsed into a single placeholder echo while Azure image push
+            # is disabled due to CI issues.
+            env_only_cmd = content["steps"][4]["commands"][5]
             assert f"--image-name {custom_byod_images[5][0]}" in env_only_cmd
             assert "--env MY_ENV=my_value" in env_only_cmd
             assert "--env OTHER_ENV=other_value" in env_only_cmd


### PR DESCRIPTION
## Description

Temporarily disables the Azure Container Registry push path in the release-test image pipeline while Azure ACR storage limit issues are being resolved out-of-band. AWS ECR and GCP Artifact Registry pushes continue as before. Every disabled block is preserved with a `temporarily disabled due to CI issues` comment plus an explanatory `logger.info` / `echo` line, so re-enabling is a mechanical revert.

**Production code changes**
- `ci/ray_ci/automation/push_release_test_image.py` — drop the Azure entry from the destination `registries` list and skip the `_run_azure_docker_login()` prerequisite. The function definition is intentionally retained so re-enable is a one-line edit.
- `ci/ray_ci/anyscale_docker_container.py` — collapse `azure_docker_login.sh` + `az acr login` into a single placeholder `echo`; comment out the Azure `docker tag` / `docker push` lines inside the alias loop; comment out the now-unused `_AZURE_REGISTRY_NAME` / `_DOCKER_AZURE_REGISTRY` imports.
- `release/ray_release/byod/build.py` — comment out the Azure tag/push at the end of `build_anyscale_custom_byod_image()` and log the skip.
- `release/ray_release/custom_byod_build_init_helper.py` — replace the two Azure login commands in the generated Buildkite step with a single placeholder `echo`.

**Test updates (mirror the production changes)**
- `ci/ray_ci/test_anyscale_docker_container.py` — drop Azure tag/push and Azure login expectations.
- `release/ray_release/tests/test_custom_byod_build_init_helper.py` — replace the `az acr login` assertion with a "Skipping Azure ACR login" substring check and shift command indices by one (two Azure commands collapsed into one placeholder).

## Known follow-up

`Test.get_byod_ecr()` in `release/ray_release/test.py:585-592` still routes `cloud_env == "azure"` tests to `byod_azure_cr`. The only consumer today is the `hello_world_azure` nightly variation in `release/release_tests.yaml:104` — that nightly will fail with image-pull errors (no fresh image at the expected tag) until Azure is re-enabled. Expected and acceptable for the duration of this disable; flagging here for the on-call triaging that test.

## Related issues

> N/A — temporary mitigation while Azure ACR storage cleanup proceeds separately.

## Additional information

**Verification**
- `pre-commit run --files \$(git diff --name-only HEAD)` on the modified set: passed.
- `bazel test //ci/ray_ci/automation:test_push_release_test_image //ci/ray_ci:test_anyscale_docker_container //release:test_custom_byod_build_init_helper //release:test_byod_build`: 4/4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)