### PR TITLE
[RLlib] Fix and introduce test for hanging aggregator actor calls

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -1697,6 +1697,17 @@ py_test(
     deps = [":conftest"],
 )
 
+py_test(
+    name = "test_aggregator_actor",
+    size = "small",
+    srcs = ["algorithms/tests/test_aggregator_actor.py"],
+    tags = [
+        "algorithms",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
 # Specific Algorithms
 
 # APPO

--- a/rllib/algorithms/tests/test_aggregator_actor.py
+++ b/rllib/algorithms/tests/test_aggregator_actor.py
@@ -1,0 +1,54 @@
+import sys
+import time
+
+import pytest
+
+import ray
+from ray.rllib.algorithms.utils import _collect_episodes
+
+
+def _good_ref(steps: int) -> ray.ObjectRef:
+    # num_cpus=0 so resource-constrained CI runners don't queue these.
+    return ray.remote(num_cpus=0)(lambda: [bytearray(steps)]).remote()
+
+
+def _stuck_ref() -> ray.ObjectRef:
+    """Ref that never resolves and never raises.
+
+    This models a lost owner that is not surfaced by Ray Core.
+    """
+
+    @ray.remote(num_cpus=0)
+    def _hang() -> list:
+        time.sleep(10**9)
+        return [bytearray(0)]
+
+    return _hang.remote()
+
+
+@pytest.mark.parametrize(
+    "make_refs, expected_env_steps, expected_drops",
+    [
+        pytest.param(lambda: [_good_ref(5), _good_ref(5)], 10, 0, id="all-good"),
+        pytest.param(
+            lambda: [_good_ref(10), _stuck_ref(), _good_ref(7)],
+            17,
+            1,
+            id="one-stuck-dropped",
+        ),
+        pytest.param(lambda: [_stuck_ref() for _ in range(3)], 0, 3, id="all-stuck"),
+    ],
+)
+def test_collect_episodes_drops_unfetchable_refs(
+    make_refs, expected_env_steps: int, expected_drops: int
+):
+    episodes, dropped = _collect_episodes(
+        make_refs(), bulk_timeout_s=2.0, per_ref_timeout_s=1.0
+    )
+
+    assert sum(len(e) for e in episodes) == expected_env_steps
+    assert dropped == expected_drops
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/rllib/algorithms/utils.py
+++ b/rllib/algorithms/utils.py
@@ -1,5 +1,6 @@
+import logging
 import platform
-from typing import List
+from typing import List, Tuple
 
 import tree  # pip install dm_tree
 
@@ -18,6 +19,69 @@ from ray.util.annotations import DeveloperAPI
 from ray.util.metrics import Counter, Histogram
 
 torch, _ = try_import_torch()
+
+logger = logging.getLogger(__name__)
+
+# Timeouts for `ray.get` on episode refs inside `AggregatorActor.get_batch`.
+# Without a timeout, a wedged ref can block the aggregator forever — e.g. when
+# the producing EnvRunner is preempted and restarted on a spot node, the
+# owner-death notification can be lost (the GCS drops the producer task's
+# status), so `OwnerDiedError` is never raised and the plasma Pull retries
+# indefinitely. The bulk timeout bounds the common-case fetch; the per-ref
+# timeout bounds the fallback so a single wedged ref cannot stall the others.
+GET_BATCH_BULK_TIMEOUT_S = 600.0
+GET_BATCH_PER_REF_TIMEOUT_S = 60.0
+
+# Exceptions that mean an episode ref is permanently unfetchable and should be
+# dropped rather than retried.
+_UNFETCHABLE_REF_EXCEPTIONS = (
+    ray.exceptions.GetTimeoutError,
+    ray.exceptions.OwnerDiedError,
+    ray.exceptions.ObjectLostError,
+    ray.exceptions.ObjectFetchTimedOutError,
+    ray.exceptions.RayActorError,
+    ray.exceptions.WorkerCrashedError,
+    ray.exceptions.NodeDiedError,
+)
+
+
+def _collect_episodes(
+    episode_refs: List[ray.ObjectRef],
+    bulk_timeout_s: float = GET_BATCH_BULK_TIMEOUT_S,
+    per_ref_timeout_s: float = GET_BATCH_PER_REF_TIMEOUT_S,
+) -> Tuple[List[EpisodeType], int]:
+    """Resolve a list of episode refs with bounded waits.
+
+    Tries one bulk ``ray.get`` first; on failure, falls back to fetching each
+    ref individually and drops the unfetchable ones. See the module-level
+    comment on ``GET_BATCH_BULK_TIMEOUT_S`` for why the timeouts are needed.
+
+    Returns ``(episodes, num_dropped)``.
+    """
+    try:
+        return tree.flatten(ray.get(episode_refs, timeout=bulk_timeout_s)), 0
+    except _UNFETCHABLE_REF_EXCEPTIONS as bulk_err:
+        logger.warning(
+            "Bulk ray.get on %d episode refs failed (%s); falling back to "
+            "per-ref fetch.",
+            len(episode_refs),
+            type(bulk_err).__name__,
+        )
+
+    episodes: List[EpisodeType] = []
+    dropped = 0
+    for ref in episode_refs:
+        try:
+            episodes.extend(ray.get(ref, timeout=per_ref_timeout_s))
+        except _UNFETCHABLE_REF_EXCEPTIONS:
+            dropped += 1
+    if dropped:
+        logger.warning(
+            "Dropped %d/%d unfetchable episode refs after per-ref fallback.",
+            dropped,
+            len(episode_refs),
+        )
+    return episodes, dropped
 
 
 @DeveloperAPI(stability="alpha")
@@ -118,18 +182,10 @@ class AggregatorActor(FaultAwareApply):
             if len(episode_refs) > 0:
                 self._metrics_get_batch_input_episode_refs.inc(value=len(episode_refs))
 
-            episodes: List[EpisodeType] = []
-            # It's possible that individual refs are invalid due to the EnvRunner
-            # that produced the ref has crashed or had its entire node go down.
-            # In this case, try each ref individually and collect only valid results.
-            try:
-                episodes = tree.flatten(ray.get(episode_refs))
-            except ray.exceptions.OwnerDiedError:
-                for ref in episode_refs:
-                    try:
-                        episodes.extend(ray.get(ref))
-                    except ray.exceptions.OwnerDiedError:
-                        self._metrics_episode_owner_died.inc(value=1)
+            # Resolve refs with bounded waits
+            episodes, dropped = _collect_episodes(episode_refs)
+            if dropped:
+                self._metrics_episode_owner_died.inc(value=dropped)
 
             env_steps = sum(len(e) for e in episodes)
 


### PR DESCRIPTION
## Description
Enables aggregator actors's "ray.get(episodes)" calls to time out.