### PR TITLE
[CI] Fix presigned URL retry logic caching error responses

### DIFF
--- a/release/ray_release/aws.py
+++ b/release/ray_release/aws.py
@@ -140,7 +140,7 @@ def _retry(f):
 @_retry
 def _get_s3_rayci_test_data_presigned():
     global S3_PRESIGNED_CACHE
-    if S3_PRESIGNED_CACHE is not None and S3_PRESIGNED_CACHE.status_code < 500:
+    if S3_PRESIGNED_CACHE is not None and S3_PRESIGNED_CACHE.status_code == 200:
         return S3_PRESIGNED_CACHE
     auth = BotoAWSRequestsAuth(
         aws_host="vop4ss7n22.execute-api.us-west-2.amazonaws.com",

--- a/release/ray_release/aws.py
+++ b/release/ray_release/aws.py
@@ -140,17 +140,18 @@ def _retry(f):
 @_retry
 def _get_s3_rayci_test_data_presigned():
     global S3_PRESIGNED_CACHE
-    if not S3_PRESIGNED_CACHE:
-        auth = BotoAWSRequestsAuth(
-            aws_host="vop4ss7n22.execute-api.us-west-2.amazonaws.com",
-            aws_region="us-west-2",
-            aws_service="execute-api",
-        )
-        S3_PRESIGNED_CACHE = requests.get(
-            "https://vop4ss7n22.execute-api.us-west-2.amazonaws.com/endpoint/",
-            auth=auth,
-            params={"job_id": os.environ["BUILDKITE_JOB_ID"]},
-        )
+    if S3_PRESIGNED_CACHE is not None and S3_PRESIGNED_CACHE.status_code < 500:
+        return S3_PRESIGNED_CACHE
+    auth = BotoAWSRequestsAuth(
+        aws_host="vop4ss7n22.execute-api.us-west-2.amazonaws.com",
+        aws_region="us-west-2",
+        aws_service="execute-api",
+    )
+    S3_PRESIGNED_CACHE = requests.get(
+        "https://vop4ss7n22.execute-api.us-west-2.amazonaws.com/endpoint/",
+        auth=auth,
+        params={"job_id": os.environ["BUILDKITE_JOB_ID"]},
+    )
     return S3_PRESIGNED_CACHE
 
 


### PR DESCRIPTION
## Summary

- Fix broken retry logic in `_get_s3_rayci_test_data_presigned` that cached HTTP 502 error responses in `S3_PRESIGNED_CACHE`, causing all subsequent retries to return the same cached error instead of making fresh requests
- The `_retry` decorator loops up to 5 times on 500+ status codes, but the inner function's `if not S3_PRESIGNED_CACHE:` guard treated any truthy `Response` object (including 502s) as a valid cache hit

## Details

When the presigned URL endpoint (`vop4ss7n22.execute-api.us-west-2.amazonaws.com`) returns a 502, the response gets stored in `S3_PRESIGNED_CACHE`. On retries 2-5, `S3_PRESIGNED_CACHE` is truthy (it's a `Response` object), so the function skips the HTTP call and returns the same 502. The retry loop sees 502 five times and calls `sys.exit(1)`.

The fix changes the cache check to only return the cached response when it exists AND has a non-5xx status code. Error responses are always re-fetched.

## Test plan

- [x] Verified the logic change: successful responses (< 500) are still cached, server errors trigger fresh requests on retry
- [x] No behavioral change for the happy path — successful responses are cached identically to before