### PR TITLE
[Data] Add locality hints and single-node variant to backpressure training prefetch benchmark

### DIFF
--- a/release/nightly_tests/dataset/backpressure_benchmark.py
+++ b/release/nightly_tests/dataset/backpressure_benchmark.py
@@ -23,6 +23,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--consumer-sleep-s", type=float, default=1.0)
     parser.add_argument("--num-trainers", type=int, default=8)
     parser.add_argument("--prefetch-batches", type=int, default=8)
+    parser.add_argument(
+        "--disable-locality-hints",
+        action="store_true",
+        default=False,
+        help="Disable locality hints for streaming_split",
+    )
     return parser.parse_args()
 
 
@@ -78,12 +84,6 @@ def run_training_prefetch(args: argparse.Namespace):
         output_row_bytes=args.output_row_bytes,
     )
 
-    iterators = (
-        ray.data.from_blocks(make_inputs(args.num_input_blocks))
-        .map_batches(producer)
-        .streaming_split(args.num_trainers, equal=True)
-    )
-
     trainers = [
         Trainer.options(scheduling_strategy="SPREAD").remote(
             consumer_sleep_s=args.consumer_sleep_s,
@@ -91,6 +91,21 @@ def run_training_prefetch(args: argparse.Namespace):
         )
         for _ in range(args.num_trainers)
     ]
+
+    trainer_node_ids = ray.get([trainer.get_node_id.remote() for trainer in trainers])
+
+    iterators = (
+        ray.data.from_blocks(make_inputs(args.num_input_blocks))
+        .map_batches(producer)
+        .streaming_split(
+            args.num_trainers,
+            equal=True,
+            locality_hints=trainer_node_ids
+            if not args.disable_locality_hints
+            else None,
+        )
+    )
+
     ray.get(
         [
             trainers[i].train.remote(iterators[i], batch_size=args.output_batch_rows)
@@ -113,6 +128,9 @@ class Trainer:
             prefetch_batches=self._prefetch_batches,
         ):
             time.sleep(self._consumer_sleep_s)
+
+    def get_node_id(self) -> str:
+        return ray.get_runtime_context().get_node_id()
 
 
 def main(args: argparse.Namespace):

--- a/release/nightly_tests/dataset/fixed_size_1_cpu_compute.yaml
+++ b/release/nightly_tests/dataset/fixed_size_1_cpu_compute.yaml
@@ -1,0 +1,7 @@
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node:
+    instance_type: m5.2xlarge

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -672,8 +672,17 @@
 
   run:
     timeout: 3600
-    script: >
-      python backpressure_benchmark.py --case training-prefetch
+
+  variations:
+    - __suffix__: multi_node
+      run:
+        script: python backpressure_benchmark.py --case training-prefetch
+
+    - __suffix__: single_node
+      cluster:
+        cluster_compute: fixed_size_1_cpu_compute.yaml
+      run:
+        script: python backpressure_benchmark.py --case training-prefetch --num-trainers 1
 
 
 ########################


### PR DESCRIPTION
  ## Summary
  - Add locality hints to `streaming_split` in the backpressure training prefetch benchmark, passing trainer node IDs so splits are opportunistically assigned to co-located consumers (with a `--disable-locality-hints` flag to opt out)
  - Add a `single_node` variant of the `backpressure_training_prefetch` release test that runs on a single m5.2xlarge with 1 trainer, alongside the existing `multi_node` variant (8 workers, 8 trainers). This is an even more basic spilling repro that rules out other confounding issues like cross-node copies and locality.
  - Add `fixed_size_1_cpu_compute.yaml` compute config (head node only, no workers)