### PR TITLE
[data] Disable DataSourceV2 by default

### DIFF
--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -77,7 +77,7 @@ DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
 
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
-DEFAULT_USE_DATASOURCE_V2 = True
+DEFAULT_USE_DATASOURCE_V2 = False
 
 # Default target chunk size for ``ParquetFileChunker``. ``None`` means the chunker
 # uses its built-in default (currently 1 GiB).

--- a/python/ray/data/tests/datasource/test_parquet.py
+++ b/python/ray/data/tests/datasource/test_parquet.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import pathlib
 import pickle
@@ -201,7 +202,10 @@ def test_include_paths(
 
 
 def test_include_paths_with_column_projection(
-    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+    ray_start_regular_shared,
+    tmp_path,
+    target_max_block_size_infinite_or_default,
+    use_datasource_v2,
 ):
     path = os.path.join(tmp_path, "test.parquet")
     table = pa.Table.from_pydict({"animals": ["cat", "dog"], "id": [1, 2]})
@@ -209,8 +213,15 @@ def test_include_paths_with_column_projection(
 
     # Exercises the deprecated ``columns=`` arg: V1 retained ``"path"``
     # implicitly under ``include_paths=True``, and read_api preserves that
-    # by appending it to the projection on the caller's behalf.
-    with pytest.warns(DeprecationWarning, match="`columns=` on `read_parquet`"):
+    # by appending it to the projection on the caller's behalf. The
+    # deprecation warning is emitted only on the V2 path.
+    if ray.data.DataContext.get_current().use_datasource_v2:
+        warn_ctx = pytest.warns(
+            DeprecationWarning, match="`columns=` on `read_parquet`"
+        )
+    else:
+        warn_ctx = contextlib.nullcontext()
+    with warn_ctx:
         ds = ray.data.read_parquet(path, columns=["id"], include_paths=True)
 
     schema_names = ds.schema().names
@@ -295,7 +306,10 @@ def test_include_row_hash_same_data_different_files(
 
 
 def test_include_row_hash_with_column_projection(
-    ray_start_regular_shared, tmp_path, target_max_block_size_infinite_or_default
+    ray_start_regular_shared,
+    tmp_path,
+    target_max_block_size_infinite_or_default,
+    use_datasource_v2,
 ):
     path = os.path.join(tmp_path, "test.parquet")
     table = pa.Table.from_pydict({"a": [1, 2], "b": [3, 4]})
@@ -303,8 +317,15 @@ def test_include_row_hash_with_column_projection(
 
     # Exercises the deprecated ``columns=`` arg: V1 retained ``"row_hash"``
     # implicitly under ``include_row_hash=True``, and read_api preserves
-    # that by appending it to the projection on the caller's behalf.
-    with pytest.warns(DeprecationWarning, match="`columns=` on `read_parquet`"):
+    # that by appending it to the projection on the caller's behalf. The
+    # deprecation warning is emitted only on the V2 path.
+    if ray.data.DataContext.get_current().use_datasource_v2:
+        warn_ctx = pytest.warns(
+            DeprecationWarning, match="`columns=` on `read_parquet`"
+        )
+    else:
+        warn_ctx = contextlib.nullcontext()
+    with warn_ctx:
         ds = ray.data.read_parquet(path, columns=["a"], include_row_hash=True)
     schema_names = ds.schema().names
     assert "a" in schema_names
@@ -1781,9 +1802,10 @@ def test_read_null_data_in_first_file(
 
 
 def test_read_parquet_does_not_call_infer_schema(
-    tmp_path, monkeypatch, ray_start_regular_shared
+    tmp_path, monkeypatch, ray_start_regular_shared, use_datasource_v2
 ):
-    """read_parquet should not call _infer_schema, which can cause O(N) metadata reads."""
+    """The V2 read path should not call _infer_schema, which can cause O(N)
+    metadata reads. V1 still calls it to reconcile per-file schemas."""
 
     num_files = 10
     for i in range(num_files):
@@ -1801,7 +1823,10 @@ def test_read_parquet_does_not_call_infer_schema(
     )
     mock.return_value = pa.schema({"data": pa.int64()})
     ray.data.read_parquet(str(tmp_path))
-    mock.assert_not_called()
+    if ray.data.DataContext.get_current().use_datasource_v2:
+        mock.assert_not_called()
+    else:
+        mock.assert_called()
 
 
 def test_parquet_row_group_size_001(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/test_streaming_executor.py
+++ b/python/ray/data/tests/test_streaming_executor.py
@@ -1180,21 +1180,27 @@ def test_execution_callbacks_executor_arg(tmp_path, restore_data_context):
         assert isinstance(datasink, ParquetDatasink)
         assert datasink.unresolved_path == output_path
     else:
-        assert len(_executor._topology) == 2
+        # V1 inserts a ``SplitBlocks`` after the read to hit the target
+        # number of output blocks, which prevents the read from fusing
+        # with the downstream ``Map(udf)->Write`` op.
+        assert len(_executor._topology) == 3
         assert isinstance(physical_ops[1], MapOperator)
-        logical_ops = physical_ops[1]._logical_operators
+        assert isinstance(physical_ops[2], MapOperator)
 
-        assert len(logical_ops) == 3
-        assert isinstance(logical_ops[0], Read)
-        datasource = logical_ops[0].datasource
+        read_logical_ops = physical_ops[1]._logical_operators
+        assert len(read_logical_ops) == 1
+        assert isinstance(read_logical_ops[0], Read)
+        datasource = read_logical_ops[0].datasource
         assert isinstance(datasource, ParquetDatasource)
         assert datasource._source_paths == input_path
 
-        assert isinstance(logical_ops[1], MapRows)
-        assert logical_ops[1].fn == udf
+        map_write_logical_ops = physical_ops[2]._logical_operators
+        assert len(map_write_logical_ops) == 2
+        assert isinstance(map_write_logical_ops[0], MapRows)
+        assert map_write_logical_ops[0].fn == udf
 
-        assert isinstance(logical_ops[2], Write)
-        datasink = logical_ops[2].datasink_or_legacy_datasource
+        assert isinstance(map_write_logical_ops[1], Write)
+        datasink = map_write_logical_ops[1].datasink_or_legacy_datasource
         assert isinstance(datasink, ParquetDatasink)
         assert datasink.unresolved_path == output_path
 


### PR DESCRIPTION
## Summary

Flip ``DEFAULT_USE_DATASOURCE_V2`` from ``True`` to ``False``. V2 currently OOMs on shuffle-heavy workloads because ``ReadFiles.infer_metadata()`` returns no ``size_bytes``, dropping ``HashShufflingOperatorBase._get_default_aggregator_ray_remote_args`` into its 1-GiB-per-aggregator fallback. Most visibly: TPC-H Q9 SF=100 autoscaling release test fails with ``HashShuffleAggregator`` actor death from host-level OOM.

The fix (sample-extrapolated ``size_bytes`` surfaced via ``ReadFiles.infer_metadata``) is on a separate branch — flipping this off keeps master green until that lands and the release tests pass.

Users can still opt in via ``DataContext.use_datasource_v2 = True``.

## Test plan

- [ ] CI is green with V1 default (no V2 regressions reintroduced).
- [ ] Run TPC-H Q9 autoscaling release test on master with this flip — expect pass.
- [ ] Confirm ``read_parquet`` users on V1 path see unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)