### PR TITLE
Fix accelerator limit calculation for dual-core TPUs

### DIFF
--- a/python/ray/_private/accelerators/accelerator.py
+++ b/python/ray/_private/accelerators/accelerator.py
@@ -156,3 +156,22 @@ class AcceleratorManager(ABC):
             A dictionary mapping accelerator related label keys to values.
         """
         return None
+
+    @staticmethod
+    def get_visible_accelerator_resource_limit(
+        visible_ids: List[str],
+        accelerator_type: Optional[str] = None,
+    ) -> int:
+        """Get the logical resource limit based on visible IDs.
+
+        Examples where resource limit is not simply the length of visible IDs:
+        - For TPUs, one visible ID might represent multiple logical cores.
+
+        Args:
+            visible_ids: List of strings representing visible accelerator IDs.
+            accelerator_type: Optional string representing the accelerator type.
+
+        Returns:
+            The logical resource limit (e.g., number of logical cores).
+        """
+        return len(visible_ids)

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -72,6 +72,7 @@ SINGLE_CORE_TPU_TYPES = ("v5litepod", "v6e")
 # The valid TPU types.
 VALID_TPU_TYPES = ("v2", "v3", "v4", "v5p", "v5litepod", "v6e", "v7x")
 
+
 # This is only used to construct TPU 3D topologies
 def _get_larger_3d_topologies(max_x: int, max_y: int, max_z: int) -> Set[str]:
     """Returns a set of larger 3D TPU topologies given the max x,y,z value. Using DEFAULT_TPU_NUM_CHIPS_PER_HOST as increment"""
@@ -493,18 +494,18 @@ class TPUAcceleratorManager(AcceleratorManager):
             os.environ.pop(TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR, None)
             os.environ.pop(TPU_HOST_BOUNDS_ENV_VAR, None)
             return
-        os.environ[
-            TPUAcceleratorManager.get_visible_accelerator_ids_env_var()
-        ] = ",".join([str(i) for i in visible_tpu_chips])
+        os.environ[TPUAcceleratorManager.get_visible_accelerator_ids_env_var()] = (
+            ",".join([str(i) for i in visible_tpu_chips])
+        )
         if num_visible_tpu_chips == 1:
-            os.environ[
-                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
-            ] = TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
+            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
+                TPU_CHIPS_PER_HOST_BOUNDS_1_CHIP_CONFIG
+            )
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
         elif num_visible_tpu_chips == 2:
-            os.environ[
-                TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR
-            ] = TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
+            os.environ[TPU_CHIPS_PER_HOST_BOUNDS_ENV_VAR] = (
+                TPU_CHIPS_PER_HOST_BOUNDS_2_CHIP_CONFIG
+            )
             os.environ[TPU_HOST_BOUNDS_ENV_VAR] = TPU_SINGLE_HOST_BOUNDS
 
     @staticmethod
@@ -787,6 +788,13 @@ class TPUAcceleratorManager(AcceleratorManager):
         if accelerator_type is None:
             accelerator_type = TPUAcceleratorManager.get_current_node_tpu_pod_type()
 
+        if accelerator_type is not None:
+            # Normalize Ray accelerator types: "TPU-V6E" -> "v6e", "TPU-V4" -> "v4"
+            accelerator_type = accelerator_type.lower().replace("tpu-", "")
+            # Normalize "tpu7x-16" -> "v7x-16" to match VALID_TPU_TYPES
+            if accelerator_type.startswith("tpu"):
+                accelerator_type = "v" + accelerator_type[3:]
+
         if not accelerator_type:
             return len(visible_tpu_chips) * DEFAULT_TPU_NUM_CORES_PER_CHIP
 
@@ -795,5 +803,3 @@ class TPUAcceleratorManager(AcceleratorManager):
             return len(visible_tpu_chips) * cores_per_chip
         except Exception:
             return len(visible_tpu_chips) * DEFAULT_TPU_NUM_CORES_PER_CHIP
-
-

--- a/python/ray/_private/accelerators/tpu.py
+++ b/python/ray/_private/accelerators/tpu.py
@@ -764,3 +764,36 @@ class TPUAcceleratorManager(AcceleratorManager):
             tpu_labels[ray._raylet.RAY_NODE_TPU_POD_TYPE_KEY] = pod_type
 
         return tpu_labels
+
+    @staticmethod
+    def get_visible_accelerator_resource_limit(
+        visible_tpu_chips: List[str],
+        accelerator_type: Optional[str] = None,
+    ) -> int:
+        """For TPUs, each visible ID in TPU_VISIBLE_CHIPS represents a physical chip.
+        The logical TPU resource count (TensorCores) is:
+        len(visible_tpu_chips) * cores_per_chip.
+
+        Args:
+            visible_tpu_chips: List of strings representing visible TPU chips.
+            accelerator_type: Optional string representing the accelerator type.
+
+        Returns:
+            The logical TPU resource limit (TensorCores).
+        """
+        if not visible_tpu_chips:
+            return 0
+
+        if accelerator_type is None:
+            accelerator_type = TPUAcceleratorManager.get_current_node_tpu_pod_type()
+
+        if not accelerator_type:
+            return len(visible_tpu_chips) * DEFAULT_TPU_NUM_CORES_PER_CHIP
+
+        try:
+            cores_per_chip = get_tpu_cores_per_chip(accelerator_type)
+            return len(visible_tpu_chips) * cores_per_chip
+        except Exception:
+            return len(visible_tpu_chips) * DEFAULT_TPU_NUM_CORES_PER_CHIP
+
+

--- a/python/ray/_private/resource_and_label_spec.py
+++ b/python/ray/_private/resource_and_label_spec.py
@@ -346,19 +346,26 @@ class ResourceAndLabelSpec:
         visible_accelerator_ids = (
             accelerator_manager.get_current_process_visible_accelerator_ids()
         )
+        accelerator_type = accelerator_manager.get_current_node_accelerator_type()
+
+        visible_limit = None
+        if visible_accelerator_ids is not None:
+            visible_limit = accelerator_manager.get_visible_accelerator_resource_limit(
+                visible_accelerator_ids, accelerator_type
+            )
 
         # Check that the number of accelerators that the raylet wants doesn't
         # exceed the amount allowed by visible accelerator ids.
         if (
             num_accelerators is not None
-            and visible_accelerator_ids is not None
-            and num_accelerators > len(visible_accelerator_ids)
+            and visible_limit is not None
+            and num_accelerators > visible_limit
         ):
             raise ValueError(
                 f"Attempting to start raylet with {num_accelerators} "
                 f"{accelerator_resource_name}, "
                 f"but {accelerator_manager.get_visible_accelerator_ids_env_var()} "
-                f"contains {visible_accelerator_ids}."
+                f"allows only up to {visible_limit} (parsed from visible IDs: {visible_accelerator_ids})."
             )
 
         if accelerator_resource_name == "GPU":
@@ -366,7 +373,6 @@ class ResourceAndLabelSpec:
         else:
             self.resources[accelerator_resource_name] = num_accelerators
 
-        accelerator_type = accelerator_manager.get_current_node_accelerator_type()
         if accelerator_type:
             self.resources[f"{RESOURCE_CONSTRAINT_PREFIX}{accelerator_type}"] = 1
         additional_resources = (
@@ -405,7 +411,6 @@ class ResourceAndLabelSpec:
             self.object_store_memory = ray._private.utils.resolve_object_store_memory(
                 available_memory_bytes
             )
-
         memory = self.memory
         if memory is None:
             memory = available_memory_bytes - self.object_store_memory
@@ -420,7 +425,6 @@ class ResourceAndLabelSpec:
                         round(memory / 1e9, 2), int(100 * (memory / system_memory))
                     )
                 )
-
         self.memory = memory
 
     @staticmethod
@@ -463,11 +467,15 @@ class ResourceAndLabelSpec:
                     accelerator_manager.get_current_process_visible_accelerator_ids()
                 )
                 if visible_accelerator_ids is not None:
-                    num_accelerators = min(
-                        num_accelerators, len(visible_accelerator_ids)
+                    accelerator_type = accelerator_manager.get_current_node_accelerator_type()
+                    visible_limit = accelerator_manager.get_visible_accelerator_resource_limit(
+                        visible_accelerator_ids, accelerator_type
                     )
-
+                    num_accelerators = min(
+                        num_accelerators, visible_limit
+                    )
             if num_accelerators > 0:
                 return accelerator_manager, num_accelerators
-
         return None, 0
+
+

--- a/python/ray/_private/resource_and_label_spec.py
+++ b/python/ray/_private/resource_and_label_spec.py
@@ -96,9 +96,7 @@ class ResourceAndLabelSpec:
         for resource_label, resource_quantity in resources.items():
             assert isinstance(resource_quantity, int) or isinstance(
                 resource_quantity, float
-            ), (
-                f"{resource_label} ({type(resource_quantity)}): " f"{resource_quantity}"
-            )
+            ), f"{resource_label} ({type(resource_quantity)}): {resource_quantity}"
             if (
                 isinstance(resource_quantity, float)
                 and not resource_quantity.is_integer()
@@ -293,9 +291,9 @@ class ResourceAndLabelSpec:
         if accelerator_manager:
             accelerator_type = accelerator_manager.get_current_node_accelerator_type()
             if accelerator_type:
-                default_labels[
-                    ray._raylet.RAY_NODE_ACCELERATOR_TYPE_KEY
-                ] = accelerator_type
+                default_labels[ray._raylet.RAY_NODE_ACCELERATOR_TYPE_KEY] = (
+                    accelerator_type
+                )
 
             # Set TPU specific default labels to enable multi-host scheduling.
             if accelerator_manager.get_resource_name() == "TPU":
@@ -467,15 +465,15 @@ class ResourceAndLabelSpec:
                     accelerator_manager.get_current_process_visible_accelerator_ids()
                 )
                 if visible_accelerator_ids is not None:
-                    accelerator_type = accelerator_manager.get_current_node_accelerator_type()
-                    visible_limit = accelerator_manager.get_visible_accelerator_resource_limit(
-                        visible_accelerator_ids, accelerator_type
+                    accelerator_type = (
+                        accelerator_manager.get_current_node_accelerator_type()
                     )
-                    num_accelerators = min(
-                        num_accelerators, visible_limit
+                    visible_limit = (
+                        accelerator_manager.get_visible_accelerator_resource_limit(
+                            visible_accelerator_ids, accelerator_type
+                        )
                     )
+                    num_accelerators = min(num_accelerators, visible_limit)
             if num_accelerators > 0:
                 return accelerator_manager, num_accelerators
         return None, 0
-
-

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -345,16 +345,28 @@ def test_get_num_tpu_visible_chips_per_host():
 @pytest.mark.parametrize(
     "visible_chips, accelerator_type, expected_limit",
     [
-        (["0", "1"], "v6e-8", 2),          # v6e has 1 core per chip (2 chips -> 2 cores)
-        (["0", "1", "2", "3"], "tpu7x-16", 8), # tpu7x has 2 cores per chip (4 chips -> 8 cores)
-        (["0", "1"], "v4-8", 4),           # v4 has 2 cores per chip (2 chips -> 4 cores)
-        (["0", "1"], None, 4),             # fallback default (2 cores per chip)
-        ([], "tpu7x-16", 0),               # empty visible chips list
+        (["0", "1"], "v6e-8", 2),  # GCP pod type (1 core/chip)
+        (["0", "1"], "TPU-V6E", 2),  # Ray internal type (1 core/chip)
+        (["0", "1", "2", "3"], "tpu7x-16", 8),  # GCP pod type (2 cores/chip)
+        (["0", "1"], "v4-8", 4),  # GCP pod type (2 cores/chip)
+        (["0", "1"], "TPU-V4", 4),  # Ray internal type (2 cores/chip)
+        (["0", "1"], None, 4),  # Fallback default (2 cores/chip)
+        ([], "tpu7x-16", 0),  # Empty list
     ],
 )
-def test_get_visible_accelerator_resource_limit(visible_chips, accelerator_type, expected_limit):
-    with patch("ray._private.accelerators.tpu.TPUAcceleratorManager.get_current_node_tpu_pod_type", return_value=accelerator_type):
-        assert TPUAcceleratorManager.get_visible_accelerator_resource_limit(visible_chips, accelerator_type) == expected_limit
+def test_get_visible_accelerator_resource_limit(
+    visible_chips, accelerator_type, expected_limit
+):
+    with patch(
+        "ray._private.accelerators.tpu.TPUAcceleratorManager.get_current_node_tpu_pod_type",
+        return_value=accelerator_type,
+    ):
+        assert (
+            TPUAcceleratorManager.get_visible_accelerator_resource_limit(
+                visible_chips, accelerator_type
+            )
+            == expected_limit
+        )
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/accelerators/test_tpu.py
+++ b/python/ray/tests/accelerators/test_tpu.py
@@ -342,5 +342,20 @@ def test_get_num_tpu_visible_chips_per_host():
     assert tpu.get_num_tpu_visible_chips_per_host("v5p-8") == 4
 
 
+@pytest.mark.parametrize(
+    "visible_chips, accelerator_type, expected_limit",
+    [
+        (["0", "1"], "v6e-8", 2),          # v6e has 1 core per chip (2 chips -> 2 cores)
+        (["0", "1", "2", "3"], "tpu7x-16", 8), # tpu7x has 2 cores per chip (4 chips -> 8 cores)
+        (["0", "1"], "v4-8", 4),           # v4 has 2 cores per chip (2 chips -> 4 cores)
+        (["0", "1"], None, 4),             # fallback default (2 cores per chip)
+        ([], "tpu7x-16", 0),               # empty visible chips list
+    ],
+)
+def test_get_visible_accelerator_resource_limit(visible_chips, accelerator_type, expected_limit):
+    with patch("ray._private.accelerators.tpu.TPUAcceleratorManager.get_current_node_tpu_pod_type", return_value=accelerator_type):
+        assert TPUAcceleratorManager.get_visible_accelerator_resource_limit(visible_chips, accelerator_type) == expected_limit
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
## Description
When TPU_VISIBLE_CHIPS is present, current resource limit clamps to chip count. It should be core count instead.

## Related issues
N/A

## Additional information
N/A
