### PR TITLE
[serve] Retain recently-stopped replica logs in the dashboard

### DIFF
--- a/python/ray/dashboard/client/src/components/StatusChip.tsx
+++ b/python/ray/dashboard/client/src/components/StatusChip.tsx
@@ -76,6 +76,7 @@ const getColorMap = (orange: string, grey: string) =>
       [ServeReplicaState.RECOVERING]: orange,
       [ServeReplicaState.RUNNING]: green,
       [ServeReplicaState.STOPPING]: red,
+      [ServeReplicaState.STOPPED]: grey,
     },
     serveProxy: {
       [ServeSystemActorStatus.HEALTHY]: green,

--- a/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.component.test.tsx
@@ -5,6 +5,7 @@ import {
   MultiTabLogViewer,
   MultiTabLogViewerTabDetails,
 } from "../../common/MultiTabLogViewer";
+import { ServeReplicaState } from "../../type/serve";
 import { TEST_APP_WRAPPER } from "../../util/test-utils";
 import { ServeEntityLogViewer } from "./ServeEntityLogViewer";
 
@@ -290,5 +291,58 @@ describe("ServeEntityLogViewer", () => {
     expect(screen.queryByText("HTTP Proxy")).not.toBeInTheDocument();
     expect(screen.getByText("Deployment replica")).toBeVisible();
     expect(screen.getByTestId("replicas-select")).toBeVisible();
+  });
+
+  it("shows recently-stopped replicas in the dropdown, labeled (stopped)", async () => {
+    expect.assertions(3);
+
+    render(
+      <ServeEntityLogViewer
+        deployments={
+          [
+            {
+              name: "test-deployment",
+              replicas: [
+                {
+                  replica_id: "live-replica",
+                  actor_id: "live-actor",
+                  node_id: "live-node",
+                  log_file_path: "live-log",
+                },
+              ],
+              dead_replicas: [
+                {
+                  replica_id: "dead-replica",
+                  state: ServeReplicaState.STOPPED,
+                  actor_id: "dead-actor",
+                  node_id: "dead-node",
+                  log_file_path: "dead-log",
+                },
+              ],
+            },
+          ] as any
+        }
+      />,
+      { wrapper: TEST_APP_WRAPPER },
+    );
+
+    await screen.findByText("Deployment replica");
+    const user = userEvent.setup();
+
+    // The stopped replica is selectable and labeled.
+    await user.click(
+      within(screen.getByTestId("replicas-select")).getByRole("combobox"),
+    );
+    expect(
+      screen.getByRole("option", { name: "dead-replica (stopped)" }),
+    ).toBeVisible();
+
+    // Selecting it loads the stopped replica's on-disk log.
+    await user.click(
+      screen.getByRole("option", { name: "dead-replica (stopped)" }),
+    );
+    await screen.findByText("nodeId: dead-node");
+    expect(screen.getByText("nodeId: dead-node")).toBeVisible();
+    expect(screen.getByText("filename: dead-log")).toBeVisible();
   });
 });

--- a/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.component.test.tsx
@@ -310,7 +310,7 @@ describe("ServeEntityLogViewer", () => {
                   log_file_path: "live-log",
                 },
               ],
-              dead_replicas: [
+              recent_dead_replicas: [
                 {
                   replica_id: "dead-replica",
                   state: ServeReplicaState.STOPPED,

--- a/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.tsx
@@ -7,7 +7,11 @@ import {
   MultiTabLogViewerTabDetails,
 } from "../../common/MultiTabLogViewer";
 import { Section } from "../../common/Section";
-import { ServeDeployment, ServeSystemActor } from "../../type/serve";
+import {
+  ServeDeployment,
+  ServeReplicaState,
+  ServeSystemActor,
+} from "../../type/serve";
 import { LOG_CONTEXT_KEY_SERVE_DEPLOYMENTS } from "./ServeReplicaDetailPage";
 import {
   LOG_CONTEXT_KEY_SERVE_CONTROLLER,
@@ -51,13 +55,21 @@ export const ServeEntityLogViewer = ({
   );
 
   const allReplicas = deployments.flatMap(
-    ({ name: deploymentName, replicas }) =>
-      replicas.map((replica) => ({
-        ...replica,
-        name: showDeploymentName
+    ({ name: deploymentName, replicas, dead_replicas }) =>
+      // Include recently-stopped replicas so their logs stay viewable after the
+      // actor dies; mark them so they're distinguishable in the dropdown.
+      [...replicas, ...(dead_replicas ?? [])].map((replica) => {
+        const baseName = showDeploymentName
           ? `${deploymentName}#${replica.replica_id}`
-          : replica.replica_id,
-      })),
+          : replica.replica_id;
+        return {
+          ...replica,
+          name:
+            replica.state === ServeReplicaState.STOPPED
+              ? `${baseName} (stopped)`
+              : baseName,
+        };
+      }),
   );
 
   const selectedReplicaId =

--- a/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.tsx
@@ -55,8 +55,8 @@ export const ServeEntityLogViewer = ({
   );
 
   const allReplicas = deployments.flatMap(
-    ({ name: deploymentName, replicas, dead_replicas }) =>
-      [...replicas, ...(dead_replicas ?? [])].map((replica) => {
+    ({ name: deploymentName, replicas, recent_dead_replicas }) =>
+      [...replicas, ...(recent_dead_replicas ?? [])].map((replica) => {
         const baseName = showDeploymentName
           ? `${deploymentName}#${replica.replica_id}`
           : replica.replica_id;

--- a/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.tsx
+++ b/python/ray/dashboard/client/src/pages/serve/ServeEntityLogViewer.tsx
@@ -56,8 +56,6 @@ export const ServeEntityLogViewer = ({
 
   const allReplicas = deployments.flatMap(
     ({ name: deploymentName, replicas, dead_replicas }) =>
-      // Include recently-stopped replicas so their logs stay viewable after the
-      // actor dies; mark them so they're distinguishable in the dropdown.
       [...replicas, ...(dead_replicas ?? [])].map((replica) => {
         const baseName = showDeploymentName
           ? `${deploymentName}#${replica.replica_id}`

--- a/python/ray/dashboard/client/src/type/serve.ts
+++ b/python/ray/dashboard/client/src/type/serve.ts
@@ -37,8 +37,7 @@ export type ServeDeployment = {
   message: string;
   deployment_config: ServeDeploymentConfig;
   replicas: ServeReplica[];
-  // Recently-stopped replicas, retained so their logs stay viewable after death.
-  dead_replicas?: ServeReplica[];
+  recent_dead_replicas?: ServeReplica[];
 };
 
 export type ServeDeploymentConfig = {

--- a/python/ray/dashboard/client/src/type/serve.ts
+++ b/python/ray/dashboard/client/src/type/serve.ts
@@ -37,6 +37,8 @@ export type ServeDeployment = {
   message: string;
   deployment_config: ServeDeploymentConfig;
   replicas: ServeReplica[];
+  // Recently-stopped replicas, retained so their logs stay viewable after death.
+  dead_replicas?: ServeReplica[];
 };
 
 export type ServeDeploymentConfig = {
@@ -67,6 +69,7 @@ export enum ServeReplicaState {
   RECOVERING = "RECOVERING",
   RUNNING = "RUNNING",
   STOPPING = "STOPPING",
+  STOPPED = "STOPPED",
 }
 
 export type ServeReplica = {

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -188,9 +188,7 @@ class ReplicaState(str, Enum):
     RECOVERING = "RECOVERING"
     RUNNING = "RUNNING"
     STOPPING = "STOPPING"
-    # Terminal state for a replica that has fully stopped. Not tracked in the
-    # live replica state machine; only used to surface recently-dead replicas
-    # (and their logs) in the dashboard.
+    # Terminal; not a live state. Surfaces recently-dead replicas (and their logs).
     STOPPED = "STOPPED"
     PENDING_MIGRATION = "PENDING_MIGRATION"
 

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -188,7 +188,6 @@ class ReplicaState(str, Enum):
     RECOVERING = "RECOVERING"
     RUNNING = "RUNNING"
     STOPPING = "STOPPING"
-    # Terminal; not a live state. Surfaces recently-dead replicas (and their logs).
     STOPPED = "STOPPED"
     PENDING_MIGRATION = "PENDING_MIGRATION"
 

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -188,6 +188,10 @@ class ReplicaState(str, Enum):
     RECOVERING = "RECOVERING"
     RUNNING = "RUNNING"
     STOPPING = "STOPPING"
+    # Terminal state for a replica that has fully stopped. Not tracked in the
+    # live replica state machine; only used to surface recently-dead replicas
+    # (and their logs) in the dashboard.
+    STOPPED = "STOPPED"
     PENDING_MIGRATION = "PENDING_MIGRATION"
 
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -675,8 +675,7 @@ RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE = get_env_int(
 # TODO (abrar): Remove this flag after the feature is stable.
 RAY_SERVE_FAIL_ON_RANK_ERROR = get_env_bool("RAY_SERVE_FAIL_ON_RANK_ERROR", "0")
 
-# Number of recently-stopped replicas to retain per deployment so their logs
-# remain accessible in the dashboard after the replica dies. Set to 0 to disable.
+# Stopped replicas to retain per deployment for dashboard log access. 0 disables.
 RAY_SERVE_RETAINED_DEAD_REPLICAS = get_env_int_non_negative(
     "RAY_SERVE_RETAINED_DEAD_REPLICAS", 10
 )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -675,6 +675,12 @@ RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE = get_env_int(
 # TODO (abrar): Remove this flag after the feature is stable.
 RAY_SERVE_FAIL_ON_RANK_ERROR = get_env_bool("RAY_SERVE_FAIL_ON_RANK_ERROR", "0")
 
+# Number of recently-stopped replicas to retain per deployment so their logs
+# remain accessible in the dashboard after the replica dies. Set to 0 to disable.
+RAY_SERVE_RETAINED_DEAD_REPLICAS = get_env_int_non_negative(
+    "RAY_SERVE_RETAINED_DEAD_REPLICAS", 10
+)
+
 # The message to return when the replica is healthy.
 HEALTHY_MESSAGE = "success"
 NO_ROUTES_MESSAGE = "Route table is not populated yet."

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -6,11 +6,11 @@ import os
 import random
 import time
 import traceback
-from collections import defaultdict
+from collections import defaultdict, deque
 from copy import copy
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Deque, Dict, List, Optional, Set, Tuple
 
 import ray
 from ray import ObjectRef, cloudpickle
@@ -58,6 +58,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_INTERNAL_DEPLOYMENT_APP_NAME_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_CODE_VERSION_ENV_VAR,
     RAY_SERVE_INTERNAL_DEPLOYMENT_NAME_ENV_VAR,
+    RAY_SERVE_RETAINED_DEAD_REPLICAS,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY,
     REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
@@ -2835,6 +2836,12 @@ class DeploymentState:
         self._replicas: ReplicaStateContainer = ReplicaStateContainer(
             on_replica_state_change=self._on_replica_state_change
         )
+        # Ring buffer of details for recently-stopped replicas. Surfaced in the
+        # dashboard so their (disk-backed) logs remain accessible after death.
+        # maxlen=0 retains nothing (feature disabled); appends are no-ops.
+        self._dead_replica_details: Deque[ReplicaDetails] = deque(
+            maxlen=RAY_SERVE_RETAINED_DEAD_REPLICAS
+        )
         self._curr_status_info: DeploymentStatusInfo = DeploymentStatusInfo(
             self._id.name,
             DeploymentStatus.UPDATING,
@@ -3277,6 +3284,12 @@ class DeploymentState:
 
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
+
+    def list_dead_replica_details(self) -> List[ReplicaDetails]:
+        # Recently-stopped replicas, retained so their logs remain accessible in
+        # the dashboard after the actor dies. Kept separate from the live list so
+        # they don't pollute replica counts or `serve status`.
+        return list(self._dead_replica_details)
 
     def broadcast_running_replicas_if_changed(self) -> None:
         """Broadcasts the set of running replicas over long poll if it has changed.
@@ -4708,6 +4721,17 @@ class DeploymentState:
             else:
                 logger.info(f"{replica.replica_id} is stopped.")
 
+                # Retain the replica's details (node id + log file path) so its
+                # logs stay accessible in the dashboard after the actor dies. Skip
+                # replicas that never allocated a log file (e.g. died before
+                # starting); they have nothing to show.
+                if replica.actor_details.log_file_path is not None:
+                    self._dead_replica_details.append(
+                        replica.actor_details.model_copy(
+                            update={"state": ReplicaState.STOPPED}
+                        )
+                    )
+
                 # Record shutdown duration metric.
                 if replica.shutdown_start_time is not None:
                     shutdown_duration_ms = (
@@ -5587,6 +5611,7 @@ class DeploymentStateManager:
                 target_num_replicas=deployment_state._target_state.target_num_replicas,
                 required_resources=deployment_state.target_info.replica_config.resource_dict,
                 replicas=deployment_state.list_replica_details(),
+                dead_replicas=deployment_state.list_dead_replica_details(),
             )
 
     def get_deployment_statuses(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2836,9 +2836,6 @@ class DeploymentState:
         self._replicas: ReplicaStateContainer = ReplicaStateContainer(
             on_replica_state_change=self._on_replica_state_change
         )
-        # Ring buffer of details for recently-stopped replicas. Surfaced in the
-        # dashboard so their (disk-backed) logs remain accessible after death.
-        # maxlen=0 retains nothing (feature disabled); appends are no-ops.
         self._dead_replica_details: Deque[ReplicaDetails] = deque(
             maxlen=RAY_SERVE_RETAINED_DEAD_REPLICAS
         )
@@ -3286,9 +3283,7 @@ class DeploymentState:
         return [replica.actor_details for replica in self._replicas.get()]
 
     def list_dead_replica_details(self) -> List[ReplicaDetails]:
-        # Recently-stopped replicas, retained so their logs remain accessible in
-        # the dashboard after the actor dies. Kept separate from the live list so
-        # they don't pollute replica counts or `serve status`.
+        # Separate from the live list so dead replicas don't affect counts or status.
         return list(self._dead_replica_details)
 
     def broadcast_running_replicas_if_changed(self) -> None:
@@ -4721,10 +4716,8 @@ class DeploymentState:
             else:
                 logger.info(f"{replica.replica_id} is stopped.")
 
-                # Retain the replica's details (node id + log file path) so its
-                # logs stay accessible in the dashboard after the actor dies. Skip
-                # replicas that never allocated a log file (e.g. died before
-                # starting); they have nothing to show.
+                # Retain replicas that allocated a log file so the dashboard can
+                # still show their logs after the actor is gone.
                 if replica.actor_details.log_file_path is not None:
                     self._dead_replica_details.append(
                         replica.actor_details.model_copy(

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -2836,7 +2836,7 @@ class DeploymentState:
         self._replicas: ReplicaStateContainer = ReplicaStateContainer(
             on_replica_state_change=self._on_replica_state_change
         )
-        self._dead_replica_details: Deque[ReplicaDetails] = deque(
+        self._recent_dead_replicas: Deque[ReplicaDetails] = deque(
             maxlen=RAY_SERVE_RETAINED_DEAD_REPLICAS
         )
         self._curr_status_info: DeploymentStatusInfo = DeploymentStatusInfo(
@@ -3282,9 +3282,8 @@ class DeploymentState:
     def list_replica_details(self) -> List[ReplicaDetails]:
         return [replica.actor_details for replica in self._replicas.get()]
 
-    def list_dead_replica_details(self) -> List[ReplicaDetails]:
-        # Separate from the live list so dead replicas don't affect counts or status.
-        return list(self._dead_replica_details)
+    def list_recent_dead_replicas(self) -> List[ReplicaDetails]:
+        return list(self._recent_dead_replicas)
 
     def broadcast_running_replicas_if_changed(self) -> None:
         """Broadcasts the set of running replicas over long poll if it has changed.
@@ -4719,7 +4718,7 @@ class DeploymentState:
                 # Retain replicas that allocated a log file so the dashboard can
                 # still show their logs after the actor is gone.
                 if replica.actor_details.log_file_path is not None:
-                    self._dead_replica_details.append(
+                    self._recent_dead_replicas.append(
                         replica.actor_details.model_copy(
                             update={"state": ReplicaState.STOPPED}
                         )
@@ -5604,7 +5603,7 @@ class DeploymentStateManager:
                 target_num_replicas=deployment_state._target_state.target_num_replicas,
                 required_resources=deployment_state.target_info.replica_config.resource_dict,
                 replicas=deployment_state.list_replica_details(),
-                dead_replicas=deployment_state.list_dead_replica_details(),
+                recent_dead_replicas=deployment_state.list_recent_dead_replicas(),
             )
 
     def get_deployment_statuses(

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -501,6 +501,7 @@ class MockReplicaActorWrapper:
         self._node_ip = None
         self._node_instance_id = None
         self._node_id_is_set = False
+        self._log_file_path = None
         self._actor_id = None
         self._internal_grpc_port = None
         self._http_port = None
@@ -580,7 +581,7 @@ class MockReplicaActorWrapper:
 
     @property
     def log_file_path(self) -> Optional[str]:
-        return None
+        return self._log_file_path
 
     @property
     def grpc_port(self) -> Optional[int]:
@@ -618,6 +619,9 @@ class MockReplicaActorWrapper:
 
     def set_ready(self, version: DeploymentVersion = None):
         self.status = ReplicaStartupStatus.SUCCEEDED
+        # A started replica reports its (relative) log file path, mirroring the
+        # real actor's is_allocated() return.
+        self._log_file_path = "serve/replica.log"
         if version:
             self.version_to_be_fetched_from_actor = version
         else:

--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -619,8 +619,7 @@ class MockReplicaActorWrapper:
 
     def set_ready(self, version: DeploymentVersion = None):
         self.status = ReplicaStartupStatus.SUCCEEDED
-        # A started replica reports its (relative) log file path, mirroring the
-        # real actor's is_allocated() return.
+        # Mirror the real actor: a started replica has allocated a log file.
         self._log_file_path = "serve/replica.log"
         if version:
             self.version_to_be_fetched_from_actor = version

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1392,6 +1392,14 @@ class DeploymentDetails(BaseModel):
     replicas: List[ReplicaDetails] = Field(
         description="Details about the live replicas of this deployment."
     )
+    dead_replicas: List[ReplicaDetails] = Field(
+        default_factory=list,
+        description=(
+            "Details about recently-stopped replicas of this deployment, retained "
+            "so their logs remain accessible in the dashboard after they die. Not "
+            "included in `replicas` and not counted toward the live replica count."
+        ),
+    )
 
     autoscaling_detail: Optional[DeploymentAutoscalingDetail] = Field(
         default=None,

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1395,9 +1395,8 @@ class DeploymentDetails(BaseModel):
     dead_replicas: List[ReplicaDetails] = Field(
         default_factory=list,
         description=(
-            "Details about recently-stopped replicas of this deployment, retained "
-            "so their logs remain accessible in the dashboard after they die. Not "
-            "included in `replicas` and not counted toward the live replica count."
+            "Recently-stopped replicas, retained so their logs stay accessible in "
+            "the dashboard after they die. Not part of `replicas` or the live count."
         ),
     )
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1392,7 +1392,7 @@ class DeploymentDetails(BaseModel):
     replicas: List[ReplicaDetails] = Field(
         description="Details about the live replicas of this deployment."
     )
-    dead_replicas: List[ReplicaDetails] = Field(
+    recent_dead_replicas: List[ReplicaDetails] = Field(
         default_factory=list,
         description=(
             "Recently-stopped replicas, retained so their logs stay accessible in "

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -230,6 +230,7 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy_nam
                                     "start_time_s": replica.start_time_s,
                                 }
                             ],
+                            "recent_dead_replicas": [],
                         }
                     },
                     "external_scaler_enabled": False,

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -2476,6 +2476,7 @@ def test_get_serve_instance_details_json_serializable(
                                     "start_time_s": replica.start_time_s,
                                 }
                             ],
+                            "recent_dead_replicas": [],
                         }
                     },
                     "external_scaler_enabled": False,

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -954,58 +954,41 @@ def test_create_delete_single_replica(mock_deployment_state_manager):
     check_counts(ds, total=0)
 
 
-def test_dead_replica_details_retained(mock_deployment_state_manager):
-    """A stopped replica's details are retained so its logs stay accessible."""
-    create_dsm, _, _, _ = mock_deployment_state_manager
-    dsm: DeploymentStateManager = create_dsm()
-
-    info_1, _ = deployment_info()
-    dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
-    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
-
-    dsm.update()
-    ds._replicas.get()[0]._actor.set_ready()
-    dsm.update()
-    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
-    dead_replica_id = ds._replicas.get()[0].replica_id.unique_id
-
-    # Stop the replica completely.
-    ds.delete()
-    dsm.update()
-    ds._replicas.get()[0]._actor.set_done_stopping()
-    dsm.update()
-    check_counts(ds, total=0)
-
-    # The live list stays empty (so counts/status are unaffected), but the
-    # stopped replica is surfaced separately via list_dead_replica_details()
-    # flagged as STOPPED, retaining its log file path.
-    assert ds.list_replica_details() == []
-    dead = ds.list_dead_replica_details()
-    assert len(dead) == 1
-    assert dead[0].replica_id == dead_replica_id
-    assert dead[0].state == ReplicaState.STOPPED
-    assert dead[0].log_file_path is not None
-
-
-def test_dead_replica_details_skips_unallocated(mock_deployment_state_manager):
-    """A replica that dies before allocating logs is not retained."""
+@pytest.mark.parametrize(
+    "allocate_logs, expected_dead",
+    [(True, 1), (False, 0)],
+    ids=["with_logs", "no_logs"],
+)
+def test_dead_replica_details_retention(
+    mock_deployment_state_manager, allocate_logs, expected_dead
+):
+    """A stopped replica is retained for the dashboard iff it allocated a log file."""
     create_dsm, _, _, _ = mock_deployment_state_manager
     dsm: DeploymentStateManager = create_dsm()
     dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info()[0])
     ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
 
-    # Bring up a replica but never mark it ready, so it has no log file path,
-    # then stop it.
     dsm.update()
-    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    if allocate_logs:
+        # set_ready() allocates the replica's log file path.
+        ds._replicas.get()[0]._actor.set_ready()
+        dsm.update()
+    replica_id = ds._replicas.get()[0].replica_id.unique_id
+
     ds.delete()
     dsm.update()
     ds._replicas.get()[0]._actor.set_done_stopping()
     dsm.update()
     check_counts(ds, total=0)
 
-    # Nothing to show logs for, so nothing is retained.
-    assert ds.list_dead_replica_details() == []
+    # Dead replicas are tracked separately, so the live list is unaffected.
+    assert ds.list_replica_details() == []
+    dead = ds.list_dead_replica_details()
+    assert len(dead) == expected_dead
+    if expected_dead:
+        assert dead[0].replica_id == replica_id
+        assert dead[0].state == ReplicaState.STOPPED
+        assert dead[0].log_file_path is not None
 
 
 @patch("ray.serve._private.deployment_state.RAY_SERVE_RETAINED_DEAD_REPLICAS", 2)

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -954,6 +954,87 @@ def test_create_delete_single_replica(mock_deployment_state_manager):
     check_counts(ds, total=0)
 
 
+def test_dead_replica_details_retained(mock_deployment_state_manager):
+    """A stopped replica's details are retained so its logs stay accessible."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+
+    info_1, _ = deployment_info()
+    dsm.deploy(TEST_DEPLOYMENT_ID, info_1)
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    dsm.update()
+    ds._replicas.get()[0]._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.RUNNING, 1, None)])
+    dead_replica_id = ds._replicas.get()[0].replica_id.unique_id
+
+    # Stop the replica completely.
+    ds.delete()
+    dsm.update()
+    ds._replicas.get()[0]._actor.set_done_stopping()
+    dsm.update()
+    check_counts(ds, total=0)
+
+    # The live list stays empty (so counts/status are unaffected), but the
+    # stopped replica is surfaced separately via list_dead_replica_details()
+    # flagged as STOPPED, retaining its log file path.
+    assert ds.list_replica_details() == []
+    dead = ds.list_dead_replica_details()
+    assert len(dead) == 1
+    assert dead[0].replica_id == dead_replica_id
+    assert dead[0].state == ReplicaState.STOPPED
+    assert dead[0].log_file_path is not None
+
+
+def test_dead_replica_details_skips_unallocated(mock_deployment_state_manager):
+    """A replica that dies before allocating logs is not retained."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+    dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info()[0])
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+
+    # Bring up a replica but never mark it ready, so it has no log file path,
+    # then stop it.
+    dsm.update()
+    check_counts(ds, total=1, by_state=[(ReplicaState.STARTING, 1, None)])
+    ds.delete()
+    dsm.update()
+    ds._replicas.get()[0]._actor.set_done_stopping()
+    dsm.update()
+    check_counts(ds, total=0)
+
+    # Nothing to show logs for, so nothing is retained.
+    assert ds.list_dead_replica_details() == []
+
+
+@patch("ray.serve._private.deployment_state.RAY_SERVE_RETAINED_DEAD_REPLICAS", 2)
+def test_dead_replica_details_bounded(mock_deployment_state_manager):
+    """Only the most recent RAY_SERVE_RETAINED_DEAD_REPLICAS are retained."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm: DeploymentStateManager = create_dsm()
+    dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info(num_replicas=3)[0])
+    ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    assert ds._dead_replica_details.maxlen == 2
+
+    # Bring up 3 replicas, then stop all of them at once.
+    dsm.update()
+    for replica in ds._replicas.get():
+        replica._actor.set_ready()
+    dsm.update()
+    check_counts(ds, total=3, by_state=[(ReplicaState.RUNNING, 3, None)])
+
+    ds.delete()
+    dsm.update()
+    for replica in ds._replicas.get():
+        replica._actor.set_done_stopping()
+    dsm.update()
+    check_counts(ds, total=0)
+
+    # Buffer is capped at 2 even though three replicas have stopped.
+    assert len(ds._dead_replica_details) == 2
+
+
 def test_force_kill(mock_deployment_state_manager):
     create_dsm, timer, _, _ = mock_deployment_state_manager
     dsm: DeploymentStateManager = create_dsm()

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -959,7 +959,7 @@ def test_create_delete_single_replica(mock_deployment_state_manager):
     [(True, 1), (False, 0)],
     ids=["with_logs", "no_logs"],
 )
-def test_dead_replica_details_retention(
+def test_recent_dead_replicas_retention(
     mock_deployment_state_manager, allocate_logs, expected_dead
 ):
     """A stopped replica is retained for the dashboard iff it allocated a log file."""
@@ -983,7 +983,7 @@ def test_dead_replica_details_retention(
 
     # Dead replicas are tracked separately, so the live list is unaffected.
     assert ds.list_replica_details() == []
-    dead = ds.list_dead_replica_details()
+    dead = ds.list_recent_dead_replicas()
     assert len(dead) == expected_dead
     if expected_dead:
         assert dead[0].replica_id == replica_id
@@ -992,13 +992,13 @@ def test_dead_replica_details_retention(
 
 
 @patch("ray.serve._private.deployment_state.RAY_SERVE_RETAINED_DEAD_REPLICAS", 2)
-def test_dead_replica_details_bounded(mock_deployment_state_manager):
+def test_recent_dead_replicas_bounded(mock_deployment_state_manager):
     """Only the most recent RAY_SERVE_RETAINED_DEAD_REPLICAS are retained."""
     create_dsm, _, _, _ = mock_deployment_state_manager
     dsm: DeploymentStateManager = create_dsm()
     dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info(num_replicas=3)[0])
     ds = dsm._deployment_states[TEST_DEPLOYMENT_ID]
-    assert ds._dead_replica_details.maxlen == 2
+    assert ds._recent_dead_replicas.maxlen == 2
 
     # Bring up 3 replicas, then stop all of them at once.
     dsm.update()
@@ -1015,7 +1015,7 @@ def test_dead_replica_details_bounded(mock_deployment_state_manager):
     check_counts(ds, total=0)
 
     # Buffer is capped at 2 even though three replicas have stopped.
-    assert len(ds._dead_replica_details) == 2
+    assert len(ds._recent_dead_replicas) == 2
 
 
 def test_force_kill(mock_deployment_state_manager):


### PR DESCRIPTION
## Why are these changes needed?

When a Serve replica dies, the controller immediately drops it from the deployment details that feed the dashboard. The log viewer then resets and the replica's logs become inaccessible, even though the log file is still on disk. This is painful when debugging a replica that just crashed.

This PR retains a bounded per-deployment ring buffer of recently-stopped replicas (`RAY_SERVE_RETAINED_DEAD_REPLICAS`, default 10; set to 0 to disable) and exposes them in a new `DeploymentDetails.dead_replicas` field. It is kept separate from the live `replicas` list, so replica counts, `serve status`, and the deployment replica table are unchanged. Only replicas that allocated a log file are retained. A terminal `ReplicaState.STOPPED` is added for these entries.

The dashboard log viewer merges dead replicas into the replica dropdown, labeled "(stopped)", so a dead replica's Serve logger file still loads from disk after the actor is gone.

Verified end to end on a live cluster: after scaling a deployment down, the stopped replica stays selectable and its logs still load. Note that the `Replicas` count and replica table stay at the live value (1), while the stopped replicas are selectable in the log dropdown and the selected one's log file loads:

![dead replica logs in the Serve dashboard](https://raw.githubusercontent.com/eicherseiji/ray/dead-replica-screenshot-asset/dead_replica_logs.png)

## Related issue number

## Checks

- [x] New unit tests in `python/ray/serve/tests/unit/test_deployment_state.py`: retention, bounded eviction, and skipping replicas that never allocated logs.
- [x] Linted with pre-commit (ruff, black, eslint, import order).
- [x] All commits signed off (DCO).
