### PR TITLE
[serve] deflake test_metrics

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1602,13 +1602,14 @@ def get_metric_dictionaries(
         timeseries = PrometheusTimeseries()
 
     def metric_available() -> bool:
-        assert name in fetch_prometheus_metric_timeseries(
+        prom_timeseries = fetch_prometheus_metric_timeseries(
             [f"localhost:{TEST_METRICS_EXPORT_PORT}"],
             timeseries,
             # pass timeout to fetch_prometheus_metric_timeseries
             # so the test doesn't hang on requests.get
             timeout=timeout,
         )
+        assert name in prom_timeseries, f"Metric {name} not found in prom_timeseries {prom_timeseries}"
         return True
 
     if wait:

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1611,7 +1611,7 @@ def get_metric_dictionaries(
         )
         assert (
             name in prom_timeseries
-        ), f"Metric {name} not found in prom_timeseries {prom_timeseries}"
+        ), f"Metric {name} not found. Available metrics: {list(prom_timeseries.keys())}"
         return True
 
     if wait:

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -1609,7 +1609,9 @@ def get_metric_dictionaries(
             # so the test doesn't hang on requests.get
             timeout=timeout,
         )
-        assert name in prom_timeseries, f"Metric {name} not found in prom_timeseries {prom_timeseries}"
+        assert (
+            name in prom_timeseries
+        ), f"Metric {name} not found in prom_timeseries {prom_timeseries}"
         return True
 
     if wait:

--- a/python/ray/serve/tests/conftest.py
+++ b/python/ray/serve/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import random
+import socket
 import subprocess
 import tempfile
 from contextlib import contextmanager
@@ -317,11 +318,47 @@ def manage_ray_with_telemetry(monkeypatch):
         wait_for_condition(check_ray_stopped, timeout=5)
 
 
+def wait_for_metrics_port_free(port=TEST_METRICS_EXPORT_PORT, timeout=30):
+    """
+    Ensures the metrics export port is freed.
+    """
+
+    def port_free():
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            s.bind(("", port))
+            return True
+        except OSError:
+            return False
+        finally:
+            s.close()
+
+    wait_for_condition(port_free, timeout=timeout, retry_interval_ms=200)
+
+
+def wait_for_metrics_endpoint(session_name, port=TEST_METRICS_EXPORT_PORT, timeout=30):
+    """
+    Ensures the current dashboard agent is serving the metrics endpoint. A
+    timeout indicates another agent is still running and holding the port.
+    """
+
+    def ready():
+        try:
+            resp = httpx.get(f"http://localhost:{port}/metrics", timeout=1.0)
+        except Exception:
+            return False
+        return resp.status_code == 200 and f'SessionName="{session_name}"' in resp.text
+
+    wait_for_condition(ready, timeout=timeout, retry_interval_ms=500)
+
+
 @pytest.fixture
 def metrics_start_shutdown(request):
     param = request.param if hasattr(request, "param") else None
     request_timeout_s = param if param else None
     """Fixture provides a fresh Ray cluster to prevent metrics state sharing."""
+    wait_for_metrics_port_free()
     ray.init(
         _metrics_export_port=TEST_METRICS_EXPORT_PORT,
         _system_config={
@@ -331,17 +368,8 @@ def metrics_start_shutdown(request):
     )
 
     try:
-        # Wait for metrics endpoint to be ready before starting Serve
-        def metrics_endpoint_ready():
-            try:
-                resp = httpx.get(
-                    f"http://localhost:{TEST_METRICS_EXPORT_PORT}", timeout=1.0
-                )
-                return resp.status_code == 200
-            except Exception:
-                return False
-
-        wait_for_condition(metrics_endpoint_ready, timeout=30, retry_interval_ms=500)
+        session_name = ray._private.worker._global_node.session_name
+        wait_for_metrics_endpoint(session_name)
 
         grpc_port = 9000
         grpc_servicer_functions = [

--- a/python/ray/serve/tests/test_metrics_haproxy.py
+++ b/python/ray/serve/tests/test_metrics_haproxy.py
@@ -40,7 +40,11 @@ from ray.serve import HTTPOptions
 from ray.serve._private.long_poll import LongPollHost, UpdatedObject
 from ray.serve._private.test_utils import get_application_url, get_metric_dictionaries
 from ray.serve._private.utils import block_until_http_ready
-from ray.serve.tests.conftest import TEST_METRICS_EXPORT_PORT
+from ray.serve.tests.conftest import (
+    TEST_METRICS_EXPORT_PORT,
+    wait_for_metrics_endpoint,
+    wait_for_metrics_port_free,
+)
 from ray.util.state import list_actors
 
 
@@ -49,6 +53,7 @@ def metrics_start_shutdown(request):
     """Fixture provides a fresh Ray cluster to prevent metrics state sharing."""
     param = request.param if hasattr(request, "param") else None
     request_timeout_s = param if param else None
+    wait_for_metrics_port_free()
     ray.init(
         _metrics_export_port=TEST_METRICS_EXPORT_PORT,
         _system_config={
@@ -56,15 +61,19 @@ def metrics_start_shutdown(request):
             "task_retry_delay_ms": 50,
         },
     )
-    yield serve.start(
-        http_options=HTTPOptions(
-            host="0.0.0.0",
-            request_timeout_s=request_timeout_s,
-        ),
-    )
-    serve.shutdown()
-    ray.shutdown()
-    reset_ray_address()
+    try:
+        session_name = ray._private.worker._global_node.session_name
+        wait_for_metrics_endpoint(session_name)
+        yield serve.start(
+            http_options=HTTPOptions(
+                host="0.0.0.0",
+                request_timeout_s=request_timeout_s,
+            ),
+        )
+    finally:
+        serve.shutdown()
+        ray.shutdown()
+        reset_ray_address()
 
 
 def extract_tags(line: str) -> Dict[str, str]:


### PR DESCRIPTION
Metrics tests are primarily flaky because the metric we check for isn't in the exported set of metrics Prometheus gives us. This is possible when the metrics endpoint we scrape belongs to a stale dashboard agent (an old process from a previous test that we aren't pushing metrics to anymore). 

Since each metrics test starts and shuts down it's own ray cluster, the dashboard agent from the previous ray cluster may still be cleaning up by the time a new test has begun it's start up sequence. This will cause the new ray cluster's dashboard agent to start but silently fail when binding it's http server to the metrics port. This causes metrics to be pushed to the new dashboard agent, but served by the server of the old agent, causing flakiness.

This PR addresses this issue by ensuring the metrics port is bindable before starting the ray cluster. To make bind failures clearer, we also enforce the metrics endpoint returns metrics of the current cluster before starting the test. If this check fails, we know the test failed because the metrics server was not setup properly.